### PR TITLE
feat(ai): GitLab-PAT Bearer auth mode for MCP servers (#12378)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -84,7 +84,16 @@ class Config extends BaseConfig {
              */
             authMiddleware: leaf(null),
             /**
-             * Base authentication configuration.
+             * Base authentication configuration for the SSE / HTTP transport.
+             *
+             * `mode` selects the authorization strategy:
+             * - `'oidc'` (default, production): OAuth 2.1 / OIDC bearer tokens validated via
+             *   RFC 7662 introspection, with `aud` audience enforcement and Protected-Resource-
+             *   Metadata advertisement.
+             * - `'gitlab-pat'`: a GitLab Personal Access Token (`read_user` scope) presented as the
+             *   bearer token, validated against `{gitlabApiBaseUrl}/api/v4/user`. No `aud` claim and
+             *   no PRM advertisement (a naked `401` on failure) — the lighter path for clients that
+             *   authenticate with a long-lived PAT from an env var instead of an OAuth dance.
              * @type {Object}
              */
             auth: {
@@ -94,7 +103,13 @@ class Config extends BaseConfig {
                 issuerUrl         : leaf(null, 'NEO_AUTH_ISSUER_URL', 'string'),
                 clientId          : leaf(null, 'NEO_OAUTH_CLIENT_ID', 'string'),
                 clientSecret      : leaf('', 'NEO_OAUTH_CLIENT_SECRET', 'string'),
-                trustProxyIdentity: leaf(false, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean')
+                trustProxyIdentity: leaf(false, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean'),
+                // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat'. See block doc above.
+                mode              : leaf('oidc', 'NEO_AUTH_MODE', 'string'),
+                // GitLab API base URL used by 'gitlab-pat' mode for token validation (self-managed configurable).
+                gitlabApiBaseUrl  : leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string'),
+                // Bounded TTL (seconds) for the per-token PAT validation cache → a revoked PAT clears within this window.
+                patCacheTtlSeconds: leaf(300, 'NEO_AUTH_PAT_CACHE_TTL_SECONDS', 'number')
             },
             /**
              * @summary Deployment-wide chat / generation model provider.

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -250,8 +250,28 @@ class AuthService extends Base {
     createGitlabPatVerifier({aiConfig, logger, InvalidTokenError}) {
         const
             apiBaseUrl = aiConfig.auth.gitlabApiBaseUrl.replace(/\/+$/, ''),
-            ttlMs      = aiConfig.auth.patCacheTtlSeconds * 1000,
-            cache      = new Map(); // tokenHash -> {info, expiresAt}
+            ttlSeconds = aiConfig.auth.patCacheTtlSeconds,
+            ttlMs      = ttlSeconds * 1000,
+            cache      = new Map(); // tokenHash -> {user, expiresAt} (cache-freshness, ms)
+
+        // Builds the AuthInfo shape consumed by the SDK `requireBearerAuth` middleware AND
+        // `RequestContextService`. `expiresAt` is REQUIRED by `requireBearerAuth` — it rejects auth
+        // info lacking a numeric expiry with `Token has no expiration time` BEFORE `req.auth` is set,
+        // so omitting it silently breaks the valid-PAT path. GitLab `/api/v4/user` does not return the
+        // PAT's own expiry, so we use the re-validation horizon: one cache window from now (Unix
+        // seconds). The cache re-validates against GitLab after that, so a revoked PAT still clears
+        // within `patCacheTtlSeconds`. Built per-call so `expiresAt` stays request-fresh on cache hits.
+        const buildInfo = (token, user) => ({
+            token,
+            clientId : user.username,
+            scopes   : [],
+            expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
+            userId   : user.username,
+            username : user.name || user.username,
+            // Provenance tag read by RequestContextService.getSource(); distinguishes a GitLab-PAT
+            // identity from OIDC / stdio env-var / gh-CLI sources.
+            source   : 'gitlab-pat'
+        });
 
         return {
             verifyAccessToken: async (token) => {
@@ -260,7 +280,7 @@ class AuthService extends Base {
                     cached    = cache.get(tokenHash);
 
                 if (cached && cached.expiresAt > Date.now()) {
-                    return cached.info
+                    return buildInfo(token, cached.user)
                 }
 
                 const response = await fetch(`${apiBaseUrl}/api/v4/user`, {
@@ -272,23 +292,12 @@ class AuthService extends Base {
                     throw new InvalidTokenError(`GitLab PAT validation failed (HTTP ${response.status})`)
                 }
 
-                const
-                    data = await response.json(),
-                    info = {
-                        token,
-                        clientId: data.username,
-                        scopes  : [],
-                        userId  : data.username,
-                        username: data.name || data.username,
-                        // Provenance tag read by RequestContextService.getSource(); distinguishes a
-                        // GitLab-PAT identity from OIDC / stdio env-var / gh-CLI sources.
-                        source  : 'gitlab-pat'
-                    };
+                const user = await response.json();
 
-                cache.set(tokenHash, {info, expiresAt: Date.now() + ttlMs});
-                logger.info(`[AuthService] GitLab PAT validated for user: ${info.username}`);
+                cache.set(tokenHash, {user, expiresAt: Date.now() + ttlMs});
+                logger.info(`[AuthService] GitLab PAT validated for user: ${user.name || user.username}`);
 
-                return info
+                return buildInfo(token, user)
             }
         }
     }

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -1,4 +1,5 @@
-import Base from '../../../../../src/core/Base.mjs';
+import Base         from '../../../../../src/core/Base.mjs';
+import {createHash} from 'crypto';
 
 /**
  * @summary Orchestrates OIDC and OAuth 2.1 authorization for Neo.mjs MCP servers.
@@ -58,9 +59,17 @@ class AuthService extends Base {
     async setup(options) {
         const {app, aiConfig, mcpServerUrl, logger, resourceName} = options;
 
+        const {requireBearerAuth} = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
+        const {InvalidTokenError} = await import('@modelcontextprotocol/sdk/server/auth/errors.js');
+
+        // GitLab-PAT mode installs a naked-401 bearer path (no `aud`, no PRM advertisement) and
+        // returns early — the OIDC discovery + introspection flow below does not apply.
+        if (aiConfig.auth.mode === 'gitlab-pat') {
+            this.setupGitlabPat({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
+            return
+        }
+
         const {mcpAuthMetadataRouter, getOAuthProtectedResourceMetadataUrl} = await import('@modelcontextprotocol/sdk/server/auth/router.js');
-        const {requireBearerAuth}                                           = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
-        const {InvalidTokenError}                                           = await import('@modelcontextprotocol/sdk/server/auth/errors.js');
         const {checkResourceAllowed}                                        = await import('@modelcontextprotocol/sdk/shared/auth-utils.js');
 
         let oauthUrls;
@@ -197,6 +206,91 @@ class AuthService extends Base {
         app.use(authMiddleware);
 
         logger.info(`[AuthService] Authorization enabled (Issuer: ${oauthUrls.issuer})`);
+    }
+
+    /**
+     * Installs the GitLab-PAT bearer auth path: a single `requireBearerAuth` middleware whose
+     * verifier validates a GitLab Personal Access Token against the GitLab API. Deliberately
+     * installs NO `mcpAuthMetadataRouter` and passes NO `resourceMetadataUrl`, so a missing/invalid
+     * token yields a bare `WWW-Authenticate: Bearer` 401 with no `resource_metadata` breadcrumb —
+     * OAuth-aware clients (e.g. MCP Inspector) therefore do not attempt Dynamic Client Registration
+     * against an identity provider that has none. PATs carry no audience claim, so `aud` enforcement
+     * is intentionally absent here (it is exactly what rejects raw PATs in OIDC mode).
+     * @param {Object}   options
+     * @param {Object}   options.app      The Express application instance
+     * @param {Object}   options.aiConfig The server configuration object
+     * @param {Object}   options.logger   The logger instance
+     * @param {Object}   deps
+     * @param {Function} deps.requireBearerAuth SDK bearer-auth middleware factory
+     * @param {Function} deps.InvalidTokenError SDK error class for rejected tokens
+     */
+    setupGitlabPat({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError}) {
+        const verifier = this.createGitlabPatVerifier({aiConfig, logger, InvalidTokenError});
+
+        app.use(requireBearerAuth({verifier, requiredScopes: []}));
+
+        logger.info(`[AuthService] Authorization enabled (mode: gitlab-pat, GitLab API: ${aiConfig.auth.gitlabApiBaseUrl})`)
+    }
+
+    /**
+     * Builds the `{verifyAccessToken}` verifier for GitLab-PAT mode. The verifier presents the
+     * incoming bearer token to `GET {gitlabApiBaseUrl}/api/v4/user`; a `200` resolves the identity
+     * (`userId` = GitLab `username`, `source` = `'gitlab-pat'`) in the same shape
+     * `RequestContextService` already consumes from the OIDC path, while any non-OK response throws
+     * `InvalidTokenError`. Successful validations are cached by SHA-256 token hash for
+     * `auth.patCacheTtlSeconds` so a revoked PAT clears within that bounded window; failures are
+     * never cached (a transient GitLab error must not lock a client out). The raw token is never
+     * logged — only its resolved identity.
+     * @param {Object}   options
+     * @param {Object}   options.aiConfig
+     * @param {Object}   options.logger
+     * @param {Function} options.InvalidTokenError
+     * @returns {{verifyAccessToken: Function}}
+     */
+    createGitlabPatVerifier({aiConfig, logger, InvalidTokenError}) {
+        const
+            apiBaseUrl = aiConfig.auth.gitlabApiBaseUrl.replace(/\/+$/, ''),
+            ttlMs      = aiConfig.auth.patCacheTtlSeconds * 1000,
+            cache      = new Map(); // tokenHash -> {info, expiresAt}
+
+        return {
+            verifyAccessToken: async (token) => {
+                const
+                    tokenHash = createHash('sha256').update(token).digest('hex'),
+                    cached    = cache.get(tokenHash);
+
+                if (cached && cached.expiresAt > Date.now()) {
+                    return cached.info
+                }
+
+                const response = await fetch(`${apiBaseUrl}/api/v4/user`, {
+                    headers: {Authorization: `Bearer ${token}`}
+                });
+
+                if (!response.ok) {
+                    cache.delete(tokenHash);
+                    throw new InvalidTokenError(`GitLab PAT validation failed (HTTP ${response.status})`)
+                }
+
+                const
+                    data = await response.json(),
+                    info = {
+                        token,
+                        clientId: data.username,
+                        scopes  : [],
+                        userId  : data.username,
+                        username: data.name || data.username,
+                        // Provenance tag read by RequestContextService.getSource(); distinguishes a
+                        // GitLab-PAT identity from OIDC / stdio env-var / gh-CLI sources.
+                        source  : 'gitlab-pat'
+                    };
+
+                cache.set(tokenHash, {info, expiresAt: Date.now() + ttlMs});
+                logger.info(`[AuthService] GitLab PAT validated for user: ${info.username}`);
+
+                return info
+            }
+        }
     }
 }
 

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -160,8 +160,8 @@ class TransportService extends Base {
         const mcpServerUrl = aiConfig.publicUrl ? new URL(aiConfig.publicUrl) : getFullUrl(process.env.HOST || 'localhost', aiConfig.mcpHttpPort);
         this.mcpServerUrl = mcpServerUrl;
 
-        // Optional OIDC/OAuth Authorization
-        if (aiConfig.auth.host || aiConfig.auth.issuerUrl) {
+        // Optional Authorization: OIDC/OAuth (host / issuerUrl) OR the GitLab-PAT bearer mode.
+        if (aiConfig.auth.host || aiConfig.auth.issuerUrl || aiConfig.auth.mode === 'gitlab-pat') {
             const { default: AuthService } = await import('./AuthService.mjs');
             await AuthService.setup({
                 app,

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -71,8 +71,12 @@ const MATERIALIZED_SERVER_IMPORTS = new Set([
  *   but kept as forward-compat surface — if templates evolve to add named-export
  *   blocks, the detector picks them up without code change.
  *
+ * - **Env-var literals**: UPPER_SNAKE string literals (the `env` arg of each `leaf(...)`). New
+ *   entries flag a template that added a config leaf — `data`-tree drift the import/export
+ *   projection cannot see. See the inline note in {@link projectSourceShape}.
+ *
  * @param {String} filePath  Absolute path to a readable `.mjs` file.
- * @returns {Promise<{imports: String[], exports: String[]}>}
+ * @returns {Promise<{imports: String[], exports: String[], envVars: String[]}>}
  */
 export function projectSourceShape(src) {
     const imports = [];
@@ -112,7 +116,18 @@ export function projectSourceShape(src) {
         .flatMap(m => m[1].split(',').map(s => s.trim()).filter(Boolean))
         .sort();
 
-    return {imports, exports}
+    // Env-var leaf projection. Every env-bound `leaf(default, 'NEO_FOO', type)` names its env var
+    // as an UPPER_SNAKE string literal. Projecting those literals lets the detector catch a template
+    // that added a NEW config leaf — a `data`-tree change the import/export projection is otherwise
+    // blind to (the dominant drift mode for non-import config evolution, e.g. a new auth mode flag) —
+    // without AST-parsing the nested data object. Dedup + sort for a stable shape. The UPPER_SNAKE
+    // shape excludes lowercase type tokens (`'string'`) and default values (`'oidc'`), so the
+    // projection isolates env names.
+    const envVars = [...new Set(
+        [...src.matchAll(/['"]([A-Z][A-Z0-9_]+)['"]/g)].map(m => m[1])
+    )].sort();
+
+    return {imports, exports, envVars}
 }
 
 export async function projectShape(filePath) {
@@ -152,6 +167,9 @@ export function isOnlyServerMaterializationDrift(drift) {
     return Boolean(
         drift.hasDrift &&
         drift.missingExports.length === 0 &&
+        // A new env-bound leaf (data-tree drift) needs the full template refresh, not an
+        // import-only patch — so env-var drift disqualifies the materialize-only fast path.
+        (drift.missingEnvVars?.length ?? 0) === 0 &&
         drift.missingImports.length > 0 &&
         drift.missingImports.every(i => MATERIALIZED_SERVER_IMPORTS.has(i))
     )
@@ -163,18 +181,21 @@ export function isOnlyServerMaterializationDrift(drift) {
  * config but not in template — operator-removed paths) is intentionally NOT
  * reported, since this is a one-way "template advanced, config stale" detector.
  *
- * @param {{imports: String[], exports: String[]}} templateShape
- * @param {{imports: String[], exports: String[]}} configShape
- * @returns {{missingImports: String[], missingExports: String[], hasDrift: Boolean}}
+ * @param {{imports: String[], exports: String[], envVars?: String[]}} templateShape
+ * @param {{imports: String[], exports: String[], envVars?: String[]}} configShape
+ * @returns {{missingImports: String[], missingExports: String[], missingEnvVars: String[], hasDrift: Boolean}}
  */
 export function detectDrift(templateShape, configShape) {
     const missingImports = templateShape.imports.filter(i => !configShape.imports.includes(i));
     const missingExports = templateShape.exports.filter(e => !configShape.exports.includes(e));
+    // `envVars` is optional on hand-built shapes (e.g. unit fixtures) → default to empty.
+    const missingEnvVars = (templateShape.envVars || []).filter(e => !(configShape.envVars || []).includes(e));
 
     return {
         missingImports,
         missingExports,
-        hasDrift: missingImports.length + missingExports.length > 0
+        missingEnvVars,
+        hasDrift: missingImports.length + missingExports.length + missingEnvVars.length > 0
     }
 }
 
@@ -259,6 +280,7 @@ export async function initConfigs({argv = process.argv, logger = console, server
             logger.warn(`[Neo AI] Stale config.mjs for '${serverName}' — template has evolved:`);
             drift.missingImports.forEach(i => logger.warn(`  + import: ${i}`));
             drift.missingExports.forEach(e => logger.warn(`  + export: ${e}`));
+            drift.missingEnvVars.forEach(e => logger.warn(`  + env: ${e}`));
             logger.warn(`  Run \`npm run prepare -- ${MIGRATE_FLAG}\` to refresh (gitignored; safe).`);
             processed.push({serverName, action: 'warn', drift});
         }
@@ -323,6 +345,7 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
     logger.warn('[Neo AI] Stale Tier-1 ai/config.mjs — template has evolved:');
     drift.missingImports.forEach(i => logger.warn(`  + import: ${i}`));
     drift.missingExports.forEach(e => logger.warn(`  + export: ${e}`));
+    drift.missingEnvVars.forEach(e => logger.warn(`  + env: ${e}`));
     logger.warn(`  Run \`npm run prepare -- ${MIGRATE_FLAG}\` to refresh (gitignored; safe).`);
 
     return {action: 'warn', drift}

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -69,6 +69,10 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT veri
         expect(info.username).toBe('The Octocat');
         expect(info.source).toBe('gitlab-pat');
         expect(info.scopes).toEqual([]);
+        // expiresAt is REQUIRED by the SDK requireBearerAuth middleware (numeric, future) — a
+        // missing/non-numeric value is rejected with "Token has no expiration time".
+        expect(typeof info.expiresAt).toBe('number');
+        expect(info.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
     });
 
     test('falls back to username when GitLab returns no name field', async () => {
@@ -109,9 +113,10 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT veri
               first    = await verifier.verifyAccessToken('same-token'),
               second   = await verifier.verifyAccessToken('same-token');
 
-        expect(calls).toBe(1);
-        expect(second.userId).toBe('cached-user');
-        expect(second).toBe(first);
+        expect(calls).toBe(1);                       // cache hit → no second GitLab round-trip
+        expect(second.userId).toBe(first.userId);
+        // info is rebuilt per-call (so `expiresAt` stays request-fresh on hits) — a new object each time.
+        expect(typeof second.expiresAt).toBe('number');
 
         // A different token is a distinct cache key → a fresh validation.
         await verifier.verifyAccessToken('other-token');
@@ -137,5 +142,116 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT veri
 
         // expiresAt = now + 0 is never strictly greater than a later Date.now() → re-fetch.
         expect(calls).toBe(2);
+    });
+});
+
+/**
+ * @summary Consumed-boundary coverage: drives the GitLab-PAT verifier through the REAL SDK
+ * `requireBearerAuth` middleware (installed by `setupGitlabPat`), not in isolation.
+ *
+ * A direct-verifier test is insufficient: `@modelcontextprotocol/sdk` `requireBearerAuth` enforces
+ * its own `AuthInfo` contract (a numeric `expiresAt`) and rejects non-conforming results with a
+ * `401` BEFORE `req.auth` is populated. This describe proves a valid PAT actually authenticates end
+ * of middleware, a missing token yields a naked `401` (no `resource_metadata` → no Inspector DCR),
+ * and an invalid PAT is rejected.
+ */
+test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT middleware boundary', () => {
+    let AuthService, requireBearerAuth, InvalidTokenError, originalFetch;
+
+    const logger   = {info: () => {}, warn: () => {}, error: () => {}};
+    const aiConfig = {auth: {mode: 'gitlab-pat', gitlabApiBaseUrl: 'https://gitlab.example.com', patCacheTtlSeconds: 300}};
+
+    test.beforeAll(async () => {
+        AuthService       = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+        requireBearerAuth = (await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js')).requireBearerAuth;
+        InvalidTokenError = (await import('@modelcontextprotocol/sdk/server/auth/errors.js')).InvalidTokenError;
+    });
+
+    test.beforeEach(() => { originalFetch = globalThis.fetch; });
+    test.afterEach(()  => { globalThis.fetch = originalFetch; });
+
+    function mockReq(authHeader) {
+        const headers = authHeader ? {authorization: authHeader} : {};
+        return {headers, get(name) { return headers[String(name).toLowerCase()]; }};
+    }
+
+    // Minimal Express-style response double recording status + headers (lower-cased) + body.
+    function mockRes() {
+        return {
+            statusCode: 200, headers: {}, body: undefined, ended: false,
+            status(code) { this.statusCode = code; return this; },
+            set(field, value) {
+                if (field && typeof field === 'object') {
+                    Object.entries(field).forEach(([k, v]) => { this.headers[String(k).toLowerCase()] = v; });
+                } else {
+                    this.headers[String(field).toLowerCase()] = value;
+                }
+                return this;
+            },
+            setHeader(field, value) { this.headers[String(field).toLowerCase()] = value; return this; },
+            header(field, value)    { this.headers[String(field).toLowerCase()] = value; return this; },
+            getHeader(field)        { return this.headers[String(field).toLowerCase()]; },
+            json(payload) { this.body = payload; this.ended = true; return this; },
+            send(payload) { this.body = payload; this.ended = true; return this; },
+            end(payload)  { if (payload !== undefined) this.body = payload; this.ended = true; return this; }
+        };
+    }
+
+    // Installs the REAL SDK requireBearerAuth via setupGitlabPat; returns the captured middleware.
+    // The single-middleware assertion also confirms the naked-401 shape (no mcpAuthMetadataRouter).
+    function installPatMiddleware() {
+        const middlewares = [],
+              app         = {use: mw => middlewares.push(mw)};
+
+        AuthService.setupGitlabPat({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
+
+        expect(middlewares.length).toBe(1);
+        return middlewares[0];
+    }
+
+    test('a valid GitLab PAT passes requireBearerAuth → next() called + req.auth populated', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({id: 7, username: 'octocat', name: 'The Octocat'})});
+
+        const mw  = installPatMiddleware(),
+              req = mockReq('Bearer glpat-valid'),
+              res = mockRes();
+
+        let nextErr = 'unset';
+        await mw(req, res, err => { nextErr = err; });
+
+        expect(nextErr).toBeUndefined();                     // next() invoked with no error
+        expect(res.ended).toBe(false);                       // no 401 short-circuit
+        expect(req.auth?.userId).toBe('octocat');
+        expect(req.auth?.source).toBe('gitlab-pat');
+        expect(typeof req.auth?.expiresAt).toBe('number');   // the SDK requires + propagates this
+    });
+
+    test('a missing token yields a naked 401 — WWW-Authenticate: Bearer, no resource_metadata', async () => {
+        const mw  = installPatMiddleware(),
+              req = mockReq(),
+              res = mockRes();
+
+        let nextCalled = false;
+        await mw(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+        const wwwAuth = String(res.headers['www-authenticate'] || '');
+        expect(wwwAuth).toContain('Bearer');
+        expect(wwwAuth).not.toContain('resource_metadata');
+    });
+
+    test('an invalid PAT (GitLab 401) is rejected — next() not called', async () => {
+        globalThis.fetch = async () => ({ok: false, status: 401, json: async () => ({})});
+
+        const mw  = installPatMiddleware(),
+              req = mockReq('Bearer glpat-bad'),
+              res = mockRes();
+
+        let nextCalled = false;
+        await mw(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
     });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -1,0 +1,141 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'AuthServicePatTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * Unit coverage for the GitLab-PAT verifier in `AuthService`. Exercises the verifier
+ * factory in isolation — `globalThis.fetch` is stubbed so no live GitLab call is made — covering
+ * the identity mapping, the `name`-absent fallback, the non-OK rejection (with no failure caching),
+ * the success cache (per-token), and the TTL boundary. A minimal stand-in for the SDK
+ * `InvalidTokenError` avoids importing the MCP SDK in a unit spec.
+ */
+test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT verifier', () => {
+    let AuthService;
+    let originalFetch;
+
+    class FakeInvalidTokenError extends Error {}
+
+    const logger   = {info: () => {}, warn: () => {}, error: () => {}};
+    const aiConfig = {
+        auth: {
+            gitlabApiBaseUrl  : 'https://gitlab.example.com/',
+            patCacheTtlSeconds: 300
+        }
+    };
+
+    test.beforeAll(async () => {
+        AuthService = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalFetch = globalThis.fetch;
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('maps a GitLab /user 200 to the RequestContextService identity shape', async () => {
+        let calledUrl, calledHeaders;
+
+        globalThis.fetch = async (url, opts) => {
+            calledUrl     = url;
+            calledHeaders = opts?.headers;
+            return {ok: true, json: async () => ({id: 42, username: 'octocat', name: 'The Octocat'})};
+        };
+
+        const verifier = AuthService.createGitlabPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError}),
+              info     = await verifier.verifyAccessToken('glpat-abc');
+
+        // Trailing slash on the configured base URL is trimmed before appending the API path.
+        expect(calledUrl).toBe('https://gitlab.example.com/api/v4/user');
+        expect(calledHeaders.Authorization).toBe('Bearer glpat-abc');
+        expect(info.userId).toBe('octocat');
+        expect(info.username).toBe('The Octocat');
+        expect(info.source).toBe('gitlab-pat');
+        expect(info.scopes).toEqual([]);
+    });
+
+    test('falls back to username when GitLab returns no name field', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({username: 'anon'})});
+
+        const verifier = AuthService.createGitlabPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError}),
+              info     = await verifier.verifyAccessToken('glpat-x');
+
+        expect(info.username).toBe('anon');
+        expect(info.userId).toBe('anon');
+    });
+
+    test('throws InvalidTokenError on a non-OK GitLab response and does NOT cache the failure', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async () => {
+            calls++;
+            return {ok: false, status: 401, json: async () => ({})};
+        };
+
+        const verifier = AuthService.createGitlabPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError});
+
+        await expect(verifier.verifyAccessToken('bad')).rejects.toBeInstanceOf(FakeInvalidTokenError);
+        // A transient failure must not lock the client out — the next call re-hits GitLab.
+        await expect(verifier.verifyAccessToken('bad')).rejects.toBeInstanceOf(FakeInvalidTokenError);
+        expect(calls).toBe(2);
+    });
+
+    test('caches a successful validation per-token (second call does not re-hit GitLab)', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async () => {
+            calls++;
+            return {ok: true, json: async () => ({username: 'cached-user'})};
+        };
+
+        const verifier = AuthService.createGitlabPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError}),
+              first    = await verifier.verifyAccessToken('same-token'),
+              second   = await verifier.verifyAccessToken('same-token');
+
+        expect(calls).toBe(1);
+        expect(second.userId).toBe('cached-user');
+        expect(second).toBe(first);
+
+        // A different token is a distinct cache key → a fresh validation.
+        await verifier.verifyAccessToken('other-token');
+        expect(calls).toBe(2);
+    });
+
+    test('a zero-TTL cache entry is never fresh — every call re-validates', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async () => {
+            calls++;
+            return {ok: true, json: async () => ({username: 'u'})};
+        };
+
+        const verifier = AuthService.createGitlabPatVerifier({
+            aiConfig         : {auth: {gitlabApiBaseUrl: 'https://gitlab.example.com', patCacheTtlSeconds: 0}},
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        await verifier.verifyAccessToken('t');
+        await verifier.verifyAccessToken('t');
+
+        // expiresAt = now + 0 is never strictly greater than a later Date.now() → re-fetch.
+        expect(calls).toBe(2);
+    });
+});

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -343,7 +343,7 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
 
     test('same-source named import drift detected: template adds specifier to existing import block', async () => {
         // Empirical regression guard against the dominant config-template evolution mode
-        // (e.g., #10812 added `parseUrl` to the existing Env.mjs import block).
+        // (e.g., a template adding `parseUrl` to an existing Env.mjs import block).
         // Source path is unchanged, so source-path projection alone wouldn't catch it.
         const templateSrc = [
             `import path from 'path';`,
@@ -511,5 +511,98 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
 
         const shape = await projectShape(filePath);
         expect(shape.exports.sort()).toEqual(['first', 'only', 'second', 'third']);
+    });
+
+    test('env-var projection: leaf() UPPER_SNAKE env literals are projected, defaults/types are not (#12378)', async () => {
+        const src = [
+            `import {parsePort} from '../../../../src/util/Env.mjs';`,
+            `export default {auth: {`,
+            `    mode: leaf('oidc', 'NEO_AUTH_MODE', 'string'),`,
+            `    port: leaf(8080, 'NEO_AUTH_PORT', 'port'),`,
+            `    base: leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string')`,
+            `}};`,
+            ``
+        ].join('\n');
+        const filePath = path.join(workRoot, 'envvars.mjs');
+        fs.writeFileSync(filePath, src);
+
+        const shape = await projectShape(filePath);
+        expect(shape.envVars).toEqual(['NEO_AUTH_GITLAB_API_BASE_URL', 'NEO_AUTH_MODE', 'NEO_AUTH_PORT']);
+        // Lowercase default values + type tokens must NOT be mistaken for env vars.
+        expect(shape.envVars).not.toContain('oidc');
+        expect(shape.envVars).not.toContain('string');
+    });
+
+    test('detectDrift reports a new env-bound leaf as missingEnvVars (data-tree drift the import projection misses)', () => {
+        const templateShape = {imports: ['a'], exports: [], envVars: ['NEO_AUTH_HOST', 'NEO_AUTH_MODE']};
+        const configShape   = {imports: ['a'], exports: [], envVars: ['NEO_AUTH_HOST']};
+
+        const drift = detectDrift(templateShape, configShape);
+        expect(drift.hasDrift).toBe(true);
+        expect(drift.missingEnvVars).toEqual(['NEO_AUTH_MODE']);
+        expect(drift.missingImports).toEqual([]);
+        expect(drift.missingExports).toEqual([]);
+    });
+
+    test('a template that adds an env-bound config leaf warns the existing config (env drift)', async () => {
+        // Identical imports/exports — only a NEW leaf carrying NEO_AUTH_MODE is added. The
+        // import/export projection alone is blind to this; env-var projection catches it.
+        const templateSrc = [
+            `import {parsePort} from '../../../../src/util/Env.mjs';`,
+            `export default {auth: {host: leaf(null, 'NEO_AUTH_HOST', 'string'), mode: leaf('oidc', 'NEO_AUTH_MODE', 'string')}};`,
+            ``
+        ].join('\n');
+        const configSrc = [
+            `import {parsePort} from '../../../../src/util/Env.mjs';`,
+            `export default {auth: {host: leaf(null, 'NEO_AUTH_HOST', 'string')}};`,
+            ``
+        ].join('\n');
+        const root = buildServerSandbox({
+            sandboxName     : 'env-leaf-drift-warn',
+            templateContents: templateSrc,
+            configContents  : configSrc
+        });
+
+        const logger = recordingLogger();
+        const result = await initConfigs({argv: ['node', 'initServerConfigs.mjs'], logger, serversRoot: root});
+
+        const action = result.processed.find(p => p.serverName === 'memory-core');
+        expect(action.action).toBe('warn');
+        expect(action.drift.missingEnvVars).toEqual(['NEO_AUTH_MODE']);
+        expect(logger.entries.warn.some(l => l.includes('+ env: NEO_AUTH_MODE'))).toBe(true);
+        // warn mode must not overwrite the operator config
+        expect(fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8')).toBe(configSrc);
+    });
+
+    test('env-leaf drift forces a full migrate (NOT the materialize-only fast path)', async () => {
+        // A config that BOTH still imports the Tier-1 TEMPLATE (materialization drift) AND lacks a
+        // new env leaf must take the full template refresh — the import-only fast path would leave
+        // the new leaf behind.
+        const templateSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {auth: {host: leaf(null, 'NEO_AUTH_HOST', 'string'), mode: leaf('oidc', 'NEO_AUTH_MODE', 'string')}};`,
+            ``
+        ].join('\n');
+        const configSrc = [
+            `import AiConfig from '../../../config.template.mjs';`,
+            `export default {auth: {host: leaf(null, 'NEO_AUTH_HOST', 'string')}};`,
+            ``
+        ].join('\n');
+        const root = buildServerSandbox({
+            sandboxName     : 'env-leaf-drift-migrate',
+            templateContents: templateSrc,
+            configContents  : configSrc
+        });
+
+        const logger = recordingLogger();
+        const result = await initConfigs({argv: ['node', 'initServerConfigs.mjs', '--migrate-config'], logger, serversRoot: root});
+
+        const action = result.processed.find(p => p.serverName === 'memory-core');
+        expect(action.action).toBe('migrate');
+        expect(action.migration).toBeUndefined();   // NOT 'materialize-import-only'
+
+        const onDisk = fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8');
+        expect(onDisk).toBe(materializeServerConfigTemplate(templateSrc));
+        expect(onDisk).toContain('NEO_AUTH_MODE');
     });
 });


### PR DESCRIPTION
**Resolves #12378**

Sub of epic #12377 (GitLab-PAT Bearer auth + MCP Inspector 0.21.2 compat). Implements the GitLab-PAT Bearer auth-mode foundation — the contract that is the start-signal for #12379.

**FAIR-band:** under-target [2/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane). Epic-sub adding a new MCP auth mode + the config-propagation tooling to ship it; additive (OIDC stays the default, untouched).

**Evidence:** L1 (static — V-B-A of `AuthService.mjs`, `RequestContextService.mjs`, `BaseConfig.mjs`, the live `auth` block, `initServerConfigs.mjs`) + L2 (dynamic — verifier unit spec **plus the consumed `requireBearerAuth` middleware boundary** [valid PAT → `next()`/`req.auth`; missing/invalid → naked-401] = 8/8, and the drift-detector spec 20/20). The live end-to-end falsification is #12379's lane against the merged endpoint.

## What + Why

MCP servers only supported OIDC bearer auth, which rejects raw Personal Access Tokens (PATs carry no `aud` claim) and advertises OAuth Protected-Resource-Metadata that triggers MCP Inspector's Dynamic Client Registration against providers (like GitLab) that have none. This adds a **config-gated `gitlab-pat` auth mode**: a real user or headless agent authenticates with a GitLab PAT supplied via an env var, validated against the GitLab API — no cookie, no OAuth dance.

## Deltas

- **`ai/config.template.mjs`** — new realm-root `auth` leaves: `mode` (`NEO_AUTH_MODE`, default `'oidc'`), `gitlabApiBaseUrl` (`NEO_AUTH_GITLAB_API_BASE_URL`, default `https://gitlab.com`), `patCacheTtlSeconds` (`NEO_AUTH_PAT_CACHE_TTL_SECONDS`, default `300`). OIDC remains the production default.
- **`AuthService.mjs`** — `setup()` early-returns to a new `setupGitlabPat()` when `mode === 'gitlab-pat'`, installing **only** `requireBearerAuth({verifier})` — no `mcpAuthMetadataRouter`, no `resourceMetadataUrl`. A missing/invalid token therefore yields a bare `WWW-Authenticate: Bearer` 401 with no `resource_metadata` breadcrumb (no PRM → no Inspector DCR). New `createGitlabPatVerifier()` validates the PAT via `GET {gitlabApiBaseUrl}/api/v4/user`, maps `username → userId` / `name || username → username` / `source: 'gitlab-pat'` (consumed unchanged by `RequestContextService`), and returns a **numeric `expiresAt`** — REQUIRED by `requireBearerAuth` (it rejects auth info lacking one with `Token has no expiration time` before `req.auth` is set); set to the re-validation horizon (`now + patCacheTtlSeconds`, Unix seconds) and built per-call so it stays request-fresh on cache hits. No `aud`/introspection; SHA-256 token-hash success cache (TTL = `patCacheTtlSeconds`; failures never cached; raw token never logged).
- **`TransportService.mjs`** — widened the `AuthService.setup()` invocation gate to also fire on `mode === 'gitlab-pat'`. It keyed only on `host`/`issuerUrl`, neither of which PAT mode sets, so PAT mode would otherwise have been silently inert.
- **`initServerConfigs.mjs`** — extended the config-template drift detector to project **env-var leaf literals** (`projectSourceShape` → `envVars`; `detectDrift` → `missingEnvVars`; the materialize-only fast path is disqualified by env drift; both warn loops emit `+ env:`). Without this, a new template `data` leaf (like `NEO_AUTH_MODE`) is invisible to the import/export-only detector, so existing operator configs would never be prompted to migrate — leaving PAT mode unreachable. This closes that propagation gap.

## MCP config-template change

This PR adds leaves to `ai/config.template.mjs` (the tracked Tier-1 SSOT). Per the config model, the gitignored per-server / Tier-1 `config.mjs` overlays are autogenerated from templates: a **fresh** deployment clones the updated template (gets PAT mode automatically), while **existing** deployments are now *prompted* by the extended drift detector to run `npm run prepare -- --migrate-config` to pick up the new leaves. No gitignored config files are modified by this PR.

## Test Evidence

- `test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs` (new) — GitLab-PAT verifier (identity mapping, `name`-absent fallback, `InvalidTokenError` on non-OK with no failure caching, per-token success cache, TTL=0 boundary) **plus the consumed-middleware boundary** (real `requireBearerAuth` installed via `setupGitlabPat`: valid PAT → `next()` + `req.auth` populated with numeric `expiresAt`; missing token → naked-401 with no `resource_metadata`; invalid PAT → 401). **8/8 green.**
- `test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` (+4) — env-var projection, `detectDrift` `missingEnvVars`, the env-drift warn path, and env-drift forcing a full migrate. Full spec **20/20 green** (no regression).
- Run: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs`.
- Syntax + whitespace clean; pre-commit hooks (whitespace / shorthand / ticket-archaeology) pass.

## Post-Merge Validation

- [ ] On a fresh deployment generated from the updated template, set `NEO_AUTH_MODE=gitlab-pat` + `NEO_AUTH_GITLAB_API_BASE_URL` and confirm a `read_user` PAT authenticates to `/mcp` (200) while a missing/invalid token gets a bare 401 with no `resource_metadata`.
- [ ] On an existing deployment, confirm `npm run prepare` warns that the configs lack the new `NEO_AUTH_*` leaves and `--migrate-config` propagates them.
- [ ] #12379 live falsification: MCP Inspector 0.21.2 manual-Bearer against the deployed `gitlab-pat` endpoint.

Refs #12377, #12379. Related #12382.

Authored by @neo-opus-4-7 (claude-opus-4.8-1m) · session ceeb5c34
