### PR TITLE
refactor(ai): remove MC+KB boot-time auto-* self-triggers + redundant MCP tools — orchestrator-SSOT (#12139 PR A)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -124,11 +124,6 @@ class DreamService extends Base {
         if (LifecycleService._initPromise) {
             await LifecycleService._initPromise;
         }
-
-        if (aiConfig.autoDream) {
-            logger.info('[Startup] DreamService: Checking for undigested session memories...');
-            this.processUndigestedSessions().catch(e => logger.error('[Startup] DreamService failed:', e));
-        }
     }
 
     /**

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -39,16 +39,6 @@ class Config extends BaseConfig {
         data: {
             neoRootDir: leaf(neoRootDir),
             /**
-             * Automatically synchronize the knowledge base on startup.
-             * @type {boolean}
-             */
-            autoSync: leaf(false, 'NEO_AUTO_SYNC', 'boolean'),
-            /**
-             * Automatically start the local Chroma database process on startup.
-             * @type {boolean}
-             */
-            autoStartDatabase: leaf(false, 'NEO_KB_AUTO_START_DATABASE', 'boolean'),
-            /**
              * Global debug flag for all MCP servers.
              * @type {boolean}
              */

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -56,56 +56,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /db/manage:
-    post:
-      summary: Manage Database
-      operationId: manage_database
-      x-pass-as-object: true
-      description: |
-        Manages the lifecycle (start/stop) of the ChromaDB database instance.
-
-        **Behavior:**
-        - **Start:**
-          - **Managed:** If no database is running on the configured port, this tool spawns a new process managed by this server. This process will be automatically cleaned up when the agent session ends.
-          - **External:** If a database is already running, this tool simply confirms the connection. The server acts as a client and will NOT kill the database on exit.
-        - **Stop:**
-          - **Managed:** Stops the process spawned by this server.
-          - **External:** **No effect.** The server cannot stop a database it did not start.
-
-        **Multi-Agent / Swarm Recommendation:**
-        For workflows involving multiple concurrent agents, it is **highly recommended** to start the database externally using `npm run ai:server` before starting the agents. This prevents unexpected disconnects for other agents when the "owner" agent exits.
-
-        **When to Use:**
-        - Use `action: start` if a `healthcheck` reveals that the database process is not running.
-        - Use `action: stop` for debugging, forcing a restart, or freeing up resources.
-      tags: ["Database Lifecycle"]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - action
-              properties:
-                action:
-                  type: string
-                  enum: [start, stop]
-                  description: The action to perform.
-      responses:
-        '200':
-          description: Operation completed successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DatabaseLifecycleResponse'
-        '500':
-          description: Operation failed.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
   /db/data/manage:
     post:
       summary: Manage Knowledge Base Data

--- a/ai/mcp/server/knowledge-base/toolService.mjs
+++ b/ai/mcp/server/knowledge-base/toolService.mjs
@@ -1,7 +1,6 @@
 import path                          from 'path';
 import {fileURLToPath}               from 'url';
 import DatabaseService               from '../../../services/knowledge-base/DatabaseService.mjs';
-import DatabaseLifecycleService      from '../../../services/knowledge-base/DatabaseLifecycleService.mjs';
 import DocumentService               from '../../../services/knowledge-base/DocumentService.mjs';
 import HealthService                 from '../../../services/knowledge-base/HealthService.mjs';
 import KBRecorderService             from '../../../services/knowledge-base/KBRecorderService.mjs';
