### PR TITLE
refactor(ai): Stage-4 source-path codemod — KB Sources read sourcePaths config verbatim (Resolves #12106)

### DIFF
--- a/ai/services/knowledge-base/source/AdrSource.mjs
+++ b/ai/services/knowledge-base/source/AdrSource.mjs
@@ -35,10 +35,9 @@ class AdrSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override. Falls through to the legacy
-        // hardcoded `learn/agentos/decisions` when `aiConfig.sourcePaths.AdrSource` is unset
-        // — byte-equivalence preserved for pre-#11660 deployments.
-        const adrDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.AdrSource ?? 'learn/agentos/decisions');
+        // Per-source path from the `sourcePaths` config (SSOT — the leaf in the KB config template
+        // defines every Source's default path).
+        const adrDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.AdrSource);
 
         if (await fs.pathExists(adrDir)) {
             const files = await fs.readdir(adrDir);

--- a/ai/services/knowledge-base/source/ApiSource.mjs
+++ b/ai/services/knowledge-base/source/ApiSource.mjs
@@ -40,15 +40,8 @@ class ApiSource extends Base {
      * @returns {Promise<Number>} The number of chunks extracted.
      */
     async extract(writeStream, createHashFn) {
-        // Phase 0/1B-β (#11660): per-source sourceMap override (path → type object). Legacy
-        // fallback preserves byte-equivalence with pre-#11660 behavior.
-        const sourceMap = aiConfig.sourcePaths?.ApiSource ?? {
-            'src'     : 'src',
-            'apps'    : 'app',
-            'examples': 'example',
-            'docs/app': 'app',
-            'ai'      : 'ai-infrastructure'
-        };
+        // Per-source sourceMap (path → type object) from the `sourcePaths` config (SSOT).
+        const sourceMap = aiConfig.sourcePaths?.ApiSource;
 
         // Load the authoritative class hierarchy
         let hierarchy = {};

--- a/ai/services/knowledge-base/source/ConceptSource.mjs
+++ b/ai/services/knowledge-base/source/ConceptSource.mjs
@@ -36,8 +36,8 @@ class ConceptSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override; legacy fallback preserves byte-equivalence.
-        const conceptsDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ConceptSource ?? 'resources/content/concepts');
+        // Per-source path from the `sourcePaths` config (SSOT).
+        const conceptsDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ConceptSource);
 
         if (await fs.pathExists(conceptsDir)) {
             const files = await fs.readdir(conceptsDir);

--- a/ai/services/knowledge-base/source/DiscussionSource.mjs
+++ b/ai/services/knowledge-base/source/DiscussionSource.mjs
@@ -58,12 +58,9 @@ class DiscussionSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override (array of paths). Each entry is
-        // resolved against `neoRootDir`. Legacy fallback preserves byte-equivalence.
-        const discussionPaths = aiConfig.sourcePaths?.DiscussionSource ?? [
-            'resources/content/discussions',
-            'resources/content/archive/discussions'
-        ];
+        // Per-source paths (array) from the `sourcePaths` config (SSOT). Each entry is resolved
+        // against `neoRootDir`.
+        const discussionPaths = aiConfig.sourcePaths?.DiscussionSource;
         const targetPaths = discussionPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
         const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'discussions');

--- a/ai/services/knowledge-base/source/LearningSource.mjs
+++ b/ai/services/knowledge-base/source/LearningSource.mjs
@@ -40,10 +40,9 @@ class LearningSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override. The config value points at the
-        // tree.json file; the base directory containing the .md files is derived as the
-        // path's containing directory. Legacy fallback preserves byte-equivalence.
-        const learnTreeRelative = aiConfig.sourcePaths?.LearningSource ?? 'learn/tree.json';
+        // Per-source path from the `sourcePaths` config (SSOT). The value points at the tree.json
+        // file; the base directory containing the .md files is its containing directory.
+        const learnTreeRelative = aiConfig.sourcePaths?.LearningSource;
         const learnTreePath     = path.resolve(aiConfig.neoRootDir, learnTreeRelative);
         const learnBaseRelative = path.dirname(learnTreeRelative);
 

--- a/ai/services/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/services/knowledge-base/source/PullRequestSource.mjs
@@ -61,11 +61,8 @@ class PullRequestSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override (array of paths). Legacy fallback preserves byte-equivalence.
-        const pullRequestPaths = aiConfig.sourcePaths?.PullRequestSource ?? [
-            'resources/content/pulls',
-            'resources/content/archive/pulls'
-        ];
+        // Per-source paths (array) from the `sourcePaths` config (SSOT).
+        const pullRequestPaths = aiConfig.sourcePaths?.PullRequestSource;
         const targetPaths = pullRequestPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
         const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'pulls');

