### PR TITLE
fix(portal): keep discussion timeline HTML literal-safe (#12325)

### DIFF
--- a/apps/portal/view/news/discussions/Component.mjs
+++ b/apps/portal/view/news/discussions/Component.mjs
@@ -205,23 +205,22 @@ class Component extends ContentComponent {
             tag  : 'body'
         });
 
-        let bodyItemHtml = `
-            <div id="${bodyId}" class="neo-timeline-item comment body-item" data-record-id="${bodyId}">
-                <div id="${bodyId}-target" class="neo-timeline-avatar">
-                    ${me.getAvatarHtml(data.author)}
-                </div>
-                <div class="neo-timeline-content">
-                    <div class="neo-timeline-header">
-                        <a class="neo-timeline-user" href="${me.repoUserUrl}${data.author}" target="_blank">${data.author}</a>
-                        <span class="neo-timeline-date">opened on ${me.formatTimestamp(data.createdAt)}</span>
-                    </div>
-                    <div class="neo-timeline-body">
-
-${fullHtml}
-
-</div>
-                </div>
-            </div>`;
+        let bodyItemHtml = [
+            `<div id="${bodyId}" class="neo-timeline-item comment body-item" data-record-id="${bodyId}">`,
+            `<div id="${bodyId}-target" class="neo-timeline-avatar">`,
+            me.getAvatarHtml(data.author),
+            '</div>',
+            '<div class="neo-timeline-content">',
+            '<div class="neo-timeline-header">',
+            `<a class="neo-timeline-user" href="${me.repoUserUrl}${data.author}" target="_blank">${data.author}</a>`,
+            `<span class="neo-timeline-date">opened on ${me.formatTimestamp(data.createdAt)}</span>`,
+            '</div>',
+            '<div class="neo-timeline-body">',
+            fullHtml,
+            '</div>',
+            '</div>',
+            '</div>'
+        ].join('');
 
         let timelineId    = `discussion-timeline-${me.id}`,
             timelineHtml  = `<div id="${timelineId}" class="neo-ticket-timeline neo-discussion-timeline">` +
@@ -351,22 +350,23 @@ ${fullHtml}
                 tag  : 'comment'
             });
 
-            html += `
-                    <div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">
-                        <div id="${id}-target" class="neo-timeline-avatar">
-                            ${me.getAvatarHtml(comment.user)}
-                        </div>
-                        <div class="neo-timeline-content">
-                            <div class="neo-timeline-header">
-                                <a class="neo-timeline-user" href="${repoUserUrl}${comment.user}" target="_blank">${comment.user}</a>
-                                <span class="neo-timeline-date">commented on ${me.formatTimestamp(comment.date)}</span>
-                            </div>
-                            <div class="neo-timeline-body">
-                                ${marked.parse(comment.body)}
-                                ${me.renderReplies(comment.replies)}
-                            </div>
-                        </div>
-                    </div>`
+            html += [
+                `<div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">`,
+                `<div id="${id}-target" class="neo-timeline-avatar">`,
+                me.getAvatarHtml(comment.user),
+                '</div>',
+                '<div class="neo-timeline-content">',
+                '<div class="neo-timeline-header">',
+                `<a class="neo-timeline-user" href="${repoUserUrl}${comment.user}" target="_blank">${comment.user}</a>`,
+                `<span class="neo-timeline-date">commented on ${me.formatTimestamp(comment.date)}</span>`,
+                '</div>',
+                '<div class="neo-timeline-body">',
+                marked.parse(comment.body),
+                me.renderReplies(comment.replies),
+                '</div>',
+                '</div>',
+                '</div>'
+            ].join('')
         });
 
         return html
@@ -388,14 +388,19 @@ ${fullHtml}
             return ''
         }
 
-        return `<div class="neo-discussion-replies">${replies.map(reply => `
-            <div class="neo-discussion-reply depth-${reply.depth}">
-                <div class="neo-discussion-reply-header">
-                    <a class="neo-timeline-user" href="${repoUserUrl}${reply.user}" target="_blank">${reply.user}</a>
-                    <span class="neo-timeline-date">replied on ${this.formatTimestamp(reply.date)}</span>
-                </div>
-                <div class="neo-discussion-reply-body">${marked.parse(reply.body)}</div>
-            </div>`).join('')}</div>`
+        return [
+            '<div class="neo-discussion-replies">',
+            replies.map(reply => [
+                `<div class="neo-discussion-reply depth-${reply.depth}">`,
+                '<div class="neo-discussion-reply-header">',
+                `<a class="neo-timeline-user" href="${repoUserUrl}${reply.user}" target="_blank">${reply.user}</a>`,
+                `<span class="neo-timeline-date">replied on ${this.formatTimestamp(reply.date)}</span>`,
+                '</div>',
+                `<div class="neo-discussion-reply-body">${marked.parse(reply.body)}</div>`,
+                '</div>'
+            ].join('')).join(''),
+            '</div>'
+        ].join('')
     }
 }
 

--- a/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
@@ -1,4 +1,5 @@
 import {setup} from '../../../../../../setup.mjs';
