### PR TITLE
docs(ai): clean orchestrator recycle comments (#11925)

### DIFF
--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -97,9 +97,9 @@ export function buildTaskDefinitions({
             pidFileName    : 'backup.pid',
             expectedCommand: 'backup.mjs'
         },
-        // One-shot KB defrag spawned by the chroma max-runtime recycle (#12138) once the
+        // One-shot KB defrag spawned by the chroma max-runtime recycle once the
         // freshly-restarted daemon is connection-ready. Unified-store-safe (rebuilds the KB
-        // collection, preserves MC segment dirs per #12140). NOT a continuousTask.
+        // collection, preserves Memory Core segment dirs). NOT a continuousTask.
         chromaDefrag: {
             label          : 'chroma defrag (knowledge-base)',
             command        : nodeBin,

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -619,7 +619,7 @@ export class ProcessSupervisorService extends Base {
     /**
      * Recycles a supervised task: SIGKILLs its tracked process (no-op under UNIT_TEST_MODE)
      * and marks it recycled so the poll loop respawns a fresh one. Used by the chroma
-     * max-runtime recycle (#12138). Safe when no pid is currently tracked (e.g. already exited).
+     * max-runtime recycle. Safe when no pid is currently tracked (e.g. already exited).
      * @param {String} taskName
      * @param {String} reason
      * @returns {void}

--- a/ai/daemons/orchestrator/services/TaskStateService.mjs
+++ b/ai/daemons/orchestrator/services/TaskStateService.mjs
@@ -225,7 +225,7 @@ export class TaskStateService extends Base {
      * Marks a task as recycled — process intentionally killed for restart. Clears running +
      * pid so the supervisor loop respawns it; intentionally records no error/success
      * timestamp (a recycle is neither a failure nor a successful completion). Used by the
-     * chroma max-runtime recycle (#12138).
+     * chroma max-runtime recycle.
      * @param {String} taskName
      * @returns {void}
      */

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -546,7 +546,7 @@ class TenantRepoSyncService extends Base {
      * `KnowledgeBaseIngestionService.listConfiguredTenantRepos` (graph node > `kb-config.yaml`
      * bootstrap > `aiConfig.tenantRepos[]` default, per-tenant single-winner, flattened). Replaces
      * the prior direct `aiConfig.tenantRepos` read so the documented bootstrap / graph tiers are
-     * actually honored on the pull path (#12145).
+     * actually honored on the pull path.
      *
      * Then materializes per-repo `mirrorRoot` via a defensive fallback chain when the per-repo
      * override is absent:


### PR DESCRIPTION
Refs #11925

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.
FAIR-band: in-band [16/30 — current author count over last 30 merged]

Removes stale ticket-number archaeology from four orchestrator recycle and tenant-repo comment surfaces without changing runtime behavior.

Evidence: L1 (static comment-shape audit plus syntax parse) → L1 required (comment-only cleanup; no runtime ACs). No residuals.

## Deltas from ticket
No behavioral delta. The comments still describe chroma max-runtime recycle behavior, Memory Core segment preservation, and tenant repo resolver behavior, but no longer embed historical issue IDs.

## Test Evidence
- `node buildScripts/util/check-ticket-archaeology.mjs ai/daemons/orchestrator/services/ProcessSupervisorService.mjs ai/daemons/orchestrator/services/TaskStateService.mjs ai/daemons/orchestrator/services/TenantRepoSyncService.mjs ai/daemons/orchestrator/TaskDefinitions.mjs` before edit: 5 ticket refs across target files.
- `node buildScripts/util/check-ticket-archaeology.mjs ai/daemons/orchestrator/services/ProcessSupervisorService.mjs ai/daemons/orchestrator/services/TaskStateService.mjs ai/daemons/orchestrator/services/TenantRepoSyncService.mjs ai/daemons/orchestrator/TaskDefinitions.mjs` after edit: 0 violations.
- `node buildScripts/util/check-shorthand.mjs ai/daemons/orchestrator/services/ProcessSupervisorService.mjs ai/daemons/orchestrator/services/TaskStateService.mjs ai/daemons/orchestrator/services/TenantRepoSyncService.mjs ai/daemons/orchestrator/TaskDefinitions.mjs`: 0 violations.
- `node --check ai/daemons/orchestrator/services/ProcessSupervisorService.mjs`
- `node --check ai/daemons/orchestrator/services/TaskStateService.mjs`
- `node --check ai/daemons/orchestrator/services/TenantRepoSyncService.mjs`
- `node --check ai/daemons/orchestrator/TaskDefinitions.mjs`
- `git diff --check`
- `git diff --cached --check`
- FAIR-band verifier: `Counter({'neo-gpt': 16, 'neo-opus-4-7': 14})`.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev` at `b988f0283f444c7fa7f9ff65e6e4ac69146f775a`.
- Branch history check: `git log origin/dev..HEAD --format=%h%x09%s%n%b` contained only `8fa890ae4 docs(ai): clean orchestrator recycle comments (#11925)` with no magic close keyword.

## Post-Merge Validation
- [ ] #11925 tracker can continue with remaining source-comment anchor cleanup; this PR intentionally does not close the umbrella ticket.

## Commit
- `8fa890ae4` — `docs(ai): clean orchestrator recycle comments (#11925)`
