### PR TITLE
fix(portal): pulls chunked lazy nav — store + controller + theme vars (#12305)

### DIFF
--- a/apps/portal/model/Pull.mjs
+++ b/apps/portal/model/Pull.mjs
@@ -49,21 +49,41 @@ class Pull extends Model {
             name: 'path', // "resources/content/pulls/chunk-N/pr-1234.md"
             type: 'String'
         }, {
-            name: 'title', // "fix(build): bypass hooks for data sync commits (#11590)"
+            name: 'title', // "fix(build): bypass hooks for data sync commits (#11590)" — ticket-ref-ok: illustrative PR-title sample, not a tracking ref
             type: 'String'
         }, {
             // Computed field for TreeList display
             name: 'treeNodeName',
             type: 'html',
             /**
-             * @param {Object}  data
-             * @param {String}  data.id
-             * @param {Boolean} data.isLeaf
-             * @param {String}  data.title
+             * @param {Object}   data
+             * @param {Number}   data.childCount
+             * @param {String}   data.childrenUrl
+             * @param {String}   data.id
+             * @param {Boolean}  data.isLeaf
+             * @param {String}   data.title
              * @returns {String}
              */
-            calculate({id, isLeaf, title}) {
-                return isLeaf ? `<b>${id}</b> <span class="pr-title">${title}</span>` : id
+            calculate({childCount, childrenUrl, id, isLeaf, title}) {
+                if (isLeaf) {
+                    return `<b>${id}</b> <span class="pr-title">${title}</span>`
+                }
+
+                // Chunk-folder nodes: render a positional PR range (e.g. "PRs 1-100") instead of the
+                // raw `chunk-N` implementation label. Mirrors Portal.model.Ticket's range scheme so the
+                // tickets + pulls chunked trees stay consistent (each chunk holds up to 100 entries).
+                if (childrenUrl && title) {
+                    let match = title.match(/chunk-(\d+)$/);
+
+                    if (match) {
+                        let start = (Number(match[1]) - 1) * 100 + 1,
+                            end   = childCount ? start + childCount - 1 : start + 99;
+
+                        return `PRs ${start}-${end}`
+                    }
+                }
+
+                return id
             }
         }]
     }

--- a/apps/portal/store/Pulls.mjs
+++ b/apps/portal/store/Pulls.mjs
@@ -2,9 +2,9 @@ import Store     from '../../../src/data/Store.mjs';
 import PullModel from '../model/Pull.mjs';
 
 /**
- * Tree store for the portal Pull Requests view. Loads the flat `pulls.json` index — state-group
- * roots with PR leaves directly beneath, each carrying its markdown `path` — matching the tickets
- * view's `tickets.json` shape.
+ * Tree store for the portal Pull Requests view. Loads the chunked lazy index `pulls/index.json` —
+ * release-group roots (`Latest` for unreleased + one per release version) with chunk-folder nodes
+ * whose PR leaves lazy-load on folder expansion. Mirrors the discussions view's chunked store.
  * @class Portal.store.Pulls
  * @extends Neo.data.Store
  */
@@ -21,9 +21,9 @@ class Pulls extends Store {
          */
         model: PullModel,
         /**
-         * @member {String} url='../../apps/portal/resources/data/pulls.json'
+         * @member {String} url='../../apps/portal/resources/data/pulls/index.json'
          */
-        url: '../../apps/portal/resources/data/pulls.json'
+        url: '../../apps/portal/resources/data/pulls/index.json'
     }
 }
 

--- a/apps/portal/view/news/pulls/MainContainerController.mjs
+++ b/apps/portal/view/news/pulls/MainContainerController.mjs
@@ -70,42 +70,89 @@ class MainContainerController extends Controller {
     }
 
     /**
-     * @returns {String}
+     * @summary Resolves the default-route id under lazy load.
+     *
+     * The chunked store loads only the group + chunk-folder skeleton; leaf records arrive on folder
+     * expansion. Expands the first chunk folder (`childrenUrl`) and returns its first leaf, so the
+     * default `#/news/pulls` route lands on a real PR instead of an unloaded id. Mirrors the
+     * discussions controller's lazy-aware resolution.
+     * @returns {String|null}
      */
