### PR TITLE
feat(ai): add Neo Claude Opus identity contract (#11821)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -121,11 +121,11 @@ export const IDENTITIES = [
     {
         id: '@neo-claude-opus',
         type: 'AgentIdentity',
-        name: 'Claude Opus Sibling',
-        description: 'Second Anthropic Claude-family generalist maintainer identity reserved for sibling activation.',
+        name: 'Neo Claude Opus',
+        description: 'Anthropic Claude-family generalist maintainer identity reserved for activation.',
         properties: {
             githubLogin: '@neo-claude-opus',
-            displayName: 'Claude Opus Sibling',
+            displayName: 'Neo Claude Opus',
             modelFamily: 'claude',
             accountType: 'agent',
             trustTier  : TRUST_TIERS.PEER_TRUSTED,
@@ -139,17 +139,17 @@ export const IDENTITIES = [
                 reviewSemantics: {
                     modelFamily                  : 'claude',
                     crossFamilyApprovalQualified : false,
-                    rationale                    : 'Same-family Claude siblings add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-authored PRs.'
+                    rationale                    : 'Same-family Claude maintainers add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-authored PRs.'
                 },
                 memoryContinuity: {
                     policy             : 'hybrid-team-readable',
                     readScope           : 'team',
                     writeProvenance     : 'separate-agent-identity',
                     sessionSummaries    : 'separate-agent-identity',
-                    rationale           : 'The sibling may read shared team context, but all memories and summaries remain authored by @neo-claude-opus so long-run continuity and provenance do not collapse into @neo-opus-4-7.'
+                    rationale           : '@neo-claude-opus may read shared team context, but all memories and summaries remain authored by @neo-claude-opus so long-run continuity and provenance do not collapse into @neo-opus-4-7.'
                 },
                 activationPrerequisites: [
-                    'Operator creates the @neo-claude-opus GitHub account or updates this root to the actual sibling login.',
+                    'Operator creates the @neo-claude-opus GitHub account or updates this root to the final maintainer login.',
                     'A minimal identity-specific wake route is defined and verified before participationStatus flips to active.'
                 ]
             },
@@ -168,13 +168,13 @@ export const IDENTITIES = [
             releaseDate       : '2026-04-16',
             pricingInput      : 5.00,
             pricingOutput     : 25.00,
-            swarmRole         : 'Pending same-family Claude generalist maintainer identity; no active routing, quorum participation, or review coverage until activation.',
+            swarmRole         : 'Pending Claude-family generalist maintainer identity; no active routing, quorum participation, or review coverage until activation.',
             sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             participationStatus : 'temporarily_unreachable',
             statusReason        : 'Operator-created GitHub account and identity-specific wake route pending; identity root is seeded so mailbox, provenance, and review-family semantics are stable before activation.',
             authority           : '@tobiu',
             since               : '2026-06-02T21:35:48.405Z',
-            reactivationTrigger : 'Operator creates the sibling GitHub account and a minimal identity-specific wake route is verified; then flip participationStatus to active.',
+            reactivationTrigger : 'Operator creates the @neo-claude-opus GitHub account and a minimal identity-specific wake route is verified; then flip participationStatus to active.',
             createdAt           : new Date().toISOString()
         }
     },

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -119,6 +119,65 @@ export const IDENTITIES = [
         }
     },
     {
+        id: '@neo-claude-opus',
+        type: 'AgentIdentity',
+        name: 'Claude Opus Sibling',
+        description: 'Second Anthropic Claude-family generalist maintainer identity reserved by #11821 under Epic #11812.',
+        properties: {
+            githubLogin: '@neo-claude-opus',
+            displayName: 'Claude Opus Sibling',
+            modelFamily: 'claude',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
+            identityContract: {
+                sourceTicket             : '#11821',
+                parentEpic               : '#11812',
+                canonicalIdentityId      : '@neo-claude-opus',
+                requiredGithubLogin      : '@neo-claude-opus',
+                requiredA2aMailboxAddress: '@neo-claude-opus',
+                siblingOf                : '@neo-opus-4-7',
+                generalistMaintainer     : true,
+                roleSpecialization       : 'rejected-by-Discussion-11792',
+                reviewSemantics: {
+                    modelFamily                  : 'claude',
+                    crossFamilyApprovalQualified : false,
+                    rationale                    : 'Same-family Claude siblings add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-authored PRs.'
+                },
+                memoryContinuity: {
+                    policy             : 'hybrid-team-readable',
+                    readScope           : 'team',
+                    writeProvenance     : 'separate-agent-identity',
+                    sessionSummaries    : 'separate-agent-identity',
+                    rationale           : 'The sibling may read shared team context, but all memories and summaries remain authored by @neo-claude-opus so long-run continuity and provenance do not collapse into @neo-opus-4-7.'
+                },
+                activationPrerequisites: [
+                    'Operator creates the @neo-claude-opus GitHub account or updates this root to the actual sibling login.',
+                    '#11822 defines and verifies the minimal wake route before participationStatus flips to active.'
+                ]
+            },
+            // No subscriptionTemplate yet: #11822 owns the minimal wake route. Reusing the
+            // existing `appName: "Claude"` route here would make same-bundle Desktop delivery
+            // ambiguous before the wake substrate can prove the target instance.
+            contextWindowInput: 1048576,
+            parallelToolCalls : true,
+            thoughtBudget     : 'max',
+            hosting           : 'cloud',
+            family            : 'claude',
+            tier              : 'frontier',
+            releaseDate       : '2026-04-16',
+            pricingInput      : 5.00,
+            pricingOutput     : 25.00,
+            swarmRole         : 'Same-family Claude throughput, generalist maintainer authorship, same-family challenge pressure; does not add cross-family review coverage for Claude-authored PRs.',
+            sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
+            participationStatus : 'temporarily_unreachable',
+            statusReason        : 'Operator-created GitHub account and identity-specific wake route pending; identity root is seeded so mailbox, provenance, and review-family semantics are stable before #11822 activation.',
+            authority           : '@tobiu',
+            since               : '2026-06-02T21:35:48.405Z',
+            reactivationTrigger : 'Operator creates the sibling GitHub account and #11822 verifies a minimal identity-specific wake route; then flip participationStatus to active.',
+            createdAt           : new Date().toISOString()
+        }
+    },
+    {
         id: '@neo-gemini-3-1-pro',
         type: 'AgentIdentity',
         name: 'Gemini 3.1 Pro',

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -122,7 +122,7 @@ export const IDENTITIES = [
         id: '@neo-claude-opus',
         type: 'AgentIdentity',
         name: 'Claude Opus Sibling',
-        description: 'Second Anthropic Claude-family generalist maintainer identity reserved by #11821 under Epic #11812.',
+        description: 'Second Anthropic Claude-family generalist maintainer identity reserved for sibling activation.',
         properties: {
             githubLogin: '@neo-claude-opus',
             displayName: 'Claude Opus Sibling',
@@ -130,14 +130,12 @@ export const IDENTITIES = [
             accountType: 'agent',
             trustTier  : TRUST_TIERS.PEER_TRUSTED,
             identityContract: {
-                sourceTicket             : '#11821',
-                parentEpic               : '#11812',
                 canonicalIdentityId      : '@neo-claude-opus',
                 requiredGithubLogin      : '@neo-claude-opus',
                 requiredA2aMailboxAddress: '@neo-claude-opus',
                 siblingOf                : '@neo-opus-4-7',
                 generalistMaintainer     : true,
-                roleSpecialization       : 'rejected-by-Discussion-11792',
+                roleSpecialization       : 'rejected-by-architecture-discussion',
                 reviewSemantics: {
                     modelFamily                  : 'claude',
                     crossFamilyApprovalQualified : false,
@@ -152,10 +150,11 @@ export const IDENTITIES = [
                 },
                 activationPrerequisites: [
                     'Operator creates the @neo-claude-opus GitHub account or updates this root to the actual sibling login.',
-                    '#11822 defines and verifies the minimal wake route before participationStatus flips to active.'
+                    'A minimal identity-specific wake route is defined and verified before participationStatus flips to active.'
                 ]
             },
-            // No subscriptionTemplate yet: #11822 owns the minimal wake route. Reusing the
+            // No subscriptionTemplate yet: the minimal identity-specific wake route is still
+            // pending. Reusing the
             // existing `appName: "Claude"` route here would make same-bundle Desktop delivery
             // ambiguous before the wake substrate can prove the target instance.
             contextWindowInput: 1048576,
@@ -170,10 +169,10 @@ export const IDENTITIES = [
             swarmRole         : 'Same-family Claude throughput, generalist maintainer authorship, same-family challenge pressure; does not add cross-family review coverage for Claude-authored PRs.',
             sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             participationStatus : 'temporarily_unreachable',
-            statusReason        : 'Operator-created GitHub account and identity-specific wake route pending; identity root is seeded so mailbox, provenance, and review-family semantics are stable before #11822 activation.',
+            statusReason        : 'Operator-created GitHub account and identity-specific wake route pending; identity root is seeded so mailbox, provenance, and review-family semantics are stable before activation.',
             authority           : '@tobiu',
             since               : '2026-06-02T21:35:48.405Z',
-            reactivationTrigger : 'Operator creates the sibling GitHub account and #11822 verifies a minimal identity-specific wake route; then flip participationStatus to active.',
+            reactivationTrigger : 'Operator creates the sibling GitHub account and a minimal identity-specific wake route is verified; then flip participationStatus to active.',
             createdAt           : new Date().toISOString()
         }
     },

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -157,6 +157,8 @@ export const IDENTITIES = [
             // pending. Reusing the
             // existing `appName: "Claude"` route here would make same-bundle Desktop delivery
             // ambiguous before the wake substrate can prove the target instance.
+            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
+            // §neo_claude_opus, which mirrors the Claude Opus model-class row until activation.
             contextWindowInput: 1048576,
             parallelToolCalls : true,
             thoughtBudget     : 'max',
@@ -166,7 +168,7 @@ export const IDENTITIES = [
             releaseDate       : '2026-04-16',
             pricingInput      : 5.00,
             pricingOutput     : 25.00,
-            swarmRole         : 'Same-family Claude throughput, generalist maintainer authorship, same-family challenge pressure; does not add cross-family review coverage for Claude-authored PRs.',
+            swarmRole         : 'Pending same-family Claude generalist maintainer identity; no active routing, quorum participation, or review coverage until activation.',
             sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             participationStatus : 'temporarily_unreachable',
             statusReason        : 'Operator-created GitHub account and identity-specific wake route pending; identity root is seeded so mailbox, provenance, and review-family semantics are stable before activation.',

--- a/ai/scripts/lifecycle/revalidationSweep.mjs
+++ b/ai/scripts/lifecycle/revalidationSweep.mjs
@@ -104,10 +104,13 @@ export function parseArgs(argv) {
 }
 
 /**
- * @summary Resolve the AgentIdentity record for a model family. MVP requires
- *   exactly one identity per family. Multi-identity families require a
- *   same-family aggregation rule before the sweep can route notifications
- *   without ambiguity.
+ * @summary Resolve the representative AgentIdentity record for a model family.
+ *
+ * Same-family sibling identities make model-family membership one-to-many.
+ * Revalidation notifications still need a single family representative when a
+ * family has exactly one active identity and one or more inactive / pending
+ * identities. If multiple active identities exist, the sweep refuses to choose
+ * silently; that future state needs an explicit notification fan-out rule.
  */
 export function resolveIdentityForFamily(family) {
     const matches = IDENTITIES.filter(node =>
@@ -119,14 +122,28 @@ export function resolveIdentityForFamily(family) {
         throw new Error(`No AgentIdentity with modelFamily=${family} in identityRoots.mjs`);
     }
 
-    if (matches.length > 1) {
+    if (matches.length === 1) {
+        return matches[0];
+    }
+
+    const activeMatches = matches.filter(node => node.properties?.participationStatus === 'active');
+
+    if (activeMatches.length === 1) {
+        return activeMatches[0];
+    }
+
+    if (activeMatches.length > 1) {
         throw new Error(
-            `Multiple identities for family=${family}; sweep MVP supports one-identity-per-family. ` +
-            `Found: ${matches.map(m => m.id).join(', ')}. See Discussion #11792 OQ5 + §6.4 same-family aggregation.`
+            `Multiple active identities for family=${family}; revalidation sweep needs an explicit ` +
+            `notification fan-out rule. Found: ${activeMatches.map(m => m.id).join(', ')}. ` +
+            `See Discussion #11792 OQ5 + §6.4 same-family aggregation.`
         );
     }
 
-    return matches[0];
+    throw new Error(
+        `Multiple inactive identities for family=${family}; cannot infer revalidation representative. ` +
+        `Found: ${matches.map(m => m.id).join(', ')}. Pass --since after selecting the intended family transition.`
+    );
 }
 
 /**

--- a/ai/scripts/lifecycle/revalidationSweep.mjs
+++ b/ai/scripts/lifecycle/revalidationSweep.mjs
@@ -106,7 +106,7 @@ export function parseArgs(argv) {
 /**
  * @summary Resolve the representative AgentIdentity record for a model family.
  *
- * Same-family sibling identities make model-family membership one-to-many.
+ * Multiple same-family identities make model-family membership one-to-many.
  * Revalidation notifications still need a single family representative when a
  * family has exactly one active identity and one or more inactive / pending
  * identities. If multiple active identities exist, the sweep refuses to choose

--- a/ai/scripts/lifecycle/revalidationSweep.mjs
+++ b/ai/scripts/lifecycle/revalidationSweep.mjs
@@ -136,7 +136,7 @@ export function resolveIdentityForFamily(family) {
         throw new Error(
             `Multiple active identities for family=${family}; revalidation sweep needs an explicit ` +
             `notification fan-out rule. Found: ${activeMatches.map(m => m.id).join(', ')}. ` +
-            `See Discussion #11792 OQ5 + §6.4 same-family aggregation.`
+            `See the same-family aggregation rule before routing notifications.`
         );
     }
 

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -11,7 +11,7 @@ Per ADR 0012 §2.5:
 3. New rows added at first swarm contact OR at model-public-release date for reference entries
 4. Updates do NOT require ADR amendment unless a capability dimension changes or new dimension is added
 
-**Last updated:** 2026-05-18
+**Last updated:** 2026-06-02
 
 ---
 
@@ -91,6 +91,43 @@ Named cross-family maintainers with active swarm participation. These models hol
 - **Primary**: [GPT-5.5 Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.5)
 - **Primary**: [openai/codex#19319 — context window implementation discrepancy](https://github.com/openai/codex/issues/19319) (authoritative for the in-harness 258,400 effective vs published 400K)
 - **Secondary/commentary**: [GPT-5.5 Complete Guide — DigitalApplied](https://www.digitalapplied.com/blog/gpt-5-5-complete-guide-thinking-pro-1m-context) (V-B-A pending — demote on next-update if not load-bearing)
+
+---
+
+## §pending_swarm_identities
+
+Named maintainer identities provisioned in the graph but excluded from active
+routing, quorum, and review-approval semantics until `participationStatus`
+transitions to `active`.
+
+### §neo_claude_opus
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-claude-opus` |
+| `name` | Claude Opus Sibling |
+| `family` | `claude` (Anthropic) |
+| `participationStatus` | `temporarily_unreachable` |
+| `hosting` | `cloud` |
+| `tier` | `frontier` |
+| `contextWindowInput` | 1,048,576 (1M) |
+| `parallelToolCalls` | `true` |
+| `thoughtBudget` | `max` (highest Claude thinking-budget setting in use for the active Claude Opus maintainer) |
+| `releaseDate` | 2026-04-16 |
+| `pricingInput` | $5.00 per 1M tokens |
+| `pricingOutput` | $25.00 per 1M tokens |
+| `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
+| `swarmRole` | Pending same-family Claude generalist maintainer identity; no active routing, quorum participation, or review coverage until activation |
+
+This row mirrors the Claude Opus model-class capability values from
+`§neo_opus_4_7` because the sibling identity is reserved for the same model
+class. Activation must re-verify the row if the operator-created account uses a
+different Claude model, provider-side capability tier, or pricing surface.
+
+**Sources** (primary first; secondary/commentary marked):
+- **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
+- **Primary**: [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
+- **Secondary/commentary**: [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/) (V-B-A pending — replace with Anthropic's own pricing page citation when next-update touches this row)
 
 ---
 
@@ -176,6 +213,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | Date | PR | Change |
 |---|---|---|
 | 2026-05-18 | (this PR) | Initial registry creation; 4 active identities (@neo-opus-4-7, @neo-gemini-3-1-pro, @neo-gpt, gemma4-31b aspirational); cloud + MLX-local reference entries |
+| 2026-06-02 | (pending PR) | Added pending Claude sibling identity row; row is inactive until account and wake-route activation are complete. |
 
 ---
 

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -105,7 +105,7 @@ transitions to `active`.
 | Field | Value |
 |---|---|
 | `id` / `githubLogin` | `@neo-claude-opus` |
-| `name` | Claude Opus Sibling |
+| `name` | Neo Claude Opus |
 | `family` | `claude` (Anthropic) |
 | `participationStatus` | `temporarily_unreachable` |
 | `hosting` | `cloud` |
@@ -117,10 +117,10 @@ transitions to `active`.
 | `pricingInput` | $5.00 per 1M tokens |
 | `pricingOutput` | $25.00 per 1M tokens |
 | `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
-| `swarmRole` | Pending same-family Claude generalist maintainer identity; no active routing, quorum participation, or review coverage until activation |
+| `swarmRole` | Pending Claude-family generalist maintainer identity; no active routing, quorum participation, or review coverage until activation |
 
 This row mirrors the Claude Opus model-class capability values from
-`§neo_opus_4_7` because the sibling identity is reserved for the same model
+`§neo_opus_4_7` because `@neo-claude-opus` is reserved for the same model
 class. Activation must re-verify the row if the operator-created account uses a
 different Claude model, provider-side capability tier, or pricing surface.
 
@@ -213,7 +213,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | Date | PR | Change |
 |---|---|---|
 | 2026-05-18 | (this PR) | Initial registry creation; 4 active identities (@neo-opus-4-7, @neo-gemini-3-1-pro, @neo-gpt, gemma4-31b aspirational); cloud + MLX-local reference entries |
-| 2026-06-02 | (pending PR) | Added pending Claude sibling identity row; row is inactive until account and wake-route activation are complete. |
+| 2026-06-02 | (pending PR) | Added pending `@neo-claude-opus` identity row; row is inactive until account and wake-route activation are complete. |
 
 ---
 

--- a/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
@@ -24,6 +24,7 @@ import {
     resolveIdentityForFamily,
     revalidationSweep
 } from '../../../../../../ai/scripts/lifecycle/revalidationSweep.mjs';
+import {IDENTITIES} from '../../../../../../ai/graph/identityRoots.mjs';
 
 test.describe('Neo.ai.scripts.revalidationSweep', () => {
     test.describe('parseArgs (commander-backed)', () => {
@@ -130,6 +131,21 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
         test('resolves claude family to @neo-opus-4-7', () => {
             const identity = resolveIdentityForFamily('claude');
             expect(identity.id).toBe('@neo-opus-4-7');
+        });
+
+        test('prefers the active Claude identity while sibling activation is pending', () => {
+            const claudeIdentities = IDENTITIES.filter(identity =>
+                identity.type === 'AgentIdentity' &&
+                identity.properties?.modelFamily === 'claude'
+            );
+
+            expect(claudeIdentities.map(identity => identity.id)).toEqual(expect.arrayContaining([
+                '@neo-opus-4-7',
+                '@neo-claude-opus'
+            ]));
+            expect(resolveIdentityForFamily('claude').id).toBe('@neo-opus-4-7');
+            expect(claudeIdentities.find(identity => identity.id === '@neo-claude-opus')?.properties.participationStatus)
+                .toBe('temporarily_unreachable');
         });
 
         test('throws on unknown family', () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
@@ -133,7 +133,7 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
             expect(identity.id).toBe('@neo-opus-4-7');
         });
 
-        test('prefers the active Claude identity while sibling activation is pending', () => {
+        test('prefers the active Claude identity while another Claude activation is pending', () => {
             const claudeIdentities = IDENTITIES.filter(identity =>
                 identity.type === 'AgentIdentity' &&
                 identity.properties?.modelFamily === 'claude'

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -922,6 +922,46 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(inbox.messages[0].subject).toBe('direct ping');
         });
 
+        test('#11821 Claude sibling routes by canonical identity while family alias stays ambiguous', async () => {
+            GraphService.upsertNode({
+                id        : '@neo-opus-4-7',
+                type      : 'AgentIdentity',
+                name      : 'Claude Opus 4.7',
+                properties: {accountType: 'agent', modelFamily: 'claude'}
+            });
+            GraphService.upsertNode({
+                id        : '@neo-claude-opus',
+                type      : 'AgentIdentity',
+                name      : 'Claude Opus Sibling',
+                properties: {accountType: 'agent', modelFamily: 'claude'}
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@neo-claude-opus' }, async () => {
+                await PermissionService.grantPermission({ to: '@neo-opus-4-7', scope: 'CAN_REPLY_TO' });
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@neo-opus-4-7' }, async () => {
+                const res = await MailboxService.addMessage({
+                    to     : '@neo-claude-opus',
+                    subject: 'sibling direct ping',
+                    body   : 'Canonical same-family sibling address must remain routable.'
+                });
+
+                expect(res.status).toBe('sent');
+                await expect(MailboxService.addMessage({
+                    to     : 'AGENT:claude/opus',
+                    subject: 'ambiguous sibling ping',
+                    body   : 'Family alias must fail closed once two Claude identities exist.'
+                })).rejects.toThrow(/Ambiguous 'to' alias.*modelFamily='claude'/);
+            });
+
+            const inbox = await RequestContextService.run({ agentIdentityNodeId: '@neo-claude-opus' }, async () => {
+                return await MailboxService.listMessages({ box: 'inbox' });
+            });
+
+            expect(inbox.messages.map(message => message.subject)).toContain('sibling direct ping');
+        });
+
         test('`AGENT:@login` prefixed form normalizes to bare `@login` SENT_TO target', async () => {
             await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
                 await PermissionService.grantPermission({ to: '@opus', scope: 'CAN_REPLY_TO' });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -922,7 +922,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(inbox.messages[0].subject).toBe('direct ping');
         });
 
-        test('Claude sibling routes by canonical identity while family alias stays ambiguous', async () => {
+        test('additional Claude identity routes by canonical identity while family alias stays ambiguous', async () => {
             GraphService.upsertNode({
                 id        : '@neo-opus-4-7',
                 type      : 'AgentIdentity',
@@ -932,7 +932,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             GraphService.upsertNode({
                 id        : '@neo-claude-opus',
                 type      : 'AgentIdentity',
-                name      : 'Claude Opus Sibling',
+                name      : 'Neo Claude Opus',
                 properties: {accountType: 'agent', modelFamily: 'claude'}
             });
 
@@ -943,14 +943,14 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             await RequestContextService.run({ agentIdentityNodeId: '@neo-opus-4-7' }, async () => {
                 const res = await MailboxService.addMessage({
                     to     : '@neo-claude-opus',
-                    subject: 'sibling direct ping',
-                    body   : 'Canonical same-family sibling address must remain routable.'
+                    subject: 'additional Claude direct ping',
+                    body   : 'Canonical same-family Claude address must remain routable.'
                 });
 
                 expect(res.status).toBe('sent');
                 await expect(MailboxService.addMessage({
                     to     : 'AGENT:claude/opus',
-                    subject: 'ambiguous sibling ping',
+                    subject: 'ambiguous Claude ping',
                     body   : 'Family alias must fail closed once two Claude identities exist.'
                 })).rejects.toThrow(/Ambiguous 'to' alias.*modelFamily='claude'/);
             });
@@ -959,7 +959,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 return await MailboxService.listMessages({ box: 'inbox' });
             });
 
-            expect(inbox.messages.map(message => message.subject)).toContain('sibling direct ping');
+            expect(inbox.messages.map(message => message.subject)).toContain('additional Claude direct ping');
         });
 
         test('`AGENT:@login` prefixed form normalizes to bare `@login` SENT_TO target', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -922,7 +922,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(inbox.messages[0].subject).toBe('direct ping');
         });
 
-        test('#11821 Claude sibling routes by canonical identity while family alias stays ambiguous', async () => {
+        test('Claude sibling routes by canonical identity while family alias stays ambiguous', async () => {
             GraphService.upsertNode({
                 id        : '@neo-opus-4-7',
                 type      : 'AgentIdentity',


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e8a0a-ee2e-7532-b5af-06fc4cc421ef.

FAIR-band: over-target [23/30] - taking this lane despite over-target because operator direction made #11812/#11821 P0 and the Neo Claude Opus identity contract unblocks the second Claude account path.

Resolves #11821
Related: #11812
Related: https://github.com/orgs/neomjs/discussions/11792

Seeds `@neo-claude-opus` as a first-class Claude-family generalist maintainer identity named `Neo Claude Opus`, while keeping it inactive until the operator account and #11822 wake route exist. The PR also hardens the one place found during implementation that assumed one identity per model family, and adds mailbox coverage proving canonical same-family direct routing while ambiguous family aliases fail closed.

Evidence: L2 (unit-proven identity resolution plus canonical mailbox send/read and alias-ambiguity checks) -> L2 required (#11821 AC8 graph/mailbox proof; AC2-AC7 static identity contract). Residual: Desktop/minimal wake activation remains #11822.

## Signal Ledger

Source discussion: https://github.com/orgs/neomjs/discussions/11792

| Family | Signal | Evidence |
|---|---|---|
| gpt | AUTHOR_SIGNAL | `@neo-gpt` author signal at discussioncomment-17028369 |
| claude | GRADUATION_APPROVED | `@neo-opus-4-7` non-author approval at discussioncomment-17028189 |
| gemini | Unresolved liveness | Gemini-family revalidation remains carried by #11812 AC13; this PR preserves the reference and does not activate new Gemini-dependent governance arithmetic. |

## Unresolved Dissent

None known for the version-bound identity contract implemented here.

## Unresolved Liveness

Gemini remains the unresolved family from #11792/#11812. This PR does not mutate always-loaded swarm rules or the cross-family approval workflow; it records the same-family limitation in the identity contract and leaves #11812 AC13 as the revalidation authority when Gemini reactivates.

## Deltas from ticket

- #11816 is treated as dropped by the operator/lead 2026-06-02 disposition, not as an active blocker.
- `@neo-claude-opus` is seeded with `participationStatus: temporarily_unreachable` rather than `active`, so active-team targeting and heartbeats cannot wake a nonexistent account.
- `@neo-claude-opus` is named `Neo Claude Opus`; relationship language is kept out of identity names and display labels.
- `ModelStats.md` now includes the required pending-identity registry row per ADR 0012, and the graph-node capability fields cite that registry row.
- No `subscriptionTemplate` is added yet. #11822 owns the minimal identity-specific wake route; reusing `appName: Claude` would be ambiguous with two Claude-family identities.
- `revalidationSweep` now chooses the single active representative when a family has inactive same-family identities, and fails closed if multiple active same-family identities exist without a fan-out rule.

## Test Evidence

- Added-line scan for stale relationship-as-name phrases across changed code/test surfaces - no matches
- `git diff --check` - pass
- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs` - 24 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` - 62 passed; Chroma cleanup warnings were non-fatal and exit code was 0
- Earlier same-branch checks: `node --check` on changed JS/spec files, GoldenPathSynthesizer 12 passed, swarmHeartbeat 24 passed.
- Pre-push freshness: fetched origin and verified `merge-base HEAD origin/dev == origin/dev` before push.

## Post-Merge Validation

- [ ] Operator creates the `@neo-claude-opus` GitHub account or updates `ai/graph/identityRoots.mjs` to the final maintainer account handle before activation.
- [ ] #11822 defines and verifies the minimal identity-specific wake route before `participationStatus` flips to `active`.
- [ ] Production identity seeding/sync is run after merge so the new graph principal exists for mailbox and provenance flows.

## Commits

- `64785058a` - initial Neo Claude Opus identity contract seed
- `1506b913a` - ticket-ID cleanup in code/test surfaces
- `077123603` - ADR 0012 ModelStats registry alignment
- `519176f2d` - explicit Neo Claude Opus naming