### PR TITLE
refactor(portal): neutralize the offscreen renderer to a shared TimelineCanvas (#12205)

### DIFF
--- a/apps/portal/canvas/Helper.mjs
+++ b/apps/portal/canvas/Helper.mjs
@@ -22,7 +22,7 @@ class Helper extends Base {
                 'importFooterCanvas',
                 'importHomeCanvas',
                 'importServicesCanvas',
-                'importTicketCanvas'
+                'importTimelineCanvas'
             ]
         },
         /**
@@ -59,8 +59,8 @@ class Helper extends Base {
     /**
      * @returns {Promise<void>}
      */
-    async importTicketCanvas() {
-        let module = await import('./TicketCanvas.mjs');
+    async importTimelineCanvas() {
+        let module = await import('./TimelineCanvas.mjs');
         await module.default.remotesReady()
     }
 }

--- a/apps/portal/canvas/TimelineCanvas.mjs
+++ b/apps/portal/canvas/TimelineCanvas.mjs
@@ -17,7 +17,7 @@ const PHYSICS = {
 };
 
 /**
- * @summary Renders the "Neural Timeline" visualization for the Portal's Ticket view.
+ * @summary Renders the "Neural Timeline" visualization for the Portal's news timeline views (tickets, pull requests, discussions).
  *
  * This class runs inside a SharedWorker (via `CanvasWorker`) to provide a high-performance,
  * main-thread-blocking-free animation. It visualizes the flow of time and activity connecting
@@ -32,11 +32,11 @@ const PHYSICS = {
  * 4. **Chameleon Effect**: The pulse dynamically changes its color to match the semantic color of the
  *    nearest node (e.g., Red for Bugs, Green for Features) as it passes by.
  *
- * @class Portal.canvas.TicketCanvas
+ * @class Portal.canvas.TimelineCanvas
  * @extends Portal.canvas.Base
  * @singleton
  */
