### PR TITLE
fix(build): order chunk folders by chunk-number not sortDate (#12309)

### DIFF
--- a/buildScripts/docs/index/pulls.mjs
+++ b/buildScripts/docs/index/pulls.mjs
@@ -131,6 +131,32 @@ function buildLegacyFlatTree(sortedGroups, pullsByGroup) {
 }
 
 /**
+ * Orders chunk-folder nodes within a group by their positional chunk number, descending (newest /
+ * highest-numbered chunk first). This matches the newest-first ordering used elsewhere in the tree
+ * (release groups are semver-descending; leaves within a chunk are id-descending) and, critically,
+ * keeps folder display order aligned with the positional `treeNodeName` range labels.
+ *
+ * The previous `sortDate`-based ordering scrambled folders relative to their labels: a chunk's max
+ * item-date is not monotonic with its number (item updates bump older chunks), so date-order and
+ * chunk-number order diverge while the labels stay positional.
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {Number}
+ */
+function sortChunkFolders(a, b) {
+    const
+        matchA = a.title?.match(/chunk-(\d+)$/),
+        matchB = b.title?.match(/chunk-(\d+)$/);
+
+    if (matchA && matchB) {
+        return Number(matchB[1]) - Number(matchA[1])
+    }
+
+    // Defensive fallback for any bucket without a `chunk-N` title: preserve the prior date-then-id order.
+    return (new Date(b.sortDate || 0) - new Date(a.sortDate || 0)) || a.id.localeCompare(b.id)
+}
+
+/**
  * @param {String[]} sortedGroups
  * @param {Map<String,Object[]>} pullsByGroup
  * @returns {{rootIndex: Object[], chunks: Map<String,Object>}}
@@ -185,10 +211,7 @@ function buildChunkedIndex(sortedGroups, pullsByGroup) {
 
         const groupChunks = Array.from(chunks.values())
             .filter(chunk => chunk.parentId === groupName)
-            .sort((a, b) => {
-                const dateDiff = new Date(b.sortDate || 0) - new Date(a.sortDate || 0);
-                return dateDiff || a.id.localeCompare(b.id)
-            });
+            .sort(sortChunkFolders);
 
         rootIndex.push(...groupChunks.map(chunk => {
             const {records, sortDate, ...node} = chunk;

--- a/buildScripts/docs/index/tickets.mjs
+++ b/buildScripts/docs/index/tickets.mjs
@@ -130,6 +130,32 @@ function buildLegacyFlatTree(sortedGroups, ticketsByGroup) {
 }
 
 /**
+ * Orders chunk-folder nodes within a group by their positional chunk number, descending (newest /
+ * highest-numbered chunk first). This matches the newest-first ordering used elsewhere in the tree
+ * (release groups are semver-descending; leaves within a chunk are date/id-descending) and, critically,
+ * keeps folder display order aligned with the positional `treeNodeName` range labels.
+ *
+ * The previous `sortDate`-based ordering scrambled folders relative to their labels: a chunk's max
+ * item-date is not monotonic with its number (item updates bump older chunks), so date-order and
+ * chunk-number order diverge while the labels stay positional.
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {Number}
+ */
+function sortChunkFolders(a, b) {
+    const
+        matchA = a.title?.match(/chunk-(\d+)$/),
+        matchB = b.title?.match(/chunk-(\d+)$/);
+
+    if (matchA && matchB) {
+        return Number(matchB[1]) - Number(matchA[1])
+    }
+
+    // Defensive fallback for any bucket without a `chunk-N` title: preserve the prior date-then-id order.
+    return (new Date(b.sortDate || 0) - new Date(a.sortDate || 0)) || a.id.localeCompare(b.id)
+}
+
+/**
  * @param {String[]} sortedGroups
  * @param {Map<String,Object[]>} ticketsByGroup
  * @returns {{rootIndex: Object[], chunks: Map<String,Object>}}
@@ -184,10 +210,7 @@ function buildChunkedIndex(sortedGroups, ticketsByGroup) {
 
         const groupChunks = Array.from(chunks.values())
             .filter(chunk => chunk.parentId === groupName)
-            .sort((a, b) => {
-                const dateDiff = new Date(b.sortDate || 0) - new Date(a.sortDate || 0);
-                return dateDiff || a.id.localeCompare(b.id)
-            });
+            .sort(sortChunkFolders);
 
         rootIndex.push(...groupChunks.map(chunk => {
             const {records, sortDate, ...node} = chunk;

--- a/test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs
@@ -124,6 +124,49 @@ test.describe('Portal content index generators (#12210)', () => {
         expect(manifest.chunks.some(chunk => chunk.childrenUrl === 'pulls/latest/active-chunk-1.json')).toBe(true)
     });
 
+    test('createPullRequestIndex orders chunk folders by chunk-number (desc), not by sortDate, matching the positional labels (#12309)', async () => {
+        const
+            inputDir          = path.join(tempDir, 'resources/content/pulls'),
+            archiveDir        = path.join(tempDir, 'resources/content/archive/pulls'),
+            outputFile        = path.join(tempDir, 'apps/portal/resources/data/pulls.json'),
+            outputDir         = path.join(tempDir, 'apps/portal/resources/data/pulls'),
+            chunkedOutputFile = path.join(tempDir, 'apps/portal/resources/data/pulls/index.json'),
+            manifestFile      = path.join(tempDir, 'apps/portal/resources/data/pulls/manifest.json');
+
+        // Same Latest group, three chunk folders, NON-MONOTONIC dates: a sortDate ordering would emit
+        // [chunk-1, chunk-3, chunk-2] — scrambled relative to the positional `treeNodeName` labels.
+        await fs.outputFile(path.join(inputDir, 'chunk-1/pr-110.md'), frontmatter({
+            number   : 110,
+            title    : 'Newest date, lowest chunk',
+            state    : 'OPEN',
+            updatedAt: '2026-05-30T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(inputDir, 'chunk-2/pr-210.md'), frontmatter({
+            number   : 210,
+            title    : 'Oldest date, middle chunk',
+            state    : 'OPEN',
+            updatedAt: '2026-05-01T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(inputDir, 'chunk-3/pr-310.md'), frontmatter({
+            number   : 310,
+            title    : 'Middle date, highest chunk',
+            state    : 'OPEN',
+            updatedAt: '2026-05-15T00:00:00Z'
+        }));
+
+        await createPullRequestIndex({archiveDir, inputDir, outputDir, outputFile, chunkedOutputFile, manifestFile});
+
+        // Chunk folders descend by chunk-number (newest/highest chunk first), regardless of sortDate.
+        const index = await fs.readJson(chunkedOutputFile);
+
+        expect(index.map(record => record.id)).toEqual([
+            'Latest',
+            'Latest/active-chunk-3',
+            'Latest/active-chunk-2',
+            'Latest/active-chunk-1'
+        ])
+    });
+
     test('createDiscussionIndex groups by frontmatter category for active and archive files', async () => {
         const
             inputDir   = path.join(tempDir, 'resources/content/discussions'),

--- a/test/playwright/unit/ai/buildScripts/docs/index/TicketIndex.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/index/TicketIndex.spec.mjs
@@ -6,7 +6,7 @@ import createTicketIndex from '../../../../../../../buildScripts/docs/index/tick
 
 /**
  * @summary Verifies the Portal ticket index generator emits both the legacy full-tree feed
- * and the chunked root-plus-leaves contract for #12217.
+ * and the chunked root-plus-leaves contract.
  */
 
 function frontmatter(data) {
@@ -128,5 +128,49 @@ test.describe('Portal ticket index generator (#12217)', () => {
                 childCount : 1
             })])
         })
