### PR TITLE
docs(ai): clean lint manifest comments (#11925)

### DIFF
--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * @summary Lints the Neo.mjs skill capability manifest (#11275).
+ * @summary Lints the Neo.mjs skill capability manifest.
  *
  * `SKILL.md` frontmatter stays runtime-canonical. The manifest mirrors that
  * data for CI and governance checks; this script enforces one-way consistency


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.
FAIR-band: in-band [16/30 — current author count over last 30 merged]

Refs #11925

Removes the stale ticket parenthetical from the `lint-skill-manifest.mjs` module summary while preserving the manifest-linting contract description below it.

Evidence: L1 (static comment-diff, syntax check, archaeology/shorthand gates) → L1 required (comment-only cleanup; no runtime behavior changes). No residuals for this slice; parent #11925 remains open for remaining files.

## Deltas from ticket
This is a deliberately narrow one-file slice: `ai/scripts/lint/lint-skill-manifest.mjs`.

## Test Evidence
- `node --check ai/scripts/lint/lint-skill-manifest.mjs`
- `node buildScripts/util/check-ticket-archaeology.mjs /private/tmp/neo-11925-lint-manifest-comments/ai/scripts/lint/lint-skill-manifest.mjs` -> `0 violations`
- `node buildScripts/util/check-shorthand.mjs /private/tmp/neo-11925-lint-manifest-comments/ai/scripts/lint/lint-skill-manifest.mjs` -> `0 violations`
- `git diff --check`
- `git diff --cached --check`
- Branch freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `97cf0d81a docs(ai): clean lint manifest comments (#11925)`.

## Post-Merge Validation
- [ ] `check-ticket-archaeology` continues to report no durable ticket refs in `lint-skill-manifest.mjs`.

## Commit
- `97cf0d81a` — `docs(ai): clean lint manifest comments (#11925)`