### PR TITLE
feat(portal): lazily load content tree children (#12218)

### DIFF
--- a/apps/portal/model/Ticket.mjs
+++ b/apps/portal/model/Ticket.mjs
@@ -15,9 +15,21 @@ class Ticket extends Model {
          * @member {Object[]} fields
          */
         fields: [{
+            name: 'childCount',
+            type: 'Integer'
+        }, {
+            name: 'childrenUrl',
+            type: 'String'
+        }, {
             name        : 'collapsed',
             type        : 'Boolean',
             defaultValue: true
+        }, {
+            name: 'contentDir',
+            type: 'String'
+        }, {
+            name: 'filePrefix',
+            type: 'String'
         }, {
             name: 'id',
             type: 'String'

--- a/apps/portal/view/news/tickets/MainContainer.mjs
+++ b/apps/portal/view/news/tickets/MainContainer.mjs
@@ -43,10 +43,12 @@ class MainContainer extends SharedContainer {
          */
         stateProvider: StateProvider,
         /**
-         * @member {Object} treeConfig={displayField:'treeNodeName'}
+         * @member {Object} treeConfig
          */
         treeConfig: {
-            displayField: 'treeNodeName'
+            displayField       : 'treeNodeName',
+            lazyChildLoad      : true,
+            lazyChildUrlPrefix : '../../apps/portal/resources/data/'
         }
     }
 }

--- a/src/app/content/TreeList.mjs
+++ b/src/app/content/TreeList.mjs
@@ -34,6 +34,19 @@ class TreeList extends BaseTreeList {
          */
         currentPageRecord_: null,
         /**
+         * @member {Boolean} lazyChildLoad=false
+         */
+        lazyChildLoad: false,
+        /**
+         * Optional URL prefix for relative child chunk URLs.
+         * @member {String|null} lazyChildUrlPrefix=null
+         */
+        lazyChildUrlPrefix: null,
+        /**
+         * @member {String} lazyChildUrlField='childrenUrl'
+         */
+        lazyChildUrlField: 'childrenUrl',
+        /**
          * Optional prefix for the route (e.g. '/learn' or '/releases')
          * @member {String|null} routePrefix=null
          */
@@ -91,6 +104,109 @@ class TreeList extends BaseTreeList {
     }
 
     /**
+     * @summary Resolves the URL used to fetch a folder node's deferred children.
+     * @param {Object} record
+     * @returns {String|null}
+     */
+    getLazyChildUrl(record) {
+        let me  = this,
+            url = record?.[me.lazyChildUrlField];
+
+        if (!url) {
+            return null
+        }
+
+        if (/^(?:[a-z]+:)?\/\//i.test(url) || url.startsWith('/') || url.startsWith('./') || url.startsWith('../')) {
+            return url
+        }
+
+        return (me.lazyChildUrlPrefix || '') + url
+    }
+
+    /**
+     * @summary Adds content paths to chunk leaves whose compact index payload omits them.
+     * @param {Object[]} records
+     * @param {Object} parentRecord
+     * @returns {Object[]}
+     */
+    normalizeLazyChildRecords(records, parentRecord) {
+        let {contentDir, filePrefix} = parentRecord;
+
+        if (!contentDir) {
+            return records
+        }
+
+        filePrefix ??= '';
+
+        return records.map(record => {
+            if (!record.path && record.id) {
+                return {
+                    ...record,
+                    path: `${contentDir}/${filePrefix}${record.id}.md`
+                }
+            }
+
+            return record
+        })
+    }
+
+    /**
+     * @summary Loads a folder node's child chunk on first expand when `lazyChildLoad` is enabled.
+     * @param {Object} record
+     * @returns {Promise<Boolean|void>} false cancels the folder toggle.
+     */
+    async onFolderItemClick(record) {
+        let me = this;
+
+        if (!me.lazyChildLoad || record.isLeaf || record.isChildrenLoaded) {
+            return
+        }
+
+        if (me.store.find('parentId', record.id).length > 0) {
+            record.isChildrenLoaded = true;
+            return
+        }
+
+        if (record.isLoading) {
+            return false
+        }
+
+        let url = me.getLazyChildUrl(record);
+
+        if (!url) {
+            return
+        }
+
+        record.isLoading = true;
+
+        try {
+            let response = await fetch(url);
+
+            if (!response.ok) {
+                throw new Error(`Failed to load tree children from ${url}: ${response.status}`)
+            }
+
+            let records = await response.json();
+
+            if (!Array.isArray(records)) {
+                records = records?.data || []
+            }
+
+            if (records.length > 0) {
+                me.store.add(me.normalizeLazyChildRecords(records, record))
+            }
+
+            record.isChildrenLoaded = true
+        } catch (error) {
+            record.hasError = true;
+            console.error('TreeList lazy child load failed', {error, record, url});
+            return false
+        } finally {
+            record.isLoading = false
+        }
+    }
+
+    /**
      * @param {Object} record
      */
     onLeafItemClick(record) {
@@ -110,7 +226,11 @@ class TreeList extends BaseTreeList {
     onStoreLoad() {
         super.onStoreLoad();
 
-        this.getStateProvider().data.countPages = this.store.getCount()
+        let stateProvider = this.getStateProvider();
+
+        if (stateProvider) {
+            stateProvider.data.countPages = this.store.getCount()
+        }
     }
 }
 

--- a/src/tree/Accordion.mjs
+++ b/src/tree/Accordion.mjs
@@ -319,9 +319,12 @@ class AccordionTree extends TreeList {
     /**
      * @param {Object} item
      * @param {Object} data
+     * @returns {Promise<Boolean|void>}
      */
-    onItemClick(item, data) {
-        super.onItemClick(item, data);
+    async onItemClick(item, data) {
+        if (await super.onItemClick(item, data) === false) {
+            return false
+        }
 
         let me               = this,
             {selectionModel} = me,
@@ -339,8 +342,6 @@ class AccordionTree extends TreeList {
              * @returns {Object} record
              */
             me.fire('folderItemClick', {record});
-
-            record.collapsed = !record.collapsed
         }
     }
 

--- a/src/tree/List.mjs
+++ b/src/tree/List.mjs
@@ -598,13 +598,13 @@ class Tree extends Base {
         if (item) {
             if (item.cls?.includes(me.folderCls)) {
                 if (await me.onFolderItemClick(record, item, data) === false) {
-                    return
+                    return false
                 }
 
                 item = me.getVdomChild(vnodeId);
 
                 if (!item) {
-                    return
+                    return false
                 }
 
                 NeoArray.toggle(item.cls, 'neo-folder-open');

--- a/src/tree/List.mjs
+++ b/src/tree/List.mjs
@@ -575,7 +575,7 @@ class Tree extends Base {
      * @param {Object} node
      * @param {Object} data
      */
-    onItemClick(node, data) {
+    async onItemClick(node, data) {
         let me          = this,
             {items}     = me.store,
             i           = 0,
@@ -597,11 +597,27 @@ class Tree extends Base {
 
         if (item) {
             if (item.cls?.includes(me.folderCls)) {
+                if (await me.onFolderItemClick(record, item, data) === false) {
+                    return
+                }
+
+                item = me.getVdomChild(vnodeId);
+
+                if (!item) {
+                    return
+                }
+
                 NeoArray.toggle(item.cls, 'neo-folder-open');
 
                 let isOpen              = item.cls.includes('neo-folder-open'),
                     {parentNode, index} = VDomUtil.find(me.vdom, item.id),
                     nextSibling         = parentNode.cn[index + 1];
+
+                if (record.isRecord) {
+                    record.setSilent({collapsed: !isOpen})
+                } else {
+                    record.collapsed = !isOpen
+                }
 
                 item.style.position = isOpen ? 'sticky' : null;
                 item.style.top      = isOpen ? (item.level * 38) + 'px' : null;
@@ -632,6 +648,18 @@ class Tree extends Base {
      * @param {Object} record
      */
     onLeafItemClick(record) {
+
+    }
+
+    /**
+     * @summary Extension hook for subclasses that need to prepare a folder before its
+     * open state is toggled, e.g. by loading children on demand.
+     * @param {Object} record
+     * @param {Object} item
+     * @param {Object} data
+     * @returns {Boolean|Promise<Boolean>|void} Return false to cancel the toggle.
+     */
+    onFolderItemClick(record, item, data) {
 
     }
 

--- a/test/playwright/unit/app/content/TreeList.spec.mjs
+++ b/test/playwright/unit/app/content/TreeList.spec.mjs
@@ -1,0 +1,156 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AppContentTreeListLazyLoadTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../src/manager/Instance.mjs';
+import TreeList       from '../../../../../src/app/content/TreeList.mjs';
+
+test.describe('Neo.app.content.TreeList lazy child loading', () => {
+    test('loads chunk children on folder expand and reconstructs markdown paths once', async () => {
+        const originalFetch = globalThis.fetch;
+        let fetchCount = 0,
+            requestedUrl;
+
+        globalThis.fetch = async url => {
+            fetchCount++;
+            requestedUrl = url;
+
+            return {
+                ok    : true,
+                status: 200,
+                json  : async () => [{
+                    id      : '12218',
+                    parentId: 'Backlog/active-chunk-16',
+                    title   : 'Opt-in load-on-folder-expand for the shared portal TreeList'
+                }]
+            }
+        };
+
+        const tree = Neo.create(TreeList, {
+            appName                   : 'AppContentTreeListLazyLoadTest',
+            id                        : 'app-content-tree-list-lazy-load',
+            lazyChildLoad             : true,
+            lazyChildUrlPrefix        : '../../apps/portal/resources/data/',
+            showCollapseExpandAllIcons: false,
+            store: {
+                model: {
+                    fields: [
+                        {name: 'childCount',  type: 'Integer'},
+                        {name: 'childrenUrl', type: 'String'},
+                        {name: 'collapsed',   type: 'Boolean', defaultValue: true},
+                        {name: 'contentDir',  type: 'String'},
+                        {name: 'filePrefix',  type: 'String'},
+                        {name: 'id',          type: 'String'},
+                        {name: 'isLeaf',      type: 'Boolean'},
+                        {name: 'parentId',    type: 'String'},
+                        {name: 'path',        type: 'String'},
+                        {name: 'title',       type: 'String'}
+                    ]
+                },
+                data: [{
+                    id       : 'Backlog',
+                    isLeaf   : false,
+                    parentId : null,
+                    collapsed: true
+                }, {
+                    id         : 'Backlog/active-chunk-16',
+                    isLeaf     : false,
+                    parentId   : 'Backlog',
+                    collapsed  : true,
+                    childrenUrl: 'tickets/backlog/active-chunk-16.json',
+                    childCount : 1,
+                    contentDir : 'resources/content/issues/chunk-16',
+                    filePrefix : 'issue-'
+                }]
+            }
+        });
+
+        try {
+            await tree.initVnode();
+
+            await tree.onItemClick(tree.getVdomChild(tree.getItemId('Backlog')), {
+                path: [{id: tree.getItemId('Backlog')}]
+            });
+
+            await tree.onItemClick(tree.getVdomChild(tree.getItemId('Backlog/active-chunk-16')), {
+                path: [{id: tree.getItemId('Backlog/active-chunk-16')}]
+            });
+
+            const chunkRecord  = tree.store.get('Backlog/active-chunk-16'),
+                  loadedRecord = tree.store.get('12218');
+
+            expect(fetchCount).toBe(1);
+            expect(requestedUrl).toBe('../../apps/portal/resources/data/tickets/backlog/active-chunk-16.json');
+            expect(chunkRecord.isChildrenLoaded).toBe(true);
+            expect(chunkRecord.collapsed).toBe(false);
+            expect(loadedRecord.parentId).toBe('Backlog/active-chunk-16');
+            expect(loadedRecord.path).toBe('resources/content/issues/chunk-16/issue-12218.md');
+
+            await tree.onItemClick(tree.getVdomChild(tree.getItemId('Backlog/active-chunk-16')), {
+                path: [{id: tree.getItemId('Backlog/active-chunk-16')}]
+            });
+
+            expect(fetchCount).toBe(1);
+            expect(chunkRecord.collapsed).toBe(true);
+            expect(tree.store.find('parentId', 'Backlog/active-chunk-16')).toHaveLength(1);
+        } finally {
+            tree.destroy();
+            globalThis.fetch = originalFetch
+        }
+    });
+
+    test('does not fetch child chunks when lazyChildLoad is disabled', async () => {
+        const originalFetch = globalThis.fetch;
+        let fetchCount = 0;
+
+        globalThis.fetch = async () => {
+            fetchCount++;
+            return {ok: true, json: async () => []}
+        };
+
+        const tree = Neo.create(TreeList, {
+            appName                   : 'AppContentTreeListLazyLoadTest',
+            id                        : 'app-content-tree-list-lazy-off',
+            showCollapseExpandAllIcons: false,
+            store: {
+                model: {
+                    fields: [
+                        {name: 'childrenUrl', type: 'String'},
+                        {name: 'collapsed',   type: 'Boolean', defaultValue: true},
+                        {name: 'id',          type: 'String'},
+                        {name: 'isLeaf',      type: 'Boolean'},
+                        {name: 'parentId',    type: 'String'},
+                        {name: 'title',       type: 'String'}
+                    ]
+                },
+                data: [{
+                    id         : 'Backlog/active-chunk-16',
+                    isLeaf     : false,
+                    parentId   : null,
+                    collapsed  : true,
+                    childrenUrl: 'tickets/backlog/active-chunk-16.json'
+                }]
+            }
+        });
+
+        try {
+            await tree.initVnode();
+            await tree.onItemClick(tree.getVdomChild(tree.getItemId('Backlog/active-chunk-16')), {
+                path: [{id: tree.getItemId('Backlog/active-chunk-16')}]
+            });
+
+            expect(fetchCount).toBe(0);
+            expect(tree.store.get('Backlog/active-chunk-16').collapsed).toBe(false)
+        } finally {
+            tree.destroy();
+            globalThis.fetch = originalFetch
+        }
+    })
+});

--- a/test/playwright/unit/tree/Accordion.spec.mjs
+++ b/test/playwright/unit/tree/Accordion.spec.mjs
@@ -1,0 +1,150 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'TreeAccordionAsyncClickTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../src/manager/Instance.mjs';
+import Accordion      from '../../../../src/tree/Accordion.mjs';
+
+class AsyncAccordion extends Accordion {
+    static config = {
+        className: 'Test.tree.AsyncAccordion'
+    }
+
+    /**
+     * @summary Captures async folder-hook ordering before the base folder toggle completes.
+     * @param {Object} record
+     * @returns {Promise<void>}
+     */
+    async onFolderItemClick(record) {
+        this.clickOrder.push('hook:start');
+
+        if (this.cancelNextClick) {
+            this.clickOrder.push('hook:cancel');
+            return false
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        this.clickOrder.push('hook:end')
+    }
+}
+
+AsyncAccordion = Neo.setupClass(AsyncAccordion);
+
+test.describe('Neo.tree.Accordion async folder clicks', () => {
+    test('awaits the tree.List folder hook before firing the accordion folder event', async () => {
+        const tree = Neo.create(AsyncAccordion, {
+            appName,
+            clickOrder                 : [],
+            id                         : 'accordion-async-click-test',
+            rootParentsAreCollapsible  : true,
+            showCollapseExpandAllIcons : false,
+            store: {
+                model: {
+                    fields: [
+                        {name: 'collapsed', type: 'Boolean'},
+                        {name: 'content',   type: 'String'},
+                        {name: 'iconCls',   type: 'String'},
+                        {name: 'id',        type: 'String'},
+                        {name: 'isLeaf',    type: 'Boolean'},
+                        {name: 'name',      type: 'String'},
+                        {name: 'parentId',  type: 'String'}
+                    ]
+                },
+                data: [{
+                    id       : 'folder1',
+                    collapsed: true,
+                    content  : 'Folder Content',
+                    iconCls  : '',
+                    isLeaf   : false,
+                    name     : 'Folder 1',
+                    parentId : null
+                }]
+            }
+        });
+
+        try {
+            await tree.initVnode();
+
+            const itemId = tree.getItemId('folder1');
+
+            tree.on('folderItemClick', ({record}) => {
+                tree.clickOrder.push(`event:${record.collapsed}`)
+            });
+
+            await tree.onItemClick(tree.getVdomChild(itemId), {
+                path: [{id: itemId}]
+            });
+
+            const record = tree.store.get('folder1');
+
+            expect(tree.clickOrder).toEqual(['hook:start', 'hook:end', 'event:false']);
+            expect(record.collapsed).toBe(false);
+            expect(tree.getVdomChild(itemId).cls).toContain('neo-folder-open')
+        } finally {
+            tree.destroy()
+        }
+    })
+
+    test('does not fire the accordion folder event when the base hook cancels', async () => {
+        const tree = Neo.create(AsyncAccordion, {
+            appName,
+            cancelNextClick            : true,
+            clickOrder                 : [],
+            id                         : 'accordion-cancelled-click-test',
+            rootParentsAreCollapsible  : true,
+            showCollapseExpandAllIcons : false,
+            store: {
+                model: {
+                    fields: [
+                        {name: 'collapsed', type: 'Boolean'},
+                        {name: 'content',   type: 'String'},
+                        {name: 'iconCls',   type: 'String'},
+                        {name: 'id',        type: 'String'},
+                        {name: 'isLeaf',    type: 'Boolean'},
+                        {name: 'name',      type: 'String'},
+                        {name: 'parentId',  type: 'String'}
+                    ]
+                },
+                data: [{
+                    id       : 'folder1',
+                    collapsed: true,
+                    content  : 'Folder Content',
+                    iconCls  : '',
+                    isLeaf   : false,
+                    name     : 'Folder 1',
+                    parentId : null
+                }]
+            }
+        });
+
+        try {
+            await tree.initVnode();
+
+            const itemId = tree.getItemId('folder1');
+
+            tree.on('folderItemClick', ({record}) => {
+                tree.clickOrder.push(`event:${record.collapsed}`)
+            });
+
+            await expect(tree.onItemClick(tree.getVdomChild(itemId), {
+                path: [{id: itemId}]
+            })).resolves.toBe(false);
+
+            expect(tree.clickOrder).toEqual(['hook:start', 'hook:cancel']);
+            expect(tree.store.get('folder1').collapsed).toBe(true);
+            expect(tree.getVdomChild(itemId).cls).not.toContain('neo-folder-open')
+        } finally {
+            tree.destroy()
+        }
+    })
+});


### PR DESCRIPTION
Resolves #12218
Related: #12207

Authored by GPT-5 (Codex Desktop). Session d9b4a887-57aa-43aa-8cec-a260ec35ce12.

FAIR-band: over-target [19/30] — taking this lane despite over-target because operator-directed nightshift prioritizes the portal ticket-index epic and #12218 is the smallest safe prerequisite for lazy activation without changing the current app route/store surface.

Adds opt-in load-on-folder-expand support to the shared portal content TreeList path. The base tree now exposes an async folder-click preparation hook, `Neo.app.content.TreeList` can fetch and append chunk children once per folder when `lazyChildLoad` is enabled, and the portal Ticket model preserves chunk metadata emitted by #12217. The tickets tree instance now opts into lazy child loading, while the store remains on `tickets.json` until #12219 makes default-route/deep-link resolution chunk-aware.

Cycle-2 also fixes the `Neo.tree.Accordion` override: it now awaits the base tree click pipeline, propagates a cancelled folder hook, and no longer double-writes `record.collapsed` after the base tree owns the folder toggle state. #12218 now has the missing Contract Ledger for the consumed lazy-loading surfaces.

Evidence: L3 (focused unit tests plus worktree-served local Chromium smoke on the portal tickets route) -> L3 required (observable portal/tree behavior in local browser surface). Residual: switching the ticket store to the chunk root and making default/deep-link routing chunk-aware remains deferred to #12219.

## Deltas from ticket
- Adds `onFolderItemClick()` as the shared `src/tree/List.mjs` extension hook and keeps existing behavior when subclasses do not opt in.
- Propagates `false` from the base folder hook so subclass overrides can skip follow-up behavior after a cancelled lazy load.
- Updates `src/tree/Accordion.mjs` to await the async base tree click pipeline and leave collapsed-state ownership to `src/tree/List.mjs`.
- Adds `lazyChildLoad`, URL resolution, first-load guards, chunk append, compact leaf path reconstruction, and a missing-state-provider guard in `src/app/content/TreeList.mjs`.
- Adds `childCount`, `childrenUrl`, `contentDir`, and `filePrefix` to `Portal.model.Ticket` so chunk index metadata survives model hydration.
- Opts the tickets `MainContainer` tree into lazy child loading with `lazyChildLoad: true` and the portal data URL prefix.
- Backfills the #12218 Contract Ledger for the lazy hook/configs, Accordion async override, Ticket metadata fields, and tickets-tree opt-in consumer.
- Deliberately leaves `Portal.store.Tickets` on `tickets.json`. A local activation smoke exposed that switching the current route/store to `tickets/index.json` would select a chunk folder before #12219 handles lazy-aware defaults and deep links.
- Theming: no MJS file moves/renames and no SCSS path changes; `resources/scss/theme-neo-light/apps/portal`, `resources/scss/theme-neo-dark/apps/portal`, and `resources/scss/src/apps/portal` remain untouched.

## Test Evidence
- `node --check src/tree/List.mjs` passed.
- `node --check src/app/content/TreeList.mjs` passed.
- `node --check apps/portal/model/Ticket.mjs` passed.
- `node --check apps/portal/view/news/tickets/MainContainer.mjs` passed.
- `node --check test/playwright/unit/app/content/TreeList.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/app/content/TreeList.spec.mjs test/playwright/unit/tree/List.spec.mjs test/playwright/unit/tree/ListRaceCondition.spec.mjs` passed: 4 passed in 857ms after the opt-in fix.
- `npm run test-unit -- test/playwright/unit/tree/Accordion.spec.mjs` passed: 1 passed in 599ms before cancellation propagation was added.
- `npm run test-unit -- test/playwright/unit/tree/Accordion.spec.mjs test/playwright/unit/app/content/TreeList.spec.mjs test/playwright/unit/tree/List.spec.mjs test/playwright/unit/tree/ListRaceCondition.spec.mjs` passed: 6 passed in 1.0s at head `fb31df686`.
- `git diff --check` and `git diff --cached --check` passed.
- `gh api repos/neomjs/neo/issues/12218 --jq '.body | contains("## Contract Ledger")'` returned `true`.
- Worktree-served portal smoke at `http://127.0.0.1:8099/apps/portal/index.html#/news/tickets` via Chromium: no page errors, console errors, or failed requests; route landed on `#/news/tickets/9569`, served the updated `MainContainer.mjs` with `lazyChildLoad: true`, and still loaded the legacy `tickets.json` path as intended for this PR. Sandbox Chromium hit the macOS MachPort ceiling, so the smoke was rerun outside the sandbox.

## Post-Merge Validation
- [ ] After #12219 switches the tickets store to the chunk root, expand a chunk folder from the dev-served Portal and confirm exactly one child chunk fetch, appended children, and stable deep-link/default selection.

## Commits
- `72e2b84a2` — `feat(portal): lazily load content tree children (#12218)`
- `bfb79c679` — `fix(portal): opt in tickets tree lazy loading (#12218)`
- `fb31df686` — `fix(tree): await accordion folder toggles (#12218)`