### PR TITLE
feat(ai): extend retired-primitive guard to block re-adding orchestrator-owned config flags + MCP tools (Resolves #12198)

### DIFF
--- a/ai/scripts/diagnostics/check-retired-primitives.mjs
+++ b/ai/scripts/diagnostics/check-retired-primitives.mjs
@@ -3,47 +3,92 @@ import path           from 'node:path';
 import process        from 'node:process';
 
 /**
- * Pre-Flight (structural fast-path): authoring `ai/scripts/diagnostics/check-retired-primitives.mjs`
- * matches sibling pattern of `ai/scripts/diagnostics/check-substrate-size.mjs` and
- * `ai/scripts/lint/lint-skill-manifest.mjs` in `ai/scripts/`; all three are mechanical-enforcement /
- * CI scripts for agent substrate validation; sibling-file-lift applies; no novel directory
- * choice.
+ * Pre-Flight (structural fast-path): `ai/scripts/diagnostics/check-retired-primitives.mjs`
+ * matches the sibling pattern of `ai/scripts/diagnostics/check-substrate-size.mjs` and
+ * `ai/scripts/lint/lint-skill-manifest.mjs` in `ai/scripts/`; all are mechanical-enforcement /
+ * CI scripts for agent substrate validation; sibling-file-lift applies; no novel directory choice.
  *
- * @summary CI grep-fail check that retired primitives (ADR 0004 §2.3) are not
- * imported from non-spec source files. Complements ADR 0004's discipline-only
- * §1.3/§2.6/§5.6 substrate-evolution-guard layer with mechanical enforcement,
- * closing the reviewer-time lookback window where dead-code preservation can
- * otherwise survive until peer review.
+ * @summary CI grep-fail check that retired Agent-OS primitives are not re-introduced under `ai/`.
+ *
+ * Three enforcement categories:
+ *   1. **Retired module imports** — a retired primitive imported from a non-spec source file
+ *      (ADR 0004 §2.3 / §2.6 Clean-Cut Pattern).
+ *   2. **Retired per-MCP-server config flags** — a removed boot-time auto-* flag re-declared as a
+ *      `leaf(...)` in a server `config.template.mjs`.
+ *   3. **Retired MCP tools** — a removed tool's `operationId` re-added to a server `openapi.yaml`
+ *      (the tool-shape SSOT).
+ *
+ * Why categories 2 + 3 exist: the orchestrator daemon is the single source of truth for background
+ * memory/KB maintenance. The Agent OS evolves fast, so a backlog ticket older than a week may carry
+ * a premise a later migration has obsoleted. A fresh session acting on such a ticket can naively
+ * "re-implement the missing config" and resurrect a per-MCP-instance self-trigger — the exact pattern
+ * that caused duplicate background work across harness-spawned instances. A comment cannot stop that;
+ * a red merge-gate can. This guard converts that regression class into an unmergeable failure with a
+ * premise-correcting message that names the owning subsystem.
  *
  * @see learn/agentos/decisions/0004-github-content-architecture.md §2.6 Clean-Cut Pattern
  */
 
+const SEARCH_ROOT = 'ai/';
+
 /**
- * Retired primitives that MUST NOT be imported from non-spec source files.
- * Add new entries as ADR 0004 §2.3 RETIRED table grows. Each entry is the import-path
- * fragment as it would appear inside a `from '...'` clause.
- *
- * Anchored to the universal GitHub-content substrate: both files are retired
- * once their call sites use `contentPath.mjs` / `contentIndex.mjs`. The §2.6
- * Clean-Cut Pattern mandates deletion, not preservation as dead code.
+ * Orchestrator-SSOT migration references, surfaced in the category 2 + 3 failure messages so a
+ * developer who hits the guard can find why the primitive was retired and who owns the behavior now.
+ * Load-bearing (it is the actionable pointer), not decorative archaeology.
+ */
+const ORCHESTRATOR_REF = '#12139 / #12065';
+
+/**
+ * Retired module-import fragments that MUST NOT be imported from non-spec source files.
+ * Each entry is the import-path fragment as it appears inside a `from '...'` clause.
+ * Add entries as the ADR 0004 §2.3 RETIRED table grows. The §2.6 Clean-Cut Pattern mandates
+ * deletion, not preservation as dead code.
  */
 const RETIRED_PRIMITIVES = [
     'shared/chunkPath.mjs',
     'shared/archivePath.mjs'
 ];
 
-const SEARCH_ROOT  = 'ai/';
-const EXCLUDE_GLOB = ['*.spec.mjs', '*.test.mjs'];
+/**
+ * Retired per-MCP-server boot-time config flags. Removed in #12139; the orchestrator daemon (#12065)
+ * drives every one of these behaviors on its own schedule (dream / summary / golden-path / chroma /
+ * kbSync tasks). Re-declaring any as a `leaf(...)` in a server `config.template.mjs` would resurrect
+ * the per-instance self-trigger that caused duplicate background work across harness-spawned MCP
+ * instances (Claude Desktop / Codex / Antigravity each spawn N instances per server).
+ *
+ * `autoStartInference` is the canonical trap: its config was string-matched but the auto-start LOGIC
+ * was never implemented. A stale ticket reading "implement inference auto-start" would lead a fresh
+ * session to re-add the flag, not knowing the orchestrator owns inference lifecycle (mlx/lms
+ * continuous tasks). De-duplicated across servers (`autoStartDatabase` was declared in both
+ * memory-core and knowledge-base).
+ */
+const RETIRED_CONFIG_FLAGS = [
+    'autoSummarize',
+    'autoStartDatabase',
+    'autoStartInference',
+    'autoDream',
+    'autoGoldenPath',
+    'realTimeMemoryParsing',
+    'autoIngestFileSystem',
+    'autoSync'
+];
 
 /**
- * Escapes ALL regex metacharacters in a string fragment so it can be safely embedded
- * in an extended-regex pattern. This keeps future retired-primitive entries
- * from becoming regex metacharacter input.
- *
- * Prior version escaped only `.`, leaving backslashes + other metacharacters (`* + ? ^ $ { } ( ) | [ ] \\`)
- * unprotected. While the current `RETIRED_PRIMITIVES` values contain none of these, defensive
- * full-metachar escaping makes the function safe for any future fragment a maintainer adds —
- * matching MDN's canonical `escapeRegExp` shape.
+ * Retired MCP tools. Removed in #12139; the orchestrator daemon owns the Chroma database lifecycle
+ * (`manage_database`) and session summarization (`summarize_sessions`) — the MCP servers are pure
+ * clients. Re-adding an `operationId` for either to a server `openapi.yaml` re-advertises a tool the
+ * orchestrator owns (and breaks the derived tool-consistency specs, which assert that every
+ * `operationId` has a `serviceMapping` handler).
+ */
+const RETIRED_MCP_TOOLS = [
+    'manage_database',
+    'summarize_sessions'
+];
+
+/**
+ * Escapes ALL regex metacharacters in a string fragment so it can be safely embedded in an
+ * extended-regex pattern, keeping retired-item entries from becoming regex metacharacter input.
+ * Matches MDN's canonical `escapeRegExp` shape.
  *
  * @param {string} s Raw fragment string to escape.
  * @returns {string} Regex-safe escaped form.
@@ -53,32 +98,80 @@ function escapeRegex(s) {
 }
 
 /**
- * Builds a single grep extended-regex pattern matching any `from '...<retired>'` style import,
- * tolerating single, double, or template-literal quoting. All regex metacharacters in path
- * fragments are escaped via `escapeRegex()` so values containing `*`, `[`, `\\`, etc. are
- * treated as literals.
- * @returns {string}
+ * Builds the three enforcement categories. Each declares: the retired `items`, the grep extended-regex
+ * `pattern` that detects a re-introduction, the file `include` globs to scan (empty = all files), the
+ * `exclude` globs, and a premise-correcting `help` footer printed on a hit. A category with zero items
+ * is skipped by {@link main}.
+ *
+ * - **import** — `from '...<fragment>'` across all of `ai/` (excluding specs), tolerating single,
+ *   double, or template-literal quoting.
+ * - **config flag** — `<flag>:` as an object key (anchored to line-start indentation, so JSDoc/comment
+ *   mentions like ` * autoSync:` or `// autoSync` do not match), scanned only in `config.template.mjs`.
+ * - **MCP tool** — `operationId: <tool>` at line end (so `manage_database_v2` does not false-match),
+ *   scanned only in `openapi.yaml`.
+ *
+ * @returns {Array<{label:string, items:string[], pattern:string, include:string[], exclude:string[], help:string[]}>}
  */
-function buildPattern() {
-    return RETIRED_PRIMITIVES
-        .map(fragment => `from[[:space:]]+['"\`].*${escapeRegex(fragment)}`)
-        .join('|');
+function buildCategories() {
+    return [
+        {
+            label  : 'retired-primitive import',
+            items  : RETIRED_PRIMITIVES,
+            pattern: RETIRED_PRIMITIVES.map(f => `from[[:space:]]+['"\`].*${escapeRegex(f)}`).join('|'),
+            include: [],
+            exclude: ['*.spec.mjs', '*.test.mjs'],
+            help   : [
+                'Refer to ADR 0004 §2.6 (Clean-Cut Pattern) and §5.6 (Deprecation-theater anti-pattern):',
+                '  learn/agentos/decisions/0004-github-content-architecture.md',
+                'Retired primitives must be DELETED, not preserved as dead code after call-site migration.'
+            ]
+        },
+        {
+            label  : 'retired config flag',
+            items  : RETIRED_CONFIG_FLAGS,
+            pattern: RETIRED_CONFIG_FLAGS.map(f => `^[[:space:]]*${escapeRegex(f)}[[:space:]]*:`).join('|'),
+            include: ['config.template.mjs'],
+            exclude: [],
+            help   : [
+                `These boot-time auto-* flags are retired (${ORCHESTRATOR_REF}). The orchestrator daemon is the`,
+                'single source of truth for dream / summary / golden-path / chroma / kbSync — per-MCP-server',
+                'self-triggers caused duplicate background work across harness-spawned instances.',
+                'Do NOT re-add the flag. If a backlog ticket told you to "implement" one of these, that ticket\'s',
+                'premise is obsolete — close/annotate it rather than resurrect the config. (e.g. autoStartInference',
+                'never had real logic; the orchestrator owns inference lifecycle via mlx/lms continuous tasks.)'
+            ]
+        },
+        {
+            label  : 'retired MCP tool',
+            items  : RETIRED_MCP_TOOLS,
+            pattern: RETIRED_MCP_TOOLS.map(t => `operationId:[[:space:]]*${escapeRegex(t)}[[:space:]]*$`).join('|'),
+            include: ['openapi.yaml'],
+            exclude: [],
+            help   : [
+                `These MCP tools are retired (${ORCHESTRATOR_REF}). The orchestrator owns the Chroma database`,
+                'lifecycle (manage_database) and session summarization (summarize_sessions); the MCP servers are',
+                'pure clients. Do NOT re-add the operationId — the orchestrator drives these behaviors.'
+            ]
+        }
+    ];
 }
 
 /**
- * Runs the grep scan. Returns matching lines on hit, empty string on clean.
- * Distinguishes "no match" (exit 1) from real grep error (exit 2+).
- *
- * Uses execFileSync (no shell intermediate) so the pattern can contain all three quote types
- * (`'`, `"`, `\``) safely without shell-quoting hazards.
+ * Runs one grep scan. Returns matching lines on hit, empty string on clean. Distinguishes "no match"
+ * (grep exit 1, the CLEAN case) from a real grep error (exit 2+, re-thrown). Uses execFileSync (no
+ * shell intermediate) so the pattern can contain all three quote types (`'`, `"`, `` ` ``) safely.
  *
  * @param {string} pattern Extended-regex pattern.
+ * @param {Object} [opts]
+ * @param {string[]} [opts.include=[]] grep `--include` globs (empty = all files).
+ * @param {string[]} [opts.exclude=[]] grep `--exclude` globs.
  * @returns {string}
  */
-function runScan(pattern) {
+function runScan(pattern, {include = [], exclude = []} = {}) {
     const args = [
         '-rnE',
-        ...EXCLUDE_GLOB.map(g => `--exclude=${g}`),
+        ...exclude.map(g => `--exclude=${g}`),
+        ...include.map(g => `--include=${g}`),
         pattern,
         SEARCH_ROOT
     ];
@@ -96,33 +189,45 @@ function runScan(pattern) {
 }
 
 function main() {
-    if (RETIRED_PRIMITIVES.length === 0) {
-        console.log('[checkRetiredPrimitives] PASS: RETIRED_PRIMITIVES table is empty — nothing to enforce.');
+    const categories = buildCategories().filter(category => category.items.length > 0);
+
+    if (categories.length === 0) {
+        console.log('[checkRetiredPrimitives] PASS: no retired items configured — nothing to enforce.');
         process.exit(0);
     }
 
-    const root    = path.resolve(process.cwd());
-    const pattern = buildPattern();
-
-    console.log(`\n🔍 Checking for retired-primitive imports under ${SEARCH_ROOT} ...`);
-    console.log(`    Enforcing ${RETIRED_PRIMITIVES.length} retired primitive(s):`);
-    RETIRED_PRIMITIVES.forEach(p => console.log(`      • ${p}`));
+    console.log(`\n🔍 Checking for retired Agent-OS primitives under ${SEARCH_ROOT} ...`);
+    categories.forEach(category => {
+        console.log(`    ${category.label} (${category.items.length}): ${category.items.join(', ')}`);
+    });
     console.log('-'.repeat(80));
 
-    const matches = runScan(pattern);
+    const failures = [];
 
-    if (matches.trim() === '') {
-        console.log(`✅ PASS: no retired-primitive imports found under ${SEARCH_ROOT}.`);
-        console.log(`    Substrate is in compliance with ADR 0004 §2.6 Clean-Cut Pattern.\n`);
+    for (const category of categories) {
+        const matches = runScan(category.pattern, {include: category.include, exclude: category.exclude});
+        if (matches.trim() !== '') {
+            failures.push({category, matches});
+        }
+    }
+
+    if (failures.length === 0) {
+        console.log(`✅ PASS: no retired imports, config flags, or MCP tools found under ${SEARCH_ROOT}.`);
+        console.log(`    Substrate is in compliance (ADR 0004 §2.6 Clean-Cut Pattern + orchestrator-SSOT ${ORCHESTRATOR_REF}).\n`);
         process.exit(0);
     }
 
-    console.error(`❌ FAIL: retired-primitive imports found under ${SEARCH_ROOT}:\n`);
-    console.error(matches);
-    console.error(`\nRoot: ${root}`);
-    console.error(`Refer to ADR 0004 §2.6 (Clean-Cut Pattern) and §5.6 (Deprecation-theater anti-pattern):`);
-    console.error(`  learn/agentos/decisions/0004-github-content-architecture.md`);
-    console.error(`Retired primitives must be DELETED, not preserved as dead code after call-site migration.\n`);
+    console.error(`❌ FAIL: retired Agent-OS primitives re-introduced under ${SEARCH_ROOT}:\n`);
+
+    for (const {category, matches} of failures) {
+        console.error(`  ▸ ${category.label}:`);
+        console.error(matches.replace(/^/gm, '      ').trimEnd());
+        console.error('');
+        category.help.forEach(line => console.error(`      ${line}`));
+        console.error('');
+    }
+
+    console.error(`Root: ${path.resolve(process.cwd())}\n`);
     process.exit(1);
 }
 

--- a/test/playwright/unit/ai/scripts/diagnostics/checkRetiredPrimitives.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/checkRetiredPrimitives.spec.mjs
@@ -1,159 +1,111 @@
-import {setup} from '../../../../setup.mjs';
-
-const appName = 'CheckRetiredPrimitivesTest';
-
-setup({
-    neoConfig: {
-        unitTestMode: true
-    },
-    appConfig: {
-        name             : appName,
-        isMounted        : () => true,
-        vnodeInitialising: false
-    }
-});
-
 import {test, expect} from '@playwright/test';
-import {execFileSync} from 'child_process';
-import path           from 'path';
-import fs             from 'fs/promises';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {execFileSync}  from 'node:child_process';
+import fs             from 'node:fs';
+import path            from 'node:path';
+
+// The Playwright unit runner executes with cwd = repo root, so resolve against it rather than
+// __dirname arithmetic — the latter is brittle across nesting depth and git-worktree layouts.
+const
+    repoRoot   = process.cwd(),
+    scriptPath = path.join(repoRoot, 'ai/scripts/diagnostics/check-retired-primitives.mjs');
 
 /**
- * @summary Coverage for `ai/scripts/diagnostics/check-retired-primitives.mjs` — the mechanical-enforcement
- * layer that complements ADR 0004's discipline-only §1.3/§2.6/§5.6 substrate-evolution-guard.
+ * Runs the guard with a throwaway fixture file written under the real SEARCH_ROOT (`ai/`), then
+ * cleans up. Returns the script's exit code + combined stdout/stderr. The fixture lives in a
+ * dedicated directory so cleanup is a single recursive remove even if the assertion throws.
  *
- * Test axes (matching ticket #11406 ACs):
- *
- * 1. **AC3 — clean substrate**: running the script against the current working tree (substrate
- *    is post-PR-#11403-clean-cut, no retired-primitive imports remain) must exit 0 and emit the
- *    PASS narrative naming the ADR 0004 §2.6 reference.
- *
- * 2. **AC4 — canary regression**: planting a deliberate retired-primitive import in a non-spec
- *    source file under `ai/` must cause the script to exit 1 and emit the FAIL narrative
- *    naming the offending file:line and the ADR 0004 §2.6 cross-reference.
- *
- * The canary is created/torn-down inside the test scope so cross-suite parallel runs cannot
- * see a transient retired-primitive import that would mask other failures. Test placement
- * deliberately uses `__retired_test_canary_*` prefix to make grep-discovery / cleanup unambiguous.
+ * @param {string} relFile Path (relative to repo root, under `ai/`) of the fixture file to write.
+ * @param {string} content File contents that should trip exactly one guard category.
+ * @returns {{exitCode:number, output:string}}
  */
-// `describe.serial` is REQUIRED: tests plant on-disk canary files under `ai/` whose visibility
-// would otherwise leak across Playwright's parallel workers (fullyParallel default). With serial
-// execution, the AC3 clean-substrate test runs first against a verified-clean tree, and each
-// canary-planting test cleans up before the next runs (`feedback_symmetric_spec_cleanup.md`).
-test.describe.serial('ai/scripts/check-retired-primitives', () => {
-    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/diagnostics/check-retired-primitives.mjs');
+function runWithFixture(relFile, content) {
+    const
+        fixtureFile = path.join(repoRoot, relFile),
+        fixtureDir  = path.dirname(fixtureFile);
 
-    test('AC3: exits 0 with PASS narrative on a clean substrate', async () => {
-        const output = execFileSync('node', [scriptPath], {encoding: 'utf-8'});
+    let exitCode = 0,
+        output   = '';
 
-        expect(output).toContain('PASS');
-        expect(output).toContain('no retired-primitive imports found');
-        expect(output).toContain('ADR 0004 §2.6');
+    try {
+        fs.mkdirSync(fixtureDir, {recursive: true});
+        fs.writeFileSync(fixtureFile, content);
+
+        execFileSync('node', [scriptPath], {cwd: repoRoot, encoding: 'utf8'});
+    } catch (err) {
+        exitCode = err.status;
+        output   = (err.stdout || '') + (err.stderr || '');
+    } finally {
+        fs.rmSync(fixtureDir, {recursive: true, force: true});
+    }
+
+    return {exitCode, output};
+}
+
+/**
+ * @summary CI guard test for `check-retired-primitives.mjs`.
+ *
+ * Verifies the guard distinguishes a clean tree from each re-introduction category: retired module
+ * import, retired per-MCP-server config flag (#12139), and retired MCP tool (#12139). Each negative
+ * case writes a throwaway fixture under `ai/`, runs the guard as a subprocess, asserts the failure,
+ * then cleans up — covering the falsifying input, not just the happy path.
+ *
+ * @see ai/scripts/diagnostics/check-retired-primitives.mjs
+ */
+// `describe.serial` is REQUIRED: the negative-case tests plant on-disk fixture files under `ai/`
+// whose visibility would otherwise leak across Playwright's parallel workers (fullyParallel default).
+// Without serial execution, the clean-tree PASS test + the JSDoc non-false-match test would race
+// against another worker's planted fixture and see a transient retired primitive that isn't theirs.
+test.describe.serial('check-retired-primitives CI guard', () => {
+    test('exits 0 (PASS) on the current clean tree', () => {
+        // The committed tree must be free of retired primitives, config flags, and MCP tools.
+        const result = execFileSync('node', [scriptPath], {cwd: repoRoot, encoding: 'utf8'});
+        expect(result).toContain('PASS');
     });
 
-    test('AC4: exits 1 with FAIL narrative when a non-spec source imports a retired primitive', async () => {
-        // Plant a deliberate canary under ai/services/github-workflow/sync/ (a path that lies
-        // INSIDE the script's SEARCH_ROOT and OUTSIDE its excluded *.spec.mjs / *.test.mjs glob).
-        const canaryPath = path.resolve(
-            process.cwd(),
-            'ai/services/github-workflow/sync/__retired_test_canary_check_retired_primitives.mjs'
+    test('exits 1 (FAIL) on a re-added retired-primitive import', () => {
+        const {exitCode, output} = runWithFixture(
+            'ai/__retired_primitive_fixture__/probe.mjs',
+            "import {chunkPath} from '../shared/chunkPath.mjs';\n"
         );
-
-        const canaryContent = [
-            '// Auto-generated test canary for check-retired-primitives.mjs AC4.',
-            "// This file deliberately imports a retired primitive to verify the CI grep-fail check.",
-            "// The script under test (ai/scripts/diagnostics/check-retired-primitives.mjs) MUST detect this import",
-            "// and exit 1; the test cleanup unlinks this file regardless of pass/fail.",
-            "import chunkPath from '../shared/chunkPath.mjs';",
-            'export default chunkPath;',
-            ''
-        ].join('\n');
-
-        await fs.writeFile(canaryPath, canaryContent, 'utf-8');
-
-        let exitCode = null;
-        let stdout   = '';
-        let stderr   = '';
-
-        try {
-            execFileSync('node', [scriptPath], {encoding: 'utf-8'});
-            // Reaching here means script exited 0 — that's the bug.
-            exitCode = 0;
-        } catch (err) {
-            exitCode = err.status;
-            stdout   = err.stdout || '';
-            stderr   = err.stderr || '';
-        } finally {
-            // Always cleanup so a failing assertion doesn't leak the canary into other tests.
-            await fs.unlink(canaryPath).catch(() => {});
-        }
 
         expect(exitCode).toBe(1);
-        const combined = stdout + stderr;
-        expect(combined).toContain('FAIL');
-        expect(combined).toContain('__retired_test_canary_check_retired_primitives.mjs');
-        expect(combined).toContain('shared/chunkPath.mjs');
-        expect(combined).toContain('ADR 0004 §2.6');
+        expect(output).toContain('FAIL');
+        expect(output).toContain('retired-primitive import');
     });
 
-    test('AC4 (assignees-deletion variant): catches archivePath.mjs imports too', async () => {
-        const canaryPath = path.resolve(
-            process.cwd(),
-            'ai/services/github-workflow/sync/__retired_test_canary_archive_path.mjs'
+    test('exits 1 (FAIL) on a re-added retired config flag in a config.template.mjs', () => {
+        // autoStartInference is the canonical trap: config string-matched, logic never implemented.
+        const {exitCode, output} = runWithFixture(
+            'ai/__retired_config_fixture__/config.template.mjs',
+            '        autoStartInference: leaf(false, "NEO_MEM_AUTO_START_INFERENCE", "boolean"),\n'
         );
-
-        await fs.writeFile(
-            canaryPath,
-            "import archivePath from '../shared/archivePath.mjs';\nexport default archivePath;\n",
-            'utf-8'
-        );
-
-        let exitCode = null;
-        let combined = '';
-
-        try {
-            execFileSync('node', [scriptPath], {encoding: 'utf-8'});
-            exitCode = 0;
-        } catch (err) {
-            exitCode = err.status;
-            combined = (err.stdout || '') + (err.stderr || '');
-        } finally {
-            await fs.unlink(canaryPath).catch(() => {});
-        }
 
         expect(exitCode).toBe(1);
-        expect(combined).toContain('shared/archivePath.mjs');
-        expect(combined).toContain('__retired_test_canary_archive_path.mjs');
+        expect(output).toContain('FAIL');
+        expect(output).toContain('retired config flag');
+        expect(output).toContain('autoStartInference');
     });
 
-    test('script does NOT flag a spec file that imports a retired primitive (excluded glob)', async () => {
-        // Spec files are excluded by design — they may legitimately reference retired primitives
-        // for negative-test fixtures (e.g., regression coverage proving the primitive is gone).
-        const canaryPath = path.resolve(
-            process.cwd(),
-            'ai/services/github-workflow/sync/__retired_test_canary_spec_exclusion.spec.mjs'
+    test('exits 1 (FAIL) on a re-added retired MCP-tool operationId in an openapi.yaml', () => {
+        const {exitCode, output} = runWithFixture(
+            'ai/__retired_tool_fixture__/openapi.yaml',
+            '      operationId: manage_database\n'
         );
 
-        await fs.writeFile(
-            canaryPath,
-            "import chunkPath from '../shared/chunkPath.mjs';\nexport default chunkPath;\n",
-            'utf-8'
+        expect(exitCode).toBe(1);
+        expect(output).toContain('FAIL');
+        expect(output).toContain('retired MCP tool');
+    });
+
+    test('does NOT false-match a config flag named in a JSDoc/comment line', () => {
+        // A documentation mention (not an object-key declaration) must not trip the guard:
+        // the config-flag pattern is anchored to line-start indentation, so ` * autoSync` and
+        // `// autoSync` are ignored. This guards against over-eager removal of explanatory prose.
+        const {exitCode} = runWithFixture(
+            'ai/__retired_comment_fixture__/config.template.mjs',
+            '            // autoSync was removed; the orchestrator owns kbSync now.\n'
         );
 
-        let exitCode = null;
-
-        try {
-            execFileSync('node', [scriptPath], {encoding: 'utf-8'});
-            exitCode = 0;
-        } catch (err) {
-            exitCode = err.status;
-        } finally {
-            await fs.unlink(canaryPath).catch(() => {});
-        }
-
-        // Substrate is still clean from the script's perspective because spec files are excluded.
         expect(exitCode).toBe(0);
     });
 });


### PR DESCRIPTION
## Summary

Extends the retired-primitive CI guard into a **mechanical merge-gate against the "dangerous stale ticket" regression class**. The orchestrator daemon is the single source of truth for background memory/KB maintenance; with the Agent OS evolving fast, a backlog ticket older than a week may carry a premise a later migration has obsoleted. A fresh session acting on such a ticket can naively "re-implement the missing config" and resurrect a per-MCP-instance self-trigger — the pattern that caused duplicate background work across harness-spawned instances (Claude Desktop / Codex / Antigravity). A comment can't stop that; a red merge-gate can.

## Deltas

`ai/scripts/diagnostics/check-retired-primitives.mjs` — generalized from one enforcement category to three (declarative tables + category-aware grep matchers; the existing `escapeRegex` + exit-code handling reused):

1. **retired-primitive import** (existing — ADR 0004 §2.6 Clean-Cut Pattern) — behavior unchanged.
2. **retired config flag** (new) — scans `config.template.mjs` for a re-added `<flag>: leaf(` declaration of any of the 8 boot-time auto-* flags removed in #12139 (`autoSummarize`, `autoStartDatabase`, `autoStartInference`, `autoDream`, `autoGoldenPath`, `realTimeMemoryParsing`, `autoIngestFileSystem`, `autoSync`). **Line-start-anchored** so JSDoc/comment mentions don't false-match.
3. **retired MCP tool** (new) — scans `openapi.yaml` for a re-added `operationId:` of `manage_database` or `summarize_sessions`. **Line-end-anchored** so `manage_database_v2`-style names don't false-match.

Each category prints a premise-correcting failure message naming the owning subsystem + migration ref (`#12139 / #12065`), so a developer who trips the guard learns *the ticket's premise is obsolete* rather than resurrecting the primitive. `autoStartInference` is the canonical trap — its config was string-matched but the auto-start logic was never implemented; the orchestrator owns inference lifecycle (mlx/lms continuous tasks).

`test/playwright/unit/ai/scripts/diagnostics/checkRetiredPrimitives.spec.mjs` — extended from 2 to 5 tests via a DRY fixture helper: clean-pass + a fail-fixture for each of the three categories + a JSDoc/comment **non**-false-match guard (falsifying inputs, not just the happy path). Restored `test.describe.serial` (the negative cases plant on-disk fixtures under `ai/` that would otherwise leak across Playwright's parallel workers).

## Test Evidence

Evidence: L2 (executed) — `npm run test-unit -- …/checkRetiredPrimitives.spec.mjs` exits 0 with **5/5 passing** on this branch (rebased onto dev with #12197 merged); CI `unit` SUCCESS on the head commit.

5/5 spec tests pass: clean tree → exit 0 / PASS; config-flag fixture → exit 1 naming `retired config flag` + `autoStartInference`; MCP-tool fixture → exit 1 naming `retired MCP tool`; import fixture → exit 1 (existing behavior intact); JSDoc-comment fixture → exit 0 (no false-match); all fixtures auto-cleaned. `node --check` clean on both files; both pre-commit gates (`check-whitespace`, `check-shorthand`) pass. The guard is the spec's sole consumer, so the output-format generalization breaks nothing else.

## Post-Merge Validation

Pure CI/build-time guard — no runtime behavior. On merge, any future PR re-adding one of these flags/tools becomes unmergeable with a self-explaining message naming the orchestrator owner.

This is the **specific** mechanical defense; the **general** stale-Agent-OS-ticket risk is addressed by throughput (shrinking the backlog faster than it decays) + per-ticket premise V-B-A at intake. Follow-up candidate (not in scope): a targeted re-triage sweep of the highest-risk behavior-tickets (e.g. the `inference server` cluster).

## Decision Record impact

`aligned-with ADR 0004` §2.6 (Clean-Cut Pattern) + §5.6 — extends the same mechanical-enforcement layer from retired modules to retired config flags + MCP tools.

FAIR-band: n/a — operator-directed lane (#12198).

Resolves #12198.

Authored by Claude Opus 4.8 (Claude Code, 1M context).
