### PR TITLE
feat(portal): add discussion news view (#12211)

### DIFF
--- a/apps/portal/model/Discussion.mjs
+++ b/apps/portal/model/Discussion.mjs
@@ -1,0 +1,67 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * @class Portal.model.Discussion
+ * @extends Neo.data.Model
+ */
+class Discussion extends Model {
+    static config = {
+        /**
+         * @member {String} className='Portal.model.Discussion'
+         * @protected
+         */
+        className: 'Portal.model.Discussion',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'childCount',
+            type: 'Integer'
+        }, {
+            name: 'childrenUrl',
+            type: 'String'
+        }, {
+            name        : 'collapsed',
+            type        : 'Boolean',
+            defaultValue: true
+        }, {
+            name: 'contentDir',
+            type: 'String'
+        }, {
+            name: 'filePrefix',
+            type: 'String'
+        }, {
+            name: 'id',
+            type: 'String'
+        }, {
+            name        : 'isLeaf',
+            type        : 'Boolean',
+            defaultValue: true
+        }, {
+            name        : 'parentId',
+            type        : 'String',
+            defaultValue: null
+        }, {
+            name: 'path',
+            type: 'String'
+        }, {
+            name: 'title',
+            type: 'String'
+        }, {
+            name: 'treeNodeName',
+            type: 'html',
+            /**
+             * @param {Object}  data
+             * @param {String}  data.id
+             * @param {Boolean} data.isLeaf
+             * @param {String}  data.title
+             * @returns {String}
+             */
+            calculate({id, isLeaf, title}) {
+                return isLeaf ? `<b>${id}</b> <span class="discussion-title">${title}</span>` : (title || id)
+            }
+        }]
+    }
+}
+
+export default Neo.setupClass(Discussion);

--- a/apps/portal/store/Discussions.mjs
+++ b/apps/portal/store/Discussions.mjs
@@ -1,0 +1,27 @@
+import DiscussionModel from '../model/Discussion.mjs';
+import Store           from '../../../src/data/Store.mjs';
+
+/**
+ * @class Portal.store.Discussions
+ * @extends Neo.data.Store
+ */
+class Discussions extends Store {
+    static config = {
+        /**
+         * @member {String} className='Portal.store.Discussions'
+         * @protected
+         */
+        className: 'Portal.store.Discussions',
+        /**
+         * @member {Neo.data.Model} model=DiscussionModel
+         * @reactive
+         */
+        model: DiscussionModel,
+        /**
+         * @member {String} url='../../apps/portal/resources/data/discussions.json'
+         */
+        url: '../../apps/portal/resources/data/discussions.json'
+    }
+}
+
+export default Neo.setupClass(Discussions);

--- a/apps/portal/view/news/TabContainer.mjs
+++ b/apps/portal/view/news/TabContainer.mjs
@@ -61,6 +61,13 @@ class NewsTabContainer extends TabContainer {
                 route  : '/news/releases',
                 text   : 'Release Notes'
             }
+        }, {
+            module: () => import('./discussions/MainContainer.mjs'),
+            header: {
+                iconCls: 'fa fa-comments',
+                route  : '/news/discussions',
+                text   : 'Discussions'
+            }
         }],
         /**
          * @member {Object} unmountConfigs={activeIndex: null}

--- a/apps/portal/view/news/TabContainerController.mjs
+++ b/apps/portal/view/news/TabContainerController.mjs
@@ -17,12 +17,14 @@ class TabContainerController extends Controller {
         routes: {
             '/news'                   : 'onReleasesRoute',
             '/news/blog'              : 'onBlogRoute',
-            '/news/blog/{*itemId}'    : 'onBlogRoute',
-            '/news/medium'            : 'onMediumRoute',
-            '/news/releases'          : 'onReleasesRoute',
-            '/news/releases/{*itemId}': 'onReleasesRoute',
-            '/news/tickets'           : 'onTicketsRoute',
-            '/news/tickets/{*itemId}' : 'onTicketsRoute'
+            '/news/blog/{*itemId}'       : 'onBlogRoute',
+            '/news/discussions'          : 'onDiscussionsRoute',
+            '/news/discussions/{*itemId}': 'onDiscussionsRoute',
+            '/news/medium'               : 'onMediumRoute',
+            '/news/releases'             : 'onReleasesRoute',
+            '/news/releases/{*itemId}'   : 'onReleasesRoute',
+            '/news/tickets'              : 'onTicketsRoute',
+            '/news/tickets/{*itemId}'    : 'onTicketsRoute'
         }
     }
 
@@ -38,6 +40,13 @@ class TabContainerController extends Controller {
      */
     onBlogPostStoreLoad(records) {
         this.getStateProvider().setData({blogPostCount: records.length})
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onDiscussionsRoute(data) {
+        this.setActiveIndexByRoute('/news/discussions')
     }
 
     /**
@@ -59,6 +68,17 @@ class TabContainerController extends Controller {
      */
     onTicketsRoute(data) {
         this.component.activeIndex = 2
+    }
+
+    /**
+     * @param {String} route
+     */
+    setActiveIndexByRoute(route) {
+        let index = this.component.items.findIndex(item => item.header?.route === route);
+
+        if (index !== -1) {
+            this.component.activeIndex = index
+        }
     }
 }
 

