### PR TITLE
docs(ai): clean idle nudge comments (#11925)

### DIFF
--- a/ai/scripts/lifecycle/idleOutNudge.mjs
+++ b/ai/scripts/lifecycle/idleOutNudge.mjs
@@ -7,8 +7,8 @@
  * Emits a Shape B GraphLog-only heartbeat pulse via
  * `WakeSubscriptionService.emitHeartbeatPulse` — `bridge-daemon` delivers via
  * its existing harness adapter set. **Zero MESSAGE-node persistence, no
- * SENT_TO edge, no inbox surfacing.** Per Epic #11993 Sub-iii (#11996 cleanup):
- * Shape A heartbeat-via-mailbox-message removed entirely.
+ * SENT_TO edge, no inbox surfacing.** Shape A heartbeat-via-mailbox-message has
+ * been removed entirely.
  *
  * **Distinct from `trioWakeCooldown.mjs`:** trio fires when ALL configured agents
  * idle simultaneously (swarm-wide signal); this dispatcher fires per-identity
@@ -48,7 +48,7 @@
  * @see ai/scripts/lifecycle/checkSunsetted.mjs    — detector emitting `recommended_action: 'idle_out_nudge'`
  * @see ai/scripts/lifecycle/inflightLock.mjs      — `idle_out_nudge` lock mode
  * @see ai/daemons/SwarmHeartbeatService.mjs       — caller; routes on `recommended_action`
- * @see ai/services/memory-core/WakeSubscriptionService.mjs — `emitHeartbeatPulse` Shape B primitive (Epic #11993 Sub-i)
+ * @see ai/services/memory-core/WakeSubscriptionService.mjs — `emitHeartbeatPulse` Shape B primitive
  * @see ai/scripts/lifecycle/trioWakeCooldown.mjs  — sibling for swarm-wide all-idle case
  * @see ai/scripts/lifecycle/resumeHarness.mjs     — sibling for sunset-restart case
  * @see test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs


### PR DESCRIPTION
Refs #11925

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.

FAIR-band: in-band [16/30 — current author count over last 30 merged]

Cleans issue/phase archaeology out of `ai/scripts/lifecycle/idleOutNudge.mjs` while preserving its Shape B GraphLog-only heartbeat-pulse contract, no-message/no-inbox behavior, and wake-delivery `@see` navigation.

Evidence: L1 (static comment-only archaeology and syntax checks) → L1 required (no runtime behavior ACs for this slice). No residuals.

## Deltas from ticket

- No behavior, config value, or API changes.
- Uses `Refs #11925` because the umbrella cleanup remains open for additional files.

## Test Evidence

- `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/lifecycle/idleOutNudge.mjs` before edit: 2 ticket references.
- `node buildScripts/util/check-ticket-archaeology.mjs /private/tmp/neo-11925-idle-out-nudge-comments/ai/scripts/lifecycle/idleOutNudge.mjs` after edit: 0 violations.
- `node buildScripts/util/check-shorthand.mjs /private/tmp/neo-11925-idle-out-nudge-comments/ai/scripts/lifecycle/idleOutNudge.mjs`: 0 violations.
- `node --check ai/scripts/lifecycle/idleOutNudge.mjs`
- `git diff --check`
- `git diff --cached --check`
- Branch freshness verified before push: `merge-base HEAD origin/dev == origin/dev`.
- Branch history verified non-closing for `#11925`: `git log origin/dev..codex/11925-idle-out-nudge-comments` contains only `ec31035e1 docs(ai): clean idle nudge comments (#11925)`.

## Post-Merge Validation

- [ ] Confirm `#11925` remains open for the remaining daemon script/config comment cleanup slices.

## Commit

- `ec31035e1` — `docs(ai): clean idle nudge comments (#11925)`
