### PR TITLE
docs(agentos): add llama.cpp cloud profile (#12302)

### DIFF
--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -133,9 +133,17 @@ Before the orchestrator runs a model-dependent task (e.g. the REM/Sandman dream 
 
 These three are orchestrator-config-scoped (`ai/config.template.mjs` `orchestrator.providerReadiness`) and are not read by the MCP server processes, so — unlike the two `keep_alive` vars above — they do not appear in the MCP-server-scoped [Config Substrate Env-Var Audit](../ConfigSubstrateEnvVarAudit.md).
 
+For llama.cpp deployments, keep the provider selector as `openAiCompatible` and
+follow the dedicated [llama.cpp profile](./LlamaCppProfile.md). It documents the
+extra operator proof required before handoff: `/v1/models` must expose both the
+configured chat and embedding model ids, both role routes must pass, and the
+deployment must not depend on switching hosts or rebuilding model context
+between role calls.
+
 ## Related
 
 - [Overview](./Overview.md) — the contract split + default-source inheritance.
+- [llama.cpp Profile](./LlamaCppProfile.md) — OpenAI-compatible llama.cpp provider profile and dual-residency smoke.
 - [Custom Sources](./CustomSources.md) / [Custom Parsers](./CustomParsers.md) — authoring the classes `customSources` / `customParsers` register.
 - [Hook Wiring](./HookWiring.md) — `mcpSyncMaxChunks` and the ingestion facades.
 - [Security](./Security.md) — `spoofRejectionMode` and the fail-closed posture.

--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -171,12 +171,14 @@ profiles are intentionally distinct:
 | Profile | Selectors | Endpoint shape | Use when |
 |---|---|---|---|
 | Native Ollama | `NEO_MODEL_PROVIDER=ollama`, `NEO_EMBEDDING_PROVIDER=ollama` | Ollama `/api/chat` and `/api/embed` | The deployment exposes a real Ollama service and you want native Ollama request semantics. |
-| OpenAI-compatible fallback | `NEO_MODEL_PROVIDER=openAiCompatible`, `NEO_EMBEDDING_PROVIDER=openAiCompatible` | `/v1/chat/completions` and `/v1/embeddings` | The deployment runs MLX, LM Studio, llama.cpp, managed OpenAI-compatible infrastructure, or an Ollama endpoint that intentionally exposes the OpenAI-compatible surface. |
+| OpenAI-compatible fallback | `NEO_MODEL_PROVIDER=openAiCompatible`, `NEO_EMBEDDING_PROVIDER=openAiCompatible` | `/v1/chat/completions` and `/v1/embeddings` | The deployment runs MLX, LM Studio, [llama.cpp](./LlamaCppProfile.md), managed OpenAI-compatible infrastructure, or an Ollama endpoint that intentionally exposes the OpenAI-compatible surface. |
 
 Do not mix the selectors accidentally. A native Ollama deployment should prove
 the native routes; an OpenAI-compatible deployment should prove both `/v1`
 routes. Container health or embeddings-only success is not enough to hand a
-cloud deployment to agents.
+cloud deployment to agents. For llama.cpp, run the dedicated
+[llama.cpp profile](./LlamaCppProfile.md) before treating the backend as
+Agent OS-ready.
 
 For the production profile, the same readiness idea is encoded in
 [`ai/deploy/docker-compose.yml`](../../../ai/deploy/docker-compose.yml): Chroma
@@ -707,6 +709,7 @@ only, or intentionally deferred.
 
 - [Deployment Cookbook](../DeploymentCookbook.md) - deployment authority and service topology.
 - [Overview](./Overview.md) - cloud ingestion concepts and tenant/Neo-shared split.
+- [llama.cpp Profile](./LlamaCppProfile.md) - OpenAI-compatible llama.cpp provider profile and dual-residency smoke.
 - [Tenant Ingestion Model](./TenantIngestionModel.md) - repo identity, parser dispatch, and source-family inventory.
 - [Hook Wiring](./HookWiring.md) - `ai:kb-push-client`, `ingest_source_files`, and `ai:ingest-tenant`.
 - [Custom Parsers](./CustomParsers.md) - client-side `parsed-chunk-v1` parser contract.

--- a/learn/agentos/cloud-deployment/LlamaCppProfile.md
+++ b/learn/agentos/cloud-deployment/LlamaCppProfile.md
@@ -1,0 +1,182 @@
+# Cloud Deployment - llama.cpp Profile
+
+> **Status - operator profile for #12302.** This guide documents llama.cpp as a
+> self-hosted OpenAI-compatible backend for Agent OS cloud deployments. It fills
+> the cloud-deployment gap left after #12090 was resolved by PR #12118: the
+> generic provider-readiness substrate exists, but operators still need a
+> backend-specific handoff profile.
+
+## Provider selector
+
+Use Neo's existing OpenAI-compatible provider keys. Do not introduce or document
+a `llamaCpp` provider selector unless a separate implementation ticket proves
+that the generic OpenAI-compatible contract is insufficient.
+
+```bash
+export NEO_MODEL_PROVIDER=openAiCompatible
+export NEO_EMBEDDING_PROVIDER=openAiCompatible
+export NEO_GRAPH_PROVIDER=openAiCompatible
+```
+
+This means llama.cpp must present the routes Neo already consumes:
+
+| Role | Neo path | llama.cpp-facing route |
+|---|---|---|
+| Chat / summaries | `Neo.ai.provider.OpenAiCompatible` | `/v1/chat/completions` |
+| Embeddings / KB + MC vectors | `TextEmbeddingService` OpenAI-compatible mode | `/v1/embeddings` |
+| Capacity visibility | `ProviderReadinessHelper` | `/v1/models` |
+
+## Residency invariant
+
+Agent OS local-model deployments are valid only when chat and embedding roles can
+remain available together. A deployment that succeeds on one chat request, then
+evicts or rebuilds before the next embedding request, is not an Agent OS-ready
+local Brain deployment.
+
+The handoff rule is:
+
+```text
+chat model resident + embedding model resident + role smoke passes without
+model swapping/context rebuilds
+```
+
+If that cannot be proven, use a remote provider, a different local backend, or
+land a provider-role-host implementation before handing the deployment to
+agents.
+
+## Supported topology
+
+Neo currently exposes one `openAiCompatible` base URL through
+`NEO_OPENAI_COMPATIBLE_HOST`. For llama.cpp, the supported deployment shape is
+therefore a single OpenAI-compatible base URL that can serve both configured
+role models:
+
+- one llama.cpp endpoint or router that advertises both configured model ids
+  through `/v1/models` and routes requests to the correct resident role model;
+  or
+- multiple role-specific `llama-server` processes behind one operator-owned
+  OpenAI-compatible router/reverse proxy that preserves `/v1/models`,
+  `/v1/chat/completions`, and `/v1/embeddings`.
+
+Do not hide two unrelated llama.cpp hosts behind one Neo config by manually
+switching `NEO_OPENAI_COMPATIBLE_HOST` between calls. That recreates the
+model-swap failure #12090 was meant to prevent.
+
+If your only safe llama.cpp topology requires separate chat and embedding hosts
+with no shared OpenAI-compatible router, current Neo config cannot express that
+cleanly. File or follow an implementation ticket for role-specific
+OpenAI-compatible hosts instead of documenting a manual operator workaround.
+
+## Environment example
+
+Pin model names and context bands to the actually loaded GGUF models. The values
+below are placeholders, not portable defaults.
+
+```bash
+export NEO_OPENAI_COMPATIBLE_HOST=http://llama-router:8080
+export NEO_OPENAI_COMPATIBLE_API_KEY=
+
+export NEO_OPENAI_COMPATIBLE_MODEL="<chat-model-id>"
+export NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL="<embedding-model-id>"
+export NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=-1
+export NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS=2
+
+export NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS="<chat-model-context>"
+export NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS="<safe-chat-band>"
+export NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS="<embedding-model-window>"
+export NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS="<safe-embedding-band>"
+export NEO_VECTOR_DIMENSION="<embedding-vector-dimension>"
+```
+
+`NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS=2` is the important handoff
+contract: Neo should warn when the OpenAI-compatible provider cannot observe the
+configured chat and embedding models as available together. A warning here is a
+deployment-readiness failure, not cosmetic noise.
+
+The embedding context values must describe the embedding model's real input
+window. Do not shrink them to a generic tiny default if the deployment expects
+large-file KB ingestion; do not inflate them beyond the model's actual capacity
+to silence preflight checks.
+
+## llama.cpp server smoke
+
+Verify the current llama.cpp server flags against the official
+[`llama-server` documentation](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md)
+for the version you deploy. The smoke below intentionally checks HTTP behavior
+rather than fossilizing startup flags.
+
+```bash
+export LLAMA_BASE_URL="${NEO_OPENAI_COMPATIBLE_HOST}"
+
+curl -fsS "$LLAMA_BASE_URL/health"
+curl -fsS "$LLAMA_BASE_URL/v1/models"
+```
+
+`/v1/models` must show the configured chat model id and embedding model id, or
+the deployment has not proven the dual-role residency contract.
+
+Then prove each role:
+
+```bash
+curl -fsS "$LLAMA_BASE_URL/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "<chat-model-id>",
+    "messages": [{"role": "user", "content": "Return the word ok."}],
+    "max_tokens": 4
+  }'
+
+curl -fsS "$LLAMA_BASE_URL/v1/embeddings" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "<embedding-model-id>",
+    "input": "Agent OS embedding smoke"
+  }'
+```
+
+Check runtime pressure when the server exposes the surfaces:
+
+```bash
+curl -fsS "$LLAMA_BASE_URL/slots"
+curl -fsS "$LLAMA_BASE_URL/metrics"
+```
+
+The slots endpoint is useful for confirming that role traffic is not constantly
+overwriting the only useful cache slot. Metrics are optional and depend on how
+the operator starts llama.cpp; absence of `/metrics` is acceptable only when the
+deployment deliberately runs without Prometheus exposure.
+
+## Neo handoff smoke
+
+After the backend smoke passes, verify the Neo-facing surfaces:
+
+1. Run the Memory Core `healthcheck` and confirm `providers.summary` points at
+   `openAiCompatible`, the llama.cpp base URL, and the configured chat model.
+2. Confirm `providers.embedding` points at `openAiCompatible`, the same base URL,
+   the configured embedding model, and the expected vector dimension.
+3. Start an orchestrator cycle only after provider-readiness warnings are gone.
+4. Run one summary-sized chat call and one KB/MC embedding call without changing
+   any provider env vars between them.
+
+Do not treat container health, `/health`, or an embeddings-only proof as enough.
+The deployment is ready for agents only after the chat role, embedding role, and
+Neo health/readiness surfaces all agree.
+
+## Failure signatures
+
+| Signature | Meaning | Operator action |
+|---|---|---|
+| `/v1/models` lists only one role model | llama.cpp has not exposed both role models through the Neo base URL | Add a router/shared endpoint or change backend topology before handoff. |
+| Chat works but embeddings fail | The endpoint is chat-only or embedding model/dimension config is wrong | Fix embedding model id, embedding mode, and `NEO_VECTOR_DIMENSION`. |
+| Embeddings work but chat fails | The endpoint is embedding-only or chat model id/template is wrong | Fix chat model id and llama.cpp chat-template/runtime config. |
+| Role calls trigger model reloads | The deployment serializes roles instead of keeping them resident | Reject the topology for Agent OS local-model use. |
+| Vector dimension mismatch | Chroma receives vectors with the wrong width | Set `NEO_VECTOR_DIMENSION` to the embedding model's actual output dimension and rebuild affected collections if needed. |
+| `NEO_MODEL_PROVIDER=llamaCpp` | The docs/config invented a provider key Neo does not implement | Use `openAiCompatible` or land a separate provider implementation first. |
+
+## Related
+
+- [Day-0 Tutorial](./Day0Tutorial.md) - first-run cloud deployment proof.
+- [Configuration](./Configuration.md) - deployment config surface and provider-readiness env vars.
+- [Deployment Cookbook](../DeploymentCookbook.md) - broader Agent OS deployment topology.
+- [Shared KB/MC Team Deployment](../SharedDeployment.md) - shared local-provider residency guidance.
+- [#12090](https://github.com/neomjs/neo/issues/12090) / [PR #12118](https://github.com/neomjs/neo/pull/12118) - generic provider-capacity warning substrate.

--- a/learn/agentos/cloud-deployment/LlamaCppProfile.md
+++ b/learn/agentos/cloud-deployment/LlamaCppProfile.md
@@ -1,16 +1,15 @@
 # Cloud Deployment - llama.cpp Profile
 
-> **Status - operator profile for #12302.** This guide documents llama.cpp as a
-> self-hosted OpenAI-compatible backend for Agent OS cloud deployments. It fills
-> the cloud-deployment gap left after #12090 was resolved by PR #12118: the
-> generic provider-readiness substrate exists, but operators still need a
-> backend-specific handoff profile.
+> **Status - operator profile.** This guide documents llama.cpp as a self-hosted
+> OpenAI-compatible backend for Agent OS cloud deployments. It turns Neo's
+> generic provider-readiness substrate into a backend-specific handoff profile
+> operators can run before assigning agents to the deployment.
 
 ## Provider selector
 
 Use Neo's existing OpenAI-compatible provider keys. Do not introduce or document
-a `llamaCpp` provider selector unless a separate implementation ticket proves
-that the generic OpenAI-compatible contract is insufficient.
+a `llamaCpp` provider selector unless implementation evidence proves that the
+generic OpenAI-compatible contract is insufficient.
 
 ```bash
 export NEO_MODEL_PROVIDER=openAiCompatible
@@ -60,11 +59,11 @@ role models:
 
 Do not hide two unrelated llama.cpp hosts behind one Neo config by manually
 switching `NEO_OPENAI_COMPATIBLE_HOST` between calls. That recreates the
-model-swap failure #12090 was meant to prevent.
+model-swap failure this profile is meant to prevent.
 
 If your only safe llama.cpp topology requires separate chat and embedding hosts
 with no shared OpenAI-compatible router, current Neo config cannot express that
-cleanly. File or follow an implementation ticket for role-specific
+cleanly. Keep that topology out of production until Neo supports role-specific
 OpenAI-compatible hosts instead of documenting a manual operator workaround.
 
 ## Environment example
@@ -179,4 +178,3 @@ Neo health/readiness surfaces all agree.
 - [Configuration](./Configuration.md) - deployment config surface and provider-readiness env vars.
 - [Deployment Cookbook](../DeploymentCookbook.md) - broader Agent OS deployment topology.
 - [Shared KB/MC Team Deployment](../SharedDeployment.md) - shared local-provider residency guidance.
-- [#12090](https://github.com/neomjs/neo/issues/12090) / [PR #12118](https://github.com/neomjs/neo/pull/12118) - generic provider-capacity warning substrate.

--- a/learn/agentos/cloud-deployment/Overview.md
+++ b/learn/agentos/cloud-deployment/Overview.md
@@ -52,6 +52,7 @@ Neo's own guides, ADRs, skills, and API docs remain in the KB under `tenantId: '
 
 - **[Security](./Security.md)** — tenant-isolation invariants, write-side stamping + spoof-rejection, parser-execution boundary framing, and the KB-as-cache vs MC-as-store recovery model.
 - **[Day-0 Tutorial](./Day0Tutorial.md)** - linear PoC walkthrough for a fresh operator or agent: remote MCP healthcheck, MC/KB connection, tenant ingestion, client-side parsing, bulk path, and backup/redeploy handoff.
+- **[llama.cpp Profile](./LlamaCppProfile.md)** - OpenAI-compatible cloud-provider profile for self-hosted llama.cpp, including chat+embedding residency and handoff smoke.
 - **[Migration Path](./MigrationPath.md)** — how an existing single-repo Neo deployment upgrades to the cloud-ingestion substrate with zero config changes.
 - **[Tenant Ingestion Model](./TenantIngestionModel.md)** — the operator-facing model for tenant repo identity, credential boundaries, parser dispatch, source-family inventory, and push-vs-bulk ingestion choices.
 - **[Configuration](./Configuration.md)** — the `aiConfig` keys and the `KnowledgeBaseTenantConfig` / `kb-config.yaml` tenant-config storage.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -47,6 +47,7 @@
             {"name": "Why Deploy the Agent OS",                        "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/WhyDeploy"},
             {"name": "Cloud-Native KB Ingestion Overview",             "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Overview"},
             {"name": "Day-0 Tutorial",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Day0Tutorial"},
+            {"name": "llama.cpp Profile",                              "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/LlamaCppProfile"},
             {"name": "Tenant Ingestion Model",                         "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/TenantIngestionModel"},
             {"name": "Configuration",                                  "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Configuration"},
             {"name": "Custom Sources",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/CustomSources"},


### PR DESCRIPTION
Resolves #12302

Authored by GPT-5.5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.

FAIR-band: over-target [20/30] — taking this lane despite over-target because the operator explicitly redirected this session to "FOCUS on llama.cpp" after V-B-A confirmed #12090 was already closed by PR #12118 and the missing scope was a cloud-deployment guide, not a reopened implementation ticket.

Adds a dedicated `learn/agentos/cloud-deployment/LlamaCppProfile.md` operator guide for running llama.cpp behind Neo's existing `openAiCompatible` provider shape. The guide documents the chat+embedding dual-residency invariant, the current single-base-URL constraint, safe router/role topology, provider env vars, role-keyed context caps, llama.cpp HTTP smoke checks, Neo handoff smoke, and failure signatures. It is linked from the cloud-deployment Overview, Day-0 Tutorial, Configuration guide, and `learn/tree.json`.

Evidence: L1 (static docs/tree diff + official llama.cpp server docs V-B-A) → L1 required (docs-only #12302 ACs). No residuals.

## Slot Rationale

- Added `learn/agentos/cloud-deployment/LlamaCppProfile.md`: disposition `keep` as a pull-loaded cloud-deployment guide leaf. Rating: trigger-frequency medium, failure-severity high, enforceability medium. The failure mode is severe operator drift: a llama.cpp backend can appear healthy while serially swapping chat and embedding roles, which breaks Agent OS local-model economics.
- Modified `Overview.md`, `Day0Tutorial.md`, and `Configuration.md`: disposition delta `keep`; small cross-links make the profile discoverable from existing operator entry points without adding always-loaded agent instructions.
- Modified `learn/tree.json`: disposition `keep`; this is the consumed navigation surface for the learn tree, so the new guide must be visible there, not only reachable by direct link.

Net loaded-byte impact: no always-loaded agent substrate was expanded. The added content lives in conditionally-read learn docs.

Decision Record impact: aligned with ADR 0014 cloud-deployment topology. No ADR update required.

## Deltas From Ticket

- Implemented the missing scope as a dedicated guide rather than burying the llama.cpp material in a generic fallback paragraph.
- Documented the current Neo config limitation directly: separate chat and embedding hosts are not cleanly expressible unless they sit behind one OpenAI-compatible base URL/router.
- Kept llama.cpp under `openAiCompatible`; no new provider selector, default retune, or runtime provider implementation is included.

## Test Evidence

- `git diff --cached --check` passed before commit.
- `node -e "JSON.parse(require('fs').readFileSync('learn/tree.json', 'utf8')); console.log('tree json ok')"` passed.
- After `origin/dev` advanced, rebased onto `d5c1f46cd5b2ba154caee9228b465db9b8576d06`.
- `git diff --check origin/dev...HEAD` passed after rebase.
- Verified branch freshness: `merge-base HEAD origin/dev == origin/dev`.
- Corrective docs pass: `rg -n "#12302|#12090|#12118|PR #12118|resolved by" learn/agentos/cloud-deployment/LlamaCppProfile.md learn/agentos/cloud-deployment/Overview.md learn/agentos/cloud-deployment/Day0Tutorial.md learn/agentos/cloud-deployment/Configuration.md learn/tree.json` returns no matches.
- Docs-only change; no runtime test was run.

## Post-Merge Validation

- [ ] Learn navigation shows **llama.cpp Profile** under **Deploying the Agent OS**.
- [ ] #12302 auto-closes on merge.

## Commits

- `4ea73deff` — `docs(agentos): add llama.cpp cloud profile (#12302)`
- `8f2c81e86` — `docs(agentos): keep llama.cpp guide intent driven (#12302)`

## Evolution

Post-open operator review caught a documentation-quality issue: the first draft exposed issue/PR archaeology inside the guide. The follow-up commit keeps ticket lineage in the PR/ticket trail and makes the guide itself intent-driven.
