### PR TITLE
fix(github-workflow): full release history for bucketing + milestone semver guard (#12188)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -197,10 +197,13 @@ class Config extends BaseConfig {
                  */
                 maxIssues: leaf(20000),
                 /**
-                 * The maximum number of releases to fetch from the GitHub API.
+                 * Safety cap on releases fetched from the GitHub API. Must exceed the repo's total
+                 * release count: the closed-item bucketing reference (`ReleaseNotesSyncer.sortedReleases`)
+                 * spans the full history, so a cap below the total would drop the oldest releases and
+                 * mis-bucket pre-cap closed items.
                  * @type {number}
                  */
-                maxReleases: leaf(1000),
+                maxReleases: leaf(2000),
                 /**
                  * The number of releases to fetch per page in GraphQL queries.
                  * @type {number}

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -353,7 +353,10 @@ class IssueSyncer extends Base {
         for (const issue of combined.values()) {
             let version = null;
             if (issue.state === 'CLOSED') {
-                if (issue.milestone?.title) {
+                // Treat a milestone as a version bucket ONLY when its title is valid semver. A
+                // descriptive milestone (e.g. "neo.d.ts - Typescript definitions") must not become
+                // a version folder; non-semver milestones fall through to closedAt→release resolution.
+                if (issue.milestone?.title && semver.valid(semver.clean(issue.milestone.title))) {
                     version = issue.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
                         ? issue.milestone.title
                         : issueSyncConfig.versionDirectoryPrefix + issue.milestone.title;

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -5,6 +5,7 @@ import fs                         from 'fs/promises';
 import logger                     from '../../../mcp/server/github-workflow/logger.mjs';
 import matter                     from 'gray-matter';
 import path                       from 'path';
+import semver                     from 'semver';
 import GraphqlService             from '../GraphqlService.mjs';
 import ReleaseNotesSyncer         from './ReleaseNotesSyncer.mjs';
 import {FETCH_PULL_REQUESTS_FOR_SYNC} from '../queries/pullRequestQueries.mjs';
@@ -108,7 +109,9 @@ class PullRequestSyncer extends Base {
 
         for (const pr of combined.values()) {
             let version = null;
-            if (pr.milestone?.title) {
+            // Treat a milestone as a version bucket ONLY when its title is valid semver — a
+            // descriptive milestone must not become a version folder (mirrors IssueSyncer).
+            if (pr.milestone?.title && semver.valid(semver.clean(pr.milestone.title))) {
                 version = pr.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
                     ? pr.milestone.title
                     : issueSyncConfig.versionDirectoryPrefix + pr.milestone.title;

--- a/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
+++ b/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
@@ -59,14 +59,16 @@ class ReleaseNotesSyncer extends Base {
     }
 
     /**
-     * Fetches releases from GitHub using an optimized two-phase approach.
+     * Fetches the full release history from GitHub using a two-phase approach.
      *
-     * This optimization is necessary because the GitHub GraphQL `releases` endpoint does not
+     * The two phases are necessary because the GitHub GraphQL `releases` endpoint does not
      * support a `since` parameter, making simple delta-based fetching impossible.
      *
-     * First, it performs a quick check to see if the latest release is already cached.
-     * If not, it performs a full, paginated fetch with an early-exit optimization that
-     * stops querying when it reaches releases older than the `syncStartDate`.
+     * First, a quick check sees whether the latest release is already cached (fast-path no-op).
+     * If not, it performs a full paginated fetch of the COMPLETE release history (bounded only by
+     * the `maxReleases` safety cap). The full set populates `sortedReleases`, the bucketing
+     * reference for closed Issues/PRs/Discussions; release-NOTES are floored to `syncStartDate`
+     * downstream in `syncNotes`.
      *
      * @param {object} metadata The sync metadata containing the cached releases.
      * @returns {Promise<void>}
@@ -108,14 +110,16 @@ class ReleaseNotesSyncer extends Base {
             }
         }
 
-        // Full paginated fetch with early exit.
-        logger.info('Fetching releases from GitHub via GraphQL...');
+        // Full paginated fetch of the COMPLETE release history. The bucketing reference
+        // (`sortedReleases`, consumed by Issue/PR/Discussion closedAt→release resolution) must span
+        // every release; otherwise closed items predating the oldest fetched release all collapse
+        // into it (a catch-all bucket). Release-NOTES are floored separately in syncNotes.
+        logger.info('Fetching the full release history from GitHub via GraphQL...');
 
         let allReleases   = [];
         let hasNextPage   = true;
         let cursor        = null;
         const maxReleases = issueSyncConfig.maxReleases;
-        const startDate   = new Date(issueSyncConfig.syncStartDate);
 
         while (hasNextPage && allReleases.length < maxReleases) {
             const data = await GraphqlService.query(FETCH_RELEASES, {
@@ -132,34 +136,29 @@ class ReleaseNotesSyncer extends Base {
                 break;
             }
 
-            // Check if oldest release in this batch is before our cutoff
-            const oldestInBatch = releases.nodes[releases.nodes.length - 1];
-            const oldestDate    = new Date(oldestInBatch.publishedAt);
-
-            // Add all releases from the batch for now; we will filter after the loop
             allReleases.push(...releases.nodes);
 
-            logger.debug(`Fetched ${releases.nodes.length} releases (total raw: ${allReleases.length})`);
-
-            // Early exit if oldest release in batch is before our cutoff
-            if (oldestDate < startDate) {
-                logger.info(`Reached releases published before ${issueSyncConfig.syncStartDate}, stopping pagination.`);
-                break;
-            }
+            logger.debug(`Fetched ${releases.nodes.length} releases (total: ${allReleases.length})`);
 
             hasNextPage = releases.pageInfo.hasNextPage;
             cursor      = releases.pageInfo.endCursor;
         }
 
-        // Now, filter and sort the collected releases
-        const filteredAndSortedReleases = allReleases
-            .filter(release => new Date(release.publishedAt) >= startDate)
+        // No silent truncation: warn if the safety cap was hit before history was exhausted.
+        if (hasNextPage && allReleases.length >= maxReleases) {
+            logger.warn(`⚠️ Hit maxReleases cap (${maxReleases}) before exhausting the release history; the oldest releases are missing from the bucketing reference. Raise issueSyncConfig.maxReleases.`);
+        }
+
+        // Sort the COMPLETE set ascending. Both the release map and the bucketing reference span the
+        // full history; release-NOTES are floored by syncStartDate in syncNotes, so this wide set
+        // never reaches disk as extra notes or SSR routes.
+        const allSorted = allReleases
             .sort((a, b) => new Date(a.publishedAt) - new Date(b.publishedAt));
 
         this.releases       = {};
         this.sortedReleases = [];
 
-        filteredAndSortedReleases.forEach(release => {
+        allSorted.forEach(release => {
             this.releases[release.tagName] = release;
             this.sortedReleases.push({
                 tagName    : release.tagName,
@@ -168,9 +167,9 @@ class ReleaseNotesSyncer extends Base {
         });
 
         if (Object.keys(this.releases).length === 0) {
-            logger.warn(`⚠️ No releases found since syncStartDate (${issueSyncConfig.syncStartDate}). Archiving may fall back to default.`);
+            logger.warn('⚠️ No releases found. Archiving will fall back to active/Backlog.');
         } else {
-            logger.info(`Found and cached ${Object.keys(this.releases).length} releases since ${issueSyncConfig.syncStartDate}.`);
+            logger.info(`Found and cached ${Object.keys(this.releases).length} releases (full history).`);
         }
     }
 
@@ -205,10 +204,18 @@ class ReleaseNotesSyncer extends Base {
         };
 
         const cachedReleases = metadata.releases || {};
+        const startDate      = new Date(issueSyncConfig.syncStartDate);
+
+        // Release-notes content is floored to syncStartDate even though the bucketing reference
+        // (`sortedReleases`) now spans the full history: we only write notes for in-window releases,
+        // keeping the on-disk notes set and its chunk layout stable. Index within the floored set so
+        // chunk numbers match the notes actually written.
+        const notesReleases = this.sortedReleases.filter(r => new Date(r.publishedAt) >= startDate);
 
         for (const release of Object.values(this.releases)) {
+            if (new Date(release.publishedAt) < startDate) continue;
             try {
-                const itemIndex = this.sortedReleases.findIndex(r => r.tagName === release.tagName);
+                const itemIndex = notesReleases.findIndex(r => r.tagName === release.tagName);
                 const chunkNumber = chunkNumberFor(itemIndex);
 
                 const filename = release.tagName.startsWith(issueSyncConfig.releaseFilenamePrefix)

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -38,6 +38,7 @@ import path            from 'path';
  */
 test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
     let IssueSyncer;
+    let ReleaseNotesSyncer;
     let GraphqlService;
     let issueSyncConfig;
     let aiConfig;
@@ -66,6 +67,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
         GraphqlService = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
         IssueSyncer    = (await import('../../../../../../ai/services/github-workflow/sync/IssueSyncer.mjs')).default;
+        ReleaseNotesSyncer = (await import('../../../../../../ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs')).default;
         logger         = (await import('../../../../../../ai/mcp/server/github-workflow/logger.mjs')).default;
 
         originalQuery = GraphqlService.query.bind(GraphqlService);
@@ -255,6 +257,49 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         expect(relativeToIssuesDir.startsWith('..')).toBe(false); // path is under issuesDir
         expect(targetPath).not.toContain('/archive/');
         expect(targetPath).not.toContain('unversioned');
+    });
+
+    test('non-semver milestone is not a version bucket — falls through to closedAt→release (#12184)', async () => {
+        // A descriptive (non-semver) milestone must NOT become a `v<title>` archive folder. Empirical:
+        // #3286/#3287 carried milestones like "neo.d.ts - Typescript definitions ..." and were archived
+        // as garbage version folders. With the semver guard, such a closed issue falls through to the
+        // closedAt→release resolution and buckets into the real release that shipped after it closed.
+        const mockIssue = buildMockIssue({
+            number       : 3286,
+            title        : 'Mock non-semver-milestone issue',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        mockIssue.state     = 'CLOSED';
+        mockIssue.closedAt  = '2024-09-15T00:00:00Z';
+        mockIssue.milestone = {title: 'neo.d.ts - Typescript definitions for all neo framework classes'};
+
+        // A real release published AFTER the issue closed → the closedAt→release fallback resolves here.
+        const originalSorted = ReleaseNotesSyncer.sortedReleases;
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v9.0.0', publishedAt: '2024-10-01T00:00:00Z'}];
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(mockIssue)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const metadata = {issues: {}};
+
+        try {
+            const stats = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
+            expect(stats.refetched.count).toBe(1);
+            expect(stats.errors).toHaveLength(0);
+
+            const bucketPath = metadata.issues[mockIssue.number].path;
+            // Bucketed into the real release, NOT a title-derived garbage folder.
+            expect(bucketPath).toContain(path.join('archive', 'issues', 'v9.0.0'));
+            expect(bucketPath).not.toContain('neo.d.ts');
+        } finally {
+            ReleaseNotesSyncer.sortedReleases = originalSorted;
+        }
     });
 
     test('pullFromGitHub enforces sealed-chunk archive semantics', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -116,6 +116,39 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         // `archiveVersion` is fully retired (#11364) — it is no longer written to metadata.
         expect(metadata.pulls[prNumber].archiveVersion).toBeUndefined();
     });
+
+    test('non-semver milestone is not a version bucket — PR falls through to closedAt→release (#12184)', async () => {
+        const prNumber = 3287;
+
+        // A descriptive (non-semver) milestone must NOT become a `v<title>` archive folder (mirror of
+        // the IssueSyncer guard). The merged PR falls through to the closedAt→release resolution and
+        // buckets into the real release that shipped after it merged.
+        const pr = buildPullRequest(prNumber);
+        pr.milestone = {title: 'Neo-Material Component Library v0.1'};
+        pr.mergedAt  = '2024-09-15T00:00:00Z';
+        pr.closedAt  = '2024-09-15T00:00:00Z';
+
+        // A real release published AFTER the PR merged → the closedAt→release fallback resolves here.
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v9.0.0', publishedAt: '2024-10-01T00:00:00Z'}];
+
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes   : [pr],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        const stats       = await PullRequestSyncer.syncPullRequests({pulls: {}});
+        const releasePath = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v9.0.0', 'chunk-1', `pr-${prNumber}.md`);
+        const garbagePath = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'vNeo-Material Component Library v0.1', 'chunk-1', `pr-${prNumber}.md`);
+
+        expect(stats.synced).toEqual([prNumber]);
+        // Bucketed into the real release, NOT a title-derived garbage folder.
+        await expect(fs.pathExists(releasePath)).resolves.toBe(true);
+        await expect(fs.pathExists(garbagePath)).resolves.toBe(false);
+    });
 });
 
 function buildPullRequest(number) {

--- a/test/playwright/unit/ai/services/github-workflow/ReleaseNotesSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ReleaseNotesSyncer.spec.mjs
@@ -92,13 +92,15 @@ test.describe('Neo.ai.services.github-workflow.sync.ReleaseNotesSyncer', () => {
     });
 
     test('syncNotes generates ordinal pathing and updates _index.json correctly', async () => {
+        // Dates must be >= syncStartDate: syncNotes floors release-notes to the configured window
+        // (the bucketing reference `sortedReleases` spans the full history, but on-disk notes do not).
         ReleaseNotesSyncer.releases = {
-            'v1.0.0': { tagName: 'v1.0.0', name: 'Release 1', publishedAt: '2024-01-01T00:00:00Z', description: 'First release' },
-            'v1.1.0': { tagName: 'v1.1.0', name: 'Release 2', publishedAt: '2024-02-01T00:00:00Z', description: 'Second release' }
+            'v1.0.0': { tagName: 'v1.0.0', name: 'Release 1', publishedAt: '2025-02-01T00:00:00Z', description: 'First release' },
+            'v1.1.0': { tagName: 'v1.1.0', name: 'Release 2', publishedAt: '2025-03-01T00:00:00Z', description: 'Second release' }
         };
         ReleaseNotesSyncer.sortedReleases = [
-            { tagName: 'v1.0.0', publishedAt: '2024-01-01T00:00:00Z' },
-            { tagName: 'v1.1.0', publishedAt: '2024-02-01T00:00:00Z' }
+            { tagName: 'v1.0.0', publishedAt: '2025-02-01T00:00:00Z' },
+            { tagName: 'v1.1.0', publishedAt: '2025-03-01T00:00:00Z' }
         ];
 
         // Ensure the directory is clean
@@ -123,5 +125,73 @@ test.describe('Neo.ai.services.github-workflow.sync.ReleaseNotesSyncer', () => {
         const indexData = await fs.readJson(indexPath);
         expect(indexData.items['v1.0.0']).toEqual({ itemIndex: 0, chunk: 1, chunkDir: 'chunk-1' });
         expect(indexData.items['v1.1.0']).toEqual({ itemIndex: 1, chunk: 1, chunkDir: 'chunk-1' });
+    });
+
+    test('cold fetch spans the full release history — no syncStartDate early-exit or filter on sortedReleases', async () => {
+        // syncStartDate floors release-NOTES (downstream in syncNotes), but the bucketing reference
+        // sortedReleases must span the ENTIRE history; otherwise closed items predating the oldest
+        // in-window release collapse into it (the catch-all bucket). Three pages: page 2 + 3 are
+        // before the floor — the pre-fix early-exit would stop after page 2 and the filter would drop them.
+        const start    = new Date(issueSyncConfig.syncStartDate).getTime();
+        const inWindow = new Date(start + 86400000).toISOString();
+        const preA     = new Date(start - 86400000).toISOString();
+        const preB     = new Date(start - 2 * 86400000).toISOString();
+
+        let page = 0;
+        GraphqlService.query = async () => {
+            page++;
+            if (page === 1) return {repository: {releases: {
+                nodes   : [{tagName: 'vIn', publishedAt: inWindow}],
+                pageInfo: {hasNextPage: true, endCursor: 'c1'}
+            }}};
+            if (page === 2) return {repository: {releases: {
+                nodes   : [{tagName: 'vOldA', publishedAt: preA}],
+                pageInfo: {hasNextPage: true, endCursor: 'c2'}
+            }}};
+            return {repository: {releases: {
+                nodes   : [{tagName: 'vOldB', publishedAt: preB}],
+                pageInfo: {hasNextPage: false, endCursor: null}
+            }}};
+        };
+
+        // Empty cache → fast-path skipped → full cold fetch.
+        await ReleaseNotesSyncer.fetchAndCacheReleases({releases: {}});
+
+        // Pagination did not early-exit at the floor boundary (would be 2 pre-fix).
+        expect(page).toBe(3);
+        // sortedReleases spans the full history, ascending — including the two pre-floor releases.
+        expect(ReleaseNotesSyncer.sortedReleases.map(r => r.tagName)).toEqual(['vOldB', 'vOldA', 'vIn']);
+    });
+
+    test('syncNotes floors release-notes to syncStartDate while sortedReleases stays full', async () => {
+        const start    = new Date(issueSyncConfig.syncStartDate).getTime();
+        const inWindow = new Date(start + 86400000).toISOString();
+        const preFloor = new Date(start - 86400000).toISOString();
+
+        // Full bucketing reference (pre-floor + in-window); the release map mirrors it.
+        ReleaseNotesSyncer.sortedReleases = [
+            {tagName: 'vOld', publishedAt: preFloor},
+            {tagName: 'vNew', publishedAt: inWindow}
+        ];
+        ReleaseNotesSyncer.releases = {
+            vOld: {tagName: 'vOld', name: 'Old', publishedAt: preFloor, description: 'old'},
+            vNew: {tagName: 'vNew', name: 'New', publishedAt: inWindow, description: 'new'}
+        };
+
+        const releaseDir = path.join(tmpRoot, 'release-notes');
+        await fs.emptyDir(releaseDir);
+
+        const stats = await ReleaseNotesSyncer.syncNotes({});
+
+        // Only the in-window release is written; the pre-floor one is skipped.
+        expect(stats.count).toBe(1);
+        expect(stats.synced).toEqual(['vNew']);
+
+        // vNew indexes at 0 WITHIN the floored notes set — not its index (1) in the full sortedReleases.
+        const indexData = await fs.readJson(path.join(releaseDir, '_index.json'));
+        expect(indexData.items['vNew']).toEqual({itemIndex: 0, chunk: 1, chunkDir: 'chunk-1'});
+        expect(indexData.items['vOld']).toBeUndefined();
+        expect(await fs.pathExists(path.join(releaseDir, 'chunk-1', 'vNew.md'))).toBe(true);
+        expect(await fs.pathExists(path.join(releaseDir, 'chunk-1', 'vOld.md'))).toBe(false);
     });
 });


### PR DESCRIPTION
Authored by Opus 4.8 (Claude Code). Session de8830c3-8d1b-47f8-90db-bd236c8b9bd2.

Resolves #12188
Resolves #12184
Related: #12186

Closed-item bucketing resolved `closedAt → release` over a `sortedReleases` list floored to `syncStartDate` (2025-01-01) and sorted ascending, so every pre-floor closed issue/PR collapsed into the oldest in-window release — a v8.1.0 catch-all holding **4,133 of 7,263 archived issues (56.9%)**. This fetches the **full** release history into the bucketing reference while keeping release-NOTES floored (the floor moves to `syncNotes`), so closed items bucket into the real release that shipped after they closed — with zero change to the on-disk notes set, its chunk layout, or the SSR route count. Separately, the milestone→version branch is now guarded by `semver.valid`, so descriptive milestones (#3286/#3287 carried titles like "neo.d.ts - Typescript definitions …") no longer become garbage version folders; they fall through to the same `closedAt → release` resolution.

FAIR-band: over-target — sole active implementer (@neo-gpt rate-limited, @neo-gemini benched per current project state) + operator-directed lane (epic #12186 P0).

Evidence: L1 (unit: full-history pagination, syncNotes floor, non-semver-milestone fall-through — 4 new tests, 206 green) → L2 required (AC: post-re-sync `archive/issues/` has no v8.1.0 catch-all + no garbage folders). Residual: live re-sync + portal tickets-view verification [#12186].

## Deltas from ticket (if any)
- **Release-notes stay floored; only bucketing goes full.** `sortedReleases` (the bucketing reference) now spans the full history; `this.releases` is full too (so the fast-path cache reconstructs a full reference), but `syncNotes` floors writes to `syncStartDate` and indexes within the floored set. This keeps the portal Releases view + release-notes chunk layout byte-identical and avoids adding ~1,028 release SSR routes — a conscious scope boundary (full release-notes history is a separate, opt-in enhancement, not this fix).
- **`maxReleases` 1000 → 2000** (config.template) — the full history (~1,194 releases) exceeds the old cap; a cap below the total would silently drop the oldest releases. A loud WARN now fires if the cap is hit before history is exhausted (no silent truncation).
- Updated one existing ReleaseNotesSyncer spec: its release dates were 2024 (pre-floor); with the floor now in `syncNotes`, in-window dates are required to exercise the "notes written" path. Production behavior is unchanged — `fetchAndCacheReleases` already filtered those pre-floor releases out before the fix, so they never reached disk.

## Config template change (per mcp-config-template-change-guide)
- **Changed key:** `issueSync.maxReleases` (1000 → 2000).
- **Local `config.mjs` follow-up (required):** each clone's gitignored `config.mjs` overrides `maxReleases` independently — bump it to `2000` after merge so the full-history fetch isn't truncated. (Not committed; gitignored.)
- **Restart:** unnecessary — the syncer reads config at run time; the next `sync-github-workflow` picks up the new value.
- **Peer notification:** A2A sent (the change affects sync behavior in other clones).

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/` → **206 passed** (4 new, 0 regressions).
- New tests:
  - `ReleaseNotesSyncer.spec`: cold full-history fetch (proves the early-exit **and** the filter were removed — pre-floor releases survive in `sortedReleases`, pagination does not stop at the floor); `syncNotes` floor (proves notes stay floored + index within the floored set while `sortedReleases` is full).
  - `IssueSyncer.spec` + `PullRequestSyncer.spec`: a non-semver milestone falls through to the `closedAt → release` fallback (v9.0.0), not a title-derived folder. Each fails without the guard.
- `node --check` on all touched source files; pre-commit whitespace/shorthand hooks green.

## Post-Merge Validation
- [ ] Bump `maxReleases` to 2000 in each clone's local `config.mjs`.
- [ ] Run a full `sync-github-workflow` re-sync; confirm `resources/content/archive/issues/` has no v8.1.0 catch-all (pre-2025 issues distribute to their true releases) and no non-semver/garbage version folders.
- [ ] Confirm portal News → Tickets shows clean release groups (no garbage groups sorted above the real versions).
- [ ] Confirm release-notes chunk layout + `releases.json` are unchanged (notes still floored to `syncStartDate`).
