### PR TITLE
fix(memory-core): refresh cached healthcheck snapshot (#12382)

### DIFF
--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -112,58 +112,6 @@ export function buildTaskOutcomesBlock(taskOutcomes) {
 }
 
 /**
- * @summary Builds a request-fresh healthcheck snapshot from a cached healthy payload.
- *
- * The broader healthcheck cache intentionally preserves expensive dependency probes for the
- * `ensureHealthy()` gate. Direct operator healthcheck calls still need request-time observability:
- * a fresh `timestamp` and live collection counts. This helper refreshes those cheap request-facing
- * fields without mutating the cached payload; returning `null` tells the caller to fall through to a
- * full healthcheck because the collection refresh indicates an unhealthy or ambiguous state.
- *
- * @param {Object} cachedHealth Previously cached healthy healthcheck payload.
- * @param {Number|Date} now Request time used for the returned `timestamp`.
- * @param {Function} refreshCollections Async function returning the collection-check payload.
- * @returns {Promise<Object|null>} Fresh request snapshot or `null` when a full healthcheck is required.
- */
-export async function buildRequestFreshCachedHealth(cachedHealth, now, refreshCollections) {
-    if (!cachedHealth || typeof refreshCollections !== 'function') {
-        return null;
-    }
-
-    let collectionsCheck;
-
-    try {
-        collectionsCheck = await refreshCollections();
-    } catch (e) {
-        return null;
-    }
-
-    if (collectionsCheck?.error ||
-        !collectionsCheck?.memories?.exists ||
-        !collectionsCheck?.summaries?.exists) {
-        return null;
-    }
-
-    const database   = cachedHealth.database || {};
-    const connection = database.connection || {};
-
-    return {
-        ...cachedHealth,
-        timestamp: new Date(now).toISOString(),
-        database : {
-            ...database,
-            connection: {
-                ...connection,
-                collections: {
-                    memories : {...collectionsCheck.memories},
-                    summaries: {...collectionsCheck.summaries}
-                }
-            }
-        }
-    };
-}
-
-/**
  * @summary Projects the effective ChromaDB topology resolution into the healthcheck `database.topology`
  *          observability block.
  *
@@ -923,6 +871,57 @@ class HealthService extends Base {
     }
 
     /**
+     * Builds a request-fresh healthcheck snapshot from a cached healthy payload.
+     *
+     * The broader healthcheck cache intentionally preserves expensive dependency probes for the
+     * `ensureHealthy()` gate. Direct operator healthcheck calls still need request-time observability:
+     * a fresh `timestamp` and live collection counts. Keeping this logic inside the singleton avoids
+     * exporting a one-off helper and lets the method use the existing private collection probe directly.
+     *
+     * @param {Object} cachedHealth Previously cached healthy healthcheck payload.
+     * @param {Number|Date} now Request time used for the returned `timestamp`.
+     * @returns {Promise<Object|null>} Fresh request snapshot or `null` when a full healthcheck is required.
+     * @private
+     */
+    async #buildRequestFreshCachedHealth(cachedHealth, now) {
+        if (!cachedHealth) {
+            return null;
+        }
+
+        let collectionsCheck;
+
+        try {
+            collectionsCheck = await this.#checkCollections();
+        } catch (e) {
+            return null;
+        }
+
+        if (collectionsCheck?.error ||
+            !collectionsCheck?.memories?.exists ||
+            !collectionsCheck?.summaries?.exists) {
+            return null;
+        }
+
+        const database   = cachedHealth.database || {};
+        const connection = database.connection || {};
+
+        return {
+            ...cachedHealth,
+            timestamp: new Date(now).toISOString(),
+            database : {
+                ...database,
+                connection: {
+                    ...connection,
+                    collections: {
+                        memories : {...collectionsCheck.memories},
+                        summaries: {...collectionsCheck.summaries}
+                    }
+                }
+            }
+        };
+    }
+
+    /**
      * Computes the untagged-legacy-node counts for the multi-tenant migration observability
      * surface. Operators scrape `healthcheck.migration.untaggedCount.total` to track
      * how much pre-tenant-aware-era data remains as natural query patterns move writes toward
@@ -1257,11 +1256,7 @@ class HealthService extends Base {
                         return this.#cachedHealth;
                     }
 
-                    const freshCachedHealth = await buildRequestFreshCachedHealth(
-                        this.#cachedHealth,
-                        now,
-                        () => this.#checkCollections()
-                    );
+                    const freshCachedHealth = await this.#buildRequestFreshCachedHealth(this.#cachedHealth, now);
 
                     if (freshCachedHealth) {
                         return freshCachedHealth;

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -112,6 +112,58 @@ export function buildTaskOutcomesBlock(taskOutcomes) {
 }
 
 /**
+ * @summary Builds a request-fresh healthcheck snapshot from a cached healthy payload.
+ *
+ * The broader healthcheck cache intentionally preserves expensive dependency probes for the
+ * `ensureHealthy()` gate. Direct operator healthcheck calls still need request-time observability:
+ * a fresh `timestamp` and live collection counts. This helper refreshes those cheap request-facing
+ * fields without mutating the cached payload; returning `null` tells the caller to fall through to a
+ * full healthcheck because the collection refresh indicates an unhealthy or ambiguous state.
+ *
+ * @param {Object} cachedHealth Previously cached healthy healthcheck payload.
+ * @param {Number|Date} now Request time used for the returned `timestamp`.
+ * @param {Function} refreshCollections Async function returning the collection-check payload.
+ * @returns {Promise<Object|null>} Fresh request snapshot or `null` when a full healthcheck is required.
+ */
+export async function buildRequestFreshCachedHealth(cachedHealth, now, refreshCollections) {
+    if (!cachedHealth || typeof refreshCollections !== 'function') {
+        return null;
+    }
+
+    let collectionsCheck;
+
+    try {
+        collectionsCheck = await refreshCollections();
+    } catch (e) {
+        return null;
+    }
+
+    if (collectionsCheck?.error ||
+        !collectionsCheck?.memories?.exists ||
+        !collectionsCheck?.summaries?.exists) {
+        return null;
+    }
+
+    const database   = cachedHealth.database || {};
+    const connection = database.connection || {};
+
+    return {
+        ...cachedHealth,
+        timestamp: new Date(now).toISOString(),
+        database : {
+            ...database,
+            connection: {
+                ...connection,
+                collections: {
+                    memories : {...collectionsCheck.memories},
+                    summaries: {...collectionsCheck.summaries}
+                }
+            }
+        }
+    };
+}
+
+/**
  * @summary Projects the effective ChromaDB topology resolution into the healthcheck `database.topology`
  *          observability block.
  *
@@ -1181,9 +1233,11 @@ class HealthService extends Base {
      * Recovery detection: If the status changes between checks (e.g., from 'unhealthy'
      * to 'healthy'), we log a clear message so users know their fix worked.
      *
+     * @param {Object} [options]
+     * @param {Boolean} [options.freshObservability=true] Refresh request-facing fields on cached healthy results.
      * @returns {Promise<object>} A health status payload with session information
      */