-    getDefaultRouteId() {
-        let store     = this.getStateProvider().getStore('tree'),
-            rootCount = 0,
-            i         = 0,
-            len       = store.getCount(),
+    async getDefaultRouteId() {
+        let tree   = this.getReference('tree'),
+            store  = this.getStateProvider().getStore('tree'),
+            folder = store.items.find(record => !record.isLeaf && record.childrenUrl),
             record;
 
-        for (; i < len; i++) {
-            record = store.getAt(i);
+        if (!folder) {
+            return store.items.find(item => item.isLeaf)?.id || null
+        }
 
-            if (record.parentId === null) {
-                rootCount++;
+        await tree.onFolderItemClick(folder);
 
-                if (rootCount === 2) {
-                    return store.getAt(i + 1)?.id
-                }
+        this.getStateProvider().data.countPages = store.getCount();
+
+        record = store.items.find(item => item.parentId === folder.id && item.isLeaf);
+
+        return record?.id || null
+    }
+
+    /**
+     * @summary Lazy-aware record resolution for deep-links.
+     *
+     * Probes the store for `itemId`; if absent (its chunk is not loaded yet), expands unloaded chunk
+     * folders (`childrenUrl` + `!isChildrenLoaded`) one at a time until the record's chunk loads. This
+     * is what makes a bare-id deep-link (`#/news/pulls/<number>`) resolve under the chunked store.
+     * @param {String} itemId
+     * @returns {Promise<Object|null>}
+     */
+    async ensureRecordLoaded(itemId) {
+        let me     = this,
+            tree   = me.getReference('tree'),
+            store  = me.getStateProvider().getStore('tree'),
+            record = store.get(itemId),
+            folders, i, len;
+
+        if (record) {
+            return record
+        }
+
+        folders = store.items.filter(record => !record.isLeaf && record.childrenUrl && !record.isChildrenLoaded);
+
+        for (i = 0, len = folders.length; i < len; i++) {
+            await tree.onFolderItemClick(folders[i]);
+
+            record = store.get(itemId);
+
+            if (record) {
+                me.getStateProvider().data.countPages = store.getCount();
+                return record
             }
         }
 
-        return store.getAt(1)?.id
+        return null
     }
 
     /**
      * @param {Object} data
      */
-    onRouteDefault(data) {
+    async onRouteDefault(data) {
         let me    = this,
             store = me.getStateProvider().getStore('tree');
 
+        const navigate = async () => {
+            let id = await me.getDefaultRouteId();
+
+            if (id) {
+                me.navigateTo(id)
+            }
+        };
+
         if (store.getCount() > 0) {
-            me.navigateTo(me.getDefaultRouteId())
+            await navigate()
         } else {
             store.on({
-                load : () => me.navigateTo(me.getDefaultRouteId()),
+                load : navigate,
                 delay: 10,
                 once : true
             })
@@ -130,7 +177,13 @@ class MainContainerController extends Controller {
         }
 
         const select = async () => {
-            stateProvider.data.currentPageRecord = store.get(itemId);
+            let record = await me.ensureRecordLoaded(itemId);
+
+            if (!record) {
+                return
+            }
+
+            stateProvider.data.currentPageRecord = record;
 
             if (!oldValue?.hashString?.startsWith('/news/pulls')) {
                 await tree.expandAndScrollToItem(itemId)

--- a/apps/portal/view/news/pulls/MainContainerController.mjs
+++ b/apps/portal/view/news/pulls/MainContainerController.mjs
@@ -76,7 +76,7 @@ class MainContainerController extends Controller {
      * expansion. Expands the first chunk folder (`childrenUrl`) and returns its first leaf, so the
      * default `#/news/pulls` route lands on a real PR instead of an unloaded id. Mirrors the
      * discussions controller's lazy-aware resolution.
-     * @returns {String|null}
+     * @returns {Promise<String|null>}
      */
     async getDefaultRouteId() {
         let tree   = this.getReference('tree'),

--- a/resources/scss/theme-neo-dark/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/theme-neo-dark/apps/portal/news/pulls/Component.scss
@@ -1,5 +1,10 @@
 // Dark-theme palette for Portal.view.news.pulls.Component (PR view). Scoped to the component so
 // the PR MERGED/CLOSED semantics (purple/red) do not redefine the tickets view's state vars.
+// Pull in the shared news timeline theme (`--gh-*` palette vars + timeline colors) so the pulls
+// view's timeline content boxes render their borders. Mirrors the structural `@use` in
+// `resources/scss/src/apps/portal/news/pulls/Component.scss`.
+@use "../tickets/Component";
+
 .neo-theme-neo-dark .portal-news-pulls-component {
     .neo-badge {
         background-color: #21262d;

--- a/resources/scss/theme-neo-light/apps/portal/news/pulls/Component.scss
+++ b/resources/scss/theme-neo-light/apps/portal/news/pulls/Component.scss
@@ -1,5 +1,10 @@
 // Light-theme palette for Portal.view.news.pulls.Component (PR view). Scoped to the component so
 // the PR MERGED/CLOSED semantics (purple/red) do not redefine the tickets view's state vars.
+// Pull in the shared news timeline theme (`--gh-*` palette vars + timeline colors) so the pulls
+// view's timeline content boxes render their borders. Mirrors the structural `@use` in
+// `resources/scss/src/apps/portal/news/pulls/Component.scss`.
+@use "../tickets/Component";
+
 .neo-theme-neo-light .portal-news-pulls-component {
     .neo-badge {
         background-color: #eff1f3;

--- a/test/playwright/unit/apps/portal/view/news/pulls/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/news/pulls/Component.spec.mjs
@@ -10,6 +10,8 @@ import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../../../src/core/_export.mjs';
 import Component       from '../../../../../../../../apps/portal/view/news/pulls/Component.mjs';
+import PullsController from '../../../../../../../../apps/portal/view/news/pulls/MainContainerController.mjs';
+import PullsStore      from '../../../../../../../../apps/portal/store/Pulls.mjs';
 
 /**
  * Unit coverage for the PR-specific parser in `Portal.view.news.pulls.Component`. These tests
@@ -119,5 +121,94 @@ test.describe('Portal.view.news.pulls.Component — PR markdown parser', () => {
         expect(getReviewStateCls('DISMISSED')).toBe('neo-review-neutral');
         expect(getReviewStateCls('SOMETHING_NEW')).toBe('neo-review-neutral');
         expect(getReviewStateCls('')).toBe('neo-review-neutral')
+    })
+});
+
+/**
+ * Chunked lazy-nav adoption: the Pulls store consumes the chunked `pulls/index.json` root index and
+ * chunk-folder nodes render a positional `PRs <range>` label (not raw `chunk-N`), while the controller
+ * resolves the default route by pre-loading the first chunk. Mirrors the tickets chunked-tree adoption
+ * so both chunked views stay consistent.
+ */
+test.describe('Portal pulls chunked tree adoption (#12305)', () => {
+    test('uses the chunked pulls index and renders chunk folders as PR ranges', () => {
+        const store = Neo.create(PullsStore, {
+            id  : 'portal-pulls-chunked-store-test',
+            data: [{
+                id       : 'Latest',
+                isLeaf   : false,
+                parentId : null,
+                collapsed: true
+            }, {
+                id         : 'Latest/active-chunk-16',
+                isLeaf     : false,
+                parentId   : 'Latest',
+                title      : 'chunk-16',
+                childCount : 9,
+                childrenUrl: 'pulls/latest/active-chunk-16.json'
+            }, {
+                id      : '12218',
+                parentId: 'Latest/active-chunk-16',
+                title   : 'Opt-in load-on-folder-expand for the shared portal TreeList'
+            }]
+        });
+
+        try {
+            expect(store.url).toBe('../../apps/portal/resources/data/pulls/index.json');
+            expect(store.get('Latest').treeNodeName).toBe('Latest');
+            expect(store.get('Latest/active-chunk-16').treeNodeName).toBe('PRs 1501-1509');
+            expect(store.get('Latest/active-chunk-16').treeNodeName).not.toContain('chunk');
+            expect(store.get('12218').treeNodeName).toBe(
+                '<b>12218</b> <span class="pr-title">Opt-in load-on-folder-expand for the shared portal TreeList</span>'
+            )
+        } finally {
+            store.destroy()
+        }
+    });
+
+    test('resolves the default route after loading the first pulls chunk', async () => {
+        const store = Neo.create(PullsStore, {
+            id  : 'portal-pulls-default-route-store-test',
+            data: [{
+                id       : 'Latest',
+                isLeaf   : false,
+                parentId : null,
+                collapsed: true
+            }, {
+                id         : 'Latest/active-chunk-16',
+                isLeaf     : false,
+                parentId   : 'Latest',
+                title      : 'chunk-16',
+                childCount : 9,
+                childrenUrl: 'pulls/latest/active-chunk-16.json'
+            }]
+        });
+
+        const stateProvider = {
+            data    : {},
+            getStore: () => store
+        };
+
+        const controller = Object.create(PullsController.prototype);
+
+        controller.getStateProvider = () => stateProvider;
+        controller.getReference = () => ({
+            async onFolderItemClick(record) {
+                store.add([{
+                    id      : '12218',
+                    parentId: record.id,
+                    title   : 'Opt-in load-on-folder-expand for the shared portal TreeList'
+                }]);
+
+                record.isChildrenLoaded = true
+            }
+        });
+
+        try {
+            expect(await controller.getDefaultRouteId()).toBe('12218');
+            expect(stateProvider.data.countPages).toBe(3)
+        } finally {
+            store.destroy()
+        }
     })
 });


### PR DESCRIPTION
Resolves #12305

Authored by Opus 4.8 (Claude Code). Session da9a6007-1250-4363-8c15-dff69eccb3be.

FAIR-band: in-band [11/30]

Evidence: L2 — borders are build-output verified (the rebuilt pulls *theme* CSS now defines `--gh-timeline-border` / `--gh-bg-default` / `--gh-bg-subtle`, previously undefined); the chunked nav + deep-link are code-verified as a faithful mirror of the discussions lazy-aware controller plus the matching `pulls/index.json` chunk-folder shape; `node --check` clean. L3 runtime (chunk folders render in the `Latest` nav, deep-link resolves under lazy load, borders visible) is operator + cross-family verification **post-merge** — the running Portal serves a different checkout, so I cannot L3 this branch directly (same posture as #12301).

The pulls sibling of #12304 (GPT's tickets-store switch) on the shared #12219 lazy-aware-nav track, per operator direction (gpt on tickets, me on pulls). After #12301 shipped the release-grouped tree + chunked surface emitter, the consumer still pointed at the flat monolith; this wires it to the chunked surface and fixes the missing theme vars.

## The fixes

### 1. Chunk folders absent from the `Latest` nav → chunked lazy store
`Portal.store.Pulls` loaded the flat all-leaves `pulls.json`; switched its `url` to the chunked `pulls/index.json` (86 nodes: release-group roots + 58 chunk-folder nodes carrying `childrenUrl`). The tree now loads only the group + chunk-folder skeleton and lazy-loads PR leaves on folder expansion (`MainContainer`'s `lazyChildLoad: true` was previously inert against the flat store).

### 2. Deep-link / default route under lazy load → lazy-aware controller
`pulls/MainContainerController` adopted the discussions controller's lazy resolution: `getDefaultRouteId` (folder-aware) + a new `ensureRecordLoaded(itemId)` that pre-loads unloaded chunk folders (`childrenUrl` + `!isChildrenLoaded`) before `store.get`, wired into async `onRouteItem` / `onRouteDefault`. A bare-id deep-link (`#/news/pulls/<number>`) now resolves even when its chunk isn't loaded yet. (Side effect: `countPages` is now set on chunk load, fixing the previously-unset next/previous-page navigation.)

### 3. No content-box borders → theme-side `@use`
The PR-view timeline `border: 1px solid var(--gh-timeline-border)` resolved to an undefined variable because the pulls *theme* scss only defined PR-specific badge colors. Added `@use "../tickets/Component"` to `theme-neo-{light,dark}/.../pulls/Component.scss` (symmetric with the structural `@use` shipped in #12301), so the shared `--gh-*` palette vars resolve. Verified the rebuilt theme CSS now carries them.

## Deltas from ticket
- The lazy controller also resolves the long-standing `countPages`-unset latent bug (next/previous-page nav was dead because the flat controller never set it).
- Folded in chunk-folder **positional range labels** (`Pull.mjs` `treeNodeName` → `PRs <start>-<end>`) during convergence with approved #12306, so the pulls + tickets chunked trees render consistently. Originally deferred to the cross-view brainstorm; the *baseline* labels are now shipped here, while only the label-*scheme refinements* stay deferred (see Out of Scope).

## Test Evidence
- `node --check` clean: `pulls/MainContainerController.mjs`, `store/Pulls.mjs`.
- Theme rebuild (`npm run build-themes -- -n -e dev -t all`) succeeded; rebuilt `theme-neo-{light,dark}/apps/portal/news/pulls/Component.css` confirmed to define `--gh-timeline-border` / `--gh-bg-default` / `--gh-bg-subtle`.
- `pulls/index.json` shape verified: release groups + chunk-folder nodes with `childrenUrl` → existing chunk JSONs (same shape `discussions.json` uses with the same controller).

## Post-Merge Validation
- [ ] L3: the `Latest` group (and release groups) show chunk-folder nodes; expanding one lazy-loads its PR leaves (first paint loads only the skeleton).
- [ ] L3: `#/news/pulls/<number>` deep-link resolves under lazy load (chunk pre-loaded); default `#/news/pulls` lands on a real PR.
- [ ] L3: PR-view timeline content boxes render their borders (light + dark).

## Out of Scope
- Chunk-folder range-label **scheme refinements** — display *direction* (ascending `1-100`-first vs newest-first), relabeling positions as IDs, and an open/closed state indicator — remain the operator's cross-view UX brainstorm, to be applied across tickets + pulls (+ discussions) together. The *baseline* positional range labels (`PRs <start>-<end>`) ARE shipped here, mirroring #12306.
- The chunk-folder display-**ordering** bug (folders sequence by `sortDate` while their labels are positional, so they can render out of order) is tracked at #12309 — a generator-side fix spanning tickets + pulls, not this consumer PR.
- Tickets adoption (#12304) and the discussions view (separate brainstorm).