--- a/apps/portal/view/news/discussions/Component.mjs
+++ b/apps/portal/view/news/discussions/Component.mjs
@@ -31,6 +31,10 @@ class Component extends ContentComponent {
          */
         cls: ['portal-news-discussions-component'],
         /**
+         * @member {String} issuesUrl='#/news/tickets/'
+         */
+        issuesUrl: '#/news/tickets/',
+        /**
          * @member {String} repoUserUrl='https://github.com/'
          */
         repoUserUrl: 'https://github.com/'

--- a/apps/portal/view/news/discussions/Component.mjs
+++ b/apps/portal/view/news/discussions/Component.mjs
@@ -229,64 +229,103 @@ ${fullHtml}
     }
 
     /**
+     * @summary Parses the Discussion `## Comments` body into stable comment entries.
+     *
+     * The synced Discussion grammar uses backtick-wrapped `@user` headings as the durable entry
+     * boundary. Separator rules (`---`) are emitted between comments, but comment bodies can also
+     * contain their own `###` headings and horizontal rules, so this method splits only on the
+     * full comment header and trims just the trailing separator before the next entry.
      * @param {String} content
-     * @returns {String}
+     * @returns {Object[]} `[{user, date, body}]`
      */
-    renderComments(content) {
-        let me             = this,
-            {repoUserUrl} = me,
-            html           = '',
-            lines          = content.split('\n'),
-            commentBuf     = [],
-            currentUser    = null,
-            currentDate    = null,
-            i              = 0,
-            len            = lines.length,
-            id, line, match;
+    parseComments(content) {
+        let lines   = content.split('\n'),
+            entries = [],
+            current = null,
+            i       = 0,
+            len     = lines.length,
+            line, match;
+
+        const trimTrailingDelimiter = (rows) => {
+            while (rows.length && rows[rows.length - 1].trim() === '') {
+                rows.pop()
+            }
+
+            if (rows[rows.length - 1]?.trim() === '---') {
+                rows.pop()
+            }
+
+            while (rows.length && rows[rows.length - 1].trim() === '') {
+                rows.pop()
+            }
+        };
 
         const flushComment = () => {
-            if (commentBuf.length > 0 && currentUser) {
-                id = `timeline-${me.record.id}-${me.timelineData.length + 1}`;
+            if (!current) return;
 
-                me.timelineData.push({
-                    id,
-                    image: repoUserUrl + currentUser + '.png',
-                    name : `Comment (${currentUser})`,
-                    tag  : 'comment'
-                });
+            trimTrailingDelimiter(current.bodyLines);
 
-                html += `
-                    <div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">
-                        <div id="${id}-target" class="neo-timeline-avatar">
-                            <img src="${repoUserUrl}${currentUser}.png" alt="${currentUser}">
-                        </div>
-                        <div class="neo-timeline-content">
-                            <div class="neo-timeline-header">
-                                <a class="neo-timeline-user" href="${repoUserUrl}${currentUser}" target="_blank">${currentUser}</a>
-                                <span class="neo-timeline-date">commented on ${me.formatTimestamp(currentDate)}</span>
-                            </div>
-                            <div class="neo-timeline-body">${marked.parse(commentBuf.join('\n'))}</div>
-                        </div>
-                    </div>`;
+            let body = current.bodyLines.join('\n').trim();
 
-                commentBuf = []
+            if (body) {
+                entries.push({
+                    user: current.user,
+                    date: current.date,
+                    body
+                })
             }
         };
 
         for (; i < len; i++) {
-            line = lines[i];
+            line  = lines[i];
             match = line.match(regexCommentHeader);
 
             if (match) {
                 flushComment();
-                currentUser = match[1];
-                currentDate = match[2]
-            } else if (currentUser && line !== '---') {
-                commentBuf.push(line)
+                current = {user: match[1], date: match[2], bodyLines: []}
+            } else if (current) {
+                current.bodyLines.push(line)
             }
         }
 
         flushComment();
+
+        return entries
+    }
+
+    /**
+     * @param {String} content
+     * @returns {String}
+     */
+    renderComments(content) {
+        let me            = this,
+            {repoUserUrl} = me,
+            html          = '';
+
+        me.parseComments(content).forEach(comment => {
+            let id = `timeline-${me.record.id}-${me.timelineData.length + 1}`;
+
+            me.timelineData.push({
+                id,
+                image: repoUserUrl + comment.user + '.png',
+                name : `Comment (${comment.user})`,
+                tag  : 'comment'
+            });
+
+            html += `
+                    <div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">
+                        <div id="${id}-target" class="neo-timeline-avatar">
+                            <img src="${repoUserUrl}${comment.user}.png" alt="${comment.user}">
+                        </div>
+                        <div class="neo-timeline-content">
+                            <div class="neo-timeline-header">
+                                <a class="neo-timeline-user" href="${repoUserUrl}${comment.user}" target="_blank">${comment.user}</a>
+                                <span class="neo-timeline-date">commented on ${me.formatTimestamp(comment.date)}</span>
+                            </div>
+                            <div class="neo-timeline-body">${marked.parse(comment.body)}</div>
+                        </div>
+                    </div>`
+        });
 
         return html
     }

--- a/apps/portal/view/news/discussions/Component.mjs
+++ b/apps/portal/view/news/discussions/Component.mjs
@@ -1,0 +1,295 @@
+import ContentComponent from '../../content/Component.mjs';
+import {marked}         from '../../../../../node_modules/marked/lib/marked.esm.js';
+
+const
+    regexComments      = /\n## Comments\s*\n([\s\S]*)$/,
+    regexCommentHeader = /^### `@([^`]+)` commented on ([\dTZ:.-]+)$/,
+    regexFrontMatter   = /^---\n([\s\S]*?)\n---\n/,
+    regexH1            = /(<h1[^>]*>.*?<\/h1>)/;
+
+/**
+ * @summary The Markdown transformer for GitHub Discussions.
+ *
+ * Discussion markdown shares the Portal timeline/canvas contract with tickets, but not the ticket grammar:
+ * frontmatter carries category + closed state, the body has no issue event timeline, and comments use
+ * `### `@user` commented on <timestamp>` headers under `## Comments`. This component keeps that grammar
+ * local while publishing `.neo-timeline-item[data-record-id]` nodes and `sections` store records in the
+ * same shape consumed by `Portal.view.content.TimelineCanvas`.
+ *
+ * @class Portal.view.news.discussions.Component
+ * @extends Portal.view.content.Component
+ */
+class Component extends ContentComponent {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.discussions.Component'
+         * @protected
+         */
+        className: 'Portal.view.news.discussions.Component',
+        /**
+         * @member {String[]} cls=['portal-news-discussions-component']
+         */
+        cls: ['portal-news-discussions-component'],
+        /**
+         * @member {String} repoUserUrl='https://github.com/'
+         */
+        repoUserUrl: 'https://github.com/'
+    }
+
+    /**
+     * @member {Object[]} timelineData=null
+     * @private
+     */
+    timelineData = null
+
+    /**
+     * @summary Extends the shared frontmatter parser with the folded block scalars used by Discussion titles.
+     * @param {String} text
+     * @returns {Object}
+     */
+    parseFrontMatter(text) {
+        let data  = super.parseFrontMatter(text),
+            lines = text.split('\n'),
+            i     = 0,
+            len   = lines.length,
+            key, match, rows;
+
+        for (; i < len; i++) {
+            match = lines[i].match(/^([\w\d_-]+):\s*([>|][+-]?)\s*$/);
+
+            if (match) {
+                key  = match[1];
+                rows = [];
+                i++;
+
+                while (i < len && !lines[i].match(/^[\w\d_-]+:\s*/)) {
+                    rows.push(lines[i].trim());
+                    i++
+                }
+
+                i--;
+
+                data[key] = match[2].startsWith('|') ? rows.join('\n') : rows.join(' ')
+            }
+        }
+
+        return data
+    }
+
+    /**
+     * @param {Object} data
+     * @returns {String}
+     */
+    frontMatterToHtml(data) {
+        let me   = this,
+            html = '<table class="neo-frontmatter-table"><tbody>';
+
+        Object.entries(data).forEach(([key, value]) => {
+            let renderedValue;
+
+            if (key === 'author') {
+                renderedValue = `<a href="${me.repoUserUrl}${value}" target="_blank">${value}</a>`
+            } else if (key === 'category') {
+                renderedValue = me.getCategoryBadgeHtml(value)
+            } else if (key === 'closed') {
+                renderedValue = me.getClosedBadgeHtml(value)
+            } else if (key === 'createdAt' || key === 'closedAt' || key === 'updatedAt') {
+                renderedValue = me.formatTimestamp(value)
+            } else {
+                renderedValue = me.formatFrontMatterValue(value)
+            }
+
+            html += `<tr><td>${key}</td><td>${renderedValue}</td></tr>`
+        });
+
+        html += '</tbody></table>';
+
+        if (me.useFrontmatterDetails) {
+            return `<details id="neo-discussion-summary-details-${me.id}"><summary>Frontmatter</summary>${html}</details>`
+        }
+
+        return html
+    }
+
+    /**
+     * @param {String} category
+     * @returns {String}
+     */
+    getCategoryBadgeHtml(category) {
+        return category ? `<span class="neo-badge neo-discussion-category-badge">${category}</span>` : ''
+    }
+
+    /**
+     * @param {Boolean|String} closed
+     * @returns {String}
+     */
+    getClosedBadgeHtml(closed) {
+        let isClosed = closed === true || closed === 'true',
+            cls      = isClosed ? 'neo-state-closed' : 'neo-state-open',
+            icon     = isClosed ? 'fa-circle-check' : 'fa-circle-dot',
+            text     = isClosed ? 'Closed' : 'Open';
+
+        return `<span class="neo-badge neo-state-badge ${cls}"><i class="fa-regular ${icon}"></i>${text}</span>`
+    }
+
+    /**
+     * @param {Object} data
+     * @returns {String}
+     */
+    getHeaderBadgesHtml(data) {
+        let html = '<div class="neo-ticket-labels neo-discussion-badges">';
+
+        if (data.category) {
+            html += this.getCategoryBadgeHtml(data.category)
+        }
+
+        if (data.closed !== undefined) {
+            html += this.getClosedBadgeHtml(data.closed)
+        }
+
+        html += '</div>';
+
+        return html
+    }
+
+    /**
+     * @param {String} content
+     * @returns {String}
+     */
+    modifyMarkdown(content) {
+        let me              = this,
+            commentsHtml    = '',
+            commentsMatch   = content.match(regexComments),
+            frontMatterHtml = '',
+            data            = {},
+            match           = content.match(regexFrontMatter),
+            titleHtml       = '';
+
+        me.timelineData = [];
+
+        if (match) {
+            data            = me.parseFrontMatter(match[1]);
+            frontMatterHtml = me.frontMatterToHtml(data);
+            content         = content.replace(regexFrontMatter, '')
+        }
+
+        if (commentsMatch) {
+            commentsHtml = me.renderComments(commentsMatch[1]);
+            content      = content.replace(regexComments, '')
+        }
+
+        let fullHtml = super.modifyMarkdown(content);
+
+        fullHtml = fullHtml.replace(regexH1, (match) => {
+            titleHtml = match.replace('<h1', `<h1 id="discussion-title-${me.id}"`);
+            return ''
+        });
+
+        if (!titleHtml && data.title) {
+            titleHtml = `<h1 id="discussion-title-${me.id}">${data.title}</h1>`
+        }
+
+        titleHtml += me.getHeaderBadgesHtml(data);
+
+        let bodyId = `timeline-${me.record.id}-0`;
+
+        me.timelineData.unshift({
+            id   : bodyId,
+            image: me.repoUserUrl + data.author + '.png',
+            name : 'Description',
+            tag  : 'body'
+        });
+
+        let bodyItemHtml = `
+            <div id="${bodyId}" class="neo-timeline-item comment body-item" data-record-id="${bodyId}">
+                <div id="${bodyId}-target" class="neo-timeline-avatar">
+                    <img src="${me.repoUserUrl}${data.author}.png" alt="${data.author}">
+                </div>
+                <div class="neo-timeline-content">
+                    <div class="neo-timeline-header">
+                        <a class="neo-timeline-user" href="${me.repoUserUrl}${data.author}" target="_blank">${data.author}</a>
+                        <span class="neo-timeline-date">opened on ${me.formatTimestamp(data.createdAt)}</span>
+                    </div>
+                    <div class="neo-timeline-body">
+
+${fullHtml}
+
+</div>
+                </div>
+            </div>`;
+
+        let timelineId    = `discussion-timeline-${me.id}`,
+            timelineHtml  = `<div id="${timelineId}" class="neo-ticket-timeline neo-discussion-timeline">` +
+                bodyItemHtml + commentsHtml + '</div>';
+
+        me.getStateProvider().getStore('sections').data = me.timelineData;
+        me.timelineData = null;
+
+        return frontMatterHtml + titleHtml + timelineHtml
+    }
+
+    /**
+     * @param {String} content
+     * @returns {String}
+     */
+    renderComments(content) {
+        let me             = this,
+            {repoUserUrl} = me,
+            html           = '',
+            lines          = content.split('\n'),
+            commentBuf     = [],
+            currentUser    = null,
+            currentDate    = null,
+            i              = 0,
+            len            = lines.length,
+            id, line, match;
+
+        const flushComment = () => {
+            if (commentBuf.length > 0 && currentUser) {
+                id = `timeline-${me.record.id}-${me.timelineData.length + 1}`;
+
+                me.timelineData.push({
+                    id,
+                    image: repoUserUrl + currentUser + '.png',
+                    name : `Comment (${currentUser})`,
+                    tag  : 'comment'
+                });
+
+                html += `
+                    <div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">
+                        <div id="${id}-target" class="neo-timeline-avatar">
+                            <img src="${repoUserUrl}${currentUser}.png" alt="${currentUser}">
+                        </div>
+                        <div class="neo-timeline-content">
+                            <div class="neo-timeline-header">
+                                <a class="neo-timeline-user" href="${repoUserUrl}${currentUser}" target="_blank">${currentUser}</a>
+                                <span class="neo-timeline-date">commented on ${me.formatTimestamp(currentDate)}</span>
+                            </div>
+                            <div class="neo-timeline-body">${marked.parse(commentBuf.join('\n'))}</div>
+                        </div>
+                    </div>`;
+
+                commentBuf = []
+            }
+        };
+
+        for (; i < len; i++) {
+            line = lines[i];
+            match = line.match(regexCommentHeader);
+
+            if (match) {
+                flushComment();
+                currentUser = match[1];
+                currentDate = match[2]
+            } else if (currentUser && line !== '---') {
+                commentBuf.push(line)
+            }
+        }
+
+        flushComment();
+
+        return html
+    }
+}
+
+export default Neo.setupClass(Component);

--- a/apps/portal/view/news/discussions/MainContainer.mjs
+++ b/apps/portal/view/news/discussions/MainContainer.mjs
@@ -1,0 +1,56 @@
+import CanvasWrapper   from '../../content/CanvasWrapper.mjs';
+import Component       from './Component.mjs';
+import Controller      from './MainContainerController.mjs';
+import PageContainer   from './PageContainer.mjs';
+import SharedContainer from '../../../../../src/app/content/Container.mjs';
+import StateProvider   from './MainContainerStateProvider.mjs';
+
+/**
+ * @class Portal.view.news.discussions.MainContainer
+ * @extends Neo.app.content.Container
+ */
+class MainContainer extends SharedContainer {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.discussions.MainContainer'
+         * @protected
+         */
+        className: 'Portal.view.news.discussions.MainContainer',
+        /**
+         * @member {String[]} cls=['portal-discussions-maincontainer']
+         * @reactive
+         */
+        cls: ['portal-discussions-maincontainer'],
+        /**
+         * @member {Neo.controller.Component} controller=MainContainerController
+         * @reactive
+         */
+        controller: Controller,
+        /**
+         * @member {Object} pageContainerConfig
+         */
+        pageContainerConfig: {
+            module         : PageContainer,
+            buttonTextField: 'id',
+            contentConfig  : {
+                contentComponent: Component,
+                module          : CanvasWrapper
+            }
+        },
+        /**
+         * @member {Neo.state.Provider} stateProvider=MainContainerStateProvider
+         * @reactive
+         */
+        stateProvider: StateProvider,
+        /**
+         * @member {Object} treeConfig
+         */
+        treeConfig: {
+            displayField       : 'treeNodeName',
+            lazyChildLoad      : true,
+            lazyChildUrlPrefix : '../../apps/portal/resources/data/'
+        }
+    }
+}
+
+export default Neo.setupClass(MainContainer);

