### PR TITLE
fix(ai): restore ollama residency readiness (#12285)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -23,7 +23,9 @@ import GoldenPathSynthesizer from '../../../services/graph/GoldenPathSynthesizer
 import AiConfig from '../../../config.mjs';
 import {
     assertProviderReadinessConfig,
+    buildOllamaReadinessConfig,
     createProviderFailureDiagnostic,
+    ensureOllamaModelsReady,
     getGraphProviderReadinessTarget,
     waitForProvider,
     warnProviderParallelModelCapacity
@@ -740,10 +742,30 @@ class DreamService extends Base {
             };
         }
 
-        const capacity = await warnProviderParallelModelCapacity({
-            config   : AiConfig,
-            timeoutMs: readinessConfig.timeoutMs
-        });
+        const ollamaReadinessConfig = buildOllamaReadinessConfig(AiConfig);
+        const capacity = ollamaReadinessConfig.roles.length > 0
+            ? await ensureOllamaModelsReady({
+                ...ollamaReadinessConfig,
+                attempts    : readinessConfig.attempts,
+                delayMs     : readinessConfig.delayMs,
+                timeoutMs   : readinessConfig.timeoutMs,
+                allowPartial: true
+            })
+            : await warnProviderParallelModelCapacity({
+                config   : AiConfig,
+                timeoutMs: readinessConfig.timeoutMs
+            });
+
+        if (capacity?.degraded) {
+            return {
+                ready     : false,
+                capacity,
+                diagnostic: createProviderFailureDiagnostic({
+                    reason: 'PROVIDER_MODEL_RESIDENCY_DEGRADED',
+                    capacity
+                })
+            };
+        }
 
         return {ready: true, capacity};
     }

