### PR TITLE
docs(ai): clean benchmark comments (#11925)

### DIFF
--- a/ai/scripts/benchmark/gemma4-rem-benchmark.mjs
+++ b/ai/scripts/benchmark/gemma4-rem-benchmark.mjs
@@ -12,8 +12,7 @@ import {summarize} from './helpers/stats.mjs';
  * @module ai/scripts/benchmark/gemma4-rem-benchmark
  * @summary REM-pipeline gemma4 cost benchmark — TTFT / TTLT / tps per session-size bucket.
  *
- * **Why this exists** (operator 2026-05-27 directive, Discussion #12062 §2.4.1 +
- * Epic #12065 Sub 8 / #12074):
+ * **Why this exists**:
  * > "we need benchmarking for gemma4 => creating context windows is the most
  * > expensive task. if there is any way to REUSE created context windows => big win."
  *

--- a/ai/scripts/benchmark/keep-alive-probe.mjs
+++ b/ai/scripts/benchmark/keep-alive-probe.mjs
@@ -10,7 +10,7 @@ import {buildGraphProvider, resolveGraphModelProvider} from '../../services/grap
  *
  * **Why this exists**:
  *
- * V-B-A on the provider substrate (2026-05-27, branch `feature-12074-gemma4-bench`):
+ * V-B-A on the provider substrate:
  * - `ai/provider/Ollama.mjs` promotes caller-supplied `keep_alive` to the top-level
  *   native `/api/chat` payload and defaults to the configured keep-alive value.
  * - `ai/provider/OpenAiCompatible.mjs` sends top-level `keep_alive` for compatible

--- a/ai/scripts/benchmark/keep-alive-probe.mjs
+++ b/ai/scripts/benchmark/keep-alive-probe.mjs
@@ -8,7 +8,7 @@ import {buildGraphProvider, resolveGraphModelProvider} from '../../services/grap
  * @module ai/scripts/benchmark/keep-alive-probe
  * @summary Empirical V-B-A of Ollama / OpenAI-compat KV-cache reuse via `keep_alive`.
  *
- * **Why this exists** (Epic #12065 Sub 8 / #12074 Part B):
+ * **Why this exists**:
  *
  * V-B-A on the provider substrate (2026-05-27, branch `feature-12074-gemma4-bench`):
  * - `ai/provider/Ollama.mjs` promotes caller-supplied `keep_alive` to the top-level


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.
FAIR-band: in-band [16/30 — current author count over last 30 merged]

Refs #11925

Removes durable ticket and discussion archaeology anchors from the two REM benchmark helper module comments while preserving the benchmark rationale, operator quote, and config-driven provider-routing explanation.

Evidence: L1 (static comment-diff, syntax checks, archaeology/shorthand gates) → L1 required (comment-only cleanup; no runtime behavior changes). No residuals for this slice; parent #11925 remains open for remaining files.

## Deltas from ticket
This is a deliberately narrow slice: only `ai/scripts/benchmark/keep-alive-probe.mjs` and `ai/scripts/benchmark/gemma4-rem-benchmark.mjs`.

## Test Evidence
- `node --check ai/scripts/benchmark/keep-alive-probe.mjs`
- `node --check ai/scripts/benchmark/gemma4-rem-benchmark.mjs`
- `node buildScripts/util/check-ticket-archaeology.mjs /private/tmp/neo-11925-benchmark-comments/ai/scripts/benchmark/keep-alive-probe.mjs /private/tmp/neo-11925-benchmark-comments/ai/scripts/benchmark/gemma4-rem-benchmark.mjs` -> `0 violations`
- `node buildScripts/util/check-shorthand.mjs /private/tmp/neo-11925-benchmark-comments/ai/scripts/benchmark/keep-alive-probe.mjs /private/tmp/neo-11925-benchmark-comments/ai/scripts/benchmark/gemma4-rem-benchmark.mjs` -> `0 violations`
- `git diff --check`
- `git diff --cached --check`
- Branch freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `180a5526a docs(ai): clean benchmark comments (#11925)`.

## Post-Merge Validation
- [ ] `check-ticket-archaeology` continues to report no durable ticket refs in the two benchmark helper comments.

## Commit
- `180a5526a` — `docs(ai): clean benchmark comments (#11925)`