### PR TITLE
fix(ai): bootstrap graphlog compactor cli (#12329)

### DIFF
--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -1,3 +1,7 @@
+// Bootstrap Neo namespace BEFORE importing runtime config; `BaseConfig` consumes core utilities
+// through `Neo.gatekeep()` / `Neo.isObject()` once the config module is loaded.
+import Neo                            from '../../../src/Neo.mjs';
+import * as core                      from '../../../src/core/_export.mjs';
 import {Command}                      from 'commander';
 import Database                       from 'better-sqlite3';
 import fs                             from 'fs-extra';

--- a/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
+import {spawnSync}    from 'node:child_process';
 import Database       from 'better-sqlite3';
 import fs             from 'fs-extra';
 import path           from 'path';
@@ -147,6 +148,44 @@ test.describe('compactGraphLog maintenance guard', () => {
             expect(command.opts().bridgeStateFile).toBe(defaults.bridgeStateFile);
             expect(command.opts().wakeStateFile).toBe(defaults.wakeStateFile);
         });
+    });
+
+    test('standalone CLI bootstraps the Neo realm before loading runtime config', async () => {
+        insertGraphLogRows(3);
+        db.close();
+        db = null;
+
+        const runtimeConfigPath  = path.resolve(process.cwd(), 'ai/mcp/server/memory-core/config.mjs');
+        const templateConfigPath = path.resolve(process.cwd(), 'ai/mcp/server/memory-core/config.template.mjs');
+        const hadRuntimeConfig   = await fs.pathExists(runtimeConfigPath);
+
+        if (!hadRuntimeConfig) {
+            await fs.copy(templateConfigPath, runtimeConfigPath);
+        }
+
+        try {
+            const result = spawnSync('node', [
+                'ai/scripts/maintenance/compactGraphLog.mjs',
+                '--db', dbPath,
+                '--bridge-state-file', bridgeStateFile,
+                '--wake-state-file', wakeStateFile,
+                '--safety-margin', '1',
+                '--consumer-watermark', 'test=3'
+            ], {
+                cwd     : process.cwd(),
+                encoding: 'utf8',
+                env     : {...process.env, UNIT_TEST_MODE: 'true'}
+            });
+
+            expect(result.status).toBe(0);
+            expect(result.stderr).not.toContain('ReferenceError: Neo is not defined');
+            expect(result.stdout).toContain('GraphLog compaction DRY-RUN');
+            expect(result.stdout).toContain('eligible rows: 2');
+        } finally {
+            if (!hadRuntimeConfig) {
+                await fs.remove(runtimeConfigPath);
+            }
+        }
     });
 
     test('computes cutoff from the minimum known consumer watermark plus safety margin', () => {


### PR DESCRIPTION
Resolves #12329

Authored by GPT-5 (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.
FAIR-band: over-target [24/30] — taking this lane despite over-target because the operator directly identified the post-merge #12329 blocker in my assigned lane; leaving the shipped compactor blocked would strand the existing production-retention work.

Bootstraps the standalone `ai:compact-graphlog` entry point as a proper Neo realm by importing `src/Neo.mjs` and `src/core/_export.mjs` before runtime Memory Core config loading. This matches the unit-test/maintenance-script invariant: `src/Neo.mjs` creates `globalThis.Neo`; `src/core/_export.mjs` installs core utilities consumed by `BaseConfig` and transitive `Neo.gatekeep()` modules.

Adds a child-process regression that runs the real CLI against a temporary SQLite GraphLog database. The spec creates the ignored runtime `config.mjs` from `config.template.mjs`, so clean worktrees test through the template path instead of depending on operator-local config files.

Evidence: L2 (syntax checks + focused Playwright unit spec with spawned standalone CLI dry-run) → L4 required (operator-gated production `--apply --vacuum` and file-size/page-count validation). Residual: AC4/AC5 [#12329].

## Deltas from ticket

- Corrects the post-merge CLI bootstrap blocker surfaced after PR #12337.
- Does not change compaction cutoff logic, deletion behavior, `--apply`, `--vacuum`, or consumer-watermark semantics.
- Keeps test-time config sourcing template-based; no operator-local `config.mjs` content is committed.

## Test Evidence

- `node --check ai/scripts/maintenance/compactGraphLog.mjs`
- `node --check test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/compactGraphLog.spec.mjs` → 8 passed
- `git diff --check`

## Post-Merge Validation

- [ ] In the operator checkout with real `ai/mcp/server/memory-core/config.mjs`, run `npm run ai:compact-graphlog` and confirm the default dry-run reaches a compaction report instead of `ReferenceError: Neo is not defined`.
- [ ] Operator runs `npm run ai:compact-graphlog -- --apply --vacuum` after confirming no unknown remote consumers need a supplied watermark.
- [ ] Append before/after `rowCount`, `page_count`, `freelist_count`, GraphLog bytes, and graph-db file size to #12329 before treating the live purge complete.

## Commit

- `2ddc1383e` — `fix(ai): bootstrap graphlog compactor cli (#12329)`