+    });
+
+    test('orders chunk folders by chunk-number (desc), not by sortDate, matching the positional labels (#12309)', async () => {
+        const
+            issuesDir         = path.join(tempDir, 'resources/content/issues'),
+            archiveDir        = path.join(tempDir, 'resources/content/archive/issues'),
+            outputFile        = path.join(tempDir, 'apps/portal/resources/data/tickets.json'),
+            outputDir         = path.join(tempDir, 'apps/portal/resources/data/tickets'),
+            chunkedOutputFile = path.join(outputDir, 'index.json'),
+            manifestFile      = path.join(outputDir, 'manifest.json');
+
+        // Three chunk folders in the SAME (Backlog) group with NON-MONOTONIC dates: the lowest-numbered
+        // chunk carries the newest date, the highest-numbered the middle date. A sortDate ordering would
+        // emit [chunk-1, chunk-3, chunk-2] — scrambled relative to the positional `treeNodeName` labels.
+        await fs.outputFile(path.join(issuesDir, 'chunk-1/issue-110.md'), frontmatter({
+            id       : 110,
+            title    : 'Newest date, lowest chunk',
+            labels   : ['enhancement'],
+            updatedAt: '2026-05-30T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(issuesDir, 'chunk-2/issue-210.md'), frontmatter({
+            id       : 210,
+            title    : 'Oldest date, middle chunk',
+            labels   : ['enhancement'],
+            updatedAt: '2026-05-01T00:00:00Z'
+        }));
+        await fs.outputFile(path.join(issuesDir, 'chunk-3/issue-310.md'), frontmatter({
+            id       : 310,
+            title    : 'Middle date, highest chunk',
+            labels   : ['enhancement'],
+            updatedAt: '2026-05-15T00:00:00Z'
+        }));
+
+        await createTicketIndex({archiveDir, chunkedOutputFile, issuesDir, manifestFile, outputDir, outputFile});
+
+        // Chunk folders descend by chunk-number (newest/highest chunk first), regardless of sortDate.
+        const root = await fs.readJson(chunkedOutputFile);
+
+        expect(root.map(record => record.id)).toEqual([
+            'Backlog',
+            'Backlog/active-chunk-3',
+            'Backlog/active-chunk-2',
+            'Backlog/active-chunk-1'
+        ])
     })
 });