@@ -58,7 +57,6 @@ const serviceMapping = {
     healthcheck          : HealthService           .healthcheck        .bind(HealthService),
     list_documents       : DocumentService         .listDocuments      .bind(DocumentService),
     list_agent_faqs      : KBRecorderService       .listAgentFaqs      .bind(KBRecorderService),
-    manage_database      : DatabaseLifecycleService.manageDatabase     .bind(DatabaseLifecycleService),
     // MCP dispatch marks `viaMcp: true` so VectorService.embed can apply the synchronous
     // work-volume gate. CLI invocations call DatabaseService.syncDatabase directly without
     // `viaMcp`, preserving explicit operator opt-in to long-running work.

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -219,17 +219,14 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary SSE-only hook fired by `TransportService` on session disconnect. Queues the
-     * disconnected session for summarization and removes the per-session McpServer from
-     * `CoalescingEngineService`'s broadcast set (counterpart to `createMcpServer`'s
-     * `addMcpServer` registration).
+     * @summary SSE-only hook fired by `TransportService` on session disconnect. Removes the
+     * per-session McpServer from `CoalescingEngineService`'s broadcast set (counterpart to
+     * `createMcpServer`'s `addMcpServer` registration). Summarization is orchestrator-driven
+     * (the `summary` task), not triggered on disconnect.
      * @param {String} sessionId
      * @param {Object} mcpServerInstance
      */
     onSessionClosed(sessionId, mcpServerInstance) {
-        if (SessionService) {
-            SessionService.queueSummarizationJob(sessionId);
-        }
         if (mcpServerInstance) {
             CoalescingEngineService.removeMcpServer(mcpServerInstance);
         }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -54,47 +54,6 @@ class Config extends BaseConfig {
              */
             neoRootDir: leaf(neoRootDir),
             /**
-             * Automatically trigger session summarization on startup.
-             * @type {boolean}
-             */
-            autoSummarize: leaf(false, 'NEO_AUTO_SUMMARIZE', 'boolean'),
-            /**
-             * Automatically start the local database process (Chroma/SQLite) on startup.
-             * @type {boolean}
-             */
-            autoStartDatabase: leaf(false, 'NEO_MEM_AUTO_START_DATABASE', 'boolean'),
-            /**
-             * Automatically start the local inference server on startup.
-             * @type {boolean}
-             */
-            autoStartInference: leaf(false, 'NEO_MEM_AUTO_START_INFERENCE', 'boolean'),
-            /**
-             * Automatically trigger GraphRAG extraction on startup.
-             * @type {boolean}
-             */
-            autoDream: leaf(false, 'NEO_AUTO_DREAM', 'boolean'),
-            /**
-             * @deprecated since PR #11101. Golden Path synthesis is now dynamically event-driven
-             * (triggered via MemoryService#mutateFrontier) rather than bound to MCP boot sequence.
-             * This boot-time flag remains for temporary backwards-compatibility but will be
-             * removed in a future release.
-             *
-             * Automatically trigger Golden Path Synthesis into the handoff file on startup.
-             * Crucial for headless swarm nodes (Mac 2) to physically generate sandman_handoff.md.
-             * @type {boolean}
-             */
-            autoGoldenPath: leaf(false, 'NEO_AUTO_GOLDEN_PATH', 'boolean'),
-            /**
-             * Immediately parse each incoming memory turn (add_memory) for Graph Injection.
-             * @type {boolean}
-             */
-            realTimeMemoryParsing: leaf(false, 'NEO_REAL_TIME_MEMORY_PARSING', 'boolean'),
-            /**
-             * Automatically trigger FileSystem ingestion (Differential Graph Sync) on MCP server startup.
-             * @type {boolean}
-             */
-            autoIngestFileSystem: leaf(false, 'NEO_AUTO_INGEST_FS', 'boolean'),
-            /**
              * Global debug flag for all MCP servers.
              * @type {boolean}
              */

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -65,53 +65,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /db/manage:
-    post:
-      summary: Manage Database
-      operationId: manage_database
-      x-pass-as-object: true
-      description: >
-        Manages the lifecycle (start/stop) of the ChromaDB database instance for the Memory Core.
-
-        **Behavior:**
-        This tool provides a lifecycle verification interface for the unified ChromaDB database instance (port 8000). Per ADR 0003, the memory-core MCP server no longer spawns or stops its own database. It only acts as an observability passthrough.
-        - **Start:** Verifies connection to the unified database.
-        - **Stop:** Disconnects the memory-core client. Does NOT stop the external database process.
-
-        **Requirement:**
-        The unified database MUST be started externally via `npm run ai:server` before attempting to use the memory core.
-
-        **When to Use:**
-        - `action: start` if `healthcheck` shows the database connection is lost.
-        - `action: stop` to intentionally sever the connection.
-      tags: ["Database Lifecycle"]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - action
-              properties:
-                action:
-                  type: string
-                  enum: [start, stop]
-                  description: The action to perform.
-      responses:
-        '200':
-          description: Operation completed successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DatabaseLifecycleResponse'
-        '500':
-          description: Operation failed.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
   /rem/pipeline-state:
     post:
       summary: Get REM Pipeline State
@@ -510,50 +463,6 @@ paths:
                 $ref: '#/components/schemas/QuerySummariesResponse'
         '400':
           description: Invalid request body
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '503':
-          description: Cannot connect to database
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /sessions/summarize:
-    post:
-      summary: Summarize Sessions
-      operationId: summarize_sessions
-      x-pass-as-object: true
-      description: |
-        Triggers the session summarization process. This is a key step at the beginning of a new session to ensure all prior work is indexed and searchable.
-
-        **When to Use:**
-        - **Batch Mode (no sessionId):** Run at the start of a new session to summarize all previously unsummarized sessions.
-        - **Specific Mode (with sessionId):** Use to re-summarize a specific session if needed, though this is less common.
-      tags: [Sessions]
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SummarizeSessionRequest'
-      responses:
-        '200':
-          description: Summarization completed successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SummarizeSessionResponse'
-        '400':
-          description: Invalid request body
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
-          description: Session not found (in specific mode)
           content:
             application/json:
               schema:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -2,7 +2,6 @@ import path                     from 'path';
 import {fileURLToPath}          from 'url';
 import ToolService              from '../../ToolService.mjs';
 import DatabaseService          from '../../../services/memory-core/DatabaseService.mjs';
-import ChromaLifecycleService   from '../../../services/memory-core/lifecycle/ChromaLifecycleService.mjs';
 import GraphService             from '../../../services/memory-core/GraphService.mjs';
 import HealthService            from '../../../services/memory-core/HealthService.mjs';
 import MemoryService            from '../../../services/memory-core/MemoryService.mjs';
@@ -25,14 +24,12 @@ const serviceMapping = {
     get_node              : GraphService            .getNode             .bind(GraphService),
     get_session_memories  : MemoryService           .listMemories        .bind(MemoryService),
     healthcheck           : HealthService           .healthcheck         .bind(HealthService),
-    manage_database       : ChromaLifecycleService  .manageDatabase      .bind(ChromaLifecycleService),
     mutate_frontier       : MemoryService           .mutateFrontier      .bind(MemoryService),
     pre_brief_session     : MemoryService           .preBriefSession     .bind(MemoryService),
     query_hybrid_graph    : GraphService            .queryNodeTopology   .bind(GraphService),
     query_raw_memories    : MemoryService           .queryMemories       .bind(MemoryService),
     query_summaries       : SummaryService          .querySummaries      .bind(SummaryService),
     search_nodes          : GraphService            .searchNodes         .bind(GraphService),
-    summarize_sessions    : SessionService          .summarizeSessions   .bind(SessionService),
     add_message           : MailboxService          .addMessage          .bind(MailboxService),
     list_messages         : MailboxService          .listMessages        .bind(MailboxService),
     get_message           : MailboxService          .getMessage          .bind(MailboxService),

--- a/ai/scripts/runners/runSandman.mjs
+++ b/ai/scripts/runners/runSandman.mjs
@@ -93,12 +93,6 @@ export async function runSandman({
     // Enable debug logging to see progress
     Memory_Config.data.debug = true;
 
-    // STRICTLY bypass daemon startup auto-queue.
-    // If autoDream fires synchronously inside init(), the await processUndigestedSessions() skips.
-    Memory_Config.data.autoDream = false;
-    Memory_Config.data.autoSummarize = false;
-    Memory_Config.data.autoGoldenPath = false;
-
     output.log('⏳ Initializing Sandman REM Extraction Pipeline...');
 
     // Run the REM cycle under the shared heavy-maintenance lease so this CLI cannot

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -36,10 +36,6 @@ import _KB_SearchService from './services/knowledge-base/SearchService.mjs';
 import KB_ChromaManager             from './services/knowledge-base/ChromaManager.mjs';
 import KB_Config                    from './mcp/server/knowledge-base/config.mjs';
 
-// Disable auto-sync and auto-start for all scripts using the SDK to prevent double-runs and daemon spawns
-KB_Config.data.autoSync = false;
-KB_Config.data.autoStartDatabase = false;
-
 // --- Memory Core Services ---
 import _Memory_Service from './services/memory-core/MemoryService.mjs';
 import _Memory_DatabaseService from './services/memory-core/DatabaseService.mjs';
@@ -59,10 +55,6 @@ import Memory_CoalescingEngineService from './services/memory-core/CoalescingEng
 import _Memory_PermissionService from './services/memory-core/PermissionService.mjs';
 import Memory_WebhookDeliveryService from './services/memory-core/WebhookDeliveryService.mjs';
 import Memory_Config                from './mcp/server/memory-core/config.mjs';
-
-Memory_Config.data.autoSummarize = false;
-Memory_Config.data.autoStartDatabase = false;
-Memory_Config.data.autoStartInference = false;
 
 // --- Neural Link Services ---
 import _NeuralLink_ComponentService from './services/neural-link/ComponentService.mjs';

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -550,18 +550,6 @@ class DatabaseService extends Base {
 
         // Wait for ChromaManager (which waits for LifecycleService) to be ready
         await ChromaManager.ready();
-
-        logger.info('[Startup] Checking knowledge base status...');
-
-        try {
-            if (aiConfig.autoSync) {
-                logger.info('[Startup] Starting full synchronization (Create + Embed)...');
-                await this.syncDatabase();
-                logger.info('✅ [Startup] Full synchronization complete.');
-            }
-        } catch (error) {
-            logger.warn('⚠️  [Startup] Knowledge base synchronization/embedding failed:', error.message);
-        }
     }
 
     /**

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -162,18 +162,6 @@ class GraphService extends Base {
                 logger.warn(`[GraphService] Non-fatal DB contention during Identity Substrate seed: ${error.message}`);
             }
 
-            // --- 3. FILE SYSTEM INGESTION (Differential Sync) ---
-            if (aiConfig.autoIngestFileSystem) {
-                try {
-                    logger.log('[GraphService] Bootstrapping FileSystem Ingestion Native Sync...');
-                    const FileSystemIngestor = (await import('./FileSystemIngestor.mjs')).default;
-                    await FileSystemIngestor.syncWorkspaceToGraph();
-                    logger.log('[GraphService] FileSystem topology synced.');
-                } catch (error) {
-                    logger.warn(`[GraphService] Non-fatal error during FileSystem ingestion: ${error.message}`);
-                }
-            }
-
             logger.log('[GraphService] SQLite database mounted securely via ai.graph.Database.');
         })();
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -428,34 +428,25 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
 }
 
 /**
- * @summary Projects background daemon feature flags into the healthcheck `features.dream`
- *          observability block.
+ * @summary Projects the orchestrator's last dream / golden-path run timestamps into the
+ *          healthcheck `features.dream` observability block.
  *
- * Pure projection: reads the active boolean status of the background data-processing
- * features and surfaces them so operators can verify boot-time evaluations (env var overrides
- * vs defaults) without having to inspect the `config.mjs` file manually.
+ * Timestamps (`lastDreamRun`, `lastGoldenPathRun`) are `null` until the orchestrator records
+ * run history. Boot-time auto-* feature flags were retired — the orchestrator daemon is the
+ * sole driver of dream / golden-path / summarize / ingest, so there are no server-side flags
+ * left to project.
  *
- * Timestamps (`lastDreamRun`, `lastGoldenPathRun`) are initialized to `null` as placeholders
- * until the orchestrator records run history.
- *
- * @param {Object} cfg aiConfig-shaped input. Reads `cfg.autoDream`, `cfg.autoGoldenPath`,
- *     `cfg.realTimeMemoryParsing`, and `cfg.autoIngestFileSystem`.
  * @param {Object|Map<String, Object>} [taskOutcomes={}] The orchestrator task outcomes map or object.
- * @returns {{autoDream: Boolean, autoGoldenPath: Boolean, realTimeMemoryParsing: Boolean,
- *     autoIngestFileSystem: Boolean, lastDreamRun: String|null, lastGoldenPathRun: String|null}}
+ * @returns {{lastDreamRun: String|null, lastGoldenPathRun: String|null}}
  */
-export function buildDreamFeaturesBlock(cfg, taskOutcomes = {}) {
+export function buildDreamFeaturesBlock(taskOutcomes = {}) {
     const isMap = taskOutcomes instanceof Map;
     const dreamState = isMap ? taskOutcomes.get('dream') : taskOutcomes['dream'];
     const goldenPathState = isMap ? taskOutcomes.get('golden-path') : taskOutcomes['golden-path'];
 
     return {
-        autoDream            : !!cfg.autoDream,
-        autoGoldenPath       : !!cfg.autoGoldenPath,
-        realTimeMemoryParsing: !!cfg.realTimeMemoryParsing,
-        autoIngestFileSystem : !!cfg.autoIngestFileSystem,
-        lastDreamRun         : dreamState?.details?.completedAt || dreamState?.details?.failedAt || null,
-        lastGoldenPathRun    : goldenPathState?.details?.completedAt || goldenPathState?.details?.failedAt || null
+        lastDreamRun     : dreamState?.details?.completedAt || dreamState?.details?.failedAt || null,
+        lastGoldenPathRun: goldenPathState?.details?.completedAt || goldenPathState?.details?.failedAt || null
     };
 }
 /**
@@ -1093,7 +1084,7 @@ class HealthService extends Base {
             features : {
                 summarization: false,
                 wake         : await buildWakeFeaturesBlock(),
-                dream        : buildDreamFeaturesBlock(aiConfig, this.#taskOutcomes)
+                dream        : buildDreamFeaturesBlock(this.#taskOutcomes)
             },
             startup  : {
                 summarizationStatus : this.#startupSummarizationStatus || 'not_attempted',

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -344,12 +344,7 @@ class MemoryService extends Base {
             // 3. Link this memory dynamically to the active context frontier
             GraphService.linkNodes('frontier', memoryId, 'SPAWNED_MEMORY', 0.8);
 
-            // 4. Real-Time A2A JSON Parsing (Deprecated)
-            if (aiConfig.realTimeMemoryParsing) {
-                logger.warn(`[MemoryService] Real-Time parsing skipped: DreamService decoupled. Awaiting REM sleep.`);
-            }
-
-            // 5. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
+            // 4. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
             //    Non-fatal — buildMailboxDelta swallows its own errors and returns null on failure,
             //    so a degraded mailbox query never blocks a successful memory write.
             const mailbox = buildMailboxDelta();

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -293,36 +293,6 @@ class SessionService extends Base {
         // Use StorageRouter
         this.memoryCollection = await StorageRouter.getMemoryCollection();
         this.sessionsCollection = await StorageRouter.getSummaryCollection();
-
-        // Do not proceed with summarization if the API key is missing.
-        if (!this.model) {
-            return;
-        }
-
-        if (aiConfig.autoSummarize) {
-            logger.info('[Startup] Checking for unsummarized sessions...');
-
-            this.summarizeSessions({}).then(result => {
-                if (result.processed > 0) {
-                    logger.info(`✅ [Startup] Summarized ${result.processed} session(s):`);
-                    result.sessions.forEach(session => {
-                        logger.info(`   - ${session.title} (${session.memoryCount} memories)`);
-                    });
-                    HealthService.recordStartupSummarization('completed', {
-                        processed: result.processed,
-                        sessions: result.sessions.map(s => ({ title: s.title, memoryCount: s.memoryCount }))
-                    });
-                } else {
-                    logger.info('[Startup] No unsummarized sessions found');
-                    HealthService.recordStartupSummarization('completed', { processed: 0 });
-                }
-            }).catch(error => {
-                logger.warn('⚠️  [Startup] Session summarization failed:', error.message);
-                logger.warn('    You can manually trigger summarization using the summarize_sessions tool');
-                HealthService.recordStartupSummarization('failed', { error: error.message });
-            });
-        }
-
     }
 
     /**
@@ -853,60 +823,6 @@ ${aggregatedContent}
         this.currentSessionId = sessionId;
 
         return { success: true, sessionId: this.currentSessionId, replacedSessionId: oldSessionId };
-    }
-
-    /**
-     * Queues a session for summarization by writing a 'pending' marker
-     * to the SummarizationJobs table and triggering the asynchronous detector.
-     * @summary Wires disconnected SSE session state to the summarization pipeline.
-     *
-     * @param {String} sessionId
-     */
-    queueSummarizationJob(sessionId) {
-        if (!aiConfig.autoSummarize) return;
-
-        const db = GraphService.db?.storage?.db;
-        if (!db) return;
-        try {
-            db.prepare(`
-                INSERT INTO SummarizationJobs (session_id, status)
-                VALUES (?, 'pending')
-                ON CONFLICT(session_id) DO UPDATE SET
-                    status = 'pending',
-                    lease_token = NULL,
-                    expires_at = NULL
-                WHERE status != 'completed' AND status != 'in_progress'
-            `).run(sessionId);
-
-            // Asynchronously trigger processing so we don't block the caller (e.g. disconnect lifecycle)
-            setTimeout(() => this.processPendingSummarizations(), 100);
-        } catch (e) {
-            logger.warn(`[SessionService] Error queuing summarization for ${sessionId}: ${e.message}`);
-        }
-    }
-
-    /**
-     * Finds pending summarization jobs and attempts to process them.
-     * @summary Asynchronously resolves pending state markers from disconnected sessions without blocking main loops.
-     */
-    async processPendingSummarizations() {
-        const db = GraphService.db?.storage?.db;
-        if (!db) return;
-
-        try {
-            const pendingJobs = db.prepare(`
-                SELECT session_id FROM SummarizationJobs WHERE status = 'pending'
-            `).all();
-
-            for (const job of pendingJobs) {
-                // Background execution. The inner call uses claimSummarizationJob to get a lease.
-                this.summarizeSessions({ sessionId: job.session_id }).catch(e => {
-                    logger.error(`[SessionService] Background summarization failed for ${job.session_id}:`, e);
-                });
-            }
-        } catch (e) {
-            logger.warn(`[SessionService] Error processing pending summarizations: ${e.message}`);
-        }
     }
 
     /**

--- a/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
+++ b/test/playwright/fixtures/knowledgeBaseConfigDefaults.mjs
@@ -133,8 +133,6 @@ export const KB_DEFAULTS = deepFreeze(Neo.clone({
     batchDelay        : 10000,
     maxRetries        : 5,
     nResults          : 100,
-    autoSync          : false,
-    autoStartDatabase : false,
     transport         : 'stdio',
     mcpHttpPort       : 3000
 }, true, true));

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -29,7 +29,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
     test.beforeAll(async () => {
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        
+
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
@@ -41,7 +41,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
         Server = (await import('../../../../../../../ai/mcp/server/memory-core/Server.mjs')).default;
         GraphService = (await import('../../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        
+
         if (fs.existsSync(testDbPath)) {
             try {
                 fs.unlinkSync(testDbPath);
@@ -118,7 +118,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
     test('bindAgentIdentity should recover from stuck vicinityLoadedNodes cache miss', async () => {
 
         await GraphService.initAsync();
-        
+
         GraphService.upsertNode({id: '@neo-opus-4-7', type: 'AgentIdentity', name: 'Identity Node'});
 
         await new Promise(resolve => setTimeout(resolve, 50));
@@ -136,31 +136,9 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
 
         const boundId = await serverInstance.bindAgentIdentity('neo-opus-4-7');
-        
+
         expect(boundId).toBe('@neo-opus-4-7');
-        
+
         serverInstance.destroy();
-    });
-
-    test('onSessionClosed triggers SessionService.queueSummarizationJob', async () => {
-        const SessionService = (await import('../../../../../../../ai/services/memory-core/SessionService.mjs')).default;
-
-        // Mock the SessionService method
-        const originalQueue = SessionService.queueSummarizationJob.bind(SessionService);
-        let queuedSessionId = null;
-
-        SessionService.queueSummarizationJob = function(sessionId) {
-            queuedSessionId = sessionId;
-        };
-
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
-
-        try {
-            serverInstance.onSessionClosed('test-session-123');
-            expect(queuedSessionId).toBe('test-session-123');
-        } finally {
-            SessionService.queueSummarizationJob = originalQueue;
-            serverInstance.destroy();
-        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -939,10 +939,12 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
 });
 
 /**
- * @summary Coverage for the #10779 features.dream observability block in the healthcheck payload.
+ * @summary Coverage for the features.dream observability block in the healthcheck payload.
  *
- * Pins the pure-projection contract of `buildDreamFeaturesBlock`. This function surfaces the
- * active boolean status of the background data-processing features based on `aiConfig` evaluation.
+ * Pins the contract of `buildDreamFeaturesBlock` — it projects the orchestrator's last
+ * dream / golden-path run timestamps from `taskOutcomes`. The boot-time auto-* feature flags
+ * were retired (the orchestrator daemon is the sole driver of dream / golden-path / summarize /
+ * ingest), so the block carries only run timestamps.
  *
  * @see Neo.ai.services.memory-core.HealthService#buildDreamFeaturesBlock
  */
@@ -954,65 +956,23 @@ test.describe('HealthService #10779, #11309 — buildDreamFeaturesBlock', () => 
         buildDreamFeaturesBlock = mod.buildDreamFeaturesBlock;
     });
 
-    test('surfaces boolean flags directly from aiConfig and defaults timestamps to null when taskOutcomes is empty', () => {
-        const cfg = {
-            autoDream: true,
-            autoGoldenPath: false,
-            realTimeMemoryParsing: true,
-            autoIngestFileSystem: false
-        };
-
-        const result = buildDreamFeaturesBlock(cfg);
-
-        expect(result).toEqual({
-            autoDream: true,
-            autoGoldenPath: false,
-            realTimeMemoryParsing: true,
-            autoIngestFileSystem: false,
-            lastDreamRun: null,
-            lastGoldenPathRun: null
-        });
-    });
-
-    test('coerces missing or falsy config values to strict booleans', () => {
-        const cfg = {
-            // autoDream missing
-            autoGoldenPath: null,
-            realTimeMemoryParsing: undefined,
-            autoIngestFileSystem: ''
-        };
-
-        const result = buildDreamFeaturesBlock(cfg);
-
-        expect(result).toEqual({
-            autoDream: false,
-            autoGoldenPath: false,
-            realTimeMemoryParsing: false,
-            autoIngestFileSystem: false,
-            lastDreamRun: null,
-            lastGoldenPathRun: null
-        });
-    });
-
     test('surfaces completedAt timestamp from task outcomes', () => {
-        const cfg = { autoDream: true, autoGoldenPath: true };
         const taskOutcomes = new Map();
         taskOutcomes.set('dream', { details: { completedAt: '2026-05-13T20:00:00.000Z' } });
         taskOutcomes.set('golden-path', { details: { completedAt: '2026-05-13T20:05:00.000Z' } });
 
-        const result = buildDreamFeaturesBlock(cfg, taskOutcomes);
+        const result = buildDreamFeaturesBlock(taskOutcomes);
 
         expect(result.lastDreamRun).toBe('2026-05-13T20:00:00.000Z');
         expect(result.lastGoldenPathRun).toBe('2026-05-13T20:05:00.000Z');
     });
 
     test('surfaces failedAt timestamp from task outcomes when completedAt is absent', () => {
-        const cfg = { autoDream: true, autoGoldenPath: true };
         const taskOutcomes = new Map();
         taskOutcomes.set('dream', { details: { failedAt: '2026-05-13T20:01:00.000Z' } });
         taskOutcomes.set('golden-path', { details: { failedAt: '2026-05-13T20:06:00.000Z' } });
 
-        const result = buildDreamFeaturesBlock(cfg, taskOutcomes);
+        const result = buildDreamFeaturesBlock(taskOutcomes);
 
         expect(result.lastDreamRun).toBe('2026-05-13T20:01:00.000Z');
         expect(result.lastGoldenPathRun).toBe('2026-05-13T20:06:00.000Z');


### PR DESCRIPTION
## Summary

**PR A of #12139** — the de-auto-trigger surface. Makes the Memory-Core + Knowledge-Base MCP servers pure clients of an orchestrator-driven substrate: no boot-time self-triggers, no redundant autonomy tools. The orchestrator daemon already drives every one of these behaviors on its own schedule (#12065: `dream` / `summary` / `golden-path` / `chroma` / `kbSync` tasks), so the server-side flags were a **redundant second source of truth** — every SDK script + `runSandman` already hardcoded them to `false` defensively to avoid double-runs.

## Deltas

- **9 boot-time auto-* config leaves removed** — MC: `autoSummarize` / `autoStartDatabase` / `autoStartInference` / `autoDream` / `autoGoldenPath` / `realTimeMemoryParsing` / `autoIngestFileSystem`; KB: `autoStartDatabase` / `autoSync` (+ env bindings).
- **Boot hooks removed** — `SessionService` startup-summarize, `DreamService` autoDream, `GraphService` autoIngestFileSystem, `MemoryService` realTimeMemoryParsing (already a dead no-op), KB `DatabaseService` autoSync.
- **On-disconnect summarize path removed** — `SessionService.queueSummarizationJob` + `processPendingSummarizations` + the `Server.onSessionClosed` call. (Summarization is orchestrator-driven; the `summary` task's drift sweep covers disconnected sessions. The path was already off under the default `autoSummarize:false`.)
- **2 redundant MCP tools removed** — `manage_database` (MC + KB) + `summarize_sessions` (MC). **`mutate_frontier` kept** (agent-facing primitive). Now-unused `ChromaLifecycleService` / `DatabaseLifecycleService` toolService imports dropped.
- **`HealthService.buildDreamFeaturesBlock`** simplified to `{lastDreamRun, lastGoldenPathRun}` (the auto-* feature flags it projected are retired).
- **Defensive `= false` overrides removed** — `ai/services.mjs` + `runSandman.mjs`.

The `summarizeSessions` *method* stays — the orchestrator's `summarize-sessions.mjs` runner calls it.

## Test Evidence

341 affected specs pass (`test-unit`): HealthService.spec, Server.spec, both KB Config specs, DatabaseService.backup.spec (85 passed) + DreamService / SessionService / SessionSummarization / QueryReRanker / ResumeValidation / ConceptIngestor / MemorySessionIngestor / LazyEdgeDrainer / SemanticGraphExtractor (256 passed).

Evidence: `node --check` clean on all 16 changed files; `grep` confirms 0 residual `aiConfig.autoX` / `.data.autoX` consumers in prod. Updated specs: HealthService.spec (`buildDreamFeaturesBlock` → timestamps-only), Server.spec (removed the obsolete `onSessionClosed → queueSummarizationJob` test), `knowledgeBaseConfigDefaults.mjs` fixture (dropped the 2 retired KB leaves).

## Post-Merge Validation

Behaviour-preserving: every removed flag defaulted to `false` (no boot trigger fired in the default config), and the orchestrator owns each behavior. No env-contract change for operators running the orchestrator (the intended topology).

Known trivial follow-up: a few unit specs retain harmless dead `aiConfig.autoX = false` setup-lines (no-ops now; all 341 specs green) — left out to keep this diff focused; a hygiene sweep will clear them.

FAIR-band: n/a — operator-directed lane (#12139, scope expanded 2026-05-30).

Refs #12139 (PR B = lifecycle-service collapse + ChromaManager simplification + healthcheck managed/strategy branching).

Authored by Claude Opus 4.8 (Claude Code, 1M context).
