### PR TITLE
fix(tab): keep left docked tabs in source order (#12321)

### DIFF
--- a/apps/portal/view/examples/TabContainer.mjs
+++ b/apps/portal/view/examples/TabContainer.mjs
@@ -42,24 +42,17 @@ class ExamplesTabContainer extends TabContainer {
             module: List
         },
         /**
+         * Items are listed in the intended top-to-bottom display order for the left-docked tab bar.
          * @member {Object[]} items
          */
         items: [{
-            reference: 'examples-devmode-list',
-            store    : {module: ExampleStore, url: '../../apps/portal/resources/data/examples_devmode.json'},
-            header   : {
-                iconCls: 'fa fa-chess-knight',
-                route  : '/examples/devmode',
-                text   : 'Dev Mode'
-            }
-        }, {
-            environment: 'dist/development',
-            reference  : 'examples-dist-dev-list',
-            store      : {module: ExampleStore, url: '../../apps/portal/resources/data/examples_dist_dev.json'},
+            environment: 'dist/production',
+            reference  : 'examples-dist-prod-list',
+            store      : {module: ExampleStore, url: '../../apps/portal/resources/data/examples_dist_prod.json'},
             header     : {
-                iconCls: 'fa fa-chess-bishop',
-                route  : '/examples/dist_dev',
-                text   : 'dist/dev'
+                iconCls: 'fa fa-chess-king',
+                route  : '/examples/dist_prod',
+                text   : 'dist/prod'
             }
         }, {
             environment: 'dist/production',
@@ -71,13 +64,21 @@ class ExamplesTabContainer extends TabContainer {
                 text   : 'dist/esm'
             }
         }, {
-            environment: 'dist/production',
-            reference  : 'examples-dist-prod-list',
-            store      : {module: ExampleStore, url: '../../apps/portal/resources/data/examples_dist_prod.json'},
+            environment: 'dist/development',
+            reference  : 'examples-dist-dev-list',
+            store      : {module: ExampleStore, url: '../../apps/portal/resources/data/examples_dist_dev.json'},
             header     : {
-                iconCls: 'fa fa-chess-king',
-                route  : '/examples/dist_prod',
-                text   : 'dist/prod'
+                iconCls: 'fa fa-chess-bishop',
+                route  : '/examples/dist_dev',
+                text   : 'dist/dev'
+            }
+        }, {
+            reference: 'examples-devmode-list',
+            store    : {module: ExampleStore, url: '../../apps/portal/resources/data/examples_devmode.json'},
+            header   : {
+                iconCls: 'fa fa-chess-knight',
+                route  : '/examples/devmode',
+                text   : 'Dev Mode'
             }
         }]
     }

--- a/apps/portal/view/examples/TabContainerController.mjs
+++ b/apps/portal/view/examples/TabContainerController.mjs
@@ -22,10 +22,11 @@ class TabContainerController extends Component {
     }
 
     /**
-     * We need to store the current positions, since drag&drop resorting of tabs is enabled
+     * We need to store the current positions, since drag&drop resorting of tabs is enabled.
+     * The initial order mirrors `TabContainer.items` and the left-docked visual order.
      * @member {String[]} tabItems
      */