--- a/apps/portal/view/news/discussions/MainContainerController.mjs
+++ b/apps/portal/view/news/discussions/MainContainerController.mjs
@@ -1,0 +1,202 @@
+import Controller from '../../../../../src/controller/Component.mjs';
+
+/**
+ * @class Portal.view.news.discussions.MainContainerController
+ * @extends Neo.controller.Component
+ */
+class MainContainerController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.discussions.MainContainerController'
+         * @protected
+         */
+        className: 'Portal.view.news.discussions.MainContainerController',
+        /**
+         * @member {Object} routes
+         */
+        routes: {
+            '/news/discussions'          : 'onRouteDefault',
+            '/news/discussions/{*itemId}': 'onRouteItem'
+        }
+    }
+
+    /**
+     * @param {String} item
+     */
+    navigateTo(item) {
+        Neo.Main.setRoute({
+            value   : `/news/discussions/${item}`,
+            windowId: this.component.windowId
+        })
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onIntersect(data) {
+        let panel    = this.getReference('page-sections-container'),
+            list     = panel.list,
+            recordId = data.data.recordId,
+            record;
+
+        if (recordId && !list.isAnimating) {
+            record = list.store.get(recordId);
+
+            if (record) {
+                list.selectionModel.select(record)
+            }
+        }
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onNextPageButtonClick(data) {
+        this.navigateTo(this.getStateProvider().getData('nextPageRecord').id)
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onPageSectionsToggleButtonClick(data) {
+        this.getReference('page-sections-container').toggleCls('neo-expanded')
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onPreviousPageButtonClick(data) {
+        this.navigateTo(this.getStateProvider().getData('previousPageRecord').id)
+    }
+
+    /**
+     * @returns {String|null}
+     */
+    async getDefaultRouteId() {
+        let tree   = this.getReference('tree'),
+            store  = this.getStateProvider().getStore('tree'),
+            folder = store.items.find(record => !record.isLeaf && record.childrenUrl),
+            record;
+
+        if (!folder) {
+            return store.items.find(item => item.isLeaf)?.id || null
+        }
+
+        await tree.onFolderItemClick(folder);
+
+        this.getStateProvider().data.countPages = store.getCount();
+
+        record = store.items.find(item => item.parentId === folder.id && item.isLeaf);
+
+        return record?.id || null
+    }
+
+    /**
+     * @param {String} itemId
+     * @returns {Promise<Object|null>}
+     */
+    async ensureRecordLoaded(itemId) {
+        let me     = this,
+            tree   = me.getReference('tree'),
+            store  = me.getStateProvider().getStore('tree'),
+            record = store.get(itemId),
+            folders, i, len;
+
+        if (record) {
+            return record
+        }
+
+        folders = store.items.filter(record => !record.isLeaf && record.childrenUrl && !record.isChildrenLoaded);
+
+        for (i = 0, len = folders.length; i < len; i++) {
+            await tree.onFolderItemClick(folders[i]);
+
+            record = store.get(itemId);
+
+            if (record) {
+                me.getStateProvider().data.countPages = store.getCount();
+                return record
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @param {Object} data
+     */
+    async onRouteDefault(data) {
+        let me    = this,
+            store = me.getStateProvider().getStore('tree');
+
+        const navigate = async () => {
+            let id = await me.getDefaultRouteId();
+
+            if (id) {
+                me.navigateTo(id)
+            }
+        };
+
+        if (store.getCount() > 0) {
+            await navigate()
+        } else {
+            store.on({
+                load : navigate,
+                delay: 10,
+                once : true
+            })
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {Object} value
+     * @param {Object} oldValue
+     */
+    async onRouteItem({itemId}, value, oldValue) {
+        let me            = this,
+            stateProvider = me.getStateProvider(),
+            store         = stateProvider.getStore('tree'),
+            tree          = me.getReference('tree');
+
+        if (tree.routePrefix !== '/news/discussions') {
+            tree.routePrefix = '/news/discussions'
+        }
+
+        const select = async () => {
+            let record = await me.ensureRecordLoaded(itemId);
+
+            if (!record) {
+                return
+            }
+
+            stateProvider.data.currentPageRecord = record;
+
+            if (!oldValue?.hashString?.startsWith('/news/discussions')) {
+                await tree.expandAndScrollToItem(itemId)
+            } else {
+                tree.expandParents(itemId)
+            }
+        };
+
+        if (store.getCount() > 0) {
+            await select()
+        } else {
+            store.on({
+                load : select,
+                delay: 10,
+                once : true
+            })
+        }
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onSideNavToggleButtonClick(data) {
+        this.getReference('sidenav-container').toggleCls('neo-expanded')
+    }
+}
+
+export default Neo.setupClass(MainContainerController);

--- a/apps/portal/view/news/discussions/MainContainerStateProvider.mjs
+++ b/apps/portal/view/news/discussions/MainContainerStateProvider.mjs
@@ -1,0 +1,135 @@
+import DiscussionsStore      from '../../../store/Discussions.mjs';
+import TimelineSectionsStore from '../../../store/TimelineSections.mjs';
+import StateProvider         from '../../../../../src/state/Provider.mjs';
+
+/**
+ * @class Portal.view.news.discussions.MainContainerStateProvider
+ * @extends Neo.state.Provider
+ */
+class MainContainerStateProvider extends StateProvider {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.discussions.MainContainerStateProvider'
+         * @protected
+         */
+        className: 'Portal.view.news.discussions.MainContainerStateProvider',
+        /**
+         * @member {Object} data
+         */
+        data: {
+            /**
+             * @member {Number|null} data.countPages=null
+             */
+            countPages: null,
+            /**
+             * @member {Number|null} data.countSections=null
+             */
+            countSections: null,
+            /**
+             * The record which gets shown as the content page
+             * @member {Object} data.currentRecord=null
+             */
+            currentPageRecord: null,
+            /**
+             * The record which gets shown as the next content page
+             * @member {Object} data.nextPageRecord=null
+             */
+            nextPageRecord: null,
+            /**
+             * The record which gets shown as the previous content page
+             * @member {Object} data.previousPageRecord=null
+             */
+            previousPageRecord: null
+        },
+        /**
+         * @member {Object} stores
+         */
+        stores: {
+            sections: {
+                module: TimelineSectionsStore
+            },
+            tree: {
+                autoLoad: true,
+                module  : DiscussionsStore
+            }
+        }
+    }
+
+    /**
+     * @param {String} key
+     * @param {*} value
+     * @param {*} oldValue
+     */
+    onDataPropertyChange(key, value, oldValue) {
+        super.onDataPropertyChange(key, value, oldValue);
+
+        let me = this;
+
+        switch (key) {
+            case 'countSections': {
+                if (value < 1) {
+                    me.component.getReference('page-sections-container')?.toggleCls('neo-expanded', false)
+                }
+
+                break
+            }
+
+            case 'currentPageRecord': {
+                let {data}             = me,
+                    {countPages}       = data,
+                    store              = me.getStore('tree'),
+                    index              = store.indexOf(value),
+                    nextPageRecord     = null,
+                    previousPageRecord = null,
+                    i, record;
+
+                for (i=index-1; i >= 0; i--) {
+                    record = store.getAt(i);
+
+                    if (record.isLeaf && !me.recordIsHidden(record, store)) {
+                        previousPageRecord = record;
+                        break
+                    }
+                }
+
+                me.setData({previousPageRecord});
+
+                for (i=index+1; i < countPages; i++) {
+                    record = store.getAt(i);
+
+                    if (record.isLeaf && !me.recordIsHidden(record, store)) {
+                        nextPageRecord = record;
+                        break
+                    }
+                }
+
+                me.setData({nextPageRecord});
+
+                me.component.getReference('sidenav-container')?.toggleCls('neo-expanded', false);
+
+                break
+            }
+        }
+    }
+
+    /**
+     * We need to check the parent-node chain inside the tree.
+     * => Any hidden parent-node results in a hidden record.
+     * @param {Object} record
+     * @param {Neo.data.Store} store
+     * @returns {Boolean}
+     */
+    recordIsHidden(record, store) {
+        if (record.hidden) {
+            return true
+        }
+
+        if (record.parentId !== null) {
+            return this.recordIsHidden(store.get(record.parentId), store)
+        }
+
+        return false
+    }
+}
+
+export default Neo.setupClass(MainContainerStateProvider);

--- a/apps/portal/view/news/discussions/PageContainer.mjs
+++ b/apps/portal/view/news/discussions/PageContainer.mjs
@@ -1,0 +1,25 @@
+import PageContainer from '../../../../../src/app/content/PageContainer.mjs';
+
+/**
+ * @class Portal.view.news.discussions.PageContainer
+ * @extends Neo.app.content.PageContainer
+ */
+class DiscussionPageContainer extends PageContainer {
+    static config = {
+        /**
+         * @member {String} className='Portal.view.news.discussions.PageContainer'
+         * @protected
+         */
+        className: 'Portal.view.news.discussions.PageContainer',
+        /**
+         * @member {Object} layout=null
+         */
+        layout: null,
+        /**
+         * @member {Object} style={flex:1,overflowY:'auto',position:'relative'}
+         */
+        style: {flex: 1, overflowY: 'auto', position: 'relative'}
+    }
+}
+
+export default Neo.setupClass(DiscussionPageContainer);

--- a/resources/scss/src/apps/portal/news/discussions/Component.scss
+++ b/resources/scss/src/apps/portal/news/discussions/Component.scss
@@ -1,0 +1,21 @@
+@use "../tickets/Component";
+
+.portal-news-discussions-component {
+    .neo-discussion-badges {
+        margin-top: 10px;
+    }
+
+    .neo-discussion-category-badge {
+        background-color: var(--gh-discussion-category-bg);
+        color           : var(--gh-discussion-category-color);
+    }
+
+    .neo-discussion-timeline {
+        blockquote {
+            border-left : 4px solid var(--gh-timeline-border);
+            color       : var(--gh-text-secondary);
+            margin-left : 0;
+            padding-left: 12px;
+        }
+    }
+}

--- a/resources/scss/src/apps/portal/news/discussions/MainContainer.scss
+++ b/resources/scss/src/apps/portal/news/discussions/MainContainer.scss
@@ -1,0 +1,3 @@
+.portal-discussions-maincontainer {
+    background-color: transparent;
+}

--- a/resources/scss/src/apps/portal/news/tickets/Component.scss
+++ b/resources/scss/src/apps/portal/news/tickets/Component.scss
@@ -1,4 +1,5 @@
-.portal-news-tickets-component {
+.portal-news-tickets-component,
+.portal-news-discussions-component {
     .neo-badge {
         align-items     : center;
         background-color: var(--gh-badge-bg); // Default fallback

--- a/resources/scss/theme-neo-dark/apps/portal/news/discussions/Component.scss
+++ b/resources/scss/theme-neo-dark/apps/portal/news/discussions/Component.scss
@@ -1,0 +1,18 @@
+:root .neo-theme-neo-dark {
+    --gh-badge-bg                    : var(--sem-color-bg-neutral-highlighted);
+    --gh-badge-border                : var(--sem-color-border-subtle);
+    --gh-bg-default                  : var(--sem-color-bg-neutral-default);
+    --gh-bg-subtle                   : var(--purple-900);
+    --gh-border-default              : var(--sem-color-border-default);
+    --gh-discussion-category-bg      : var(--sem-color-bg-neutral-highlighted);
+    --gh-discussion-category-color   : var(--sem-color-text-primary-default);
+    --gh-event-text-color            : var(--markdown-text-color);
+    --gh-header-text-color           : var(--markdown-text-color);
+    --gh-icon-muted                  : var(--sem-color-icon-neutral-subdued);
+    --gh-state-closed-bg             : #a371f7;
+    --gh-state-open-bg               : #3fb950;
+    --gh-text-inverse                : #ffffff;
+    --gh-text-primary                : var(--sem-color-text-neutral-default);
+    --gh-text-secondary              : var(--sem-color-text-neutral-subdued);
+    --gh-timeline-border             : var(--purple-700);
+}

--- a/resources/scss/theme-neo-light/apps/portal/news/discussions/Component.scss
+++ b/resources/scss/theme-neo-light/apps/portal/news/discussions/Component.scss
@@ -1,0 +1,18 @@
+:root .neo-theme-neo-light {
+    --gh-badge-bg                    : #eff1f3;
+    --gh-badge-border                : rgba(0, 0, 0, 0.1);
+    --gh-bg-default                  : #ffffff;
+    --gh-bg-subtle                   : #f6f8fa;
+    --gh-border-default              : #d0d7de;
+    --gh-discussion-category-bg      : #ddf4ff;
+    --gh-discussion-category-color   : #0969da;
+    --gh-event-text-color            : #57606a;
+    --gh-header-text-color           : #57606a;
+    --gh-icon-muted                  : #8c959f;
+    --gh-state-closed-bg             : #8250df;
+    --gh-state-open-bg               : #2da44e;
+    --gh-text-inverse                : #ffffff;
+    --gh-text-primary                : #24292f;
+    --gh-text-secondary              : #57606a;
+    --gh-timeline-border             : #d0d7de;
+}

--- a/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'PortalDiscussionsComponentTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+import Component      from '../../../../../../../../apps/portal/view/news/discussions/Component.mjs';
+
+/**
+ * Unit coverage for the Discussion-specific parser in `Portal.view.news.discussions.Component`.
+ *
+ * The view inherits the shared timeline/canvas contract from the ticket content stack; these tests pin
+ * only the irreducibly Discussion-specific pieces: folded YAML titles, the backtick-`@user` comment
+ * entry boundary, and category / closed-state badges. `parseComments` and the badge helpers are tested
+ * directly on the prototype to avoid constructing the full state-provider-backed content component.
+ */
+const {parseFrontMatter, parseComments, getClosedBadgeHtml, getCategoryBadgeHtml} = Component.prototype;
+
+test.describe('Portal.view.news.discussions.Component - Discussion markdown parser', () => {
+    test('parses folded and literal frontmatter block scalars used by discussion titles', () => {
+        const component = Object.create(Component.prototype);
+
+        const data = parseFrontMatter.call(component, [
+            'title: >-',
+            '  Discussion titles can be',
+            '  folded across lines',
+            'body: |',
+            '  first line',
+            '  second line',
+            'closed: false'
+        ].join('\n'));
+
+        expect(data.title).toBe('Discussion titles can be folded across lines');
+        expect(data.body).toBe('first line\nsecond line');
+        expect(data.closed).toBe(false)
+    });
+
+    test('comment entry-split ignores inner ### headings and horizontal rules', () => {
+        const commentsRaw = [
+            '### `@alice` commented on 2026-05-20T17:39:52Z',
+            '',
+            'First comment.',
+            '',
+            '---',
+            '',
+            '### Inner heading (must NOT split)',
+            '',
+            'Still Alice.',
+            '',
+            '---',
+            '',
+            '### `@bob` commented on 2026-05-20T17:50:28Z',
+            '',
+            'Second comment.'
+        ].join('\n');
+
+        const entries = parseComments(commentsRaw);
+
+        expect(entries).toHaveLength(2);
+        expect(entries[0]).toMatchObject({
+            user: 'alice',
+            date: '2026-05-20T17:39:52Z'
+        });
+        expect(entries[0].body).toContain('### Inner heading (must NOT split)');
+        expect(entries[0].body).toContain('---');
+        expect(entries[0].body).toContain('Still Alice.');
+        expect(entries[0].body).not.toMatch(/\n---$/);
+        expect(entries[1]).toMatchObject({
+            user: 'bob',
+            body: 'Second comment.'
+        })
+    });
+
+    test('category and closed-state badges render stable semantic classes', () => {
+        const category = getCategoryBadgeHtml('Ideas'),
+              closed   = getClosedBadgeHtml(true),
+              open     = getClosedBadgeHtml('false');
+
+        expect(category).toContain('neo-discussion-category-badge');
+        expect(category).toContain('Ideas');
+        expect(closed).toContain('neo-state-closed');
+        expect(closed).toContain('Closed');
+        expect(open).toContain('neo-state-open');
+        expect(open).toContain('Open');
+        expect(getCategoryBadgeHtml('')).toBe('')
+    })
+});


### PR DESCRIPTION
Resolves #12211
Related: #12204
Related: #12207

Authored by GPT-5.5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.

FAIR-band: over-target [22/30] — taking this lane despite over-target because #12211 was already assigned to @neo-gpt under the operator's portal-news nightshift goal; Claude is carrying #12213 in parallel and Gemini is unavailable.

Adds `Portal.view.news.discussions` as the Discussions content type for Portal News. The view consumes `apps/portal/resources/data/discussions.json`, lazy-loads discussion chunks through the shared content tree, resolves compact leaf records into `resources/content/discussions/...` markdown paths, and renders discussion bodies/comments on the shared timeline + canvas contract.

Evidence: L3 (local webpack server + headless Chromium route probe rendered `/apps/portal/#/news/discussions`, lazy-loaded discussion `12100`, and found 14 timeline items with no browser console/request errors) -> L3 required (browser-rendered portal discussion route). No residuals.

## Deltas from ticket
- Added folded frontmatter parsing for Discussion titles using `title: >-`, which the shared Markdown parser does not currently normalize.
- Appended the Discussions tab after existing News tabs and resolved its active index by route so it composes with Claude's draft #12213 Pull Requests tab.
- Kept discussion timeline styling independent of ticket route load order by importing the shared ticket timeline SCSS into the discussion SCSS and defining discussion theme variables in both light and dark theme paths.
- Factored Discussion comment parsing into `parseComments()` so the header-boundary parser can be unit-tested without constructing the full state-provider-backed content component.
- Declared `issuesUrl: '#/news/tickets/'` on the Discussion component so the view remains stable after #12292 moves the generic base to per-content-type cross-link config.

## Test Evidence
- `node --check` on the new Discussion model/store/view modules and modified News tab modules.
- `node --check` on `test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs`.
- `npm run test-unit -- test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs` passed: 3 tests covering folded/literal frontmatter block scalars, safe comment entry-splitting across inner `###` / `---`, and category + closed-state badges.
- `git diff --check` and `git diff --cached --check`.
- `node ./buildScripts/build/themes.mjs -f -n -t theme-neo-light,theme-neo-dark` passed.
- `node ./buildScripts/webpack/buildThreads.mjs -f -n -t all -e all` passed for development and production workers.
- Headless Chromium against local webpack server: route `/apps/portal/#/news/discussions` rendered the Discussions tab, lazy-loaded `12100`, displayed the folded title correctly, produced 14 `.neo-timeline-item` nodes, and reported no browser console/request errors.
- `npm run build-all` reached successful webpack thread builds but failed later in docs generation on pre-existing `ai/**` JSDoc type-expression parse errors plus missing `docs/output`; no branch files are in that failure set.

## Post-Merge Validation
- [ ] Verify the deployed Portal News tabs after #12211 and #12213 both merge, since #12213 adds the sibling Pull Requests tab.
