### PR TITLE
feat(ai): aiConfig realm split — KB + MC inherit Tier-1 leaves via getParent chain (#12166)

### DIFF
--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -243,16 +243,62 @@ class BaseConfig extends Provider {
     }
 
     /**
-     * The single write funnel. Validates any value written to a known leaf path
-     * (metadata-path-first), then delegates to the Provider pipeline (reactivity bubbling,
-     * config-map updates).
+     * Resolves the parent provider for hierarchical (chain) data resolution. The Brain has no
+     * component tree, so the Provider's component-tree fallback never applies; instead the Tier-1
+     * singleton `Neo.ai.Config` is the realm root and every other config is its child.
+     *
+     * Returns the **raw** Tier-1 instance (`globalThis.Neo.ai.Config`, placed by `applyToGlobalNs`)
+     * — never the {@link createConfigProxy} export — because `getOwnerOfDataProperty` reads the
+     * parent's private `#dataConfigs`, which a Proxy cannot expose. The `root !== this` identity
+     * guard stops the root from parenting itself (infinite recursion); a not-yet-loaded root yields
+     * `null`, so a child resolves locally until the root module is imported (lazy: the root need
+     * only exist before the first realm-leaf *read*, not before a child constructs).
+     * @returns {Neo.state.Provider|null}
+     * @override
+     */
+    getParent() {
+        const root = Neo.ai?.Config;
+
+        return root && root !== this ? root : null
+    }
+
+    /**
+     * Validates a value against the registry of whichever provider in the chain OWNS the leaf:
+     * local first (fast path), else the owner resolved up the parent chain via
+     * {@link Neo.state.Provider#getOwnerOfDataProperty}. A cross-tier write — a child writing a
+     * Tier-1-owned leaf — is therefore validated against the parent's metadata instead of bypassing
+     * validation on both tiers (facet-8). The `#leafMetadataRegistry in owner` brand check guards
+     * the cross-instance private access (every chain member is a BaseConfig).
+     * @param {String} key
+     * @param {*} value
+     * @returns {*}
+     */
+    #validateAgainstOwner(key, value) {
+        if (this.#leafMetadataRegistry.has(key)) {
+            return this.#validateLeafValue(key, value)
+        }
+
+        const owner = this.getOwnerOfDataProperty(key)?.owner;
+
+        if (owner && owner !== this && #leafMetadataRegistry in owner && owner.#leafMetadataRegistry.has(key)) {
+            return owner.#validateLeafValue(key, value)
+        }
+
+        return value
+    }
+
+    /**
+     * The single write funnel. Validates any string-keyed write against the leaf registry of the
+     * provider that OWNS the key — local or resolved up the parent chain (see
+     * {@link #validateAgainstOwner}) — then delegates to the Provider pipeline (reactivity
+     * bubbling, config-map updates).
      * @param {String|Object} key
      * @param {*} value
      * @param {Neo.state.Provider} [originStateProvider]
      */
     internalSetData(key, value, originStateProvider) {
-        if (typeof key === 'string' && this.#leafMetadataRegistry.has(key)) {
-            value = this.#validateLeafValue(key, value)
+        if (typeof key === 'string') {
+            value = this.#validateAgainstOwner(key, value)
         }
 
         super.internalSetData(key, value, originStateProvider)

--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -267,7 +267,7 @@ class BaseConfig extends Provider {
      * local first (fast path), else the owner resolved up the parent chain via
      * {@link Neo.state.Provider#getOwnerOfDataProperty}. A cross-tier write — a child writing a
      * Tier-1-owned leaf — is therefore validated against the parent's metadata instead of bypassing
-     * validation on both tiers (facet-8). The `#leafMetadataRegistry in owner` brand check guards
+     * validation on both tiers. The `#leafMetadataRegistry in owner` brand check guards
      * the cross-instance private access (every chain member is a BaseConfig).
      * @param {String} key
      * @param {*} value

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -38,11 +38,9 @@ class Config extends BaseConfig {
          */
         data: {
             neoRootDir: leaf(neoRootDir),
-            /**
-             * Universal JSONL backup/export directory inherited from Tier-1 config.
-             * @type {string}
-             */
-            backupPath: leaf(AiConfig.backupPath, 'NEO_BACKUP_PATH', 'string'),
+            // backupPath is inherited from the Tier-1 realm (Neo.ai.Config) via the
+            // BaseConfig.getParent() chain (#12166): declared once at Tier-1, resolved up the chain
+            // at read time, no local snapshot.
             /**
              * Automatically synchronize the knowledge base on startup.
              * @type {boolean}
@@ -85,43 +83,13 @@ class Config extends BaseConfig {
              * @type {Function|null}
              */
             authMiddleware: leaf(null),
-            /**
-             * Authentication configuration for the server (OAuth 2.1 / OIDC).
-             * Only used when transport is 'sse'.
-             * @type {Object}
-             */
-            auth: {
-                host              : leaf(AiConfig.auth.host, 'NEO_AUTH_HOST', 'string'),
-                port              : leaf(AiConfig.auth.port, 'NEO_AUTH_PORT', 'port'),
-                realm             : leaf(AiConfig.auth.realm, 'NEO_AUTH_REALM', 'string'),
-                issuerUrl         : leaf(AiConfig.auth.issuerUrl, 'NEO_AUTH_ISSUER_URL', 'string'),
-                clientId          : leaf(AiConfig.auth.clientId, 'NEO_OAUTH_CLIENT_ID', 'string'),
-                clientSecret      : leaf(AiConfig.auth.clientSecret, 'NEO_OAUTH_CLIENT_SECRET', 'string'),
-                trustProxyIdentity: leaf(AiConfig.auth.trustProxyIdentity, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean')
-            },
-            /**
-             * A dummy embedding function to satisfy the ChromaDB API when embeddings are provided manually.
-             *
-             * NOTE: This verbose structure is strictly required to prevent the ChromaDB client from
-             * flagging this as a "legacy" function, which triggers a persistent console warning:
-             * "No embedding function configuration found for collection..."
-             *
-             * The `chromadb` library checks for the presence of `name`, `getConfig`, and `buildFromConfig`.
-             * If any are missing, it defaults to legacy mode.
-             * @returns {Object} The dummy embedding function satisfying IEmbeddingFunction
-             */
-            dummyEmbeddingFunction: leaf({
-                generate   : () => null,
-                name       : 'dummy_embedding_function',
-                getConfig  : () => ({}),
-                constructor: {
-                    buildFromConfig: () => ({
-                        generate : () => null,
-                        name     : 'dummy_embedding_function',
-                        getConfig: () => ({})
-                    })
-                }
-            }, null, 'object'),
+            // auth.* (OAuth 2.1 / OIDC; used only when transport === 'sse') is inherited from the
+            // Tier-1 realm (Neo.ai.Config) via the getParent() chain (#12166): same dotted paths +
+            // env vars, declared once at Tier-1, no local snapshot.
+            // dummyEmbeddingFunction is inherited from the Tier-1 realm (Neo.ai.Config) via the
+            // getParent() chain (#12166) — resolving the child-snapshot anti-pattern: the verbose
+            // chromadb legacy-guard structure (name/getConfig/buildFromConfig) is declared once at
+            // Tier-1, never re-copied per child.
             /**
              * The hostname of the ChromaDB server for the knowledge base.
              *

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -38,9 +38,6 @@ class Config extends BaseConfig {
          */
         data: {
             neoRootDir: leaf(neoRootDir),
-            // backupPath is inherited from the Tier-1 realm (Neo.ai.Config) via the
-            // BaseConfig.getParent() chain (#12166): declared once at Tier-1, resolved up the chain
-            // at read time, no local snapshot.
             /**
              * Automatically synchronize the knowledge base on startup.
              * @type {boolean}
@@ -83,13 +80,6 @@ class Config extends BaseConfig {
              * @type {Function|null}
              */
             authMiddleware: leaf(null),
-            // auth.* (OAuth 2.1 / OIDC; used only when transport === 'sse') is inherited from the
-            // Tier-1 realm (Neo.ai.Config) via the getParent() chain (#12166): same dotted paths +
-            // env vars, declared once at Tier-1, no local snapshot.
-            // dummyEmbeddingFunction is inherited from the Tier-1 realm (Neo.ai.Config) via the
-            // getParent() chain (#12166) — resolving the child-snapshot anti-pattern: the verbose
-            // chromadb legacy-guard structure (name/getConfig/buildFromConfig) is declared once at
-            // Tier-1, never re-copied per child.
             /**
              * The hostname of the ChromaDB server for the knowledge base.
              *

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -1,8 +1,6 @@
 import path                                    from 'path';
-// Side-effect import: load the Tier-1 realm root (Neo.ai.Config) so the getParent() chain resolves
-// in this MC process (#12166). MC declares no realm leaves locally (all inherited), so there is no
-// value binding or value-snapshot of any parent-realm leaf. `materializeServerConfigTemplate` rewrites this to
-// the operator overlay (config.mjs) for the generated runtime config.
+// Loads the Tier-1 realm root (Neo.ai.Config) so getParent() inheritance resolves in this process;
+// MC reads no AiConfig values directly — they resolve via the chain, not a binding.
 import '../../../config.template.mjs';
 import BaseConfig, {createConfigProxy, leaf}   from '../../../BaseConfig.mjs';
 import {fileURLToPath}                          from 'url';
@@ -128,15 +126,6 @@ class Config extends BaseConfig {
              * @type {Function|null}
              */
             authMiddleware: leaf(null),
-            // auth.* (OAuth 2.1 / OIDC; used only when transport === 'sse') is inherited from the
-            // Tier-1 realm (Neo.ai.Config) via the getParent() chain (#12166): same dotted paths +
-            // env vars, declared once at Tier-1, no local snapshot.
-            // The deployment-wide model realm — modelProvider, graphProvider, embeddingProvider, the
-            // ollama + openAiCompatible provider blocks, localModels (role-keyed context limits),
-            // vectorDimension, modelName, embeddingModel — is inherited from the Tier-1 realm
-            // (Neo.ai.Config) via the getParent() chain (#12166): same dotted paths + env vars,
-            // declared once at Tier-1, no local snapshots. localModels resolves keyed (e.g.
-            // localModels.chat.contextLimitTokens — every consumer reads it dotted, never whole-object).
             /**
              * Pagination limit for fetching records during session summarization scans.
              * Controls the batch size for memory and summary retrieval.
@@ -156,9 +145,6 @@ class Config extends BaseConfig {
              * The default is explicitly 'hybrid' per Epic #9922 Two-Pillar RAG architecture.
              */
             engine: leaf('hybrid'),
-            // engines.chroma.* (the unified Chroma persist dir + host/port shared with the KB, ADR
-            // 0003) is inherited from the Tier-1 realm (Neo.ai.Config) via the getParent() chain
-            // (#12166): same nested dotted paths + env vars, declared once at Tier-1, no local snapshot.
             /**
              * Physical file paths for embedded/local datasets.
              */
@@ -236,8 +222,6 @@ class Config extends BaseConfig {
                 prScanLimit    : leaf(20, 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', 'number'),
                 minSourceLength: leaf(200, 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', 'number')
             },
-            // backupPath is inherited from the Tier-1 realm (Neo.ai.Config) via the getParent()
-            // chain (#12166): declared once at Tier-1, resolved up the chain, no local snapshot.
             /**
              * Phase 4 (#11663): bundle retention policy for `ai/scripts/maintenance/backup.mjs`.
              * Bundles older than `maxDays` are eligible for deletion, but the newest

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -1,5 +1,9 @@
 import path                                    from 'path';
-import AiConfig                                from '../../../config.template.mjs';
+// Side-effect import: load the Tier-1 realm root (Neo.ai.Config) so the getParent() chain resolves
+// in this MC process (#12166). MC declares no realm leaves locally (all inherited), so there is no
+// value binding or value-snapshot of any parent-realm leaf. `materializeServerConfigTemplate` rewrites this to
+// the operator overlay (config.mjs) for the generated runtime config.
+import '../../../config.template.mjs';
 import BaseConfig, {createConfigProxy, leaf}   from '../../../BaseConfig.mjs';
 import {fileURLToPath}                          from 'url';
 
@@ -124,103 +128,15 @@ class Config extends BaseConfig {
              * @type {Function|null}
              */
             authMiddleware: leaf(null),
-            /**
-             * Authentication configuration for the server (OAuth 2.1 / OIDC).
-             * Only used when transport is 'sse'.
-             * @type {Object}
-             */
-            auth: {
-                host              : leaf(AiConfig.auth.host, 'NEO_AUTH_HOST', 'string'),
-                port              : leaf(AiConfig.auth.port, 'NEO_AUTH_PORT', 'port'),
-                realm             : leaf(AiConfig.auth.realm, 'NEO_AUTH_REALM', 'string'),
-                issuerUrl         : leaf(AiConfig.auth.issuerUrl, 'NEO_AUTH_ISSUER_URL', 'string'),
-                clientId          : leaf(AiConfig.auth.clientId, 'NEO_OAUTH_CLIENT_ID', 'string'),
-                clientSecret      : leaf(AiConfig.auth.clientSecret, 'NEO_OAUTH_CLIENT_SECRET', 'string'),
-                trustProxyIdentity: leaf(AiConfig.auth.trustProxyIdentity, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean')
-            },
-            /**
-             * Explicit override provider for the core LLM Engine (e.g. summarization).
-             * Supported values: 'gemini', 'ollama', 'openAiCompatible'
-             * @type {String}
-             */
-            modelProvider: leaf(AiConfig.modelProvider, 'NEO_MODEL_PROVIDER', 'string'),
-            /**
-             * Provider selector for Dream/Sandman graph-generation lanes.
-             * Supported values: 'ollama', 'openAiCompatible'
-             * @type {String}
-             */
-            graphProvider: leaf(AiConfig.graphProvider, 'NEO_GRAPH_PROVIDER', 'string'),
-            /**
-             * Canonical embedding provider for Memory Core and Knowledge Base embedding callsites.
-             * Supported values: 'gemini', 'ollama', 'openAiCompatible'
-             * Defaults to the local OpenAI-compatible Qwen3 route so the source tuple matches the
-             * unified 4096-dimension Chroma collection invariant. Gemini remains available as an
-             * explicit operator override and must be paired with `vectorDimension: 3072`.
-             *
-             * @type {String}
-             */
-            embeddingProvider: leaf(AiConfig.embeddingProvider, 'NEO_EMBEDDING_PROVIDER', 'string'),
-            /**
-             * Settings for the Ollama integration
-             */
-            ollama: {
-                host                 : leaf(AiConfig.ollama.host, 'NEO_OLLAMA_HOST', 'string'),
-                model                : leaf(AiConfig.ollama.model, 'NEO_OLLAMA_MODEL', 'string'),
-                embeddingModel       : leaf(AiConfig.ollama.embeddingModel, 'NEO_OLLAMA_EMBEDDING_MODEL', 'string'),
-                keep_alive           : leaf(AiConfig.ollama.keep_alive, 'NEO_OLLAMA_KEEP_ALIVE', 'keepAlive'),
-                requireParallelModels: leaf(AiConfig.ollama.requireParallelModels, 'NEO_OLLAMA_REQUIRE_PARALLEL_MODELS', 'number')
-            },
-            /**
-             * Settings for the OpenAI-Compatible API integration (e.g., mlx-lm or mlx-openai-server)
-             * WARNING: Never hardcode API keys here. Always export them via .env or globally.
-             */
-            openAiCompatible: {
-                host                 : leaf(AiConfig.openAiCompatible.host, 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
-                model                : leaf(AiConfig.openAiCompatible.model, 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
-                embeddingModel       : leaf(AiConfig.openAiCompatible.embeddingModel, 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
-                apiKey               : leaf(AiConfig.openAiCompatible.apiKey, 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
-                unloadRetryCount     : leaf(AiConfig.openAiCompatible.unloadRetryCount, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
-                unloadRetryDelayMs   : leaf(AiConfig.openAiCompatible.unloadRetryDelayMs, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', 'number'),
-                keep_alive           : leaf(AiConfig.openAiCompatible.keep_alive, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
-                requireParallelModels: leaf(AiConfig.openAiCompatible.requireParallelModels, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')
-            },
-            /**
-             * Local-model role-keyed context limits passthrough.
-             *
-             * Mirrors `AiConfig.localModels` into the Memory_Config surface so consumers
-             * importing the MC overlay (chat-path: SemanticGraphExtractor + TopologyInferenceEngine
-             * + SessionService summarizer; embedding-path: future TextEmbeddingService consumer
-             * surface) can read the role-keyed context-limit knobs directly. The context-window
-             * axis is model-role (chat vs embedding), not provider-namespace — local providers
-             * share these caps because the practical limit comes from the loaded model.
-             * @type {Object}
-             */
-            localModels: leaf({
-                chat: {
-                    contextLimitTokens      : AiConfig.localModels.chat.contextLimitTokens,
-                    safeProcessingLimitTokens: AiConfig.localModels.chat.safeProcessingLimitTokens
-                },
-                embedding: {
-                    contextLimitTokens      : AiConfig.localModels.embedding.contextLimitTokens,
-                    safeProcessingLimitTokens: AiConfig.localModels.embedding.safeProcessingLimitTokens
-                }
-            }),
-            /**
-             * The enforced vector dimension across all SQLite collections.
-             * Hard-configured here to prevent catastrophic schema wipes due to dynamic model changes.
-             * @type {number}
-             */
-            vectorDimension: leaf(AiConfig.vectorDimension, 'NEO_VECTOR_DIMENSION', 'number'),
-            /**
-             * The name of the Google Generative AI model for content generation.
-             * @type {string}
-             */
-            modelName: leaf(AiConfig.modelName),
-            /**
-             * The name of the Google Generative AI model for text embeddings.
-             * @type {string}
-             */
-            embeddingModel: leaf(AiConfig.embeddingModel),
+            // auth.* (OAuth 2.1 / OIDC; used only when transport === 'sse') is inherited from the
+            // Tier-1 realm (Neo.ai.Config) via the getParent() chain (#12166): same dotted paths +
+            // env vars, declared once at Tier-1, no local snapshot.
+            // The deployment-wide model realm — modelProvider, graphProvider, embeddingProvider, the
+            // ollama + openAiCompatible provider blocks, localModels (role-keyed context limits),
+            // vectorDimension, modelName, embeddingModel — is inherited from the Tier-1 realm
+            // (Neo.ai.Config) via the getParent() chain (#12166): same dotted paths + env vars,
+            // declared once at Tier-1, no local snapshots. localModels resolves keyed (e.g.
+            // localModels.chat.contextLimitTokens — every consumer reads it dotted, never whole-object).
             /**
              * Pagination limit for fetching records during session summarization scans.
              * Controls the batch size for memory and summary retrieval.
@@ -240,22 +156,9 @@ class Config extends BaseConfig {
              * The default is explicitly 'hybrid' per Epic #9922 Two-Pillar RAG architecture.
              */
             engine: leaf('hybrid'),
-            /**
-             * Database Engine Definitions
-             * This defines WHERE data is stored physically (for engines MC owns) and WHERE MC reaches
-             * into other services' engines. The flat `engines.chroma` path specifies the unified
-             * ChromaDB instance shared with the Knowledge Base.
-             */
-            engines: {
-                chroma: {
-                    // Read the unified persist dir from the SSOT. Was the stale
-                    // '.neo-ai-data/chroma/memory-core' — MC is a CLIENT of the one unified store
-                    // (ADR 0003), so its physical dir must be the shared dir, not a server-local one.
-                    dataDir: leaf(AiConfig.engines.chroma.dataDir),
-                    host   : leaf(AiConfig.engines.chroma.host, 'NEO_CHROMA_HOST', 'string'),
-                    port   : leaf(AiConfig.engines.chroma.port, 'NEO_CHROMA_PORT', 'port')
-                }
-            },
+            // engines.chroma.* (the unified Chroma persist dir + host/port shared with the KB, ADR
+            // 0003) is inherited from the Tier-1 realm (Neo.ai.Config) via the getParent() chain
+            // (#12166): same nested dotted paths + env vars, declared once at Tier-1, no local snapshot.
             /**
              * Physical file paths for embedded/local datasets.
              */
@@ -333,11 +236,8 @@ class Config extends BaseConfig {
                 prScanLimit    : leaf(20, 'NEO_CONCEPT_DISCOVERY_PR_SCAN_LIMIT', 'number'),
                 minSourceLength: leaf(200, 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', 'number')
             },
-            /**
-             * Universal JSONL backup/export directory for all databases.
-             * @type {string}
-             */
-            backupPath: leaf(AiConfig.backupPath, 'NEO_BACKUP_PATH', 'string'),
+            // backupPath is inherited from the Tier-1 realm (Neo.ai.Config) via the getParent()
+            // chain (#12166): declared once at Tier-1, resolved up the chain, no local snapshot.
             /**
              * Phase 4 (#11663): bundle retention policy for `ai/scripts/maintenance/backup.mjs`.
              * Bundles older than `maxDays` are eligible for deletion, but the newest

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -135,9 +135,8 @@ export function materializeServerConfigTemplate(src) {
     return src
         .replaceAll("from '../../../config.template.mjs'", "from '../../../config.mjs'")
         .replaceAll('from "../../../config.template.mjs"', 'from "../../../config.mjs"')
-        // Side-effect imports (no `from`) — e.g. a server config that loads the Tier-1 realm root
-        // purely to register `Neo.ai.Config` for the getParent() chain (#12166) — must also point at
-        // the operator overlay in the generated runtime config.
+        // Side-effect imports of the Tier-1 template (a server config that loads it only to register
+        // the realm root) must also point at the operator overlay in the generated runtime config.
         .replaceAll("import '../../../config.template.mjs'", "import '../../../config.mjs'")
         .replaceAll('import "../../../config.template.mjs"', 'import "../../../config.mjs"')
 }

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -135,6 +135,11 @@ export function materializeServerConfigTemplate(src) {
     return src
         .replaceAll("from '../../../config.template.mjs'", "from '../../../config.mjs'")
         .replaceAll('from "../../../config.template.mjs"', 'from "../../../config.mjs"')
+        // Side-effect imports (no `from`) — e.g. a server config that loads the Tier-1 realm root
+        // purely to register `Neo.ai.Config` for the getParent() chain (#12166) — must also point at
+        // the operator overlay in the generated runtime config.
+        .replaceAll("import '../../../config.template.mjs'", "import '../../../config.mjs'")
+        .replaceAll('import "../../../config.template.mjs"', 'import "../../../config.mjs"')
 }
 
 /**

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -78,7 +78,7 @@ class DatabaseService extends Base {
      */
     createContentHash(chunk) {
         // Prefer the nested tenant-shape only when it exposes a tenant field; Tier-1's inherited
-        // `knowledgeBase` ops leaf (#12166) is not one (see VectorService.getTenantIsolationConfig).
+        // `knowledgeBase` ops leaf is not one (see VectorService.getTenantIsolationConfig).
         // A wrong surface here would corrupt content-hash tenant collision-safety.
         const nestedKb = aiConfig.knowledgeBase;
         const kbConfig = (nestedKb != null && (

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -77,7 +77,15 @@ class DatabaseService extends Base {
      * @private
      */
     createContentHash(chunk) {
-        const kbConfig = aiConfig.knowledgeBase ?? aiConfig;
+        // Prefer the nested tenant-shape only when it exposes a tenant field; Tier-1's inherited
+        // `knowledgeBase` ops leaf (#12166) is not one (see VectorService.getTenantIsolationConfig).
+        // A wrong surface here would corrupt content-hash tenant collision-safety.
+        const nestedKb = aiConfig.knowledgeBase;
+        const kbConfig = (nestedKb != null && (
+            nestedKb.defaultTenantId   !== undefined ||
+            nestedKb.defaultRepoSlug   !== undefined ||
+            nestedKb.defaultVisibility !== undefined
+        )) ? nestedKb : aiConfig;
         const contentString = JSON.stringify({
             tenantId   : chunk.tenantId ?? kbConfig.defaultTenantId ?? 'neo-shared',
             repoSlug   : chunk.repoSlug ?? kbConfig.defaultRepoSlug ?? 'neo',

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -107,7 +107,19 @@ class VectorService extends Base {
      * @returns {Object} Tenant-isolation configuration object.
      */
     getTenantIsolationConfig() {
-        return aiConfig.knowledgeBase ?? aiConfig;
+        const nested = aiConfig.knowledgeBase;
+        // The portable nested tenant-shape carries tenant fields. Post-#12166, Tier-1's
+        // `knowledgeBase` leaf (KB OPS config: alerting / reconciliation / GC) is inherited here via
+        // the realm chain and is NOT a tenant-shape — so a naked `?? aiConfig` would wrongly select
+        // it (security regression: tenant fields read as undefined). Prefer the nested object only
+        // when it actually exposes a tenant field; otherwise fall through to the flat top-level config.
+        const hasTenantShape = nested != null && (
+            nested.defaultTenantId    !== undefined ||
+            nested.defaultRepoSlug    !== undefined ||
+            nested.defaultVisibility  !== undefined ||
+            nested.spoofRejectionMode !== undefined
+        );
+        return hasTenantShape ? nested : aiConfig;
     }
 
     /**

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -108,7 +108,7 @@ class VectorService extends Base {
      */
     getTenantIsolationConfig() {
         const nested = aiConfig.knowledgeBase;
-        // The portable nested tenant-shape carries tenant fields. Post-#12166, Tier-1's
+        // The portable nested tenant-shape carries tenant fields. Tier-1's
         // `knowledgeBase` leaf (KB OPS config: alerting / reconciliation / GC) is inherited here via
         // the realm chain and is NOT a tenant-shape — so a naked `?? aiConfig` would wrongly select
         // it (security regression: tenant fields read as undefined). Prefer the nested object only

--- a/test/playwright/unit/ai/BaseConfig.spec.mjs
+++ b/test/playwright/unit/ai/BaseConfig.spec.mjs
@@ -306,7 +306,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
         }
     });
 
-    test('cross-tier write validates against the OWNER registry (facet-8 bypass closed)', () => {
+    test('cross-tier write validates against the OWNER registry', () => {
         const root     = Neo.create(BaseConfig, {data: {sharedPort: leaf(3000, null, 'port')}}),
               child    = Neo.create(BaseConfig, {data: {own: leaf('x')}}),
               warnings = [],

--- a/test/playwright/unit/ai/BaseConfig.spec.mjs
+++ b/test/playwright/unit/ai/BaseConfig.spec.mjs
@@ -277,4 +277,56 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
 
         config.destroy()
     });
+
+    test('getParent() resolves the Tier-1 root; root self-parents to null; bare instance resolves locally', () => {
+        const root     = Neo.create(BaseConfig, {data: {sharedRealmLeaf: leaf('root-owned')}}),
+              child    = Neo.create(BaseConfig, {data: {own: leaf('child-owned')}}),
+              prevRoot = Neo.ai?.Config;
+
+        Neo.ai = Neo.ai || {};
+        delete Neo.ai.Config;
+
+        try {
+            // No root registered → getParent is null → the child resolves only its own leaves.
+            expect(child.getParent()).toBe(null);
+            expect(child.getOwnerOfDataProperty('sharedRealmLeaf')).toBe(null);
+
+            // Register the RAW root instance (mirrors applyToGlobalNs placing the singleton).
+            Neo.ai.Config = root;
+
+            // The child now inherits up the chain; the root self-parents to null (identity guard).
+            expect(child.getParent()).toBe(root);
+            expect(root.getParent()).toBe(null);
+            expect(child.getOwnerOfDataProperty('own').owner).toBe(child);            // local still wins
+            expect(child.getOwnerOfDataProperty('sharedRealmLeaf').owner).toBe(root); // resolved via chain
+        } finally {
+            if (prevRoot === undefined) {delete Neo.ai.Config} else {Neo.ai.Config = prevRoot}
+            root.destroy();
+            child.destroy()
+        }
+    });
+
+    test('cross-tier write validates against the OWNER registry (facet-8 bypass closed)', () => {
+        const root     = Neo.create(BaseConfig, {data: {sharedPort: leaf(3000, null, 'port')}}),
+              child    = Neo.create(BaseConfig, {data: {own: leaf('x')}}),
+              warnings = [],
+              origWarn = console.warn,
+              prevRoot = Neo.ai?.Config;
+
+        Neo.ai = Neo.ai || {};
+        Neo.ai.Config = root;
+        console.warn   = msg => warnings.push(String(msg));
+
+        try {
+            // The child does not own `sharedPort`; the write resolves the owner (root) up the chain
+            // and validates against the root's 'port' registry entry → warns (was silently bypassed).
+            child.setData('sharedPort', 'not-a-port');
+            expect(warnings.some(w => w.includes('sharedPort'))).toBe(true)
+        } finally {
+            console.warn = origWarn;
+            if (prevRoot === undefined) {delete Neo.ai.Config} else {Neo.ai.Config = prevRoot}
+            root.destroy();
+            child.destroy()
+        }
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -216,30 +216,35 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
     });
 
     // Post-#12101 the AiConfig singleton is a reactive `Neo.state.Provider`, so its
-    // `orchestrator.mlx`/`.lms` leaves are seeded from the data tree at construction and
-    // ALWAYS exist on the singleton (defaults: enabled=false, model+port set). `delete`
-    // on the hierarchical data proxy is a silent no-op (the throwaway nested-proxy target
-    // is deleted, not the underlying reactive Config), and nulling the parent leaf is a
-    // one-way door (the leaf-bubble breaks on a non-object parent, so the singleton can't
-    // be restored for sibling tests). The faithful, reachable "config missing" state is a
-    // fresh BaseConfig instance whose data tree omits the namespace — the canonical pattern
-    // from BaseConfig.spec.mjs — exercising the same undefined-safe `?.` delegation the
-    // Orchestrator `mlx*`/`lms*` getters use against `AiConfig.orchestrator.{mlx,lms}`.
+    // `orchestrator.mlx`/`.lms` leaves are seeded from the data tree at construction and ALWAYS
+    // exist on the singleton. A fresh BaseConfig instance whose data tree omits the namespace is the
+    // faithful "config missing" state — BUT post-#12166 `BaseConfig.getParent()` makes every instance
+    // inherit the registered realm root (`Neo.ai.Config`), so the fresh instance would otherwise
+    // resolve the namespace UP the chain. Detach the root for the duration so it resolves in
+    // isolation, exercising the same undefined-safe `?.` delegation the Orchestrator `mlx*`/`lms*`
+    // getters use against `AiConfig.orchestrator.{mlx,lms}`.
     test('mlx getter delegation is undefined-safe when AiConfig.orchestrator.mlx is missing', () => {
-        const config = Neo.create(BaseConfig, {data: {
-                  orchestrator: {intervals: {pollMs: {default: 3000}}}
-              }}),
-              cfg    = createConfigProxy(config);
+        const prevRoot = Neo.ai?.Config;
+        if (Neo.ai) {delete Neo.ai.Config}
 
-        // mlx namespace entirely absent → the parent resolves undefined, not a stale default.
-        expect(cfg.orchestrator.mlx).toBeUndefined();
+        try {
+            const config = Neo.create(BaseConfig, {data: {
+                      orchestrator: {intervals: {pollMs: {default: 3000}}}
+                  }}),
+                  cfg    = createConfigProxy(config);
 
-        // Mirror of `Orchestrator#mlxEnabled` / `#mlxModel` / `#mlxPort`.
-        expect(!!cfg.orchestrator.mlx?.enabled).toBe(false);
-        expect(cfg.orchestrator.mlx?.model).toBeUndefined();
-        expect(cfg.orchestrator.mlx?.port).toBeUndefined();
+            // mlx absent locally + no realm root → resolves undefined, not a stale default.
+            expect(cfg.orchestrator.mlx).toBeUndefined();
 
-        config.destroy();
+            // Mirror of `Orchestrator#mlxEnabled` / `#mlxModel` / `#mlxPort`.
+            expect(!!cfg.orchestrator.mlx?.enabled).toBe(false);
+            expect(cfg.orchestrator.mlx?.model).toBeUndefined();
+            expect(cfg.orchestrator.mlx?.port).toBeUndefined();
+
+            config.destroy();
+        } finally {
+            if (prevRoot !== undefined) {Neo.ai.Config = prevRoot}
+        }
     });
 
     test('lmsEnabled / lmsModel / lmsPort getters read AiConfig.orchestrator.lms verbatim', () => {
@@ -262,23 +267,30 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
     });
 
 
-    // See the mlx-missing test above for why "config missing" is simulated via a fresh
-    // data-omitted BaseConfig instance rather than `delete`/null on the singleton.
+    // See the mlx-missing test above: post-#12166 a fresh instance inherits the realm root via
+    // getParent(), so the root is detached here to simulate a genuinely-missing namespace.
     test('lms getter delegation is undefined-safe when AiConfig.orchestrator.lms is missing', () => {
-        const config = Neo.create(BaseConfig, {data: {
-                  orchestrator: {intervals: {pollMs: {default: 3000}}}
-              }}),
-              cfg    = createConfigProxy(config);
+        const prevRoot = Neo.ai?.Config;
+        if (Neo.ai) {delete Neo.ai.Config}
 
-        // lms namespace entirely absent → the parent resolves undefined, not a stale default.
-        expect(cfg.orchestrator.lms).toBeUndefined();
+        try {
+            const config = Neo.create(BaseConfig, {data: {
+                      orchestrator: {intervals: {pollMs: {default: 3000}}}
+                  }}),
+                  cfg    = createConfigProxy(config);
 
-        // Mirror of `Orchestrator#lmsEnabled` / `#lmsModel` / `#lmsPort`.
-        expect(!!cfg.orchestrator.lms?.enabled).toBe(false);
-        expect(cfg.orchestrator.lms?.model).toBeUndefined();
-        expect(cfg.orchestrator.lms?.port).toBeUndefined();
+            // lms absent locally + no realm root → resolves undefined, not a stale default.
+            expect(cfg.orchestrator.lms).toBeUndefined();
 
-        config.destroy();
+            // Mirror of `Orchestrator#lmsEnabled` / `#lmsModel` / `#lmsPort`.
+            expect(!!cfg.orchestrator.lms?.enabled).toBe(false);
+            expect(cfg.orchestrator.lms?.model).toBeUndefined();
+            expect(cfg.orchestrator.lms?.port).toBeUndefined();
+
+            config.destroy();
+        } finally {
+            if (prevRoot !== undefined) {Neo.ai.Config = prevRoot}
+        }
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -218,7 +218,7 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
     // Post-#12101 the AiConfig singleton is a reactive `Neo.state.Provider`, so its
     // `orchestrator.mlx`/`.lms` leaves are seeded from the data tree at construction and ALWAYS
     // exist on the singleton. A fresh BaseConfig instance whose data tree omits the namespace is the
-    // faithful "config missing" state — BUT post-#12166 `BaseConfig.getParent()` makes every instance
+    // faithful "config missing" state — BUT `BaseConfig.getParent()` makes every instance
     // inherit the registered realm root (`Neo.ai.Config`), so the fresh instance would otherwise
     // resolve the namespace UP the chain. Detach the root for the duration so it resolves in
     // isolation, exercising the same undefined-safe `?.` delegation the Orchestrator `mlx*`/`lms*`
@@ -267,7 +267,7 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
     });
 
 
-    // See the mlx-missing test above: post-#12166 a fresh instance inherits the realm root via
+    // See the mlx-missing test above: a fresh instance inherits the realm root via
     // getParent(), so the root is detached here to simulate a genuinely-missing namespace.
     test('lms getter delegation is undefined-safe when AiConfig.orchestrator.lms is missing', () => {
         const prevRoot = Neo.ai?.Config;

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -33,6 +33,14 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         }
 
         config = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
+
+        // Deterministic realm root (#12166): KB now inherits backupPath / auth.* /
+        // dummyEmbeddingFunction from Tier-1 via the getParent() chain. The template import registers
+        // Neo.ai.Config only on first module-eval, so install a fresh Tier-1 root to keep inheritance
+        // deterministic across reused Playwright workers.
+        const tier1Template = (await import('../../../../../../../ai/config.template.mjs')).default;
+        Neo.ai = Neo.ai || {};
+        Neo.ai.Config = Neo.create(BaseConfig, {data: tier1Template._data});
     });
 
     test.afterAll(() => {
@@ -71,32 +79,55 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         });
     });
 
-    test('maps deployment-wide Tier-1 auth and unified Chroma defaults', () => {
-        expect(config.auth).toEqual(TIER1_DEFAULTS.auth);
+    test('inherits Tier-1 auth + backupPath via the realm chain; keeps KB-local Chroma + collection', () => {
+        // #12166: auth.* and backupPath are no longer declared locally — they resolve UP the
+        // getParent() chain to the Tier-1 realm root. Read them KEYED, never as a whole namespace:
+        // `toEqual(config.auth)` would enumerate, and namespace enumeration is the deferred
+        // getTopLevelDataKeys local-only edge → inherited keys are invisible to it.
+        expect(config.auth.host).toBe(TIER1_DEFAULTS.auth.host);
+        expect(config.auth.port).toBe(TIER1_DEFAULTS.auth.port);
+        expect(config.auth.realm).toBe(TIER1_DEFAULTS.auth.realm);
+        expect(config.auth.issuerUrl).toBe(TIER1_DEFAULTS.auth.issuerUrl);
+        expect(config.auth.clientId).toBe(TIER1_DEFAULTS.auth.clientId);
+        expect(config.auth.clientSecret).toBe(TIER1_DEFAULTS.auth.clientSecret);
+        expect(config.auth.trustProxyIdentity).toBe(TIER1_DEFAULTS.auth.trustProxyIdentity);
         expect(config.backupPath).toBe(TIER1_DEFAULTS.backupPath);
+
+        // KB-local leaves: Chroma host/port stay local top-level aliases (pending the S3/S4
+        // consumer codemod to engines.chroma.*); collection + path are genuinely KB-owned.
         expect(config.host).toBe(TIER1_DEFAULTS.engines.chroma.host);
         expect(config.port).toBe(TIER1_DEFAULTS.engines.chroma.port);
-
         expect(config.collectionName).toBe('neo-knowledge-base');
         expect(config.path).toContain('.neo-ai-data/chroma/knowledge-base');
     });
 
-    test('env overrides remain final after Tier-1 default mapping', () => {
-        process.env.NEO_AUTH_REALM = 'tenant-realm';
-        process.env.NEO_BACKUP_PATH = '/tmp/neo-kb-backups';
+    test('env overrides win — KB-local leaves at the child, Tier-1-owned leaves at the owner (inherited)', () => {
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
+        process.env.NEO_AUTH_REALM  = 'tenant-realm';
+        process.env.NEO_BACKUP_PATH = '/tmp/neo-kb-backups';
 
-        // Build a FRESH isolated instance (env set above) instead of re-constructing the
-        // shared module-cached singleton, whose reactive state is contaminated by sibling
-        // specs in the parallel suite. config._data carries the raw Tier-1 meta-leaf tree.
-        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        // KB-LOCAL leaves (Chroma host/port) — env applies at the CHILD instance directly.
+        // Fresh isolated instance (not the module-cached singleton, whose reactive state is
+        // contaminated by sibling specs). config._data carries the raw KB meta-leaf tree.
+        const freshKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
 
-        expect(freshCfg.auth.realm).toBe('tenant-realm');
-        expect(freshCfg.backupPath).toBe('/tmp/neo-kb-backups');
-        expect(freshCfg.host).toBe('chroma');
-        expect(freshCfg.port).toBe(8010);
+        // TIER-1-OWNED leaves (auth.*, backupPath) — post-split the child no longer declares them,
+        // so env precedence lives at the OWNER. Build a fresh realm root WITH the env set and
+        // register it so the child inherits the override up the getParent() chain.
+        const prevRoot  = Neo.ai?.Config;
+        const freshRoot = Neo.create(BaseConfig, {data: Neo.ai.Config._data});
+        Neo.ai.Config   = freshRoot;
 
-        freshCfg.destroy();
+        try {
+            expect(freshKB.host).toBe('chroma');                    // KB-local, env at child
+            expect(freshKB.port).toBe(8010);                        // KB-local, env at child
+            expect(freshKB.auth.realm).toBe('tenant-realm');        // Tier-1-owned, env at owner → inherited
+            expect(freshKB.backupPath).toBe('/tmp/neo-kb-backups'); // Tier-1-owned → inherited
+        } finally {
+            if (prevRoot === undefined) {delete Neo.ai.Config} else {Neo.ai.Config = prevRoot}
+            freshKB.destroy();
+            freshRoot.destroy()
+        }
     });
 });

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -34,7 +34,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
 
         config = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
 
-        // Deterministic realm root (#12166): KB now inherits backupPath / auth.* /
+        // Deterministic realm root: KB now inherits backupPath / auth.* /
         // dummyEmbeddingFunction from Tier-1 via the getParent() chain. The template import registers
         // Neo.ai.Config only on first module-eval, so install a fresh Tier-1 root to keep inheritance
         // deterministic across reused Playwright workers.
@@ -80,7 +80,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
     });
 
     test('inherits Tier-1 auth + backupPath via the realm chain; keeps KB-local Chroma + collection', () => {
-        // #12166: auth.* and backupPath are no longer declared locally — they resolve UP the
+        // auth.* and backupPath are no longer declared locally — they resolve UP the
         // getParent() chain to the Tier-1 realm root. Read them KEYED, never as a whole namespace:
         // `toEqual(config.auth)` would enumerate, and namespace enumeration is the deferred
         // getTopLevelDataKeys local-only edge → inherited keys are invisible to it.

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -37,7 +37,7 @@ test.describe('Memory Core Config (#10010)', () => {
 
         config = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
 
-        // Deterministic realm root: MC declares no realm leaves locally (#12166) and inherits them
+        // Deterministic realm root: MC declares no realm leaves locally and inherits them
         // up the getParent() chain, so these tests need Neo.ai.Config present. The MC template's
         // side-effect import only registers it on FIRST module-eval — in a reused Playwright worker
         // (cached module) that's a no-op — so install a fresh Tier-1 root built from the canonical
@@ -90,7 +90,7 @@ test.describe('Memory Core Config (#10010)', () => {
     });
 
     test('inherits deployment-wide Tier-1 defaults (provider, auth, ollama, openAiCompatible, storage) via the realm chain', () => {
-        // #12166: MC declares none of these locally — they resolve UP the getParent() chain to the
+        // MC declares none of these locally — they resolve UP the getParent() chain to the
         // Tier-1 realm root. Read KEYED, never whole-namespace: `toEqual(config.ollama)` would
         // enumerate, and namespace enumeration is the deferred getTopLevelDataKeys local-only edge.
         expect(config.modelProvider).toBe(TIER1_DEFAULTS.modelProvider);
@@ -140,7 +140,7 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
 
-        // Post-split (#12166) MC declares none of these locally — they are Tier-1-owned, so env
+        // Post-split, MC declares none of these locally — they are Tier-1-owned, so env
         // precedence lives at the OWNER. Build a fresh realm root WITH the env set, register it, and
         // a fresh MC child inherits the overrides up the getParent() chain. (config._data is the raw
         // MC meta-leaf tree; Neo.ai.Config._data is the Tier-1 realm tree, loaded via MC's import.)

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -36,6 +36,15 @@ test.describe('Memory Core Config (#10010)', () => {
         }
 
         config = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
+
+        // Deterministic realm root: MC declares no realm leaves locally (#12166) and inherits them
+        // up the getParent() chain, so these tests need Neo.ai.Config present. The MC template's
+        // side-effect import only registers it on FIRST module-eval — in a reused Playwright worker
+        // (cached module) that's a no-op — so install a fresh Tier-1 root built from the canonical
+        // template tree, making inheritance deterministic across workers.
+        const tier1Template = (await import('../../../../../../../ai/config.template.mjs')).default;
+        Neo.ai = Neo.ai || {};
+        Neo.ai.Config = Neo.create(BaseConfig, {data: tier1Template._data});
     });
 
     test.afterAll(() => {
@@ -80,24 +89,35 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.memorySharing.defaultPolicy).toBe('legacy');
     });
 
-    test('maps deployment-wide Tier-1 defaults for provider, auth, and storage groups', () => {
+    test('inherits deployment-wide Tier-1 defaults (provider, auth, ollama, openAiCompatible, storage) via the realm chain', () => {
+        // #12166: MC declares none of these locally — they resolve UP the getParent() chain to the
+        // Tier-1 realm root. Read KEYED, never whole-namespace: `toEqual(config.ollama)` would
+        // enumerate, and namespace enumeration is the deferred getTopLevelDataKeys local-only edge.
         expect(config.modelProvider).toBe(TIER1_DEFAULTS.modelProvider);
         expect(config.graphProvider).toBe(TIER1_DEFAULTS.graphProvider);
         expect(config.embeddingProvider).toBe(TIER1_DEFAULTS.embeddingProvider);
-        expect(config.ollama).toEqual(TIER1_DEFAULTS.ollama);
-        expect(config.openAiCompatible).toEqual(TIER1_DEFAULTS.openAiCompatible);
         expect(config.vectorDimension).toBe(TIER1_DEFAULTS.vectorDimension);
         expect(config.backupPath).toBe(TIER1_DEFAULTS.backupPath);
         expect(config.modelName).toBe(TIER1_DEFAULTS.modelName);
         expect(config.embeddingModel).toBe(TIER1_DEFAULTS.embeddingModel);
 
-        expect(config.auth).toEqual(TIER1_DEFAULTS.auth);
-        expect(config.engines.chroma).toMatchObject({
-            host: TIER1_DEFAULTS.engines.chroma.host,
-            port: TIER1_DEFAULTS.engines.chroma.port
-        });
-        // MC reads the unified persist-dir SSOT (`AiConfig.engines.chroma.dataDir`),
-        // not a server-local dir. Was the stale `.neo-ai-data/chroma/memory-core` — the bug.
+        expect(config.auth.host).toBe(TIER1_DEFAULTS.auth.host);
+        expect(config.auth.port).toBe(TIER1_DEFAULTS.auth.port);
+        expect(config.auth.realm).toBe(TIER1_DEFAULTS.auth.realm);
+        expect(config.auth.trustProxyIdentity).toBe(TIER1_DEFAULTS.auth.trustProxyIdentity);
+
+        expect(config.ollama.host).toBe(TIER1_DEFAULTS.ollama.host);
+        expect(config.ollama.model).toBe(TIER1_DEFAULTS.ollama.model);
+        expect(config.ollama.embeddingModel).toBe(TIER1_DEFAULTS.ollama.embeddingModel);
+
+        expect(config.openAiCompatible.host).toBe(TIER1_DEFAULTS.openAiCompatible.host);
+        expect(config.openAiCompatible.model).toBe(TIER1_DEFAULTS.openAiCompatible.model);
+        expect(config.openAiCompatible.embeddingModel).toBe(TIER1_DEFAULTS.openAiCompatible.embeddingModel);
+
+        expect(config.engines.chroma.host).toBe(TIER1_DEFAULTS.engines.chroma.host);
+        expect(config.engines.chroma.port).toBe(TIER1_DEFAULTS.engines.chroma.port);
+        // MC reads the unified persist-dir SSOT, not a server-local dir.
+        // Was the stale `.neo-ai-data/chroma/memory-core` — the bug.
         expect(config.engines.chroma.dataDir).toBe(TIER1_DEFAULTS.engines.chroma.dataDir);
         expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/knowledge-base');
     });
@@ -120,27 +140,32 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
 
-        // Env is decoded at construction via #applyEnvLayer. Build a FRESH isolated
-        // instance (env set above) instead of re-constructing the shared module-cached
-        // singleton, whose reactive state is contaminated by sibling specs in the parallel
-        // suite. config._data carries the raw Tier-1 meta-leaf tree.
-        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        // Post-split (#12166) MC declares none of these locally — they are Tier-1-owned, so env
+        // precedence lives at the OWNER. Build a fresh realm root WITH the env set, register it, and
+        // a fresh MC child inherits the overrides up the getParent() chain. (config._data is the raw
+        // MC meta-leaf tree; Neo.ai.Config._data is the Tier-1 realm tree, loaded via MC's import.)
+        const prevRoot  = Neo.ai?.Config;
+        const freshRoot = Neo.create(BaseConfig, {data: Neo.ai.Config._data});
+        Neo.ai.Config   = freshRoot;
+        const freshMC   = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
 
-        expect(freshCfg.modelProvider).toBe('openAiCompatible');
-        expect(freshCfg.graphProvider).toBe('ollama');
-        expect(freshCfg.embeddingProvider).toBe('ollama');
-        expect(freshCfg.auth.realm).toBe('tenant-realm');
-        expect(freshCfg.backupPath).toBe('/tmp/neo-memory-backups');
-        expect(freshCfg.ollama.keep_alive).toBe(0);
-        expect(freshCfg.ollama.requireParallelModels).toBe(3);
-        expect(freshCfg.openAiCompatible.keep_alive).toBe('10m');
-        expect(freshCfg.openAiCompatible.requireParallelModels).toBe(4);
-        expect(freshCfg.engines.chroma).toMatchObject({
-            host: 'chroma',
-            port: 8010
-        });
-
-        freshCfg.destroy();
+        try {
+            expect(freshMC.modelProvider).toBe('openAiCompatible');
+            expect(freshMC.graphProvider).toBe('ollama');
+            expect(freshMC.embeddingProvider).toBe('ollama');
+            expect(freshMC.auth.realm).toBe('tenant-realm');
+            expect(freshMC.backupPath).toBe('/tmp/neo-memory-backups');
+            expect(freshMC.ollama.keep_alive).toBe(0);
+            expect(freshMC.ollama.requireParallelModels).toBe(3);
+            expect(freshMC.openAiCompatible.keep_alive).toBe('10m');
+            expect(freshMC.openAiCompatible.requireParallelModels).toBe(4);
+            expect(freshMC.engines.chroma.host).toBe('chroma');
+            expect(freshMC.engines.chroma.port).toBe(8010);
+        } finally {
+            if (prevRoot === undefined) {delete Neo.ai.Config} else {Neo.ai.Config = prevRoot}
+            freshMC.destroy();
+            freshRoot.destroy()
+        }
     });
 
     test('NEO_MEMORY_SHARING_DEFAULT_POLICY env override parses correctly', () => {


### PR DESCRIPTION
Resolves #12166
Related: #12101

Stage 2 of the aiConfig parent-chain epic: the per-server config snapshots of deployment-wide realm leaves are removed so Knowledge Base + Memory Core inherit them from the Tier-1 root (`Neo.ai.Config`) through the `BaseConfig.getParent()` chain (added in Stage 1, this branch). This resolves the `dummyEmbeddingFunction` child-snapshot anti-pattern and eliminates ~40 duplicated leaf declarations across the two servers, with no change to how any consumer reads its config (`ServerConfig.x.y` resolves up the chain, keyed/dotted).

Authored by Claude Opus 4.8 (Claude Code). Session 653970c8-8466-4609-8a15-28350234af10.

FAIR-band: over-target — operator-directed, in-session continuation of the #12101 epic ("let us continue!"); this is the in-flight lane I authored end-to-end across Stage 1 + Stage 2, not a new-lane pickup, so over-target-with-rationale applies (not a yield candidate).

Evidence: L2 (node smoke — KB + MC inherit the realm via `createConfigProxy` → `getParent` chain, env-cleared so defaults prove inheritance not passthrough; + targeted unit suites green, see Test Evidence) → L2 required (close-target ACs are config-shape + chain-resolution, fully unit+smoke coverable; the operator separately runtime-confirmed the live orchestrator boots on this realm at qwen3-8b/4096). No residuals.

## Changed config keys (per mcp-config-template-change-guide)
- **knowledge-base/config.template.mjs** — removed (now inherited from Tier-1): `backupPath`, `auth.{host,port,realm,issuerUrl,clientId,clientSecret,trustProxyIdentity}`, `dummyEmbeddingFunction`. Kept local (path-mismatched top-level chroma aliases, pending the S3/S4 consumer-read codemod): `host`, `port`, `path` (+ retains `import AiConfig`).
- **memory-core/config.template.mjs** — removed (now inherited): `auth.*`, `modelProvider`, `graphProvider`, `embeddingProvider`, `ollama.*`, `openAiCompatible.*`, `localModels`, `vectorDimension`, `modelName`, `embeddingModel`, `engines.chroma.*`, `backupPath`. `import AiConfig` → bare side-effect import (loads the Tier-1 realm root for the chain; no value snapshot).
- **scripts/setup/initServerConfigs.mjs** — `materializeServerConfigTemplate` extended to rewrite side-effect Tier-1 imports (template → overlay) so the generated MC runtime `config.mjs` points at the operator overlay.

**Local config.mjs follow-up:** YES — see Post-Merge Validation. **Restart:** recommended after a config.mjs regen. **Gitignored config.mjs:** not committed (verified).

## Deltas from ticket (if any)
- **Ticket Fix §1 / avoided-traps amended (load-order):** the ticket assumed "runtime boot imports ai/config.mjs / no import edge." V-B-A of the KB + MC MCP-server import graphs falsified this — each server *process's* only Tier-1 load path was its config's `import AiConfig`. So MC keeps a bare side-effect import (no value snapshot ⇒ anti-pattern still resolved), and KB keeps its value import (still needed by the retained chroma aliases). This mooted the originally-floated "side-effect-import everywhere" option.
- **Chroma deferred to S3/S4:** KB exposes chroma at top-level `host`/`port`/`path` while Tier-1 owns `engines.chroma.*`; the chain resolves by exact path, so collapsing them is a consumer-read change (S3/S4 codemod), out of #12166 scope. KB therefore retains those 3 snapshots + `import AiConfig`. MC keeps `engines.chroma.*` nested (same path) → fully inherited.
- **Enumeration-asymmetry is real for tests:** facet-9 ("no runtime consumer enumerates a shared namespace") held, but the #11963 / #10010 config specs DID enumerate (`toEqual(config.auth)`) — rewritten to keyed assertions. The deferred `getTopLevelDataKeys` merge remains a documented latent hazard.
- **getParent blast-radius:** the Stage-1 override makes every fresh `BaseConfig` inherit the registered realm root; `Orchestrator.invariants` mlx/lms undefined-safe tests now detach the root to simulate a genuinely-missing namespace. Config specs install a deterministic Tier-1 root in `beforeAll` (the template side-effect import only registers `Neo.ai.Config` on first module-eval → reused Playwright workers would otherwise see it unset).

## Test Evidence
`npm run test-unit` (targeted), all green:
- `BaseConfig.spec` 17/17; `config.template.spec` (Tier-1) 5/5; KB `config.template.spec` 2/2; MC `config.template.spec` 6/6.
- Consumers 24/24: `SemanticGraphExtractor`, `SessionService`, `ChromaManager`, KB + MC `DatabaseService`.
- `daemons/orchestrator` (incl. `Orchestrator.invariants`) + `initServerConfigs.spec` — 406 passed; `ConfigCompleteness` 5/5.
- node smoke (env-cleared): KB inherits `auth.realm=master` / `dummyEmbeddingFunction.name` / `backupPath`; MC inherits the full realm incl. `localModels.chat.contextLimitTokens=262144` + `engines.chroma.host=localhost`; both via `createConfigProxy` → `getParent`. Materializer rewrites MC's side-effect import → overlay.

## Post-Merge Validation
- [ ] Operators regenerate local `config.mjs` to ADOPT the dedup (config.mjs then inherits from Tier-1). NOTE: `--migrate-config` will NOT auto-trigger — this is a leaf-body change (KB) / side-effect-import change (MC), neither captured by the import-shape `detectDrift` (the S0 #12102 fragility). The stale `config.mjs` stays FUNCTIONAL (retains local snapshots + still loads Tier-1) ⇒ **no boot-break**. To adopt, force-regenerate the gitignored `config.mjs` from templates, then restart.
- [ ] All three core clones (Claude / GPT / Gemini) force-regenerate + restart to adopt the inheriting shape.

## Commits
- `9256e9c0c` — Stage 1: `getParent()` override + cross-tier write validation + BaseConfig.spec tests.
- `18feed683` — Stage 2: realm split (KB + MC inherit) + materializer + config-spec + Orchestrator.invariants updates.

Decision Record impact: none (extends Epic #12101's "extend Provider, don't reinvent" mandate; the ticket's load-order assumption is corrected in Deltas).
