### PR TITLE
fix(portal): scope news table overflow (#12332)

### DIFF
--- a/apps/portal/view/news/discussions/Component.mjs
+++ b/apps/portal/view/news/discussions/Component.mjs
@@ -361,7 +361,7 @@ class Component extends ContentComponent {
                 `<span class="neo-timeline-date">commented on ${me.formatTimestamp(comment.date)}</span>`,
                 '</div>',
                 '<div class="neo-timeline-body">',
-                marked.parse(comment.body),
+                me.wrapMarkdownTables(marked.parse(comment.body)),
                 me.renderReplies(comment.replies),
                 '</div>',
                 '</div>',
@@ -382,7 +382,8 @@ class Component extends ContentComponent {
      * @returns {String}
      */
     renderReplies(replies = []) {
-        let {repoUserUrl} = this;
+        let me            = this,
+            {repoUserUrl} = me;
 
         if (!replies.length) {
             return ''
@@ -394,9 +395,9 @@ class Component extends ContentComponent {
                 `<div class="neo-discussion-reply depth-${reply.depth}">`,
                 '<div class="neo-discussion-reply-header">',
                 `<a class="neo-timeline-user" href="${repoUserUrl}${reply.user}" target="_blank">${reply.user}</a>`,
-                `<span class="neo-timeline-date">replied on ${this.formatTimestamp(reply.date)}</span>`,
+                `<span class="neo-timeline-date">replied on ${me.formatTimestamp(reply.date)}</span>`,
                 '</div>',
-                `<div class="neo-discussion-reply-body">${marked.parse(reply.body)}</div>`,
+                `<div class="neo-discussion-reply-body">${me.wrapMarkdownTables(marked.parse(reply.body))}</div>`,
                 '</div>'
             ].join('')).join(''),
             '</div>'

--- a/apps/portal/view/news/pulls/Component.mjs
+++ b/apps/portal/view/news/pulls/Component.mjs
@@ -222,7 +222,7 @@ class Component extends ContentComponent {
                 id,
                 user    : entry.user,
                 date    : entry.date,
-                bodyHtml: marked.parse(entry.body),
+                bodyHtml: me.wrapMarkdownTables(marked.parse(entry.body)),
                 extraCls: isReview ? `comment review ${stateCls}` : 'comment',
                 action  : isReview ? `${badge} reviewed` : 'commented',
                 meta    : entry.meta

--- a/apps/portal/view/news/tickets/Component.mjs
+++ b/apps/portal/view/news/tickets/Component.mjs
@@ -343,7 +343,7 @@ ${fullHtml}
                     tag  : 'comment'
                 });
 
-                let body = marked.parse(commentBuf.join('\n'));
+                let body = me.wrapMarkdownTables(marked.parse(commentBuf.join('\n')));
                 html += `
                     <div id="${id}" class="neo-timeline-item comment" data-record-id="${id}">
                         <div id="${id}-target" class="neo-timeline-avatar">

--- a/resources/scss/src/apps/portal/news/tickets/Component.scss
+++ b/resources/scss/src/apps/portal/news/tickets/Component.scss
@@ -237,7 +237,6 @@
 
                     .neo-timeline-body {
                         font-size    : 14px;
-                        overflow-x   : auto;
                         overflow-wrap: anywhere;
                         padding      : 16px;
 
@@ -250,6 +249,11 @@
                             overflow-x: auto;
                         }
 
+                        .neo-markdown-table-wrapper {
+                            max-width : 100%;
+                            overflow-x: auto;
+                        }
+
                         table {
                             border         : 1px solid var(--gh-timeline-border);
                             border-collapse: separate;
@@ -257,7 +261,6 @@
                             border-spacing : 0;
                             color          : var(--gh-text-primary);
                             margin         : 12px 0;
-                            max-width      : none;
                             min-width      : 100%;
                             overflow       : hidden;
                             width          : max-content;
@@ -267,6 +270,8 @@
                         td {
                             border-bottom: 1px solid var(--gh-timeline-border);
                             border-right : 1px solid var(--gh-timeline-border);
+                            max-width    : 48ch;
+                            overflow-wrap: anywhere;
                             padding      : 8px 12px;
                             text-align   : left;
                             vertical-align: top;

--- a/resources/scss/src/component/Markdown.scss
+++ b/resources/scss/src/component/Markdown.scss
@@ -143,7 +143,8 @@
     }
 
     .neo-frontmatter-table,
-    > table {
+    > table,
+    .neo-markdown-table-wrapper > table {
         border         : 1px solid var(--markdown-table-border);
         border-collapse: separate;
         border-radius  : 4px;
@@ -155,8 +156,11 @@
         th, td {
             border-bottom: 1px solid var(--markdown-table-border);
             border-right : 1px solid var(--markdown-table-border);
+            max-width    : 48ch;
+            overflow-wrap: anywhere;
             padding      : 8px 12px;
             text-align   : left;
+            vertical-align: top;
         }
 
         th:last-child,
@@ -171,6 +175,17 @@
         th {
             background-color: var(--markdown-table-header-bg);
             font-weight     : bold;
+        }
+    }
+
+    .neo-markdown-table-wrapper {
+        max-width : 100%;
+        overflow-x: auto;
+
+        > table {
+            margin   : 1em 0;
+            min-width: 100%;
+            width    : max-content;
         }
     }
 

--- a/src/component/Markdown.mjs
+++ b/src/component/Markdown.mjs
@@ -244,6 +244,24 @@ class Markdown extends Component {
     }
 
     /**
+     * @summary Wraps Markdown-generated tables in a scroll container while preserving manual frontmatter tables.
+     *
+     * Mirrors the image-wrapper post-processing step: the rendered content keeps native table layout, while
+     * overflow is scoped to the table region instead of the surrounding Markdown body.
+     * @param {String} html Rendered Markdown HTML.
+     * @returns {String}
+     */
+    wrapMarkdownTables(html) {
+        return html.replace(/<table\b([^>]*)>([\s\S]*?)<\/table>/g, (match, attrs, body) => {
+            if (/\bclass=["'][^"']*\bneo-frontmatter-table\b/.test(attrs)) {
+                return match
+            }
+
+            return `<div class="neo-markdown-table-wrapper"><table${attrs}>${body}</table></div>`
+        })
+    }
+
+    /**
      * Modifies the markdown content before rendering.
      * Default implementation parses headlines to add specific classes.
      * @param {String} content
@@ -552,6 +570,8 @@ class Markdown extends Component {
         content = content.replace(/\\```/g, '```');
         
         html = marked.parse(content);
+
+        html = me.wrapMarkdownTables(html);
 
         // Wrap raw HTML img tags in a scrollable container
         html = html.replace(/<img([^>]*)>/g, '<div class="neo-markdown-image-wrapper"><img$1></div>');

--- a/src/component/Markdown.mjs
+++ b/src/component/Markdown.mjs
@@ -252,6 +252,7 @@ class Markdown extends Component {
      * @returns {String}
      */
     wrapMarkdownTables(html) {
+        // Marked-generated tables do not nest, keeping this post-process scoped and deterministic.
         return html.replace(/<table\b([^>]*)>([\s\S]*?)<\/table>/g, (match, attrs, body) => {
             if (/\bclass=["'][^"']*\bneo-frontmatter-table\b/.test(attrs)) {
                 return match

--- a/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
@@ -152,20 +152,28 @@ test.describe('Portal.view.news.discussions.Component - Discussion markdown pars
 
     test('renders replies inside the parent comment bubble without timeline section records', () => {
         const html = renderReplies.call({
-            repoUserUrl    : 'https://github.com/',
-            formatTimestamp: value => value
+            repoUserUrl       : 'https://github.com/',
+            formatTimestamp   : value => value,
+            wrapMarkdownTables: Component.prototype.wrapMarkdownTables
         }, [{
             depth: 1,
             user : 'child',
             date : '2026-05-20T18:00:00Z',
-            body : 'Reply body.'
+            body : [
+                'Reply body.',
+                '',
+                '| Key | Value |',
+                '| --- | --- |',
+                '| mode | nested reply |'
+            ].join('\n')
         }]);
 
         expect(html).toContain('neo-discussion-replies');
         expect(html).toContain('neo-discussion-reply depth-1');
         expect(html).toContain('https://github.com/child');
         expect(html).toContain('replied on 2026-05-20T18:00:00Z');
-        expect(html).toContain('<p>Reply body.</p>')
+        expect(html).toContain('<p>Reply body.</p>');
+        expect(html).toContain('<div class="neo-markdown-table-wrapper"><table>')
     });
 
     test('category and closed-state badges render stable semantic classes', () => {

--- a/test/playwright/unit/component/Markdown.spec.mjs
+++ b/test/playwright/unit/component/Markdown.spec.mjs
@@ -1,0 +1,46 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'MarkdownTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import '../../../../src/Neo.mjs';
+import '../../../../src/core/_export.mjs';
+import Markdown from '../../../../src/component/Markdown.mjs';
+
+test.describe('Neo.component.Markdown', () => {
+    const markdown = Object.create(Markdown.prototype);
+
+    test('wrapMarkdownTables wraps rendered Markdown tables', () => {
+        const html = '<p>Intro</p><table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Neo</td></tr></tbody></table>';
+
+        expect(markdown.wrapMarkdownTables(html)).toBe(
+            '<p>Intro</p><div class="neo-markdown-table-wrapper"><table><thead><tr><th>Name</th></tr></thead><tbody><tr><td>Neo</td></tr></tbody></table></div>'
+        )
+    });
+
+    test('wrapMarkdownTables preserves frontmatter tables', () => {
+        const html = '<details><summary>Frontmatter</summary><table class="neo-frontmatter-table"><tbody><tr><td>title</td><td>News</td></tr></tbody></table></details>';
+
+        expect(markdown.wrapMarkdownTables(html)).toBe(html)
+    });
+
+    test('wrapMarkdownTables leaves content without tables unchanged', () => {
+        const html = '<p>No tabular content here.</p>';
+
+        expect(markdown.wrapMarkdownTables(html)).toBe(html)
+    });
+
+    test('wrapMarkdownTables wraps each rendered Markdown table', () => {
+        const html = '<table><tbody><tr><td>One</td></tr></tbody></table><p>Between</p><table class="wide"><tbody><tr><td>Two</td></tr></tbody></table>';
+
+        expect(markdown.wrapMarkdownTables(html)).toBe(
+            '<div class="neo-markdown-table-wrapper"><table><tbody><tr><td>One</td></tr></tbody></table></div><p>Between</p><div class="neo-markdown-table-wrapper"><table class="wide"><tbody><tr><td>Two</td></tr></tbody></table></div>'
+        )
+    })
+});


### PR DESCRIPTION
Resolves #12332

Authored by GPT-5 Codex (Codex Desktop). Session 53179687-64cf-4ca1-9a42-30455724ec68.
FAIR-band: over-target [17/30] — taking this lane despite over-target because it is an operator-requested UX follow-up to the just-merged #12330 table styling, the ticket is self-authored/self-assigned, and the implementation is a narrow Portal-news fix.

Moves Markdown table overflow to a table-specific wrapper so Portal news timeline bubbles stay fixed while wide tables scroll inside their own region. Adds a shared `Neo.component.Markdown#wrapMarkdownTables()` post-processing helper, mirrors the existing image-wrapper pattern, skips generated `.neo-frontmatter-table` output, applies the helper to Portal news direct `marked.parse()` timeline paths, and adds a `48ch` cell max-width/wrapping policy for long single-cell values.

Evidence: L2 (source helper smoke + focused unit coverage + generated development app chunk + compiled CSS/theme build) -> L3 required (fresh browser visual/runtime UX). Residual: reviewer/operator hard-refresh visual check for #12332 because the active Neural Link browser worker retained a cached pre-change JS module during this session.

## Deltas from ticket
- Added `wrapMarkdownTables(html)` to the shared Markdown component and invoked it from Portal news direct `marked.parse()` paths so tickets, discussions, discussion replies, PR comments, and PR reviews all use the same table wrapper helper.
- Added `.neo-markdown-table-wrapper` SCSS in the shared Markdown component stylesheet.
- Moved Portal news timeline table overflow from `.neo-timeline-body` to `.neo-markdown-table-wrapper`.
- Added `max-width: 48ch` and `overflow-wrap: anywhere` to Markdown table cells so very long values wrap before forcing page-scale horizontal scroll.

## Test Evidence
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `node --check src/component/Markdown.mjs` passed.
- `node --check apps/portal/view/news/tickets/Component.mjs` passed.
- `node --check apps/portal/view/news/discussions/Component.mjs` passed.
- `node --check apps/portal/view/news/pulls/Component.mjs` passed.
- `node --check test/playwright/unit/component/Markdown.spec.mjs` passed.
- `node --check test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/component/Markdown.spec.mjs` passed twice after the review-response update: 4 tests, covering normal table wrapping, frontmatter-table preservation, no-table passthrough, and multiple table wrapping.
- `npm run test-unit -- test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs` passed after the CI-reproduced fixture correction: 8 tests, including nested reply table wrapper coverage.
- `node ./buildScripts/build/themes.mjs -f -n -t all -e dev` passed.
- `node ./buildScripts/webpack/buildThreads.mjs -f -n -t app -e dev` passed; generated `dist/development/chunks/app/src_component_Markdown_mjs.js` contains `wrapMarkdownTables()` and `me.wrapMarkdownTables(html)`.
- Focused wrapper smoke: parsed a Markdown table with `marked`, verified `.neo-markdown-table-wrapper` is added, and verified `.neo-frontmatter-table` is not wrapped.
- Neural Link: reloaded Portal, routed to `#/news/tickets/11507`, verified route `/news/tickets/11507`, and observed no console errors. Caveat: the connected worker still exposed the old `Neo.component.Markdown.render()` method after reload, so live DOM wrapper verification requires a clean browser cache/hard refresh.

## Post-Merge Validation
- [ ] Hard-refresh Portal and visually spot-check a timeline item with a wide Markdown table and a long-cell table: surrounding prose/timeline bubble must stay fixed, and only the table wrapper should scroll when needed.

## Commit
- `edb06f204` — `fix(portal): scope news table overflow (#12332)`
- `6a44070ed` — `fix(portal): wrap news timeline tables (#12332)`
- `5e015a00b` — `test(portal): cover discussion reply table wrapping (#12332)`
