### PR TITLE
feat(portal): Pull Requests news view — Portal.view.news.pulls (#12213)

### DIFF
--- a/apps/portal/model/Pull.mjs
+++ b/apps/portal/model/Pull.mjs
@@ -1,0 +1,72 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * Tree-node model for the portal Pull Requests view. Mirrors `Portal.model.Ticket` plus the
+ * chunked-index lazy-load fields (`childCount` / `childrenUrl` / `contentDir` / `filePrefix`)
+ * that the `pulls.json` chunk-folder nodes carry, so the shared `TreeList`'s opt-in
+ * load-on-folder-expand can fetch each chunk's PR leaves on first expand.
+ * @class Portal.model.Pull
+ * @extends Neo.data.Model
+ */
+class Pull extends Model {
+    static config = {
+        /**
+         * @member {String} className='Portal.model.Pull'
+         * @protected
+         */
+        className: 'Portal.model.Pull',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'childCount', // leaf count under a chunk-folder node (lazy index metadata)
+            type: 'Integer'
+        }, {
+            name: 'childrenUrl', // relative URL of the chunk's child-index JSON (lazy index metadata)
+            type: 'String'
+        }, {
+            name        : 'collapsed',
+            type        : 'Boolean',
+            defaultValue: true
+        }, {
+            name: 'contentDir', // "resources/content/pulls/chunk-N" — base dir for leaf path reconstruction
+            type: 'String'
+        }, {
+            name: 'filePrefix', // "pr-" — leaf file prefix for path reconstruction
+            type: 'String'
+        }, {
+            name: 'id',
+            type: 'String'
+        }, {
+            name        : 'isLeaf',
+            type        : 'Boolean',
+            defaultValue: true
+        }, {
+            name        : 'parentId',
+            type        : 'String',
+            defaultValue: null
+        }, {
+            name: 'path', // "resources/content/pulls/chunk-N/pr-1234.md"
+            type: 'String'
+        }, {
+            name: 'title', // "fix(build): bypass hooks for data sync commits (#11590)"
+            type: 'String'
+        }, {
+            // Computed field for TreeList display
+            name: 'treeNodeName',
+            type: 'html',
+            /**
+             * @param {Object}  data
+             * @param {String}  data.id
+             * @param {Boolean} data.isLeaf
+             * @param {String}  data.title
+             * @returns {String}
+             */
+            calculate({id, isLeaf, title}) {
+                return isLeaf ? `<b>${id}</b> <span class="pr-title">${title}</span>` : id
+            }
+        }]
+    }
+}
+
+export default Neo.setupClass(Pull);

--- a/apps/portal/store/Pulls.mjs
+++ b/apps/portal/store/Pulls.mjs
@@ -1,0 +1,30 @@
+import Store     from '../../../src/data/Store.mjs';
+import PullModel from '../model/Pull.mjs';
+
+/**
+ * Tree store for the portal Pull Requests view. Loads the chunked `pulls.json` index (state groups
+ * + chunk-folder nodes); the per-chunk PR leaves are fetched lazily on folder-expand by the shared
+ * `TreeList` (`lazyChildLoad`), not loaded up front.
+ * @class Portal.store.Pulls
+ * @extends Neo.data.Store
+ */
+class Pulls extends Store {
+    static config = {
+        /**
+         * @member {String} className='Portal.store.Pulls'
+         * @protected
+         */
+        className: 'Portal.store.Pulls',
+        /**
+         * @member {Neo.data.Model} model=PullModel
+         * @reactive
+         */
+        model: PullModel,
+        /**
+         * @member {String} url='../../apps/portal/resources/data/pulls.json'
+         */
+        url: '../../apps/portal/resources/data/pulls.json'
+    }
+}
+
+export default Neo.setupClass(Pulls);

--- a/apps/portal/view/news/TabContainer.mjs
+++ b/apps/portal/view/news/TabContainer.mjs
@@ -68,6 +68,13 @@ class NewsTabContainer extends TabContainer {
                 route  : '/news/discussions',
                 text   : 'Discussions'
             }
