### PR TITLE
docs(ai): clean sync workflow comments (#11925)

### DIFF
--- a/ai/scripts/maintenance/syncGithubWorkflow.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflow.mjs
@@ -14,7 +14,7 @@ import {withHeavyMaintenanceLease}     from '../../daemons/orchestrator/services
  * + delegated to by `ai/services/github-workflow/toolService.mjs`'s `sync_all`
  * MCP handler). The MCP path is bound to MCP-request-response timing — fine for
  * delta-syncs (the "cached for fast no-ops" path) but inadequate for clean-slate
- * full emission post-ADR-0004 §3.6 purge (~8.5k issues + ~2.8k PRs + ~165
+ * full emission after a clean-slate mirror purge (~8.5k issues + ~2.8k PRs + ~165
  * discussions + ~166 release notes via GraphQL pagination = many minutes).
  *
  * The CLI dual:
@@ -31,7 +31,7 @@ import {withHeavyMaintenanceLease}     from '../../daemons/orchestrator/services
  * `defragChromaDB.mjs`, and other operator-runnable CLI scripts. No direct
  * `ai/mcp/server/...` or `ai/services/...` deep imports.
  *
- * The authority boundary is ADR 0004's regeneratable-cache model: this script exists
+ * The authority boundary is the regeneratable-cache model: this script exists
  * to rebuild workflow mirrors outside the MCP request-timeout envelope while preserving
  * the same service path as `sync_all`.
  *


### PR DESCRIPTION
Refs #11925

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.

FAIR-band: in-band [16/30 — current author count over last 30 merged]

Cleans durable comment archaeology from `ai/scripts/maintenance/syncGithubWorkflow.mjs` while preserving the CLI's full GitHub Workflow sync contract, regeneratable-cache authority boundary, service-path description, and final EOF newline.

Evidence: L1 (static comment-only archaeology, syntax, EOF-byte, and branch-history checks) → L1 required (no runtime behavior ACs for this slice). No residuals.

## Deltas from ticket

- No behavior, config value, import, or API changes.
- Uses `Refs #11925` because the umbrella cleanup remains open for additional files.
- Replaces ADR-number anchors with stable concepts: clean-slate mirror purge and regeneratable-cache model.
- Remote branch was published via the GitHub Git Data API using base64 blob creation so the final branch content preserves the EOF newline.

## Test Evidence

- `node buildScripts/util/check-ticket-archaeology.mjs ai/scripts/maintenance/syncGithubWorkflow.mjs` before edit: 2 durable-comment refs.
- `node buildScripts/util/check-ticket-archaeology.mjs /private/tmp/neo-11925-sync-workflow-comments/ai/scripts/maintenance/syncGithubWorkflow.mjs`: 0 violations.
- `node buildScripts/util/check-shorthand.mjs /private/tmp/neo-11925-sync-workflow-comments/ai/scripts/maintenance/syncGithubWorkflow.mjs`: 0 violations.
- `node --check ai/scripts/maintenance/syncGithubWorkflow.mjs`
- `git diff --check`
- `git diff --cached --check`
- Final remote branch content EOF byte check: `0a`.
- Branch freshness verified before publication: `merge-base HEAD origin/dev == origin/dev` (`b988f0283f444c7fa7f9ff65e6e4ac69146f775a`).
- Branch history verified non-closing for `#11925`: `d1be53bc docs(ai): clean sync workflow comments (#11925)`.

## Post-Merge Validation

- [ ] Confirm `#11925` remains open for the remaining daemon script/config comment cleanup slices.

## Commit

- `d1be53bc` — `docs(ai): clean sync workflow comments (#11925)`