### PR TITLE
fix(github-workflow): skip sync metadata timestamp-only writes (#10267)

### DIFF
--- a/ai/services/github-workflow/sync/MetadataManager.mjs
+++ b/ai/services/github-workflow/sync/MetadataManager.mjs
@@ -32,6 +32,34 @@ class MetadataManager extends Base {
     }
 
     /**
+     * @summary Returns a clone of metadata without root-level telemetry timestamps.
+     * @param {object} metadata The pruned metadata object.
+     * @returns {object} The comparable metadata payload.
+     * @private
+     */
+    #withoutRootTelemetryTimestamps(metadata) {
+        const clone = structuredClone(metadata);
+
+        delete clone.lastSync;
+        delete clone.releasesLastFetched;
+
+        return clone;
+    }
+
+    /**
+     * @summary Detects when saving would only update root-level telemetry timestamps.
+     * @param {object} existingMetadata The currently persisted metadata.
+     * @param {object} nextMetadata The next pruned metadata payload.
+     * @returns {boolean}
+     * @private
+     */
+    #onlyRootTelemetryTimestampsChanged(existingMetadata, nextMetadata) {
+        return JSON.stringify(this.#withoutRootTelemetryTimestamps(existingMetadata)) ===
+            JSON.stringify(this.#withoutRootTelemetryTimestamps(nextMetadata)) &&
+            JSON.stringify(existingMetadata) !== JSON.stringify(nextMetadata);
+    }
+
+    /**
      * Loads the synchronization metadata file from disk.
      * If the file doesn't exist, it returns a default empty metadata object.
      * @returns {Promise<object>} The parsed metadata object.
@@ -139,6 +167,20 @@ class MetadataManager extends Base {
 
         const dir = path.dirname(issueSyncConfig.metadataFile);
         await fs.mkdir(dir, { recursive: true });
+
+        try {
+            const existingData     = await fs.readFile(issueSyncConfig.metadataFile, 'utf-8');
+            const existingMetadata = JSON.parse(existingData);
+
+            if (this.#onlyRootTelemetryTimestampsChanged(existingMetadata, prunedMetadata)) {
+                return;
+            }
+        } catch (error) {
+            if (error.code !== 'ENOENT' && !(error instanceof SyntaxError)) {
+                throw error;
+            }
+        }
+
         await fs.writeFile(issueSyncConfig.metadataFile, JSON.stringify(prunedMetadata, null, 2), 'utf-8');
     }
 }

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -58,7 +58,7 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
                     commentsTotal: 5,
                     extraFieldShouldBePruned: true
                 },
-                // Regression #11594 — object form (freshly fetched, post-API hydrate):
+                // Milestone metadata regression — object form (freshly fetched, post-API hydrate):
                 // closed issue with milestone object persists as string title.
                 '7910': {
                     state: 'CLOSED',
@@ -69,12 +69,11 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
                     commentsTotal: 1,
                     milestone: {title: '11.12.0'}
                 },
-                // Regression #11594 — string form (cached, carried forward from previous save):
+                // Milestone metadata regression — string form (cached, carried forward from previous save):
                 // `IssueSyncer.pullFromGitHub` seeds newMetadata.issues from existing serialized
                 // metadata, then only overwrites fetched issues. Unchanged cached entries arrive at
                 // save() with milestone already as a string. Naive `value.milestone?.title || null`
-                // would prune to `null` here (regression of regression — caught by @neo-gpt PR #11607
-                // Cycle 1). String form MUST pass through verbatim.
+                // would prune to `null` here. String form MUST pass through verbatim.
                 '7911': {
                     state: 'CLOSED',
                     path: 'issues/v11.13.0/issue-7911.md',
@@ -132,13 +131,13 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         // Open issue without milestone persists as null (defensive)
         expect(loaded.issues['123'].milestone).toBeNull();
 
-        // Regression #11594: closed issue with milestone object form persists as string title only.
+        // Milestone metadata regression: closed issue with object form persists as string title only.
         // Symmetric with IssueSyncer hydrate-from-disk path which wraps string back to {title: ...} object.
         expect(loaded.issues['7910'].milestone).toBe('11.12.0');
         expect(loaded.issues['7910'].state).toBe('CLOSED');
         expect(loaded.issues['7910'].path).toBe('issues/v11.12.0/issue-7910.md');
 
-        // Regression #11594 (PR #11607 Cycle 1): cached string-form milestone passes through verbatim.
+        // Milestone metadata regression: cached string-form milestone passes through verbatim.
         // Unchanged issues seeded from existing serialized metadata arrive as strings, not objects.
         // The prune MUST handle both shapes.
         expect(loaded.issues['7911'].milestone).toBe('11.13.0');
@@ -160,7 +159,7 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         expect(loaded.pulls['789'].extraFieldShouldBePruned).toBeUndefined();
         expect(loaded.pulls['789'].mergedAt).toBe('2026-05-13T00:00:00Z');
         expect(loaded.pulls['789'].milestone).toBe('v1.0.0');
-        // #11364: `archiveVersion` is retired — `save()` must prune it, never persist it.
+        // `archiveVersion` is retired — `save()` must prune it, never persist it.
         expect(loaded.pulls['789'].archiveVersion).toBeUndefined();
         expect(loaded.pulls['789'].contentHash).toBe('hash3');
 
@@ -168,5 +167,56 @@ test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
         expect(loaded.pulls['790'].mergedAt).toBeUndefined();
         expect(loaded.pulls['790'].milestone).toBeUndefined();
         expect(loaded.pulls['790'].contentHash).toBe('hash3_legacy');
+    });
+
+    test('save() skips timestamp-only metadata writes (#10267)', async () => {
+        const metadata = {
+            lastSync: '2026-04-23T22:00:00Z',
+            releasesLastFetched: '2026-04-23T22:00:00Z',
+            pushFailures: [],
+            issues: {
+                '10267': {
+                    state: 'OPEN',
+                    path: 'issues/10267.md',
+                    closedAt: null,
+                    updatedAt: '2026-04-23T22:03:18Z',
+                    contentHash: 'hash-10267',
+                    commentsTotal: 0
+                }
+            },
+            releases: {},
+            pulls: {},
+            discussions: {}
+        };
+
+        await MetadataManager.save(metadata);
+        const originalContent = await fs.readFile(testMetadataFile, 'utf-8');
+
+        await MetadataManager.save({
+            ...metadata,
+            lastSync: '2026-06-03T00:00:00Z',
+            releasesLastFetched: '2026-06-03T00:00:00Z'
+        });
+
+        expect(await fs.readFile(testMetadataFile, 'utf-8')).toBe(originalContent);
+
+        await MetadataManager.save({
+            ...metadata,
+            lastSync: '2026-06-03T00:00:00Z',
+            releasesLastFetched: '2026-06-03T00:00:00Z',
+            issues: {
+                ...metadata.issues,
+                '10267': {
+                    ...metadata.issues['10267'],
+                    contentHash: 'hash-10267-updated'
+                }
+            }
+        });
+
+        const loaded = await MetadataManager.load();
+
+        expect(loaded.lastSync).toBe('2026-06-03T00:00:00Z');
+        expect(loaded.releasesLastFetched).toBe('2026-06-03T00:00:00Z');
+        expect(loaded.issues['10267'].contentHash).toBe('hash-10267-updated');
     });
 });

--- a/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs
@@ -21,6 +21,8 @@ import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 
 test.describe('Neo.ai.services.github-workflow.sync.MetadataManager', () => {
+    test.describe.configure({mode: 'serial'});
+
     let MetadataManager;
     let aiConfig;
     let originalMetadataFile;


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019e8abc-27db-7bd1-8ed1-9c0dc64f70ac.
FAIR-band: over-target [21/30] - taking this lane despite over-target because the operator explicitly set nightshift backlog reduction as the active goal and #10267 was unassigned, concrete, and positive-ROI.

Resolves #10267

MetadataManager now treats root-level sync telemetry timestamps as non-content fields during persistence. If the pruned metadata payload is unchanged except for `lastSync` and `releasesLastFetched`, `save()` returns without rewriting `resources/content/.sync-metadata.json`; content-hash, path, state, release, PR, discussion, and `pushFailures` changes still write normally.

Evidence: L2 (unit persistence guard plus full github-workflow service slice) -> L3 required (real boot-sync no-content `git status` confirmation). Residual: post-merge boot-sync and next-PR diff observation [#10267].

## Deltas from ticket

Selected the ticket's Option A rather than splitting metadata into a new local file. The existing `SyncService` auto-push guard already covers metadata-only commits; this PR fixes the earlier write layer so no-op boot syncs stop surfacing the timestamp-only local diff in the first place.

Also removed stale ticket-number anchors from durable comments in the touched spec while preserving the behavioral regression descriptions, satisfying the ticket-archaeology pre-commit guard.

## Test Evidence

- `node --check ai/services/github-workflow/sync/MetadataManager.mjs`
- `node --check test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs`
- `node buildScripts/util/check-ticket-archaeology.mjs ai/services/github-workflow/sync/MetadataManager.mjs test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs` -> 0 violations
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/MetadataManager.spec.mjs` -> 2 passed
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs` -> 3 passed
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow` -> 221 passed
- `git diff --check`

## Post-Merge Validation

- [ ] Run boot sync with zero ticket/PR/discussion/release content changes; verify `git status --short resources/content` does not show `resources/content/.sync-metadata.json`.
- [ ] Confirm the next unrelated multi-file PR does not include `.sync-metadata.json` unless synced content genuinely changed.

## Commit

- `84fb2bf74` - `fix(github-workflow): skip sync metadata timestamp-only writes (#10267)`
