### PR TITLE
fix(orchestrator): HTTP-probe liveness for fire-and-exit lms lane (#12262)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -665,38 +665,10 @@ export class Orchestrator extends Base {
                 continue;
             }
 
-            if (state && !state.running) {
-                const lastRunAt = state.lastRunAt || 0;
-                if (now - lastRunAt > RESTART_COOLDOWN_MS) {
-                    const task = this.taskDefinitions[taskName];
-
-                    if (typeof task?.livenessProbe === 'function') {
-                        // HTTP-liveness-gated lane (#12262): a fire-and-exit launcher (`lms server
-                        // start`) whose served process persists out-of-band, so `!state.running` is
-                        // permanently true and a process-match restart would loop every cooldown.
-                        // Probe the endpoint instead — healthy => silent no-op (re-probed one
-                        // cooldown out), down => (re)start. The confirmed-at + in-flight guards keep
-                        // a healthy server quiet (no per-poll probe/log storm).
-                        const confirmedAt = this._livenessConfirmedAt?.[taskName] || 0;
-
-                        if (now - confirmedAt > RESTART_COOLDOWN_MS && !this._livenessProbeInFlight?.[taskName]) {
-                            (this._livenessProbeInFlight ||= {})[taskName] = true;
-                            task.livenessProbe()
-                                .then(up => {
-                                    if (up) {
-                                        (this._livenessConfirmedAt ||= {})[taskName] = Date.now();
-                                    } else {
-                                        executeTask(taskName, 'supervisor-restart');
-                                    }
-                                })
-                                .catch(() => executeTask(taskName, 'supervisor-restart'))
-                                .finally(() => { this._livenessProbeInFlight[taskName] = false; });
-                        }
-                    } else {
-                        executeTask(taskName, 'supervisor-restart');
-                    }
-                }
-            }
+            // Liveness-gated (re)start is owned by the supervisor: process-match by default, or a
+            // task-owned liveness probe for a fire-and-exit lane whose served process persists
+            // out-of-band (so the running flag never recovers and a process match would loop).
+            this.processSupervisorService.superviseTask(taskName, now, RESTART_COOLDOWN_MS);
 
             // Post-recycle defrag (#12138): once the restarted chroma is connection-ready, run
             // the unified-store-safe KB defrag against the fresh daemon. MC defrag is deferred

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -668,7 +668,33 @@ export class Orchestrator extends Base {
             if (state && !state.running) {
                 const lastRunAt = state.lastRunAt || 0;
                 if (now - lastRunAt > RESTART_COOLDOWN_MS) {
-                    executeTask(taskName, 'supervisor-restart');
+                    const task = this.taskDefinitions[taskName];
+
+                    if (typeof task?.livenessProbe === 'function') {
+                        // HTTP-liveness-gated lane (#12262): a fire-and-exit launcher (`lms server
+                        // start`) whose served process persists out-of-band, so `!state.running` is
+                        // permanently true and a process-match restart would loop every cooldown.
+                        // Probe the endpoint instead — healthy => silent no-op (re-probed one
+                        // cooldown out), down => (re)start. The confirmed-at + in-flight guards keep
+                        // a healthy server quiet (no per-poll probe/log storm).
+                        const confirmedAt = this._livenessConfirmedAt?.[taskName] || 0;
+
+                        if (now - confirmedAt > RESTART_COOLDOWN_MS && !this._livenessProbeInFlight?.[taskName]) {
+                            (this._livenessProbeInFlight ||= {})[taskName] = true;
+                            task.livenessProbe()
+                                .then(up => {
+                                    if (up) {
+                                        (this._livenessConfirmedAt ||= {})[taskName] = Date.now();
+                                    } else {
+                                        executeTask(taskName, 'supervisor-restart');
+                                    }
+                                })
+                                .catch(() => executeTask(taskName, 'supervisor-restart'))
+                                .finally(() => { this._livenessProbeInFlight[taskName] = false; });
+                        }
+                    } else {
+                        executeTask(taskName, 'supervisor-restart');
+                    }
                 }
             }
 

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -161,6 +161,21 @@ export function buildTaskDefinitions({
             pidFileName    : 'lms.pid',
             expectedCommand: 'lms server',
             requiredModels,
+            // `lms server start` is fire-and-exit: it wakes the LM Studio service and returns, so
+            // the launched server never matches `expectedCommand` for the supervisor's
+            // process-liveness check (`!state.running` stays permanently true). Liveness is the
+            // HTTP endpoint instead — the poll gates the restart on this probe so a healthy server
+            // is a silent no-op rather than a re-spawn loop (#12262).
+            livenessProbe  : async () => {
+                const {fetchOpenAiCompatibleModelIds} = await import('../../services/graph/ProviderReadinessHelper.mjs');
+
+                try {
+                    await fetchOpenAiCompatibleModelIds({host: lmsHost, timeoutMs: providerReadiness?.timeoutMs ?? 2000});
+                    return true;
+                } catch {
+                    return false;
+                }
+            },
             postSpawn      : async () => {
                 const {ensureLmsModelsLoaded} = await import('../../services/graph/ProviderReadinessHelper.mjs');
 

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -164,8 +164,8 @@ export function buildTaskDefinitions({
             // `lms server start` is fire-and-exit: it wakes the LM Studio service and returns, so
             // the launched server never matches `expectedCommand` for the supervisor's
             // process-liveness check (`!state.running` stays permanently true). Liveness is the
-            // HTTP endpoint instead — the poll gates the restart on this probe so a healthy server
-            // is a silent no-op rather than a re-spawn loop (#12262).
+            // HTTP endpoint instead — the supervisor gates the restart on this probe so a healthy
+            // server is a silent no-op rather than a re-spawn loop.
             livenessProbe  : async () => {
                 const {fetchOpenAiCompatibleModelIds} = await import('../../services/graph/ProviderReadinessHelper.mjs');
 

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -413,6 +413,76 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
+     * @summary Liveness-gated (re)start decision for one continuous task, evaluated once per poll.
+     *
+     * The orchestrator stays a thin scheduler: it forwards the poll timestamp and the restart
+     * cooldown and lets the supervisor own the "is this task alive, restart if not" decision.
+     *
+     * Default liveness is process-match — the `running` flag tracks the supervised child, so a
+     * down flag past the cooldown is a real restart. A task may instead expose a `livenessProbe()`:
+     * a fire-and-exit launcher (LM Studio's `lms server start`) wakes a service that then persists
+     * out-of-band, so the supervised child exits and the `running` flag is permanently false. A
+     * process match would re-spawn such a task every cooldown; it is gated on the probe instead.
+     *
+     * @param {String} taskName Task key.
+     * @param {Number} now Epoch ms (poll timestamp).
+     * @param {Number} cooldownMs Minimum gap between (re)start attempts.
+     * @returns {void}
+     */
+    superviseTask(taskName, now, cooldownMs) {
+        const state = this.taskStateService.getTaskState(taskName);
+
+        if (!state || state.running || now - (state.lastRunAt || 0) <= cooldownMs) {
+            return;
+        }
+
+        const task = this.taskDefinitions[taskName];
+
+        if (typeof task?.livenessProbe === 'function') {
+            this.gateRestartOnLivenessProbe(taskName, task, now, cooldownMs);
+        } else {
+            this.runTask(taskName, 'supervisor-restart');
+        }
+    }
+
+    /**
+     * @summary Probe-gated restart for a fire-and-exit lane (see `superviseTask`).
+     *
+     * Stays provider-agnostic: the task owns the actual check via `livenessProbe()` (e.g. an
+     * HTTP poll of an OpenAI-compatible endpoint); this method only schedules and de-dupes it.
+     * The confirmed-at + in-flight guards keep a healthy endpoint silent — after an `up` result
+     * the lane is skipped for a full cooldown (at most one cheap probe per cooldown, no log
+     * storm), and overlapping probes are suppressed. `down` or a throwing probe restarts the lane.
+     *
+     * @param {String} taskName Task key.
+     * @param {Object} task Task definition (carries `livenessProbe`).
+     * @param {Number} now Epoch ms (poll timestamp).
+     * @param {Number} cooldownMs Minimum gap between probes / restart attempts.
+     * @returns {void}
+     */
+    gateRestartOnLivenessProbe(taskName, task, now, cooldownMs) {
+        this._livenessConfirmedAt   ??= {};
+        this._livenessProbeInFlight ??= {};
+
+        if (now - (this._livenessConfirmedAt[taskName] || 0) <= cooldownMs || this._livenessProbeInFlight[taskName]) {
+            return;
+        }
+
+        this._livenessProbeInFlight[taskName] = true;
+
+        task.livenessProbe()
+            .then(up => {
+                if (up) {
+                    this._livenessConfirmedAt[taskName] = Date.now();
+                } else {
+                    this.runTask(taskName, 'supervisor-restart');
+                }
+            })
+            .catch(() => this.runTask(taskName, 'supervisor-restart'))
+            .finally(() => { this._livenessProbeInFlight[taskName] = false; });
+    }
+
+    /**
      * @summary Enforces a single live process for a port-owning ("singleton") task by
      * SIGKILLing any extra listeners on its port.
      *

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -448,8 +448,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         }]);
     });
 
-    test('supervises lms via HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {
-        const started = [];
+    test('supervises lms via the supervisor HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {
         const taskDefinitions = buildTaskDefinitions({
             scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
             nodeBin   : process.argv[0],
@@ -464,40 +463,31 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         let probeUp = false;
         taskDefinitions.lms.livenessProbe = async () => probeUp;
 
-        const orchestrator = createTestOrchestrator({
-            taskDefinitions,
-            kbSyncEnabled: false
-        });
-        orchestrator.processSupervisorService = {
-            runTask(taskName, reason) {
-                started.push({taskName, reason});
-                return true;
-            }
+        const orchestrator = createTestOrchestrator({taskDefinitions, kbSyncEnabled: false});
+        const flushProbe   = () => new Promise(resolve => setTimeout(resolve, 0));
+
+        // A fresh supervisor per case resets the probe-gate state without the test reaching into
+        // its internals; `runTask` is the restart spy. The supervisor owns the probe decision now.
+        const pollDownLms = async () => {
+            const started = [];
+            orchestrator.processSupervisorService = {
+                runTask(taskName, reason) { started.push({taskName, reason}); return true; }
+            };
+            TaskStateService.taskState.lms.running   = false;
+            TaskStateService.taskState.lms.lastRunAt = 0;
+            orchestrator.poll();
+            await flushProbe();
+            return started;
         };
 
-        const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
-
         // Endpoint DOWN → the lane is (re)started.
-        TaskStateService.taskState.lms.running   = false;
-        TaskStateService.taskState.lms.lastRunAt = 0;
-        orchestrator._livenessConfirmedAt   = {};
-        orchestrator._livenessProbeInFlight = {};
         probeUp = false;
-        orchestrator.poll();
-        await flushProbe();
-        expect(started).toContainEqual({taskName: 'lms', reason: 'supervisor-restart'});
+        expect(await pollDownLms()).toContainEqual({taskName: 'lms', reason: 'supervisor-restart'});
 
-        // Endpoint UP → silent no-op, NO restart (the #12262 fix: a healthy fire-and-exit lane
-        // must not re-spawn every cooldown).
-        started.length = 0;
-        TaskStateService.taskState.lms.running   = false;
-        TaskStateService.taskState.lms.lastRunAt = 0;
-        orchestrator._livenessConfirmedAt   = {};
-        orchestrator._livenessProbeInFlight = {};
+        // Endpoint UP → silent no-op, NO restart (a healthy fire-and-exit lane must not re-spawn
+        // every cooldown).
         probeUp = true;
-        orchestrator.poll();
-        await flushProbe();
-        expect(started.find(entry => entry.taskName === 'lms')).toBeUndefined();
+        expect((await pollDownLms()).find(entry => entry.taskName === 'lms')).toBeUndefined();
     });
 
     test('skips chroma daemon supervision in cloud mode while keeping local default (#12019)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -448,7 +448,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         }]);
     });
 
-    test('supervises lms as a continuous provider task when configured (#12090)', () => {
+    test('supervises lms via HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {
         const started = [];
         const taskDefinitions = buildTaskDefinitions({
             scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
@@ -459,13 +459,15 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             lmsPort   : 1234,
             providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50}
         });
+        // `lms server start` is fire-and-exit, so liveness is the HTTP endpoint, not the launcher
+        // child. Stub the probe for determinism (no real :1234) and drive both branches.
+        let probeUp = false;
+        taskDefinitions.lms.livenessProbe = async () => probeUp;
+
         const orchestrator = createTestOrchestrator({
             taskDefinitions,
             kbSyncEnabled: false
         });
-
-        TaskStateService.taskState.lms.running   = false;
-        TaskStateService.taskState.lms.lastRunAt = 0;
         orchestrator.processSupervisorService = {
             runTask(taskName, reason) {
                 started.push({taskName, reason});
@@ -473,12 +475,29 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             }
         };
 
-        orchestrator.poll();
+        const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
 
-        expect(started).toContainEqual({
-            taskName: 'lms',
-            reason  : 'supervisor-restart'
-        });
+        // Endpoint DOWN → the lane is (re)started.
+        TaskStateService.taskState.lms.running   = false;
+        TaskStateService.taskState.lms.lastRunAt = 0;
+        orchestrator._livenessConfirmedAt   = {};
+        orchestrator._livenessProbeInFlight = {};
+        probeUp = false;
+        orchestrator.poll();
+        await flushProbe();
+        expect(started).toContainEqual({taskName: 'lms', reason: 'supervisor-restart'});
+
+        // Endpoint UP → silent no-op, NO restart (the #12262 fix: a healthy fire-and-exit lane
+        // must not re-spawn every cooldown).
+        started.length = 0;
+        TaskStateService.taskState.lms.running   = false;
+        TaskStateService.taskState.lms.lastRunAt = 0;
+        orchestrator._livenessConfirmedAt   = {};
+        orchestrator._livenessProbeInFlight = {};
+        probeUp = true;
+        orchestrator.poll();
+        await flushProbe();
+        expect(started.find(entry => entry.taskName === 'lms')).toBeUndefined();
     });
 
     test('skips chroma daemon supervision in cloud mode while keeping local default (#12019)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -180,8 +180,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         // for why importing the template collides with daemon.mjs's config.mjs singleton).
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
 
+        // `lms.enabled` defaults to `true` (lms lane is the canonical local-inference launcher);
+        // the model id (`qwen3-embedding-8b`) and port (`1234`) are the rest of the launch shape.
         expect(templateSource).toMatch(
-            /lms:\s*\{[\s\S]*?leaf\(false[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
+            /lms:\s*\{[\s\S]*?leaf\(true[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
         );
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -302,4 +302,67 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(process.env.UNIT_TEST_MODE).toBe('true');
         expect(() => service.killProcess(999999999)).not.toThrow();
     });
+
+    // === superviseTask: liveness-gated (re)start decision (moved out of the orchestrator poll loop) ===
+
+    test('superviseTask restarts a down process-match task once the cooldown elapses', () => {
+        const {service} = createTestService();
+        const calls     = [];
+        service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
+        service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
+
+        service.superviseTask('mockTask', 1_000_000, 15000);
+
+        expect(calls).toEqual([{taskName: 'mockTask', reason: 'supervisor-restart'}]);
+    });
+
+    test('superviseTask leaves a running task alone — no restart', () => {
+        const {service} = createTestService();
+        const calls     = [];
+        service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
+        service.taskStateService.getTaskState = () => ({running: true, lastRunAt: 0, pid: 1234});
+
+        service.superviseTask('mockTask', 1_000_000, 15000);
+
+        expect(calls).toEqual([]);
+    });
+
+    test('superviseTask holds off within the cooldown window', () => {
+        const {service} = createTestService();
+        const calls     = [];
+        service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
+        // lastRunAt only 5s before `now`: still inside the 15s cooldown.
+        service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 995_000});
+
+        service.superviseTask('mockTask', 1_000_000, 15000);
+
+        expect(calls).toEqual([]);
+    });
+
+    test('superviseTask gates a fire-and-exit lane on its liveness probe — UP yields a silent no-op', async () => {
+        const {service} = createTestService();
+        const calls     = [];
+        service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
+        service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
+        service.taskDefinitions = {probeTask: {label: 'Probe Task', livenessProbe: async () => true}};
+
+        service.superviseTask('probeTask', 1_000_000, 15000);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(calls).toEqual([]);
+        expect(service._livenessConfirmedAt.probeTask).toBeTruthy();
+    });
+
+    test('superviseTask gates a fire-and-exit lane on its liveness probe — DOWN triggers a restart', async () => {
+        const {service} = createTestService();
+        const calls     = [];
+        service.runTask = (taskName, reason) => { calls.push({taskName, reason}); return true; };
+        service.taskStateService.getTaskState = () => ({running: false, lastRunAt: 0});
+        service.taskDefinitions = {probeTask: {label: 'Probe Task', livenessProbe: async () => false}};
+
+        service.superviseTask('probeTask', 1_000_000, 15000);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(calls).toEqual([{taskName: 'probeTask', reason: 'supervisor-restart'}]);
+    });
 });


### PR DESCRIPTION
Resolves #12262

Authored by Claude Opus 4.8 (Claude Code), operating as @neo-opus-4-7. Session eaa08543-4186-45e6-96fc-9963adb41f60.

FAIR-band: nightshift-exempt (operator-directed fix; FAIR-band author-lane pickup discipline is suspended during nightshift sessions).

The orchestrator's `lms` (LM Studio CLI) lane restart-loops. `lms server start` is **fire-and-exit** — it wakes the LM Studio background service and returns, so the served process never matches `expectedCommand: 'lms server'` for the supervisor's process-match liveness check. `!state.running` stays permanently true, so the poll re-spawns the lane every `RESTART_COOLDOWN_MS` (~15s), flooding the orchestrator logs.

The fix mirrors the operator's spec ("like for chroma, there has to be a check. running => all good, no logs. not running => start") by gating the restart on an **HTTP liveness probe** of the OpenAI-compatible endpoint instead of a process match. The supervision decision lives in **ProcessSupervisorService** (the supervision owner); the orchestrator poll loop stays a thin scheduler.

- **`TaskDefinitions.mjs`** — the `lms` task gains a `livenessProbe()` (a task-owned readiness contract, alongside the existing `postSpawn`) that calls `fetchOpenAiCompatibleModelIds({host, timeoutMs})` (GET `/v1/models` via `ProviderReadinessHelper`). Resolves => up; throws => down.
- **`ProcessSupervisorService.mjs`** — owns the liveness-gated (re)start via `superviseTask(taskName, now, cooldownMs)`:
  - **process-match** (default) => a down `running` flag past the cooldown is a real restart (`chroma`, `bridgeDaemon`, `mlx` — unchanged behavior).
  - **probe-gated** (a task exposing a `livenessProbe`) => `gateRestartOnLivenessProbe` probes the endpoint; **up** records a confirmed-at stamp and no-ops silently (re-probed one cooldown out — at most one cheap probe per cooldown, no log storm); **down / probe-throws** restarts via the existing `runTask` + `ensureLmsModelsLoaded` postSpawn. The provider-specific detail stays in the task; the supervisor only schedules + de-dupes the probe (matching its existing "provider-agnostic supervisor" design note).
- **`Orchestrator.mjs`** (poll loop) — delegates in one line: `this.processSupervisorService.superviseTask(taskName, now, RESTART_COOLDOWN_MS)`. No probe/flag/task detail left in the orchestrator.

Evidence: L2 (unit specs drive both branches at both layers — supervisor `superviseTask` directly + orchestrator `poll()` delegation; endpoint-down => `supervisor-restart`, endpoint-up => silent no-op). **Bug confirmed live** in the prod orchestrator log (see Test Evidence): the `lms` lane fire-and-exits ("completed successfully") and is re-spawned every ~15s — the exact signature this fix targets. L4 fix-confirmation (the flood going silent) is pending merge + orchestrator restart on the new code. Residual: live-silence confirmation [operator-side, #12262].

## Deltas from ticket

- **mlx lane audit (ticket AC):** `mlx` is **not** in the same fire-and-exit class. Its command is `python -m mlx_lm.server --model … --port …`, a genuine **foreground** HTTP server — the process command-line contains `mlx_lm.server`, so `expectedCommand: 'mlx_lm.server'` matches it and process-match liveness is correct. No change to the `mlx` lane. Only `lms server start` (a CLI that daemonizes-and-exits) breaks the process-match assumption.
- The probe-gate is generic (any task with a `livenessProbe`), so a future fire-and-exit lane opts in by adding a probe — no further supervisor or poll-loop changes.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs \
  test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
→ 58 passed
```

- `ProcessSupervisorService.spec.mjs` — 5 new `superviseTask` tests at the supervisor layer: process-match restart after cooldown, running-task no-op, within-cooldown hold-off, and both probe branches (UP => silent no-op + confirmed-at stamp; DOWN => restart).
- `Orchestrator.spec.mjs` — rewrote the prior `#12090` lms-supervision test to assert the poll loop **delegates** to the supervisor and both probe branches behave (down => `supervisor-restart`, up => no `lms` restart). Stubbed probe for determinism (no real `:1234`).

**Live bug repro** (prod orchestrator on `dev`, pre-fix):
```
[16:56:08] lms server (LM Studio CLI) stderr: Success! Server is now running on port 1234
[16:56:08] lms server (LM Studio CLI) completed successfully.
[16:56:19] Starting lms server (LM Studio CLI) (supervisor-restart).   <- ~15s later, re-spawn
[16:56:19] ... Success! Server is now running on port 1234
[16:56:19] ... completed successfully.
[16:56:34] Starting lms server (LM Studio CLI) (supervisor-restart).   <- loops forever
```
With this fix, the down `running` flag routes through `superviseTask`, which probes GET /v1/models (the server is up => resolves) instead of re-spawning: a confirmed-at stamp is recorded, the lane is skipped for a full cooldown — no restart, no log line.

## Post-Merge Validation

- [ ] On the next orchestrator restart with the lms lane enabled + LM Studio up on the configured port: confirm the `lms` log-flood is gone (no `supervisor-restart` every ~15s) and the endpoint stays served.
- [ ] Confirm a genuinely-down `lms` endpoint still triggers exactly one `lms server start` per cooldown (recovery path intact).

## Commits

- `a6bc688d0` — fix(orchestrator): HTTP-probe liveness for fire-and-exit lms lane
- `7f8750f61` — refactor(orchestrator): move liveness-gated restart into ProcessSupervisorService

## Evolution

Cycle-1 review feedback (operator): the orchestrator poll loop must stay a thin scheduler and carry no task-supervision detail, and ticket-ids do not belong in shipped `.mjs` comments. The liveness-gated restart logic (and its process-local probe-gate flags) moved from `Orchestrator.poll` into `ProcessSupervisorService` (`superviseTask` / `gateRestartOnLivenessProbe`); the poll loop now delegates in one line. Ticket-id anchors were stripped from the code comments (retained only in commit subjects, this PR body, and test-name traceability tags).
