### PR TITLE
docs(ai): add MCP Inspector PAT compatibility guide (#12379)

### DIFF
--- a/learn/agentos/cloud-deployment/McpInspectorCompatibility.md
+++ b/learn/agentos/cloud-deployment/McpInspectorCompatibility.md
@@ -1,0 +1,106 @@
+# MCP Inspector PAT Compatibility
+
+This guide records the verified MCP Inspector path for a cloud-deployed Neo MCP
+server running GitLab-PAT bearer authentication. The useful baseline is
+Inspector v0.21.2 with a manually supplied bearer token.
+
+## Result
+
+Inspector v0.21.2 works with Neo's PAT mode when the request carries an explicit
+`Authorization: Bearer <token>` header.
+
+No OAuth Dynamic Client Registration shim is justified for this path. The server
+must return a bare bearer `401` for missing or invalid tokens, without OAuth
+protected-resource metadata. With that shape, Inspector does not need GitLab to
+support Dynamic Client Registration.
+
+## Prerequisites
+
+- The MCP server is reachable over Streamable HTTP at its `/mcp` endpoint.
+- PAT authentication is enabled on the server.
+- The token validates against the configured GitLab API `/api/v4/user` endpoint.
+- The PAT is stored in an environment variable, not in a committed config file.
+
+Example:
+
+```bash
+export NEO_MCP_TOKEN="<your-gitlab-pat>"
+export NEO_MC_MCP_URL="https://mcp.<your-host>/mc/mcp"
+export NEO_KB_MCP_URL="https://mcp.<your-host>/kb/mcp"
+```
+
+## Inspector UI
+
+Start Inspector:
+
+```bash
+npx -y @modelcontextprotocol/inspector@0.21.2
+```
+
+Use these connection settings:
+
+| Field | Value |
+|---|---|
+| Transport | Streamable HTTP |
+| URL | `https://mcp.<your-host>/mc/mcp` or `https://mcp.<your-host>/kb/mcp` |
+| Authentication type | Bearer token |
+| Header name | `Authorization` |
+| Token value | the GitLab PAT from `NEO_MCP_TOKEN` |
+
+Then connect and run `tools/list`. A successful connection lists the server's
+tools. If Inspector reports a bearer `401`, first verify that the token value is
+present in the UI and that the server can validate it against GitLab.
+
+## Inspector CLI
+
+Use the CLI path for a deterministic smoke test:
+
+```bash
+npx -y @modelcontextprotocol/inspector@0.21.2 --cli "$NEO_MC_MCP_URL" \
+  --transport http \
+  --method tools/list \
+  --header "Authorization: Bearer ${NEO_MCP_TOKEN}"
+```
+
+For Knowledge Base, replace the target URL with `$NEO_KB_MCP_URL`.
+
+Expected outcome:
+
+- Without `--header`, Inspector fails during `initialize` with the server's bare
+  bearer `401`.
+- With `--header "Authorization: Bearer ${NEO_MCP_TOKEN}"`, Inspector completes
+  `initialize`, sends `notifications/initialized`, and returns `tools/list`.
+
+## Falsification Matrix
+
+The verified matrix used a local GitLab API mock and a local Neo Memory Core
+server running PAT mode. The mock accepted only `Bearer test-token` at
+`/api/v4/user`; all other requests returned `401`.
+
+| Probe | Expected result |
+|---|---|
+| Direct Inspector CLI without bearer header | Fails with the server's bare bearer `401` |
+| Direct Inspector CLI with bearer header | Succeeds and returns `tools/list` |
+| Inspector proxy path without bearer header | Returns an upstream `401` envelope with `WWW-Authenticate: Bearer` |
+| Inspector proxy path with bearer header | Succeeds and returns the server `initialize` result |
+
+This proves that Inspector v0.21.2 forwards an explicit bearer header in both
+the direct CLI and proxy-mediated paths. If a later Inspector version regresses,
+rerun the matrix before proposing a heavier OAuth or Dynamic Client Registration
+adapter.
+
+## Failure Triage
+
+| Symptom | Meaning | Next check |
+|---|---|---|
+| `Missing Authorization header` | Inspector reached the server but did not send a bearer token. | Re-enter the token or add the CLI `--header`. |
+| `GitLab PAT validation failed` | The server forwarded the token to GitLab and GitLab rejected it. | Verify token scope, expiry, and GitLab API base URL. |
+| OAuth or Dynamic Client Registration prompt | The server likely advertised OAuth metadata or a proxy inserted it. | Confirm PAT mode returns a bare bearer `401` with no protected-resource metadata. |
+| `Invalid Host` | The MCP SDK host allowlist rejected the request before auth. | Set the server public URL or allowed-host list for the deployment hostname. |
+
+## Decision
+
+Use the manual bearer path for Inspector v0.21.2. Do not add a Dynamic Client
+Registration shim unless a future Inspector version removes or breaks explicit
+bearer-header forwarding and the regression is reproduced against a PAT-mode
+Neo endpoint.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -48,6 +48,7 @@
             {"name": "Cloud-Native KB Ingestion Overview",             "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Overview"},
             {"name": "Day-0 Tutorial",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Day0Tutorial"},
             {"name": "llama.cpp Profile",                              "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/LlamaCppProfile"},
+            {"name": "MCP Inspector PAT Compatibility",                "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/McpInspectorCompatibility"},
             {"name": "Tenant Ingestion Model",                         "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/TenantIngestionModel"},
             {"name": "Configuration",                                  "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/Configuration"},
             {"name": "Custom Sources",                                 "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/CustomSources"},


### PR DESCRIPTION
Resolves #12379

Authored by GPT-5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.

FAIR-band: over-target [28/30] - taking this lane despite over-target because #12379 is assigned to @neo-gpt, the falsification evidence is already in this GPT lane, Claude is carrying the adjacent docs/a partner tenant lanes, and this is the single coherent PR for the epic sub rather than fragmenting the result across other PRs.

Adds the canonical MCP Inspector PAT compatibility guide for cloud deployments. The guide records that Inspector v0.21.2 works with Neo's GitLab-PAT bearer mode when an explicit `Authorization: Bearer <token>` header is supplied, and that no OAuth Dynamic Client Registration shim is justified for this path.

Evidence: L3 (local Inspector v0.21.2 direct CLI + proxy-mediated probes against actual #12383 Memory Core PAT-mode code using a local GitLab `/api/v4/user` mock) -> L3 required (#12379 AC1/AC2 repro + verified recipe). Residual: none for #12379; production smoke remains post-merge/operator validation once the runtime auth PR is merged and deployed.

## Deltas from Ticket

- Adds `learn/agentos/cloud-deployment/McpInspectorCompatibility.md` as the decision artifact + operator recipe.
- Adds the matching `learn/tree.json` cloud-deployment navigation leaf.
- Avoids modifying Claude's already-approved #12385 branch; this keeps #12379 as one focused PR for one epic sub.
- Does not add a DCR/OAuth shim because both Inspector direct CLI and Inspector proxy path forward an explicit bearer header successfully.

## Slot Rationale

- Added `learn/agentos/cloud-deployment/McpInspectorCompatibility.md`
  - Disposition: keep in the cloud-deployment guide tree.
  - Rating: trigger-frequency medium, failure-severity high, enforceability high.
  - Rationale: the guide is loaded only when operators need Inspector/PAT deployment support, but the failure mode blocks cloud auth validation and has deterministic CLI/proxy repro commands.
  - Retirement trigger: retire or rewrite if Inspector removes explicit bearer-header support, or if a broader client-auth guide fully subsumes the version-specific matrix.
- Modified `learn/tree.json`
  - Disposition delta: add navigable leaf for the new guide.
  - Rating: trigger-frequency medium, failure-severity medium, enforceability high.
  - Rationale: docs-tree navigation is the consumed surface; an unlisted guide would be harder for operators and reviewers to find.

## Test Evidence

- `git diff --cached --check` - pass.
- `node ai/scripts/lint/lint-tree-json.mjs` - pass; tree mirrors the learn folder structure.
- `node buildScripts/util/check-whitespace.mjs learn/agentos/cloud-deployment/McpInspectorCompatibility.md learn/tree.json` - pass.
- `curl` against temporary #12383 Memory Core PAT-mode server without bearer header - returned bare bearer `401` / missing authorization.
- `curl` against the same server with `Authorization: Bearer test-token` - returned `HTTP 200` initialize result and `mcp-session-id`.
- `npx -y @modelcontextprotocol/inspector@0.21.2 --cli ... --transport http --method tools/list` without header - failed with the server's missing-authorization error.
- Same Inspector CLI command with `--header "Authorization: Bearer test-token"` - succeeded and returned `tools/list`.
- Inspector proxy path on v0.21.2 without bearer header - returned upstream `401` envelope with `WWW-Authenticate: Bearer`.
- Inspector proxy path with `Authorization: Bearer test-token` - returned the Neo Memory Core `initialize` result.
- Socket cleanup verified: temporary repro ports `17983`, `17984`, `17985`, and `17986` are no longer listening.

## Dependencies

- Runtime dependency: #12383 must merge before this recipe is production-live.
- Docs adjacency: #12385 can link to this guide after both PRs land; this PR does not depend on #12385 to render.

## Post-Merge Validation

- [ ] Portal renders `McpInspectorCompatibility.md` and the new nav leaf.
- [ ] After #12383 is deployed with a real GitLab PAT, run the documented Inspector CLI smoke against public MC and KB endpoints.

## Commit

- `da1a55765` - `docs(ai): add Inspector PAT compatibility guide (#12379)`