+import {readFileSync} from 'node:fs';
 
 setup({
     appConfig: {
@@ -11,6 +12,7 @@ import Neo              from '../../../../../../../../src/Neo.mjs';
 import * as core        from '../../../../../../../../src/core/_export.mjs';
 import Component        from '../../../../../../../../apps/portal/view/news/discussions/Component.mjs';
 import DiscussionsStore from '../../../../../../../../apps/portal/store/Discussions.mjs';
+import {marked}         from '../../../../../../../../node_modules/marked/lib/marked.esm.js';
 
 /**
  * Unit coverage for the Discussion-specific parser in `Portal.view.news.discussions.Component`.
@@ -21,7 +23,14 @@ import DiscussionsStore from '../../../../../../../../apps/portal/store/Discussi
  * helpers are tested directly on the prototype to avoid constructing the full state-provider-backed
  * content component.
  */
-const {parseFrontMatter, parseComments, renderReplies, getClosedBadgeHtml, getCategoryBadgeHtml} = Component.prototype;
+const {
+    getCategoryBadgeHtml,
+    getClosedBadgeHtml,
+    modifyMarkdown,
+    parseComments,
+    parseFrontMatter,
+    renderReplies
+} = Component.prototype;
 
 test.describe('Portal.view.news.discussions.Component - Discussion markdown parser', () => {
     test('parses folded and literal frontmatter block scalars used by discussion titles', () => {
@@ -171,6 +180,59 @@ test.describe('Portal.view.news.discussions.Component - Discussion markdown pars
         expect(open).toContain('neo-state-open');
         expect(open).toContain('Open');
         expect(getCategoryBadgeHtml('')).toBe('')
+    })
+
+    test('keeps generated timeline HTML out of escaped markdown code blocks', () => {
+        const
+            content       = readFileSync('resources/content/discussions/chunk-2/discussion-11891.md', 'utf8'),
+            sectionsStore = {data: []};
+
+        const component = Object.create(Component.prototype);
+
+        Object.defineProperties(component, {
+            getStateProvider: {
+                value() {
+                    return {
+                        getStore: () => sectionsStore
+                    }
+                }
+            },
+            formatTimestamp: {
+                value: value => value
+            },
+            id: {
+                value: 'discussion-html-literal-regression-test'
+            },
+            issuesUrl: {
+                value: '#/news/tickets/'
+            },
+            record: {
+                value: {id: '11891'}
+            },
+            renderFrontmatter: {
+                value: true
+            },
+            replaceTicketIds: {
+                value: true
+            },
+            repoUserUrl: {
+                value: 'https://github.com/'
+            },
+            updateSectionsStore: {
+                value: false
+            },
+            useFrontmatterDetails: {
+                value: true
+            }
+        });
+
+        const html = marked.parse(modifyMarkdown.call(component, content));
+
+        expect(html).toContain('<div id="timeline-11891-2" class="neo-timeline-item comment"');
+        expect(html).toContain('<div id="timeline-11891-2-target" class="neo-timeline-avatar">');
+        expect(html).not.toContain('&lt;div id=&quot;timeline-11891-2');
+        expect(html).not.toContain('&lt;div id=&quot;timeline-11891-2-target');
+        expect(sectionsStore.data.map(record => record.id)).toContain('timeline-11891-2')
     })
 });
 


### PR DESCRIPTION
Resolves #12325

Authored by GPT-5 (Codex Desktop). Session 53179687-64cf-4ca1-9a42-30455724ec68.
FAIR-band: over-target [17/30] - taking this lane despite over-target because this was operator-delegated and fixes a live Portal News Discussions regression.

Keeps generated Discussion timeline skeleton markup out of markdown code-block interpretation by emitting the generated timeline shell as column-0 HTML fragments. The markdown body/comment fragments still flow through `marked`, but the surrounding `.neo-timeline-item` structure no longer starts as indented markdown text that `marked` can convert into escaped `<pre><code>` output after blockquote-heavy comments.

Evidence: L2 (focused unit regression plus live pre-fix Neural Link reproduction) -> L3 required (post-fix browser-rendered Portal verification). Residual: post-merge hard reload/cache-clear verification for `/news/discussions/11891`, because the current Portal window kept serving the previous module source after reload.

## Deltas from ticket

The ticket suspected a second-parse/generated-HTML boundary. Live Neural Link inspection narrowed the concrete root: the rendered #11891 component HTML contained escaped `timeline-11891-2` markup inside `<pre><code>` immediately after a blockquote-heavy comment, and `get_method_source()` confirmed the live worker was still running the old indented template literal implementation.

No scope expansion: the fix stays inside `Portal.view.news.discussions.Component` and its focused unit spec.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs` - 8 passed.
- `git diff --check` - passed.
- Neural Link pre-fix diagnostic on `/news/discussions/11891`: component HTML contained escaped `&lt;div id=&quot;timeline-11891-2` inside `<pre><code>`, and console showed `Component not found: timeline-11891-0-target`.
- Neural Link post-patch reload was attempted, but the browser worker still reported the old `renderComments()` method source, so no post-fix live DOM claim is made here.

## Post-Merge Validation

- [ ] Hard reload or cache-clear Portal, open `/news/discussions/11891`, and verify `timeline-11891-2-target` exists as a real DOM node.
- [ ] Verify the rendered article contains no escaped `&lt;div id=&quot;timeline-11891-` snippets.

## Commit

- `3657a9af8` - `fix(portal): keep discussion timeline html literal-safe (#12325)`