### PR TITLE
refactor(ai): BaseConfig prototype shape — data+afterSetData + leaf() factory (#12168)

### DIFF
--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -4,19 +4,77 @@ import Provider from '../src/state/Provider.mjs';
 import Env      from '../src/util/Env.mjs';
 
 /**
+ * Maps a {@link leaf} `type` token to the name-based `Neo.util.Env` parser that decodes its env
+ * var. Reuses the Tier-1 Env primitive (Epic #12101 AC-Epic-1: extend, don't reinvent — no
+ * parallel parser set).
+ * @type {Object<String,Function>}
+ */
+const typeParsers = {
+    boolean  : Env.parseBool,
+    keepAlive: Env.parseKeepAlive,
+    number   : Env.parseNumber,
+    port     : Env.parsePort,
+    string   : Env.parseString,
+    url      : Env.parseUrl
+};
+
+/**
+ * Maps a {@link leaf} `type` token to a value validator used at the `internalSetData` write
+ * choke point. A type without an entry here (e.g. `object`, `array`, or an unknown token)
+ * validates as `true`, so non-scalar leaves pass through.
+ * @type {Object<String,Function>}
+ */
+const typeValidators = {
+    boolean: value => typeof value === 'boolean',
+    number : value => typeof value === 'number' && !Number.isNaN(value),
+    port   : value => Number.isInteger(value) && value >= 0 && value <= 65535,
+    string : value => typeof value === 'string',
+    url    : value => typeof value === 'string'
+};
+
+/**
+ * @summary Declares a single configuration leaf with an explicit type.
+ *
+ * Replaces the raw `{env, default, parse}` literal. The `type` token selects both the name-based
+ * `Env` parser (for env decoding) and the validator (at the write choke point). Unlike inferring
+ * the type from the default value, an explicit `type` survives a `null`/`undefined` default —
+ * e.g. `leaf(null, 'NEO_PUBLIC_URL', 'url')` stays validatable. Object/array leaves omit `env`
+ * and may pass `type: 'object'` for documentation; they carry no parser.
+ *
+ * @param {*} defaultValue The default value.
+ * @param {String|null} [env=null] Env var name, or null for a non-env leaf.
+ * @param {String|null} [type=null] One of `typeParsers` / `typeValidators` keys. Inferred from
+ *        `defaultValue` via `Neo.typeOf` (lower-cased) when omitted and the default is non-null.
+ * @returns {{default:*, env:(String|null), type:(String|null), parse:(Function|null)}}
+ */
+export function leaf(defaultValue, env = null, type = null) {
+    const resolvedType = type ?? (defaultValue === null || defaultValue === undefined
+        ? null
+        : Neo.typeOf(defaultValue).toLowerCase());
+
+    return {
+        default: defaultValue,
+        env,
+        type   : resolvedType,
+        parse  : env ? (typeParsers[resolvedType] ?? Env.parseString) : null
+    }
+}
+
+/**
  * @summary Reactive base configuration manager for Neo MCP servers.
  *
- * Extends the Body-tier reactive state Provider. A subclass supplies a single
- * meta-leaf `metaTree` config — each leaf is `{env?, default, parse?}` — which is
- * compiled at construction into the reactive `data` tree plus a separate
- * leaf-metadata registry. Consumers read values directly (`config.namespace.leaf`)
- * via the proxy returned by {@link createConfigProxy}; the inherited hierarchical
- * data proxy resolves nested paths and routes assignments back through `setData`.
+ * Extends the Body-tier reactive state Provider. A subclass assigns its meta-leaf tree to the
+ * inherited `data` config — each leaf is `{env?, default, parse?, type?}`, typically produced by
+ * the {@link leaf} factory. The {@link afterSetData} override compiles that tree into the reactive
+ * `data` tree (via the Provider's canonical `processDataObject` seam) plus a separate
+ * leaf-metadata registry, then applies the env layer.
  *
- * Environment variables and runtime overrides take precedence over leaf defaults
- * and are re-asserted after any overlay file load. Per-leaf parser metadata is kept
- * in a registry independent of the Provider's reactive config map, so set-time
- * validation can resolve a leaf by its full dotted path.
+ * Consumers read values directly (`config.namespace.leaf`) via the proxy returned by
+ * {@link createConfigProxy}; the inherited hierarchical data proxy resolves nested paths and
+ * routes assignments back through `setData`.
+ *
+ * Env precedence is **bounded** (re-resolved at construct / {@link setEnvOverride} / {@link load} /
+ * {@link refreshEnv}), NOT live-per-read — see {@link #applyEnvLayer} for the rationale.
  *
  * @class Neo.ai.BaseConfig
  * @extends Neo.state.Provider
@@ -27,27 +85,18 @@ class BaseConfig extends Provider {
          * @member {String} className='Neo.ai.BaseConfig'
          * @protected
          */
-        className: 'Neo.ai.BaseConfig',
-        /**
-         * The meta-leaf source tree; subclasses override it. Each leaf is an object
-         * owning a `default` value plus optional `env` (variable name) and `parse`
-         * (decoder). Compiled into reactive `data` + the leaf-metadata registry at
-         * construction. The reactive `data` config is inherited from the Provider.
-         * @member {Object} metaTree={}
-         */
-        metaTree: {}
+        className: 'Neo.ai.BaseConfig'
     }
 
     /**
-     * Leaf metadata keyed by full dotted path (`{env, parse, type}`). Kept independent
-     * of the Provider's reactive config map so set-time validation can resolve a leaf
-     * by path without coupling to reactivity state.
+     * Leaf metadata keyed by full dotted path (`{env, parse, type}`). Kept independent of the
+     * Provider's reactive config map so set-time validation can resolve a leaf by path.
      * @member {Map<String,Object>} #leafMetadataRegistry
      */
     #leafMetadataRegistry = new Map()
     /**
-     * Runtime env-layer overrides keyed by full dotted path; re-asserted over defaults
-     * and overlay files so explicit overrides always win.
+     * Runtime env-layer overrides keyed by ENV VAR NAME (one var may feed multiple leaves);
+     * re-asserted over `process.env` and overlay files so explicit overrides always win.
      * @member {Map<String,*>} #runtimeEnvOverrides
      */
     #runtimeEnvOverrides = new Map()
@@ -58,97 +107,115 @@ class BaseConfig extends Provider {
     #observerSeq = 0
     /**
      * Cleanup fns for active {@link observeData} subscriptions, released on {@link destroy}.
-     * Mirrors `core.Base#observeConfig`'s `#configSubscriptionCleanups` contract: a leaf may
-     * be owned by a parent provider whose Config outlives this instance, so the subscription
-     * must be torn down explicitly on destroy rather than leaking.
+     * Mirrors `core.Base#observeConfig`'s `#configSubscriptionCleanups` contract.
      * @member {Function[]} #dataObserveCleanups=[]
      */
     #dataObserveCleanups = []
 
     /**
-     * Compiles a meta-leaf tree into a plain defaults object and a leaf-metadata
-     * registry. A leaf is any object owning a `default` key; every other object is a
-     * namespace and is walked recursively. Does not apply env values — see
-     * `#applyEnvLayer`.
+     * Compiles a meta-leaf tree into plain data plus a leaf-metadata registry. A leaf is any
+     * object owning a `default` key; every other object is a namespace, walked recursively.
+     * Does not apply env values — see {@link #applyEnvLayer}.
      * @param {Object} tree
-     * @returns {{defaults: Object, registry: Map<String,Object>}}
+     * @returns {{plainData: Object, registry: Map<String,Object>}}
      */
     static compileMetaLeaves(tree) {
-        const defaults = {},
-              registry = new Map();
+        const plainData = {},
+              registry  = new Map();
 
         const walk = (node, pathParts) => {
             for (const [key, value] of Object.entries(node)) {
                 const path = [...pathParts, key];
 
                 if (Neo.isObject(value) && Object.prototype.hasOwnProperty.call(value, 'default')) {
-                    const dotted     = path.join('.'),
-                          defaultVal = value.default;
-
-                    Neo.assignToNs(path, defaultVal, defaults);
-                    registry.set(dotted, {
+                    Neo.assignToNs(path, value.default, plainData);
+                    registry.set(path.join('.'), {
                         env  : value.env   ?? null,
                         parse: value.parse ?? null,
-                        type : defaultVal === null || defaultVal === undefined ? null : Neo.typeOf(defaultVal)
-                    });
+                        type : value.type  ?? (value.default === null || value.default === undefined
+                            ? null
+                            : Neo.typeOf(value.default).toLowerCase())
+                    })
                 } else if (Neo.isObject(value)) {
-                    walk(value, path);
+                    walk(value, path)
                 }
             }
         };
 
         walk(tree, []);
-        return {defaults, registry};
+        return {plainData, registry}
     }
 
     /**
-     * Seeds the reactive data tree from the compiled meta-leaf tree, then applies the
-     * env layer. Runs through the canonical Provider pipeline; data is reactive and
-     * readable synchronously afterwards.
-     * @param {Object} config
+     * The compile seam. A subclass assigns its meta-leaf tree to `data`; this override compiles it
+     * into plain data + the leaf-metadata registry, forwards the plain data to the Provider's
+     * reactive pipeline (`processDataObject`), then applies the env layer. Fires at construction
+     * (when the `data` config is applied) and on any later `data` reassignment.
+     * @param {Object|null} value    The assigned meta-leaf tree.
+     * @param {Object|null} oldValue
      */
-    construct(config) {
-        super.construct(config);
+    afterSetData(value, oldValue) {
+        if (!value) {
+            return
+        }
 
-        const {defaults, registry} = BaseConfig.compileMetaLeaves(this.metaTree);
+        const {plainData, registry} = BaseConfig.compileMetaLeaves(value);
 
         this.#leafMetadataRegistry = registry;
-        this.setData(defaults);
-        this.#applyEnvLayer();
+        super.afterSetData(plainData, oldValue);
+        this.#applyEnvLayer()
     }
 
     /**
-     * Re-asserts env precedence: for each registered leaf with an env binding, decodes
-     * the env var and writes it over the current value, then re-applies any runtime
-     * overrides. Idempotent — safe to call after construction and after each overlay load.
+     * Re-asserts env precedence: for each registered env-bound leaf, the value is the runtime
+     * override (keyed by env var name) if present, else the decoded `process.env` value; it is
+     * written over the current value. Runtime overrides win. Idempotent.
+     *
+     * **Bounded, not live-per-read (deliberate).** Env is re-resolved only at construct (via
+     * {@link afterSetData}), {@link setEnvOverride}, {@link load}, and {@link refreshEnv} — never on
+     * every property read. A live env value decoupled from the running side it configures is
+     * dangerous: e.g. a changed `NEO_CHROMA_PORT` would make new reads target a port the Chroma DB
+     * is not actually listening on (the DB only moves on a coordinated restart). Live env that
+     * drives coordinated restart/reconnection is a separate Body-tier concern, out of scope here.
      * @param {Object} [env=process.env]
      * @param {Function} [warn=console.warn]
      */
     #applyEnvLayer(env = process.env, warn = console.warn) {
         for (const [leafPath, meta] of this.#leafMetadataRegistry) {
             if (!meta.env) {
-                continue;
+                continue
             }
 
-            const decode = meta.parse ?? Env.parseString,
-                  value  = decode(meta.env, {env, warn});
+            let value;
+
+            if (this.#runtimeEnvOverrides.has(meta.env)) {
+                value = this.#runtimeEnvOverrides.get(meta.env)
+            } else {
+                const decode = meta.parse ?? Env.parseString;
+                value = decode(meta.env, {env, warn})
+            }
 
             if (value !== undefined) {
-                this.setData(leafPath, value);
+                this.setData(leafPath, value)
             }
-        }
-
-        for (const [leafPath, value] of this.#runtimeEnvOverrides) {
-            this.setData(leafPath, value);
         }
     }
 
     /**
-     * Validates a value against its leaf metadata. Metadata-path-first: only values
-     * written to a known leaf path are checked; namespace-recursion intermediates pass
-     * through. Lenient — warns on a type mismatch but keeps the value (coercion is
-     * deferred; see the Stage 1 PR notes).
-     * @param {String} leafPath Full dotted leaf path.
+     * Re-reads env vars + re-applies runtime overrides on demand — the explicit bounded "refresh"
+     * handle. Call after a deliberate env change the configured side can tolerate without a
+     * coordinated restart (see {@link #applyEnvLayer} for why this is not automatic per read).
+     */
+    refreshEnv() {
+        this.#applyEnvLayer()
+    }
+
+    /**
+     * Validates a value against its leaf metadata at the write choke point. Metadata-path-first:
+     * ANY value written to a known leaf path is validated (object/JSON leaves included); namespace
+     * recursion intermediates have no registry entry and pass through. Lenient — warns on a type
+     * mismatch but keeps the value.
+     * @param {String} leafPath
      * @param {*} value
      * @returns {*}
      */
@@ -156,53 +223,59 @@ class BaseConfig extends Provider {
         const meta = this.#leafMetadataRegistry.get(leafPath);
 
         if (meta?.type && value !== null && value !== undefined) {
-            const actual = Neo.typeOf(value);
+            const validator = typeValidators[meta.type];
 
-            if (actual !== meta.type) {
-                console.warn(`[Neo.ai.BaseConfig] "${leafPath}" expected ${meta.type}, got ${actual}; keeping value.`);
+            if (validator && !validator(value)) {
+                console.warn(`[Neo.ai.BaseConfig] "${leafPath}" expected ${meta.type}, got ${Neo.typeOf(value)}; keeping value.`)
             }
         }
 
-        return value;
+        return value
     }
 
     /**
-     * The single write funnel. Applies leaf validation for non-object values written to
-     * a known leaf path, then delegates to the Provider pipeline (reactivity bubbling,
+     * The single write funnel. Validates any value written to a known leaf path
+     * (metadata-path-first), then delegates to the Provider pipeline (reactivity bubbling,
      * config-map updates).
      * @param {String|Object} key
      * @param {*} value
      * @param {Neo.state.Provider} [originStateProvider]
      */
     internalSetData(key, value, originStateProvider) {
-        if (typeof key === 'string' && Neo.typeOf(value) !== 'Object' && this.#leafMetadataRegistry.has(key)) {
-            value = this.#validateLeafValue(key, value);
+        if (typeof key === 'string' && this.#leafMetadataRegistry.has(key)) {
+            value = this.#validateLeafValue(key, value)
         }
 
-        super.internalSetData(key, value, originStateProvider);
+        super.internalSetData(key, value, originStateProvider)
     }
 
     /**
-     * Records and applies a runtime env-layer override. The override is re-asserted by
-     * `#applyEnvLayer` so it survives subsequent overlay loads.
-     * @param {String} leafPath
+     * Records and applies a runtime env-layer override, keyed by ENV VAR NAME (one var may feed
+     * multiple leaves). The override wins over `process.env` and is re-asserted by
+     * {@link #applyEnvLayer} so it survives subsequent overlay loads.
+     * @param {String} envName
      * @param {*} value
      */
-    setEnvOverride(leafPath, value) {
-        this.#runtimeEnvOverrides.set(leafPath, value);
-        this.setData(leafPath, value);
+    setEnvOverride(envName, value) {
+        for (const [leafPath, meta] of this.#leafMetadataRegistry) {
+            if (meta.env === envName) {
+                this.#validateLeafValue(leafPath, value)
+            }
+        }
+
+        this.#runtimeEnvOverrides.set(envName, value);
+        this.#applyEnvLayer()
     }
 
     /**
      * Path-scoped reactive subscription to a data leaf. Resolves the owning provider via
-     * `getOwnerOfDataProperty` — the same hierarchy-aware resolution `Provider#getData` and the
-     * hierarchical data proxy use — so a leaf owned by a parent provider is observed correctly
-     * (reaching into `this.getDataConfig` directly would miss the parent chain). The cleanup is
-     * tracked and released on {@link destroy}, mirroring `core.Base#observeConfig`.
+     * `getOwnerOfDataProperty` (the same hierarchy-aware resolution `Provider#getData` and the
+     * hierarchical data proxy use), so a leaf owned by a parent provider is observed correctly.
+     * The cleanup is tracked and released on {@link destroy}.
      *
      * Named `observeData` (NOT `observeConfig`) to avoid shadowing
      * `core.Base#observeConfig(publisher, configName, fn)`, which `Provider#createBinding` uses.
-     * @param {String} leafPath Full dotted leaf path.
+     * @param {String} leafPath
      * @param {Function} fn Invoked as `(value, oldValue)` when the leaf changes.
      * @returns {Function} Cleanup function that removes the subscription.
      */
@@ -211,7 +284,7 @@ class BaseConfig extends Provider {
 
         if (!ownerDetails) {
             console.warn(`[Neo.ai.BaseConfig] observeData: no data leaf at "${leafPath}".`);
-            return () => {};
+            return () => {}
         }
 
         const
@@ -237,47 +310,45 @@ class BaseConfig extends Provider {
     }
 
     /**
-     * Loads an overlay configuration file, deep-merges it into the reactive data tree,
-     * then re-asserts the env layer so env vars and runtime overrides keep precedence.
+     * Loads an overlay configuration file, then re-asserts the env layer so env vars and runtime
+     * overrides keep precedence.
      * @param {String} filePath
      * @returns {Promise<void>}
      */
     async load(filePath) {
         if (!filePath) {
-            return;
+            return
         }
 
         try {
             const absolutePath = path.resolve(filePath),
                   ext          = path.extname(absolutePath);
-            let overlay;
 
             // A `.mjs` overlay default-exports the already-compiled config singleton
-            // (createConfigProxy); its data + env layer are applied at construction, so there
-            // is nothing to merge here (the legacy `Neo.merge(data, proxy)` was a no-op too —
-            // the proxy does not enumerate data leaves). The import validates the file exists.
-            // A JSON overlay carries partial operator overrides that merge into reactive data.
+            // (createConfigProxy); its data + env layer are applied at construction, so there is
+            // nothing to merge here. The import validates the file exists. A JSON overlay carries
+            // partial operator overrides that merge into reactive data.
             if (ext === '.mjs' || ext === '.js') {
-                await import(absolutePath);
+                await import(absolutePath)
             } else {
-                this.setData(JSON.parse(await fs.readFile(absolutePath, 'utf-8')));
+                this.setData(JSON.parse(await fs.readFile(absolutePath, 'utf-8')))
             }
 
             this.#applyEnvLayer();
 
-            console.error(`[Neo.ai.BaseConfig] Loaded overlay configuration from ${absolutePath}`);
+            console.error(`[Neo.ai.BaseConfig] Loaded overlay configuration from ${absolutePath}`)
         } catch (error) {
             console.error(`[Neo.ai.BaseConfig] Failed to load configuration from ${filePath}:`, error.message);
-            throw error;
+            throw error
         }
     }
 }
 
 /**
  * Wraps a BaseConfig instance in a Proxy so consumers read leaf values directly
- * (`config.namespace.leaf`) and assign top-level keys (`config.key = value`). Instance
- * members win; unknown keys delegate to the reactive data tree, whose own hierarchical
- * proxy resolves nested paths and routes nested assignments through `setData`.
+ * (`config.namespace.leaf`) and assign top-level keys (`config.key = value`). Instance members
+ * win; unknown keys delegate to the reactive data tree, whose own hierarchical proxy resolves
+ * nested paths and routes nested assignments through `setData`.
  * @param {Neo.ai.BaseConfig} instance
  * @returns {Proxy}
  */
@@ -286,22 +357,22 @@ export function createConfigProxy(instance) {
         get(target, prop) {
             // Unknown keys delegate to the reactive data tree (enables `config.namespace.leaf`).
             if (typeof prop !== 'symbol' && !Reflect.has(target, prop)) {
-                return target.data?.[prop];
+                return target.data?.[prop]
             }
             // Resolve via the target (NOT the outer proxy) so reactive-config getters and
             // private-field methods run with `this` bound to the real instance.
             const value = target[prop];
-            return typeof value === 'function' ? value.bind(target) : value;
+            return typeof value === 'function' ? value.bind(target) : value
         },
         set(target, prop, value) {
             if (typeof prop !== 'symbol' && !Reflect.has(target, prop)) {
-                target.setData(prop, value);
+                target.setData(prop, value)
             } else {
-                target[prop] = value;
+                target[prop] = value
             }
-            return true;
+            return true
         }
-    });
+    })
 }
 
 export default Neo.setupClass(BaseConfig);

