### PR TITLE
feat(ai): add graphlog compaction maintenance (#12329)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -17,9 +17,10 @@ function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-const neoRootDir = path.resolve(__dirname, '../../../../');
-const cwd        = neoRootDir;
-const DAY_MS     = 24 * 60 * 60 * 1000;
+const neoRootDir        = path.resolve(__dirname, '../../../../');
+const cwd               = neoRootDir;
+const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.resolve(cwd, '.neo-ai-data/wake-daemon'));
+const DAY_MS            = 24 * 60 * 60 * 1000;
 
 /**
  * @summary Configuration manager for the Memory Core MCP server.
@@ -110,6 +111,14 @@ class Config extends BaseConfig {
              */
             storagePaths: {
                 graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string')
+            },
+            /**
+             * Durable wake-daemon watermarks consumed by GraphLog maintenance.
+             */
+            wakeDaemon: {
+                dataDir: leaf(wakeDaemonDataDir, 'NEO_AI_DAEMON_DIR', 'string'),
+                bridgeLastSyncIdPath: leaf(path.join(wakeDaemonDataDir, 'lastSyncId'), 'NEO_BRIDGE_LAST_SYNC_ID_PATH', 'string'),
+                wakeSubscriptionLiveCursorPath: leaf(path.join(wakeDaemonDataDir, 'wakeSubscriptionLiveCursor'), 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string')
             },
             /**
              * Data Schema/Table Names

--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -2,7 +2,7 @@ import {Command}                      from 'commander';
 import Database                       from 'better-sqlite3';
 import fs                             from 'fs-extra';
 import path                           from 'path';
-import {fileURLToPath, pathToFileURL} from 'url';
+import {pathToFileURL}                from 'url';
 
 /**
  * @module ai.scripts.maintenance.compactGraphLog
@@ -23,14 +23,34 @@ import {fileURLToPath, pathToFileURL} from 'url';
  * @see ai/daemons/bridge/queries.mjs
  */
 
-const __filename   = fileURLToPath(import.meta.url);
-const __dirname    = path.dirname(__filename);
-const PROJECT_ROOT = path.resolve(__dirname, '../../..');
-
-export const DEFAULT_DB_PATH            = path.join(PROJECT_ROOT, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
-export const DEFAULT_BRIDGE_STATE_FILE  = path.join(PROJECT_ROOT, '.neo-ai-data/wake-daemon/lastSyncId');
-export const DEFAULT_WAKE_STATE_FILE    = path.join(PROJECT_ROOT, '.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor');
 export const DEFAULT_SAFETY_MARGIN_ROWS = 1000;
+
+/**
+ * @summary Loads the runtime Memory Core config for CLI execution.
+ * @returns {Promise<Object>}
+ */
+export async function loadMemoryCoreConfig() {
+    return (await import('../../mcp/server/memory-core/config.mjs')).default;
+}
+
+/**
+ * @summary Resolves default compaction paths from a Memory Core config instance.
+ * @param {Object} options
+ * @param {Object} options.aiConfig Runtime or template Memory Core config.
+ * @returns {{dbPath:String, bridgeStateFile:String, wakeStateFile:String, safetyMarginRows:Number}}
+ */
+export function getDefaultGraphLogCompactionOptions({aiConfig}) {
+    if (!aiConfig) {
+        throw new TypeError('aiConfig is required to resolve GraphLog compaction defaults.');
+    }
+
+    return {
+        dbPath          : aiConfig.storagePaths.graph,
+        bridgeStateFile: aiConfig.wakeDaemon.bridgeLastSyncIdPath,
+        wakeStateFile  : aiConfig.wakeDaemon.wakeSubscriptionLiveCursorPath,
+        safetyMarginRows: DEFAULT_SAFETY_MARGIN_ROWS
+    };
+}
 
 /**
  * @summary Parses a non-negative integer CLI value.
@@ -346,9 +366,10 @@ export function checkpointWal(db) {
  * @returns {Object}
  */
 export function runGraphLogCompaction({
-    dbPath             = DEFAULT_DB_PATH,
-    bridgeStateFile   = DEFAULT_BRIDGE_STATE_FILE,
-    wakeStateFile     = DEFAULT_WAKE_STATE_FILE,
+    aiConfig          = null,
+    dbPath            = null,
+    bridgeStateFile   = null,
+    wakeStateFile     = null,
     safetyMarginRows  = DEFAULT_SAFETY_MARGIN_ROWS,
     extraWatermarks   = [],
     wakeLiveCursor    = null,
@@ -358,6 +379,18 @@ export function runGraphLogCompaction({
     fsModule          = fs,
     logger            = console
 } = {}) {
+    if (aiConfig) {
+        const defaults = getDefaultGraphLogCompactionOptions({aiConfig});
+
+        dbPath          ??= defaults.dbPath;
+        bridgeStateFile ??= defaults.bridgeStateFile;
+        wakeStateFile   ??= defaults.wakeStateFile;
+    }
+
+    if (!dbPath || !bridgeStateFile || !wakeStateFile) {
+        throw new TypeError('dbPath, bridgeStateFile, and wakeStateFile are required unless aiConfig is provided.');
+    }
+
     const db = new Database(dbPath, {fileMustExist: true});
 
     try {
@@ -445,17 +478,21 @@ export function logCompactionResult(result, {apply = false, vacuum = false, logg
 
 /**
  * @summary Creates the CLI command object.
+ * @param {Object} options
+ * @param {Object} options.aiConfig Runtime or template Memory Core config.
  * @returns {Command}
  */
-export function createCommand() {
+export function createCommand({aiConfig} = {}) {
+    const defaults = getDefaultGraphLogCompactionOptions({aiConfig});
+
     return new Command()
         .name('compactGraphLog')
         .description('Dry-run-first GraphLog CDC compaction past known consumer watermarks.')
         .option('--apply', 'Actually delete eligible GraphLog rows. Without this flag the script is dry-run only.', false)
-        .option('--db <path>', 'SQLite graph db path.', DEFAULT_DB_PATH)
-        .option('--bridge-state-file <path>', 'Bridge daemon lastSyncId file.', DEFAULT_BRIDGE_STATE_FILE)
-        .option('--wake-state-file <path>', 'WakeSubscriptionService live cursor file.', DEFAULT_WAKE_STATE_FILE)
-        .option('--safety-margin <rows>', 'Rows to retain below the minimum known consumer watermark.', String(DEFAULT_SAFETY_MARGIN_ROWS))
+        .option('--db <path>', 'SQLite graph db path.', defaults.dbPath)
+        .option('--bridge-state-file <path>', 'Bridge daemon lastSyncId file.', defaults.bridgeStateFile)
+        .option('--wake-state-file <path>', 'WakeSubscriptionService live cursor file.', defaults.wakeStateFile)
+        .option('--safety-margin <rows>', 'Rows to retain below the minimum known consumer watermark.', String(defaults.safetyMarginRows))
         .option('--consumer-watermark <name=logId>', 'Additional durable consumer watermark. May be repeated.', collect, [])
         .option('--wake-live-cursor <logId>', 'Current WakeSubscriptionService liveCursor when active mcp-notifications consumers exist.')
         .option('--vacuum', 'Run VACUUM after deletion to physically shrink the SQLite db. Operator-gated heavy maintenance.', false);
@@ -475,10 +512,14 @@ function collect(value, previous) {
 /**
  * @summary Runs the CLI from process argv.
  * @param {String[]} argv
- * @returns {Object}
+ * @param {Object} options
+ * @param {Object} [options.aiConfig] Runtime or template Memory Core config.
+ * @returns {Promise<Object>}
  */
-export function runCli(argv = process.argv) {
-    const command = createCommand();
+export async function runCli(argv = process.argv, {aiConfig = null} = {}) {
+    aiConfig ??= await loadMemoryCoreConfig();
+
+    const command = createCommand({aiConfig});
 
     command.parse(argv);
 
@@ -499,5 +540,5 @@ export function runCli(argv = process.argv) {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    runCli();
+    await runCli();
 }

--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -1,0 +1,503 @@
+import {Command}                      from 'commander';
+import Database                       from 'better-sqlite3';
+import fs                             from 'fs-extra';
+import path                           from 'path';
+import {fileURLToPath, pathToFileURL} from 'url';
+
+/**
+ * @module ai.scripts.maintenance.compactGraphLog
+ * @summary Dry-run-first maintenance CLI for pruning consumed SQLite GraphLog rows.
+ *
+ * `GraphLog` is the Native Edge Graph CDC table. Consumers advance by durable watermarks
+ * (`WHERE log_id > watermark`), so rows at or below the minimum known live-consumer
+ * watermark are replay-dead. This script computes that cutoff, blocks on unknown active
+ * consumers, and deletes only under `--apply`.
+ *
+ * Usage:
+ *   node ai/scripts/maintenance/compactGraphLog.mjs
+ *   node ai/scripts/maintenance/compactGraphLog.mjs --apply
+ *   node ai/scripts/maintenance/compactGraphLog.mjs --apply --vacuum
+ *   node ai/scripts/maintenance/compactGraphLog.mjs --consumer-watermark remote=123456
+ *
+ * @see ai/graph/storage/SQLite.mjs
+ * @see ai/daemons/bridge/queries.mjs
+ */
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+
+export const DEFAULT_DB_PATH            = path.join(PROJECT_ROOT, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
+export const DEFAULT_BRIDGE_STATE_FILE  = path.join(PROJECT_ROOT, '.neo-ai-data/wake-daemon/lastSyncId');
+export const DEFAULT_WAKE_STATE_FILE    = path.join(PROJECT_ROOT, '.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor');
+export const DEFAULT_SAFETY_MARGIN_ROWS = 1000;
+
+/**
+ * @summary Parses a non-negative integer CLI value.
+ * @param {String|Number} value
+ * @param {String} name
+ * @returns {Number}
+ */
+export function parseNonNegativeInteger(value, name) {
+    const parsed = Number(value);
+
+    if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new Error(`${name} must be a non-negative integer; received ${value}`);
+    }
+
+    return parsed;
+}
+
+/**
+ * @summary Parses `name=logId` consumer-watermark CLI values.
+ * @param {String} value
+ * @returns {{name:String, watermark:Number}}
+ */
+export function parseConsumerWatermark(value) {
+    const separator = value.indexOf('=');
+
+    if (separator <= 0 || separator === value.length - 1) {
+        throw new Error(`Consumer watermark must use name=logId shape; received ${value}`);
+    }
+
+    return {
+        name     : value.slice(0, separator),
+        watermark: parseNonNegativeInteger(value.slice(separator + 1), value.slice(0, separator))
+    };
+}
+
+/**
+ * @summary Reads high-level GraphLog size and boundary stats.
+ * @param {Object} options
+ * @param {Database} options.db
+ * @param {String} [options.dbPath]
+ * @param {Object} [options.fsModule=fs]
+ * @returns {Object}
+ */
+export function getGraphLogStats({db, dbPath = null, fsModule = fs}) {
+    const row = db.prepare(`
+        SELECT
+            COUNT(*)    AS rowCount,
+            MIN(log_id) AS minLogId,
+            MAX(log_id) AS maxLogId
+        FROM GraphLog
+    `).get();
+
+    const pageSize     = db.pragma('page_size', {simple: true});
+    const pageCount    = db.pragma('page_count', {simple: true});
+    const freelist     = db.pragma('freelist_count', {simple: true});
+    const fileSize     = dbPath && fsModule.existsSync(dbPath) ? fsModule.statSync(dbPath).size : null;
+    const graphLogSize = db.prepare(`
+        SELECT COALESCE(SUM(pgsize), 0) AS bytes
+        FROM dbstat
+        WHERE name = 'GraphLog'
+    `).get()?.bytes ?? null;
+
+    return {
+        rowCount    : row.rowCount || 0,
+        minLogId    : row.minLogId || 0,
+        maxLogId    : row.maxLogId || 0,
+        pageSize,
+        pageCount,
+        freelist,
+        fileSize,
+        graphLogSize
+    };
+}
+
+/**
+ * @summary Reads the bridge daemon's durable `lastSyncId` watermark.
+ * @param {Object} options
+ * @param {String} options.stateFile
+ * @param {Number} options.latestLogId
+ * @param {Object} [options.fsModule=fs]
+ * @returns {{name:String, watermark:Number, source:String}}
+ */
+export function readBridgeWatermark({stateFile, latestLogId, fsModule = fs}) {
+    if (fsModule.existsSync(stateFile)) {
+        const raw = fsModule.readFileSync(stateFile, 'utf8').trim();
+
+        return {
+            name     : 'bridge-daemon',
+            watermark: parseNonNegativeInteger(raw || '0', 'bridge-daemon lastSyncId'),
+            source   : stateFile
+        };
+    }
+
+    // Mirrors bridge daemon boot semantics: absent state starts at current GraphLog head.
+    return {
+        name     : 'bridge-daemon',
+        watermark: latestLogId,
+        source   : 'latest-log-id fallback (state file absent)'
+    };
+}
+
+/**
+ * @summary Reads an optional durable WakeSubscriptionService live cursor.
+ * @param {Object} options
+ * @param {String} options.stateFile
+ * @param {Object} [options.fsModule=fs]
+ * @returns {{name:String, watermark:Number, source:String}|null}
+ */
+export function readWakeSubscriptionWatermark({stateFile, fsModule = fs}) {
+    if (!fsModule.existsSync(stateFile)) return null;
+
+    const raw = fsModule.readFileSync(stateFile, 'utf8').trim();
+
+    return {
+        name     : 'wake-subscription-live-cursor',
+        watermark: parseNonNegativeInteger(raw || '0', 'wake-subscription-live-cursor'),
+        source   : stateFile
+    };
+}
+
+/**
+ * @summary Lists active graph-resident wake subscriptions from SQLite.
+ * @param {Object} options
+ * @param {Database} options.db
+ * @returns {Object[]}
+ */
+export function listActiveWakeSubscriptions({db}) {
+    const table = db.prepare(`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name = 'Nodes'
+    `).get();
+
+    if (!table) return [];
+
+    return db.prepare(`
+        SELECT id, data FROM Nodes
+        WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+          AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+    `).all()
+        .map(row => parseWakeSubscriptionRow(row))
+        .filter(Boolean);
+}
+
+/**
+ * @summary Converts a durable WAKE_SUBSCRIPTION node row into a compact consumer descriptor.
+ * @param {Object} row
+ * @returns {Object|null}
+ */
+export function parseWakeSubscriptionRow(row) {
+    try {
+        const node  = JSON.parse(row.data);
+        const props = node.properties || {};
+
+        return {
+            id           : row.id,
+            agentIdentity: props.agentIdentity || null,
+            harnessTarget: props.harnessTarget || null,
+            trigger      : props.trigger || null,
+            status       : props.status || 'active'
+        };
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * @summary Finds an explicit supplied watermark for a subscription.
+ * @param {Object} subscription
+ * @param {Object[]} extraWatermarks
+ * @returns {Object|null}
+ */
+export function findExplicitSubscriptionWatermark(subscription, extraWatermarks = []) {
+    const aliases = new Set([
+        subscription.id,
+        subscription.agentIdentity,
+        subscription.harnessTarget ? `harnessTarget:${subscription.harnessTarget}` : null
+    ].filter(Boolean));
+
+    return extraWatermarks.find(entry => aliases.has(entry.name)) || null;
+}
+
+/**
+ * @summary Computes the safe GraphLog compaction cutoff from known consumer watermarks.
+ * @param {Object} options
+ * @param {Object} options.stats
+ * @param {Object} options.bridgeWatermark
+ * @param {Object[]} [options.subscriptions=[]]
+ * @param {Object[]} [options.extraWatermarks=[]]
+ * @param {Number} [options.wakeLiveCursor=null]
+ * @param {Number} [options.safetyMarginRows=DEFAULT_SAFETY_MARGIN_ROWS]
+ * @returns {Object}
+ */
+export function computeCompactionPlan({
+    stats,
+    bridgeWatermark,
+    subscriptions       = [],
+    extraWatermarks     = [],
+    wakeLiveCursor      = null,
+    wakeWatermark       = null,
+    safetyMarginRows    = DEFAULT_SAFETY_MARGIN_ROWS
+}) {
+    const consumers        = [...extraWatermarks];
+    const unknownConsumers = [];
+    const bridgeNeeded     = subscriptions.some(sub => sub.harnessTarget === 'bridge-daemon');
+    const mcpNeeded        = subscriptions.some(sub => sub.harnessTarget === 'mcp-notifications');
+
+    if (bridgeNeeded) {
+        consumers.push(bridgeWatermark);
+    }
+
+    if (mcpNeeded) {
+        if (Number.isInteger(wakeLiveCursor)) {
+            consumers.push({name: 'wake-subscription-live-cursor', watermark: wakeLiveCursor});
+        } else if (wakeWatermark) {
+            consumers.push(wakeWatermark);
+        } else {
+            unknownConsumers.push({
+                name  : 'wake-subscription-live-cursor',
+                reason: 'active mcp-notifications subscriptions have no durable cursor file'
+            });
+        }
+    }
+
+    for (const sub of subscriptions) {
+        if (sub.harnessTarget === 'bridge-daemon' || sub.harnessTarget === 'mcp-notifications') {
+            continue;
+        }
+
+        if (sub.harnessTarget === 'disabled' || sub.harnessTarget === 'none') {
+            continue;
+        }
+
+        const explicit = findExplicitSubscriptionWatermark(sub, extraWatermarks);
+
+        if (explicit) {
+            continue;
+        }
+
+        unknownConsumers.push({
+            name  : sub.id,
+            reason: `active ${sub.harnessTarget || 'unknown'} subscription has no supplied durable watermark`
+        });
+    }
+
+    if (unknownConsumers.length > 0) {
+        return {
+            canApply        : false,
+            cutoffLogId     : 0,
+            consumers,
+            unknownConsumers,
+            reason          : 'unknown-consumer-watermark',
+            safetyMarginRows
+        };
+    }
+
+    if (consumers.length === 0) {
+        return {
+            canApply        : false,
+            cutoffLogId     : 0,
+            consumers,
+            unknownConsumers,
+            reason          : 'no-known-consumer-watermark',
+            safetyMarginRows
+        };
+    }
+
+    const minWatermark = Math.min(...consumers.map(entry => entry.watermark));
+    const cutoffLogId  = Math.max(0, Math.min(stats.maxLogId, minWatermark - safetyMarginRows));
+
+    return {
+        canApply        : cutoffLogId > 0,
+        cutoffLogId,
+        consumers,
+        unknownConsumers,
+        minWatermark,
+        reason          : cutoffLogId > 0 ? 'ready' : 'cutoff-not-positive',
+        safetyMarginRows
+    };
+}
+
+/**
+ * @summary Deletes GraphLog rows through a safe cutoff, optionally dry-run only.
+ * @param {Object} options
+ * @param {Database} options.db
+ * @param {Number} options.cutoffLogId
+ * @param {Boolean} [options.apply=false]
+ * @returns {{eligibleRows:Number, deletedRows:Number}}
+ */
+export function compactGraphLogRows({db, cutoffLogId, apply = false}) {
+    const eligibleRows = db.prepare('SELECT COUNT(*) AS count FROM GraphLog WHERE log_id <= ?').get(cutoffLogId).count || 0;
+
+    if (!apply || eligibleRows === 0) {
+        return {eligibleRows, deletedRows: 0};
+    }
+
+    const result = db.prepare('DELETE FROM GraphLog WHERE log_id <= ?').run(cutoffLogId);
+
+    return {eligibleRows, deletedRows: result.changes || 0};
+}
+
+/**
+ * @summary Runs a WAL truncate checkpoint after compaction.
+ * @param {Database} db
+ * @returns {Object}
+ */
+export function checkpointWal(db) {
+    return db.pragma('wal_checkpoint(TRUNCATE)');
+}
+
+/**
+ * @summary Executes the full compaction planning and optional apply flow.
+ * @param {Object} options
+ * @returns {Object}
+ */
+export function runGraphLogCompaction({
+    dbPath             = DEFAULT_DB_PATH,
+    bridgeStateFile   = DEFAULT_BRIDGE_STATE_FILE,
+    wakeStateFile     = DEFAULT_WAKE_STATE_FILE,
+    safetyMarginRows  = DEFAULT_SAFETY_MARGIN_ROWS,
+    extraWatermarks   = [],
+    wakeLiveCursor    = null,
+    apply             = false,
+    vacuum            = false,
+    checkpoint        = true,
+    fsModule          = fs,
+    logger            = console
+} = {}) {
+    const db = new Database(dbPath, {fileMustExist: true});
+
+    try {
+        db.pragma('journal_mode = WAL');
+        db.pragma('busy_timeout = 5000');
+
+        const before          = getGraphLogStats({db, dbPath, fsModule});
+        const subscriptions   = listActiveWakeSubscriptions({db});
+        const bridgeWatermark = readBridgeWatermark({
+            stateFile  : bridgeStateFile,
+            latestLogId: before.maxLogId,
+            fsModule
+        });
+        const wakeWatermark = wakeLiveCursor === null
+            ? readWakeSubscriptionWatermark({stateFile: wakeStateFile, fsModule})
+            : null;
+        const plan = computeCompactionPlan({
+            stats: before,
+            bridgeWatermark,
+            subscriptions,
+            extraWatermarks,
+            wakeLiveCursor,
+            wakeWatermark,
+            safetyMarginRows
+        });
+
+        const compaction = plan.canApply
+            ? compactGraphLogRows({db, cutoffLogId: plan.cutoffLogId, apply})
+            : {eligibleRows: 0, deletedRows: 0};
+
+        let checkpointResult = null;
+        if (apply && checkpoint && compaction.deletedRows > 0) {
+            checkpointResult = checkpointWal(db);
+        }
+
+        if (apply && vacuum && compaction.deletedRows > 0) {
+            db.exec('VACUUM');
+        }
+
+        const after = getGraphLogStats({db, dbPath, fsModule});
+        const result = {before, after, subscriptions, bridgeWatermark, wakeWatermark, plan, compaction, checkpointResult};
+
+        logCompactionResult(result, {apply, vacuum, logger});
+
+        return result;
+    } finally {
+        db.close();
+    }
+}
+
+/**
+ * @summary Logs a concise human-readable compaction report.
+ * @param {Object} result
+ * @param {Object} options
+ */
+export function logCompactionResult(result, {apply = false, vacuum = false, logger = console} = {}) {
+    const {before, after, plan, compaction, subscriptions, bridgeWatermark, wakeWatermark} = result;
+
+    logger.log(`GraphLog compaction ${apply ? 'APPLY' : 'DRY-RUN'}`);
+    logger.log(`  rows: ${before.rowCount} before -> ${after.rowCount} after`);
+    logger.log(`  max log_id: ${before.maxLogId}; cutoff: ${plan.cutoffLogId}; safety margin: ${plan.safetyMarginRows}`);
+    logger.log(`  active wake subscriptions: ${subscriptions.length}`);
+    logger.log(`  bridge watermark: ${bridgeWatermark.watermark} (${bridgeWatermark.source})`);
+    logger.log(`  wake subscription watermark: ${wakeWatermark ? `${wakeWatermark.watermark} (${wakeWatermark.source})` : '(missing)'}`);
+
+    if (!plan.canApply) {
+        logger.log(`  blocked: ${plan.reason}`);
+        for (const consumer of plan.unknownConsumers) {
+            logger.log(`    unknown ${consumer.name}: ${consumer.reason}`);
+        }
+        return;
+    }
+
+    logger.log(`  eligible rows: ${compaction.eligibleRows}`);
+
+    if (!apply) {
+        logger.log('  dry-run only; re-run with --apply to delete eligible rows.');
+        return;
+    }
+
+    logger.log(`  deleted rows: ${compaction.deletedRows}`);
+    logger.log(`  wal checkpoint: ${compaction.deletedRows > 0 ? 'complete' : 'skipped'}`);
+    logger.log(`  vacuum: ${vacuum && compaction.deletedRows > 0 ? 'complete' : 'skipped'}`);
+}
+
+/**
+ * @summary Creates the CLI command object.
+ * @returns {Command}
+ */
+export function createCommand() {
+    return new Command()
+        .name('compactGraphLog')
+        .description('Dry-run-first GraphLog CDC compaction past known consumer watermarks.')
+        .option('--apply', 'Actually delete eligible GraphLog rows. Without this flag the script is dry-run only.', false)
+        .option('--db <path>', 'SQLite graph db path.', DEFAULT_DB_PATH)
+        .option('--bridge-state-file <path>', 'Bridge daemon lastSyncId file.', DEFAULT_BRIDGE_STATE_FILE)
+        .option('--wake-state-file <path>', 'WakeSubscriptionService live cursor file.', DEFAULT_WAKE_STATE_FILE)
+        .option('--safety-margin <rows>', 'Rows to retain below the minimum known consumer watermark.', String(DEFAULT_SAFETY_MARGIN_ROWS))
+        .option('--consumer-watermark <name=logId>', 'Additional durable consumer watermark. May be repeated.', collect, [])
+        .option('--wake-live-cursor <logId>', 'Current WakeSubscriptionService liveCursor when active mcp-notifications consumers exist.')
+        .option('--vacuum', 'Run VACUUM after deletion to physically shrink the SQLite db. Operator-gated heavy maintenance.', false);
+}
+
+/**
+ * @summary Commander collector for repeatable options.
+ * @param {String} value
+ * @param {String[]} previous
+ * @returns {String[]}
+ */
+function collect(value, previous) {
+    previous.push(value);
+    return previous;
+}
+
+/**
+ * @summary Runs the CLI from process argv.
+ * @param {String[]} argv
+ * @returns {Object}
+ */
+export function runCli(argv = process.argv) {
+    const command = createCommand();
+
+    command.parse(argv);
+
+    const options = command.opts();
+
+    return runGraphLogCompaction({
+        dbPath           : path.resolve(options.db),
+        bridgeStateFile : path.resolve(options.bridgeStateFile),
+        wakeStateFile   : path.resolve(options.wakeStateFile),
+        safetyMarginRows: parseNonNegativeInteger(options.safetyMargin, 'safety-margin'),
+        extraWatermarks : options.consumerWatermark.map(parseConsumerWatermark),
+        wakeLiveCursor  : options.wakeLiveCursor === undefined
+            ? null
+            : parseNonNegativeInteger(options.wakeLiveCursor, 'wake-live-cursor'),
+        apply           : options.apply,
+        vacuum          : options.vacuum
+    });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    runCli();
+}

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -1,4 +1,6 @@
 import crypto                 from 'crypto';
+import fs                     from 'fs-extra';
+import path                   from 'path';
 import Base                   from '../../../src/core/Base.mjs';
 import GraphService           from './GraphService.mjs';
 import RequestContextService  from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -10,7 +12,7 @@ import CoalescingEngineService from './CoalescingEngineService.mjs';
  * `manage_wake_subscription` MCP tool surface — the graph-backed substrate for
  * cross-harness autonomous wake delivery.
  *
- * Subscriptions are graph-resident (durable across MCP server restarts per ADR 0002 §6.6.2)
+ * Subscriptions are graph-resident (durable across MCP server restarts per ADR 0002 §6.6.2; ticket-ref-ok: decision-record authority, not issue archaeology)
  * with a write-through in-memory cache for sub-millisecond trigger evaluation.
  * Per-agent ownership is enforced via `RequestContextService.getAgentIdentityNodeId()`
  * and an explicit `SUBSCRIBES_TO` edge from the AgentIdentity node to the WAKE_SUBSCRIPTION
@@ -95,6 +97,12 @@ class WakeSubscriptionService extends Base {
     liveCursor = 0
 
     /**
+     * @member {String} liveCursorStateFile='.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor'
+     * @protected
+     */
+    liveCursorStateFile = path.resolve(process.env.NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE || '.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor')
+
+    /**
      * Sets the initial live cursor to the current graph log head to prevent
      * replaying historical events on boot.
      */
@@ -104,7 +112,7 @@ class WakeSubscriptionService extends Base {
         if (storage?.db) {
             try {
                 const row = storage.db.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get();
-                this.liveCursor = row.maxId || 0;
+                this._setLiveCursor(row.maxId || 0);
             } catch (e) {
                 logger.warn('[WakeSubscription] Failed to read max log_id on init', e);
             }
@@ -137,7 +145,7 @@ class WakeSubscriptionService extends Base {
 
             const delta = storage.getDeltaLog(this.liveCursor);
             if (delta.invalidEdges.length === 0 && delta.invalidNodes.length === 0) {
-                this.liveCursor = delta.lastLogId;
+                this._setLiveCursor(delta.lastLogId);
                 return;
             }
 
@@ -149,7 +157,7 @@ class WakeSubscriptionService extends Base {
                 .filter(sub => sub.harnessTarget === 'mcp-notifications' && sub.status === 'active');
 
             if (activeSubs.length === 0) {
-                this.liveCursor = delta.lastLogId;
+                this._setLiveCursor(delta.lastLogId);
                 return;
             }
 
@@ -167,11 +175,48 @@ class WakeSubscriptionService extends Base {
             }
 
 
-            this.liveCursor = delta.lastLogId;
+            this._setLiveCursor(delta.lastLogId);
         } catch (e) {
             logger.error('[WakeSubscription] Background pump failed:', e);
         } finally {
             this._pumping = false;
+        }
+    }
+
+    /**
+     * @summary Advances the in-process GraphLog cursor and mirrors it to an operator-readable file.
+     *
+     * The file is the durable watermark consumed by `ai:compact-graphlog`; it is intentionally
+     * outside the graph so persisting the cursor does not recursively append another GraphLog row.
+     *
+     * @param {Number} logId
+     * @protected
+     */
+    _setLiveCursor(logId) {
+        const next = Number.isFinite(Number(logId)) ? Number(logId) : 0;
+
+        this.liveCursor = next;
+        this._persistLiveCursor();
+    }
+
+    /**
+     * @summary Persists the WakeSubscriptionService GraphLog cursor for maintenance compaction.
+     *
+     * Unit tests skip the default repo-local state write unless they provide an explicit
+     * `NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE` override.
+     *
+     * @protected
+     */
+    _persistLiveCursor() {
+        if (process.env.UNIT_TEST_MODE === 'true' && !process.env.NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE) {
+            return;
+        }
+
+        try {
+            fs.ensureDirSync(path.dirname(this.liveCursorStateFile));
+            fs.writeFileSync(this.liveCursorStateFile, String(this.liveCursor), 'utf8');
+        } catch (e) {
+            logger.warn(`[WakeSubscription] Failed to persist live cursor at ${this.liveCursorStateFile}`, e);
         }
     }
 
@@ -195,7 +240,7 @@ class WakeSubscriptionService extends Base {
 
     /**
      * Unified entry point for the `manage_wake_subscription` MCP tool. Dispatches to
-     * action-specific handlers per ADR 0002 §6.6.
+     * action-specific handlers per ADR 0002 §6.6. ticket-ref-ok: decision-record authority, not issue archaeology
      *
      * @param {Object} opts
      * @param {String} opts.action One of 'subscribe' | 'unsubscribe' | 'update' | 'list' | 'resync'
@@ -414,7 +459,7 @@ class WakeSubscriptionService extends Base {
         const now            = new Date().toISOString();
 
         // Shape B requires an HMAC signing key for webhook authenticity.
-        // Per ADR 0002 §6.2.3 the server generates and returns it once at subscribe-time;
+            // Per ADR 0002 §6.2.3 the server generates and returns it once at subscribe-time; ticket-ref-ok: decision-record authority, not issue archaeology
         // it is stored in the node's harnessTargetMetadata for subsequent verification.
         let signingKey;
         if (harnessTarget === 'a2a-webhook') {
@@ -653,7 +698,7 @@ class WakeSubscriptionService extends Base {
      * starting from `sinceLogId`. Returns the matching event payloads as data; the
      * channel-specific re-emission (MCP notifications / webhook POST / daemon dispatch)
      * is the responsibility of Shape A/B/C consumers wiring this output to their
-     * delivery surfaces. Per ADR 0002 §6.1.6 + §6.6.2.
+     * delivery surfaces. Per ADR 0002 §6.1.6 + §6.6.2. ticket-ref-ok: decision-record authority, not issue archaeology
      *
      * @param {Object} opts
      * @param {String} opts.subscriptionId
@@ -708,7 +753,7 @@ class WakeSubscriptionService extends Base {
 
     /**
      * Retrieves the specific GraphLog log_id for an entity, to anchor the wake event
-     * per ADR 0002 §6.1.6.
+     * per ADR 0002 §6.1.6. ticket-ref-ok: decision-record authority, not issue archaeology
      * @protected
      * @param {String} entityId
      * @returns {Number|null}
@@ -853,7 +898,7 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
-     * Wraps a payload in the standard wake notification envelope per ADR 0002 §6.1.1-§6.1.3.
+     * Wraps a payload in the standard wake notification envelope per ADR 0002 §6.1.1-§6.1.3. ticket-ref-ok: decision-record authority, not issue archaeology
      * @protected
      * @param {String} eventType One of `wake/sent_to_me`, `wake/task_state_changed`, `wake/permission_granted`, `wake/heartbeat_pulse`
      * @param {Object} subscription Cached WAKE_SUBSCRIPTION entry (provides `id` + `agentIdentity`)

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -3,6 +3,7 @@ import fs                     from 'fs-extra';
 import path                   from 'path';
 import Base                   from '../../../src/core/Base.mjs';
 import GraphService           from './GraphService.mjs';
+import aiConfig               from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService  from '../../mcp/server/shared/services/RequestContextService.mjs';
 import logger                 from '../../mcp/server/memory-core/logger.mjs';
 import CoalescingEngineService from './CoalescingEngineService.mjs';
@@ -97,10 +98,10 @@ class WakeSubscriptionService extends Base {
     liveCursor = 0
 
     /**
-     * @member {String} liveCursorStateFile='.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor'
+     * @member {String} liveCursorStateFile
      * @protected
      */
-    liveCursorStateFile = path.resolve(process.env.NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE || '.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor')
+    liveCursorStateFile = aiConfig.wakeDaemon.wakeSubscriptionLiveCursorPath
 
     /**
      * Sets the initial live cursor to the current graph log head to prevent

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "ai:check-identity-facts"      : "node ./ai/scripts/diagnostics/check-identity-facts.mjs",
         "ai:check-retired-primitives"  : "node ./ai/scripts/diagnostics/check-retired-primitives.mjs",
         "ai:check-substrate-size"      : "node ./ai/scripts/diagnostics/check-substrate-size.mjs",
+        "ai:compact-graphlog"          : "node ./ai/scripts/maintenance/compactGraphLog.mjs",
         "ai:restore"                   : "node ./ai/scripts/maintenance/restore.mjs",
         "ai:build-kb-faqs"             : "node ./ai/scripts/maintenance/buildKbAgentFaqs.mjs",
         "ai:defrag-kb"                 : "node ./ai/scripts/maintenance/defragChromaDB.mjs --target knowledge-base",

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -127,6 +127,25 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.graphProvider).toBe('openAiCompatible');
     });
 
+    test('declares GraphLog compaction watermark paths', () => {
+        expect(config.wakeDaemon.bridgeLastSyncIdPath).toContain('.neo-ai-data/wake-daemon/lastSyncId');
+        expect(config.wakeDaemon.wakeSubscriptionLiveCursorPath).toContain('.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor');
+    });
+
+    test('env overrides GraphLog compaction watermark paths', () => {
+        process.env.NEO_BRIDGE_LAST_SYNC_ID_PATH = '/tmp/neo-bridge-last-sync-id';
+        process.env.NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE = '/tmp/neo-wake-live-cursor';
+
+        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+
+        try {
+            expect(freshCfg.wakeDaemon.bridgeLastSyncIdPath).toBe('/tmp/neo-bridge-last-sync-id');
+            expect(freshCfg.wakeDaemon.wakeSubscriptionLiveCursorPath).toBe('/tmp/neo-wake-live-cursor');
+        } finally {
+            freshCfg.destroy();
+        }
+    });
+
     test('env overrides remain final after Tier-1 default mapping', () => {
         process.env.NEO_MODEL_PROVIDER = 'openAiCompatible';
         process.env.NEO_GRAPH_PROVIDER = 'ollama';

--- a/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
@@ -1,0 +1,189 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AiCompactGraphLogTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import Database       from 'better-sqlite3';
+import fs             from 'fs-extra';
+import path           from 'path';
+
+import {
+    compactGraphLogRows,
+    computeCompactionPlan,
+    getGraphLogStats,
+    listActiveWakeSubscriptions,
+    parseConsumerWatermark,
+    readBridgeWatermark,
+    readWakeSubscriptionWatermark,
+    runGraphLogCompaction
+} from '../../../../../../ai/scripts/maintenance/compactGraphLog.mjs';
+
+/**
+ * @summary Regression guard for GraphLog CDC compaction safety.
+ *
+ * The maintenance script may only delete rows at or below the minimum known live-consumer
+ * watermark, must block on unknown active consumers, and is dry-run by default.
+ */
+test.describe('compactGraphLog maintenance guard', () => {
+    let tmpRoot, dbPath, bridgeStateFile, wakeStateFile, db;
+
+    test.beforeEach(async () => {
+        tmpRoot         = path.resolve(process.cwd(), 'tmp', `compact-graphlog-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        dbPath          = path.join(tmpRoot, 'memory-core-graph.sqlite');
+        bridgeStateFile = path.join(tmpRoot, 'wake-daemon', 'lastSyncId');
+        wakeStateFile   = path.join(tmpRoot, 'wake-daemon', 'wakeSubscriptionLiveCursor');
+
+        await fs.ensureDir(path.dirname(bridgeStateFile));
+
+        db = new Database(dbPath);
+        db.exec(`
+            CREATE TABLE GraphLog (
+                log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_id TEXT NOT NULL,
+                entity_type TEXT NOT NULL
+            );
+            CREATE TABLE Nodes (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            );
+        `);
+    });
+
+    test.afterEach(async () => {
+        db?.close();
+        db = null;
+        await fs.remove(tmpRoot);
+    });
+
+    function insertGraphLogRows(count) {
+        const insert = db.prepare('INSERT INTO GraphLog(entity_id, entity_type) VALUES (?, ?)');
+
+        for (let i = 1; i <= count; i++) {
+            insert.run(`entity-${i}`, i % 2 === 0 ? 'nodes' : 'edges');
+        }
+    }
+
+    function insertWakeSubscription(id, properties) {
+        db.prepare('INSERT INTO Nodes(id, data) VALUES (?, ?)').run(id, JSON.stringify({
+            id,
+            label     : 'WAKE_SUBSCRIPTION',
+            properties: {
+                status: 'active',
+                ...properties
+            }
+        }));
+    }
+
+    test('computes cutoff from the minimum known consumer watermark plus safety margin', () => {
+        const plan = computeCompactionPlan({
+            stats          : {maxLogId: 20},
+            bridgeWatermark: {name: 'bridge-daemon', watermark: 18},
+            subscriptions  : [{id: 'WAKE_SUB:1', harnessTarget: 'bridge-daemon'}],
+            extraWatermarks: [parseConsumerWatermark('remote-worker=12')],
+            safetyMarginRows: 2
+        });
+
+        expect(plan.canApply).toBe(true);
+        expect(plan.minWatermark).toBe(12);
+        expect(plan.cutoffLogId).toBe(10);
+    });
+
+    test('blocks when an active mcp-notifications consumer has no durable cursor', () => {
+        const plan = computeCompactionPlan({
+            stats          : {maxLogId: 20},
+            bridgeWatermark: {name: 'bridge-daemon', watermark: 18},
+            subscriptions  : [{id: 'WAKE_SUB:2', harnessTarget: 'mcp-notifications'}],
+            safetyMarginRows: 2
+        });
+
+        expect(plan.canApply).toBe(false);
+        expect(plan.reason).toBe('unknown-consumer-watermark');
+        expect(plan.unknownConsumers[0].name).toBe('wake-subscription-live-cursor');
+    });
+
+    test('uses a durable wake cursor when active mcp-notifications consumers exist', () => {
+        const plan = computeCompactionPlan({
+            stats          : {maxLogId: 20},
+            bridgeWatermark: {name: 'bridge-daemon', watermark: 18},
+            wakeWatermark  : {name: 'wake-subscription-live-cursor', watermark: 15},
+            subscriptions  : [{id: 'WAKE_SUB:2', harnessTarget: 'mcp-notifications'}],
+            safetyMarginRows: 2
+        });
+
+        expect(plan.canApply).toBe(true);
+        expect(plan.minWatermark).toBe(15);
+        expect(plan.cutoffLogId).toBe(13);
+    });
+
+    test('dry-run reports eligible rows without deleting; apply deletes only through cutoff', () => {
+        insertGraphLogRows(10);
+
+        const dryRun = compactGraphLogRows({db, cutoffLogId: 5, apply: false});
+        expect(dryRun).toEqual({eligibleRows: 5, deletedRows: 0});
+        expect(getGraphLogStats({db, dbPath}).rowCount).toBe(10);
+
+        const applied = compactGraphLogRows({db, cutoffLogId: 5, apply: true});
+        expect(applied).toEqual({eligibleRows: 5, deletedRows: 5});
+
+        const remaining = db.prepare('SELECT log_id FROM GraphLog ORDER BY log_id ASC').all().map(row => row.log_id);
+        expect(remaining).toEqual([6, 7, 8, 9, 10]);
+    });
+
+    test('runGraphLogCompaction uses bridge state and preserves unsynced rows above cutoff', async () => {
+        insertGraphLogRows(10);
+        insertWakeSubscription('WAKE_SUB:bridge', {
+            agentIdentity: '@neo-gpt',
+            harnessTarget: 'bridge-daemon',
+            trigger      : 'SENT_TO_ME'
+        });
+        await fs.writeFile(bridgeStateFile, '8', 'utf8');
+
+        const result = runGraphLogCompaction({
+            dbPath,
+            bridgeStateFile,
+            wakeStateFile,
+            safetyMarginRows: 1,
+            apply           : true,
+            checkpoint      : false,
+            logger          : {log: () => {}}
+        });
+
+        expect(result.plan.cutoffLogId).toBe(7);
+        expect(result.compaction.deletedRows).toBe(7);
+
+        const remaining = db.prepare('SELECT log_id FROM GraphLog ORDER BY log_id ASC').all().map(row => row.log_id);
+        expect(remaining).toEqual([8, 9, 10]);
+    });
+
+    test('lists active wake subscriptions and reads missing bridge state as latest-log fallback', () => {
+        insertGraphLogRows(4);
+        insertWakeSubscription('WAKE_SUB:bridge', {
+            agentIdentity: '@neo-gpt',
+            harnessTarget: 'bridge-daemon',
+            trigger      : 'SENT_TO_ME'
+        });
+        insertWakeSubscription('WAKE_SUB:retired', {
+            agentIdentity: '@neo-gpt',
+            harnessTarget: 'bridge-daemon',
+            status       : 'retired',
+            trigger      : 'SENT_TO_ME'
+        });
+
+        const subscriptions = listActiveWakeSubscriptions({db});
+        expect(subscriptions.map(sub => sub.id)).toEqual(['WAKE_SUB:bridge']);
+
+        const stats = getGraphLogStats({db, dbPath});
+        const bridge = readBridgeWatermark({stateFile: bridgeStateFile, latestLogId: stats.maxLogId});
+        const missingWake = readWakeSubscriptionWatermark({stateFile: wakeStateFile});
+
+        expect(bridge.watermark).toBe(4);
+        expect(bridge.source).toContain('latest-log-id fallback');
+        expect(missingWake).toBe(null);
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
@@ -12,10 +12,13 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import Database       from 'better-sqlite3';
 import fs             from 'fs-extra';
 import path           from 'path';
+import MemoryCoreConfigTemplate from '../../../../../../ai/mcp/server/memory-core/config.template.mjs';
 
 import {
     compactGraphLogRows,
     computeCompactionPlan,
+    createCommand,
+    getDefaultGraphLogCompactionOptions,
     getGraphLogStats,
     listActiveWakeSubscriptions,
     parseConsumerWatermark,
@@ -79,6 +82,21 @@ test.describe('compactGraphLog maintenance guard', () => {
             }
         }));
     }
+
+    test('resolves CLI defaults from the Memory Core template config in tests', () => {
+        const defaults = getDefaultGraphLogCompactionOptions({aiConfig: MemoryCoreConfigTemplate});
+        const command  = createCommand({aiConfig: MemoryCoreConfigTemplate});
+
+        command.parse([], {from: 'user'});
+
+        expect(defaults.dbPath).toBe(MemoryCoreConfigTemplate.storagePaths.graph);
+        expect(defaults.bridgeStateFile).toBe(MemoryCoreConfigTemplate.wakeDaemon.bridgeLastSyncIdPath);
+        expect(defaults.wakeStateFile).toBe(MemoryCoreConfigTemplate.wakeDaemon.wakeSubscriptionLiveCursorPath);
+
+        expect(command.opts().db).toBe(defaults.dbPath);
+        expect(command.opts().bridgeStateFile).toBe(defaults.bridgeStateFile);
+        expect(command.opts().wakeStateFile).toBe(defaults.wakeStateFile);
+    });
 
     test('computes cutoff from the minimum known consumer watermark plus safety margin', () => {
         const plan = computeCompactionPlan({

--- a/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
@@ -12,7 +12,6 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import Database       from 'better-sqlite3';
 import fs             from 'fs-extra';
 import path           from 'path';
-import MemoryCoreConfigTemplate from '../../../../../../ai/mcp/server/memory-core/config.template.mjs';
 
 import {
     compactGraphLogRows,
@@ -35,6 +34,56 @@ import {
  */
 test.describe('compactGraphLog maintenance guard', () => {
     let tmpRoot, dbPath, bridgeStateFile, wakeStateFile, db;
+
+    async function withMemoryCoreConfigTemplate(callback) {
+        const originalTier1Config         = Neo.ai?.Config;
+        const originalTier1ClassHierarchy = Neo.classHierarchyMap?.['Neo.ai.Config'];
+        const originalConfig              = Neo.ai?.mcp?.server?.['memory-core']?.Config;
+        const originalClassHierarchy      = Neo.classHierarchyMap?.['Neo.ai.mcp.server.memory-core.Config'];
+
+        if (Neo.ai?.Config) {
+            delete Neo.ai.Config;
+        }
+        if (Neo.classHierarchyMap?.['Neo.ai.Config']) {
+            delete Neo.classHierarchyMap['Neo.ai.Config'];
+        }
+        if (Neo.ai?.mcp?.server?.['memory-core']?.Config) {
+            delete Neo.ai.mcp.server['memory-core'].Config;
+        }
+        if (Neo.classHierarchyMap?.['Neo.ai.mcp.server.memory-core.Config']) {
+            delete Neo.classHierarchyMap['Neo.ai.mcp.server.memory-core.Config'];
+        }
+
+        const config = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
+
+        try {
+            return await callback(config);
+        } finally {
+            if (originalTier1Config !== undefined) {
+                Neo.ai.Config = originalTier1Config;
+            } else if (Neo.ai?.Config) {
+                delete Neo.ai.Config;
+            }
+
+            if (originalTier1ClassHierarchy !== undefined) {
+                Neo.classHierarchyMap['Neo.ai.Config'] = originalTier1ClassHierarchy;
+            } else if (Neo.classHierarchyMap?.['Neo.ai.Config']) {
+                delete Neo.classHierarchyMap['Neo.ai.Config'];
+            }
+
+            if (originalConfig !== undefined) {
+                Neo.ai.mcp.server['memory-core'].Config = originalConfig;
+            } else if (Neo.ai?.mcp?.server?.['memory-core']?.Config) {
+                delete Neo.ai.mcp.server['memory-core'].Config;
+            }
+
+            if (originalClassHierarchy !== undefined) {
+                Neo.classHierarchyMap['Neo.ai.mcp.server.memory-core.Config'] = originalClassHierarchy;
+            } else if (Neo.classHierarchyMap?.['Neo.ai.mcp.server.memory-core.Config']) {
+                delete Neo.classHierarchyMap['Neo.ai.mcp.server.memory-core.Config'];
+            }
+        }
+    }
 
     test.beforeEach(async () => {
         tmpRoot         = path.resolve(process.cwd(), 'tmp', `compact-graphlog-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -83,19 +132,21 @@ test.describe('compactGraphLog maintenance guard', () => {
         }));
     }
 
-    test('resolves CLI defaults from the Memory Core template config in tests', () => {
-        const defaults = getDefaultGraphLogCompactionOptions({aiConfig: MemoryCoreConfigTemplate});
-        const command  = createCommand({aiConfig: MemoryCoreConfigTemplate});
+    test('resolves CLI defaults from the Memory Core template config in tests', async () => {
+        await withMemoryCoreConfigTemplate(async MemoryCoreConfigTemplate => {
+            const defaults = getDefaultGraphLogCompactionOptions({aiConfig: MemoryCoreConfigTemplate});
+            const command  = createCommand({aiConfig: MemoryCoreConfigTemplate});
 
-        command.parse([], {from: 'user'});
+            command.parse([], {from: 'user'});
 
-        expect(defaults.dbPath).toBe(MemoryCoreConfigTemplate.storagePaths.graph);
-        expect(defaults.bridgeStateFile).toBe(MemoryCoreConfigTemplate.wakeDaemon.bridgeLastSyncIdPath);
-        expect(defaults.wakeStateFile).toBe(MemoryCoreConfigTemplate.wakeDaemon.wakeSubscriptionLiveCursorPath);
+            expect(defaults.dbPath).toBe(MemoryCoreConfigTemplate.storagePaths.graph);
+            expect(defaults.bridgeStateFile).toBe(MemoryCoreConfigTemplate.wakeDaemon.bridgeLastSyncIdPath);
+            expect(defaults.wakeStateFile).toBe(MemoryCoreConfigTemplate.wakeDaemon.wakeSubscriptionLiveCursorPath);
 
-        expect(command.opts().db).toBe(defaults.dbPath);
-        expect(command.opts().bridgeStateFile).toBe(defaults.bridgeStateFile);
-        expect(command.opts().wakeStateFile).toBe(defaults.wakeStateFile);
+            expect(command.opts().db).toBe(defaults.dbPath);
+            expect(command.opts().bridgeStateFile).toBe(defaults.bridgeStateFile);
+            expect(command.opts().wakeStateFile).toBe(defaults.wakeStateFile);
+        });
     });
 
     test('computes cutoff from the minimum known consumer watermark plus safety margin', () => {


### PR DESCRIPTION
Refs #12329

Authored by GPT-5 (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.
FAIR-band: over-target [16/30] - taking this lane despite over-target because the operator delegated GPT /lead-role for Neo nightshift backlog reduction and #12329 was the newest unassigned production-retention issue with validated positive ROI.

Adds a dry-run-first `ai:compact-graphlog` maintenance CLI for pruning consumed SQLite `GraphLog` CDC rows, plus a durable WakeSubscriptionService cursor file so active MCP-notification consumers can participate in min-watermark compaction without keeping the cursor only in process memory.

Evidence: L3 (live non-destructive dry-run against current graph plus L2 focused unit apply tests) -> L4 required (operator-gated production `--apply --vacuum` purge for AC4/AC5). Residual: AC4/AC5 [#12329].

## Deltas from ticket
- Added durable `WakeSubscriptionService` cursor persistence at `.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor` so the compactor can read the MCP-notification consumer watermark outside the graph.
- Added fail-closed compaction planning: unknown active consumers block deletion instead of falling back to an unsafe cutoff.
- Added operator escape hatches for future consumers: `--consumer-watermark name=logId`, `--wake-live-cursor`, `--safety-margin`, and optional `--vacuum`.
- Kept the one-time live production purge out of this branch; that remains operator-gated post-merge validation.

## Test Evidence
- `node --check ai/services/memory-core/WakeSubscriptionService.mjs`
- `node --check ai/scripts/maintenance/compactGraphLog.mjs`
- `node --check test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs` -> 6 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` -> 46 passed
- `npm run ai:compact-graphlog` -> dry-run, no deletion, correctly blocked on missing wake cursor in the still-running pre-patch service process
- `npm run ai:compact-graphlog -- --wake-live-cursor 7415366` -> dry-run, no deletion, computed cutoff `7414366` and `7414364` eligible rows
- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/services/memory-core/WakeSubscriptionService.mjs ai/scripts/maintenance/compactGraphLog.mjs test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs`
- `node ./buildScripts/util/check-shorthand.mjs ai/services/memory-core/WakeSubscriptionService.mjs ai/scripts/maintenance/compactGraphLog.mjs test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs`
- `git diff --check origin/dev...HEAD`

## Post-Merge Validation
- [ ] Restart or reload Memory Core so `WakeSubscriptionService` writes `.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor`.
- [ ] Run `npm run ai:compact-graphlog` and confirm default dry-run no longer blocks on a missing wake cursor.
- [ ] Operator runs `npm run ai:compact-graphlog -- --apply --vacuum` after confirming no unknown remote consumers need a supplied watermark.
- [ ] Append before/after `rowCount`, `page_count`, `freelist_count`, GraphLog bytes, and graph-db file size to #12329 before closing it.

## Commit
- `1227239dc` - `feat(ai): add graphlog compaction maintenance (#12329)`