### PR TITLE
feat(lint): validate learn/tree.json mirrors the learn/ folder structure (#12247)

### DIFF
--- a/.github/workflows/tree-json-lint.yml
+++ b/.github/workflows/tree-json-lint.yml
@@ -1,0 +1,34 @@
+name: Tree JSON Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'learn/**'
+      - 'ai/scripts/lint/lint-tree-json.mjs'
+      - '.github/workflows/tree-json-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'learn/**'
+      - 'ai/scripts/lint/lint-tree-json.mjs'
+      - '.github/workflows/tree-json-lint.yml'
+
+concurrency:
+  group: tree-json-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Lint learn/tree.json against the learn/ folder structure
+        run: node ai/scripts/lint/lint-tree-json.mjs

--- a/ai/scripts/lint/lint-tree-json.mjs
+++ b/ai/scripts/lint/lint-tree-json.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * @summary Structural lint that verifies `learn/tree.json` (the docs-portal navigation
+ * tree, which also feeds `buildScripts/docs/seo/generate.mjs` content URLs + sitemap)
+ * mirrors the on-disk `learn/` folder structure.
+ *
+ * `tree.json` is a flat `parentId` adjacency list — `{"data": [ {name, parentId, id,
+ * isLeaf?, collapsed?} ... ]}` — not a nested tree. Hierarchy is encoded via `parentId`;
+ * a **leaf**'s `id` is its `learn/`-relative path (`benefits/Introduction` →
+ * `learn/benefits/Introduction.md`); a **group** carries `isLeaf:false` and a PascalCase
+ * `id` referenced by its children's `parentId`.
+ *
+ * Because it is hand-edited JSON with no schema enforcement, drift is silent until it
+ * breaks portal nav / SEO. This lint enforces four mechanical invariants:
+ *
+ *   1. LEAF_FILE        — every leaf `id` resolves to an existing `learn/<id>.md`.
+ *   2. PARENT_INTEGRITY — every non-null `parentId` references an existing group node.
+ *   3. GROUP_COHESION   — a group's direct leaf-children all share ONE folder-prefix
+ *                         (a nav group maps to at most one folder).
+ *   4. FOLDER_UNIQUENESS — no two distinct groups own leaves of the same folder-prefix
+ *                         (a folder maps to at most one nav group; the phantom-group guard).
+ *
+ * (3) + (4) together assert a group ↔ folder bijection for leaf-bearing groups: the
+ * mechanical form of "the nav tree mirrors the folder layout." (1) transitively covers
+ * folder existence, so no separate folder-existence check is needed.
+ *
+ * The validator core (`lintTree`) is pure — it takes parsed tree data plus an injectable
+ * `fileExists` probe — so it is unit-testable without touching `git` or the real
+ * filesystem. The CLI wrapper supplies a real `fs`-backed probe.
+ *
+ * Usage: `node ai/scripts/lint/lint-tree-json.mjs` (no arguments; validates the whole file).
+ */
+import fs               from 'node:fs';
+import path             from 'node:path';
+import process          from 'node:process';
+import {fileURLToPath}  from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT_DIR   = path.resolve(__dirname, '../../..');
+const LEARN_DIR  = path.join(ROOT_DIR, 'learn');
+const TREE_PATH  = path.join(LEARN_DIR, 'tree.json');
+
+/**
+ * Returns the folder-prefix (directory part) of a leaf `id`, using POSIX semantics so
+ * the result is OS-independent. Root-level leaves (no slash) yield `''`.
+ * @param {string} id
+ * @returns {string}
+ */
+function folderPrefix(id) {
+    const dir = path.posix.dirname(id);
+    return dir === '.' ? '' : dir;
+}
+
+/**
+ * A node is a GROUP iff it is **explicitly** marked `isLeaf:false`; everything else is a
+ * LEAF. Classification is deliberately explicit (not "is this node referenced as a
+ * parent?") so that a leaf mistakenly used as a parent — or a real group that forgot its
+ * `isLeaf:false` flag — surfaces as a `PARENT_NOT_GROUP` violation instead of being
+ * silently reclassified into a group (which would also mask its missing-file check).
+ * @param {object} node
+ * @returns {boolean}
+ */
+function isGroup(node) {
+    return node.isLeaf === false;
+}
+
+/**
+ * Pure structural validator. Feed it parsed tree data and a `fileExists(relPath)` probe
+ * (relative to `learn/`); get back a flat list of violation records. No `git`, no `fs`
+ * unless the caller's probe touches it — exported for unit testing.
+ *
+ * @param {{data: Array<object>}} treeData Parsed `tree.json`.
+ * @param {{fileExists?: (relPathFromLearn: string) => boolean}} [probes]
+ * @returns {Array<{code: string, message: string}>}
+ */
+function lintTree(treeData, {fileExists} = {}) {
+    const violations = [];
+    const nodes      = treeData?.data;
+
+    if (!Array.isArray(nodes)) {
+        return [{code: 'STRUCTURE', message: 'tree.json must be an object of the form {"data": [ ...nodes ]}.'}];
+    }
+
+    const byId = new Map();
+
+    for (const node of nodes) {
+        if (node.id == null) {
+            violations.push({code: 'MISSING_ID', message: `Node "${node.name ?? '(unnamed)'}" has no id.`});
+            continue;
+        }
+        if (byId.has(node.id)) {
+            violations.push({code: 'DUP_ID', message: `Duplicate node id "${node.id}".`});
+        }
+        byId.set(node.id, node);
+    }
+
+    // Invariant 2: parentId integrity — parent exists AND is a group.
+    for (const node of nodes) {
+        if (node.parentId == null) continue;
+
+        const parent = byId.get(node.parentId);
+
+        if (!parent) {
+            violations.push({code: 'ORPHAN', message: `Node "${node.id}" has parentId "${node.parentId}", which does not exist.`});
+        } else if (!isGroup(parent)) {
+            violations.push({code: 'PARENT_NOT_GROUP', message: `Node "${node.id}" is parented by "${node.parentId}", which is not marked as a group (isLeaf:false) — either a leaf misused as a parent, or a group missing its isLeaf:false flag.`});
+        }
+    }
+
+    // Invariant 1: leaf id -> backing file exists.
+    if (fileExists) {
+        for (const node of nodes) {
+            if (isGroup(node) || node.id == null) continue;
+
+            if (!fileExists(`${node.id}.md`)) {
+                violations.push({code: 'LEAF_FILE', message: `Leaf "${node.id}" has no backing file learn/${node.id}.md.`});
+            }
+        }
+    }
+
+    // Invariants 3 + 4: group <-> folder bijection (leaf-bearing groups only).
+    const groupFolders = new Map(); // groupId -> Set<folderPrefix>
+    const folderGroups = new Map(); // folderPrefix -> Set<groupId>
+
+    for (const node of nodes) {
+        if (isGroup(node) || node.id == null || node.parentId == null) continue; // skip groups + root leaves
+
+        const prefix = folderPrefix(node.id);
+
+        if (!groupFolders.has(node.parentId)) groupFolders.set(node.parentId, new Set());
+        groupFolders.get(node.parentId).add(prefix);
+
+        if (!folderGroups.has(prefix)) folderGroups.set(prefix, new Set());
+        folderGroups.get(prefix).add(node.parentId);
+    }
+
+    // Invariant 3: a group's direct leaves share exactly one folder-prefix.
+    for (const [groupId, prefixes] of groupFolders) {
+        if (prefixes.size > 1) {
+            const folders = [...prefixes].map(p => p || '(learn root)').join(', ');
+            violations.push({code: 'GROUP_SPANS_FOLDERS', message: `Group "${groupId}" has leaf children from multiple folders: ${folders}. A nav group must map to a single folder.`});
+        }
+    }
+
+    // Invariant 4: a folder-prefix is owned by exactly one group (phantom-group guard).
+    for (const [prefix, groupIds] of folderGroups) {
+        if (groupIds.size > 1) {
+            const groups = [...groupIds].join(', ');
+            violations.push({code: 'PHANTOM_GROUP', message: `Folder "learn/${prefix}" is split across multiple nav groups: ${groups}. Each folder maps to exactly one group — drop the phantom group or back it with a real subfolder.`});
+        }
+    }
+
+    return violations;
+}
+
+/**
+ * CLI entry. Reads + parses `tree.json`, runs `lintTree` with a real fs-backed probe,
+ * prints a report, and returns a numeric exit code (so tests can drive it without
+ * triggering `process.exit`).
+ * @param {{treePath?: string, learnDir?: string}} [options]
+ * @returns {{exitCode: number, violations: Array<{code: string, message: string}>}}
+ */
+function runLint({treePath = TREE_PATH, learnDir = LEARN_DIR} = {}) {
+    let treeData;
+
+    try {
+        treeData = JSON.parse(fs.readFileSync(treePath, 'utf8'));
+    } catch (error) {
+        console.error(`[lint-tree-json] FAILED — cannot read/parse ${path.relative(ROOT_DIR, treePath)}: ${error.message}`);
+        return {exitCode: 1, violations: [{code: 'PARSE', message: error.message}]};
+    }
+
+    const fileExists = relPath => fs.existsSync(path.join(learnDir, relPath));
+    const violations = lintTree(treeData, {fileExists});
+
+    if (violations.length === 0) {
+        console.log(`[lint-tree-json] OK — learn/tree.json mirrors the learn/ folder structure (${treeData.data.length} nodes).`);
+        return {exitCode: 0, violations};
+    }
+
+    console.error(`[lint-tree-json] FAILED — ${violations.length} structural violation(s) in learn/tree.json:\n`);
+    for (const violation of violations) {
+        console.error(`- [${violation.code}] ${violation.message}`);
+    }
+    console.error('\nlearn/tree.json must mirror the on-disk learn/ folder: every leaf id maps to learn/<id>.md,');
+    console.error('every parentId references a real group, and each folder maps to exactly one nav group.');
+    return {exitCode: 1, violations};
+}
+
+function main() {
+    const arg = process.argv[2];
+
+    if (arg === '--help' || arg === '-h') {
+        console.log('Usage: node ai/scripts/lint/lint-tree-json.mjs');
+        console.log('');
+        console.log('Validates that learn/tree.json mirrors the learn/ folder structure:');
+        console.log('  1. LEAF_FILE         every leaf id -> learn/<id>.md exists');
+        console.log('  2. PARENT_INTEGRITY  every parentId references an existing group');
+        console.log('  3. GROUP_COHESION    a group\'s direct leaves share one folder');
+        console.log('  4. FOLDER_UNIQUENESS each folder maps to one group (phantom-group guard)');
+        process.exit(0);
+    }
+
+    const {exitCode} = runLint();
+    process.exit(exitCode);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main();
+}
+
+export {
+    folderPrefix,
+    isGroup,
+    lintTree,
+    runLint
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
+        "ai:lint-tree-json"            : "node ./ai/scripts/lint/lint-tree-json.mjs",
         "ai:skill-size-report"         : "node ./ai/scripts/lint/lint-skill-manifest.mjs --report-sizes",
         "ai:kb-alerting"               : "node ./ai/daemons/kb-alerting/daemon.mjs",
         "ai:kb-reconciliation"         : "node ./ai/daemons/kb-reconciliation/daemon.mjs",

--- a/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
@@ -1,0 +1,133 @@
+import {test, expect}   from '@playwright/test';
+import {spawnSync}      from 'node:child_process';
+import path             from 'node:path';
+
+import {
+    folderPrefix,
+    isGroup,
+    lintTree,
+    runLint
+} from '../../../../../../ai/scripts/lint/lint-tree-json.mjs';
+
+/**
+ * @summary Coverage for `ai/scripts/lint/lint-tree-json.mjs` — the structural lint that
+ * verifies `learn/tree.json` mirrors the on-disk `learn/` folder structure (#12247).
+ *
+ * Empirical anchors (the drift this lint mechanizes): #12238 added a phantom `BenefitsBrain`
+ * nav group over files that were flat in `learn/benefits/` (PHANTOM_GROUP); #12240 let a
+ * parent label outgrow its contents. Both were caught by human / cross-family review, not
+ * tooling — this spec proves the four invariants now catch the mechanical cases at CI time.
+ *
+ * Test axes:
+ *   - LEAF_FILE          leaf id with no backing learn/<id>.md
+ *   - PARENT_NOT_GROUP   parentId pointing at a leaf (or a group missing isLeaf:false)
+ *   - ORPHAN             parentId referencing a non-existent node
+ *   - GROUP_SPANS_FOLDERS a group whose direct leaves span >1 folder
+ *   - PHANTOM_GROUP      >1 nav group owning the same folder (the #12238 reproducer)
+ *   - DUP_ID / MISSING_ID / STRUCTURE  malformed input guards
+ *   - happy path: a well-formed fixture + the real learn/tree.json both pass
+ *
+ * The `lintTree` core is pure (injectable `fileExists`), so the bulk runs without a shell-out.
+ */
+test.describe('ai/scripts/lint-tree-json (#12247 — learn/tree.json mirrors learn/ folder structure)', () => {
+    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-tree-json.mjs');
+
+    /** Convenience: run lintTree and return the sorted set of violation codes. */
+    const codes = (nodes, fileExists = () => true) =>
+        lintTree({data: nodes}, {fileExists}).map(v => v.code).sort();
+
+    // ---- CLI ----
+
+    test('CLI: --help exits 0 with usage text', () => {
+        const result = spawnSync('node', [scriptPath, '--help'], {cwd: process.cwd(), encoding: 'utf8'});
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: node ai/scripts/lint/lint-tree-json.mjs');
+        expect(result.stdout).toContain('LEAF_FILE');
+        expect(result.stdout).toContain('FOLDER_UNIQUENESS');
+    });
+
+    test('CLI: the real learn/tree.json passes (mirrors the folder structure)', () => {
+        const result = spawnSync('node', [scriptPath], {cwd: process.cwd(), encoding: 'utf8'});
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('[lint-tree-json] OK');
+    });
+
+    // ---- pure invariants ----
+
+    test('happy path: a well-formed group + leaf produces no violations', () => {
+        expect(codes([
+            {id: 'Benefits', isLeaf: false, parentId: null},
+            {id: 'benefits/A', parentId: 'Benefits'}
+        ])).toEqual([]);
+    });
+
+    test('LEAF_FILE: a leaf id with no backing file is flagged', () => {
+        expect(codes(
+            [{id: 'Benefits', isLeaf: false, parentId: null}, {id: 'benefits/Gone', parentId: 'Benefits'}],
+            rel => rel !== 'benefits/Gone.md'
+        )).toEqual(['LEAF_FILE']);
+    });
+
+    test('PARENT_NOT_GROUP: a leaf used as a parent is flagged', () => {
+        expect(codes([
+            {id: 'benefits/Parent', parentId: null},              // a leaf (no isLeaf:false)
+            {id: 'benefits/Child', parentId: 'benefits/Parent'}   // parented by the leaf
+        ])).toEqual(['PARENT_NOT_GROUP']);
+    });
+
+    test('ORPHAN: a parentId referencing a non-existent node is flagged', () => {
+        expect(codes([
+            {id: 'Benefits', isLeaf: false, parentId: null},
+            {id: 'benefits/A', parentId: 'Ghost'}
+        ])).toEqual(['ORPHAN']);
+    });
+
+    test('GROUP_SPANS_FOLDERS: a group whose leaves span two folders is flagged', () => {
+        expect(codes([
+            {id: 'Mixed', isLeaf: false, parentId: null},
+            {id: 'benefits/A', parentId: 'Mixed'},
+            {id: 'guides/B', parentId: 'Mixed'}
+        ])).toEqual(['GROUP_SPANS_FOLDERS']);
+    });
+
+    test('PHANTOM_GROUP: two nav groups owning the same folder are flagged (#12238 reproducer)', () => {
+        expect(codes([
+            {id: 'Benefits', isLeaf: false, parentId: null},
+            {id: 'BenefitsBrain', isLeaf: false, parentId: null},
+            {id: 'benefits/A', parentId: 'Benefits'},
+            {id: 'benefits/B', parentId: 'BenefitsBrain'}         // distinct leaf, SAME folder
+        ])).toEqual(['PHANTOM_GROUP']);
+    });
+
+    test('DUP_ID / MISSING_ID / STRUCTURE guards fire', () => {
+        expect(codes([
+            {id: 'Benefits', isLeaf: false, parentId: null},
+            {id: 'Benefits', isLeaf: false, parentId: null}
+        ])).toContain('DUP_ID');
+        expect(codes([{name: 'no-id', parentId: null}])).toContain('MISSING_ID');
+        expect(lintTree({nope: 1}).map(v => v.code)).toEqual(['STRUCTURE']);
+    });
+
+    // ---- exported helpers ----
+
+    test('folderPrefix: nested id → directory part; root-level id → empty string', () => {
+        expect(folderPrefix('benefits/Introduction')).toBe('benefits');
+        expect(folderPrefix('agentos/cloud-deployment/Overview')).toBe('agentos/cloud-deployment');
+        expect(folderPrefix('UsingTheseTopics')).toBe('');
+    });
+
+    test('isGroup: only an explicit isLeaf:false node is a group', () => {
+        expect(isGroup({id: 'G', isLeaf: false})).toBe(true);
+        expect(isGroup({id: 'L'})).toBe(false);
+        expect(isGroup({id: 'L', isLeaf: true})).toBe(false);
+    });
+
+    test('runLint: exported entry returns a numeric exit code on the real tree', () => {
+        const {exitCode, violations} = runLint();
+
+        expect(exitCode).toBe(0);
+        expect(violations).toEqual([]);
+    });
+});


### PR DESCRIPTION
Resolves #12247

Authored by Claude Opus 4.8 (Claude Code). Session d2fbe3b2-44c4-4aab-b8c7-62621babc790.
FAIR-band: over-target [30/30] — nightshift session; FAIR-band author-lane discipline suspended per operator 2026-05-28. This lane is friction→gold from the #12225 identity rollout (mechanizing the phantom-group failure mode), authored in parallel while #12229 is in-flight per the nightshift anti-idle discipline.

`learn/tree.json` is the docs-portal navigation tree and also feeds `buildScripts/docs/seo/generate.mjs` (content URLs + sitemap). It is hand-edited JSON with no structural enforcement, so it can silently diverge from the on-disk `learn/` folder — and that drift surfaced **twice in one session** during the identity rollout, caught by human / cross-family review rather than tooling:

- **#12238** — a phantom `BenefitsBrain` nav group over files that were flat in `learn/benefits/`.
- **#12240** — a parent group label that outgrew its contents.

This adds a structural lint that catches the mechanical cases at authoring / CI time.

## What it enforces

`tree.json` is a flat `parentId` adjacency list (`{"data": [ {name, parentId, id, isLeaf?} ... ]}`); a leaf's `id` is its `learn/`-relative path. The new `ai/scripts/lint/lint-tree-json.mjs` checks four invariants:

1. **LEAF_FILE** — every leaf `id` resolves to an existing `learn/<id>.md`.
2. **PARENT_NOT_GROUP / ORPHAN** — every non-null `parentId` references an existing node that is a group (`isLeaf:false`).
3. **GROUP_COHESION** — a group's direct leaf-children share one folder-prefix (a group maps to ≤ 1 folder).
4. **PHANTOM_GROUP** — no two groups own leaves of the same folder-prefix (a folder maps to ≤ 1 group).

(3) + (4) together assert a group ↔ folder bijection — the mechanical form of "the nav tree mirrors the folder layout"; (4) is exactly what catches the #12238 phantom group. (1) transitively covers folder existence. The `lintTree` core is pure (injectable `fileExists`), so it is unit-testable without `git` or fs.

## Deltas

- **Classification is explicit (`isLeaf:false`), not "referenced-as-parent".** I started with an implicit-group classifier and caught — during negative testing — that it made `PARENT_NOT_GROUP` dead code: a leaf misused as a parent would be silently reclassified into a group, masking the error. Verified all 25 referenced parents in the live tree are explicitly `isLeaf:false`, so explicit classification is safe *and* keeps the check live.
- **Reframed the ticket's "folder-prefix exists" invariant into group-cohesion + folder-uniqueness.** A raw folder-existence check is fully subsumed by LEAF_FILE (if the file exists, its folder does); the cohesion/uniqueness pair is the non-redundant, higher-value form that actually mechanizes the phantom-group rule.
- **Separate CI workflow** (`.github/workflows/tree-json-lint.yml`, path-triggered on `learn/**`) rather than extending `skill-manifest-lint.yml` — `tree.json` is docs-nav, a different concern from skill/agents substrate; full-file validation needs no diff-base.
- **Out of scope (per ticket):** nav *ordering* and parent-label *naming fit* (the #12240 case) — both need human judgment; flagged for a possible later advisory check, not enforced now.
- **Evergreen JSDoc / error messages** — no decay-prone ticket anchors in the shipped `.mjs`; origin context lives here + in the ticket (durable-shipped vs tracking-coordination).
- **No §1.1 substrate slot-rationale section:** this PR touches `ai/scripts/lint/`, `.github/`, `package.json`, `test/` — none are turn-loaded or skill-loaded substrate, so the gate does not fire.

Evidence: L1 (static — the validator + 12 unit tests run under the unit config; the real `learn/tree.json` passes) → L1 required (tooling / docs-structure ACs, no runtime surface). No residuals.

## Test Evidence

- `npm run ai:lint-tree-json` → exit 0: `[lint-tree-json] OK — learn/tree.json mirrors the learn/ folder structure (190 nodes)`.
- `test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs` — **12 passed** under `playwright.config.unit.mjs`. Each invariant in isolation (incl. the #12238 `PHANTOM_GROUP` reproducer), the happy path, the `DUP_ID` / `MISSING_ID` / `STRUCTURE` guards, `folderPrefix`, `isGroup`, and the CLI (`--help` + real-tree pass).
- Verified all 25 referenced parents in the live tree are explicitly `isLeaf:false`.
- `git diff --cached --check` clean; `package.json` valid JSON; `lint-agents` unaffected by the diff.

## Post-Merge Validation

- [ ] The `Tree JSON Lint` workflow appears and passes on a subsequent `learn/**` PR.
- [ ] A deliberately-malformed `tree.json` (e.g. a reintroduced phantom group) fails the workflow as designed.

## Related

- Resolves #12247
- Empirical anchors: #12238 (phantom `BenefitsBrain` group), #12240 (parent-label mismatch) — both under Epic #12225.
- Related: #12225 (identity-rollout epic — not Closes; this is adjacent tooling-hardening).
- Sibling tooling: `ai/scripts/lint/lint-agents.mjs`, `lint-skill-manifest.mjs`.
