### PR TITLE
docs(ai): aiConfig hierarchical-nested-data model guide + BaseConfig @see (#12102)

### DIFF
--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -79,8 +79,15 @@ export function leaf(defaultValue, env = null, type = null) {
  * Env precedence is **bounded** (re-resolved at construct / {@link setEnvOverride} / {@link load} /
  * {@link refreshEnv}), NOT live-per-read — see {@link #applyEnvLayer} for the rationale.
  *
+ * Configs compose into a **hierarchical realm**: the Tier-1 singleton `Neo.ai.Config` is the root
+ * and every per-server config is its child via the {@link getParent} override. Each layer declares
+ * only the leaves it owns and inherits the rest up the chain — so an operator overlay is a *thin
+ * child* of its template, never a clone, and bringing it up to a newer template is inheritance, not
+ * a source-level merge.
+ *
  * @class Neo.ai.BaseConfig
  * @extends Neo.state.Provider
+ * @see learn/agentos/AiConfigModel.md — the hierarchical-nested-data model + its rationale
  */
 class BaseConfig extends Provider {
     static config = {

--- a/learn/agentos/AiConfigModel.md
+++ b/learn/agentos/AiConfigModel.md
@@ -1,0 +1,48 @@
+# The aiConfig configuration model
+
+> The Brain's configuration (`aiConfig`) is **hierarchical nested data**: a tree of `Neo.state.Provider`s where each layer owns only its slice and inherits the rest up a parent chain. This page is the *intent* behind that shape. Read it before changing how config is loaded, merged, or migrated — the model quietly makes several "obvious" approaches (source-level drift detection, overlay cloning, hand-written merge) the **wrong layer**.
+
+## The shape
+
+`Neo.ai.BaseConfig extends Neo.state.Provider`, so every config *is* a reactive state provider, and they compose into one tree:
+
+- **Tier-1 — `Neo.ai.Config`** (singleton): the *realm root*. It owns the deployment-wide leaves — model providers, `auth`, `ollama` / `openAiCompatible`, storage, the orchestrator intervals.
+- **Per-server configs — `Neo.ai.mcp.server.<name>.Config`**: children of the realm root. Each owns only the leaves that are genuinely server-local — the Knowledge Base's `collectionName`, the Memory Core's `memorySharing`, and so on.
+
+A child resolves a leaf it does not own by walking **up** to the owner: `getOwnerOfDataProperty` checks the local data first, then delegates to `getParent()`. The Brain has no component tree, so `ai/BaseConfig.mjs` overrides `getParent()` to return the Tier-1 singleton — that override is what roots the realm chain.
+
+This is the same hierarchy the Body uses for component state providers. The canonical illustration lives in [examples/stateProvider/advanced](../../examples/stateProvider/advanced/MainContainer.mjs): a `Panel` reads `button1Text` that only the top-level `Viewport` owns (the lookup walks up), and a write to `button1Text` *initiated on the Panel* bubbles up and lands on the `Viewport`'s provider, which owns it.
+
+Two properties fall out of "each layer owns only its slice":
+
+1. **Reads resolve override-else-inherit, lazily, per key.** No layer holds a copy of another layer's data.
+2. **Writes bubble to the owner.** `setData('auth.realm', …)` on a server config lands on Tier-1, because Tier-1 owns `auth`.
+
+## Leaves and the env layer
+
+A config's `data` is a *meta-leaf tree* — each leaf is `leaf(default, env?, type?)`. `BaseConfig.compileMetaLeaves` walks it into (a) plain reactive data and (b) a metadata registry keyed by dotted path. A bounded **env layer** then overlays environment variables onto env-bound leaves — re-resolved at construction and on explicit refresh, never live-per-read (a port that silently moves without a coordinated restart is a footgun, not a feature). See `ai/BaseConfig.mjs`.
+
+## Templates, overlays, and why advancement is *inheritance*
+
+Each config exists as a pair: a tracked `config.template.mjs` (the canonical defaults) and a gitignored `config.mjs` (the operator overlay). The overlay's job is to carry the operator's **deltas** — nothing more.
+
+The trap — and the reason this page exists — is to treat the overlay as a **clone** of the template that must be kept in sync as the template evolves. Down that road lie source-level drift detectors (regex-parsing `.mjs` text for leaf paths) and source-level merges (splicing new leaves into the operator's file, normalizing commas and indentation). **That is the wrong layer.** A config is not text to diff and splice; it is a mergeable data tree the Provider already resolves hierarchically and merges deeply:
+
+- `data_` is a `merge: 'deep'` descriptor — *"when new data is assigned, it will be deeply merged with existing data."*
+- `setData(obj)` recursively merges an object into the reactive tree, creating missing leaves and keeping existing ones.
+- `load()` merges a JSON overlay into reactive data the same way.
+
+So the model that follows from the hierarchy:
+
+- An overlay **owns only the operator's overrides** and inherits everything else from its canonical parent. It cannot go "stale": a template that grows a leaf is inherited automatically, because the new leaf lives in the parent, not in a frozen copy.
+- "Advancing" an overlay to a newer template is therefore **not an operation at all** — there is nothing to reconcile. Operator overrides persist as the child's own data; new defaults arrive by inheritance.
+- The override channels are the **env layer** (bounded env vars) and the **overlay's own data** (operator deltas, including a JSON delta via `load()`).
+
+The one-line test: **if you are parsing or rewriting config *source* to reconcile a template and an overlay, stop.** You are re-implementing — by hand, and fragilely — a deep-merge the framework already performs on the data tree, against a clone that should never have existed.
+
+## Related
+
+- [examples/stateProvider/advanced](../../examples/stateProvider/advanced/MainContainer.mjs) — the canonical hierarchical-state illustration (read up, write-to-owner).
+- [src/state/Provider.mjs](../../src/state/Provider.mjs) — `getOwnerOfDataProperty`, owner-routed `setData` / `internalSetData`, and the `data_` `merge: 'deep'` descriptor.
+- [ai/BaseConfig.mjs](../../ai/BaseConfig.mjs) — the meta-leaf compile, the bounded env layer, and the `getParent()` override that roots the realm chain.
+- [Cloud-Native KB Ingestion — Configuration](./cloud-deployment/Configuration.md) — the operator-facing config keys this model carries.


### PR DESCRIPTION
## Summary

Captures the **aiConfig configuration model** as intent-driven documentation, so the next session inherits the conclusion instead of re-deriving it. It surfaced while picking up Stage 0 (#12102): re-reading `state.Provider` + the `BaseConfig` proxy showed the source-level drift/merge approach is the **wrong layer** — aiConfig is hierarchical nested data, and the Provider already deep-merges it.

The model: a tree of `state.Provider`s (the Tier-1 realm root `Neo.ai.Config` + per-server children via `getParent`), each owning only its slice; reads walk up to the owner, writes bubble to the owner. So an operator overlay is a **thin child** of its template, never a clone — advancing it is inheritance, not a source merge.

## Deltas

- `learn/agentos/AiConfigModel.md` (new) — the model + the source-merge anti-pattern it rules out, closing on the test *"if you're parsing or rewriting config source to reconcile a template and an overlay, stop."*
- `ai/BaseConfig.mjs` — the class JSDoc gains the hierarchical-realm intent + a `@see` link to the guide.

## Test Evidence

Documentation-only; no runtime logic changed.

- `node --check ai/BaseConfig.mjs` passes (JSDoc-only edit).
- The guide's four relative links resolve to real files: `examples/stateProvider/advanced/MainContainer.mjs`, `src/state/Provider.mjs`, `ai/BaseConfig.mjs`, `learn/agentos/cloud-deployment/Configuration.md`.

## Post-Merge Validation

None required — no behavior change. Discoverability: the guide is reachable via the `@see` on `Neo.ai.BaseConfig` + grep/KB; it intentionally stays out of `learn/tree.json` (agent-facing architecture intent, like its `ConfigSubstrate*` / `v13-path` neighbours).

Evidence: the model is grounded in `src/state/Provider.mjs` (`data_` `merge: 'deep'` lines 47/61, owner-routed `internalSetData`, `getOwnerOfDataProperty`) and `ai/BaseConfig.mjs` (the `getParent` override + `compileMetaLeaves`).

FAIR-band: n/a — operator-directed documentation.

Refs #12102 — its source-merge prescription is retired; the thin-child overlay *implementation* (a `config.mjs` that is a thin child rather than a materialized clone) is high-blast follow-on to scope with the epic.

Authored by Claude Opus 4.8 (Claude Code, 1M context).