--- a/ai/services/knowledge-base/source/ReleaseNotesSource.mjs
+++ b/ai/services/knowledge-base/source/ReleaseNotesSource.mjs
@@ -36,8 +36,8 @@ class ReleaseNotesSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override; legacy fallback preserves byte-equivalence.
-        const releaseNotesPath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ReleaseNotesSource ?? '.github/RELEASE_NOTES');
+        // Per-source path from the `sourcePaths` config (SSOT).
+        const releaseNotesPath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ReleaseNotesSource);
 
         if (await fs.pathExists(releaseNotesPath)) {
             const releaseFiles = await fs.readdir(releaseNotesPath);

--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -38,8 +38,8 @@ class SkillSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override; legacy fallback preserves byte-equivalence.
-        const skillsBasePath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.SkillSource ?? '.agents/skills');
+        // Per-source path from the `sourcePaths` config (SSOT).
+        const skillsBasePath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.SkillSource);
 
         if (await fs.pathExists(skillsBasePath)) {
             // Using fast-glob to recursively find all .md files in the skills directory

--- a/ai/services/knowledge-base/source/TestSource.mjs
+++ b/ai/services/knowledge-base/source/TestSource.mjs
@@ -40,8 +40,8 @@ class TestSource extends Base {
      * @returns {Promise<Number>} The number of chunks extracted.
      */
     async extract(writeStream, createHashFn) {
-        // Phase 0/1B-β (#11660): per-source path override; legacy fallback preserves byte-equivalence.
-        const testPath = aiConfig.sourcePaths?.TestSource ?? 'test/playwright';
+        // Per-source path from the `sourcePaths` config (SSOT).
+        const testPath = aiConfig.sourcePaths?.TestSource;
         return await this.indexRawDirectory(writeStream, createHashFn, testPath, 'test', {
             include: ['.mjs'],
             exclude: ['node_modules', 'test-results', 'reports']

--- a/ai/services/knowledge-base/source/TicketSource.mjs
+++ b/ai/services/knowledge-base/source/TicketSource.mjs
@@ -61,11 +61,8 @@ class TicketSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Phase 0/1B-β (#11660): per-source path override (array of paths). Legacy fallback preserves byte-equivalence.
-        const ticketPaths = aiConfig.sourcePaths?.TicketSource ?? [
-            'resources/content/issues',
-            'resources/content/archive/issues'
-        ];
+        // Per-source paths (array) from the `sourcePaths` config (SSOT).
+        const ticketPaths = aiConfig.sourcePaths?.TicketSource;
         const targetPaths = ticketPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
         const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'issues');


### PR DESCRIPTION
## Summary

Final Stage-4 piece of Epic #12101 — the 10 KB `Source` classes now read their path from the `sourcePaths` config leaf directly, dropping #11660's `?? '<default>'` byte-equivalence shims (the leaf defines all 10 verbatim). With #12185 (A/B/D-prod + scalar/tenant E) merged, this **completes Stage 4 → Resolves #12106**.

## Deltas

- 10 KB Sources: `aiConfig.sourcePaths?.<Source> ?? '<default>'` → `aiConfig.sourcePaths?.<Source>` (kept the `?.` null-safe nav). AdrSource, ConceptSource, LearningSource, TestSource, SkillSource, ReleaseNotesSource, TicketSource, PullRequestSource, DiscussionSource, ApiSource. The stale `#11660` byte-equivalence comments are replaced with SSOT-pointing prose (also clears those `#11660` code-comment anchors).

## Test Evidence

296 KB unit specs pass (incl. VectorService tenant-stamping + work-volume-branching + the Source-exercising specs). `node --check` clean; grep confirms 0 remaining `sourcePaths ??` + 0 `#11660` anchors in the sources.

Evidence: the `sourcePaths` leaf in `ai/mcp/server/knowledge-base/config.template.mjs` defines every Source's default verbatim (`AdrSource: 'learn/agentos/decisions'`, `ApiSource: {…}`, the array sources, etc.) — so the removed fallbacks were exact duplicates of the config default.

## Post-Merge Validation

⚠️ **Behaviour change for stale overlays:** an operator `config.mjs` predating #11660's `sourcePaths` block no longer falls back to the in-code default — it regenerates from the template (config is SSOT). Current overlays (which carry `sourcePaths`) are byte-identical. This applies the no-hidden-default contract, superseding the older #11660 compat — flagged here for the merge-gate.

FAIR-band: n/a — operator-directed epic lane (#12101 Stage 4).

Resolves #12106.

Authored by Claude Opus 4.8 (Claude Code, 1M context).
