### PR TITLE
refactor(ai): collapse MC+KB lifecycle services to readiness gates; drop managed-mode artifacts (Resolves #12139)

### DIFF
--- a/ai/services/knowledge-base/DatabaseLifecycleService.mjs
+++ b/ai/services/knowledge-base/DatabaseLifecycleService.mjs
@@ -1,39 +1,32 @@
-import {spawn}  from 'child_process';
-import aiConfig from '../../mcp/server/knowledge-base/config.mjs';
-import logger   from '../../mcp/server/knowledge-base/logger.mjs';
-import Base     from '../../../src/core/Base.mjs';
-import Observable from '../../../src/core/Observable.mjs';
+import logger from '../../mcp/server/knowledge-base/logger.mjs';
+import Base   from '../../../src/core/Base.mjs';
 
 /**
- * @summary Manages the lifecycle of the ChromaDB process for the Knowledge Base.
+ * @summary Readiness gate for the shared ChromaDB backend, as seen by the Knowledge Base.
  *
- * This service is responsible for starting, stopping, and monitoring the ChromaDB server process.
- * It ensures that the database is running when needed and handles graceful shutdowns.
+ * **Unified topology (orchestrator-SSOT):** the orchestrator daemon owns the ChromaDB lifecycle.
+ * The Knowledge Base connects as a downstream client via `ChromaManager`; this service neither spawns
+ * nor stops a daemon. It survives only as a readiness/observability gate: `initAsync` participates in
+ * the boot sequence (awaited by `ChromaManager` via `ready()`), and `getDatabaseStatus` projects an
+ * external-only status into the healthcheck (no KB-managed process).
+ *
+ * The managed-mode surface (`startDatabase` / `stopDatabase` / `waitForHeartbeat` / `manageDatabase` /
+ * `cleanup`, the `chromaProcess` handle, and the `processActive` event) was removed once the
+ * `manage_database` MCP tool was retired and the orchestrator became the sole Chroma driver — keeping
+ * it as dead code invited a future session to wire it back up.
  *
  * @class Neo.ai.services.knowledge-base.DatabaseLifecycleService
  * @extends Neo.core.Base
  * @singleton
+ * @see Neo.ai.services.knowledge-base.ChromaManager
  */
 class DatabaseLifecycleService extends Base {
-    /**
-     * True automatically applies the core.Observable mixin
-     * @member {Boolean} observable=true
-     * @static
-     */
-    static observable = true;
-
     static config = {
         /**
          * @member {String} className='Neo.ai.services.knowledge-base.DatabaseLifecycleService'
          * @protected
          */
         className: 'Neo.ai.services.knowledge-base.DatabaseLifecycleService',
-        /**
-         * Holds the child process object for the ChromaDB server.
-         * @member {ChildProcess|null} chromaProcess=null
-         * @protected
-         */
-        chromaProcess: null,
         /**
          * @member {Boolean} singleton=true
          * @protected
@@ -46,98 +39,19 @@ class DatabaseLifecycleService extends Base {
      */
     async initAsync() {
         await super.initAsync();
-        logger.log('[DatabaseLifecycleService] Knowledge Base assumes ChromaDB is managed by AgentOrchestrator.');
+        logger.log('[DatabaseLifecycleService] Unified topology — Knowledge Base connects to the orchestrator-managed ChromaDB; no daemon spawn.');
     }
 
     /**
-     * Checks if a ChromaDB instance is already running on the configured port.
-     * @returns {Promise<boolean>}
-     */
-    async isDbRunning() {
-        try {
-            const ChromaManager = (await import('./ChromaManager.mjs')).default;
-            await ChromaManager.client.heartbeat();
-            return true;
-        } catch (e) {
-            return false;
-        }
-    }
-
-    /**
-     * Manages the database lifecycle based on the provided action.
-     * @param {Object} params
-     * @param {String} params.action - 'start' or 'stop'
-     * @returns {Promise<Object>}
-     */
-    async manageDatabase({action}) {
-        if (action === 'start') {
-            return this.startDatabase();
-        } else if (action === 'stop') {
-            return this.stopDatabase();
-        } else {
-            throw new Error(`Invalid action: ${action}. Must be 'start' or 'stop'.`);
-        }
-    }
-
-    /**
-     * Starts the ChromaDB server as a background process, if not already running.
-     * @returns {Promise<object>} A promise that resolves with the status.
-     */
-    async startDatabase() {
-        if (await this.isDbRunning()) {
-            const result = { status: 'already_running', pid: null, detail: 'Server is managed by AgentOrchestrator.' };
-            this.fire('processActive', { pid: null, managedByService: false, detail: result.detail });
-            return result;
-        }
-
-        logger.log('[DatabaseLifecycleService] Knowledge Base assumes ChromaDB is managed by AgentOrchestrator. Waiting for heartbeat...');
-        await this.waitForHeartbeat();
-
-        const result = { status: 'started_externally', pid: null };
-        this.fire('processActive', { pid: null, managedByService: false, detail: 'started externally' });
-        return result;
-    }
-
-    /**
-     * Handles process termination signals to ensure the child process is killed.
-     * @param {string|number} signalOrCode
-     */
-    async cleanup(signalOrCode) {
-        if (typeof signalOrCode === 'string') {
-            process.exit(0);
-        }
-    }
-
-    /**
-     * Waits for the ChromaDB server to respond to a heartbeat.
-     * @returns {Promise<void>}
-     */
-    async waitForHeartbeat() {
-        logger.log('Waiting for ChromaDB heartbeat...');
-        for (let i = 0; i < 30; i++) {
-            if (await this.isDbRunning()) {
-                logger.log('ChromaDB heartbeat detected.');
-                return;
-            }
-            await new Promise(resolve => setTimeout(resolve, 500));
-        }
-        throw new Error('ChromaDB failed to start (timeout waiting for heartbeat).');
-    }
-
-    /**
-     * Stops the ChromaDB server process if it was started by this server.
-     * @returns {Promise<object>} A promise that resolves with the status.
-     */
-    async stopDatabase() {
-        return { status: 'not_running', detail: 'Knowledge Base does not manage the ChromaDB daemon.' };
-    }
-
-    /**
-     * Gets the status of the ChromaDB process.
-     * @returns {object} The status of the ChromaDB process.
+     * @summary Projects external-only database status into the healthcheck payload.
+     *
+     * The Chroma daemon is orchestrator-owned, so there is no KB-managed process or pid to report —
+     * `running` reflects "no KB-managed process" (actual reachability is the separate
+     * `database.connection.connected` field). It is the only field healthcheck consumers read.
+     * @returns {{running: Boolean}}
      */
     getDatabaseStatus() {
-        return { running: false, pid: null, managed: false };
+        return {running: false};
     }
 }
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1156,16 +1156,10 @@ class HealthService extends Base {
 
         // If we made it here with no errors, report success
         if (payload.status === 'healthy') {
-            if (payload.database.process.managed) {
-                payload.details.push('Connected to a server-managed ChromaDB instance');
-            } else {
-                payload.details.push('Connected to an externally managed ChromaDB instance');
-            }
+            // Unified topology: ChromaDB is orchestrator-owned; Memory Core is always an external client.
+            payload.details.push('Connected to the orchestrator-managed ChromaDB instance');
             payload.details.push('All features are operational');
         }
-
-        // Add strategy for clarity
-        payload.database.process.strategy = payload.database.process.managed ? 'managed' : 'external';
 
         return payload;
     }

--- a/ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs
+++ b/ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs
@@ -1,33 +1,25 @@
-import { spawn } from 'child_process';
-import aiConfig from '../../../mcp/server/memory-core/config.mjs';
 import logger from '../../../mcp/server/memory-core/logger.mjs';
-import Base from '../../../../src/core/Base.mjs';
-import Observable from '../../../../src/core/Observable.mjs';
+import Base   from '../../../../src/core/Base.mjs';
 
 /**
- * @summary Orchestrates the daemon lifecycle specifically for the ChromaDB backend engine.
+ * @summary Readiness gate for the shared ChromaDB backend, as seen by Memory Core.
  *
- * Following the dismantling of the monolithic database service, this class is now an explicitly isolated orchestrator
- * responsible for managing the local ChromaDB vector database daemon. It handles asynchronous initialization,
- * persistent heartbeat monitoring (`waitForHeartbeat`), and safe termination sequences independently.
+ * **Unified topology (orchestrator-SSOT):** the orchestrator daemon owns the ChromaDB lifecycle.
+ * Memory Core connects as a downstream client via `ChromaManager`; this service neither spawns nor
+ * stops a daemon. It survives only as a readiness/observability gate: `initAsync` participates in the
+ * boot sequence (awaited by `SystemLifecycleService` + `ChromaManager` via `ready()`), and
+ * `getDatabaseStatus` projects an external-only status into the healthcheck (no MC-managed process).
  *
- * **Unified topology:** Memory Core connects as a downstream client via `ChromaManager` to a shared
- * ChromaDB instance. This service no longer attempts to spawn or manage a local daemon.
+ * The managed-mode surface (`startDatabase` / `stopDatabase` / `waitForHeartbeat` / `manageDatabase`)
+ * was removed once the `manage_database` MCP tool was retired and the orchestrator became the sole
+ * Chroma driver — keeping it as dead code invited a future session to wire it back up.
  *
  * @class Neo.ai.services.memory-core.lifecycle.ChromaLifecycleService
  * @extends Neo.core.Base
  * @singleton
- * @see Neo.ai.services.memory-core.lifecycle.InferenceLifecycleService
  * @see Neo.ai.services.memory-core.managers.ChromaManager
  */
 class ChromaLifecycleService extends Base {
-    /**
-     * @member {Boolean} observable=true
-     * @protected
-     * @static
-     */
-    static observable = true;
-
     static config = {
         /**
          * @member {String} className='Neo.ai.services.memory-core.lifecycle.ChromaLifecycleService'
@@ -42,93 +34,24 @@ class ChromaLifecycleService extends Base {
     }
 
     /**
-     * @summary Asynchronously initializes the ChromaLifecycleService.
-     *
-     * In the unified-topology deployment this skips daemon-spawn so MC does not attempt to
-     * manage the shared ChromaDB process.
+     * @summary Asynchronously initializes the service. In unified topology this only logs that MC
+     * does not manage the shared ChromaDB process — boot ordering is owned by `SystemLifecycleService`.
      */
     async initAsync() {
         await super.initAsync();
-        logger.log('[ChromaLifecycleService] Unified topology — skipping own ChromaDB spawn; Memory Core connects to the shared instance.');
+        logger.log('[ChromaLifecycleService] Unified topology — Memory Core connects to the shared ChromaDB; no daemon spawn.');
     }
 
     /**
-     * @summary Actively pings the Chroma backend to confirm topological readiness.
-     * @returns {Promise<Boolean>}
-     */
-    async isDbRunning() {
-        try {
-            const ChromaManager = (await import('../managers/ChromaManager.mjs')).default;
-            await ChromaManager.client.heartbeat();
-            return true;
-        } catch (e) {
-            return false;
-        }
-    }
-
-    /**
-     * @summary Boots the explicit local ChromaDB daemon.
+     * @summary Projects external-only database status into the healthcheck payload.
      *
-     * In unified topology this returns `{status: 'shared_topology'}` without
-     * attempting any spawn.
-     * @returns {Promise<Object>}
-     */
-    async startDatabase() {
-        return {
-            status: 'shared_topology',
-            detail: 'Memory Core runs as a downstream client of the shared ChromaDB in unified mode. No daemon spawn required.'
-        };
-    }
-
-    /**
-     * @summary Polls the managed ChromaDB daemon backend until the heartbeat API succeeds.
-     * @returns {Promise<void>}
-     */
-    async waitForHeartbeat() {
-        logger.log('Waiting for ChromaDB heartbeat...');
-        for (let i = 0; i < 30; i++) {
-            if (await this.isDbRunning()) {
-                logger.log('ChromaDB heartbeat detected.');
-                return;
-            }
-            await new Promise(resolve => setTimeout(resolve, 500));
-        }
-        throw new Error('ChromaDB failed to start (timeout).');
-    }
-
-    /**
-     * @summary Intentionally drops the ongoing ChromaDB daemon process when transitioning to offline.
-     * @returns {Promise<Object>}
-     */
-    async stopDatabase() {
-        return { status: 'not_running', detail: 'Memory Core does not manage the ChromaDB daemon in unified topology.' };
-    }
-
-    /**
-     * @summary Resolves the current internal status and PID tracking for the ChromaDB backend engine.
-     * @returns {Object}
+     * The Chroma daemon is orchestrator-owned, so there is no MC-managed process or pid to report —
+     * `running` reflects "no MC-managed process" (actual reachability is the separate
+     * `database.connection.connected` field). It is the only field healthcheck consumers read.
+     * @returns {{running: Boolean}}
      */
     getDatabaseStatus() {
-        return { running: false, pid: null, managed: false };
-    }
-
-    /**
-     * @summary High-level router for managing ChromaDB process state (start/stop) from the orchestrator.
-     *
-     * Backs the `manage_database` MCP tool (see `services/toolService.mjs`). In unified topology
-     * the `start` action propagates `startDatabase`'s `{status: 'shared_topology'}` response
-     * rather than spawning; the `stop` action falls through to `stopDatabase`'s existing
-     * `{status: 'not_running'}` path.
-     * @param {Object} args
-     * @returns {Promise<Object>}
-     */
-    async manageDatabase(args) {
-        if (args.action === 'start') {
-            return await this.startDatabase();
-        } else if (args.action === 'stop') {
-            return await this.stopDatabase();
-        }
-        return { error: 'Unknown action' };
+        return {running: false};
     }
 }
 

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseLifecycleService.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../../setup.mjs';
 
-const appName = 'KBDatabaseLifecycleServiceTest';
+const appName = 'DatabaseLifecycleServiceTest';
 
 setup({
     neoConfig: {
@@ -13,107 +13,25 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}            from '@playwright/test';
+import DatabaseLifecycleService from '../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs';
 
-test.describe('Neo.ai.services.knowledge-base.DatabaseLifecycleService', () => {
-    let DatabaseLifecycleService;
-    let originalFire;
-    let originalIsDbRunning;
-    let originalWaitForHeartbeat;
-
-    test.beforeAll(async () => {
-        DatabaseLifecycleService = (await import('../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs')).default;
-
-        originalFire             = DatabaseLifecycleService.fire;
-        originalIsDbRunning      = DatabaseLifecycleService.isDbRunning;
-        originalWaitForHeartbeat = DatabaseLifecycleService.waitForHeartbeat;
+/**
+ * @summary Coverage for the collapsed DatabaseLifecycleService readiness gate (unified topology).
+ *
+ * The managed-mode surface (`startDatabase` / `stopDatabase` / `waitForHeartbeat` / `manageDatabase` /
+ * `cleanup`, the `chromaProcess` handle, and the `processActive` event) was removed once the
+ * orchestrator became the sole Chroma driver; the service is now a readiness + observability gate.
+ * These tests pin the kept surface.
+ */
+test.describe('Neo.ai.services.knowledge-base.DatabaseLifecycleService — unified-topology readiness gate', () => {
+    test('initAsync completes without error', async () => {
+        await DatabaseLifecycleService.initAsync();
+        // Unified topology: no daemon spawn — initAsync only logs and resolves.
+        expect(true).toBe(true);
     });
 
-    test.afterEach(() => {
-        DatabaseLifecycleService.fire             = originalFire;
-        DatabaseLifecycleService.isDbRunning      = originalIsDbRunning;
-        DatabaseLifecycleService.waitForHeartbeat = originalWaitForHeartbeat;
-    });
-
-    test('manageDatabase dispatches start and stop actions', async () => {
-        DatabaseLifecycleService.isDbRunning = async () => true;
-
-        await expect(DatabaseLifecycleService.manageDatabase({action: 'start'}))
-            .resolves.toEqual({
-                status: 'already_running',
-                pid   : null,
-                detail: 'Server is managed by AgentOrchestrator.'
-            });
-
-        await expect(DatabaseLifecycleService.manageDatabase({action: 'stop'}))
-            .resolves.toEqual({
-                status: 'not_running',
-                detail: 'Knowledge Base does not manage the ChromaDB daemon.'
-            });
-    });
-
-    test('manageDatabase rejects unsupported actions', async () => {
-        await expect(DatabaseLifecycleService.manageDatabase({action: 'restart'}))
-            .rejects.toThrow("Invalid action: restart. Must be 'start' or 'stop'.");
-    });
-
-    test('startDatabase reports already_running when Chroma heartbeat is reachable', async () => {
-        const events = [];
-
-        DatabaseLifecycleService.fire        = (name, payload) => events.push({name, payload});
-        DatabaseLifecycleService.isDbRunning = async () => true;
-
-        const result = await DatabaseLifecycleService.startDatabase();
-
-        expect(result).toEqual({
-            status: 'already_running',
-            pid   : null,
-            detail: 'Server is managed by AgentOrchestrator.'
-        });
-        expect(events).toEqual([{
-            name   : 'processActive',
-            payload: {
-                pid             : null,
-                managedByService: false,
-                detail          : 'Server is managed by AgentOrchestrator.'
-            }
-        }]);
-    });
-
-    test('startDatabase waits for the externally managed daemon when heartbeat is initially absent', async () => {
-        const events = [];
-        let waited = false;
-
-        DatabaseLifecycleService.fire             = (name, payload) => events.push({name, payload});
-        DatabaseLifecycleService.isDbRunning      = async () => false;
-        DatabaseLifecycleService.waitForHeartbeat = async () => {
-            waited = true;
-        };
-
-        const result = await DatabaseLifecycleService.startDatabase();
-
-        expect(waited).toBe(true);
-        expect(result).toEqual({
-            status: 'started_externally',
-            pid   : null
-        });
-        expect(events).toEqual([{
-            name   : 'processActive',
-            payload: {
-                pid             : null,
-                managedByService: false,
-                detail          : 'started externally'
-            }
-        }]);
-    });
-
-    test('getDatabaseStatus exposes observability-only unified topology state', () => {
-        expect(DatabaseLifecycleService.getDatabaseStatus()).toEqual({
-            running: false,
-            pid    : null,
-            managed: false
-        });
+    test('getDatabaseStatus reports external-only state', () => {
+        expect(DatabaseLifecycleService.getDatabaseStatus()).toEqual({running: false});
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/lifecycle/ChromaLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/lifecycle/ChromaLifecycleService.spec.mjs
@@ -1,4 +1,4 @@
-import { setup } from '../../../../../setup.mjs';
+import {setup} from '../../../../../setup.mjs';
 
 const appName = 'ChromaLifecycleServiceTest';
 
@@ -7,41 +7,30 @@ setup({
         unitTestMode: true
     },
     appConfig: {
-        name: appName,
-        isMounted: () => true,
+        name             : appName,
+        isMounted        : () => true,
         vnodeInitialising: false
     }
 });
 
-import {test, expect}         from '@playwright/test';
-import Neo                    from '../../../../../../../src/Neo.mjs';
-import * as core              from '../../../../../../../src/core/_export.mjs';
-import aiConfig               from '../../../../../../../ai/mcp/server/memory-core/config.mjs';
+import {test, expect} from '@playwright/test';
 import ChromaLifecycleService from '../../../../../../../ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs';
 
-test.describe('Neo.ai.services.memory-core.lifecycle.ChromaLifecycleService — permanent unified topology (#11011)', () => {
-    test('startDatabase always returns shared_topology', async () => {
-        const result = await ChromaLifecycleService.startDatabase();
-
-        expect(result.status).toBe('shared_topology');
-        expect(result.detail).toMatch(/downstream client of the shared ChromaDB/i);
-    });
-
-    test('manageDatabase({action:"start"}) propagates shared_topology', async () => {
-        const result = await ChromaLifecycleService.manageDatabase({action: 'start'});
-
-        expect(result.status).toBe('shared_topology');
-    });
-
+/**
+ * @summary Coverage for the collapsed ChromaLifecycleService readiness gate (unified topology).
+ *
+ * The managed-mode surface (`startDatabase` / `stopDatabase` / `waitForHeartbeat` / `manageDatabase`)
+ * was removed once the orchestrator became the sole Chroma driver; the service is now a readiness +
+ * observability gate. These tests pin the kept surface.
+ */
+test.describe('Neo.ai.services.memory-core.lifecycle.ChromaLifecycleService — unified-topology readiness gate', () => {
     test('initAsync completes without error', async () => {
-        const originalInitPromise = ChromaLifecycleService._initPromise;
+        await ChromaLifecycleService.initAsync();
+        // Unified topology: no daemon spawn — initAsync only logs and resolves.
+        expect(true).toBe(true);
+    });
 
-        try {
-            ChromaLifecycleService._initPromise = null;
-            await ChromaLifecycleService.initAsync();
-            // Test passes if it does not throw or hang
-        } finally {
-            ChromaLifecycleService._initPromise = originalInitPromise;
-        }
+    test('getDatabaseStatus reports external-only state', () => {
+        expect(ChromaLifecycleService.getDatabaseStatus()).toEqual({running: false});
     });
 });


### PR DESCRIPTION
## Summary

**PR B of #12139** — the external-only Chroma lifecycle cleanup, completing the ticket. With the orchestrator daemon as the sole Chroma driver (#12065) and the `manage_database` MCP tool retired (PR A / #12197), the per-server lifecycle services carried only dead managed-mode surface. This collapses them to readiness/observability gates and drops the now-dead managed/strategy healthcheck branching.

## Deltas

- **`ChromaLifecycleService` (MC) + `DatabaseLifecycleService` (KB)** — deleted `startDatabase` / `stopDatabase` / `waitForHeartbeat` / `manageDatabase` / `cleanup` (grep-confirmed **0 prod callers**), the `spawn`/`child_process` + unused `aiConfig` imports, the KB `chromaProcess` config member, and the `Observable` mixin + `processActive` event (no listener anywhere). **Kept** `initAsync` (boot ordering, awaited by `SystemLifecycleService` + `ChromaManager` via `ready()`) and `getDatabaseStatus` (healthcheck), simplified to `{running: false}`.
- **`HealthService` (MC)** — dropped the `database.process.managed` / `strategy` branching. The only downstream reader consumes `.running` (KB Server); nothing read `managed`/`strategy`. Reports external-only now.
- **Tests** — rewrote the two lifecycle specs to the kept surface; removed dead `aiConfig.<retired-flag> = false` setup-lines across 9 specs (`autoDream`/`autoSummarize`/`realTimeMemoryParsing`/`autoIngestFileSystem` no longer exist post-#12139) + the 4 now-orphaned `import aiConfig` lines they left behind.

**`ChromaManager`s needed no change** — they only `await <Lifecycle>.ready()`, which is preserved; AC6's "ChromaManagers simplified" was already satisfied (no lifecycle coupling beyond the readiness gate).

## Test Evidence

Evidence: L2 (executed) — `npm run test-unit` over the 12 affected spec files exits 0 with **124 passing** (incl. the 51-test HealthService suite confirming the managed/strategy removal is non-breaking, and the 2 rewritten lifecycle specs).

`node --check` clean on all 14 changed files (disk-truth — confirms no duplicate/orphaned imports). Both pre-commit gates (`check-whitespace`, `check-shorthand`) pass. The retired-primitive guard (#12198) still passes on this branch. `grep` confirms 0 remaining retired-flag setup-lines + 0 orphaned `aiConfig` imports across `test/`.

## Post-Merge Validation

Behaviour-preserving: the deleted methods had no callers; `getDatabaseStatus` keeps the `running` field its sole consumer reads; the healthcheck `details` now states "Connected to the orchestrator-managed ChromaDB instance" instead of the managed/external conditional. On merge this **closes #12139** (ACs 1–5 + 7 satisfied by PRs #12197 + #12200; AC6 satisfied here).

## Decision Record impact

`aligned-with ADR 0003` (unified Chroma topology) — establishes the orchestrator as the sole Chroma lifecycle authority for both MCP servers; the services retain only a readiness gate.

FAIR-band: n/a — operator-directed lane (#12139 PR B).

Resolves #12139.

Authored by Claude Opus 4.8 (Claude Code, 1M context).
