### PR TITLE
refactor(ai): Stage-4 consumer codemod — Proxy-routed reads + scalar/tenant hidden-default removal (#12106)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -125,7 +125,7 @@ class DreamService extends Base {
             await LifecycleService._initPromise;
         }
 
-        if (aiConfig.data.autoDream) {
+        if (aiConfig.autoDream) {
             logger.info('[Startup] DreamService: Checking for undigested session memories...');
             this.processUndigestedSessions().catch(e => logger.error('[Startup] DreamService failed:', e));
         }

--- a/ai/mcp/client/mcp-cli.mjs
+++ b/ai/mcp/client/mcp-cli.mjs
@@ -36,7 +36,7 @@ const options = program.opts();
 
 // Apply debug flag immediately
 if (options.debug) {
-    aiConfig.data.debug = true;
+    aiConfig.debug = true;
 }
 
 async function run() {

--- a/ai/mcp/server/github-workflow/mcp-server.mjs
+++ b/ai/mcp/server/github-workflow/mcp-server.mjs
@@ -21,7 +21,7 @@ const options = program.opts();
 
 // Apply debug flag immediately
 if (options.debug) {
-    aiConfig.data.debug = true;
+    aiConfig.debug = true;
 }
 
 try {

--- a/ai/mcp/server/gitlab-workflow/mcp-server.mjs
+++ b/ai/mcp/server/gitlab-workflow/mcp-server.mjs
@@ -20,7 +20,7 @@ program
 const options = program.opts();
 
 if (options.debug) {
-    aiConfig.data.debug = true;
+    aiConfig.debug = true;
 }
 
 try {

--- a/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
+++ b/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
@@ -72,7 +72,7 @@ const ingestSourceFilesViaMcp = async args => {
     const
         files     = Array.isArray(args?.files) ? args.files : [],
         batchSize = files.reduce((sum, file) => sum + (Array.isArray(file?.parsedChunks) ? file.parsedChunks.length : 1), 0),
-        threshold = aiConfig.mcpSyncMaxChunks ?? 50;
+        threshold = aiConfig.mcpSyncMaxChunks;
 
     if (batchSize > threshold) {
         return {

--- a/ai/mcp/server/knowledge-base/mcp-server.mjs
+++ b/ai/mcp/server/knowledge-base/mcp-server.mjs
@@ -21,7 +21,7 @@ const options = program.opts();
 
 // Apply debug flag immediately
 if (options.debug) {
-    aiConfig.data.debug = true;
+    aiConfig.debug = true;
 }
 
 try {

--- a/ai/mcp/server/memory-core/mcp-server.mjs
+++ b/ai/mcp/server/memory-core/mcp-server.mjs
@@ -21,7 +21,7 @@ const options = program.opts();
 
 // Apply debug flag immediately
 if (options.debug) {
-    aiConfig.data.debug = true;
+    aiConfig.debug = true;
 }
 
 try {

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -22,7 +22,7 @@ const options = program.opts();
 
 // Apply debug flag immediately
 if (options.debug) {
-    aiConfig.data.debug = true;
+    aiConfig.debug = true;
 }
 
 try {

--- a/ai/mcp/server/neural-link/run-bridge.mjs
+++ b/ai/mcp/server/neural-link/run-bridge.mjs
@@ -18,7 +18,7 @@ program
 const options = program.opts();
 
 if (options.debug) {
-    aiConfig.data.debug = true;
+    aiConfig.debug = true;
 }
 
 (async () => {

--- a/ai/services/graph/GapInferenceEngine.mjs
+++ b/ai/services/graph/GapInferenceEngine.mjs
@@ -44,7 +44,7 @@ const ISO_VERIFIED_AT_PATTERN = /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}\.\d{3}Z
  *      (logger is ephemeral; the graph + handoff is the durable substrate).
  *    - `[KB_DEMAND_GAP]` — repeated agent questions from the Knowledge Base FAQ telemetry
  *      table map to this concept, but the FAQ cluster still lacks strong guide coverage.
- *    The three coverage signals share the `aiConfig.data.guideGapWeightThreshold` gate
+ *    The three coverage signals share the `aiConfig.guideGapWeightThreshold` gate
  *    (config-lifted for curator tuning; defaults to `0.8` = tier-1 baseline).
  *    `[CONCEPT_REVERIFY_DUE]` is not weight-gated because freshness review is a curation
  *    cadence, not a severity claim. Low-priority concepts may need review without becoming
@@ -157,7 +157,7 @@ class GapInferenceEngine extends Base {
      *   to live in `ConceptIngestor` — routing through `capabilityGap` + `sandman_handoff.md`
      *   makes the signal durable and aggregatable.
      *
-     * The three coverage signals share the same `aiConfig.data.guideGapWeightThreshold` weight gate
+     * The three coverage signals share the same `aiConfig.guideGapWeightThreshold` weight gate
      * (default `0.8` = tier-1 baseline; config-lifted for curator tuning). Lower-weight
      * concepts (tier-3 without uniqueness or coverage deficit lift) are considered low-priority —
      * missing guides/examples/implementations for them aren't worth surfacing in the handoff at
@@ -192,7 +192,7 @@ class GapInferenceEngine extends Base {
 
         // Resolved once per cycle (not per concept) — the config value is read at gate time so
         // mid-cycle config mutations in tests / runtime take effect without re-importing.
-        const threshold = aiConfig.data.guideGapWeightThreshold ?? 0.8;
+        const threshold = aiConfig.guideGapWeightThreshold;
 
         for (const concept of conceptNodes) {
             // Unvalidated concepts (candidates from ConceptDiscoveryService awaiting curator

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -13,7 +13,7 @@ import {isGraphModelProviderSupported, resolveGraphModelProvider} from './provid
  * @param {Object} config
  * @returns {String|undefined}
  */
-export function getOpenAiCompatibleHost(config = aiConfig.data) {
+export function getOpenAiCompatibleHost(config = aiConfig) {
     return config.openAiCompatible?.host;
 }
 
@@ -348,7 +348,7 @@ export async function ensureLmsModelsLoaded({
  * @param {Object} config
  * @returns {Object}
  */
-export function getGraphProviderReadinessTarget(config = aiConfig.data) {
+export function getGraphProviderReadinessTarget(config = aiConfig) {
     const provider  = resolveGraphModelProvider(config);
     const supported = isGraphModelProviderSupported(provider);
 
@@ -669,7 +669,7 @@ export function assertProviderReadinessConfig(readinessConfig) {
  * @returns {Object}
  */
 export function createProviderFailureDiagnostic({
-    config = aiConfig.data,
+    config = aiConfig,
     waitResult,
     lifecycleStatus,
     reason = 'PROVIDER_READINESS_TIMEOUT'

--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -133,7 +133,7 @@ class ConceptDiscoveryService extends Base {
 
     /**
      * Instance-level override for the per-cycle PR cap. Tests mutate this directly for
-     * deterministic cap behavior; production falls back to `aiConfig.data.conceptDiscovery
+     * deterministic cap behavior; production falls back to `aiConfig.conceptDiscovery
      * .prScanLimit` so config is read at call time instead of module load.
      * @member {Number|null} prScanLimit=null
      */
@@ -154,15 +154,15 @@ class ConceptDiscoveryService extends Base {
      * @protected
      */
     async extractConceptsFromSource(sourceRef, text) {
-        const minSourceLength = aiConfig.data.conceptDiscovery?.minSourceLength ?? 200;
+        const minSourceLength = aiConfig.conceptDiscovery?.minSourceLength;
         if (!text || text.trim().length < minSourceLength) return [];
 
         let provider;
         try {
             provider = Neo.create(OpenAiCompatible, {
-                modelName: aiConfig.data.openAiCompatible?.model,
-                host     : aiConfig.data.openAiCompatible?.host,
-                keepAlive: aiConfig.data.openAiCompatible?.keep_alive
+                modelName: aiConfig.openAiCompatible?.model,
+                host     : aiConfig.openAiCompatible?.host,
+                keepAlive: aiConfig.openAiCompatible?.keep_alive
             });
         } catch (e) {
             logger.warn(`[ConceptDiscoveryService] OpenAiCompatible provider could not be constructed; skipping ${sourceRef}:`, e.message);
@@ -286,7 +286,7 @@ class ConceptDiscoveryService extends Base {
             return nb - na;
         });
 
-        const scanLimit   = this.prScanLimit ?? aiConfig.data.conceptDiscovery?.prScanLimit ?? 20;
+        const scanLimit   = this.prScanLimit ?? aiConfig.conceptDiscovery?.prScanLimit;
         const cappedFiles = files.slice(0, scanLimit);
         const sources     = [];
 

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -554,7 +554,7 @@ class DatabaseService extends Base {
         logger.info('[Startup] Checking knowledge base status...');
 
         try {
-            if (aiConfig.data.autoSync) {
+            if (aiConfig.autoSync) {
                 logger.info('[Startup] Starting full synchronization (Create + Embed)...');
                 await this.syncDatabase();
                 logger.info('✅ [Startup] Full synchronization complete.');

--- a/ai/services/knowledge-base/DocumentService.mjs
+++ b/ai/services/knowledge-base/DocumentService.mjs
@@ -54,7 +54,7 @@ class DocumentService extends Base {
         // QueryService.queryDocuments clause (inline per the memory-core MemoryService pattern).
         const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
         if (requesterTenantId) {
-            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId ?? 'neo-shared']}};
+            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId]}};
         }
 
         const results = await collection.get(getOptions);
@@ -94,7 +94,7 @@ class DocumentService extends Base {
         // error leaks no cross-tenant existence signal. Mirrors QueryService.queryDocuments.
         const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
         if (requesterTenantId) {
-            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId ?? 'neo-shared']}};
+            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId]}};
         }
 
         const result = await collection.get(getOptions);

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -124,7 +124,7 @@ class QueryService extends Base {
         // / offline daemon) → no tenant filter, byte-equivalent with pre-#11632 behavior.
         const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
         if (requesterTenantId) {
-            whereClause.tenantId = {$in: [requesterTenantId, aiConfig.defaultTenantId ?? 'neo-shared']};
+            whereClause.tenantId = {$in: [requesterTenantId, aiConfig.defaultTenantId]};
         }
 
         const queryOptions = {

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -85,8 +85,8 @@ class SearchService extends Base {
      * @returns {Boolean} True when local filesystem hydration is unsafe for this reference.
      */
     isNonLocalTenantReference(metadata = {}) {
-        const defaultTenantId = aiConfig.defaultTenantId ?? 'neo-shared';
-        const defaultRepoSlug = aiConfig.defaultRepoSlug ?? 'neo';
+        const defaultTenantId = aiConfig.defaultTenantId;
+        const defaultRepoSlug = aiConfig.defaultRepoSlug;
 
         if (metadata.repoSlug && metadata.repoSlug !== defaultRepoSlug) {
             return true;

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -589,7 +589,7 @@ class VectorService extends Base {
         // synchronously"); real latency is provider/tier/retry-state-dependent so
         // the threshold is empirically tunable rather than timing-derived.
         // CLI invocations pass viaMcp: false and bypass.
-        const mcpThreshold = aiConfig.mcpSyncMaxChunks ?? 50;
+        const mcpThreshold = aiConfig.mcpSyncMaxChunks;
         if (viaMcp && workVolume > mcpThreshold) {
             // Defensive log-path resolution mirrors logger.mjs's lazy resolution — keeps
             // the refusal message coherent even on existing gitignored config.mjs deployments

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -163,7 +163,7 @@ class GraphService extends Base {
             }
 
             // --- 3. FILE SYSTEM INGESTION (Differential Sync) ---
-            if (aiConfig.data.autoIngestFileSystem) {
+            if (aiConfig.autoIngestFileSystem) {
                 try {
                     logger.log('[GraphService] Bootstrapping FileSystem Ingestion Native Sync...');
                     const FileSystemIngestor = (await import('./FileSystemIngestor.mjs')).default;

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -299,7 +299,7 @@ class SessionService extends Base {
             return;
         }
 
-        if (aiConfig.data.autoSummarize) {
+        if (aiConfig.autoSummarize) {
             logger.info('[Startup] Checking for unsummarized sessions...');
 
             this.summarizeSessions({}).then(result => {


### PR DESCRIPTION
## Summary

Stage 4 of Epic #12101 — consumer-side codemod migrating `ai/services` + `ai/mcp` off the non-getter `aiConfig` anti-patterns (Discussion #12100 sub-classes A / B / D-prod / E) onto the canonical Proxy-routed read + the no-hidden-default contract. Behaviour-preserving.

## Deltas

- **A (12):** `aiConfig.data.X` → `aiConfig.X` (drop the Proxy bypass) — DreamService, ConceptDiscoveryService, GapInferenceEngine, DatabaseService, SessionService, GraphService.
- **D-prod (8):** bootstrap `aiConfig.data.debug = true` → `aiConfig.debug = true` (proxy set-trap → `setData`) — the 6 mcp-servers + run-bridge + mcp-cli. (No `aiConfig.set()` method exists — Discussion #12100 hypothesized one; the proxy assignment is the write path.)
- **B (3):** `ProviderReadinessHelper` default-params `config = aiConfig.data` → `config = aiConfig`.
- **E (scalar + tenant):** removed config-backed redundant `?? <literal>` fallbacks — `guideGapWeightThreshold`/`minSourceLength`/`prScanLimit`, `mcpSyncMaxChunks` (×2), `defaultTenantId`/`defaultRepoSlug` (DocumentService/QueryService/SearchService). The config leaf provides each value verbatim; behaviour-identical.

## Test Evidence

963 `ai/services` unit specs pass. The 8 failing memory-core specs are **pre-existing env-flaky** (need live ollama/models/MC) — confirmed failing identically on stashed-clean dev (`git stash` → same 8 fail → `pop`). `node --check` clean on all 19 files.

Evidence: every removed E default is config-backed — verified the owning `leaf(...)` in the templates (`guideGapWeightThreshold: leaf(0.8)`, `mcpSyncMaxChunks: leaf(50)`, `defaultTenantId: leaf('neo-shared')`, …). The tenant filters now read `aiConfig.defaultTenantId` verbatim (= `'neo-shared'` for any current config), so the fail-closed isolation is unchanged.

## Post-Merge Validation

None for the bulk — behaviour-preserving.

⚠️ **Open sub-decision (deliberately NOT in this PR):** the 9 KB `Source` `?? '<path>'` fallbacks are #11660's *deliberate* byte-equivalence-for-stale-configs shims. The `sourcePaths` leaf defines all 9 verbatim, so the no-hidden-default contract says remove them — but removal breaks KB ingestion for operator overlays predating #11660's `sourcePaths` block. Surfaced as a config-SSOT-vs-backward-compat call before removal.

FAIR-band: n/a — operator-directed epic lane (#12101 Stage 4).

Refs #12106.

Authored by Claude Opus 4.8 (Claude Code, 1M context).