### PR DESCRIPTION
Resolves #12309

Authored by Opus 4.8 (Claude Code). Session da9a6007-1250-4363-8c15-dff69eccb3be.

FAIR-band: in-band — authoring my own backlog lane while peer-reviewing GPT's PRs.

Evidence: L2 — generator unit tests assert chunk-folder ordering against temp-dir fixtures with non-monotonic dates, and a negative check confirms both new tests FAIL on the old `sortDate` sort and PASS on the fix. L3 (portal tree displays folders in order) is verified post-merge once the data-sync pipeline regenerates the indexes. No code-path residuals.

The chunk-folder follow-up from the tickets/pulls chunked-tree work (#12306 merged, #12307 open): chunk folders displayed out of sequence relative to their positional `treeNodeName` labels.

## The fix
`buildChunkedIndex` in `tickets.mjs` + `pulls.mjs` sorted chunk-folder nodes by `sortDate` (a chunk's max item-date), while the model's `treeNodeName` labels them positionally by chunk-number (`Tickets/PRs <start>-<end>`). When a chunk's max-date is non-monotonic with its number — which happens whenever an item in an older chunk is updated — the date order and the chunk-number order diverge, so the folders render scrambled against their own labels (operator-observed: `1501-1509`, `1401-1500`, `601-700`, `1301-1400`, …).

Added a `sortChunkFolders` comparator that orders folders by chunk-number **descending** (newest/highest chunk first). This keeps folder order aligned with the positional labels and makes the whole tree consistently newest-first — release groups are already semver-descending, and leaves within a chunk are already date/id-descending; only the chunk-folder level was out of step.

## Deltas from ticket
- The ticket prescribed "(+ align discussions.mjs)". V-B-A of `Portal.model.Discussion` showed it labels chunk folders with the **raw title** (`title || id`), not positional ranges — so discussions has no label/order *mismatch* bug. Aligning its sort would change discussions folder order for no fix benefit and pre-empt the operator's separate discussions folder-naming + open/closed brainstorm. Scope narrowed to tickets + pulls; discussions deferred.
- Generator code + tests only. The index JSON is regenerated and committed by the data-sync pipeline (§critical_gate 3 exception), so this PR does not commit regenerated data — the fix takes effect on the next sync.

## Test Evidence
- `node --check` clean on both generators and both spec files.
- `UNIT_TEST_MODE=true playwright test … TicketIndex.spec.mjs PortalContentIndexes.spec.mjs` → **5 passed** (3 pre-existing + 2 new ordering tests).
- **Negative check (anti-blind-spot):** stashed only the generator fixes and re-ran → exactly the 2 new ordering tests **fail** (3 pre-existing pass); restored the fix → all 5 pass. Confirms the tests catch the regression rather than vacuously passing.
- New tests build multi-chunk groups with non-monotonic dates (lowest chunk = newest date) and assert the chunked index root emits `[group, active-chunk-3, active-chunk-2, active-chunk-1]`.

## Post-Merge Validation
- [ ] After the data-sync pipeline regenerates `tickets/index.json` + `pulls/index.json`, the `Latest` group's chunk folders display in descending range order (`PRs 1501-1509`, `1401-1500`, `1301-1400`, …) with no scramble.
- [ ] Per-release groups likewise display their chunk folders in descending range order.

## Out of Scope
- The sort **direction** (descending newest-first vs ascending) and the broader label **scheme** (positions-read-as-IDs, open/closed indicator) — the operator's cross-view UX brainstorm. Descending was chosen for whole-tree newest-first consistency and is a one-line reversal if the brainstorm prefers ascending.
- `discussions.mjs` (see Deltas).
