### PR TITLE
feat(github-workflow): gate milestone archive routing (#11365)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -174,6 +174,12 @@ class Config extends BaseConfig {
                  */
                 versionDirectoryPrefix: leaf('v'),
                 /**
+                 * Whether closed issues and pull requests may use semver milestone titles as an
+                 * archive-bucket fallback when release-date bucketing finds no cut release.
+                 * @type {boolean}
+                 */
+                routeByMilestone: leaf(false),
+                /**
                  * The maximum number of items per chunk directory in the archive.
                  * @type {number}
                  */

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -1,6 +1,7 @@
 import aiConfig                                      from '../../../mcp/server/github-workflow/config.mjs';
 import Base                                          from '../../../../src/core/Base.mjs';
 import crypto                                        from 'crypto';
+import {existsSync}                                  from 'fs';
 import fs                                            from 'fs/promises';
 import logger                                        from '../../../mcp/server/github-workflow/logger.mjs';
 import matter                                        from 'gray-matter';
@@ -62,6 +63,44 @@ class IssueSyncer extends Base {
      */
     #calculateContentHash(content) {
         return crypto.createHash('sha256').update(content).digest('hex');
+    }
+
+    /**
+     * @summary Resolves a closed issue's release-date bucket.
+     * @param {String} closedAt GitHub close timestamp.
+     * @returns {String|null} Version bucket, or null when no cut release follows the close date.
+     * @private
+     */
+    #deriveClosedAtVersion(closedAt) {
+        const closed  = new Date(closedAt);
+        const release = (ReleaseNotesSyncer.sortedReleases || []).find(r => new Date(r.publishedAt) > closed);
+
+        if (!release) return null;
+
+        return release.tagName.startsWith(issueSyncConfig.versionDirectoryPrefix)
+            ? release.tagName
+            : issueSyncConfig.versionDirectoryPrefix + release.tagName;
+    }
+
+    /**
+     * @summary Resolves an opt-in milestone archive bucket without pre-staging future releases.
+     * @param {Object} issue GitHub issue node or cached issue entry.
+     * @returns {String|null} Existing milestone bucket, or null when disabled, invalid, or uncut.
+     * @private
+     */
+    #deriveMilestoneVersion(issue) {
+        const title = issue.milestone?.title;
+
+        if (!issueSyncConfig.routeByMilestone || !title || !semver.valid(semver.clean(title))) {
+            return null;
+        }
+
+        const candidate = title.startsWith(issueSyncConfig.versionDirectoryPrefix)
+            ? title
+            : issueSyncConfig.versionDirectoryPrefix + title;
+        const archiveDir = path.join(issueSyncConfig.archiveRoot, 'issues', candidate);
+
+        return existsSync(archiveDir) ? candidate : null;
     }
 
     /**
@@ -313,7 +352,8 @@ class IssueSyncer extends Base {
                 state: issue.state,
                 milestone: issue.milestone ? { title: issue.milestone } : null,
                 closedAt: issue.closedAt,
-                oldVersion
+                oldVersion,
+                fromFetched: false
             });
         }
 
@@ -336,13 +376,15 @@ class IssueSyncer extends Base {
                 existing.state = issue.state;
                 existing.milestone = issue.milestone;
                 existing.closedAt = issue.closedAt;
+                existing.fromFetched = true;
             } else {
                 combined.set(issue.number, {
                     number: issue.number,
                     state: issue.state,
                     milestone: issue.milestone,
                     closedAt: issue.closedAt,
-                    oldVersion: null
+                    oldVersion: null,
+                    fromFetched: true
                 });
             }
         }
@@ -353,14 +395,7 @@ class IssueSyncer extends Base {
         for (const issue of combined.values()) {
             let version = null;
             if (issue.state === 'CLOSED') {
-                // Treat a milestone as a version bucket ONLY when its title is valid semver. A
-                // descriptive milestone (e.g. "neo.d.ts - Typescript definitions") must not become
-                // a version folder; non-semver milestones fall through to closedAt→release resolution.
-                if (issue.milestone?.title && semver.valid(semver.clean(issue.milestone.title))) {
-                    version = issue.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
-                        ? issue.milestone.title
-                        : issueSyncConfig.versionDirectoryPrefix + issue.milestone.title;
-                } else if (!ignoreOldVersion && issue.oldVersion && semver.valid(semver.clean(issue.oldVersion)) !== null) {
+                if (!issue.fromFetched && !ignoreOldVersion && issue.oldVersion && semver.valid(semver.clean(issue.oldVersion)) !== null) {
                     // Use cached path-derived version when present and valid semver. Unchanged closed
                     // issues seeded from existing serialized metadata may lack milestone data but still
                     // have a known on-disk bucket via oldVersion. Skipping closedAt timestamp inference
@@ -368,13 +403,15 @@ class IssueSyncer extends Base {
                     // path is the canonical bucket when no milestone data exists.
                     version = issue.oldVersion;
                 } else if (issue.closedAt) {
-                    const closed = new Date(issue.closedAt);
-                    const release = (ReleaseNotesSyncer.sortedReleases || []).find(r => new Date(r.publishedAt) > closed);
-                    if (release) {
-                        version = release.tagName.startsWith(issueSyncConfig.versionDirectoryPrefix)
-                            ? release.tagName
-                            : issueSyncConfig.versionDirectoryPrefix + release.tagName;
-                    }
+                    version = this.#deriveClosedAtVersion(issue.closedAt);
+                }
+
+                if (!version) {
+                    version = this.#deriveMilestoneVersion(issue);
+                }
+
+                if (!version && !ignoreOldVersion && issue.oldVersion && semver.valid(semver.clean(issue.oldVersion)) !== null) {
+                    version = issue.oldVersion;
                 }
             }
 
@@ -529,7 +566,7 @@ class IssueSyncer extends Base {
                     cursor,
                     states          : ['OPEN', 'CLOSED'],
                     // Clean-slate sync (`metadata.lastSync === null`) must traverse the full repo
-                    // history per ADR 0004. Falling back to the normal syncStartDate would miss old
+                    // history per ADR 0004 (ticket-ref-ok: file-owned decision record). Falling back to the normal syncStartDate would miss old
                     // issues that have not been touched since that date. Use an explicit pre-Neo date,
                     // then let droppedLabels and maxIssues caps trim the actual processed set.
                     since           : metadata.lastSync || '2017-01-01T00:00:00Z',

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,6 +1,7 @@
 import aiConfig                   from '../../../mcp/server/github-workflow/config.mjs';
 import Base                       from '../../../../src/core/Base.mjs';
 import crypto                     from 'crypto';
+import {existsSync}               from 'fs';
 import fs                         from 'fs/promises';
 import logger                     from '../../../mcp/server/github-workflow/logger.mjs';
 import matter                     from 'gray-matter';
@@ -49,6 +50,46 @@ class PullRequestSyncer extends Base {
      */
     #calculateContentHash(content) {
         return crypto.createHash('sha256').update(content).digest('hex');
