### PR TITLE
refactor(portal): promote canvas glue to shared Portal.view.content (#12206)

### DIFF
--- a/apps/portal/view/content/CanvasWrapper.mjs
+++ b/apps/portal/view/content/CanvasWrapper.mjs
@@ -1,26 +1,25 @@
-import Container        from '../../../../../src/container/Base.mjs';
-import ContentComponent from './Component.mjs';
-import TimelineCanvas   from './TimelineCanvas.mjs';
+import Container      from '../../../../../src/container/Base.mjs';
+import TimelineCanvas from './TimelineCanvas.mjs';
 
 /**
- * @class Portal.view.news.tickets.CanvasWrapper
+ * @class Portal.view.content.CanvasWrapper
  * @extends Neo.container.Base
  */
 class CanvasWrapper extends Container {
     static config = {
         /**
-         * @member {String} className='Portal.view.news.tickets.CanvasWrapper'
+         * @member {String} className='Portal.view.content.CanvasWrapper'
          * @protected
          */
-        className: 'Portal.view.news.tickets.CanvasWrapper',
+        className: 'Portal.view.content.CanvasWrapper',
         /**
          * @member {String[]} cls=['portal-canvas-wrapper']
          */
         cls: ['portal-canvas-wrapper'],
         /**
-         * @member {Neo.component.Base|null} contentComponent=ContentComponent
+         * @member {Neo.component.Base|null} contentComponent=null
          */
-        contentComponent: ContentComponent,
+        contentComponent: null,
         /**
          * @member {Object} layout=null
          */

--- a/apps/portal/view/content/TimelineCanvas.mjs
+++ b/apps/portal/view/content/TimelineCanvas.mjs
@@ -3,15 +3,15 @@ import SharedCanvas from '../../../../../src/app/SharedCanvas.mjs';
 /**
  * @summary The "Coordinator" component for the Neural Timeline, bridging the App Worker and Canvas Worker.
  *
- * This component renders a transparent canvas overlay on top of the Ticket List. It is responsible for:
- * 1. **Data Bridge**: Listening to the `sections` store and passing ticket data to the `TimelineCanvas` (SharedWorker).
+ * This component renders a transparent canvas overlay on top of the content list. It is responsible for:
+ * 1. **Data Bridge**: Listening to the `sections` store and passing record data to the `TimelineCanvas` (SharedWorker).
  * 2. **Visual Alignment**: Calculating the precise DOM positions of Ticket Avatars/Badges to ensure the
  *    canvas nodes align perfectly with the HTML content.
  * 3. **Lifecycle Management**: initializing the offscreen canvas transfer and handling resize events.
  *
  * It uses the `Portal.canvas.TimelineCanvas` singleton (via Remote Method Access) to drive the actual animation.
  *
- * @class Portal.view.news.tickets.TimelineCanvas
+ * @class Portal.view.content.TimelineCanvas
  * @extends Neo.app.SharedCanvas
  */
 class TimelineCanvas extends SharedCanvas {
@@ -27,10 +27,10 @@ class TimelineCanvas extends SharedCanvas {
 
     static config = {
         /**
-         * @member {String} className='Portal.view.news.tickets.TimelineCanvas'
+         * @member {String} className='Portal.view.content.TimelineCanvas'
          * @protected
          */
-        className: 'Portal.view.news.tickets.TimelineCanvas',
+        className: 'Portal.view.content.TimelineCanvas',
         /**
          * @member {String} rendererClassName='Portal.canvas.TimelineCanvas'
          */
@@ -43,7 +43,7 @@ class TimelineCanvas extends SharedCanvas {
          * @member {Object} _vdom
          */
         _vdom:
-        {tag: 'div', cls: ['neo-ticket-timeline-wrapper'], style: {width: '100%', height: '100%'}, cn: [
+        {tag: 'div', cls: ['neo-timeline-wrapper'], style: {width: '100%', height: '100%'}, cn: [
             {tag: 'canvas', style: {width: '100%', height: '100%'}}
         ]}
     }
@@ -143,7 +143,7 @@ class TimelineCanvas extends SharedCanvas {
      * This method synchronizes the Canvas nodes with the DOM elements (Avatars/Badges).
      *
      * **Strategy:**
-     * 1. **Targeting**: It uses the `-target` ID suffix to find the specific DOM elements (Avatars) within the ticket list.
+     * 1. **Targeting**: It uses the `-target` ID suffix to find the specific DOM elements (Avatars) within the content list.
      * 2. **Measurement**: It fetches the `DOMRect` for every target to get its exact screen position.
      * 3. **Translation**: It converts these screen coordinates into Canvas-local coordinates.
      * 4. **Handoff**: It packages this geometric data (x, y, radius, color) and sends it to the

--- a/apps/portal/view/news/tickets/MainContainer.mjs
+++ b/apps/portal/view/news/tickets/MainContainer.mjs
@@ -1,4 +1,5 @@
-import CanvasWrapper    from './CanvasWrapper.mjs';
+import CanvasWrapper    from '../../content/CanvasWrapper.mjs';
+import Component        from './Component.mjs';
 import Controller       from './MainContainerController.mjs';
 import PageContainer    from './PageContainer.mjs';
 import SharedContainer  from '../../../../../src/app/content/Container.mjs';
@@ -32,7 +33,8 @@ class MainContainer extends SharedContainer {
             module         : PageContainer,
             buttonTextField: 'id',
             contentConfig  : {
-                module: CanvasWrapper
+                contentComponent: Component,
+                module          : CanvasWrapper
             }
         },
         /**


### PR DESCRIPTION
Authored by Opus 4.8 (Claude Code). Session 94a91ebc.

Resolves #12206

Foundation step 2 of epic #12204. Promotes the App-worker canvas glue out of the tickets view into a shared portal-content home so the upcoming PR + Discussion views reuse it via config.

- Relocates the bridge `Portal.view.news.tickets.TimelineCanvas` → `Portal.view.content.TimelineCanvas` and the wrapper `...tickets.CanvasWrapper` → `Portal.view.content.CanvasWrapper` (into `apps/portal/view/content/`).
- Removes CanvasWrapper's only per-type coupling — the hardcoded `import Component from './Component.mjs'` default. `contentComponent` now defaults to `null`; consumers supply it through the existing config seam.
- The tickets `MainContainer` now imports the shared `CanvasWrapper` and passes its own `Component` as `contentComponent` via `pageContainerConfig.contentConfig`.
- Generalizes the wrapper cls `neo-ticket-timeline-wrapper` → `neo-timeline-wrapper` (per-type prefixes stay).

Per the operator's call, the shared home is portal-scoped (`Portal.view.content.*`), not framework — #12208 still adds the `Neo.app.content.Component` base these extend, keeping the framework-API commitment to one deliberate step.

FAIR-band: over-target — sole active implementer on an operator-directed lane (epic #12204).

Evidence: L1 — `grep` for the old `view.news.tickets.{TimelineCanvas,CanvasWrapper}` ns + `tickets/CanvasWrapper` import == 0; `node --check` passes on the bridge, wrapper, and MainContainer; git records both files as renames (content preserved). The `sections` store key and `.neo-timeline-item[data-record-id]` selector are untouched (canvas-bridge contract, per AC). Residual: L2 — Tickets tab renders + animates unchanged (post-merge/deploy).

## Deltas from ticket (if any)
- Shared home is `apps/portal/view/content/` (`Portal.view.content.*`), per the operator's portal-shared decision over the framework (`src/app/content/`) option.

## Test Evidence
- `grep -rn "view.news.tickets.TimelineCanvas|...CanvasWrapper|tickets/CanvasWrapper" apps/portal` → 0 matches.
- `node --check` on `view/content/TimelineCanvas.mjs`, `view/content/CanvasWrapper.mjs`, `view/news/tickets/MainContainer.mjs` → pass.
- `sections` store key + `.neo-timeline-item[data-record-id]` selector present and unchanged.

## Post-Merge Validation
- [ ] Tickets tab timeline still renders + animates (behavior-neutral relocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
