### PR TITLE
feat(codex): add sandbox sqlite probe (#10714)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -85,11 +85,11 @@ Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../ai/mcp/server/github-workf
 **Before running any SDK-consuming script or `test-unit` command in a worktree, execute:**
 
 ```bash
-node ai/scripts/bootstrapWorktree.mjs
-node ai/scripts/bootstrapWorktree.mjs --link-data
-node ai/scripts/bootstrapWorktree.mjs --link-data --canonical-root <canonical-checkout>
-node ai/scripts/bootstrapWorktree.mjs --link-data --install
-node ai/scripts/bootstrapWorktree.mjs --link-data --build-all
+node ai/scripts/migrations/bootstrapWorktree.mjs
+node ai/scripts/migrations/bootstrapWorktree.mjs --link-data
+node ai/scripts/migrations/bootstrapWorktree.mjs --link-data --canonical-root <canonical-checkout>
+node ai/scripts/migrations/bootstrapWorktree.mjs --link-data --install
+node ai/scripts/migrations/bootstrapWorktree.mjs --link-data --build-all
 ```
 
 It copies the four `config.mjs` files from the main checkout (resolved via `git worktree list --porcelain`) and — with `--link-data` — symlinks gitignored shared data substrates from the main checkout: `.neo-ai-data/` subdirs plus gitignored single-file handoffs such as `resources/content/sandman_handoff.md`. Independent sibling clones (Codex / Antigravity style) cannot infer the canonical checkout from `git worktree list`; pass `--canonical-root <canonical-checkout>` or set `NEO_AI_CANONICAL_ROOT`. Idempotent; no-op from the main checkout.
@@ -100,6 +100,16 @@ It copies the four `config.mjs` files from the main checkout (resolved via `git 
 - **Frontend / Webpack-distribution tickets** — add `--build-all`. Implies `--install`; runs the full `npm run build-all` after dependencies are present. Use only when the ticket actually touches frontend bundles, themes, or Webpack thread distributions — backend tickets pay the full build cost for nothing otherwise.
 
 **Why `--link-data` matters (per #10224):** without it, each worktree gets its own empty `.neo-ai-data/sqlite/memory-core-graph.sqlite`, which means AgentIdentity nodes seeded in the main checkout are invisible to the worktree's MCP server. `bindAgentIdentity('neo-opus-4-7')` returns null, the mailbox throws `"no agent identity context bound"`, and A2A handshakes silently fail — the #10184 symptom from a different root cause than cache coherence. The symlink unifies the Memory Core substrate (SQLite + Chroma + concepts + backups) so ADR 0001's "one SQLite file shared across N processes" assumption holds across worktrees.
+
+#### Codex Sandbox SQLite Probe
+
+Codex Desktop can run unit tests in a sandbox that blocks SQLite file creation through the shared `.neo-ai-data/sqlite` symlink. Before running a Codex unit-test lane that touches `.neo-ai-data/sqlite`, run:
+
+```bash
+npm run ai:bootstrap-codex-sandbox
+```
+
+The probe creates, opens, closes, and deletes a transient SQLite file at `.neo-ai-data/sqlite/codex-sandbox-probe-*.sqlite`. Success means the current sandbox can open the same path shape used by affected tests. Failure prints the logical path, resolved physical/symlink target, SQLite error, detected sandbox mode when available, and the remediation: rerun the affected probe/test with `sandbox_permissions=require_escalated` or intentionally replace the symlink with a local writable path. It is diagnostic-only and never auto-escalates.
 
 **Symlink discipline — code vs data:**
 - **Source code** (`src/core/Base.mjs`, `ai/mcp/server/*/config.mjs`): **do NOT symlink.** Node's ESM resolver walks to the canonical (target) path, and `Neo.setupClass` sees the same namespace registered from two different file paths → `Namespace collision in unitTestMode`. Config files MUST be real copies.

--- a/ai/scripts/diagnostics/bootstrapCodexSandbox.mjs
+++ b/ai/scripts/diagnostics/bootstrapCodexSandbox.mjs
@@ -1,0 +1,265 @@
+/**
+ * @summary Probe Codex Desktop sandbox reachability for `.neo-ai-data/sqlite`.
+ *
+ * Codex Desktop sandboxed test runs can fail late with repeated
+ * `SqliteError: unable to open database file` messages when a spec creates a
+ * transient database under the shared `.neo-ai-data/sqlite` symlink. This
+ * diagnostic turns that failure into one early, pathful probe: create, open,
+ * close, and delete a transient SQLite file with the same path shape affected
+ * unit tests use.
+ *
+ * Usage:
+ *   node ai/scripts/diagnostics/bootstrapCodexSandbox.mjs
+ *   npm run ai:bootstrap-codex-sandbox
+ *
+ * Diagnostic only: the script does not auto-escalate sandbox permissions and
+ * does not rewrite the `.neo-ai-data/sqlite` topology. Operators decide whether
+ * to rerun with escalated permissions or replace a symlink with a local path.
+ *
+ * @see https://github.com/neomjs/neo/issues/10714
+ */
+import crypto          from 'node:crypto';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import Database        from 'better-sqlite3';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';
+export const PROBE_PREFIX       = 'codex-sandbox-probe';
+
+/**
+ * @summary Resolves the repo root from this CLI module directory.
+ * @param {String} moduleDir Absolute directory containing this script.
+ * @returns {String} Absolute repository root.
+ */
+export function resolveCliProjectRoot(moduleDir = __dirname) {
+    return path.resolve(moduleDir, '..', '..', '..');
+}
+
+/**
+ * @summary Best-effort detection of sandbox mode from known harness env vars.
+ * @param {Object} env Environment map.
+ * @returns {String} Detected `KEY=value` pair, or `unknown`.
+ */
+export function detectSandboxMode(env = process.env) {
+    const keys = [
+        'CODEX_SANDBOX_MODE',
+        'CODEX_SANDBOX',
+        'CODEX_CLI_SANDBOX',
+        'SANDBOX_MODE'
+    ];
+
+    for (const key of keys) {
+        if (env[key]) return `${key}=${env[key]}`;
+    }
+
+    return 'unknown';
+}
+
+/**
+ * @summary Resolves logical + physical probe paths, including symlink targets.
+ * @param {Object} options
+ * @param {String} options.projectRoot Absolute repository root.
+ * @param {String} [options.sqliteDir] Relative sqlite directory.
+ * @param {String} [options.probeId] Stable probe id for tests.
+ * @param {Object} [options.fsImpl] Filesystem implementation seam.
+ * @returns {Object} Probe path bundle.
+ */
+export function buildProbePaths({
+    projectRoot,
+    sqliteDir = DEFAULT_SQLITE_DIR,
+    probeId   = crypto.randomUUID(),
+    fsImpl    = fs
+} = {}) {
+    if (!projectRoot) throw new Error('Missing projectRoot.');
+
+    const logicalDir = path.resolve(projectRoot, sqliteDir);
+    const fileName   = `${PROBE_PREFIX}-${probeId}.sqlite`;
+
+    let physicalDir   = logicalDir;
+    let symlinkTarget = null;
+
+    try {
+        const stat = fsImpl.lstatSync(logicalDir);
+        if (stat.isSymbolicLink()) {
+            const rawTarget = fsImpl.readlinkSync(logicalDir);
+            symlinkTarget   = path.resolve(path.dirname(logicalDir), rawTarget);
+            physicalDir     = fsImpl.realpathSync(logicalDir);
+        } else if (stat.isDirectory()) {
+            physicalDir = fsImpl.realpathSync(logicalDir);
+        }
+    } catch {
+        // Missing directory is valid: the probe will attempt to create it.
+    }
+
+    return {
+        logicalDir,
+        physicalDir,
+        symlinkTarget,
+        fileName,
+        probePath        : path.join(logicalDir, fileName),
+        physicalProbePath: path.join(physicalDir, fileName)
+    };
+}
+
+/**
+ * @summary Remove transient SQLite artifacts created by the probe.
+ * @param {Object} options
+ * @param {String} options.probePath Logical probe database path.
+ * @param {String} options.logicalDir Logical sqlite directory.
+ * @param {Boolean} options.removeCreatedDir Remove logical dir if probe created it.
+ * @param {Object} [options.fsImpl] Filesystem implementation seam.
+ * @returns {{removed: String[], failed: Array<{path: String, message: String}>}}
+ */
+export function cleanupProbeArtifacts({probePath, logicalDir, removeCreatedDir = false, fsImpl = fs} = {}) {
+    const removed = [];
+    const failed  = [];
+
+    for (const candidate of [probePath, `${probePath}-wal`, `${probePath}-shm`]) {
+        try {
+            fsImpl.rmSync(candidate, {force: true});
+            removed.push(candidate);
+        } catch (error) {
+            failed.push({path: candidate, message: error.message});
+        }
+    }
+
+    if (removeCreatedDir) {
+        try {
+            fsImpl.rmdirSync(logicalDir);
+            removed.push(logicalDir);
+        } catch {
+            // Directory may contain unrelated files after a concurrent local test run.
+        }
+    }
+
+    return {removed, failed};
+}
+
+/**
+ * @summary Execute the Codex sandbox SQLite probe.
+ * @param {Object} options
+ * @param {String} options.projectRoot Absolute repository root.
+ * @param {String} [options.probeId] Stable probe id for tests.
+ * @param {Function} [options.DatabaseClass] better-sqlite3-compatible constructor.
+ * @param {Object} [options.fsImpl] Filesystem implementation seam.
+ * @param {Object} [options.env] Environment map for sandbox-mode detection.
+ * @returns {Object} Structured probe result.
+ */
+export function runCodexSandboxProbe({
+    projectRoot,
+    probeId,
+    DatabaseClass = Database,
+    fsImpl        = fs,
+    env           = process.env
+} = {}) {
+    const paths           = buildProbePaths({projectRoot, probeId, fsImpl});
+    const dirExistedBefore = fsImpl.existsSync(paths.logicalDir);
+    const sandboxMode     = detectSandboxMode(env);
+
+    let db = null;
+
+    try {
+        fsImpl.mkdirSync(paths.logicalDir, {recursive: true});
+        db = new DatabaseClass(paths.probePath);
+        db.exec?.('CREATE TABLE IF NOT EXISTS codex_sandbox_probe (id INTEGER PRIMARY KEY);');
+        db.close?.();
+        db = null;
+
+        const cleanup = cleanupProbeArtifacts({
+            probePath       : paths.probePath,
+            logicalDir      : paths.logicalDir,
+            removeCreatedDir: !dirExistedBefore,
+            fsImpl
+        });
+
+        return {ok: true, paths, sandboxMode, cleanup};
+    } catch (error) {
+        try {
+            db?.close?.();
+        } catch {}
+
+        const cleanup = cleanupProbeArtifacts({
+            probePath       : paths.probePath,
+            logicalDir      : paths.logicalDir,
+            removeCreatedDir: !dirExistedBefore,
+            fsImpl
+        });
+
+        return {
+            ok: false,
+            paths,
+            sandboxMode,
+            cleanup,
+            error: {
+                code   : error.code || error.name || 'UNKNOWN',
+                message: error.message || String(error)
+            }
+        };
+    }
+}
+
+/**
+ * @summary Format the probe result for operator-facing CLI output.
+ * @param {Object} result Result from {@link runCodexSandboxProbe}.
+ * @returns {String} Multi-line report.
+ */
+export function formatProbeResult(result) {
+    const lines = [];
+
+    if (result.ok) {
+        lines.push('Codex sandbox SQLite probe: ok');
+        lines.push(`logical path: ${result.paths.probePath}`);
+        lines.push(`physical path: ${result.paths.physicalProbePath}`);
+        if (result.paths.symlinkTarget) lines.push(`symlink target: ${result.paths.symlinkTarget}`);
+        lines.push('cleanup: transient SQLite probe artifacts removed');
+        return lines.join('\n');
+    }
+
+    lines.push('Codex sandbox SQLite probe: failed');
+    lines.push(`logical path: ${result.paths.probePath}`);
+    lines.push(`physical path: ${result.paths.physicalProbePath}`);
+    if (result.paths.symlinkTarget) lines.push(`symlink target: ${result.paths.symlinkTarget}`);
+    lines.push(`sandbox mode: ${result.sandboxMode}`);
+    lines.push(`sqlite error: ${result.error.code}: ${result.error.message}`);
+    lines.push('remediation: rerun the probe or affected test with sandbox_permissions=require_escalated, or replace the sqlite symlink with a local writable path if clone-local test DBs are intentional.');
+    if (result.cleanup.failed.length) {
+        lines.push(`cleanup warning: ${result.cleanup.failed.map(item => `${item.path} (${item.message})`).join('; ')}`);
+    } else {
+        lines.push('cleanup: transient SQLite probe artifacts removed');
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * @summary CLI entry point.
+ * @param {Object} options Test seams.
+ * @returns {Number} Process exit code.
+ */
+export function main({
+    projectRoot    = process.cwd(),
+    DatabaseClass  = Database,
+    fsImpl         = fs,
+    env            = process.env,
+    log            = console.log,
+    error          = console.error
+} = {}) {
+    const result = runCodexSandboxProbe({projectRoot, DatabaseClass, fsImpl, env});
+    const report = formatProbeResult(result);
+
+    if (result.ok) {
+        log(report);
+        return 0;
+    }
+
+    error(report);
+    return 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    process.exitCode = main({projectRoot: resolveCliProjectRoot()});
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "ai:audit-integrity"           : "node ./ai/scripts/maintenance/auditGraphIntegrity.mjs",
         "ai:backup"                    : "node ./ai/scripts/maintenance/backup.mjs",
         "ai:benchmark-gemma4"          : "node ./ai/scripts/benchmark/gemma4-rem-benchmark.mjs",
+        "ai:bootstrap-codex-sandbox"   : "node ./ai/scripts/diagnostics/bootstrapCodexSandbox.mjs",
         "ai:check-identity-facts"      : "node ./ai/scripts/diagnostics/check-identity-facts.mjs",
         "ai:check-retired-primitives"  : "node ./ai/scripts/diagnostics/check-retired-primitives.mjs",
         "ai:check-substrate-size"      : "node ./ai/scripts/diagnostics/check-substrate-size.mjs",

--- a/test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs
@@ -1,0 +1,132 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    buildProbePaths,
+    detectSandboxMode,
+    formatProbeResult,
+    runCodexSandboxProbe
+} from '../../../../../../ai/scripts/diagnostics/bootstrapCodexSandbox.mjs';
+
+function makeTempRoot() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'neo-codex-sandbox-probe-'));
+}
+
+function listProbeArtifacts(root) {
+    const sqliteDir = path.join(root, '.neo-ai-data/sqlite');
+    if (!fs.existsSync(sqliteDir)) return [];
+
+    return fs.readdirSync(sqliteDir)
+        .filter(name => name.startsWith('codex-sandbox-probe-'));
+}
+
+/**
+ * @summary Coverage for the Codex Desktop SQLite sandbox diagnostic (#10714).
+ *
+ * The tests keep all file writes in OS temp dirs and inject the failure-path
+ * SQLite constructor so the diagnostic can prove cleanup and remediation output
+ * without depending on the current harness sandbox mode.
+ */
+test.describe('bootstrapCodexSandbox diagnostic (#10714)', () => {
+    let tempRoot;
+
+    test.beforeEach(() => {
+        tempRoot = makeTempRoot();
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempRoot, {recursive: true, force: true});
+    });
+
+    test('creates, opens, and removes a transient sqlite probe on success', () => {
+        const result = runCodexSandboxProbe({
+            projectRoot: tempRoot,
+            probeId    : 'success'
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.paths.probePath).toContain('.neo-ai-data/sqlite/codex-sandbox-probe-success.sqlite');
+        expect(listProbeArtifacts(tempRoot)).toEqual([]);
+
+        const report = formatProbeResult(result);
+        expect(report).toContain('Codex sandbox SQLite probe: ok');
+        expect(report).toContain('transient SQLite probe artifacts removed');
+    });
+
+    test('reports symlink target and still cleans artifacts through the logical path', () => {
+        const physicalDir = path.join(tempRoot, 'canonical-sqlite');
+        const logicalDir  = path.join(tempRoot, '.neo-ai-data/sqlite');
+        fs.mkdirSync(path.dirname(logicalDir), {recursive: true});
+        fs.mkdirSync(physicalDir, {recursive: true});
+        fs.symlinkSync(physicalDir, logicalDir, 'dir');
+
+        const result = runCodexSandboxProbe({
+            projectRoot: tempRoot,
+            probeId    : 'symlink'
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.paths.symlinkTarget).toBe(physicalDir);
+        expect(result.paths.physicalProbePath).toBe(path.join(
+            fs.realpathSync(physicalDir),
+            'codex-sandbox-probe-symlink.sqlite'
+        ));
+        expect(fs.readdirSync(physicalDir).filter(name => name.startsWith('codex-sandbox-probe-'))).toEqual([]);
+
+        const report = formatProbeResult(result);
+        expect(report).toContain(`symlink target: ${physicalDir}`);
+    });
+
+    test('failure output includes paths, sqlite error, sandbox mode, remediation, and cleanup', () => {
+        class FailingDatabase {
+            constructor(filePath) {
+                fs.writeFileSync(filePath, 'partial sqlite allocation');
+                const error = new Error('unable to open database file');
+                error.code  = 'SQLITE_CANTOPEN';
+                throw error;
+            }
+        }
+
+        const result = runCodexSandboxProbe({
+            projectRoot  : tempRoot,
+            probeId      : 'failure',
+            DatabaseClass: FailingDatabase,
+            env          : {CODEX_SANDBOX_MODE: 'workspace-write'}
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toEqual({
+            code   : 'SQLITE_CANTOPEN',
+            message: 'unable to open database file'
+        });
+        expect(listProbeArtifacts(tempRoot)).toEqual([]);
+
+        const report = formatProbeResult(result);
+        expect(report).toContain('Codex sandbox SQLite probe: failed');
+        expect(report).toContain(result.paths.probePath);
+        expect(report).toContain(result.paths.physicalProbePath);
+        expect(report).toContain('CODEX_SANDBOX_MODE=workspace-write');
+        expect(report).toContain('SQLITE_CANTOPEN: unable to open database file');
+        expect(report).toContain('sandbox_permissions=require_escalated');
+        expect(report).toContain('transient SQLite probe artifacts removed');
+    });
+
+    test('detectSandboxMode reports known env keys and falls back to unknown', () => {
+        expect(detectSandboxMode({CODEX_SANDBOX: 'read-only'})).toBe('CODEX_SANDBOX=read-only');
+        expect(detectSandboxMode({})).toBe('unknown');
+    });
+
+    test('buildProbePaths resolves missing sqlite directories without requiring them to exist first', () => {
+        const paths = buildProbePaths({
+            projectRoot: tempRoot,
+            probeId    : 'paths'
+        });
+
+        expect(paths.logicalDir).toBe(path.join(tempRoot, '.neo-ai-data/sqlite'));
+        expect(paths.physicalDir).toBe(paths.logicalDir);
+        expect(paths.symlinkTarget).toBeNull();
+        expect(paths.fileName).toBe('codex-sandbox-probe-paths.sqlite');
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e7350d91-49b1-48ac-9c23-443006b6a2e5.

Resolves #10714

Adds a diagnostic-only Codex Desktop SQLite sandbox probe that fails early with pathful remediation instead of letting affected unit specs repeat `SQLITE_CANTOPEN` without context. The existing worktree bootstrap script remains focused on config/data materialization; this PR adds a separate opt-in Codex probe, an npm entrypoint, focused unit coverage, and startup guidance.

FAIR-band: over-target-with-rationale. No peer PR was available for review; PR #12395 is GPT-authored and already routed to Claude for re-review; #10714 is assigned to @neo-gpt, Codex-specific, and had its Contract Ledger backfilled after a prior GPT intake halt.

Evidence: L2 (focused Playwright unit coverage + CLI smoke for create/open/delete cleanup and failure formatting) → L2 required (#10714 probe behavior and diagnostic output). No residuals.

## Deltas from ticket (if any)

- Implemented the target as `ai/scripts/diagnostics/bootstrapCodexSandbox.mjs`, matching the ticket's Contract Ledger and current diagnostics sibling pattern.
- Left `ai/scripts/migrations/bootstrapWorktree.mjs` unchanged. It is not wrong; it solves worktree config/data setup. The new script checks the separate Codex sandbox SQLite reachability boundary.
- Corrected existing `AGENTS_STARTUP.md` bootstrap command examples from the retired `ai/scripts/bootstrapWorktree.mjs` path to the live `ai/scripts/migrations/bootstrapWorktree.mjs` path while adding the Codex probe guidance.

Startup-doc placement audit:
- `AGENTS_STARTUP.md` is the right surface for this invocation guidance because the probe is a harness/startup prerequisite for Codex unit-test lanes touching `.neo-ai-data/sqlite`.
- Loader V-B-A: `.codex/hooks.json` loads `.codex/hooks/codex-context.mjs`; `.codex/hooks/codex-context.mjs` loads `.codex/CODEX.md`; `.claude/CLAUDE.md` points to `../AGENTS.md`.
- No always-loaded `AGENTS.md` rule or skill payload was expanded.

## Test Evidence

- `node --check ai/scripts/diagnostics/bootstrapCodexSandbox.mjs`
- `node --check test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs` -> 5 passed
- `npm run ai:bootstrap-codex-sandbox` -> probe ok, transient artifact removed
- `git diff --cached --check`
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `3e0dd907a feat(codex): add sandbox sqlite probe (#10714)`

## Post-Merge Validation

- [ ] In a Codex Desktop checkout that previously hit `SQLITE_CANTOPEN` through `.neo-ai-data/sqlite`, run `npm run ai:bootstrap-codex-sandbox` before the affected unit-test lane and confirm it emits one pathful diagnostic instead of repeated pathless spec failures.

## Commits

- `3e0dd907a` — `feat(codex): add sandbox sqlite probe (#10714)`
