### PR TITLE
feat(ci): require a Resolves #N in agent PR bodies; forbid Closes/Fixes (#12367)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -108,33 +108,26 @@ When challenging a specific architectural pattern or complex implementation deta
 
 ### 5.2 Close-Target Audit
 
-When reviewing a PR, audit every issue named as a close-target via GitHub's magic keywords (`Closes #N`, `Resolves #N`, `Fixes #N` — case-insensitive, in the PR body or commit messages) against the target issue's labels AND syntax validity.
+When reviewing a PR, audit every issue named as a close-target via GitHub's magic keywords (`Closes #N`, `Resolves #N`, `Fixes #N` — case-insensitive, in the PR body or commit messages) against labels, syntax, and branch-history safety. For Neo agent / `ai` PRs, `Resolves #N` is the only valid closing keyword; `Closes #N` / `Fixes #N` are invalid, and `Refs #N` / `Related: #N` are non-closing extras only.
 
 **Squash-merge commit-body hazard:** branch commit bodies are merge-time close-target surfaces. GitHub's squash merge can concatenate commit bodies into the default-branch commit; a stale `Resolves #N` inside any branch commit body can auto-close `#N` even when the PR body has been corrected to `Refs #N` and `gh pr view --json closingIssuesReferences` returns `[]`. Provenance: #11185 / PR #11183.
 
-**Rule 1: Validity (Epics are not valid close-targets)**
-Epics represent a body of work delivered across multiple sub-issues; closing an epic is a *project-management* event that fires when the last sub closes (or when the epic is explicitly retired with rationale). PRs deliver subs, not epics. GitHub's auto-close-on-merge semantics fire indiscriminately on any magic-keyword reference, so the discipline-layer enforcement is the reviewer's job.
-
-**Rule 2: Syntax-Exact Keyword Mandate**
-Author-side discipline (`pull-request §2`) mandates strict newline-isolated PR closing syntax. Prose-embedded closures or comma-separated lists are forbidden. The reviewer MUST enforce this syntax to prevent automated parsing failures during Retrospective ingestion.
+**Rules:**
+- **Epics are invalid close-targets:** PRs deliver leaf sub-issues; epics close only when their sub-issue topology is complete or explicitly retired.
+- **Resolves-only for agent PRs:** author-side discipline (`pull-request §9`) mandates newline-isolated `Resolves #N`; `Closes` means no-delivery/no-PR, `Fixes` is ambiguous, and `Refs` / `Related` do not satisfy the close-target requirement.
+- **Syntax-exact:** prose-embedded close targets and comma-separated lists are forbidden.
 
 **Reviewer-side check:**
 
 1. Parse the PR body + commit messages for `Closes #N` / `Resolves #N` / `Fixes #N` patterns (case-insensitive). For local checkout reviews, use `git log origin/dev..HEAD --format='%h%x09%s%n%b'` or an equivalent exact-head commit-message fetch; do not rely on PR body or `closingIssuesReferences` alone.