-class TicketCanvas extends Base {
+class TimelineCanvas extends Base {
     static colors = {
         dark : {
             spine: ['rgba(62, 99, 221, 0.2)', 'rgba(64, 196, 255, 0.4)', 'rgba(62, 99, 221, 0.2)']
@@ -48,10 +48,10 @@ class TicketCanvas extends Base {
 
     static config = {
         /**
-         * @member {String} className='Portal.canvas.TicketCanvas'
+         * @member {String} className='Portal.canvas.TimelineCanvas'
          * @protected
          */
-        className: 'Portal.canvas.TicketCanvas',
+        className: 'Portal.canvas.TimelineCanvas',
         /**
          * Remote method access
          * @member {Object} remote
@@ -420,4 +420,4 @@ class TicketCanvas extends Base {
     }
 }
 
-export default Neo.setupClass(TicketCanvas);
+export default Neo.setupClass(TimelineCanvas);

--- a/apps/portal/view/news/tickets/TimelineCanvas.mjs
+++ b/apps/portal/view/news/tickets/TimelineCanvas.mjs
@@ -4,12 +4,12 @@ import SharedCanvas from '../../../../../src/app/SharedCanvas.mjs';
  * @summary The "Coordinator" component for the Neural Timeline, bridging the App Worker and Canvas Worker.
  *
  * This component renders a transparent canvas overlay on top of the Ticket List. It is responsible for:
- * 1. **Data Bridge**: Listening to the `sections` store and passing ticket data to the `TicketCanvas` (SharedWorker).
+ * 1. **Data Bridge**: Listening to the `sections` store and passing ticket data to the `TimelineCanvas` (SharedWorker).
  * 2. **Visual Alignment**: Calculating the precise DOM positions of Ticket Avatars/Badges to ensure the
  *    canvas nodes align perfectly with the HTML content.
  * 3. **Lifecycle Management**: initializing the offscreen canvas transfer and handling resize events.
  *
- * It uses the `Portal.canvas.TicketCanvas` singleton (via Remote Method Access) to drive the actual animation.
+ * It uses the `Portal.canvas.TimelineCanvas` singleton (via Remote Method Access) to drive the actual animation.
  *
  * @class Portal.view.news.tickets.TimelineCanvas
  * @extends Neo.app.SharedCanvas
@@ -32,13 +32,13 @@ class TimelineCanvas extends SharedCanvas {
          */
         className: 'Portal.view.news.tickets.TimelineCanvas',
         /**
-         * @member {String} rendererClassName='Portal.canvas.TicketCanvas'
+         * @member {String} rendererClassName='Portal.canvas.TimelineCanvas'
          */
-        rendererClassName: 'Portal.canvas.TicketCanvas',
+        rendererClassName: 'Portal.canvas.TimelineCanvas',
         /**
-         * @member {String} rendererImportPath='apps/portal/canvas/TicketCanvas.mjs'
+         * @member {String} rendererImportPath='apps/portal/canvas/TimelineCanvas.mjs'
          */
-        rendererImportPath: 'apps/portal/canvas/TicketCanvas.mjs',
+        rendererImportPath: 'apps/portal/canvas/TimelineCanvas.mjs',
         /**
          * @member {Object} _vdom
          */
@@ -68,7 +68,7 @@ class TimelineCanvas extends SharedCanvas {
      * Lifecycle hook that runs once the `OffscreenCanvas` has been transferred to the Canvas Worker.
      *
      * This method:
-     * 1. Imports the `TicketCanvas` logic into the Canvas Worker context.
+     * 1. Imports the `TimelineCanvas` logic into the Canvas Worker context.
      * 2. Initializes the graph in the worker via Remote Method Access (`initGraph`).
      * 3. Sets up a `ResizeObserver` to keep the canvas size synced with the DOM.
      * 4. Triggers the initial data load if store data is available.
@@ -147,7 +147,7 @@ class TimelineCanvas extends SharedCanvas {
      * 2. **Measurement**: It fetches the `DOMRect` for every target to get its exact screen position.
      * 3. **Translation**: It converts these screen coordinates into Canvas-local coordinates.
      * 4. **Handoff**: It packages this geometric data (x, y, radius, color) and sends it to the
-     *    `TicketCanvas` worker to update the physics simulation.
+     *    `TimelineCanvas` worker to update the physics simulation.
      *
      * @param {Object[]|Object} records Array of records or Store load event object {items: [...]}
      * @param {Boolean} [isResize=false]


### PR DESCRIPTION
Authored by Opus 4.8 (Claude Code). Session 94a91ebc.

Resolves #12205

Foundation step 1 of epic #12204. Neutralizes the portal's offscreen "Neural Timeline" renderer so the upcoming Pull Request + Discussion views can reuse it unchanged. The renderer was already content-agnostic (its draw loop reads only `node.x/y/radius/color`); only its identity said "Ticket".

Renames `Portal.canvas.TicketCanvas` → `Portal.canvas.TimelineCanvas` (`apps/portal/canvas/TicketCanvas.mjs` → `TimelineCanvas.mjs`) and updates its two consumers:
- `apps/portal/canvas/Helper.mjs` — the `importTicketCanvas` remote method + its dynamic import path.
- `apps/portal/view/news/tickets/TimelineCanvas.mjs` (the App-worker bridge) — `rendererClassName` + `rendererImportPath` + JSDoc references.

Pure rename, zero behavior change.

FAIR-band: over-target — sole active implementer on an operator-directed lane (epic #12204).

Evidence: L1 — `grep TicketCanvas apps/portal src` == 0 after the rename; `node --check` passes on all three changed files; git records the renderer as a rename (content preserved). Residual: L2 — visual confirmation that the Tickets-tab timeline still animates (post-merge / deploy).

## Deltas from ticket (if any)
- Renderer named `Portal.canvas.TimelineCanvas` (kept in `apps/portal/canvas/`, matching the `<Subject>Canvas` sibling convention — FooterCanvas/HomeCanvas/ServicesCanvas) rather than relocated to `src/canvas/`: the reuse scope is portal content types, not framework-wide. The basename overlap with the view-layer bridge `Portal.view.news.tickets.TimelineCanvas` is namespace-distinct and is resolved when #12206 promotes/renames that bridge.

## Test Evidence
- `grep -rn TicketCanvas apps/portal src --include='*.mjs'` → 0 matches.
- `node --check` on `canvas/TimelineCanvas.mjs`, `canvas/Helper.mjs`, `view/news/tickets/TimelineCanvas.mjs` → all pass.
- No `.scss` / `.json` / test references to the old name.

## Post-Merge Validation
- [ ] Tickets-tab timeline canvas still renders + animates (the rename is behavior-neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
