### PR TITLE
refactor(portal): make content cross-link URLs per-content-type config (#12209)

### DIFF
--- a/apps/portal/view/content/Component.mjs
+++ b/apps/portal/view/content/Component.mjs
@@ -28,6 +28,10 @@ class Component extends ContentComponent {
             resize: 'onResize'
         },
         /**
+         * @member {String} issuesUrl='#/news/tickets/'
+         */
+        issuesUrl: '#/news/tickets/',
+        /**
          * @member {Boolean} updateSectionsStore=false
          */
         updateSectionsStore: false

--- a/apps/portal/view/learn/Component.mjs
+++ b/apps/portal/view/learn/Component.mjs
@@ -10,7 +10,11 @@ class Component extends ContentComponent {
          * @member {String} className='Portal.view.learn.Component'
          * @protected
          */
-        className: 'Portal.view.learn.Component'
+        className: 'Portal.view.learn.Component',
+        /**
+         * @member {String} issuesUrl='#/news/tickets/'
+         */
+        issuesUrl: '#/news/tickets/'
     }
 
     /**

--- a/apps/portal/view/news/blog/Component.mjs
+++ b/apps/portal/view/news/blog/Component.mjs
@@ -10,7 +10,11 @@ class Component extends ContentComponent {
          * @member {String} className='Portal.view.news.blog.Component'
          * @protected
          */
-        className: 'Portal.view.news.blog.Component'
+        className: 'Portal.view.news.blog.Component',
+        /**
+         * @member {String} issuesUrl='#/news/tickets/'
+         */
+        issuesUrl: '#/news/tickets/'
     }
 
     /**

--- a/apps/portal/view/news/release/Component.mjs
+++ b/apps/portal/view/news/release/Component.mjs
@@ -10,7 +10,11 @@ class Component extends ContentComponent {
          * @member {String} className='Portal.view.news.release.Component'
          * @protected
          */
-        className: 'Portal.view.news.release.Component'
+        className: 'Portal.view.news.release.Component',
+        /**
+         * @member {String} issuesUrl='#/news/tickets/'
+         */
+        issuesUrl: '#/news/tickets/'
     }
 
     /**

--- a/apps/portal/view/news/tickets/Component.mjs
+++ b/apps/portal/view/news/tickets/Component.mjs
@@ -42,6 +42,10 @@ class Component extends ContentComponent {
          */
         commitsUrl: 'https://github.com/neomjs/neo/commit/',
         /**
+         * @member {String} issuesUrl='#/news/tickets/'
+         */
+        issuesUrl: '#/news/tickets/',
+        /**
          * @member {String} repoUserUrl='https://github.com/'
          */
         repoUserUrl: 'https://github.com/'

