### PR TITLE
fix(portal): render bot/app avatar glyph in news summary list (#12317)

### DIFF
--- a/apps/portal/model/TimelineSection.mjs
+++ b/apps/portal/model/TimelineSection.mjs
@@ -21,6 +21,9 @@ class TimelineSection extends ContentSection {
             name: 'icon',
             type: 'String'
         }, {
+            name: 'iconCls',
+            type: 'String'
+        }, {
             name: 'image',
             type: 'String'
         }, {

--- a/apps/portal/view/content/Component.mjs
+++ b/apps/portal/view/content/Component.mjs
@@ -73,6 +73,18 @@ class Component extends ContentComponent {
     }
 
     /**
+     * @summary True for GitHub bot/app actors whose `github.com/<login>.png` avatar 404s.
+     *
+     * Single source of truth for the bot/app actor decision, shared by `getAvatarHtml` (timeline HTML)
+     * and `getAvatarRecordProps` (summary list), so the bot list is never duplicated in a consumer renderer.
+     * @param {String} user GitHub login.
+     * @returns {Boolean}
+     */
+    isBotActor(user) {
+        return botActors.has(user) || user.endsWith('[bot]')
+    }
+
+    /**
      * @summary Renders a bounded avatar for a timeline actor.
      *
      * Normal users get the sized `<img>`; bot/app actors (whose `github.com/<login>.png` 404s) fall back
@@ -82,11 +94,25 @@ class Component extends ContentComponent {
      * @returns {String}
      */
     getAvatarHtml(user) {
-        if (botActors.has(user) || user.endsWith('[bot]')) {
+        if (this.isBotActor(user)) {
             return `<i class="neo-timeline-avatar-icon fa-brands fa-github" role="img" aria-label="${user}"></i>`
         }
 
         return `<img src="${this.getAvatarUrl(user)}" alt="${user}" loading="lazy">`
+    }
+
+    /**
+     * @summary Resolves the avatar fields for a timeline entry record, consumed by both the timeline and
+     * the `Neo.app.content.SectionsList` "On this page" summary.
+     *
+     * Normal users get a bounded `image` URL; bot/app actors get an `iconCls` (Font Awesome GitHub glyph)
+     * instead — so the summary list renders the same no-network glyph the timeline does, rather than a
+     * broken `<img>` for a 404ing bot avatar. The bot decision stays centralized via `isBotActor`.
+     * @param {String} user GitHub login.
+     * @returns {Object} `{image}` for normal users, `{iconCls}` for bot/app actors.
+     */
+    getAvatarRecordProps(user) {
+        return this.isBotActor(user) ? {iconCls: 'fa-brands fa-github'} : {image: this.getAvatarUrl(user)}
     }
 
     /**

--- a/apps/portal/view/news/discussions/Component.mjs
+++ b/apps/portal/view/news/discussions/Component.mjs
@@ -200,7 +200,7 @@ class Component extends ContentComponent {
 
         me.timelineData.unshift({
             id   : bodyId,
-            image: me.getAvatarUrl(data.author),
+            ...me.getAvatarRecordProps(data.author),
             name : 'Description',
             tag  : 'body'
         });
@@ -346,7 +346,7 @@ ${fullHtml}
 
             me.timelineData.push({
                 id,
-                image: me.getAvatarUrl(comment.user),
+                ...me.getAvatarRecordProps(comment.user),
                 name : `Comment (${comment.user})`,
                 tag  : 'comment'
             });

--- a/apps/portal/view/news/pulls/Component.mjs
+++ b/apps/portal/view/news/pulls/Component.mjs
@@ -50,7 +50,7 @@ class Component extends ContentComponent {
         cls: ['portal-news-pulls-component'],
         /**
          * `#N` references in PR bodies are issue numbers → resolve to the portal tickets view.
-         * Per-content-type config (#12209): the generic content base no longer defaults this.
+         * Per-content-type config: the generic content base no longer defaults this.
          * @member {String} issuesUrl='#/news/tickets/'
          */
         issuesUrl: '#/news/tickets/',
@@ -196,7 +196,7 @@ class Component extends ContentComponent {
 
         me.timelineData.push({
             id   : bodyId,
-            image: me.getAvatarUrl(author),
+            ...me.getAvatarRecordProps(author),
             name : 'Description',
             tag  : 'body'
         });
@@ -213,7 +213,7 @@ class Component extends ContentComponent {
 
             me.timelineData.push({
                 id,
-                image: me.getAvatarUrl(entry.user),
+                ...me.getAvatarRecordProps(entry.user),
                 name : isReview ? `Review (${entry.user})` : `Comment (${entry.user})`,
                 tag  : entry.type
             });

--- a/apps/portal/view/news/tickets/Component.mjs
+++ b/apps/portal/view/news/tickets/Component.mjs
@@ -264,7 +264,7 @@ class Component extends ContentComponent {
 
         me.timelineData.unshift({
             id   : bodyId,
-            image: me.getAvatarUrl(author),
+            ...me.getAvatarRecordProps(author),
             name : 'Description',
             tag  : 'body'
         });
@@ -338,7 +338,7 @@ ${fullHtml}
 
                 me.timelineData.push({
                     id,
-                    image: me.getAvatarUrl(currentUser),
+                    ...me.getAvatarRecordProps(currentUser),
                     name : `Comment (${currentUser})`,
                     tag  : 'comment'
                 });

--- a/src/app/content/SectionsList.mjs
+++ b/src/app/content/SectionsList.mjs
@@ -40,6 +40,10 @@ class SectionsList extends List {
 
         if (record.image) {
             content.push({tag: 'img', src: record.image, cls: ['neo-list-icon', 'avatar']})
+        } else if (record.iconCls) {
+            // A full Font Awesome class string (e.g. a `fa-brands fa-github` bot glyph) rendered as an
+            // avatar-sized icon — lets a record supply a no-network glyph instead of an `image` URL.
+            content.push({tag: 'i', cls: ['neo-list-icon', 'avatar', ...record.iconCls.split(' ')]})
         } else if (record.icon) {
             content.push({tag: 'i', cls: ['neo-list-icon', 'fa-solid', record.icon]})
         }

--- a/test/playwright/unit/apps/portal/view/content/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/content/Component.spec.mjs
@@ -19,7 +19,7 @@ import Component       from '../../../../../../../apps/portal/view/content/Compo
  * no-network glyph. Both helpers are pure (they read only `this.repoUserUrl` / `this.getAvatarUrl`), so
  * they are exercised directly on the prototype with a stub context.
  */
-const {getAvatarHtml, getAvatarUrl} = Component.prototype;
+const {getAvatarHtml, getAvatarRecordProps, getAvatarUrl, isBotActor} = Component.prototype;
 
 test.describe('Portal.view.content.Component — shared avatar helpers', () => {
     test('getAvatarUrl bounds the avatar request to ?size=40', () => {
@@ -28,7 +28,7 @@ test.describe('Portal.view.content.Component — shared avatar helpers', () => {
     });
 
     test('getAvatarHtml: normal user → sized lazy <img>; bot/app actor → no-network glyph', () => {
-        const ctx = {repoUserUrl: 'https://github.com/', getAvatarUrl};
+        const ctx = {repoUserUrl: 'https://github.com/', getAvatarUrl, isBotActor};
 
         // Normal user: bounded (?size=40) lazy <img>, never the full-resolution original.
         const normal = getAvatarHtml.call(ctx, 'alice');
@@ -43,5 +43,21 @@ test.describe('Portal.view.content.Component — shared avatar helpers', () => {
 
         // `[bot]`-suffixed app actor: same no-network fallback.
         expect(getAvatarHtml.call(ctx, 'some-app[bot]')).toContain('fa-github')
+    });
+
+    test('isBotActor flags known bot/app actors, not normal users', () => {
+        expect(isBotActor('dependabot')).toBe(true);
+        expect(isBotActor('github-actions')).toBe(true);
+        expect(isBotActor('some-app[bot]')).toBe(true);
+        expect(isBotActor('alice')).toBe(false)
+    });
+
+    test('getAvatarRecordProps: normal user → {image:?size=40}; bot/app actor → {iconCls: github glyph}', () => {
+        // Drives the summary-list (SectionsList) avatar shape: a normal user yields a bounded image URL,
+        // a bot/app actor yields a glyph class so the summary renders the no-network glyph, not a 404 <img>.
+        const ctx = {repoUserUrl: 'https://github.com/', getAvatarUrl, isBotActor};
+
+        expect(getAvatarRecordProps.call(ctx, 'alice')).toEqual({image: 'https://github.com/alice.png?size=40'});
+        expect(getAvatarRecordProps.call(ctx, 'dependabot')).toEqual({iconCls: 'fa-brands fa-github'})
     })
 });

--- a/test/playwright/unit/apps/portal/view/content/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/content/Component.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import Component       from '../../../../../../../apps/portal/view/content/Component.mjs';
+import TimelineSections from '../../../../../../../apps/portal/store/TimelineSections.mjs';
 
 /**
  * Unit coverage for the shared avatar helpers on the Portal news timeline base
@@ -59,5 +60,31 @@ test.describe('Portal.view.content.Component — shared avatar helpers', () => {
 
         expect(getAvatarRecordProps.call(ctx, 'alice')).toEqual({image: 'https://github.com/alice.png?size=40'});
         expect(getAvatarRecordProps.call(ctx, 'dependabot')).toEqual({iconCls: 'fa-brands fa-github'})
+    })
+});
+
+/**
+ * The summary list (`Neo.app.content.SectionsList`) renders `record.iconCls` for bot/app actors. That
+ * only works if `iconCls` is a declared field on the `Portal.model.TimelineSection` contract — an
+ * undeclared field is dropped during record hydration, so the glyph would silently vanish from the
+ * summary even though the parser emitted it. This pins the field on the model.
+ */
+test.describe('Portal.model.TimelineSection — iconCls hydration contract', () => {
+    test('iconCls survives store hydration as a declared field, alongside image', () => {
+        const store = Neo.create(TimelineSections, {
+            id  : 'portal-timeline-iconcls-hydration-test',
+            data: [
+                {id: 'bot',   iconCls: 'fa-brands fa-github'},
+                {id: 'human', image  : 'https://github.com/alice.png?size=40'}
+            ]
+        });
+
+        try {
+            // An undeclared field would be undefined here → the summary bot-glyph would silently break.
+            expect(store.get('bot').iconCls).toBe('fa-brands fa-github');
+            expect(store.get('human').image).toBe('https://github.com/alice.png?size=40')
+        } finally {
+            store.destroy()
+        }
     })
 });


### PR DESCRIPTION
Resolves #12317

Authored by Opus 4.8 (Claude Code). Session da9a6007-1250-4363-8c15-dff69eccb3be.

FAIR-band: in-band [10/30] — operator-reported portal-news follow-up.

Evidence: L2 — the avatar helpers are unit-tested (`isBotActor`, `getAvatarRecordProps` → `{image:?size=40}` for normal / `{iconCls:'fa-brands fa-github'}` for bots), the routing is diff-verified (all 6 parser sites now spread `getAvatarRecordProps`; 0 raw `image:getAvatarUrl` remain), and the news specs stay green. L3 (the summary "On this page" row shows the glyph for a bot actor) is confirmable on the live instance — see Post-Merge Validation.

Follow-up to #12316 (operator observation post-merge): #12316 fixed the timeline HTML avatars (glyph for bots via `getAvatarHtml`), but the "On this page" summary is a separate consumer — the parsers publish a record `image` URL into the `sections` store, and `Neo.app.content.SectionsList` renders `record.image` as a plain `<img>`, so bot/app actors (whose `<login>.png` 404s) still rendered a broken image there.

## The fix
Close the consumer-shape gap, keeping the bot decision centralized:
- `Portal.view.content.Component`: extract **`isBotActor(user)`** (single source of truth for the bot/app check, shared by `getAvatarHtml` + the new helper); add **`getAvatarRecordProps(user)`** → `{image: getAvatarUrl(user)}` for normal users, `{iconCls: 'fa-brands fa-github'}` for bot/app actors.
- tickets / pulls / discussions parsers: spread `...getAvatarRecordProps(user)` into the timeline records (replacing the raw `image: getAvatarUrl`), so a bot record carries `iconCls` instead of a 404ing image URL.
- `Neo.app.content.SectionsList`: add a **backward-compatible `iconCls` render branch** (generic Font Awesome class string → avatar-sized `<i>`; the existing `image`/`icon` branches are untouched, so no GitHub-specific knowledge leaks into the generic renderer).

## Deltas from ticket
- Builds directly on #12316 (modifies the same parser sites) — landed after #12316 merged.
- AC4: all three news views covered (tickets, pulls, discussions). AC3: SectionsList stays generic (`iconCls` is a neutral FA-class field; the bot list stays in the Portal content Component via `isBotActor`).
- Removed a stale `(#12209)` ticket ref from a pre-existing `pulls/Component.mjs` JSDoc line that the `#12295` archaeology guard surfaced when the file was staged (durable-prose hygiene).

## Test Evidence
- `node --check` clean on all 5 changed `.mjs` + the spec.
- `content/Component.spec.mjs` → **4 passed** (incl. new `isBotActor` + `getAvatarRecordProps` tests). The suite **caught my own refactor gap** — `getAvatarHtml` now delegates to `this.isBotActor`, so its test stub needed `isBotActor` added; fixed, re-green.
- discussions + pulls `Component.spec.mjs` → **12 passed** (parser record-shape change didn't regress the existing parsers).
- `grep` confirms 0 raw `image: me.getAvatarUrl` parser sites remain (all 6 → `getAvatarRecordProps`).

## Post-Merge Validation
- [ ] L3: open a Portal news item with a bot/app actor (e.g. `github-actions`, a `[bot]`); confirm BOTH the timeline AND the "On this page" summary row show the Font Awesome GitHub glyph (no broken image request).
- [ ] L3: a normal human actor still shows the bounded `?size=40` avatar in the summary.

## Out of Scope
- Avatar source host / bot-list contents (unchanged from #12316).
- Broader summary-panel redesign.