-    async healthcheck() {
+    async healthcheck({freshObservability = true} = {}) {
         try {
             const now = Date.now();
 
@@ -1194,10 +1248,26 @@ class HealthService extends Base {
                 this.#lastCheckTime) {
                 const age = now - this.#lastCheckTime;
 
-                // If the cache is still fresh (< 5 minutes old), return it immediately
+                // If the cache is still fresh (< 5 minutes old), reuse it while keeping
+                // direct healthcheck observability request-fresh when requested.
                 if (age < this.#cacheDuration) {
                     logger.debug(`[HealthService] Using cached health status (age: ${Math.round(age / 1000)}s)`);
-                    return this.#cachedHealth;
+
+                    if (!freshObservability) {
+                        return this.#cachedHealth;
+                    }
+
+                    const freshCachedHealth = await buildRequestFreshCachedHealth(
+                        this.#cachedHealth,
+                        now,
+                        () => this.#checkCollections()
+                    );
+
+                    if (freshCachedHealth) {
+                        return freshCachedHealth;
+                    }
+
+                    this.clearCache();
                 }
             }
 
@@ -1288,7 +1358,7 @@ class HealthService extends Base {
      * @returns {Promise<void>}
      */
     async ensureHealthy() {
-        const health = await this.healthcheck();
+        const health = await this.healthcheck({freshObservability: false});
 
         if (health.status !== 'healthy') {
             // Build a multi-line error message with all the issues detected

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -157,6 +157,91 @@ test.describe('HealthService #11009 — buildTaskOutcomesBlock', () => {
 });
 
 /**
+ * @summary Coverage for the #12382 request-fresh cached healthcheck snapshot.
+ *
+ * The live bug was in the healthy-cache fast path: direct healthcheck callers observed the cached
+ * payload's original `timestamp` and collection counts even after later writes. This pure helper
+ * covers the request-facing snapshot logic without booting ChromaDB.
+ *
+ * @see Neo.ai.services.memory-core.HealthService#buildRequestFreshCachedHealth
+ */
+test.describe('HealthService #12382 — buildRequestFreshCachedHealth', () => {
+    let buildRequestFreshCachedHealth;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
+        buildRequestFreshCachedHealth = mod.buildRequestFreshCachedHealth;
+    });
+
+    test('refreshes timestamp and collection counts without mutating the cached payload', async () => {
+        const cachedHealth = {
+            status   : 'healthy',
+            timestamp: '2026-06-02T12:00:00.000Z',
+            database : {
+                connection: {
+                    connected  : true,
+                    collections: {
+                        memories : {name: 'neo-agent-memory', exists: true, count: 10},
+                        summaries: {name: 'neo-agent-sessions', exists: true, count: 20}
+                    },
+                    engines: {chroma: true}
+                },
+                topology: {mode: 'unified'}
+            },
+            details: ['cached']
+        };
+
+        const result = await buildRequestFreshCachedHealth(
+            cachedHealth,
+            new Date('2026-06-02T12:05:00.000Z'),
+            async () => ({
+                memories : {name: 'neo-agent-memory', exists: true, count: 11},
+                summaries: {name: 'neo-agent-sessions', exists: true, count: 21}
+            })
+        );
+
+        expect(result.timestamp).toBe('2026-06-02T12:05:00.000Z');
+        expect(result.database.connection.collections).toEqual({
+            memories : {name: 'neo-agent-memory', exists: true, count: 11},
+            summaries: {name: 'neo-agent-sessions', exists: true, count: 21}
+        });
+
+        expect(result).not.toBe(cachedHealth);
+        expect(result.database).not.toBe(cachedHealth.database);
+        expect(result.database.connection).not.toBe(cachedHealth.database.connection);
+        expect(cachedHealth.timestamp).toBe('2026-06-02T12:00:00.000Z');
+        expect(cachedHealth.database.connection.collections.memories.count).toBe(10);
+        expect(cachedHealth.database.connection.collections.summaries.count).toBe(20);
+    });
+
+    test('returns null when the collection refresh reports an unhealthy shape', async () => {
+        const cachedHealth = {
+            status  : 'healthy',
+            database: {connection: {collections: null}}
+        };
+
+        await expect(buildRequestFreshCachedHealth(
+            cachedHealth,
+            Date.now(),
+            async () => ({
+                memories : {name: 'neo-agent-memory', exists: true,  count: 1},
+                summaries: {name: 'neo-agent-sessions', exists: false, count: 0}
+            })
+        )).resolves.toBeNull();
+    });
+
+    test('returns null when collection refresh throws so callers can run a full healthcheck', async () => {
+        await expect(buildRequestFreshCachedHealth(
+            {status: 'healthy', database: {connection: {collections: null}}},
+            Date.now(),
+            async () => {
+                throw new Error('count failed');
+            }
+        )).resolves.toBeNull();
+    });
+});
+
+/**
  * @summary Coverage for Chroma migration observability after #11181.
  *
  * The live regression was not just "missing userId"; restored session summaries also had

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -17,6 +17,10 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+import ChromaManager   from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
+import StorageRouter   from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import ChromaLifecycleService from '../../../../../../ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs';
+import MailboxService  from '../../../../../../ai/services/memory-core/MailboxService.mjs';
 
 /**
  * @summary Coverage for the #10176 identity observability block in the healthcheck payload.
@@ -157,87 +161,143 @@ test.describe('HealthService #11009 — buildTaskOutcomesBlock', () => {
 });
 
 /**
- * @summary Coverage for the #12382 request-fresh cached healthcheck snapshot.
+ * @summary Coverage for the #12382 request-fresh cached healthcheck path.
  *
  * The live bug was in the healthy-cache fast path: direct healthcheck callers observed the cached
- * payload's original `timestamp` and collection counts even after later writes. This pure helper
- * covers the request-facing snapshot logic without booting ChromaDB.
+ * payload's original `timestamp` and collection counts even after later writes. The tests patch the
+ * singleton collaborators to keep the path unit-fast while still exercising the public `healthcheck()`
+ * API instead of a detached helper.
  *
- * @see Neo.ai.services.memory-core.HealthService#buildRequestFreshCachedHealth
+ * @see Neo.ai.services.memory-core.HealthService#healthcheck
  */
-test.describe('HealthService #12382 — buildRequestFreshCachedHealth', () => {
-    let buildRequestFreshCachedHealth;
+test.describe('HealthService #12382 — cached healthcheck freshness', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let HealthService;
+    let memoryCount;
+    let originalDateNow;
+    let originalGeminiApiKey;
+    let originals;
+    let summaryCount;
+    let summaryGetCalls;
+    let summaryUnavailableOnCall;
+
+    const makeCollection = countGetter => ({
+        count: async () => countGetter(),
+        get  : async () => ({ids: [], metadatas: []})
+    });
 
     test.beforeAll(async () => {
-        const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
-        buildRequestFreshCachedHealth = mod.buildRequestFreshCachedHealth;
+        HealthService = (await import('../../../../../../ai/services/memory-core/HealthService.mjs')).default;
     });
 
-    test('refreshes timestamp and collection counts without mutating the cached payload', async () => {
-        const cachedHealth = {
-            status   : 'healthy',
-            timestamp: '2026-06-02T12:00:00.000Z',
-            database : {
-                connection: {
-                    connected  : true,
-                    collections: {
-                        memories : {name: 'neo-agent-memory', exists: true, count: 10},
-                        summaries: {name: 'neo-agent-sessions', exists: true, count: 20}
-                    },
-                    engines: {chroma: true}
-                },
-                topology: {mode: 'unified'}
-            },
-            details: ['cached']
+    test.beforeEach(() => {
+        originalDateNow    = Date.now;
+        originalGeminiApiKey = process.env.GEMINI_API_KEY;
+        memoryCount        = 10;
+        summaryCount       = 20;
+        summaryGetCalls    = 0;
+        summaryUnavailableOnCall = null;
+
+        const memoryCollection  = makeCollection(() => memoryCount);
+        const summaryCollection = makeCollection(() => summaryCount);
+
+        originals = {
+            chromaConnected         : ChromaManager.connected,
+            chromaReady             : ChromaManager.ready,
+            chromaConnect           : ChromaManager.connect,
+            getMemoryCollection     : StorageRouter.getMemoryCollection,
+            getSummaryCollection    : StorageRouter.getSummaryCollection,
+            getDatabaseStatus       : ChromaLifecycleService.getDatabaseStatus,
+            getHealthcheckPreview   : MailboxService.getHealthcheckPreview
         };
 
-        const result = await buildRequestFreshCachedHealth(
-            cachedHealth,
-            new Date('2026-06-02T12:05:00.000Z'),
-            async () => ({
-                memories : {name: 'neo-agent-memory', exists: true, count: 11},
-                summaries: {name: 'neo-agent-sessions', exists: true, count: 21}
-            })
-        );
-
-        expect(result.timestamp).toBe('2026-06-02T12:05:00.000Z');
-        expect(result.database.connection.collections).toEqual({
-            memories : {name: 'neo-agent-memory', exists: true, count: 11},
-            summaries: {name: 'neo-agent-sessions', exists: true, count: 21}
-        });
-
-        expect(result).not.toBe(cachedHealth);
-        expect(result.database).not.toBe(cachedHealth.database);
-        expect(result.database.connection).not.toBe(cachedHealth.database.connection);
-        expect(cachedHealth.timestamp).toBe('2026-06-02T12:00:00.000Z');
-        expect(cachedHealth.database.connection.collections.memories.count).toBe(10);
-        expect(cachedHealth.database.connection.collections.summaries.count).toBe(20);
-    });
-
-    test('returns null when the collection refresh reports an unhealthy shape', async () => {
-        const cachedHealth = {
-            status  : 'healthy',
-            database: {connection: {collections: null}}
+        ChromaManager.connected = true;
+        ChromaManager.ready     = async () => {};
+        ChromaManager.connect   = async () => {
+            ChromaManager.connected = true;
+            return true;
         };
 
-        await expect(buildRequestFreshCachedHealth(
-            cachedHealth,
-            Date.now(),
-            async () => ({
-                memories : {name: 'neo-agent-memory', exists: true,  count: 1},
-                summaries: {name: 'neo-agent-sessions', exists: false, count: 0}
-            })
-        )).resolves.toBeNull();
+        StorageRouter.getMemoryCollection = async () => memoryCollection;
+        StorageRouter.getSummaryCollection = async () => {
+            summaryGetCalls++;
+            return summaryGetCalls === summaryUnavailableOnCall ? null : summaryCollection
+        };
+
+        ChromaLifecycleService.getDatabaseStatus = () => ({running: true});
+        MailboxService.getHealthcheckPreview     = async () => ({unreadCount: 0, latestPreview: null});
+        process.env.GEMINI_API_KEY               = 'unit-test-key';
+
+        HealthService.clearCache();
     });
 
-    test('returns null when collection refresh throws so callers can run a full healthcheck', async () => {
-        await expect(buildRequestFreshCachedHealth(
-            {status: 'healthy', database: {connection: {collections: null}}},
-            Date.now(),
-            async () => {
-                throw new Error('count failed');
-            }
-        )).resolves.toBeNull();
+    test.afterEach(() => {
+        Date.now = originalDateNow;
+
+        if (originalGeminiApiKey === undefined) {
+            delete process.env.GEMINI_API_KEY;
+        } else {
+            process.env.GEMINI_API_KEY = originalGeminiApiKey;
+        }
+
+        ChromaManager.connected = originals.chromaConnected;
+        ChromaManager.ready     = originals.chromaReady;
+        ChromaManager.connect   = originals.chromaConnect;
+        StorageRouter.getMemoryCollection      = originals.getMemoryCollection;
+        StorageRouter.getSummaryCollection     = originals.getSummaryCollection;
+        ChromaLifecycleService.getDatabaseStatus = originals.getDatabaseStatus;
+        MailboxService.getHealthcheckPreview     = originals.getHealthcheckPreview;
+
+        HealthService.clearCache();
+    });
+
+    test('direct healthcheck refreshes cached timestamp and collection counts without mutating the cache', async () => {
+        const cached = await HealthService.healthcheck();
+
+        expect(cached.status).toBe('healthy');
+        expect(cached.database.connection.collections.memories.count).toBe(10);
+        expect(cached.database.connection.collections.summaries.count).toBe(20);
+
+        memoryCount  = 11;
+        summaryCount = 21;
+
+        const requestNow = originalDateNow() + 60_000;
+        Date.now = () => requestNow;
+
+        const fresh = await HealthService.healthcheck();
+
+        expect(fresh.timestamp).toBe(new Date(requestNow).toISOString());
+        expect(fresh.database.connection.collections.memories).toMatchObject({exists: true, count: 11});
+        expect(fresh.database.connection.collections.summaries).toMatchObject({exists: true, count: 21});
+
+        expect(fresh).not.toBe(cached);
+        expect(fresh.database).not.toBe(cached.database);
+        expect(fresh.database.connection).not.toBe(cached.database.connection);
+        expect(cached.database.connection.collections.memories.count).toBe(10);
+        expect(cached.database.connection.collections.summaries.count).toBe(20);
+
+        const ensureHealthyFastPath = await HealthService.healthcheck({freshObservability: false});
+        expect(ensureHealthyFastPath).toBe(cached);
+        expect(ensureHealthyFastPath.database.connection.collections.memories.count).toBe(10);
+    });
+
+    test('unhealthy cached-refresh shape clears cache and falls through to a full healthcheck', async () => {
+        const cached = await HealthService.healthcheck();
+
+        expect(cached.database.connection.collections.summaries.count).toBe(20);
+
+        memoryCount  = 12;
+        summaryCount = 22;
+        summaryUnavailableOnCall = summaryGetCalls + 1;
+        Date.now = () => originalDateNow() + 60_000;
+
+        const refreshed = await HealthService.healthcheck();
+
+        expect(refreshed.status).toBe('healthy');
+        expect(refreshed).not.toBe(cached);
+        expect(refreshed.database.connection.collections.memories.count).toBe(12);
+        expect(refreshed.database.connection.collections.summaries.count).toBe(22);
     });
 });
 


### PR DESCRIPTION
Resolves #12382
Related: #12377

Authored by GPT-5 Codex (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.

FAIR-band: over-target [28/30] — taking this lane despite over-target because the operator explicitly asked for non-conflicting epic-help lanes, and #12382 was unassigned, source-backed, and fixes Memory Core healthcheck observability currently relevant to the cloud-deployment support path.

Refreshes the healthy-cache healthcheck path so direct operator calls keep request-facing observability fresh. Cached healthy payloads are now reused as a base, but direct `healthcheck()` calls refresh the response timestamp and live collection counts before returning. `ensureHealthy()` keeps the low-cost cached path because tool preflight only needs the health gate, not fresh operator telemetry.

Evidence: L2 (focused Playwright unit coverage through the `HealthService.healthcheck()` cached fast path + full HealthService spec in stable single-worker mode) → L3 required (live MCP healthcheck after a Memory Core write). Residual: post-merge/live-deploy probe below.

## Deltas from ticket

- Kept the request-fresh cached snapshot logic inside the `HealthService` singleton as a private method, so the behavior stays local to the owner of `#cachedHealth` and `#checkCollections()`.
- Added `healthcheck({freshObservability = true})`; direct healthcheck callers get fresh timestamp/counts, while `ensureHealthy()` opts out to preserve the low-cost gate path.
- If collection refresh fails or reports missing collections, the cache is cleared and the call falls through to a full healthcheck instead of returning stale healthy data.
- Retargeted #12382 tests to the public singleton API by patching Memory Core collaborators and calling `HealthService.healthcheck()` directly; no exported one-off helper remains.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs -g "#12382"` → 2 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs --workers=1` → 45 passed.
- `git diff --check` → passed.
- Note: after materializing gitignored config overlays for the temporary worktree, the earlier default parallel full-file run surfaced one ambient parallel-worker import/cache failure in the existing #10783 wake block; the #12382 focused tests and full single-worker file are green.

## Post-Merge Validation

- [ ] In a live Memory Core process, call `healthcheck`, perform a memory write, call `healthcheck` again within the 5-minute TTL, and verify `timestamp` advances and `database.connection.collections.*.count` reflects the live write without restarting the server.

## Commits

- `f9efc62f5` — `fix(memory-core): refresh cached healthcheck snapshot (#12382)`
- `5ce50b505` — `fix(memory-core): keep cached health refresh on singleton (#12382)`
