### PR TITLE
docs(ai): clean seed identity comments (#11925)

### DIFF
--- a/ai/scripts/setup/seedAgentIdentities.mjs
+++ b/ai/scripts/setup/seedAgentIdentities.mjs
@@ -9,13 +9,13 @@
  *
  * @summary Seeds initial system, AgentIdentity, and BroadcastSentinel nodes into the Neo.mjs Memory Core Native Graph.
  *
- * These nodes form the **addressable identity surface** for the A2A Mailbox substrate (#10139):
+ * These nodes form the **addressable identity surface** for the A2A Mailbox substrate:
  * the lifecycle system sender (`@system`), human owners (`@tobiu`), model-backed agents
  * (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`), and the `AGENT:*` broadcast sentinel that carries
  * fan-out `SENT_TO` edges emitted by {@link Neo.ai.services.memory-core.MailboxService#addMessage}
  * for broadcast traffic.
  *
- * **Why the broadcast sentinel needs to be a real graph node (#10174):** `GraphService.linkNodes`
+ * **Why the broadcast sentinel needs to be a real graph node:** `GraphService.linkNodes`
  * enforces an FK-style guard that culls edges whose endpoints aren't present in the Nodes table.
  * The guard is correct defense-in-depth against hallucinated LLM-generated edges but wrongly
  * dropped every broadcast `SENT_TO` edge while this sentinel was merely a sentinel string. Seeding


### PR DESCRIPTION
Refs #11925
Related: #11912

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.
FAIR-band: over-target [16/30] - taking this lane despite over-target because #11925 is already assigned to @neo-gpt, the change is a narrow non-overlapping nightshift cleanup batch, and it carries low review cost while reducing an existing backlog ticket under the operator's directive.

Removes stale ticket anchors from durable comments in `ai/scripts/setup/seedAgentIdentities.mjs` while preserving the explanation for the A2A identity surface and why the broadcast sentinel is materialized as a real graph node.

Evidence: L1 (static comment-archaeology, shorthand, syntax, and diff hygiene checks) -> L1 required (comment-only cleanup; no runtime ACs). No residuals.

## Deltas from ticket
- This is a partial #11925 batch, not a full closeout.
- Runtime behavior, imports, setup flow, and graph seed data are unchanged.
- The open #12339 and #12340 cleanup PRs own separate files and do not overlap this diff.

## Test Evidence
- Before patch: `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/setup/seedAgentIdentities.mjs` reported 2 durable-comment ticket refs.
- `node --check ai/scripts/setup/seedAgentIdentities.mjs`
- `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/setup/seedAgentIdentities.mjs` -> 0 violations.
- `node buildScripts/util/check-shorthand.mjs ai/scripts/setup/seedAgentIdentities.mjs` -> 0 violations.
- `git diff --check`
- `git log origin/dev..HEAD --format='%h%x09%s%n%b'` verified the branch has no magic close keyword for #11925.

## Post-Merge Validation
- [ ] #11925 remains open for remaining daemon/script/config comment cleanup batches.

## Commits
- `36fb4b4a3` - `docs(ai): clean seed identity comments (#11925)`
