### PR TITLE
fix(portal): route news timeline avatars through getAvatarUrl/getAvatarHtml (#12315)

### DIFF
--- a/apps/portal/view/news/discussions/Component.mjs
+++ b/apps/portal/view/news/discussions/Component.mjs
@@ -200,7 +200,7 @@ class Component extends ContentComponent {
 
         me.timelineData.unshift({
             id   : bodyId,
-            image: me.repoUserUrl + data.author + '.png',
+            image: me.getAvatarUrl(data.author),
             name : 'Description',
             tag  : 'body'
         });
@@ -208,7 +208,7 @@ class Component extends ContentComponent {
         let bodyItemHtml = `
             <div id="${bodyId}" class="neo-timeline-item comment body-item" data-record-id="${bodyId}">
                 <div id="${bodyId}-target" class="neo-timeline-avatar">
-                    <img src="${me.repoUserUrl}${data.author}.png" alt="${data.author}">
+                    ${me.getAvatarHtml(data.author)}
                 </div>
                 <div class="neo-timeline-content">
                     <div class="neo-timeline-header">
@@ -346,7 +346,7 @@ ${fullHtml}
 
             me.timelineData.push({
                 id,
-                image: repoUserUrl + comment.user + '.png',
+                image: me.getAvatarUrl(comment.user),
                 name : `Comment (${comment.user})`,
                 tag  : 'comment'
             });
@@ -354,7 +354,7 @@ ${fullHtml}
             html += `
                     <div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">
                         <div id="${id}-target" class="neo-timeline-avatar">
-                            <img src="${repoUserUrl}${comment.user}.png" alt="${comment.user}">
+                            ${me.getAvatarHtml(comment.user)}
                         </div>
                         <div class="neo-timeline-content">
                             <div class="neo-timeline-header">

--- a/apps/portal/view/news/tickets/Component.mjs
+++ b/apps/portal/view/news/tickets/Component.mjs
@@ -264,7 +264,7 @@ class Component extends ContentComponent {
 
         me.timelineData.unshift({
             id   : bodyId,
-            image: me.repoUserUrl + author + '.png',
+            image: me.getAvatarUrl(author),
             name : 'Description',
             tag  : 'body'
         });
@@ -272,7 +272,7 @@ class Component extends ContentComponent {
         let bodyItemHtml = `
             <div id="${bodyId}" class="neo-timeline-item comment body-item" data-record-id="${bodyId}">
                 <div id="${bodyId}-target" class="neo-timeline-avatar">
-                    <img src="${me.repoUserUrl}${author}.png" alt="${author}">
+                    ${me.getAvatarHtml(author)}
                 </div>
                 <div class="neo-timeline-content">
                     <div class="neo-timeline-header">
@@ -338,7 +338,7 @@ ${fullHtml}
 
                 me.timelineData.push({
                     id,
-                    image: repoUserUrl + currentUser + '.png',
+                    image: me.getAvatarUrl(currentUser),
                     name : `Comment (${currentUser})`,
                     tag  : 'comment'
                 });
@@ -347,7 +347,7 @@ ${fullHtml}
                 html += `
                     <div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">
                         <div id="${id}-target" class="neo-timeline-avatar">
-                            <img src="${repoUserUrl}${currentUser}.png" alt="${currentUser}">
+                            ${me.getAvatarHtml(currentUser)}
                         </div>
                         <div class="neo-timeline-content">
                             <div class="neo-timeline-header">

--- a/test/playwright/unit/apps/portal/view/content/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/content/Component.spec.mjs
@@ -1,0 +1,47 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'PortalContentComponentTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import Component       from '../../../../../../../apps/portal/view/content/Component.mjs';
+
+/**
+ * Unit coverage for the shared avatar helpers on the Portal news timeline base
+ * `Portal.view.content.Component`. Every timeline view (tickets / pull requests / discussions) renders
+ * actor avatars through these, so a 40px timeline avatar fetches GitHub's ~1KB `?size=40` image instead
+ * of the full-resolution original, and bot/app actors (whose `<login>.png` 404s) fall back to a
+ * no-network glyph. Both helpers are pure (they read only `this.repoUserUrl` / `this.getAvatarUrl`), so
+ * they are exercised directly on the prototype with a stub context.
+ */
+const {getAvatarHtml, getAvatarUrl} = Component.prototype;
+
+test.describe('Portal.view.content.Component — shared avatar helpers', () => {
+    test('getAvatarUrl bounds the avatar request to ?size=40', () => {
+        expect(getAvatarUrl.call({repoUserUrl: 'https://github.com/'}, 'alice'))
+            .toBe('https://github.com/alice.png?size=40')
+    });
+
+    test('getAvatarHtml: normal user → sized lazy <img>; bot/app actor → no-network glyph', () => {
+        const ctx = {repoUserUrl: 'https://github.com/', getAvatarUrl};
+
+        // Normal user: bounded (?size=40) lazy <img>, never the full-resolution original.
+        const normal = getAvatarHtml.call(ctx, 'alice');
+        expect(normal).toContain('<img');
+        expect(normal).toContain('https://github.com/alice.png?size=40');
+        expect(normal).toContain('loading="lazy"');
+
+        // Known bot actor: Font Awesome glyph, no `.png` network request.
+        const bot = getAvatarHtml.call(ctx, 'dependabot');
+        expect(bot).toContain('fa-github');
+        expect(bot).not.toContain('.png');
+
+        // `[bot]`-suffixed app actor: same no-network fallback.
+        expect(getAvatarHtml.call(ctx, 'some-app[bot]')).toContain('fa-github')
+    })
+});


### PR DESCRIPTION
Resolves #12315

Authored by Opus 4.8 (Claude Code). Session da9a6007-1250-4363-8c15-dff69eccb3be.

FAIR-band: in-band [10/30] — operator-reported portal-news fix.

Evidence: L2 — the shared avatar helpers are unit-tested (`getAvatarUrl` → `?size=40`, `getAvatarHtml` bot-glyph fallback), and the routing fix is diff-verified (all 8 raw-`.png` sites now call the helpers; grep confirms zero raw avatar URLs remain). L3 (the browser issues `?size=40` avatar requests + bot actors render the glyph) is confirmable on the live instance — see Post-Merge Validation.

Operator-reported: timeline avatars in the news views fetch the full-resolution image instead of a bounded thumbnail.

## Root cause
The base `Portal.view.content.Component` ships `getAvatarUrl(user)` (`…/<user>.png?size=40`) and `getAvatarHtml(user)` (sized lazy `<img>`, or a no-network Font Awesome glyph for bot/app actors). The **pulls** view already uses them — but the **tickets** and **discussions** views emitted raw `${repoUserUrl}${user}.png`, bypassing both. So each 40px timeline avatar downloaded the ~40KB original, and bot actors (whose `<login>.png` 404s) rendered a broken image.

## The fix
Routed all 8 avatar sites (4 tickets, 4 discussions) through the helpers, matching the pulls view:
- vdom `image:` configs → `me.getAvatarUrl(user)` (bounded `?size=40` URL)
- `<img>` HTML strings → `${me.getAvatarHtml(user)}` (sized lazy `<img>`, or the bot/app glyph)

## Deltas from ticket
- pulls was already correct (uses the helpers) — scope is tickets + discussions only.
- AC2 (bot fallback) is satisfied as an **improvement**: tickets/discussions previously had **no** bot handling (raw `.png` → 404 for bots); routing through `getAvatarHtml` adds the no-network glyph fallback.
- The new test exercises the shared helper on `Portal.view.content.Component` (the canonical home); the per-view render methods are app-container-coupled, so the routing itself is diff-verified rather than render-unit-tested.

## Test Evidence
- `node --check` clean: tickets `Component.mjs`, discussions `Component.mjs`, the new spec.
- `UNIT_TEST_MODE=true playwright test … apps/portal/view/content/Component.spec.mjs` → **2 passed** (`getAvatarUrl` `?size=40`; `getAvatarHtml` normal→sized-lazy-img / bot+`[bot]`→glyph).
- `grep` confirms zero `repoUserUrl…\.png` avatar sites remain in tickets/discussions; `repoUserUrl` is still used for the actor profile `<a href>` links (not dead).

## Post-Merge Validation
- [ ] L3: load `#/news/tickets/<n>` and `#/news/discussions/<n>`; DevTools Network shows avatar requests carry `?size=40` (not the full-res original).
- [ ] L3: a bot/app actor (e.g. `dependabot`, `github-actions`) renders the Font Awesome GitHub glyph, not a broken image.

## Out of Scope
- Avatar source host / bot-fallback list (unchanged).
- Other portal-news items (discussions canvas timeline, tab order) — separate.
