### PR TITLE
chore(ai): clean KB daemon source comments (#11925)

### DIFF
--- a/ai/daemons/kb-alerting/KbAlertingService.mjs
+++ b/ai/daemons/kb-alerting/KbAlertingService.mjs
@@ -1,7 +1,7 @@
-// Class-only file (#11058-style split). Entry-point bootstrap (Neo + core/_export +
-// InstanceManager) lives in `ai/daemons/kb-alerting/daemon.mjs` per the canonical
-// Orchestrator class+wrapper pattern. `Neo.setupClass(KbAlertingService)` at file
-// bottom works via `globalThis.Neo`, populated by the entry-point bootstrap chain.
+// Class-only daemon implementation. Entry-point bootstrap (Neo + core/_export +
+// InstanceManager) lives in `ai/daemons/kb-alerting/daemon.mjs`, following the
+// canonical Orchestrator class+wrapper pattern. `Neo.setupClass(KbAlertingService)`
+// at file bottom uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
 import Base                           from '../../../src/core/Base.mjs';
 import {Memory_Config as aiConfig}    from '../../services.mjs';
 import KBRecorderService              from '../../services/knowledge-base/KBRecorderService.mjs';
@@ -34,12 +34,12 @@ const DEFAULT_WINDOW_MS = 60 * 60 * 1000;
 const DEFAULT_SENDER = '@system';
 
 /**
- * @summary Phase 4D KB operator-alerting daemon — telemetry thresholds → A2A / console alerts (#11642).
+ * @summary KB operator-alerting daemon — telemetry thresholds → A2A / console alerts.
  *
- * Closes the Phase 4 operability loop: Phase 4A (#11639) collects per-tenant KB ingestion
- * telemetry into `kb_ingestion_metrics`; this daemon polls the per-tenant rollup, evaluates
- * it against operator-configured `aiConfig.knowledgeBase.alertRules`, and dispatches an alert
- * to each breached rule's channels. Without it, operators must manually poll telemetry.
+ * Provides the alerting leg of KB operability: ingestion records per-tenant metrics in
+ * `kb_ingestion_metrics`; this daemon polls the per-tenant rollup, evaluates it against
+ * operator-configured `aiConfig.knowledgeBase.alertRules`, and dispatches an alert to each
+ * breached rule's channels. Without it, operators must manually poll telemetry.
  *
  * **Shape** — the canonical poll-loop daemon (the `SwarmHeartbeatService` precedent): a
  * `Neo.core.Base` singleton with `start()` / `stop()` / `scheduleNext()` / `pulse()`. The
@@ -52,9 +52,9 @@ const DEFAULT_SENDER = '@system';
  * **Opt-in** — `start()` is a no-op unless `aiConfig.knowledgeBase.alertingEnabled` is true,
  * so a default deployment never runs the daemon.
  *
- * **Channels** (per the #11642 Contract Ledger): `console` → `logger`; `a2a:<target>` →
- * `MailboxService.addMessage` under a bound sender identity; `webhook:<url>` → V1.5-deferred
- * (recognized but warn-skipped). Cooldown state is held in-memory and reset on `start()`.
+ * **Channels** — `console` → `logger`; `a2a:<target>` → `MailboxService.addMessage`
+ * under a bound sender identity; `webhook:<url>` is recognized but warn-skipped until
+ * webhook delivery is implemented. Cooldown state is held in-memory and reset on `start()`.
  *
  * @class Neo.ai.daemons.KbAlertingService
  * @extends Neo.core.Base
@@ -224,9 +224,9 @@ class KbAlertingService extends Base {
     /**
      * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
      *
-     * Reads defensively: a stale gitignored `ai/config.mjs` deployment predating #11642
-     * has no `knowledgeBase` key, so a naked `aiConfig.knowledgeBase.alertRules` would
-     * throw. Returns `{}` when the key is absent.
+     * Reads defensively: a stale gitignored `ai/config.mjs` deployment may lack the
+     * `knowledgeBase` key, so a naked `aiConfig.knowledgeBase.alertRules` would throw.
+     * Returns `{}` when the key is absent.
      *
      * @returns {Object}
      * @protected
@@ -261,7 +261,7 @@ class KbAlertingService extends Base {
             } else if (channel.startsWith('a2a:')) {
                 await this.dispatchA2A(alert)
             } else if (channel.startsWith('webhook:')) {
-                // V1.5-deferred per the #11642 Contract Ledger — recognized but not POSTed.
+                // Webhook delivery is recognized in config but not yet POSTed.
                 logger.warn(`[KbAlertingService] Webhook channel deferred to V1.5; skipping "${channel}" (tenant ${alert.tenantId})`)
             } else {
                 logger.warn(`[KbAlertingService] Unknown channel "${channel}" (tenant ${alert.tenantId}); skipping`)
@@ -305,9 +305,8 @@ class KbAlertingService extends Base {
     async dispatchA2A(alert) {
         const target = alert.channel.slice('a2a:'.length);
 
-        // Reject an unresolvable target BEFORE dispatch (#11642 Contract Ledger; @neo-gpt
-        // PR #11709 Cycle-1 review). A target that is neither a registered `@<identity>`
-        // nor the `AGENT:*` sentinel is skipped with a warn — `MailboxService.addMessage`
+        // Reject an unresolvable target before dispatch. A target that is neither a registered
+        // `@<identity>` nor the `AGENT:*` sentinel is skipped with a warn; `MailboxService.addMessage`
         // is never reached, so a misconfigured rule cannot attempt orphan-target dispatch.
         if (!MailboxService.isReachableTarget(target)) {
             logger.warn(`[KbAlertingService] Skipping alert for unresolvable A2A target "${target}" (tenant ${alert.tenantId})`);

--- a/ai/daemons/kb-alerting/daemon.mjs
+++ b/ai/daemons/kb-alerting/daemon.mjs
@@ -1,6 +1,6 @@
 /**
  * @module ai/daemons/kb-alerting/daemon
- * @summary Thin Node-process boot wrapper for the Phase 4D KB operator-alerting daemon (#11642).
+ * @summary Thin Node-process boot wrapper for the KB operator-alerting daemon.
  *
  * Owns Neo namespace bootstrap + SIGTERM / SIGINT clean-stop signal handling +
  * `KbAlertingService.start()` invocation. The class definition (poll loop, rule
@@ -16,7 +16,6 @@
  *
  * @see ai/daemons/kb-alerting/KbAlertingService.mjs
  * @see ai/daemons/orchestrator/daemon.mjs (sibling entry-point wrapper precedent)
- * @see #11642 (Phase 4D operator alerting), #11628 (Phase 4 epic)
  */
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate

--- a/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
+++ b/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
@@ -1,7 +1,7 @@
-// Class-only file (#11058-style split). Entry-point bootstrap (Neo + core/_export +
-// InstanceManager) lives in `ai/daemons/kb-gc/daemon.mjs` per the canonical Orchestrator
-// class+wrapper pattern. `Neo.setupClass(KbGarbageCollectionService)` at file bottom works
-// via `globalThis.Neo`, populated by the entry-point bootstrap chain.
+// Class-only daemon implementation. Entry-point bootstrap (Neo + core/_export +
+// InstanceManager) lives in `ai/daemons/kb-gc/daemon.mjs`, following the canonical
+// Orchestrator class+wrapper pattern. `Neo.setupClass(KbGarbageCollectionService)`
+// at file bottom uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
 import Base                        from '../../../src/core/Base.mjs';
 import {Memory_Config as aiConfig} from '../../services.mjs';
 import ChromaManager               from '../../services/knowledge-base/ChromaManager.mjs';
@@ -25,14 +25,14 @@ const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const ROWS_PAGE_SIZE = 2000;
 
 /**
- * @summary Phase 4C KB garbage-collection daemon — retention-policy chunk expiry (#11641).
+ * @summary KB garbage-collection daemon — retention-policy chunk expiry.
  *
- * Closes part of the Phase 4 operability loop: a cloud KB accretes chunks indefinitely
+ * Provides the retention leg of KB operability: a cloud KB accretes chunks indefinitely
  * unless a retention policy bounds them. This daemon periodically evaluates each tenant's
  * persisted Chroma chunks against an operator retention policy (time- and/or count-based,
- * keyed on the #11712 `ingestedAt` chunk stamp), emits Phase 4A telemetry, and — opt-in —
- * deletes the retention-expired chunks; when a tick's cumulative deletion is large it emits
- * a `defrag-recommended` signal.
+ * keyed on the chunk `ingestedAt` metadata stamp), emits KB ingestion telemetry, and —
+ * opt-in — deletes the retention-expired chunks; when a tick's cumulative deletion is large
+ * it emits a `defrag-recommended` signal.
  *
  * **Shape** — the canonical poll-loop daemon (the `KbReconciliationService` / `KbAlertingService`
  * precedent): a `Neo.core.Base` singleton with `start()` / `stop()` / `scheduleNext()` /
@@ -48,18 +48,18 @@ const ROWS_PAGE_SIZE = 2000;
  * daemon detects retention-expired chunks + emits telemetry only and issues no
  * `collection.delete`.
  *
- * **V1 scope** (per the #11641 Contract Ledger, ticket body): V1 = retention-policy chunk
- * expiration + a `defrag-recommended` signal. Config-orphan detection is #11640's domain;
- * a per-tenant retention override and the automated `ai:defrag-kb` spawn are V1.x-deferred.
- * V1 is purely additive — it touches no merged Phase 2 code (it reuses only the documented
- * `where: {tenantId}` Chroma read idiom).
+ * **Scope boundary** — this daemon owns retention-policy chunk expiration plus
+ * `defrag-recommended` telemetry. Config-orphan detection belongs to
+ * `KbReconciliationService`; per-tenant retention overrides and automatic `ai:defrag-kb`
+ * spawning are intentionally outside this daemon's current contract. The implementation is
+ * additive and reuses the documented `where: {tenantId}` Chroma read idiom.
  *
  * @class Neo.ai.daemons.KbGarbageCollectionService
  * @extends Neo.core.Base
  * @singleton
  * @see ai/daemons/kb-gc/daemon.mjs — the entry-point wrapper.
  * @see ai/services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs — the pure retention engine.
- * @see ai/daemons/kb-reconciliation/KbReconciliationService.mjs — the sibling Phase 4B poll-loop daemon precedent (#11640).
+ * @see ai/daemons/kb-reconciliation/KbReconciliationService.mjs — the sibling poll-loop daemon precedent.
  */
 class KbGarbageCollectionService extends Base {
     static config = {
@@ -263,9 +263,9 @@ class KbGarbageCollectionService extends Base {
     /**
      * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
      *
-     * Reads defensively: a stale gitignored `ai/config.mjs` predating #11641 lacks the `gc*`
-     * keys, so a naked `aiConfig.knowledgeBase.gcEnabled` would throw. Returns `{}` when the
-     * `knowledgeBase` key is absent.
+     * Reads defensively: a stale gitignored `ai/config.mjs` deployment may lack the `gc*`
+     * keys, so a naked `aiConfig.knowledgeBase.gcEnabled` would throw. Returns `{}` when
+     * the `knowledgeBase` key is absent.
      *
      * @returns {Object}
      * @protected
@@ -322,8 +322,8 @@ class KbGarbageCollectionService extends Base {
      * @summary Test-stubbable seam — fetches all of a tenant's Chroma rows, batched.
      *
      * Mirrors the batched `collection.get({where: {tenantId}})` idiom of
-     * `KnowledgeBaseIngestionService.getTenantRows`; kept local (rather than calling that
-     * `@protected` method) so V1 touches zero merged Phase 2 code.
+     * `KnowledgeBaseIngestionService.getTenantRows`; kept local rather than calling that
+     * `@protected` method so garbage collection remains additive to ingestion internals.
      *
      * @param {Object} collection The Chroma `knowledge-base` collection.
      * @param {String} tenantId
@@ -371,7 +371,7 @@ class KbGarbageCollectionService extends Base {
     }
 
     /**
-     * @summary Test-stubbable seam — emits one Phase 4A `tombstone` telemetry event.
+     * @summary Test-stubbable seam — emits one KB `tombstone` telemetry event.
      *
      * `recordIngestionMetric` is best-effort (never throws into the caller). A GC delete is
      * a `'tombstone'`-class event — the telemetry taxonomy has no dedicated `'gc'` type, so

--- a/ai/daemons/kb-gc/daemon.mjs
+++ b/ai/daemons/kb-gc/daemon.mjs
@@ -1,6 +1,6 @@
 /**
  * @module ai/daemons/kb-gc/daemon
- * @summary Thin Node-process boot wrapper for the Phase 4C KB garbage-collection daemon (#11641).
+ * @summary Thin Node-process boot wrapper for the KB garbage-collection daemon.
  *
  * Owns Neo namespace bootstrap + SIGTERM / SIGINT clean-stop signal handling +
  * `KbGarbageCollectionService.start()` invocation. The class definition (poll loop, tenant
@@ -18,7 +18,6 @@
  *
  * @see ai/daemons/kb-gc/KbGarbageCollectionService.mjs
  * @see ai/daemons/kb-reconciliation/daemon.mjs (sibling wrapper precedent)
- * @see #11641 (Phase 4C GC daemon), #11628 (Phase 4 epic)
  */
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate

--- a/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
+++ b/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
@@ -1,7 +1,7 @@
-// Class-only file (#11058-style split). Entry-point bootstrap (Neo + core/_export +
-// InstanceManager) lives in `ai/daemons/kb-reconciliation/daemon.mjs` per the canonical
-// Orchestrator class+wrapper pattern. `Neo.setupClass(KbReconciliationService)` at file
-// bottom works via `globalThis.Neo`, populated by the entry-point bootstrap chain.
+// Class-only daemon implementation. Entry-point bootstrap (Neo + core/_export +
+// InstanceManager) lives in `ai/daemons/kb-reconciliation/daemon.mjs`, following the
+// canonical Orchestrator class+wrapper pattern. `Neo.setupClass(KbReconciliationService)`
+// at file bottom uses `globalThis.Neo`, populated by the entry-point bootstrap chain.
 import Base                          from '../../../src/core/Base.mjs';
 import {Memory_Config as aiConfig}   from '../../services.mjs';
 import ChromaManager                 from '../../services/knowledge-base/ChromaManager.mjs';
@@ -28,14 +28,14 @@ const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
 const ROWS_PAGE_SIZE = 2000;
 
 /**
- * @summary Phase 4B KB reconciliation daemon — config-invalidation drift detection (#11640).
+ * @summary KB reconciliation daemon — config-invalidation drift detection.
  *
- * Closes part of the Phase 4 operability loop: when a tenant mutates its
+ * Provides the config-drift leg of KB operability: when a tenant mutates its
  * `KnowledgeBaseTenantConfig`, `getTenantConfig().version` increments and every chunk
- * ingested under the prior config is now *config-stale* (#11637 stamps each chunk's
- * `tenantConfigVersion`). This daemon periodically diffs each tenant's persisted Chroma
- * chunks against the tenant's current config version, emits Phase 4A reconciliation
- * telemetry, and — opt-in — tombstones the chunks left stale by a config change.
+ * ingested under the prior config is now *config-stale* via its `tenantConfigVersion`
+ * metadata. This daemon periodically diffs each tenant's persisted Chroma chunks against
+ * the tenant's current config version, emits reconciliation telemetry, and — opt-in —
+ * tombstones the chunks left stale by a config change.
  *
  * **Shape** — the canonical poll-loop daemon (the `SwarmHeartbeatService` / `KbAlertingService`
  * precedent): a `Neo.core.Base` singleton with `start()` / `stop()` / `scheduleNext()` /
@@ -52,18 +52,18 @@ const ROWS_PAGE_SIZE = 2000;
  * *second* opt-in (`reconciliationAutoTombstone`, default false): with it off, the daemon
  * detects + emits telemetry only and issues no `collection.delete`.
  *
- * **V1.x scope** (#11711): after V1 shipped the config-invalidation signal, ingestion now
- * persists claimed path manifests in `kb-manifest:<tenantId>`. This daemon reads those
- * manifests and runs a second pure diff pass so force-push / partial-push / hook-failure
- * leftovers become manifest orphans. Config-stale and manifest-orphan actionable ids are
- * unioned before the opt-in tombstone call.
+ * **Manifest reconciliation** — ingestion persists claimed path manifests in
+ * `kb-manifest:<tenantId>`. This daemon reads those manifests and runs a second pure diff
+ * pass so force-push, partial-push, or hook-failure leftovers become manifest orphans.
+ * Config-stale and manifest-orphan actionable ids are unioned before the opt-in tombstone
+ * call.
  *
  * @class Neo.ai.daemons.KbReconciliationService
  * @extends Neo.core.Base
  * @singleton
  * @see ai/daemons/kb-reconciliation/daemon.mjs — the entry-point wrapper.
  * @see ai/services/knowledge-base/helpers/KbReconciliationEngine.mjs — the pure diff engine.
- * @see ai/daemons/kb-alerting/KbAlertingService.mjs — the sibling Phase 4D poll-loop daemon precedent (#11642).
+ * @see ai/daemons/kb-alerting/KbAlertingService.mjs — the sibling poll-loop daemon precedent.
  */
 class KbReconciliationService extends Base {
     static config = {
@@ -247,8 +247,8 @@ class KbReconciliationService extends Base {
     /**
      * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
      *
-     * Reads defensively: a stale gitignored `ai/config.mjs` deployment predating #11640 has
-     * no `knowledgeBase` key (or lacks the reconciliation keys), so a naked
+     * Reads defensively: a stale gitignored `ai/config.mjs` deployment may have no
+     * `knowledgeBase` key (or lack the reconciliation keys), so a naked
      * `aiConfig.knowledgeBase.reconciliationEnabled` would throw. Returns `{}` when absent.
      *
      * @returns {Object}
@@ -292,7 +292,7 @@ class KbReconciliationService extends Base {
     }
 
     /**
-     * @summary Test-stubbable seam — resolves a tenant's current config version (#11637).
+     * @summary Test-stubbable seam — resolves a tenant's current config version.
      * @param {String} tenantId
      * @returns {Promise<Number>} `getTenantConfig().version`, or `0` on the yaml/default tier.
      * @protected
@@ -304,7 +304,7 @@ class KbReconciliationService extends Base {
     }
 
     /**
-     * @summary Test-stubbable seam — reads the persisted claimed-state manifests for a tenant (#11711).
+     * @summary Test-stubbable seam — reads the persisted claimed-state manifests for a tenant.
      * @param {String} tenantId
      * @returns {Promise<Object<String, {pathsAfterPush: Array<String>, updatedAt: Number}>>}
      * @protected
@@ -314,7 +314,7 @@ class KbReconciliationService extends Base {
     }
 
     /**
-     * @summary Combines config-stale and manifest-orphan diff axes into one delete/telemetry contract (#11711).
+     * @summary Combines config-stale and manifest-orphan diff axes into one delete/telemetry contract.
      * @param {Object} params
      * @param {Object} params.configDiff Result from `diffTenantChunks`.
      * @param {Object} params.manifestDiff Result from `diffTenantManifest`.
@@ -346,9 +346,8 @@ class KbReconciliationService extends Base {
      * @summary Test-stubbable seam — fetches all of a tenant's Chroma rows, batched.
      *
      * Mirrors the batched `collection.get({where: {tenantId}})` idiom of
-     * `KnowledgeBaseIngestionService.getTenantRows`; kept local (rather than calling that
-     * `@protected` method) so V1 touches zero merged Phase 2 code — the #11640 Contract
-     * Ledger's "purely additive" scope guarantee.
+     * `KnowledgeBaseIngestionService.getTenantRows`; kept local rather than calling that
+     * `@protected` method so reconciliation remains additive to ingestion internals.
      *
      * @param {Object} collection The Chroma `knowledge-base` collection.
      * @param {String} tenantId
@@ -396,12 +395,12 @@ class KbReconciliationService extends Base {
     }
 
     /**
-     * @summary Test-stubbable seam — emits one Phase 4A `reconcile` telemetry event.
+     * @summary Test-stubbable seam — emits one KB `reconcile` telemetry event.
      *
      * `recordIngestionMetric` is best-effort (it never throws into the caller); the
      * `reconcile` event type + the `chunksDeleted` / `reconcileEvents` rollup fields it
      * feeds are already first-class `KBRecorderService` / `KbAlertRuleEngine` surfaces, so
-     * an operator can alert on reconciliation drift via #11642 with no extra wiring.
+     * an operator can alert on reconciliation drift with no extra wiring.
      *
      * @param {Object}  params
      * @param {String}  params.tenantId

--- a/ai/daemons/kb-reconciliation/daemon.mjs
+++ b/ai/daemons/kb-reconciliation/daemon.mjs
@@ -1,6 +1,6 @@
 /**
  * @module ai/daemons/kb-reconciliation/daemon
- * @summary Thin Node-process boot wrapper for the Phase 4B KB reconciliation daemon (#11640).
+ * @summary Thin Node-process boot wrapper for the KB reconciliation daemon.
  *
  * Owns Neo namespace bootstrap + SIGTERM / SIGINT clean-stop signal handling +
  * `KbReconciliationService.start()` invocation. The class definition (poll loop, tenant
@@ -18,7 +18,6 @@
  *
  * @see ai/daemons/kb-reconciliation/KbReconciliationService.mjs
  * @see ai/daemons/kb-alerting/daemon.mjs (sibling wrapper precedent)
- * @see #11640 (Phase 4B reconciliation daemon), #11628 (Phase 4 epic)
  */
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate


### PR DESCRIPTION
Refs #11925
Related: #11912

Authored by GPT-5.5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.
FAIR-band: over-target [20/30] - taking this lane despite over-target because #11925 is already assigned to @neo-gpt, this is a narrow comment-only cleanup batch under the active source-comment archaeology epic, and the current under-target peer is already carrying review/author work.

This PR cleans the KB daemon slice of #11925 by rewriting ticket/phase/contract-ledger archaeology in the alerting, garbage-collection, and reconciliation daemon comments into stable daemon/operator contracts. Runtime code, config keys, command names, and operator-visible strings are left unchanged.

Evidence: L1 (comment-only diff, focused archaeology scan, diff hygiene, branch-history close-keyword check) -> L1 required (source-comment cleanup ACs; no runtime behavior ACs). Residual: script/config/residual cleanup remains on #11925.

## Deltas from Ticket

- Scoped this PR to the KB daemon batch only: `kb-alerting`, `kb-gc`, and `kb-reconciliation` entry wrappers plus their service classes.
- Left the existing `Webhook channel deferred to V1.5` runtime warning untouched as an intentional false positive because #11925 preserves operator-visible runtime strings.
- Kept #11925 open with `Refs` because this is a partial contribution, not the full daemon/script/config cleanup.

## Test Evidence

- `git diff --check` passed.
- `git diff --cached --check` passed.
- Focused archaeology scan over the touched KB daemon directories leaves one intentional false positive: the existing runtime warning string in `KbAlertingService.mjs`.
- `git log origin/dev..HEAD --format=%H%x09%s%n%b` shows one branch commit and no ticket-closing keyword body.
- Pre-push freshness passed: `merge-base HEAD origin/dev == origin/dev`.

## Post-Merge Validation

- [ ] Confirm #11925 remains open for the remaining daemon/script/config/residual cleanup batches.
- [ ] Parent #11912 remains open until all grouped cleanup subissues are complete.

## Commit

- 735cd3f52 - `chore(ai): clean KB daemon comments (#11925)`
