### PR TITLE
fix(docs): render AgentMemory.md mermaid — rename reserved 'graph' keyword (#12375)

### DIFF
--- a/learn/benefits/AgentMemory.md
+++ b/learn/benefits/AgentMemory.md
@@ -12,16 +12,16 @@ This is the memory half of the [Agent OS](ArchitectureOverview.md) — and it is
 flowchart TD
     classDef agent fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
     classDef mem fill:#4a1942,stroke:#e74c3c,stroke-width:1px,color:#eee
-    classDef graph fill:#3d1f00,stroke:#f39c12,stroke-width:1px,color:#eee
+    classDef edgegraph fill:#3d1f00,stroke:#f39c12,stroke-width:1px,color:#eee
 
     Memory["Memory Core (episodic, cross-session)"]:::mem
     KB["Knowledge Base (semantic RAG)"]:::mem
-    Graph["Native Edge Graph (Active Hybrid GraphRAG)"]:::graph
+    EdgeGraph["Native Edge Graph (Active Hybrid GraphRAG)"]:::edgegraph
     Agent["Agent reasoning (any model family)"]:::agent
 
     Memory --> Agent
     KB --> Agent
-    Graph --> Agent
+    EdgeGraph --> Agent
     Agent -->|"persist decisions"| Memory
 ```
 


### PR DESCRIPTION
**Resolves #12375**

**FAIR-band:** operator-flagged defect — @tobiu reported the broken render directly. Quick-win bug fix.

**Evidence:** L1 (static — V-B-A'd the cause: `classDef graph` / node `Graph` uses the reserved mermaid `graph` keyword; confirmed the parentheses in quoted labels are NOT the issue, since `learn/agentos/cloud-deployment/WhyDeploy.md:29` renders the identical `["… (…)"]` pattern). The actual portal render is post-merge — see below.

## What + Why

The `learn/benefits/AgentMemory.md` "Three substrates, one memory" diagram failed to render (`Syntax error in text / mermaid version 11.15.0`). Cause: `graph` is a reserved mermaid diagram-type keyword, and the 11.x parser rejects it as a `classDef` name / node id. Pure rename — diagram semantics unchanged.

## Deltas
- `AgentMemory.md`: `classDef graph` → `classDef edgegraph`; node `Graph` → `EdgeGraph`; the `:::graph` + edge references updated to match. No label/content change.

## Test Evidence
- Static V-B-A: `grep` confirmed no other working `learn/` diagram uses a `graph`-named classDef, and `WhyDeploy.md:29` proves parens-in-labels render fine — isolating the reserved keyword as the unique breaker. No local mermaid renderer is available (the portal renders these docs), so the render itself is post-merge-verified.
- `check-whitespace`: clean. `check-ticket-archaeology` / `check-shorthand` are `*.mjs`-only → N/A for this `.md`.

## Post-Merge Validation
- [ ] The `AgentMemory.md` diagram renders in the portal with no mermaid syntax error.

Authored by @neo-opus-4-7 (claude-opus-4.8-1m) · session 98c1b6cb
