### PR TITLE
feat(orchestrator): restore pending summary markers (#12199)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -4,11 +4,43 @@ import {
 } from '../../bridge/queries.mjs';
 
 /**
+ * Reads pending low-latency summarization markers from the coordinator table.
+ *
+ * @summary Keeps the scheduler's pending-lane check cheap: it only needs to know
+ * whether pending rows exist, while the spawned summary child remains responsible
+ * for lease-claiming and draining the actual jobs.
+ * @param {Object} db SQLite database handle.
+ * @param {Object} [options]
+ * @param {Number} [options.limit=50] Maximum marker ids to return.
+ * @returns {String[]}
+ */
+export function getPendingSummarizationJobs(db, {limit = 50} = {}) {
+    if (!db?.prepare) {
+        return [];
+    }
+
+    const numericLimit = Number.isInteger(limit) && limit > 0 ? limit : 50;
+
+    try {
+        return db.prepare(`
+            SELECT session_id
+            FROM SummarizationJobs
+            WHERE status = 'pending'
+            ORDER BY rowid ASC
+            LIMIT ?
+        `).all(numericLimit).map(row => row.session_id).filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+
+/**
  * Builds the task trigger for the summarization sweep lane.
  *
- * Two wake-up sources, in priority order:
+ * Three wake-up sources, in priority order:
  * 1. Unread sunset handovers — priority because they unblock the next agent boot
- * 2. Periodic sweep — fallback for ordinary unsummarized sessions
+ * 2. Pending disconnect markers — targeted low-latency session close handling
+ * 3. Periodic sweep — fallback for ordinary unsummarized sessions
  *
  * Pure function. Test the scheduling contract without mounting the SQLite graph.
  *
@@ -17,15 +49,25 @@ import {
  * @param {Number} options.lastRunAt Last summary task start timestamp.
  * @param {Number} options.intervalMs Periodic sweep interval; `0` disables the interval source.
  * @param {Object[]} [options.handovers=[]] Unread sunset-handover message nodes.
+ * @param {String[]} [options.pendingJobs=[]] Pending SummarizationJobs session ids.
  * @returns {Object|null} A summary task trigger or null when no work is due.
  */
-export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = []}) {
+export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [], pendingJobs = []}) {
     if (handovers.length > 0) {
         return {
             taskName     : 'summary',
             source       : 'sunset-handover',
             reason       : `sunset-handover:${handovers.length}`,
             handoverCount: handovers.length
+        };
+    }
+
+    if (pendingJobs.length > 0) {
+        return {
+            taskName    : 'summary',
+            source      : 'pending-summarization',
+            reason      : `pending-summarization:${pendingJobs.length}`,
+            pendingCount: pendingJobs.length
         };
     }
 
@@ -50,6 +92,7 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = []}
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.summarySweepIntervalMs Periodic summary sweep interval.
  * @param {Function} [options.getUnreadSunsetHandoversFn] Test seam for handover reads.
+ * @param {Function} [options.getPendingSummarizationJobsFn] Test seam for pending marker reads.
  * @param {Function} [options.markNodesAsReadFn] Test seam for handover mark-read writes.
  * @param {Function} [options.log] Optional orchestrator log function.
  * @returns {Object|null} Task trigger with optional `onSuccess` callback, or null.