+    }
+
+    /**
+     * @summary Resolves a closed or merged pull request's release-date bucket.
+     * @param {Object} pr GitHub pull request node or cached pull entry.
+     * @returns {String|null} Version bucket, or null when no cut release follows the close/merge date.
+     * @private
+     */
+    #deriveClosedAtVersion(pr) {
+        if (!pr.mergedAt && !pr.closedAt) return null;
+
+        const closed  = new Date(pr.mergedAt || pr.closedAt);
+        const release = (ReleaseNotesSyncer.sortedReleases || []).find(r => new Date(r.publishedAt) > closed);
+
+        if (!release) return null;
+
+        return release.tagName.startsWith(issueSyncConfig.versionDirectoryPrefix)
+            ? release.tagName
+            : issueSyncConfig.versionDirectoryPrefix + release.tagName;
+    }
+
+    /**
+     * @summary Resolves an opt-in milestone archive bucket without pre-staging future releases.
+     * @param {Object} pr GitHub pull request node or cached pull entry.
+     * @returns {String|null} Existing milestone bucket, or null when disabled, invalid, or uncut.
+     * @private
+     */
+    #deriveMilestoneVersion(pr) {
+        const title = pr.milestone?.title;
+
+        if (!issueSyncConfig.routeByMilestone || !title || !semver.valid(semver.clean(title))) {
+            return null;
+        }
+
+        const candidate = title.startsWith(issueSyncConfig.versionDirectoryPrefix)
+            ? title
+            : issueSyncConfig.versionDirectoryPrefix + title;
+        const archiveDir = path.join(issueSyncConfig.archiveRoot, 'pulls', candidate);
+
+        return existsSync(archiveDir) ? candidate : null;
     }
 
     /**
@@ -109,20 +150,12 @@ class PullRequestSyncer extends Base {
 
         for (const pr of combined.values()) {
             let version = null;
-            // Treat a milestone as a version bucket ONLY when its title is valid semver — a
-            // descriptive milestone must not become a version folder (mirrors IssueSyncer).
-            if (pr.milestone?.title && semver.valid(semver.clean(pr.milestone.title))) {
-                version = pr.milestone.title.startsWith(issueSyncConfig.versionDirectoryPrefix)
-                    ? pr.milestone.title
-                    : issueSyncConfig.versionDirectoryPrefix + pr.milestone.title;
-            } else if (pr.mergedAt || pr.closedAt) {
-                const closed = new Date(pr.mergedAt || pr.closedAt);
-                const release = (ReleaseNotesSyncer.sortedReleases || []).find(r => new Date(r.publishedAt) > closed);
-                if (release) {
-                    version = release.tagName.startsWith(issueSyncConfig.versionDirectoryPrefix)
-                        ? release.tagName
-                        : issueSyncConfig.versionDirectoryPrefix + release.tagName;
-                }
+            if (pr.mergedAt || pr.closedAt) {
+                version = this.#deriveClosedAtVersion(pr);
+            }
+
+            if (!version) {
+                version = this.#deriveMilestoneVersion(pr);
             }
 
             if (pr.state !== 'CLOSED' && pr.state !== 'MERGED' || !version) {

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
@@ -126,6 +126,12 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
         }
     });
 
+    test('config.template.mjs keeps milestone archive routing opt-in by default', async () => {
+        const config = (await importTemplateConfig()).default;
+
+        expect(config.issueSync.routeByMilestone).toBe(false);
+    });
+
     test('NEO_LOG_LEVEL overrides config.logLevel with validation', async () => {
         // Env binding + its parser-based validation run at construction, so each case uses a
         // fresh instance built from the template's meta-leaf tree (the singleton is already

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -25,12 +25,12 @@ import path            from 'path';
  *
  * Two axes of coverage:
  *
- * 1. **Timeline pagination (#10090).** Builds a mocked GitHub issue whose `timelineItems`
+     * 1. **Timeline pagination.** Builds a mocked GitHub issue whose `timelineItems`
  *    connection has 75 events split across two pages — more than `maxTimelineItemsPerIssue` (50) —
  *    and drives the refetch path to confirm that every comment body and structural event makes
  *    it into the rendered markdown. Before the fix, the second-page tail was silently dropped.
  *
- * 2. **Timeline-derived `commentsTotal` (#10110).** Asserts that the `commentsTotal` metadata
+     * 2. **Timeline-derived `commentsTotal`.** Asserts that the `commentsTotal` metadata
  *    field and the frontmatter `commentsCount` are both derived from `timelineItems.nodes`
  *    filtered for `__typename === 'IssueComment'` — the authoritative post-exhaust count — not
  *    from the dropped `issue.comments.totalCount` scalar. Guards against regression back to the
@@ -46,6 +46,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
     let originalArchiveRoot;
     let originalIssuesDir;
     let originalContentRoot;
+    let originalRouteByMilestone;
     let tmpRoot;
     let logger;
 
@@ -55,6 +56,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         originalArchiveRoot = issueSyncConfig.archiveRoot;
         originalIssuesDir   = issueSyncConfig.issuesDir;
         originalContentRoot = issueSyncConfig.contentRoot;
+        originalRouteByMilestone = issueSyncConfig.routeByMilestone;
 
         tmpRoot = path.resolve(process.cwd(), 'tmp', `issue-syncer-test-${process.pid}-${Date.now()}`);
         await fs.ensureDir(tmpRoot);
@@ -78,6 +80,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         issueSyncConfig.archiveRoot = originalArchiveRoot;
         issueSyncConfig.issuesDir   = originalIssuesDir;
         issueSyncConfig.contentRoot = originalContentRoot;
+        issueSyncConfig.routeByMilestone = originalRouteByMilestone;
         await fs.remove(tmpRoot).catch(() => {});
     });
 
@@ -148,7 +151,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const eventLines = written.match(/^- 2026-04-19T[^ ]+ @tobiu cross-referenced by #\d+$/gm) || [];
         expect(eventLines).toHaveLength(TOTAL_EVENTS - PAGE_SIZE);
 
-        // Frontmatter commentsCount is now derived from timelineItems (#10110) — authoritative
+        // Frontmatter commentsCount is now derived from timelineItems — authoritative
         // against what the markdown actually renders in its Timeline section.
         expect(written).toContain(`id: ${mockIssue.number}`);
         expect(written).toContain(`commentsCount: ${PAGE_SIZE}`);
@@ -200,18 +203,18 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
     });
 
     test('closed-post-latest-release issue lands in active when no archive-version applies (#11360 supersedes #11288 unversioned-target scenario)', async () => {
-        // PRE-#11360: closed-post-latest-release issues with no matching release
+        // Before the archive fallback cleanup: closed-post-latest-release issues with no matching release
         // would fall through to `'unversioned'` archive bucket. That fallback was the
-        // architectural bug fixed by #11360 — pre-staging items into a not-yet-existing
-        // version archive violates Epic #11187 sealed-chunk semantics.
+        // architectural bug fixed by the cleanup — pre-staging items into a not-yet-existing
+        // version archive violates sealed-chunk semantics.
         //
-        // POST-#11360: such items land in ACTIVE path; archive folders for vN.M.K are
+        // After the cleanup: such items land in ACTIVE path; archive folders for vN.M.K are
         // created at release-cut by publish.mjs, never pre-staged.
         //
-        // The #11288 anomaly-hook contract (warn on closedAt-shift across buckets) is
+        // The anomaly-hook contract (warn on closedAt-shift across buckets) is
         // preserved for shifts between REAL release buckets (e.g., v11.0.0 → v12.0.0).
         // The "shift to 'unversioned'" / "archive → active" anomaly variant needs to be
-        // re-established in a follow-up sub-ticket; deliberately not in scope for #11360.
+        // re-established in a follow-up sub-ticket; deliberately not in scope here.
         const mockIssue = buildMockIssue({
             number       : 50001,
             title        : 'Mock issue — closed-post-latest-release lands in active #11360',
@@ -247,10 +250,10 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         expect(stats.refetched.count).toBe(1);
         expect(stats.errors).toHaveLength(0);
 
-        // Item lands in active (per Epic #11187 mental model: closed-for-next-release stays in active).
+        // Item lands in active: closed-for-next-release stays in active.
         // Assert via configured active root (issuesDir) rather than literal '/issues/' substring —
         // the test rewrites issuesDir to a tmp dir, so the literal substring no longer matches even
-        // when behavior is correct. Per @neo-gpt PR #11362 Cycle 1 review correction.
+        // when behavior is correct.
         const targetPath           = metadata.issues['50001'].path;
         const absoluteTargetPath   = path.resolve(aiConfig.projectRoot, targetPath);
         const relativeToIssuesDir  = path.relative(issueSyncConfig.issuesDir, absoluteTargetPath);
@@ -261,7 +264,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
     test('non-semver milestone is not a version bucket — falls through to closedAt→release (#12184)', async () => {
         // A descriptive (non-semver) milestone must NOT become a `v<title>` archive folder. Empirical:
-        // #3286/#3287 carried milestones like "neo.d.ts - Typescript definitions ..." and were archived
+        // Real issues carried milestones like "neo.d.ts - Typescript definitions ..." and were archived
         // as garbage version folders. With the semver guard, such a closed issue falls through to the
         // closedAt→release resolution and buckets into the real release that shipped after it closed.
         const mockIssue = buildMockIssue({
@@ -299,6 +302,102 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
             expect(bucketPath).not.toContain('neo.d.ts');
         } finally {
             ReleaseNotesSyncer.sortedReleases = originalSorted;
+        }
+    });
+
+    test('routeByMilestone=false ignores semver milestones and keeps post-latest closed issues active', async () => {
+        const mockIssue = buildMockIssue({
+            number       : 50004,
+            title        : 'Mock post-latest issue with future semver milestone',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        mockIssue.state     = 'CLOSED';
+        mockIssue.closedAt  = '2026-01-15T00:00:00Z';
+        mockIssue.milestone = {title: 'v99.0.0'};
+
+        const originalSorted           = ReleaseNotesSyncer.sortedReleases;
+        const originalRouteByMilestone = issueSyncConfig.routeByMilestone;
+        ReleaseNotesSyncer.sortedReleases = [];
+        issueSyncConfig.routeByMilestone  = false;
+        await fs.ensureDir(path.join(issueSyncConfig.archiveRoot, 'issues', 'v99.0.0'));
+
+        GraphqlService.query = async (query) => {
+            if (query.includes('FetchSingleIssue')) {
+                return {repository: {issue: structuredClone(mockIssue)}};
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        try {
+            const metadata = {issues: {}};
+            const stats    = await IssueSyncer.refetchIssuesByNumber([mockIssue.number], metadata);
+            const targetPath = metadata.issues[mockIssue.number].path;
+
+            expect(stats.refetched.count).toBe(1);
+            expect(stats.errors).toHaveLength(0);
+            expect(targetPath).not.toContain('/archive/');
+            expect(path.relative(issueSyncConfig.issuesDir, path.resolve(aiConfig.projectRoot, targetPath)).startsWith('..')).toBe(false);
+        } finally {
+            ReleaseNotesSyncer.sortedReleases = originalSorted;
+            issueSyncConfig.routeByMilestone  = originalRouteByMilestone;
+        }
+    });
+
+    test('routeByMilestone=true only routes semver milestones into already-cut archive buckets', async () => {
+        const missingBucketIssue = buildMockIssue({
+            number       : 50005,
+            title        : 'Mock issue with uncut milestone',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        missingBucketIssue.state     = 'CLOSED';
+        missingBucketIssue.closedAt  = '2026-01-15T00:00:00Z';
+        missingBucketIssue.milestone = {title: 'v97.0.0'};
+
+        const cutBucketIssue = buildMockIssue({
+            number       : 50006,
+            title        : 'Mock issue with cut milestone bucket',
+            timelineFirst: [],
+            hasNextPage  : false,
+            endCursor    : null
+        });
+        cutBucketIssue.state     = 'CLOSED';
+        cutBucketIssue.closedAt  = '2026-01-15T00:00:00Z';
+        cutBucketIssue.milestone = {title: 'v98.0.0'};
+
+        const originalSorted           = ReleaseNotesSyncer.sortedReleases;
+        const originalRouteByMilestone = issueSyncConfig.routeByMilestone;
+        ReleaseNotesSyncer.sortedReleases = [];
+        issueSyncConfig.routeByMilestone  = true;
+        await fs.ensureDir(path.join(issueSyncConfig.archiveRoot, 'issues', 'v98.0.0'));
+
+        GraphqlService.query = async (query, variables) => {
+            if (query.includes('FetchSingleIssue')) {
+                return {
+                    repository: {
+                        issue: variables.number === cutBucketIssue.number
+                            ? structuredClone(cutBucketIssue)
+                            : structuredClone(missingBucketIssue)
+                    }
+                };
+            }
+            throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+        };
+
+        try {
+            const metadata = {issues: {}};
+            const stats    = await IssueSyncer.refetchIssuesByNumber([missingBucketIssue.number, cutBucketIssue.number], metadata);
+
+            expect(stats.refetched.count).toBe(2);
+            expect(stats.errors).toHaveLength(0);
+            expect(metadata.issues[missingBucketIssue.number].path).not.toContain('/archive/');
+            expect(metadata.issues[cutBucketIssue.number].path).toContain(path.join('archive', 'issues', 'v98.0.0'));
+        } finally {
+            ReleaseNotesSyncer.sortedReleases = originalSorted;
+            issueSyncConfig.routeByMilestone  = originalRouteByMilestone;
         }
     });
 
@@ -432,7 +531,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
     });
 
     test('formatTimelineEvent null-safety: null assignee / label / subIssue / source produce fallback markers, no crash (#11474)', async () => {
-        // Empirical anchor: post-#11470-merge sync_all crashed at IssueSyncer.mjs:202 on
+        // Empirical anchor: sync_all crashed at IssueSyncer.mjs:202 on
         // `event.assignee.login` when a GitHub user had been deleted. Same null-deref risk
         // exists across the entire #formatTimelineEvent switch (label, subIssue, parent,
         // blockingIssue, blockedIssue, commit, source). This test exercises four representative
@@ -502,10 +601,10 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
     });
 
     test('formatIssueMarkdown null-safety: ghost issue (null author + null label/assignee/subIssue nodes) renders without crash (#11481)', async () => {
-        // Empirical anchor: post-#11476-merge sync_all crashed at IssueSyncer.mjs:145 on
+        // Empirical anchor: sync_all crashed at IssueSyncer.mjs:145 on
         // `issue.author.login` when the GitHub author had been deleted (Ghost user). This is
-        // the whack-a-mole companion to the #11474 timeline-event fix — same null-deref class
-        // in the FRONTMATTER ASSEMBLY method (#formatIssueMarkdown) that PR #11476 didn't sweep.
+        // the whack-a-mole companion to the timeline-event fix — same null-deref class
+        // in the FRONTMATTER ASSEMBLY method (#formatIssueMarkdown) that the prior sweep missed.
         // This test exercises EVERY nullable frontmatter site simultaneously ("ghost issue")
         // to prevent future whack-a-mole regressions.
         const ghostIssue = {
@@ -579,11 +678,11 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
 
     test('ARCHIVE ANOMALY WARN: only fires when both buckets parse as valid semver tags (#11486)', async () => {
         // Empirical anchor: operator 2026-05-16T19:33Z paste — `npm run ai:sync-github-workflow`
-        // post-#11485-merge produced thousands of `[WARN] 🚨 [ARCHIVE ANOMALY]` lines, dominated by
+        // sync produced thousands of `[WARN] 🚨 [ARCHIVE ANOMALY]` lines, dominated by
         // migration-shape false positives (oldVersion = title-derived garbage like
         // 'vneo.d.ts - Typescript definitions for all neo framework classes') where sealed-chunk
         // semantics already prevent any actual move. Only genuine vX.Y.Z → vX.Y.Z shifts (e.g.
-        // #7910 v11.12.0 → v11.13.0) are actionable anomalies and should retain WARN level.
+        // a v11.12.0 → v11.13.0 shift) are actionable anomalies and should retain WARN level.
         //
         // This test exercises two issues simultaneously:
         // - Issue A: cached path bucket is title-derived garbage → semver.valid returns null →
@@ -674,6 +773,8 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         // Pre-create the two cached files so sealed-chunk path-resolution works.
         await fs.ensureDir(path.dirname(issueAOldAbsolutePath));
         await fs.ensureDir(path.dirname(issueBOldAbsolutePath));
+        await fs.ensureDir(path.join(issueSyncConfig.archiveRoot, 'issues', 'v8.1.0'));
+        await fs.ensureDir(path.join(issueSyncConfig.archiveRoot, 'issues', 'v11.13.0'));
         await fs.writeFile(issueAOldAbsolutePath, 'mock content A', 'utf8');
         await fs.writeFile(issueBOldAbsolutePath, 'mock content B', 'utf8');
 
@@ -682,14 +783,17 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         const debugCalls = [];
         const originalWarn  = logger.warn;
         const originalDebug = logger.debug;
+        const originalRouteByMilestone = issueSyncConfig.routeByMilestone;
         logger.warn  = (...args) => { warnCalls.push(args[0]); };
         logger.debug = (...args) => { debugCalls.push(args[0]); };
+        issueSyncConfig.routeByMilestone = true;
 
         try {
             await IssueSyncer.pullFromGitHub(metadata);
         } finally {
             logger.warn  = originalWarn;
             logger.debug = originalDebug;
+            issueSyncConfig.routeByMilestone = originalRouteByMilestone;
             await fs.unlink(issueAOldAbsolutePath).catch(() => {});
             await fs.unlink(issueBOldAbsolutePath).catch(() => {});
         }
@@ -710,9 +814,9 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
     });
 
     test('planBuckets oldVersion precedence: unchanged closed issue with no milestone skips closedAt timestamp fallback (#11594 AC4(b))', async () => {
-        // Regression #11594 AC4(b) per @neo-gpt PR #11607 Cycle 2 review:
+        // Regression coverage for oldVersion precedence:
         // Legacy archived issues seeded from existing serialized metadata may lack milestone data
-        // (pre-#11594-persistence-fix entries). When such an issue is NOT in the delta fetch (it
+        // (pre-persistence-fix entries). When such an issue is NOT in the delta fetch (it
         // hasn't been modified since lastSync), `#planBuckets` receives `milestone: null/undefined`
         // and previously fell through to closedAt-based timestamp inference, which could re-emit
         // ARCHIVE ANOMALY WARN for issues already at their canonical on-disk bucket.
@@ -722,7 +826,7 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         // valid-semver oldVersion + no milestone → version = oldVersion → no WARN, no closedAt
         // heuristic invocation.
         //
-        // Empirical anchor: #7910 (CLOSED 2025-11-29, milestone v11.12.0) was re-bucketed to
+        // Empirical anchor: a closed issue with milestone v11.12.0 was re-bucketed to
         // v11.13.0 every sync because the persistence-shape bug meant milestone data was missing
         // post-persist (Cycle 1 fix), AND planBuckets had no oldVersion precedence even when the
         // cached path WAS the canonical bucket (this Cycle 2 fix).
@@ -976,7 +1080,7 @@ function buildCrossRef(i) {
 
 /**
  * Builds the minimal GraphQL issue shape that `IssueSyncer.#formatIssueMarkdown` accepts.
- * Post-#10110 the `comments` subselect is gone from the query, so the mock omits it too.
+     * The `comments` subselect is gone from the query, so the mock omits it too.
  */
 function buildMockIssue({number, title, timelineFirst, hasNextPage, endCursor}) {
     return {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -30,6 +30,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
     let originalQuery;
     let originalSortedReleases;
     let originalVersionDirectoryPrefix;
+    let originalRouteByMilestone;
     let tmpRoot;
 
     test.beforeAll(async () => {
@@ -44,6 +45,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         originalQuery                  = GraphqlService.query.bind(GraphqlService);
         originalSortedReleases         = ReleaseNotesSyncer.sortedReleases;
         originalVersionDirectoryPrefix = aiConfig.issueSync.versionDirectoryPrefix;
+        originalRouteByMilestone       = aiConfig.issueSync.routeByMilestone;
     });
 
     test.beforeEach(async () => {
@@ -54,6 +56,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         aiConfig.issueSync.pullsDir               = path.join(tmpRoot, 'pulls');
         aiConfig.issueSync.contentRoot            = tmpRoot;
         aiConfig.issueSync.versionDirectoryPrefix = 'v';
+        aiConfig.issueSync.routeByMilestone       = false;
         ReleaseNotesSyncer.sortedReleases              = [];
     });
 
@@ -64,6 +67,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         aiConfig.issueSync.pullsDir               = originalPullsDir;
         aiConfig.issueSync.contentRoot            = originalContentRoot;
         aiConfig.issueSync.versionDirectoryPrefix = originalVersionDirectoryPrefix;
+        aiConfig.issueSync.routeByMilestone       = originalRouteByMilestone;
 
         await fs.remove(tmpRoot).catch(() => {});
     });