-    tabItems = ['devmode', 'dist_dev', 'dist_esm', 'dist_prod']
+    tabItems = ['dist_prod', 'dist_esm', 'dist_dev', 'devmode']
 
     /**
      *
@@ -37,6 +38,7 @@ class TabContainerController extends Component {
     }
 
     /**
+     * @summary Activates the examples tab whose id is carried by the current route.
      * @param {Object} params
      * @param {Object} value
      * @param {Object} oldValue
@@ -55,6 +57,7 @@ class TabContainerController extends Component {
     }
 
     /**
+     * @summary Keeps route-to-index resolution aligned after manual tab resorting.
      * @param {Object} data
      * @param {Number} data.fromIndex
      * @param {Number} data.toIndex

--- a/apps/portal/view/news/TabContainer.mjs
+++ b/apps/portal/view/news/TabContainer.mjs
@@ -31,41 +31,15 @@ class NewsTabContainer extends TabContainer {
             cls: ['portal-shared-tab-header-toolbar', 'neo-tab-header-toolbar']
         },
         /**
-         * NOTE: the tab bar is docked left (`tabBarPosition: 'left'`), so its header toolbar lays out
-         * with `column-reverse` (see `src/tab/header/Toolbar.mjs` `getLayoutConfig`) — the LAST entry in
-         * this list renders as the TOP (first) tab. Items are therefore listed in REVERSE of the intended
-         * top-to-bottom display order, which is:
-         *   Release Notes, Tickets, Discussions, Blog, Medium, Pull Requests.
-         * Append a new tab to the END of this array to make it the first/top tab.
+         * Items are listed in the intended top-to-bottom display order for the left-docked tab bar.
          * @member {Object[]} items
          */
         items: [{
-            module: () => import('./pulls/MainContainer.mjs'),
+            module: () => import('./release/MainContainer.mjs'),
             header: {
-                iconCls: 'fa fa-code-pull-request',
-                route  : '/news/pulls',
-                text   : 'Pull Requests'
-            }
-        }, {
-            module: () => import('./medium/Container.mjs'),
-            header: {
-                iconCls: 'fab fa-medium',
-                route  : '/news/medium',
-                text   : 'Medium'
-            }
-        }, {
-            module: () => import('./blog/MainContainer.mjs'),
-            header: {
-                iconCls: 'neo-logo-blue',
-                route  : '/news/blog',
-                text   : 'Blog'
-            }
-        }, {
-            module: () => import('./discussions/MainContainer.mjs'),
-            header: {
-                iconCls: 'fa fa-comments',
-                route  : '/news/discussions',
-                text   : 'Discussions'
+                iconCls: 'fa fa-scroll',
+                route  : '/news/releases',
+                text   : 'Release Notes'
             }
         }, {
             module: () => import('./tickets/MainContainer.mjs'),
@@ -75,11 +49,32 @@ class NewsTabContainer extends TabContainer {
                 text   : 'Tickets'
             }
         }, {
-            module: () => import('./release/MainContainer.mjs'),
+            module: () => import('./discussions/MainContainer.mjs'),
             header: {
-                iconCls: 'fa fa-scroll',
-                route  : '/news/releases',
-                text   : 'Release Notes'
+                iconCls: 'fa fa-comments',
+                route  : '/news/discussions',
+                text   : 'Discussions'
+            }
+        }, {
+            module: () => import('./blog/MainContainer.mjs'),
+            header: {
+                iconCls: 'neo-logo-blue',
+                route  : '/news/blog',
+                text   : 'Blog'
+            }
+        }, {
+            module: () => import('./medium/Container.mjs'),
+            header: {
+                iconCls: 'fab fa-medium',
+                route  : '/news/medium',
+                text   : 'Medium'
+            }
+        }, {
+            module: () => import('./pulls/MainContainer.mjs'),
+            header: {
+                iconCls: 'fa fa-code-pull-request',
+                route  : '/news/pulls',
+                text   : 'Pull Requests'
             }
         }],
         /**

--- a/apps/portal/view/news/TabContainerController.mjs
+++ b/apps/portal/view/news/TabContainerController.mjs
@@ -34,8 +34,7 @@ class TabContainerController extends Controller {
      * @summary Activates the tab whose header button carries the given route.
      *
      * Resolves `activeIndex` by matching the tab button's `route` rather than hardcoding a position, so
-     * the controller stays correct when the `items` array is reordered — which it is: the left-docked tab
-     * header renders `column-reverse`, so the array is the reverse of the visual display.
+     * the controller stays correct when the `items` array is reordered.
      *
      * The lookup MUST use `getTabBar().items` (the header buttons), NOT `component.items`:
      * `Neo.tab.Container.createItems()` transforms the user `items` into `[HeaderToolbar, Strip,

--- a/src/tab/header/Toolbar.mjs
+++ b/src/tab/header/Toolbar.mjs
@@ -68,7 +68,7 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
-     * Returns the layout config matching to the dock position
+     * @summary Returns the layout config matching the dock position.
      * @returns {Object} layoutConfig
      * @protected
      */