@@ -60,13 +103,16 @@ export function getDueTask({
     now,
     summarySweepIntervalMs,
     getUnreadSunsetHandoversFn = getUnreadSunsetHandovers,
+    getPendingSummarizationJobsFn = getPendingSummarizationJobs,
     markNodesAsReadFn          = markNodesAsRead,
     log
 }) {
     const handovers = getUnreadSunsetHandoversFn(db);
+    const pendingJobs = handovers.length > 0 ? [] : getPendingSummarizationJobsFn(db);
     const trigger   = buildSummaryTrigger({
         now,
         handovers,
+        pendingJobs,
         intervalMs: summarySweepIntervalMs,
         lastRunAt : state.summary?.lastRunAt || 0
     });

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -221,8 +221,9 @@ class Server extends BaseServer {
     /**
      * @summary SSE-only hook fired by `TransportService` on session disconnect. Removes the
      * per-session McpServer from `CoalescingEngineService`'s broadcast set (counterpart to
-     * `createMcpServer`'s `addMcpServer` registration). Summarization is orchestrator-driven
-     * (the `summary` task), not triggered on disconnect.
+     * `createMcpServer`'s `addMcpServer` registration) and writes a cheap idempotent
+     * `SummarizationJobs.pending` marker. The orchestrator `summary` task drains that marker;
+     * this hook never summarizes inline.
      * @param {String} sessionId
      * @param {Object} mcpServerInstance
      */
@@ -230,6 +231,8 @@ class Server extends BaseServer {
         if (mcpServerInstance) {
             CoalescingEngineService.removeMcpServer(mcpServerInstance);
         }
+
+        SessionService.queueSummarizationJob(sessionId);
     }
 
     /**

--- a/ai/scripts/lifecycle/summarize-sessions.mjs
+++ b/ai/scripts/lifecycle/summarize-sessions.mjs
@@ -27,7 +27,17 @@ async function summarize() {
     try {
         await Memory_SessionService.initAsync();
 
-        console.log('[summarize-sessions] Starting session summarization...');
+        console.log('[summarize-sessions] Draining pending session summarization markers...');
+        const pendingResult = await Memory_SessionService.summarizePendingSessions();
+
+        if (pendingResult && pendingResult.error) {
+            console.error(`[summarize-sessions] Pending summarization failed: ${pendingResult.message}`);
+            process.exit(1);
+        }
+
+        console.log(`[summarize-sessions] Pending drain complete. Pending: ${pendingResult?.pending || 0}; processed: ${pendingResult?.processed || 0}`);
+
+        console.log('[summarize-sessions] Starting drift-detection session summarization...');
         // includeAll: false will only summarize sessions from the last 30 days
         const result = await Memory_SessionService.summarizeSessions({ includeAll: false });
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -954,6 +954,109 @@ ${aggregatedContent}
     }
 
     /**
+     * Queues a low-latency summarization marker for a disconnected session.
+     *
+     * @summary Writes an idempotent `pending` SummarizationJobs row without running
+     * summarization inline. Multiple MCP server instances can race this cheap marker
+     * safely; the orchestrator-owned summary lane remains the only drainer and the
+     * existing lease transition serializes the expensive summarization work.
+     * @param {String} sessionId Session id whose transport disconnected.
+     * @returns {Boolean} true when the marker was written, false otherwise.
+     */
+    queueSummarizationJob(sessionId) {
+        if (!sessionId || typeof sessionId !== 'string') {
+            return false;
+        }
+
+        const db = GraphService.db?.storage?.db;
+        if (!db) {
+            logger.warn(`[SessionService] queueSummarizationJob skipped for ${sessionId}: SQLite graph is not available.`);
+            return false;
+        }
+
+        try {
+            db.prepare(`
+                INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+                VALUES (?, 'pending', NULL, NULL, 0)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    status      = 'pending',
+                    lease_token = NULL,
+                    expires_at  = NULL
+                WHERE SummarizationJobs.status != 'completed'
+                    AND SummarizationJobs.status != 'in_progress'
+            `).run(sessionId);
+
+            return true;
+        } catch (e) {
+            logger.warn(`[SessionService] Error queueing summarization job for ${sessionId}: ${e.message}`);
+            return false;
+        }
+    }
+
+    /**
+     * Reads pending low-latency summarization job ids in insertion order.
+     *
+     * @summary Provides the orchestrator child process with the exact pending lane
+     * payload before it falls back to the broader drift sweep.
+     * @param {Object} [options]
+     * @param {Number} [options.limit=50] Maximum pending rows to drain in one child run.
+     * @returns {String[]}
+     */
+    getPendingSummarizationJobIds({limit = 50} = {}) {
+        const db = GraphService.db?.storage?.db;
+        if (!db) return [];
+
+        const numericLimit = Number.isInteger(limit) && limit > 0 ? limit : 50;
+
+        try {
+            return db.prepare(`
+                SELECT session_id
+                FROM SummarizationJobs
+                WHERE status = 'pending'
+                ORDER BY rowid ASC
+                LIMIT ?
+            `).all(numericLimit).map(row => row.session_id).filter(Boolean);
+        } catch (e) {
+            logger.warn(`[SessionService] Error reading pending summarization jobs: ${e.message}`);
+            return [];
+        }
+    }
+
+    /**
+     * Drains pending summarization markers through the existing lease-backed summarizer.
+     *
+     * @summary Reuses {@link summarizeSessions} with explicit session ids so each
+     * `pending` row travels through `claimSummarizationJob()` and cannot be processed
+     * twice by overlapping pending/drift drains.
+     * @param {Object} [options]
+     * @param {Number} [options.limit=50] Maximum pending rows to drain in one child run.
+     * @returns {Promise<{processed: number, sessions: object[], pending: number}>}
+     */
+    async summarizePendingSessions({limit = 50} = {}) {
+        const sessionIds = this.getPendingSummarizationJobIds({limit});
+        const processed  = [];
+
+        for (const sessionId of sessionIds) {
+            const result = await this.summarizeSessions({sessionId});
+
+            if (result?.error) {
+                logger.warn(`[SessionService] Pending summarization failed for ${sessionId}: ${result.message}`);
+                continue;
+            }
+
+            if (Array.isArray(result?.sessions)) {
+                processed.push(...result.sessions);
+            }
+        }
+
+        return {
+            pending  : sessionIds.length,
+            processed: processed.length,
+            sessions : processed
+        };
+    }
+
+    /**
      * Claims an exclusive lease on a summarization job using the SummarizationJobs table.
      * Prevents race conditions across concurrent MCP instances.
      * @summary Provides exclusive lock acquisition for the background summarization coordinator loop.

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test';
 import {
     buildSummaryTrigger,
+    getPendingSummarizationJobs,
     getDueTask
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/summary.mjs';
 
@@ -16,6 +17,36 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
             source       : 'sunset-handover',
             reason       : 'sunset-handover:2',
             handoverCount: 2
+        });
+    });
+
+    test('#12199: buildSummaryTrigger prioritizes pending summarization markers before the periodic sweep', () => {
+        expect(buildSummaryTrigger({
+            now        : 600000,
+            lastRunAt  : 0,
+            intervalMs : 600000,
+            handovers  : [],
+            pendingJobs: ['session-1', 'session-2']
+        })).toEqual({
+            taskName    : 'summary',
+            source      : 'pending-summarization',
+            reason      : 'pending-summarization:2',
+            pendingCount: 2
+        });
+    });
+
+    test('#12199: sunset handovers stay higher priority than pending summarization markers', () => {
+        expect(buildSummaryTrigger({
+            now        : 600000,
+            lastRunAt  : 0,
+            intervalMs : 600000,
+            handovers  : [{id: 'MESSAGE:1'}],
+            pendingJobs: ['session-1']
+        })).toEqual({
+            taskName     : 'summary',
+            source       : 'sunset-handover',
+            reason       : 'sunset-handover:1',
+            handoverCount: 1
         });
     });
 
@@ -60,6 +91,24 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
         expect(result.onSuccess).toBeUndefined();
     });
 
+    test('#12199: getDueTask reads pending markers when no handover is waiting', () => {
+        const result = getDueTask({
+            db                            : 'mock-db',
+            state                         : {summary: {lastRunAt: 0}},
+            now                           : 100,
+            summarySweepIntervalMs        : 600000,
+            getUnreadSunsetHandoversFn    : () => [],
+            getPendingSummarizationJobsFn : () => ['session-1']
+        });
+
+        expect(result).toEqual({
+            taskName    : 'summary',
+            source      : 'pending-summarization',
+            reason      : 'pending-summarization:1',
+            pendingCount: 1
+        });
+    });
+
     test('getDueTask returns sunset-handover trigger with onSuccess callback', () => {
         const markCalls = [];
         const handovers = [{id: 'MESSAGE:1'}, {id: 'MESSAGE:2'}];
@@ -78,5 +127,24 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
 
         result.onSuccess();
         expect(markCalls).toEqual([{db: 'mock-db', nodes: handovers}]);
+    });
+
+    test('#12199: getPendingSummarizationJobs reads pending session ids only', () => {
+        const calls = [];
+        const db = {
+            prepare: (sql) => {
+                calls.push(sql);
+                return {
+                    all: (limit) => {
+                        calls.push(limit);
+                        return [{session_id: 'session-1'}, {session_id: 'session-2'}, {session_id: null}];
+                    }
+                };
+            }
+        };
+
+        expect(getPendingSummarizationJobs(db, {limit: 2})).toEqual(['session-1', 'session-2']);
+        expect(calls[0]).toContain("WHERE status = 'pending'");
+        expect(calls[1]).toBe(2);
     });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -141,4 +141,34 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
         serverInstance.destroy();
     });
+
+    test('#12199: onSessionClosed writes a pending summarization marker without summarizing inline', async () => {
+        const SDK = await import('../../../../../../../ai/services.mjs');
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const mcpServerInstance = {id: 'mcp-session-server'};
+        const calls = [];
+        const removed = [];
+
+        const originalQueue = SDK.Memory_SessionService.queueSummarizationJob;
+        const originalRemove = SDK.Memory_CoalescingEngineService.removeMcpServer;
+
+        SDK.Memory_SessionService.queueSummarizationJob = (sessionId) => {
+            calls.push(sessionId);
+            return true;
+        };
+        SDK.Memory_CoalescingEngineService.removeMcpServer = (instance) => {
+            removed.push(instance);
+        };
+
+        try {
+            serverInstance.onSessionClosed('closed-session-1', mcpServerInstance);
+
+            expect(removed).toEqual([mcpServerInstance]);
+            expect(calls).toEqual(['closed-session-1']);
+        } finally {
+            SDK.Memory_SessionService.queueSummarizationJob = originalQueue;
+            SDK.Memory_CoalescingEngineService.removeMcpServer = originalRemove;
+            serverInstance.destroy();
+        }
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
@@ -87,6 +87,117 @@ test.describe('SessionService validateSessionForResume (#10725)', () => {
         expect(result.sessionId).toBe(sessionId);
     });
 
+    test('#12199: queueSummarizationJob writes an idempotent pending marker', async () => {
+        const sessionId    = `pending-marker-${crypto.randomUUID()}`;
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        try {
+            expect(SDK.Memory_SessionService.queueSummarizationJob(sessionId)).toBe(true);
+            expect(SDK.Memory_SessionService.queueSummarizationJob(sessionId)).toBe(true);
+
+            const row = sqlite.prepare('SELECT status, lease_token, expires_at, retry_count FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+
+            expect(row.status).toBe('pending');
+            expect(row.lease_token).toBeNull();
+            expect(row.expires_at).toBeNull();
+            expect(row.retry_count).toBe(0);
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+
+    test('#12199: queueSummarizationJob does not steal an active summarization lease', async () => {
+        const sessionId    = `active-lease-${crypto.randomUUID()}`;
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        const futureExpiresAt = Date.now() + 60_000;
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'in_progress', 'active-token', ?, 3)
+        `).run(sessionId, futureExpiresAt);
+
+        try {
+            expect(SDK.Memory_SessionService.queueSummarizationJob(sessionId)).toBe(true);
+
+            const row = sqlite.prepare('SELECT status, lease_token, expires_at, retry_count FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+
+            expect(row.status).toBe('in_progress');
+            expect(row.lease_token).toBe('active-token');
+            expect(row.expires_at).toBe(futureExpiresAt);
+            expect(row.retry_count).toBe(3);
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+
+    test('#12199: queueSummarizationJob does not reopen a completed summary', async () => {
+        const sessionId    = `completed-summary-${crypto.randomUUID()}`;
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'completed', NULL, NULL, 2)
+        `).run(sessionId);
+
+        try {
+            expect(SDK.Memory_SessionService.queueSummarizationJob(sessionId)).toBe(true);
+
+            const row = sqlite.prepare('SELECT status, lease_token, expires_at, retry_count FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+
+            expect(row.status).toBe('completed');
+            expect(row.lease_token).toBeNull();
+            expect(row.expires_at).toBeNull();
+            expect(row.retry_count).toBe(2);
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+
+    test('#12199: summarizePendingSessions drains explicit pending ids through summarizeSessions', async () => {
+        const calls = [];
+        const originalGetPending = SDK.Memory_SessionService.getPendingSummarizationJobIds;
+        const originalSummarize = SDK.Memory_SessionService.summarizeSessions;
+
+        SDK.Memory_SessionService.getPendingSummarizationJobIds = ({limit}) => {
+            calls.push({type: 'getPending', limit});
+            return ['pending-session-1', 'pending-session-2'];
+        };
+        SDK.Memory_SessionService.summarizeSessions = async ({sessionId}) => {
+            calls.push({type: 'summarize', sessionId});
+            return {processed: 1, sessions: [{sessionId}]};
+        };
+
+        try {
+            const result = await SDK.Memory_SessionService.summarizePendingSessions({limit: 2});
+
+            expect(result).toEqual({
+                pending  : 2,
+                processed: 2,
+                sessions : [{sessionId: 'pending-session-1'}, {sessionId: 'pending-session-2'}]
+            });
+            expect(calls).toEqual([
+                {type: 'getPending', limit: 2},
+                {type: 'summarize', sessionId: 'pending-session-1'},
+                {type: 'summarize', sessionId: 'pending-session-2'}
+            ]);
+        } finally {
+            SDK.Memory_SessionService.getPendingSummarizationJobIds = originalGetPending;
+            SDK.Memory_SessionService.summarizeSessions = originalSummarize;
+        }
+    });
+
     test('resumable success when memories exist with no SummarizationJobs row', async () => {
         const sessionId = `resumable-memories-${crypto.randomUUID()}`;
         const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;


### PR DESCRIPTION
Resolves #12199

Authored by GPT-5 (Codex Desktop). Session d9b4a887-57aa-43aa-8cec-a260ec35ce12.

FAIR-band: in-band [15/30 — current author count over last 30 merged]

Restores the low-latency disconnect marker path without resurrecting per-MCP-instance summarization drains. `Server.onSessionClosed()` now writes only an idempotent `SummarizationJobs.pending` marker; the orchestrator summary scheduler sees pending markers ahead of the 10-minute drift sweep; the summary child drains those markers through the existing `claimSummarizationJob()` lease path.

Evidence: L2 (source + focused unit proof: default orchestrator poll is 3000ms, pending markers bypass the 600000ms drift sweep, and pending/drift drains share the existing lease transition) -> L2 required (scheduler/lease contract; no browser-only or operator-only surface). No residuals.

## Deltas from ticket

- Preserved the pre-#12139 invariant that a late disconnect must not reopen a `completed` summarization job. The ticket asked for an idempotent marker writer; source archaeology showed the old writer intentionally skipped `completed` and `in_progress` rows, so the restored writer keeps that finalized-session boundary.
- The summary script drains pending markers first, then keeps the existing drift-detection sweep as a fallback. This keeps coverage intact when no pending marker exists.

## Test Evidence

- `node --check ai/services/memory-core/SessionService.mjs` -> passed.
- `node --check test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs` -> passed.
- `git diff --check` -> passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs` -> 23 passed (1.2s after rebase onto `32806e65c`).

## Post-Merge Validation

- [ ] Observe the next live orchestrator disconnect cycle record a `pending-summarization:<n>` summary trigger before the periodic drift sweep would be due.

## Commit

- `84cd6361b` — `feat(orchestrator): restore pending summary markers (#12199)`

## Related

- Parent epic #12065
- Source-regression anchor #12139 / PR #12197
