### PR TITLE
fix(orchestrator): degrade oversized lms preloads (#12264)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -456,8 +456,7 @@ class Config extends BaseConfig {
                 /**
                  * Orchestrator-owned LM Studio CLI (`lms`) inference server config. Operators
                  * tune via gitignored `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_LMS_ENABLED`,
-                 * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`,
-                 * `NEO_ORCHESTRATOR_LMS_PRELOAD_MAX_CONTEXT_LENGTH`).
+                 * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`).
                  *
                  * Parallel alternative to `orchestrator.mlx` — both serve OpenAI-compatible HTTP
                  * for local chat + embedding workloads; pick at most one via the respective `enabled` flag.
@@ -469,21 +468,16 @@ class Config extends BaseConfig {
                  *   cloud-deployment substrate).
                  * - `model`: legacy single-model field kept for existing operator overlays. The
                  *   orchestrator-managed `lms server start` lane pre-warms the configured
-                 *   OpenAI-compatible chat + embedding models (`openAiCompatible.model` and
-                 *   `openAiCompatible.embeddingModel`) via `lms load <model>` after server spawn.
+                 *   OpenAI-compatible models for roles actively routed through the
+                 *   `openAiCompatible` provider via `lms load <model>` after server spawn.
                  *   Distinct from the OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
                  * - `port`: OpenAI-compatible local-inference port (LM Studio CLI default `1234`).
-                 * - `preloadMaxContextLength`: guardrail for orchestrator-owned `lms load`
-                 *   calls. Configured chat + embedding roles remain required; a role whose
-                 *   requested context is above this cap is skipped with WARN and reported as
-                 *   degraded instead of killing the lane or starving the other role.
                  * @type {Object}
                  */
                 lms: {
-                    enabled                : leaf(true, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
-                    model                  : leaf('qwen3-embedding-8b', 'NEO_ORCHESTRATOR_LMS_MODEL', 'string'),
-                    port                   : leaf('1234', 'NEO_ORCHESTRATOR_LMS_PORT', 'string'),
-                    preloadMaxContextLength: leaf(32768, 'NEO_ORCHESTRATOR_LMS_PRELOAD_MAX_CONTEXT_LENGTH', 'number')
+                    enabled: leaf(true, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
+                    model  : leaf('qwen3-embedding-8b', 'NEO_ORCHESTRATOR_LMS_MODEL', 'string'),
+                    port   : leaf('1234', 'NEO_ORCHESTRATOR_LMS_PORT', 'string')
                 }
             },
             /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -143,12 +143,16 @@ class Config extends BaseConfig {
              * @summary Deployment-wide OpenAI-compatible provider defaults.
              *
              * Covers MLX, LM Studio, Ollama's OpenAI-compatible surface, llama.cpp, and
-             * managed OpenAI-compatible endpoints.
+             * managed OpenAI-compatible endpoints. Local OpenAI-compatible deployments are
+             * a dual-role contract: the chat model and embedding model must both stay
+             * resident with stable context windows. A provider that swaps between the two
+             * roles per call and rebuilds the context window is not serviceable for Agent OS
+             * workloads.
              * @type {Object}
              */
             openAiCompatible: {
                 host                 : leaf('http://127.0.0.1:11434', 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
-                model                : leaf('gemma-4-31b-it', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
+                model                : leaf('qwen3-8b', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
                 embeddingModel       : leaf('text-embedding-qwen3-embedding-8b', 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
                 apiKey               : leaf('', 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
                 unloadRetryCount     : leaf(3, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
@@ -171,22 +175,28 @@ class Config extends BaseConfig {
              * - Chat-path consumers (graph extraction, session summary) → `localModels.chat.*`
              * - Embedding-path consumers (Memory Core embedding, KB ingestion) → `localModels.embedding.*`
              *
+             * The orchestrator's LM Studio preload path converts these role caps into
+             * per-model `lms load --context-length` values. Keep them model-owned and
+             * stable: local providers must hold chat + embedding resident in parallel,
+             * not unload/reload one role to serve the other.
+             *
              * @type {Object}
              */
             localModels: {
                 /**
                  * @summary Chat-model context limits in tokens.
                  *
-                 * Tuned for `gemma-4-31b-it` (native 256K context). Operators serving
-                 * smaller chat models should pin this to the actual loaded-model capacity;
+                 * Tuned for the local-dev OpenAI-compatible chat default (`qwen3-8b`).
+                 * Operators serving larger or smaller chat models should pin this to the
+                 * actual loaded-model capacity;
                  * `ConsumerFrictionHelper.invokeWithGuardrail` uses these values to fire
                  * the upstream pre-check skip (emits `'context-overflow'` /
                  * `'size-precheck-skip'` friction) when composed input exceeds the safe
                  * processing band.
                  *
-                 * `safeProcessingLimitTokens` is the explicit ~76% headroom band — leaves
-                 * ~62K tokens for system-prompt envelope + LLM response generation. Explicit
-                 * value avoids implicit `0.75 × cap` derivation drift if the cap moves.
+                 * `safeProcessingLimitTokens` is the explicit 75% headroom band — leaves
+                 * ~8K tokens for system-prompt envelope + LLM response generation. Explicit
+                 * value avoids implicit ratio derivation drift if the cap moves.
                  *
                  * Env overrides: `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS`,
                  * `NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS`.
@@ -194,8 +204,8 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 chat: {
-                    contextLimitTokens       : leaf(262144, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(200000, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
+                    contextLimitTokens       : leaf(32768, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(24576, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
                 },
                 /**
                  * @summary Embedding-model context limits in tokens.

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -456,7 +456,8 @@ class Config extends BaseConfig {
                 /**
                  * Orchestrator-owned LM Studio CLI (`lms`) inference server config. Operators
                  * tune via gitignored `ai/config.mjs` or env vars (`NEO_ORCHESTRATOR_LMS_ENABLED`,
-                 * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`).
+                 * `NEO_ORCHESTRATOR_LMS_MODEL`, `NEO_ORCHESTRATOR_LMS_PORT`,
+                 * `NEO_ORCHESTRATOR_LMS_PRELOAD_MAX_CONTEXT_LENGTH`).
                  *
                  * Parallel alternative to `orchestrator.mlx` — both serve OpenAI-compatible HTTP
                  * for local chat + embedding workloads; pick at most one via the respective `enabled` flag.
@@ -472,12 +473,17 @@ class Config extends BaseConfig {
                  *   `openAiCompatible.embeddingModel`) via `lms load <model>` after server spawn.
                  *   Distinct from the OpenAI-compatible API payload label (`NEO_OPENAI_COMPATIBLE_MODEL`).
                  * - `port`: OpenAI-compatible local-inference port (LM Studio CLI default `1234`).
+                 * - `preloadMaxContextLength`: guardrail for orchestrator-owned `lms load`
+                 *   calls. Configured chat + embedding roles remain required; a role whose
+                 *   requested context is above this cap is skipped with WARN and reported as
+                 *   degraded instead of killing the lane or starving the other role.
                  * @type {Object}
                  */
                 lms: {
-                    enabled: leaf(true, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
-                    model  : leaf('qwen3-embedding-8b', 'NEO_ORCHESTRATOR_LMS_MODEL', 'string'),
-                    port   : leaf('1234', 'NEO_ORCHESTRATOR_LMS_PORT', 'string')
+                    enabled                : leaf(true, 'NEO_ORCHESTRATOR_LMS_ENABLED', 'boolean'),
+                    model                  : leaf('qwen3-embedding-8b', 'NEO_ORCHESTRATOR_LMS_MODEL', 'string'),
+                    port                   : leaf('1234', 'NEO_ORCHESTRATOR_LMS_PORT', 'string'),
+                    preloadMaxContextLength: leaf(32768, 'NEO_ORCHESTRATOR_LMS_PRELOAD_MAX_CONTEXT_LENGTH', 'number')
                 }
             },
             /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -143,16 +143,12 @@ class Config extends BaseConfig {
              * @summary Deployment-wide OpenAI-compatible provider defaults.
              *
              * Covers MLX, LM Studio, Ollama's OpenAI-compatible surface, llama.cpp, and
-             * managed OpenAI-compatible endpoints. Local OpenAI-compatible deployments are
-             * a dual-role contract: the chat model and embedding model must both stay
-             * resident with stable context windows. A provider that swaps between the two
-             * roles per call and rebuilds the context window is not serviceable for Agent OS
-             * workloads.
+             * managed OpenAI-compatible endpoints.
              * @type {Object}
              */
             openAiCompatible: {
                 host                 : leaf('http://127.0.0.1:11434', 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
-                model                : leaf('qwen3-8b', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
+                model                : leaf('gemma-4-31b-it', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
                 embeddingModel       : leaf('text-embedding-qwen3-embedding-8b', 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
                 apiKey               : leaf('', 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
                 unloadRetryCount     : leaf(3, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
@@ -175,28 +171,22 @@ class Config extends BaseConfig {
              * - Chat-path consumers (graph extraction, session summary) → `localModels.chat.*`
              * - Embedding-path consumers (Memory Core embedding, KB ingestion) → `localModels.embedding.*`
              *
-             * The orchestrator's LM Studio preload path converts these role caps into
-             * per-model `lms load --context-length` values. Keep them model-owned and
-             * stable: local providers must hold chat + embedding resident in parallel,
-             * not unload/reload one role to serve the other.
-             *
              * @type {Object}
              */
             localModels: {
                 /**
                  * @summary Chat-model context limits in tokens.
                  *
-                 * Tuned for the local-dev OpenAI-compatible chat default (`qwen3-8b`).
-                 * Operators serving larger or smaller chat models should pin this to the
-                 * actual loaded-model capacity;
+                 * Tuned for `gemma-4-31b-it` (native 256K context). Operators serving
+                 * smaller chat models should pin this to the actual loaded-model capacity;
                  * `ConsumerFrictionHelper.invokeWithGuardrail` uses these values to fire
                  * the upstream pre-check skip (emits `'context-overflow'` /
                  * `'size-precheck-skip'` friction) when composed input exceeds the safe
                  * processing band.
                  *
-                 * `safeProcessingLimitTokens` is the explicit 75% headroom band — leaves
-                 * ~8K tokens for system-prompt envelope + LLM response generation. Explicit
-                 * value avoids implicit ratio derivation drift if the cap moves.
+                 * `safeProcessingLimitTokens` is the explicit ~76% headroom band — leaves
+                 * ~62K tokens for system-prompt envelope + LLM response generation. Explicit
+                 * value avoids implicit `0.75 × cap` derivation drift if the cap moves.
                  *
                  * Env overrides: `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS`,
                  * `NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS`.
@@ -204,8 +194,8 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 chat: {
-                    contextLimitTokens       : leaf(32768, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(24576, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
+                    contextLimitTokens       : leaf(262144, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(200000, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
                 },
                 /**
                  * @summary Embedding-model context limits in tokens.

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -452,6 +452,7 @@ export class Orchestrator extends Base {
             lmsModels : this.lmsModels,
             lmsHost   : AiConfig.openAiCompatible?.host,
             lmsPort   : AiConfig.orchestrator.lms?.port,
+            lmsPreloadMaxContextLength: AiConfig.orchestrator.lms?.preloadMaxContextLength,
             lmsContextLengths: buildLmsContextLengthsMap({
                 chatModel             : AiConfig.openAiCompatible?.model,
                 embeddingModel        : AiConfig.openAiCompatible?.embeddingModel,

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -10,7 +10,7 @@ import path                        from 'path';
 import Base                        from '../../../src/core/Base.mjs';
 import ClassSystemUtil             from '../../../src/util/ClassSystem.mjs';
 import AiConfig                    from '../../config.mjs';
-import {buildLmsContextLengthsMap} from '../../services/graph/ProviderReadinessHelper.mjs';
+import {buildLmsPreloadConfig}     from '../../services/graph/ProviderReadinessHelper.mjs';
 import HealthService               from '../../services/memory-core/HealthService.mjs';
 import SQLite                      from '../../graph/storage/SQLite.mjs';
 import MaintenanceBackpressureService, {
@@ -35,37 +35,6 @@ import {
     DEFAULT_SCRIPT_DIR,
     buildTaskDefinitions
 } from './TaskDefinitions.mjs';
-
-const OPEN_AI_COMPATIBLE_PROVIDER = 'openAiCompatible';
-
-/**
- * @summary Builds the LM Studio preload set from roles routed through OpenAI-compatible local inference.
- *
- * LM Studio owns the `openAiCompatible` local HTTP surface only. Native Ollama is
- * local too, but it is not preloaded via `lms load`; its residency contract is
- * handled by the parallel-model capacity probe. Remote providers simply do not
- * contribute models or context windows to this preload set.
- *
- * @param {Object} config aiConfig-shaped provider config.
- * @returns {{models: String[], contextLengths: Object}} Role-aware LMS preload config.
- */
-export function buildLmsPreloadConfig(config = AiConfig) {
-    const chatProvider      = config.modelProvider || config.chatProvider;
-    const usesLocalChat     = chatProvider === OPEN_AI_COMPATIBLE_PROVIDER || config.graphProvider === OPEN_AI_COMPATIBLE_PROVIDER;
-    const usesLocalEmbedding = config.embeddingProvider === OPEN_AI_COMPATIBLE_PROVIDER;
-    const chatModel         = usesLocalChat ? config.openAiCompatible?.model : null;
-    const embeddingModel    = usesLocalEmbedding ? config.openAiCompatible?.embeddingModel : null;
-
-    return {
-        models: [...new Set([chatModel, embeddingModel].filter(Boolean))],
-        contextLengths: buildLmsContextLengthsMap({
-            chatModel,
-            embeddingModel,
-            chatContextLength     : config.localModels?.chat?.contextLimitTokens,
-            embeddingContextLength: config.localModels?.embedding?.contextLimitTokens
-        })
-    };
-}
 
 /**
  * Resolves the dev-sync roots config while preserving env-var precedence.

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -36,6 +36,37 @@ import {
     buildTaskDefinitions
 } from './TaskDefinitions.mjs';
 
+const OPEN_AI_COMPATIBLE_PROVIDER = 'openAiCompatible';
+
+/**
+ * @summary Builds the LM Studio preload set from roles routed through OpenAI-compatible local inference.
+ *
+ * LM Studio owns the `openAiCompatible` local HTTP surface only. Native Ollama is
+ * local too, but it is not preloaded via `lms load`; its residency contract is
+ * handled by the parallel-model capacity probe. Remote providers simply do not
+ * contribute models or context windows to this preload set.
+ *
+ * @param {Object} config aiConfig-shaped provider config.
+ * @returns {{models: String[], contextLengths: Object}} Role-aware LMS preload config.
+ */
+export function buildLmsPreloadConfig(config = AiConfig) {
+    const chatProvider      = config.modelProvider || config.chatProvider;
+    const usesLocalChat     = chatProvider === OPEN_AI_COMPATIBLE_PROVIDER || config.graphProvider === OPEN_AI_COMPATIBLE_PROVIDER;
+    const usesLocalEmbedding = config.embeddingProvider === OPEN_AI_COMPATIBLE_PROVIDER;
+    const chatModel         = usesLocalChat ? config.openAiCompatible?.model : null;
+    const embeddingModel    = usesLocalEmbedding ? config.openAiCompatible?.embeddingModel : null;
+
+    return {
+        models: [...new Set([chatModel, embeddingModel].filter(Boolean))],
+        contextLengths: buildLmsContextLengthsMap({
+            chatModel,
+            embeddingModel,
+            chatContextLength     : config.localModels?.chat?.contextLimitTokens,
+            embeddingContextLength: config.localModels?.embedding?.contextLimitTokens
+        })
+    };
+}
+
 /**
  * Resolves the dev-sync roots config while preserving env-var precedence.
  * @param {Object} options
@@ -401,12 +432,8 @@ export class Orchestrator extends Base {
     // live in `ai/config.template.mjs::orchestrator.{mlx,lms}` + `envBindings.orchestrator.{mlx,lms}`.
     get mlxEnabled() { return !!AiConfig.orchestrator.mlx?.enabled; }
     get lmsEnabled() { return !!AiConfig.orchestrator.lms?.enabled; }
-    get lmsModels()  {
-        return [...new Set([
-            AiConfig.openAiCompatible?.model,
-            AiConfig.openAiCompatible?.embeddingModel
-        ].filter(Boolean))];
-    }
+    get lmsPreloadConfig() { return buildLmsPreloadConfig(AiConfig); }
+    get lmsModels()        { return this.lmsPreloadConfig.models;      }
 
     /**
      * Starts the orchestrator process loop after the wrapper has selected this process.
@@ -439,8 +466,9 @@ export class Orchestrator extends Base {
 
         // Set reactive parent props FIRST so afterSet* propagation lands when
         // processSupervisorService gets re-created below.
-        this.dataDir         = dataDir;
-        this.taskDefinitions = options.taskDefinitions || buildTaskDefinitions({
+        this.dataDir           = dataDir;
+        const lmsPreloadConfig = this.lmsPreloadConfig;
+        this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin   : options.nodeBin || process.argv[0],
             chromaPort: AiConfig.engines.chroma?.port,
@@ -449,16 +477,10 @@ export class Orchestrator extends Base {
             mlxPort   : AiConfig.orchestrator.mlx?.port,
             lmsEnabled: this.lmsEnabled,
             lmsModel  : AiConfig.orchestrator.lms?.model,
-            lmsModels : this.lmsModels,
+            lmsModels : lmsPreloadConfig.models,
             lmsHost   : AiConfig.openAiCompatible?.host,
             lmsPort   : AiConfig.orchestrator.lms?.port,
-            lmsPreloadMaxContextLength: AiConfig.orchestrator.lms?.preloadMaxContextLength,
-            lmsContextLengths: buildLmsContextLengthsMap({
-                chatModel             : AiConfig.openAiCompatible?.model,
-                embeddingModel        : AiConfig.openAiCompatible?.embeddingModel,
-                chatContextLength     : AiConfig.localModels?.chat?.contextLimitTokens,
-                embeddingContextLength: AiConfig.localModels?.embedding?.contextLimitTokens
-            }),
+            lmsContextLengths: lmsPreloadConfig.contextLengths,
             providerReadiness: AiConfig.orchestrator.providerReadiness
         });
 

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -37,7 +37,6 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String} [options.lmsHost] OpenAI-compatible host exposed by the LM Studio server.
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
  * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
- * @param {Number} [options.lmsPreloadMaxContextLength] Max `--context-length` the orchestrator may pass to `lms load` during preload.
  * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
  * @returns {Object}
  */
@@ -54,7 +53,6 @@ export function buildTaskDefinitions({
     lmsHost,
     lmsPort,
     lmsContextLengths,
-    lmsPreloadMaxContextLength,
     providerReadiness
 } = {}) {
     const tasks = {
@@ -152,8 +150,8 @@ export function buildTaskDefinitions({
     }
 
     if (lmsEnabled) {
-        const requiredModels = Array.isArray(lmsModels) && lmsModels.length > 0
-            ? lmsModels
+        const requiredModels = Array.isArray(lmsModels)
+            ? [...new Set(lmsModels.filter(Boolean))]
             : [lmsModel].filter(Boolean);
 
         tasks.lms = {
@@ -181,12 +179,23 @@ export function buildTaskDefinitions({
             postSpawn      : async () => {
                 const {ensureLmsModelsLoaded} = await import('../../services/graph/ProviderReadinessHelper.mjs');
 
+                if (requiredModels.length === 0) {
+                    return {
+                        ready          : true,
+                        loadedModels   : [],
+                        requiredModels,
+                        availableModels: [],
+                        attempts       : 0,
+                        skipped        : true,
+                        reason         : 'no-openai-compatible-local-roles'
+                    };
+                }
+
                 return ensureLmsModelsLoaded({
                     host           : lmsHost,
                     models         : requiredModels,
                     contextLengths : lmsContextLengths,
                     allowPartial   : true,
-                    maxContextLength: lmsPreloadMaxContextLength,
                     attempts       : providerReadiness?.attempts,
                     delayMs        : providerReadiness?.delayMs,
                     timeoutMs      : providerReadiness?.timeoutMs

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -37,6 +37,7 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String} [options.lmsHost] OpenAI-compatible host exposed by the LM Studio server.
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
  * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
+ * @param {Number} [options.lmsPreloadMaxContextLength] Max `--context-length` the orchestrator may pass to `lms load` during preload.
  * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
  * @returns {Object}
  */
@@ -53,6 +54,7 @@ export function buildTaskDefinitions({
     lmsHost,
     lmsPort,
     lmsContextLengths,
+    lmsPreloadMaxContextLength,
     providerReadiness
 } = {}) {
     const tasks = {
@@ -183,6 +185,8 @@ export function buildTaskDefinitions({
                     host           : lmsHost,
                     models         : requiredModels,
                     contextLengths : lmsContextLengths,
+                    allowPartial   : true,
+                    maxContextLength: lmsPreloadMaxContextLength,
                     attempts       : providerReadiness?.attempts,
                     delayMs        : providerReadiness?.delayMs,
                     timeoutMs      : providerReadiness?.timeoutMs

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -266,14 +266,15 @@ export class ProcessSupervisorService extends Base {
      * @param {Object} options.child Spawned child process.
      * @param {Function} options.clear Completion/failure finalizer.
      * @param {Function} options.isCleared Completion-state guard.
-     * @returns {void}
+     * @param {Function} [options.onReadinessOutcome] Readiness-status callback.
+     * @returns {Promise|null}
      */
-    runPostSpawnHook({taskName, task, reason, child, clear, isCleared}) {
+    runPostSpawnHook({taskName, task, reason, child, clear, isCleared, onReadinessOutcome}) {
         if (typeof task.postSpawn !== 'function') {
-            return;
+            return null;
         }
 
-        Promise.resolve()
+        return Promise.resolve()
             .then(() => task.postSpawn({
                 taskName,
                 task,
@@ -285,6 +286,18 @@ export class ProcessSupervisorService extends Base {
                 if (isCleared?.()) {
                     return;
                 }
+                if (result?.ready === false || result?.degraded === true) {
+                    onReadinessOutcome?.('degraded');
+                    this.writeLog?.('WARN', `[ProcessSupervisor] ${task.label} readiness hook completed with degraded readiness.`);
+                    this.recordTaskOutcome(taskName, 'degraded', {
+                        reason,
+                        pid      : child.pid || null,
+                        readyAt  : new Date().toISOString(),
+                        readiness: result || null
+                    });
+                    return;
+                }
+                onReadinessOutcome?.('ready');
                 this.taskStateService.markReady?.(taskName);
                 this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} readiness hook completed successfully.`);
                 this.recordTaskOutcome(taskName, 'ready', {
@@ -298,6 +311,7 @@ export class ProcessSupervisorService extends Base {
                 if (isCleared?.()) {
                     return;
                 }
+                onReadinessOutcome?.('failed');
                 this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} readiness hook failed: ${error.message}`);
                 try {
                     child.kill?.('SIGTERM');
@@ -361,8 +375,12 @@ export class ProcessSupervisorService extends Base {
 
         this.recordTaskOutcome(taskName, 'running', {reason, pid: child.pid || null, startedAt: new Date().toISOString()});
 
-        let cleared = false;
-        const clear = (code, error, phase = 'start') => {
+        let cleared          = false;
+        let deferredClear    = null;
+        let readinessPending = typeof task.postSpawn === 'function';
+        let readinessOutcome = null;
+
+        const executeClear = (code, error, phase = 'start') => {
             if (cleared) {
                 return;
             }
@@ -385,7 +403,9 @@ export class ProcessSupervisorService extends Base {
                     onSuccess?.();
                     this.taskStateService.markCompleted(taskName);
                     this.writeLog?.('INFO', `[ProcessSupervisor] ${task.label} completed successfully.`);
-                    this.recordTaskOutcome(taskName, 'completed', {reason, code, completedAt});
+                    if (readinessOutcome !== 'degraded') {
+                        this.recordTaskOutcome(taskName, 'completed', {reason, code, completedAt});
+                    }
                 } catch (e) {
                     this.taskStateService.markFailed(taskName, null);
                     this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} success hook failed: ${e.message}`);
@@ -404,7 +424,32 @@ export class ProcessSupervisorService extends Base {
             }
         };
 
-        this.runPostSpawnHook({taskName, task, reason, child, clear, isCleared: () => cleared});
+        const clear = (code, error, phase = 'start') => {
+            if (readinessPending && !error && code === 0) {
+                deferredClear = {code, error, phase};
+                return;
+            }
+
+            executeClear(code, error, phase);
+        };
+
+        this.runPostSpawnHook({
+            taskName,
+            task,
+            reason,
+            child,
+            clear,
+            isCleared: () => cleared,
+            onReadinessOutcome: status => { readinessOutcome = status; }
+        })?.finally(() => {
+            readinessPending = false;
+
+            if (deferredClear && !cleared) {
+                const {code, error, phase} = deferredClear;
+                deferredClear = null;
+                clear(code, error, phase);
+            }
+        });
 
         child.on('close', code => clear(code));
         child.on('error', err => clear(null, err, 'child-process'));

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -2,7 +2,11 @@ import http from 'http';
 import {execFile} from 'child_process';
 import {Memory_Config as aiConfig} from '../../services.mjs';
 import logger from '../../mcp/server/memory-core/logger.mjs';
-import {isGraphModelProviderSupported, resolveGraphModelProvider} from './providerDispatch.mjs';
+import {
+    isGraphModelProviderSupported,
+    isOpenAiCompatibleProvider,
+    resolveGraphModelProvider
+} from './providerDispatch.mjs';
 
 /**
  * @module ai/services/graph/ProviderReadinessHelper
@@ -199,6 +203,52 @@ export function buildLmsContextLengthsMap({
     setMax(chatModel, chatContextLength);
     setMax(embeddingModel, embeddingContextLength);
     return map;
+}
+
+/**
+ * @summary Builds the LM Studio preload set from configured provider-role selectors.
+ *
+ * The state-provider config chooses which provider serves each role. The OpenAI-compatible
+ * model defaults remain populated even when a role is routed to Gemini or native Ollama, so
+ * this helper must never infer activity from non-null model leaves. It only includes roles
+ * whose selector explicitly targets the OpenAI-compatible surface that LM Studio serves.
+ *
+ * Role ownership:
+ * - `modelProvider` / `chatProvider`: session-summary chat role.
+ * - `graphProvider`: REM graph-generation chat role.
+ * - `embeddingProvider`: vector embedding role.
+ *
+ * @param {Object} config aiConfig-shaped provider config.
+ * @returns {{models: String[], contextLengths: Object}} Role-aware LMS preload config.
+ */
+export function buildLmsPreloadConfig(config = aiConfig) {
+    const openAiCompatibleConfig = config.openAiCompatible || {},
+          chatContextLength      = config.localModels?.chat?.contextLimitTokens,
+          embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
+          roles                  = [{
+              provider     : config.modelProvider ?? config.chatProvider,
+              model        : openAiCompatibleConfig.model,
+              contextLength: chatContextLength
+          }, {
+              provider     : config.graphProvider,
+              model        : openAiCompatibleConfig.model,
+              contextLength: chatContextLength
+          }, {
+              provider     : config.embeddingProvider,
+              model        : openAiCompatibleConfig.embeddingModel,
+              contextLength: embeddingContextLength
+          }].filter(role => isOpenAiCompatibleProvider(role.provider) && role.model);
+
+    const models         = [...new Set(roles.map(role => role.model))],
+          contextLengths = {};
+
+    roles.forEach(({model, contextLength}) => {
+        if (Neo.isNumber(contextLength) && (contextLengths[model] === undefined || contextLength > contextLengths[model])) {
+            contextLengths[model] = contextLength
+        }
+    });
+
+    return {models, contextLengths}
 }
 
 /**

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -225,7 +225,6 @@ export function buildLmsContextLengthsMap({
  * @param {Number} options.timeoutMs HTTP probe timeout.
  * @param {Object} [options.contextLengths] Per-model context-length override map keyed by model id.
  * @param {Boolean} [options.allowPartial=false] Return degraded readiness instead of throwing when one model cannot be loaded.
- * @param {Number} [options.maxContextLength] Optional max `--context-length` for preload safety; larger requests are skipped.
  * @param {Function} [options.fetchModelIds] Injectable model-list probe.
  * @param {Function} [options.loadModel] Injectable model-load function.
  * @param {Object} [options.log=logger] Logger seam.
@@ -239,7 +238,6 @@ export async function ensureLmsModelsLoaded({
     timeoutMs,
     contextLengths = {},
     allowPartial   = false,
-    maxContextLength,
     fetchModelIds = opts => fetchOpenAiCompatibleModelIds(opts),
     loadModel     = (model, options) => loadLmsModel(model, options),
     log           = logger
@@ -279,9 +277,7 @@ export async function ensureLmsModelsLoaded({
 
     let {availableModels} = await probeModels('initial /v1/models probe');
     const initialMissing  = getMissing(availableModels);
-    const hasMaxContextLength = Neo.isNumber(maxContextLength) && maxContextLength > 0;
-    const skippedModels = [];
-    const failedModels  = [];
+    const failedModels   = [];
 
     // Force-include context-configured models in the load set even when already
     // resident in /v1/models. `/v1/models` reports presence only — it does NOT
@@ -292,43 +288,14 @@ export async function ensureLmsModelsLoaded({
     // be accepted as ready while every chat invocation silently overflows.
     // Force-include each context-configured model in the load set even if resident,
     // BUT preserve the declared requiredModels input order (filter rather than concat-dedupe).
-    const candidateModelsToLoad = requiredModels.filter(model => {
+    const modelsToLoad = requiredModels.filter(model => {
         if (initialMissing.includes(model)) return true;
         return Neo.isNumber(contextLengths?.[model]);
-    });
-    const modelsToLoad = candidateModelsToLoad.filter(model => {
-        const contextLength = contextLengths?.[model];
-
-        if (!hasMaxContextLength || !Neo.isNumber(contextLength) || contextLength <= maxContextLength) {
-            return true;
-        }
-
-        const skipped = {
-            model,
-            contextLength,
-            maxContextLength,
-            reason: 'context-length-exceeds-preload-max'
-        };
-        skippedModels.push(skipped);
-        log.warn?.(
-            `[ProviderReadinessHelper] Skipping LM Studio model '${model}' preload: context-length ` +
-            `${contextLength} exceeds preload max ${maxContextLength}. The model remains required; ` +
-            'readiness will be reported as degraded until the operator raises the cap or retunes the model/context.'
-        );
-
-        if (!allowPartial) {
-            throw new Error(
-                `LM Studio model preload skipped for ${model}: context-length ${contextLength} exceeds ` +
-                `preload max ${maxContextLength}.`
-            );
-        }
-
-        return false;
     });
     const attemptedModels = [...modelsToLoad];
     const loadedModels    = [];
 
-    if (modelsToLoad.length === 0 && skippedModels.length === 0) {
+    if (modelsToLoad.length === 0) {
         return {
             ready       : true,
             loadedModels: [],
@@ -372,19 +339,17 @@ export async function ensureLmsModelsLoaded({
         missingModels = getMissing(availableModels);
 
         const knownUnavailable = new Set([
-            ...skippedModels.map(item => item.model),
             ...failedModels.map(item => item.model)
         ]);
         const serviceableMissing = missingModels.filter(model => !knownUnavailable.has(model));
 
         if (missingModels.length === 0 || (allowPartial && serviceableMissing.length === 0)) {
-            const ready = missingModels.length === 0 && skippedModels.length === 0 && failedModels.length === 0;
+            const ready = missingModels.length === 0 && failedModels.length === 0;
             return {
                 ready,
                 degraded    : !ready,
                 loadedModels,
                 attemptedModels,
-                skippedModels,
                 failedModels,
                 missingModels,
                 requiredModels,
@@ -405,7 +370,6 @@ export async function ensureLmsModelsLoaded({
             degraded    : true,
             loadedModels,
             attemptedModels,
-            skippedModels,
             failedModels,
             missingModels,
             requiredModels,

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -214,7 +214,7 @@ export function buildLmsContextLengthsMap({
  * whose selector explicitly targets the OpenAI-compatible surface that LM Studio serves.
  *
  * Role ownership:
- * - `modelProvider` / `chatProvider`: session-summary chat role.
+ * - `modelProvider`: session-summary chat role.
  * - `graphProvider`: REM graph-generation chat role.
  * - `embeddingProvider`: vector embedding role.
  *
@@ -226,7 +226,7 @@ export function buildLmsPreloadConfig(config = aiConfig) {
           chatContextLength      = config.localModels?.chat?.contextLimitTokens,
           embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
           roles                  = [{
-              provider     : config.modelProvider ?? config.chatProvider,
+              provider     : config.modelProvider,
               model        : openAiCompatibleConfig.model,
               contextLength: chatContextLength
           }, {

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -224,6 +224,8 @@ export function buildLmsContextLengthsMap({
  * @param {Number} options.delayMs Delay between probes.
  * @param {Number} options.timeoutMs HTTP probe timeout.
  * @param {Object} [options.contextLengths] Per-model context-length override map keyed by model id.
+ * @param {Boolean} [options.allowPartial=false] Return degraded readiness instead of throwing when one model cannot be loaded.
+ * @param {Number} [options.maxContextLength] Optional max `--context-length` for preload safety; larger requests are skipped.
  * @param {Function} [options.fetchModelIds] Injectable model-list probe.
  * @param {Function} [options.loadModel] Injectable model-load function.
  * @param {Object} [options.log=logger] Logger seam.
@@ -236,6 +238,8 @@ export async function ensureLmsModelsLoaded({
     delayMs,
     timeoutMs,
     contextLengths = {},
+    allowPartial   = false,
+    maxContextLength,
     fetchModelIds = opts => fetchOpenAiCompatibleModelIds(opts),
     loadModel     = (model, options) => loadLmsModel(model, options),
     log           = logger
@@ -275,6 +279,9 @@ export async function ensureLmsModelsLoaded({
 
     let {availableModels} = await probeModels('initial /v1/models probe');
     const initialMissing  = getMissing(availableModels);
+    const hasMaxContextLength = Neo.isNumber(maxContextLength) && maxContextLength > 0;
+    const skippedModels = [];
+    const failedModels  = [];
 
     // Force-include context-configured models in the load set even when already
     // resident in /v1/models. `/v1/models` reports presence only — it does NOT
@@ -285,13 +292,43 @@ export async function ensureLmsModelsLoaded({
     // be accepted as ready while every chat invocation silently overflows.
     // Force-include each context-configured model in the load set even if resident,
     // BUT preserve the declared requiredModels input order (filter rather than concat-dedupe).
-    const modelsToLoad = requiredModels.filter(model => {
+    const candidateModelsToLoad = requiredModels.filter(model => {
         if (initialMissing.includes(model)) return true;
         return Neo.isNumber(contextLengths?.[model]);
     });
-    const loadedModels = [...modelsToLoad];
+    const modelsToLoad = candidateModelsToLoad.filter(model => {
+        const contextLength = contextLengths?.[model];
 
-    if (modelsToLoad.length === 0) {
+        if (!hasMaxContextLength || !Neo.isNumber(contextLength) || contextLength <= maxContextLength) {
+            return true;
+        }
+
+        const skipped = {
+            model,
+            contextLength,
+            maxContextLength,
+            reason: 'context-length-exceeds-preload-max'
+        };
+        skippedModels.push(skipped);
+        log.warn?.(
+            `[ProviderReadinessHelper] Skipping LM Studio model '${model}' preload: context-length ` +
+            `${contextLength} exceeds preload max ${maxContextLength}. The model remains required; ` +
+            'readiness will be reported as degraded until the operator raises the cap or retunes the model/context.'
+        );
+
+        if (!allowPartial) {
+            throw new Error(
+                `LM Studio model preload skipped for ${model}: context-length ${contextLength} exceeds ` +
+                `preload max ${maxContextLength}.`
+            );
+        }
+
+        return false;
+    });
+    const attemptedModels = [...modelsToLoad];
+    const loadedModels    = [];
+
+    if (modelsToLoad.length === 0 && skippedModels.length === 0) {
         return {
             ready       : true,
             loadedModels: [],
@@ -310,7 +347,21 @@ export async function ensureLmsModelsLoaded({
             ? 'missing from /v1/models'
             : 'context-length enforcement on resident model';
         log.info?.(`[ProviderReadinessHelper] Loading LM Studio model '${model}' via lms load${contextSuffix} (${reason}).`);
-        await loadModel(model, {contextLength});
+        try {
+            await loadModel(model, {contextLength});
+            loadedModels.push(model);
+        } catch (error) {
+            failedModels.push({
+                model,
+                contextLength,
+                error: error.message
+            });
+            log.warn?.(`[ProviderReadinessHelper] LM Studio model '${model}' preload failed: ${error.message}`);
+
+            if (!allowPartial) {
+                throw error;
+            }
+        }
     }
 
     let missingModels = initialMissing;
@@ -318,12 +369,24 @@ export async function ensureLmsModelsLoaded({
     const startedAt = Date.now();
     for (let attempt = 1; attempt <= attempts; attempt++) {
         ({availableModels} = await probeModels('post-load /v1/models probe'));
-        missingModels   = getMissing(availableModels);
+        missingModels = getMissing(availableModels);
 
-        if (missingModels.length === 0) {
+        const knownUnavailable = new Set([
+            ...skippedModels.map(item => item.model),
+            ...failedModels.map(item => item.model)
+        ]);
+        const serviceableMissing = missingModels.filter(model => !knownUnavailable.has(model));
+
+        if (missingModels.length === 0 || (allowPartial && serviceableMissing.length === 0)) {
+            const ready = missingModels.length === 0 && skippedModels.length === 0 && failedModels.length === 0;
             return {
-                ready       : true,
+                ready,
+                degraded    : !ready,
                 loadedModels,
+                attemptedModels,
+                skippedModels,
+                failedModels,
+                missingModels,
                 requiredModels,
                 availableModels,
                 attempts    : attempt,
@@ -334,6 +397,22 @@ export async function ensureLmsModelsLoaded({
         if (attempt < attempts) {
             await new Promise(resolve => setTimeout(resolve, delayMs));
         }
+    }
+
+    if (allowPartial) {
+        return {
+            ready       : false,
+            degraded    : true,
+            loadedModels,
+            attemptedModels,
+            skippedModels,
+            failedModels,
+            missingModels,
+            requiredModels,
+            availableModels,
+            attempts,
+            elapsedMs    : Date.now() - startedAt
+        };
     }
 
     throw new Error(

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -222,30 +222,35 @@ export function buildLmsContextLengthsMap({
  * @returns {{models: String[], contextLengths: Object}} Role-aware LMS preload config.
  */
 export function buildLmsPreloadConfig(config = aiConfig) {
-    const openAiCompatibleConfig = config.openAiCompatible || {},
+    const openAiCompatibleConfig = config.openAiCompatible ?? {},
+          chatModel              = openAiCompatibleConfig.model,
+          embeddingModel         = openAiCompatibleConfig.embeddingModel,
           chatContextLength      = config.localModels?.chat?.contextLimitTokens,
           embeddingContextLength = config.localModels?.embedding?.contextLimitTokens,
           roles                  = [{
               provider     : config.modelProvider,
-              model        : openAiCompatibleConfig.model,
+              model        : chatModel,
+              contextRole  : 'chat',
               contextLength: chatContextLength
           }, {
               provider     : config.graphProvider,
-              model        : openAiCompatibleConfig.model,
+              model        : chatModel,
+              contextRole  : 'chat',
               contextLength: chatContextLength
           }, {
               provider     : config.embeddingProvider,
-              model        : openAiCompatibleConfig.embeddingModel,
+              model        : embeddingModel,
+              contextRole  : 'embedding',
               contextLength: embeddingContextLength
           }].filter(role => isOpenAiCompatibleProvider(role.provider) && role.model);
 
-    const models         = [...new Set(roles.map(role => role.model))],
-          contextLengths = {};
-
-    roles.forEach(({model, contextLength}) => {
-        if (Neo.isNumber(contextLength) && (contextLengths[model] === undefined || contextLength > contextLengths[model])) {
-            contextLengths[model] = contextLength
-        }
+    const models              = [...new Set(roles.map(role => role.model))],
+          selectedContextRole = role => roles.some(({contextRole}) => contextRole === role),
+          contextLengths      = buildLmsContextLengthsMap({
+              chatModel       : selectedContextRole('chat') ? chatModel : undefined,
+              embeddingModel  : selectedContextRole('embedding') ? embeddingModel : undefined,
+              chatContextLength,
+              embeddingContextLength
     });
 
     return {models, contextLengths}

--- a/ai/services/graph/providerDispatch.mjs
+++ b/ai/services/graph/providerDispatch.mjs
@@ -4,6 +4,15 @@ import OpenAiCompatible from '../../provider/OpenAiCompatible.mjs';
 export const GRAPH_MODEL_PROVIDERS = Object.freeze(['ollama', 'openAiCompatible']);
 
 /**
+ * @summary Identifies provider selectors that route through an OpenAI-compatible HTTP surface.
+ * @param {String} provider
+ * @returns {Boolean}
+ */
+export function isOpenAiCompatibleProvider(provider) {
+    return provider === 'openAiCompatible'
+}
+
+/**
  * @summary Resolves the provider selector used by Dream/Sandman graph-generation lanes.
  *
  * Graph extraction is not the same provider axis as generic Memory Core summarization:

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -141,6 +141,15 @@ test.describe('Tier 1 Config Immutability', () => {
             delayMs  : Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS)   || 1000,
             timeoutMs: Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS) || 3000
         });
+        const lmsEnabledEnv = process.env.NEO_ORCHESTRATOR_LMS_ENABLED?.trim().toLowerCase();
+        const lmsDisabled   = ['false', 'no', 'off', '0'].includes(lmsEnabledEnv);
+
+        expect(Config.orchestrator.lms).toMatchObject({
+            enabled                : lmsEnabledEnv === undefined ? true : !lmsDisabled,
+            model                  : process.env.NEO_ORCHESTRATOR_LMS_MODEL || 'qwen3-embedding-8b',
+            port                   : process.env.NEO_ORCHESTRATOR_LMS_PORT || '1234',
+            preloadMaxContextLength: Number(process.env.NEO_ORCHESTRATOR_LMS_PRELOAD_MAX_CONTEXT_LENGTH) || 32768
+        });
 
         expect(Config.maintenance.backup).toEqual({
             intervalMs: 24 * 60 * 60 * 1000,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -75,7 +75,7 @@ test.describe('Tier 1 Config Immutability', () => {
         });
         expect(Config.openAiCompatible).toMatchObject({
             host                 : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-            model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+            model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'qwen3-8b',
             embeddingModel       : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
             apiKey               : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
             unloadRetryCount     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
@@ -85,14 +85,31 @@ test.describe('Tier 1 Config Immutability', () => {
         });
         expect(Config.localModels).toMatchObject({
             chat: {
-                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144,
-                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
+                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 32768,
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 24576
             },
             embedding: {
                 contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 8192,
                 safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 6144
             }
         });
+
+        const openAiCompatibleRequiredModels = new Set([
+            Config.openAiCompatible.model,
+            Config.openAiCompatible.embeddingModel
+        ].filter(Boolean));
+        const ollamaRequiredModels = new Set([
+            Config.ollama.model,
+            Config.ollama.embeddingModel
+        ].filter(Boolean));
+
+        expect(Config.openAiCompatible.requireParallelModels).toBeGreaterThanOrEqual(openAiCompatibleRequiredModels.size);
+        expect(Config.ollama.requireParallelModels).toBeGreaterThanOrEqual(ollamaRequiredModels.size);
+        expect(Config.localModels.chat.safeProcessingLimitTokens).toBeLessThanOrEqual(Config.localModels.chat.contextLimitTokens);
+        expect(Config.localModels.embedding.safeProcessingLimitTokens).toBeLessThanOrEqual(Config.localModels.embedding.contextLimitTokens);
+        expect(Config.localModels.chat.contextLimitTokens).toBeLessThanOrEqual(Config.orchestrator.lms.preloadMaxContextLength);
+        expect(Config.localModels.embedding.contextLimitTokens).toBeLessThanOrEqual(Config.orchestrator.lms.preloadMaxContextLength);
+
         expect(Config.engines.chroma).toEqual({
             dataDir: expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
             host   : process.env.NEO_CHROMA_HOST || 'localhost',

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -145,10 +145,9 @@ test.describe('Tier 1 Config Immutability', () => {
         const lmsDisabled   = ['false', 'no', 'off', '0'].includes(lmsEnabledEnv);
 
         expect(Config.orchestrator.lms).toMatchObject({
-            enabled                : lmsEnabledEnv === undefined ? true : !lmsDisabled,
-            model                  : process.env.NEO_ORCHESTRATOR_LMS_MODEL || 'qwen3-embedding-8b',
-            port                   : process.env.NEO_ORCHESTRATOR_LMS_PORT || '1234',
-            preloadMaxContextLength: Number(process.env.NEO_ORCHESTRATOR_LMS_PRELOAD_MAX_CONTEXT_LENGTH) || 32768
+            enabled: lmsEnabledEnv === undefined ? true : !lmsDisabled,
+            model  : process.env.NEO_ORCHESTRATOR_LMS_MODEL || 'qwen3-embedding-8b',
+            port   : process.env.NEO_ORCHESTRATOR_LMS_PORT || '1234'
         });
 
         expect(Config.maintenance.backup).toEqual({

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -75,7 +75,7 @@ test.describe('Tier 1 Config Immutability', () => {
         });
         expect(Config.openAiCompatible).toMatchObject({
             host                 : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-            model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'qwen3-8b',
+            model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
             embeddingModel       : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
             apiKey               : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
             unloadRetryCount     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
@@ -85,31 +85,14 @@ test.describe('Tier 1 Config Immutability', () => {
         });
         expect(Config.localModels).toMatchObject({
             chat: {
-                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 32768,
-                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 24576
+                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144,
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
             },
             embedding: {
                 contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 8192,
                 safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 6144
             }
         });
-
-        const openAiCompatibleRequiredModels = new Set([
-            Config.openAiCompatible.model,
-            Config.openAiCompatible.embeddingModel
-        ].filter(Boolean));
-        const ollamaRequiredModels = new Set([
-            Config.ollama.model,
-            Config.ollama.embeddingModel
-        ].filter(Boolean));
-
-        expect(Config.openAiCompatible.requireParallelModels).toBeGreaterThanOrEqual(openAiCompatibleRequiredModels.size);
-        expect(Config.ollama.requireParallelModels).toBeGreaterThanOrEqual(ollamaRequiredModels.size);
-        expect(Config.localModels.chat.safeProcessingLimitTokens).toBeLessThanOrEqual(Config.localModels.chat.contextLimitTokens);
-        expect(Config.localModels.embedding.safeProcessingLimitTokens).toBeLessThanOrEqual(Config.localModels.embedding.contextLimitTokens);
-        expect(Config.localModels.chat.contextLimitTokens).toBeLessThanOrEqual(Config.orchestrator.lms.preloadMaxContextLength);
-        expect(Config.localModels.embedding.contextLimitTokens).toBeLessThanOrEqual(Config.orchestrator.lms.preloadMaxContextLength);
-
         expect(Config.engines.chroma).toEqual({
             dataDir: expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
             host   : process.env.NEO_CHROMA_HOST || 'localhost',

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -7,7 +7,8 @@ import * as core from '../../../../../../src/core/_export.mjs';
 import AiConfig from '../../../../../../ai/config.mjs';
 import BaseConfig, {createConfigProxy} from '../../../../../../ai/BaseConfig.mjs';
 import {
-    Orchestrator
+    Orchestrator,
+    buildLmsPreloadConfig
 } from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
 import {
     buildTaskDefinitions
@@ -29,6 +30,10 @@ let savedDeploymentMode  = null;
 let savedMlxConfig                   = undefined;
 let savedLmsConfig                   = undefined;
 let savedOpenAiCompatibleConfig      = undefined;
+let savedChatProvider                = undefined;
+let savedModelProvider               = undefined;
+let savedGraphProvider               = undefined;
+let savedEmbeddingProvider           = undefined;
 let savedEnvKbSyncEnabled            = undefined;
 let savedEnvKbSyncInterval           = undefined;
 let savedEnvTenantRepoSyncEnabled    = undefined;
@@ -74,6 +79,10 @@ test.beforeEach(() => {
     savedMlxConfig      = AiConfig.orchestrator.mlx ? {...AiConfig.orchestrator.mlx} : undefined;
     savedLmsConfig      = AiConfig.orchestrator.lms ? {...AiConfig.orchestrator.lms} : undefined;
     savedOpenAiCompatibleConfig = AiConfig.openAiCompatible ? {...AiConfig.openAiCompatible} : undefined;
+    savedChatProvider           = AiConfig.chatProvider;
+    savedModelProvider          = AiConfig.modelProvider;
+    savedGraphProvider          = AiConfig.graphProvider;
+    savedEmbeddingProvider      = AiConfig.embeddingProvider;
 
     savedEnvKbSyncEnabled          = process.env.NEO_ORCHESTRATOR_KB_SYNC_ENABLED;
     savedEnvKbSyncInterval         = process.env.NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS;
@@ -111,6 +120,10 @@ test.afterEach(() => {
     } else {
         AiConfig.openAiCompatible = savedOpenAiCompatibleConfig;
     }
+    AiConfig.chatProvider      = savedChatProvider;
+    AiConfig.modelProvider     = savedModelProvider;
+    AiConfig.graphProvider     = savedGraphProvider;
+    AiConfig.embeddingProvider = savedEmbeddingProvider;
 
     restoreEnv('NEO_ORCHESTRATOR_KB_SYNC_ENABLED',           savedEnvKbSyncEnabled);
     restoreEnv('NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS',       savedEnvKbSyncInterval);
@@ -235,20 +248,50 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         }
     });
 
-    test('lmsEnabled coerces to boolean + lmsModels parses AiConfig.openAiCompatible models (model/port/host inlined at call sites)', () => {
+    test('lmsEnabled coerces to boolean + lmsModels only preloads OpenAI-compatible roles (model/port/host inlined at call sites)', () => {
         AiConfig.orchestrator.lms = {enabled: true, model: 'lms-from-config', port: '4242'};
         AiConfig.openAiCompatible = {
             host          : 'http://127.0.0.1:4242',
             model         : 'chat-from-config',
             embeddingModel: 'embedding-from-config'
         };
+        AiConfig.chatProvider      = 'gemini';
+        AiConfig.modelProvider     = 'gemini';
+        AiConfig.graphProvider     = 'openAiCompatible';
+        AiConfig.embeddingProvider = 'openAiCompatible';
 
         const o = createMinimalOrchestrator();
         expect(o.lmsEnabled).toBe(true);
         expect(o.lmsModels).toEqual(['chat-from-config', 'embedding-from-config']);
 
+        AiConfig.embeddingProvider = 'gemini';
+        expect(createMinimalOrchestrator().lmsModels).toEqual(['chat-from-config']);
+
+        AiConfig.graphProvider = 'ollama';
+        expect(createMinimalOrchestrator().lmsModels).toEqual([]);
+
         AiConfig.orchestrator.lms = {enabled: false, model: 'qwen', port: '1234'};
         expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
+    });
+
+    test('buildLmsPreloadConfig does not let remote roles inflate same-model local context (#12264)', () => {
+        expect(buildLmsPreloadConfig({
+            chatProvider     : 'gemini',
+            modelProvider    : 'gemini',
+            graphProvider    : 'gemini',
+            embeddingProvider: 'openAiCompatible',
+            openAiCompatible: {
+                model         : 'shared-model',
+                embeddingModel: 'shared-model'
+            },
+            localModels: {
+                chat     : {contextLimitTokens: 262144},
+                embedding: {contextLimitTokens: 8192}
+            }
+        })).toEqual({
+            models        : ['shared-model'],
+            contextLengths: {'shared-model': 8192}
+        });
     });
 
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -7,9 +7,9 @@ import * as core from '../../../../../../src/core/_export.mjs';
 import AiConfig from '../../../../../../ai/config.mjs';
 import BaseConfig, {createConfigProxy} from '../../../../../../ai/BaseConfig.mjs';
 import {
-    Orchestrator,
-    buildLmsPreloadConfig
+    Orchestrator
 } from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {buildLmsPreloadConfig} from '../../../../../../ai/services/graph/ProviderReadinessHelper.mjs';
 import {
     buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/TaskDefinitions.mjs';
@@ -248,7 +248,7 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         }
     });
 
-    test('lmsEnabled coerces to boolean + lmsModels only preloads OpenAI-compatible roles (model/port/host inlined at call sites)', () => {
+    test('lmsEnabled coerces to boolean + lmsModels follow state-provider role selectors (model/port/host inlined at call sites)', () => {
         AiConfig.orchestrator.lms = {enabled: true, model: 'lms-from-config', port: '4242'};
         AiConfig.openAiCompatible = {
             host          : 'http://127.0.0.1:4242',
@@ -274,11 +274,11 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         expect(createMinimalOrchestrator().lmsEnabled).toBe(false);
     });
 
-    test('buildLmsPreloadConfig does not let remote roles inflate same-model local context (#12264)', () => {
+    test('buildLmsPreloadConfig only reads provider-role selectors, not non-null model leaves (#12264)', () => {
         expect(buildLmsPreloadConfig({
             chatProvider     : 'gemini',
             modelProvider    : 'gemini',
-            graphProvider    : 'gemini',
+            graphProvider    : 'ollama',
             embeddingProvider: 'openAiCompatible',
             openAiCompatible: {
                 model         : 'shared-model',
@@ -292,6 +292,23 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             models        : ['shared-model'],
             contextLengths: {'shared-model': 8192}
         });
+
+        expect(buildLmsPreloadConfig({
+            modelProvider    : 'openAiCompatible',
+            graphProvider    : 'ollama',
+            embeddingProvider: 'gemini',
+            openAiCompatible: {
+                model         : 'chat-model',
+                embeddingModel: 'embedding-model'
+            },
+            localModels: {
+                chat     : {contextLimitTokens: 262144},
+                embedding: {contextLimitTokens: 8192}
+            }
+        })).toEqual({
+            models        : ['chat-model'],
+            contextLengths: {'chat-model': 262144}
+        })
     });
 
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -255,7 +255,6 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
             model         : 'chat-from-config',
             embeddingModel: 'embedding-from-config'
         };
-        AiConfig.chatProvider      = 'gemini';
         AiConfig.modelProvider     = 'gemini';
         AiConfig.graphProvider     = 'openAiCompatible';
         AiConfig.embeddingProvider = 'openAiCompatible';
@@ -276,7 +275,6 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
 
     test('buildLmsPreloadConfig only reads provider-role selectors, not non-null model leaves (#12264)', () => {
         expect(buildLmsPreloadConfig({
-            chatProvider     : 'gemini',
             modelProvider    : 'gemini',
             graphProvider    : 'ollama',
             embeddingProvider: 'openAiCompatible',

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -175,6 +175,26 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         }
     });
 
+    test('buildTaskDefinitions honors an explicit empty lmsModels list without legacy fallback (#12264)', async () => {
+        const tasks = buildTaskDefinitions({
+            scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
+            nodeBin   : '/test/node',
+            lmsEnabled: true,
+            lmsModel  : 'legacy-fallback-model',
+            lmsModels : [],
+            lmsHost   : 'http://127.0.0.1:4242',
+            lmsPort   : 4242
+        });
+
+        expect(tasks.lms.requiredModels).toEqual([]);
+        await expect(tasks.lms.postSpawn()).resolves.toMatchObject({
+            ready         : true,
+            requiredModels: [],
+            skipped       : true,
+            reason        : 'no-openai-compatible-local-roles'
+        });
+    });
+
     test('AiConfig.orchestrator.lms ships default-enabled LM Studio launch defaults', () => {
         // Tier-1 template is the stable source of truth; read as text (see the MLX test
         // for why importing the template collides with daemon.mjs's config.mjs singleton).

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -173,6 +173,51 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         }));
     });
 
+    test('runTask records degraded state when a post-spawn hook returns partial readiness (#12264)', async () => {
+        const { service, logEntries, taskOutcomes } = createTestService();
+        let readyMarked = false;
+        let closeHandler;
+
+        service.taskDefinitions.mockTask.postSpawn = async () => ({
+            ready        : false,
+            degraded     : true,
+            missingModels: ['chat-model']
+        });
+        service.taskStateService.markReady = () => {
+            readyMarked = true;
+        };
+        service.spawnFn = () => ({
+            pid   : 9999,
+            stderr: {on: () => {}},
+            on    : (eventName, handler) => {
+                if (eventName === 'close') {
+                    closeHandler = handler;
+                }
+            }
+        });
+
+        expect(service.runTask('mockTask', 'test-reason')).toBe(true);
+        closeHandler(0);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(readyMarked).toBe(false);
+        expect(logEntries).toContainEqual(expect.objectContaining({
+            level  : 'WARN',
+            message: expect.stringContaining('degraded readiness')
+        }));
+        expect(taskOutcomes).toContainEqual(expect.objectContaining({
+            status  : 'degraded',
+            taskName: 'mockTask',
+            details : expect.objectContaining({
+                readiness: expect.objectContaining({
+                    ready        : false,
+                    missingModels: ['chat-model']
+                })
+            })
+        }));
+        expect(taskOutcomes.filter(entry => entry.status === 'completed')).toEqual([]);
+    });
+
     test('runTask fails and terminates the child when a post-spawn hook fails', async () => {
         const { service, taskOutcomes } = createTestService();
         let killed = false;

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -392,7 +392,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
     });
 
-    test('ensureLmsModelsLoaded skips above-cap chat preload and keeps embedding serviceable (#12264)', async () => {
+    test('ensureLmsModelsLoaded does not pre-skip large local chat contexts (#12264)', async () => {
         const loadCalls = [];
         const warnings  = [];
         const modelSnapshots = [
@@ -405,12 +405,16 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             models          : ['chat-model', 'embedding-model'],
             contextLengths  : {'chat-model': 262144, 'embedding-model': 8192},
             allowPartial    : true,
-            maxContextLength: 32768,
             attempts        : 2,
             delayMs         : 0,
             timeoutMs       : 50,
             fetchModelIds   : async () => modelSnapshots.shift() || ['embedding-model'],
-            loadModel       : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            loadModel       : async (model, options) => {
+                loadCalls.push({model, contextLength: options?.contextLength});
+                if (model === 'chat-model') {
+                    throw new Error('LM Studio rejected 262K chat load');
+                }
+            },
             log             : {
                 info: () => {},
                 warn: message => warnings.push(message)
@@ -418,19 +422,19 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         });
 
         expect(loadCalls).toEqual([
+            {model: 'chat-model',      contextLength: 262144},
             {model: 'embedding-model', contextLength: 8192}
         ]);
         expect(result.ready).toBe(false);
         expect(result.degraded).toBe(true);
         expect(result.loadedModels).toEqual(['embedding-model']);
-        expect(result.skippedModels).toEqual([{
-            model           : 'chat-model',
-            contextLength   : 262144,
-            maxContextLength: 32768,
-            reason          : 'context-length-exceeds-preload-max'
+        expect(result.failedModels).toEqual([{
+            model        : 'chat-model',
+            contextLength: 262144,
+            error        : 'LM Studio rejected 262K chat load'
         }]);
         expect(result.missingModels).toEqual(['chat-model']);
-        expect(warnings[0]).toContain('Skipping LM Studio model');
+        expect(warnings[0]).toContain('preload failed');
     });
 
     test('ensureLmsModelsLoaded continues loading remaining models after a partial preload failure (#12264)', async () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -186,13 +186,13 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 modelProvider: 'gemini',
                 openAiCompatible: {
                     host                 : 'http://oai.test',
-                    model                : 'gemma-4-31b-it',
+                    model                : 'qwen3-8b',
                     embeddingModel       : 'text-embedding-qwen3-embedding-8b',
                     requireParallelModels: 2
                 }
             },
             timeoutMs                     : 25,
-            fetchOpenAiCompatibleModels   : async () => ['gemma-4-31b-it', 'text-embedding-qwen3-embedding-8b'],
+            fetchOpenAiCompatibleModels   : async () => ['qwen3-8b', 'text-embedding-qwen3-embedding-8b'],
             log                           : {warn: (...args) => warnings.push(args)}
         });
 
@@ -212,7 +212,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 graphProvider: 'openAiCompatible',
                 openAiCompatible: {
                     host          : 'http://oai.test',
-                    model         : 'gemma-4-31b-it',
+                    model         : 'qwen3-8b',
                     embeddingModel: 'text-embedding-qwen3-embedding-8b'
                 }
             },
@@ -234,7 +234,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                     graphProvider: 'openAiCompatible',
                     openAiCompatible: {
                         host          : 'http://oai.test',
-                        model         : 'gemma-4-31b-it',
+                        model         : 'qwen3-8b',
                         embeddingModel: 'text-embedding-qwen3-embedding-8b',
                         requireParallelModels
                     }

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -392,6 +392,92 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
     });
 
+    test('ensureLmsModelsLoaded skips above-cap chat preload and keeps embedding serviceable (#12264)', async () => {
+        const loadCalls = [];
+        const warnings  = [];
+        const modelSnapshots = [
+            [],
+            ['embedding-model']
+        ];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host            : 'http://127.0.0.1:1234',
+            models          : ['chat-model', 'embedding-model'],
+            contextLengths  : {'chat-model': 262144, 'embedding-model': 8192},
+            allowPartial    : true,
+            maxContextLength: 32768,
+            attempts        : 2,
+            delayMs         : 0,
+            timeoutMs       : 50,
+            fetchModelIds   : async () => modelSnapshots.shift() || ['embedding-model'],
+            loadModel       : async (model, options) => loadCalls.push({model, contextLength: options?.contextLength}),
+            log             : {
+                info: () => {},
+                warn: message => warnings.push(message)
+            }
+        });
+
+        expect(loadCalls).toEqual([
+            {model: 'embedding-model', contextLength: 8192}
+        ]);
+        expect(result.ready).toBe(false);
+        expect(result.degraded).toBe(true);
+        expect(result.loadedModels).toEqual(['embedding-model']);
+        expect(result.skippedModels).toEqual([{
+            model           : 'chat-model',
+            contextLength   : 262144,
+            maxContextLength: 32768,
+            reason          : 'context-length-exceeds-preload-max'
+        }]);
+        expect(result.missingModels).toEqual(['chat-model']);
+        expect(warnings[0]).toContain('Skipping LM Studio model');
+    });
+
+    test('ensureLmsModelsLoaded continues loading remaining models after a partial preload failure (#12264)', async () => {
+        const loadCalls = [];
+        const warnings  = [];
+        const modelSnapshots = [
+            [],
+            ['embedding-model']
+        ];
+
+        const result = await providerReadinessHelper.ensureLmsModelsLoaded({
+            host          : 'http://127.0.0.1:1234',
+            models        : ['chat-model', 'embedding-model'],
+            contextLengths: {'chat-model': 32768, 'embedding-model': 8192},
+            allowPartial  : true,
+            attempts      : 2,
+            delayMs       : 0,
+            timeoutMs     : 50,
+            fetchModelIds : async () => modelSnapshots.shift() || ['embedding-model'],
+            loadModel     : async (model, options) => {
+                loadCalls.push({model, contextLength: options?.contextLength});
+                if (model === 'chat-model') {
+                    throw new Error('LM Studio rejected chat load');
+                }
+            },
+            log: {
+                info: () => {},
+                warn: message => warnings.push(message)
+            }
+        });
+
+        expect(loadCalls).toEqual([
+            {model: 'chat-model',      contextLength: 32768},
+            {model: 'embedding-model', contextLength: 8192}
+        ]);
+        expect(result.ready).toBe(false);
+        expect(result.degraded).toBe(true);
+        expect(result.loadedModels).toEqual(['embedding-model']);
+        expect(result.failedModels).toEqual([{
+            model        : 'chat-model',
+            contextLength: 32768,
+            error        : 'LM Studio rejected chat load'
+        }]);
+        expect(result.missingModels).toEqual(['chat-model']);
+        expect(warnings[0]).toContain('preload failed');
+    });
+
     test('loadLmsModel appends --context-length to execFile args when provided (#12117)', async () => {
         const execCalls = [];
         const execFileStub = (cmd, args, callback) => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -186,13 +186,13 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 modelProvider: 'gemini',
                 openAiCompatible: {
                     host                 : 'http://oai.test',
-                    model                : 'qwen3-8b',
+                    model                : 'gemma-4-31b-it',
                     embeddingModel       : 'text-embedding-qwen3-embedding-8b',
                     requireParallelModels: 2
                 }
             },
             timeoutMs                     : 25,
-            fetchOpenAiCompatibleModels   : async () => ['qwen3-8b', 'text-embedding-qwen3-embedding-8b'],
+            fetchOpenAiCompatibleModels   : async () => ['gemma-4-31b-it', 'text-embedding-qwen3-embedding-8b'],
             log                           : {warn: (...args) => warnings.push(args)}
         });
 
@@ -212,7 +212,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 graphProvider: 'openAiCompatible',
                 openAiCompatible: {
                     host          : 'http://oai.test',
-                    model         : 'qwen3-8b',
+                    model         : 'gemma-4-31b-it',
                     embeddingModel: 'text-embedding-qwen3-embedding-8b'
                 }
             },
@@ -234,7 +234,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                     graphProvider: 'openAiCompatible',
                     openAiCompatible: {
                         host          : 'http://oai.test',
-                        model         : 'qwen3-8b',
+                        model         : 'gemma-4-31b-it',
                         embeddingModel: 'text-embedding-qwen3-embedding-8b',
                         requireParallelModels
                     }

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -77,7 +77,7 @@ test.describe('Memory Core Offline Summarization', () => {
         SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
         SDK.Memory_Config.data.embeddingProvider     = 'openAiCompatible';
         SDK.Memory_Config.data.openAiCompatible.host           = 'http://127.0.0.1:1234';
-        SDK.Memory_Config.data.openAiCompatible.model          = 'qwen3-8b';
+        SDK.Memory_Config.data.openAiCompatible.model          = 'gemma-4-31b-it';
         SDK.Memory_Config.data.openAiCompatible.embeddingModel = 'text-embedding-qwen3-embedding-8b';
         SDK.Memory_Config.data.autoSummarize         = false;
 
@@ -87,14 +87,14 @@ test.describe('Memory Core Offline Summarization', () => {
         // Offline tests cannot hit APIs. Mock TextEmbeddingService for Qwen3-Embedding (4096D)
         TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
 
-        // Check if openAiCompatible daemon and the local-dev chat default are available
+        // Check if openAiCompatible daemon and gemma4 are available
         try {
             const host = SDK.Memory_Config.data.openAiCompatible.host;
             const res  = await fetch(`${host}/v1/models`);
             if (res.ok) {
                 const data      = await res.json();
-                const hasQwen3 = data.data?.some(m => m.id.includes('qwen3-8b'));
-                if (hasQwen3) {
+                const hasGemma4 = data.data?.some(m => m.id.includes('gemma-4'));
+                if (hasGemma4) {
                     localModelActive = true;
                 }
             }
@@ -111,11 +111,11 @@ test.describe('Memory Core Offline Summarization', () => {
         }
     });
 
-    test('SessionService routes to openAiCompatible (qwen3-8b) via SDK and correctly summarizes memories', async () => {
-        test.setTimeout(300000); // 5 minutes to allow a local model to summarize on slow hardware
+    test('SessionService routes to openAiCompatible (gemma4) via SDK and correctly summarizes memories', async () => {
+        test.setTimeout(300000); // 5 minutes to allow Gemma 4 to fully summarize on slow hardware
 
         if (!localModelActive) {
-            test.skip(true, 'Skipping: openAiCompatible or qwen3-8b not found locally');
+            test.skip(true, 'Skipping: openAiCompatible or gemma4 not found locally');
             return;
         }
 
@@ -149,13 +149,13 @@ test.describe('Memory Core Offline Summarization', () => {
             thought : "Check iconCls.",
             response: "Yes, use the iconCls property.",
             agent   : "librarian",
-            model   : "qwen3-8b"
+            model   : "gemma4"
         }, {
             prompt  : "How to handle clicks?",
             thought : "DOM events dispatcher.",
             response: "Bind a click listener via domListeners property.",
             agent   : "librarian",
-            model   : "qwen3-8b"
+            model   : "gemma4"
         }, {
             prompt  : "Can a button float?",
             thought : "Neo components support floating.",

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -77,7 +77,7 @@ test.describe('Memory Core Offline Summarization', () => {
         SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
         SDK.Memory_Config.data.embeddingProvider     = 'openAiCompatible';
         SDK.Memory_Config.data.openAiCompatible.host           = 'http://127.0.0.1:1234';
-        SDK.Memory_Config.data.openAiCompatible.model          = 'gemma-4-31b-it';
+        SDK.Memory_Config.data.openAiCompatible.model          = 'qwen3-8b';
         SDK.Memory_Config.data.openAiCompatible.embeddingModel = 'text-embedding-qwen3-embedding-8b';
         SDK.Memory_Config.data.autoSummarize         = false;
 
@@ -87,14 +87,14 @@ test.describe('Memory Core Offline Summarization', () => {
         // Offline tests cannot hit APIs. Mock TextEmbeddingService for Qwen3-Embedding (4096D)
         TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
 
-        // Check if openAiCompatible daemon and gemma4 are available
+        // Check if openAiCompatible daemon and the local-dev chat default are available
         try {
             const host = SDK.Memory_Config.data.openAiCompatible.host;
             const res  = await fetch(`${host}/v1/models`);
             if (res.ok) {
                 const data      = await res.json();
-                const hasGemma4 = data.data?.some(m => m.id.includes('gemma-4'));
-                if (hasGemma4) {
+                const hasQwen3 = data.data?.some(m => m.id.includes('qwen3-8b'));
+                if (hasQwen3) {
                     localModelActive = true;
                 }
             }
@@ -111,11 +111,11 @@ test.describe('Memory Core Offline Summarization', () => {
         }
     });
 
-    test('SessionService routes to openAiCompatible (gemma4) via SDK and correctly summarizes memories', async () => {
-        test.setTimeout(300000); // 5 minutes to allow Gemma 4 to fully summarize on slow hardware
+    test('SessionService routes to openAiCompatible (qwen3-8b) via SDK and correctly summarizes memories', async () => {
+        test.setTimeout(300000); // 5 minutes to allow a local model to summarize on slow hardware
 
         if (!localModelActive) {
-            test.skip(true, 'Skipping: openAiCompatible or gemma4 not found locally');
+            test.skip(true, 'Skipping: openAiCompatible or qwen3-8b not found locally');
             return;
         }
 
@@ -149,13 +149,13 @@ test.describe('Memory Core Offline Summarization', () => {
             thought : "Check iconCls.",
             response: "Yes, use the iconCls property.",
             agent   : "librarian",
-            model   : "gemma4"
+            model   : "qwen3-8b"
         }, {
             prompt  : "How to handle clicks?",
             thought : "DOM events dispatcher.",
             response: "Bind a click listener via domListeners property.",
             agent   : "librarian",
-            model   : "gemma4"
+            model   : "qwen3-8b"
         }, {
             prompt  : "Can a button float?",
             thought : "Neo components support floating.",


### PR DESCRIPTION
Refs #12264

Authored by GPT-5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.

FAIR-band: in-band [15/30]

This PR is scoped strictly to the LMS preload-policy code path. It keeps the local provider contract intact: OpenAI-compatible local roles are preloaded with their declared role-owned context windows, remote roles are not preloaded through LM Studio, native Ollama remains covered by the existing parallel-model capacity probe, and failed `lms load` attempts degrade honestly instead of being silently skipped.

The PR intentionally does not retune `openAiCompatible.model`, `localModels.chat.*`, or `localModels.embedding.*`. #12264 AC3 reserves those values for the config SSOT owner; the final net diff leaves model/context defaults unchanged and only fixes the preload handler shape around them.

Cycle-5 follow-up: folded in the approved non-blocking review cleanup. `buildLmsPreloadConfig()` now reuses `buildLmsContextLengthsMap()` for the max-per-model context merge and uses `config.openAiCompatible ?? {}` rather than an `||` fallback.

Evidence: L2 (unit-seam coverage for role-aware LMS preload derivation, state-provider selector behavior, remote-role exclusion, large-context no-skip behavior, partial `lms load` failure, and supervisor degraded outcome persistence) -> L2 required (preload policy and config-SSOT behavior are deterministic at the helper/supervisor/config boundary). No code residuals for the preload-policy piece.

## Deltas from ticket

- Preserved `orchestrator.lms.enabled: true`; this PR does not disable the lane or make chat disposable.
- Preserved both `openAiCompatible.model` and `openAiCompatible.embeddingModel` as required config leaves for OpenAI-compatible roles.
- Preserved existing chat and embedding context defaults; config/model selection is not changed by this PR.
- Removed `orchestrator.lms.preloadMaxContextLength` and the `ensureLmsModelsLoaded` max-context skip branch. There is no hand-set cap below a role-declared context window.
- Moved LMS preload derivation out of `ai/daemons/orchestrator/Orchestrator.mjs` into `ai/services/graph/ProviderReadinessHelper.mjs`, keeping Orchestrator as a thin config-forwarding consumer.
- Added role-aware LMS preload derivation from StateProvider selectors: summary chat, graph chat, and embedding are separate roles that contribute models only when their provider selector routes through the OpenAI-compatible surface.
- Summary chat reads `modelProvider` directly. There is no `modelProvider || chatProvider` or `modelProvider ?? chatProvider` fallback in the LMS preload path.
- Corrected tests to avoid the invalid `graphProvider = gemini` shortcut; non-LMS graph routing is represented with the supported native `ollama` provider.
- Preloads each selected local role with the declared `localModels.{role}.contextLimitTokens`. Same-model chat/embedding still keeps the larger context only when both roles are local consumers of that same model.
- Explicit empty `lmsModels: []` now means no OpenAI-compatible local roles for the LMS preload path, so the legacy `lms.model` fallback is not used for remote-only or non-LMS-local role sets.
- `buildLmsPreloadConfig()` now reuses `buildLmsContextLengthsMap()` instead of duplicating the max-per-model context merge.
- `ensureLmsModelsLoaded` still supports partial degradation for real `lms load` failures and continues attempting remaining serviceable models.
- Changed `ProcessSupervisorService` so a `ready:false` / `degraded:true` post-spawn result records `degraded` instead of being converted into a healthy `ready` outcome or overwritten by the fire-and-exit launcher completion.

## Test Evidence

- `node --check ai/services/graph/ProviderReadinessHelper.mjs`
- `node --check ai/daemons/orchestrator/TaskDefinitions.mjs`
- `node --check ai/daemons/orchestrator/Orchestrator.mjs`
- `node --check ai/config.template.mjs`
- `node --check test/playwright/unit/ai/config.template.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs`
- `node --check test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` -> 128 passed after rebase onto current `origin/dev`.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/services/graph/providerDispatch.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` -> 97 passed at `f4e5a2641`.
- `git diff --check` and `git diff --cached --check` passed before commits `b1f7488f`, `3debfde70`, and `f4e5a2641`.
- `rg -n "openAiCompatible \|\||OPEN_AI_COMPATIBLE_PROVIDER|usesLocalChat|config\.modelProvider\s*\?\?|config\.modelProvider\s*\|\|" ai/services/graph ai/daemons/orchestrator test/playwright/unit/ai -g "*.mjs"` returned no stale orchestrator-policy matches.
- Close-target audit: PR body uses `Refs #12264` by design; branch commit bodies contain no magic-close keyword.

## Residual / Owner Boundary

- `openAiCompatible.model`, `localModels.chat.*`, and `localModels.embedding.*` remain config SSOT-owner decisions per #12264 AC3.
- The current embedding 8K/6144 default was introduced by PR #12115 (`ea1d4816e`) as a conservative placeholder; it is not changed here because that would be a separate config-SSOT decision.

## Post-Merge Validation

- [ ] Optional operator smoke: start the local orchestrator with default config and confirm the LMS readiness outcome attempts configured OpenAI-compatible local roles at their declared context windows, while remote roles are not preloaded through LM Studio.

## Commits

- `123141890` - `fix(orchestrator): degrade oversized lms preloads (#12264)`
- `d341e45fe` - `fix(ai): retune local chat default for lms (#12264)`
- `71cc99cb8` - `Revert "fix(ai): retune local chat default for lms (#12264)"`
- `e2a3a685b` - `fix(orchestrator): derive lms preload roles (#12264)`
- `b1f7488f6` - `fix(orchestrator): move lms preload policy (#12264)`
- `3debfde70` - `fix(orchestrator): remove lms provider fallback (#12264)`
- `f4e5a2641` - `fix(orchestrator): reuse lms context map helper (#12264)`