-2. **Syntax Check:** If the keyword is embedded in prose (e.g., "This PR closes #123 by adding...") or uses a comma-separated list (e.g., "Resolves #123, #124"), flag as **Required Action**:
-   > *"PR uses prose-embedded or comma-separated close targets. Required: apply the Syntax-Exact Keyword Mandate by isolating each `Resolves #N` declaration on its own independent line."*
-3. **Validity Check:** For each `#N`, fetch the issue's labels (via the appropriate `github-workflow` MCP tool).
-4. If the issue carries the `epic` label → flag as **Required Action**:
-
-   > *"PR names epic #N as close-target via `Closes`/`Resolves`/`Fixes` keyword. Epics close when their last sub-issue closes, not on PR-merge. Required: change close-target to a specific sub-issue this PR resolves, or remove the magic-close keyword and reference the epic via `Related: #N` instead."*
-5. **Partial-resolution / stale commit-body check:** If the PR body uses `Refs #N` / `Related: #N` because `#N` must remain open, but any branch commit body still contains `Closes #N`, `Fixes #N`, or `Resolves #N`, flag as **Required Action**:
-
-   > *"PR is a partial-resolution PR for #N, but branch commit history still contains a magic-close keyword for #N. Required: use a clean superseding branch/PR, or obtain operator-explicit authorization for amend/rebase/force-push cleanup. Do not approve while stale branch commit bodies can survive squash merge and auto-close the issue."*
+2. For Neo agent / `ai` PRs, flag any missing PR-body `Resolves #N`, any `Closes #N` / `Fixes #N`, prose-embedded close target, or comma-separated close target as a **Required Action**. Required shape: one newline-isolated `Resolves #N` per delivered leaf ticket; use `Refs #N` / `Related: #N` only for additional references.
+3. Fetch labels for every close-target issue. If any target carries `epic`, flag as **Required Action**: change the close-target to the delivered leaf sub-issue, or move the epic reference to `Related: #N`.
+4. If a referenced ticket must stay open (`Refs` / `Related` in the PR body), but any branch commit body still contains `Closes #N`, `Fixes #N`, or `Resolves #N`, flag as **Required Action**: use a clean superseding branch/PR, or obtain operator-explicit authorization before amend/rebase/force-push cleanup.
 
 **Author response options** when these Required Actions fire:
 - **Syntax:** Isolate the keyword to a separate line per ticket.
-- **Validity:** Change `Closes #N` → `Closes #M` where `#M` is the specific sub-issue the PR resolves.
-- **Validity:** Remove the close-target entirely if the PR is an incremental contribution toward the epic without fully closing any single issue.
+- **Validity:** Change the close target to `Resolves #M` where `#M` is the specific leaf sub-issue the PR fully delivers.
+- **Validity:** Split broad work into an epic + leaf subs if the PR cannot honestly name one fully delivered leaf ticket.
 - **Validity:** Move the epic reference to `Related: #N` (no magic-close behavior).
 - **Partial-resolution stale commit body:** Prefer Drop+Supersede / clean branch when no operator authorization exists for history rewrite. If preserving the PR is preferred, get operator-explicit authorization before amend/rebase/force-push cleanup.
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -325,19 +325,19 @@ until shape is correct.
 Do not blindly copy the entire ticket body into the PR description. The ticket holds the original context; the PR body summarizes the implementation delta.
 
 **The Epic Close-Target Ban (Mandatory):**
-You are strictly FORBIDDEN from using magic close keywords (e.g., `Closes #N`, `Resolves #N`, `Fixes #N`) where `#N` is an Epic ticket. GitHub's auto-close-on-merge semantics will prematurely close the entire epic when the PR merges. PRs deliver sub-issues, not epics.
-- If your PR contributes to an epic but does not close it, use `Related: #N` instead.
-- You may only use magic close keywords on leaf sub-issues that the PR fully implements.
+You are strictly FORBIDDEN from pointing `Resolves #N` at an Epic ticket. GitHub's auto-close-on-merge semantics would prematurely close the entire epic when the PR merges. PRs deliver sub-issues, not epics.
+- `Resolves` only the leaf sub-issue the PR fully implements.
+- To reference the parent epic without closing it, use `Related: #N` (or `Refs #N`).
 
