### PR TITLE
fix(portal): drop zero-rect timeline canvas nodes + realign on nav (#12322)

### DIFF
--- a/apps/portal/view/content/TimelineCanvas.mjs
+++ b/apps/portal/view/content/TimelineCanvas.mjs
@@ -138,6 +138,55 @@ class TimelineCanvas extends SharedCanvas {
     }
 
     /**
+     * @summary Translates avatar/badge DOM rects into canvas-local node descriptors, skipping unmeasured elements.
+     *
+     * A zero-size rect (`{x:0,y:0,width:0,height:0}`) is returned for any `-target` element that is not
+     * laid out at capture time — a content-visibility-collapsed `<details>` body, a lazy avatar image
+     * not yet loaded, or an element mid route-transition. Such rects MUST be rejected: translated into
+     * canvas-local space (`x = rect.x - canvasRect.x`) a zero rect yields a bogus node at the far-left
+     * edge (`x = -canvasRect.x`), which the renderer draws as a spurious spine segment angling off to
+     * the left / a second spine converging on the last node.
+     *
+     * @param {Object[]} records    The timeline records, parallel to `rects`
+     * @param {Object[]} rects      The fetched DOMRects for each record's `-target` element
+     * @param {Object}   canvasRect The canvas overlay's DOMRect, for screen→canvas-local translation
+     * @returns {Object} `{nodes, startY}`
+     */
+    buildNodes(records, rects, canvasRect) {
+        let nodes  = [],
+            startY = 0;
+
+        rects.forEach((rect, index) => {
+            let record = records[index];
+
+            // Reject zero-size rects — an unmeasured element would translate to a bogus far-left node.
+            if (rect && rect.width > 0 && rect.height > 0) {
+                // PRECISE CENTERING: `rect` is the actual avatar/badge.
+                let offset  = rect.height / 2,
+                    nodeY   = rect.y - canvasRect.y + offset,
+                    nodeX   = rect.x - canvasRect.x + (rect.width / 2),
+                    // Distinct padding for the Orbit effect: avatars (~40px) get more room than badges (~28px)
+                    padding = rect.height > 32 ? 6 : 3;
+
+                nodes.push({
+                    color : record.color, // Hex color (e.g. #ff0000)
+                    id    : record.id,
+                    radius: offset + padding,
+                    y     : nodeY,
+                    x     : nodeX
+                });
+
+                // Anchor startY to the first rendered (measurable) node
+                if (nodes.length === 1) {
+                    startY = nodeY
+                }
+            }
+        });
+
+        return {nodes, startY}
+    }
+
+    /**
      * The core "Alignment Engine" of the timeline.
      *
      * This method synchronizes the Canvas nodes with the DOM elements (Avatars/Badges).
@@ -207,40 +256,19 @@ class TimelineCanvas extends SharedCanvas {
                 await me.updateSize()
             }
 
-            let canvasRect = await me.getDomRect(me.getCanvasId()),
-                nodes      = [],
-                startY     = 0;
+            let canvasRect      = await me.getDomRect(me.getCanvasId()),
+                {nodes, startY} = me.buildNodes(records, rects, canvasRect);
 
-            ids.forEach((targetId, index) => {
-                let rect   = rects[index],
-                    record = records[index];
+            await me.renderer.updateGraphData({nodes, reset, startY});
 
-                if (rect) {
-                    // PRECISE CENTERING
-                    // Now 'rect' is the actual avatar/badge.
-                    let offset = rect.height / 2,
-                        nodeY  = rect.y - canvasRect.y + offset,
-                        nodeX  = rect.x - canvasRect.x + (rect.width / 2),
-                        // Distinct padding for Orbit effect
-                        // Avatars (~40px) get more breathing room than Badges (~28px)
-                        padding = rect.height > 32 ? 6 : 3;
-
-                    nodes.push({
-                        color : record.color, // Pass Hex Color (e.g. #ff0000)
-                        id    : record.id,
-                        radius: offset + padding,
-                        y     : nodeY,
-                        x     : nodeX
-                    });
-
-                    // Set the startY of the line to the first node
-                    if (index === 0) {
-                        startY = nodeY
-                    }
-                }
-            });
-
-            await me.renderer.updateGraphData({nodes, reset, startY})
+            // Some `-target` rects can be zero-sized at first capture — a content-visibility-collapsed
+            // `<details>` body, a lazy avatar image not yet loaded, or a mid-route-transition layout.
+            // `buildNodes` skips those (a zero rect would translate to a bogus far-left node),
+            // so re-run the alignment once layout settles to pick them up. Mirrors the `onResize` path;
+            // guarded on `!isResize` so the `ensureFinalAlignment` re-entry (isResize=true) cannot recurse.
+            if (!isResize) {
+                me.ensureFinalAlignment()
+            }
         } catch (e) {
             console.error('TimelineCanvas update failed', e)
         }

--- a/test/playwright/unit/apps/portal/view/content/TimelineCanvas.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/content/TimelineCanvas.spec.mjs
@@ -1,0 +1,102 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'PortalContentTimelineCanvasTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import TimelineCanvas from '../../../../../../../apps/portal/view/content/TimelineCanvas.mjs';
+
+/**
+ * `Portal.view.content.TimelineCanvas#buildNodes` translates avatar/badge `-target` DOM rects into
+ * canvas-local node descriptors. A zero-size rect (`{x:0,y:0,width:0,height:0}`) is returned for any
+ * `-target` element not laid out at capture time — a content-visibility-collapsed `<details>` body, a
+ * lazy avatar image not yet loaded, or an element mid route-transition. Those MUST be rejected:
+ * translated to canvas-local space (`x = rect.x - canvasRect.x`) a zero rect yields a bogus node at the
+ * far-left edge (`x = -canvasRect.x`), which the renderer draws as a spurious spine segment angling off
+ * to the left / a second spine converging on the last node.
+ *
+ * Tests the real method directly (no stub) on a prototype instance, since `buildNodes` is pure over its
+ * arguments and holds no instance state.
+ */
+test.describe("Portal.view.content.TimelineCanvas — buildNodes zero-rect rejection (#12322)", () => {
+    const canvasRect = {x: 408, y: -100, width: 689, height: 8706};
+
+    const records = [
+        {id: 'timeline-1-0', color: '#ff0000'},
+        {id: 'timeline-1-1', color: '#00ff00'},
+        {id: 'timeline-1-2', color: '#0000ff'}
+    ];
+
+    const coordinator = Object.create(TimelineCanvas.prototype);
+
+    test('rejects zero-size rects and keeps measurable nodes correctly placed', () => {
+        // rect[1] is a zero rect — an off-screen / collapsed / not-yet-loaded -target element.
+        const rects = [
+            {x: 466, y: 200, width: 40, height: 40},
+            {x: 0,   y: 0,   width: 0,  height: 0},
+            {x: 466, y: 500, width: 40, height: 40}
+        ];
+
+        const {nodes, startY} = coordinator.buildNodes(records, rects, canvasRect);
+
+        // The zero rect is dropped — only the 2 measurable nodes survive.
+        expect(nodes.length).toBe(2);
+        expect(nodes.map(n => n.id)).toEqual(['timeline-1-0', 'timeline-1-2']);
+
+        // Canvas-local translation: x = rect.x - canvasRect.x + width/2 = 466 - 408 + 20 = 78.
+        expect(nodes[0].x).toBe(78);
+        expect(nodes[1].x).toBe(78);
+
+        // y = rect.y - canvasRect.y + height/2 ; canvasRect.y = -100 → 200 + 100 + 20 = 320 / 500 + 100 + 20 = 620.
+        expect(nodes[0].y).toBe(320);
+        expect(nodes[1].y).toBe(620);
+        expect(startY).toBe(320);
+
+        // Bug signature negative-check: NO far-left node at x = -canvasRect.x (-408) — i.e. no x < 0.
+        expect(nodes.some(node => node.x < 0)).toBe(false)
+    });
+
+    test('startY anchors to the first MEASURABLE node when the leading rect is zero', () => {
+        const rects = [
+            {x: 0,   y: 0,   width: 0,  height: 0}, // leading item unmeasured
+            {x: 466, y: 500, width: 40, height: 40}
+        ];
+
+        const {nodes, startY} = coordinator.buildNodes(records.slice(0, 2), rects, canvasRect);
+
+        expect(nodes.length).toBe(1);
+        expect(nodes[0].id).toBe('timeline-1-1');
+        // startY must be the surviving node's y (620), NOT 0 carried from the dropped leading rect.
+        expect(startY).toBe(620)
+    });
+
+    test('returns no nodes when every rect is zero (empty spine, never a far-left one)', () => {
+        const rects = [
+            {x: 0, y: 0, width: 0, height: 0},
+            {x: 0, y: 0, width: 0, height: 0}
+        ];
+
+        const {nodes, startY} = coordinator.buildNodes(records.slice(0, 2), rects, canvasRect);
+
+        expect(nodes.length).toBe(0);
+        expect(startY).toBe(0)
+    });
+
+    test('preserves record color and computes orbit radius per marker height', () => {
+        const rects = [
+            {x: 466, y: 200, width: 40, height: 40}, // avatar (~40px) → padding 6 → radius 26
+            {x: 470, y: 500, width: 28, height: 28}  // badge  (~28px) → padding 3 → radius 17
+        ];
+
+        const {nodes} = coordinator.buildNodes(records.slice(0, 2), rects, canvasRect);
+
+        expect(nodes[0].color).toBe('#ff0000');
+        expect(nodes[0].radius).toBe(26); // 40/2 + 6
+        expect(nodes[1].radius).toBe(17)  // 28/2 + 3
+    })
+});


### PR DESCRIPTION
Related: #12322

Authored by Opus 4.8 (1M context) (Claude Code). Session da9a6007-1250-4363-8c15-dff69eccb3be.

FAIR-band: In-band [13/30] — operator-delegated bug fix (the discussions "B" item); single own-lane PR this cycle.

> **Close-target note:** uses `Related:` (not `Resolves`) per the evidence ladder — #12322 carries a residual **L3 visual** AC the agent sandbox can't reach, so merging must NOT auto-close it. #12322 stays open as the L3-tracking anchor; the operator finishes it by hand (and thereby epic #12204) once the spine renders clean.

The discussions news timeline canvas drew a broken "spine": from the last item it angled ~20° to the left, and in some discussions a second spine came in from the left and converged on the last node — worse on navigation (the route-transition animation). Root-caused empirically via Neural Link on a live discussion: the timeline-canvas coordinator builds nodes from live `-target` avatar DOM rects, and some below-the-fold items return **zero-size rects** (`{x:0,y:0,width:0,height:0}`) — a content-visibility-collapsed `<details>` body, a lazy avatar image not yet loaded, or an element mid route-transition. The node-builder guarded only with `if (rect)`; a zero rect is truthy, so it produced a node at `nodeX = rect.x(0) - canvasRect.x = -canvasRect.x` (the far-left edge), which the renderer drew as the spurious angled / second spine.

Fix is canvas-side and cause-agnostic — the shared Markdown `content-visibility` perf optimization is untouched:
- Extracted a testable `buildNodes(records, rects, canvasRect)` that **rejects zero-size rects** (`rect.width > 0 && rect.height > 0`) — no more far-left nodes; the spine draws only through measurable avatars. `startY` now anchors to the first *measurable* node rather than a possibly-dropped index 0.
- **Re-align on navigation**: `onTimelineDataLoad` now fires the debounced `ensureFinalAlignment` after a fresh load (previously only `onResize` did), so items that were zero-sized mid-transition are re-captured once layout settles. Guarded on `!isResize` to prevent re-entry recursion.

Evidence: L2 (4 unit tests over `buildNodes` zero-rect rejection + node geometry, all green; root cause empirically confirmed via Neural Link node-geometry inspection on the live instance) → L3 required (visual: discussions timeline spine renders clean, no far-left/angled segments). Residual: L3 visual confirmation [#12322].

## Deltas from ticket (if any)
- The fix is cause-agnostic (any zero-rect source is rejected), so it also covers the lazy-avatar and route-transition triggers, not only the collapsed-`<details>` one observed live.
- The separate discussions issue (markdown renders unescaped raw HTML as literal strings) is tracked + owned independently as #12325 (@neo-gpt) — NOT part of this canvas fix.

## Test Evidence
New `test/playwright/unit/apps/portal/view/content/TimelineCanvas.spec.mjs` — 4 tests, all pass:
- rejects zero-size rects, keeps measurable nodes at correct canvas-local coords, negative-checks no `x < 0` (the bug signature)
- `startY` anchors to the first measurable node when the leading rect is zero
- returns no nodes when every rect is zero (empty spine, never a far-left one)
- preserves record color + per-marker orbit radius

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/portal/view/content/TimelineCanvas.spec.mjs` → **4 passed**.

## Post-Merge Validation
- [ ] Visual L3 (operator): navigate between several discussions (`#/news/discussions/...`) and confirm the timeline spine renders as a clean vertical line through the avatars — no ~20° left angle, no second spine from the left, no breakage during the navigation animation.
- [ ] Confirm the spine covers the visible items; if below-fold items still lack spine coverage while scrolling a long discussion, a scroll-triggered re-capture is the follow-up (file as a sub of the epic if observed).
- [ ] #12322 stays **OPEN** (this PR uses `Related:`, not a magic-close keyword) until the operator confirms the L3 visual above. The operator then wraps up #12322 by hand, which finishes epic #12204.