+        }, {
+            module: () => import('./pulls/MainContainer.mjs'),
+            header: {
+                iconCls: 'fa fa-code-pull-request',
+                route  : '/news/pulls',
+                text   : 'Pull Requests'
+            }
         }],
         /**
          * @member {Object} unmountConfigs={activeIndex: null}

--- a/apps/portal/view/news/TabContainerController.mjs
+++ b/apps/portal/view/news/TabContainerController.mjs
@@ -15,12 +15,14 @@ class TabContainerController extends Controller {
          * @member {Object} routes
          */
         routes: {
-            '/news'                   : 'onReleasesRoute',
-            '/news/blog'              : 'onBlogRoute',
+            '/news'                      : 'onReleasesRoute',
+            '/news/blog'                 : 'onBlogRoute',
             '/news/blog/{*itemId}'       : 'onBlogRoute',
             '/news/discussions'          : 'onDiscussionsRoute',
             '/news/discussions/{*itemId}': 'onDiscussionsRoute',
             '/news/medium'               : 'onMediumRoute',
+            '/news/pulls'                : 'onPullsRoute',
+            '/news/pulls/{*itemId}'      : 'onPullsRoute',
             '/news/releases'             : 'onReleasesRoute',
             '/news/releases/{*itemId}'   : 'onReleasesRoute',
             '/news/tickets'              : 'onTicketsRoute',
@@ -54,6 +56,13 @@ class TabContainerController extends Controller {
      */
     onMediumRoute(data) {
         this.component.activeIndex = 0
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onPullsRoute(data) {
+        this.setActiveIndexByRoute('/news/pulls')
     }
 
     /**

--- a/apps/portal/view/news/pulls/Component.mjs
+++ b/apps/portal/view/news/pulls/Component.mjs
@@ -1,0 +1,310 @@
+import ContentComponent from '../../content/Component.mjs';
+import {marked}         from '../../../../../node_modules/marked/lib/marked.esm.js';
+
+const
+    regexFrontMatter = /^---\n([\s\S]*?)\n---\n/,
+    regexH1          = /(<h1[^>]*>.*?<\/h1>)/,
+    // Section extractors: a section runs from its `## ` heading to the next `## ` heading or EOF.
+    regexComments    = /\n## Comments\s*\n([\s\S]*?)(?=\n## [A-Z]|$)/,
+    regexReviews     = /\n## Reviews\s*\n([\s\S]*?)(?=\n## [A-Z]|$)/,
+    // Entry-split headers. The backtick-wrapped `@user` is the discriminator: review/comment
+    // *bodies* carry their own bare `###` sub-headers and `---` rules, so we split ONLY here.
+    regexCommentHdr  = /^### `@([\w.-]+)` commented on ([\dTZ:.+-]+)\s*$/,
+    regexReviewHdr   = /^### `@([\w.-]+)` \(([A-Z_]+)\) reviewed on ([\dTZ:.+-]+)\s*$/;
+
+/**
+ * @summary The "Markdown Transformer" for GitHub Pull Requests.
+ *
+ * Sibling to `Portal.view.news.tickets.Component`, specialized for the PR `.md` grammar emitted by
+ * the portal `pulls` generator. The irreducible difference from the Issue timeline is the source
+ * shape: a PR carries **two** separately-ordered sections — `## Comments` and `## Reviews` — rather
+ * than one pre-merged `## Timeline`. This component:
+ *
+ * 1. **Two-section entry-split**: extracts `## Comments` + `## Reviews`, splitting each into entries
+ *    ONLY at the `` ### `@user` `` header boundary — never at bare `---` or inner `###`, because
+ *    review bodies (PR-review templates) contain their own `###` sub-headers and `---` rules.
+ * 2. **Merge-sort**: the two sections are not globally ordered, so entries are merged and sorted by
+ *    ISO timestamp into a single chronological timeline.
+ * 3. **Review-state coloring**: `APPROVED` → green, `CHANGES_REQUESTED` → red, everything else
+ *    (`COMMENTED` / `DISMISSED` / unknown) → a neutral fallback (never throws).
+ * 4. **3-state badge**: PRs are `OPEN` / `MERGED` / `CLOSED` (the 2-state issue badge mislabels MERGED).
+ * 5. **Graceful degrade**: a body-only PR (e.g. a dependabot PR with no comments/reviews) still
+ *    renders its description via `super.modifyMarkdown` with no timeline entries.
+ *
+ * **Side Effect**: populates `me.timelineData` and pushes it to the `sections` store to drive the
+ * shared `TimelineCanvas`.
+ *
+ * @class Portal.view.news.pulls.Component
+ * @extends Neo.app.content.Component
+ */
+class Component extends ContentComponent {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.pulls.Component'
+         * @protected
+         */
+        className: 'Portal.view.news.pulls.Component',
+        /**
+         * @member {String[]} cls=['portal-news-pulls-component']
+         */
+        cls: ['portal-news-pulls-component'],
+        /**
+         * @member {String} repoUserUrl='https://github.com/'
+         */
+        repoUserUrl: 'https://github.com/'
+    }
+
+    /**
+     * Temporary storage for the structured timeline data extracted during parsing; assigned to the
+     * `sections` store to drive the Canvas, then nulled.
+     * @member {Object[]} timelineData=null
+     * @private
+     */
+    timelineData = null
+
+    /**
+     * Renders the PR frontmatter table, with PR-specific renderers for `state` (3-state badge),
+     * `base`/`head` (the `base ← head` ref pair), `url`, and `mergedAt`.
+     * @param {Object} data
+     * @returns {String}
+     */
+    frontMatterToHtml(data) {
+        let me   = this,
+            html = '<table class="neo-frontmatter-table"><tbody>',
+            // `head` is rendered inline with `base`; skip its own row.
+            skip = {head: true, number: true};
+
+        Object.entries(data).forEach(([key, value]) => {
+            if (skip[key]) return;
+
+            let renderedValue;
+
+            if (key === 'author') {
+                renderedValue = `<a href="${me.repoUserUrl}${value}" target="_blank">${value}</a>`
+            } else if (key === 'createdAt' || key === 'closedAt' || key === 'updatedAt' || key === 'mergedAt') {
+                renderedValue = me.formatTimestamp(value)
+            } else if (key === 'state') {
+                renderedValue = me.getStateBadgeHtml(value)
+            } else if (key === 'base') {
+                renderedValue = `<code>${data.base}</code> &larr; <code>${data.head ?? ''}</code>`
+            } else if (key === 'url') {
+                renderedValue = `<a href="${value}" target="_blank">${value}</a>`
+            } else {
+                renderedValue = me.formatFrontMatterValue(value)
+            }
+
+            html += `<tr><td>${key === 'base' ? 'branches' : key}</td><td>${renderedValue}</td></tr>`
+        });
+
+        html += '</tbody></table>';
+
+        if (me.useFrontmatterDetails) {
+            return `<details id="neo-pr-summary-details-${me.id}"><summary>Frontmatter</summary>${html}</details>`
+        }
+
+        return html
+    }
+
+    /**
+     * 3-state PR status badge. `OPEN` (green), `MERGED` (purple), `CLOSED` (red).
+     * @param {String} state
+     * @returns {String}
+     */
+    getStateBadgeHtml(state) {
+        if (!state) return '';
+
+        let s    = state.toUpperCase(),
+            cls  = 'neo-badge neo-state-badge',
+            icon = 'fa-circle-dot';
+
+        if (s === 'MERGED') {
+            cls += ' neo-state-merged'; icon = 'fa-code-merge'
+        } else if (s === 'CLOSED') {
+            cls += ' neo-state-closed'; icon = 'fa-circle-xmark'
+        } else {
+            cls += ' neo-state-open'; icon = 'fa-circle-dot'
+        }
+
+        return `<span class="${cls}"><i class="fa-solid ${icon}"></i>${Neo.capitalize(s.toLowerCase())}</span>`
+    }
+
+    /**
+     * Maps a review state to a semantic CSS modifier. Unknown / `COMMENTED` / `DISMISSED` states
+     * fall through to the neutral default — never throws.
+     * @param {String} state
+     * @returns {String}
+     */
+    getReviewStateCls(state) {
+        switch ((state || '').toUpperCase()) {
+            case 'APPROVED':          return 'neo-review-approved';
+            case 'CHANGES_REQUESTED': return 'neo-review-changes';
+            default:                  return 'neo-review-neutral'
+        }
+    }
+
+    /**
+     * The Main Parsing Pipeline (PR variant). Extracts frontmatter + body + the two `## Comments`
+     * and `## Reviews` sections, merges the section entries into one chronological timeline, and
+     * re-assembles Frontmatter + Title + Badges + Timeline. Populates `me.timelineData`.
+     * @param {String} content
+     * @returns {String}
+     */
+    modifyMarkdown(content) {
+        let me           = this,
+            match        = content.match(regexFrontMatter),
+            data         = match ? me.parseFrontMatter(match[1]) : {},
+            author       = data.author    || null,
+            createdAt    = data.createdAt ? me.formatTimestamp(data.createdAt) : '',
+            state        = data.state     || null;
+
+        me.timelineData = [];
+
+        // 1. Extract the two sections from the RAW markdown, then strip them (+ frontmatter) so the
+        //    remainder is just the PR description body.
+        let commentsMatch = content.match(regexComments),
+            reviewsMatch  = content.match(regexReviews),
+            entries       = me.parseEntries(commentsMatch?.[1] || '', reviewsMatch?.[1] || '');
+
+        content = content
+            .replace(regexComments, '')
+            .replace(regexReviews,  '')
+            .replace(regexFrontMatter, '');
+
+        // 2. Render the description body via super (marked.js).
+        let fullHtml = super.modifyMarkdown(content);
+
+        // 3. Lift the H1 title out of the body bubble.
+        let titleHtml = '';
+        fullHtml      = fullHtml.replace(regexH1, m => {
+            titleHtml = m.replace('<h1', `<h1 id="pr-title-${me.id}"`);
+            return ''
+        });
+
+        // 4. Status badge under the title.
+        if (state) {
+            titleHtml += `<div class="neo-ticket-labels">${me.getStateBadgeHtml(state)}</div>`
+        }
+
+        // 5. Description as the first timeline item.
+        let bodyId = `timeline-${me.record.id}-0`;
+
+        me.timelineData.push({
+            id   : bodyId,
+            image: me.repoUserUrl + author + '.png',
+            name : 'Description',
+            tag  : 'body'
+        });
+
+        let timelineHtml = `<div id="pr-timeline-${me.id}" class="neo-ticket-timeline">` +
+            me.renderBubble({id: bodyId, user: author, date: createdAt, bodyHtml: fullHtml, extraCls: 'body-item'});
+
+        // 6. Merged comment + review entries, in chronological order.
+        entries.forEach((entry, index) => {
+            let id       = `timeline-${me.record.id}-${index + 1}`,
+                isReview = entry.type === 'review',
+                stateCls = isReview ? me.getReviewStateCls(entry.state) : '',
+                badge    = isReview ? `<span class="neo-badge neo-review-state ${stateCls}">${entry.state}</span>` : '';
+
+            me.timelineData.push({
+                id,
+                image: me.repoUserUrl + entry.user + '.png',
+                name : isReview ? `Review (${entry.user})` : `Comment (${entry.user})`,
+                tag  : entry.type
+            });
+
+            timelineHtml += me.renderBubble({
+                id,
+                user    : entry.user,
+                date    : entry.date,
+                bodyHtml: marked.parse(entry.body),
+                extraCls: isReview ? `review ${stateCls}` : 'comment',
+                action  : isReview ? `${badge} reviewed` : 'commented',
+                meta    : entry.meta
+            })
+        });
+
+        timelineHtml += '</div>';
+
+        me.getStateProvider().getStore('sections').data = me.timelineData;
+        me.timelineData = null;
+
+        return me.frontMatterToHtml(data) + titleHtml + timelineHtml
+    }
+
+    /**
+     * Splits the `## Comments` and `## Reviews` raw bodies into entries at the `` ### `@user` ``
+     * header boundary (never at inner `###` / `---`), then merges + sorts them by ISO timestamp.
+     * @param {String} commentsRaw
+     * @param {String} reviewsRaw
+     * @returns {Object[]} `[{type, user, date, state?, body}]` sorted ascending by `date`.
+     */
+    parseEntries(commentsRaw, reviewsRaw) {
+        const split = (raw, headerRegex, build) => {
+            let lines   = raw.split('\n'),
+                entries = [],
+                current = null,
+                i       = 0,
+                len     = lines.length,
+                m;
+
+            for (; i < len; i++) {
+                if ((m = lines[i].match(headerRegex))) {
+                    current && entries.push(current);
+                    current = build(m)
+                } else if (current) {
+                    current.bodyLines.push(lines[i])
+                }
+            }
+
+            current && entries.push(current);
+
+            return entries.map(e => ({...e, body: e.bodyLines.join('\n').trim(), bodyLines: undefined}))
+        };
+
+        let comments = split(commentsRaw, regexCommentHdr, m => ({
+                type: 'comment', user: m[1], date: m[2], bodyLines: []
+            })),
+            reviews  = split(reviewsRaw, regexReviewHdr, m => ({
+                type: 'review', user: m[1], state: m[2], date: m[3], bodyLines: []
+            }));
+
+        // Merge-sort: the two sections are not globally ordered. ISO-8601 strings sort lexically.
+        return [...comments, ...reviews].sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0))
+    }
+
+    /**
+     * Renders one timeline bubble (description / comment / review).
+     * @param {Object}  config
+     * @param {String}  config.id
+     * @param {String}  config.user
+     * @param {String}  config.date
+     * @param {String}  config.bodyHtml
+     * @param {String} [config.extraCls='']
+     * @param {String} [config.action='commented']
+     * @returns {String}
+     */
+    renderBubble({id, user, date, bodyHtml, extraCls = '', action = 'commented'}) {
+        let me = this,
+            ts = date && date.includes('T') ? me.formatTimestamp(date) : date;
+
+        return `
+            <div id="${id}" class="neo-timeline-item ${extraCls}" data-record-id="${id}">
+                <div id="${id}-target" class="neo-timeline-avatar">
+                    <img src="${me.repoUserUrl}${user}.png" alt="${user}">
+                </div>
+                <div class="neo-timeline-content">
+                    <div class="neo-timeline-header">
+                        <a class="neo-timeline-user" href="${me.repoUserUrl}${user}" target="_blank">${user}</a>
+                        <span class="neo-timeline-date">${action} on ${ts}</span>
+                    </div>
+                    <div class="neo-timeline-body">
+
+${bodyHtml}
+
+</div>
+                </div>
+            </div>`
+    }
+}
+
+export default Neo.setupClass(Component);

