### PR TITLE
fix(github-workflow): needsUpdate compares persisted updatedAt field (#12191)

### DIFF
--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -624,7 +624,10 @@ class IssueSyncer extends Base {
             }
 
             const needsUpdate = !oldIssue ||
-                oldIssue.updated !== issue.updatedAt ||
+                // Persisted metadata field is `updatedAt` (see MetadataManager); comparing the
+                // non-existent `oldIssue.updated` made this always true → every issue re-formatted,
+                // re-hashed and re-written every sync, defeating the content-hash short-circuit.
+                oldIssue.updatedAt !== issue.updatedAt ||
                 oldAbsolutePath !== targetPath;
 
             let contentHash = oldIssue?.contentHash;

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -806,6 +806,49 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         );
         expect(archiveAnomalyWarns).toHaveLength(0);
     });
+
+    test('needsUpdate compares the persisted updatedAt — an unchanged archived issue is not re-rendered (#12191)', async () => {
+        // Pre-fix, needsUpdate compared oldIssue.updated — a field that is never persisted (the metadata
+        // field is updatedAt) — so it was always true → every issue re-formatted, re-hashed and re-written
+        // every sync. For an ARCHIVED issue, sealed-chunk guarantees targetPath === oldAbsolutePath, so
+        // updatedAt is the sole discriminator: an unchanged archived issue must be left on disk untouched.
+        const N  = 9100;
+        const ts = '2026-05-01T00:00:00Z';
+
+        const cachedAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v12.0.0', 'chunk-1', `issue-${N}.md`);
+        const cachedRel = path.relative(aiConfig.projectRoot, cachedAbs);
+        await fs.ensureDir(path.dirname(cachedAbs));
+        await fs.writeFile(cachedAbs, 'SENTINEL — must not be re-rendered', 'utf8');
+
+        const mockIssue = buildMockIssue({number: N, title: 'Unchanged archived issue', timelineFirst: [], hasNextPage: false, endCursor: null});
+        mockIssue.state     = 'CLOSED';
+        mockIssue.closedAt  = ts;
+        mockIssue.updatedAt = ts;
+        mockIssue.milestone = {title: 'v12.0.0'};
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchIssuesForSync')) {
+                return {
+                    rateLimit : {cost: 1, remaining: 4999, resetAt: ts},
+                    repository: {issues: {pageInfo: {hasNextPage: false, endCursor: null}, nodes: [structuredClone(mockIssue)]}}
+                };
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        const metadata = {
+            lastSync: '2026-01-01T00:00:00Z',
+            issues: {
+                [N]: {state: 'CLOSED', updatedAt: ts, closedAt: ts, milestone: 'v12.0.0', path: cachedRel, contentHash: 'h', commentsTotal: 0}
+            }
+        };
+
+        await IssueSyncer.pullFromGitHub(metadata);
+
+        // Unchanged updatedAt + sealed path → needsUpdate false → file left untouched.
+        const after = await fs.readFile(cachedAbs, 'utf8');
+        expect(after).toBe('SENTINEL — must not be re-rendered');
+    });
 });
 
 function buildComment(i) {


### PR DESCRIPTION
Authored by Opus 4.8 (Claude Code). Session de8830c3-8d1b-47f8-90db-bd236c8b9bd2.

Resolves #12191
Related: #12186

`IssueSyncer` `needsUpdate` compared `oldIssue.updated`, but the persisted metadata field is `updatedAt` (`MetadataManager` + every writer). So `oldIssue.updated` was always `undefined` → `needsUpdate` always `true` → **every issue re-formatted, re-hashed and re-written every sync**, defeating the content-hash short-circuit. One-character field fix.

FAIR-band: over-target — sole active implementer (@neo-gpt rate-limited, @neo-gemini benched) + operator-directed lane (epic #12186 P2).

Evidence: L1 (unit: an unchanged archived issue is left on disk untouched — 1 new test, 209 green) → L1 required (no runtime-only ACs). No residuals.

## Deltas from ticket (if any)
#12191's second item — **hoisting the per-iteration `#planBuckets(metadata)` out of the reconcile loop (`:1010`)** — was investigated and **dropped as unsafe** (not deferred):
- `#planBuckets` derives each issue's `oldVersion` from `metadata.issues[*].path` (`:300-306`), and the reconcile loop **mutates** `metadata.issues[issueNumber].path` per-iteration (`:1046`, after each archive move). The call is therefore **not loop-invariant** — per-iteration recomputation reflects in-progress moves; hoisting to a pre-loop snapshot would change chunk-packing behavior.
- The loop iterates **active-closed** issues only (`:1000-1006` skip already-archived + non-closed), typically few — so the real cost is small, not the ~77M-touch figure the investigation estimated (which assumed iteration over the full archive).

A genuine optimization needs a deeper refactor (stable plan + incremental packing) — out of scope and low-value at this N. The field fix is the substantive bug in #12191.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/` → **209 passed** (1 new, 0 regressions).
- New test (`IssueSyncer.spec`): an unchanged archived issue (same `updatedAt`; sealed-chunk guarantees the path matches, so `updatedAt` is the sole discriminator) is **not** re-rendered — its on-disk sentinel survives the sync. Fails pre-fix (always-true `needsUpdate` overwrites it).
- `node --check`; pre-commit whitespace/shorthand hooks green.

## Post-Merge Validation
- [ ] On the next live sync, confirm unchanged issues are no longer re-written every run (`stats.pulled` reflects only genuinely-changed issues, not the whole corpus).