--- a/ai/services/graph/ProviderReadinessHelper.mjs
+++ b/ai/services/graph/ProviderReadinessHelper.mjs
@@ -125,6 +125,72 @@ export async function fetchOllamaRunningModelIds({host, timeoutMs, fetchFn = fet
 }
 
 /**
+ * @summary Warms one native Ollama model through the role-specific Ollama endpoint.
+ *
+ * Native Ollama is not an OpenAI-compatible provider behind a different selector:
+ * chat/generation work is warmed through `/api/chat`, while vector work is warmed
+ * through `/api/embed`. `keep_alive` flows from operator config so readiness
+ * matches the same residency policy used by normal provider calls.
+ *
+ * @param {Object} options
+ * @param {String} options.host Ollama host.
+ * @param {String} options.model Ollama model identifier.
+ * @param {String} options.role Either `'chat'` or `'embedding'`.
+ * @param {String|Number} [options.keepAlive] Ollama keep_alive value.
+ * @param {Number} options.timeoutMs HTTP timeout. Required; no module-level default.
+ * @param {Function} [options.fetchFn=fetch] Fetch seam for tests.
+ * @returns {Promise<Object>}
+ */
+export async function warmOllamaRoleModel({
+    host,
+    model,
+    role,
+    keepAlive,
+    timeoutMs,
+    fetchFn = fetch
+} = {}) {
+    if (!host) {
+        throw new TypeError('warmOllamaRoleModel: host is required');
+    }
+    if (!model) {
+        throw new TypeError('warmOllamaRoleModel: model is required');
+    }
+    if (typeof timeoutMs !== 'number') {
+        throw new TypeError('warmOllamaRoleModel: timeoutMs is required');
+    }
+    if (role !== 'chat' && role !== 'embedding') {
+        throw new TypeError("warmOllamaRoleModel: role must be 'chat' or 'embedding'");
+    }
+
+    const endpoint = role === 'embedding' ? '/api/embed' : '/api/chat';
+    const payload  = role === 'embedding'
+        ? {model, input: ''}
+        : {model, messages: [{role: 'user', content: ''}], stream: false};
+
+    if (keepAlive !== undefined) {
+        payload.keep_alive = keepAlive;
+    }
+
+    const response = await fetchFn(new URL(endpoint, host).toString(), {
+        method : 'POST',
+        headers: {'content-type': 'application/json'},
+        body   : JSON.stringify(payload),
+        signal : AbortSignal.timeout(timeoutMs)
+    });
+
+    if (!response.ok) {
+        const text = typeof response.text === 'function' ? await response.text() : '';
+        throw new Error(`Ollama ${role} model warmup failed for '${model}': HTTP ${response.status}${text ? ` - ${text}` : ''}`);
+    }
+
+    if (typeof response.text === 'function') {
+        await response.text();
+    }
+
+    return {model, role, endpoint};
+}
+
+/**
  * @summary Invokes `lms load <model> [--context-length <N>]` for one LM Studio model.
  *
  * When `contextLength` is provided, appends `--context-length <N>` to the `lms`
@@ -254,6 +320,61 @@ export function buildLmsPreloadConfig(config = aiConfig) {
     });
 
     return {models, contextLengths}
+}
+
+/**
+ * @summary Builds the native Ollama readiness set from provider-role selectors.
+ *
+ * Non-null Ollama model leaves are deployment configuration, not proof that the
+ * native Ollama provider owns a role. This mirrors {@link buildLmsPreloadConfig}:
+ * only explicit provider selectors participate, preserving operator choice when
+ * chat, graph, or embedding is routed to another provider family.
+ *
+ * @param {Object} config aiConfig-shaped provider config.
+ * @returns {{provider: String, host: String, keepAlive: *, requireParallelModels: Number, model: String, embeddingModel: String, roles: Object[], models: String[]}}
+ */
+export function buildOllamaReadinessConfig(config = aiConfig) {
+    const ollamaConfig   = config.ollama ?? {},
+          chatModel      = ollamaConfig.model,
+          embeddingModel = ollamaConfig.embeddingModel,
+          roles          = [{
+              provider    : config.modelProvider,
+              providerRole: 'modelProvider',
+              role        : 'chat',
+              model       : chatModel
+          }, {
+              provider    : config.graphProvider,
+              providerRole: 'graphProvider',
+              role        : 'chat',
+              model       : chatModel
+          }, {
+              provider    : config.embeddingProvider,
+              providerRole: 'embeddingProvider',
+              role        : 'embedding',
+              model       : embeddingModel
+          }].filter(role => role.provider === 'ollama' && role.model);
+
+    const dedupedRoles = [];
+    const seenRoles    = new Set();
+
+    for (const role of roles) {
+        const key = `${role.role}:${role.model}`;
+        if (!seenRoles.has(key)) {
+            seenRoles.add(key);
+            dedupedRoles.push(role);
+        }
+    }
+
+    return {
+        provider             : 'ollama',
+        host                 : ollamaConfig.host,
+        keepAlive            : ollamaConfig.keep_alive,
+        requireParallelModels: ollamaConfig.requireParallelModels,
+        model                : chatModel,
+        embeddingModel,
+        roles                : dedupedRoles,
+        models               : [...new Set(dedupedRoles.map(role => role.model))]
+    }
 }
 
 /**
@@ -438,6 +559,217 @@ export async function ensureLmsModelsLoaded({
         `LM Studio model readiness failed: missing ${missingModels.join(', ')} from ${host}/v1/models after ` +
         `${attempts} attempt(s). Run ${missingModels.map(model => `lms load ${model}`).join(' && ')} ` +
         'or raise the LM Studio loaded-model cap so chat and embedding models can stay resident together.'
+    );
+}
+
+/**
+ * @summary Ensures native Ollama has all configured role models resident.
+ *
+ * Ollama has no `lms load` equivalent and must be warmed through its native API.
+ * This helper probes `/api/ps`, warms only missing role/model pairs through
+ * `/api/chat` or `/api/embed`, and then verifies that the required chat and
+ * embedding models are resident together. Partial failure returns a degraded
+ * readiness envelope when `allowPartial` is true so callers can fail readiness
+ * with operator-actionable diagnostics instead of emitting warning-only drift.
+ *
+ * @param {Object} options
+ * @param {String} options.host Ollama host.
+ * @param {Object[]} options.roles Role entries from {@link buildOllamaReadinessConfig}.
+ * @param {Number} options.requireParallelModels Minimum resident-model count.
+ * @param {Number} options.attempts Probe attempts after warm-up.
+ * @param {Number} options.delayMs Delay between probes.
+ * @param {Number} options.timeoutMs HTTP probe timeout.
+ * @param {String|Number} [options.keepAlive] Ollama keep_alive value.
+ * @param {Boolean} [options.allowPartial=false] Return degraded readiness instead of throwing when one role cannot be warmed.
+ * @param {Function} [options.fetchModelIds] Injectable `/api/ps` probe.
+ * @param {Function} [options.warmModel] Injectable warm-up function.
+ * @param {Object} [options.log=logger] Logger seam.
+ * @returns {Promise<Object>}
+ */
+export async function ensureOllamaModelsReady({
+    host,
+    roles,
+    requireParallelModels,
+    attempts,
+    delayMs,
+    timeoutMs,
+    keepAlive,
+    allowPartial = false,
+    fetchModelIds = opts => fetchOllamaRunningModelIds(opts),
+    warmModel     = (role, options) => warmOllamaRoleModel({...role, ...options}),
+    log           = logger
+} = {}) {
+    if (!Array.isArray(roles) || roles.length === 0) {
+        throw new TypeError('ensureOllamaModelsReady: roles must contain at least one configured Ollama role');
+    }
+    if (!Neo.isNumber(requireParallelModels)) {
+        throw new TypeError('ensureOllamaModelsReady: requireParallelModels is required');
+    }
+    if (typeof attempts !== 'number' || typeof delayMs !== 'number' || typeof timeoutMs !== 'number') {
+        throw new TypeError('ensureOllamaModelsReady: attempts, delayMs, and timeoutMs are required');
+    }
+
+    const requiredModels = [...new Set(roles.map(role => role.model).filter(Boolean))];
+    if (requiredModels.length === 0) {
+        throw new TypeError('ensureOllamaModelsReady: roles must contain at least one configured model');
+    }
+
+    const requiredResidentModels = Math.min(requireParallelModels, requiredModels.length);
+    const getMissing             = available => requiredModels.filter(model => !available.includes(model));
+    const getWarning = ({availableModels, missingModels}) => createParallelModelCapacityWarning({
+        provider             : 'ollama',
+        model                : roles.find(role => role.role === 'chat')?.model,
+        embeddingModel       : roles.find(role => role.role === 'embedding')?.model,
+        requiredModels,
+        availableModels,
+        missingModels,
+        observedCount        : availableModels.length,
+        requireParallelModels: requiredResidentModels
+    });
+
+    const probeModels = async phase => {
+        let lastError;
+
+        for (let attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                return {
+                    attempt,
+                    availableModels: [...new Set(await fetchModelIds({host, timeoutMs}))]
+                };
+            } catch (error) {
+                lastError = error;
+                if (attempt < attempts) {
+                    await new Promise(resolve => setTimeout(resolve, delayMs));
+                }
+            }
+        }
+
+        throw new Error(`Ollama model readiness failed during ${phase}: ${lastError?.message || lastError}`);
+    };
+
+    const startedAt = Date.now();
+    let availableModels;
+
+    try {
+        ({availableModels} = await probeModels('initial /api/ps probe'));
+    } catch (error) {
+        if (!allowPartial) {
+            throw error;
+        }
+
+        return {
+            ready                : false,
+            degraded             : true,
+            provider             : 'ollama',
+            host,
+            requiredModels,
+            availableModels      : [],
+            missingModels        : requiredModels,
+            observedCount        : 0,
+            requireParallelModels,
+            requiredResidentModels,
+            warmedModels         : [],
+            attemptedModels      : [],
+            failedModels         : [],
+            error                : {message: error.message},
+            warning              : `[provider/ollama] model residency probe failed: ${error.message}`,
+            attempts,
+            elapsedMs            : Date.now() - startedAt
+        };
+    }
+
+    const initialMissing = getMissing(availableModels);
+    const rolesToWarm    = roles.filter(role => initialMissing.includes(role.model));
+    const warmedModels   = [];
+    const failedModels   = [];
+    const attemptedModels = [];
+
+    for (const role of rolesToWarm) {
+        attemptedModels.push({model: role.model, role: role.role, providerRole: role.providerRole});
+        log.info?.(`[ProviderReadinessHelper] Warming native Ollama ${role.role} model '${role.model}' via ${role.role === 'embedding' ? '/api/embed' : '/api/chat'}.`);
+
+        try {
+            await warmModel(role, {host, keepAlive, timeoutMs});
+            warmedModels.push({model: role.model, role: role.role, providerRole: role.providerRole});
+        } catch (error) {
+            failedModels.push({
+                model       : role.model,
+                role        : role.role,
+                providerRole: role.providerRole,
+                error       : error.message
+            });
+            log.warn?.(`[ProviderReadinessHelper] Ollama ${role.role} model '${role.model}' warm-up failed: ${error.message}`);
+
+            if (!allowPartial) {
+                throw error;
+            }
+        }
+    }
+
+    let missingModels = initialMissing;
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        ({availableModels} = await probeModels('post-warm /api/ps probe'));
+        missingModels = getMissing(availableModels);
+
+        const failedModelIds     = new Set(failedModels.map(item => item.model));
+        const serviceableMissing = missingModels.filter(model => !failedModelIds.has(model));
+        const observedCount      = availableModels.length;
+        const capacityReady      = observedCount >= requiredResidentModels;
+        const ready              = capacityReady && missingModels.length === 0 && failedModels.length === 0;
+        const capacityOnlyGap    = missingModels.length === 0 && !capacityReady;
+
+        if (ready || (allowPartial && (serviceableMissing.length === 0 || capacityOnlyGap))) {
+            const degraded = !ready;
+            return {
+                ready,
+                degraded,
+                provider             : 'ollama',
+                host,
+                warmedModels,
+                attemptedModels,
+                failedModels,
+                missingModels,
+                requiredModels,
+                availableModels,
+                observedCount,
+                requireParallelModels,
+                requiredResidentModels,
+                warning              : degraded ? getWarning({availableModels, missingModels}) : null,
+                attempts             : attempt,
+                elapsedMs            : Date.now() - startedAt
+            };
+        }
+
+        if (attempt < attempts) {
+            await new Promise(resolve => setTimeout(resolve, delayMs));
+        }
+    }
+
+    const warning = getWarning({availableModels, missingModels});
+    if (allowPartial) {
+        return {
+            ready                : false,
+            degraded             : true,
+            provider             : 'ollama',
+            host,
+            warmedModels,
+            attemptedModels,
+            failedModels,
+            missingModels,
+            requiredModels,
+            availableModels,
+            observedCount        : availableModels.length,
+            requireParallelModels,
+            requiredResidentModels,
+            warning,
+            attempts,
+            elapsedMs            : Date.now() - startedAt
+        };
+    }
+
+    throw new Error(
+        `Ollama model readiness failed: ${warning}`
     );
 }
 
