### PR TITLE
fix(ai): preserve GraphQL partial data in non-strict mode (#10096)

### DIFF
--- a/ai/services/github-workflow/GraphqlService.mjs
+++ b/ai/services/github-workflow/GraphqlService.mjs
@@ -204,14 +204,45 @@ class GraphqlService extends Base {
     }
 
     /**
-     * Executes a GraphQL query or mutation against the GitHub API.
-     * @param {string}  query                   The GraphQL query string.
-     * @param {object}  [variables={}]          Optional variables for the query.
-     * @param {boolean} [enableSubIssues=false] Whether to enable sub-issues feature header
-     * @returns {Promise<object>} The `data` object from the GraphQL response.
-     * @throws {Error} If the request fails or the API returns errors.
+     * @summary Detects whether a GraphQL response contains usable partial data.
+     *
+     * GitHub can return `{data, errors}` when only one aliased field fails. A top-level `data`
+     * object with at least one non-null field is useful partial data; `null`/empty/all-null data
+     * still represents a hard semantic failure.
+     *
+     * @param {*} data The GraphQL `data` payload.
+     * @returns {Boolean}
+     * @private
      */
-    async query(query, variables={}, enableSubIssues=false) {
+    #hasPartialData(data) {
+        if (data == null) {
+            return false;
+        }
+
+        if (Array.isArray(data)) {
+            return data.some(item => item != null);
+        }
+
+        if (typeof data === 'object') {
+            return Object.values(data).some(value => value != null);
+        }
+
+        return true;
+    }
+
+    /**
+     * Executes a GraphQL query or mutation against the GitHub API.
+     * @param {string}         query                         The GraphQL query string.
+     * @param {object}         [variables={}]                Optional variables for the query.
+     * @param {boolean|object} [options=false]               Legacy boolean enables sub-issues; object form configures behavior.
+     * @param {boolean}        [options.enableSubIssues=false] Whether to enable sub-issues feature header.
+     * @param {boolean}        [options.strict=true]         Whether any GraphQL `errors` entry is a hard failure.
+     * @returns {Promise<object>} The `data` object, or `{data, errors}` for non-strict partial-data responses.
+     * @throws {Error} If the request fails, or if strict GraphQL error handling rejects the response.
+     */
+    async query(query, variables={}, options=false) {
+        const enableSubIssues = typeof options === 'boolean' ? options : Boolean(options?.enableSubIssues);
+        const strict          = typeof options === 'object' ? options?.strict !== false : true;
         const token = await this.#getAuthToken();
 
         const headers = {
@@ -259,6 +290,14 @@ class GraphqlService extends Base {
         const json = await response.json();
 
         if (json.errors) {
+            if (!strict && this.#hasPartialData(json.data)) {
+                logger.warn('GitHub API returned partial data with GraphQL errors:', json.errors);
+                return {
+                    data  : json.data,
+                    errors: json.errors
+                };
+            }
+
             logger.error('GitHub API returned errors:', json.errors);
             throw new Error(`GitHub API error: ${json.errors.map(e => e.message).join(', ')}`);
         }

--- a/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
@@ -18,7 +18,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Contract coverage for `GraphqlService.query` transient GitHub retry behavior (#11585).
+ * @summary Contract coverage for `GraphqlService.query` transient GitHub retry behavior.
  *
  * GitHub's GraphQL edge can return transient `502`/`503`/`504` gateway failures or
  * terminate a fetch mid-flight. The GitHub Workflow sync pipeline is long-running,
@@ -147,5 +147,74 @@ test.describe('Neo.ai.services.github-workflow.GraphqlService — transient retr
 
         await expect(GraphqlService.query(QUERY)).rejects.toThrow('GitHub API error: Field does not exist');
         expect(callCount).toBe(1);
+    });
+
+    test('strict mode throws when GraphQL errors include partial data (#10096)', async () => {
+        globalThis.fetch = async () => new Response(JSON.stringify({
+            data: {
+                repository: {
+                    issue42: {number: 42},
+                    issue43: null
+                }
+            },
+            errors: [{message: 'Could not resolve to an Issue with the number of 43'}]
+        }), {
+            status : 200,
+            headers: {'content-type': 'application/json'}
+        });
+
+        await expect(GraphqlService.query(QUERY)).rejects.toThrow(
+            'GitHub API error: Could not resolve to an Issue with the number of 43'
+        );
+    });
+
+    test('non-strict mode returns partial data with GraphQL errors (#10096)', async () => {
+        const errors = [{message: 'Could not resolve to an Issue with the number of 43'}];
+        const data   = {
+            repository: {
+                issue42: {number: 42},
+                issue43: null
+            }
+        };
+
+        globalThis.fetch = async () => new Response(JSON.stringify({data, errors}), {
+            status : 200,
+            headers: {'content-type': 'application/json'}
+        });
+
+        const result = await GraphqlService.query(QUERY, {}, {strict: false});
+
+        expect(result).toEqual({data, errors});
+    });
+
+    test('non-strict mode throws when GraphQL errors have no usable data (#10096)', async () => {
+        globalThis.fetch = async () => new Response(JSON.stringify({
+            data  : {repository: null},
+            errors: [{message: 'Could not resolve to a Repository'}]
+        }), {
+            status : 200,
+            headers: {'content-type': 'application/json'}
+        });
+
+        await expect(GraphqlService.query(QUERY, {}, {strict: false}))
+            .rejects.toThrow('GitHub API error: Could not resolve to a Repository');
+    });
+
+    test('legacy boolean option still enables the sub-issues header (#10096)', async () => {
+        let featureHeader;
+
+        globalThis.fetch = async (url, options) => {
+            featureHeader = options.headers['GraphQL-Features'];
+
+            return new Response(JSON.stringify({data: {ok: true}}), {
+                status : 200,
+                headers: {'content-type': 'application/json'}
+            });
+        };
+
+        const result = await GraphqlService.query(QUERY, {}, true);
+
+        expect(result).toEqual({ok: true});
+        expect(featureHeader).toBe('sub_issues');
     });
 });


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e8abc-27db-7bd1-8ed1-9c0dc64f70ac.

FAIR-band: over-target [22/30] — taking this lane despite over-target because this is operator-directed nightshift backlog reduction, resolves an unassigned concrete bug, opens no new ticket, and is covered by targeted plus folder-level unit evidence.

Resolves #10096

`GraphqlService.query()` now preserves GitHub GraphQL partial-data responses when callers explicitly opt into non-strict semantics. The default remains strict for back-compat, the legacy third-argument boolean still enables the sub-issues header, and non-strict mode still throws when `errors` arrive without any usable `data`.

Evidence: L1 (unit-test and static service-contract verification) → L1 required (service-level GraphQL error semantics). No residuals.

## Deltas from Ticket

The ticket's named downstream consumer, `detectStaleCommentsCounts`, no longer exists on current `dev`; `rg` found no live symbol to update. This PR implements the service-level contract and compatibility guard instead of patching a stale consumer reference.

## Test Evidence

- `node --check ai/services/github-workflow/GraphqlService.mjs` passed.
- `node --check test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs` passed: 9/9.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow` passed: 224/224.
- `git diff --check` passed.

## Post-Merge Validation

- [ ] Confirm #10096 is closed by the merge.

## Commits

- `f54ff1054` — `fix(ai): preserve GraphQL partial data in non-strict mode (#10096)`