--- a/src/app/content/Component.mjs
+++ b/src/app/content/Component.mjs
@@ -24,10 +24,10 @@ class Component extends Markdown {
         bind: {
             record: data => data.currentPageRecord
         },
-        /**
-         * @member {String} issuesUrl='#/news/tickets/'
-         */
-        issuesUrl: '#/news/tickets/',
+        // issuesUrl is intentionally NOT defaulted here: this generic content base must not bake in a
+        // portal-app route. It inherits Neo.component.Markdown's neutral default
+        // (https://github.com/neomjs/neo/issues/); each consuming portal view sets its own cross-link
+        // target (e.g. '#/news/tickets/') as a per-content-type config (#12209).
         /**
          * @member {Object} record_=null
          * @reactive

--- a/test/playwright/unit/app/content/CrossLinkIssuesUrl.spec.mjs
+++ b/test/playwright/unit/app/content/CrossLinkIssuesUrl.spec.mjs
@@ -1,0 +1,64 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AppContentCrossLinkTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import ContentComponent from '../../../../../src/app/content/Component.mjs';
+import Markdown        from '../../../../../src/component/Markdown.mjs';
+
+const appName = 'AppContentCrossLinkTest';
+
+// Exercise the VM-free parent renderer directly so the app/content sidenav (state-provider) path is
+// not required to assert cross-link behavior.
+const renderTicketRefs = (instance, content) => Markdown.prototype.modifyMarkdown.call(instance, content);
+
+/**
+ * #12209 — cross-link URLs are a per-content-type config, not a framework-base assumption.
+ *
+ * Before: `Neo.app.content.Component` (a generic src/ content class) hard-coded
+ * `issuesUrl: '#/news/tickets/'`, so every consuming portal view inherited the portal-app route.
+ * After: the generic base carries no portal route — it inherits `Neo.component.Markdown`'s neutral
+ * GitHub default — and each portal view declares its own cross-link target (the dev-merged views
+ * learn / content / tickets / release / blog each set `'#/news/tickets/'` to preserve behavior; PR
+ * and Discussion views set their own). The layering is now correct: the framework base stays
+ * app-agnostic while the routing decision lives with the app-level view.
+ */
+test.describe('Neo.app.content.Component cross-link issuesUrl (#12209)', () => {
+    test('generic content base no longer bakes in the portal route — inherits the Markdown GitHub default', () => {
+        const instance = Neo.create(ContentComponent, {appName});
+
+        // The tickets-specific override is gone; the generic base falls through to Markdown's default.
+        expect(instance.issuesUrl).toBe('https://github.com/neomjs/neo/issues/');
+
+        instance.destroy();
+    });
+
+    test('base default renders a #N reference as an external GitHub link (new tab)', () => {
+        const instance = Neo.create(ContentComponent, {appName}),
+              html     = renderTicketRefs(instance, 'see #123 for details');
+
+        expect(html).toContain('href="https://github.com/neomjs/neo/issues/123"');
+        expect(html).toContain('target="_blank"');
+
+        instance.destroy();
+    });
+
+    test('a per-type internal issuesUrl flows into the rendered #N cross-link (no new tab)', () => {
+        // Models exactly what each portal view now declares as its own config.
+        const instance = Neo.create(ContentComponent, {appName, issuesUrl: '#/news/tickets/'}),
+              html     = renderTicketRefs(instance, 'see #123 for details');
+
+        expect(instance.issuesUrl).toBe('#/news/tickets/');
+        expect(html).toContain('href="#/news/tickets/123"');
+        // internal routes must NOT open a new tab
+        expect(html).not.toContain('target="_blank"');
+
+        instance.destroy();
+    });
+});


### PR DESCRIPTION
Resolves #12209

Authored by Opus 4.8 (Claude Code). Session 758163a2-3619-4110-8364-44250500595f.

FAIR-band: in-band [8/30]

Evidence: L2 (unit-tested — 3 passing tests covering the base default, external-link render, and per-type internal-route render; all `.mjs` syntax-valid). Residual: none — the change is config placement with no runtime AC beyond the rendered cross-link, which the unit tests cover.

## What this delivers

Removes the hard-coded `issuesUrl: '#/news/tickets/'` default from the generic framework base `src/app/content/Component.mjs`. A `src/` content class must not bake in a portal-app route — the base now inherits `Neo.component.Markdown`'s neutral default (`https://github.com/neomjs/neo/issues/`), and each consuming portal view declares its own cross-link target as a per-content-type config.

- **`src/app/content/Component.mjs`** — drops the `issuesUrl` override; an intent-comment documents that the route is now a per-view decision (sub 5 of epic #12204 / #12207 foundation).
- **5 dev-merged consumers** (`learn`, `content`, `news/tickets`, `news/release`, `news/blog`) — each sets `issuesUrl: '#/news/tickets/'` explicitly, preserving exactly the value they previously inherited. **Zero behavior change.**
- **PR view (#12287)** + **Discussion view (#12288)** set their own `issuesUrl` in their own PRs (A2A'd @neo-gpt for the Discussion view).

### Honest framing — this is a layering cleanup, not a functional bug fix

The ticket frames it as preventing "mis-linked PR/Discussion content," but I V-B-A'd that premise: a `#N` reference is an **issue number**, which resolves correctly to the tickets view for *every* content type — so `issuesUrl` did not actually mis-link PR/Discussion content. The genuinely tickets-specific assumptions (`commitsUrl`, the release-badge) already live in the `tickets/Component.mjs` subclass, so PR/Discussion views never inherited them. The real, valid win here is **layering**: the framework `Neo.app.content.Component` no longer hardcodes a portal-app route, so the routing decision lives with the app-level view (and PR/Discussion views *can* now diverge if a future need arises). Shipping it as cleanup, framed honestly, rather than as a fix for a bug that wasn't there.

## Deltas

- Framed as a layering cleanup (not the ticket's "mis-link" functional premise) per the V-B-A above.
- Scope on this PR = framework base + the 5 dev-merged views. The two in-flight view PRs (#12287 pulls, #12288 discussions) adopt their own `issuesUrl` in their branches to avoid cross-PR conflicts on the same files.

## Test Evidence

- **New unit spec** (`test/playwright/unit/app/content/CrossLinkIssuesUrl.spec.mjs`) — **3 passing (646ms)**: (a) the generic base now resolves `issuesUrl` to the GitHub default (override removed); (b) the base default renders `#123` as an external GitHub link with `target="_blank"`; (c) a per-type internal `issuesUrl` (`'#/news/tickets/'`, exactly what each view declares) renders `#123` → `#/news/tickets/123` with no new tab. The render assertions exercise the VM-free `Neo.component.Markdown.prototype.modifyMarkdown` to isolate cross-linking from the app/content state-provider path.
- `node --check` passes for all 7 changed `.mjs`; `git diff --cached --check` clean.

## Post-Merge Validation

- [ ] On the dev-served portal: a tickets/release/blog entry with a `#N` reference still links to `#/news/tickets/N` (unchanged); once #12287/#12288 land, PR/Discussion entries link `#N` per their own configured route.