@@ -763,22 +1095,26 @@ export function assertProviderReadinessConfig(readinessConfig) {
  * @param {Object} options.config Provider-source config (aiConfig-shaped).
  * @param {Object} [options.waitResult] Result envelope from `waitForProvider`; omit when emitting on the unsupported-provider path.
  * @param {Object} [options.lifecycleStatus] Consumer-sourced lifecycle snapshot; surfaces verbatim on the envelope.
- * @param {String} [options.reason] One of `'PROVIDER_READINESS_TIMEOUT'`, `'UNSUPPORTED_GRAPH_PROVIDER'`.
+ * @param {String} [options.reason] One of `'PROVIDER_READINESS_TIMEOUT'`, `'UNSUPPORTED_GRAPH_PROVIDER'`, `'PROVIDER_MODEL_RESIDENCY_DEGRADED'`.
  * @returns {Object}
  */
 export function createProviderFailureDiagnostic({
     config = aiConfig,
     waitResult,
     lifecycleStatus,
-    reason = 'PROVIDER_READINESS_TIMEOUT'
+    reason = 'PROVIDER_READINESS_TIMEOUT',
+    capacity
 } = {}) {
     const target = getGraphProviderReadinessTarget(config);
     const unsupported = reason === 'UNSUPPORTED_GRAPH_PROVIDER';
+    const degraded    = reason === 'PROVIDER_MODEL_RESIDENCY_DEGRADED';
 
     return {
         event          : unsupported
             ? 'runSandman.unsupported_graph_provider'
-            : 'runSandman.provider_readiness_timeout',
+            : degraded
+                ? 'runSandman.provider_model_residency_degraded'
+                : 'runSandman.provider_readiness_timeout',
         reason,
         provider       : target.provider,
         graphProvider  : target.provider,
@@ -792,8 +1128,11 @@ export function createProviderFailureDiagnostic({
         attempts       : waitResult?.attempts,
         elapsedMs      : waitResult?.elapsedMs,
         timeoutMs      : waitResult?.timeoutMs,
+        capacity,
         lifecycleStatus,
-        nextAction     : target.supported
+        nextAction     : degraded && capacity?.warning
+            ? capacity.warning
+            : target.supported
             ? (
                 target.provider === 'openAiCompatible'
                     ? 'Start the configured OpenAI-compatible / MLX provider, then rerun npm run ai:run-sandman.'
@@ -820,12 +1159,16 @@ export async function recordProviderReadinessFailure(
 ) {
     const message = diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
         ? `\n❌ Unsupported Sandman graph provider '${diagnostic.graphProvider}'. Expected one of: 'ollama', 'openAiCompatible'.`
+        : diagnostic.reason === 'PROVIDER_MODEL_RESIDENCY_DEGRADED'
+            ? `\n❌ ${diagnostic.provider} provider model residency degraded on ${diagnostic.host}. ${diagnostic.nextAction}`
         : `\n❌ ${diagnostic.provider} provider is not running on ${diagnostic.host}${diagnostic.endpoint || ''}. Please start the configured provider manually.`;
 
     stderr(message);
     log.error(
         diagnostic.reason === 'UNSUPPORTED_GRAPH_PROVIDER'
             ? '[runSandman] unsupported graph provider'
+            : diagnostic.reason === 'PROVIDER_MODEL_RESIDENCY_DEGRADED'
+                ? `[runSandman] ${diagnostic.provider} provider model residency degraded`
             : `[runSandman] ${diagnostic.provider} provider readiness timeout`,
         diagnostic
     );

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -153,6 +153,60 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(calls).toEqual([{url: 'http://ollama.test/api/ps', method: 'GET'}]);
     });
 
+    test('warmOllamaRoleModel uses native role endpoints and keep_alive', async () => {
+        const calls = [];
+        const fetchFn = async (url, options) => {
+            calls.push({
+                url,
+                method : options.method,
+                headers: options.headers,
+                body   : JSON.parse(options.body)
+            });
+            return {
+                ok  : true,
+                text: async () => ''
+            };
+        };
+
+        await providerReadinessHelper.warmOllamaRoleModel({
+            host     : 'http://ollama.test',
+            model    : 'gemma4:31b',
+            role     : 'chat',
+            keepAlive: '-1',
+            timeoutMs: 25,
+            fetchFn
+        });
+        await providerReadinessHelper.warmOllamaRoleModel({
+            host     : 'http://ollama.test',
+            model    : 'qwen3-embedding',
+            role     : 'embedding',
+            keepAlive: '-1',
+            timeoutMs: 25,
+            fetchFn
+        });
+
+        expect(calls).toEqual([{
+            url    : 'http://ollama.test/api/chat',
+            method : 'POST',
+            headers: {'content-type': 'application/json'},
+            body   : {
+                model     : 'gemma4:31b',
+                messages  : [{role: 'user', content: ''}],
+                stream    : false,
+                keep_alive: '-1'
+            }
+        }, {
+            url    : 'http://ollama.test/api/embed',
+            method : 'POST',
+            headers: {'content-type': 'application/json'},
+            body   : {
+                model     : 'qwen3-embedding',
+                input     : '',
+                keep_alive: '-1'
+            }
+        }]);
+    });
+
     test('warnProviderParallelModelCapacity warns for native Ollama missing the embedding model', async () => {
         const warnings = [];
         const result = await providerReadinessHelper.warnProviderParallelModelCapacity({
@@ -482,6 +536,141 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(warnings[0]).toContain('preload failed');
     });
 
+    test('ensureOllamaModelsReady warms missing chat and embedding models through native roles (#12285)', async () => {
+        const warmCalls = [];
+        const modelSnapshots = [
+            [],
+            ['gemma4:31b', 'qwen3-embedding']
+        ];
+
+        const result = await providerReadinessHelper.ensureOllamaModelsReady({
+            host                 : 'http://ollama.test',
+            roles                : [{
+                providerRole: 'modelProvider',
+                role        : 'chat',
+                model       : 'gemma4:31b'
+            }, {
+                providerRole: 'embeddingProvider',
+                role        : 'embedding',
+                model       : 'qwen3-embedding'
+            }],
+            requireParallelModels: 2,
+            attempts             : 2,
+            delayMs              : 0,
+            timeoutMs            : 25,
+            keepAlive            : '-1',
+            fetchModelIds        : async () => modelSnapshots.shift() || ['gemma4:31b', 'qwen3-embedding'],
+            warmModel            : async (role, options) => warmCalls.push({role, options}),
+            log                  : {info: () => {}}
+        });
+
+        expect(warmCalls).toEqual([{
+            role: {
+                providerRole: 'modelProvider',
+                role        : 'chat',
+                model       : 'gemma4:31b'
+            },
+            options: {
+                host     : 'http://ollama.test',
+                keepAlive: '-1',
+                timeoutMs: 25
+            }
+        }, {
+            role: {
+                providerRole: 'embeddingProvider',
+                role        : 'embedding',
+                model       : 'qwen3-embedding'
+            },
+            options: {
+                host     : 'http://ollama.test',
+                keepAlive: '-1',
+                timeoutMs: 25
+            }
+        }]);
+        expect(result).toMatchObject({
+            ready                : true,
+            provider             : 'ollama',
+            warmedModels         : [{
+                model       : 'gemma4:31b',
+                role        : 'chat',
+                providerRole: 'modelProvider'
+            }, {
+                model       : 'qwen3-embedding',
+                role        : 'embedding',
+                providerRole: 'embeddingProvider'
+            }],
+            requiredModels       : ['gemma4:31b', 'qwen3-embedding'],
+            availableModels      : ['gemma4:31b', 'qwen3-embedding'],
+            requireParallelModels: 2
+        });
+    });
+
+    test('ensureOllamaModelsReady returns degraded when one native role cannot be warmed (#12285)', async () => {
+        const warnings = [];
+        const result = await providerReadinessHelper.ensureOllamaModelsReady({
+            host                 : 'http://ollama.test',
+            roles                : [{
+                providerRole: 'modelProvider',
+                role        : 'chat',
+                model       : 'gemma4:31b'
+            }, {
+                providerRole: 'embeddingProvider',
+                role        : 'embedding',
+                model       : 'qwen3-embedding'
+            }],
+            requireParallelModels: 2,
+            allowPartial         : true,
+            attempts             : 2,
+            delayMs              : 0,
+            timeoutMs            : 25,
+            fetchModelIds        : async () => ['qwen3-embedding'],
+            warmModel            : async role => {
+                if (role.role === 'chat') {
+                    throw new Error('Ollama refused chat model');
+                }
+            },
+            log                  : {
+                info: () => {},
+                warn: message => warnings.push(message)
+            }
+        });
+
+        expect(result.ready).toBe(false);
+        expect(result.degraded).toBe(true);
+        expect(result.failedModels).toEqual([{
+            model       : 'gemma4:31b',
+            role        : 'chat',
+            providerRole: 'modelProvider',
+            error       : 'Ollama refused chat model'
+        }]);
+        expect(result.missingModels).toEqual(['gemma4:31b']);
+        expect(result.availableModels).toEqual(['qwen3-embedding']);
+        expect(result.warning).toContain('set OLLAMA_MAX_LOADED_MODELS=2');
+        expect(warnings[0]).toContain('warm-up failed');
+    });
+
+    test('ensureOllamaModelsReady does not require inactive role models (#12285)', async () => {
+        const result = await providerReadinessHelper.ensureOllamaModelsReady({
+            host                 : 'http://ollama.test',
+            roles                : [{
+                providerRole: 'graphProvider',
+                role        : 'chat',
+                model       : 'gemma4:31b'
+            }],
+            requireParallelModels: 2,
+            attempts             : 1,
+            delayMs              : 0,
+            timeoutMs            : 25,
+            fetchModelIds        : async () => ['gemma4:31b']
+        });
+
+        expect(result.ready).toBe(true);
+        expect(result.requiredModels).toEqual(['gemma4:31b']);
+        expect(result.requiredResidentModels).toBe(1);
+        expect(result.requireParallelModels).toBe(2);
+        expect(result.warning).toBeNull();
+    });
+
     test('loadLmsModel appends --context-length to execFile args when provided (#12117)', async () => {
         const execCalls = [];
         const execFileStub = (cmd, args, callback) => {
@@ -617,6 +806,56 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
                 'text-embedding-qwen3-embedding-8b': 32768
             }
         });
+    });
+
+    test('buildOllamaReadinessConfig only includes explicitly selected native Ollama roles (#12285)', () => {
+        expect(providerReadinessHelper.buildOllamaReadinessConfig({
+            modelProvider    : 'gemini',
+            graphProvider    : 'ollama',
+            embeddingProvider: 'ollama',
+            ollama: {
+                host                 : 'http://ollama.test',
+                model                : 'gemma4:31b',
+                embeddingModel       : 'qwen3-embedding',
+                keep_alive           : '-1',
+                requireParallelModels: 2
+            },
+            openAiCompatible: {
+                model         : 'gemma-openai',
+                embeddingModel: 'openai-embedding'
+            }
+        })).toEqual({
+            provider             : 'ollama',
+            host                 : 'http://ollama.test',
+            keepAlive            : '-1',
+            requireParallelModels: 2,
+            model                : 'gemma4:31b',
+            embeddingModel       : 'qwen3-embedding',
+            roles                : [{
+                provider    : 'ollama',
+                providerRole: 'graphProvider',
+                role        : 'chat',
+                model       : 'gemma4:31b'
+            }, {
+                provider    : 'ollama',
+                providerRole: 'embeddingProvider',
+                role        : 'embedding',
+                model       : 'qwen3-embedding'
+            }],
+            models               : ['gemma4:31b', 'qwen3-embedding']
+        });
+
+        expect(providerReadinessHelper.buildOllamaReadinessConfig({
+            modelProvider    : 'openAiCompatible',
+            graphProvider    : 'openAiCompatible',
+            embeddingProvider: 'openAiCompatible',
+            ollama: {
+                host                 : 'http://ollama.test',
+                model                : 'gemma4:31b',
+                embeddingModel       : 'qwen3-embedding',
+                requireParallelModels: 2
+            }
+        }).roles).toEqual([]);
     });
 
     test('loadLmsModel omits --context-length when contextLength is non-finite (defensive)', async () => {
@@ -773,6 +1012,59 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
             host          : null,
             endpoint      : null
         });
+    });
+
+    test('provider model-residency diagnostic carries degraded Ollama capacity (#12285)', async () => {
+        const stderrMessages = [];
+        const logErrors      = [];
+        const capacity       = {
+            degraded             : true,
+            provider             : 'ollama',
+            host                 : 'http://ollama.test',
+            requiredModels       : ['gemma4:31b', 'qwen3-embedding'],
+            availableModels      : ['qwen3-embedding'],
+            missingModels        : ['gemma4:31b'],
+            observedCount        : 1,
+            requireParallelModels: 2,
+            warning              : '[provider/ollama] expected 2+ models loaded; set OLLAMA_MAX_LOADED_MODELS=2 in the Ollama server environment.'
+        };
+        const diagnostic = runSandmanModule.createProviderFailureDiagnostic({
+            config: {
+                modelProvider : 'ollama',
+                graphProvider : 'ollama',
+                ollama        : {
+                    host          : 'http://ollama.test',
+                    model         : 'gemma4:31b',
+                    embeddingModel: 'qwen3-embedding'
+                }
+            },
+            reason: 'PROVIDER_MODEL_RESIDENCY_DEGRADED',
+            capacity
+        });
+
+        expect(diagnostic).toMatchObject({
+            event         : 'runSandman.provider_model_residency_degraded',
+            reason        : 'PROVIDER_MODEL_RESIDENCY_DEGRADED',
+            provider      : 'ollama',
+            graphProvider : 'ollama',
+            host          : 'http://ollama.test',
+            endpoint      : '/api/tags',
+            capacity,
+            nextAction    : capacity.warning
+        });
+
+        const result = await runSandmanModule.recordProviderReadinessFailure(diagnostic, {
+            stderr: message => stderrMessages.push(message),
+            log   : {
+                error: (...args) => logErrors.push(args),
+                flush: async () => {}
+            }
+        });
+
+        expect(result.message).toContain('provider model residency degraded');
+        expect(stderrMessages[0]).toContain('OLLAMA_MAX_LOADED_MODELS=2');
+        expect(logErrors[0][0]).toContain('provider model residency degraded');
+        expect(logErrors[0][1]).toBe(diagnostic);
     });
 
     test('runSandman delegates exactly one canonical REM cycle inside the lease (#12070)', async () => {


### PR DESCRIPTION
Resolves #12285

Authored by GPT-5.5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.
FAIR-band: over-target [20/30] - taking this lane despite over-target because the operator surfaced a local-provider parity regression during the #12274 merge gate, the verified fix was already complete before the auth outage, and leaving the branch unpublished would preserve an active local-provider startup drift.

Restores native Ollama to the same role-aware local-provider readiness contract as the OpenAI-compatible lane without routing Ollama through LMS-specific commands. `ProviderReadinessHelper` now builds native Ollama chat/embedding requirements, warms each active role through Ollama-native endpoints, reports degraded readiness with operator remediation when one role cannot be made available, and keeps remote-provider lanes excluded. `DreamService` consumes that helper so startup readiness fails closed when native Ollama is configured but chat or embedding residency is degraded.

Evidence: L2 (unit-level mocked native Ollama readiness, DreamService startup integration, static syntax/diff checks) -> L2 required (ticket ACs are helper/service contract behavior with mocked provider endpoints). No residuals.

## Deltas from ticket

The implementation excludes non-Ollama or model-less roles from the Ollama readiness role list; they are absent, not represented as `inactive` entries. Single-active-role stability comes from clamping `requiredResidentModels` to the number of active Ollama role requirements via `Math.min(requireParallelModels, requiredModels.length)`, so a mixed local/remote configuration only requires the Ollama models actually assigned to native Ollama.

## Test Evidence

- `node --check ai/services/graph/ProviderReadinessHelper.mjs`
- `node --check ai/daemons/orchestrator/services/DreamService.mjs`
- `node --check test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs` - 40 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs` - 13 passed
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; branch contains only `5806c3382 fix(ai): restore ollama residency readiness (#12285)`.

## Post-Merge Validation

- [ ] Run one native Ollama operator smoke with distinct configured chat + embedding models and confirm degraded readiness only when one role is unavailable.

## Commits

- `5806c3382` - `fix(ai): restore ollama residency readiness (#12285)`