@@ -87,8 +87,8 @@ class Toolbar extends BaseToolbar {
             case 'left':
                 layoutConfig = {
                     align    : 'center',
-                    direction: 'column-reverse',
-                    pack     : 'end'
+                    direction: 'column',
+                    pack     : 'start'
                 };
                 break
             case 'right':

--- a/test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs
@@ -1,0 +1,86 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'PortalExamplesTabControllerTest'
+    }
+});
+
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../../src/core/_export.mjs';
+import ExamplesTabContainer   from '../../../../../../../apps/portal/view/examples/TabContainer.mjs';
+import TabContainerController from '../../../../../../../apps/portal/view/examples/TabContainerController.mjs';
+
+/**
+ * The examples tab routes resolve `activeIndex` through the controller's `tabItems` array.
+ * Keep that array mirrored to `TabContainer.items`, which is now authored in the left-docked
+ * top-to-bottom display order.
+ */
+test.describe('Portal.view.examples.TabContainerController — route → activeIndex', () => {
+    function createController() {
+        const component = {
+            activeIndex   : null,
+            isConstructed: true,
+            on           : () => {}
+        };
+
+        const controller = Neo.create(TabContainerController, {component});
+
+        controller.getReference = reference => ({
+            store: {
+                getCount: () => 1,
+                load    : () => {
+                    throw new Error(`Unexpected load for ${reference}`)
+                }
+            }
+        });
+
+        return controller
+    }
+
+    test('keeps tab item ids mirrored to the authored display order', () => {
+        const
+            controller = createController(),
+            itemIds    = ExamplesTabContainer.config.items.map(item => item.header.route.replace('/examples/', ''));
+
+        expect(itemIds).toEqual(['dist_prod', 'dist_esm', 'dist_dev', 'devmode']);
+        expect(controller.tabItems).toEqual(itemIds);
+
+        controller.destroy()
+    });
+
+    test('defaults to dist_prod at the top tab and resolves each route index', () => {
+        const controller = createController();
+
+        controller.onExamplesRoute();
+        expect(controller.component.activeIndex).toBe(0);
+
+        controller.onExamplesRoute({itemId: 'dist_esm'});
+        expect(controller.component.activeIndex).toBe(1);
+
+        controller.onExamplesRoute({itemId: 'dist_dev'});
+        expect(controller.component.activeIndex).toBe(2);
+
+        controller.onExamplesRoute({itemId: 'devmode'});
+        expect(controller.component.activeIndex).toBe(3);
+
+        controller.destroy()
+    });
+
+    test('updates route indexes when tabs are manually resorted', () => {
+        const controller = createController();
+
+        controller.onMoveTab({
+            fromIndex: 0,
+            toIndex  : 3
+        });
+
+        expect(controller.tabItems).toEqual(['dist_esm', 'dist_dev', 'devmode', 'dist_prod']);
+
+        controller.onExamplesRoute({itemId: 'dist_prod'});
+        expect(controller.component.activeIndex).toBe(3);
+
+        controller.destroy()
+    })
+});

