### PR TITLE
docs(github-workflow): document canonical PR + Discussion markdown grammar (#12214)

### DIFF
--- a/ai/services/github-workflow/sync/CONTENT_GRAMMAR.md
+++ b/ai/services/github-workflow/sync/CONTENT_GRAMMAR.md
@@ -1,0 +1,57 @@
+# Synced Content Markdown Grammar
+
+Single source of truth for the markdown structure the gh-workflow syncers emit for **Issues**, **Pull Requests**, and **Discussions** — so downstream consumers (notably the portal news view parsers `Portal.view.news.{tickets,pulls,discussions}.Component`) don't re-derive, and mis-derive, it.
+
+Verified against the emit code (`PullRequestSyncer.mjs`, `DiscussionSyncer.mjs`, `IssueSyncer.mjs`) and corpus samples (`pr-105.md`, `discussion-11089.md`, `issue-9.md`).
+
+## Common rules
+
+- Each file is `gray-matter` frontmatter followed by a markdown body.
+- The body opens with a `## Description` section (the item's own body text); type-specific sections follow.
+- Conversation entries are delimited by their `###` header. **Never split on a bare `---`** — horizontal rules appear inside entry bodies.
+- Timestamps are ISO-8601 UTC (`<ISO_Z>`, e.g. `2026-05-10T01:43:13Z`).
+
+## Issues — `IssueSyncer`
+
+- Frontmatter: `number, title, state` (`OPEN`|`CLOSED`), `labels[], author, createdAt, updatedAt, closedAt, parentIssue, subIssues[]`.
+- Sections: `## Description`, then `## Timeline`.
+- `## Timeline` interleaves:
+  - **Events** — `- <ISO_Z> @user <action>` (e.g. `created the issue`, ``added the `bug` label``, `closed this issue`, ``referenced in commit `<sha>` ``, `cross-referenced by PR #N`).
+  - **Comments** — a `### @user - <ISO_Z>` header, then comment markdown until the next header.
+
+## Pull Requests — `PullRequestSyncer`
+
+- Frontmatter: `number, title, state` (`OPEN`|`MERGED`|`CLOSED`), `author, createdAt, updatedAt, closedAt, mergedAt` (null if never merged), `base, head, url`.
+- Sections, in order, each optional: `## Description`, `## Comments`, `## Reviews`, `## Commits`, `## Files Changed`.
+  - `## Comments` entries: `` ### `@user` commented on <ISO_Z> ``
+  - `## Reviews` entries: `` ### `@user` (<STATE>) reviewed on <ISO_Z> `` — `STATE` ∈ `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED` (treat unknown as neutral).
+  - `## Commits`: `` - `<sha>` <message> (by <author>) `` lines.
+  - `## Files Changed`: a `` | `<file>` | +<adds> | -<dels> | `` table.
+- `## Comments` and `## Reviews` are **separate sections, not globally time-ordered** — a unified timeline must merge-sort by timestamp.
+- Common case: a PR with no review/comment activity (e.g. dependabot) has only `## Description`.
+
+## Discussions — `DiscussionSyncer`
+
+- Frontmatter: `number, title, author, category` (`Ideas`|`General`|`Q&A`|…), `createdAt, updatedAt, closed` (boolean), `closedAt`. No `state`, no `labels`.
+- Sections: `## Description`, then `## Comments`.
+- `## Comments` entries: `` ### `@user` commented on <ISO_Z> `` — the backtick form, **like PRs, not** the issue `- <ts> @user` event form.
+- Threaded replies follow their parent comment, each headed `` > **Reply by `@user`** on <ISO_Z> `` with the reply body as `> `-blockquoted lines (flattened; parent→child depth is not yet structured — see #12216).
+- An accepted answer is **not yet emitted** — see #12215 (gate any answer affordance to `category === 'Q&A'`).
+
+## Quick reference — entry header by type
+
+| Type | Section | Entry header |
+|---|---|---|
+| Issue event | `## Timeline` | `- <ISO_Z> @user <action>` |
+| Issue comment | `## Timeline` | `### @user - <ISO_Z>` |
+| PR comment | `## Comments` | `` ### `@user` commented on <ISO_Z> `` |
+| PR review | `## Reviews` | `` ### `@user` (<STATE>) reviewed on <ISO_Z> `` |
+| Discussion comment | `## Comments` | `` ### `@user` commented on <ISO_Z> `` |
+
+## Consumers
+
+- `Portal.view.news.tickets.Component` — issues (exists).
+- `Portal.view.news.pulls.Component` — pull requests (#12213).
+- `Portal.view.news.discussions.Component` — discussions (#12211).
+
+When changing the emitted grammar, update this file and the affected parser(s) in the same change.


### PR DESCRIPTION
Authored by Opus 4.8 (Claude Code). Session 94a91ebc.

Resolves #12214

Epic #12204 — the single source of truth for the PR view (#12213) and Discussion view (#12211) parsers, so they don't re-derive (and mis-derive) the syncer markdown grammar.

Adds `ai/services/github-workflow/sync/CONTENT_GRAMMAR.md`, documenting — verified against the syncer emit code + corpus samples — the exact section + entry-header grammar for Issues / PRs / Discussions, including the gotchas the view parsers must respect:
- entries split at the `###` header, **not** at a bare `---` (which appears inside entry bodies);
- PRs have **five** sections (`## Description/Comments/Reviews/Commits/Files Changed`) and Comments/Reviews are not globally time-ordered (merge-sort);
- discussions use `## Comments` with PR-style backtick `` ### `@user` commented on `` headers (**not** `## Timeline`).

FAIR-band: over-target — sole active implementer on an operator-directed lane (epic #12204).

Evidence: L1 — each header verified against `PullRequestSyncer.mjs:89-160` (Description/Comments/Reviews/Commits/Files-Changed emit), `DiscussionSyncer.mjs`, `IssueSyncer.mjs`, and corpus samples (`pr-105.md`, `discussion-11089.md`, `issue-9.md`). Doc-only — no runtime impact.

## Deltas from ticket (if any)
- Documented PR `## Commits` + `## Files Changed` too (the ticket named only Comments/Reviews) — the corpus emits them; the PR view (#12213) can use or skip them.
- Corrected: discussions use `## Comments` (not `## Timeline`) — captured so #12211 targets the right section.

## Test Evidence
- Doc-only; every grammar claim cross-checked against the emit code (file:line cited) and a corpus sample.

## Post-Merge Validation
- [ ] The PR (#12213) and Discussion (#12211) view parsers cite this doc for their regexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
