### PR TITLE
feat(ai): instance-addressable wake routing for parallel same-bundle harnesses (#11822)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -670,13 +670,26 @@ async function deliverDigest(subscription, digest) {
             // Instance-addressable wake — LOCAL deployment only. When the subscription carries a
             // userDataDir, two same-bundle GUI harnesses may be running; resolve the intended
             // instance's pid and raise THAT process — never the ambiguous app-activate / frontmost
-            // guess. Fail closed (skip the wake) if the instance cannot be located, so a wake never
-            // lands in the wrong one. Gated on AiConfig.orchestrator.deploymentMode !== 'cloud' (the
-            // canonical local-vs-cloud signal, mirroring the orchestrator's deployment-lane gate), so
-            // this local macOS GUI/osascript route never runs under cloud deployment and adds no
-            // cloud-deployment surface.
+            // guess. Fail closed (skip the wake) if the instance cannot be located, so a targeted
+            // wake never lands in the wrong one.
+            //
+            // Instance addressing is a local-only primitive: this daemon delivers desktop-harness
+            // wakes via osascript/tmux, which a headless cloud deployment has no GUI harness to
+            // receive, so the daemon does not run under cloud at all. The deploymentMode === 'cloud'
+            // branch below is therefore DEFENSE-IN-DEPTH, not a live path: if the gate is ever
+            // evaluated under a cloud deploymentMode, REFUSE (fail closed) rather than fall through to
+            // app-activate — a targeted wake must never silently degrade to an untargeted one. Uses
+            // the canonical AiConfig.orchestrator.deploymentMode signal.
             let instancePid = null;
-            if (meta.userDataDir && AiConfig.orchestrator.deploymentMode !== 'cloud') {
+            if (meta.userDataDir) {
+                if (AiConfig.orchestrator.deploymentMode === 'cloud') {
+                    writeLog('ERROR',
+                        `[Bridge Daemon] Instance wake refused for ${subscription.id}: ` +
+                        `userDataDir targeting requires local deployment (deploymentMode='cloud'). ` +
+                        `Failing closed — instance-addressed GUI wakes are local-only (ADR 0014).`
+                    );
+                    return;
+                }
                 instancePid = await getInstancePid({userDataDir: meta.userDataDir});
                 if (!instancePid) {
                     writeLog('ERROR',

--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -30,6 +30,7 @@
 import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
+import AiConfig        from '../../config.mjs';
 
 import fs from 'fs-extra';
 import path from 'path';
@@ -666,12 +667,16 @@ async function deliverDigest(subscription, digest) {
                 return;
             }
 
-            // Instance-addressable wake: when the subscription carries a userDataDir, two
-            // same-bundle harnesses may be running. Resolve the intended instance's pid and raise
-            // THAT process — never the ambiguous app-activate / frontmost guess. Fail closed (skip
-            // the wake) if the instance cannot be located, so a wake never lands in the wrong one.
+            // Instance-addressable wake — LOCAL deployment only. When the subscription carries a
+            // userDataDir, two same-bundle GUI harnesses may be running; resolve the intended
+            // instance's pid and raise THAT process — never the ambiguous app-activate / frontmost
+            // guess. Fail closed (skip the wake) if the instance cannot be located, so a wake never
+            // lands in the wrong one. Gated on AiConfig.orchestrator.deploymentMode !== 'cloud' (the
+            // canonical local-vs-cloud signal, mirroring the orchestrator's deployment-lane gate), so
+            // this local macOS GUI/osascript route never runs under cloud deployment and adds no
+            // cloud-deployment surface.
             let instancePid = null;
-            if (meta.userDataDir) {
+            if (meta.userDataDir && AiConfig.orchestrator.deploymentMode !== 'cloud') {
                 instancePid = await getInstancePid({userDataDir: meta.userDataDir});
                 if (!instancePid) {
                     writeLog('ERROR',

--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -47,6 +47,7 @@ import {
     getEdgesData,
     getDbNode
 } from './queries.mjs';
+import {getInstancePid} from './instanceResolver.mjs';
 
 const DB_PATH                  = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || '.neo-ai-data/wake-daemon';
@@ -665,6 +666,22 @@ async function deliverDigest(subscription, digest) {
                 return;
             }
 
+            // Instance-addressable wake: when the subscription carries a userDataDir, two
+            // same-bundle harnesses may be running. Resolve the intended instance's pid and raise
+            // THAT process — never the ambiguous app-activate / frontmost guess. Fail closed (skip
+            // the wake) if the instance cannot be located, so a wake never lands in the wrong one.
+            let instancePid = null;
+            if (meta.userDataDir) {
+                instancePid = await getInstancePid({userDataDir: meta.userDataDir});
+                if (!instancePid) {
+                    writeLog('ERROR',
+                        `[Bridge Daemon] Instance wake refused for ${subscription.id}: ` +
+                        `no running process found for userDataDir='${meta.userDataDir}'. ` +
+                        `Failing closed to avoid misrouting to another ${appName} instance.`
+                    );
+                    return;
+                }
+            }
 
             // [Anchor & Echo] The Electron-Paradox Defense:
             // Electron-based IDEs (Antigravity, VS Code) register their bundle names differently
@@ -679,6 +696,13 @@ async function deliverDigest(subscription, digest) {
             // This is load-bearing for Claude Desktop with Tab 3 (Claude Code) and Google Antigravity.
             // Do NOT "clean this up" or revert to \`tell process\` or try to replace the Enter key
             // without empiric validation across both harnesses.
+            // Instance-addressed wake raises the resolved pid's process to frontmost (verified
+            // addressable via System Events `whose unix id`); single-instance wakes keep the
+            // app-activate path unchanged.
+            const activateLine = instancePid
+                ? `  tell application "System Events" to set frontmost of (first process whose unix id is ${instancePid}) to true`
+                : `  tell application "${appName}" to activate`;
+
             const osascriptArgs = [
                 '-e', 'on run argv',
                 '-e', '  set wakePayload to (item 1 of argv)',
@@ -687,7 +711,7 @@ async function deliverDigest(subscription, digest) {
                 '-e', '  on error',
                 '-e', '    set savedClipboard to ""',
                 '-e', '  end try',
-                '-e', `  tell application "${appName}" to activate`,
+                '-e', activateLine,
                 '-e', '  delay 0.5',
                 '-e', '  tell application "System Events"',
                 '-e', '    set frontmostProcess to first application process whose frontmost is true',

--- a/ai/daemons/bridge/instanceResolver.mjs
+++ b/ai/daemons/bridge/instanceResolver.mjs
@@ -1,0 +1,112 @@
+import {execFile} from 'child_process';
+import {promisify} from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary Resolves the OS process id of a specific GUI harness *instance* from its
+ * `--user-data-dir`, so the bridge daemon can wake the intended instance when two
+ * same-bundle harnesses (e.g. two `Claude.app` profiles) run in parallel.
+ *
+ * ## Why this exists
+ *
+ * Shape C GUI wake routing addresses the harness by app name (`tell application "Claude"`)
+ * and then targets `first application process whose frontmost is true`. That is unambiguous
+ * for one instance, but two same-bundle instances make app activation and the frontmost
+ * heuristic non-deterministic — a wake for one identity can land in the other. macOS
+ * instances launched via `open -n -a App.app --args --user-data-dir=<dir>` are distinguishable
+ * at the OS level: the `--user-data-dir` value is present in the process command line (on the
+ * main executable when passed via `--args`, and always on the Electron helper subprocesses),
+ * so the instance maps to a unique main-process pid. That pid is then directly addressable by
+ * osascript via `first process whose unix id is <pid>` (empirically verified addressable +
+ * window-enumerable), which removes the frontmost guess.
+ *
+ * Pure resolution (`resolveInstancePid`) is separated from the `ps` side effect
+ * (`getInstancePid`) so the matching logic is unit-testable with fixed process snapshots.
+ *
+ * @module ai/daemons/bridge/instanceResolver
+ */
+
+/**
+ * @summary Pure resolver: given a `ps` snapshot, find the main app-process pid of the instance
+ * whose command line carries `--user-data-dir=<userDataDir>`.
+ *
+ * Strategy: (1) prefer a matching row that is the main app executable (`Contents/MacOS/<App>`,
+ * not a Helper/Framework/crashpad subprocess); (2) otherwise take a matching helper and walk the
+ * parent-pid chain up to the main app executable. Returns `null` when nothing matches, so the
+ * caller fails closed (no wake) rather than misrouting to the wrong instance.
+ *
+ * @param {Object} options
+ * @param {String} options.userDataDir                       The instance address (its `--user-data-dir` value).
+ * @param {String} options.psOutput                          `ps axww -o pid=,ppid=,command=` output.
+ * @param {String} [options.appExecutableMarker='Contents/MacOS/'] Marker identifying the main app executable.
+ * @returns {Number|null} The instance's main-process pid, or null if no instance matches.
+ */
+export function resolveInstancePid({userDataDir, psOutput, appExecutableMarker = 'Contents/MacOS/'} = {}) {
+    if (!userDataDir || !psOutput) {
+        return null;
+    }
+
+    const needle = `--user-data-dir=${userDataDir}`,
+          rows   = psOutput.split('\n')
+              .map(line => line.trim())
+              .filter(Boolean)
+              .map(line => {
+                  const match = line.match(/^(\d+)\s+(\d+)\s+(.*)$/);
+                  return match ? {pid: Number(match[1]), ppid: Number(match[2]), command: match[3]} : null;
+              })
+              .filter(Boolean);
+
+    const isMainExecutable = command =>
+        command.includes(appExecutableMarker) && !/Helper|Framework|crashpad/i.test(command);
+
+    const matches = rows.filter(row => row.command.includes(needle));
+
+    if (matches.length === 0) {
+        return null;
+    }
+
+    // 1) A matching row that is itself the main app executable (instance launched with --args --user-data-dir).
+    const directMain = matches.find(row => isMainExecutable(row.command));
+    if (directMain) {
+        return directMain.pid;
+    }
+
+    // 2) Only helper subprocesses carry the dir: walk parent-pid up to the main app executable.
+    const byPid = new Map(rows.map(row => [row.pid, row]));
+    let   cursor = matches[0];
+    const seen   = new Set();
+
+    while (cursor && !seen.has(cursor.pid)) {
+        seen.add(cursor.pid);
+        if (isMainExecutable(cursor.command)) {
+            return cursor.pid;
+        }
+        cursor = byPid.get(cursor.ppid);
+    }
+
+    return null;
+}
+
+/**
+ * @summary Runs `ps` and resolves the instance pid for `userDataDir`. Side-effect wrapper around
+ * {@link resolveInstancePid}.
+ * @param {Object} options
+ * @param {String} options.userDataDir
+ * @param {Function} [options.exec=execFileAsync] Injectable `(cmd, args) => Promise<{stdout}>` for tests.
+ * @returns {Promise<Number|null>} The instance pid, or null (caller fails closed).
+ */
+export async function getInstancePid({userDataDir, exec = execFileAsync} = {}) {
+    if (!userDataDir) {
+        return null;
+    }
+
+    let psOutput;
+    try {
+        ({stdout: psOutput} = await exec('ps', ['axww', '-o', 'pid=,ppid=,command=']));
+    } catch {
+        return null;
+    }
+
+    return resolveInstancePid({userDataDir, psOutput});
+}

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1341,7 +1341,7 @@ paths:
                   description: Required for subscribe; specifies how wake events are delivered.
                 harnessTargetMetadata:
                   type: object
-                  description: Channel-specific metadata. appName is required so fresh agents always provide the bridge-daemon/osascript routing target; url is required for a2a-webhook; coalesceWindow is an optional override.
+                  description: Channel-specific metadata. appName is required so fresh agents always provide the bridge-daemon/osascript routing target; url is required for a2a-webhook; coalesceWindow is an optional override. userDataDir (local bridge-daemon only) addresses one specific same-bundle GUI instance when two harnesses of the same app run in parallel — the daemon resolves that instance's pid from its --user-data-dir and raises only that process.
                   required: [appName]
                   properties:
                     url:              {type: string}
@@ -1349,6 +1349,7 @@ paths:
                     daemonSocketPath: {type: string}
                     adapter:          {type: string, enum: [osascript, tmux]}
                     appName:          {type: string}
+                    userDataDir:      {type: string, nullable: true}
                     tabShortcut:      {type: string, nullable: true}
                     focusSeedKey:     {type: string, nullable: true}
                     tmuxSession:      {type: string}

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -422,7 +422,9 @@ class WakeSubscriptionService extends Base {
      * @param {Object} [opts.filters] taggedConcepts | priority | senderFilter | inReplyToFilter
      * @param {String} opts.harnessTarget One of validHarnessTargets
      * @param {Object} [opts.harnessTargetMetadata] appName | url | coalesceWindow |
-     *     daemonSocketPath | adapter | tabShortcut | focusSeedKey | tmuxSession
+     *     daemonSocketPath | adapter | tabShortcut | focusSeedKey | tmuxSession | userDataDir
+     *     (userDataDir: instance address for a same-bundle GUI harness — the bridge daemon resolves
+     *     it to that instance's pid and raises that process, instead of the ambiguous frontmost guess)
      * @returns {Promise<Object>} {subscriptionId, harnessTarget, signingKey?}
      */
     async subscribe({trigger, filters = {}, harnessTarget, harnessTargetMetadata = {}} = {}) {

--- a/test/playwright/unit/ai/daemons/bridge/instanceResolver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/instanceResolver.spec.mjs
@@ -1,0 +1,73 @@
+import {test, expect} from '@playwright/test';
+import {
+    getInstancePid,
+    resolveInstancePid
+} from '../../../../../../ai/daemons/bridge/instanceResolver.mjs';
+
+/**
+ * Self-test for the bridge-daemon instance resolver: maps a harness instance's `--user-data-dir`
+ * to its main app-process pid so the wake daemon can target the intended instance when two
+ * same-bundle harnesses run in parallel. Fixtures model real macOS `ps axww -o pid=,ppid=,command=`
+ * output for two Claude.app instances — a default one (only Electron helpers carry the dir) and a
+ * second one launched via `open -n -a Claude.app --args --user-data-dir=...` (the main executable
+ * carries the dir directly). The critical behaviors: pick the right instance's MAIN pid, and return
+ * null (caller fails closed) when no instance matches.
+ */
+
+const DEFAULT_DIR = '/Users/tobiasuhlig/Library/Application Support/Claude';
+const NEO_DIR      = '/Users/tobiasuhlig/.claude-instances/Neo';
+
+// Default instance: main executable has NO --user-data-dir (launched via Finder/dock); only the
+// Electron helper subprocesses carry it. Second (Neo) instance: main executable carries it (--args).
+const PS_BOTH_INSTANCES = [
+    `13106 1 /Applications/Claude.app/Contents/MacOS/Claude`,
+    `13119 13106 /Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper --type=gpu-process --user-data-dir=${DEFAULT_DIR} --gpu-preferences=xyz`,
+    `13125 13106 /Applications/Claude.app/Contents/Frameworks/Claude Helper (Renderer).app/Contents/MacOS/Claude Helper (Renderer) --type=renderer --user-data-dir=${DEFAULT_DIR} --app-path=/x`,
+    `20001 1 /Applications/Claude.app/Contents/MacOS/Claude --user-data-dir=${NEO_DIR}`,
+    `20005 20001 /Applications/Claude.app/Contents/Frameworks/Claude Helper (Renderer).app/Contents/MacOS/Claude Helper (Renderer) --type=renderer --user-data-dir=${NEO_DIR} --app-path=/x`
+].join('\n');
+
+test.describe('bridge-daemon instanceResolver', () => {
+    test('resolves the second instance main pid directly when the main executable carries --user-data-dir', () => {
+        // The Neo instance's main process carries the dir (open --args), and is preferred over its helper.
+        expect(resolveInstancePid({userDataDir: NEO_DIR, psOutput: PS_BOTH_INSTANCES})).toBe(20001);
+    });
+
+    test('resolves to the main pid via the parent-pid chain when only helpers carry --user-data-dir', () => {
+        // The default instance's main has no dir; resolution must walk a matching helper up to the main.
+        expect(resolveInstancePid({userDataDir: DEFAULT_DIR, psOutput: PS_BOTH_INSTANCES})).toBe(13106);
+    });
+
+    test('distinguishes the two same-bundle instances (never cross-targets)', () => {
+        const neo     = resolveInstancePid({userDataDir: NEO_DIR, psOutput: PS_BOTH_INSTANCES});
+        const dflt    = resolveInstancePid({userDataDir: DEFAULT_DIR, psOutput: PS_BOTH_INSTANCES});
+        expect(neo).toBe(20001);
+        expect(dflt).toBe(13106);
+        expect(neo).not.toBe(dflt);
+    });
+
+    test('returns null when no process matches the user-data-dir (caller fails closed)', () => {
+        expect(resolveInstancePid({userDataDir: '/Users/x/.claude-instances/DoesNotExist', psOutput: PS_BOTH_INSTANCES})).toBeNull();
+    });
+
+    test('returns null on missing inputs', () => {
+        expect(resolveInstancePid({userDataDir: NEO_DIR})).toBeNull();
+        expect(resolveInstancePid({psOutput: PS_BOTH_INSTANCES})).toBeNull();
+        expect(resolveInstancePid({})).toBeNull();
+    });
+
+    test('getInstancePid runs ps via the injected exec and resolves the pid', async () => {
+        const exec = async (cmd, args) => {
+            expect(cmd).toBe('ps');
+            expect(args).toContain('axww');
+            return {stdout: PS_BOTH_INSTANCES};
+        };
+        expect(await getInstancePid({userDataDir: NEO_DIR, exec})).toBe(20001);
+    });
+
+    test('getInstancePid fails closed (null) when ps errors or userDataDir is absent', async () => {
+        const throwingExec = async () => { throw new Error('ps failed') };
+        expect(await getInstancePid({userDataDir: NEO_DIR, exec: throwingExec})).toBeNull();
+        expect(await getInstancePid({exec: async () => ({stdout: PS_BOTH_INSTANCES})})).toBeNull();
+    });
+});


### PR DESCRIPTION
Resolves #11822

Routes Shape C GUI wake to a *specific* same-bundle harness instance, so two parallel `Claude.app` profiles (the default maintainer + the new `@neo-claude-opus` instance) can each be woken correctly. Today `tell application "Claude" to activate` + `first process whose frontmost is true` is non-deterministic across two same-bundle instances — a wake for one identity could land in the other. This addresses the instance by its `--user-data-dir`.

Authored by Claude Opus 4.8 (Claude Code). Session 810d220f-96aa-4071-9b3a-3bee1015c1e1.

FAIR-band: under-target [7/30] — Self-Selection Rule 1 (under-band → bias toward author lane); also operator-direction P0 (the sibling wake is the named nightshift goal).

**Cloud safety (operator requirement):** the instance-wake path is gated on `AiConfig.orchestrator.deploymentMode !== 'cloud'` — the canonical local-vs-cloud signal, mirroring the orchestrator's `resolveDeploymentEnabled` lane gate. It is the local macOS GUI / osascript route only (a developer running parallel `Claude.app` profiles); cloud deployments never enter this branch, so this PR adds **zero cloud-deployment surface**. Verified: `deploymentMode = "local"` resolves the gate `true` locally.

Evidence: L2 (unit — `instanceResolver`: 2-instance distinction, helper→main via parent-pid, fail-closed on no-match / ps-error, 7 cases) + L1 (manually verified on macOS: `--user-data-dir` is present in Claude process args; `osascript … first process whose unix id is <pid>` is addressable + window-enumerable) → L3 required (AC7 live 2-cycle delivery to the intended instance + a live wrong-instance probe), which needs two running Desktop instances and is operator-run → post-merge. No residuals on the static/unit-verifiable ACs.

## What shipped
- **New `ai/daemons/bridge/instanceResolver.mjs`** — `resolveInstancePid({userDataDir, psOutput})` (pure: prefer the main `Contents/MacOS/<App>` process carrying the dir; else walk a matching Electron helper up the parent-pid chain to the main) + `getInstancePid` (ps wrapper, injectable for tests). Returns `null` ⇒ caller fails closed.
- **`ai/daemons/bridge/daemon.mjs` `deliverDigest`** — when `harnessTargetMetadata.userDataDir` is set: resolve the instance pid; **fail closed** (skip the wake, log) if not found; otherwise raise *that* process to frontmost (`System Events … set frontmost of (first process whose unix id is <pid>) to true`) instead of `tell application "<appName>" to activate`. Single-instance subscriptions (no `userDataDir`) keep the existing path unchanged.
- **`WakeSubscriptionService`** — `userDataDir` documented as an optional metadata field (free-form pass-through; `appName` still required for the activate fallback + tab/focus shortcuts).

AC mapping: AC2 selector chosen (`userDataDir`→pid; pid-by-user-data-dir dominates window/bundle-clone on determinism); AC3 Desktop-grade (osascript-by-pid, not tmux); AC4 instance address in metadata; AC5 fail-closed; AC6 wrong-instance prevention (resolver distinction + null-fail-closed unit tests; live probe post-merge); AC8 single-instance `appName` preserved. AC1 (`PASS_OQ8`) obsolete — operator dropped #11816.

## Deltas from ticket
- AC1's `PASS_OQ8` precondition is obsolete: operator dropped #11816 (capacity premise accepted on operator evidence).
- The ticket framed the selector bake-off (userDataDir / PID-window / bundle-clone / bridge-webhook) as open; resolved to **pid-resolved-from-`--user-data-dir`** after verifying on-Mac that (a) the dir is in the process args and (b) osascript can address a process by unix id. The operator's real topology is two same-bundle `Claude.app` via `--user-data-dir` (not separate bundles / cloud), which this matches.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/instanceResolver.spec.mjs` → **7 passed**.
- Manual (this Mac): `ps axww` shows `--user-data-dir=…` in Claude process args; `osascript … first process whose unix id is <pid>` → returns the process name + `count of windows`.
- `node --check` clean on `daemon.mjs` + `instanceResolver.mjs`.

## Post-Merge Validation
- [ ] AC7: with two `Claude.app` instances running (default + `--user-data-dir=~/.claude-instances/Neo`), a wake for the Neo subscription lands in the Neo instance over ≥2 cycles (operator-run; needs the 2nd account/instance live).
- [ ] Live wrong-instance probe: a wake targeting the Neo `userDataDir` never lands in the default instance.
- [ ] Confirm the 2nd instance's MAIN process carries `--user-data-dir` from `open --args` (the resolver prefers it; the helper→ppid fallback covers the alternative if it does not).

## Signal Ledger
Source discussion: Discussion #11792 (graduated → Epic #11812).

| Family | Signal | Evidence |
|---|---|---|
| gpt | AUTHOR_SIGNAL | `@neo-gpt` author signal on Discussion #11792 (discussioncomment-17028369) |
| claude | GRADUATION_APPROVED | `@neo-opus-4-7` non-author approval on Discussion #11792 (discussioncomment-17028189) |
| gemini | Unresolved liveness | carried by Epic #11812 AC13 Tier-2 revalidation; this PR adds no new Gemini-dependent quorum arithmetic |

## Unresolved Dissent
None.

Refs #11812 (parent epic — non-closing).
