### PR TITLE
feat(github-workflow): mark discussion accepted answers (#12215)

### DIFF
--- a/ai/services/github-workflow/queries/discussionQueries.mjs
+++ b/ai/services/github-workflow/queries/discussionQueries.mjs
@@ -99,6 +99,7 @@ export const FETCH_DISCUSSIONS_FOR_SYNC = `
               }
               body
               createdAt
+              isAnswer
               replies(first: $maxReplies) {
                 nodes {
                   author {
@@ -106,6 +107,7 @@ export const FETCH_DISCUSSIONS_FOR_SYNC = `
                   }
                   body
                   createdAt
+                  isAnswer
                 }
               }
             }

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -268,11 +268,18 @@ class DiscussionSyncer extends Base {
                 if (discussion.comments && discussion.comments.nodes && discussion.comments.nodes.length > 0) {
                     body += '\n\n## Comments\n\n';
                     for (const comment of discussion.comments.nodes) {
-                        body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n${comment.body}\n\n`;
+                        body += `### \`@${comment.author?.login || 'unknown'}\` commented on ${comment.createdAt}\n\n`;
+                        if (comment.isAnswer) {
+                            body += '> [!ANSWER]\n\n';
+                        }
+                        body += `${comment.body}\n\n`;
 
                         // Parse replies if any
                         if (comment.replies && comment.replies.nodes && comment.replies.nodes.length > 0) {
                             for (const reply of comment.replies.nodes) {
+                                if (reply.isAnswer) {
+                                    body += '> [!ANSWER]\n>\n';
+                                }
                                 body += `> **Reply by \`@${reply.author?.login || 'unknown'}\`** on ${reply.createdAt}\n>\n`;
                                 const blockquotedReply = reply.body.split('\n').map(l => `> ${l}`).join('\n');
                                 body += `${blockquotedReply}\n\n`;

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -18,6 +18,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs-extra';
 import path           from 'path';
+import {FETCH_DISCUSSIONS_FOR_SYNC} from '../../../../../../ai/services/github-workflow/queries/discussionQueries.mjs';
 
 test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
     let aiConfig;
@@ -101,6 +102,94 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(content).toMatch(/^closedAt: null$/m);
     });
 
+    test('fetches accepted-answer flags for comments and replies', () => {
+        const answerFlagMatches = FETCH_DISCUSSIONS_FOR_SYNC.match(/\bisAnswer\b/g) || [];
+
+        expect(answerFlagMatches).toHaveLength(2);
+    });
+
+    test('marks accepted Q&A comments with a parseable answer callout', async () => {
+        const discussion = buildDiscussion(24003, {
+            category: 'Q&A',
+            comments: {nodes: [{
+                author: {login: 'neo-answer'},
+                body: 'Accepted answer body.',
+                createdAt: '2026-05-02T01:00:00Z',
+                isAnswer: true,
+                replies: {nodes: []}
+            }, {
+                author: {login: 'neo-thread'},
+                body: 'Regular follow-up.',
+                createdAt: '2026-05-02T02:00:00Z',
+                isAnswer: false,
+                replies: {nodes: [{
+                    author: {login: 'neo-reply-answer'},
+                    body: 'Nested accepted answer.',
+                    createdAt: '2026-05-02T03:00:00Z',
+                    isAnswer: true
+                }]}
+            }]}
+        });
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes: [discussion],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        await DiscussionSyncer.syncDiscussions({discussions: {}});
+
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24003.md');
+        const content = await fs.readFile(targetPath, 'utf8');
+
+        expect(content).toContain([
+            '### `@neo-answer` commented on 2026-05-02T01:00:00Z',
+            '',
+            '> [!ANSWER]',
+            '',
+            'Accepted answer body.'
+        ].join('\n'));
+        expect(content).toContain([
+            '> [!ANSWER]',
+            '>',
+            '> **Reply by `@neo-reply-answer`** on 2026-05-02T03:00:00Z',
+            '>',
+            '> Nested accepted answer.'
+        ].join('\n'));
+    });
+
+    test('does not add answer markers for regular non-Q&A comments', async () => {
+        const discussion = buildDiscussion(24004, {
+            category: 'General',
+            comments: {nodes: [{
+                author: {login: 'neo-comment'},
+                body: 'Regular discussion comment.',
+                createdAt: '2026-05-02T01:00:00Z',
+                replies: {nodes: []}
+            }]}
+        });
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes: [discussion],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        await DiscussionSyncer.syncDiscussions({discussions: {}});
+
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24004.md');
+        const content = await fs.readFile(targetPath, 'utf8');
+
+        expect(content).toContain('Regular discussion comment.');
+        expect(content).not.toContain('> [!ANSWER]');
+    });
+
     test('writes archived discussions through contentPath and maintains _index.json', async () => {
         const discussion = buildDiscussion(24002, {
             closed: true,
@@ -166,7 +255,12 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
 });
 
 function buildDiscussion(number, config = {}) {
-    const {closed = false, closedAt = null} = config;
+    const {
+        category = 'General',
+        closed = false,
+        closedAt = null,
+        comments = {nodes: []}
+    } = config;
 
     return {
         number,
@@ -175,9 +269,9 @@ function buildDiscussion(number, config = {}) {
         closed,
         closedAt,
         author: {login: 'neo-test'},
-        category: {name: 'General'},
+        category: {name: category},
         createdAt: '2026-05-01T00:00:00Z',
         updatedAt: '2026-05-02T00:00:00Z',
-        comments: {nodes: []}
+        comments
     };
 }


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d9b4a887-57aa-43aa-8cec-a260ec35ce12.

FAIR-band: in-band [13/30 - current author count over last 30 merged]

Resolves #12215

Related: #12204

Adds accepted-answer data to the Discussion sync producer. The sync GraphQL query now asks GitHub for `DiscussionComment.isAnswer` on top-level comments and replies, and the markdown sync output emits a parseable `> [!ANSWER]` marker inside accepted comment blocks without changing regular discussion comments.

Evidence: L2 (GitHub GraphQL schema introspection + focused syncer unit coverage) -> L2 required (producer query/output contract ACs). No residuals.

## Deltas from ticket

- Corrected the ticket's stale parent reference in implementation context: #12215 belongs under portal epic #12204; #12207 is a closed rename sub.
- Queried `isAnswer` on both top-level comments and replies because GitHub schema exposes both as `DiscussionComment` nodes.
- Left the view-side `category === 'Q&A'` affordance gate to the later Discussion view work; this PR only emits producer data when GitHub reports an accepted answer.

## Test Evidence

- `gh api graphql -f query='query { __type(name: "DiscussionComment") { fields { name type { kind name ofType { kind name } } } } }'` confirmed `DiscussionComment.isAnswer`.
- `gh api graphql -f query='query { __type(name: "Discussion") { fields { name type { kind name ofType { kind name } } } } }'` confirmed discussion answer-related fields.
- `node --check ai/services/github-workflow/queries/discussionQueries.mjs`
- `node --check ai/services/github-workflow/sync/DiscussionSyncer.mjs`
- `node --check test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs` -> 6 passed
- `git diff --check`

## Post-Merge Validation

- [ ] The next GitHub Workflow discussion sync against a Q&A discussion with an accepted answer emits the `> [!ANSWER]` marker in the generated markdown.
- [ ] The future Discussion view lane consumes the marker without inventing a second accepted-answer data shape.

## Commit

- `7177382a0` - `feat(github-workflow): mark discussion accepted answers (#12215)`
