### PR TITLE
fix(seo): prioritize identity routes in sitemap (#12255)

### DIFF
--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -42,34 +42,42 @@
   <url>
     <loc>https://neomjs.com/learn/benefits/ArchitectureOverview</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/AIEngineeringTeam</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/AgentMemory</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/SelfEvolution</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/AgentOSOnYourCodebase</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/DeployingTheAgentOS</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/ObjectPermanence</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/JSONFirstUIs</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/OffTheMainThread</loc>
@@ -109,17 +117,17 @@
   <url>
     <loc>https://neomjs.com/learn/benefits/Effort</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/FormsEngine</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/Features</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/gettingstarted/Setup</loc>
@@ -169,94 +177,117 @@
   <url>
     <loc>https://neomjs.com/learn/agentos/StrategicWorkflows</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/SwarmIntelligence</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/ProgressiveDisclosureSkills</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/DreamPipeline</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/ConceptOntology</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/NeuralLink</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/KnowledgeBase</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/MemoryCore</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/GitHubWorkflow</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/CodeExecution</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/SharedDeployment</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/DeploymentCookbook</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/WhyDeploy</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Overview</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Day0Tutorial</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/TenantIngestionModel</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Configuration</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/CustomSources</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/CustomParsers</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/HookWiring</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/PipelineWiring</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Security</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/MigrationPath</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/ConfigSubstrateEnvVarAudit</loc>
@@ -696,32 +727,32 @@
   <url>
     <loc>https://neomjs.com/learn/comparisons/NeoVsReact</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/comparisons/NeoVsAngular</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/comparisons/NeoVsVue</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/comparisons/NeoVsSolid</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/comparisons/NeoVsNextJs</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/comparisons/NeoVsExtJs</loc>
     <lastmod>2026-05-31T12:47:26+02:00</lastmod>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/Glossary</loc>

--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -34,22 +34,60 @@ const PRIORITIES = new Map([
     ['/about-us', 0.7],
     ['/services', 0.7],
 
-    // High-value content (Application Engine & AI)
-    ['guides/fundamentals/CodebaseOverview'         , 1.0],
-    ['guides/mcp/Introduction'                      , 1.0], // AI Priority
-    ['guides/mcp/NeuralLink'                        , 1.0], // AI Priority
-
-    ['benefits/ConfigSystem'                        , 0.9],
-    ['benefits/Effort'                              , 0.9],
-    ['benefits/Features'                            , 0.9],
-    ['benefits/FormsEngine'                         , 0.9],
-    ['benefits/FourEnvironments'                    , 0.9],
+    // Identity apex: organism / Agent OS / AI engineering team
     ['benefits/Introduction'                        , 0.9],
-    ['benefits/MultiWindow'                         , 0.9],
+    ['benefits/ArchitectureOverview'                , 1.0],
+    ['benefits/AIEngineeringTeam'                   , 1.0],
+    ['benefits/AgentMemory'                         , 1.0],
+    ['benefits/SelfEvolution'                       , 1.0],
+    ['benefits/AgentOSOnYourCodebase'               , 1.0],
+    ['benefits/DeployingTheAgentOS'                 , 1.0],
+
+    // Agent OS guide cluster
+    ['agentos/StrategicWorkflows'                   , 1.0],
+    ['agentos/SwarmIntelligence'                    , 1.0],
+    ['agentos/ProgressiveDisclosureSkills'          , 0.9],
+    ['agentos/DreamPipeline'                        , 1.0],
+    ['agentos/ConceptOntology'                      , 0.9],
+    ['agentos/NeuralLink'                           , 1.0],
+    ['agentos/KnowledgeBase'                        , 1.0],
+    ['agentos/MemoryCore'                           , 1.0],
+    ['agentos/GitHubWorkflow'                       , 0.8],
+    ['agentos/CodeExecution'                        , 0.8],
+    ['agentos/SharedDeployment'                     , 1.0],
+    ['agentos/DeploymentCookbook'                   , 1.0],
+
+    // Cloud deployment: team-ready operational surface
+    ['agentos/cloud-deployment/WhyDeploy'           , 1.0],
+    ['agentos/cloud-deployment/Overview'            , 1.0],
+    ['agentos/cloud-deployment/Day0Tutorial'        , 0.9],
+    ['agentos/cloud-deployment/TenantIngestionModel', 0.9],
+    ['agentos/cloud-deployment/Security'            , 0.9],
+    ['agentos/cloud-deployment/Configuration'       , 0.8],
+    ['agentos/cloud-deployment/HookWiring'          , 0.8],
+    ['agentos/cloud-deployment/PipelineWiring'      , 0.8],
+    ['agentos/cloud-deployment/CustomSources'       , 0.7],
+    ['agentos/cloud-deployment/CustomParsers'       , 0.7],
+    ['agentos/cloud-deployment/MigrationPath'       , 0.7],
+
+    // Body/runtime benefits
+    ['benefits/ObjectPermanence'                    , 0.9],
+    ['benefits/JSONFirstUIs'                        , 0.9],
     ['benefits/OffTheMainThread'                    , 0.9],
+    ['benefits/FourEnvironments'                    , 0.9],
+    ['benefits/ConfigSystem'                        , 0.9],
     ['benefits/Quick'                               , 0.9],
     ['benefits/RPCLayer'                            , 0.9],
     ['benefits/Speed'                               , 0.9],
+    ['benefits/MultiWindow'                         , 0.9],
+    ['benefits/Effort'                              , 0.8],
+    ['benefits/FormsEngine'                         , 0.8],
+    ['benefits/Features'                            , 0.8],
+
+    // High-value implementation guides
+    ['guides/fundamentals/CodebaseOverview'         , 1.0],
+    ['guides/mcp/Introduction'                      , 1.0], // AI Priority
+    ['guides/mcp/NeuralLink'                        , 1.0], // AI Priority
 
     ['blog/context-engineering-done-right'          , 0.9],
     ['blog/ai-native-platform-answers-questions'    , 0.9],
@@ -61,12 +99,12 @@ const PRIORITIES = new Map([
     ['blog/v10-post1-love-story'                    , 0.9],
     ['blog/json-blueprints-and-shared-workers'      , 0.9],
 
-    ['comparisons/NeoVsAngular'                     , 0.8],
-    ['comparisons/NeoVsExtJs'                       , 0.8],
-    ['comparisons/NeoVsNextJs'                      , 0.8],
-    ['comparisons/NeoVsReact'                       , 0.8],
-    ['comparisons/NeoVsSolid'                       , 0.8],
-    ['comparisons/NeoVsVue'                         , 0.8],
+    ['comparisons/NeoVsAngular'                     , 0.7],
+    ['comparisons/NeoVsExtJs'                       , 0.7],
+    ['comparisons/NeoVsNextJs'                      , 0.7],
+    ['comparisons/NeoVsReact'                       , 0.7],
+    ['comparisons/NeoVsSolid'                       , 0.7],
+    ['comparisons/NeoVsVue'                         , 0.7],
 
     ['gettingstarted/ComponentModels'               , 0.8],
     ['gettingstarted/Config'                        , 0.8],


### PR DESCRIPTION
Resolves #12255

Authored by GPT-5 (Codex Desktop). Session 87203e0b-c9ff-4a82-a67b-9a0dda760c32.

FAIR-band: under-target [8/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane)

Updates the generated SEO priority surface so the current Neo identity routes are no longer treated as default-priority pages. The priority map now explicitly leads with the organism / Agent OS / AI engineering team Benefits routes, adds the Agent OS and cloud-deployment guide clusters, keeps Body/runtime benefits high but subordinate, and lowers comparison pages beneath the identity surfaces.

Evidence: L1 (static source audit + generated sitemap priority verification) → L1 required (SEO priority map and sitemap priority lines are static build artifacts). No residuals.

## Deltas from ticket

- Preserved existing sitemap `lastmod` values while applying priority-line deltas, because a full no-op regeneration recalculated unrelated timestamps across the entire sitemap.
- Added explicit priority tiers for core Agent OS guides, not only Benefits and cloud deployment, so the map no longer half-updates the identity surface.
- Lowered comparison routes from `0.8` to `0.7`; they remain discoverable but no longer outrank the organism / Agent OS pages.

## Test Evidence

- `node --check buildScripts/docs/seo/generate.mjs`
- `git diff --check`
- `node --input-type=module -e '<getSitemapXml priority assertions>'` passed for representative Benefits, Agent OS, cloud-deployment, and comparison routes.
- `node buildScripts/docs/seo/generate.mjs --format xml --base-url https://neomjs.com --output apps/portal/sitemap.xml` completed successfully; generated output then normalized to priority-only XML deltas to avoid unrelated `lastmod` churn.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `f344d9ff2 fix(seo): prioritize identity routes in sitemap (#12255)`.

## Post-Merge Validation

- [ ] Verify deployed `/sitemap.xml` exposes `1.0` priority for `/learn/benefits/AIEngineeringTeam`, `/learn/benefits/AgentOSOnYourCodebase`, and `/learn/agentos/cloud-deployment/WhyDeploy`.

## Commit

- `f344d9ff2` — `fix(seo): prioritize identity routes in sitemap (#12255)`

## Related

Related: #12225
