### PR TITLE
fix(portal): restore shared timeline import paths (#12265)

### DIFF
--- a/apps/portal/view/content/CanvasWrapper.mjs
+++ b/apps/portal/view/content/CanvasWrapper.mjs
@@ -1,4 +1,4 @@
-import Container      from '../../../../../src/container/Base.mjs';
+import Container      from '../../../../src/container/Base.mjs';
 import TimelineCanvas from './TimelineCanvas.mjs';
 
 /**

--- a/apps/portal/view/content/TimelineCanvas.mjs
+++ b/apps/portal/view/content/TimelineCanvas.mjs
@@ -1,4 +1,4 @@
-import SharedCanvas from '../../../../../src/app/SharedCanvas.mjs';
+import SharedCanvas from '../../../../src/app/SharedCanvas.mjs';
 
 /**
  * @summary The "Coordinator" component for the Neural Timeline, bridging the App Worker and Canvas Worker.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.

FAIR-band: in-band [12/30]

Resolves #12265

Related: #12204

Restores the shared portal timeline files after their move into `apps/portal/view/content/` by correcting their framework import depth. The tickets tab no longer gets stranded at the lazy-module boundary when it imports `Portal.view.content.CanvasWrapper` and `Portal.view.content.TimelineCanvas`.

Evidence: L3 (local browser + Neural Link runtime probe on the patched branch) -> L3 required (portal runtime mount + theming/style surface verification). No residuals.

## Deltas from ticket

No scope expansion. The fix is exactly the two moved import paths; route config, parser behavior, canvas behavior, and SCSS files are untouched.

## Test Evidence

- `node --input-type=module -e "await import('./apps/portal/view/news/tickets/MainContainer.mjs')"` now reaches the expected runtime-only `Neo is not defined` boundary instead of `ERR_MODULE_NOT_FOUND` for `apps/portal/view/content/*`.
- Temporary local server from this branch at `http://localhost:63343/apps/portal/index.html#/news/tickets`; Neural Link session `d4dd45d2-7063-4068-b4b1-be67c2e38d8a` showed `Portal.view.news.tickets.MainContainer`, `Portal.view.content.CanvasWrapper`, and `Portal.view.content.TimelineCanvas` mounted.
- NL console logs on that session contained no runtime errors.
- Computed styles for `Portal.view.content.CanvasWrapper` preserved `position: relative`, `overflow: visible`, and `padding-bottom: 20px`; server logs showed `src/apps/portal/content/CanvasWrapper.css` plus existing ticket component light/dark CSS loading.
- `git diff --check origin/dev..HEAD` passed.

## Post-Merge Validation

- [ ] Open the operator JetBrains-served portal URL after merge and verify `/news/tickets` no longer reports `Failed to fetch dynamically imported module` for `tickets/MainContainer.mjs`.

## Commit

- `5f65e3c9b` — `fix(portal): restore shared timeline import paths (#12265)`