@@ -71,7 +75,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
     test('stale cached archiveVersion does not force a closed-post-latest-release PR into archive/pulls/v13.0.0 (#11364)', async () => {
         const prNumber = 12345;
 
-        // Pre-#11364 metadata pinned this PR to a v13.0.0 archive bucket via the
+        // Legacy metadata pinned this PR to a v13.0.0 archive bucket via the
         // `archiveVersion` carry-forward. With the carry-forward retired, archive placement
         // is derived fresh from real milestone/release logic — and a PR merged after the
         // latest release with no milestone must land ACTIVE, not in the stale v13.0.0 bucket.
@@ -113,7 +117,7 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         await expect(fs.pathExists(activePath)).resolves.toBe(true);
         await expect(fs.pathExists(stalePath)).resolves.toBe(false);
         expect(metadata.pulls[prNumber].path).toBe(path.relative(aiConfig.projectRoot, activePath));
-        // `archiveVersion` is fully retired (#11364) — it is no longer written to metadata.
+        // `archiveVersion` is fully retired — it is no longer written to metadata.
         expect(metadata.pulls[prNumber].archiveVersion).toBeUndefined();
     });
 
@@ -148,6 +152,58 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         // Bucketed into the real release, NOT a title-derived garbage folder.
         await expect(fs.pathExists(releasePath)).resolves.toBe(true);
         await expect(fs.pathExists(garbagePath)).resolves.toBe(false);
