### PR TITLE
feat(ai): isolate unit-test Chroma into a dedicated database (#12335)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,6 +1,10 @@
 import path                                  from 'path';
 import {fileURLToPath}                       from 'url';
 import BaseConfig, {createConfigProxy, leaf} from './BaseConfig.mjs';
+import {
+    CHROMA_PRODUCTION_DATABASE,
+    CHROMA_TEST_DATABASE
+}                                            from './services/shared/vector/chromaTestIsolation.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -283,9 +287,18 @@ class Config extends BaseConfig {
              */
             engines: {
                 chroma: {
-                    dataDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
-                    host   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
-                    port   : leaf(8000, 'NEO_CHROMA_PORT', 'port')
+                    dataDir : leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
+                    host    : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
+                    port    : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
+                    /**
+                     * Chroma database the client connects to. Under `UNIT_TEST_MODE` this resolves to a
+                     * dedicated, droppable test database so unit-test collections never enter the
+                     * production `default_database` by construction (the prevention half of the
+                     * store-isolation cluster); production is `default_database` verbatim. Consumed by
+                     * the Memory Core `ChromaManager`. The Knowledge Base ChromaManager currently reads
+                     * only host/port, so this field is inert for it until separately migrated.
+                     */
+                    database: leaf(process.env.UNIT_TEST_MODE === 'true' ? CHROMA_TEST_DATABASE : CHROMA_PRODUCTION_DATABASE, 'NEO_CHROMA_DATABASE', 'string')
                 }
             },
             /**

--- a/ai/scripts/maintenance/purgeTestCollections.mjs
+++ b/ai/scripts/maintenance/purgeTestCollections.mjs
@@ -4,6 +4,10 @@ import fs                              from 'fs-extra';
 import path                            from 'path';
 import {fileURLToPath, pathToFileURL}  from 'url';
 import Neo                             from '../../../src/Neo.mjs'; // side-effect: defines globalThis.Neo so the memory-core config module evaluates
+import {
+    CHROMA_TEST_DATABASE,
+    dropChromaTestDatabase
+}                                     from '../../services/shared/vector/chromaTestIsolation.mjs';
 
 /**
  * @summary Purges leaked unit-test stores: orphaned `test-*` ChromaDB collections + leftover
@@ -179,6 +183,39 @@ export async function cleanDaemonSqliteResidue({dataDir, apply, fsModule = fs, l
 }
 
 /**
+ * @summary Drops the isolated unit-test Chroma database wholesale.
+ *
+ * Once `UNIT_TEST_MODE` routes test collections into their own database, the whole namespace is
+ * droppable in a single call — the prevention-era cleanup that supersedes enumerating `test-*`
+ * names. The underlying {@link dropChromaTestDatabase} refuses to touch `default_database`, so this
+ * can never reach production. Dry-run by default; a non-existent test database is treated as benign.
+ * @param {Object} options
+ * @param {String} options.host
+ * @param {Number} options.port
+ * @param {Boolean} options.apply
+ * @param {String} [options.database=CHROMA_TEST_DATABASE]
+ * @param {Function} [options.dropFn=dropChromaTestDatabase] Injectable drop seam for unit tests.
+ * @param {Function} [options.log=console.log]
+ * @returns {Promise<Boolean>} True if the database was dropped (apply) or would be (dry-run); false on a drop error.
+ */
+export async function dropTestDatabase({host, port, apply, database = CHROMA_TEST_DATABASE, dropFn = dropChromaTestDatabase, log = console.log}) {
+    log(`\n🗄️  Test database "${database}": ${apply ? 'dropping wholesale' : '[dry-run] would drop wholesale'}.`);
+
+    if (!apply) {
+        return true;
+    }
+
+    try {
+        await dropFn({host, port, database});
+        log(`   ✅ Dropped "${database}".`);
+        return true;
+    } catch (e) {
+        log(`   ⚠️  Could not drop "${database}" (already absent or unreachable): ${e.message}`);
+        return false;
+    }
+}
+
+/**
  * @summary Orchestrates the purge: list → partition → (dry-run report | delete) → residue cleanup → verify.
  * @returns {Promise<void>}
  */
@@ -189,6 +226,7 @@ async function purgeTestCollections() {
         .option('--apply', 'Actually delete. Without this flag the script is a dry-run report.', false)
         .option('--host <host>', 'Chroma host override (defaults to memory-core config).')
         .option('--port <port>', 'Chroma port override (defaults to memory-core config).')
+        .option('--drop-test-db', `Also drop the isolated unit-test database "${CHROMA_TEST_DATABASE}" wholesale (prevention-era cleanup).`, false)
         .parse(process.argv);
 
     const options = program.opts(),
@@ -236,6 +274,10 @@ async function purgeTestCollections() {
     console.log(`\n🧽 SQLite-daemon residue under ${DATA_DIR}:`);
     const residue = await cleanDaemonSqliteResidue({dataDir: DATA_DIR, apply});
     if (residue.length === 0) console.log('   ✅ none found.');
+
+    if (options.dropTestDb) {
+        await dropTestDatabase({host, port, apply});
+    }
 
     if (!apply) {
         console.log(`\nℹ️  Dry-run complete. Re-run with --apply to delete ${purge.length} collections + ${residue.length} residue paths.`);

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -8,6 +8,7 @@ import {
     chromaDeleteCollection,
     createSilentExecutor
 } from '../../shared/vector/chromaClientPrimitives.mjs';
+import {ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
 
 /**
  * Predicate suppression filter for MC: the four Chroma library messages that surface noisily
@@ -78,14 +79,18 @@ class ChromaManager extends AbstractVectorManager {
         super.construct(config);
 
         // The client is constructed here; heartbeat/connection is evaluated lazily by `connect()`.
-        const {host, port} = this.resolveChromaClientConfig(aiConfig);
-        this.client        = new ChromaClient({host, port, ssl: false});
+        // Under UNIT_TEST_MODE `database` resolves to a dedicated, droppable test database, so test
+        // collections never enter the production `default_database` by construction.
+        const {host, port, database} = this.resolveChromaClientConfig(aiConfig);
+        this.client                  = new ChromaClient({host, port, ssl: false, database});
     }
 
     /**
      * @summary Resolves and validates Memory Core's Chroma client coordinates before boot continues.
      * @param {Object} config aiConfig-shaped configuration object.
-     * @returns {{host: String, port: Number}}
+     * @returns {{host: String, port: Number, database: String}} `database` is read verbatim from
+     *     config (the SSOT): `default_database` in production, the dedicated test database under
+     *     `UNIT_TEST_MODE`. No fallback substitution — config owns the value.
      * @throws {Error} When `engines.chroma.{host, port}` is missing or malformed.
      */
     resolveChromaClientConfig(config) {
@@ -101,8 +106,9 @@ class ChromaManager extends AbstractVectorManager {
         }
 
         return {
-            host: chroma.host,
-            port
+            host    : chroma.host,
+            port,
+            database: chroma.database
         }
     }
 
@@ -121,6 +127,16 @@ class ChromaManager extends AbstractVectorManager {
      */
     async connect() {
         this.connected = await chromaConnect({client: this.client, logger});
+
+        // Under UNIT_TEST_MODE the client targets a dedicated test database. chromadb 3.x has no
+        // getOrCreateDatabase and the ChromaClient constructor does not create the database, so it
+        // must be ensured-to-exist here — after the heartbeat proves the server is reachable, before the
+        // first lazy getOrCreateCollection. Idempotent; the production path (default_database) is untouched.
+        if (this.connected && process.env.UNIT_TEST_MODE === 'true') {
+            const {host, port, database} = this.resolveChromaClientConfig(aiConfig);
+            await ensureChromaTestDatabase({host, port, database});
+        }
+
         return this.connected
     }
 

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -8,7 +8,7 @@ import {
     chromaDeleteCollection,
     createSilentExecutor
 } from '../../shared/vector/chromaClientPrimitives.mjs';
-import {ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
+import {CHROMA_PRODUCTION_DATABASE, ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
 
 /**
  * Predicate suppression filter for MC: the four Chroma library messages that surface noisily
@@ -105,10 +105,25 @@ class ChromaManager extends AbstractVectorManager {
             throw new Error(message);
         }
 
+        const database = chroma.database;
+
+        // Fail-closed test-isolation guard: under UNIT_TEST_MODE the client must never resolve to the
+        // production database, even via a NEO_CHROMA_DATABASE override — refuse to construct/connect
+        // rather than risk a unit run touching the production namespace. Production override behavior
+        // remains intact outside UNIT_TEST_MODE.
+        if (process.env.UNIT_TEST_MODE === 'true' && database === CHROMA_PRODUCTION_DATABASE) {
+            const message = `ChromaManager: refusing the production database "${CHROMA_PRODUCTION_DATABASE}" under ` +
+                `UNIT_TEST_MODE — unit-test isolation must not be overridable into the production namespace.`;
+
+            logger.error(`[ChromaManager] Test-isolation guard: ${message}`);
+
+            throw new Error(message);
+        }
+
         return {
             host    : chroma.host,
             port,
-            database: chroma.database
+            database
         }
     }
 

--- a/ai/services/shared/vector/chromaTestIsolation.mjs
+++ b/ai/services/shared/vector/chromaTestIsolation.mjs
@@ -1,0 +1,123 @@
+/**
+ * @summary Stateless helpers for ephemeral ChromaDB database isolation under `UNIT_TEST_MODE`.
+ *
+ * ## Why this exists
+ *
+ * Under `UNIT_TEST_MODE` the Memory Core names its Chroma collections `test-memory-*` /
+ * `test-session-*` (`config.template.mjs`), but historically they still landed in the SAME
+ * `default_tenant`/`default_database` as production. Interrupted runs (`Ctrl-C`, CI-cancel,
+ * bare-`npx` bypasses) skip `afterAll` teardown, so orphan collections accumulate in the prod
+ * namespace (the 1,281-orphan backlog `purgeTestCollections.mjs` reclaims).
+ *
+ * This module is the *prevention* half of that isolation: it routes the unit-test
+ * Chroma client to a dedicated, droppable test DATABASE so test collections never enter the prod
+ * namespace by construction — the chroma analogue of the graph store's `:memory:` isolation.
+ * chromadb 3.x exposes no `getOrCreateDatabase`, and database management lives on a separate
+ * `AdminClient`, so the test database must be ensured-to-exist before the first collection op and
+ * is droppable wholesale.
+ *
+ * Stateless functions (not a Neo class), matching the `chromaClientPrimitives.mjs` sibling idiom:
+ * the chromadb `AdminClient` is lazy-imported and injectable, so this module is cheap to import
+ * (config reads only the constants) and the helpers are unit-testable with a fake admin client.
+ *
+ * @module ai/services/shared/vector/chromaTestIsolation
+ * @see ai/services/shared/vector/chromaClientPrimitives.mjs  Sibling: connection-lifecycle helpers
+ */
+
+/**
+ * The dedicated ChromaDB database used under `UNIT_TEST_MODE`. Stable (not per-run) so the whole
+ * namespace is droppable wholesale and a crashed run leaks — at worst — into THIS database, never
+ * `default_database`. Single source of truth consumed by `config.template.mjs` (the active
+ * `engines.chroma.database` leaf default under `UNIT_TEST_MODE`) and `purgeTestCollections.mjs`
+ * (the wholesale-drop target).
+ * @type {String}
+ */
+export const CHROMA_TEST_DATABASE = 'neo-unit-test';
+
+/**
+ * The chromadb production database name. Explicitly named so the prod config branch is verbatim
+ * (not an implicit client default) and so {@link dropChromaTestDatabase} can refuse to touch it.
+ * @type {String}
+ */
+export const CHROMA_PRODUCTION_DATABASE = 'default_database';
+
+/**
+ * The chromadb default tenant. The isolation is at the database grain; the tenant stays default.
+ * @type {String}
+ */
+export const CHROMA_DEFAULT_TENANT = 'default_tenant';
+
+/**
+ * @summary Lazily constructs a chromadb `AdminClient`. Database/tenant management lives off the
+ * `ChromaClient`, so callers that only need collection ops never pay for this import. The lazy
+ * import is also what keeps this module cheap for `config.template.mjs` to import (constants only).
+ * @param {Object} options
+ * @param {String} options.host
+ * @param {Number} options.port
+ * @param {Boolean} [options.ssl=false]
+ * @returns {Promise<Object>} A chromadb `AdminClient` instance.
+ */
+async function createAdminClient({host, port, ssl = false}) {
+    const {AdminClient} = await import('chromadb');
+    return new AdminClient({host, port, ssl})
+}
+
+/**
+ * @summary Ensures the unit-test Chroma database exists before the first collection op. chromadb
+ * 3.x has no `getOrCreateDatabase`, so this is `getDatabase` → catch → `createDatabase`. Idempotent;
+ * safe to call on every connect.
+ * @param {Object} options
+ * @param {String} options.host
+ * @param {Number} options.port
+ * @param {Boolean} [options.ssl=false]
+ * @param {String} options.database                     The test database name (e.g. {@link CHROMA_TEST_DATABASE}).
+ * @param {String} [options.tenant=CHROMA_DEFAULT_TENANT]
+ * @param {Object} [options.adminClient]                Injected `AdminClient` seam for unit tests.
+ * @returns {Promise<String>} The ensured database name.
+ * @throws {Error} When `database` is falsy.
+ */
+export async function ensureChromaTestDatabase({host, port, ssl = false, database, tenant = CHROMA_DEFAULT_TENANT, adminClient} = {}) {
+    if (!database) {
+        throw new Error('ensureChromaTestDatabase: `database` is required');
+    }
+
+    const admin = adminClient || await createAdminClient({host, port, ssl});
+
+    try {
+        await admin.getDatabase({name: database, tenant})
+    } catch {
+        await admin.createDatabase({name: database, tenant})
+    }
+
+    return database
+}
+
+/**
+ * @summary Drops the unit-test Chroma database wholesale — the prevention-era cleanup that
+ * supersedes enumerating `test-*` collection names. REFUSES to drop {@link CHROMA_PRODUCTION_DATABASE}
+ * (defense-in-depth), so a misconfigured caller can never wipe production.
+ * @param {Object} options
+ * @param {String} options.host
+ * @param {Number} options.port
+ * @param {Boolean} [options.ssl=false]
+ * @param {String} options.database
+ * @param {String} [options.tenant=CHROMA_DEFAULT_TENANT]
+ * @param {Object} [options.adminClient]                Injected `AdminClient` seam for unit tests.
+ * @returns {Promise<String>} The dropped database name.
+ * @throws {Error} When `database` is falsy or is the production database.
+ */
+export async function dropChromaTestDatabase({host, port, ssl = false, database, tenant = CHROMA_DEFAULT_TENANT, adminClient} = {}) {
+    if (!database) {
+        throw new Error('dropChromaTestDatabase: `database` is required');
+    }
+
+    if (database === CHROMA_PRODUCTION_DATABASE) {
+        throw new Error(`dropChromaTestDatabase: refusing to drop the production database "${database}"`);
+    }
+
+    const admin = adminClient || await createAdminClient({host, port, ssl});
+
+    await admin.deleteDatabase({name: database, tenant});
+
+    return database
+}

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -4,6 +4,7 @@ import Neo from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 import BaseConfig from '../../../../ai/BaseConfig.mjs';
 import {TIER1_DEFAULTS} from '../../fixtures/aiConfigDefaults.mjs';
+import {CHROMA_TEST_DATABASE} from '../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
 test.describe('Tier 1 Config Immutability', () => {
     let Config;
@@ -94,9 +95,10 @@ test.describe('Tier 1 Config Immutability', () => {
             }
         });
         expect(Config.engines.chroma).toEqual({
-            dataDir: expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
-            host   : process.env.NEO_CHROMA_HOST || 'localhost',
-            port   : Number(process.env.NEO_CHROMA_PORT) || 8000
+            dataDir : expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
+            host    : process.env.NEO_CHROMA_HOST || 'localhost',
+            port    : Number(process.env.NEO_CHROMA_PORT) || 8000,
+            database: process.env.NEO_CHROMA_DATABASE || CHROMA_TEST_DATABASE
         });
     });
 
@@ -139,8 +141,8 @@ test.describe('Tier 1 Config Immutability', () => {
             wakeDispatchEnabled  : null
         });
 
-        // #12003: swarm-heartbeat candidate-discovery default is the activity-derived
-        // source per Discussion #11992 §5.1.1 "activity-derived signals" framing.
+        // The swarm-heartbeat candidate-discovery default is the activity-derived source
+        // ("activity-derived signals" framing).
         // Per-MC-instance derived; no team-registry coupling; tenant-safe for external
         // workspaces (each deployment's MC has its own A2A activity). `targets` is the
         // optional explicit-handle-list override (highest resolver precedence) — null by

--- a/test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/purgeTestCollections.spec.mjs
@@ -1,7 +1,8 @@
 import {test, expect} from '@playwright/test';
 import {
-    isPurgeableTestCollection, partitionCollections, listAllCollectionNames, cleanDaemonSqliteResidue
+    isPurgeableTestCollection, partitionCollections, listAllCollectionNames, cleanDaemonSqliteResidue, dropTestDatabase
 } from '../../../../../../ai/scripts/maintenance/purgeTestCollections.mjs';
+import {CHROMA_TEST_DATABASE} from '../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
 /**
  * Self-test for the test-collection purge: the on-demand reclaimer for leaked unit-test Chroma
@@ -88,5 +89,33 @@ test.describe('purgeTestCollections guard', () => {
 
         expect(removed.map(p => p.split('/').pop()).sort()).toEqual(['test-daemon-1.sqlite', 'wake-daemon-test-abc']);
         expect(removed.some(p => p.includes('memory-core-graph.sqlite'))).toBe(false)
+    });
+
+    test('dropTestDatabase dry-run does not invoke the drop seam', async () => {
+        const calls  = [];
+        const dropFn = async args => { calls.push(args) };
+
+        const result = await dropTestDatabase({host: 'h', port: 1, apply: false, dropFn, log: () => {}});
+
+        expect(calls).toEqual([]);
+        expect(result).toBe(true)
+    });
+
+    test('dropTestDatabase --apply drops the isolated test database wholesale', async () => {
+        const calls  = [];
+        const dropFn = async args => { calls.push(args) };
+
+        const result = await dropTestDatabase({host: 'h', port: 1, apply: true, dropFn, log: () => {}});
+
+        expect(calls).toEqual([{host: 'h', port: 1, database: CHROMA_TEST_DATABASE}]);
+        expect(result).toBe(true)
+    });
+
+    test('dropTestDatabase --apply reports false (not throw) when the test database is absent', async () => {
+        const dropFn = async () => { throw new Error('database not found') };
+
+        const result = await dropTestDatabase({host: 'h', port: 1, apply: true, dropFn, log: () => {}});
+
+        expect(result).toBe(false)
     })
 });

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -19,6 +19,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
 import aiConfig       from '../../../../../../../ai/mcp/server/memory-core/config.mjs';
 import ChromaManager  from '../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
+import {CHROMA_PRODUCTION_DATABASE, CHROMA_TEST_DATABASE} from '../../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 import logger         from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
 import SystemLifecycleService from '../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import path           from 'path';
@@ -43,6 +44,33 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         } finally {
             logger.error = originalError;
         }
+    });
+
+    test('resolveChromaClientConfig returns the configured database verbatim (no fallback substitution)', () => {
+        const resolved = ChromaManager.resolveChromaClientConfig({
+            engines: {chroma: {host: 'localhost', port: 8000, database: 'some-explicit-db'}}
+        });
+
+        expect(resolved).toEqual({host: 'localhost', port: 8000, database: 'some-explicit-db'});
+    });
+
+    test('under UNIT_TEST_MODE the Chroma database is isolated from production (#12335 AC1/AC2)', () => {
+        // The spec runs with unitTestMode:true, so the config leaf must resolve to the dedicated
+        // test database — never default_database — by construction. No crashed/npx-bypassed run can
+        // create collections in the production namespace because the client never points there.
+        expect(aiConfig.engines.chroma.database).toBe(CHROMA_TEST_DATABASE);
+        expect(aiConfig.engines.chroma.database).not.toBe(CHROMA_PRODUCTION_DATABASE);
+
+        // …and the resolver carries that isolated namespace through to the client coordinates.
+        const {database} = ChromaManager.resolveChromaClientConfig(aiConfig);
+        expect(database).toBe(CHROMA_TEST_DATABASE);
+    });
+
+    test('the constructed ChromaClient targets the isolated test database', () => {
+        // construct() wires resolveChromaClientConfig(...).database into `new ChromaClient({database})`,
+        // so the live client's database getter reflects the isolated namespace, not default_database.
+        expect(ChromaManager.client.database).toBe(aiConfig.engines.chroma.database);
+        expect(ChromaManager.client.database).not.toBe(CHROMA_PRODUCTION_DATABASE);
     });
 
     test('should prevent console.warn global state theft during concurrent collection fetching', async () => {

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -73,6 +73,20 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         expect(ChromaManager.client.database).not.toBe(CHROMA_PRODUCTION_DATABASE);
     });
 
+    test('resolveChromaClientConfig fails closed: refuses the production database under UNIT_TEST_MODE (#12335 AC1)', () => {
+        // The spec runs with UNIT_TEST_MODE=true. Even an inherited NEO_CHROMA_DATABASE=default_database
+        // override must not let a unit run resolve into the production namespace — the resolver throws
+        // fail-closed before any ChromaClient construct/connect, so no test can touch production.
+        expect(() => ChromaManager.resolveChromaClientConfig({
+            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_PRODUCTION_DATABASE}}
+        })).toThrow(/refusing the production database .* under\s+UNIT_TEST_MODE/);
+
+        // A normal isolated test database resolves cleanly (the guard only fires for the production name).
+        expect(ChromaManager.resolveChromaClientConfig({
+            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_TEST_DATABASE}}
+        }).database).toBe(CHROMA_TEST_DATABASE);
+    });
+
     test('should prevent console.warn global state theft during concurrent collection fetching', async () => {
         // Set up a custom warn logger to inspect leaks
         const warningLogs = [];

--- a/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
@@ -1,0 +1,79 @@
+import {test, expect} from '@playwright/test';
+import {
+    CHROMA_PRODUCTION_DATABASE,
+    CHROMA_TEST_DATABASE,
+    dropChromaTestDatabase,
+    ensureChromaTestDatabase
+} from '../../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
+
+/**
+ * Self-test for the unit-test Chroma database-isolation helpers. chromadb 3.x has no
+ * getOrCreateDatabase and manages databases on a separate AdminClient, so these helpers ensure the
+ * dedicated test database exists before collection ops and drop it wholesale for cleanup. The
+ * AdminClient is injected here (no live Chroma server), and the critical assertion is the
+ * defense-in-depth guard: `dropChromaTestDatabase` must NEVER reach `default_database`.
+ */
+test.describe('chromaTestIsolation helpers', () => {
+    test('constants: the test database is isolated from production', () => {
+        expect(CHROMA_TEST_DATABASE).not.toBe(CHROMA_PRODUCTION_DATABASE);
+        expect(CHROMA_PRODUCTION_DATABASE).toBe('default_database');
+    });
+
+    test('ensureChromaTestDatabase is a no-op create when the database already exists', async () => {
+        const calls = [];
+        const adminClient = {
+            getDatabase   : async args => { calls.push(['get',    args]) },
+            createDatabase: async args => { calls.push(['create', args]) }
+        };
+
+        const result = await ensureChromaTestDatabase({database: CHROMA_TEST_DATABASE, adminClient});
+
+        expect(calls.map(c => c[0])).toEqual(['get']); // getDatabase resolved → createDatabase NOT called
+        expect(result).toBe(CHROMA_TEST_DATABASE);
+    });
+
+    test('ensureChromaTestDatabase creates the database when getDatabase rejects (not-found)', async () => {
+        const created = [];
+        const adminClient = {
+            getDatabase   : async () => { throw new Error('database not found') },
+            createDatabase: async args => { created.push(args) }
+        };
+
+        const result = await ensureChromaTestDatabase({
+            database: CHROMA_TEST_DATABASE, tenant: 'default_tenant', adminClient
+        });
+
+        expect(created).toEqual([{name: CHROMA_TEST_DATABASE, tenant: 'default_tenant'}]);
+        expect(result).toBe(CHROMA_TEST_DATABASE);
+    });
+
+    test('ensureChromaTestDatabase rejects when database is missing', async () => {
+        await expect(ensureChromaTestDatabase({adminClient: {}})).rejects.toThrow(/`database` is required/);
+    });
+
+    test('dropChromaTestDatabase drops the named test database', async () => {
+        const deleted = [];
+        const adminClient = {deleteDatabase: async args => { deleted.push(args) }};
+
+        const result = await dropChromaTestDatabase({
+            database: CHROMA_TEST_DATABASE, tenant: 'default_tenant', adminClient
+        });
+
+        expect(deleted).toEqual([{name: CHROMA_TEST_DATABASE, tenant: 'default_tenant'}]);
+        expect(result).toBe(CHROMA_TEST_DATABASE);
+    });
+
+    test('dropChromaTestDatabase REFUSES to drop the production database', async () => {
+        const deleted = [];
+        const adminClient = {deleteDatabase: async args => { deleted.push(args) }};
+
+        await expect(dropChromaTestDatabase({database: CHROMA_PRODUCTION_DATABASE, adminClient}))
+            .rejects.toThrow(/refusing to drop the production database/);
+
+        expect(deleted).toEqual([]); // deleteDatabase must never be reached for default_database
+    });
+
+    test('dropChromaTestDatabase rejects when database is missing', async () => {
+        await expect(dropChromaTestDatabase({adminClient: {}})).rejects.toThrow(/`database` is required/);
+    });
+});


### PR DESCRIPTION
Resolves #12335

Routes the unit-test ChromaDB client to a dedicated, droppable test database under `UNIT_TEST_MODE`, so unit-test collections never enter the production `default_database` by construction — a fail-closed guard in `ChromaManager` refuses the production database under `UNIT_TEST_MODE` even via a `NEO_CHROMA_DATABASE` override. This is the prevention half of the store-isolation work whose reclaimer + daemon isolation shipped in PR #12336. This shuts the gap where interrupted / `Ctrl-C` / CI-cancel / bare-`npx` runs leak `test-memory-*` / `test-session-*` orphans into the prod namespace (the ~1,281-orphan backlog the purge reclaims).

Authored by Claude Opus 4.8 (Claude Code). Session 810d220f-96aa-4071-9b3a-3bee1015c1e1.

FAIR-band: under-target [7/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Evidence: L2 (unit — config resolution under/without `UNIT_TEST_MODE`, ChromaClient database wiring, ensure/drop/guard via injected AdminClient, dropTestDatabase dry-run/apply) + L1 (live config-proxy probe: TEST→`neo-unit-test`, PROD→`default_database`) → L2 required (AC1/AC2 statically verifiable, AC3 unit-verifiable). Live ensure-on-connect against a real Chroma server is L3, exercised post-merge. No residuals on the close-target ACs.

## What shipped

- **New `ai/services/shared/vector/chromaTestIsolation.mjs`** — stateless helpers (sibling to `chromaClientPrimitives.mjs`): `ensureChromaTestDatabase` (getDatabase → catch → createDatabase, since chromadb 3.x has no getOrCreateDatabase) and `dropChromaTestDatabase` (wholesale drop). The chromadb `AdminClient` is lazy-imported + injectable; `dropChromaTestDatabase` **refuses to drop `default_database`** (defense-in-depth). Owns the `CHROMA_TEST_DATABASE` SSOT constant.
- **`ai/config.template.mjs`** — new `engines.chroma.database` leaf: `neo-unit-test` under `UNIT_TEST_MODE`, `default_database` in production (`NEO_CHROMA_DATABASE` override). The Knowledge Base ChromaManager reads only host/port, so the field is inert for it until separately migrated.
- **`ChromaManager.mjs`** — `construct` passes `database` to `new ChromaClient`; `connect` ensures the test database exists under `UNIT_TEST_MODE` (after heartbeat, before the first `getOrCreateCollection`); `resolveChromaClientConfig` returns `database` verbatim from config (no fallback substitution) **and fails closed** — under `UNIT_TEST_MODE` it throws if the resolved database is the production `default_database`, so no unit run (even with an inherited env override) can construct/connect into the prod namespace.
- **`purgeTestCollections.mjs`** — `--drop-test-db` wholesale-drops the isolated database (AC3), alongside the existing `default_database` name-pattern reclaimer for the legacy backlog.

Acceptance criteria: AC1 (isolated namespace, statically verifiable) ✓ · AC2 (prod unchanged, prod-wipe guards intact) ✓ · AC3 (wholesale-droppable) ✓.

## Deltas from ticket (if any)

- Mechanism confirmed against chromadb 3.3.1 per the ticket's "confirm at implementation" note: ChromaManager connects in **server mode** (`new ChromaClient({host, port})`), so throwaway-persist-dir / in-memory isolation are not viable; a dedicated **database** (`ChromaClientArgs.database`, ensured via the separate `AdminClient`) is the correct mechanism. Tenant stays `default_tenant`; isolation is at the database grain (minimal-blast).
- The test database is **stable** (`neo-unit-test`), not per-run-unique — a per-run name would just move orphan-accumulation up one level; a stable, wholesale-droppable database bounds the blast and satisfies AC3.

## Test Evidence

- `chromaTestIsolation.spec.mjs` (new, 7): constants isolation, ensure no-op-when-exists, ensure-creates-on-not-found, ensure-requires-database, drop, **drop-refuses-`default_database`** (deleteDatabase never reached), drop-requires-database.
- `purgeTestCollections.spec.mjs` (+3, 9 total): dropTestDatabase dry-run (no seam call), `--apply` (drops the configured test db), `--apply` error → reports false not throw.
- `ChromaManager.spec.mjs` (+3, 5 total): resolveChromaClientConfig returns database verbatim, isolation active under `UNIT_TEST_MODE`, constructed client targets the isolated database. Existing canonical prod-wipe-guard suite green (20/20 managers dir).
- Live config-proxy probe: `UNIT_TEST_MODE=true` → `engines.chroma.database = neo-unit-test`; unset → `default_database`.
- Commands: `npm run test-unit -- <the three specs>` → 21 passed; `npm run test-unit -- test/playwright/unit/ai/services/memory-core/managers/` → 20 passed.

## Post-Merge Validation

- [ ] In an environment with a live Chroma server, a real unit-test run creates its `test-*` collections in `neo-unit-test`, not `default_database` (AC1 live confirmation).
- [ ] `npm run ai:purge-test-collections -- --apply --drop-test-db` wholesale-drops `neo-unit-test` against a live store (AC3 live confirmation).
- [ ] config.mjs overlays regenerate from the template with the new `database` leaf during CI / deploy hydration.

## Evolution

- **cycle-1 (review by @neo-gpt):** the original `UNIT_TEST_MODE` default isolated by default, but an inherited `NEO_CHROMA_DATABASE=default_database` env override could still resolve the unit client to production — AC1 was not fail-closed by construction. Added the `resolveChromaClientConfig` fail-closed guard (throws under `UNIT_TEST_MODE` when the resolved database is the production name) + test coverage. Production `NEO_CHROMA_DATABASE` override behavior remains intact outside unit mode.

Refs #12331 (parent cluster — parts 1 + 3 shipped in #12336). Related: #12143, #12180 (orphan leak / accumulation — these stay open until the operator-gated purge-run lands; not addressed-to-completion by this PR).
