### PR TITLE
feat(ai): configurable MCP transport host-allowlist for cloud deploy behind a proxy (#12371)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -64,6 +64,15 @@ class Config extends BaseConfig {
              */
             publicUrl: leaf(null, 'NEO_PUBLIC_URL', 'url'),
             /**
+             * Comma-separated extra hostnames added to the MCP transport's Host-header allowlist
+             * (the SDK's DNS-rebinding protection). localhost/127.0.0.1/[::1] and the `publicUrl`
+             * hostname are always allowed; set this for multi-hostname deployments or where the
+             * client `Host` differs from `publicUrl`. Empty/null → only the implicit localhost +
+             * publicUrl hosts. Consumed by TransportService.computeAllowedHosts.
+             * @type {string|null}
+             */
+            allowedHosts: leaf(null, 'NEO_MCP_ALLOWED_HOSTS', 'string'),
+            /**
              * Port the MCP server's HTTP/SSE transport listens on.
              * Sub-servers will typically override this with their own defaultPort.
              * @type {number}

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -66,6 +66,15 @@ class Config extends BaseConfig {
              */
             publicUrl: leaf(null, 'NEO_PUBLIC_URL', 'url'),
             /**
+             * Comma-separated extra hostnames added to the MCP transport's Host-header allowlist
+             * (the SDK's DNS-rebinding protection). localhost/127.0.0.1/[::1] and the `publicUrl`
+             * hostname are always allowed; set this for multi-hostname deployments or where the
+             * client `Host` differs from `publicUrl`. Empty/null → only the implicit localhost +
+             * publicUrl hosts. Consumed by TransportService.computeAllowedHosts.
+             * @type {string|null}
+             */
+            allowedHosts: leaf(null, 'NEO_MCP_ALLOWED_HOSTS', 'string'),
+            /**
              * Optional Express middleware function for authentication (only used if transport is 'sse').
              * @type {Function|null}
              */

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -83,6 +83,15 @@ class Config extends BaseConfig {
              */
             publicUrl: leaf(null, 'NEO_PUBLIC_URL', 'url'),
             /**
+             * Comma-separated extra hostnames added to the MCP transport's Host-header allowlist
+             * (the SDK's DNS-rebinding protection). localhost/127.0.0.1/[::1] and the `publicUrl`
+             * hostname are always allowed; set this for multi-hostname deployments or where the
+             * client `Host` differs from `publicUrl`. Empty/null → only the implicit localhost +
+             * publicUrl hosts. Consumed by TransportService.computeAllowedHosts.
+             * @type {string|null}
+             */
+            allowedHosts: leaf(null, 'NEO_MCP_ALLOWED_HOSTS', 'string'),
+            /**
              * Optional Express middleware function for authentication (only used if transport is 'sse').
              * @type {Function|null}
              */

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -86,6 +86,40 @@ class TransportService extends Base {
     mcpServers = new Map()
 
     /**
+     * Computes the Host-header allowlist for the SDK's DNS-rebinding protection
+     * (`createMcpExpressApp({allowedHosts})`). Pure + static so it is unit-testable without a live
+     * transport. The localhost set is ALWAYS included — the container healthcheck hits
+     * `http://127.0.0.1:<port>`, so dropping it would fail the healthcheck (restart loop). The
+     * public hostname is derived from `aiConfig.publicUrl` (the existing `NEO_PUBLIC_URL` leaf) and
+     * augmented by the comma-separated `aiConfig.allowedHosts` (`NEO_MCP_ALLOWED_HOSTS`) for
+     * multi-hostname deployments or where the client `Host` differs from the advertised URL.
+     * @param {Object} [aiConfig={}]
+     * @param {String|null} [aiConfig.publicUrl]
+     * @param {String|null} [aiConfig.allowedHosts] Comma-separated extra hostnames
+     * @returns {String[]} De-duplicated allowlist (hostnames, port-agnostic; IPv6 in brackets)
+     */
+    computeAllowedHosts(aiConfig={}) {
+        const hosts = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+        if (aiConfig.publicUrl) {
+            try {
+                hosts.add(new URL(aiConfig.publicUrl).hostname)
+            } catch {
+                // Unparseable publicUrl is ignored here; an explicit NEO_MCP_ALLOWED_HOSTS entry can still cover it.
+            }
+        }
+
+        if (aiConfig.allowedHosts) {
+            for (const host of String(aiConfig.allowedHosts).split(',')) {
+                const trimmed = host.trim();
+                trimmed && hosts.add(trimmed)
+            }
+        }
+
+        return [...hosts]
+    }
+
+    /**
      * Setups the SSE transport for an MCP server.
      * @param {Object} options
      * @param {Object} options.server The Neo MCP Server instance
@@ -101,7 +135,11 @@ class TransportService extends Base {
         const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
         const crypto = await import('crypto');
         const cors = await import('cors');
-        const app = createMcpExpressApp();
+        // Host-allowlist for the SDK's DNS-rebinding protection. Always includes localhost (the
+        // container healthcheck hits 127.0.0.1) plus the publicUrl hostname + NEO_MCP_ALLOWED_HOSTS,
+        // so a cloud deployment behind a reverse proxy on a public hostname is not rejected with
+        // `-32000 Invalid Host`.
+        const app = createMcpExpressApp({allowedHosts: this.computeAllowedHosts(aiConfig)});
 
         this.app = app;
 

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -87,8 +87,9 @@ class TransportService extends Base {
 
     /**
      * Computes the Host-header allowlist for the SDK's DNS-rebinding protection
-     * (`createMcpExpressApp({allowedHosts})`). Pure + static so it is unit-testable without a live
-     * transport. The localhost set is ALWAYS included — the container healthcheck hits
+     * (`createMcpExpressApp({allowedHosts})`). Pure + side-effect-free so it is unit-testable
+     * (an instance method on the singleton, callable as `TransportService.computeAllowedHosts(...)`)
+     * without a live transport. The localhost set is ALWAYS included — the container healthcheck hits
      * `http://127.0.0.1:<port>`, so dropping it would fail the healthcheck (restart loop). The
      * public hostname is derived from `aiConfig.publicUrl` (the existing `NEO_PUBLIC_URL` leaf) and
      * augmented by the comma-separated `aiConfig.allowedHosts` (`NEO_MCP_ALLOWED_HOSTS`) for

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -93,7 +93,7 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
     });
 
     test('setup() awaits listener accept-state before resolving (#10932)', async () => {
-        // Bind-race regression guard: prior to #10932, TransportService.setup() returned
+        // Bind-race regression guard: prior to the listen-callback fix, TransportService.setup() returned
         // synchronously after `app.listen()` without awaiting the listen-callback. Under load
         // or fullyParallel test interleaving, the calling spec's subsequent `fetch()` could
         // race the bind and observe the response object lacking expected shape (e.g.,
@@ -303,6 +303,41 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
             expect(TransportService.mcpServerUrl.href).toBe('https://internal-host:3000/');
             process.env.HOST = originalHost;
+        });
+    });
+
+    test.describe('computeAllowedHosts host-allowlist (DNS-rebinding) — #12371', () => {
+        let TransportService;
+
+        test.beforeAll(async () => {
+            TransportService = (await import('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
+        });
+
+        test('always includes the localhost set (empty config) — healthcheck-safe', () => {
+            expect(TransportService.computeAllowedHosts({})).toEqual(['localhost', '127.0.0.1', '[::1]']);
+        });
+
+        test('derives the public hostname from publicUrl, keeping localhost', () => {
+            const hosts = TransportService.computeAllowedHosts({publicUrl: 'https://mcp.example.com/knowledge-base'});
+            expect(hosts).toContain('mcp.example.com');
+            expect(hosts).toContain('localhost');
+            expect(hosts).toContain('127.0.0.1');
+        });
+
+        test('adds comma-separated NEO_MCP_ALLOWED_HOSTS entries, trimmed, dropping blanks', () => {
+            const hosts = TransportService.computeAllowedHosts({allowedHosts: 'a.example.com, b.example.com ,, c.example.com'});
+            expect(hosts).toEqual(expect.arrayContaining(['a.example.com', 'b.example.com', 'c.example.com']));
+            expect(hosts).not.toContain('');
+            expect(hosts).toContain('127.0.0.1');
+        });
+
+        test('de-duplicates when publicUrl host also appears in the explicit list', () => {
+            const hosts = TransportService.computeAllowedHosts({publicUrl: 'https://mcp.example.com', allowedHosts: 'mcp.example.com'});
+            expect(hosts.filter(host => host === 'mcp.example.com')).toHaveLength(1);
+        });
+
+        test('ignores an unparseable publicUrl without throwing', () => {
+            expect(TransportService.computeAllowedHosts({publicUrl: 'not a url'})).toEqual(['localhost', '127.0.0.1', '[::1]']);
         });
     });
 


### PR DESCRIPTION
**Resolves #12371**
**Refs** #12368 (sibling deployment-hardening; not a dependency).

**FAIR-band:** operator-directed lane — @tobiu surfaced this from the first real-world public cloud deployment and directed the fix (env-var surface confirmed + "address both kb and mc"). Operator-priority work.

**Evidence:** L2 (16/16 `TransportService` unit specs — 5 new `computeAllowedHosts` cases + 11 existing). The end-to-end "public Host accepted by a live server behind a proxy" is L3, observable only on a rebuilt image in a real deployment — see Post-Merge Validation.

## What + Why

MCP HTTP/SSE servers (knowledge-base + memory-core) behind a reverse proxy on a real public hostname were rejected with `-32000 Invalid Host: <host>` on every request. `TransportService` called the SDK's `createMcpExpressApp()` with no options → SDK default `host='127.0.0.1'` → `localhostHostValidation()` → only `localhost`/`127.0.0.1`/`[::1]` allowed. The public Host a proxy forwards (Caddy v2 preserves the original Host by default) was never allowlisted, so the SDK 403'd **before any MCP handling** — client-agnostic (browser and MCP client alike).

Canonical gap: `ai/deploy/Caddyfile` only worked because it defaults `NEO_DEPLOY_HOSTNAME=localhost`. Any real public hostname hit this wall.

`TransportService.computeAllowedHosts(aiConfig)` now builds the list passed to `createMcpExpressApp({allowedHosts})`:
`['localhost','127.0.0.1','[::1]']` ∪ (publicUrl hostname) ∪ (`NEO_MCP_ALLOWED_HOSTS`, comma-split).

## Deltas
- `TransportService.mjs`: new instance method `computeAllowedHosts(aiConfig)` (pure; instance method to match the singleton-callable convention of `resolveAuthContext`) + wires `createMcpExpressApp({allowedHosts: this.computeAllowedHosts(aiConfig)})`.
- `ai/config.template.mjs` + `knowledge-base/config.template.mjs` + `memory-core/config.template.mjs`: new `allowedHosts` leaf → `NEO_MCP_ALLOWED_HOSTS` (comma-separated). Declared in all three because each declares its transport block independently.
- `TransportService.spec.mjs`: 5 new `computeAllowedHosts` cases; also paid down 1 pre-existing decay-prone `#10932` ref in a `//` comment (the on-touch archaeology guard; provenance retained in the string-literal test title).
- **Invariant:** the localhost set is ALWAYS included — the container healthcheck hits `http://127.0.0.1:<port>`; dropping it would restart-loop. Localhost-only deploys are unchanged (computed list == prior default) → zero regression.
- **New env var** `NEO_MCP_ALLOWED_HOSTS` is additive (not a rename); reuses the existing `NEO_PUBLIC_URL`.

## MCP Config-Template Change (clone-sync)

Per `.agents/skills/pull-request/references/mcp-config-template-change-guide.md` — this PR changes the base + `knowledge-base` + `memory-core` `config.template.mjs` files.
- **Changed keys:** `allowedHosts` → `NEO_MCP_ALLOWED_HOSTS` (new leaf; default `null`).
- **Local `config.mjs` follow-up:** required *only to use* the new var. The leaf defaults to `null` and `computeAllowedHosts` guards on it (`if (aiConfig.allowedHosts)`), so a stale local `config.mjs` lacking the leaf degrades gracefully — no crash; the allowlist is just the localhost-set ∪ the `publicUrl` host. To set `NEO_MCP_ALLOWED_HOSTS`, re-run config initialization (or manually add the `allowedHosts` leaf) so the key exists locally.
- **Harness restart:** required to pick up the new code/env — `allowedHosts` is read at transport `setup()` (SSE-mode only); stdio clients are unaffected. No rebuild beyond the normal image rebuild for the code change.
- **Peer notification:** A2A broadcast on PR-open + a clone-sync FYI on this update. No gitignored `config.mjs` committed.

## Test Evidence
- `npx playwright test -c test/playwright/playwright.config.unit.mjs .../TransportService.spec.mjs` → **16/16 pass** (11 existing + 5 new: localhost-always/healthcheck-safe, publicUrl-derived, `NEO_MCP_ALLOWED_HOSTS`-extra+trim+blank-drop, de-dup, unparseable-publicUrl-ignored).
- `check-ticket-archaeology` / `check-shorthand` / `check-whitespace`: clean (pre-commit passed after the paydown).
- CI: pending — will confirm green before merge-eligibility.

## Post-Merge Validation
- [ ] On a rebuilt image with `NEO_PUBLIC_URL=https://<public-host>` set, a request with `Host: <public-host>` is accepted (no `-32000`).
- [ ] The container healthcheck (`http://127.0.0.1:<port>`) still passes (localhost retained).
- [ ] A deployment can drop any reverse-proxy `header_up Host` workaround once on the new image.

Authored by @neo-opus-4-7 (claude-opus-4.8-1m) · session 98c1b6cb