+    });
+
+    test('routeByMilestone=false ignores semver milestones and keeps post-latest merged PRs active', async () => {
+        const prNumber = 3288;
+        const pr = buildPullRequest(prNumber);
+        pr.milestone = {title: 'v99.0.0'};
+        await fs.ensureDir(path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v99.0.0'));
+
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes   : [pr],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        const stats       = await PullRequestSyncer.syncPullRequests({pulls: {}});
+        const activePath  = path.join(aiConfig.issueSync.contentRoot, 'pulls', 'chunk-1', `pr-${prNumber}.md`);
+        const archivePath = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v99.0.0', 'chunk-1', `pr-${prNumber}.md`);
+
+        expect(stats.synced).toEqual([prNumber]);
+        await expect(fs.pathExists(activePath)).resolves.toBe(true);
+        await expect(fs.pathExists(archivePath)).resolves.toBe(false);
+    });
+
+    test('routeByMilestone=true only routes semver milestones into already-cut archive buckets', async () => {
+        const missingBucketPr = buildPullRequest(3289);
+        missingBucketPr.milestone = {title: 'v99.0.0'};
+
+        const cutBucketPr = buildPullRequest(3290);
+        cutBucketPr.milestone = {title: 'v98.0.0'};
+
+        aiConfig.issueSync.routeByMilestone = true;
+        await fs.ensureDir(path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v98.0.0'));
+
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes   : [missingBucketPr, cutBucketPr],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        const stats             = await PullRequestSyncer.syncPullRequests({pulls: {}});
+        const missingActivePath = path.join(aiConfig.issueSync.contentRoot, 'pulls', 'chunk-1', `pr-${missingBucketPr.number}.md`);
+        const cutArchivePath    = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v98.0.0', 'chunk-1', `pr-${cutBucketPr.number}.md`);
+
+        expect(stats.synced).toEqual([missingBucketPr.number, cutBucketPr.number]);
+        await expect(fs.pathExists(missingActivePath)).resolves.toBe(true);
+        await expect(fs.pathExists(cutArchivePath)).resolves.toBe(true);
     });
 
     test('delta cutoff stops PR pagination once a batch predates the cached high-water mark (#12190)', async () => {


### PR DESCRIPTION
Resolves #11365

Authored by GPT-5 (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.
FAIR-band: over-target [29/30] - taking this lane despite over-target because the operator explicitly resumed GPT backlog-reduction lead after the fragmentation correction, #11365 is a non-epic ticket-level lane with positive ROI, and Claude is on a partner tenant/observer/review lanes.

Restores milestone-aware archive routing as an explicit opt-in instead of defaulting semver milestones into archive buckets. `IssueSyncer` and `PullRequestSyncer` now prefer closedAt release mapping, consult semver milestones only when `issueSync.routeByMilestone` is true, and only route to milestone buckets that already exist.

Evidence: L2 (focused unit specs + static source/template gates) -> L2 required (syncer routing/config ACs are unit-verifiable). No residuals.

## Config Template Change

- Changed key: `issueSync.routeByMilestone` (new default `false`) in `ai/mcp/server/github-workflow/config.template.mjs`.
- Local `config.mjs` follow-up: each clone with a stale gitignored `ai/mcp/server/github-workflow/config.mjs` can add the key or refresh via `node ai/scripts/setup/initServerConfigs.mjs --migrate-config`. Missing local keys read as false in the source path, so stale clones keep the no-milestone-routing behavior until intentionally refreshed.
- Restart: required for already-running GitHub Workflow MCP/sync processes to load a refreshed config module; not required for the next new CLI/sync process.
- Peer notification: A2A will be sent after PR open; reviewer request waits for current-head CI green.

## Deltas From Ticket

- `config.mjs` is gitignored, so the PR changes `config.template.mjs`; local overlays are generated or refreshed after merge.
- File-owned ADR 0004 anchors were preserved with `ticket-ref-ok: file-owned decision record`; unrelated stale ticket refs in touched comments were removed.
- Existing metadata-only `oldVersion` pins still keep unchanged archived issues in their prior bucket, while freshly fetched entries compute the current route from closedAt before optional milestone routing.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs` - 27 passed.
- `node --check ai/services/github-workflow/sync/IssueSyncer.mjs` - passed.
- `node --check ai/services/github-workflow/sync/PullRequestSyncer.mjs` - passed.
- `node --check ai/mcp/server/github-workflow/config.template.mjs` - passed.
- `node buildScripts/util/check-ticket-archaeology.mjs <six touched files>` - 6 files scanned, 0 violations.
- `node buildScripts/util/check-shorthand.mjs <six touched files>` - 6 files scanned, 0 violations.
- `git diff --check origin/dev..HEAD` - passed.
- Remote branch verification: `gh api repos/neomjs/neo/compare/dev...codex/11365-milestone-routing` reported `ahead_by: 1`, `behind_by: 0`, and the six expected files. Remote tree `96d10a105f52220c58467a9ebbb185067b3fc45e` matched the local commit tree.

## Post-Merge Validation

- [ ] Refresh local GitHub Workflow config overlays in active agent clones or confirm `issueSync.routeByMilestone` exists and intentionally remains false.
- [ ] If Neo later opts into milestone routing, set `routeByMilestone: true` only after confirming archive bucket directories exist for the intended release milestones.

## Commit

- `06cd90cbe` - `feat(github-workflow): gate milestone archive routing (#11365)`