### PR TITLE
fix(github-workflow): PR + Discussion delta-fetch cutoffs (#12190)

### DIFF
--- a/ai/services/github-workflow/queries/pullRequestQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestQueries.mjs
@@ -74,7 +74,6 @@ export const FETCH_PULL_REQUESTS = `
  * - $limit: Int!
  * - $cursor: String
  * - $states: [PullRequestState!]
- * - $since: DateTime
  * - $maxComments: Int!
  * - $maxReviews: Int!
  */

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -199,6 +199,15 @@ class DiscussionSyncer extends Base {
         let hasNextPage    = true;
         let cursor         = null;
 
+        // Delta cutoff. Mirror the PR/issue delta: the query orders UPDATED_AT DESC and we stop
+        // paginating once a batch's oldest discussion predates the cached high-water mark. A
+        // clean-slate run (lastSync === null) or an empty cache traverses the full history.
+        const cachedDiscDates = Object.values(metadata.discussions || {})
+            .map(d => Date.parse(d.updatedAt)).filter(t => !isNaN(t));
+        const sinceCutoff = (metadata.lastSync == null || cachedDiscDates.length === 0)
+            ? 0
+            : cachedDiscDates.reduce((max, t) => t > max ? t : max, 0);
+
         // Ensure directory exists
         await fs.mkdir(issueSyncConfig.discussionsDir, { recursive: true });
 
@@ -219,6 +228,11 @@ class DiscussionSyncer extends Base {
             }
 
             allDiscussions.push(...discussions.nodes);
+
+            // Stop once the oldest discussion in this UPDATED_AT-DESC batch predates the cutoff —
+            // everything beyond is already current (re-processed in-window items no-op via content-hash).
+            const oldestDisc = discussions.nodes[discussions.nodes.length - 1];
+            if (Date.parse(oldestDisc.updatedAt) < sinceCutoff) break;
 
             hasNextPage = discussions.pageInfo.hasNextPage;
             cursor      = discussions.pageInfo.endCursor;

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -201,6 +201,16 @@ class PullRequestSyncer extends Base {
         let hasNextPage     = true;
         let cursor          = null;
 
+        // Delta cutoff. The `pullRequests` connection (unlike `issues`) has no server-side `since`
+        // filter, so the query orders UPDATED_AT DESC and we stop paginating once a batch's oldest PR
+        // predates the cached high-water mark. A clean-slate run (lastSync === null) or an empty cache
+        // traverses the full history. Mirrors the issue delta semantics — the dominant rate-limit win.
+        const cachedPrDates = Object.values(metadata.pulls || {})
+            .map(p => Date.parse(p.updatedAt)).filter(t => !isNaN(t));
+        const sinceCutoff = (metadata.lastSync == null || cachedPrDates.length === 0)
+            ? 0
+            : cachedPrDates.reduce((max, t) => t > max ? t : max, 0);
+
         // Ensure directory exists
         await fs.mkdir(issueSyncConfig.pullsDir, { recursive: true });
 
@@ -222,6 +232,11 @@ class PullRequestSyncer extends Base {
             }
 
             allPullRequests.push(...pullRequests.nodes);
+
+            // Stop once the oldest PR in this UPDATED_AT-DESC batch predates the cutoff — everything
+            // beyond is already current (re-processed in-window items no-op via the content-hash skip).
+            const oldestPr = pullRequests.nodes[pullRequests.nodes.length - 1];
+            if (Date.parse(oldestPr.updatedAt) < sinceCutoff) break;
 
             hasNextPage = pullRequests.pageInfo.hasNextPage;
             cursor      = pullRequests.pageInfo.endCursor;

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -136,6 +136,33 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(content).toMatch(/^closed: true$/m);
         expect(content).toMatch(/^closedAt: '2026-05-01T00:00:00Z'$/m);
     });
+
+    test('delta cutoff stops discussion pagination once a batch predates the cached high-water mark (#12190)', async () => {
+        // Mirror of the PR/issue delta: order UPDATED_AT DESC + stop at the cached high-water mark.
+        const metadata = {
+            lastSync: '2026-05-01T00:00:00Z',
+            discussions: {
+                9001: {updatedAt: '2026-05-01T00:00:00Z', path: 'resources/content/discussions/chunk-1/discussion-9001.md'}
+            }
+        };
+
+        const discNew    = buildDiscussion(8001); discNew.updatedAt    = '2026-05-03T00:00:00Z'; // after hwm → fetched
+        const discOld    = buildDiscussion(7001); discOld.updatedAt    = '2026-04-29T00:00:00Z'; // before hwm → trips cutoff
+        const discTooOld = buildDiscussion(6001); discTooOld.updatedAt = '2026-04-28T00:00:00Z'; // must never be fetched
+
+        let queryCalls = 0;
+        GraphqlService.query = async () => {
+            queryCalls++;
+            if (queryCalls === 1) return {repository: {discussions: {nodes: [discNew],    pageInfo: {hasNextPage: true,  endCursor: 'c1'}}}};
+            if (queryCalls === 2) return {repository: {discussions: {nodes: [discOld],    pageInfo: {hasNextPage: true,  endCursor: 'c2'}}}};
+            return                       {repository: {discussions: {nodes: [discTooOld], pageInfo: {hasNextPage: false, endCursor: null}}}};
+        };
+
+        await DiscussionSyncer.syncDiscussions(metadata);
+
+        // Stopped at page 2 (its oldest discussion predates the high-water mark); page 3 never requested.
+        expect(queryCalls).toBe(2);
+    });
 });
 
 function buildDiscussion(number, config = {}) {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -149,6 +149,35 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         await expect(fs.pathExists(releasePath)).resolves.toBe(true);
         await expect(fs.pathExists(garbagePath)).resolves.toBe(false);
     });
+
+    test('delta cutoff stops PR pagination once a batch predates the cached high-water mark (#12190)', async () => {
+        // The `pullRequests` connection has no server-side `since`, so the syncer orders UPDATED_AT
+        // DESC and stops paginating at the cached high-water mark. Pre-fix it scanned the full corpus.
+        const metadata = {
+            lastSync: '2026-05-01T00:00:00Z',
+            pulls: {
+                9001: {state: 'MERGED', updatedAt: '2026-05-01T00:00:00Z', path: 'resources/content/archive/pulls/v12.0.0/chunk-1/pr-9001.md'}
+            }
+        };
+
+        const prNew    = buildPullRequest(8001); prNew.updatedAt    = '2026-05-03T00:00:00Z'; // after hwm → fetched
+        const prOld    = buildPullRequest(7001); prOld.updatedAt    = '2026-04-29T00:00:00Z'; // before hwm → trips cutoff
+        const prTooOld = buildPullRequest(6001); prTooOld.updatedAt = '2026-04-28T00:00:00Z'; // must never be fetched
+
+        let queryCalls = 0;
+        GraphqlService.query = async () => {
+            queryCalls++;
+            if (queryCalls === 1) return {repository: {pullRequests: {nodes: [prNew],    pageInfo: {hasNextPage: true,  endCursor: 'c1'}}}};
+            if (queryCalls === 2) return {repository: {pullRequests: {nodes: [prOld],    pageInfo: {hasNextPage: true,  endCursor: 'c2'}}}};
+            return                       {repository: {pullRequests: {nodes: [prTooOld], pageInfo: {hasNextPage: false, endCursor: null}}}};
+        };
+
+        await PullRequestSyncer.syncPullRequests(metadata);
+
+        // Stopped at page 2 (its oldest PR predates the high-water mark); page 3 never requested.
+        // Pre-fix (full-corpus scan) this would be 3.
+        expect(queryCalls).toBe(2);
+    });
 });
 
 function buildPullRequest(number) {


### PR DESCRIPTION
Authored by Opus 4.8 (Claude Code). Session de8830c3-8d1b-47f8-90db-bd236c8b9bd2.

Related: #12190
Related: #12186

PR + Discussion sync scanned the **entire corpus every run** — the dominant driver of the rising GitHub rate-limit hits (issues were already delta-gated; PRs/Discussions were not). The `pullRequests` and `discussions` GraphQL connections have no server-side `since` filter (only `issues` does), but both already order `UPDATED_AT DESC`. This adds a **client-side cutoff**: stop paginating once a batch's oldest item predates the cached high-water mark (max `updatedAt` across `metadata.pulls` / `metadata.discussions`). A clean-slate run (`lastSync === null`) or an empty cache still traverses the full history — consistent with the issue delta + sealed-chunk model (archived items stay put; only new/changed items re-bucket).

FAIR-band: over-target — sole active implementer (@neo-gpt rate-limited, @neo-gemini benched per current project state) + operator-directed lane (epic #12186 P1).

Evidence: L1 (unit: cutoff stops pagination at the high-water mark — 2 new tests, 208 green) → L1 required (no runtime-only ACs; the win is fewer GraphQL page-fetches, asserted via query-call count). No residuals for the delta.

## Deltas from ticket (if any)
This PR delivers the **substantive** half of #12190 — the PR + Discussion **delta cutoffs**, which are the dominant rate-limit driver. Two items from #12190's body are intentionally **not** pursued here, with rationale:
- **Discussion query-cost reduction** (the `replies(first:$maxReplies)` nesting): **unnecessary post-delta.** Once the discussion sync fetches only changed discussions (a handful of pages, not the full corpus), the per-page nesting cost is marginal. Reducing it would add continuation-query complexity (like the issue timeline) for negligible gain.
- **Shared rate-limit governance** (lifting the low-remaining guard out of IssueSyncer): **low-urgency post-delta.** With both syncers delta-gated, PR/Discussion runs are cheap; the guard gap is a robustness nicety, not a driver. Easy follow-up if the reviewer deems it worth a dedicated lane.

`Related: #12190` (not `Resolves`) so the operator decides whether the delta suffices to close it or to keep it open for the optional governance item.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/` → **208 passed** (2 new, 0 regressions).
- New tests (`PullRequestSyncer.spec` + `DiscussionSyncer.spec`): a 3-page stub where page 2's oldest item predates the cached high-water mark → the sync issues exactly **2** GraphQL calls (page 3 never requested). Pre-fix this would be 3 (full-corpus scan). Existing tests (empty/clean-slate metadata → cutoff 0 → full fetch) are unaffected.
- `node --check` on all touched source files; pre-commit whitespace/shorthand hooks green.

## Post-Merge Validation
- [ ] On the next live sync, confirm PR + Discussion fetch only changed items (log shows pagination stopping early; far fewer GraphQL page-fetches than a full-corpus scan).
- [ ] Confirm a clean-slate re-sync (`lastSync === null`) still traverses the full PR/Discussion history — the eventual v8.1.0 re-bucket re-sync must not be truncated by the cutoff.
