### PR TITLE
fix(kb): enforce read-side visibility — private chunks only to their owner (#12163)

### DIFF
--- a/ai/services/knowledge-base/DocumentService.mjs
+++ b/ai/services/knowledge-base/DocumentService.mjs
@@ -1,7 +1,6 @@
-import aiConfig      from '../../mcp/server/knowledge-base/config.mjs';
 import Base          from '../../../src/core/Base.mjs';
 import ChromaManager from './ChromaManager.mjs';
-import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {buildReadWhereClause} from './readVisibilityFilter.mjs';
 
 /**
  * @summary Retrieves documents from the knowledge base.
@@ -47,14 +46,11 @@ class DocumentService extends Base {
             include: ["metadatas", "documents"]
         };
 
-        // #11632 read-side tenant filter: a requester lists its own tenant's documents plus
-        // Neo's curated `neo-shared` corpus. The requester is derived server-side from the
-        // request context — never a client parameter. No context (stdio single-tenant /
-        // offline daemon) → no filter, byte-equivalent with pre-#11632 behavior. Mirrors the
-        // QueryService.queryDocuments clause (inline per the memory-core MemoryService pattern).
-        const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
-        if (requesterTenantId) {
-            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId]}};
+        // Tenant isolation (#11632) + per-chunk visibility (#12163) from the authenticated context
+        // (see readVisibilityFilter); offline / no-context → no filter, pre-#11632 byte-equivalent.
+        const whereClause = buildReadWhereClause();
+        if (whereClause) {
+            getOptions.where = whereClause;
         }
 
         const results = await collection.get(getOptions);
@@ -89,12 +85,12 @@ class DocumentService extends Base {
             include: ["metadatas", "documents"]
         };
 
-        // #11632 read-side tenant filter: a document owned by another tenant resolves to
-        // "not found" — fail-closed, indistinguishable from a genuinely absent id, so the
-        // error leaks no cross-tenant existence signal. Mirrors QueryService.queryDocuments.
-        const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
-        if (requesterTenantId) {
-            getOptions.where = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId]}};
+        // Tenant isolation (#11632) + per-chunk visibility (#12163) from the authenticated context
+        // (see readVisibilityFilter). A doc owned by another tenant — or another user's private doc
+        // — resolves to "not found", fail-closed, leaking no cross-tenant/owner existence signal.
+        const whereClause = buildReadWhereClause();
+        if (whereClause) {
+            getOptions.where = whereClause;
         }
 
         const result = await collection.get(getOptions);

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -4,7 +4,7 @@ import mcConfig             from '../../mcp/server/memory-core/config.mjs';
 import aiConfig             from '../../mcp/server/knowledge-base/config.mjs';
 import Base                 from '../../../src/core/Base.mjs';
 import ChromaManager        from './ChromaManager.mjs';
-import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {buildReadWhereClause} from './readVisibilityFilter.mjs';
 import dotenv               from 'dotenv';
 import path                 from 'path';
 
@@ -115,26 +115,18 @@ class QueryService extends Base {
         const queryEmbeddingValues = await TextEmbeddingService.embedText(query, mcConfig.embeddingProvider);
         const queryLower     = query.toLowerCase();
 
-        const whereClause = (type && type !== 'all') ? { type } : {};
-
-        // #11632 read-side tenant filter: a requester retrieves its own tenant's chunks plus
-        // Neo's curated `neo-shared` corpus. The requester is derived server-side from the
-        // authenticated request context — never from a client-supplied parameter (a forged
-        // `tenantId` query arg is therefore ignored). No request context (stdio single-tenant
-        // / offline daemon) → no tenant filter, byte-equivalent with pre-#11632 behavior.
-        const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
-        if (requesterTenantId) {
-            whereClause.tenantId = {$in: [requesterTenantId, aiConfig.defaultTenantId]};
-        }
+        // Tenant isolation (#11632) + per-chunk visibility (#12163), derived from the authenticated
+        // request context (see readVisibilityFilter). A forged client `tenantId` arg is ignored; an
+        // offline / no-context daemon gets no filter, byte-equivalent with pre-#11632 behavior.
+        const whereClause = buildReadWhereClause((type && type !== 'all') ? {type} : {});
 
         const queryOptions = {
             queryEmbeddings: [queryEmbeddingValues],
-            nResults       : aiConfig.nResults,
-            where          : whereClause
+            nResults       : aiConfig.nResults
         };
 
-        if (Object.keys(whereClause).length === 0) {
-            delete queryOptions.where;
+        if (whereClause) {
+            queryOptions.where = whereClause;
         }
 
         const results = await collection.query(queryOptions);

--- a/ai/services/knowledge-base/readVisibilityFilter.mjs
+++ b/ai/services/knowledge-base/readVisibilityFilter.mjs
@@ -1,0 +1,59 @@
+import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
+import aiConfig                                   from '../../mcp/server/knowledge-base/config.mjs';
+
+/**
+ * @module ai/services/knowledge-base/readVisibilityFilter
+ *
+ * Single source of truth for the Knowledge Base **read-side** Chroma `where` clause. Every KB read
+ * path (`QueryService.queryDocuments`, `DocumentService` getters) builds its filter here so the two
+ * isolation layers can never drift apart between call sites:
+ *
+ * 1. **Tenant isolation (#11632):** a requester only sees its own tenant's chunks plus Neo's curated
+ *    `neo-shared` corpus. The tenant is derived server-side from the authenticated context — never
+ *    from a client-supplied argument, so a forged `tenantId` query parameter is ignored.
+ * 2. **Per-chunk visibility (#12163):** a `visibility: 'private'` chunk is returned ONLY to its
+ *    owner; `team` (and any non-private) chunks stay visible to every same-tenant requester. This
+ *    mirrors Memory Core's read-side RLS predicate (`GraphService.isRlsVisible`).
+ *
+ * **Why ownership is matched on `originAgentIdentity`, not the tenant id:** `VectorService` stamps a
+ * private chunk's owner as the writer's **agent-identity node id** (`getAgentIdentityNodeId()`), not
+ * the tenant. In a *shared* tenant (e.g. the cloud `defaultTenantId` tier) many users resolve to one
+ * tenant but keep distinct agent identities — so matching on the tenant would leak every private
+ * chunk to every member. The ownership check therefore uses `getAgentIdentityNodeId()`.
+ *
+ * **Fail-safe:** a private chunk whose `originAgentIdentity` is absent matches no requester and stays
+ * hidden; and when the requester has no agent identity at all, the ownership branch is dropped
+ * entirely, so they see only non-private content.
+ *
+ * **Offline / single-tenant:** with no authenticated request context (stdio single-tenant, offline
+ * daemon) there is no tenant and no visibility filter — byte-equivalent with the pre-#11632 / pre
+ * -#12163 behavior. The caller omits `where` entirely in that case.
+ */
+
+/**
+ * @summary Builds the combined tenant + visibility read `where` clause from the authenticated context.
+ * @param {Object} [base={}] Pre-existing scalar conditions to AND in (e.g. a `{type}` filter).
+ * @returns {Object|null} `{$and: [...]}` when a request context exists; the bare `base` (or `null`)
+ *          when there is no context, signalling the caller to skip filtering.
+ */
+export function buildReadWhereClause(base = {}) {
+    const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
+
+    // No authenticated context → no tenant + no visibility filter (pre-#11632 single-tenant parity).
+    if (!requesterTenantId) {
+        return Object.keys(base).length > 0 ? base : null;
+    }
+
+    const tenantClause = {tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId]}};
+
+    const requesterAgentId = RequestContextService.getAgentIdentityNodeId();
+    const visibilityClause = requesterAgentId
+        ? {$or: [{visibility: {$ne: 'private'}}, {originAgentIdentity: requesterAgentId}]}
+        : {visibility: {$ne: 'private'}};
+
+    const conditions = Object.keys(base).length > 0
+        ? [base, tenantClause, visibilityClause]
+        : [tenantClause, visibilityClause];
+
+    return {$and: conditions}
+}

