### PR TITLE
docs(ai): document graph edge FK constraint (#10089)

### DIFF
--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -75,7 +75,7 @@ class Database extends Base {
      * Evaluates hardware SQLite `GraphLog` boundaries securely identifying structural mutations dynamically created by concurrent Nodes/AppWorkers.
      * Splices identified cache diffs executing perfectly accurately guaranteeing perfect isolated thread execution topologies.
      *
-     * Cache-coherence invariants:
+     * Cache-coherence invariants (ADR 0001; ticket-ref-ok: file-owned decision record):
      * 1. A fresh boot (`lastSyncId === 0`) is a legitimate "catch me up" trigger, not a short-circuit skip.
      * 2. This method INVALIDATES stale cache entries; it does not upsert new ones (lazy-load handles that).
      *

--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -9,6 +9,8 @@ import StorageBase     from './storage/Base.mjs';
  * The Database class serves as the core coordinator for the Native Edge Graph Database engine.
  * Operating in headless MCP server environments (Sandman, memory-core), it orchestrates local
  * Native Node embeddings tracking alongside Semantic vectors natively inside ChromaDB (GraphRAG).
+ * When backed by SQLite storage, persisted edges must reference existing node IDs for both
+ * `source` and `target`; the storage schema enforces this with foreign keys on `Edges`.
  *
  * Implements strict Multi-Worker Cache Coherence via SQLite Hardware Triggers & Delta Logs, combined
  * with completely Synchronous Lazy Loading architectures and automated LRU Garbage Collection
@@ -72,11 +74,11 @@ class Database extends Base {
      * Executes strict cache synchronization polling Native SQLite triggers for identical cross-worker coherence cleanly natively.
      * Evaluates hardware SQLite `GraphLog` boundaries securely identifying structural mutations dynamically created by concurrent Nodes/AppWorkers.
      * Splices identified cache diffs executing perfectly accurately guaranteeing perfect isolated thread execution topologies.
-     * 
-     * Invariants (ADR 0001):
+     *
+     * Cache-coherence invariants:
      * 1. A fresh boot (`lastSyncId === 0`) is a legitimate "catch me up" trigger, not a short-circuit skip.
      * 2. This method INVALIDATES stale cache entries; it does not upsert new ones (lazy-load handles that).
-     * 
+     *
      * @see Neo.ai.graph.storage.SQLite#getDeltaLog
      */
     syncCache() {
@@ -176,6 +178,10 @@ class Database extends Base {
     /**
      * Injects a relationship edge into the Native Edge Graph Database topology.
      * @param {Object} edge
+     * @throws {SqliteError} When SQLite storage is attached and `edge.source` or `edge.target`
+     * is not already present as a node ID. The storage schema enforces
+     * `FOREIGN KEY(source|target) REFERENCES Nodes(id)`, so callers must create endpoint
+     * nodes before inserting persisted edges.
      */
     addEdge(edge) {
         edge.id ??= globalThis.crypto.randomUUID();


### PR DESCRIPTION
Resolves #10089

Authored by GPT-5 (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.
FAIR-band: over-target [16/30] — taking this lane despite over-target because the operator delegated GPT lead-role for nightshift backlog reduction, live survey found the newer no-assignee candidates blocked/deferred or owned by Claude-adjacent work, and #10089 is a closeable documentation-only ticket after triage.

Documents the SQLite foreign-key contract on the public `Neo.ai.graph.Database#addEdge` API so callers see that persisted edges require existing `source` and `target` node IDs before insertion.

Evidence: L2 (focused graph unit spec plus static source gates) -> L2 required (doc-only ACs with existing SQLite FK test coverage). No residuals.

## Deltas from ticket
- Added class-level context that SQLite-backed persisted edges must reference existing endpoint nodes.
- Added `@throws {SqliteError}` guidance to `addEdge(edge)` for missing `source` or `target` node IDs.
- Preserved the file-owned `ADR 0001` cache-coherence decision anchor with an explicit archaeology escape rationale. ADR provenance is load-bearing design context; unlike ticket IDs, it should not be erased from the owning file.

## Test Evidence
- `node --check ai/graph/Database.mjs`
- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/graph/Database.mjs`
- `node ./buildScripts/util/check-shorthand.mjs ai/graph/Database.mjs`
- `git diff --check origin/dev...HEAD`
- `npm run test-unit -- test/playwright/unit/ai/graph/Database.spec.mjs` - 18 passed
- Fixup: `node --check /private/tmp/neo-12338-adr-fix/ai/graph/Database.mjs` - passed
- Fixup: `node buildScripts/util/check-ticket-archaeology.mjs /private/tmp/neo-12338-adr-fix/ai/graph/Database.mjs` - passed; 1 file scanned, 0 violations.
- Fixup: `node buildScripts/util/check-shorthand.mjs /private/tmp/neo-12338-adr-fix/ai/graph/Database.mjs` - passed; 1 file scanned, 0 violations.
- Fixup: `git diff --check` - passed.
- Pre-commit hook passed for `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology`.

## Post-Merge Validation
- [ ] After the next Knowledge Base sync, `ask_knowledge_base("can I add an edge to a non-existent node?")` surfaces the `addEdge` endpoint-node requirement.

## Commits
- `02f1316b3` - `docs(ai): document graph edge FK constraint (#10089)`
- `b0f894d39` - `docs(ai): preserve graph ADR anchor (#10089)`
