### PR TITLE
feat(github-workflow): one-time non-destructive archive re-bucket migration (#12194)

### DIFF
--- a/ai/scripts/migrations/rebucketArchive.mjs
+++ b/ai/scripts/migrations/rebucketArchive.mjs
@@ -1,0 +1,48 @@
+/**
+ * @summary One-time, non-destructive re-bucket migration for the issue archive (#12194).
+ *
+ * Relocates mis-bucketed issue markdown into the correct release folders using the current bucketing
+ * logic + the FULL release history, then rewrites the issues `_index.json`. This corrects historical
+ * mis-bucketing — notably the v8.1.0 catch-all created before full-release-history fetching existed,
+ * where pre-window closed issues collapsed into the oldest in-window release. The normal sync leaves
+ * these PINNED (sealed-chunk + `oldVersion` precedence); this migration deliberately re-buckets them.
+ *
+ * Non-destructive: it relocates existing `.md` files (no delete, no GitHub re-fetch) using a two-phase
+ * staged move so files swapping chunks cannot collide. Scope: issues only (the dominant pile-up).
+ *
+ *   node ai/scripts/migrations/rebucketArchive.mjs --dry-run   # preview the redistribution
+ *   node ai/scripts/migrations/rebucketArchive.mjs             # execute the moves + save metadata
+ *
+ * After executing: regenerate the portal index (`buildScripts/docs/index/tickets.mjs`) and run the
+ * concurrency-capped SSR regen + deploy so the portal tickets view reflects the corrected buckets.
+ *
+ * @see ai/services/github-workflow/sync/IssueSyncer.mjs (migrateArchiveBuckets)
+ * @see ai/services/github-workflow/SyncService.mjs (facade)
+ */
+import {GH_SyncService} from '../../services.mjs';
+
+async function main() {
+    const dryRun = process.argv.includes('--dry-run');
+
+    console.log(`${dryRun ? '[DRY RUN] ' : ''}Re-bucketing the issue archive (full release history + corrected logic)...`);
+    const result = await GH_SyncService.migrateArchiveBuckets({dryRun});
+
+    const versions = Object.entries(result.byVersion).sort((a, b) => b[1] - a[1]);
+    console.log('\nResulting distribution by version (count, descending):');
+    for (const [version, count] of versions) {
+        console.log(`  ${version.padEnd(16)} ${count}`);
+    }
+
+    console.log(`\n${dryRun ? 'Would move' : 'Moved'}: ${dryRun ? result.moves.length : result.moved}  ·  unchanged: ${result.unchanged}`);
+
+    if (dryRun) {
+        console.log('\nDry run — no files moved, metadata untouched. Re-run without --dry-run to execute.');
+    } else {
+        console.log('\nDone. Next: regenerate the portal index + run the concurrency-capped SSR regen + deploy.');
+    }
+}
+
+main().catch(e => {
+    console.error('Re-bucket migration failed:', e);
+    process.exit(1);
+});

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -282,6 +282,21 @@ class SyncService extends Base {
 
         return stats;
     }
+
+    /**
+     * Facade for the one-time archive re-bucket migration (#12194). Loads metadata, delegates to
+     * `IssueSyncer.migrateArchiveBuckets`, then persists the updated metadata (unless `dryRun`).
+     * Invoked out-of-band by `ai/scripts/migrations/rebucketArchive.mjs` — never the regular sync loop.
+     * @param {object} [opts]
+     * @param {boolean} [opts.dryRun=false] Preview the redistribution without moving files.
+     * @returns {Promise<object>} The migration summary from `IssueSyncer.migrateArchiveBuckets`.
+     */
+    async migrateArchiveBuckets({dryRun = false} = {}) {
+        const metadata = await MetadataManager.load();
+        const result   = await IssueSyncer.migrateArchiveBuckets(metadata, {dryRun});
+        if (!dryRun) await MetadataManager.save(metadata);
+        return result;
+    }
 }
 
 export default Neo.setupClass(SyncService);

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -292,7 +292,7 @@ class IssueSyncer extends Base {
      * @returns {Map<number, {version: string|null, itemCount: number, itemIndex: number}>}
      * @private
      */
-    #planBuckets(metadata, fetchedIssues = []) {
+    #planBuckets(metadata, fetchedIssues = [], {ignoreOldVersion = false} = {}) {
         const combined = new Map();
 
         for (const [idStr, issue] of Object.entries(metadata.issues || {})) {
@@ -360,7 +360,7 @@ class IssueSyncer extends Base {
                     version = issue.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
                         ? issue.milestone.title
                         : issueSyncConfig.versionDirectoryPrefix + issue.milestone.title;
-                } else if (issue.oldVersion && semver.valid(semver.clean(issue.oldVersion)) !== null) {
+                } else if (!ignoreOldVersion && issue.oldVersion && semver.valid(semver.clean(issue.oldVersion)) !== null) {
                     // Use cached path-derived version when present and valid semver. Unchanged closed
                     // issues seeded from existing serialized metadata may lack milestone data but still
                     // have a known on-disk bucket via oldVersion. Skipping closedAt timestamp inference
@@ -1062,6 +1062,131 @@ class IssueSyncer extends Base {
         }
 
         return stats;
+    }
+
+    /**
+     * One-time, non-destructive re-bucket migration. Recomputes EVERY issue's correct on-disk path
+     * from the current bucketing logic + the full release history, then MOVES mis-bucketed files into
+     * place and rewrites their issues `_index.json` entries.
+     *
+     * The normal sync deliberately PINS archived items to their cached bucket (sealed-chunk +
+     * `oldVersion` precedence) to avoid churn. This migration ignores both, so a historical
+     * mis-bucketing can be corrected — e.g. the v8.1.0 catch-all created before full-release-history
+     * fetching existed, where thousands of pre-window closed issues collapsed into the oldest
+     * in-window release. It NEVER deletes content and NEVER re-fetches from GitHub: it only relocates
+     * existing `.md` files. Moves run in two phases (stage → final) so files swapping chunks within or
+     * between buckets cannot collide mid-move. Scope: issues only (the dominant pile-up); pulls and
+     * discussions, if mis-bucketed, are a sibling follow-up on their own syncers.
+     *
+     * Intended to be invoked ONCE, out-of-band, by an operator-run migration script — not the regular
+     * sync loop. Run with `{dryRun: true}` first to preview the redistribution.
+     *
+     * @param {object} metadata Sync metadata; issue `path`s are updated in place (caller persists).
+     * @param {object} [opts]
+     * @param {boolean} [opts.dryRun=false] Compute and return the plan without moving any file.
+     * @returns {Promise<object>} `{moved, unchanged, byVersion, dryRun, moves: [{number, from, to}]}`
+     */
+    async migrateArchiveBuckets(metadata, {dryRun = false} = {}) {
+        await ReleaseNotesSyncer.fetchAndCacheReleases(metadata);
+
+        if (!ReleaseNotesSyncer.sortedReleases || ReleaseNotesSyncer.sortedReleases.length === 0) {
+            throw new Error('migrateArchiveBuckets aborted: no releases loaded — refusing to re-bucket without the full release history.');
+        }
+
+        // Recompute from scratch: ignore the cached-path `oldVersion` (which would re-pin the existing
+        // mis-bucketing) so each closed issue resolves via milestone-guard / closedAt→release.
+        const plan = this.#planBuckets(metadata, [], {ignoreOldVersion: true});
+
+        const moves     = [];
+        const upserts   = [];
+        const byVersion = {};
+        let   unchanged = 0;
+
+        for (const idStr of Object.keys(metadata.issues || {})) {
+            const number    = parseInt(idStr, 10);
+            const targetAbs = this.#getIssuePath({number, labels: []}, plan);
+            if (!targetAbs) continue; // dropped — not expected for stored items
+
+            const targetRel  = this.#relativePath(targetAbs);
+            const currentRel = metadata.issues[idStr].path;
+            const planEntry  = plan.get(number) || {};
+            const vkey       = planEntry.version || 'active';
+
+            byVersion[vkey] = (byVersion[vkey] || 0) + 1;
+
+            if (currentRel === targetRel) { unchanged++; continue; }
+
+            moves.push({number, from: currentRel, to: targetRel, targetAbs});
+            upserts.push(createContentIndexEntry({
+                issueSyncConfig,
+                type     : 'issues',
+                id       : number,
+                filePath : targetAbs,
+                itemIndex: planEntry.itemIndex || 0,
+                version  : planEntry.version || null
+            }));
+        }
+
+        const summary = {
+            moved    : dryRun ? 0 : moves.length,
+            unchanged,
+            dryRun,
+            byVersion,
+            moves    : moves.map(({number, from, to}) => ({number, from, to}))
+        };
+
+        if (dryRun) {
+            logger.info(`[REBUCKET dry-run] ${moves.length} would move, ${unchanged} unchanged. Distribution: ${JSON.stringify(byVersion)}`);
+            return summary;
+        }
+
+        // Two-phase move: stage every source out of the tree first, so a target path currently
+        // occupied by another mover is free by the time we place the final file.
+        const stageDir = path.join(issueSyncConfig.contentRoot, '.rebucket-stage');
+        await fs.mkdir(stageDir, {recursive: true});
+
+        for (const m of moves) {
+            await fs.rename(this.#resolvePath(m.from), path.join(stageDir, `issue-${m.number}.md`));
+        }
+        for (const m of moves) {
+            await fs.mkdir(path.dirname(m.targetAbs), {recursive: true});
+            await fs.rename(path.join(stageDir, `issue-${m.number}.md`), m.targetAbs);
+            metadata.issues[String(m.number)].path = m.to;
+        }
+        await fs.rm(stageDir, {recursive: true, force: true});
+
+        await updateContentIndex(issueSyncConfig, {upsert: upserts});
+
+        // Prune chunk/version directories emptied by the relocation.
+        await this.#pruneEmptyDirs(path.join(issueSyncConfig.archiveRoot, 'issues'));
+        await this.#pruneEmptyDirs(issueSyncConfig.issuesDir);
+
+        logger.info(`[REBUCKET] moved ${moves.length} issue(s), ${unchanged} unchanged. Distribution: ${JSON.stringify(byVersion)}`);
+        return summary;
+    }
+
+    /**
+     * Recursively removes now-empty directories under `root` (after a re-bucket relocation leaves
+     * source chunk/version folders empty). Children are pruned before parents; `root` is never removed.
+     * @param {string} root Absolute directory to prune within.
+     * @private
+     */
+    async #pruneEmptyDirs(root) {
+        let entries;
+        try {
+            entries = await fs.readdir(root, {withFileTypes: true});
+        } catch {
+            return; // root absent — nothing to prune
+        }
+
+        for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            const child = path.join(root, entry.name);
+            await this.#pruneEmptyDirs(child);
+            try {
+                if ((await fs.readdir(child)).length === 0) await fs.rmdir(child);
+            } catch { /* race / already removed */ }
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -849,6 +849,109 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const after = await fs.readFile(cachedAbs, 'utf8');
         expect(after).toBe('SENTINEL — must not be re-rendered');
     });
+
+    test('migrateArchiveBuckets re-buckets a sealed-pinned issue into its true release (#12194)', async () => {
+        // The v8.1.0 catch-all: a pre-window closed issue archived under the oldest in-window release
+        // (v8.1.0), whose true release (v7.0.0) predates the syncStartDate floor. Sealed-chunk +
+        // oldVersion-precedence keep it pinned during a normal sync; the migration ignores both and,
+        // with the full release history, recomputes closedAt→release and moves it to v7.0.0.
+        const originalSorted = ReleaseNotesSyncer.sortedReleases;
+        const N        = 6001;
+        const wrongAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v8.1.0', 'chunk-1', `issue-${N}.md`);
+        const wrongRel = path.relative(aiConfig.projectRoot, wrongAbs);
+        await fs.ensureDir(path.dirname(wrongAbs));
+        await fs.writeFile(wrongAbs, 'ISSUE 6001 CONTENT', 'utf8');
+
+        GraphqlService.query = async () => ({
+            repository: {releases: {
+                nodes: [
+                    {tagName: 'v8.1.0', publishedAt: '2025-01-15T00:00:00Z'},
+                    {tagName: 'v7.0.0', publishedAt: '2024-10-01T00:00:00Z'}
+                ],
+                pageInfo: {hasNextPage: false, endCursor: null}
+            }}
+        });
+
+        const metadata = {
+            releases: {},
+            issues: {
+                [N]: {state: 'CLOSED', closedAt: '2024-09-15T00:00:00Z', updatedAt: '2024-09-15T00:00:00Z', milestone: null, path: wrongRel, contentHash: 'h'}
+            }
+        };
+
+        try {
+            const result     = await IssueSyncer.migrateArchiveBuckets(metadata);
+            const correctAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v7.0.0', 'chunk-1', `issue-${N}.md`);
+
+            expect(result.moved).toBe(1);
+            await expect(fs.pathExists(correctAbs)).resolves.toBe(true);
+            expect(await fs.readFile(correctAbs, 'utf8')).toBe('ISSUE 6001 CONTENT'); // content preserved
+            await expect(fs.pathExists(wrongAbs)).resolves.toBe(false);              // old location gone
+            // Emptied source version dir pruned.
+            await expect(fs.pathExists(path.join(issueSyncConfig.archiveRoot, 'issues', 'v8.1.0'))).resolves.toBe(false);
+            expect(metadata.issues[N].path).toBe(path.relative(aiConfig.projectRoot, correctAbs));
+
+            const idx   = await fs.readJson(path.join(tmpRoot, '_index.json'));
+            const entry = idx.find(e => e.type === 'issues' && e.id === N);
+            expect(entry.version).toBe('v7.0.0');
+            expect(entry.chunkNumber).toBe(1);
+        } finally {
+            ReleaseNotesSyncer.sortedReleases = originalSorted;
+        }
+    });
+
+    test('migrateArchiveBuckets dryRun reports the plan without moving any file (#12194)', async () => {
+        const originalSorted = ReleaseNotesSyncer.sortedReleases;
+        const N        = 6002;
+        const wrongAbs = path.join(issueSyncConfig.archiveRoot, 'issues', 'v8.1.0', 'chunk-1', `issue-${N}.md`);
+        const wrongRel = path.relative(aiConfig.projectRoot, wrongAbs);
+        await fs.ensureDir(path.dirname(wrongAbs));
+        await fs.writeFile(wrongAbs, 'DRYRUN CONTENT', 'utf8');
+
+        GraphqlService.query = async () => ({
+            repository: {releases: {
+                nodes: [
+                    {tagName: 'v7.0.0', publishedAt: '2024-10-01T00:00:00Z'},
+                    {tagName: 'v8.1.0', publishedAt: '2025-01-15T00:00:00Z'}
+                ],
+                pageInfo: {hasNextPage: false, endCursor: null}
+            }}
+        });
+
+        const metadata = {
+            releases: {},
+            issues: {[N]: {state: 'CLOSED', closedAt: '2024-09-15T00:00:00Z', updatedAt: '2024-09-15T00:00:00Z', milestone: null, path: wrongRel, contentHash: 'h'}}
+        };
+
+        try {
+            const result = await IssueSyncer.migrateArchiveBuckets(metadata, {dryRun: true});
+
+            expect(result.dryRun).toBe(true);
+            expect(result.moved).toBe(0);
+            expect(result.moves).toHaveLength(1);
+            expect(result.moves[0].number).toBe(N);
+            // File NOT moved; metadata path unchanged.
+            await expect(fs.pathExists(wrongAbs)).resolves.toBe(true);
+            expect(await fs.readFile(wrongAbs, 'utf8')).toBe('DRYRUN CONTENT');
+            expect(metadata.issues[N].path).toBe(wrongRel);
+        } finally {
+            ReleaseNotesSyncer.sortedReleases = originalSorted;
+        }
+    });
+
+    test('migrateArchiveBuckets aborts (throws) when no releases are available (#12194)', async () => {
+        const originalSorted = ReleaseNotesSyncer.sortedReleases;
+        GraphqlService.query = async () => ({
+            repository: {releases: {nodes: [], pageInfo: {hasNextPage: false, endCursor: null}}}
+        });
+
+        try {
+            // No releases → re-bucketing would mis-assign everything; the migration must fail loud.
+            await expect(IssueSyncer.migrateArchiveBuckets({releases: {}, issues: {}})).rejects.toThrow(/no releases loaded/);
+        } finally {
+            ReleaseNotesSyncer.sortedReleases = originalSorted;
+        }
+    });
 });
 
 function buildComment(i) {


### PR DESCRIPTION
Authored by Opus 4.8 (Claude Code). Session de8830c3-8d1b-47f8-90db-bd236c8b9bd2.

Related: #12194
Related: #12186

The merged bucketing fixes (#12188/#12184) are **forward-only**: sealed-chunk + `oldVersion`-precedence pin the existing ~4,133 v8.1.0 issues, so a normal re-sync won't clear the tickets-view pile-up. This PR delivers the **tool** to clear it — a non-destructive, one-time re-bucket migration:

- `IssueSyncer.migrateArchiveBuckets(metadata, {dryRun})` — recomputes every issue's version from the full release history with `oldVersion` ignored (`#planBuckets(..., {ignoreOldVersion:true})`), relocates mis-bucketed `.md` files via a **two-phase staged move** (no collisions, no delete, no GitHub re-fetch), rewrites the issues `_index.json`, and prunes emptied dirs. Fails loud if no releases load.
- `SyncService.migrateArchiveBuckets({dryRun})` — facade (load → migrate → save), mirroring `refetchIssuesByNumber`.
- `ai/scripts/migrations/rebucketArchive.mjs` — operator-run entry with a `--dry-run` preview.

**Execution is operator-gated + deferred** (large content diff; pair with the concurrency-capped regen + deploy). This PR is the reviewable, tested tool; #12194 closes after the operator runs it and verifies the result ACs.

FAIR-band: over-target — sole active implementer (@neo-gpt rate-limited, @neo-gemini benched) + operator-directed lane (epic #12186; operator chose approach B).

Evidence: L1 (unit: re-bucket moves a sealed-pinned issue to its true release with content preserved + source dir pruned + index updated; dryRun previews without moving; no-releases aborts — 3 new tests, 212 green) → L2 required for the AC that the LIVE archive clears (operator execution). Residual: live run + portal verification [#12194].

## Deltas from ticket (if any)
- **Approach B** (non-destructive) per your call. The recompute hinges on a new `ignoreOldVersion` option on `#planBuckets` — without it, `oldVersion`-precedence re-confirms v8.1.0 (the cached path is valid semver) and the corrected `closedAt→release` is never reached. Default-false keeps all existing call sites unchanged.
- **Scope: issues only** (the dominant pile-up = the tickets-view). Pulls/Discussions, if similarly mis-bucketed, are a sibling follow-up on their own syncers (same pattern).
- **Two-phase staged move** (stage → final) so files swapping chunks during the re-chunk cannot collide mid-move.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/` → **212 passed** (3 new, 0 regressions).
- New (`IssueSyncer.spec`): core re-bucket (v8.1.0 → true release; content preserved; source dir pruned; `_index.json` version+chunk updated); dryRun (plan only — file + metadata untouched); no-releases guard (throws).
- `node --check` on all touched files; pre-commit whitespace/shorthand hooks green.

## Post-Merge Validation
- [ ] `node ai/scripts/migrations/rebucketArchive.mjs --dry-run` against the real metadata — review the distribution before executing.
- [ ] Run it for real; confirm `resources/content/archive/issues/` has no v8.1.0 catch-all and no data loss.
- [ ] Regenerate the portal index + run the concurrency-capped SSR regen + deploy; confirm a clean tickets-view.
- [ ] Then close #12194.
