### PR TITLE
docs(agentos): update memory-mining freshness order (#10651)

### DIFF
--- a/.agents/skills/memory-mining/references/memory-mining-protocol.md
+++ b/.agents/skills/memory-mining/references/memory-mining-protocol.md
@@ -34,18 +34,10 @@ Do not issue one query with many keywords. Issue 2–4 queries with **different 
 
 Choose the first memory surface by freshness, not by habit.
 
-1. **Recent / active-session investigations:** run **`query_raw_memories` first or in parallel with `query_summaries`** when the event is same-day, just happened, active-ticket / active-PR bound, wake/A2A coordination, or otherwise likely to live in unsummarized turns. `add_memory()` can persist raw turns before any session summary exists, so summaries can be stale or empty for fresh incidents.
+1. **Recent / active-session investigations:** run **`query_raw_memories` first or in parallel with `query_summaries`** when the event is same-day, just happened, active-ticket / active-PR bound, wake/A2A coordination, or otherwise likely to live in unsummarized turns. `add_memory()` can persist raw turns before any session summary exists, so a summary miss is not a memory miss until a freshness-shaped raw query also misses.
 2. **Older / stable history:** run **`query_summaries` first** for broad conceptual exploration, older decisions, and low-freshness historical context. Session-level topics surface cheaply when summarization has had time to digest the work.
 3. **`query_raw_memories` after a summary hit:** use raw memories to recover turn-level reasoning, exact commands, message IDs, or decision texture behind a relevant summary.
 4. **`ask_knowledge_base`** — only when the answer lives in indexed code/guides, not in session memory. If unsure, run memory first; KB is cheaper to skip than memory is. This is the Memory Core analogue of the GitHub/KB freshness gap corrected in #10646.
-
-### Freshness examples
-
-| Situation | First query | Companion query |
-|---|---|---|
-| Same-day wake/A2A regression | `query_raw_memories("bridge restart wake regression osascript exit 1")` | `query_summaries("wake substrate bridge restart regression")` |
-| Active PR review churn | `query_raw_memories("PR 12399 force push review reclassification approval")` | `query_summaries("PR review exact head re-check")` |
-| Older architecture pattern | `query_summaries("skill vs rule enforcement reliability")` | `query_raw_memories("state-transition gate for reflexes")` after a relevant summary hit |
 
 ### Good vs bad query shapes
 
@@ -62,8 +54,6 @@ Short framings rank better in semantic search. Reserve keyword-dense queries for
 Stop when you have either:
 - **Hit** — a memory summary or raw entry whose framing clearly overlaps your current task. Read it; cite it; proceed informed.
 - **Clear miss** — 2–4 queries with different framings all return low-relevance or off-topic hits. Memory has nothing; proceed with the caveat explicitly stated in your plan.
-
-For recent / active-session investigations, a summary miss is **not** a memory miss. Do not conclude "memory has no prior mapping" until `query_raw_memories` also misses with at least one freshness-shaped query.
 
 Do not keep querying past a clear miss. The absence of prior context is itself a useful signal.
 

--- a/.agents/skills/memory-mining/references/memory-mining-protocol.md
+++ b/.agents/skills/memory-mining/references/memory-mining-protocol.md
@@ -30,11 +30,22 @@ If you are about to narrate the organism's state, the organism has probably alre
 
 Do not issue one query with many keywords. Issue 2–4 queries with **different semantic framings**, each shorter and sharper.
 
-### Tool order
+### Tool order by freshness
 
-1. **`query_summaries`** (breadth first) — session-level topics surface cheapest. Start here.
-2. **`query_raw_memories`** (depth second) — turn-level detail; use when a summary looked relevant but you need the reasoning trail.
-3. **`ask_knowledge_base`** — only when the answer lives in indexed code/guides, not in session memory. If unsure, run memory first; KB is cheaper to skip than memory is.
+Choose the first memory surface by freshness, not by habit.
+
+1. **Recent / active-session investigations:** run **`query_raw_memories` first or in parallel with `query_summaries`** when the event is same-day, just happened, active-ticket / active-PR bound, wake/A2A coordination, or otherwise likely to live in unsummarized turns. `add_memory()` can persist raw turns before any session summary exists, so summaries can be stale or empty for fresh incidents.
+2. **Older / stable history:** run **`query_summaries` first** for broad conceptual exploration, older decisions, and low-freshness historical context. Session-level topics surface cheaply when summarization has had time to digest the work.
+3. **`query_raw_memories` after a summary hit:** use raw memories to recover turn-level reasoning, exact commands, message IDs, or decision texture behind a relevant summary.
+4. **`ask_knowledge_base`** — only when the answer lives in indexed code/guides, not in session memory. If unsure, run memory first; KB is cheaper to skip than memory is. This is the Memory Core analogue of the GitHub/KB freshness gap corrected in #10646.
+
+### Freshness examples
+
+| Situation | First query | Companion query |
+|---|---|---|
+| Same-day wake/A2A regression | `query_raw_memories("bridge restart wake regression osascript exit 1")` | `query_summaries("wake substrate bridge restart regression")` |
+| Active PR review churn | `query_raw_memories("PR 12399 force push review reclassification approval")` | `query_summaries("PR review exact head re-check")` |
+| Older architecture pattern | `query_summaries("skill vs rule enforcement reliability")` | `query_raw_memories("state-transition gate for reflexes")` after a relevant summary hit |
 
 ### Good vs bad query shapes
 
@@ -51,6 +62,8 @@ Short framings rank better in semantic search. Reserve keyword-dense queries for
 Stop when you have either:
 - **Hit** — a memory summary or raw entry whose framing clearly overlaps your current task. Read it; cite it; proceed informed.
 - **Clear miss** — 2–4 queries with different framings all return low-relevance or off-topic hits. Memory has nothing; proceed with the caveat explicitly stated in your plan.
+
+For recent / active-session investigations, a summary miss is **not** a memory miss. Do not conclude "memory has no prior mapping" until `query_raw_memories` also misses with at least one freshness-shaped query.
 
 Do not keep querying past a clear miss. The absence of prior context is itself a useful signal.
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019e8abc-27db-7bd1-8ed1-9c0dc64f70ac.

FAIR-band: over-target [21/30] - taking this lane despite over-target because the active nightshift backlog goal is to retire valid open tickets, the lane passed intake, and the fix is a one-file positive-ROI substrate payload correction with no new-ticket expansion.

Resolves #10651

Updates the `memory-mining` query strategy so fresh, active-session investigations use raw memories first or in parallel with summaries, while retaining summary-first lookup for older stable history.

Evidence: L1 (static skill payload audit + manifest lint + targeted lint unit suite) -> L1 required (protocol-text ACs, no runtime surface). No residuals.

## Slot Rationale

Modified section: `.agents/skills/memory-mining/references/memory-mining-protocol.md` §2 Query strategy.

- Disposition delta: `rewrite` inside the payload atlas; router `SKILL.md` remains unchanged.
- 3-axis rating: trigger-frequency = memory-mining invocation only; failure-severity = high for fresh incident/regression context loss; enforceability = discipline-only, with manifest lint preventing skill-shape drift.
- Decay mitigation: no always-loaded substrate expansion. Retire or compress this guidance if Memory Core gains an executable freshness-aware query router that makes manual ordering obsolete.

## Deltas from ticket

- Kept `memory-mining/SKILL.md` untouched per Progressive Disclosure.
- Review-response trim removed the illustrative `Freshness examples` table so the payload carries the freshness rule without per-invocation example bloat.

## Test Evidence

- `git diff --check`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` - 25 passed
- Pre-push freshness: rebased onto current `origin/dev` before force-with-lease push; outgoing log contained only `d77fb3593 docs(agentos): update memory-mining freshness order (#10651)` and `23adf2506 docs(agentos): trim memory-mining examples (#10651)`.

## Post-Merge Validation

- [ ] Confirm #10651 auto-closes on merge.
- [ ] Confirm future memory-mining invocations still route through the lightweight `SKILL.md` into the payload without router bloat.

## Commit

- `d77fb3593` - `docs(agentos): update memory-mining freshness order (#10651)`
- `23adf2506` - `docs(agentos): trim memory-mining examples (#10651)`
