### PR TITLE
docs(ai): clean defrag script comments (#11925)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -14,11 +14,11 @@ import AiConfig        from '../../config.mjs';
  * within ChromaDB. It is target-agnostic at the collection-group layer: Knowledge Base and Memory Core
  * share one unified persist directory, while the target controls which logical collections are rewritten.
  *
- * ## Peer Architecture (#10129)
+ * ## Peer Architecture
  *
  * This script and `ai/scripts/maintenance/backup.mjs` are **peer scripts with orthogonal responsibilities**.
  * Defrag does NOT call the canonical backup orchestrator — it retains its own private pre-nuke
- * physical-copy snapshot (step 1 below). The rationale is captured in #10129 Phase 3:
+ * physical-copy snapshot (step 1 below). The rationale:
  *
  * - `backup.mjs` captures current state as portable JSONL via the `ai/services.mjs` SDK boundary
  * - Defrag needs a *fast* pre-nuke snapshot that preserves exact HNSW index state, which a
@@ -356,7 +356,7 @@ async function defragChromaDB() {
         // 1. Pre-Nuke Snapshot (Defrag-Internal Safety)
         // Fast physical copy preserving exact HNSW index state. This is defrag-exclusive —
         // it is NOT the canonical backup. For portable JSONL snapshots see `ai/scripts/maintenance/backup.mjs`.
-        // Peer architecture per #10129: neither script calls the other.
+        // Peer architecture: neither script calls the other.
         const timestamp  = Date.now();
         const backupRoot = path.resolve(PROJECT_ROOT, 'dist', 'chromadb-backups', targetName);
         const backupName = `backup-${timestamp}`;
@@ -377,7 +377,7 @@ async function defragChromaDB() {
             port: config.port
         });
 
-        // Dummy embedding function — single source of truth: Tier-1 AiConfig.dummyEmbeddingFunction (#12165).
+        // Dummy embedding function — single source of truth: Tier-1 AiConfig.dummyEmbeddingFunction.
         // Satisfies the Chroma client for raw embeddings without re-generating via a provider.
         const dummyEf = AiConfig.dummyEmbeddingFunction;
 


### PR DESCRIPTION
Refs #11925
Related: #11912

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.
FAIR-band: over-target [16/30] - taking this lane despite over-target because #11925 is already assigned to @neo-gpt, the change is a narrow non-overlapping nightshift cleanup batch, and it carries low review cost while reducing an existing backlog ticket under the operator's directive.

Removes stale ticket and phase anchors from durable comments in `ai/scripts/maintenance/defragChromaDB.mjs` while preserving the behavioral explanation for defrag/backup peer architecture and the Tier-1 dummy embedding function source-of-truth note.

Evidence: L1 (static comment-archaeology, shorthand, syntax, and diff hygiene checks) -> L1 required (comment-only cleanup; no runtime ACs). No residuals.

## Deltas from ticket
- This is a partial #11925 batch, not a full closeout.
- Runtime values, imports, control flow, CLI behavior, and config references are unchanged.
- The open #12339 config-template cleanup PR owns a separate file and does not overlap this diff.

## Test Evidence
- Before patch: `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/maintenance/defragChromaDB.mjs` reported 4 durable-comment ticket refs.
- `node --check ai/scripts/maintenance/defragChromaDB.mjs`
- `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/maintenance/defragChromaDB.mjs` -> 0 violations.
- `node buildScripts/util/check-shorthand.mjs ai/scripts/maintenance/defragChromaDB.mjs` -> 0 violations.
- `git diff --check`
- `git log origin/dev..HEAD --format='%h%x09%s%n%b'` verified the branch has no magic close keyword for #11925.

## Post-Merge Validation
- [ ] #11925 remains open for remaining daemon/script/config comment cleanup batches.

## Commits
- `d64b2387c` - `docs(ai): clean defrag script comments (#11925)`