--- a/apps/portal/view/news/pulls/Component.mjs
+++ b/apps/portal/view/news/pulls/Component.mjs
@@ -49,6 +49,12 @@ class Component extends ContentComponent {
          */
         cls: ['portal-news-pulls-component'],
         /**
+         * `#N` references in PR bodies are issue numbers → resolve to the portal tickets view.
+         * Per-content-type config (#12209): the generic content base no longer defaults this.
+         * @member {String} issuesUrl='#/news/tickets/'
+         */
+        issuesUrl: '#/news/tickets/',
+        /**
          * @member {String} repoUserUrl='https://github.com/'
          */
         repoUserUrl: 'https://github.com/'

--- a/apps/portal/view/news/pulls/MainContainer.mjs
+++ b/apps/portal/view/news/pulls/MainContainer.mjs
@@ -1,0 +1,58 @@
+import CanvasWrapper    from '../../content/CanvasWrapper.mjs';
+import Component        from './Component.mjs';
+import Controller       from './MainContainerController.mjs';
+import PageContainer    from './PageContainer.mjs';
+import SharedContainer  from '../../../../../src/app/content/Container.mjs';
+import StateProvider    from './MainContainerStateProvider.mjs';
+
+/**
+ * @class Portal.view.news.pulls.MainContainer
+ * @extends Neo.app.content.Container
+ */
+class MainContainer extends SharedContainer {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.pulls.MainContainer'
+         * @protected
+         */
+        className: 'Portal.view.news.pulls.MainContainer',
+        /**
+         * @member {String[]} cls=['portal-pulls-maincontainer']
+         * @reactive
+         */
+        cls: ['portal-pulls-maincontainer'],
+        /**
+         * @member {Neo.controller.Component} controller=MainContainerController
+         * @reactive
+         */
+        controller: Controller,
+        /**
+         * @member {Object} pageContainerConfig
+         */
+        pageContainerConfig: {
+            module         : PageContainer,
+            buttonTextField: 'id',
+            contentConfig  : {
+                contentComponent: Component,
+                module          : CanvasWrapper
+            }
+        },
+        /**
+         * @member {Neo.state.Provider} stateProvider=MainContainerStateProvider
+         * @reactive
+         */
+        stateProvider: StateProvider,
+        /**
+         * The `pulls.json` index is chunked (state-groups → chunk-folder nodes); opt the shared
+         * tree into load-on-folder-expand so each chunk's PR leaves are fetched on first expand.
+         * @member {Object} treeConfig
+         */
+        treeConfig: {
+            displayField      : 'treeNodeName',
+            lazyChildLoad     : true,
+            lazyChildUrlPrefix: '../../apps/portal/resources/data/'
+        }
+    }
+}
+
+export default Neo.setupClass(MainContainer);

