### PR TITLE
feat(orchestrator): recover stale lms maintenance locks (#12264)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -474,7 +474,7 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 lms: {
-                    enabled: leaf(true, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
+                    enabled: leaf(false, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
                     model  : leaf('qwen3-embedding-8b', 'NEO_ORCHESTRATOR_LMS_MODEL', 'string'),
                     port   : leaf('1234', 'NEO_ORCHESTRATOR_LMS_PORT', 'string')
                 }

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -459,10 +459,11 @@ class Config extends BaseConfig {
                  * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`).
                  *
                  * Parallel alternative to `orchestrator.mlx` — both serve OpenAI-compatible HTTP
-                 * for local embedding workloads; pick at most one via the respective `enabled` flag.
+                 * for local chat + embedding workloads; pick at most one via the respective `enabled` flag.
                  *
                  * - `enabled`: whether the orchestrator should supervise an `lms server start`
-                 *   child process. Disabled by default; **macOS-only** (LM Studio CLI is not
+                 *   child process. Enabled by default for local Agent OS chat + embedding roles;
+                 *   **macOS-only** (LM Studio CLI is not
                  *   shipped for Linux containers, so this lane is local-dev substrate, not
                  *   cloud-deployment substrate).
                  * - `model`: legacy single-model field kept for existing operator overlays. The
@@ -474,7 +475,7 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 lms: {
-                    enabled: leaf(false, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
+                    enabled: leaf(true, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
                     model  : leaf('qwen3-embedding-8b', 'NEO_ORCHESTRATOR_LMS_MODEL', 'string'),
                     port   : leaf('1234', 'NEO_ORCHESTRATOR_LMS_PORT', 'string')
                 }

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -26,6 +26,33 @@ export function toTimestamp(value) {
 }
 
 /**
+ * @summary Checks whether a process id still has a live owner.
+ *
+ * `process.kill(pid, 0)` is the cross-platform Node probe for process existence.
+ * `EPERM` still means a process exists but cannot be signalled by this user; only
+ * `ESRCH` / invalid pid shapes are treated as dead. Used by lease inspection so
+ * crashed orchestrator-owned maintenance tasks do not hold the mutex until the
+ * long wall-clock TTL expires.
+ *
+ * @param {Number|String} pid Process id recorded in a lease payload.
+ * @returns {Boolean}
+ */
+export function isPidAlive(pid) {
+    const numericPid = Number(pid);
+
+    if (!Number.isInteger(numericPid) || numericPid <= 0) {
+        return false;
+    }
+
+    try {
+        process.kill(numericPid, 0);
+        return true;
+    } catch (e) {
+        return e.code === 'EPERM';
+    }
+}
+
+/**
  * @summary Determines whether a persisted heavy-maintenance lease has expired.
  *
  * The stale check is intentionally payload-based instead of file-mtime-based so
@@ -35,9 +62,10 @@ export function toTimestamp(value) {
  * @param {Object|null} lease Persisted lease payload.
  * @param {Object} [options]
  * @param {Date|Number|String} [options.now=new Date()] Current time.
+ * @param {Function} [options.isPidAlive=isPidAlive] Process liveness probe seam.
  * @returns {Boolean}
  */
-export function isLeaseStale(lease, {now = new Date()} = {}) {
+export function isLeaseStale(lease, {now = new Date(), isPidAlive: isPidAliveFn = isPidAlive} = {}) {
     if (!lease || !lease.acquiredAt) {
         return true;
     }
@@ -46,6 +74,10 @@ export function isLeaseStale(lease, {now = new Date()} = {}) {
 
     if (!Number.isFinite(nowMs)) {
         return false;
+    }
+
+    if (lease.pid !== undefined && lease.pid !== null && typeof isPidAliveFn === 'function' && !isPidAliveFn(lease.pid)) {
+        return true;
     }
 
     const expiresAtMs = lease.expiresAt ? toTimestamp(lease.expiresAt) : NaN;
@@ -108,7 +140,8 @@ export function buildLeasePayload({
 export async function inspectHeavyMaintenanceLease({
     leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
     fsModule  = fs,
-    now       = new Date()
+    now       = new Date(),
+    isPidAlive: isPidAliveFn = isPidAlive
 } = {}) {
     let raw;
 
@@ -124,7 +157,7 @@ export async function inspectHeavyMaintenanceLease({
 
     try {
         const lease = JSON.parse(raw);
-        const stale = isLeaseStale(lease, {now});
+        const stale = isLeaseStale(lease, {now, isPidAlive: isPidAliveFn});
 
         return {
             status: stale ? 'stale' : 'active',
@@ -162,7 +195,8 @@ function writeLeaseFileSync(leasePath, lease, fsModule) {
 export function inspectHeavyMaintenanceLeaseSync({
     leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
     fsModule  = fs,
-    now       = new Date()
+    now       = new Date(),
+    isPidAlive: isPidAliveFn = isPidAlive
 } = {}) {
     let raw;
 
@@ -178,7 +212,7 @@ export function inspectHeavyMaintenanceLeaseSync({
 
     try {
         const lease = JSON.parse(raw);
-        const stale = isLeaseStale(lease, {now});
+        const stale = isLeaseStale(lease, {now, isPidAlive: isPidAliveFn});
 
         return {
             status: stale ? 'stale' : 'active',
@@ -211,6 +245,7 @@ export function acquireHeavyMaintenanceLeaseSync({
     now          = new Date(),
     pid          = process.pid,
     staleAfterMs = DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS,
+    isPidAlive: isPidAliveFn = isPidAlive,
     token
 } = {}) {
     if (!owner) {
@@ -228,7 +263,7 @@ export function acquireHeavyMaintenanceLeaseSync({
         }
     }
 
-    const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now});
+    const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
 
     if (current.active) {
         return {status: 'held', acquired: false, lease: current.lease};
@@ -249,7 +284,7 @@ export function acquireHeavyMaintenanceLeaseSync({
             throw e;
         }
 
-        const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now});
+        const raced = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
         return {status: 'held', acquired: false, lease: raced.lease};
     }
 }
@@ -264,13 +299,14 @@ export function releaseHeavyMaintenanceLeaseSync({
     token,
     leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
     fsModule  = fs,
-    now       = new Date()
+    now       = new Date(),
+    isPidAlive: isPidAliveFn = isPidAlive
 } = {}) {
     if (!token) {
         throw new Error('Heavy-maintenance lease token is required for release.');
     }
 
-    const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now});
+    const current = inspectHeavyMaintenanceLeaseSync({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
 
     if (current.status === 'missing') {
         return {status: 'missing', released: false};
@@ -312,6 +348,7 @@ export async function acquireHeavyMaintenanceLease({
     now          = new Date(),
     pid          = process.pid,
     staleAfterMs = DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS,
+    isPidAlive: isPidAliveFn = isPidAlive,
     token
 } = {}) {
     if (!owner) {
@@ -329,7 +366,7 @@ export async function acquireHeavyMaintenanceLease({
         }
     }
 
-    const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now});
+    const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
 
     if (current.active) {
         return {status: 'held', acquired: false, lease: current.lease};
@@ -350,7 +387,7 @@ export async function acquireHeavyMaintenanceLease({
             throw e;
         }
 
-        const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now});
+        const raced = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
         return {status: 'held', acquired: false, lease: raced.lease};
     }
 }
@@ -369,13 +406,14 @@ export async function releaseHeavyMaintenanceLease({
     token,
     leasePath = DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH,
     fsModule  = fs,
-    now       = new Date()
+    now       = new Date(),
+    isPidAlive: isPidAliveFn = isPidAlive
 } = {}) {
     if (!token) {
         throw new Error('Heavy-maintenance lease token is required for release.');
     }
 
-    const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now});
+    const current = await inspectHeavyMaintenanceLease({leasePath, fsModule, now, isPidAlive: isPidAliveFn});
 
     if (current.status === 'missing') {
         return {status: 'missing', released: false};
@@ -492,7 +530,8 @@ export async function withHeavyMaintenanceLease(task, options = {}) {
         const current = await inspectHeavyMaintenanceLease({
             leasePath: options.leasePath,
             fsModule : options.fsModule,
-            now      : options.now
+            now      : options.now,
+            isPidAlive: options.isPidAlive
         });
 
         if (current.active && current.lease && current.lease.token === inheritedToken) {
@@ -524,7 +563,8 @@ export async function withHeavyMaintenanceLease(task, options = {}) {
             token    : acquisition.lease.token,
             leasePath: options.leasePath,
             fsModule : options.fsModule,
-            now      : options.now
+            now      : options.now,
+            isPidAlive: options.isPidAlive
         });
     }
 }
@@ -582,7 +622,8 @@ export class HeavyMaintenanceLeaseService extends Base {
         return inspectHeavyMaintenanceLease({
             leasePath: options.leasePath ?? this.leasePath,
             fsModule : options.fsModule  ?? this.fsModule,
-            now      : options.now       ?? new Date()
+            now      : options.now       ?? new Date(),
+            isPidAlive: options.isPidAlive
         });
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -175,15 +175,17 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         }
     });
 
-    test('AiConfig.orchestrator.lms ships canonical LM Studio launch defaults', () => {
+    test('AiConfig.orchestrator.lms ships opt-in LM Studio launch defaults', () => {
         // Tier-1 template is the stable source of truth; read as text (see the MLX test
         // for why importing the template collides with daemon.mjs's config.mjs singleton).
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
 
-        // `lms.enabled` defaults to `true` (lms lane is the canonical local-inference launcher);
-        // the model id (`qwen3-embedding-8b`) and port (`1234`) are the rest of the launch shape.
+        // `lms.enabled` defaults to `false`: the lane remains available for local-model
+        // operators, but default orchestrator boot must not force-load both heavyweight local roles.
+        // When explicitly enabled, the model id (`qwen3-embedding-8b`) and port (`1234`)
+        // are the rest of the launch shape.
         expect(templateSource).toMatch(
-            /lms:\s*\{[\s\S]*?leaf\(true[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
+            /lms:\s*\{[\s\S]*?leaf\(false[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
         );
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -175,17 +175,16 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         }
     });
 
-    test('AiConfig.orchestrator.lms ships opt-in LM Studio launch defaults', () => {
+    test('AiConfig.orchestrator.lms ships default-enabled LM Studio launch defaults', () => {
         // Tier-1 template is the stable source of truth; read as text (see the MLX test
         // for why importing the template collides with daemon.mjs's config.mjs singleton).
         const templateSource = fs.readFileSync(path.resolve(process.cwd(), 'ai/config.template.mjs'), 'utf8');
 
-        // `lms.enabled` defaults to `false`: the lane remains available for local-model
-        // operators, but default orchestrator boot must not force-load both heavyweight local roles.
-        // When explicitly enabled, the model id (`qwen3-embedding-8b`) and port (`1234`)
+        // `lms.enabled` defaults to `true`: local Agent OS needs both chat and embedding
+        // roles resident by default; the model id (`qwen3-embedding-8b`) and port (`1234`)
         // are the rest of the launch shape.
         expect(templateSource).toMatch(
-            /lms:\s*\{[\s\S]*?leaf\(false[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
+            /lms:\s*\{[\s\S]*?leaf\(true[\s\S]*?'qwen3-embedding-8b'[\s\S]*?'1234'/
         );
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -9,6 +9,7 @@ import {
     acquireHeavyMaintenanceLeaseSync,
     inspectHeavyMaintenanceLease,
     inspectHeavyMaintenanceLeaseSync,
+    isPidAlive,
     isLeaseStale,
     releaseHeavyMaintenanceLease,
     releaseHeavyMaintenanceLeaseSync,
@@ -38,7 +39,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             owner       : 'kbSync',
             reason      : 'periodic-sync:1800000',
             metadata    : {taskName: 'kbSync'},
-            pid         : 1234,
+            pid         : process.pid,
             staleAfterMs: 60000,
             now,
             token       : 'owner-token'
@@ -50,7 +51,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             lease   : {
                 owner       : 'kbSync',
                 reason      : 'periodic-sync:1800000',
-                pid         : 1234,
+                pid         : process.pid,
                 token       : 'owner-token',
                 staleAfterMs: 60000,
                 metadata    : {taskName: 'kbSync'}
@@ -68,6 +69,12 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
                 token: 'owner-token'
             }
         });
+    });
+
+    test('process liveness detects invalid owner pids', () => {
+        expect(isPidAlive(process.pid)).toBe(true);
+        expect(isPidAlive(-1)).toBe(false);
+        expect(isPidAlive('not-a-pid')).toBe(false);
     });
 
     test('returns held status for active contention without throwing', async () => {
@@ -96,6 +103,52 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
             status  : 'held',
             acquired: false,
             lease   : {
+                owner: 'summary',
+                token: 'summary-token'
+            }
+        });
+    });
+
+    test('#12264: dead owner pid makes a wall-clock-active lease stale', async () => {
+        const leasePath = createLeasePath('dead-owner-pid');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        await acquireHeavyMaintenanceLease({
+            leasePath,
+            owner       : 'kbSync',
+            reason      : 'periodic-sync:1800000',
+            pid         : 60789,
+            staleAfterMs: 6 * 60 * 60 * 1000,
+            now,
+            token       : 'dead-owner-token'
+        });
+
+        await expect(inspectHeavyMaintenanceLease({
+            leasePath,
+            now,
+            isPidAlive: () => false
+        })).resolves.toMatchObject({
+            status: 'stale',
+            active: false,
+            stale : true,
+            lease : {
+                owner: 'kbSync',
+                pid  : 60789,
+                token: 'dead-owner-token'
+            }
+        });
+
+        await expect(acquireHeavyMaintenanceLease({
+            leasePath,
+            owner     : 'summary',
+            now,
+            token     : 'summary-token',
+            isPidAlive: () => false
+        })).resolves.toMatchObject({
+            status        : 'acquired-after-stale',
+            acquired      : true,
+            previousStatus: 'stale',
+            lease         : {
                 owner: 'summary',
                 token: 'summary-token'
             }
@@ -618,6 +671,45 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
 
         expect(inspectHeavyMaintenanceLeaseSync({leasePath, now})).toMatchObject({
             status: 'missing'
+        });
+    });
+
+    test('#12264: sync acquire replaces dead-owner leases for orchestrator poll callers', () => {
+        const leasePath = createLeasePath('sync-dead-owner');
+        const now       = new Date('2026-05-16T20:00:00.000Z');
+
+        expect(acquireHeavyMaintenanceLeaseSync({
+            leasePath,
+            owner       : 'kbSync',
+            pid         : 60789,
+            now,
+            staleAfterMs: 6 * 60 * 60 * 1000,
+            token       : 'dead-owner-token'
+        })).toMatchObject({
+            status: 'acquired',
+            lease : {owner: 'kbSync', pid: 60789}
+        });
+
+        expect(inspectHeavyMaintenanceLeaseSync({
+            leasePath,
+            now,
+            isPidAlive: () => false
+        })).toMatchObject({
+            status: 'stale',
+            stale : true,
+            lease : {owner: 'kbSync', pid: 60789}
+        });
+
+        expect(acquireHeavyMaintenanceLeaseSync({
+            leasePath,
+            owner     : 'dream',
+            now,
+            token     : 'dream-token',
+            isPidAlive: () => false
+        })).toMatchObject({
+            status        : 'acquired-after-stale',
+            previousStatus: 'stale',
+            lease         : {owner: 'dream', token: 'dream-token'}
         });
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d9b4a887-57aa-43aa-8cec-a260ec35ce12.

FAIR-band: in-band (neo-gpt authored 11 of the last 30 merged PRs before opening; below ceiling and still behind the current Claude-heavy merge window).

Refs #12264

Operator correction: the LM Studio orchestrator lane must remain default-enabled because local Agent OS needs both configured roles - chat and embedding - resident. This PR therefore no longer claims to close #12264's preload-policy ACs. It keeps the existing two-role preload contract intact and repairs the live stale-lock failure mode surfaced during the same lane: heavy-maintenance leases now treat a dead recorded owner PID as stale, so a crashed orchestrator-owned `kbSync` lease cannot block the 30-minute maintenance cadence until a 6-hour wall-clock TTL expires.

Evidence: L2 (unit tests + live lease/PID falsification: `kbSync` lease pid 60789 was dead while lease expiry was 2026-06-01T00:08:39.189Z) -> L3 required (post-merge daemon/CLI recovery on the live host). Residual: post-merge validation and #12264's remaining preload-policy solution.

## Deltas from ticket
- Operator evidence expanded the ticket from preload safety into the stale heavy-maintenance lock it caused/left behind: the live lease was held by `kbSync`, but the recorded owner process was gone.
- Operator correction rejected the disable/default-opt-in direction: `AiConfig.orchestrator.lms.enabled` remains `true`.
- Operator correction also rejects making chat disposable: when LMS is enabled, the lms preload path still requires both configured models to become resident before readiness succeeds.
- #12264 remains open for the actual preload-policy work. The next solution must preserve both chat and embedding rather than disabling the lane, skipping chat, or silently marking the local model surface healthy when a required role is missing.

## Test Evidence
- `node --check ai/config.template.mjs` -> passed.
- `node --check test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` -> passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` -> 32 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs` -> 22 passed.
- `git diff --check` -> clean.

## Post-Merge Validation
- [ ] On the live host, a manual heavy-maintenance script no longer defers behind the dead `kbSync` lease once the merged code is active; the next acquisition should replace the dead-owner lease.
- [ ] `AiConfig.orchestrator.lms.enabled` remains default-enabled and preloads both configured roles; if either configured model cannot be resident, readiness must fail loudly rather than silently marking the local model surface healthy.

## Commits
- `1fe0bcecb` - stale heavy-maintenance lease recovery.
- `3d8dd9673` - LMS lane remains default-enabled and preserves the two-role preload contract.
