### PR TITLE
feat(portal): activate chunked tickets tree (#12304)

### DIFF
--- a/apps/portal/model/Ticket.mjs
+++ b/apps/portal/model/Ticket.mjs
@@ -52,14 +52,31 @@ class Ticket extends Model {
             name: 'treeNodeName',
             type: 'html',
             /**
-             * @param {Object}  data
-             * @param {String}  data.id
-             * @param {Boolean} data.isLeaf
-             * @param {String}  data.title
+             * @param {Object}   data
+             * @param {Number}   data.childCount
+             * @param {String}   data.childrenUrl
+             * @param {String}   data.id
+             * @param {Boolean}  data.isLeaf
+             * @param {String}   data.title
              * @returns {String}
              */
-            calculate({id, isLeaf, title}) {
-                return isLeaf ? `<b>${id}</b> <span class="ticket-title">${title}</span>` : id
+            calculate({childCount, childrenUrl, id, isLeaf, title}) {
+                if (isLeaf) {
+                    return `<b>${id}</b> <span class="ticket-title">${title}</span>`
+                }
+
+                if (childrenUrl && title) {
+                    let match = title.match(/chunk-(\d+)$/);
+
+                    if (match) {
+                        let start = (Number(match[1]) - 1) * 100 + 1,
+                            end   = childCount ? start + childCount - 1 : start + 99;
+
+                        return `Tickets ${start}-${end}`
+                    }
+                }
+
+                return id
             }
         }]
     }

--- a/apps/portal/store/Tickets.mjs
+++ b/apps/portal/store/Tickets.mjs
@@ -2,6 +2,9 @@ import Store       from '../../../src/data/Store.mjs';
 import TicketModel from '../model/Ticket.mjs';
 
 /**
+ * Tree store for the portal Tickets view. Loads the chunked root index so
+ * `TreeList.lazyChildLoad` can fetch ticket leaves on folder expansion instead
+ * of eagerly loading the legacy all-leaves `tickets.json` payload.
  * @class Portal.store.Tickets
  * @extends Neo.data.Store
  */
@@ -18,9 +21,9 @@ class Tickets extends Store {
          */
         model: TicketModel,
         /**
-         * @member {String} url='../../apps/portal/resources/data/tickets.json'
+         * @member {String} url='../../apps/portal/resources/data/tickets/index.json'
          */
-        url: '../../apps/portal/resources/data/tickets.json'
+        url: '../../apps/portal/resources/data/tickets/index.json'
     }
 }
 

--- a/apps/portal/view/news/tickets/MainContainerController.mjs
+++ b/apps/portal/view/news/tickets/MainContainerController.mjs
@@ -70,42 +70,78 @@ class MainContainerController extends Controller {
     }
 
     /**
-     * @returns {String}
+     * @returns {Promise<String|null>}
      */