--- a/ai/services/knowledge-base/readVisibilityFilter.mjs
+++ b/ai/services/knowledge-base/readVisibilityFilter.mjs
@@ -8,26 +8,31 @@ import aiConfig                                   from '../../mcp/server/knowled
  * path (`QueryService.queryDocuments`, `DocumentService` getters) builds its filter here so the two
  * isolation layers can never drift apart between call sites:
  *
- * 1. **Tenant isolation (#11632):** a requester only sees its own tenant's chunks plus Neo's curated
+ * 1. **Tenant isolation:** a requester only sees its own tenant's chunks plus Neo's curated
  *    `neo-shared` corpus. The tenant is derived server-side from the authenticated context — never
  *    from a client-supplied argument, so a forged `tenantId` query parameter is ignored.
- * 2. **Per-chunk visibility (#12163):** a `visibility: 'private'` chunk is returned ONLY to its
- *    owner; `team` (and any non-private) chunks stay visible to every same-tenant requester. This
- *    mirrors Memory Core's read-side RLS predicate (`GraphService.isRlsVisible`).
+ * 2. **Per-chunk visibility:** a `visibility: 'private'` chunk is returned ONLY to its owner; `team`
+ *    (and any non-private) chunks stay visible to every same-tenant requester.
  *
- * **Why ownership is matched on `originAgentIdentity`, not the tenant id:** `VectorService` stamps a
- * private chunk's owner as the writer's **agent-identity node id** (`getAgentIdentityNodeId()`), not
- * the tenant. In a *shared* tenant (e.g. the cloud `defaultTenantId` tier) many users resolve to one
- * tenant but keep distinct agent identities — so matching on the tenant would leak every private
- * chunk to every member. The ownership check therefore uses `getAgentIdentityNodeId()`.
+ * **Owner identity — and its current transport limit:** a private chunk's owner is the writer's
+ * agent-identity node id (`getAgentIdentityNodeId()`, stamped by `VectorService`), matched against the
+ * requester's. Matching on the agent identity rather than the tenant is what would distinguish users
+ * inside a *shared* tenant (the cloud `defaultTenantId` tier). BUT that identity is populated only in
+ * stdio / env / gh-cli contexts; the OIDC/proxy transport a cloud deployment uses resolves a `userId`
+ * but **no** agent-identity node id. So in an OIDC deployment owner-scoped read-back is currently
+ * inert: a `private` chunk has no resolvable owner on read and fails safe — hidden from everyone,
+ * including its writer. Restoring owner read-back there requires keying ownership on a
+ * transport-populated identity (`userId`); that is the tracked owner-key follow-up.
  *
- * **Fail-safe:** a private chunk whose `originAgentIdentity` is absent matches no requester and stays
- * hidden; and when the requester has no agent identity at all, the ownership branch is dropped
- * entirely, so they see only non-private content.
+ * **Fail-safe:** a private chunk whose owner is absent matches no requester and stays hidden; and when
+ * the requester has no agent identity at all, the ownership branch is dropped entirely, so they see
+ * only non-private content. This null-owner policy intentionally **diverges** from Memory Core's RLS
+ * predicate (`GraphService.isRlsVisible`): the non-null-owner match is similar in shape, but Memory
+ * Core treats a null owner as visible whereas this fails closed.
  *
  * **Offline / single-tenant:** with no authenticated request context (stdio single-tenant, offline
- * daemon) there is no tenant and no visibility filter — byte-equivalent with the pre-#11632 / pre
- * -#12163 behavior. The caller omits `where` entirely in that case.
+ * daemon) there is no tenant and no visibility filter — byte-equivalent with the pre-isolation
+ * behavior. The caller omits `where` entirely in that case.
  */
 
 /**

--- a/learn/agentos/cloud-deployment/Security.md
+++ b/learn/agentos/cloud-deployment/Security.md
@@ -6,7 +6,7 @@
 
 A cloud-native KB deployment indexes content from mutually-untrusting tenants in one shared Chroma collection. The security model must guarantee:
 
-1. **No cross-tenant read leakage** — a tenant's `private` content is never returned to another tenant's query.
+1. **No read leakage across tenants or users** — a tenant only ever sees its own content plus `neo-shared`; and within a (possibly shared) tenant, a `private` chunk is returned only to the user who wrote it.
 2. **No identity spoofing on write** — a tenant cannot stamp its chunks with another tenant's `tenantId` to poison or impersonate.
 3. **No chunk-ID collision** — byte-identical content ingested by two tenants must not overwrite each other in the index.
 4. **No untrusted-code execution escape** — a tenant-supplied Parser must not be able to read or mutate another tenant's substrate.
@@ -30,7 +30,12 @@ A cloud-deployment operator running mutually-untrusting tenants should consider 
 
 ## Read-side tenant filter
 
-Write-side stamping puts the `tenantId` / `visibility` fields *into* the index. Read-side enforcement injects tenant-aware Chroma `where` clauses into query paths from the authenticated requester identity. A tenant can see its own content plus `neo-shared`; another tenant's `private` content is filtered out. The fail-closed test suite for "tenant A cannot see tenant B's private content" is part of #11632.
+Write-side stamping puts the `tenantId` and `visibility` fields *into* the index. Read-side enforcement then builds a Chroma `where` clause from the authenticated requester's identity, with two layers:
+
+- **Tenant filter** — you see your own tenant's content plus the shared `neo-shared` corpus, never another tenant's content.
+- **Visibility filter** — a `private` chunk is returned only to the user who wrote it (matched on the writer's identity, not the tenant — this matters when several users share one tenant, such as a shared default-tenant tier), while `team` content stays visible to everyone in the tenant. A `private` chunk with no recorded owner is returned to nobody.
+
+With no authenticated request context (a single-tenant / offline daemon) no filter is applied. The fail-closed coverage lives in `KnowledgeBase.TenantIsolation.spec.mjs`.
 
 ## Parser-execution boundary
 

--- a/learn/agentos/cloud-deployment/Security.md
+++ b/learn/agentos/cloud-deployment/Security.md
@@ -33,7 +33,9 @@ A cloud-deployment operator running mutually-untrusting tenants should consider 
 Write-side stamping puts the `tenantId` and `visibility` fields *into* the index. Read-side enforcement then builds a Chroma `where` clause from the authenticated requester's identity, with two layers:
 
 - **Tenant filter** — you see your own tenant's content plus the shared `neo-shared` corpus, never another tenant's content.
-- **Visibility filter** — a `private` chunk is returned only to the user who wrote it (matched on the writer's identity, not the tenant — this matters when several users share one tenant, such as a shared default-tenant tier), while `team` content stays visible to everyone in the tenant. A `private` chunk with no recorded owner is returned to nobody.
+- **Visibility filter** — a `private` chunk is owner-scoped: returned only to the identity that wrote it (matched on the writer's identity, not the tenant — which matters when several users share one tenant, such as a shared default-tenant tier), while `team` content stays visible to everyone in the tenant.
+
+> **Cloud limitation today — owner read-back of `private` is not yet available over OIDC/proxy.** Owner matching uses an *agent identity* that is currently populated only for local (stdio) agents. A cloud deployment behind OIDC/proxy resolves a per-user `userId` but not that agent identity, so on read a `private` chunk has **no resolvable owner and fails safe — it is hidden from everyone, including its writer**. This still closes the cross-user leak (no other user sees it), but a user cannot yet read their own `private` content back in a cloud deployment. `team` and `neo-shared` content are unaffected. Restoring owner read-back requires keying ownership on the transport-populated `userId` — tracked as the owner-key follow-up.
 
 With no authenticated request context (a single-tenant / offline daemon) no filter is applied. The fail-closed coverage lives in `KnowledgeBase.TenantIsolation.spec.mjs`.
 

--- a/test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs
+++ b/test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs
@@ -28,6 +28,11 @@ function toolText(result) {
     return result.content?.map(item => item.text).join('\n') || '';
 }
 
+// Cross-tenant isolation is enforced by the read-side tenant filter (`tenantId $in [requester, shared]`),
+// which is independent of the per-chunk visibility tier. This spec exercises the OIDC/proxy transport,
+// which populates a tenant but no agent-identity node id, so per-chunk `private` owner-scoping (#12163)
+// is inert here and is unit-covered (`KnowledgeBase.TenantIsolation.spec.mjs`); a `team`-tier chunk is
+// the right fixture for proving a foreign tenant's content never crosses the tenant boundary.
 function kbRecord({id, tenantId, source, name, content}) {
     return {
         id,
@@ -41,13 +46,13 @@ function kbRecord({id, tenantId, source, name, content}) {
             sourcePath: source,
             tenantId,
             type: 'guide',
-            visibility: 'private'
+            visibility: 'team'
         }
     };
 }
 
 test.describe('Dockerized KB cross-tenant isolation integration (#11645)', () => {
-    test('public KB facades do not expose another tenant private chunk', async () => {
+    test('public KB facades do not expose another tenant chunk', async () => {
         const readiness = await getReadiness();
 
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
@@ -62,7 +67,7 @@ test.describe('Dockerized KB cross-tenant isolation integration (#11645)', () =>
             tenantId: bobTenant,
             source  : `integration/${runId}/bob/Secret.md`,
             name    : 'BobOnly',
-            content : `BOB_ONLY_PRIVATE_${runId}`
+            content : `BOB_ONLY_TEAM_${runId}`
         });
         const alice       = await createIdentityClient({
             baseUrl   : KB_URL,

--- a/test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs
+++ b/test/playwright/integration/KBCrossTenantIsolation.integration.spec.mjs
@@ -30,7 +30,7 @@ function toolText(result) {
 
 // Cross-tenant isolation is enforced by the read-side tenant filter (`tenantId $in [requester, shared]`),
 // which is independent of the per-chunk visibility tier. This spec exercises the OIDC/proxy transport,
-// which populates a tenant but no agent-identity node id, so per-chunk `private` owner-scoping (#12163)
+// which populates a tenant but no agent-identity node id, so per-chunk `private` owner-scoping
 // is inert here and is unit-covered (`KnowledgeBase.TenantIsolation.spec.mjs`); a `team`-tier chunk is
 // the right fixture for proving a foreign tenant's content never crosses the tenant boundary.
 function kbRecord({id, tenantId, source, name, content}) {

--- a/test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs
+++ b/test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs
@@ -22,7 +22,7 @@ function documentsById(result) {
 
 // These integration specs run against the dockerized MCP server over the OIDC/proxy transport, which
 // resolves a `userId`/tenant from the identity header but does NOT populate an agent-identity node id.
-// Per-chunk `private` owner-scoping (#12163) keys on `originAgentIdentity`, which is therefore absent
+// Per-chunk `private` owner-scoping keys on `originAgentIdentity`, which is therefore absent
 // here — so the owner axis cannot be exercised end-to-end in this transport and is covered by the unit
 // suite (`KnowledgeBase.TenantIsolation.spec.mjs`). These dockerized specs validate the TENANT axis:
 // `team`-scoped chunks are visible to same-tenant requesters and isolated across tenants.

--- a/test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs
+++ b/test/playwright/integration/KBTeamPrivateRetrieval.integration.spec.mjs
@@ -20,6 +20,12 @@ function documentsById(result) {
     return new Map((result.documents || []).map(document => [document.id, document]));
 }
 
+// These integration specs run against the dockerized MCP server over the OIDC/proxy transport, which
+// resolves a `userId`/tenant from the identity header but does NOT populate an agent-identity node id.
+// Per-chunk `private` owner-scoping (#12163) keys on `originAgentIdentity`, which is therefore absent
+// here — so the owner axis cannot be exercised end-to-end in this transport and is covered by the unit
+// suite (`KnowledgeBase.TenantIsolation.spec.mjs`). These dockerized specs validate the TENANT axis:
+// `team`-scoped chunks are visible to same-tenant requesters and isolated across tenants.
 function kbRecord({id, tenantId, source, name, content}) {
     return {
         id,
@@ -33,13 +39,13 @@ function kbRecord({id, tenantId, source, name, content}) {
             sourcePath: source,
             tenantId,
             type: 'guide',
-            visibility: tenantId === 'neo-shared' ? 'team' : 'private'
+            visibility: 'team'
         }
     };
 }
 
-test.describe('Dockerized KB team/private retrieval integration (#11645)', () => {
-    test('tenant clients see own private chunks plus neo-shared chunks only', async () => {
+test.describe('Dockerized KB team retrieval + tenant isolation integration (#11645)', () => {
+    test('tenant clients see own team chunks plus neo-shared chunks only', async () => {
         const readiness = await getReadiness();
 
         test.skip(readiness.dockerAvailable === false, `Docker unavailable: ${readiness.reason}`);
@@ -54,14 +60,14 @@ test.describe('Dockerized KB team/private retrieval integration (#11645)', () =>
             tenantId: aliceTenant,
             source  : `integration/${runId}/alice/Own.md`,
             name    : 'AliceOwn',
-            content : `ALICE_PRIVATE_VISIBLE_${runId}`
+            content : `ALICE_TEAM_VISIBLE_${runId}`
         });
         const foreign     = kbRecord({
             id      : `kb-team-foreign-${runId}`,
             tenantId: bobTenant,
             source  : `integration/${runId}/bob/Secret.md`,
             name    : 'BobSecret',
-            content : `BOB_PRIVATE_HIDDEN_${runId}`
+            content : `BOB_TEAM_HIDDEN_${runId}`
         });
         const shared      = kbRecord({
             id      : `kb-team-shared-${runId}`,

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
@@ -53,9 +53,14 @@ function createSpyCollection() {
     const matchesWhere = (metadata, where) => {
         if (!where) return true;
         return Object.entries(where).every(([key, cond]) => {
-            if (cond && typeof cond === 'object' && Array.isArray(cond.$in)) {
-                return cond.$in.includes(metadata?.[key]);
+            if (key === '$and') return cond.every(sub => matchesWhere(metadata, sub));
+            if (key === '$or')  return cond.some(sub => matchesWhere(metadata, sub));
+
+            if (cond && typeof cond === 'object') {
+                if (Array.isArray(cond.$in)) return cond.$in.includes(metadata?.[key]);
+                if ('$ne' in cond)           return metadata?.[key] !== cond.$ne;
             }
+
             return metadata?.[key] === cond;
         });
     };
@@ -113,7 +118,7 @@ function createSpyCollection() {
  * `QueryService.queryDocuments` expects (it `JSON.parse`s the field).
  * @returns {{id: String, metadata: Object}}
  */
-function chunk({id, tenantId, source, name, type = 'guide', content, repoSlug}) {
+function chunk({id, tenantId, source, name, type = 'guide', content, repoSlug, visibility, originAgentIdentity}) {
     const metadata = {tenantId, source, name, type, inheritanceChain: '[]'};
 
     if (content) {
@@ -122,6 +127,17 @@ function chunk({id, tenantId, source, name, type = 'guide', content, repoSlug}) 
 
     if (repoSlug) {
         metadata.repoSlug = repoSlug;
+    }
+
+    // VectorService stamps `visibility` (default 'team') on every write, so production chunks always
+    // carry it; the read-side `{visibility: {$ne: 'private'}}` gate therefore runs against a present
+    // field. Fixtures mirror that. `originAgentIdentity` is the owner of a private chunk.
+    if (visibility) {
+        metadata.visibility = visibility;
+    }
+
+    if (originAgentIdentity) {
+        metadata.originAgentIdentity = originAgentIdentity;
     }
 
     return {
@@ -142,24 +158,27 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
         id      : 'c-own',
         tenantId: 'tenant-a',
         repoSlug: 'tenant-app',
-        source  : 'kb/tenant-a/Own.md',
-        name    : 'Own',
-        content : 'TENANT_A_VISIBLE_CONTENT'
+        source    : 'kb/tenant-a/Own.md',
+        name      : 'Own',
+        content   : 'TENANT_A_VISIBLE_CONTENT',
+        visibility: 'team'
     });
     const FOREIGN = chunk({
         id      : 'c-foreign',
         tenantId: 'tenant-b',
         repoSlug: 'tenant-app',
-        source  : 'kb/tenant-b/Secret.md',
-        name    : 'Secret',
-        content : 'TENANT_B_SECRET_CONTENT'
+        source    : 'kb/tenant-b/Secret.md',
+        name      : 'Secret',
+        content   : 'TENANT_B_SECRET_CONTENT',
+        visibility: 'team'
     });
     const SHARED = chunk({
         id      : 'c-shared',
         tenantId: 'neo-shared',
         repoSlug: 'neo',
-        source  : 'kb/neo-shared/Curated.md',
-        name    : 'Curated'
+        source    : 'kb/neo-shared/Curated.md',
+        name      : 'Curated',
+        visibility: 'team'
     });
 
     test.beforeAll(async () => {
@@ -219,7 +238,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
         expect(sources).not.toContain(FOREIGN.metadata.source);
 
         // The filter is server-derived and carries exactly the requester plus the team namespace.
-        expect(spy.calls.query.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+        expect(spy.calls.query.at(-1).where).toEqual({$and: [{tenantId: {$in: ['tenant-a', 'neo-shared']}}, {visibility: {$ne: 'private'}}]});
     });
 
     test('case 2 — team visibility: neo-shared chunks stay visible across every tenant', async () => {
@@ -232,6 +251,57 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
 
         expect(asTenantA.results.map(r => r.source)).toContain(SHARED.metadata.source);
         expect(asTenantB.results.map(r => r.source)).toContain(SHARED.metadata.source);
+    });
+
+    test('case 9 — visibility: a private chunk is hidden from a same-tenant non-owner, shown to its owner (#12163)', async () => {
+        // A private chunk in tenant-a, owned by `agent-owner`.
+        const PRIVATE = chunk({
+            id                 : 'c-private',
+            tenantId           : 'tenant-a',
+            repoSlug           : 'tenant-app',
+            source             : 'kb/tenant-a/Private.md',
+            name               : 'Private',
+            content            : 'TENANT_A_PRIVATE_CONTENT',
+            visibility         : 'private',
+            originAgentIdentity: 'agent-owner'
+        });
+        spy.seed(PRIVATE.id, PRIVATE.metadata);
+
+        // A same-tenant requester who is NOT the owner: sees the team chunk, never the private one.
+        const asNonOwner = await RequestContextService.run({userId: 'tenant-a', agentIdentityNodeId: 'agent-other'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all'})
+        );
+        expect(asNonOwner.results.map(r => r.source)).toContain(OWN.metadata.source);
+        expect(asNonOwner.results.map(r => r.source)).not.toContain(PRIVATE.metadata.source);
+
+        // The owner sees their own private chunk, and the read filter carries the ownership branch
+        // keyed on the requester's agent-identity node id (NOT the tenant).
+        const asOwner = await RequestContextService.run({userId: 'tenant-a', agentIdentityNodeId: 'agent-owner'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all'})
+        );
+        expect(asOwner.results.map(r => r.source)).toContain(PRIVATE.metadata.source);
+        expect(spy.calls.query.at(-1).where).toEqual({$and: [
+            {tenantId: {$in: ['tenant-a', 'neo-shared']}},
+            {$or    : [{visibility: {$ne: 'private'}}, {originAgentIdentity: 'agent-owner'}]}
+        ]});
+    });
+
+    test('case 10 — visibility fail-safe: a private chunk with no owner stays hidden from everyone (#12163)', async () => {
+        const ORPHAN = chunk({
+            id        : 'c-orphan',
+            tenantId  : 'tenant-a',
+            repoSlug  : 'tenant-app',
+            source    : 'kb/tenant-a/Orphan.md',
+            name      : 'Orphan',
+            content   : 'ORPHAN_PRIVATE_CONTENT',
+            visibility: 'private' // no originAgentIdentity → owned by nobody, so nobody may read it
+        });
+        spy.seed(ORPHAN.id, ORPHAN.metadata);
+
+        const asAnyone = await RequestContextService.run({userId: 'tenant-a', agentIdentityNodeId: 'agent-anyone'}, () =>
+            QueryService.queryDocuments({query: 'anything', type: 'all'})
+        );
+        expect(asAnyone.results.map(r => r.source)).not.toContain(ORPHAN.metadata.source);
     });
 
     test('case 3 — chunk-shadow: identical content under two tenants yields distinct chunk ids', () => {
@@ -269,7 +339,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
             QueryService.queryDocuments({query: 'anything', type: 'all', tenantId: 'tenant-b'})
         );
 
-        expect(spy.calls.query.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+        expect(spy.calls.query.at(-1).where).toEqual({$and: [{tenantId: {$in: ['tenant-a', 'neo-shared']}}, {visibility: {$ne: 'private'}}]});
         expect(result.results.map(r => r.source)).not.toContain(FOREIGN.metadata.source);
     });
 
@@ -345,7 +415,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
             expect(ids).toContain(OWN.id);
             expect(ids).toContain(SHARED.id);
             expect(ids).not.toContain(FOREIGN.id);
-            expect(spy.calls.get.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+            expect(spy.calls.get.at(-1).where).toEqual({$and: [{tenantId: {$in: ['tenant-a', 'neo-shared']}}, {visibility: {$ne: 'private'}}]});
         });
 
         test('get_document_by_id (DocumentService.getDocumentById) — a foreign id is not found', async () => {


### PR DESCRIPTION
Refs #12163

Authored by Opus 4.8 (Claude Code). Session af888fcb-6a68-45bd-8a34-13be477733b1.

FAIR-band: in-band [8/30]

Evidence: L2 (the leak-closure is unit-verified — `KnowledgeBase.TenantIsolation.spec.mjs` exercises the real `QueryService`/`DocumentService` read paths through an in-memory Chroma stand-in that faithfully evaluates `$and`/`$or`/`$ne`). **Residual:** owner *read-back* of `private` content over the OIDC/proxy transport is **not** delivered here — see "## Residual" below (tracked as #12296). This PR ships the read-time leak-closure + fail-safe; it does **not** close #12163 (hence `Refs`, not `Resolves`).

## Why this is needed (security)

KB reads filtered on `tenantId` + `type` **only**. The `visibility` field is stamped on every chunk at write time (`VectorService`, default `'team'`, optionally `'private'`) but was **never consulted on any read path** — so `visibility: 'private'` was inert: any **same-tenant** requester could read it. Benign while each user is their own tenant, but **live-relevant** the moment a tenant is shared across users — the cloud deployment's shared default-tenant tier (`NEO_KB_DEFAULT_TENANT_ID`) collapses many users into one tenant, so a `private` chunk leaked to every reader of that tenant. This closes that leak.

## What changed

- **`ai/services/knowledge-base/readVisibilityFilter.mjs`** (new): one source of truth for the read-side `where` clause, consumed by both read services so the two layers can't drift between call sites. It combines, via `$and`: the **tenant filter** (own tenant + `neo-shared`) and the **visibility gate** (`{$or: [{visibility: {$ne: 'private'}}, {originAgentIdentity: <requester>}]}`).
- **Ownership is matched on `getAgentIdentityNodeId()`** — the writer's agent-identity node id, which is what `VectorService` stamps as `originAgentIdentity`, not the tenant id (in a shared tenant many users share one tenant but keep distinct identities).
- **Fail-safe:** a `private` chunk whose owner is absent matches no requester and stays hidden; when the requester has no agent identity, the ownership branch is dropped entirely (they see only non-private). This null-owner policy intentionally **diverges** from Memory Core's RLS (`GraphService.isRlsVisible`): the non-null-owner match is similar in shape, but Memory Core treats a null owner as *visible* whereas this fails closed.
- **Offline / single-tenant** (no request context) → no filter, byte-equivalent with pre-isolation behavior.
- Wired `QueryService.queryDocuments` + both `DocumentService` read paths to the helper.
- `Security.md`: updated to describe the now-enforced tenant + visibility layers **and** the OIDC owner-read-back limitation (below).

## Residual — owner read-back over OIDC/proxy is deferred (#12296)

Owner matching keys on `getAgentIdentityNodeId()`, which is populated only in stdio / env / gh-cli contexts. The **OIDC/proxy transport a cloud deployment uses resolves a `userId` but no agent-identity node id** (`TransportService.mjs` proxy path; `AuthService.mjs` OIDC path). So in a cloud deployment a `private` chunk has no resolvable owner on read and **fails safe — hidden from everyone, including its writer**.

Net: this PR **closes the cross-user leak** (#12163's core threat — no *other* user sees a `private` chunk) but does **not** yet deliver owner read-back of `private` content in a cloud deployment. Restoring that requires keying ownership on the transport-populated `userId` — tracked as **#12296**. Because #12163's owner-read-back acceptance criterion is therefore not fully met over OIDC, this PR uses `Refs #12163` (not `Resolves`) so the ticket stays open until #12296 lands.

## Contract Ledger

The KB read filter (`QueryService.queryDocuments`, `DocumentService` getters) adds a `visibility` `$or` gate; offline/no-auth → no filter (unchanged); `Security.md` made accurate **including the OIDC owner-read-back limitation**. Drift vs the #12163 ledger row: the row's "`private` returned to its `originAgentIdentity`" holds where an agent identity is present (stdio) but is inert over OIDC — captured as residual #12296 rather than claimed as delivered.

## Deltas from ticket

- Visibility logic factored into a shared pure helper rather than inlined per call site — DRY + single security source of truth.
- The owner-read-back limitation over OIDC was discovered during integration (the dockerized specs run that transport); split out as #12296 rather than folding an owner-key model change into this leak-closure PR.

## Test Evidence

- `KnowledgeBase.TenantIsolation.spec.mjs` → **16 passing** (tenant cases updated to `{$and:[tenant, visibility]}`; spy extended for `$and`/`$or`/`$ne`; case 9 = private hidden from same-tenant non-owner + returned to owner; case 10 = ownerless private hidden from everyone, fail-safe).
- Dockerized integration specs (`KBTeamPrivateRetrieval`, `KBCrossTenantIsolation`) reframed to the **tenant axis** (`team` visibility) — the owner axis is inert over their OIDC transport, so it is unit-covered. `integration-unified` is **green**.
- `node --check` + `git diff --check` clean.

## Post-Merge Validation

- [ ] Shared-default-tenant deployment: user A writes a `private` chunk; user B (same tenant, different identity) queries → does **not** see it (leak closed).
- [ ] Known interim limitation (until #12296): user A also cannot read their own `private` chunk back over OIDC (fail-safe). `team` / `neo-shared` content unaffected.