### PR TITLE
docs(ai): clean mcp config comments (#11925)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -191,8 +191,8 @@ class Config extends BaseConfig {
                 /**
                  * The maximum number of issues to fetch from the GitHub API in a single sync.
                  * Defensive ceiling against runaway pagination on a misconfigured GraphQL pageInfo while
-                 * leaving enough headroom for clean-slate exhaustive emission under ADR 0004. The local
-                 * droppedLabels filter further trims the actual processed set.
+                 * leaving enough headroom for clean-slate exhaustive emission under the archive contract.
+                 * The local droppedLabels filter further trims the actual processed set.
                  * @type {number}
                  */
                 maxIssues: leaf(20000),

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -37,9 +37,9 @@ class Config extends BaseConfig {
         data: {
             /**
              * Repo root, computed from this module's path. Exported for symmetry with the
-             * KB and Memory Core configs (#10584) so consumers (loggers, services, future)
-             * can read `aiConfig.neoRootDir` rather than recomputing the 4-level traversal
-             * locally. Module path is stable; the resolution is deterministic at boot.
+             * KB and Memory Core configs so consumers (loggers, services, future) can read
+             * `aiConfig.neoRootDir` rather than recomputing the 4-level traversal locally.
+             * Module path is stable; the resolution is deterministic at boot.
              * @type {string}
              */
             neoRootDir: leaf(neoRootDir),
@@ -69,9 +69,9 @@ class Config extends BaseConfig {
              */
             memoryCoreDbPath: leaf(path.join(os.homedir(), '.neo-ai-data', 'memory-core.sqlite'), 'NEO_MEMORY_DB_PATH', 'string'),
             /**
-             * Directory for the always-on Neural Link diagnostic log files (#10582). The NL
-             * server's `logger.mjs` writes daily-rotated entries here regardless of `debug`,
-             * so long-running inspection chains and DOM/VDOM introspection sweeps leave a
+             * Directory for the always-on Neural Link diagnostic log files. The NL server's
+             * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so
+             * long-running inspection chains and DOM/VDOM introspection sweeps leave a
              * tail-able diagnostic trail observable from the host shell. Default:
              * `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Memory Core servers
              * (each uses a distinct filename prefix: `nl-server-`, `kb-server-`, `mc-server-`).


### PR DESCRIPTION
Refs #11925

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.

FAIR-band: in-band [16/30 — current author count over last 30 merged]

Cleans durable source comments in the GitHub Workflow and Neural Link MCP config templates by replacing issue-number archaeology with stable contract language. The exported config object shapes and runtime values are unchanged.

Evidence: L1 (static config-template/comment archaeology audit) → L1 required (comment-only cleanup; no runtime ACs). No residuals for this slice.

## Deltas from ticket
This is a partial #11925 slice limited to two MCP config templates; the broader ticket remains open for additional daemon/config comment cleanup.

## MCP Config Template Guidance
Changed config keys: none (comment-only).
Local `config.mjs` updates: not required.
Harness restart: unnecessary.
Live MCP behavior change: none.

## Test Evidence
- `node --check ai/mcp/server/github-workflow/config.template.mjs`
- `node --check ai/mcp/server/neural-link/config.template.mjs`
- `node buildScripts/util/check-ticket-archaeology.mjs /private/tmp/neo-11925-mcp-config-comments/ai/mcp/server/github-workflow/config.template.mjs /private/tmp/neo-11925-mcp-config-comments/ai/mcp/server/neural-link/config.template.mjs`
- `node buildScripts/util/check-shorthand.mjs /private/tmp/neo-11925-mcp-config-comments/ai/mcp/server/github-workflow/config.template.mjs /private/tmp/neo-11925-mcp-config-comments/ai/mcp/server/neural-link/config.template.mjs`
- `git diff --check`
- `git diff --cached --check`
- `git log origin/dev..HEAD --format=%h%x09%s%n%b` confirmed only `8f17f03e0 docs(ai): clean mcp config comments (#11925)` and no stale magic close keywords.

## Post-Merge Validation
- [ ] Confirm #11925 remains open for remaining cleanup slices.

## Commit
- `8f17f03e0` — `docs(ai): clean mcp config comments (#11925)`