-**The Syntax-Exact Keyword Mandate (Mandatory):**
-When your PR fully implements a ticket, you MUST use the exact GitHub-supported magic keyword syntax on its own line. Prefer `Resolves #N` for shipped work, or `Fixes #N` for bugs; avoid `Closes #N` unless the semantics are "closed but not necessarily delivered" such as not-planned, superseded, or dropped scope.
-You are strictly FORBIDDEN from embedding the closing keyword in a conversational sentence (e.g., "Closes Sub 3 of Epic #X (#Y)"). GitHub's parser requires strict syntax to establish the automatic close link. If you fail to use the exact syntax, the ticket will remain open after merge.
+**The `Resolves`-Only Mandate (Mandatory, CI-enforced — #12367):**
+Every PR body MUST contain ≥1 `Resolves #N` — the only sanctioned closing keyword (= delivered work); `agent-pr-body-lint.yml` rejects agent/`ai` PRs without one. `Closes #N` is forbidden (closed-without-delivery needs no PR); `Fixes #N` is forbidden (ambiguous). `Refs #N` / `Related: #N` are allowed only as *additional* references. This makes 1-PR-per-ticket mechanical: N PRs cannot share N valid `Resolves`, so split the work into subs.
+You are strictly FORBIDDEN from embedding the keyword in a conversational sentence (e.g., "Resolves Sub 3 of Epic #X (#Y)"). GitHub's parser requires strict syntax to establish the automatic close link. If you fail to use the exact syntax, the ticket will remain open after merge.
 **Multiple Tickets Loophole:** While we strive for a 1-Ticket-to-1-PR ratio, if your PR fully resolves multiple tickets, you MUST flag each one individually. Do NOT use comma-separated lists like `Resolves #X, #Y`. Instead, use a distinct line for each ticket:
 `Resolves #X`
 `Resolves #Y`
 
-**Partial-resolution branch-history check (#11185):**
-If the ticket must remain open and your PR body uses `Refs #N`, `Related: #N`, or another non-closing reference, the entire branch history must agree. Before handoff, run:
+**Branch-history close-keyword hygiene (#11185):**
+For any *additional* ticket your PR references but must NOT close (e.g. a parent epic via `Refs #N` / `Related: #N`), the entire branch history must agree it stays open. Before handoff, run:
 
 ```bash
 git log origin/dev..HEAD --format='%h%x09%s%n%b'

--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -67,11 +67,30 @@ jobs:
             const missingVisible   = VISIBLE_PR_BODY_ANCHORS  .filter(a => !body.includes(a));
             const missingInvisible = INVISIBLE_PR_BODY_ANCHORS.filter(a => !body.includes(a));
 
-            // Ticket-reference is a separate visible check (regex pattern, not substring)
-            const ticketRegex   = /(Resolves|Closes|Fixes|Related:|Refs)\s+#\d+/i;
-            const missingTicket = !ticketRegex.test(body);
-            if (missingTicket) {
-              missingVisible.push("Ticket reference (e.g., Resolves #N, Related: #N)");
+            // Ticket-reference is a separate visible check (regex pattern, not substring).
+            //
+            // Operator rule (#12367): every agent PR body MUST contain at least one `Resolves #N`
+            // — the ONLY sanctioned closing keyword (it means *delivered work*). This mechanically
+            // enforces the 1-PR-per-ticket model: a ticket that needs N PRs cannot have N valid
+            // `Resolves` (only one PR can resolve it), so it must become an epic + subs or be split.
+            //   - `Closes #N` is FORBIDDEN: "Closes" = closed-without-delivery (not-planned /
+            //     superseded / dropped) — that outcome needs NO PR, so a PR must never carry it.
+            //   - `Fixes #N`  is FORBIDDEN: ambiguous; use `Resolves` (bug fixes included).
+            //   - `Refs #N` / `Related: #N` are allowed as ADDITIONAL references (e.g. a parent
+            //     epic), and multiple `Resolves` lines are fine — but they never substitute for
+            //     the mandatory `Resolves`.
+            const hasResolves    = /\bResolves:?\s+#\d+/i.test(body);
+            const forbiddenClose = body.match(/\b(Closes|Fixes):?\s+#\d+/i);
+
+            if (forbiddenClose) {
+              missingVisible.push(
+                "`" + forbiddenClose[1] + " #N` is forbidden — use `Resolves #N` " +
+                "(`Closes` = closed-without-delivery → no PR needed; `Fixes` is ambiguous)"
+              );
+            }
+
+            if (!hasResolves) {
+              missingVisible.push("`Resolves #N` (mandatory closing keyword — `Refs`/`Related` alone is NOT sufficient)");
             }
 
             if (missingVisible.length === 0 && missingInvisible.length === 0) {


### PR DESCRIPTION
**Resolves #12367**
**Related:** #11501 (the original agent PR-body lint), #11925 (the ~27-PR fragmentation this prevents).

**FAIR-band:** operator-directed lane — @tobiu explicitly requested this CI check ("we need a check 'Resolves: <ticket id>'. no exceptions"). Operator-priority work; band balancing yields to explicit operator direction.

**Evidence:** L1 (static — the check is a pure regex test on the PR-body string; verified the workflow is valid YAML and the embedded github-script body parses as valid async JS) + L2 (12/12 logic cases exercised via `node`, covering every AC). L3 — the live workflow firing on a real PR — is observable only once this is on `dev`; see Post-Merge Validation.

## What + Why

`agent-pr-body-lint.yml` accepted any of `Resolves|Closes|Fixes|Related:|Refs #N` as the ticket reference, so a single ticket could be fragmented across many PRs (each `Refs #N`, none resolving it) — the gap behind ~27 PRs for the one ticket #11925.

The check now requires every agent/`ai` PR body to contain at least one `Resolves #N` — the only sanctioned closing keyword (= delivered work). This mechanically enforces the 1-PR-per-ticket model: a ticket that needs N PRs cannot carry N valid `Resolves` (only one PR can resolve it), so it must become an epic + subs or be split.

- `Closes #N` forbidden — Closes = closed-without-delivery (not-planned / superseded / dropped) → that outcome needs no PR.
- `Fixes #N` forbidden — ambiguous; use `Resolves`.
- `Refs #N` / `Related: #N` allowed as additional references; multiple `Resolves` lines fine — but they no longer satisfy the requirement on their own.

This very PR dogfoods the rule: the `Related:` extras above plus the one mandatory `Resolves #12367`.

## Deltas
- `agent-pr-body-lint.yml`: replaced the permissive `(Resolves|Closes|Fixes|Related:|Refs)\s+#\d+` accept-any regex with (a) require ≥1 `\bResolves:?\s+#\d+`, (b) reject `\b(Closes|Fixes):?\s+#\d+` with an explanatory message naming why (`Closes` → no PR needed; `Fixes` → ambiguous). The existing anchor + self-identification checks are untouched.
- `pull-request-workflow.md` §3.3: rewrote the close-keyword mandate to "`Resolves`-only; `Closes`/`Fixes` forbidden; `Refs`/`Related` allowed as additional", and updated the Epic Close-Target Ban + the branch-history hygiene note to match.
- `pr-review-guide.md` §5.2: synced reviewer-side close-target audit with the same `Resolves`-only convention while preserving the epic-close and squash-merge branch-history hazards.

## Test Evidence
- `node` regex harness — 12/12 cases pass:
  - a `Resolves` reference (incl. two `Resolves` lines; lowercase `resolves`; the colon form `Resolves:`) → **accepted**.
  - `Refs`-only / `Related:`-only (no `Resolves`) → **rejected** (missing mandatory `Resolves`).
  - a `Closes`/`Fixes` keyword adjacent to an id → **rejected** with the explanatory message, even when a valid `Resolves` is also present.
  - prose such as "this fixes the bug described in &lt;ref&gt;" → correctly **not** mis-flagged as a forbidden `Fixes` (keyword not adjacent to the id).
- `js-yaml` parse: workflow is valid YAML; the embedded github-script body parses as valid async JS (the form github-script runs it).
- `check-whitespace`: clean on the original workflow/doc patch (pre-commit passed). `check-ticket-archaeology` is `*.mjs`-only → N/A for the touched `.yml`/`.md`.
- Fixup `c4967e3e0`: `git diff --check` clean; `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` OK; `node ai/scripts/lint/lint-agents.mjs` OK.
- CI: pending after fixup `c4967e3e0` — will confirm green before merge-eligibility. NOTE: `pull_request` workflows run the version from the **base** branch, so this PR is still linted by the OLD check; the strengthened rule takes effect for PRs opened after this merges to `dev`.

## Post-Merge Validation
- [ ] First agent PR opened after merge: a body with only `Refs #N` (no `Resolves`) fails the lint.
- [ ] A body containing a `Closes`/`Fixes` close-keyword fails with the explanatory comment.
- [ ] A normal `Resolves #N` body passes unchanged.

Authored by @neo-opus-4-7 (claude-opus-4.8-1m) · session 98c1b6cb

