### PR TITLE
fix(kb): expose debug mode via NEO_DEBUG (#12370)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -40,9 +40,11 @@ class Config extends BaseConfig {
             neoRootDir: leaf(neoRootDir),
             /**
              * Global debug flag for all MCP servers.
+             *
+             * Operator env var: `NEO_DEBUG`.
              * @type {boolean}
              */
-            debug: leaf(false),
+            debug: leaf(false, 'NEO_DEBUG', 'boolean'),
             /**
              * Transport protocol for the MCP server ('stdio' or 'sse').
              * @type {string}

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -102,6 +102,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
     });
 
     test('env overrides win — KB-local leaves at the child, Tier-1-owned leaves at the owner (inherited)', () => {
+        process.env.NEO_DEBUG       = 'true';
         process.env.NEO_CHROMA_HOST = 'chroma';
         process.env.NEO_CHROMA_PORT = '8010';
         process.env.NEO_AUTH_REALM  = 'tenant-realm';
@@ -120,6 +121,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         Neo.ai.Config   = freshRoot;
 
         try {
+            expect(freshKB.debug).toBe(true);                       // KB-local, env at child
             expect(freshKB.host).toBe('chroma');                    // KB-local, env at child
             expect(freshKB.port).toBe(8010);                        // KB-local, env at child
             expect(freshKB.auth.realm).toBe('tenant-realm');        // Tier-1-owned, env at owner → inherited
@@ -128,6 +130,48 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
             if (prevRoot === undefined) {delete Neo.ai.Config} else {Neo.ai.Config = prevRoot}
             freshKB.destroy();
             freshRoot.destroy()
+        }
+    });
+
+    test('keeps debug off by default and accepts NEO_DEBUG as a KB-local override', () => {
+        const defaultKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+
+        try {
+            expect(defaultKB.debug).toBe(false);
+        } finally {
+            defaultKB.destroy()
+        }
+
+        process.env.NEO_DEBUG = 'true';
+
+        const freshKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+
+        try {
+            expect(freshKB.debug).toBe(true);
+        } finally {
+            freshKB.destroy()
+        }
+    });
+
+    test('invalid NEO_DEBUG values fall back to the debug-off default', () => {
+        process.env.NEO_DEBUG = 'maybe';
+
+        const
+            warnings     = [],
+            originalWarn = console.warn;
+
+        let freshKB;
+
+        console.warn = message => warnings.push(message);
+
+        try {
+            freshKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+
+            expect(freshKB.debug).toBe(false);
+            expect(warnings.some(message => message.includes('Invalid NEO_DEBUG'))).toBe(true);
+        } finally {
+            console.warn = originalWarn;
+            freshKB?.destroy()
         }
     });
 });


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.

FAIR-band: over-target [24/30] — taking this lane despite over-target because #12370 was operator-requested, newly unassigned, the open PR queue had drained, and the fix is one coherent config-template parity PR rather than fragmented cleanup.

Resolves #12370

Knowledge Base MCP debug mode now matches the Memory Core and global AI config contract: `NEO_DEBUG=true` resolves through the KB config template, while the existing `--debug` CLI path remains unchanged. Focused template-import coverage asserts default-off behavior, valid env override behavior, and invalid boolean fallback behavior through the shared `BaseConfig` / `Neo.util.Env` parser path.

Evidence: L2 (targeted template-import unit coverage + static whitespace checks) → L2 required (config env parsing ACs are fully covered by focused unit/static evidence). No residuals.

## Deltas from ticket

- No Memory Core behavior changes were introduced; MC remains the sibling precedent.
- No logger rewrite was introduced; KB keeps the existing always-on file sink plus debug-gated stderr policy.
- Invalid `NEO_DEBUG` tokens are explicitly covered as fallback-to-default using the existing shared boolean parser contract.

## MCP Config Template Change

- Changed key: `ai/mcp/server/knowledge-base/config.template.mjs` `debug`.
- New binding: `debug: leaf(false, 'NEO_DEBUG', 'boolean')`.
- Local clone follow-up: existing gitignored `ai/mcp/server/knowledge-base/config.mjs` overlays generated from the old template need either regeneration or a manual `debug` leaf shape update before `NEO_DEBUG` affects that local KB server.
- Restart expectation: active KB MCP server processes must restart to pick up changed env/config module state. Memory Core and global AI config do not need changes for this PR.
- Peer notification: sent `[lane-claim] #12370 — KB MCP NEO_DEBUG env parity` via A2A before editing.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs` — 4 passed.
- `git diff --check` — passed.
- `node buildScripts/util/check-whitespace.mjs ai/mcp/server/knowledge-base/config.template.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs` — passed.

## Post-Merge Validation

- [ ] Refresh/regenerate any live gitignored KB `config.mjs` overlay that still has the old `debug: leaf(false)` shape.
- [ ] Restart any active KB MCP process that should honor `NEO_DEBUG` at boot.

## Commit

- `fe19f1c83` — `fix(kb): expose debug mode via NEO_DEBUG (#12370)`
