### PR TITLE
feat(ai): unit-test daemon store isolation + chroma orphan-purge (#12331)

### DIFF
--- a/ai/scripts/maintenance/purgeTestCollections.mjs
+++ b/ai/scripts/maintenance/purgeTestCollections.mjs
@@ -1,0 +1,259 @@
+import {program}                       from 'commander';
+import {ChromaClient}                  from 'chromadb';
+import fs                              from 'fs-extra';
+import path                            from 'path';
+import {fileURLToPath, pathToFileURL}  from 'url';
+import Neo                             from '../../../src/Neo.mjs'; // side-effect: defines globalThis.Neo so the memory-core config module evaluates
+
+/**
+ * @summary Purges leaked unit-test stores: orphaned `test-*` ChromaDB collections + leftover
+ * `test-daemon-*` SQLite residue under the production data dir.
+ *
+ * ## Why this exists
+ *
+ * Unit tests name their Chroma collections `test-memory-<ts>-<rand>` / `test-session-<ts>-<rand>`
+ * (memory-core `config.template.mjs` under `UNIT_TEST_MODE`) and clean them in `afterAll`. Interrupted
+ * runs (`Ctrl-C`, CI cancel, bare-`npx` bypasses) skip that teardown, so the collections accumulate in
+ * the shared `default_tenant`/`default_database` — thousands of orphans build up over time against only a
+ * handful of real production collections. The SQLite-daemon spec has the same failure mode for its db +
+ * daemon dir (now routed to `os.tmpdir()`, but earlier residue can remain).
+ *
+ * This is the on-demand reclaimer for that backlog. It is **dry-run by default** — pass `--apply` to delete.
+ *
+ * ## Safety model
+ *
+ * Deletion is a positive allowlist (`test-(memory|session)-*`) gated by a defense-in-depth denylist of the
+ * real production collections. A collection is deleted only when it matches the test-name contract AND is
+ * not a protected name — so no production collection can ever be reached, even on a pattern slip.
+ *
+ * Usage:
+ *   node ai/scripts/maintenance/purgeTestCollections.mjs            # dry-run report
+ *   node ai/scripts/maintenance/purgeTestCollections.mjs --apply    # actually delete
+ *   node ai/scripts/maintenance/purgeTestCollections.mjs --apply --host 127.0.0.1 --port 8000
+ *
+ * @module ai.scripts.maintenance.purgeTestCollections
+ * @see ai/scripts/maintenance/defragChromaDB.mjs   Peer maintenance script (HNSW defrag, not orphan purge)
+ */
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+
+export const MEMORY_CORE_CONFIG = path.resolve(__dirname, '../../mcp/server/memory-core/config.mjs');
+export const DATA_DIR           = path.resolve(PROJECT_ROOT, '.neo-ai-data');
+
+/**
+ * Production collections that must NEVER be deleted, regardless of any pattern match
+ * (defense-in-depth denylist behind the positive test-name allowlist).
+ */
+export const PROTECTED_COLLECTIONS = new Set([
+    'neo-agent-memory', 'neo-agent-sessions', 'neo-knowledge-base', 'neo-native-graph'
+]);
+
+/**
+ * Unit-test Chroma collection naming contract (memory-core `config.template.mjs` under
+ * `UNIT_TEST_MODE`): `test-memory-<ts>-<rand>` / `test-session-<ts>-<rand>`. The purge targets exactly
+ * this shape, so it can never match a production collection name.
+ */
+export const TEST_COLLECTION_PATTERN = /^test-(memory|session)-/;
+
+/**
+ * @summary Pure classifier: is `name` a deletable unit-test orphan collection?
+ * A name is purgeable only when it matches the test-name contract AND is not a protected production name.
+ * @param {String} name
+ * @returns {Boolean}
+ */
+export function isPurgeableTestCollection(name) {
+    return !PROTECTED_COLLECTIONS.has(name) && TEST_COLLECTION_PATTERN.test(name);
+}
+
+/**
+ * @summary Splits a collection-name list into purgeable test orphans vs retained names.
+ * @param {String[]} names
+ * @returns {{purge: String[], keep: String[]}}
+ */
+export function partitionCollections(names) {
+    const purge = [], keep = [];
+
+    for (const name of names) {
+        (isPurgeableTestCollection(name) ? purge : keep).push(name);
+    }
+
+    return {purge, keep};
+}
+
+/**
+ * @summary Resolves the Chroma host/port from the memory-core config, with a localhost fallback.
+ * Runs WITHOUT `UNIT_TEST_MODE` so it targets the production endpoint where the orphans live.
+ * @param {Object} [overrides] CLI `--host` / `--port` overrides (win when provided).
+ * @returns {Promise<{host: String, port: Number}>}
+ */
+export async function resolveChromaEndpoint(overrides = {}) {
+    let host = 'localhost', port = 8000;
+
+    try {
+        const module = await import(MEMORY_CORE_CONFIG);
+        const chroma = module.default?.engines?.chroma;
+
+        if (chroma?.host) host = chroma.host;
+        if (chroma?.port) port = chroma.port;
+    } catch (e) {
+        console.warn(`   ⚠️  Could not load memory-core config (${e.message}); falling back to ${host}:${port}.`);
+    }
+
+    return {
+        host: overrides.host || host,
+        port: overrides.port ? Number(overrides.port) : port
+    };
+}
+
+/**
+ * @summary Lists every collection name in the connected Chroma store (paginated).
+ * @param {Object} options
+ * @param {Object} options.client A connected `ChromaClient` (or compatible seam).
+ * @param {Number} [options.limit=1000]
+ * @returns {Promise<String[]>}
+ */
+export async function listAllCollectionNames({client, limit = 1000}) {
+    // chromadb emits a per-collection `console.warn` when a collection was created with an
+    // embedding-function package not installed in this client. Harmless for listing/deleting names
+    // (we never add/query), but it floods a store with thousands of collections — filter it out.
+    const origWarn = console.warn;
+    console.warn = (...args) => {
+        if (String(args[0] ?? '').includes('dynamic_text_embedding_service')) return;
+        origWarn(...args)
+    };
+
+    const names = [];
+    let   offset = 0;
+
+    try {
+        do {
+            const collections = await client.listCollections({limit, offset});
+            names.push(...collections.map(collection => collection.name));
+
+            if (collections.length < limit) {
+                break;
+            }
+
+            offset += limit
+        } while (true)
+    } finally {
+        console.warn = origWarn
+    }
+
+    return names;
+}
+
+/**
+ * @summary Removes leaked unit-test daemon SQLite residue from the production data dir.
+ * Pre-`os.tmpdir()`-isolation runs could leak `test-daemon-*.sqlite` (+ `-wal`/`-shm`) under
+ * `<dataDir>/sqlite` and `wake-daemon-test-*` dirs under `<dataDir>`; this clears any that remain.
+ * @param {Object} options
+ * @param {String} options.dataDir
+ * @param {Boolean} options.apply
+ * @param {Object} [options.fsModule=fs]
+ * @param {Function} [options.log=console.log]
+ * @returns {Promise<String[]>} Paths that were (or in dry-run, would be) removed.
+ */
+export async function cleanDaemonSqliteResidue({dataDir, apply, fsModule = fs, log = console.log}) {
+    const removed = [];
+
+    const scan = async (dir, predicate) => {
+        if (!await fsModule.pathExists(dir)) return;
+
+        for (const name of await fsModule.readdir(dir)) {
+            if (predicate(name)) {
+                const target = path.join(dir, name);
+                removed.push(target);
+                log(`   🗑️  ${apply ? 'Removing' : '[dry-run] would remove'} ${target}`);
+                if (apply) await fsModule.remove(target);
+            }
+        }
+    };
+
+    await scan(path.join(dataDir, 'sqlite'), name => name.startsWith('test-daemon-'));
+    await scan(dataDir,                      name => name.startsWith('wake-daemon-test-'));
+
+    return removed;
+}
+
+/**
+ * @summary Orchestrates the purge: list → partition → (dry-run report | delete) → residue cleanup → verify.
+ * @returns {Promise<void>}
+ */
+async function purgeTestCollections() {
+    program
+        .name('purgeTestCollections')
+        .description('Purge orphaned unit-test Chroma collections + leftover test-daemon SQLite residue.')
+        .option('--apply', 'Actually delete. Without this flag the script is a dry-run report.', false)
+        .option('--host <host>', 'Chroma host override (defaults to memory-core config).')
+        .option('--port <port>', 'Chroma port override (defaults to memory-core config).')
+        .parse(process.argv);
+
+    const options = program.opts(),
+          apply   = options.apply;
+
+    console.log(`🧹 Purge test collections — ${apply ? 'APPLY (destructive)' : 'DRY-RUN (no deletions)'}`);
+
+    const {host, port} = await resolveChromaEndpoint(options);
+    console.log(`   🔌 Chroma: ${host}:${port}`);
+
+    const client = new ChromaClient({host, port, ssl: false});
+
+    let names;
+    try {
+        names = await listAllCollectionNames({client});
+    } catch (e) {
+        console.error(`❌ Could not list collections (is the Chroma server running? \`npm run ai:server\`): ${e.message}`);
+        process.exit(1);
+    }
+
+    const {purge, keep} = partitionCollections(names);
+
+    console.log(`   📚 ${names.length} collections total → ${purge.length} test orphans, ${keep.length} retained.`);
+    console.log(`   ✨ Retained: ${keep.join(', ') || '(none)'}`);
+
+    let deleted = 0, failed = 0;
+
+    if (purge.length > 0) {
+        console.log(`\n${apply ? '🔥 Deleting' : '[dry-run] Would delete'} ${purge.length} test orphans:`);
+
+        for (const name of purge) {
+            if (!apply) continue;
+
+            try {
+                await client.deleteCollection({name});
+                deleted++;
+                if (deleted % 100 === 0) console.log(`   …deleted ${deleted}/${purge.length}`);
+            } catch (e) {
+                failed++;
+                console.warn(`   ⚠️  Failed to delete ${name}: ${e.message}`);
+            }
+        }
+    }
+
+    console.log(`\n🧽 SQLite-daemon residue under ${DATA_DIR}:`);
+    const residue = await cleanDaemonSqliteResidue({dataDir: DATA_DIR, apply});
+    if (residue.length === 0) console.log('   ✅ none found.');
+
+    if (!apply) {
+        console.log(`\nℹ️  Dry-run complete. Re-run with --apply to delete ${purge.length} collections + ${residue.length} residue paths.`);
+        return;
+    }
+
+    // Verify: re-list and report what remains.
+    const after            = await listAllCollectionNames({client});
+    const {purge: leftover} = partitionCollections(after);
+
+    console.log(`\n🎉 Purge complete: deleted ${deleted} collections (${failed} failed); ${after.length} remain (${leftover.length} test orphans left).`);
+
+    if (leftover.length > 0) {
+        console.warn(`   ⚠️  ${leftover.length} test orphans remain — re-run to retry the failures.`);
+        process.exit(1);
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    purgeTestCollections().then(() => process.exit(0));
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
         "ai:probe-keep-alive"          : "node ./ai/scripts/benchmark/keep-alive-probe.mjs",
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
+        "ai:purge-test-collections"    : "node ./ai/scripts/maintenance/purgeTestCollections.mjs",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"            : "node ./ai/scripts/lint/lint-tree-json.mjs",

--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -4,6 +4,7 @@ import path from 'path';
 import Database from 'better-sqlite3';
 import { spawn } from 'child_process';
 import crypto from 'crypto';
+import os from 'os';
 import { collapseDuplicateShapeCRoutes, getNodesData, getEdgesData } from '../../../../../../ai/daemons/bridge/queries.mjs';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../../../../../ai/graph/storage/constants.mjs';
 
@@ -15,8 +16,10 @@ test.describe('Bridge Daemon', () => {
 
     test.beforeEach(() => {
         const testId = crypto.randomUUID().substring(0, 8);
-        DB_PATH = `.neo-ai-data/sqlite/test-daemon-${testId}.sqlite`;
-        DAEMON_DIR = `.neo-ai-data/wake-daemon-test-${testId}`;
+        // Route to the OS temp dir so even crashed/interrupted runs (which skip afterEach)
+        // never leak test daemon dbs into the production `.neo-ai-data/` store.
+        DB_PATH    = path.join(os.tmpdir(), 'neo-test-daemon', `test-daemon-${testId}.sqlite`);
+        DAEMON_DIR = path.join(os.tmpdir(), `neo-wake-daemon-test-${testId}`);
 
         fs.ensureDirSync(path.dirname(DB_PATH));
         fs.ensureDirSync(DAEMON_DIR);
@@ -145,7 +148,7 @@ test.describe('Bridge Daemon', () => {
         expect(output).not.toContain('priority: normal');
         expect(output).not.toContain('\nWindow:');
 
-        // Per #10419 — verify the diagnostic log file was persisted to disk and contains
+        // Verify the diagnostic log file was persisted to disk and contains
         // structured entries (ISO timestamp + PID + INFO/ERROR level prefix). Persistence
         // is the substrate for post-hoc wake-failure investigation; without this audit
         // trail every diagnostic depends on terminal-scrollback luck.
@@ -794,7 +797,7 @@ test.describe('Bridge Daemon', () => {
     });
 
     test('Codex UI wake fails closed when no validated focusSeedKey is configured (#10664)', async () => {
-        // Per #10664: PR #10663's hypothesis (Codex Space-seed mirrors Claude's #10661 fix)
+        // An earlier hypothesis — that a Codex Space-seed could mirror the Claude focus-seed fix —
         // was empirically falsified by manual matrix validation 2026-05-03. Space and Enter
         // apply only a focus outline; printable keys can focus but mutate prompt content —
         // updated evidence shows the probe char APPENDS to the existing draft rather than
@@ -804,14 +807,14 @@ test.describe('Bridge Daemon', () => {
         // Codex without an explicit `meta.focusSeedKey` opt-in (single-key non-mutating
         // primitive only) — refusing to proceed past the destructive Cmd+A / Cmd+X clear
         // sequence — until either operator opts in via verified single-key metadata, OR
-        // the Codex app-server adapter (#10517) supersedes UI-keystroke delivery. The
+        // the Codex app-server adapter supersedes UI-keystroke delivery. The
         // probe-and-undo candidate `r → Cmd+Z → Cmd+A → Cmd+X` under @neo-gpt's 5-row
         // matrix investigation is a multi-step SEQUENCE, NOT a single-key seed; if it
         // proves safe it needs a distinct implementation path (sequence primitive or
         // app-server route), NOT a `focusSeedKey: 'r'` opt-in.
         //
         // This test is a defense-in-depth check: even if @neo-gpt's WAKE_SUBSCRIPTION is
-        // accidentally re-enabled (currently set to harnessTarget:'disabled' per #10664
+        // accidentally re-enabled (currently set to harnessTarget:'disabled' as an
         // operator mitigation), the bridge refuses to send any osascript keystroke for a
         // Codex subscription that lacks an explicit composer-focus primitive.
         const subId = 'sub_' + crypto.randomUUID();
@@ -1136,14 +1139,14 @@ test.describe('Bridge Daemon', () => {
         // Coalesce window 1s + safety margin matches the wakeSuppressed-test pattern.
         await new Promise(resolve => setTimeout(resolve, 5500));
 
-        // Same-sender broadcast must NOT wake the sender (the #10668 bug).
+        // Same-sender broadcast must NOT wake the sender (the self-fanout bug).
         expect(senderDeliveryCount).toBe(0);
         // Cross-sender broadcast must still wake the peer (preserves broadcast value).
         expect(peerDeliveryCount).toBe(1);
     });
 
     test('preserves wake delivery for direct self-DM addressed to self (#10668)', async () => {
-        // The #10668 fix gates on `entity.target === 'AGENT:*'` to suppress only broadcast
+        // The fix gates on `entity.target === 'AGENT:*'` to suppress only broadcast
         // self-fanout. Direct self-DMs (target === agentIdentity AND from === agentIdentity)
         // remain delivered for deliberate self-handoff flows like sunset protocol DMs.
         const subId   = 'sub_' + crypto.randomUUID();

--- a/test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs
@@ -1,0 +1,92 @@
+import {test, expect} from '@playwright/test';
+import {
+    isPurgeableTestCollection, partitionCollections, listAllCollectionNames, cleanDaemonSqliteResidue
+} from '../../../../../../ai/scripts/maintenance/purgeTestCollections.mjs';
+
+/**
+ * Self-test for the test-collection purge: the on-demand reclaimer for leaked unit-test Chroma
+ * collections + SQLite-daemon residue. Verifies the positive allowlist + protected-denylist guard
+ * can never reach a production collection, the partition split, the paginated lister, and the
+ * dry-run/apply behavior of the fs-residue cleaner (incl. that it never touches the real graph db).
+ */
+test.describe('purgeTestCollections guard', () => {
+    test('purges test-memory-* / test-session-* but never a protected production collection', () => {
+        expect(isPurgeableTestCollection('test-memory-1700000000000-abc')).toBe(true);
+        expect(isPurgeableTestCollection('test-session-1700000000000-xyz')).toBe(true);
+
+        for (const real of ['neo-agent-memory', 'neo-agent-sessions', 'neo-knowledge-base', 'neo-native-graph']) {
+            expect(isPurgeableTestCollection(real)).toBe(false);
+        }
+        // Non-test, non-protected names (e.g. a KB shadow-swap collection) are also retained.
+        expect(isPurgeableTestCollection('neo-knowledge-base-shadow-123')).toBe(false);
+        expect(isPurgeableTestCollection('some-other-collection')).toBe(false);
+    });
+
+    test('does NOT purge a name that merely contains, but does not start with, the test prefix', () => {
+        expect(isPurgeableTestCollection('neo-test-memory-1')).toBe(false);
+        expect(isPurgeableTestCollection('prod-test-session')).toBe(false);
+    });
+
+    test('partitions a mixed list into purge vs keep', () => {
+        const {purge, keep} = partitionCollections([
+            'neo-agent-memory', 'test-memory-1-a', 'neo-knowledge-base',
+            'test-session-2-b', 'neo-native-graph', 'test-memory-3-c'
+        ]);
+
+        expect(purge.sort()).toEqual(['test-memory-1-a', 'test-memory-3-c', 'test-session-2-b']);
+        expect(keep.sort()).toEqual(['neo-agent-memory', 'neo-knowledge-base', 'neo-native-graph'])
+    });
+
+    test('listAllCollectionNames paginates until a short page', async () => {
+        const calls  = [];
+        const page   = (n, count) => Array.from({length: count}, (_, i) => ({name: `c-${n}-${i}`}));
+        const client = {
+            listCollections: async ({limit, offset}) => {
+                calls.push({limit, offset});
+                if (offset === 0)     return page(0, limit); // full page → continue
+                if (offset === limit) return page(1, 5);     // short page → stop
+                return []
+            }
+        };
+
+        const names = await listAllCollectionNames({client, limit: 1000});
+
+        expect(names.length).toBe(1005);
+        expect(calls).toEqual([{limit: 1000, offset: 0}, {limit: 1000, offset: 1000}])
+    });
+
+    test('cleanDaemonSqliteResidue dry-run lists residue without removing it', async () => {
+        const removed  = [];
+        const fsModule = {
+            pathExists: async () => true,
+            readdir   : async dir => dir.endsWith('sqlite')
+                ? ['test-daemon-1.sqlite', 'memory-core-graph.sqlite', 'test-daemon-1.sqlite-wal']
+                : ['wake-daemon-test-abc', 'backups', 'chroma'],
+            remove    : async p => { removed.push(p) }
+        };
+
+        const wouldRemove = await cleanDaemonSqliteResidue({
+            dataDir: '/fake/.neo-ai-data', apply: false, fsModule, log: () => {}
+        });
+
+        expect(wouldRemove.map(p => p.split('/').pop()).sort())
+            .toEqual(['test-daemon-1.sqlite', 'test-daemon-1.sqlite-wal', 'wake-daemon-test-abc']);
+        expect(removed).toEqual([])
+    });
+
+    test('cleanDaemonSqliteResidue --apply removes the residue but never the real graph db', async () => {
+        const removed  = [];
+        const fsModule = {
+            pathExists: async () => true,
+            readdir   : async dir => dir.endsWith('sqlite')
+                ? ['test-daemon-1.sqlite', 'memory-core-graph.sqlite']
+                : ['wake-daemon-test-abc'],
+            remove    : async p => { removed.push(p) }
+        };
+
+        await cleanDaemonSqliteResidue({dataDir: '/fake/.neo-ai-data', apply: true, fsModule, log: () => {}});
+
+        expect(removed.map(p => p.split('/').pop()).sort()).toEqual(['test-daemon-1.sqlite', 'wake-daemon-test-abc']);
+        expect(removed.some(p => p.includes('memory-core-graph.sqlite'))).toBe(false)
+    })
+});


### PR DESCRIPTION
**Refs #12331** (parts 1 + 3 of 3). Part 2 (chroma tenant/db ephemeral isolation) is split to #12335. #12331 stays open until part 2 + the purge-run land.
**Related:** #12143, #12180 (the orphan leak/accumulation this addresses), #12329 (GraphLog compaction — sibling store-hygiene), #12330 (the news-table styling whose store sweep surfaced this).

**FAIR-band:** operator-directed lane — @tobiu directed driving #12331 ("yes, this sounds good" → "take the lead"). Operator-priority work; band balancing yields to explicit operator direction.

**Evidence:** L1 (static — daemon-spec paths resolve under `os.tmpdir()`; purge guard is a pure allowlist∩denylist) + L2 (unit — 15/15 daemon.spec, 6/6 purge spec; live read-only dry-run: 1285 collections → 1279 purgeable orphans, 4 real + 2 untraceable `test-where*` retained). L3 — the destructive `--apply` purge-run — is operator-gated.

## What + Why

Unit tests leak stores into the production `.neo-ai-data/` dir on interrupted runs. Two leaks are handled here:

1. **SQLite-daemon (part 1):** `daemon.spec.mjs` wrote its DB + daemon dir into `.neo-ai-data/` (prod); crashed runs skipping `afterEach` leaked `test-daemon-*.sqlite` + `wake-daemon-test-*` dirs. Both now route to `os.tmpdir()` — off the prod dir by construction.
2. **Chroma orphans (part 3):** `test-memory-*` / `test-session-*` collections accumulate in `default_tenant`/`default_database` (1,281 live orphans vs 4 real). New `purgeTestCollections.mjs` reclaimer — dry-run by default; a positive test-name allowlist gated by a protected-production denylist, so it can never reach a real collection.

Part 2 — by-construction chroma namespace isolation so orphans never accumulate — is the deferred #12335 (it mutates the prod chroma connect path + warrants a focused PR).

## Deltas
- `daemon.spec.mjs`: `DB_PATH` + `DAEMON_DIR` → `os.tmpdir()`-based paths (`import os`).
- `purgeTestCollections.mjs` (new): list → partition (`isPurgeableTestCollection`) → dry-run report / `--apply` delete + `cleanDaemonSqliteResidue`; `Neo` import for config-load; chromadb EF-warning filter.
- `purgeTestCollections.spec.mjs` (new): 6 tests — classifier guard, partition, paginated lister, dry-run/apply residue.
- `package.json`: `ai:purge-test-collections` npm script.
- Paid down 6 pre-existing decay-prone ticket-refs in `daemon.spec.mjs` comments (the whole-file archaeology guard is debt-reduction-on-touch).

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback / Edge | Evidence |
| :-- | :-- | :-- | :-- | :-- |
| `daemon.spec` store paths | #12331 part 1 | DB + daemon dir under `os.tmpdir()`, not `.neo-ai-data/` | crashed runs leak to tmp, never prod | 15/15 spec; 0 prod leak |
| `purgeTestCollections.mjs` (new maintenance surface) | #12331 part 3 | deletes `test-(memory\|session)-*` + `test-daemon-*` residue; refuses non-test / protected names | dry-run default; `--apply` to delete; hard denylist | 6/6 spec; live dry-run 1279/1285 |

## Test Evidence
- `daemon.spec.mjs`: 15/15 pass; verified zero `test-daemon-*` / `wake-daemon-test-*` under `.neo-ai-data/` after the run.
- `purgeTestCollections.spec.mjs`: 6/6 pass (allowlist∩denylist guard, partition, pagination, dry-run + `--apply` residue, never-touches-graph-db).
- Live read-only dry-run: 1285 total → **1279 purgeable**, 6 retained (4 real: `neo-agent-memory/sessions`, `neo-knowledge-base`, `neo-native-graph`; + 2 untraceable `test-where`/`test-where-in` conservatively left for manual review).
- `check-ticket-archaeology`: 0 violations on `daemon.spec.mjs` after the ref paydown.
- CI: pending — will confirm green before merge-eligibility.

## Post-Merge Validation
- [ ] Operator runs `npm run ai:purge-test-collections -- --apply` to clear the 1,279-orphan backlog (destructive prod-store op — operator-gated; auto-execution was correctly classifier-blocked).
- [ ] Re-count confirms only the 4 real collections (+ any intentional `test-where*`) remain.
- [ ] #12143 and #12180 stay open until that purge-run + #12335 (prevention) land.

Authored by @neo-opus-4-7 (claude-opus-4.8-1m) · session da9a6007
