### PR TITLE
fix(orchestrator): cool down overflowed REM cycles (#12289)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -314,6 +314,12 @@ class Config extends BaseConfig {
                     primaryDevSyncMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
                     tenantRepoSyncMs      : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),
                     dreamMs               : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS', 'number'),
+                    /**
+                     * Fraction of `dreamMs` runtime that triggers completion-time cooldown for the
+                     * next dream cycle. This is intentionally below the #12088 `cycleOverflowRatio > 1`
+                     * telemetry signal: it prevents tight reacquire windows before a cycle exceeds
+                     * the full cadence.
+                     */
                     dreamOverflowThreshold: leaf(0.8, 'NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD', 'number'),
                     goldenPathMs          : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS', 'number'),
                     swarmHeartbeatMs      : leaf(15 * 60 * 1000, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS', 'number')

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -22,6 +22,7 @@ import TenantRepoSyncService             from './services/TenantRepoSyncService.
 import {getDueTask as summaryGetDueTaskImport}        from './scheduling/summary.mjs';
 import {getDueTask as backupGetDueTaskImport}         from './scheduling/backup.mjs';
 import {getDueTask as primaryDevSyncGetDueTaskImport} from './scheduling/primaryDevSync.mjs';
+import {getDueTask as dreamGetDueTaskImport}          from './scheduling/dream.mjs';
 import TaskStateService                  from './services/TaskStateService.mjs';
 import ProcessSupervisorService          from './services/ProcessSupervisorService.mjs';
 import CadenceEngine                     from './services/CadenceEngine.mjs';
@@ -153,7 +154,8 @@ function resolveCloudOnlyEnabled(key) {
  * - **(C) Simple imported collaborator** — direct-import instance fields
  *   (`primaryRepoSyncService`, `dreamService`, etc.) for class-shaped execution
  *   collaborators, and function-typed instance fields
- *   (`summaryGetDueTask`, `backupGetDueTask`, `primaryDevSyncGetDueTask`) for
+ *   (`summaryGetDueTask`, `backupGetDueTask`, `primaryDevSyncGetDueTask`,
+ *   `dreamGetDueTask`) for
  *   pure-function scheduling triggers from `./scheduling/<task>.mjs` — no
  *   class-system conversion, no parent-child propagation, no lifecycle side effect.
  *   The function-typed fields default to the imported pure functions so tests can
@@ -255,6 +257,7 @@ export class Orchestrator extends Base {
     backupGetDueTask         = backupGetDueTaskImport
     primaryDevSyncGetDueTask = primaryDevSyncGetDueTaskImport
     tenantRepoSyncGetDueTask = tenantRepoSyncGetDueTaskImport
+    dreamGetDueTask          = dreamGetDueTaskImport
 
     // === Instance state (mutated at runtime; non-reactive) ===
     isPolling                     = false
@@ -758,14 +761,12 @@ export class Orchestrator extends Base {
         }), context);
 
         this.cadenceEngine.runIfDue('dream', () => {
-            if (this.cadenceEngine.shouldRunIntervalTask({
+            return this.dreamGetDueTask({
+                state                 : this.taskStateService.getTaskState('dream') ?? {},
                 now,
-                lastRunAt : this.taskStateService.getTaskState('dream')?.lastRunAt,
-                intervalMs: AiConfig.orchestrator.intervals.dreamMs
-            })) {
-                return { reason: `periodic-dream:${AiConfig.orchestrator.intervals.dreamMs}` };
-            }
-            return null;
+                dreamIntervalMs       : AiConfig.orchestrator.intervals.dreamMs,
+                dreamOverflowThreshold: AiConfig.orchestrator.intervals.dreamOverflowThreshold
+            });
         }, executeMaintenanceTask(async (taskName, reason) => {
             this.taskStateService.markStarted(taskName, reason);
             this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });

--- a/ai/daemons/orchestrator/scheduling/dream.mjs
+++ b/ai/daemons/orchestrator/scheduling/dream.mjs
@@ -1,16 +1,65 @@
+const DEFAULT_DREAM_OVERFLOW_THRESHOLD = 0.8;
+
 /**
- * Dream-cycle due-trigger projection. Returns a trigger descriptor when the
- * configured interval has elapsed since `lastRunAt`; null otherwise. Pure function.
- *
+ * @summary Parses persisted task-state timestamps without throwing on legacy or
+ * partially written state envelopes.
+ * @param {Number|String|null|undefined} value Persisted timestamp value.
+ * @returns {Number|null} Epoch milliseconds or null when the value is unusable.
+ */
+function toTimestampMs(value) {
+    if (Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && value.length > 0) {
+        const parsed = Date.parse(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    return null;
+}
+
+/**
+ * @summary Resolves the timestamp from which the next REM cadence should be
+ * measured. Normal cycles retain start-time cadence; overflowed cycles cool down
+ * from completion so one long run cannot immediately reacquire heavy maintenance.
  * @param {Object} options
- * @param {Object} [options.state] Current task state for the dream lane (`{lastRunAt}`).
+ * @param {Object} [options.state] Current task state for the dream lane.
+ * @param {Number} options.dreamIntervalMs Periodic REM interval.
+ * @param {Number} [options.dreamOverflowThreshold=0.8] Fraction of cadence that
+ * marks a completed cycle as overflowing.
+ * @returns {Number} Epoch millisecond cadence anchor.
+ */
+export function getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold = DEFAULT_DREAM_OVERFLOW_THRESHOLD}) {
+    const lastRunAt        = toTimestampMs(state?.lastRunAt) ?? 0;
+    const lastSuccessAt    = toTimestampMs(state?.lastSuccessAt);
+    const threshold        = Number.isFinite(dreamOverflowThreshold) && dreamOverflowThreshold > 0
+        ? dreamOverflowThreshold
+        : DEFAULT_DREAM_OVERFLOW_THRESHOLD;
+    const thresholdMs      = dreamIntervalMs * threshold;
+    const completedRuntime = lastSuccessAt !== null && lastSuccessAt > lastRunAt
+        ? lastSuccessAt - lastRunAt
+        : 0;
+
+    return completedRuntime > thresholdMs ? lastSuccessAt : lastRunAt;
+}
+
+/**
+ * @summary Dream-cycle due-trigger projection. Returns a trigger descriptor when
+ * the configured interval has elapsed since the resolved cadence anchor; null
+ * otherwise. Pure function.
+ * @param {Object} options
+ * @param {Object} [options.state] Current task state for the dream lane.
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.dreamIntervalMs Periodic interval; `<= 0` disables.
+ * @param {Number} [options.dreamOverflowThreshold=0.8] Fraction of cadence that
+ * makes the completed prior cycle use completion-time cooldown.
  * @returns {Object|null} A dream task trigger or null when no work is due.
  */
-export function getDueTask({state, now, dreamIntervalMs}) {
-    const lastRunAt = state?.lastRunAt ?? 0;
-    if (dreamIntervalMs > 0 && now - lastRunAt >= dreamIntervalMs) {
+export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold = DEFAULT_DREAM_OVERFLOW_THRESHOLD}) {
+    const cadenceAnchor = getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold});
+
+    if (dreamIntervalMs > 0 && now - cadenceAnchor >= dreamIntervalMs) {
         return {
             taskName: 'dream',
             source  : 'periodic-dream',

--- a/ai/daemons/orchestrator/scheduling/dream.mjs
+++ b/ai/daemons/orchestrator/scheduling/dream.mjs
@@ -1,5 +1,3 @@
-const DEFAULT_DREAM_OVERFLOW_THRESHOLD = 0.8;
-
 /**
  * @summary Parses persisted task-state timestamps without throwing on legacy or
  * partially written state envelopes.
@@ -26,17 +24,14 @@ function toTimestampMs(value) {
  * @param {Object} options
  * @param {Object} [options.state] Current task state for the dream lane.
  * @param {Number} options.dreamIntervalMs Periodic REM interval.
- * @param {Number} [options.dreamOverflowThreshold=0.8] Fraction of cadence that
- * marks a completed cycle as overflowing.
+ * @param {Number} options.dreamOverflowThreshold Config-owned fraction of cadence that triggers
+ * completion-time cooldown for a completed cycle.
  * @returns {Number} Epoch millisecond cadence anchor.
  */
-export function getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold = DEFAULT_DREAM_OVERFLOW_THRESHOLD}) {
+export function getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold}) {
     const lastRunAt        = toTimestampMs(state?.lastRunAt) ?? 0;
     const lastSuccessAt    = toTimestampMs(state?.lastSuccessAt);
-    const threshold        = Number.isFinite(dreamOverflowThreshold) && dreamOverflowThreshold > 0
-        ? dreamOverflowThreshold
-        : DEFAULT_DREAM_OVERFLOW_THRESHOLD;
-    const thresholdMs      = dreamIntervalMs * threshold;
+    const thresholdMs      = dreamIntervalMs * dreamOverflowThreshold;
     const completedRuntime = lastSuccessAt !== null && lastSuccessAt > lastRunAt
         ? lastSuccessAt - lastRunAt
         : 0;
@@ -52,11 +47,11 @@ export function getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold
  * @param {Object} [options.state] Current task state for the dream lane.
  * @param {Number} options.now Current timestamp in milliseconds.
  * @param {Number} options.dreamIntervalMs Periodic interval; `<= 0` disables.
- * @param {Number} [options.dreamOverflowThreshold=0.8] Fraction of cadence that
- * makes the completed prior cycle use completion-time cooldown.
+ * @param {Number} options.dreamOverflowThreshold Config-owned fraction of cadence that makes
+ * the completed prior cycle use completion-time cooldown.
  * @returns {Object|null} A dream task trigger or null when no work is due.
  */
-export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold = DEFAULT_DREAM_OVERFLOW_THRESHOLD}) {
+export function getDueTask({state, now, dreamIntervalMs, dreamOverflowThreshold}) {
     const cadenceAnchor = getCadenceAnchor({state, dreamIntervalMs, dreamOverflowThreshold});
 
     if (dreamIntervalMs > 0 && now - cadenceAnchor >= dreamIntervalMs) {

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -104,9 +104,10 @@ export const TASK_REGISTRY = Object.freeze([
         dependencies    : [],
         getDueTask({state, now, intervals}) {
             return getDreamDueTask({
-                state            : state.dream ?? {},
+                state                 : state.dream ?? {},
                 now,
-                dreamIntervalMs  : intervals.dream
+                dreamIntervalMs       : intervals.dream,
+                dreamOverflowThreshold: intervals.dreamOverflowThreshold
             });
         }
     },

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -63,6 +63,7 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.intervals.primaryDevSyncMs = config.primaryDevSyncIntervalMs ?? 600000;
     AiConfig.orchestrator.intervals.tenantRepoSyncMs = config.tenantRepoSyncIntervalMs ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.dreamMs          = config.dreamIntervalMs          ?? Number.MAX_SAFE_INTEGER;
+    AiConfig.orchestrator.intervals.dreamOverflowThreshold = config.dreamOverflowThreshold ?? 0.8;
     AiConfig.orchestrator.intervals.goldenPathMs     = config.goldenPathIntervalMs     ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.swarmHeartbeatMs = config.swarmHeartbeatIntervalMs ?? Number.MAX_SAFE_INTEGER;
     if (config.pollIntervalMs !== undefined) AiConfig.orchestrator.intervals.pollMs = config.pollIntervalMs;
@@ -97,6 +98,7 @@ function createTestOrchestrator(config = {}) {
     orchestrator.primaryRepoSyncService   = config.primaryRepoSyncService   || {runTask: () => null};
     orchestrator.tenantRepoSyncService    = config.tenantRepoSyncService    || {runTask: () => null};
     orchestrator.tenantRepoSyncGetDueTask = config.tenantRepoSyncGetDueTask || (() => null);
+    orchestrator.dreamGetDueTask          = config.dreamGetDueTask          || orchestrator.dreamGetDueTask;
     orchestrator.dreamService             = config.dreamService             || {processUndigestedSessions: () => Promise.resolve()};
     orchestrator.goldenPathSynthesizer    = config.goldenPathSynthesizer    || {synthesizeGoldenPath: () => Promise.resolve()};
     orchestrator.swarmHeartbeatService    = config.swarmHeartbeatService    || {initAsync: () => Promise.resolve(), pulse: () => Promise.resolve()};
@@ -881,6 +883,54 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                 reasonCode      : 'heavy-maintenance-backpressure'
             })
         });
+    });
+
+    test('dream — does not immediately rerun after a cadence-overflowing completed cycle (#12289)', () => {
+        const cycleCalls  = [];
+        const outcomes    = [];
+        const intervalMs  = 3600000;
+        const completedAt = Date.now() - 13000;
+        const runtimeMs   = 5262119;
+
+        const orchestrator = createTestOrchestrator({
+            summarySweepIntervalMs  : Number.MAX_SAFE_INTEGER,
+            kbSyncIntervalMs        : Number.MAX_SAFE_INTEGER,
+            backupIntervalMs        : Number.MAX_SAFE_INTEGER,
+            primaryDevSyncIntervalMs: Number.MAX_SAFE_INTEGER,
+            tenantRepoSyncIntervalMs: Number.MAX_SAFE_INTEGER,
+            dreamIntervalMs         : intervalMs,
+            dreamOverflowThreshold  : 0.8,
+            goldenPathIntervalMs    : Number.MAX_SAFE_INTEGER,
+            swarmHeartbeatIntervalMs: Number.MAX_SAFE_INTEGER,
+            healthService           : {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            dreamService: {
+                executeRemCycle: async options => {
+                    cycleCalls.push(options);
+                    return {
+                        status           : 'completed',
+                        runId            : 'rem-unexpected',
+                        reason           : options.reason,
+                        mode             : options.mode,
+                        startedAt        : new Date().toISOString(),
+                        completedAt      : new Date().toISOString(),
+                        durationMs       : 1,
+                        sessionsProcessed: 0
+                    };
+                }
+            }
+        });
+
+        TaskStateService.taskState.dream.lastRunAt     = completedAt - runtimeMs;
+        TaskStateService.taskState.dream.lastSuccessAt = new Date(completedAt).toISOString();
+
+        orchestrator.poll();
+
+        expect(cycleCalls).toEqual([]);
+        expect(outcomes.filter(o => o.taskName === 'dream')).toEqual([]);
     });
 
     test('defers due primary-dev-sync when another heavy maintenance task is already running (#11513 AC6 — umbrella AC2 gap fill)', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
@@ -7,9 +7,10 @@ import {
 test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
     test('returns a periodic-dream trigger when the interval has elapsed since lastRunAt', () => {
         expect(getDueTask({
-            state          : {lastRunAt: 0},
-            now            : 600000,
-            dreamIntervalMs: 600000
+            state                 : {lastRunAt: 0},
+            now                   : 600000,
+            dreamIntervalMs       : 600000,
+            dreamOverflowThreshold: 0.8
         })).toEqual({
             taskName: 'dream',
             source  : 'periodic-dream',
@@ -19,31 +20,35 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
 
     test('returns null when the interval has not yet elapsed', () => {
         expect(getDueTask({
-            state          : {lastRunAt: 0},
-            now            : 599999,
-            dreamIntervalMs: 600000
+            state                 : {lastRunAt: 0},
+            now                   : 599999,
+            dreamIntervalMs       : 600000,
+            dreamOverflowThreshold: 0.8
         })).toBeNull();
     });
 
     test('treats intervalMs <= 0 as disabled (does not fire)', () => {
         expect(getDueTask({
-            state          : {lastRunAt: 0},
-            now            : 999999999,
-            dreamIntervalMs: 0
+            state                 : {lastRunAt: 0},
+            now                   : 999999999,
+            dreamIntervalMs       : 0,
+            dreamOverflowThreshold: 0.8
         })).toBeNull();
 
         expect(getDueTask({
-            state          : {lastRunAt: 0},
-            now            : 999999999,
-            dreamIntervalMs: -1
+            state                 : {lastRunAt: 0},
+            now                   : 999999999,
+            dreamIntervalMs       : -1,
+            dreamOverflowThreshold: 0.8
         })).toBeNull();
     });
 
     test('handles missing state gracefully (lastRunAt defaults to 0)', () => {
         expect(getDueTask({
-            state          : undefined,
-            now            : 600000,
-            dreamIntervalMs: 600000
+            state                 : undefined,
+            now                   : 600000,
+            dreamIntervalMs       : 600000,
+            dreamOverflowThreshold: 0.8
         })).toEqual({
             taskName: 'dream',
             source  : 'periodic-dream',

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 import {
+    getCadenceAnchor,
     getDueTask
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/dream.mjs';
 
@@ -47,6 +48,64 @@ test.describe('orchestrator/scheduling/dream (#11858 / Epic #11831)', () => {
             taskName: 'dream',
             source  : 'periodic-dream',
             reason  : 'periodic-dream:600000'
+        });
+    });
+
+    test('uses completion-time cooldown after a cadence-overflowing REM cycle (#12289)', () => {
+        const intervalMs  = 3600000;
+        const runtimeMs   = 5262119;
+        const completedAt = runtimeMs;
+        const state       = {
+            lastRunAt    : 0,
+            lastSuccessAt: new Date(completedAt).toISOString()
+        };
+
+        expect(getCadenceAnchor({
+            state,
+            dreamIntervalMs       : intervalMs,
+            dreamOverflowThreshold: 0.8
+        })).toBe(completedAt);
+
+        expect(getDueTask({
+            state,
+            now                   : completedAt + 13000,
+            dreamIntervalMs       : intervalMs,
+            dreamOverflowThreshold: 0.8
+        })).toBeNull();
+
+        expect(getDueTask({
+            state,
+            now                   : completedAt + intervalMs,
+            dreamIntervalMs       : intervalMs,
+            dreamOverflowThreshold: 0.8
+        })).toEqual({
+            taskName: 'dream',
+            source  : 'periodic-dream',
+            reason  : 'periodic-dream:3600000'
+        });
+    });
+
+    test('preserves start-time cadence for non-overflowing REM cycles (#12289)', () => {
+        const state = {
+            lastRunAt    : 0,
+            lastSuccessAt: new Date(600000).toISOString()
+        };
+
+        expect(getCadenceAnchor({
+            state,
+            dreamIntervalMs       : 3600000,
+            dreamOverflowThreshold: 0.8
+        })).toBe(0);
+
+        expect(getDueTask({
+            state,
+            now                   : 3600000,
+            dreamIntervalMs       : 3600000,
+            dreamOverflowThreshold: 0.8
+        })).toEqual({
+            taskName: 'dream',
+            source  : 'periodic-dream',
+            reason  : 'periodic-dream:3600000'
         });
     });
 });


### PR DESCRIPTION
Resolves #12289

Authored by GPT-5 (Codex Desktop). Session f3165fbb-7c0e-4790-8a97-b2557f5340e3.

FAIR-band: over-target [22/30] — taking this lane despite over-target because operator-reported live CPU/fan pressure and REM scheduler starvation required same-session incident response.

Prevents a cadence-overflowing REM cycle from immediately reacquiring the heavy-maintenance lane. The dream scheduler now measures the next due window from completion time only when the previous completed run exceeded the configured overflow band; normal REM cycles keep the existing start-time cadence.

Evidence: L2 (pure scheduling + orchestrator poll unit coverage simulating a 5,262,119ms REM cycle on a 3,600,000ms cadence) → L2 required (scheduler fairness and no immediate REM heavy-maintenance reacquire are unit-verifiable). No residuals.

## Deltas from ticket

- Uses existing persisted task state (`lastRunAt` + `lastSuccessAt`) to infer prior cycle overflow; no JSONL read path, no extra scheduler state file.
- Preserves normal start-time cadence for non-overflowing REM cycles.
- Wires both the direct `Orchestrator.poll()` dream path and the scheduling registry adapter through the same REM due projection.
- Keeps `dreamOverflowThreshold` config-owned: `ai/config.template.mjs` remains the single source for the `0.8` default, with no duplicate `DEFAULT_*` constant or silent code fallback.

## Test Evidence

- `node --check ai/daemons/orchestrator/scheduling/dream.mjs`
- `node --check ai/daemons/orchestrator/Orchestrator.mjs`
- `node --check ai/daemons/orchestrator/scheduling/registry.mjs`
- `node --check ai/config.template.mjs`
- `git diff --check`
- `git diff --cached --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/dream.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 46 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs` — 6 passed

## Post-Merge Validation

- [ ] Observe the next overflowing REM cycle: the next dream run should wait one full `dreamMs` window from completion, giving summary, backup, and primary dev sync a chance to run.

## Commits

- `ed058823b` — `fix(orchestrator): cool down overflowed REM cycles (#12289)`
- `755d9446c` — `fix(orchestrator): keep dream overflow threshold config-owned (#12289)`
