### PR TITLE
feat(tooling): mechanical guard against ticket-ref archaeology in .mjs comments (#12294)

### DIFF
--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -1,0 +1,215 @@
+import {program}             from 'commander';
+import {execSync, spawnSync}  from 'node:child_process';
+import {readFileSync}         from 'node:fs';
+import path                   from 'node:path';
+import process                from 'node:process';
+import {fileURLToPath}        from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
+
+const DEFAULT_DIRS    = ['ai', 'src', 'test/playwright'];
+const DEFAULT_IGNORES = ['.claude', '.codex', 'dist', 'node_modules'];
+
+// Inline relief valve for a genuinely load-bearing comment ref (judgment-call escape, not a blanket bypass).
+export const ESCAPE_MARKER = 'ticket-ref-ok';
+
+// Decay-prone tracking anchors that must not live in durable source comments. `#\d{4,}\b` targets
+// issue/PR numbers (Neo tickets are 5 digits) while a trailing word boundary avoids matching hex colors
+// like `#1234ff`; the named forms catch the prose variants.
+export const TICKET_PATTERNS = [
+    /#\d{4,}\b/,
+    /\bEpic\s+#?\d+\b/i,
+    /\bDiscussion\s+#?\d+\b/i,
+    /\bADR[-\s]?\d{3,4}\b/i
+];
+
+/**
+ * @summary Extracts the comment portion(s) of a single line of source via a small string-aware scan.
+ *
+ * Only true comment context is returned: line (slash-slash) and block (slash-star) comments. String
+ * literals are skipped, so a ticket ref that lives inside a string — a `describe(...)` test anchor or a
+ * URL such as the issues endpoint — is never mistaken for a durable comment. Block-comment state is
+ * carried across lines via `state.inBlock`; per-line string state is intentionally not carried (a ref
+ * buried in a multi-line template literal is the rare case the inline escape marker covers).
+ * @param {String} line
+ * @param {{inBlock: Boolean}} state Mutated in place as block comments open and close across lines.
+ * @returns {String} The comment text on this line (empty when the line carries no comment).
+ */
+export function extractComment(line, state) {
+    let comment = '',
+        i       = 0;
+
+    const n = line.length;
+
+    if (state.inBlock) {
+        const end = line.indexOf('*/');
+
+        if (end === -1) {
+            return line
+        }
+
+        comment      += line.slice(0, end) + ' ';
+        i             = end + 2;
+        state.inBlock = false
+    }
+
+    let inString = null;
+
+    while (i < n) {
+        const ch   = line[i],
+              next = line[i + 1];
+
+        if (inString) {
+            if (ch === '\\') {
+                i += 2;
+                continue
+            }
+            if (ch === inString) {
+                inString = null
+            }
+            i++;
+            continue
+        }
+
+        if (ch === '"' || ch === "'" || ch === '`') {
+            inString = ch;
+            i++;
+            continue
+        }
+
+        if (ch === '/' && next === '/') {
+            comment += ' ' + line.slice(i);
+            break
+        }
+
+        if (ch === '/' && next === '*') {
+            const end = line.indexOf('*/', i + 2);
+
+            if (end === -1) {
+                comment      += ' ' + line.slice(i + 2);
+                state.inBlock = true;
+                break
+            }
+
+            comment += ' ' + line.slice(i + 2, end);
+            i        = end + 2;
+            continue
+        }
+
+        i++
+    }
+
+    return comment
+}
+
+/**
+ * @summary Scans file content for decay-prone ticket refs that live in comment context.
+ * @param {String} content
+ * @returns {Object[]} `[{line, text}]` — one entry per offending line (1-based line numbers).
+ */
+export function findTicketRefs(content) {
+    const lines = content.split('\n'),
+          state = {inBlock: false},
+          hits  = [];
+
+    lines.forEach((line, index) => {
+        const comment = extractComment(line, state);
+
+        if (!comment || line.includes(ESCAPE_MARKER)) {
+            return
+        }
+
+        if (TICKET_PATTERNS.some(re => re.test(comment))) {
+            hits.push({line: index + 1, text: line.trim()})
+        }
+    });
+
+    return hits
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+    } catch (e) {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1);
+    }
+
+    if (path.resolve(scriptRoot) !== path.resolve(gitRoot)) {
+        console.error('\x1b[31mError: Script repository root mismatch.\x1b[0m');
+        console.error(`check-ticket-archaeology.mjs is located under '${scriptRoot}', but the git repository root is '${gitRoot}'.`);
+        process.exit(1);
+    }
+
+    program
+        .name('check-ticket-archaeology')
+        .description('Substrate gate against decay-prone ticket/Epic/Discussion/ADR refs in durable .mjs comments/JSDoc.')
+        .argument('[files...]', 'Specific .mjs files to scan (lint-staged passes staged paths here). When omitted, falls back to scanning --dirs.')
+        .option('-d, --dirs <list>', 'Comma-separated directories to scan in default mode.', DEFAULT_DIRS.join(','))
+        .option('-i, --ignore <list>', 'Comma-separated path fragments to exclude from default-mode scan.', DEFAULT_IGNORES.join(','))
+        .option('-q, --quiet', 'Suppress the per-violation listing; print summary only.', false)
+        .showHelpAfterError();
+
+    program.parse(process.argv);
+
+    const argvFiles = program.args,
+          options   = program.opts(),
+          scanDirs  = options.dirs.split(',').map(s => s.trim()).filter(Boolean),
+          ignores   = options.ignore.split(',').map(s => s.trim()).filter(Boolean);
+
+    function collectDefaultFiles() {
+        const findArgs = ['-type', 'f', '-name', '*.mjs'];
+        ignores.forEach(ignore => findArgs.push('-not', '-path', `*/${ignore}/*`));
+
+        const result = spawnSync('find', [...scanDirs, ...findArgs], {cwd: gitRoot, encoding: 'utf-8'});
+        if (result.status !== 0) {
+            console.error('\x1b[31mError: find command failed.\x1b[0m');
+            console.error(result.stderr);
+            process.exit(1);
+        }
+        return result.stdout.trim().split('\n').filter(Boolean);
+    }
+
+    const files = argvFiles.length > 0
+        ? argvFiles.filter(f => f.endsWith('.mjs'))
+        : collectDefaultFiles();
+
+    if (files.length === 0) {
+        console.log('check-ticket-archaeology: 0 .mjs files in scope, nothing to check.');
+        process.exit(0);
+    }
+
+    const violations = [];
+    for (const file of files) {
+        let content;
+        try {
+            content = readFileSync(file, 'utf-8');
+        } catch (e) {
+            console.error(`check-ticket-archaeology: could not read ${file}: ${e.message}`);
+            continue;
+        }
+
+        findTicketRefs(content).forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
+    }
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-ticket-archaeology: ${violations.length} ticket ref(s) in durable comments:\x1b[0m`);
+        if (!options.quiet) {
+            violations.forEach(v => console.error('  ' + v));
+            console.error('\nDurable comments/JSDoc must describe behavior, not cite tracking tickets (they rot when');
+            console.error('tickets close/rename). Move the ref to the PR body / commit subject, or — only if genuinely');
+            console.error(`load-bearing — add a "${ESCAPE_MARKER}: <reason>" marker on the line.`);
+        }
+        process.exit(1);
+    }
+
+    console.log(`check-ticket-archaeology: ${files.length} files scanned, 0 violations.`);
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
             "node ./buildScripts/util/check-whitespace.mjs"
         ],
         "*.mjs": [
-            "node ./buildScripts/util/check-shorthand.mjs"
+            "node ./buildScripts/util/check-shorthand.mjs",
+            "node ./buildScripts/util/check-ticket-archaeology.mjs"
         ]
     }
 }

--- a/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -1,0 +1,71 @@
+import {test, expect}                    from '@playwright/test';
+import {extractComment, findTicketRefs}  from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
+
+/**
+ * Self-test for the ticket-archaeology guard: the mechanical replacement for the discipline-only
+ * "no decay-prone ticket refs in durable comments" rule. Verifies it flags comment/JSDoc refs,
+ * exempts load-bearing string-literal anchors, and honors the inline escape marker.
+ */
+test.describe('check-ticket-archaeology guard', () => {
+    test('flags a numeric ticket ref inside a JSDoc block comment', () => {
+        const hits = findTicketRefs([
+            '/**',
+            ' * Resolves #12345 by reshaping the owner clause.',
+            ' */',
+            'const x = 1;'
+        ].join('\n'));
+
+        expect(hits).toEqual([{line: 2, text: '* Resolves #12345 by reshaping the owner clause.'}])
+    });
+
+    test('flags a ref in a full-line // comment and a trailing // comment', () => {
+        const full = findTicketRefs('// see #12345 for context\nconst a = 1;');
+        expect(full.map(h => h.line)).toEqual([1]);
+
+        const trailing = findTicketRefs('const b = 2; // added in #12345');
+        expect(trailing.map(h => h.line)).toEqual([1])
+    });
+
+    test('does NOT flag a ticket ref inside a string literal (load-bearing test.describe anchor)', () => {
+        const hits = findTicketRefs([
+            '/** behavior-only summary */',
+            "test.describe('Dockerized KB retrieval (#11645)', () => {});",
+            "const url = 'https://github.com/neomjs/neo/issues/12345';"
+        ].join('\n'));
+
+        expect(hits).toEqual([])
+    });
+
+    test('honors the inline escape marker on a genuinely load-bearing line', () => {
+        const hits = findTicketRefs('// keep this ref — see #12345 ticket-ref-ok: pins a retired-primitive successor');
+
+        expect(hits).toEqual([])
+    });
+
+    test('flags the named Epic / Discussion / ADR prose forms in comments', () => {
+        const hits = findTicketRefs([
+            '// part of Epic #11624',
+            '// graduated from Discussion #10137',
+            '// aligned-with ADR-0003'
+        ].join('\n'));
+
+        expect(hits.map(h => h.line)).toEqual([1, 2, 3])
+    });
+
+    test('does NOT flag a 6-hex-with-letters color or a markdown-style "# 12345" heading in a comment', () => {
+        const hits = findTicketRefs([
+            '// fallback color #1234ff for the badge',
+            '// # 12345 (spaced — markdown-style, not a ticket ref)'
+        ].join('\n'));
+
+        expect(hits).toEqual([])
+    });
+
+    test('closes block-comment state so post-block code lines are not treated as comments', () => {
+        // Regression guard: a `* /`-closed block must reset state.inBlock so a later string-literal
+        // line is not mis-scanned as comment context.
+        const state = {inBlock: false};
+        extractComment('/** opens */', state);
+        expect(state.inBlock).toBe(false)
+    });
+});


### PR DESCRIPTION
Resolves #12294

Authored by Opus 4.8 (Claude Code). Session 758163a2-3619-4110-8364-44250500595f.

FAIR-band: in-band [8/30]

Evidence: L2 (unit-tested — 7 passing self-tests covering flag / string-exempt / escape / named-forms / hex-non-false-positive / block-close; the guard self-applies cleanly to its own two .mjs files). Residual: none — the guard is a static line scanner fully covered by the spec.

## What this delivers

Turns the recurring **"no decay-prone ticket/Epic/Discussion/ADR refs in durable .mjs comments/JSDoc"** discipline into a **mechanical pre-commit gate**. The discipline has recurred repeatedly despite living in agent memory, because it relies on the author remembering + judging at every comment — and `AGENTS.md §self_evolving_systems` is explicit that a mechanical guard beats discipline-only. This is the §friction_to_gold response: a repeat discipline-slip is a substrate signal for a guard, not another reminder.

- **`buildScripts/util/check-ticket-archaeology.mjs`** — mirrors `check-shorthand.mjs`: takes staged `[files...]` (or a default-dir scan), exits non-zero on violations.
  - **String-aware scanner**: flags refs only in *true comment context* (line + block + JSDoc). String literals are skipped, so load-bearing string anchors — `describe(...)` test titles, issue-endpoint URLs — stay exempt.
  - **Escape hatch**: an inline `ticket-ref-ok` marker exempts a genuinely load-bearing line (judgment relief valve, not a blanket bypass).
- **`lint-staged` wiring** (`*.mjs`, alongside `check-shorthand`): staged-files scan → **incremental adoption** (a file is only checked when touched; no big-bang repo cleanup required).

## Deltas

- Scoped to `.mjs` comments for v1 (the highest-signal, clearest-rule surface where the slip recurs). `.md`/`learn/` + Dockerfile/compose scanning and a repo-wide CI gate are deliberate follow-ups (Out of Scope on the ticket) — they carry more legit-ref edge cases and need a pre-existing-violation sweep first.
- Per-line string state is not carried across lines (a ref inside a multi-line template literal is the rare case the escape marker covers); block-comment state IS carried.

## Test Evidence

- **Self-test** (`test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs`) — **7 passing (656ms)**: JSDoc-block ref flagged; full-line + trailing `//` refs flagged; string-literal ref (`describe(...)` anchor + issue URL) NOT flagged; `ticket-ref-ok` escape honored; Epic / Discussion / ADR prose forms flagged; hex-with-letters color + spaced markdown heading NOT flagged; block-comment state closes.
- Meta-check: running the guard on its own script + spec → `0 violations`.
- `node --check` passes; `git diff --cached --check` clean.

## Post-Merge Validation

- [ ] On the next `.mjs` commit that introduces a `#NNNN` in a comment, the pre-commit gate blocks it with the remediation hint.
- [ ] Follow-up: once proven, compress/retire the MEMORY.md `jsdoc_archaeology_self_audit` entry (discipline → mechanism) and consider the `.md`/CI-gate extensions.
