### PR TITLE
fix(portal): style news timeline tables (#12328)

### DIFF
--- a/resources/scss/src/apps/portal/news/tickets/Component.scss
+++ b/resources/scss/src/apps/portal/news/tickets/Component.scss
@@ -237,6 +237,7 @@
 
                     .neo-timeline-body {
                         font-size    : 14px;
+                        overflow-x   : auto;
                         overflow-wrap: anywhere;
                         padding      : 16px;
 
@@ -247,6 +248,43 @@
 
                         pre {
                             overflow-x: auto;
+                        }
+
+                        table {
+                            border         : 1px solid var(--gh-timeline-border);
+                            border-collapse: separate;
+                            border-radius  : 4px;
+                            border-spacing : 0;
+                            color          : var(--gh-text-primary);
+                            margin         : 12px 0;
+                            max-width      : none;
+                            min-width      : 100%;
+                            overflow       : hidden;
+                            width          : max-content;
+                        }
+
+                        th,
+                        td {
+                            border-bottom: 1px solid var(--gh-timeline-border);
+                            border-right : 1px solid var(--gh-timeline-border);
+                            padding      : 8px 12px;
+                            text-align   : left;
+                            vertical-align: top;
+                        }
+
+                        th {
+                            background-color: var(--gh-bg-subtle);
+                            color           : var(--gh-header-text-color);
+                            font-weight     : 600;
+                        }
+
+                        th:last-child,
+                        td:last-child {
+                            border-right: none;
+                        }
+
+                        tr:last-child td {
+                            border-bottom: none;
                         }
                     }
                 }


### PR DESCRIPTION
Resolves #12328

Authored by GPT-5 Codex (Codex Desktop). Session 53179687-64cf-4ca1-9a42-30455724ec68.
FAIR-band: over-target [16/30] — taking this lane despite over-target because heartbeat recovery required progress evidence, #12328 is a fresh GPT-authored/corrected ticket with no active peer claim, and the implementation is a narrow positive-ROI Portal CSS fix.

Adds scoped table styling to the shared Portal news timeline body rules so ticket, discussion, and pull-request timeline Markdown tables get cell borders, header color, and horizontal overflow behavior from the existing GitHub-style `--gh-*` palette.

Evidence: L3 (Neural Link live Portal route `/news/tickets/11507` rendered a real table inside `.neo-timeline-body`; clean console; theme build compiled target CSS) -> L3 required (visual/runtime Portal news timeline table behavior). No residuals.

## Deltas from ticket
- Implemented as structural SCSS only in `resources/scss/src/apps/portal/news/tickets/Component.scss`.
- No new theme tokens: uses existing shared `--gh-*` palette from `resources/scss/theme-neo-light/apps/portal/content/Component.scss` and the dark counterpart.
- No parser wrapper needed: `.neo-timeline-body` owns horizontal overflow and tables use `width: max-content; min-width: 100%`.

## Test Evidence
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `node ./buildScripts/build/themes.mjs -f -n -t all -e dev` passed; compiled CSS includes table rules in `dist/development/css/src/apps/portal/news/tickets/Component.css`.
- Neural Link: reloaded Portal, routed to `#/news/tickets/11507`, and verified route `/news/tickets/11507`.
- Neural Link: `Portal.view.news.tickets.Component` rendered issue #11507 body with a real `<table>` inside `.neo-timeline-body`.
- Neural Link: `get_console_logs(type: 'error')` returned `[]`.

## Post-Merge Validation
- [ ] Operator/browser visual spot-check in light and dark themes for a wide Portal news timeline table.

## Commit
- `87a378e45` — `fix(portal): style news timeline tables (#12328)`