--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -131,8 +131,13 @@ class BaseConfig extends Provider {
                 const path = [...pathParts, key];
 
                 if (Neo.isObject(value) && Object.prototype.hasOwnProperty.call(value, 'default')) {
+                    // Capture the dotted path BEFORE assignToNs — it mutates its `path` arg via
+                    // `path.pop()`, which would otherwise collapse a nested leaf onto its parent
+                    // namespace key (dropping env metadata for every nested leaf).
+                    const dotted = path.join('.');
+
                     Neo.assignToNs(path, value.default, plainData);
-                    registry.set(path.join('.'), {
+                    registry.set(dotted, {
                         env  : value.env   ?? null,
                         parse: value.parse ?? null,
                         // Guard inference: Neo.typeOf is undefined for objects with an own `constructor` key.

--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -48,9 +48,12 @@ const typeValidators = {
  * @returns {{default:*, env:(String|null), type:(String|null), parse:(Function|null)}}
  */
 export function leaf(defaultValue, env = null, type = null) {
-    const resolvedType = type ?? (defaultValue === null || defaultValue === undefined
+    // Neo.typeOf returns undefined for objects carrying an own `constructor` key (e.g. the
+    // dummy embedding fn's anti-legacy duck-type), so guard the inference. Such object leaves
+    // simply resolve to a null type (no validator) — pass an explicit `type` to override.
+    const resolvedType = type ?? (defaultValue == null
         ? null
-        : Neo.typeOf(defaultValue).toLowerCase());
+        : (Neo.typeOf(defaultValue)?.toLowerCase() ?? null));
 
     return {
         default: defaultValue,
@@ -132,9 +135,10 @@ class BaseConfig extends Provider {
                     registry.set(path.join('.'), {
                         env  : value.env   ?? null,
                         parse: value.parse ?? null,
-                        type : value.type  ?? (value.default === null || value.default === undefined
+                        // Guard inference: Neo.typeOf is undefined for objects with an own `constructor` key.
+                        type : value.type  ?? (value.default == null
                             ? null
-                            : Neo.typeOf(value.default).toLowerCase())
+                            : (Neo.typeOf(value.default)?.toLowerCase() ?? null))
                     })
                 } else if (Neo.isObject(value)) {
                     walk(value, path)

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,7 +1,6 @@
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import BaseConfig, {createConfigProxy} from './BaseConfig.mjs';
-import Env             from '../src/util/Env.mjs';
+import BaseConfig, {createConfigProxy, leaf} from './BaseConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -32,61 +31,61 @@ class Config extends BaseConfig {
         /**
          * Top-level meta-leaf configuration tree (Tier 1).
          * Defines the core immutable plain-data structures applied universally across all AI/MCP infrastructure.
-         * Each leaf owns a `default` plus optional `env` (variable name) and `parse` (decoder).
-         * @member {Object} metaTree
+         * Each leaf owns a `default` plus optional `env` (variable name) and `type` (selecting the env decoder + validator).
+         * @member {Object} data
          */
-        metaTree: {
-            neoRootDir : {default: neoRootDir},
-            projectRoot: {default: projectRoot},
+        data: {
+            neoRootDir : leaf(neoRootDir),
+            projectRoot: leaf(projectRoot),
             /**
              * Universal JSONL backup/export directory for Agent OS databases.
              * @type {string}
              */
-            backupPath: {env: 'NEO_BACKUP_PATH', default: path.resolve(neoRootDir, '.neo-ai-data/backups'), parse: Env.parseString},
+            backupPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/backups'), 'NEO_BACKUP_PATH', 'string'),
             /**
              * Path to the wake-daemon liveness sentinel touched on every swarm-heartbeat
              * pulse. Operators / tests can isolate the path via `NEO_HEARTBEAT_ALIVE_PATH`.
              * @type {string}
              */
-            wakeDaemonHeartbeatAlivePath: {env: 'NEO_HEARTBEAT_ALIVE_PATH', default: path.resolve(neoRootDir, '.neo-ai-data/wake-daemon/heartbeat.alive'), parse: Env.parseString},
+            wakeDaemonHeartbeatAlivePath: leaf(path.resolve(neoRootDir, '.neo-ai-data/wake-daemon/heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string'),
             /**
              * Global debug flag for all AI processes.
              * @type {boolean}
              */
-            debug: {env: 'NEO_DEBUG', default: false, parse: Env.parseBool},
+            debug: leaf(false, 'NEO_DEBUG', 'boolean'),
             /**
              * Transport protocol ('stdio' or 'sse').
              * @type {string}
              */
-            transport: {env: 'NEO_TRANSPORT', default: 'stdio', parse: Env.parseString},
+            transport: leaf('stdio', 'NEO_TRANSPORT', 'string'),
             /**
              * Optional public canonical URL.
              * @type {string|null}
              */
-            publicUrl: {env: 'NEO_PUBLIC_URL', default: null, parse: Env.parseUrl},
+            publicUrl: leaf(null, 'NEO_PUBLIC_URL', 'url'),
             /**
              * Port the MCP server's HTTP/SSE transport listens on.
              * Sub-servers will typically override this with their own defaultPort.
              * @type {number}
              */
-            mcpHttpPort: {env: 'MCP_HTTP_PORT', default: 3000, parse: Env.parsePort},
+            mcpHttpPort: leaf(3000, 'MCP_HTTP_PORT', 'port'),
             /**
              * Optional Express middleware function for authentication.
              * @type {Function|null}
              */
-            authMiddleware: {default: null},
+            authMiddleware: leaf(null),
             /**
              * Base authentication configuration.
              * @type {Object}
              */
             auth: {
-                host              : {env: 'NEO_AUTH_HOST', default: null, parse: Env.parseString},
-                port              : {env: 'NEO_AUTH_PORT', default: 8080, parse: Env.parsePort},
-                realm             : {env: 'NEO_AUTH_REALM', default: 'master', parse: Env.parseString},
-                issuerUrl         : {env: 'NEO_AUTH_ISSUER_URL', default: null, parse: Env.parseString},
-                clientId          : {env: 'NEO_OAUTH_CLIENT_ID', default: null, parse: Env.parseString},
-                clientSecret      : {env: 'NEO_OAUTH_CLIENT_SECRET', default: '', parse: Env.parseString},
-                trustProxyIdentity: {env: 'NEO_AUTH_TRUST_PROXY_IDENTITY', default: false, parse: Env.parseBool}
+                host              : leaf(null, 'NEO_AUTH_HOST', 'string'),
+                port              : leaf(8080, 'NEO_AUTH_PORT', 'port'),
+                realm             : leaf('master', 'NEO_AUTH_REALM', 'string'),
+                issuerUrl         : leaf(null, 'NEO_AUTH_ISSUER_URL', 'string'),
+                clientId          : leaf(null, 'NEO_OAUTH_CLIENT_ID', 'string'),
+                clientSecret      : leaf('', 'NEO_OAUTH_CLIENT_SECRET', 'string'),
+                trustProxyIdentity: leaf(false, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean')
             },
             /**
              * @summary Deployment-wide chat / generation model provider.
@@ -97,7 +96,7 @@ class Config extends BaseConfig {
              * `openAiCompatible`.
              * @type {String}
              */
-            chatProvider: {env: 'NEO_MODEL_PROVIDER', default: 'gemini', parse: Env.parseString},
+            chatProvider: leaf('gemini', 'NEO_MODEL_PROVIDER', 'string'),
             /**
              * @summary Runtime alias for the active chat provider.
              *
@@ -106,7 +105,7 @@ class Config extends BaseConfig {
              * one canonical key.
              * @type {String}
              */
-            modelProvider: {env: 'NEO_MODEL_PROVIDER', default: 'gemini', parse: Env.parseString},
+            modelProvider: leaf('gemini', 'NEO_MODEL_PROVIDER', 'string'),
             /**
              * @summary Provider selector for Dream/Sandman graph-generation work.
              *
@@ -117,7 +116,7 @@ class Config extends BaseConfig {
              * deployments that run graph extraction against native Ollama.
              * @type {'ollama'|'openAiCompatible'}
              */
-            graphProvider: {env: 'NEO_GRAPH_PROVIDER', default: 'openAiCompatible', parse: Env.parseString},
+            graphProvider: leaf('openAiCompatible', 'NEO_GRAPH_PROVIDER', 'string'),
             /**
              * @summary Deployment-wide embedding provider selector.
              *
@@ -125,7 +124,7 @@ class Config extends BaseConfig {
              * paths.
              * @type {String}
              */
-            embeddingProvider: {env: 'NEO_EMBEDDING_PROVIDER', default: 'openAiCompatible', parse: Env.parseString},
+            embeddingProvider: leaf('openAiCompatible', 'NEO_EMBEDDING_PROVIDER', 'string'),
             /**
              * @summary Deployment-wide Ollama provider defaults.
              *
@@ -134,11 +133,11 @@ class Config extends BaseConfig {
              * @type {Object}
              */
             ollama: {
-                host                 : {env: 'NEO_OLLAMA_HOST', default: 'http://127.0.0.1:11434', parse: Env.parseString},
-                model                : {env: 'NEO_OLLAMA_MODEL', default: 'gemma4:31b', parse: Env.parseString},
-                embeddingModel       : {env: 'NEO_OLLAMA_EMBEDDING_MODEL', default: 'qwen3-embedding', parse: Env.parseString},
-                keep_alive           : {env: 'NEO_OLLAMA_KEEP_ALIVE', default: -1, parse: Env.parseKeepAlive},
-                requireParallelModels: {env: 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', default: 2, parse: Env.parseNumber}
+                host                 : leaf('http://127.0.0.1:11434', 'NEO_OLLAMA_HOST', 'string'),
+                model                : leaf('gemma4:31b', 'NEO_OLLAMA_MODEL', 'string'),
+                embeddingModel       : leaf('qwen3-embedding', 'NEO_OLLAMA_EMBEDDING_MODEL', 'string'),
+                keep_alive           : leaf(-1, 'NEO_OLLAMA_KEEP_ALIVE', 'keepAlive'),
+                requireParallelModels: leaf(2, 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', 'number')
             },
             /**
              * @summary Deployment-wide OpenAI-compatible provider defaults.
@@ -148,14 +147,14 @@ class Config extends BaseConfig {
              * @type {Object}
              */
             openAiCompatible: {
-                host                 : {env: 'NEO_OPENAI_COMPATIBLE_HOST', default: 'http://127.0.0.1:11434', parse: Env.parseString},
-                model                : {env: 'NEO_OPENAI_COMPATIBLE_MODEL', default: 'gemma-4-31b-it', parse: Env.parseString},
-                embeddingModel       : {env: 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', default: 'text-embedding-qwen3-embedding-8b', parse: Env.parseString},
-                apiKey               : {env: 'NEO_OPENAI_COMPATIBLE_API_KEY', default: '', parse: Env.parseString},
-                unloadRetryCount     : {env: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', default: 3, parse: Env.parseNumber},
-                unloadRetryDelayMs   : {env: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', default: 500, parse: Env.parseNumber},
-                keep_alive           : {env: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', default: -1, parse: Env.parseKeepAlive},
-                requireParallelModels: {env: 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', default: 2, parse: Env.parseNumber}
+                host                 : leaf('http://127.0.0.1:11434', 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
+                model                : leaf('gemma-4-31b-it', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
+                embeddingModel       : leaf('text-embedding-qwen3-embedding-8b', 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
+                apiKey               : leaf('', 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
+                unloadRetryCount     : leaf(3, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
+                unloadRetryDelayMs   : leaf(500, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', 'number'),
+                keep_alive           : leaf(-1, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
+                requireParallelModels: leaf(2, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')
             },
             /**
              * @summary Local-model role-keyed context limits.
@@ -195,8 +194,8 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 chat: {
-                    contextLimitTokens      : {env: 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', default: 262144, parse: Env.parseNumber},
-                    safeProcessingLimitTokens: {env: 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', default: 200000, parse: Env.parseNumber}
+                    contextLimitTokens      : leaf(262144, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(200000, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
                 },
                 /**
                  * @summary Embedding-model context limits in tokens.
@@ -217,8 +216,8 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 embedding: {
-                    contextLimitTokens      : {env: 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', default: 8192, parse: Env.parseNumber},
-                    safeProcessingLimitTokens: {env: 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', default: 6144, parse: Env.parseNumber}
+                    contextLimitTokens      : leaf(8192, 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(6144, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
                 }
             },
             /**
@@ -228,12 +227,12 @@ class Config extends BaseConfig {
              * summary and embedding paths; Tier-1 owns the default tuple.
              * @type {String}
              */
-            modelName: {default: 'gemini-2.5-flash'},
+            modelName: leaf('gemini-2.5-flash'),
             /**
              * @summary Deployment-wide Gemini embedding model default.
              * @type {String}
              */
-            embeddingModel: {default: 'gemini-embedding-001'},
+            embeddingModel: leaf('gemini-embedding-001'),
             /**
              * @summary Enforced vector dimension across shared vector collections.
              *
@@ -242,7 +241,7 @@ class Config extends BaseConfig {
              * overrides.
              * @type {Number}
              */
-            vectorDimension: {env: 'NEO_VECTOR_DIMENSION', default: 4096, parse: Env.parseNumber},
+            vectorDimension: leaf(4096, 'NEO_VECTOR_DIMENSION', 'number'),
             /**
              * @summary Deployment-wide storage engine coordinates.
              *
@@ -255,9 +254,9 @@ class Config extends BaseConfig {
              */
             engines: {
                 chroma: {
-                    dataDir: {default: path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base')},
-                    host   : {env: 'NEO_CHROMA_HOST', default: 'localhost', parse: Env.parseString},
-                    port   : {env: 'NEO_CHROMA_PORT', default: 8000, parse: Env.parsePort}
+                    dataDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/knowledge-base')),
+                    host   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
+                    port   : leaf(8000, 'NEO_CHROMA_PORT', 'port')
                 }
             },
             /**
@@ -271,7 +270,7 @@ class Config extends BaseConfig {
                  * maintenance lanes unless a narrower localOnly override opts them back in.
                  * @type {'local'|'cloud'}
                  */
-                deploymentMode: {env: 'NEO_AI_DEPLOYMENT_MODE', default: 'local', parse: Env.parseString},
+                deploymentMode: leaf('local', 'NEO_AI_DEPLOYMENT_MODE', 'string'),
                 /**
                  * Filesystem root under which tenant-repo mirrors are stored. The
                  * `deriveTenantRepoMirrorPath` helper appends `tenant-repos/<tenant>/<repo>`,
@@ -282,7 +281,7 @@ class Config extends BaseConfig {
                  * `NEO_TENANT_REPO_MIRROR_ROOT`.
                  * @type {String}
                  */
-                tenantRepoMirrorRoot: {env: 'NEO_TENANT_REPO_MIRROR_ROOT', default: '/app/.neo-ai-data', parse: Env.parseString},
+                tenantRepoMirrorRoot: leaf('/app/.neo-ai-data', 'NEO_TENANT_REPO_MIRROR_ROOT', 'string'),
                 /**
                  * Provider-readiness probe parameters consumed by the orchestrator dream task
                  * and the standalone Sandman CLI runner. The probe issues an HTTP GET against
@@ -296,9 +295,9 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 providerReadiness: {
-                    attempts : {env: 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS', default: 30, parse: Env.parseNumber},
-                    delayMs  : {env: 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS', default: 1000, parse: Env.parseNumber},
-                    timeoutMs: {env: 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS', default: 3000, parse: Env.parseNumber}
+                    attempts : leaf(30, 'NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS', 'number'),
+                    delayMs  : leaf(1000, 'NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS', 'number'),
+                    timeoutMs: leaf(3000, 'NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS', 'number')
                 },
                 /**
                  * Maintenance-loop intervals consumed by the orchestrator daemon.
@@ -306,16 +305,16 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 intervals: {
-                    pollMs           : {env: 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS',              default: 3000, parse: Env.parseNumber},
-                    summarySweepMs   : {env: 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS',     default: 10 * 60 * 1000, parse: Env.parseNumber},
-                    kbSyncMs         : {env: 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS',           default: 30 * 60 * 1000, parse: Env.parseNumber},
-                    backupMs         : {env: 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS',            default: DAY_MS, parse: Env.parseNumber},
-                    primaryDevSyncMs : {env: 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS',  default: 10 * 60 * 1000, parse: Env.parseNumber},
-                    tenantRepoSyncMs : {env: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS',  default: 30 * 60 * 1000, parse: Env.parseNumber},
-                    dreamMs               : {env: 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS',             default: HOUR_MS, parse: Env.parseNumber},
-                    dreamOverflowThreshold: {env: 'NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD', default: 0.8, parse: Env.parseNumber},
-                    goldenPathMs          : {env: 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS',       default: HOUR_MS, parse: Env.parseNumber},
-                    swarmHeartbeatMs      : {env: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS',   default: 15 * 60 * 1000, parse: Env.parseNumber}
+                    pollMs           : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
+                    summarySweepMs   : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
+                    kbSyncMs         : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
+                    backupMs         : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
+                    primaryDevSyncMs : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
+                    tenantRepoSyncMs : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),
+                    dreamMs               : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS', 'number'),
+                    dreamOverflowThreshold: leaf(0.8, 'NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD', 'number'),
+                    goldenPathMs          : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS', 'number'),
+                    swarmHeartbeatMs      : leaf(15 * 60 * 1000, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS', 'number')
                 },
                 /**
                  * Chroma daemon recycle policy (#12138). The orchestrator kills and respawns the
@@ -326,7 +325,7 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 chroma: {
-                    maxRuntimeMs: {env: 'NEO_CHROMA_MAX_RUNTIME_MS', default: DAY_MS, parse: Env.parseNumber}
+                    maxRuntimeMs: leaf(DAY_MS, 'NEO_CHROMA_MAX_RUNTIME_MS', 'number')
                 },
                 /**
                  * Swarm-heartbeat target-resolver config. Controls which identity set
@@ -358,14 +357,14 @@ class Config extends BaseConfig {
                      *
                      * @type {'self'|'active-local-team'|'active-subscribers'|'active-a2a-participants'|'disabled'|null}
                      */
-                    targetSource: {env: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE', default: 'active-a2a-participants', parse: Env.parseString},
+                    targetSource: leaf('active-a2a-participants', 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE', 'string'),
                     /**
                      * Explicit comma-separated handle list override (highest resolver precedence).
                      * Raw string; the consumer (`Orchestrator.swarmHeartbeatExplicitTargets`) splits
                      * and trims. `null`/absent → resolver falls through to `targetSource` semantics.
                      * @type {String|null}
                      */
-                    targets: {env: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS', default: null, parse: Env.parseString}
+                    targets: leaf(null, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS', 'string')
                 },
                 /**
                  * Local-only maintenance lane switches. Cloud deployments can disable these
@@ -375,19 +374,19 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 localOnly: {
-                    primaryDevSyncEnabled: {env: 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', default: null, parse: Env.parseBool},
-                    kbSyncEnabled        : {env: 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', default: null, parse: Env.parseBool},
+                    primaryDevSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', 'boolean'),
+                    kbSyncEnabled        : leaf(null, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', 'boolean'),
                     // Local profile may supervise a child Chroma process; cloud profile
                     // reaches the compose-owned `chroma` peer container instead (#12019).
-                    chromaDaemonEnabled  : {env: 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', default: null, parse: Env.parseBool},
-                    bridgeDaemonEnabled  : {env: 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', default: null, parse: Env.parseBool},
-                    goldenPathRepoEnrichmentEnabled: {env: 'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED', default: null, parse: Env.parseBool},
+                    chromaDaemonEnabled  : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),
+                    bridgeDaemonEnabled  : leaf(null, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
+                    goldenPathRepoEnrichmentEnabled: leaf(null, 'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED', 'boolean'),
                     // `null` = use the deployment-profile default (local enables, cloud disables);
                     // the swarm-heartbeat lane is the folded-in wake-substrate pulse (#11766).
-                    swarmHeartbeatEnabled: {env: 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED', default: null, parse: Env.parseBool},
+                    swarmHeartbeatEnabled: leaf(null, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED', 'boolean'),
                     // Reserved policy placeholder: no runtime consumer yet.
                     // `bridgeDaemonEnabled` is the active scheduler gate for desktop wake delivery.
-                    wakeDispatchEnabled  : {default: null}
+                    wakeDispatchEnabled  : leaf(null)
                 },
                 /**
                  * Cloud-only maintenance lane switches (mirror of `localOnly` with inverted
@@ -401,7 +400,7 @@ class Config extends BaseConfig {
                     // tenant-repo-sync: cloud-deployable per ADR 0014 + #11740. Cloud
                     // profile defaults enabled when tenant repos are configured; local
                     // Neo-maintainer profile defaults disabled unless explicitly opted in.
-                    tenantRepoSyncEnabled: {env: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED', default: null, parse: Env.parseBool}
+                    tenantRepoSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_ENABLED', 'boolean')
                 },
                 /**
                  * Optional local Neo repo roots for the primary-dev-sync lane.
@@ -409,7 +408,7 @@ class Config extends BaseConfig {
                  * `ai/config.mjs` or via `NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`.
                  * @type {String[]}
                  */
-                devSyncRoots: {env: 'NEO_ORCHESTRATOR_DEV_SYNC_ROOTS', default: [], parse: Env.parseString},
+                devSyncRoots: leaf([], 'NEO_ORCHESTRATOR_DEV_SYNC_ROOTS', 'string'),
                 /**
                  * Tenant-repo-sync per-repo scheduling parameters (#11942 AC1).
                  *
@@ -430,8 +429,8 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 tenantRepoSync: {
-                    jitterRatio   : {env: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', default: 0.20, parse: Env.parseNumber},
-                    sweepCadenceMs: {env: 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', default: 60 * 1000, parse: Env.parseNumber}
+                    jitterRatio   : leaf(0.20, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_JITTER_RATIO', 'number'),
+                    sweepCadenceMs: leaf(60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_SWEEP_CADENCE_MS', 'number')
                 },
                 /**
                  * Orchestrator-owned MLX inference server config. Operators tune via gitignored
@@ -448,9 +447,9 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 mlx: {
-                    enabled: {env: 'NEO_ORCHESTRATOR_MLX_ENABLED', default: false, parse: Env.parseBool},
-                    model  : {env: 'NEO_ORCHESTRATOR_MLX_MODEL', default: 'mlx-community/gemma-4-31b-it-bf16', parse: Env.parseString},
-                    port   : {env: 'NEO_ORCHESTRATOR_MLX_PORT', default: '11435', parse: Env.parseString}
+                    enabled: leaf(false, 'NEO_ORCHESTRATOR_MLX_ENABLED', 'boolean'),
+                    model  : leaf('mlx-community/gemma-4-31b-it-bf16', 'NEO_ORCHESTRATOR_MLX_MODEL', 'string'),
+                    port   : leaf('11435', 'NEO_ORCHESTRATOR_MLX_PORT', 'string')
                 },
                 /**
                  * Orchestrator-owned LM Studio CLI (`lms`) inference server config. Operators
@@ -473,16 +472,16 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 lms: {
-                    enabled: {env: 'NEO_ORCHESTRATOR_LMS_ENABLED', default: false, parse: Env.parseBool},
-                    model  : {env: 'NEO_ORCHESTRATOR_LMS_MODEL', default: 'qwen3-embedding-8b', parse: Env.parseString},
-                    port   : {env: 'NEO_ORCHESTRATOR_LMS_PORT', default: '1234', parse: Env.parseString}
+                    enabled: leaf(false, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
+                    model  : leaf('qwen3-embedding-8b', 'NEO_ORCHESTRATOR_LMS_MODEL', 'string'),
+                    port   : leaf('1234', 'NEO_ORCHESTRATOR_LMS_PORT', 'string')
                 }
             },
             /**
              * Agent OS maintenance policy shared by operator scripts and daemons.
              * @type {Object}
              */
-            maintenance: {default: {
+            maintenance: leaf({
                 /**
                  * Canonical atomic-bundle backup policy. Bundles remain atomic; per-substrate
                  * retention is intentionally not represented here.
@@ -509,12 +508,12 @@ class Config extends BaseConfig {
                         maxDays    : 7
                     }
                 }
-            }},
+            }),
             /**
              * Knowledge Base operations configuration (Cloud-Native KB Ingestion, Epic #11624).
              * @type {Object}
              */
-            knowledgeBase: {default: {
+            knowledgeBase: leaf({
                 /**
                  * Phase 4D (#11642) — operator alert rules. Each entry is
                  * `{metric, threshold, severity, channels, deliveryMode?}`; see the #11642
@@ -604,12 +603,12 @@ class Config extends BaseConfig {
                  * @type {Number}
                  */
                 gcDefragThreshold: 0.10
-            }},
+            }),
             /**
              * A dummy embedding function to satisfy ChromaDB when embeddings are provided manually.
              * @returns {Object}
              */
-            dummyEmbeddingFunction: {default: {
+            dummyEmbeddingFunction: leaf({
                 generate   : () => null,
                 name       : 'dummy_embedding_function',
                 getConfig  : () => ({}),
@@ -620,7 +619,7 @@ class Config extends BaseConfig {
                         getConfig: () => ({})
                     })
                 }
-            }}
+            })
         }
     }
 }

--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -1,6 +1,6 @@
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import BaseConfig, { createConfigProxy } from '../../../BaseConfig.mjs';
+import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
 
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
@@ -47,19 +47,19 @@ class Config extends BaseConfig {
          */
         singleton: true,
         /**
-         * @member {Object} metaTree
+         * @member {Object} data
          */
-        metaTree: {
+        data: {
             /**
              * The root directory of the project.
              * @type {string}
              */
-            projectRoot: {default: projectRoot},
+            projectRoot: leaf(projectRoot),
             /**
              * Global debug flag for all MCP servers.
              * @type {boolean}
              */
-            debug: {default: false},
+            debug: leaf(false),
             /**
              * Minimum stderr log level for the GitHub workflow logger.
              * @type {string}
@@ -72,43 +72,43 @@ class Config extends BaseConfig {
              * threshold to `debug`; no file sink is used for this workflow server.
              * @type {Object}
              */
-            logger: {default: {
+            logger: leaf({
                 defaultLevel: 'warn',
                 fileSink    : false,
                 stderrMode  : 'threshold'
-            }},
+            }),
             /**
              * Cache duration for healthy health checks (in milliseconds).
              * Unhealthy results are never cached.
              * @type {number}
              */
-            healthCheckCacheDuration: {default: 5 * 60 * 1000}, // 5 minutes
+            healthCheckCacheDuration: leaf(5 * 60 * 1000), // 5 minutes
             /**
              * The minimum required version of the GitHub CLI (`gh`).
              * @type {string}
              */
-            minGhVersion: {default: '2.0.0'},
+            minGhVersion: leaf('2.0.0'),
             /**
              * The owner of the GitHub repository.
              * @type {string}
              */
-            owner: {default: 'neomjs'},
+            owner: leaf('neomjs'),
             /**
              * The name of the GitHub repository.
              * @type {string}
              */
-            repo: {default: 'neo'},
+            repo: leaf('neo'),
             /**
              * Whether to automatically trigger a full sync when the server starts.
              * @type {boolean}
              */
-            syncOnStartup: {default: false},
+            syncOnStartup: leaf(false),
             /**
              * Whether to automatically commit and push changes after a sync.
              * Only executes if the user has write permissions and there are non-metadata changes.
              * @type {boolean}
              */
-            pushToRepoAfterSync: {default: true},
+            pushToRepoAfterSync: leaf(true),
             /**
              * Configuration for the issue synchronization service.
              */
@@ -117,77 +117,77 @@ class Config extends BaseConfig {
                  * The root directory for synced content.
                  * @type {string}
                  */
-                contentRoot: {default: path.resolve(projectRoot, 'resources/content')},
+                contentRoot: leaf(path.resolve(projectRoot, 'resources/content')),
                 /**
                  * The path to the directory for active issues.
                  * @type {string}
                  */
-                issuesDir: {default: path.resolve(projectRoot, 'resources/content/issues')},
+                issuesDir: leaf(path.resolve(projectRoot, 'resources/content/issues')),
                 /**
                  * The root directory for version-based archives across all entities.
                  * @type {string}
                  */
-                archiveRoot: {env: 'NEO_MCP_GITHUB_ARCHIVE_ROOT', default: path.resolve(projectRoot, 'resources/content/archive')},
+                archiveRoot: leaf(path.resolve(projectRoot, 'resources/content/archive'), 'NEO_MCP_GITHUB_ARCHIVE_ROOT'),
                 /**
                  * The path to the directory for discussions.
                  * @type {string}
                  */
-                discussionsDir: {default: path.resolve(projectRoot, 'resources/content/discussions')},
+                discussionsDir: leaf(path.resolve(projectRoot, 'resources/content/discussions')),
                 /**
                  * The path to the directory for pull requests.
                  * @type {string}
                  */
-                pullsDir: {default: path.resolve(projectRoot, 'resources/content/pulls')},
+                pullsDir: leaf(path.resolve(projectRoot, 'resources/content/pulls')),
                 /**
                  * The path to the synchronization metadata file.
                  * @type {string}
                  */
-                metadataFile: {default: path.resolve(projectRoot, 'resources/content/.sync-metadata.json')},
+                metadataFile: leaf(path.resolve(projectRoot, 'resources/content/.sync-metadata.json')),
                 /**
                  * Labels that, when present on an issue, will cause it to be ignored and deleted locally.
                  * @type {string[]}
                  */
-                droppedLabels: {default: ['dropped', 'wontfix', 'duplicate']},
+                droppedLabels: leaf(['dropped', 'wontfix', 'duplicate']),
                 /**
                  * The date from which to start synchronizing issues and releases.
                  * @type {string}
                  */
-                syncStartDate: {default: '2025-01-01T00:00:00Z'},
+                syncStartDate: leaf('2025-01-01T00:00:00Z'),
                 /**
                  * The path to the directory for release notes.
                  * @type {string}
                  */
-                releaseNotesDir: {default: path.resolve(projectRoot, 'resources/content/release-notes')},
+                releaseNotesDir: leaf(path.resolve(projectRoot, 'resources/content/release-notes')),
                 /**
                  * A prefix for issue filenames to prevent them from starting with a number (e.g., 'issue-').
                  * @type {string}
                  */
-                issueFilenamePrefix: {default: 'issue-'},
+                issueFilenamePrefix: leaf('issue-'),
                 /**
                  * @member {String} discussionFilenamePrefix='discussion-'
                  */
-                discussionFilenamePrefix: {default: 'discussion-'},
+                discussionFilenamePrefix: leaf('discussion-'),
                 /**
                  * A prefix for version-based archive directories (e.g., 'v' for 'v1.2.3').
                  * Applies to both milestone titles and release tags.
                  * @type {string}
                  */
-                versionDirectoryPrefix: {default: 'v'},
+                versionDirectoryPrefix: leaf('v'),
                 /**
                  * The maximum number of items per chunk directory in the archive.
                  * @type {number}
                  */
-                archiveChunkThreshold: {default: 100},
+                archiveChunkThreshold: leaf(100),
                 /**
                  * A prefix for archive chunk directories (e.g., 'chunk-').
                  * @type {string}
                  */
-                archiveChunkPrefix: {default: 'chunk-'},
+                archiveChunkPrefix: leaf('chunk-'),
                 /**
                  * A prefix for release note filenames (e.g., 'v').
                  * @type {string}
                  */
-                releaseFilenamePrefix: {default: 'v'},
+                releaseFilenamePrefix: leaf('v'),
                 /**
                  * The maximum number of issues to fetch from the GitHub API in a single sync.
                  * Defensive ceiling against runaway pagination on a misconfigured GraphQL pageInfo while
@@ -195,52 +195,52 @@ class Config extends BaseConfig {
                  * droppedLabels filter further trims the actual processed set.
                  * @type {number}
                  */
-                maxIssues: {default: 20000},
+                maxIssues: leaf(20000),
                 /**
                  * The maximum number of releases to fetch from the GitHub API.
                  * @type {number}
                  */
-                maxReleases: {default: 1000},
+                maxReleases: leaf(1000),
                 /**
                  * The number of releases to fetch per page in GraphQL queries.
                  * @type {number}
                  */
-                releaseQueryLimit: {default: 50},
+                releaseQueryLimit: leaf(50),
                 /**
                  * The maximum buffer size for the `gh` CLI command output.
                  * @type {number}
                  */
-                maxGhOutputBuffer: {default: 10 * 1024 * 1024}, // 10 MB
+                maxGhOutputBuffer: leaf(10 * 1024 * 1024), // 10 MB
                 /**
                  * The markdown delimiter used to separate the issue body from the comments section.
                  * @type {string}
                  */
-                commentSectionDelimiter: {default: '## Comments'},
+                commentSectionDelimiter: leaf('## Comments'),
                 /**
                  * Maximum number of labels to fetch per issue in GraphQL queries.
                  * @type {number}
                  */
-                maxLabelsPerIssue: {default: 20},
+                maxLabelsPerIssue: leaf(20),
                 /**
                  * Maximum number of labels to fetch for the entire repository in GraphQL queries.
                  * @type {number}
                  */
-                maxRepoLabels: {default: 100},
+                maxRepoLabels: leaf(100),
                 /**
                  * Maximum number of assignees to fetch per issue in GraphQL queries.
                  * @type {number}
                  */
-                maxAssigneesPerIssue: {default: 10},
+                maxAssigneesPerIssue: leaf(10),
                 /**
                  * Maximum number of sub-issues to fetch per issue in GraphQL queries.
                  * @type {number}
                  */
-                maxSubIssuesPerIssue: {default: 100},
+                maxSubIssuesPerIssue: leaf(100),
                 /**
                  * Maximum number of timeline items to fetch per issue in GraphQL queries.
                  * @type {number}
                  */
-                maxTimelineItemsPerIssue: {default: 50}
+                maxTimelineItemsPerIssue: leaf(50)
             },
             /**
              * Configuration for pull request queries.
@@ -254,23 +254,23 @@ class Config extends BaseConfig {
                      * The default number of pull requests to return.
                      * @type {number}
                      */
-                    limit: {default: 30},
+                    limit: leaf(30),
                     /**
                      * The default state of pull requests to list.
                      * @type {string}
                      */
-                    state: {default: 'open'}
+                    state: leaf('open')
                 },
                 /**
                  * The maximum number of pull requests that can be fetched in a single API call.
                  * @type {number}
                  */
-                maxLimit: {default: 100},
+                maxLimit: leaf(100),
                 /**
                  * Maximum number of comments to fetch per pull request in GraphQL queries.
                  * @type {number}
                  */
-                maxCommentsPerPullRequest: {default: 100}
+                maxCommentsPerPullRequest: leaf(100)
             }
         }
     }

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -1,7 +1,6 @@
 import path                                       from 'path';
 import {fileURLToPath}                            from 'url';
-import BaseConfig, {createConfigProxy}            from '../../../BaseConfig.mjs';
-import Env from '../../../../src/util/Env.mjs';
+import BaseConfig, {createConfigProxy, leaf}      from '../../../BaseConfig.mjs';
 
 const __filename     = fileURLToPath(import.meta.url);
 const __dirname      = path.dirname(__filename);
@@ -52,17 +51,17 @@ class Config extends BaseConfig {
          *
          * Keeps client-project GitLab host / PAT configuration out of tracked files.
          * The real GitLabClient subtask consumes the same keys when API calls land.
-         * @member {Object} metaTree
+         * @member {Object} data
          */
-        metaTree: {
+        data: {
             /**
              * @member {String} projectRoot
              */
-            projectRoot: {default: projectRoot},
+            projectRoot: leaf(projectRoot),
             /**
              * @member {Boolean} debug=false
              */
-            debug: {env: 'NEO_GITLAB_WORKFLOW_DEBUG', default: false, parse: Env.parseBool},
+            debug: leaf(false, 'NEO_GITLAB_WORKFLOW_DEBUG', 'boolean'),
             /**
              * @member {String} logLevel='warn'
              */
@@ -74,15 +73,15 @@ class Config extends BaseConfig {
              * threshold to `debug`; no file sink is used for this workflow server.
              * @member {Object} logger
              */
-            logger: {default: {
+            logger: leaf({
                 defaultLevel: 'warn',
                 fileSink    : false,
                 stderrMode  : 'threshold'
-            }},
+            }),
             /**
              * @member {String} transport='stdio'
              */
-            transport: {env: 'NEO_GITLAB_WORKFLOW_TRANSPORT', default: 'stdio', parse: Env.parseString},
+            transport: leaf('stdio', 'NEO_GITLAB_WORKFLOW_TRANSPORT', 'string'),
             /**
              * @member {Object} gitlab
              */
@@ -91,12 +90,12 @@ class Config extends BaseConfig {
                  * GitLab instance base URL.
                  * @member {String} hostUrl='https://gitlab.com'
                  */
-                hostUrl: {env: 'NEO_GITLAB_HOST', default: 'https://gitlab.com', parse: Env.parseUrl},
+                hostUrl: leaf('https://gitlab.com', 'NEO_GITLAB_HOST', 'url'),
                 /**
                  * GitLab Personal Access Token. Empty in the tracked template.
                  * @member {String} token=''
                  */
-                token: {env: 'NEO_GITLAB_PAT', default: '', parse: Env.parseString}
+                token: leaf('', 'NEO_GITLAB_PAT', 'string')
             }
         }
     }

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -1,9 +1,8 @@
 import os              from 'os';
 import path            from 'path';
 import AiConfig        from '../../../config.template.mjs';
-import BaseConfig, { createConfigProxy } from '../../../BaseConfig.mjs';
+import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
 import {fileURLToPath} from 'url';
-import Env from '../../../../src/util/Env.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -35,42 +34,42 @@ class Config extends BaseConfig {
          */
         singleton: true,
         /**
-         * @member {Object} metaTree
+         * @member {Object} data
          */
-        metaTree: {
-            neoRootDir: {default: neoRootDir},
+        data: {
+            neoRootDir: leaf(neoRootDir),
             /**
              * Universal JSONL backup/export directory inherited from Tier-1 config.
              * @type {string}
              */
-            backupPath: {env: 'NEO_BACKUP_PATH', default: AiConfig.backupPath, parse: Env.parseString},
+            backupPath: leaf(AiConfig.backupPath, 'NEO_BACKUP_PATH', 'string'),
             /**
              * Automatically synchronize the knowledge base on startup.
              * @type {boolean}
              */
-            autoSync: {env: 'NEO_AUTO_SYNC', default: false, parse: Env.parseBool},
+            autoSync: leaf(false, 'NEO_AUTO_SYNC', 'boolean'),
             /**
              * Automatically start the local Chroma database process on startup.
              * @type {boolean}
              */
-            autoStartDatabase: {env: 'NEO_KB_AUTO_START_DATABASE', default: false, parse: Env.parseBool},
+            autoStartDatabase: leaf(false, 'NEO_KB_AUTO_START_DATABASE', 'boolean'),
             /**
              * Global debug flag for all MCP servers.
              * @type {boolean}
              */
-            debug: {default: false},
+            debug: leaf(false),
             /**
              * Transport protocol for the MCP server ('stdio' or 'sse').
              * @type {string}
              */
-            transport: {env: 'NEO_TRANSPORT', default: 'stdio', parse: Env.parseString},
+            transport: leaf('stdio', 'NEO_TRANSPORT', 'string'),
             /**
              * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
              *
              * Operator env var: `MCP_HTTP_PORT`.
              * @type {number}
              */
-            mcpHttpPort: {env: 'MCP_HTTP_PORT', default: 3000, parse: Env.parsePort},
+            mcpHttpPort: leaf(3000, 'MCP_HTTP_PORT', 'port'),
             /**
              * Optional public canonical URL for this MCP server.
              * When configured, this URL is explicitly used as the resource indicator
@@ -80,25 +79,25 @@ class Config extends BaseConfig {
              * Example: 'https://mcp.neo.mjs.com/knowledge-base'
              * @type {string|null}
              */
-            publicUrl: {env: 'NEO_PUBLIC_URL', default: null, parse: Env.parseUrl},
+            publicUrl: leaf(null, 'NEO_PUBLIC_URL', 'url'),
             /**
              * Optional Express middleware function for authentication (only used if transport is 'sse').
              * @type {Function|null}
              */
-            authMiddleware: {default: null},
+            authMiddleware: leaf(null),
             /**
              * Authentication configuration for the server (OAuth 2.1 / OIDC).
              * Only used when transport is 'sse'.
              * @type {Object}
              */
             auth: {
-                host              : {env: 'NEO_AUTH_HOST', default: AiConfig.auth.host, parse: Env.parseString},
-                port              : {env: 'NEO_AUTH_PORT', default: AiConfig.auth.port, parse: Env.parsePort},
-                realm             : {env: 'NEO_AUTH_REALM', default: AiConfig.auth.realm, parse: Env.parseString},
-                issuerUrl         : {env: 'NEO_AUTH_ISSUER_URL', default: AiConfig.auth.issuerUrl, parse: Env.parseString},
-                clientId          : {env: 'NEO_OAUTH_CLIENT_ID', default: AiConfig.auth.clientId, parse: Env.parseString},
-                clientSecret      : {env: 'NEO_OAUTH_CLIENT_SECRET', default: AiConfig.auth.clientSecret, parse: Env.parseString},
-                trustProxyIdentity: {env: 'NEO_AUTH_TRUST_PROXY_IDENTITY', default: AiConfig.auth.trustProxyIdentity, parse: Env.parseBool}
+                host              : leaf(AiConfig.auth.host, 'NEO_AUTH_HOST', 'string'),
+                port              : leaf(AiConfig.auth.port, 'NEO_AUTH_PORT', 'port'),
+                realm             : leaf(AiConfig.auth.realm, 'NEO_AUTH_REALM', 'string'),
+                issuerUrl         : leaf(AiConfig.auth.issuerUrl, 'NEO_AUTH_ISSUER_URL', 'string'),
+                clientId          : leaf(AiConfig.auth.clientId, 'NEO_OAUTH_CLIENT_ID', 'string'),
+                clientSecret      : leaf(AiConfig.auth.clientSecret, 'NEO_OAUTH_CLIENT_SECRET', 'string'),
+                trustProxyIdentity: leaf(AiConfig.auth.trustProxyIdentity, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean')
             },
             /**
              * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
@@ -111,7 +110,7 @@ class Config extends BaseConfig {
              * If any are missing, it defaults to legacy mode.
              * @returns {Object} The dummy embedding function satisfying IEmbeddingFunction
              */
-            dummyEmbeddingFunction: {default: {
+            dummyEmbeddingFunction: leaf({
                 generate   : () => null,
                 name       : 'dummy_embedding_function',
                 getConfig  : () => ({}),
@@ -122,7 +121,7 @@ class Config extends BaseConfig {
                         getConfig: () => ({})
                     })
                 }
-            }},
+            }, null, 'object'),
             /**
              * The hostname of the ChromaDB server for the knowledge base.
              *
@@ -130,7 +129,7 @@ class Config extends BaseConfig {
              * unified Chroma instance for both KB + MC, this points at the shared cloud-hosted Chroma.
              * @type {string}
              */
-            host: {env: 'NEO_CHROMA_HOST', default: AiConfig.engines.chroma.host, parse: Env.parseString},
+            host: leaf(AiConfig.engines.chroma.host, 'NEO_CHROMA_HOST', 'string'),
             /**
              * The port the ChromaDB server for the knowledge base is listening on.
              *
@@ -138,14 +137,14 @@ class Config extends BaseConfig {
              * fall back to the default with a console warning per the resolver validity contract.
              * @type {number}
              */
-            port: {env: 'NEO_CHROMA_PORT', default: AiConfig.engines.chroma.port, parse: Env.parsePort},
+            port: leaf(AiConfig.engines.chroma.port, 'NEO_CHROMA_PORT', 'port'),
             /**
              * The unified Chroma persist directory, read from the single source of truth
              * `AiConfig.engines.chroma.dataDir`. MUST equal the orchestrator daemon's
              * `--path` (kept literal there for daemon-launch resilience against a stale config.mjs).
              * @type {string}
              */
-            path: {default: AiConfig.engines.chroma.dataDir},
+            path: leaf(AiConfig.engines.chroma.dataDir),
             /**
              * @summary Shared SQLite destination for Knowledge Base query telemetry.
              *
@@ -154,7 +153,7 @@ class Config extends BaseConfig {
              * land beside `nl_action_log` without coupling either MCP server's schema.
              * @type {string}
              */
-            memoryCoreDbPath: {env: 'NEO_MEMORY_DB_PATH', default: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'), parse: Env.parseString},
+            memoryCoreDbPath: leaf(path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'), 'NEO_MEMORY_DB_PATH', 'string'),
             /**
              * @summary Repetition threshold for promoting KB queries into Agent FAQ clusters.
              *
@@ -162,7 +161,7 @@ class Config extends BaseConfig {
              * eligible for `[KB_DEMAND_GAP]` inference and `list_agent_faqs` reporting.
              * @type {number}
              */
-            kbFaqMinCount: {env: 'NEO_KB_FAQ_MIN_COUNT', default: 3, parse: Env.parseNumber},
+            kbFaqMinCount: leaf(3, 'NEO_KB_FAQ_MIN_COUNT', 'number'),
             /**
              * @summary Calibration threshold for future embedding-backed Agent FAQ clustering.
              *
@@ -171,24 +170,24 @@ class Config extends BaseConfig {
              * lower this once embedding-backed similarity is measured against real traffic.
              * @type {number}
              */
-            kbFaqSimilarityThreshold: {env: 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', default: 1.0, parse: Env.parseNumber},
+            kbFaqSimilarityThreshold: leaf(1.0, 'NEO_KB_FAQ_SIMILARITY_THRESHOLD', 'number'),
             /**
              * @summary Bound for Concept Ontology IDs attached to each Agent FAQ cluster.
              *
              * Maximum number of Concept Ontology IDs attached to each Agent FAQ.
              * @type {number}
              */
-            kbFaqConceptLimit: {env: 'NEO_KB_FAQ_CONCEPT_LIMIT', default: 5, parse: Env.parseNumber},
+            kbFaqConceptLimit: leaf(5, 'NEO_KB_FAQ_CONCEPT_LIMIT', 'number'),
             /**
              * The path to the generated knowledge base JSONL file.
              * @type {string}
              */
-            dataPath: {default: path.resolve(neoRootDir, 'dist/ai-knowledge-base.jsonl')},
+            dataPath: leaf(path.resolve(neoRootDir, 'dist/ai-knowledge-base.jsonl')),
             /**
              * The path to the generated class hierarchy JSON file.
              * @type {string}
              */
-            hierarchyPath: {default: path.resolve(neoRootDir, 'docs/output/class-hierarchy.json')},
+            hierarchyPath: leaf(path.resolve(neoRootDir, 'docs/output/class-hierarchy.json')),
             /**
              * Directory for the always-on KB server diagnostic log files. The KB server's
              * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-running
@@ -196,7 +195,7 @@ class Config extends BaseConfig {
              * trail observable from the host shell. Default: `<neoRootDir>/.neo-ai-data/logs/`.
              * @type {string}
              */
-            logPath: {default: path.resolve(neoRootDir, '.neo-ai-data/logs')},
+            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
             /**
              * @summary Shared MCP logger policy for Knowledge Base.
              *
@@ -205,24 +204,24 @@ class Config extends BaseConfig {
              * `logPath` / `debug` before the next write without re-importing the module.
              * @type {Object}
              */
-            logger: {default: {
+            logger: leaf({
                 filePrefix    : 'kb-server',
                 fileSink      : true,
                 stderrMode    : 'debug',
                 timestampStyle: 'plain'
-            }},
+            }),
             /**
              * The name of the ChromaDB collection for the knowledge base.
              * @type {string}
              */
-            collectionName: {default: 'neo-knowledge-base'},
+            collectionName: leaf('neo-knowledge-base'),
             /**
              * When `true` (default), the SourceRegistry auto-registers Neo's
              * 10 curated default Source classes. Cloud deployments that ingest only tenant content
              * can set `false` to skip Neo's curated sources entirely.
              * @type {boolean}
              */
-            useDefaultSources: {default: true},
+            useDefaultSources: leaf(true),
             /**
              * @summary Explicit opt-in fallback Source for unknown tenant repository shapes.
              *
@@ -233,25 +232,25 @@ class Config extends BaseConfig {
              * Operator env var: `NEO_KB_RAW_REPO_SOURCE`.
              * @type {boolean}
              */
-            rawRepoSource: {env: 'NEO_KB_RAW_REPO_SOURCE', default: false, parse: Env.parseBool},
+            rawRepoSource: leaf(false, 'NEO_KB_RAW_REPO_SOURCE', 'boolean'),
             /**
              * When `true` (default), the SourceRegistry auto-registers Neo's
              * built-in Parser classes. The default registry may be empty until parser modules are added.
              * @type {boolean}
              */
-            useDefaultParsers: {default: true},
+            useDefaultParsers: leaf(true),
             /**
              * Declarative tenant-supplied Source registration.
              * Each entry: `{SourceClass, sourceName?}`.
              * @type {Array<{SourceClass: Object, sourceName?: string}>}
              */
-            customSources: {default: []},
+            customSources: leaf([]),
             /**
              * Declarative tenant-supplied Parser registration.
              * Each entry: `{ParserClass, parserId?}`.
              * @type {Array<{ParserClass: Object, parserId?: string}>}
              */
-            customParsers: {default: []},
+            customParsers: leaf([]),
             /**
              * Per-source path overrides keyed by Source-class registry name.
              * Empty entries or missing keys fall through to each Source class's hardcoded fallback
@@ -259,7 +258,7 @@ class Config extends BaseConfig {
              * each interprets its own entry shape (string / string-array / path→type object).
              * @type {Object<string,string|string[]|Object<string,string>>}
              */
-            sourcePaths: {default: {
+            sourcePaths: leaf({
                 AdrSource         : 'learn/agentos/decisions',
                 ConceptSource     : 'resources/content/concepts',
                 ReleaseNotesSource: '.github/RELEASE_NOTES',
@@ -304,7 +303,7 @@ class Config extends BaseConfig {
                         'yarn.lock'
                     ]
                 }
-            }},
+            }),
             /**
              * @summary Default tenant identity for Neo's curated Knowledge Base corpus — the team
              * namespace visible across every tenant.
@@ -316,7 +315,7 @@ class Config extends BaseConfig {
              * value with server-derived tenant context; client-supplied chunk metadata is never authoritative.
              * @type {string}
              */
-            defaultTenantId: {env: 'NEO_KB_DEFAULT_TENANT_ID', default: 'neo-shared', parse: Env.parseString},
+            defaultTenantId: leaf('neo-shared', 'NEO_KB_DEFAULT_TENANT_ID', 'string'),
             /**
              * @summary Default repository slug for Neo's curated Knowledge Base corpus.
              *
@@ -324,7 +323,7 @@ class Config extends BaseConfig {
              * tenant repositories cannot collide.
              * @type {string}
              */
-            defaultRepoSlug: {env: 'NEO_KB_DEFAULT_REPO_SLUG', default: 'neo', parse: Env.parseString},
+            defaultRepoSlug: leaf('neo', 'NEO_KB_DEFAULT_REPO_SLUG', 'string'),
             /**
              * @summary Default read visibility for embedded Knowledge Base chunks.
              *
@@ -332,7 +331,7 @@ class Config extends BaseConfig {
              * filtering.
              * @type {string}
              */
-            defaultVisibility: {env: 'NEO_KB_DEFAULT_VISIBILITY', default: 'team', parse: Env.parseString},
+            defaultVisibility: leaf('team', 'NEO_KB_DEFAULT_VISIBILITY', 'string'),
             /**
              * @summary Policy for conflicting client-supplied tenant metadata.
              *
@@ -341,17 +340,17 @@ class Config extends BaseConfig {
              * embedding call with `KB_TENANT_SPOOF_REJECTED`.
              * @type {'overwrite'|'reject'}
              */
-            spoofRejectionMode: {env: 'NEO_KB_SPOOF_REJECTION_MODE', default: 'overwrite', parse: Env.parseString},
+            spoofRejectionMode: leaf('overwrite', 'NEO_KB_SPOOF_REJECTION_MODE', 'string'),
             /**
              * The name of the Google Generative AI model for content generation.
              * @type {string}
              */
-            modelName: {default: 'gemini-2.5-flash'},
+            modelName: leaf('gemini-2.5-flash'),
             /**
              * The number of chunks to process in a single batch when embedding.
              * @type {number}
              */
-            batchSize: {default: 50},
+            batchSize: leaf(50),
             /**
              * Work-volume gate for MCP-callable `manage_knowledge_base sync`: when
              * the post-delta `chunksToProcess.length` exceeds this value AND the call originates
@@ -364,27 +363,27 @@ class Config extends BaseConfig {
              * threshold is empirically tunable per deployment.
              * @type {number}
              */
-            mcpSyncMaxChunks: {default: 50},
+            mcpSyncMaxChunks: leaf(50),
             /**
              * Delay in milliseconds between batches to avoid rate limits.
              * @type {number}
              */
-            batchDelay: {default: 10000},
+            batchDelay: leaf(10000),
             /**
              * The maximum number of times to retry a failed embedding batch.
              * @type {number}
              */
-            maxRetries: {default: 5},
+            maxRetries: leaf(5),
             /**
              * The number of results to fetch from ChromaDB for a query.
              * @type {number}
              */
-            nResults: {default: 100},
+            nResults: leaf(100),
             /**
              * Weights used in the query scoring algorithm.
              * @type {Object}
              */
-            queryScoreWeights: {default: {
+            queryScoreWeights: leaf({
                 baseIncrement    : 1,
                 sourcePathMatch  : 40,
                 fileNameMatch    : 30,
@@ -399,7 +398,7 @@ class Config extends BaseConfig {
                 releaseExactMatch: 1000,
                 inheritanceBoost : 80,
                 inheritanceDecay : 0.6
-            }}
+            })
         }
     }
 }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -1,8 +1,7 @@
-import path                              from 'path';
-import AiConfig                          from '../../../config.template.mjs';
-import BaseConfig, {createConfigProxy}   from '../../../BaseConfig.mjs';
-import {fileURLToPath}                   from 'url';
-import Env                               from '../../../../src/util/Env.mjs';
+import path                                    from 'path';
+import AiConfig                                from '../../../config.template.mjs';
+import BaseConfig, {createConfigProxy, leaf}   from '../../../BaseConfig.mjs';
+import {fileURLToPath}                          from 'url';
 
 function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
     const rawValue = env[envVarName];
@@ -41,9 +40,9 @@ class Config extends BaseConfig {
          */
         singleton: true,
         /**
-         * @member {Object} metaTree
+         * @member {Object} data
          */
-        metaTree: {
+        data: {
             /**
              * Repo root, computed from this module's path. Exported for symmetry with the
              * KB and Neural Link configs (#10584) so consumers (loggers, services, future)
@@ -51,27 +50,27 @@ class Config extends BaseConfig {
              * locally. Module path is stable; the resolution is deterministic at boot.
              * @type {string}
              */
-            neoRootDir: {default: neoRootDir},
+            neoRootDir: leaf(neoRootDir),
             /**
              * Automatically trigger session summarization on startup.
              * @type {boolean}
              */
-            autoSummarize: {env: 'NEO_AUTO_SUMMARIZE', default: false, parse: Env.parseBool},
+            autoSummarize: leaf(false, 'NEO_AUTO_SUMMARIZE', 'boolean'),
             /**
              * Automatically start the local database process (Chroma/SQLite) on startup.
              * @type {boolean}
              */
-            autoStartDatabase: {env: 'NEO_MEM_AUTO_START_DATABASE', default: false, parse: Env.parseBool},
+            autoStartDatabase: leaf(false, 'NEO_MEM_AUTO_START_DATABASE', 'boolean'),
             /**
              * Automatically start the local inference server on startup.
              * @type {boolean}
              */
-            autoStartInference: {env: 'NEO_MEM_AUTO_START_INFERENCE', default: false, parse: Env.parseBool},
+            autoStartInference: leaf(false, 'NEO_MEM_AUTO_START_INFERENCE', 'boolean'),
             /**
              * Automatically trigger GraphRAG extraction on startup.
              * @type {boolean}
              */
-            autoDream: {env: 'NEO_AUTO_DREAM', default: false, parse: Env.parseBool},
+            autoDream: leaf(false, 'NEO_AUTO_DREAM', 'boolean'),
             /**
              * @deprecated since PR #11101. Golden Path synthesis is now dynamically event-driven
              * (triggered via MemoryService#mutateFrontier) rather than bound to MCP boot sequence.
@@ -82,34 +81,34 @@ class Config extends BaseConfig {
              * Crucial for headless swarm nodes (Mac 2) to physically generate sandman_handoff.md.
              * @type {boolean}
              */
-            autoGoldenPath: {env: 'NEO_AUTO_GOLDEN_PATH', default: false, parse: Env.parseBool},
+            autoGoldenPath: leaf(false, 'NEO_AUTO_GOLDEN_PATH', 'boolean'),
             /**
              * Immediately parse each incoming memory turn (add_memory) for Graph Injection.
              * @type {boolean}
              */
-            realTimeMemoryParsing: {env: 'NEO_REAL_TIME_MEMORY_PARSING', default: false, parse: Env.parseBool},
+            realTimeMemoryParsing: leaf(false, 'NEO_REAL_TIME_MEMORY_PARSING', 'boolean'),
             /**
              * Automatically trigger FileSystem ingestion (Differential Graph Sync) on MCP server startup.
              * @type {boolean}
              */
-            autoIngestFileSystem: {env: 'NEO_AUTO_INGEST_FS', default: false, parse: Env.parseBool},
+            autoIngestFileSystem: leaf(false, 'NEO_AUTO_INGEST_FS', 'boolean'),
             /**
              * Global debug flag for all MCP servers.
              * @type {boolean}
              */
-            debug: {env: 'NEO_DEBUG', default: false, parse: Env.parseBool},
+            debug: leaf(false, 'NEO_DEBUG', 'boolean'),
             /**
              * Transport protocol for the MCP server ('stdio' or 'sse').
              * @type {string}
              */
-            transport: {env: 'NEO_TRANSPORT', default: 'stdio', parse: Env.parseString},
+            transport: leaf('stdio', 'NEO_TRANSPORT', 'string'),
             /**
              * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
              *
              * Operator env var: `MCP_HTTP_PORT`.
              * @type {number}
              */
-            mcpHttpPort: {env: 'MCP_HTTP_PORT', default: 3001, parse: Env.parsePort},
+            mcpHttpPort: leaf(3001, 'MCP_HTTP_PORT', 'port'),
             /**
              * Optional public canonical URL for this MCP server.
              * When configured, this URL is explicitly used as the resource indicator
@@ -119,38 +118,38 @@ class Config extends BaseConfig {
              * Example: 'https://mcp.neo.mjs.com/memory-core'
              * @type {string|null}
              */
-            publicUrl: {env: 'NEO_PUBLIC_URL', default: null, parse: Env.parseUrl},
+            publicUrl: leaf(null, 'NEO_PUBLIC_URL', 'url'),
             /**
              * Optional Express middleware function for authentication (only used if transport is 'sse').
              * @type {Function|null}
              */
-            authMiddleware: {default: null},
+            authMiddleware: leaf(null),
             /**
              * Authentication configuration for the server (OAuth 2.1 / OIDC).
              * Only used when transport is 'sse'.
              * @type {Object}
              */
             auth: {
-                host              : {env: 'NEO_AUTH_HOST', default: AiConfig.auth.host, parse: Env.parseString},
-                port              : {env: 'NEO_AUTH_PORT', default: AiConfig.auth.port, parse: Env.parsePort},
-                realm             : {env: 'NEO_AUTH_REALM', default: AiConfig.auth.realm, parse: Env.parseString},
-                issuerUrl         : {env: 'NEO_AUTH_ISSUER_URL', default: AiConfig.auth.issuerUrl, parse: Env.parseString},
-                clientId          : {env: 'NEO_OAUTH_CLIENT_ID', default: AiConfig.auth.clientId, parse: Env.parseString},
-                clientSecret      : {env: 'NEO_OAUTH_CLIENT_SECRET', default: AiConfig.auth.clientSecret, parse: Env.parseString},
-                trustProxyIdentity: {env: 'NEO_AUTH_TRUST_PROXY_IDENTITY', default: AiConfig.auth.trustProxyIdentity, parse: Env.parseBool}
+                host              : leaf(AiConfig.auth.host, 'NEO_AUTH_HOST', 'string'),
+                port              : leaf(AiConfig.auth.port, 'NEO_AUTH_PORT', 'port'),
+                realm             : leaf(AiConfig.auth.realm, 'NEO_AUTH_REALM', 'string'),
+                issuerUrl         : leaf(AiConfig.auth.issuerUrl, 'NEO_AUTH_ISSUER_URL', 'string'),
+                clientId          : leaf(AiConfig.auth.clientId, 'NEO_OAUTH_CLIENT_ID', 'string'),
+                clientSecret      : leaf(AiConfig.auth.clientSecret, 'NEO_OAUTH_CLIENT_SECRET', 'string'),
+                trustProxyIdentity: leaf(AiConfig.auth.trustProxyIdentity, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean')
             },
             /**
              * Explicit override provider for the core LLM Engine (e.g. summarization).
              * Supported values: 'gemini', 'ollama', 'openAiCompatible'
              * @type {String}
              */
-            modelProvider: {env: 'NEO_MODEL_PROVIDER', default: AiConfig.modelProvider, parse: Env.parseString},
+            modelProvider: leaf(AiConfig.modelProvider, 'NEO_MODEL_PROVIDER', 'string'),
             /**
              * Provider selector for Dream/Sandman graph-generation lanes.
              * Supported values: 'ollama', 'openAiCompatible'
              * @type {String}
              */
-            graphProvider: {env: 'NEO_GRAPH_PROVIDER', default: AiConfig.graphProvider, parse: Env.parseString},
+            graphProvider: leaf(AiConfig.graphProvider, 'NEO_GRAPH_PROVIDER', 'string'),
             /**
              * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
              * Supported values: 'gemini', 'ollama', 'openAiCompatible'
@@ -160,30 +159,30 @@ class Config extends BaseConfig {
              *
              * @type {String}
              */
-            embeddingProvider: {env: 'NEO_EMBEDDING_PROVIDER', default: AiConfig.embeddingProvider, parse: Env.parseString},
+            embeddingProvider: leaf(AiConfig.embeddingProvider, 'NEO_EMBEDDING_PROVIDER', 'string'),
             /**
              * Settings for the Ollama integration
              */
             ollama: {
-                host                 : {env: 'NEO_OLLAMA_HOST', default: AiConfig.ollama.host, parse: Env.parseString},
-                model                : {env: 'NEO_OLLAMA_MODEL', default: AiConfig.ollama.model, parse: Env.parseString},
-                embeddingModel       : {env: 'NEO_OLLAMA_EMBEDDING_MODEL', default: AiConfig.ollama.embeddingModel, parse: Env.parseString},
-                keep_alive           : {env: 'NEO_OLLAMA_KEEP_ALIVE', default: AiConfig.ollama.keep_alive, parse: Env.parseKeepAlive},
-                requireParallelModels: {env: 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', default: AiConfig.ollama.requireParallelModels, parse: Env.parseNumber}
+                host                 : leaf(AiConfig.ollama.host, 'NEO_OLLAMA_HOST', 'string'),
+                model                : leaf(AiConfig.ollama.model, 'NEO_OLLAMA_MODEL', 'string'),
+                embeddingModel       : leaf(AiConfig.ollama.embeddingModel, 'NEO_OLLAMA_EMBEDDING_MODEL', 'string'),
+                keep_alive           : leaf(AiConfig.ollama.keep_alive, 'NEO_OLLAMA_KEEP_ALIVE', 'keepAlive'),
+                requireParallelModels: leaf(AiConfig.ollama.requireParallelModels, 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', 'number')
             },
             /**
              * Settings for the OpenAI-Compatible API integration (e.g., mlx-lm or mlx-openai-server)
              * WARNING: Never hardcode API keys here. Always export them via .env or globally.
              */
             openAiCompatible: {
-                host                 : {env: 'NEO_OPENAI_COMPATIBLE_HOST', default: AiConfig.openAiCompatible.host, parse: Env.parseString},
-                model                : {env: 'NEO_OPENAI_COMPATIBLE_MODEL', default: AiConfig.openAiCompatible.model, parse: Env.parseString},
-                embeddingModel       : {env: 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', default: AiConfig.openAiCompatible.embeddingModel, parse: Env.parseString},
-                apiKey               : {env: 'NEO_OPENAI_COMPATIBLE_API_KEY', default: AiConfig.openAiCompatible.apiKey, parse: Env.parseString},
-                unloadRetryCount     : {env: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', default: AiConfig.openAiCompatible.unloadRetryCount, parse: Env.parseNumber},
-                unloadRetryDelayMs   : {env: 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', default: AiConfig.openAiCompatible.unloadRetryDelayMs, parse: Env.parseNumber},
-                keep_alive           : {env: 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', default: AiConfig.openAiCompatible.keep_alive, parse: Env.parseKeepAlive},
-                requireParallelModels: {env: 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', default: AiConfig.openAiCompatible.requireParallelModels, parse: Env.parseNumber}
+                host                 : leaf(AiConfig.openAiCompatible.host, 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
+                model                : leaf(AiConfig.openAiCompatible.model, 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
+                embeddingModel       : leaf(AiConfig.openAiCompatible.embeddingModel, 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
+                apiKey               : leaf(AiConfig.openAiCompatible.apiKey, 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
+                unloadRetryCount     : leaf(AiConfig.openAiCompatible.unloadRetryCount, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
+                unloadRetryDelayMs   : leaf(AiConfig.openAiCompatible.unloadRetryDelayMs, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', 'number'),
+                keep_alive           : leaf(AiConfig.openAiCompatible.keep_alive, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
+                requireParallelModels: leaf(AiConfig.openAiCompatible.requireParallelModels, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')
             },
             /**
              * Local-model role-keyed context limits passthrough.
@@ -196,53 +195,51 @@ class Config extends BaseConfig {
              * share these caps because the practical limit comes from the loaded model.
              * @type {Object}
              */
-            localModels: {
-                default: {
-                    chat: {
-                        contextLimitTokens      : AiConfig.localModels.chat.contextLimitTokens,
-                        safeProcessingLimitTokens: AiConfig.localModels.chat.safeProcessingLimitTokens
-                    },
-                    embedding: {
-                        contextLimitTokens      : AiConfig.localModels.embedding.contextLimitTokens,
-                        safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
-                    }
+            localModels: leaf({
+                chat: {
+                    contextLimitTokens      : AiConfig.localModels.chat.contextLimitTokens,
+                    safeProcessingLimitTokens: AiConfig.localModels.chat.safeProcessingLimitTokens
+                },
+                embedding: {
+                    contextLimitTokens      : AiConfig.localModels.embedding.contextLimitTokens,
+                    safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
                 }
-            },
+            }),
             /**
              * The enforced vector dimension across all SQLite collections.
              * Hard-configured here to prevent catastrophic schema wipes due to dynamic model changes.
              * @type {number}
              */
-            vectorDimension: {env: 'NEO_VECTOR_DIMENSION', default: AiConfig.vectorDimension, parse: Env.parseNumber},
+            vectorDimension: leaf(AiConfig.vectorDimension, 'NEO_VECTOR_DIMENSION', 'number'),
             /**
              * The name of the Google Generative AI model for content generation.
              * @type {string}
              */
-            modelName: {default: AiConfig.modelName},
+            modelName: leaf(AiConfig.modelName),
             /**
              * The name of the Google Generative AI model for text embeddings.
              * @type {string}
              */
-            embeddingModel: {default: AiConfig.embeddingModel},
+            embeddingModel: leaf(AiConfig.embeddingModel),
             /**
              * Pagination limit for fetching records during session summarization scans.
              * Controls the batch size for memory and summary retrieval.
              * @type {number}
              */
-            summarizationBatchLimit: {default: 2000},
+            summarizationBatchLimit: leaf(2000),
             /**
              * Maximum number of concurrent session summarization requests.
              * Prevents hitting LLM/Embedding API rate limits during bulk operations.
              * @type {number}
              */
-            summarizationConcurrency: {default: 5},
+            summarizationConcurrency: leaf(5),
             /**
              * The target Storage Architecture to use.
              * Note: Chroma is the only supported Vector DB.
              * Options: 'hybrid' (Chroma vectors + SQLite graph), 'chroma' (Chroma vectors only).
              * The default is explicitly 'hybrid' per Epic #9922 Two-Pillar RAG architecture.
              */
-            engine: {default: 'hybrid'},
+            engine: leaf('hybrid'),
             /**
              * Database Engine Definitions
              * This defines WHERE data is stored physically (for engines MC owns) and WHERE MC reaches
@@ -254,25 +251,25 @@ class Config extends BaseConfig {
                     // Read the unified persist dir from the SSOT. Was the stale
                     // '.neo-ai-data/chroma/memory-core' — MC is a CLIENT of the one unified store
                     // (ADR 0003), so its physical dir must be the shared dir, not a server-local one.
-                    dataDir: {default: AiConfig.engines.chroma.dataDir},
-                    host   : {env: 'NEO_CHROMA_HOST', default: AiConfig.engines.chroma.host, parse: Env.parseString},
-                    port   : {env: 'NEO_CHROMA_PORT', default: AiConfig.engines.chroma.port, parse: Env.parsePort}
+                    dataDir: leaf(AiConfig.engines.chroma.dataDir),
+                    host   : leaf(AiConfig.engines.chroma.host, 'NEO_CHROMA_HOST', 'string'),
+                    port   : leaf(AiConfig.engines.chroma.port, 'NEO_CHROMA_PORT', 'port')
                 }
             },
             /**
              * Physical file paths for embedded/local datasets.
              */
             storagePaths: {
-                graph: {env: 'NEO_MEMORY_DB_PATH', default: process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite'), parse: Env.parseString}
+                graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string')
             },
             /**
              * Data Schema/Table Names
              * This defines WHAT the tables/collections are called logically.
              */
             collections: {
-                memory : {env: 'NEO_MEMORY_COLLECTION_NAME', default: process.env.UNIT_TEST_MODE === 'true' ? `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-memory', parse: Env.parseString},
-                session: {env: 'NEO_SESSION_COLLECTION_NAME', default: process.env.UNIT_TEST_MODE === 'true' ? `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-sessions', parse: Env.parseString},
-                graph  : {env: 'NEO_GRAPH_COLLECTION_NAME', default: 'neo-native-graph', parse: Env.parseString}
+                memory : leaf(process.env.UNIT_TEST_MODE === 'true' ? `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-memory', 'NEO_MEMORY_COLLECTION_NAME', 'string'),
+                session: leaf(process.env.UNIT_TEST_MODE === 'true' ? `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-sessions', 'NEO_SESSION_COLLECTION_NAME', 'string'),
+                graph  : leaf('neo-native-graph', 'NEO_GRAPH_COLLECTION_NAME', 'string')
             },
             /**
              * Datasets Schema/Paths
@@ -280,29 +277,29 @@ class Config extends BaseConfig {
              */
             datasets: {
                 rlaif: {
-                    trajectories: {env: 'NEO_RLAIF_PATH', default: path.resolve(cwd, '.neo-ai-data/datasets/rlaif/trajectories.jsonl'), parse: Env.parseString}
+                    trajectories: leaf(path.resolve(cwd, '.neo-ai-data/datasets/rlaif/trajectories.jsonl'), 'NEO_RLAIF_PATH', 'string')
                 }
             },
             /**
              * Directory for per-cycle REM run/stage JSONL state artifacts.
              * @type {string}
              */
-            remRunStateDir: {env: 'NEO_REM_RUN_STATE_DIR', default: path.resolve(cwd, '.neo-ai-data/rem-runs'), parse: Env.parseString},
+            remRunStateDir: leaf(path.resolve(cwd, '.neo-ai-data/rem-runs'), 'NEO_REM_RUN_STATE_DIR', 'string'),
             /**
              * Number of recent REM cycles projected by `get_rem_pipeline_state`.
              * @type {number}
              */
-            remRunRecentLimit: {env: 'NEO_REM_RUN_RECENT_LIMIT', default: 5, parse: Env.parseNumber},
+            remRunRecentLimit: leaf(5, 'NEO_REM_RUN_RECENT_LIMIT', 'number'),
             /**
              * Target markdown file used for autonomous agent-to-user reporting (offline jobs).
              * @type {string}
              */
-            handoffFilePath: {default: path.resolve(cwd, 'resources/content/sandman_handoff.md')},
+            handoffFilePath: leaf(path.resolve(cwd, 'resources/content/sandman_handoff.md')),
             /**
              * The Hebbian decay factor applied every 24 hours to the edge graph (e.g., 0.98 for ~79 day half-life).
              * @type {number}
              */
-            decayFactor: {env: 'NEO_GRAPH_DECAY_FACTOR', default: 0.98, parse: Env.parseNumber},
+            decayFactor: leaf(0.98, 'NEO_GRAPH_DECAY_FACTOR', 'number'),
             /**
              * Minimum weight threshold for emitting `[GUIDE_GAP]`, `[EXAMPLE_GAP]`, and `[ORPHAN_CONCEPT]`
              * signals on CONCEPT nodes during `GapInferenceEngine.inferConceptGraphGaps`.
@@ -317,7 +314,7 @@ class Config extends BaseConfig {
              * surface lower-priority concepts in the handoff.
              * @type {number}
              */
-            guideGapWeightThreshold: {env: 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', default: 0.8, parse: Env.parseNumber},
+            guideGapWeightThreshold: leaf(0.8, 'NEO_GUIDE_GAP_WEIGHT_THRESHOLD', 'number'),
             /**
              * Operator-tuning knobs for `ConceptDiscoveryService` (#10036). Both values are read live
              * at method-call time (not captured at module load) so tests + runtime overrides are honored.
@@ -333,14 +330,14 @@ class Config extends BaseConfig {
              * @type {Object}
              */
             conceptDiscovery: {
-                prScanLimit    : {env: 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', default: 20, parse: Env.parseNumber},
-                minSourceLength: {env: 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', default: 200, parse: Env.parseNumber}
+                prScanLimit    : leaf(20, 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', 'number'),
+                minSourceLength: leaf(200, 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', 'number')
             },
             /**
              * Universal JSONL backup/export directory for all databases.
              * @type {string}
              */
-            backupPath: {env: 'NEO_BACKUP_PATH', default: AiConfig.backupPath, parse: Env.parseString},
+            backupPath: leaf(AiConfig.backupPath, 'NEO_BACKUP_PATH', 'string'),
             /**
              * Phase 4 (#11663): bundle retention policy for `ai/scripts/maintenance/backup.mjs`.
              * Bundles older than `maxDays` are eligible for deletion, but the newest
@@ -349,12 +346,10 @@ class Config extends BaseConfig {
              * existing deployments are unaffected without operator action.
              * @type {{keepMinimum: number, maxDays: number}}
              */
-            backupRetention: {
-                default: {
-                    keepMinimum: 3,
-                    maxDays    : 30
-                }
-            },
+            backupRetention: leaf({
+                keepMinimum: 3,
+                maxDays    : 30
+            }),
             /**
              * Directory for the always-on Memory Core diagnostic log files (#10582). The MC
              * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
@@ -365,7 +360,7 @@ class Config extends BaseConfig {
              * `nl-server-`). Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: {default: path.resolve(cwd, '.neo-ai-data/logs')},
+            logPath: leaf(path.resolve(cwd, '.neo-ai-data/logs')),
             /**
              * @summary Shared MCP logger policy for Memory Core.
              *
@@ -373,15 +368,13 @@ class Config extends BaseConfig {
              * short-lived script contract used by Sandman and other immediate-exit paths.
              * @type {Object}
              */
-            logger: {
-                default: {
-                    filePrefix    : 'mc-server',
-                    fileSink      : true,
-                    flush         : true,
-                    stderrMode    : 'debug',
-                    timestampStyle: 'plain'
-                }
-            },
+            logger: leaf({
+                filePrefix    : 'mc-server',
+                fileSink      : true,
+                flush         : true,
+                stderrMode    : 'debug',
+                timestampStyle: 'plain'
+            }),
             /**
              * Mailbox substrate behavior configuration (#10252).
              *
@@ -425,7 +418,7 @@ class Config extends BaseConfig {
                  *
                  * @type {'blocked'|'open'}
                  */
-                defaultReplyPolicy: {env: 'NEO_MAILBOX_DEFAULT_REPLY_POLICY', default: 'open', parse: Env.parseString}
+                defaultReplyPolicy: leaf('open', 'NEO_MAILBOX_DEFAULT_REPLY_POLICY', 'string')
             },
             /**
              * Memory sharing policy for multi-tenant isolation (#10010).
@@ -450,7 +443,7 @@ class Config extends BaseConfig {
              * Target file path for the lazy backfill queue of unresolved provenance edges.
              * @type {string}
              */
-            lazyEdgesQueuePath: {env: 'NEO_LAZY_EDGES_QUEUE_PATH', default: path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl'), parse: Env.parseString}
+            lazyEdgesQueuePath: leaf(path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl'), 'NEO_LAZY_EDGES_QUEUE_PATH', 'string')
         }
     }
 }

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,8 +1,7 @@
 import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import BaseConfig, { createConfigProxy } from '../../../BaseConfig.mjs';
-import Env from '../../../../src/util/Env.mjs';
+import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -33,9 +32,9 @@ class Config extends BaseConfig {
          */
         singleton: true,
         /**
-         * @member {Object} metaTree
+         * @member {Object} data
          */
-        metaTree: {
+        data: {
             /**
              * Repo root, computed from this module's path. Exported for symmetry with the
              * KB and Memory Core configs (#10584) so consumers (loggers, services, future)
@@ -43,32 +42,32 @@ class Config extends BaseConfig {
              * locally. Module path is stable; the resolution is deterministic at boot.
              * @type {string}
              */
-            neoRootDir: {default: neoRootDir},
+            neoRootDir: leaf(neoRootDir),
             /**
              * Automatically connect to the bridge on startup.
              * @type {boolean}
              */
-            autoConnect: {env: 'NEO_NL_AUTO_CONNECT', default: true, parse: Env.parseBool},
+            autoConnect: leaf(true, 'NEO_NL_AUTO_CONNECT', 'boolean'),
             /**
              * Global debug flag.
              * @type {boolean}
              */
-            debug: {env: 'NEO_DEBUG', default: false, parse: Env.parseBool},
+            debug: leaf(false, 'NEO_DEBUG', 'boolean'),
             /**
              * The port the WebSocket server is listening on.
              * @type {number}
              */
-            port: {env: 'NEO_NL_PORT', default: 8081, parse: Env.parsePort},
+            port: leaf(8081, 'NEO_NL_PORT', 'port'),
             /**
              * Timeout for RPC calls in milliseconds.
              * @type {number}
              */
-            rpcTimeout: {env: 'NEO_NL_RPC_TIMEOUT', default: 10000, parse: Env.parseNumber},
+            rpcTimeout: leaf(10000, 'NEO_NL_RPC_TIMEOUT', 'number'),
             /**
              * Path to the memory core SQLite database for action logging.
              * @type {string}
              */
-            memoryCoreDbPath: {env: 'NEO_MEMORY_DB_PATH', default: path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'), parse: Env.parseString},
+            memoryCoreDbPath: leaf(path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'), 'NEO_MEMORY_DB_PATH', 'string'),
             /**
              * Directory for the always-on Neural Link diagnostic log files (#10582). The NL
              * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
@@ -79,7 +78,7 @@ class Config extends BaseConfig {
              * Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: {default: path.resolve(neoRootDir, '.neo-ai-data/logs')},
+            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
             /**
              * @summary Shared MCP logger policy for Neural Link.
              *
@@ -87,17 +86,17 @@ class Config extends BaseConfig {
              * debug, while debug stays gated by `debug: true`.
              * @type {Object}
              */
-            logger: {default: {
+            logger: leaf({
                 filePrefix    : 'nl-server',
                 fileSink      : true,
                 stderrMode    : 'tiered',
                 timestampStyle: 'bracketed'
-            }},
+            }),
             /**
              * Number of days to retain Action logs in the Neural Link Database.
              * @type {number}
              */
-            pruneLogsAfterDays: {env: 'NEO_NL_PRUNE_LOGS_AFTER_DAYS', default: 14, parse: Env.parseNumber}
+            pruneLogsAfterDays: leaf(14, 'NEO_NL_PRUNE_LOGS_AFTER_DAYS', 'number')
         }
     }
 }

--- a/test/playwright/unit/ai/BaseConfig.spec.mjs
+++ b/test/playwright/unit/ai/BaseConfig.spec.mjs
@@ -15,108 +15,161 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 
-let BaseConfig, createConfigProxy, Env, originalEnv;
+let BaseConfig, createConfigProxy, leaf, Env, originalEnv;
 
 /**
- * Fresh prototype meta-leaf tree per test (must run after Env is imported in beforeAll).
- * Mixes env-bound + env-free leaves, multiple parser types, and a nested namespace.
+ * Fresh meta-leaf tree per test, assigned to the `data` config (the new #12168 shape).
+ * Mixes env-bound + env-free leaves, multiple `leaf()` types, a null-default-with-type leaf,
+ * a nested namespace, and an object leaf whose value carries an own `constructor` key
+ * (the dummy-EF duck-type that breaks `Neo.typeOf` inference — guarded by `leaf()`).
  */
 function buildTree() {
     return {
-        debug: {env: 'NEO_TEST_DEBUG', default: false, parse: Env.parseBool},
-        port : {env: 'NEO_TEST_PORT',  default: 3000,  parse: Env.parsePort},
-        name : {default: 'neo'},
-        server: {
-            host   : {default: 'localhost'},
-            timeout: {env: 'NEO_TEST_TIMEOUT', default: 5000, parse: Env.parseNumber}
-        }
-    };
+        debug    : leaf(false, 'NEO_TEST_DEBUG'),
+        port     : leaf(3000, 'NEO_TEST_PORT', 'port'),
+        name     : leaf('neo'),
+        publicUrl: leaf(null, 'NEO_TEST_URL', 'url'),
+        server   : {
+            host   : leaf('localhost'),
+            timeout: leaf(5000, 'NEO_TEST_TIMEOUT', 'number')
+        },
+        ef: leaf({
+            name       : 'dummy_embedding_function',
+            generate   : () => null,
+            getConfig  : () => ({}),
+            constructor: {buildFromConfig: () => ({generate: () => null})}
+        }, null, 'object')
+    }
 }
 
-test.describe('Neo.ai.BaseConfig (meta-leaf tree + Provider extension)', () => {
+test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', () => {
     test.beforeAll(async () => {
-        ({default: BaseConfig, createConfigProxy} = await import('../../../../ai/BaseConfig.mjs'));
+        ({default: BaseConfig, createConfigProxy, leaf} = await import('../../../../ai/BaseConfig.mjs'));
         Env         = (await import('../../../../src/util/Env.mjs')).default;
-        originalEnv = {...process.env};
+        originalEnv = {...process.env}
     });
 
     test.afterEach(() => {
         Object.keys(process.env).forEach(key => {
             if (!(key in originalEnv)) {
-                delete process.env[key];
+                delete process.env[key]
             } else {
-                process.env[key] = originalEnv[key];
+                process.env[key] = originalEnv[key]
             }
-        });
+        })
     });
 
-    test('compileMetaLeaves seeds reactive data from leaf defaults', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+    test('leaf() factory: parser by type, inference, null-default type, object-no-env', () => {
+        const portLeaf = leaf(3000, 'NEO_X', 'port');
+        expect(portLeaf.type).toBe('port');
+        expect(portLeaf.parse).toBe(Env.parsePort);
+        expect(portLeaf.default).toBe(3000);
+
+        // type inferred from a non-null default
+        expect(leaf(false, 'NEO_X').type).toBe('boolean');
+        expect(leaf(false, 'NEO_X').parse).toBe(Env.parseBool);
+
+        // explicit type survives a null default (stays validatable)
+        const urlLeaf = leaf(null, 'NEO_X', 'url');
+        expect(urlLeaf.type).toBe('url');
+        expect(urlLeaf.parse).toBe(Env.parseUrl);
+
+        // env-free leaf carries no parser
+        expect(leaf('x').parse).toBe(null);
+        // object value with an own `constructor` key must not throw during inference
+        const efLeaf = leaf({constructor: {buildFromConfig: () => ({})}}, null, 'object');
+        expect(efLeaf.type).toBe('object');
+        expect(efLeaf.parse).toBe(null)
+    });
+
+    test('afterSetData compiles reactive data from leaf defaults', () => {
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
         expect(config.getDataConfig('debug').get()).toBe(false);
         expect(config.getDataConfig('port').get()).toBe(3000);
         expect(config.getDataConfig('name').get()).toBe('neo');
+        expect(config.getDataConfig('publicUrl').get()).toBe(null);
         expect(config.getDataConfig('server.host').get()).toBe('localhost');
         expect(config.getDataConfig('server.timeout').get()).toBe(5000);
 
-        config.destroy();
+        config.destroy()
     });
 
-    test('env vars override leaf defaults (parsed to typed values)', () => {
+    test('object leaf with an own constructor key survives compile (typeOf guard)', () => {
+        const config = Neo.create(BaseConfig, {data: buildTree()}),
+              ef     = config.getDataConfig('ef').get();
+
+        expect(ef.name).toBe('dummy_embedding_function');
+        expect(typeof ef.generate).toBe('function');
+        expect(typeof ef.constructor.buildFromConfig).toBe('function');
+
+        config.destroy()
+    });
+
+    test('env vars override leaf defaults (bounded, parsed to typed values)', () => {
         process.env.NEO_TEST_PORT  = '8080';
         process.env.NEO_TEST_DEBUG = 'true';
 
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
         expect(config.getDataConfig('port').get()).toBe(8080);
         expect(config.getDataConfig('debug').get()).toBe(true);
-        // env-free leaf keeps its default
-        expect(config.getDataConfig('name').get()).toBe('neo');
+        expect(config.getDataConfig('name').get()).toBe('neo'); // env-free keeps default
 
-        config.destroy();
+        config.destroy()
     });
 
     test('setData() writes a value through the reactive pipeline', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
         config.setData('server.timeout', 9999);
         expect(config.getDataConfig('server.timeout').get()).toBe(9999);
 
-        config.destroy();
+        config.destroy()
     });
 
-    test('setEnvOverride() applies and wins over the default', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+    test('setEnvOverride() is keyed by env var name and wins over the default', () => {
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
-        config.setEnvOverride('debug', true);
+        config.setEnvOverride('NEO_TEST_DEBUG', true);
         expect(config.getDataConfig('debug').get()).toBe(true);
 
-        config.destroy();
+        config.destroy()
+    });
+
+    test('refreshEnv() re-resolves env; runtime override persists', () => {
+        const config = Neo.create(BaseConfig, {data: buildTree()});
+
+        config.setEnvOverride('NEO_TEST_DEBUG', true);
+        process.env.NEO_TEST_PORT = '9090';
+        config.refreshEnv();
+
+        expect(config.getDataConfig('port').get()).toBe(9090);  // re-read from env
+        expect(config.getDataConfig('debug').get()).toBe(true); // override survives
+
+        config.destroy()
     });
 
     test('direct assignment via createConfigProxy routes through setData', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()}),
+        const config = Neo.create(BaseConfig, {data: buildTree()}),
               proxy  = createConfigProxy(config);
 
-        // read-through
         expect(proxy.name).toBe('neo');
         expect(proxy.server.host).toBe('localhost');
 
-        // top-level assignment (proxy set trap)
         proxy.name = 'changed';
         expect(config.getDataConfig('name').get()).toBe('changed');
 
-        // nested assignment (Provider hierarchical proxy set trap)
         proxy.server.host = 'remote';
         expect(config.getDataConfig('server.host').get()).toBe('remote');
 
-        config.destroy();
+        config.destroy()
     });
 
     test('observeData fires on change and stops after cleanup', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
-        let calls   = 0;
+        let calls     = 0;
         const cleanup = config.observeData('name', () => {calls++});
 
         config.setData('name', 'a');
@@ -127,54 +180,57 @@ test.describe('Neo.ai.BaseConfig (meta-leaf tree + Provider extension)', () => {
         config.setData('name', 'b');
         expect(calls).toBe(afterFirstChange);
 
-        config.destroy();
+        config.destroy()
     });
 
-    test('internalSetData warns on a leaf type mismatch but keeps the value', () => {
-        const config   = Neo.create(BaseConfig, {metaTree: buildTree()}),
+    test('internalSetData validates ANY value at a known leaf path (object leaves included)', () => {
+        const config   = Neo.create(BaseConfig, {data: buildTree()}),
               warnings = [],
               origWarn = console.warn;
 
         console.warn = msg => warnings.push(String(msg));
 
         try {
+            // object leaf is validated (no `!== 'Object'` bypass) and kept without warning
+            config.setData('ef', {name: 'x', generate: () => null});
+            expect(config.getDataConfig('ef').get().name).toBe('x');
+
+            // scalar type mismatch warns but keeps the value
             config.setData('port', 'not-a-number');
             expect(config.getDataConfig('port').get()).toBe('not-a-number');
-            expect(warnings.some(w => w.includes('port'))).toBe(true);
+            expect(warnings.some(w => w.includes('port'))).toBe(true)
         } finally {
-            console.warn = origWarn;
+            console.warn = origWarn
         }
 
-        config.destroy();
+        config.destroy()
     });
 
     test('nested namespaces are preserved as a deep structure', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
         expect(config.data.server.host).toBe('localhost');
         expect(config.data.server.timeout).toBe(5000);
         expect(config.data.name).toBe('neo');
 
-        config.destroy();
+        config.destroy()
     });
 
     test('createConfigProxy: .data getter + method calls bind to the real instance', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()}),
+        const config = Neo.create(BaseConfig, {data: buildTree()}),
               proxy  = createConfigProxy(config);
 
-        // `.data` access must NOT run the reactive getter with `this` = outer proxy
         expect(proxy.data.server.host).toBe('localhost');
         expect(proxy.data.name).toBe('neo');
 
-        // a method invoked through the proxy must run with `this` = the real instance
         proxy.setData('name', 'viaMethod');
         expect(config.getDataConfig('name').get()).toBe('viaMethod');
 
-        config.destroy();
+        config.destroy()
     });
 
     test('destroy() releases observeData subscriptions (no manual cleanup needed)', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
         let calls = 0;
         config.observeData('name', () => {calls++}); // intentionally not cleaned up manually
@@ -182,15 +238,12 @@ test.describe('Neo.ai.BaseConfig (meta-leaf tree + Provider extension)', () => {
         config.setData('name', 'x');
         expect(calls).toBeGreaterThan(0);
 
-        // destroy must tear down the tracked subscription without throwing
-        expect(() => config.destroy()).not.toThrow();
+        expect(() => config.destroy()).not.toThrow()
     });
 
     test('observeData resolves leaves via getOwnerOfDataProperty (hierarchy-aware)', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
-        // The resolved Config must be the exact instance getOwnerOfDataProperty points at —
-        // i.e. resolution goes through the owner, not a direct this.#dataConfigs reach-in.
         const {owner, propertyName} = config.getOwnerOfDataProperty('server.host');
         expect(owner).toBe(config);
         expect(owner.getDataConfig(propertyName)).toBe(config.getDataConfig('server.host'));
@@ -201,23 +254,21 @@ test.describe('Neo.ai.BaseConfig (meta-leaf tree + Provider extension)', () => {
         expect(observed).toBe('remote-host');
 
         cleanup();
-        config.destroy();
+        config.destroy()
     });
 
     test('does not shadow core.Base set() / observeConfig()', () => {
-        const config = Neo.create(BaseConfig, {metaTree: buildTree()});
+        const config = Neo.create(BaseConfig, {data: buildTree()});
 
-        // core.Base#observeConfig(publisher, configName, fn) is a cross-instance subscription
-        // returning a cleanup fn — and Provider#createBinding depends on it. BaseConfig must
-        // NOT shadow it with a path-scoped override (that surface is `observeData`).
+        // core.Base#observeConfig(publisher, configName, fn) — Provider#createBinding depends on it.
         let calls     = 0;
         const cleanup = config.observeConfig(config, 'data', () => {calls++});
         expect(typeof cleanup).toBe('function');
         cleanup();
 
-        // core.Base#set(values) is the batch config setter — must accept an object, not a path.
+        // core.Base#set(values) — batch config setter, must accept an object.
         expect(() => config.set({})).not.toThrow();
 
-        config.destroy();
+        config.destroy()
     });
 });

--- a/test/playwright/unit/ai/BaseConfig.spec.mjs
+++ b/test/playwright/unit/ai/BaseConfig.spec.mjs
@@ -106,14 +106,19 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
         config.destroy()
     });
 
-    test('env vars override leaf defaults (bounded, parsed to typed values)', () => {
-        process.env.NEO_TEST_PORT  = '8080';
-        process.env.NEO_TEST_DEBUG = 'true';
+    test('env vars override leaf defaults — top-level AND nested (bounded, parsed)', () => {
+        process.env.NEO_TEST_PORT    = '8080';
+        process.env.NEO_TEST_DEBUG   = 'true';
+        process.env.NEO_TEST_TIMEOUT = '1234';
 
         const config = Neo.create(BaseConfig, {data: buildTree()});
 
         expect(config.getDataConfig('port').get()).toBe(8080);
         expect(config.getDataConfig('debug').get()).toBe(true);
+        // A NESTED env-bound leaf must also be env-overridden. Regression guard: `assignToNs`
+        // mutates its `path` arg (pops the last segment), which had collapsed every nested leaf
+        // onto its parent namespace key — dropping the nested leaf's env binding entirely.
+        expect(config.getDataConfig('server.timeout').get()).toBe(1234);
         expect(config.getDataConfig('name').get()).toBe('neo'); // env-free keeps default
 
         config.destroy()
@@ -191,11 +196,12 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
         console.warn = msg => warnings.push(String(msg));
 
         try {
-            // object leaf is validated (no `!== 'Object'` bypass) and kept without warning
-            config.setData('ef', {name: 'x', generate: () => null});
-            expect(config.getDataConfig('ef').get().name).toBe('x');
+            // The old `!== 'Object'` gate skipped validation for object values; now an object
+            // written to a known SCALAR leaf path is validated → warns (the bypass is gone).
+            config.setData('name', {unexpected: 1});
+            expect(warnings.some(w => w.includes('name'))).toBe(true);
 
-            // scalar type mismatch warns but keeps the value
+            // a scalar type mismatch also warns but keeps the value
             config.setData('port', 'not-a-number');
             expect(config.getDataConfig('port').get()).toBe('not-a-number');
             expect(warnings.some(w => w.includes('port'))).toBe(true)

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'fs/promises';
 import Neo from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
+import BaseConfig from '../../../../ai/BaseConfig.mjs';
 import {TIER1_DEFAULTS} from '../../fixtures/aiConfigDefaults.mjs';
 
 test.describe('Tier 1 Config Immutability', () => {
@@ -37,19 +38,18 @@ test.describe('Tier 1 Config Immutability', () => {
         }
     });
 
-    test('defaultConfig remains unmutated across singleton instantiations', async () => {
+    test('leaf defaults are not mutated by instance writes (fresh instances get clean defaults)', async () => {
         const initialPort = Config.mcpHttpPort;
 
-        // Modify through the singleton instance
+        // Mutate the runtime value through the singleton instance
         Config.data.mcpHttpPort = 9999;
         expect(Config.mcpHttpPort).toBe(9999);
 
-        // Re-run construct to re-clone from defaultConfig using the unwrapped instance
-        Neo.ns('Neo.ai.Config').construct({});
-
-        // The re-cloned instance should not inherit the mutated port
-        expect(Neo.ns('Neo.ai.Config').data.mcpHttpPort).not.toBe(9999);
-        expect(Neo.ns('Neo.ai.Config').data.mcpHttpPort).toBe(initialPort);
+        // A fresh instance built from the same meta-leaf tree (`_data`) gets the clean default —
+        // the instance write touched the reactive Config value, not the leaf `default`.
+        const fresh = Neo.create(BaseConfig, {data: Config._data});
+        expect(fresh.getDataConfig('mcpHttpPort').get()).not.toBe(9999);
+        expect(fresh.getDataConfig('mcpHttpPort').get()).toBe(initialPort);
     });
 
     test('ships a machine-neutral orchestrator dev-sync root default', async () => {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -172,12 +172,12 @@ test.describe('Tier 1 Config Immutability', () => {
             const source = await fs.readFile(new URL(templateUrl, import.meta.url), 'utf8');
 
             // The ledger lives inside the config class as a single `static config` block
-            // whose `metaTree` holds the `{env?, default, parse?}` leaves — never as a
+            // whose `data` config holds the `{env?, default, parse?}` leaves — never as a
             // module-level `const` (the old parallel defaultConfig/envBindings shape, and
             // its meta-leaf successor, would both leak the ledger out of the class).
             expect(source).not.toMatch(/^const\s+(defaultConfig|envBindings|metaTree)\s*=/m);
             expect(source).toMatch(/static\s+config\s*=/);
-            expect(source).toMatch(/metaTree\s*:/);
+            expect(source).toMatch(/data\s*:/);
         }
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -97,7 +97,7 @@ test.afterEach(() => {
     AiConfig.orchestrator.deploymentMode = savedDeploymentMode;
 
     // Restore the full mlx/lms objects (overwrites every leaf on the still-healthy parent).
-    // Post-#12101 these leaves are metaTree-seeded and always present on the singleton, so
+    // Post-#12101 these leaves are data-seeded and always present on the singleton, so
     // there is no `delete`-to-absent branch — the verbatim tests above only swap object
     // values, never null the parent.
     if (savedMlxConfig !== undefined) {
@@ -143,7 +143,7 @@ function restoreConfigObject(target, prior) {
     Object.assign(target, prior);
 }
 
-test.describe('Orchestrator config getters delegate to AiConfig (metaTree env/parse layer is the env-precedence SSOT)', () => {
+test.describe('Orchestrator config getters delegate to AiConfig (data env/parse layer is the env-precedence SSOT)', () => {
     test('interval getter reads AiConfig.orchestrator.intervals verbatim', () => {
         AiConfig.orchestrator.intervals.kbSyncMs = 60_000;
         expect(createMinimalOrchestrator().kbSyncIntervalMs).toBe(60_000);
@@ -216,17 +216,17 @@ test.describe('Orchestrator config getters delegate to AiConfig (metaTree env/pa
     });
 
     // Post-#12101 the AiConfig singleton is a reactive `Neo.state.Provider`, so its
-    // `orchestrator.mlx`/`.lms` leaves are seeded from the metaTree at construction and
+    // `orchestrator.mlx`/`.lms` leaves are seeded from the data tree at construction and
     // ALWAYS exist on the singleton (defaults: enabled=false, model+port set). `delete`
     // on the hierarchical data proxy is a silent no-op (the throwaway nested-proxy target
     // is deleted, not the underlying reactive Config), and nulling the parent leaf is a
     // one-way door (the leaf-bubble breaks on a non-object parent, so the singleton can't
     // be restored for sibling tests). The faithful, reachable "config missing" state is a
-    // fresh BaseConfig instance whose metaTree omits the namespace — the canonical pattern
+    // fresh BaseConfig instance whose data tree omits the namespace — the canonical pattern
     // from BaseConfig.spec.mjs — exercising the same undefined-safe `?.` delegation the
     // Orchestrator `mlx*`/`lms*` getters use against `AiConfig.orchestrator.{mlx,lms}`.
     test('mlx getter delegation is undefined-safe when AiConfig.orchestrator.mlx is missing', () => {
-        const config = Neo.create(BaseConfig, {metaTree: {
+        const config = Neo.create(BaseConfig, {data: {
                   orchestrator: {intervals: {pollMs: {default: 3000}}}
               }}),
               cfg    = createConfigProxy(config);
@@ -263,9 +263,9 @@ test.describe('Orchestrator config getters delegate to AiConfig (metaTree env/pa
 
 
     // See the mlx-missing test above for why "config missing" is simulated via a fresh
-    // metaTree-omitted BaseConfig instance rather than `delete`/null on the singleton.
+    // data-omitted BaseConfig instance rather than `delete`/null on the singleton.
     test('lms getter delegation is undefined-safe when AiConfig.orchestrator.lms is missing', () => {
-        const config = Neo.create(BaseConfig, {metaTree: {
+        const config = Neo.create(BaseConfig, {data: {
                   orchestrator: {intervals: {pollMs: {default: 3000}}}
               }}),
               cfg    = createConfigProxy(config);

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -99,14 +99,14 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
 
     test('AiConfig.orchestrator.mlx ships canonical MLX launch defaults', () => {
         // The Tier-1 template (NOT the gitignored config.mjs overlay) is the stable
-        // source of truth for MLX defaults. Read it as text and assert the metaTree
+        // source of truth for MLX defaults. Read it as text and assert the `data`
         // leaf defaults: importing the template here would register Neo.ai.Config a
         // second time alongside the config.mjs singleton daemon.mjs loads, tripping
         // the unitTestMode namespace-collision gatekeeper.
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
 
         expect(templateSource).toMatch(
-            /mlx:\s*\{[\s\S]*?default:\s*false[\s\S]*?'mlx-community\/gemma-4-31b-it-bf16'[\s\S]*?'11435'/
+            /mlx:\s*\{[\s\S]*?leaf\(false[\s\S]*?'mlx-community\/gemma-4-31b-it-bf16'[\s\S]*?'11435'/
         );
     });
 
@@ -181,7 +181,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
 
         expect(templateSource).toMatch(
-            /lms:\s*\{[\s\S]*?default:\s*false[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
+            /lms:\s*\{[\s\S]*?leaf\(false[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
         );
     });
 

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
@@ -113,11 +113,11 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
         // override must be present before the instance is built. The template singleton is
         // constructed (and env-bound) at import time, so we build a fresh raw instance from
         // the template's meta-leaf tree to exercise boot-time env binding deterministically.
-        const {metaTree} = (await importTemplateConfig()).default;
+        const {_data} = (await importTemplateConfig()).default;
 
         process.env.NEO_MCP_GITHUB_ARCHIVE_ROOT = '/custom/archive/path';
 
-        const config = Neo.create(BaseConfig, {metaTree});
+        const config = Neo.create(BaseConfig, {data: _data});
 
         try {
             expect(config.getDataConfig('issueSync.archiveRoot').get()).toBe('/custom/archive/path');
@@ -130,12 +130,12 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
         // Env binding + its parser-based validation run at construction, so each case uses a
         // fresh instance built from the template's meta-leaf tree (the singleton is already
         // env-bound at import). The leaf default is the SSOT for the fallback expectation.
-        const {metaTree} = (await importTemplateConfig()).default;
-        const defaultLogLevel = metaTree.logLevel.default;
+        const {_data} = (await importTemplateConfig()).default;
+        const defaultLogLevel = _data.logLevel.default;
 
         // Valid value: parsed + normalized to lower-case.
         process.env.NEO_LOG_LEVEL = 'DEBUG';
-        const validConfig = Neo.create(BaseConfig, {metaTree});
+        const validConfig = Neo.create(BaseConfig, {data: _data});
 
         try {
             expect(validConfig.getDataConfig('logLevel').get()).toBe('debug');
@@ -152,7 +152,7 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
 
         let invalidConfig;
         try {
-            invalidConfig = Neo.create(BaseConfig, {metaTree});
+            invalidConfig = Neo.create(BaseConfig, {data: _data});
         } finally {
             console.warn = originalWarn;
         }

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -89,8 +89,8 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
 
         // Build a FRESH isolated instance (env set above) instead of re-constructing the
         // shared module-cached singleton, whose reactive state is contaminated by sibling
-        // specs in the parallel suite. config.metaTree carries the resolved Tier-1 defaults.
-        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {metaTree: config.metaTree}));
+        // specs in the parallel suite. config._data carries the raw Tier-1 meta-leaf tree.
+        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
 
         expect(freshCfg.auth.realm).toBe('tenant-realm');
         expect(freshCfg.backupPath).toBe('/tmp/neo-kb-backups');

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -123,8 +123,8 @@ test.describe('Memory Core Config (#10010)', () => {
         // Env is decoded at construction via #applyEnvLayer. Build a FRESH isolated
         // instance (env set above) instead of re-constructing the shared module-cached
         // singleton, whose reactive state is contaminated by sibling specs in the parallel
-        // suite. config.metaTree carries the resolved Tier-1 leaf defaults.
-        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {metaTree: config.metaTree}));
+        // suite. config._data carries the raw Tier-1 meta-leaf tree.
+        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
 
         expect(freshCfg.modelProvider).toBe('openAiCompatible');
         expect(freshCfg.graphProvider).toBe('ollama');
@@ -147,7 +147,7 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_MEMORY_SHARING_DEFAULT_POLICY = 'team';
 
         // Fresh isolated instance picks up the env via #applyEnvLayer at construction.
-        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {metaTree: config.metaTree}));
+        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
 
         expect(freshCfg.memorySharing.defaultPolicy).toBe('team');
 
@@ -159,7 +159,7 @@ test.describe('Memory Core Config (#10010)', () => {
 
         // The leaf `parse` fn (parseMemorySharingPolicy) runs inside #applyEnvLayer at
         // construction; a throwing parser propagates out of Neo.create.
-        expect(() => Neo.create(BaseConfig, {metaTree: config.metaTree})).toThrow(
+        expect(() => Neo.create(BaseConfig, {data: config._data})).toThrow(
             /\[Config\] Invalid NEO_MEMORY_SHARING_DEFAULT_POLICY value: "public"\. Must be one of: legacy, private, team/
         );
     });


### PR DESCRIPTION
Resolves #12168
Related: #12101, #12166

Authored by Claude Opus 4.8 (Claude Code 1M). Session b124b83a-2cca-4a2b-a711-64868439ba1e.

FAIR-band: over-target [21/30] — operator-direction (operator "wrap up the epic; a half-finished version is dangerous"; @neo-gpt did not claim #12168 after the offer). Rebalance: #12166 (parent-chain, sequences after this) offered to under-target @neo-gpt.

Conforms `BaseConfig` to the graduated Discussion #12100 **prototype shape** — the shape #12164 diverged from (a re-derived `metaTree` config + construct-time compile). This is the foundation the parent-chain realm inheritance (#12166) builds on.

## What shipped

**`ai/BaseConfig.mjs` (core):**
- Meta-leaf tree now lives in the standard `data` config (the parallel `metaTree` config is gone), compiled in an `afterSetData` override via the Provider's own `processDataObject` seam — reactive + AC-Epic-1-aligned ("extend, don't reinvent").
- `leaf(default, env, type)` factory replaces `{env, default, parse}` literals. Reuses the name-based `Env` parsers (`typeParsers`) + a `typeValidators` map. Explicit `type` survives a `null` default (e.g. `leaf(null, 'NEO_PUBLIC_URL', 'url')` stays validatable — the old `Neo.typeOf`-inference lost the type on null).
- `internalSetData` validates **any** value at a known leaf path — object/JSON leaves no longer bypass (closes what #12167 targeted; **#12167 closed as superseded**).
- `setEnvOverride(envName, value)` keyed by **env-var name** (one var → N leaves); new `refreshEnv()` for bounded on-demand re-resolution.
- **Bounded env (not live-per-read), deliberately.** A live env value decoupled from a coordinated restart is dangerous — a changed `NEO_CHROMA_PORT` would make new reads target a port the DB isn't listening on. Rationale baked into `#applyEnvLayer`'s JSDoc. True live-env-with-coordinated-restart is a separate Body-tier topic.
- Guard: `Neo.typeOf` returns `undefined` for an object with an own `constructor` key (the dummy-EF duck-type) — both inference sites guard it.

**6 `config.template.mjs`** converted `metaTree`+literals → `data`+`leaf()`. **Shape only** — the `AiConfig.x` snapshots are kept (the realm-split that removes them is #12166). 3 leaves with custom (non-`Env`) parsers — `logLevel` (github + gitlab) and `memorySharing.defaultPolicy` (memory-core) — kept as explicit `{env, default, parse}` literals (the valid escape hatch; `compileMetaLeaves` honors any `{default}` object).

**7 specs** adapted: `{metaTree: cfg.metaTree}` → `{data: cfg._data}`, text-asserts `metaTree:`→`data:`, `daemon.spec` template-text `default:\s*false`→`leaf\(false` (the `leaf()` conversion changed the asserted source), env-name-keyed `setEnvOverride`.

## Changed config keys (MCP config-template change guide)

- All 6 `config.template.mjs` reshaped (`metaTree`→`data` slot + `leaf()` leaves). **No leaf VALUES changed** (defaults preserved).
- **Local `config.mjs` follow-up REQUIRED after merge:** regenerate each clone's gitignored `config.mjs` from the updated templates + restart MCP servers + orchestrator. No `config.mjs` is committed.

## Deltas from ticket

- #12167 (object-leaf validation) is subsumed here (the leaf-factory typed validation does it properly) — #12167 closed as superseded.
- 3 custom-parser leaves kept as literals (the `leaf()` factory covers `Env` parsers only; a custom-parser escape hatch is out of scope).

## Evidence

Evidence: L1 (standalone Neo-bootstrapped verification — core 16/16 checks; 6/6 templates compile+resolve; 7 specs `node --check` clean; shape-sensitive spec tail assessed safe) → L2 full Playwright unit suite in CI (the authoritative full-suite gate; the worktree has no `node_modules` + a parse5-build prerequisite locally). Verified: **no runtime consumer** of `setEnvOverride` or `.metaTree` exists, so the signature/shape changes break zero production code; the consumer read API (`aiConfig.X.Y`) is unchanged.

## Test Evidence

- Standalone harness (`node`): leaf() factory, afterSetData compile, nested + object leaves, bounded env, setEnvOverride (env-name), refreshEnv, validate-any, typeOf-guard — all pass.
- All 6 converted templates import + resolve.
- 7 affected specs adapted + syntax-clean; an 11-file broad sweep resolved to safe (false-positives / value-preserving compiled-config reads / `SourcePathsConfig` `toContain(string)` checks preserved by the conversion / already-stale comments).
- Full unit suite runs in CI.

## Post-Merge Validation
- [ ] Regenerate each clone's `config.mjs` from the templates; restart MCP servers + orchestrator.
- [ ] Confirm orchestrator boots + MCP servers start on the new shape.

## Commits
- `8afa5ce7c` — BaseConfig core (data + afterSetData seam + leaf() factory + bounded env + typeOf-safe inference)
- `019fcb43c` — 6 templates → data+leaf() + typeOf guard
- `a90549839` — 7 specs adapted to the new shape