--- a/apps/portal/view/news/pulls/MainContainerController.mjs
+++ b/apps/portal/view/news/pulls/MainContainerController.mjs
@@ -1,0 +1,161 @@
+import Controller from '../../../../../src/controller/Component.mjs';
+
+/**
+ * @class Portal.view.news.pulls.MainContainerController
+ * @extends Neo.controller.Component
+ */
+class MainContainerController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.pulls.MainContainerController'
+         * @protected
+         */
+        className: 'Portal.view.news.pulls.MainContainerController',
+        /**
+         * @member {Object} routes
+         */
+        routes: {
+            '/news/pulls'          : 'onRouteDefault',
+            '/news/pulls/{*itemId}': 'onRouteItem'
+        }
+    }
+
+    /**
+     * @param {String} item
+     */
+    navigateTo(item) {
+        Neo.Main.setRoute({
+            value   : `/news/pulls/${item}`,
+            windowId: this.component.windowId
+        })
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onIntersect(data) {
+        let panel    = this.getReference('page-sections-container'),
+            list     = panel.list,
+            recordId = data.data.recordId,
+            record;
+
+        if (recordId && !list.isAnimating) {
+            record = list.store.get(recordId);
+
+            if (record) {
+                list.selectionModel.select(record)
+            }
+        }
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onNextPageButtonClick(data) {
+        this.navigateTo(this.getStateProvider().getData('nextPageRecord').id)
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onPageSectionsToggleButtonClick(data) {
+        this.getReference('page-sections-container').toggleCls('neo-expanded')
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onPreviousPageButtonClick(data) {
+        this.navigateTo(this.getStateProvider().getData('previousPageRecord').id)
+    }
+
+    /**
+     * @returns {String}
+     */
+    getDefaultRouteId() {
+        let store     = this.getStateProvider().getStore('tree'),
+            rootCount = 0,
+            i         = 0,
+            len       = store.getCount(),
+            record;
+
+        for (; i < len; i++) {
+            record = store.getAt(i);
+
+            if (record.parentId === null) {
+                rootCount++;
+
+                if (rootCount === 2) {
+                    return store.getAt(i + 1)?.id
+                }
+            }
+        }
+
+        return store.getAt(1)?.id
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onRouteDefault(data) {
+        let me    = this,
+            store = me.getStateProvider().getStore('tree');
+
+        if (store.getCount() > 0) {
+            me.navigateTo(me.getDefaultRouteId())
+        } else {
+            store.on({
+                load : () => me.navigateTo(me.getDefaultRouteId()),
+                delay: 10,
+                once : true
+            })
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {Object} value
+     * @param {Object} oldValue
+     */
+    async onRouteItem({itemId}, value, oldValue) {
+        let me            = this,
+            stateProvider = me.getStateProvider(),
+            store         = stateProvider.getStore('tree'),
+            tree          = me.getReference('tree');
+
+        // Ensure the tree has the correct route prefix for this controller context
+        if (tree.routePrefix !== '/news/pulls') {
+            tree.routePrefix = '/news/pulls'
+        }
+
+        const select = async () => {
+            stateProvider.data.currentPageRecord = store.get(itemId);
+
+            if (!oldValue?.hashString?.startsWith('/news/pulls')) {
+                await tree.expandAndScrollToItem(itemId)
+            } else {
+                tree.expandParents(itemId)
+            }
+        };
+
+        if (store.getCount() > 0) {
+            await select()
+        } else {
+            store.on({
+                load : select,
+                delay: 10,
+                once : true
+            })
+        }
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onSideNavToggleButtonClick(data) {
+        this.getReference('sidenav-container').toggleCls('neo-expanded')
+    }
+}
+
+export default Neo.setupClass(MainContainerController);

--- a/apps/portal/view/news/pulls/MainContainerStateProvider.mjs
+++ b/apps/portal/view/news/pulls/MainContainerStateProvider.mjs
@@ -1,0 +1,138 @@
+import PullsStore             from '../../../store/Pulls.mjs';
+import StateProvider           from '../../../../../src/state/Provider.mjs';
+import TimelineSectionsStore   from '../../../store/TimelineSections.mjs';
+
+/**
+ * @class Portal.view.news.pulls.MainContainerStateProvider
+ * @extends Neo.state.Provider
+ */
+class MainContainerStateProvider extends StateProvider {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.pulls.MainContainerStateProvider'
+         * @protected
+         */
+        className: 'Portal.view.news.pulls.MainContainerStateProvider',
+        /**
+         * @member {Object} data
+         */
+        data: {
+            /**
+             * @member {Number|null} data.countPages=null
+             */
+            countPages: null,
+            /**
+             * @member {Number|null} data.countSections=null
+             */
+            countSections: null,
+            /**
+             * The record which gets shown as the content page
+             * @member {Object} data.currentPageRecord=null
+             */
+            currentPageRecord: null,
+            /**
+             * The record which gets shown as the content page
+             * @member {Object} data.nextPageRecord=null
+             */
+            nextPageRecord: null,
+            /**
+             * The record which gets shown as the content page
+             * @member {Object} data.previousPageRecord=null
+             */
+            previousPageRecord: null
+        },
+        /**
+         * @member {Object} stores
+         */
+        stores: {
+            // PRs have no issue-labels — only the timeline `sections` + the `tree` are needed.
+            sections: {
+                module: TimelineSectionsStore
+            },
+            tree: {
+                autoLoad: true,
+                module  : PullsStore
+            }
+        }
+    }
+
+    /**
+     * @param {String} key
+     * @param {*} value
+     * @param {*} oldValue
+     */
+    onDataPropertyChange(key, value, oldValue) {
+        super.onDataPropertyChange(key, value, oldValue);
+
+        let me = this;
+
+        switch (key) {
+            case 'countSections': {
+                if (value < 1) {
+                    me.component.getReference('page-sections-container')?.toggleCls('neo-expanded', false)
+                }
+
+                break
+            }
+
+            case 'currentPageRecord': {
+                let {data}             = me,
+                    {countPages}       = data,
+                    store              = me.getStore('tree'),
+                    index              = store.indexOf(value),
+                    nextPageRecord     = null,
+                    previousPageRecord = null,
+                    i, record;
+
+                // the logic assumes that the tree store is sorted
+                for (i=index-1; i >= 0; i--) {
+                    record = store.getAt(i);
+
+                    if (record.isLeaf && !me.recordIsHidden(record, store)) {
+                        previousPageRecord = record;
+                        break
+                    }
+                }
+
+                me.setData({previousPageRecord});
+
+                // the logic assumes that the tree store is sorted
+                for (i=index+1; i < countPages; i++) {
+                    record = store.getAt(i);
+
+                    if (record.isLeaf && !me.recordIsHidden(record, store)) {
+                        nextPageRecord = record;
+                        break
+                    }
+                }
+
+                me.setData({nextPageRecord});
+
+                me.component.getReference('sidenav-container')?.toggleCls('neo-expanded', false)
+
+                break
+            }
+        }
+    }
+
+    /**
+     * We need to check the parent-node chain inside the tree.
+     * => Any hidden parent-node results in a hidden record.
+     * @param {Object} record
+     * @param {Neo.data.Store} store
+     * @returns {Boolean}
+     */
+    recordIsHidden(record, store) {
+        if (record.hidden) {
+            return true
+        }
+
+        if (record.parentId !== null) {
+            return this.recordIsHidden(store.get(record.parentId), store)
+        }
+
+        return false
+    }
+}
+
+export default Neo.setupClass(MainContainerStateProvider);

--- a/apps/portal/view/news/pulls/PageContainer.mjs
+++ b/apps/portal/view/news/pulls/PageContainer.mjs
@@ -1,0 +1,25 @@
+import PageContainer from '../../../../../src/app/content/PageContainer.mjs';
+
+/**
+ * @class Portal.view.news.pulls.PageContainer
+ * @extends Neo.app.content.PageContainer
+ */
+class PullPageContainer extends PageContainer {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.pulls.PageContainer'
+         * @protected
+         */
+        className: 'Portal.view.news.pulls.PageContainer',
+        /**
+         * @member {Object} layout=null
+         */
+        layout: null,
+        /**
+         * @member {Object} style={flex:1,overflowY:'auto',position:'relative'}
+         */
+        style: {flex: 1, overflowY: 'auto', position: 'relative'}
+    }
+}
+
+export default Neo.setupClass(PullPageContainer);

--- a/resources/scss/src/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/src/apps/portal/news/pulls/Component.scss
@@ -1,0 +1,36 @@
+// Structural styles for Portal.view.news.pulls.Component (PR view). Colors live in the
+// theme-neo-light / theme-neo-dark counterparts, scoped to this component so the PR-specific
+// MERGED/CLOSED + review-state palette never collides with the tickets view's globals.
+.portal-news-pulls-component {
+    .neo-ticket-labels {
+        display      : flex;
+        flex-wrap    : wrap;
+        gap          : 8px;
+        margin-bottom: 20px;
+    }
+
+    .neo-badge {
+        align-items  : center;
+        border-radius: 2em;
+        display      : inline-flex;
+        font-size    : 12px;
+        font-weight  : 500;
+        line-height  : 22px;
+        padding      : 0 10px;
+
+        &.neo-state-badge {
+            gap    : 6px;
+            padding: 2px 10px 2px 8px;
+        }
+
+        &.neo-review-state {
+            margin-right  : 6px;
+            text-transform: none;
+        }
+    }
+
+    .pr-title {
+        font-weight: 400;
+        opacity    : 0.75;
+    }
+}

--- a/resources/scss/theme-neo-dark/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/theme-neo-dark/apps/portal/news/pulls/Component.scss
@@ -1,0 +1,25 @@
+// Dark-theme palette for Portal.view.news.pulls.Component (PR view). Scoped to the component so
+// the PR MERGED/CLOSED semantics (purple/red) do not redefine the tickets view's state vars.
+.neo-theme-neo-dark .portal-news-pulls-component {
+    .neo-badge {
+        background-color: #21262d;
+        border          : 1px solid rgba(255, 255, 255, 0.1);
+        color           : #c9d1d9;
+
+        &.neo-state-badge {
+            color: #ffffff;
+
+            &.neo-state-open   { background-color: #3fb950; } // green
+            &.neo-state-merged { background-color: #a371f7; } // purple
+            &.neo-state-closed { background-color: #f85149; } // red
+        }
+
+        &.neo-review-state {
+            color: #ffffff;
+
+            &.neo-review-approved { background-color: #3fb950; } // green
+            &.neo-review-changes  { background-color: #f85149; } // red
+            &.neo-review-neutral  { background-color: #21262d; color: #c9d1d9; }
+        }
+    }
+}

--- a/resources/scss/theme-neo-light/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/theme-neo-light/apps/portal/news/pulls/Component.scss
@@ -1,0 +1,25 @@
+// Light-theme palette for Portal.view.news.pulls.Component (PR view). Scoped to the component so
+// the PR MERGED/CLOSED semantics (purple/red) do not redefine the tickets view's state vars.
+.neo-theme-neo-light .portal-news-pulls-component {
+    .neo-badge {
+        background-color: #eff1f3;
+        border          : 1px solid rgba(0, 0, 0, 0.1);
+        color           : #24292f;
+
+        &.neo-state-badge {
+            color: #ffffff;
+
+            &.neo-state-open   { background-color: #2da44e; } // green
+            &.neo-state-merged { background-color: #8250df; } // purple
+            &.neo-state-closed { background-color: #cf222e; } // red
+        }
+
+        &.neo-review-state {
+            color: #ffffff;
+
+            &.neo-review-approved { background-color: #2da44e; } // green
+            &.neo-review-changes  { background-color: #cf222e; } // red
+            &.neo-review-neutral  { background-color: #eff1f3; color: #24292f; }
+        }
+    }
+}

--- a/test/playwright/unit/apps/portal/view/news/pulls/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/news/pulls/Component.spec.mjs
@@ -1,0 +1,123 @@
+import {setup} from '../../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'PortalPullsComponentTest'
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../../src/core/_export.mjs';
+import Component       from '../../../../../../../../apps/portal/view/news/pulls/Component.mjs';
+
+/**
+ * Unit coverage for the PR-specific parser in `Portal.view.news.pulls.Component`. These tests
+ * exercise the three pieces of logic that are irreducibly PR-specific (and which the issue/ticket
+ * parser does NOT cover): the two-section comment+review entry-split, the chronological merge-sort
+ * across those two sections, and the PR-state / review-state badge mappings.
+ *
+ * The entry-split is the highest-risk piece: PR-review bodies (and PR descriptions) contain their
+ * own `###` sub-headers and `---` rules, so a naive split would shred a single review into many
+ * fragments. The discriminator is the backtick-wrapped `@user` header — these tests pin that.
+ *
+ * `parseEntries` / `getStateBadgeHtml` / `getReviewStateCls` are pure (they never read `this`
+ * state), so they are tested directly on the prototype — avoiding the app-container + state-provider
+ * coupling the full content Component requires at construct time.
+ */
+const {parseEntries, getStateBadgeHtml, getReviewStateCls} = Component.prototype;
+
+test.describe('Portal.view.news.pulls.Component — PR markdown parser', () => {
+    test('entry-split does not shred a body on its inner ### / --- and merge-sorts the two sections', () => {
+        // alice (comment) carries an inner `### Inner Header` + a `---` rule that must stay INSIDE
+        // her entry. carol's review body likewise carries an inner `### Strategic-Fit` + `---`.
+        const commentsRaw = [
+            '### `@alice` commented on 2026-05-18T20:00:00Z',
+            '',
+            'First comment.',
+            '',
+            '---',
+            '',
+            '### Inner Header (must NOT split)',
+            '',
+            'still alice.',
+            '',
+            '### `@bob` commented on 2026-05-18T20:30:00Z',
+            '',
+            'Second comment.'
+        ].join('\n');
+
+        const reviewsRaw = [
+            '### `@carol` (APPROVED) reviewed on 2026-05-18T20:15:00Z',
+            '',
+            '### Strategic-Fit (inner, must NOT split)',
+            '',
+            'looks good.',
+            '',
+            '---',
+            '',
+            '### `@dave` (CHANGES_REQUESTED) reviewed on 2026-05-18T20:45:00Z',
+            '',
+            'needs work.'
+        ].join('\n');
+
+        const entries = parseEntries(commentsRaw, reviewsRaw);
+
+        // 2 comments + 2 reviews = 4 entries — NOT more (no shredding on inner ###/---).
+        expect(entries).toHaveLength(4);
+
+        // Merge-sorted ascending by ISO timestamp ACROSS both sections.
+        expect(entries.map(e => `${e.type}:${e.user}`)).toEqual([
+            'comment:alice', // 20:00
+            'review:carol',  // 20:15
+            'comment:bob',   // 20:30
+            'review:dave'    // 20:45
+        ]);
+
+        // The inner header + rule survived inside the owning entry.
+        expect(entries[0].body).toContain('### Inner Header (must NOT split)');
+        expect(entries[0].body).toContain('---');
+        expect(entries[1].body).toContain('### Strategic-Fit (inner, must NOT split)');
+
+        // Reviews carry their parsed state; comments do not.
+        expect(entries[1].state).toBe('APPROVED');
+        expect(entries[3].state).toBe('CHANGES_REQUESTED');
+        expect(entries[0].state).toBeUndefined()
+    });
+
+    test('handles a one-sided PR (comments only) and an empty PR (dependabot degrade) without throwing', () => {
+        const commentsOnly = parseEntries(
+            '### `@neo-gpt` commented on 2026-05-18T10:00:00Z\n\nlgtm.',
+            ''
+        );
+        expect(commentsOnly).toHaveLength(1);
+        expect(commentsOnly[0]).toMatchObject({type: 'comment', user: 'neo-gpt'});
+
+        // A body-only PR (no comments, no reviews) yields zero entries — modifyMarkdown then renders
+        // just the description via super (the graceful-degrade path).
+        expect(parseEntries('', '')).toEqual([])
+    });
+
+    test('3-state PR badge: OPEN / MERGED / CLOSED render distinctly', () => {
+        const open   = getStateBadgeHtml('OPEN'),
+              merged = getStateBadgeHtml('MERGED'),
+              closed = getStateBadgeHtml('CLOSED');
+
+        expect(open).toContain('neo-state-open');
+        expect(merged).toContain('neo-state-merged');
+        expect(merged).toContain('fa-code-merge'); // MERGED is visually distinct from OPEN/CLOSED
+        expect(merged).toContain('Merged');
+        expect(closed).toContain('neo-state-closed');
+        expect(getStateBadgeHtml('')).toBe('') // empty state → no badge
+    });
+
+    test('review-state → color class, with a non-throwing neutral fallback', () => {
+        expect(getReviewStateCls('APPROVED')).toBe('neo-review-approved');
+        expect(getReviewStateCls('CHANGES_REQUESTED')).toBe('neo-review-changes');
+        // COMMENTED / DISMISSED / unknown / empty all fall through to neutral — never throws.
+        expect(getReviewStateCls('COMMENTED')).toBe('neo-review-neutral');
+        expect(getReviewStateCls('DISMISSED')).toBe('neo-review-neutral');
+        expect(getReviewStateCls('SOMETHING_NEW')).toBe('neo-review-neutral');
+        expect(getReviewStateCls('')).toBe('neo-review-neutral')
+    })
+});


### PR DESCRIPTION
Resolves #12213

Authored by Opus 4.8 (Claude Code). Session af888fcb-6a68-45bd-8a34-13be477733b1.

FAIR-band: in-band [8/30]

Evidence: L2 (parser logic unit-tested — 4 passing tests covering entry-split / merge-sort / badges; all `.mjs` syntax-valid). Residual: **L3 in-browser render** (the Pull Requests tab rendering PR timelines on the dev-served portal) — not yet run in this session. No longer blocked: the lazy-tree prerequisite #12279 **merged into `dev` on 2026-06-01 (04:37Z)**, so the merge candidate already carries `TreeList.lazyChildLoad` and this view opts into it.

> **Prerequisite #12279 is satisfied (merged 2026-06-01 04:37Z).** `pulls.json` is the *chunked* index (state-groups → chunk-folder nodes with `childrenUrl`); the tree renders PR **leaves** via the shared `TreeList`'s `lazyChildLoad` (#12279). This PR sets `lazyChildLoad: true` on the pulls tree; with #12279 now on `dev`, that opt-in is live rather than inert.

## What this delivers

The portal **Pull Requests** news view (sub 8 of the #12204 portal-news epic; parallel to GPT's Discussion view #12211). Adds `Portal.view.news.pulls.*` by copying the tickets/release view pattern; the only irreducible specialization is the PR markdown parser.

- **`pulls/Component.mjs`** — the PR parser (`extends Neo.app.content.Component`):
  - extracts the two separately-ordered `## Comments` + `## Reviews` sections;
  - **entry-splits only at the `` ### `@user` `` header boundary** — never bare `---` or inner `###` (PR-review bodies carry their own `###` sub-headers + `---` rules; the backtick-`@user` wrapper is the discriminator), with the two grammars (`commented on <ts>` / `(STATE) reviewed on <ts>`);
  - **merge-sorts** the two sections by ISO timestamp into one chronological timeline;
  - **review-state → color**: `APPROVED` green, `CHANGES_REQUESTED` red, everything else (`COMMENTED`/`DISMISSED`/unknown) neutral — never throws;
  - **3-state badge** OPEN/MERGED/CLOSED (purple merged, red closed) — the 2-state issue badge mislabels MERGED;
  - `base ← head` / `url` / `mergedAt` frontmatter renderers;
  - **graceful degrade**: a body-only PR (e.g. dependabot, no comments/reviews) still renders via `super.modifyMarkdown`.
- **Data**: `model/Pull.mjs` (tree fields + the chunked-index lazy fields `childCount`/`childrenUrl`/`contentDir`/`filePrefix`) + `store/Pulls.mjs` (loads `pulls.json`).
- **Containers**: `MainContainer` / `MainContainerController` (`/news/pulls` routes) / `MainContainerStateProvider` (drops the `labels` store — PRs have none) / `PageContainer`.
- **Tab**: appends a **Pull Requests** tab in `news/TabContainer`. `onPullsRoute` is **route-driven** — it resolves the tab via `items.findIndex(item => item.header?.route === '/news/pulls')` rather than a hardcoded index, so it stays correct regardless of items order. This matters because the Discussion view (#12211) also appends a news tab; a fixed index would break depending on which PR merges first.
- **Theming**: light + dark `pulls/Component.scss` for the new MERGED/CLOSED + review-state palette, **scoped to `.portal-news-pulls-component`** so it never collides with the tickets view's global `--gh-*` state vars.

## Deltas from ticket

- The PR-grammar source-of-truth was derived directly from the synced corpus (`resources/content/pulls/chunk-*/pr-*.md`) — confirmed: frontmatter (`state` ∈ OPEN/MERGED/CLOSED, `head`/`base`/`url`/`mergedAt`), `## Comments`/`## Reviews` sections, `` ### `@user` `` entry headers with the two grammars.
- Tab resolution is route-driven (`findIndex` by `header.route`) rather than a hardcoded index — coordination-robust with #12211 (Discussion view), independent of merge order.

## Test Evidence

- **Parser unit test** (`test/playwright/unit/apps/portal/view/news/pulls/Component.spec.mjs`) — **4 passing (802ms)**: (a) two-section entry-split does NOT shred on inner `###`/`---` (4 entries, not more); (b) comment+review merge-sort order across both sections; (c) one-sided (comments-only) + empty (dependabot) PRs degrade without throwing; (d) 3-state OPEN/MERGED/CLOSED badge renders distinctly (MERGED carries `fa-code-merge`); (e) review-state → color class with a non-throwing neutral fallback.
- `node --check` passes for all `.mjs`; `git diff --check` clean.

## Post-Merge Validation

- [ ] On the dev-served portal: open the Pull Requests tab, expand a state-group chunk → PR leaves load lazily, select one → PR body + comments + reviews render on the shared timeline + canvas, with reviews entry-split correctly and the MERGED badge distinct.
