### PR TITLE
fix(ai): retune embedding context defaults (#12286)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -200,15 +200,14 @@ class Config extends BaseConfig {
                 /**
                  * @summary Embedding-model context limits in tokens.
                  *
-                 * Conservative placeholder defaults. Operators must pin to their loaded
-                 * embedding model's actual capability before operational reliance — for
-                 * instance Qwen3-8B-embedding typically supports 32K context, but this
-                 * default holds an 8K conservative floor until V-B-A confirms the value
-                 * against the configured embedding model.
+                 * Tuned for the default OpenAI-compatible embedding model
+                 * `text-embedding-qwen3-embedding-8b`, whose upstream Qwen model card
+                 * advertises a 32K context window. Operators serving smaller embedding
+                 * models must pin this to the actual loaded-model capacity.
                  *
-                 * No active consumer reads these yet; pre-positioned for the embedding
-                 * consumer surface (TextEmbeddingService + KB ingestion retry-on-unload
-                 * telemetry paths).
+                 * `safeProcessingLimitTokens` is the explicit 28K operational band —
+                 * large enough for file-scale KB / Memory Core ingestion while leaving a
+                 * 4K-token margin below the advertised model maximum.
                  *
                  * Env overrides: `NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS`,
                  * `NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS`.
@@ -216,8 +215,8 @@ class Config extends BaseConfig {
                  * @type {Object}
                  */
                 embedding: {
-                    contextLimitTokens       : leaf(8192, 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(6144, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
+                    contextLimitTokens       : leaf(32768, 'NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(28672, 'NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
                 }
             },
             /**

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -123,8 +123,8 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
         },
         embedding: {
-            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 8192,
-            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 6144
+            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
+            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672
         }
     },
     vectorDimension: Number(process.env.NEO_VECTOR_DIMENSION) || 4096,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -89,8 +89,8 @@ test.describe('Tier 1 Config Immutability', () => {
                 safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
             },
             embedding: {
-                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 8192,
-                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 6144
+                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672
             }
         });
         expect(Config.engines.chroma).toEqual({
@@ -98,6 +98,23 @@ test.describe('Tier 1 Config Immutability', () => {
             host   : process.env.NEO_CHROMA_HOST || 'localhost',
             port   : Number(process.env.NEO_CHROMA_PORT) || 8000
         });
+    });
+
+    test('keeps local embedding context env overrides role-scoped (#12286)', () => {
+        const originalContext = Config.localModels.embedding.contextLimitTokens,
+              originalSafe    = Config.localModels.embedding.safeProcessingLimitTokens;
+
+        Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', 12345);
+        Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 11111);
+
+        expect(Config.localModels.embedding).toMatchObject({
+            contextLimitTokens      : 12345,
+            safeProcessingLimitTokens: 11111
+        });
+        expect(Config.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144);
+
+        Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', originalContext);
+        Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', originalSafe);
     });
 
     test('ships top-level deployment and maintenance policy defaults', async () => {

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -309,7 +309,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
             host          : 'http://127.0.0.1:1234',
             models        : ['chat-model', 'embedding-model'],
-            contextLengths: {'chat-model': 262144, 'embedding-model': 8192},
+            contextLengths: {'chat-model': 262144, 'embedding-model': 32768},
             attempts      : 1,
             delayMs       : 0,
             timeoutMs     : 50,
@@ -324,7 +324,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(loadCalls).toEqual([
             {model: 'chat-model',      contextLength: 262144},
-            {model: 'embedding-model', contextLength: 8192}
+            {model: 'embedding-model', contextLength: 32768}
         ]);
         expect(result.ready).toBe(true);
         expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
@@ -375,7 +375,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
             host          : 'http://127.0.0.1:1234',
             models        : ['chat-model', 'embedding-model'],
-            contextLengths: {'chat-model': 262144, 'embedding-model': 8192},
+            contextLengths: {'chat-model': 262144, 'embedding-model': 32768},
             attempts      : 2,
             delayMs       : 0,
             timeoutMs     : 50,
@@ -386,7 +386,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(loadCalls).toEqual([
             {model: 'chat-model',      options: {contextLength: 262144}},
-            {model: 'embedding-model', options: {contextLength: 8192}}
+            {model: 'embedding-model', options: {contextLength: 32768}}
         ]);
         expect(result.ready).toBe(true);
         expect(result.loadedModels).toEqual(['chat-model', 'embedding-model']);
@@ -403,7 +403,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
             host            : 'http://127.0.0.1:1234',
             models          : ['chat-model', 'embedding-model'],
-            contextLengths  : {'chat-model': 262144, 'embedding-model': 8192},
+            contextLengths  : {'chat-model': 262144, 'embedding-model': 32768},
             allowPartial    : true,
             attempts        : 2,
             delayMs         : 0,
@@ -423,7 +423,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(loadCalls).toEqual([
             {model: 'chat-model',      contextLength: 262144},
-            {model: 'embedding-model', contextLength: 8192}
+            {model: 'embedding-model', contextLength: 32768}
         ]);
         expect(result.ready).toBe(false);
         expect(result.degraded).toBe(true);
@@ -448,7 +448,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         const result = await providerReadinessHelper.ensureLmsModelsLoaded({
             host          : 'http://127.0.0.1:1234',
             models        : ['chat-model', 'embedding-model'],
-            contextLengths: {'chat-model': 32768, 'embedding-model': 8192},
+            contextLengths: {'chat-model': 32768, 'embedding-model': 32768},
             allowPartial  : true,
             attempts      : 2,
             delayMs       : 0,
@@ -468,7 +468,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(loadCalls).toEqual([
             {model: 'chat-model',      contextLength: 32768},
-            {model: 'embedding-model', contextLength: 8192}
+            {model: 'embedding-model', contextLength: 32768}
         ]);
         expect(result.ready).toBe(false);
         expect(result.degraded).toBe(true);
@@ -518,10 +518,10 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             chatModel             : 'chat-from-config',
             embeddingModel        : 'embedding-from-config',
             chatContextLength     : 262144,
-            embeddingContextLength: 8192
+            embeddingContextLength: 32768
         })).toEqual({
             'chat-from-config'     : 262144,
-            'embedding-from-config': 8192
+            'embedding-from-config': 32768
         });
     });
 
@@ -538,7 +538,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         // Context-lengths present but models missing
         expect(providerReadinessHelper.buildLmsContextLengthsMap({
             chatContextLength     : 262144,
-            embeddingContextLength: 8192
+            embeddingContextLength: 32768
         })).toEqual({});
 
         // Non-finite context-lengths defensive: NaN, Infinity, non-number all skipped
@@ -557,7 +557,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             chatModel             : 'shared-model',
             embeddingModel        : 'shared-model',
             chatContextLength     : 262144,
-            embeddingContextLength: 8192
+            embeddingContextLength: 32768
         })).toEqual({'shared-model': 262144});
 
         // Order independence: same result if smaller declared first (already handled
@@ -565,7 +565,7 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(providerReadinessHelper.buildLmsContextLengthsMap({
             chatModel             : 'shared-model',
             embeddingModel        : 'shared-model',
-            chatContextLength     : 8192,
+            chatContextLength     : 32768,
             embeddingContextLength: 262144
         })).toEqual({'shared-model': 262144});
 
@@ -586,8 +586,37 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
 
         expect(providerReadinessHelper.buildLmsContextLengthsMap({
             embeddingModel        : 'embedding-only',
-            embeddingContextLength: 8192
-        })).toEqual({'embedding-only': 8192});
+            embeddingContextLength: 32768
+        })).toEqual({'embedding-only': 32768});
+    });
+
+    test('buildLmsPreloadConfig uses the retuned embedding role context for OpenAI-compatible embeddings (#12286)', () => {
+        expect(providerReadinessHelper.buildLmsPreloadConfig({
+            modelProvider    : 'gemini',
+            graphProvider    : 'openAiCompatible',
+            embeddingProvider: 'openAiCompatible',
+            openAiCompatible: {
+                model         : 'gemma-4-31b-it',
+                embeddingModel: 'text-embedding-qwen3-embedding-8b'
+            },
+            localModels: {
+                chat: {
+                    contextLimitTokens: 262144
+                },
+                embedding: {
+                    contextLimitTokens: 32768
+                }
+            }
+        })).toEqual({
+            models: [
+                'gemma-4-31b-it',
+                'text-embedding-qwen3-embedding-8b'
+            ],
+            contextLengths: {
+                'gemma-4-31b-it'                  : 262144,
+                'text-embedding-qwen3-embedding-8b': 32768
+            }
+        });
     });
 
     test('loadLmsModel omits --context-length when contextLength is non-finite (defensive)', async () => {


### PR DESCRIPTION
Resolves #12286

Authored by GPT-5.5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.

FAIR-band: over-target [22/30] — taking this lane despite over-target because this is an operator-raised local-model config regression, #12216 is still contract-blocked, and the active portal PRs are waiting on peer body-fix cycles.

Retunes the local embedding role from the obsolete 8K placeholder to the configured Qwen3 embedding model's 32K-class window. The new defaults are `contextLimitTokens: 32768` and `safeProcessingLimitTokens: 28672`, with the config comment updated to make the embedding role an active KB / Memory Core ingestion consumer rather than a future placeholder.

Evidence: L2 (config + provider-readiness unit coverage, upstream model-card V-B-A, syntax checks) -> L2 required (#12286 config-SSOT defaults and role-aware consumer tests). No residuals.

## Deltas from ticket

- Primary-doc V-B-A: the Qwen/Qwen3-Embedding-8B model card lists Qwen3-Embedding-8B as a text embedding model with 32K sequence length and 4096 embedding dimension: https://huggingface.co/Qwen/Qwen3-Embedding-8B
- Served-stack V-B-A: `curl --max-time 2 http://127.0.0.1:11434/v1/models` and `/api/tags` both failed with connection refused, so the PR uses the ticket-allowed primary model docs path rather than local server metadata.
- Safe band chosen: 28672 tokens, leaving a 4096-token margin below the advertised 32768-token maximum while removing the old 6144-token file-ingestion choke point.

## Test Evidence

- `node --check ai/config.template.mjs`
- `node --check test/playwright/fixtures/aiConfigDefaults.mjs`
- `node --check test/playwright/unit/ai/config.template.spec.mjs`
- `node --check test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs` -> 6 passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` -> 34 passed
- `git diff --check` and `git diff --cached --check` clean before commit; `git diff --check origin/dev..HEAD` clean after rebase.

## Post-Merge Validation

- [ ] Local operators using smaller embedding models can keep the same provider selection and override only `NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS` / `NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS`.

## Commit

- `fdd89397b` — `fix(ai): retune embedding context defaults (#12286)`
