### PR TITLE
docs(ai): clean setup maintenance comments (#11925)

### DIFF
--- a/ai/scripts/maintenance/auditGraphIntegrity.mjs
+++ b/ai/scripts/maintenance/auditGraphIntegrity.mjs
@@ -25,7 +25,7 @@ const SEVERITY_RANK = {
 /**
  * @summary Creates the Commander parser for the graph-integrity audit runner.
  *
- * The default threshold follows #10462: any non-zero divergence up to 5% is
+ * The default threshold treats any non-zero divergence up to 5% as
  * `soft`; divergence above 5% is `hard`. Operators can override it via
  * `--hard-threshold` or `GRAPH_INTEGRITY_HARD_THRESHOLD`.
  *
@@ -181,7 +181,7 @@ export async function collectSummarySessions(collection, {pageSize = 1000} = {})
 /**
  * @summary List SESSION graph nodes directly from the Memory Core graph store.
  *
- * #10462 is an observation-only runner. This direct SQLite read mirrors the
+ * This observation-only runner uses a direct SQLite read that mirrors the
  * graph observability helpers without adding a public service method before
  * the report contract has empirical mileage.
  *
@@ -358,7 +358,7 @@ export async function writeReport(report, {
  * @summary Count graph `ORIGINATES_IN` memory edges targeting one session.
  *
  * This is intentionally narrower than `GraphService.getSessionEntityCount()`,
- * which counts every inbound entity relation to the session. #10462's
+ * which counts every inbound entity relation to the session. The
  * `actualMemoryCount` contract compares raw Chroma memory rows with graph
  * `ORIGINATES_IN(Memory -> Session)` edges, so the edge-type filter is part
  * of the audit contract.

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -183,7 +183,7 @@ export function detectDrift(templateShape, configShape) {
  * `config.mjs` exists. Three branches per server:
  *
  *   1. Template absent — skip (log warning).
- *   2. Config missing — clone materialized template (preserves pre-#10815 behavior).
+ *   2. Config missing — clone materialized template (preserves legacy first-run behavior).
  *   3. Config present + drift detected — warn-only (default) OR migrate when
  *      invoked with `--migrate-config`. Pure Tier-1 import materialization
  *      patches the existing file in place; broader drift overwrites from the


### PR DESCRIPTION
Refs #11925
Related: #11912

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.
FAIR-band: over-target [16/30] - taking this lane despite over-target because #11925 is already assigned to @neo-gpt, the change is a narrow non-overlapping nightshift cleanup batch, and it carries low review cost while reducing an existing backlog ticket under the operator's directive.

Removes stale ticket anchors from durable comments in `ai/scripts/setup/initServerConfigs.mjs` and `ai/scripts/maintenance/auditGraphIntegrity.mjs` while preserving the first-run config behavior explanation and graph-integrity audit contract.

Evidence: L1 (static comment-archaeology, shorthand, syntax, and diff hygiene checks) -> L1 required (comment-only cleanup; no runtime ACs). No residuals.

## Deltas from ticket
- This is a partial #11925 batch, not a full closeout.
- Runtime behavior, imports, setup flow, audit thresholds, report output, and graph query logic are unchanged.
- Existing open #11925 cleanup PRs own separate files and do not overlap this diff.

## Test Evidence
- Before patch: `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/setup/initServerConfigs.mjs ai/scripts/maintenance/auditGraphIntegrity.mjs` reported 4 durable-comment ticket refs.
- `node --check ai/scripts/setup/initServerConfigs.mjs`
- `node --check ai/scripts/maintenance/auditGraphIntegrity.mjs`
- `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/setup/initServerConfigs.mjs ai/scripts/maintenance/auditGraphIntegrity.mjs` -> 0 violations.
- `node buildScripts/util/check-shorthand.mjs ai/scripts/setup/initServerConfigs.mjs ai/scripts/maintenance/auditGraphIntegrity.mjs` -> 0 violations.
- `git diff --check`
- `git log origin/dev..HEAD --format='%h%x09%s%n%b'` verified the branch has no magic close keyword for #11925.

## Post-Merge Validation
- [ ] #11925 remains open for remaining daemon/script/config comment cleanup batches.

## Commits
- `c3b6856f` - `docs(ai): clean setup maintenance comments (#11925)`
