### PR TITLE
fix(agentos): separate bot stale bands from ticket currency (#10758)

### DIFF
--- a/.agents/skills/ticket-intake/references/successor-risk-audit.md
+++ b/.agents/skills/ticket-intake/references/successor-risk-audit.md
@@ -2,12 +2,24 @@
 
 This document provides the Atlas-level mechanics for executing the Age / Successor-Risk Audit Gate during Ticket Intake.
 
-## 1. Workflow-Derived Age Bands
-Do not use arbitrary hard-coded thresholds. Derive age bands from `.github/workflows/close-inactive-issues.yml` (`days-before-issue-stale` and `days-before-issue-close`).
+## 1. Workflow-Derived Bot-State Bands
+Do not use arbitrary hard-coded thresholds. Derive bot-state bands from `.github/workflows/close-inactive-issues.yml` (`days-before-issue-stale` and `days-before-issue-close`).
 
-- **pre-stale** (inactivity / `updatedAt` age < `days-before-issue-stale`): Standard duplicate and first-pass successor sweep. Record `createdAt` separately to distinguish same-day duplicates (hot context) from older-ticket successor-risk classification.
+These bands describe close-inactive automation risk only. They are NOT evidence that a ticket is architecturally current. A ticket can be stale-by-birth or stale after a short interval when newer PRs, tickets, Discussions, ADRs, operator corrections, or current source/docs/tests supersede its premise. Never cite `pre-stale` as a reason to skip successor, duplicate, existing-enforcement, or current-source checks.
+
+- **pre-stale** (inactivity / `updatedAt` age < `days-before-issue-stale`): Standard duplicate and first-pass successor sweep. Record `createdAt` separately to distinguish same-day duplicates and hot-context drift from older-ticket successor-risk classification.
 - **in-stale-window** (>= stale-days, < stale-days + close-days OR has `stale` label): Explicitly sweep newer PRs, tickets, and discussions before proceeding.
 - **post-stale-with-exemption** (>= stale-days + close-days AND has `no auto close` label): Operator-parked. Full successor sweep and escalation flag required.
+
+### 1.1 Short-Horizon Currency Check
+Before emitting `valid-as-written`, explicitly check for same-day or short-horizon successor evidence when any freshness trigger is present:
+
+- the ticket touches Agent OS substrate, skills, workflow templates, CI guards, config contracts, or ADR/Decision Record surfaces;
+- the ticket body cites recently landed rules, PRs, sibling layers, or active release work;
+- the operator or a peer has just corrected the premise, priority, or implementation shape;
+- the ticket was created during active swarm work where local/KB state can lag remote reality.
+
+If a newer artifact or current source state already solves or reshapes the failure mode, route to `already-resolved`, `superseded`, `duplicate`, `needs-narrowing`, or `invalid-or-negative-roi` instead of treating bot pre-stale status as low risk.
 
 ## 2. Missing Close-Link Sweep
 Explicitly check for merged PRs that completed the ticket but missed a GitHub close keyword (`Resolves #N`, `Closes #N`). A merged PR touching the target surface or mentioned in the conversation may mean the ticket is `already-resolved`. If you find one, you MUST cite the PR number, merged status, target surface touched, and issue/thread link as evidence.

--- a/.agents/skills/ticket-intake/references/ticket-intake-workflow.md
+++ b/.agents/skills/ticket-intake/references/ticket-intake-workflow.md
@@ -37,8 +37,8 @@ Before executing a `git checkout`, you MUST interrogate the codebase and Memory 
    - A matrix is incomplete when a row names an existing field, method, helper, tool, config key, docs path, or runtime surface that does not match current substrate reality or lacks the Surface-Anchor V-B-A required by `learn/agentos/contract-ledger.md`.
    - **Hand-back loop:** You MUST post a comment explaining the missing fields, requesting the author or maintainer to update the ticket body. You are forbidden from guessing the contract or starting branch/code work. Once the ticket is updated, intake re-verifies the ledger before proceeding.
 
-7.5. **Age / Successor-Risk Audit Gate:** Before classifying ticket reality, you MUST audit the ticket's age, stale bot state, and missing PR close-link hygiene.
-   - **Protocol:** You MUST execute the detailed mechanics defined in `.agents/skills/ticket-intake/references/successor-risk-audit.md` for age-band classification, missing close-link sweeps, and stale renewal discipline.
+7.5. **Age / Successor-Risk Audit Gate:** Before classifying ticket reality, you MUST audit the ticket's age, stale bot state, short-horizon currency risk, and missing PR close-link hygiene.
+   - **Protocol:** You MUST execute the detailed mechanics defined in `.agents/skills/ticket-intake/references/successor-risk-audit.md` for bot-state band classification, same-day / short-horizon successor checks, missing close-link sweeps, and stale renewal discipline.
    - **ADR branch:** If the ticket cites, predates, conflicts with, or depends on an ADR / Decision Record, also execute `.agents/skills/ticket-intake/references/adr-successor-risk-audit.md` and record the ADR successor-risk verdict before `valid-as-written`.
 
 8. **Ticket Reality Classification:** Before ROI acceptance or branch/code work, you MUST emit a concise classification artifact that converts the validation sweep into a stable verdict. Ticket prose is not authoritative; the classification must be grounded in the live issue conversation, linked PRs/commits, current source/docs/tests, and relevant Knowledge Base / Memory Core evidence when applicable.
@@ -46,7 +46,8 @@ Before executing a `git checkout`, you MUST interrogate the codebase and Memory 
    **Required Classification Artifact Data:**
    You MUST explicitly record the following in your intake reasoning:
    - `Ticket age`: `createdAt` and `updatedAt`.
-   - `Age state`: Workflow-derived age state (`pre-stale`, `in-stale-window`, `post-stale-with-exemption`), `stale` label state, and `no auto close` label state.
+   - `Bot stale-band`: Workflow-derived bot-state band (`pre-stale`, `in-stale-window`, `post-stale-with-exemption`), `stale` label state, and `no auto close` label state. This is automation metadata only, never evidence that the ticket is architecturally current.
+   - `Currency / successor-risk evidence`: same-day, short-horizon, newer-artifact, existing-enforcement, and current-source checks that determine whether `valid-as-written` can proceed.
    - `ADR successor-risk`: when triggered, the verdict from `adr-successor-risk-audit.md`.
 
    **Allowed verdicts:**


### PR DESCRIPTION
Resolves #10758

Authored by GPT-5.5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.

FAIR-band: over-target [29/30] — taking this lane despite over-target because @tobiu explicitly elevated the stale-threshold friction immediately after the #12373 priority review, #10758 is already assigned to neo-gpt, and the fix prevents further intake false-current classifications while Claude is occupied on a partner tenant.

Evidence: L1 (static skill-payload audit + skill-manifest lint) -> L1 required (ticket-intake workflow substrate text). No residuals.

## What changed

This corrects the successor-risk audit regression surfaced during #10646 intake: I treated the close-inactive workflow's 90-day stale threshold as evidence that a 29-day-old ticket was low currency risk. That was wrong. The close-inactive workflow describes bot automation state, not architectural freshness.

The PR updates `ticket-intake` so the workflow-derived `pre-stale` / `in-stale-window` / `post-stale-with-exemption` bands are explicitly bot-state metadata only. It adds a short-horizon currency check for freshness-sensitive lanes, including Agent OS substrate, skills, workflow templates, CI guards, config contracts, ADR surfaces, recent operator or peer corrections, and active swarm work where KB/local state can lag live reality.

## Deltas from ticket

#10758 was reopened instead of creating a new duplicate ticket. Its original implementation was directionally correct, but the current substrate still allowed a false inference: `pre-stale` could be cited as low-risk/currency evidence. This PR narrows that failure mode directly inside the existing `successor-risk-audit.md` payload and the ticket reality classification artifact.

## Substrate Mutation Rationale

- Modified section: `.agents/skills/ticket-intake/references/successor-risk-audit.md` section 1. Disposition delta: `rewrite` plus one compact new subsection in the existing conditional payload. Trigger-frequency is ticket-intake only; failure-severity is high because false-current intake can open wrong PRs; enforceability is discipline-only. Keeping this in the Atlas payload avoids `AGENTS.md` or `SKILL.md` bloat.
- Modified section: `.agents/skills/ticket-intake/references/ticket-intake-workflow.md` sections 7.5 and 8 artifact fields. Disposition delta: `rewrite`; the map needs a compact trigger and required artifact field so the detailed payload actually fires. No new always-loaded substrate was added.
- Decay mitigation: this is a net clarification of existing #10758 substrate, not a new process layer. It prevents future agents from preserving stale tickets as active lanes based on bot timing alone.

Decision Record impact: aligned with ADR 0007 and ADR 0008. The change uses Progressive Disclosure by keeping detailed mechanics in the ticket-intake reference payload.

## Test Evidence

- `git diff --check` passed.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` passed.
- Verified the current script path because the older guide path `ai/scripts/lint-skill-manifest.mjs` is stale on current `dev`; the live package script points at `ai/scripts/lint/lint-skill-manifest.mjs`.
- Branch freshness check passed: `merge-base HEAD origin/dev == origin/dev` before push.

## Post-Merge Validation

- [ ] Next ticket-intake classification examples should record `Bot stale-band` separately from `Currency / successor-risk evidence` and avoid citing bot `pre-stale` as currentness proof.

## Commit

- `f0c4fa03d` - `fix(agentos): separate bot stale bands from ticket currency (#10758)`