### PR TITLE
feat(data): backend-first remoteCreate/remoteUpdate/remoteDestroy on Store (#12173)

### DIFF
--- a/src/data/Store.mjs
+++ b/src/data/Store.mjs
@@ -1238,6 +1238,123 @@ class Store extends Collection {
     }
 
     /**
+     * Backend-first create over the remotes-api.
+     *
+     * If `api.create` is configured, the record is persisted to the backend **first** and only inserted
+     * into the store on success — using the server-authoritative response, so backend-assigned fields
+     * (e.g. an `id`) are reflected. `add()` re-sorts when a sorter is present, so position is correct.
+     * Without an `api.create`, falls back to a local {@link #add}.
+     *
+     * Rejects and fires the `mutationFailed` event on a backend error, leaving the store unchanged.
+     * @param {Object} data The new record's field values
+     * @returns {Promise<Neo.data.Record[]>} The added record(s)
+     */
+    async remoteCreate(data) {
+        let me = this;
+
+        if (!Neo.isObject(me.api) || !me.api.create) {
+            return me.add(data)
+        }
+
+        let response = await me.remoteRpc('create', data);
+
+        if (response?.success) {
+            return me.add(Neo.ns(me.responseRoot, false, response) ?? data)
+        }
+
+        me.fire('mutationFailed', {action: 'create', data, response});
+        throw new Error(response?.message || 'Neo.data.Store: remoteCreate() failed')
+    }
+
+    /**
+     * Backend-first destroy over the remotes-api.
+     *
+     * If `api.destroy` is configured, the record is deleted on the backend **first** and only removed
+     * from the store on success. Without an `api.destroy`, falls back to a local remove.
+     *
+     * Rejects and fires the `mutationFailed` event on a backend error, leaving the store unchanged.
+     * @param {Neo.data.Record} record
+     * @returns {Promise<void>}
+     */
+    async remoteDestroy(record) {
+        let me  = this,
+            key = me.getKey(record);
+
+        if (!Neo.isObject(me.api) || !me.api.destroy) {
+            me.remove(key);
+            return
+        }
+
+        let response = await me.remoteRpc('destroy', {[me.getKeyProperty()]: key});
+
+        if (response?.success) {
+            me.remove(key);
+            return
+        }
+
+        me.fire('mutationFailed', {action: 'destroy', record, response});
+        throw new Error(response?.message || 'Neo.data.Store: remoteDestroy() failed')
+    }
+
+    /**
+     * Resolves the `api[verb]` remote stub — awaiting the remotes-api registration if it is still racing
+     * the call, mirroring {@link #load} — and invokes it with the given payload.
+     * @param {String} verb One of 'create', 'update' or 'destroy'
+     * @param {Object} payload
+     * @returns {Promise<Object>} The raw backend response (expected shape: `{success, data}`)
+     * @protected
+     */
+    async remoteRpc(verb, payload) {
+        let me       = this,
+            apiArray = me.api[verb].split('.'),
+            fn       = apiArray.pop(),
+            service  = Neo.ns(apiArray.join('.'));
+
+        if (!service && Neo.config.remotesApiUrl) {
+            await (await import('../remotes/Api.mjs')).default.ready();
+            service = Neo.ns(apiArray.join('.'))
+        }
+
+        if (!service?.[fn]) {
+            throw new Error(`Neo.data.Store: api.${verb} is not defined (${me.api[verb]})`)
+        }
+
+        return me.trap(service[fn](payload))
+    }
+
+    /**
+     * Backend-first update over the remotes-api.
+     *
+     * If `api.update` is configured, the changed `data` (keyed by the record's `keyProperty`) is persisted
+     * to the backend **first** and the server-authoritative result is applied to the record only on success.
+     * Without an `api.update`, falls back to a local `record.set(data)`.
+     *
+     * Rejects and fires the `mutationFailed` event on a backend error, leaving the record unchanged.
+     * @param {Neo.data.Record} record
+     * @param {Object} data The changed field values to persist
+     * @returns {Promise<Neo.data.Record>} The updated record
+     */
+    async remoteUpdate(record, data) {
+        let me = this;
+
+        if (!Neo.isObject(me.api) || !me.api.update) {
+            record.set(data);
+            return record
+        }
+
+        let payload  = {...data, [me.getKeyProperty()]: me.getKey(record)},
+            response = await me.remoteRpc('update', payload);
+
+        if (response?.success) {
+            record.set(Neo.ns(me.responseRoot, false, response) ?? data);
+            return record
+        }
+
+        me.fire('mutationFailed', {action: 'update', record, data, response});
+        throw new Error(response?.message || 'Neo.data.Store: remoteUpdate() failed')
+    }
+
+    /**
      * @param {Object} opts={}
      * @param {String} opts.direction
      * @param {String} opts.property

--- a/test/playwright/unit/data/StoreRemoteCrud.spec.mjs
+++ b/test/playwright/unit/data/StoreRemoteCrud.spec.mjs
@@ -1,0 +1,125 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'StoreRemoteCrudTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import Model           from '../../../../src/data/Model.mjs';
+import Store           from '../../../../src/data/Store.mjs';
+
+const
+    apiNs = 'Test.backend.CrudService',
+    model = {
+        module: Model,
+        fields: [
+            {name: 'id',   type: 'Int'},
+            {name: 'name', type: 'String'}
+        ]
+    };
+
+/**
+ * @summary Backend-first CRUD on Neo.data.Store: remoteCreate / remoteUpdate / remoteDestroy.
+ * A fake api service is registered directly into the Neo namespace, so no real websocket /
+ * remotes-api registration is involved — the methods just resolve `api.<verb>` and call it.
+ */
+test.describe.serial('Neo.data.Store remote CRUD', () => {
+    test('remoteCreate persists, then inserts the server-authoritative record', async () => {
+        Neo.ns(apiNs, true).create = async data => ({success: true, data: {...data, id: 99}});
+
+        const store = Neo.create(Store, {keyProperty: 'id', model, api: {create: `${apiNs}.create`}}),
+              added = await store.remoteCreate({name: 'New'});
+
+        expect(store.count).toBe(1);
+        expect(added[0].id).toBe(99);      // backend-assigned id is reflected
+        expect(added[0].name).toBe('New');
+
+        store.destroy()
+    });
+
+    test('remoteCreate rejects + fires mutationFailed + leaves the store unchanged on failure', async () => {
+        Neo.ns(apiNs, true).create = async () => ({success: false, message: 'denied'});
+
+        const store = Neo.create(Store, {keyProperty: 'id', model, api: {create: `${apiNs}.create`}});
+
+        let failed = null, error = null;
+        store.on('mutationFailed', data => failed = data);
+
+        try { await store.remoteCreate({name: 'X'}) } catch (e) { error = e }
+
+        expect(error).toBeTruthy();
+        expect(error.message).toContain('denied');
+        expect(store.count).toBe(0);
+        expect(failed?.action).toBe('create');
+
+        store.destroy()
+    });
+
+    test('remoteCreate falls back to a local add when no api.create is configured', async () => {
+        const store = Neo.create(Store, {keyProperty: 'id', model, api: {read: `${apiNs}.read`}}),
+              added = await store.remoteCreate({id: 1, name: 'Local'});
+
+        expect(store.count).toBe(1);
+        expect(added[0].name).toBe('Local');
+
+        store.destroy()
+    });
+
+    test('remoteUpdate applies the server-authoritative response on success', async () => {
+        Neo.ns(apiNs, true).update = async data => ({success: true, data: {...data, name: 'Server'}});
+
+        const store  = Neo.create(Store, {keyProperty: 'id', model, api: {update: `${apiNs}.update`}, items: [{id: 1, name: 'A'}]}),
+              record = store.get(1);
+
+        await store.remoteUpdate(record, {name: 'Edited'});
+
+        expect(record.name).toBe('Server');
+
+        store.destroy()
+    });
+
+    test('remoteUpdate falls back to a local set when no api.update is configured', async () => {
+        const store  = Neo.create(Store, {keyProperty: 'id', model, api: {read: `${apiNs}.read`}, items: [{id: 1, name: 'A'}]}),
+              record = store.get(1);
+
+        await store.remoteUpdate(record, {name: 'LocalEdit'});
+
+        expect(record.name).toBe('LocalEdit');
+
+        store.destroy()
+    });
+
+    test('remoteDestroy removes the record on success', async () => {
+        Neo.ns(apiNs, true).destroy = async () => ({success: true});
+
+        const store = Neo.create(Store, {keyProperty: 'id', model, api: {destroy: `${apiNs}.destroy`}, items: [{id: 1, name: 'A'}, {id: 2, name: 'B'}]});
+
+        await store.remoteDestroy(store.get(1));
+
+        expect(store.count).toBe(1);
+        expect(store.get(1)).toBeFalsy();
+
+        store.destroy()
+    });
+
+    test('remoteDestroy rejects + leaves the store unchanged on failure', async () => {
+        Neo.ns(apiNs, true).destroy = async () => ({success: false, message: 'locked'});
+
+        const store = Neo.create(Store, {keyProperty: 'id', model, api: {destroy: `${apiNs}.destroy`}, items: [{id: 1, name: 'A'}]});
+
+        let error = null;
+        try { await store.remoteDestroy(store.get(1)) } catch (e) { error = e }
+
+        expect(error).toBeTruthy();
+        expect(store.count).toBe(1);
+
+        store.destroy()
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Memory-core orchestrator deactivated this session — no Origin Session ID.

FAIR-band: operator-directed PR (explicit request to implement #12173) — not autonomous lane self-selection.

Resolves #12173

Adds the async backend-first CRUD layer on `Neo.data.Store`: `remoteCreate` / `remoteUpdate` / `remoteDestroy`. The sync mutators (`add`/`insert`/`remove`) stay sync; the new methods call `api.{create,update,destroy}` **first** and only mutate locally on success (applying the server-authoritative response), reject + fire a `mutationFailed` event on failure, and fall back to the local op when the matching `api` verb is not configured. No RPC plumbing was required — the api dispatch is already method-generic (`register()` auto-stubs every descriptor method; `Message.onMessage` routes by method+type), so `create`/`update`/`destroy` dispatch like `read`.

Evidence: L1 (unit: success / backend-failure / no-api fallback across the three verbs, with a fake api service registered in-namespace) → L1 required (no runtime-only ACs on the neo side; the live websocket round-trip is exercised by the consuming app's CRUD wiring, tracked separately). No residuals.

## Deltas from ticket

- `remoteUpdate(record, data)` takes the changed `data` explicitly (the caller passes the form values) rather than auto-deriving the `trackModifiedFields` delta. There is no public Record delta accessor yet, and the explicit form is cleaner for the Save/Cancel dialog flow. Auto-delta is deferred as a follow-up enhancement.
- Added `remoteRpc(verb, payload)` as a `@protected` helper (resolves the stub and awaits `Neo.remotes.Api.ready()` when racing registration, mirroring `load()`).
- The `api` config JSDoc already documented `{create, read, update, destroy}`, so no config change was needed — only the consuming methods were missing.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/data/StoreRemoteCrud.spec.mjs` → **7 passed**
- `npm run test-unit -- test/playwright/unit/data/` → **63 passed** (no regression across Store/TreeStore)

## Post-Merge Validation

- [ ] A consuming app wires its CRUD dialogs to `remoteCreate`/`remoteUpdate`/`remoteDestroy` over a live remotes-api websocket and persists create/update/delete end-to-end (tracked in that app's own backlog).
