### PR TITLE
feat(auth): harden GitLab bearer verifier (#12390)

### DIFF
--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -11,6 +11,7 @@ import Env      from '../src/util/Env.mjs';
  */
 const typeParsers = {
     boolean  : Env.parseBool,
+    csv      : Env.parseCsv,
     keepAlive: Env.parseKeepAlive,
     number   : Env.parseNumber,
     port     : Env.parsePort,
@@ -26,6 +27,7 @@ const typeParsers = {
  */
 const typeValidators = {
     boolean: value => typeof value === 'boolean',
+    csv    : value => Array.isArray(value) && value.every(item => typeof item === 'string'),
     number : value => typeof value === 'number' && !Number.isNaN(value),
     port   : value => Number.isInteger(value) && value >= 0 && value <= 65535,
     string : value => typeof value === 'string',

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -109,7 +109,11 @@ class Config extends BaseConfig {
                 // GitLab API base URL used by 'gitlab-pat' mode for token validation (self-managed configurable).
                 gitlabApiBaseUrl  : leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string'),
                 // Bounded TTL (seconds) for the per-token PAT validation cache → a revoked PAT clears within this window.
-                patCacheTtlSeconds: leaf(300, 'NEO_AUTH_PAT_CACHE_TTL_SECONDS', 'number')
+                patCacheTtlSeconds: leaf(300, 'NEO_AUTH_PAT_CACHE_TTL_SECONDS', 'number'),
+                // Optional GitLab OAuth app binding for 'gitlab-pat' mode. Empty means no app gate.
+                allowedClientIds  : leaf([], 'NEO_AUTH_ALLOWED_CLIENT_IDS', 'csv'),
+                // Optional GitLab username allowlist for 'gitlab-pat' mode. Empty means any resolved GitLab user.
+                allowedUsers      : leaf([], 'NEO_AUTH_ALLOWED_USERS', 'csv')
             },
             /**
              * @summary Deployment-wide chat / generation model provider.

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -233,14 +233,66 @@ class AuthService extends Base {
     }
 
     /**
+     * @summary Normalizes a GitLab-PAT allowlist config leaf.
+     *
+     * Config templates resolve CSV env vars to arrays; the string branch is a compatibility guard
+     * for stale gitignored overlays copied into worktrees before the `csv` type existed.
+     * @param {String[]|String|null|undefined} value
+     * @returns {String[]}
+     */
+    #normalizeGitlabPatAllowlist(value) {
+        if (Array.isArray(value)) {
+            return value.map(item => String(item).trim()).filter(Boolean)
+        }
+
+        if (typeof value === 'string') {
+            return value.split(',').map(item => item.trim()).filter(Boolean)
+        }
+
+        return []
+    }
+
+    /**
+     * Extracts the GitLab OAuth application client id from `/oauth/token/info`.
+     * GitLab documents this as `application.uid`; the fallbacks keep the verifier tolerant of
+     * self-managed version drift without weakening the default-off path.
+     * @param {Object|null} tokenInfo
+     * @returns {String|null}
+     */
+    #getGitlabTokenInfoClientId(tokenInfo) {
+        return tokenInfo?.application?.uid || tokenInfo?.application_uid || tokenInfo?.client_id || null
+    }
+
+    /**
+     * Extracts scopes from GitLab `/oauth/token/info` into the SDK AuthInfo shape.
+     * @param {Object|null} tokenInfo
+     * @returns {String[]}
+     */
+    #getGitlabTokenInfoScopes(tokenInfo) {
+        const scope = tokenInfo?.scope ?? tokenInfo?.scopes;
+
+        if (!scope) {
+            return []
+        }
+
+        if (Array.isArray(scope)) {
+            return scope
+        }
+
+        return String(scope).split(/\s+/).filter(Boolean)
+    }
+
+    /**
      * Builds the `{verifyAccessToken}` verifier for GitLab-PAT mode. The verifier presents the
      * incoming bearer token to `GET {gitlabApiBaseUrl}/api/v4/user`; a `200` resolves the identity
      * (`userId` = GitLab `username`, `source` = `'gitlab-pat'`) in the same shape
-     * `RequestContextService` already consumes from the OIDC path, while any non-OK response throws
-     * `InvalidTokenError`. Successful validations are cached by SHA-256 token hash for
+     * `RequestContextService` already consumes from the OIDC path. Optional allowlists can then
+     * gate the resolved GitLab username and/or the GitLab OAuth app client id returned by
+     * `/oauth/token/info`; both gates are default-off so the shipped PAT behavior remains unchanged
+     * unless the deployment opts in. Successful validations are cached by SHA-256 token hash for
      * `auth.patCacheTtlSeconds` so a revoked PAT clears within that bounded window; failures are
      * never cached (a transient GitLab error must not lock a client out). The raw token is never
-     * logged — only its resolved identity.
+     * logged — only its resolved identity and, when checked, the resolved OAuth client id.
      * @param {Object}   options
      * @param {Object}   options.aiConfig
      * @param {Object}   options.logger
@@ -249,10 +301,14 @@ class AuthService extends Base {
      */
     createGitlabPatVerifier({aiConfig, logger, InvalidTokenError}) {
         const
-            apiBaseUrl = aiConfig.auth.gitlabApiBaseUrl.replace(/\/+$/, ''),
-            ttlSeconds = aiConfig.auth.patCacheTtlSeconds,
-            ttlMs      = ttlSeconds * 1000,
-            cache      = new Map(); // tokenHash -> {user, expiresAt} (cache-freshness, ms)
+            apiBaseUrl       = aiConfig.auth.gitlabApiBaseUrl.replace(/\/+$/, ''),
+            ttlSeconds       = aiConfig.auth.patCacheTtlSeconds,
+            ttlMs            = ttlSeconds * 1000,
+            allowedClientIds = this.#normalizeGitlabPatAllowlist(aiConfig.auth.allowedClientIds),
+            allowedUsers     = this.#normalizeGitlabPatAllowlist(aiConfig.auth.allowedUsers),
+            requireClientId  = allowedClientIds.length > 0,
+            requireUser      = allowedUsers.length > 0,
+            cache            = new Map(); // tokenHash -> {user, tokenInfo, expiresAt} (cache-freshness, ms)
 
         // Builds the AuthInfo shape consumed by the SDK `requireBearerAuth` middleware AND
         // `RequestContextService`. `expiresAt` is REQUIRED by `requireBearerAuth` — it rejects auth
@@ -261,17 +317,21 @@ class AuthService extends Base {
         // PAT's own expiry, so we use the re-validation horizon: one cache window from now (Unix
         // seconds). The cache re-validates against GitLab after that, so a revoked PAT still clears
         // within `patCacheTtlSeconds`. Built per-call so `expiresAt` stays request-fresh on cache hits.
-        const buildInfo = (token, user) => ({
-            token,
-            clientId : user.username,
-            scopes   : [],
-            expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
-            userId   : user.username,
-            username : user.name || user.username,
-            // Provenance tag read by RequestContextService.getSource(); distinguishes a GitLab-PAT
-            // identity from OIDC / stdio env-var / gh-CLI sources.
-            source   : 'gitlab-pat'
-        });
+        const buildInfo = (token, user, tokenInfo = null) => {
+            const tokenInfoClientId = this.#getGitlabTokenInfoClientId(tokenInfo);
+
+            return {
+                token,
+                clientId : tokenInfoClientId || user.username,
+                scopes   : this.#getGitlabTokenInfoScopes(tokenInfo),
+                expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
+                userId   : user.username,
+                username : user.name || user.username,
+                // Provenance tag read by RequestContextService.getSource(); distinguishes a GitLab-PAT
+                // identity from OIDC / stdio env-var / gh-CLI sources.
+                source   : 'gitlab-pat'
+            }
+        };
 
         return {
             verifyAccessToken: async (token) => {
@@ -280,24 +340,55 @@ class AuthService extends Base {
                     cached    = cache.get(tokenHash);
 
                 if (cached && cached.expiresAt > Date.now()) {
-                    return buildInfo(token, cached.user)
+                    return buildInfo(token, cached.user, cached.tokenInfo)
                 }
 
-                const response = await fetch(`${apiBaseUrl}/api/v4/user`, {
+                const userResponse = await fetch(`${apiBaseUrl}/api/v4/user`, {
                     headers: {Authorization: `Bearer ${token}`}
                 });
 
-                if (!response.ok) {
+                if (!userResponse.ok) {
                     cache.delete(tokenHash);
-                    throw new InvalidTokenError(`GitLab PAT validation failed (HTTP ${response.status})`)
+                    throw new InvalidTokenError(`GitLab PAT validation failed (HTTP ${userResponse.status})`)
                 }
 
-                const user = await response.json();
+                const user = await userResponse.json();
 
-                cache.set(tokenHash, {user, expiresAt: Date.now() + ttlMs});
-                logger.info(`[AuthService] GitLab PAT validated for user: ${user.name || user.username}`);
+                if (requireUser && !allowedUsers.includes(user.username)) {
+                    cache.delete(tokenHash);
+                    throw new InvalidTokenError('GitLab user is not allowed')
+                }
 
-                return buildInfo(token, user)
+                let tokenInfo = null;
+
+                if (requireClientId) {
+                    const tokenInfoResponse = await fetch(`${apiBaseUrl}/oauth/token/info`, {
+                        headers: {Authorization: `Bearer ${token}`}
+                    });
+
+                    if (!tokenInfoResponse.ok) {
+                        cache.delete(tokenHash);
+                        throw new InvalidTokenError(`GitLab token info validation failed (HTTP ${tokenInfoResponse.status})`)
+                    }
+
+                    tokenInfo = await tokenInfoResponse.json();
+
+                    const tokenInfoClientId = this.#getGitlabTokenInfoClientId(tokenInfo);
+
+                    if (!tokenInfoClientId || !allowedClientIds.includes(tokenInfoClientId)) {
+                        cache.delete(tokenHash);
+                        throw new InvalidTokenError('GitLab OAuth application is not allowed')
+                    }
+                }
+
+                cache.set(tokenHash, {user, tokenInfo, expiresAt: Date.now() + ttlMs});
+
+                const tokenInfoClientId = this.#getGitlabTokenInfoClientId(tokenInfo),
+                      appSuffix         = tokenInfoClientId ? `, client: ${tokenInfoClientId}` : '';
+
+                logger.info(`[AuthService] GitLab PAT validated for user: ${user.name || user.username}${appSuffix}`);
+
+                return buildInfo(token, user, tokenInfo)
             }
         }
     }

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -104,6 +104,27 @@ const Env = {
     },
 
     /**
+     * Decode env value as a comma-separated string list.
+     *
+     * Empty items are ignored so operators can format values as
+     * `client-a, client-b` without introducing blank allowlist entries.
+     *
+     * @param {String} envVarName
+     * @param {Object} [opts]
+     * @param {Object} [opts.env=process.env]
+     * @returns {String[]|undefined}
+     */
+    parseCsv(envVarName, {env = process.env} = {}) {
+        const rawValue = env[envVarName];
+        if (Neo.isEmpty(rawValue)) return;
+
+        return String(rawValue)
+            .split(',')
+            .map(item => item.trim())
+            .filter(Boolean)
+    },
+
+    /**
      * Decode env value as port (integer 1..65535).
      * @param {String} envVarName
      * @param {Object} [opts]

--- a/test/playwright/unit/ai/BaseConfig.spec.mjs
+++ b/test/playwright/unit/ai/BaseConfig.spec.mjs
@@ -27,6 +27,7 @@ function buildTree() {
     return {
         debug    : leaf(false, 'NEO_TEST_DEBUG'),
         port     : leaf(3000, 'NEO_TEST_PORT', 'port'),
+        names    : leaf([], 'NEO_TEST_NAMES', 'csv'),
         name     : leaf('neo'),
         publicUrl: leaf(null, 'NEO_TEST_URL', 'url'),
         server   : {
@@ -69,6 +70,11 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
         expect(leaf(false, 'NEO_X').type).toBe('boolean');
         expect(leaf(false, 'NEO_X').parse).toBe(Env.parseBool);
 
+        // explicit csv type binds to the shared comma-list env parser
+        const csvLeaf = leaf([], 'NEO_X', 'csv');
+        expect(csvLeaf.type).toBe('csv');
+        expect(csvLeaf.parse).toBe(Env.parseCsv);
+
         // explicit type survives a null default (stays validatable)
         const urlLeaf = leaf(null, 'NEO_X', 'url');
         expect(urlLeaf.type).toBe('url');
@@ -87,6 +93,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
 
         expect(config.getDataConfig('debug').get()).toBe(false);
         expect(config.getDataConfig('port').get()).toBe(3000);
+        expect(config.getDataConfig('names').get()).toEqual([]);
         expect(config.getDataConfig('name').get()).toBe('neo');
         expect(config.getDataConfig('publicUrl').get()).toBe(null);
         expect(config.getDataConfig('server.host').get()).toBe('localhost');
@@ -109,12 +116,14 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     test('env vars override leaf defaults — top-level AND nested (bounded, parsed)', () => {
         process.env.NEO_TEST_PORT    = '8080';
         process.env.NEO_TEST_DEBUG   = 'true';
+        process.env.NEO_TEST_NAMES   = 'neo-gpt, neo-opus-4-7';
         process.env.NEO_TEST_TIMEOUT = '1234';
 
         const config = Neo.create(BaseConfig, {data: buildTree()});
 
         expect(config.getDataConfig('port').get()).toBe(8080);
         expect(config.getDataConfig('debug').get()).toBe(true);
+        expect(config.getDataConfig('names').get()).toEqual(['neo-gpt', 'neo-opus-4-7']);
         // A NESTED env-bound leaf must also be env-overridden. Regression guard: `assignToNs`
         // mutates its `path` arg (pops the last segment), which had collapsed every nested leaf
         // onto its parent namespace key — dropping the nested leaf's env binding entirely.
@@ -204,7 +213,11 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
             // a scalar type mismatch also warns but keeps the value
             config.setData('port', 'not-a-number');
             expect(config.getDataConfig('port').get()).toBe('not-a-number');
-            expect(warnings.some(w => w.includes('port'))).toBe(true)
+            expect(warnings.some(w => w.includes('port'))).toBe(true);
+
+            // csv leaves are arrays of strings, not raw comma strings at the Provider layer.
+            config.setData('names', 'neo-gpt,neo-opus');
+            expect(warnings.some(w => w.includes('names'))).toBe(true)
         } finally {
             console.warn = origWarn
         }

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -183,6 +183,20 @@ test.describe('Tier 1 Config Immutability', () => {
         });
     });
 
+    test('ships default-off GitLab-PAT hardening leaves as CSV-backed arrays', () => {
+        expect(Config.auth.allowedClientIds).toEqual([]);
+        expect(Config.auth.allowedUsers).toEqual([]);
+
+        Config.setEnvOverride('NEO_AUTH_ALLOWED_CLIENT_IDS', ['mcp-oauth-app']);
+        Config.setEnvOverride('NEO_AUTH_ALLOWED_USERS', ['neo-gpt']);
+
+        expect(Config.auth.allowedClientIds).toEqual(['mcp-oauth-app']);
+        expect(Config.auth.allowedUsers).toEqual(['neo-gpt']);
+
+        Config.setEnvOverride('NEO_AUTH_ALLOWED_CLIENT_IDS', []);
+        Config.setEnvOverride('NEO_AUTH_ALLOWED_USERS', []);
+    });
+
     test('keeps config ledgers inside config classes', async () => {
         const templateUrls = [
             '../../../../ai/config.template.mjs',

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -38,6 +38,31 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT veri
         }
     };
 
+    function withAuth(overrides) {
+        return {auth: {...aiConfig.auth, ...overrides}}
+    }
+
+    function stubFetchQueue(responses) {
+        const calls = [];
+
+        globalThis.fetch = async (url, opts = {}) => {
+            calls.push({url, headers: opts.headers});
+
+            const response = responses.shift();
+            if (!response) {
+                throw new Error(`Unexpected fetch call: ${url}`)
+            }
+
+            return {
+                ok    : response.ok ?? true,
+                status: response.status ?? 200,
+                json  : async () => response.body ?? {}
+            }
+        };
+
+        return calls
+    }
+
     test.beforeAll(async () => {
         AuthService = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
     });
@@ -83,6 +108,97 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT veri
 
         expect(info.username).toBe('anon');
         expect(info.userId).toBe('anon');
+    });
+
+    test('allows a configured GitLab username and rejects an unlisted user without caching the failure', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async () => {
+            calls++;
+            return {ok: true, json: async () => ({username: calls < 3 ? 'outsider' : 'neo-gpt'})}
+        };
+
+        const verifier = AuthService.createGitlabPatVerifier({
+            aiConfig         : withAuth({allowedUsers: ['neo-gpt']}),
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        await expect(verifier.verifyAccessToken('same-token')).rejects.toBeInstanceOf(FakeInvalidTokenError);
+        await expect(verifier.verifyAccessToken('same-token')).rejects.toBeInstanceOf(FakeInvalidTokenError);
+        expect(calls).toBe(2);
+
+        const info = await verifier.verifyAccessToken('same-token');
+
+        expect(info.userId).toBe('neo-gpt');
+        expect(calls).toBe(3);
+    });
+
+    test('binds an OAuth access token to an allowed GitLab application client id', async () => {
+        const calls = stubFetchQueue([
+            {body: {id: 7, username: 'neo-gpt', name: 'Neo GPT'}},
+            {body: {application: {uid: 'mcp-oauth-app'}, scope: ['read_user', 'api']}}
+        ]);
+        const logEntries = [];
+
+        const verifier = AuthService.createGitlabPatVerifier({
+            aiConfig         : withAuth({allowedClientIds: ['mcp-oauth-app']}),
+            logger           : {...logger, info: message => logEntries.push(String(message))},
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        const info = await verifier.verifyAccessToken('secret-token-value');
+
+        expect(calls.map(call => call.url)).toEqual([
+            'https://gitlab.example.com/api/v4/user',
+            'https://gitlab.example.com/oauth/token/info'
+        ]);
+        expect(calls[0].headers.Authorization).toBe('Bearer secret-token-value');
+        expect(calls[1].headers.Authorization).toBe('Bearer secret-token-value');
+        expect(info.userId).toBe('neo-gpt');          // Memory Core tenant identity remains GitLab username.
+        expect(info.username).toBe('Neo GPT');
+        expect(info.clientId).toBe('mcp-oauth-app');
+        expect(info.scopes).toEqual(['read_user', 'api']);
+        expect(logEntries.join('\n')).not.toContain('secret-token-value');
+    });
+
+    test('rejects tokens from non-listed GitLab OAuth apps', async () => {
+        stubFetchQueue([
+            {body: {username: 'neo-gpt'}},
+            {body: {application: {uid: 'other-app'}, scope: 'read_user'}}
+        ]);
+
+        const verifier = AuthService.createGitlabPatVerifier({
+            aiConfig         : withAuth({allowedClientIds: ['mcp-oauth-app']}),
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        await expect(verifier.verifyAccessToken('wrong-app-token')).rejects.toBeInstanceOf(FakeInvalidTokenError);
+    });
+
+    test('rejects bare PATs when OAuth app binding is enabled and does not cache the failure', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async (url) => {
+            calls++;
+
+            if (String(url).endsWith('/api/v4/user')) {
+                return {ok: true, json: async () => ({username: 'neo-gpt'})}
+            }
+
+            return {ok: false, status: 404, json: async () => ({})}
+        };
+
+        const verifier = AuthService.createGitlabPatVerifier({
+            aiConfig         : withAuth({allowedClientIds: ['mcp-oauth-app']}),
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        await expect(verifier.verifyAccessToken('bare-pat')).rejects.toBeInstanceOf(FakeInvalidTokenError);
+        await expect(verifier.verifyAccessToken('bare-pat')).rejects.toBeInstanceOf(FakeInvalidTokenError);
+        expect(calls).toBe(4); // /user + /oauth/token/info for each attempt; failed gates are not cached.
     });
 
     test('throws InvalidTokenError on a non-OK GitLab response and does NOT cache the failure', async () => {
@@ -199,11 +315,11 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT midd
 
     // Installs the REAL SDK requireBearerAuth via setupGitlabPat; returns the captured middleware.
     // The single-middleware assertion also confirms the naked-401 shape (no mcpAuthMetadataRouter).
-    function installPatMiddleware() {
+    function installPatMiddleware(config = aiConfig) {
         const middlewares = [],
               app         = {use: mw => middlewares.push(mw)};
 
-        AuthService.setupGitlabPat({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
+        AuthService.setupGitlabPat({app, aiConfig: config, logger}, {requireBearerAuth, InvalidTokenError});
 
         expect(middlewares.length).toBe(1);
         return middlewares[0];
@@ -246,6 +362,79 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT midd
 
         const mw  = installPatMiddleware(),
               req = mockReq('Bearer glpat-bad'),
+              res = mockRes();
+
+        let nextCalled = false;
+        await mw(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+    });
+
+    test('allowedUsers gate passes through real requireBearerAuth with GitLab username identity intact', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({username: 'neo-gpt', name: 'Neo GPT'})});
+
+        const mw  = installPatMiddleware({auth: {...aiConfig.auth, allowedUsers: ['neo-gpt']}}),
+              req = mockReq('Bearer glpat-valid'),
+              res = mockRes();
+
+        let nextErr = 'unset';
+        await mw(req, res, err => { nextErr = err; });
+
+        expect(nextErr).toBeUndefined();
+        expect(res.ended).toBe(false);
+        expect(req.auth?.userId).toBe('neo-gpt');
+        expect(req.auth?.username).toBe('Neo GPT');
+    });
+
+    test('allowedUsers gate rejects an unlisted user through real requireBearerAuth', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({username: 'outsider'})});
+
+        const mw  = installPatMiddleware({auth: {...aiConfig.auth, allowedUsers: ['neo-gpt']}}),
+              req = mockReq('Bearer glpat-outsider'),
+              res = mockRes();
+
+        let nextCalled = false;
+        await mw(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+    });
+
+    test('allowedClientIds gate passes through real requireBearerAuth and preserves GitLab username', async () => {
+        globalThis.fetch = async (url) => {
+            if (String(url).endsWith('/api/v4/user')) {
+                return {ok: true, json: async () => ({username: 'neo-gpt', name: 'Neo GPT'})}
+            }
+
+            return {ok: true, json: async () => ({application: {uid: 'mcp-oauth-app'}, scope: 'read_user'})}
+        };
+
+        const mw  = installPatMiddleware({auth: {...aiConfig.auth, allowedClientIds: ['mcp-oauth-app']}}),
+              req = mockReq('Bearer oauth-token'),
+              res = mockRes();
+
+        let nextErr = 'unset';
+        await mw(req, res, err => { nextErr = err; });
+
+        expect(nextErr).toBeUndefined();
+        expect(res.ended).toBe(false);
+        expect(req.auth?.userId).toBe('neo-gpt');
+        expect(req.auth?.clientId).toBe('mcp-oauth-app');
+        expect(req.auth?.scopes).toEqual(['read_user']);
+    });
+
+    test('allowedClientIds gate rejects a non-listed OAuth app through real requireBearerAuth', async () => {
+        globalThis.fetch = async (url) => {
+            if (String(url).endsWith('/api/v4/user')) {
+                return {ok: true, json: async () => ({username: 'neo-gpt'})}
+            }
+
+            return {ok: true, json: async () => ({application: {uid: 'other-app'}, scope: 'read_user'})}
+        };
+
+        const mw  = installPatMiddleware({auth: {...aiConfig.auth, allowedClientIds: ['mcp-oauth-app']}}),
+              req = mockReq('Bearer oauth-token'),
               res = mockRes();
 
         let nextCalled = false;

--- a/test/playwright/unit/util/Env.spec.mjs
+++ b/test/playwright/unit/util/Env.spec.mjs
@@ -79,6 +79,30 @@ test.describe('Neo.util.Env', () => {
         });
     });
 
+    test.describe('parseCsv', () => {
+        test('returns undefined for absent / null / empty', () => {
+            expect(Env.parseCsv('X', opts({}))).toBe(undefined);
+            expect(Env.parseCsv('X', opts({X: null}))).toBe(undefined);
+            expect(Env.parseCsv('X', opts({X: ''}))).toBe(undefined);
+            expect(warns.length).toBe(0);
+        });
+
+        test('decodes comma-separated values into a trimmed string array', () => {
+            expect(Env.parseCsv('X', opts({X: 'client-a, client-b,client-c'}))).toEqual([
+                'client-a',
+                'client-b',
+                'client-c'
+            ]);
+            expect(warns.length).toBe(0);
+        });
+
+        test('drops blank entries without warning', () => {
+            expect(Env.parseCsv('X', opts({X: ' user-a, , user-b ,, '}))).toEqual(['user-a', 'user-b']);
+            expect(Env.parseCsv('X', opts({X: ' , '}))).toEqual([]);
+            expect(warns.length).toBe(0);
+        });
+    });
+
     test.describe('parseBool', () => {
         test('returns undefined for absent / null / empty', () => {
             expect(Env.parseBool('X', opts({}))).toBe(undefined);


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019e85e3-5739-7733-8b9b-c53d0baa99c3.

FAIR-band: over-target [24/30] — taking this lane despite over-target because the operator explicitly made GitLab-auth hardening priority until DONE, Claude claimed the sibling docs/a partner tenant lanes, and #12390 was assigned to neo-gpt.

Resolves #12390
Related: #12377
Related: #12378
Related: #12391
Related: #12392

Adds default-off GitLab bearer hardening to the shared AuthService verifier: the existing `/api/v4/user` call remains mandatory and keeps the GitLab `username` as the Memory Core tenant identity, while optional `allowedUsers` and `allowedClientIds` gates can reject unlisted users, bare PATs, or OAuth tokens from non-listed GitLab apps. The new allowlist leaves are wired through the Tier-1 config substrate via a shared `csv` env parser instead of service-local env parsing.

Evidence: L2 (unit tests with mocked GitLab API plus the real MCP SDK `requireBearerAuth` middleware boundary; official GitLab OAuth API docs verified `/oauth/token/info` response shape with `application.uid` + `scope`) → L2 required (verifier/config/test behavior). No residual runtime ACs.

## Deltas From Ticket

- Kept `/api/v4/user` as the identity source of truth. `/oauth/token/info` is only called when `auth.allowedClientIds` is configured, so app binding augments username resolution instead of replacing it.
- Added `Neo.util.Env.parseCsv` and BaseConfig `csv` parser/validator so `NEO_AUTH_ALLOWED_CLIENT_IDS` and `NEO_AUTH_ALLOWED_USERS` resolve as config leaves.
- Did not edit `ClientAuthentication.md` in this code PR to avoid duplicating Claude's claimed #12391 docs lane. PR #12392 is the active docs sibling for the broader client-auth page and should carry the operator-side migration wording correction plus the hardening-knob docs.

## Test Evidence

- `node --check` passed for the edited implementation/config/spec files.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs test/playwright/unit/util/Env.spec.mjs test/playwright/unit/ai/BaseConfig.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` → 63 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` → 55 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs` → 16 passed after private-helper cleanup.
- `git diff --check` passed.

## Post-Merge Validation

- [ ] In a real GitLab-backed deployment, set `NEO_AUTH_ALLOWED_USERS` and verify listed users pass while unlisted users receive a clean bearer rejection.
- [ ] In a real GitLab-backed deployment, set `NEO_AUTH_ALLOWED_CLIENT_IDS` and verify a listed OAuth app passes while a bare PAT and a non-listed OAuth app are rejected.
- [ ] Ensure #12392 or equivalent docs have landed before treating the client-auth documentation surface as complete.

## Commit

- `e637edf11` — `feat(auth): harden GitLab bearer verifier (#12390)`