--- a/test/playwright/unit/apps/portal/view/news/TabContainerController.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/news/TabContainerController.spec.mjs
@@ -9,12 +9,12 @@ setup({
 import {test, expect}        from '@playwright/test';
 import Neo                   from '../../../../../../../src/Neo.mjs';
 import * as core             from '../../../../../../../src/core/_export.mjs';
+import HeaderToolbar         from '../../../../../../../src/tab/header/Toolbar.mjs';
 import TabContainerController from '../../../../../../../apps/portal/view/news/TabContainerController.mjs';
 
 /**
  * The news tab routes resolve `activeIndex` by matching the tab button's `route` (not a hardcoded
- * position), so the controller stays correct when the `items` array is reordered for the left-docked
- * `column-reverse` header.
+ * position), so the controller stays correct when the `items` array is reordered.
  *
  * The stub mirrors the POST-`createItems` reality: routes live on the header tab buttons
  * (`getTabBar().items`, carrying the surviving `route` + `index` configs), NOT on `component.items`
@@ -25,14 +25,14 @@ import TabContainerController from '../../../../../../../apps/portal/view/news/T
 test.describe('Portal.view.news.TabContainerController — route → activeIndex', () => {
     test('each route handler activates the tab button whose route matches, for any array order', () => {
         // Header buttons as they exist after createItems: `route` (Neo.button.Base config) + `index`
-        // (original tab index). Order mirrors the production reversed `items` array.
+        // (original tab index). Order mirrors the production top-to-bottom `items` array.
         const tabButtons = [
-            {route: '/news/pulls',       index: 0},
-            {route: '/news/medium',      index: 1},
-            {route: '/news/blog',        index: 2},
-            {route: '/news/discussions', index: 3},
-            {route: '/news/tickets',     index: 4},
-            {route: '/news/releases',    index: 5}
+            {route: '/news/releases',    index: 0},
+            {route: '/news/tickets',     index: 1},
+            {route: '/news/discussions', index: 2},
+            {route: '/news/blog',        index: 3},
+            {route: '/news/medium',      index: 4},
+            {route: '/news/pulls',       index: 5}
         ];
 
         const controller = Object.create(TabContainerController.prototype);
@@ -43,21 +43,43 @@ test.describe('Portal.view.news.TabContainerController — route → activeIndex
         };
 
         controller.onPullsRoute();
-        expect(controller.component.activeIndex).toBe(0);
+        expect(controller.component.activeIndex).toBe(5);
 
         controller.onMediumRoute();
-        expect(controller.component.activeIndex).toBe(1);
-
-        controller.onBlogRoute();
-        expect(controller.component.activeIndex).toBe(2);
-
-        controller.onDiscussionsRoute();
-        expect(controller.component.activeIndex).toBe(3);
-
-        controller.onTicketsRoute();
         expect(controller.component.activeIndex).toBe(4);
 
+        controller.onBlogRoute();
+        expect(controller.component.activeIndex).toBe(3);
+
+        controller.onDiscussionsRoute();
+        expect(controller.component.activeIndex).toBe(2);
+
+        controller.onTicketsRoute();
+        expect(controller.component.activeIndex).toBe(1);
+
         controller.onReleasesRoute();
-        expect(controller.component.activeIndex).toBe(5)
+        expect(controller.component.activeIndex).toBe(0)
+    });
+
+    test('left-docked tab header keeps array order as visual order', () => {
+        const toolbar = Neo.create(HeaderToolbar, {
+            appName: 'PortalNewsTabControllerTest'
+        });
+
+        toolbar.dock = 'left';
+        expect(toolbar.getLayoutConfig()).toEqual({
+            align    : 'center',
+            direction: 'column',
+            pack     : 'start'
+        });
+
+        toolbar.dock = 'right';
+        expect(toolbar.getLayoutConfig()).toEqual({
+            align    : 'center',
+            direction: 'column',
+            pack     : 'start'
+        });
+
+        toolbar.destroy()
     })
 });

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -188,4 +188,32 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
         expect(container.items[3].id).toBe('btnD');
         expect(container.items[4].id).toBe('btnB');
     });
+
+    test('Treats non-reversed vertical layouts as forward sort direction', async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        sortZone = container.sortZone;
+        container.layout.direction = 'column';
+
+        await sortZone.onDragStart({
+            path: [{id: 'btnA', cls: ['neo-draggable'], rect: {left: 0, top: 0, width: 100, height: 100}}]
+        });
+
+        expect(sortZone.sortDirection).toBe('vertical');
+        expect(sortZone.reversedLayoutDirection).toBe(false);
+        expect(sortZone.currentIndex).toBe(0)
+    });
+
+    test('Keeps explicit column-reverse layouts on the reverse sort path', async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        sortZone = container.sortZone;
+        container.layout.direction = 'column-reverse';
+
+        await sortZone.onDragStart({
+            path: [{id: 'btnA', cls: ['neo-draggable'], rect: {left: 0, top: 0, width: 100, height: 100}}]
+        });
+
+        expect(sortZone.sortDirection).toBe('vertical');
+        expect(sortZone.reversedLayoutDirection).toBe(true);
+        expect(sortZone.currentIndex).toBe(0)
+    });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019e7f45-ad55-75e0-bfff-a21c2385df00.
FAIR-band: over-target [17/30] - taking this lane despite over-target because #12321 is operator-directed Portal news prio-0 follow-through after the left-dock inversion repeatedly broke the active epic lane.

Resolves #12321

Drops the left-docked tab header from `column-reverse`/`pack:end` to a non-reversing `column`/`pack:start` layout, so `items[0]` is the top tab. Portal News and Examples tab containers are migrated to real top-to-bottom source order, obsolete inversion comments are removed, and route-index specs validate the post-migration indexes.

Evidence: L2 (source-contract unit tests plus focused Portal News, Portal Examples, and SortZone specs; Neural Link runtime probe invalidated by stale service-worker bundle still serving pre-change `column-reverse`) -> L3 required (AC3 visual per affected app). Residual: AC3 visual [#12321].

## Deltas from ticket
- Portal Examples is now migrated as the third live left-docked Portal consumer: existing visual/default order is preserved as dist/prod, dist/esm, dist/dev, Dev Mode.
- Consumer audit found `apps/covid` / `apps/sharedcovid` matches are docked table columns, not `Neo.tab.header.Toolbar` consumers; they are intentionally not migrated in this tab-header PR.
- `examples/viewport/MainContainer.mjs` is the other standalone `tabBarPosition: "left"` tab consumer; its source order already matches the new real-order contract, so no reorder is needed.
- The tab-header drag-sort path is covered through the shared container SortZone reverse-detection contract: non-reversed `column` stays forward, explicit `column-reverse` still takes the reverse path.

## Test Evidence
- `node --check src/tab/header/Toolbar.mjs` passed.
- `node --check apps/portal/view/news/TabContainer.mjs` passed.
- `node --check apps/portal/view/news/TabContainerController.mjs` passed.
- `node --check apps/portal/view/examples/TabContainer.mjs` passed.
- `node --check apps/portal/view/examples/TabContainerController.mjs` passed.
- `node --check test/playwright/unit/apps/portal/view/news/TabContainerController.spec.mjs` passed.
- `node --check test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs` passed.
- `node --check test/playwright/unit/draggable/container/SortZone.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/apps/portal/view/news/TabContainerController.spec.mjs` passed: 2 tests.
- `npm run test-unit -- test/playwright/unit/apps/portal/view/examples/TabContainerController.spec.mjs` passed: 3 tests.
- `npm run test-unit -- test/playwright/unit/draggable/container/SortZone.spec.mjs` passed: 6 tests.
- `git diff --check` and `git diff --cached --check` passed before commits.
- Neural Link attached to Portal, but the live app still reported `useServiceWorker:"dist/production"` and old `Neo.tab.header.Toolbar#getLayoutConfig()` source (`column-reverse` / `pack:end`) after reload, so that probe was treated as cache-stale and excluded from pass evidence.

## Post-Merge Validation
- [ ] Hard-refresh Portal without the stale service worker and confirm News left-tab visual order: Release Notes, Tickets, Discussions, Blog, Medium, Pull Requests.
- [ ] Hard-refresh Portal without the stale service worker and confirm Examples left-tab visual order: dist/prod, dist/esm, dist/dev, Dev Mode, with `/examples` defaulting to dist/prod.
- [ ] Spot-check `examples/viewport` left-tab demo shows Tab 1, Tab 2, Tab 3 top-to-bottom under the new source-order contract.

## Commits
- `6ad0cb978` - `fix(tab): keep left docked tabs in source order (#12321)`
- `11e06fcfb` - `fix(portal): migrate examples left tab order (#12321)`

## Related
- Related: #12204
- Related: #12319
- Related: #12320