### PR TITLE
test(memory-core): assert graph backup jsonl separators (#10134)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs
@@ -85,6 +85,15 @@ test.describe('Memory_DatabaseService — graph backup import (#10949)', () => {
             reason: 'unit backup restore proof'
         });
 
+        const db = GraphService.db.storage.db;
+        const expectedRecordCount = db.prepare(`
+            SELECT
+                (SELECT count(*) FROM Nodes) +
+                (SELECT count(*) FROM Edges) AS c
+        `).get().c;
+
+        expect(expectedRecordCount).toBeGreaterThanOrEqual(3);
+
         const exportResult = await Memory_DatabaseService.manageDatabaseBackup({
             action    : 'export',
             include   : ['graph'],
@@ -98,12 +107,22 @@ test.describe('Memory_DatabaseService — graph backup import (#10949)', () => {
 
         expect(graphBackupFile).toBeTruthy();
 
-        const db = GraphService.db.storage.db;
+        const graphBackupPath    = path.join(tmpDir, graphBackupFile);
+        const graphBackupContent = fs.readFileSync(graphBackupPath, 'utf8');
+        const graphBackupLines   = graphBackupContent.trimEnd().split('\n');
+        const graphBackupRecords = graphBackupLines.map(line => JSON.parse(line));
+
+        expect(graphBackupContent.endsWith('\n')).toBe(true);
+        expect(graphBackupLines).toHaveLength(expectedRecordCount);
+        expect(graphBackupRecords.filter(record => record.type === 'node')).toHaveLength(2);
+        expect(graphBackupRecords.filter(record => record.type === 'edge')).toHaveLength(1);
+        expect(graphBackupRecords.some(record => record.type === 'edge' && record.data.type === 'TEST_RESTORE_EDGE')).toBe(true);
+
         db.exec('DELETE FROM Edges; DELETE FROM Nodes;');
 
         const importResult = await Memory_DatabaseService.manageDatabaseBackup({
             action: 'import',
-            file  : path.join(tmpDir, graphBackupFile),
+            file  : graphBackupPath,
             mode  : 'merge'
         });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.

FAIR-band: over-target [29/30] — taking this lane despite over-target because the operator explicitly allowed GPT to pick new lanes while Claude is busy, this pays down an existing unassigned ticket after #12370 creation, and the change is a narrow test-only regression guard with no PR fragmentation.

Resolves #10134

Adds direct JSONL separator assertions to the existing Memory Core graph backup spec. The test now checks that exported graph backups end with a physical newline, contain one parseable JSON record per line, and preserve the expected node/edge record shape before exercising the existing import/restore path.

Evidence: L2 (focused Playwright unit spec plus local mutant separator failure) -> L2 required (CI regression coverage for JSONL newline emission). No residuals.

## Deltas from ticket

The ticket proposed a new `DatabaseService.exportGraph.spec.mjs`. Current repo reality already has `DatabaseService.graphBackup.spec.mjs` from later graph backup coverage, so this PR extends that sibling spec instead of adding another file for the same export/import surface.

## Test Evidence

- `git diff --check` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs` passed on the final diff.
- Temporary local mutation changed both graph export separators from physical newlines to literal `\\n`; the same focused spec failed at per-line `JSON.parse`, confirming the regression guard trips.

## Post-Merge Validation

- [ ] CI unit job confirms the focused spec passes in the canonical runner.

## Commit

- `ada01df58` — `test(memory-core): assert graph backup jsonl separators (#10134)`
