### PR TITLE
feat(orchestrator): schedule graphlog compaction (#12394)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -338,6 +338,7 @@ class Config extends BaseConfig {
                     summarySweepMs        : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
                     kbSyncMs              : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
                     backupMs              : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
+                    graphLogCompactionMs  : leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
                     primaryDevSyncMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
                     tenantRepoSyncMs      : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),
                     dreamMs               : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS', 'number'),
@@ -361,6 +362,17 @@ class Config extends BaseConfig {
                  */
                 chroma: {
                     maxRuntimeMs: leaf(DAY_MS, 'NEO_CHROMA_MAX_RUNTIME_MS', 'number')
+                },
+                /**
+                 * GraphLog compaction policy. The scheduled lane invokes the existing
+                 * `compactGraphLog.mjs --apply` maintenance script; the script owns retention
+                 * safety and cursor handling. `vacuum` stays explicit because SQLite VACUUM is
+                 * heavier than logical GraphLog compaction and physically rewrites the DB file.
+                 * @type {Object}
+                 */
+                graphLogCompaction: {
+                    enabled: leaf(true, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_ENABLED', 'boolean'),
+                    vacuum : leaf(false, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_VACUUM', 'boolean')
                 },
                 /**
                  * Swarm-heartbeat target-resolver config. Controls which identity set

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -399,7 +399,7 @@ export class Orchestrator extends Base {
     get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
-    get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction?.enabled !== false;}
+    get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction.enabled;      }
 
     // MLX + LM Studio CLI inference-server lane config. Canonical defaults + env overrides
     // live in `ai/config.template.mjs::orchestrator.{mlx,lms}` + `envBindings.orchestrator.{mlx,lms}`.
@@ -455,7 +455,7 @@ export class Orchestrator extends Base {
             lmsPort   : AiConfig.orchestrator.lms?.port,
             lmsContextLengths: lmsPreloadConfig.contextLengths,
             providerReadiness: AiConfig.orchestrator.providerReadiness,
-            graphLogCompactionVacuum: AiConfig.orchestrator.graphLogCompaction?.vacuum === true
+            graphLogCompactionVacuum: AiConfig.orchestrator.graphLogCompaction.vacuum
         });
 
         // Non-reactive boot-wrapper-provided instance state
@@ -725,7 +725,7 @@ export class Orchestrator extends Base {
             return this.graphLogCompactionGetDueTask({
                 state                        : this.taskStateService.getState(),
                 now,
-                graphLogCompactionIntervalMs: AiConfig.orchestrator.intervals.graphLogCompactionMs ?? AiConfig.orchestrator.intervals.backupMs,
+                graphLogCompactionIntervalMs: AiConfig.orchestrator.intervals.graphLogCompactionMs,
                 enabled                      : this.graphLogCompactionEnabled
             });
         }, executeMaintenanceTask(executeTask), context);

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -21,6 +21,7 @@ import PrimaryRepoSyncService from './services/PrimaryRepoSyncService.mjs';
 import TenantRepoSyncService             from './services/TenantRepoSyncService.mjs';
 import {getDueTask as summaryGetDueTaskImport}        from './scheduling/summary.mjs';
 import {getDueTask as backupGetDueTaskImport}         from './scheduling/backup.mjs';
+import {getDueTask as graphLogCompactionGetDueTaskImport} from './scheduling/graphLogCompaction.mjs';
 import {getDueTask as primaryDevSyncGetDueTaskImport} from './scheduling/primaryDevSync.mjs';
 import {getDueTask as dreamGetDueTaskImport}          from './scheduling/dream.mjs';
 import TaskStateService                  from './services/TaskStateService.mjs';
@@ -152,8 +153,8 @@ function resolveCloudOnlyEnabled(key) {
  * - **(C) Simple imported collaborator** — direct-import instance fields
  *   (`primaryRepoSyncService`, `dreamService`, etc.) for class-shaped execution
  *   collaborators, and function-typed instance fields
- *   (`summaryGetDueTask`, `backupGetDueTask`, `primaryDevSyncGetDueTask`,
- *   `dreamGetDueTask`) for
+ *   (`summaryGetDueTask`, `backupGetDueTask`, `graphLogCompactionGetDueTask`,
+ *   `primaryDevSyncGetDueTask`, `dreamGetDueTask`) for
  *   pure-function scheduling triggers from `./scheduling/<task>.mjs` — no
  *   class-system conversion, no parent-child propagation, no lifecycle side effect.
  *   The function-typed fields default to the imported pure functions so tests can
@@ -253,6 +254,7 @@ export class Orchestrator extends Base {
     initializeDatabaseFn     = initializeDatabaseSelfBootstrap
     summaryGetDueTask        = summaryGetDueTaskImport
     backupGetDueTask         = backupGetDueTaskImport
+    graphLogCompactionGetDueTask = graphLogCompactionGetDueTaskImport
     primaryDevSyncGetDueTask = primaryDevSyncGetDueTaskImport
     tenantRepoSyncGetDueTask = tenantRepoSyncGetDueTaskImport
     dreamGetDueTask          = dreamGetDueTaskImport
@@ -397,6 +399,7 @@ export class Orchestrator extends Base {
     get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
+    get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction?.enabled !== false;}
 
     // MLX + LM Studio CLI inference-server lane config. Canonical defaults + env overrides
     // live in `ai/config.template.mjs::orchestrator.{mlx,lms}` + `envBindings.orchestrator.{mlx,lms}`.
@@ -451,7 +454,8 @@ export class Orchestrator extends Base {
             lmsHost   : AiConfig.openAiCompatible?.host,
             lmsPort   : AiConfig.orchestrator.lms?.port,
             lmsContextLengths: lmsPreloadConfig.contextLengths,
-            providerReadiness: AiConfig.orchestrator.providerReadiness
+            providerReadiness: AiConfig.orchestrator.providerReadiness,
+            graphLogCompactionVacuum: AiConfig.orchestrator.graphLogCompaction?.vacuum === true
         });
 
         // Non-reactive boot-wrapper-provided instance state
@@ -714,6 +718,15 @@ export class Orchestrator extends Base {
                 state           : this.taskStateService.getState(),
                 now,
                 backupIntervalMs: AiConfig.orchestrator.intervals.backupMs
+            });
+        }, executeMaintenanceTask(executeTask), context);
+
+        this.cadenceEngine.runIfDue('graphlog-compaction', () => {
+            return this.graphLogCompactionGetDueTask({
+                state                        : this.taskStateService.getState(),
+                now,
+                graphLogCompactionIntervalMs: AiConfig.orchestrator.intervals.graphLogCompactionMs ?? AiConfig.orchestrator.intervals.backupMs,
+                enabled                      : this.graphLogCompactionEnabled
             });
         }, executeMaintenanceTask(executeTask), context);
 

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -38,6 +38,7 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
  * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
  * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
+ * @param {Boolean} [options.graphLogCompactionVacuum=false] Whether scheduled GraphLog compaction also runs SQLite VACUUM.
  * @returns {Object}
  */
 export function buildTaskDefinitions({
@@ -53,7 +54,8 @@ export function buildTaskDefinitions({
     lmsHost,
     lmsPort,
     lmsContextLengths,
-    providerReadiness
+    providerReadiness,
+    graphLogCompactionVacuum = false
 } = {}) {
     const tasks = {
         chroma: {
@@ -96,6 +98,17 @@ export function buildTaskDefinitions({
             args           : [path.join(scriptDir, 'maintenance', 'backup.mjs')],
             pidFileName    : 'backup.pid',
             expectedCommand: 'backup.mjs'
+        },
+        'graphlog-compaction': {
+            label          : 'GraphLog compaction',
+            command        : nodeBin,
+            args           : [
+                path.join(scriptDir, 'maintenance', 'compactGraphLog.mjs'),
+                '--apply',
+                ...(graphLogCompactionVacuum ? ['--vacuum'] : [])
+            ],
+            pidFileName    : 'graphlog-compaction.pid',
+            expectedCommand: 'compactGraphLog.mjs'
         },
         // One-shot KB defrag spawned by the chroma max-runtime recycle once the
         // freshly-restarted daemon is connection-ready. Unified-store-safe (rebuilds the KB

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -38,7 +38,7 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String|Number} [options.lmsPort] LM Studio OpenAI-compatible local inference port (CLI default `1234`).
  * @param {Object} [options.lmsContextLengths] Per-model `--context-length` override map keyed by model id (chat + embedding from `aiConfig.localModels.{chat,embedding}.contextLimitTokens`).
  * @param {Object} [options.providerReadiness] Provider-readiness retry / timeout config.
- * @param {Boolean} [options.graphLogCompactionVacuum=false] Whether scheduled GraphLog compaction also runs SQLite VACUUM.
+ * @param {Boolean} [options.graphLogCompactionVacuum] Whether scheduled GraphLog compaction also runs SQLite VACUUM.
  * @returns {Object}
  */
 export function buildTaskDefinitions({
@@ -55,7 +55,7 @@ export function buildTaskDefinitions({
     lmsPort,
     lmsContextLengths,
     providerReadiness,
-    graphLogCompactionVacuum = false
+    graphLogCompactionVacuum
 } = {}) {
     const tasks = {
         chroma: {

--- a/ai/daemons/orchestrator/scheduling/graphLogCompaction.mjs
+++ b/ai/daemons/orchestrator/scheduling/graphLogCompaction.mjs
@@ -1,0 +1,53 @@
+/**
+ * @summary Builds the recurring GraphLog compaction trigger for Orchestrator scheduling.
+ *
+ * The orchestrator owns cadence only. Compaction safety, cursor handling, batching,
+ * WAL checkpointing, and optional VACUUM behavior remain inside
+ * `ai/scripts/maintenance/compactGraphLog.mjs`.
+ *
+ * @param {Object} options
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.lastRunAt Last recorded task start timestamp.
+ * @param {Number} options.intervalMs Cadence interval; `0` disables.
+ * @param {Boolean} [options.enabled=true] Runtime lane enable flag.
+ * @returns {Object|null}
+ */
+export function buildGraphLogCompactionTrigger({
+    now,
+    lastRunAt,
+    intervalMs,
+    enabled = true
+}) {
+    if (enabled && intervalMs > 0 && now - lastRunAt >= intervalMs) {
+        return {
+            taskName: 'graphlog-compaction',
+            source  : 'periodic-sweep',
+            reason  : `periodic-graphlog-compaction:${intervalMs}`
+        };
+    }
+    return null;
+}
+
+/**
+ * @summary Projects task state + config into a due trigger for GraphLog compaction.
+ *
+ * @param {Object} options
+ * @param {Object} options.state Orchestrator task state map.
+ * @param {Number} options.now Current timestamp in milliseconds.
+ * @param {Number} options.graphLogCompactionIntervalMs Cadence interval.
+ * @param {Boolean} [options.enabled=true] Runtime lane enable flag.
+ * @returns {Object|null}
+ */
+export function getDueTask({
+    state,
+    now,
+    graphLogCompactionIntervalMs,
+    enabled = true
+}) {
+    return buildGraphLogCompactionTrigger({
+        now,
+        lastRunAt : state['graphlog-compaction']?.lastRunAt || 0,
+        intervalMs: graphLogCompactionIntervalMs,
+        enabled
+    });
+}

--- a/ai/daemons/orchestrator/scheduling/graphLogCompaction.mjs
+++ b/ai/daemons/orchestrator/scheduling/graphLogCompaction.mjs
@@ -1,35 +1,9 @@
 /**
- * @summary Builds the recurring GraphLog compaction trigger for Orchestrator scheduling.
+ * @summary Projects task state + config into a due trigger for GraphLog compaction.
  *
  * The orchestrator owns cadence only. Compaction safety, cursor handling, batching,
  * WAL checkpointing, and optional VACUUM behavior remain inside
  * `ai/scripts/maintenance/compactGraphLog.mjs`.
- *
- * @param {Object} options
- * @param {Number} options.now Current timestamp in milliseconds.
- * @param {Number} options.lastRunAt Last recorded task start timestamp.
- * @param {Number} options.intervalMs Cadence interval; `0` disables.
- * @param {Boolean} [options.enabled=true] Runtime lane enable flag.
- * @returns {Object|null}
- */
-export function buildGraphLogCompactionTrigger({
-    now,
-    lastRunAt,
-    intervalMs,
-    enabled = true
-}) {
-    if (enabled && intervalMs > 0 && now - lastRunAt >= intervalMs) {
-        return {
-            taskName: 'graphlog-compaction',
-            source  : 'periodic-sweep',
-            reason  : `periodic-graphlog-compaction:${intervalMs}`
-        };
-    }
-    return null;
-}
-
-/**
- * @summary Projects task state + config into a due trigger for GraphLog compaction.
  *
  * @param {Object} options
  * @param {Object} options.state Orchestrator task state map.
@@ -44,10 +18,15 @@ export function getDueTask({
     graphLogCompactionIntervalMs,
     enabled = true
 }) {
-    return buildGraphLogCompactionTrigger({
-        now,
-        lastRunAt : state['graphlog-compaction']?.lastRunAt || 0,
-        intervalMs: graphLogCompactionIntervalMs,
-        enabled
-    });
+    const lastRunAt = state['graphlog-compaction']?.lastRunAt || 0;
+
+    if (enabled && graphLogCompactionIntervalMs > 0 && now - lastRunAt >= graphLogCompactionIntervalMs) {
+        return {
+            taskName: 'graphlog-compaction',
+            source  : 'periodic-sweep',
+            reason  : `periodic-graphlog-compaction:${graphLogCompactionIntervalMs}`
+        };
+    }
+
+    return null;
 }

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -2,7 +2,6 @@ import {getDueTask as getSummaryDueTask}             from './summary.mjs';
 import {getDueTask as getBackupDueTask}              from './backup.mjs';
 import {getDueTask as getDreamDueTask}               from './dream.mjs';
 import {getDueTask as getGoldenPathDueTask}          from './goldenPath.mjs';
-import {getDueTask as getGraphLogCompactionDueTask}  from './graphLogCompaction.mjs';
 import {getDueTask as getPrimaryDevSyncDueTask}      from './primaryDevSync.mjs';
 import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs';
 
@@ -79,21 +78,6 @@ export const TASK_REGISTRY = Object.freeze([
                 state,
                 now,
                 backupIntervalMs: intervals.backup
-            });
-        }
-    },
-    {
-        taskName        : 'graphlog-compaction',
-        executionKind   : 'supervised-child-process',
-        maintenanceClass: 'heavy',
-        backpressure    : 'exclusive-heavy',
-        dependencies    : [],
-        getDueTask({state, now, intervals, enables}) {
-            return getGraphLogCompactionDueTask({
-                state,
-                now,
-                graphLogCompactionIntervalMs: intervals.graphLogCompaction,
-                enabled                     : enables.graphLogCompaction
             });
         }
     },

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -2,6 +2,7 @@ import {getDueTask as getSummaryDueTask}             from './summary.mjs';
 import {getDueTask as getBackupDueTask}              from './backup.mjs';
 import {getDueTask as getDreamDueTask}               from './dream.mjs';
 import {getDueTask as getGoldenPathDueTask}          from './goldenPath.mjs';
+import {getDueTask as getGraphLogCompactionDueTask}  from './graphLogCompaction.mjs';
 import {getDueTask as getPrimaryDevSyncDueTask}      from './primaryDevSync.mjs';
 import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs';
 
@@ -78,6 +79,21 @@ export const TASK_REGISTRY = Object.freeze([
                 state,
                 now,
                 backupIntervalMs: intervals.backup
+            });
+        }
+    },
+    {
+        taskName        : 'graphlog-compaction',
+        executionKind   : 'supervised-child-process',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
+        dependencies    : [],
+        getDueTask({state, now, intervals, enables}) {
+            return getGraphLogCompactionDueTask({
+                state,
+                now,
+                graphLogCompactionIntervalMs: intervals.graphLogCompaction,
+                enabled                     : enables.graphLogCompaction
             });
         }
     },

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -19,6 +19,7 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
     'kbSync',
     'backup',
+    'graphlog-compaction',
     'primary-dev-sync',
     'dream'
 ]);

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -124,6 +124,7 @@ test.describe('Tier 1 Config Immutability', () => {
             summarySweepMs  : 10 * 60 * 1000,
             kbSyncMs        : 30 * 60 * 1000,
             backupMs        : 24 * 60 * 60 * 1000,
+            graphLogCompactionMs: 24 * 60 * 60 * 1000,
             primaryDevSyncMs: 10 * 60 * 1000,
             dreamMs         : 60 * 60 * 1000,
             goldenPathMs    : 60 * 60 * 1000,
@@ -148,6 +149,15 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.orchestrator.swarmHeartbeat).toEqual({
             targetSource: 'active-a2a-participants',
             targets     : null
+        });
+        const graphLogCompactionEnabledEnv = process.env.NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_ENABLED?.trim().toLowerCase();
+        const graphLogCompactionVacuumEnv  = process.env.NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_VACUUM?.trim().toLowerCase();
+        const graphLogCompactionDisabled   = ['false', 'no', 'off', '0'].includes(graphLogCompactionEnabledEnv);
+        const graphLogCompactionVacuum     = ['true', 'yes', 'on', '1'].includes(graphLogCompactionVacuumEnv);
+
+        expect(Config.orchestrator.graphLogCompaction).toEqual({
+            enabled: graphLogCompactionEnabledEnv === undefined ? true : !graphLogCompactionDisabled,
+            vacuum : graphLogCompactionVacuum
         });
 
         // Provider-readiness probe parameters consumed by the orchestrator dream task

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -17,6 +17,7 @@ let savedIntervals = null;
 let savedLocalOnly = null;
 let savedCloudOnly = null;
 let savedGraphLogCompaction = null;
+let savedGraphLogCompactionMissing = false;
 let savedDeploymentMode = null;
 
 /**
@@ -55,7 +56,10 @@ function createTestOrchestrator(config = {}) {
     savedIntervals = savedIntervals || {...AiConfig.orchestrator.intervals};
     savedLocalOnly = savedLocalOnly || {...AiConfig.orchestrator.localOnly};
     savedCloudOnly = savedCloudOnly || {...AiConfig.orchestrator.cloudOnly};
-    savedGraphLogCompaction = savedGraphLogCompaction || {...(AiConfig.orchestrator.graphLogCompaction || {})};
+    if (savedGraphLogCompaction === null) {
+        savedGraphLogCompactionMissing = AiConfig.orchestrator.graphLogCompaction === undefined;
+        savedGraphLogCompaction = {...(AiConfig.orchestrator.graphLogCompaction || {})};
+    }
     savedDeploymentMode = savedDeploymentMode ?? AiConfig.orchestrator.deploymentMode;
 
     // Class D operator policy values — AiConfig.data mutation reaches lazy getters.
@@ -80,9 +84,10 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.localOnly.goldenPathRepoEnrichmentEnabled = config.goldenPathRepoEnrichmentEnabled ?? true;
 
     AiConfig.orchestrator.cloudOnly.tenantRepoSyncEnabled = config.tenantRepoSyncEnabled ?? false;
-    AiConfig.orchestrator.graphLogCompaction ??= {};
-    AiConfig.orchestrator.graphLogCompaction.enabled      = config.graphLogCompactionEnabled ?? true;
-    AiConfig.orchestrator.graphLogCompaction.vacuum       = config.graphLogCompactionVacuum ?? false;
+    AiConfig.setData('orchestrator.graphLogCompaction', {
+        enabled: config.graphLogCompactionEnabled ?? true,
+        vacuum : config.graphLogCompactionVacuum ?? false
+    });
 
     const orchestrator = Neo.create(Orchestrator, {
         dataDir                  : '/tmp/orchestrator-test',
@@ -131,8 +136,13 @@ test.afterEach(() => {
         savedCloudOnly = null;
     }
     if (savedGraphLogCompaction) {
-        restoreConfigObject(AiConfig.orchestrator.graphLogCompaction, savedGraphLogCompaction);
+        if (savedGraphLogCompactionMissing) {
+            AiConfig.setData('orchestrator.graphLogCompaction', undefined);
+        } else {
+            AiConfig.setData('orchestrator.graphLogCompaction', {...savedGraphLogCompaction});
+        }
         savedGraphLogCompaction = null;
+        savedGraphLogCompactionMissing = false;
     }
     if (savedDeploymentMode !== null) {
         AiConfig.orchestrator.deploymentMode = savedDeploymentMode;
@@ -653,11 +663,12 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         }]);
     });
 
-    test('falls back to backup cadence when stale config lacks graphLogCompactionMs (#12394)', () => {
+    test('passes graphlog-compaction cadence from config verbatim (#12394 / #12061)', () => {
         const dueCalls = [];
         const orchestrator = createTestOrchestrator({
             kbSyncIntervalMs             : 0,
             backupIntervalMs             : 123456,
+            graphLogCompactionIntervalMs : 777777,
             graphLogCompactionGetDueTask : options => {
                 dueCalls.push(options);
                 return null;
@@ -669,12 +680,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             swarmHeartbeatIntervalMs     : Number.MAX_SAFE_INTEGER
         });
 
-        AiConfig.orchestrator.intervals.graphLogCompactionMs = null;
-
         orchestrator.poll();
 
         expect(dueCalls).toEqual([expect.objectContaining({
-            graphLogCompactionIntervalMs: 123456
+            graphLogCompactionIntervalMs: 777777
         })]);
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -16,6 +16,7 @@ let testOrchestratorSeq = 0;
 let savedIntervals = null;
 let savedLocalOnly = null;
 let savedCloudOnly = null;
+let savedGraphLogCompaction = null;
 let savedDeploymentMode = null;
 
 /**
@@ -31,7 +32,8 @@ let savedDeploymentMode = null;
 function createTestOrchestrator(config = {}) {
     const taskDefinitions = config.taskDefinitions || buildTaskDefinitions({
         scriptDir: '/repo/ai/scripts',
-        nodeBin  : '/node'
+        nodeBin  : '/node',
+        graphLogCompactionVacuum: config.graphLogCompactionVacuum ?? false
     });
 
     const heavyMaintenanceLeasePath = config.heavyMaintenanceLeasePath
@@ -53,6 +55,7 @@ function createTestOrchestrator(config = {}) {
     savedIntervals = savedIntervals || {...AiConfig.orchestrator.intervals};
     savedLocalOnly = savedLocalOnly || {...AiConfig.orchestrator.localOnly};
     savedCloudOnly = savedCloudOnly || {...AiConfig.orchestrator.cloudOnly};
+    savedGraphLogCompaction = savedGraphLogCompaction || {...(AiConfig.orchestrator.graphLogCompaction || {})};
     savedDeploymentMode = savedDeploymentMode ?? AiConfig.orchestrator.deploymentMode;
 
     // Class D operator policy values — AiConfig.data mutation reaches lazy getters.
@@ -60,6 +63,7 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.intervals.summarySweepMs   = config.summarySweepIntervalMs   ?? 600000;
     AiConfig.orchestrator.intervals.kbSyncMs         = config.kbSyncIntervalMs         ?? 600000;
     AiConfig.orchestrator.intervals.backupMs         = config.backupIntervalMs         ?? 86400000;
+    AiConfig.orchestrator.intervals.graphLogCompactionMs = config.graphLogCompactionIntervalMs ?? 86400000;
     AiConfig.orchestrator.intervals.primaryDevSyncMs = config.primaryDevSyncIntervalMs ?? 600000;
     AiConfig.orchestrator.intervals.tenantRepoSyncMs = config.tenantRepoSyncIntervalMs ?? Number.MAX_SAFE_INTEGER;
     AiConfig.orchestrator.intervals.dreamMs          = config.dreamIntervalMs          ?? Number.MAX_SAFE_INTEGER;
@@ -76,6 +80,9 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.localOnly.goldenPathRepoEnrichmentEnabled = config.goldenPathRepoEnrichmentEnabled ?? true;
 
     AiConfig.orchestrator.cloudOnly.tenantRepoSyncEnabled = config.tenantRepoSyncEnabled ?? false;
+    AiConfig.orchestrator.graphLogCompaction ??= {};
+    AiConfig.orchestrator.graphLogCompaction.enabled      = config.graphLogCompactionEnabled ?? true;
+    AiConfig.orchestrator.graphLogCompaction.vacuum       = config.graphLogCompactionVacuum ?? false;
 
     const orchestrator = Neo.create(Orchestrator, {
         dataDir                  : '/tmp/orchestrator-test',
@@ -94,6 +101,7 @@ function createTestOrchestrator(config = {}) {
     // collaborators stay object-typed (class singletons / per-instance services).
     orchestrator.summaryGetDueTask        = config.summaryGetDueTask        || (() => null);
     orchestrator.backupGetDueTask         = config.backupGetDueTask         || (() => null);
+    orchestrator.graphLogCompactionGetDueTask = config.graphLogCompactionGetDueTask || (() => null);
     orchestrator.primaryDevSyncGetDueTask = config.primaryDevSyncGetDueTask || (() => null);
     orchestrator.primaryRepoSyncService   = config.primaryRepoSyncService   || {runTask: () => null};
     orchestrator.tenantRepoSyncService    = config.tenantRepoSyncService    || {runTask: () => null};
@@ -122,6 +130,10 @@ test.afterEach(() => {
         restoreConfigObject(AiConfig.orchestrator.cloudOnly, savedCloudOnly);
         savedCloudOnly = null;
     }
+    if (savedGraphLogCompaction) {
+        restoreConfigObject(AiConfig.orchestrator.graphLogCompaction, savedGraphLogCompaction);
+        savedGraphLogCompaction = null;
+    }
     if (savedDeploymentMode !== null) {
         AiConfig.orchestrator.deploymentMode = savedDeploymentMode;
         savedDeploymentMode = null;
@@ -145,7 +157,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -573,6 +585,134 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         });
     });
 
+    test('defines graphlog-compaction as compactGraphLog --apply child task (#12394)', () => {
+        const taskDefinitions = buildTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node'
+        });
+
+        expect(taskDefinitions['graphlog-compaction']).toEqual({
+            label          : 'GraphLog compaction',
+            command        : '/node',
+            args           : ['/repo/ai/scripts/maintenance/compactGraphLog.mjs', '--apply'],
+            pidFileName    : 'graphlog-compaction.pid',
+            expectedCommand: 'compactGraphLog.mjs'
+        });
+
+        expect(buildTaskDefinitions({
+            scriptDir: '/repo/ai/scripts',
+            nodeBin  : '/node',
+            graphLogCompactionVacuum: true
+        })['graphlog-compaction'].args).toEqual([
+            '/repo/ai/scripts/maintenance/compactGraphLog.mjs',
+            '--apply',
+            '--vacuum'
+        ]);
+    });
+
+    test('routes graphlog-compaction through Orchestrator.poll() in cloud deployment (#12394)', () => {
+        const started = [];
+        const dueCalls = [];
+        const orchestrator = createTestOrchestrator({
+            deploymentMode               : 'cloud',
+            kbSyncIntervalMs             : 0,
+            backupIntervalMs             : 0,
+            graphLogCompactionEnabled    : true,
+            graphLogCompactionIntervalMs : 600000,
+            graphLogCompactionGetDueTask : options => {
+                dueCalls.push(options);
+                return {
+                    taskName: 'graphlog-compaction',
+                    source  : 'periodic-sweep',
+                    reason  : 'periodic-graphlog-compaction:600000'
+                };
+            },
+            primaryDevSyncIntervalMs     : 0,
+            tenantRepoSyncIntervalMs     : 0,
+            dreamIntervalMs              : Number.MAX_SAFE_INTEGER,
+            goldenPathIntervalMs         : Number.MAX_SAFE_INTEGER,
+            swarmHeartbeatIntervalMs     : Number.MAX_SAFE_INTEGER
+        });
+
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(dueCalls).toEqual([expect.objectContaining({
+            graphLogCompactionIntervalMs: 600000,
+            enabled                     : true
+        })]);
+        expect(started).toEqual([{
+            taskName: 'graphlog-compaction',
+            reason  : 'periodic-graphlog-compaction:600000'
+        }]);
+    });
+
+    test('falls back to backup cadence when stale config lacks graphLogCompactionMs (#12394)', () => {
+        const dueCalls = [];
+        const orchestrator = createTestOrchestrator({
+            kbSyncIntervalMs             : 0,
+            backupIntervalMs             : 123456,
+            graphLogCompactionGetDueTask : options => {
+                dueCalls.push(options);
+                return null;
+            },
+            primaryDevSyncIntervalMs     : 0,
+            tenantRepoSyncIntervalMs     : 0,
+            dreamIntervalMs              : Number.MAX_SAFE_INTEGER,
+            goldenPathIntervalMs         : Number.MAX_SAFE_INTEGER,
+            swarmHeartbeatIntervalMs     : Number.MAX_SAFE_INTEGER
+        });
+
+        AiConfig.orchestrator.intervals.graphLogCompactionMs = null;
+
+        orchestrator.poll();
+
+        expect(dueCalls).toEqual([expect.objectContaining({
+            graphLogCompactionIntervalMs: 123456
+        })]);
+    });
+
+    test('skips graphlog-compaction when config disables the lane (#12394)', () => {
+        const started = [];
+        const dueCalls = [];
+        const orchestrator = createTestOrchestrator({
+            kbSyncIntervalMs             : 0,
+            backupIntervalMs             : 0,
+            graphLogCompactionEnabled    : false,
+            graphLogCompactionIntervalMs : 600000,
+            graphLogCompactionGetDueTask : options => {
+                dueCalls.push(options);
+                return options.enabled ? {
+                    taskName: 'graphlog-compaction',
+                    reason  : 'periodic-graphlog-compaction:600000'
+                } : null;
+            },
+            primaryDevSyncIntervalMs     : 0,
+            tenantRepoSyncIntervalMs     : 0,
+            dreamIntervalMs              : Number.MAX_SAFE_INTEGER,
+            goldenPathIntervalMs         : Number.MAX_SAFE_INTEGER,
+            swarmHeartbeatIntervalMs     : Number.MAX_SAFE_INTEGER
+        });
+
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(dueCalls).toEqual([expect.objectContaining({enabled: false})]);
+        expect(started).toEqual([]);
+    });
+
     test('resolves default paths correctly without configuration overrides', () => {
         // Post Sub 1 #11833: configure() removed; path resolution is direct instance-field
         // assignment + buildTaskDefinitions(), mirroring the substrate-correct shape used
@@ -766,6 +906,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         // sorted-set assertion to decouple from declaration order.
         expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
             'backup',
+            'graphlog-compaction',
             'kbSync',
             'primary-dev-sync',
             'dream',
@@ -808,6 +949,43 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(started.filter(s => s.taskName === 'backup')).toEqual([]);
         expect(outcomes).toContainEqual({
             taskName: 'backup',
+            status  : 'skipped',
+            details : expect.objectContaining({
+                blockingTaskName: 'summary',
+                reasonCode      : 'heavy-maintenance-backpressure'
+            })
+        });
+    });
+
+    test('defers due graphlog-compaction when another heavy maintenance task is already running (#12394)', () => {
+        const outcomes = [];
+        const started  = [];
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            graphLogCompactionGetDueTask: () => ({
+                taskName: 'graphlog-compaction',
+                reason  : 'periodic-graphlog-compaction:test'
+            })
+        });
+
+        TaskStateService.taskState.summary.running = true;
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started.filter(s => s.taskName === 'graphlog-compaction')).toEqual([]);
+        expect(outcomes).toContainEqual({
+            taskName: 'graphlog-compaction',
             status  : 'skipped',
             details : expect.objectContaining({
                 blockingTaskName: 'summary',

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -34,6 +34,13 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(tasks.backup.args).toEqual([path.join(scriptDir, 'maintenance', 'backup.mjs')]);
         expect(tasks.backup.label).toBe('agent OS backup');
         expect(tasks.backup.expectedCommand).toBe('backup.mjs');
+
+        expect(tasks['graphlog-compaction'].command).toBe('/test/node');
+        expect(tasks['graphlog-compaction'].args).toEqual([
+            path.join(scriptDir, 'maintenance', 'compactGraphLog.mjs'),
+            '--apply'
+        ]);
+        expect(tasks['graphlog-compaction'].expectedCommand).toBe('compactGraphLog.mjs');
     });
 
     test('buildTaskDefinitions is pure: tasks.mlx is omitted when mlxEnabled is false', () => {
@@ -239,6 +246,7 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(taskDefSource).toContain('summarize-sessions.mjs');
         expect(taskDefSource).toContain('syncKnowledgeBase.mjs');
         expect(taskDefSource).toContain('backup.mjs');
+        expect(taskDefSource).toContain('compactGraphLog.mjs');
     });
 
     test('matches only the orchestrator daemon path-tail for singleton self-detection', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/graphLogCompaction.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/graphLogCompaction.spec.mjs
@@ -1,0 +1,51 @@
+import {test, expect} from '@playwright/test';
+import Neo from '../../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../../src/core/_export.mjs';
+import {
+    buildGraphLogCompactionTrigger,
+    getDueTask
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/graphLogCompaction.mjs';
+
+test.describe('orchestrator/scheduling/graphLogCompaction (#12394)', () => {
+    test('buildGraphLogCompactionTrigger fires when the interval has elapsed', () => {
+        expect(buildGraphLogCompactionTrigger({now: 86400000, lastRunAt: 0, intervalMs: 86400000})).toEqual({
+            taskName: 'graphlog-compaction',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-graphlog-compaction:86400000'
+        });
+    });
+
+    test('buildGraphLogCompactionTrigger returns null when the interval has not elapsed', () => {
+        expect(buildGraphLogCompactionTrigger({now: 86399999, lastRunAt: 0, intervalMs: 86400000})).toBeNull();
+    });
+
+    test('buildGraphLogCompactionTrigger treats disabled lanes and intervalMs <= 0 as disabled', () => {
+        expect(buildGraphLogCompactionTrigger({
+            now      : 999999999,
+            lastRunAt: 0,
+            intervalMs: 86400000,
+            enabled  : false
+        })).toBeNull();
+        expect(buildGraphLogCompactionTrigger({now: 999999999, lastRunAt: 0, intervalMs: 0})).toBeNull();
+    });
+
+    test('getDueTask wraps buildGraphLogCompactionTrigger with state mapping', () => {
+        expect(getDueTask({
+            state                       : {'graphlog-compaction': {lastRunAt: 1000}},
+            now                         : 1000 + 86400000,
+            graphLogCompactionIntervalMs: 86400000
+        })).toEqual({
+            taskName: 'graphlog-compaction',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-graphlog-compaction:86400000'
+        });
+    });
+
+    test('getDueTask handles missing state.graphlog-compaction gracefully', () => {
+        expect(getDueTask({state: {}, now: 86400000, graphLogCompactionIntervalMs: 86400000})).toEqual({
+            taskName: 'graphlog-compaction',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-graphlog-compaction:86400000'
+        });
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/graphLogCompaction.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/graphLogCompaction.spec.mjs
@@ -1,35 +1,36 @@
 import {test, expect} from '@playwright/test';
 import Neo from '../../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../../src/core/_export.mjs';
-import {
-    buildGraphLogCompactionTrigger,
-    getDueTask
-} from '../../../../../../../ai/daemons/orchestrator/scheduling/graphLogCompaction.mjs';
+import {getDueTask} from '../../../../../../../ai/daemons/orchestrator/scheduling/graphLogCompaction.mjs';
 
 test.describe('orchestrator/scheduling/graphLogCompaction (#12394)', () => {
-    test('buildGraphLogCompactionTrigger fires when the interval has elapsed', () => {
-        expect(buildGraphLogCompactionTrigger({now: 86400000, lastRunAt: 0, intervalMs: 86400000})).toEqual({
+    test('getDueTask fires when the interval has elapsed', () => {
+        expect(getDueTask({state: {}, now: 86400000, graphLogCompactionIntervalMs: 86400000})).toEqual({
             taskName: 'graphlog-compaction',
             source  : 'periodic-sweep',
             reason  : 'periodic-graphlog-compaction:86400000'
         });
     });
 
-    test('buildGraphLogCompactionTrigger returns null when the interval has not elapsed', () => {
-        expect(buildGraphLogCompactionTrigger({now: 86399999, lastRunAt: 0, intervalMs: 86400000})).toBeNull();
-    });
-
-    test('buildGraphLogCompactionTrigger treats disabled lanes and intervalMs <= 0 as disabled', () => {
-        expect(buildGraphLogCompactionTrigger({
-            now      : 999999999,
-            lastRunAt: 0,
-            intervalMs: 86400000,
-            enabled  : false
+    test('getDueTask returns null when the interval has not elapsed', () => {
+        expect(getDueTask({
+            state: {'graphlog-compaction': {lastRunAt: 0}},
+            now  : 86399999,
+            graphLogCompactionIntervalMs: 86400000
         })).toBeNull();
-        expect(buildGraphLogCompactionTrigger({now: 999999999, lastRunAt: 0, intervalMs: 0})).toBeNull();
     });
 
-    test('getDueTask wraps buildGraphLogCompactionTrigger with state mapping', () => {
+    test('getDueTask treats disabled lanes and intervalMs <= 0 as disabled', () => {
+        expect(getDueTask({
+            state: {},
+            now  : 999999999,
+            graphLogCompactionIntervalMs: 86400000,
+            enabled                     : false
+        })).toBeNull();
+        expect(getDueTask({state: {}, now: 999999999, graphLogCompactionIntervalMs: 0})).toBeNull();
+    });
+
+    test('getDueTask maps prior graphlog-compaction state into the due check', () => {
         expect(getDueTask({
             state                       : {'graphlog-compaction': {lastRunAt: 1000}},
             now                         : 1000 + 86400000,

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -40,9 +40,14 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
     test('expected scheduling lanes are registered (#11862 Prescription parity)', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
         expect(names).toEqual(expect.arrayContaining([
-            'summary', 'kbSync', 'backup', 'graphlog-compaction', 'primary-dev-sync',
+            'summary', 'kbSync', 'backup', 'primary-dev-sync',
             'dream', 'golden-path', 'swarm-heartbeat'
         ]));
+    });
+
+    test('graphlog-compaction stays out until collectDueCandidates is wired into Orchestrator.poll()', () => {
+        const names = TASK_REGISTRY.map(d => d.taskName);
+        expect(names).not.toContain('graphlog-compaction');
     });
 
     test('continuous tasks (chroma/bridgeDaemon/mlx) are intentionally NOT in registry', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -40,7 +40,7 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
     test('expected scheduling lanes are registered (#11862 Prescription parity)', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
         expect(names).toEqual(expect.arrayContaining([
-            'summary', 'kbSync', 'backup', 'primary-dev-sync',
+            'summary', 'kbSync', 'backup', 'graphlog-compaction', 'primary-dev-sync',
             'dream', 'golden-path', 'swarm-heartbeat'
         ]));
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -57,6 +57,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect([...DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES].sort()).toEqual([
             'backup',
             'dream',
+            'graphlog-compaction',
             'kbSync',
             'primary-dev-sync',
             'summary'
@@ -505,4 +506,3 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(result).toBe('gp-done');
     });
 });
-


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session a605f115-e0f6-42f6-a0f1-42c2fee9410d.

FAIR-band: over-target [23/30] — taking this lane despite over-target because #12394 was the operator/scheduler follow-up unblocked by merged #12389, assigned to neo-gpt, and implemented as one PR for one leaf ticket to avoid PR fragmentation.

Resolves #12394

Adds the recurring `graphlog-compaction` Orchestrator maintenance lane. The lane schedules the existing `compactGraphLog.mjs --apply` CLI, keeps watermark/batch safety inside that CLI, classifies the job as heavy maintenance, and exposes config-driven cadence/enable/VACUUM leaves.

Evidence: L2 (unit-covered scheduler due checks, `Orchestrator.poll()` dispatch, child-task command shape, heavy-maintenance backpressure, config-template/default propagation, and drift-bootstrap coverage) → L2 required (lane-definition, cadence, cloud-policy, and no-duplicated-safety ACs). No residuals.

Related: #12329, #12389

## Deltas From Ticket

- `--vacuum` is config-gated and default-off; recurring logical compaction runs daily by default, while physical SQLite VACUUM remains explicit.
- Config fallback logic was removed during review response: `config.template.mjs` remains the source of graphlog interval/enabled/vacuum defaults, and stale generated configs must be migrated rather than masked per-lane.
- New env leaves are hard-cut additions only: `NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS`, `NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_ENABLED`, and `NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_VACUUM`. No legacy env aliases or deprecation chain.

## Test Evidence

- `node ai/scripts/setup/initServerConfigs.mjs` — created gitignored worktree configs from the updated templates for local validation.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/graphLogCompaction.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs` — 137 passed.
- Stale-overlay reproduction: temporarily removed `graphLogCompactionMs` and `graphLogCompaction` from ignored local `ai/config.mjs`, ran `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 45 passed; restored the ignored config afterward.
- `git diff --check` — passed.
- `git diff --cached --check` — passed before follow-up commit.

## Post-Merge Validation

- [ ] Observe one orchestrator maintenance cycle recording a `graphlog-compaction` outcome in the daemon task state / health substrate after the configured cadence.

## Commits

- `3d43ae7a3` — `feat(orchestrator): schedule graphlog compaction (#12394)`
- `9abe3af63` — `fix(orchestrator): align graphlog compaction with config ssot (#12394)`
