### PR TITLE
feat(ai): defrag chroma collection groups (#12156)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -8,11 +8,11 @@ import Neo             from '../../../src/Neo.mjs';
 import AiConfig        from '../../config.mjs';
 
 /**
- * @summary A generic CLI tool to defragment ChromaDB instances (Knowledge Base & Memory Core).
+ * @summary Defragments collection groups inside the unified ChromaDB store.
  *
  * This script implements the "Nuke and Pave" strategy to eliminate HNSW index fragmentation and file bloat
- * within ChromaDB. It is designed to be target-agnostic, capable of processing different database instances
- * (e.g., Knowledge Base, Memory Core) by dynamically loading their specific configurations.
+ * within ChromaDB. It is target-agnostic at the collection-group layer: Knowledge Base and Memory Core
+ * share one unified persist directory, while the target controls which logical collections are rewritten.
  *
  * ## Peer Architecture (#10129)
  *
@@ -34,8 +34,8 @@ import AiConfig        from '../../config.mjs';
  *     restore if the nuke-and-pave ETL fails mid-flight. Snapshots live at `dist/chromadb-backups/<target>/`
  *     and are explicitly NOT the canonical backup — that lives at `.neo-ai-data/backups/backup-<ts>/` via
  *     `ai/scripts/maintenance/backup.mjs`. Automated retention: keep last 3, delete others older than 7 days.
- * 2.  **Extract (ETL)**: All data (IDs, embeddings, metadata, documents) is fetched from *all* target collections
- *     into an in-memory buffer.
+ * 2.  **Extract (ETL)**: All data (IDs, embeddings, metadata, documents) is fetched from every collection in the
+ *     selected collection group into an in-memory buffer.
  * 3.  **Nuke (Logical Reset)**: The collections are deleted via the API. This releases the logical references to the data,
  *     marking the underlying index files as obsolete.
  * 4.  **Load (Restoration)**: The collections are recreated, and the buffered data is re-inserted in batches.
@@ -46,10 +46,10 @@ import AiConfig        from '../../config.mjs';
  *     never a single target's collection ids.
  *
  * Usage:
- * `node buildScripts/defragChromaDB.mjs --target knowledge-base`
- * `node buildScripts/defragChromaDB.mjs --target memory-core`
+ * `node ai/scripts/maintenance/defragChromaDB.mjs --target knowledge-base`
+ * `node ai/scripts/maintenance/defragChromaDB.mjs --target memory-core`
  *
- * @module buildScripts/defragChromaDB
+ * @module ai.scripts.maintenance.defragChromaDB
  * @see ai/scripts/maintenance/backup.mjs   Canonical JSONL bundle backup orchestrator (peer, not dependency)
  * @see Neo.ai.mcp.server.knowledge-base.Config
  * @see Neo.ai.mcp.server.memory-core.Config
@@ -62,9 +62,9 @@ const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 export const LOCAL_AI_CONFIG_FILE = path.join(PROJECT_ROOT, 'ai', 'config.mjs');
 
 // Configuration Mapping
-// Maps CLI target names to their respective config files and adapts the config structure
-// to a unified format used by this script.
-const TARGETS = {
+// Maps CLI target names to their collection-group config files. Both targets resolve
+// to the same unified Chroma persist dir; only the collection set differs.
+export const TARGETS = {
     'knowledge-base': {
         configPath: '../../mcp/server/knowledge-base/config.mjs',
         adapt: (cfg) => ({
@@ -80,7 +80,11 @@ const TARGETS = {
             host       : cfg.engines.chroma.host,
             path       : cfg.engines.chroma.dataDir,
             port       : cfg.engines.chroma.port,
-            collections: [cfg.collections.memory, cfg.collections.session]
+            collections: [
+                cfg.collections.memory,
+                cfg.collections.session,
+                cfg.collections.graph
+            ].filter(Boolean)
         })
     }
 };

--- a/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
@@ -40,6 +40,7 @@ import path           from 'path';
 test.describe.configure({mode: 'serial'});
 
 test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#12140)', () => {
+    let TARGETS;
     let resolveLiveSegmentIds;
     let cleanOrphanedSegmentDirs;
     let tmpRoot;
@@ -48,6 +49,7 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/scripts/maintenance/defragChromaDB.mjs');
+        TARGETS                  = mod.TARGETS;
         resolveLiveSegmentIds    = mod.resolveLiveSegmentIds;
         cleanOrphanedSegmentDirs = mod.cleanOrphanedSegmentDirs;
 
@@ -123,6 +125,41 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
         // Return contract.
         expect(kept.sort()).toEqual([thisTargetLive, siblingLive].sort());
         expect(removed).toEqual([trueOrphan]);
+    });
+
+    test('target adapters share one unified store path while scoping collections per group', () => {
+        const unifiedPath = path.join(tmpRoot, 'chroma', 'unified');
+
+        const kbConfig = TARGETS['knowledge-base'].adapt({
+            collectionName: 'neo-knowledge-base',
+            host          : 'localhost',
+            path          : unifiedPath,
+            port          : 8000
+        });
+
+        const mcConfig = TARGETS['memory-core'].adapt({
+            collections: {
+                graph  : 'neo-native-graph',
+                memory : 'neo-agent-memory',
+                session: 'neo-agent-sessions'
+            },
+            engines: {
+                chroma: {
+                    dataDir: unifiedPath,
+                    host   : 'localhost',
+                    port   : 8000
+                }
+            }
+        });
+
+        expect(kbConfig.path).toBe(unifiedPath);
+        expect(mcConfig.path).toBe(unifiedPath);
+        expect(kbConfig.collections).toEqual(['neo-knowledge-base']);
+        expect(mcConfig.collections).toEqual([
+            'neo-agent-memory',
+            'neo-agent-sessions',
+            'neo-native-graph'
+        ]);
     });
 
     test('skips UUID-named entries that are files, not directories', async () => {


### PR DESCRIPTION
Resolves #12156

Authored by GPT-5.5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.

FAIR-band: in-band [18/30 — current author count over last 30 merged]

Related: #12153

This changes `defragChromaDB.mjs` from thinking in two physical targets into thinking in collection-groups over the one unified Chroma store. The store path remains shared, while the memory-core group now owns the Memory, Session, and Native Graph collections as one defrag target shape.

Evidence: L2 (unit coverage for target adapter shape and unified-store-safe segment keep-set) -> L3 required before live operator defrag. The implementation changes deterministic target metadata only; destructive live defrag remains an explicit operator validation step because the target script mutates Chroma segment directories.

## Deltas from ticket

- Keeps the existing unified Chroma path as the only store path for both target groups.
- Extends the memory-core target group to include the native graph collection (`neo-native-graph`) alongside memory and session collections.
- Exports `TARGETS` for focused unit coverage instead of duplicating the target shape in tests.
- Updates the defrag script docs/usage language from physical target wording to collection-group wording.

## Test Evidence

- `node --check ai/scripts/maintenance/defragChromaDB.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs` -> 6 passed
- `git diff --check`
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `5acc0eb1a feat(ai): defrag chroma collection groups (#12156)`.

## Residual Risk

- Live defrag was not executed. That should remain post-merge/operator-gated because `defragChromaDB.mjs` deletes segment directories.
- Existing test-pollution risks from #12143/#12180 still apply to broad Chroma cleanup validation; this PR avoids broad live mutation and covers the target metadata seam directly.

## Post-Merge Validation

- [ ] After test-pollution cleanup, run a live memory-core defrag against a prepared unified Chroma store and confirm Memory, Session, and Native Graph collections remain intact.
- [ ] Run a knowledge-base defrag against the same prepared store and confirm memory-core collections and segment directories are preserved.

## Commit

- `5acc0eb1a` - `feat(ai): defrag chroma collection groups (#12156)`
