### PR TITLE
chore(content): remove retired issue-archive/pr-archive references (#12177)

### DIFF
--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -19,8 +19,6 @@ const generatedSyncPaths = [
     'resources/content/pulls/',
     'resources/content/release-notes/',
     'resources/content/archive/',
-    'resources/content/issue-archive/',
-    'resources/content/pr-archive/',
     'resources/content/_index.json',
     'resources/content/.sync-metadata.json'
 ];

--- a/buildScripts/release/publish.mjs
+++ b/buildScripts/release/publish.mjs
@@ -241,13 +241,10 @@ async function main() {
 
     // Commit Archived Tickets
     //
-    // Per Epic #11187 7-bucket fan-out: `GH_SyncService.runFullSync()` above writes
-    // archived items to the new lazy-ordinal-chunked shape via `archivePath()` helper
-    // (canonical: `resources/content/archive/{type}/v*/{flat|chunk-N}/`). Legacy paths
-    // (`resources/content/issue-archive/`, `resources/content/pr-archive/`) remain
-    // tracked during the migration transition until the data corpus fully migrates
-    // (B1/AC8/B5 lanes). The `git add .` below is intentionally broad to capture both
-    // new archive/ moves AND any residual legacy-path moves during transition.
+    // `GH_SyncService.runFullSync()` above writes archived items to the universal
+    // ordinal-100 chunked shape (`resources/content/archive/{type}/v*/chunk-N/`).
+    // The `git add .` below is intentionally broad to capture the archive/ moves plus
+    // the `_index.json` / `.sync-metadata.json` updates produced by the sync.
     console.log('💾 Committing archived tickets...');
     const status = runCommandWithOutput('git status --porcelain');
 

--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -63,8 +63,6 @@ const generatedSyncPaths = [
     'resources/content/pulls/',
     'resources/content/release-notes/',
     'resources/content/archive/',
-    'resources/content/issue-archive/',
-    'resources/content/pr-archive/',
     'resources/content/_index.json',
     'resources/content/.sync-metadata.json'
 ];

--- a/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
@@ -83,8 +83,6 @@ test.describe('check-chore-sync.mjs', () => {
             'resources/content/pulls/chunk-1/pr-1.md',
             'resources/content/release-notes/chunk-1/v1.0.0.md',
             'resources/content/archive/issues/v1.0.0/chunk-1/issue-2.md',
-            'resources/content/issue-archive/chunk-1/issue-3.md',
-            'resources/content/pr-archive/chunk-1/pr-2.md',
             'resources/content/_index.json',
             'resources/content/.sync-metadata.json'
         ].forEach(stageFile);


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), operating as the @neo-opus-4-7 swarm identity. Session: worktree `claude/silly-goldberg-5aa653`.

FAIR-band: over-target [22/30] — operator-directed (tobiu directed the neo-first ADR-0004 Phase-2 cleanup); cross-family review effectively unavailable this window (gpt rate-limited reviews-only, gemini benched).

Resolves #12177

Removes the retired `issue-archive/`/`pr-archive/` references left behind after ADR 0004's clean-slate chunk-N migration. Those dirs no longer exist on disk, so the refs were dead: two duplicated `generatedSyncPaths` defensive lists (`SyncService.mjs`, `check-chore-sync.mjs`) carried entries that can never match, and `publish.mjs` carried a stale comment claiming the migration is still "in transition." Cleaned all three, plus the matching legacy staged paths in `check-chore-sync.spec.mjs`.

**Micro-change exemption (§6.1):** `chore` + 17 lines changed + zero runtime impact (dead entries never matched; comment + test-only edits). Flagging so this need not consume @neo-gpt's rate-limited review capacity — merge remains @tobiu's call.

Evidence: L2 (ran the 2 affected specs under the unit config — 16/16 pass; grep confirms no live `issue-archive`/`pr-archive` code refs remain) → L2 required (no runtime-only ACs). No residuals.

## Deltas from ticket

The ticket body overcounted; V-B-A refined the real scope:
- **TicketSource.mjs was already clean** — no ref present (4 files → 3).
- **LocalFileService has NO legacy-read logic** (grep-confirmed) — it's index-only per ADR 0004 §3.2. `LocalFileService.spec.mjs:105`'s `issue-archive/88xx` path is a **deliberate negative-assertion fixture** (test: *"getIssueById does not probe retired legacy paths"*) and was **left intact**.
- Removing the `check-chore-sync.mjs` entries required a **coordinated `check-chore-sync.spec.mjs` update** (dropped the 2 legacy staged paths) — not flagged in the ticket.
- Note (out of scope): `generatedSyncPaths` is **duplicated verbatim** across `SyncService.mjs` + `check-chore-sync.mjs` — a DRY smell worth a future dedup ticket.

## Test Evidence

- `UNIT_TEST_MODE=true playwright -c test/playwright/playwright.config.unit.mjs check-chore-sync.spec.mjs LocalFileService.spec.mjs` → **16 passed**.
- `LocalFileService.spec` initially failed on a missing gitignored `config.mjs`; hydrated via `bootstrapWorktree.mjs` (worktree-env, not a regression) → green.
- `grep -rn "issue-archive|pr-archive" ai/ buildScripts/ src/` (non-test) → **CLEAN**; only the intentional `LocalFileService.spec` negative-fixture remains under `test/`.
- `check-whitespace` + `check-shorthand` pre-commit hooks pass.

## Related

- Parent epic: #11372 (ADR 0004), Phase 1 §9 item 9 (stale-reference cleanup — code side)
- Config-fallback removal (distinct surface): #11363
- Sibling release-index fix (merged): #12176 / #12178
- Authority: `learn/agentos/decisions/0004-github-content-architecture.md` §2.3, §2.6