-    getDefaultRouteId() {
-        let store     = this.getStateProvider().getStore('tree'),
-            rootCount = 0,
-            i         = 0,
-            len       = store.getCount(),
+    async getDefaultRouteId() {
+        let tree   = this.getReference('tree'),
+            store  = this.getStateProvider().getStore('tree'),
+            folder = store.items.find(record => !record.isLeaf && record.childrenUrl),
             record;
 
-        for (; i < len; i++) {
-            record = store.getAt(i);
+        if (!folder) {
+            return store.items.find(item => item.isLeaf)?.id || null
+        }
 
-            if (record.parentId === null) {
-                rootCount++;
+        await tree.onFolderItemClick(folder);
 
-                if (rootCount === 2) {
-                    return store.getAt(i + 1)?.id
-                }
+        this.getStateProvider().data.countPages = store.getCount();
+
+        record = store.items.find(item => item.parentId === folder.id && item.isLeaf);
+
+        return record?.id || null
+    }
+
+    /**
+     * @param {String} itemId
+     * @returns {Promise<Object|null>}
+     */
+    async ensureRecordLoaded(itemId) {
+        let me     = this,
+            tree   = me.getReference('tree'),
+            store  = me.getStateProvider().getStore('tree'),
+            record = store.get(itemId),
+            folders, i, len;
+
+        if (record) {
+            return record
+        }
+
+        folders = store.items.filter(record => !record.isLeaf && record.childrenUrl && !record.isChildrenLoaded);
+
+        for (i = 0, len = folders.length; i < len; i++) {
+            await tree.onFolderItemClick(folders[i]);
+
+            record = store.get(itemId);
+
+            if (record) {
+                me.getStateProvider().data.countPages = store.getCount();
+                return record
             }
         }
 
-        return store.getAt(1)?.id
+        return null
     }
 
     /**
      * @param {Object} data
      */
-    onRouteDefault(data) {
+    async onRouteDefault(data) {
         let me    = this,
             store = me.getStateProvider().getStore('tree');
 
+        const navigate = async () => {
+            let id = await me.getDefaultRouteId();
+
+            if (id) {
+                me.navigateTo(id)
+            }
+        };
+
         if (store.getCount() > 0) {
-            me.navigateTo(me.getDefaultRouteId())
+            await navigate()
         } else {
             store.on({
-                load : () => me.navigateTo(me.getDefaultRouteId()),
+                load : navigate,
                 delay: 10,
                 once : true
             })
@@ -130,7 +166,13 @@ class MainContainerController extends Controller {
         }
 
         const select = async () => {
-            stateProvider.data.currentPageRecord = store.get(itemId);
+            let record = await me.ensureRecordLoaded(itemId);
+
+            if (!record) {
+                return
+            }
+
+            stateProvider.data.currentPageRecord = record;
 
             if (!oldValue?.hashString?.startsWith('/news/tickets')) {
                 await tree.expandAndScrollToItem(itemId)

--- a/test/playwright/unit/app/content/TreeList.spec.mjs
+++ b/test/playwright/unit/app/content/TreeList.spec.mjs
@@ -7,10 +7,12 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../src/Neo.mjs';
-import * as core      from '../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../src/manager/Instance.mjs';
-import TreeList       from '../../../../../src/app/content/TreeList.mjs';
+import Neo               from '../../../../../src/Neo.mjs';
+import * as core         from '../../../../../src/core/_export.mjs';
+import InstanceManager   from '../../../../../src/manager/Instance.mjs';
+import TicketsController from '../../../../../apps/portal/view/news/tickets/MainContainerController.mjs';
+import TicketsStore      from '../../../../../apps/portal/store/Tickets.mjs';
+import TreeList          from '../../../../../src/app/content/TreeList.mjs';
 
 test.describe('Neo.app.content.TreeList lazy child loading', () => {
     test('loads chunk children on folder expand and reconstructs markdown paths once', async () => {
@@ -151,6 +153,89 @@ test.describe('Neo.app.content.TreeList lazy child loading', () => {
         } finally {
             tree.destroy();
             globalThis.fetch = originalFetch
+        }
+    })
+});
+
+test.describe('Portal tickets chunked tree adoption', () => {
+    test('uses the chunked tickets index and renders chunk folders as ticket ranges', () => {
+        const store = Neo.create(TicketsStore, {
+            id  : 'portal-tickets-chunked-store-test',
+            data: [{
+                id       : 'Backlog',
+                isLeaf   : false,
+                parentId : null,
+                collapsed: true
+            }, {
+                id         : 'Backlog/active-chunk-16',
+                isLeaf     : false,
+                parentId   : 'Backlog',
+                title      : 'chunk-16',
+                childCount : 9,
+                childrenUrl: 'tickets/backlog/active-chunk-16.json'
+            }, {
+                id      : '12218',
+                parentId: 'Backlog/active-chunk-16',
+                title   : 'Opt-in load-on-folder-expand for the shared portal TreeList'
+            }]
+        });
+
+        try {
+            expect(store.url).toBe('../../apps/portal/resources/data/tickets/index.json');
+            expect(store.get('Backlog').treeNodeName).toBe('Backlog');
+            expect(store.get('Backlog/active-chunk-16').treeNodeName).toBe('Tickets 1501-1509');
+            expect(store.get('Backlog/active-chunk-16').treeNodeName).not.toContain('chunk');
+            expect(store.get('12218').treeNodeName).toBe(
+                '<b>12218</b> <span class="ticket-title">Opt-in load-on-folder-expand for the shared portal TreeList</span>'
+            )
+        } finally {
+            store.destroy()
+        }
+    })
+
+    test('resolves the default route after loading the first ticket chunk', async () => {
+        const store = Neo.create(TicketsStore, {
+            id  : 'portal-tickets-default-route-store-test',
+            data: [{
+                id       : 'Backlog',
+                isLeaf   : false,
+                parentId : null,
+                collapsed: true
+            }, {
+                id         : 'Backlog/active-chunk-16',
+                isLeaf     : false,
+                parentId   : 'Backlog',
+                title      : 'chunk-16',
+                childCount : 9,
+                childrenUrl: 'tickets/backlog/active-chunk-16.json'
+            }]
+        });
+
+        const stateProvider = {
+            data    : {},
+            getStore: () => store
+        };
+
+        const controller = Object.create(TicketsController.prototype);
+
+        controller.getStateProvider = () => stateProvider;
+        controller.getReference = () => ({
+            async onFolderItemClick(record) {
+                store.add([{
+                    id      : '12218',
+                    parentId: record.id,
+                    title   : 'Opt-in load-on-folder-expand for the shared portal TreeList'
+                }]);
+
+                record.isChildrenLoaded = true
+            }
+        });
+
+        try {
+            expect(await controller.getDefaultRouteId()).toBe('12218');
+            expect(stateProvider.data.countPages).toBe(3)
+        } finally {
+            store.destroy()
         }
     })
 });


### PR DESCRIPTION
Resolves #12304

Authored by GPT-5.5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.
FAIR-band: over-target [20/30] — taking this lane despite over-target because the operator explicitly prioritized portal-news recovery and directed GPT to proceed on this P0 portal lane.

Switches the portal Tickets tree store onto the chunked `tickets/index.json` payload, keeps lazy folder expansion active, and preserves route usability by loading the first ticket chunk before resolving the default ticket route. Chunk folder rows now render as user-facing ticket ranges instead of exposing raw `chunk-N` labels.

Evidence: L3 (fresh no-cache local Chromium portal-route check: `index.json` requested, first chunk requested, visible ticket range labels, ticket leaf selected, article content rendered, no console/request failures) -> L3 required (portal UI/runtime AC). No residuals.

Related: #12204

## Deltas from ticket

The implementation includes a tickets-controller routing guard copied from the already chunked discussions view pattern: default route resolution and direct ticket selection now load lazy chunks when needed so the chunked store does not route to a folder record.

## Test Evidence

- `node --check apps/portal/model/Ticket.mjs`
- `node --check apps/portal/store/Tickets.mjs`
- `node --check apps/portal/view/news/tickets/MainContainerController.mjs`
- `node --check test/playwright/unit/app/content/TreeList.spec.mjs`
- `npm run test-unit -- test/playwright/unit/app/content/TreeList.spec.mjs` — 4 passed
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/docs/index/TicketIndex.spec.mjs` — 1 passed
- `git diff --check` and `git diff --cached --check`
- L3 portal runtime check: loaded `/apps/portal/#/news/tickets` from a no-cache static server in Chromium; server log showed `/apps/portal/resources/data/tickets/index.json?page=1&pageSize=0` and `/apps/portal/resources/data/tickets/backlog/active-chunk-16.json`; runtime state reported `indexRequested: true`, `chunkRequested: true`, `rawChunkLabelVisible: false`, `articleHasContent: true`, `consoleErrors: []`, `failed: []`.

## Post-Merge Validation

- [ ] Verify the deployed portal Tickets tab still requests `tickets/index.json` first and fetches chunk files only when folders are opened.

## Commits

- `ea16cd7b2` — `feat(portal): activate chunked tickets tree (#12304)`
