### PR TITLE
fix(ai): register local Chroma embedding functions (#12156)

### DIFF
--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -6,6 +6,7 @@ import path            from 'path';
 import {fileURLToPath, pathToFileURL} from 'url';
 import Neo             from '../../../src/Neo.mjs';
 import AiConfig        from '../../config.mjs';
+import {registerNeoChromaEmbeddingFunctions} from '../../services/shared/vector/chromaClientPrimitives.mjs';
 
 /**
  * @summary Defragments collection groups inside the unified ChromaDB store.
@@ -60,6 +61,8 @@ const __filename   = fileURLToPath(import.meta.url);
 const __dirname    = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 export const LOCAL_AI_CONFIG_FILE = path.join(PROJECT_ROOT, 'ai', 'config.mjs');
+
+registerNeoChromaEmbeddingFunctions();
 
 // Configuration Mapping
 // Maps CLI target names to their collection-group config files. Both targets resolve

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -62,7 +62,9 @@ const __dirname    = path.dirname(__filename);
 const PROJECT_ROOT = path.resolve(__dirname, '../../..');
 export const LOCAL_AI_CONFIG_FILE = path.join(PROJECT_ROOT, 'ai', 'config.mjs');
 
-registerNeoChromaEmbeddingFunctions();
+registerNeoChromaEmbeddingFunctions({
+    dummyEmbeddingFunction: AiConfig.dummyEmbeddingFunction
+});
 
 // Configuration Mapping
 // Maps CLI target names to their collection-group config files. Both targets resolve

--- a/ai/scripts/migrations/backfillChromaSharedUserId.mjs
+++ b/ai/scripts/migrations/backfillChromaSharedUserId.mjs
@@ -42,6 +42,10 @@
 
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {
+    createDynamicTextEmbeddingFunction,
+    registerNeoChromaEmbeddingFunctions
+} from '../../services/shared/vector/chromaClientPrimitives.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -66,6 +70,8 @@ const CORE_SWARM_USER_IDS = Object.freeze([
 const COLLECTION_MEMORY  = 'neo-agent-memory';
 const COLLECTION_SESSION = 'neo-agent-sessions';
 const BATCH_SIZE         = 500;
+
+registerNeoChromaEmbeddingFunctions();
 
 function parseArgs(argv) {
     const args = {
@@ -260,56 +266,43 @@ async function processCollection(client, collectionName, args) {
     const apply = args.apply;
     console.log(`\n[${collectionName}]`);
 
-    // Suppress noisy chromadb-js deserialization warnings; the dummy embedding-function
-    // package isn't installed locally but `.get`/`.update` don't need it (metadata-only).
-    const origWarn   = console.warn;
-    console.warn     = () => {};
-    const dummyEmbFn = {
-        generate    : async () => [],
-        name        : 'dynamic_text_embedding_service',
-        getConfig   : () => ({}),
-        constructor : {buildFromConfig: () => dummyEmbFn}
-    };
+    const embeddingFunction = createDynamicTextEmbeddingFunction();
 
-    try {
-        const collection = await client.getOrCreateCollection({
-            name             : collectionName,
-            embeddingFunction: dummyEmbFn
-        });
+    const collection = await client.getOrCreateCollection({
+        name             : collectionName,
+        embeddingFunction
+    });
 
-        const total = await collection.count();
-        console.log(`  total records: ${total}`);
+    const total = await collection.count();
+    console.log(`  total records: ${total}`);
 
-        const promoteCoreSwarmSummaries = collectionName === COLLECTION_SESSION;
-        const {tagRecords: recordsToTag, totalScanned, alreadyTagged, untagged, alreadyShared, coreSwarmParticipant} = await findRecordsToTag(collection, {
-            promoteCoreSwarmSummaries,
-            debugHidden: args.debugHidden
-        });
-        console.log(`  scanned:                  ${totalScanned}`);
-        console.log(`  already tagged:           ${alreadyTagged}`);
-        console.log(`  already shared:           ${alreadyShared}`);
-        console.log(`  untagged:                 ${untagged}`);
-        if (promoteCoreSwarmSummaries) {
-            console.log(`  core swarm participants:  ${coreSwarmParticipant}`);
-        }
-        console.log(`  to tag:                   ${recordsToTag.length}`);
-
-        if (recordsToTag.length === 0) {
-            console.log(`  → no work needed for this collection`);
-            return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged: 0, plannedTags: 0};
-        }
-
-        if (!apply) {
-            console.log(`  → DRY-RUN: would tag ${recordsToTag.length} records with userId='${SHARED_USER_ID}'`);
-            return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged: 0, plannedTags: recordsToTag.length};
-        }
-
-        console.log(`  → APPLY: tagging ${recordsToTag.length} records...`);
-        const tagged = await tagRecords(collection, recordsToTag);
-        return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged, plannedTags: recordsToTag.length};
-    } finally {
-        console.warn = origWarn;
+    const promoteCoreSwarmSummaries = collectionName === COLLECTION_SESSION;
+    const {tagRecords: recordsToTag, totalScanned, alreadyTagged, untagged, alreadyShared, coreSwarmParticipant} = await findRecordsToTag(collection, {
+        promoteCoreSwarmSummaries,
+        debugHidden: args.debugHidden
+    });
+    console.log(`  scanned:                  ${totalScanned}`);
+    console.log(`  already tagged:           ${alreadyTagged}`);
+    console.log(`  already shared:           ${alreadyShared}`);
+    console.log(`  untagged:                 ${untagged}`);
+    if (promoteCoreSwarmSummaries) {
+        console.log(`  core swarm participants:  ${coreSwarmParticipant}`);
     }
+    console.log(`  to tag:                   ${recordsToTag.length}`);
+
+    if (recordsToTag.length === 0) {
+        console.log(`  → no work needed for this collection`);
+        return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged: 0, plannedTags: 0};
+    }
+
+    if (!apply) {
+        console.log(`  → DRY-RUN: would tag ${recordsToTag.length} records with userId='${SHARED_USER_ID}'`);
+        return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged: 0, plannedTags: recordsToTag.length};
+    }
+
+    console.log(`  → APPLY: tagging ${recordsToTag.length} records...`);
+    const tagged = await tagRecords(collection, recordsToTag);
+    return {totalScanned, alreadyTagged, alreadyShared, untagged, coreSwarmParticipant, tagged, plannedTags: recordsToTag.length};
 }
 
 async function main() {

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -6,12 +6,17 @@ import DatabaseLifecycleService             from './DatabaseLifecycleService.mjs
 import {
     chromaConnect,
     chromaDeleteCollection,
-    createSilentExecutor
+    createSilentExecutor,
+    registerNeoChromaEmbeddingFunctions
 } from '../shared/vector/chromaClientPrimitives.mjs';
 
 const COLLECTION_ALREADY_EXISTS_RE = /already exists|already contains|conflict/i;
 const COLLECTION_NOT_FOUND_RE      = /does not exist|not found|not be found|could not be found|404/i;
 const SWAP_ACTIVE_PHASES           = ['parking', 'shadow'];
+
+registerNeoChromaEmbeddingFunctions({
+    dummyEmbeddingFunction: aiConfig.dummyEmbeddingFunction
+});
 
 /**
  * @summary Simple manager around the Chroma client that lazily caches the knowledge-base collection.
@@ -72,7 +77,7 @@ class ChromaManager extends Base {
     }
 
     /**
-     * Establishes connection to ChromaDB via the shared `chromaConnect` primitive (#11111).
+     * Establishes connection to ChromaDB via the shared `chromaConnect` primitive.
      * @returns {Promise<boolean>} True if connected, false otherwise
      */
     async connect() {
@@ -95,7 +100,7 @@ class ChromaManager extends Base {
     }
 
     /**
-     * Per-instance silent-execution function from the shared primitive (#11111).
+     * Per-instance silent-execution function from the shared primitive.
      * Each consumer gets its own isolated sequential lock. KB uses blanket suppression
      * (no `filter` passed at call sites); MC's per-message filter is unaffected.
      * @member {Function} #executeSilently
@@ -257,7 +262,7 @@ class ChromaManager extends Base {
 
     /**
      * Guarded delete-collection wrapper. Delegates to the shared `chromaDeleteCollection`
-     * primitive (#11111) which routes through `assertCanonicalCollectionDeleteAllowed` with
+     * primitive which routes through `assertCanonicalCollectionDeleteAllowed` with
      * `subsystem: 'knowledge-base'`. Refuses canonical production collection names unless
      * `UNIT_TEST_MODE=true` or a valid production `confirmation` token is supplied.
      *

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -6,7 +6,9 @@ import ChromaLifecycleService               from '../lifecycle/ChromaLifecycleSe
 import {
     chromaConnect,
     chromaDeleteCollection,
-    createSilentExecutor
+    createDynamicTextEmbeddingFunction,
+    createSilentExecutor,
+    registerNeoChromaEmbeddingFunctions
 } from '../../shared/vector/chromaClientPrimitives.mjs';
 import {CHROMA_PRODUCTION_DATABASE, ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
 
@@ -21,6 +23,10 @@ const MC_WARN_FILTER = msg =>
     msg.includes('Could not deserialize the collection metadata') ||
     msg.includes('dummy_embedding_function') ||
     msg.includes('dynamic_text_embedding_service');
+
+registerNeoChromaEmbeddingFunctions({
+    dummyEmbeddingFunction: aiConfig.dummyEmbeddingFunction
+});
 
 /**
  * @summary Simple manager around the Chroma client that lazily caches frequently used collections.
@@ -186,20 +192,9 @@ class ChromaManager extends AbstractVectorManager {
      * @returns {Object} A locally valid implementation of IEmbeddingFunction
      */
     #createEmbeddingFunction() {
-        return {
-            generate   : async (texts) => {
-                // Pass arrays of texts sequentially or via promise.all to TextEmbeddingService
-                const {default: TextEmbeddingService} = await import('../TextEmbeddingService.mjs');
-                const provider                        = aiConfig.embeddingProvider;
-                const vectors                         = await Promise.all(texts.map(text => TextEmbeddingService.embedText(text, provider)));
-                return vectors;
-            },
-            name       : 'dynamic_text_embedding_service',
-            getConfig  : () => ({}),
-            constructor: {
-                buildFromConfig: () => this.#createEmbeddingFunction()
-            }
-        };
+        return createDynamicTextEmbeddingFunction({
+            providerResolver: () => aiConfig.embeddingProvider
+        })
     }
 
     /**

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -1,15 +1,121 @@
+import {knownEmbeddingFunctions, registerEmbeddingFunction} from 'chromadb';
 import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
 
 /**
+ * @summary Local Chroma embedding placeholder for collections that always provide raw vectors.
+ *
+ * Chroma 3.x serializes embedding functions as named "known" configs and later
+ * resolves them through its process-local registry while hydrating collection
+ * schemas. The Neo dummy function is intentionally not an npm package, so it must
+ * be registered locally before defrag / list / get-collection paths touch schema
+ * deserialization.
+ */
+class NeoDummyEmbeddingFunction {
+    /**
+     * @returns {String}
+     */
+    get name() {
+        return 'dummy_embedding_function'
+    }
+
+    /**
+     * @returns {Object}
+     */
+    getConfig() {
+        return {}
+    }
+
+    /**
+     * @returns {Promise<null>}
+     */
+    async generate() {
+        return null
+    }
+
+    /**
+     * @returns {NeoDummyEmbeddingFunction}
+     */
+    static buildFromConfig() {
+        return new NeoDummyEmbeddingFunction()
+    }
+}
+
+/**
+ * @summary Registry-backed wrapper for Memory Core's dynamic text embedding service.
+ *
+ * Existing Memory Core collections serialize this name into their Chroma schema.
+ * Registering it keeps SDK schema hydration on the local implementation path
+ * instead of falling through to `@chroma-core/dynamic_text_embedding_service`.
+ */
+class NeoDynamicTextEmbeddingService {
+    /**
+     * @returns {String}
+     */
+    get name() {
+        return 'dynamic_text_embedding_service'
+    }
+
+    /**
+     * @returns {Object}
+     */
+    getConfig() {
+        return {}
+    }
+
+    /**
+     * @param {String[]} texts
+     * @returns {Promise<Number[][]>}
+     */
+    async generate(texts) {
+        const {default: TextEmbeddingService} = await import('../../memory-core/TextEmbeddingService.mjs');
+        const {default: aiConfig}             = await import('../../../mcp/server/memory-core/config.mjs');
+        const provider                        = aiConfig.embeddingProvider;
+
+        return Promise.all(texts.map(text => TextEmbeddingService.embedText(text, provider)))
+    }
+
+    /**
+     * @returns {NeoDynamicTextEmbeddingService}
+     */
+    static buildFromConfig() {
+        return new NeoDynamicTextEmbeddingService()
+    }
+}
+
+/**
+ * @summary Registers Neo-local Chroma embedding functions for SDK schema hydration.
+ *
+ * @returns {String[]} Names registered during this call.
+ */
+export function registerNeoChromaEmbeddingFunctions() {
+    const registered = [];
+    const entries    = [
+        ['dummy_embedding_function', NeoDummyEmbeddingFunction],
+        ['dynamic_text_embedding_service', NeoDynamicTextEmbeddingService]
+    ];
+
+    for (const [name, EmbeddingFunction] of entries) {
+        if (!knownEmbeddingFunctions.has(name)) {
+            registerEmbeddingFunction(name, EmbeddingFunction);
+            registered.push(name);
+        }
+    }
+
+    return registered
+}
+
+registerNeoChromaEmbeddingFunctions();
+
+/**
  * @summary Stateless helpers for the Chroma-client connection lifecycle, shared between the
- * Knowledge Base ChromaManager and Memory Core ChromaManager (#11111).
+ * Knowledge Base ChromaManager and Memory Core ChromaManager.
  *
  * Each per-subsystem ChromaManager remains the owner of its `this.client` (the chromadb
  * library's `ChromaClient` instance) so tests that mock-replace `ChromaManager.client =
  * fakeClient` continue to work without modification. This module exports plain functions
  * that read the client at call-time from the caller's argument list.
  *
- * **What this module owns (the dedup-eligible shared layer per #11111):**
+ * **What this module owns (the dedup-eligible shared layer):**
  *
  * 1. **`chromaConnect({client, logger})`** — heartbeat-based readiness check. Returns a
  *    boolean (true on success, false on failure). Non-throwing — the caller decides how to
@@ -20,14 +126,14 @@ import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared
  *    once (typically as a private field) so its `executeSilently` calls don't race each
  *    other's `console.warn` restore. Two filter shapes accepted:
  *      - `{filter: null}` (default) — blanket suppression of all `console.warn` for the
- *        duration of `fn`. Matches pre-#11111 KB behavior.
+ *        duration of `fn`. Matches the previous KB behavior.
  *      - `{filter: (msg) => boolean}` — predicate suppression; only messages whose joined-args
- *        string returns true are suppressed. Matches pre-#11111 MC behavior which filters
+ *        string returns true are suppressed. Matches the previous MC behavior which filters
  *        for four specific Chroma library warnings.
  *
  * 3. **`chromaDeleteCollection({client, name, subsystem, confirmation})`** — guarded delete
  *    wrapper. Routes through `assertCanonicalCollectionDeleteAllowed` with subsystem-scoped
- *    canonical-name refusal. The substrate-level invariant (#11652) fires regardless of
+ *    canonical-name refusal. The substrate-level invariant fires regardless of
  *    harness or config state.
  *
  * **What this module does NOT own (per V-B-A on the ticket's prescription):**
@@ -63,7 +169,7 @@ import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared
  * plain module for stateless utility" idiom, and produce a smaller, easier-to-review diff.
  *
  * @module ai/services/shared/vector/chromaClientPrimitives
- * @see #11111
+ * @see chromaConnect
  */
 
 /**

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -1,5 +1,6 @@
 import {knownEmbeddingFunctions, registerEmbeddingFunction} from 'chromadb';
-import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
+
+export const CHROMA_DYNAMIC_TEXT_EMBEDDING_FUNCTION_NAME = 'dynamic_text_embedding_service';
 
 /**
  * @summary Local Chroma embedding placeholder for collections that always provide raw vectors.
@@ -11,88 +12,97 @@ import {assertCanonicalCollectionDeleteAllowed} from '../../../mcp/server/shared
  * deserialization.
  */
 class NeoDummyEmbeddingFunction {
+    static embeddingFunction = null;
+
     /**
-     * @returns {String}
+     * @param {Object} embeddingFunction
+     * @returns {void}
      */
-    get name() {
-        return 'dummy_embedding_function'
+    static configure(embeddingFunction) {
+        assertEmbeddingFunction(embeddingFunction, 'dummyEmbeddingFunction');
+        this.embeddingFunction = embeddingFunction;
     }
 
     /**
      * @returns {Object}
      */
-    getConfig() {
-        return {}
-    }
-
-    /**
-     * @returns {Promise<null>}
-     */
-    async generate() {
-        return null
-    }
-
-    /**
-     * @returns {NeoDummyEmbeddingFunction}
-     */
     static buildFromConfig() {
-        return new NeoDummyEmbeddingFunction()
+        return this.embeddingFunction
     }
+}
+
+/**
+ * @summary Creates the canonical Memory Core dynamic text embedding function wrapper.
+ *
+ * Existing Memory Core collections serialize this name into their Chroma schema. The
+ * returned object satisfies Chroma's `IEmbeddingFunction` duck-type for both live
+ * collection creation and registry `buildFromConfig()` hydration.
+ *
+ * @param {Object} [options]
+ * @param {Function} [options.providerResolver] Returns the active embedding provider.
+ * @returns {Object}
+ */
+export function createDynamicTextEmbeddingFunction({providerResolver = null} = {}) {
+    const embeddingFunction = {
+        generate: async (texts) => {
+            const {default: TextEmbeddingService} = await import('../../memory-core/TextEmbeddingService.mjs');
+            const {default: aiConfig}             = await import('../../../mcp/server/memory-core/config.mjs');
+            const provider                        = providerResolver?.() ?? aiConfig.embeddingProvider;
+
+            return Promise.all(texts.map(text => TextEmbeddingService.embedText(text, provider)))
+        },
+        name       : CHROMA_DYNAMIC_TEXT_EMBEDDING_FUNCTION_NAME,
+        getConfig  : () => ({}),
+        constructor: {
+            buildFromConfig: () => createDynamicTextEmbeddingFunction({providerResolver})
+        }
+    };
+
+    return embeddingFunction
 }
 
 /**
  * @summary Registry-backed wrapper for Memory Core's dynamic text embedding service.
  *
- * Existing Memory Core collections serialize this name into their Chroma schema.
  * Registering it keeps SDK schema hydration on the local implementation path
  * instead of falling through to `@chroma-core/dynamic_text_embedding_service`.
  */
 class NeoDynamicTextEmbeddingService {
     /**
-     * @returns {String}
-     */
-    get name() {
-        return 'dynamic_text_embedding_service'
-    }
-
-    /**
      * @returns {Object}
      */
-    getConfig() {
-        return {}
-    }
-
-    /**
-     * @param {String[]} texts
-     * @returns {Promise<Number[][]>}
-     */
-    async generate(texts) {
-        const {default: TextEmbeddingService} = await import('../../memory-core/TextEmbeddingService.mjs');
-        const {default: aiConfig}             = await import('../../../mcp/server/memory-core/config.mjs');
-        const provider                        = aiConfig.embeddingProvider;
-
-        return Promise.all(texts.map(text => TextEmbeddingService.embedText(text, provider)))
-    }
-
-    /**
-     * @returns {NeoDynamicTextEmbeddingService}
-     */
     static buildFromConfig() {
-        return new NeoDynamicTextEmbeddingService()
+        return createDynamicTextEmbeddingFunction()
     }
 }
 
 /**
  * @summary Registers Neo-local Chroma embedding functions for SDK schema hydration.
  *
+ * The dummy embedding function remains owned by the Tier-1 `AiConfig.dummyEmbeddingFunction`
+ * leaf. Callers that already own a config object pass that leaf in, keeping this registry
+ * free of local `ai/config.mjs` overlay coupling while still hydrating Chroma's process registry.
+ *
+ * @param {Object} [options]
+ * @param {Object|null} [options.dummyEmbeddingFunction=null] Tier-1 dummy EF leaf.
+ * @param {Boolean} [options.includeDynamicTextEmbedding=true] Register the Memory Core dynamic EF.
  * @returns {String[]} Names registered during this call.
  */
-export function registerNeoChromaEmbeddingFunctions() {
+export function registerNeoChromaEmbeddingFunctions({
+    dummyEmbeddingFunction      = null,
+    includeDynamicTextEmbedding = true
+} = {}) {
     const registered = [];
-    const entries    = [
-        ['dummy_embedding_function', NeoDummyEmbeddingFunction],
-        ['dynamic_text_embedding_service', NeoDynamicTextEmbeddingService]
-    ];
+    const entries    = [];
+
+    if (dummyEmbeddingFunction) {
+        NeoDummyEmbeddingFunction.configure(dummyEmbeddingFunction);
+        entries.push([dummyEmbeddingFunction.name, NeoDummyEmbeddingFunction]);
+    }
+
+    if (includeDynamicTextEmbedding) {
+        entries.push([CHROMA_DYNAMIC_TEXT_EMBEDDING_FUNCTION_NAME, NeoDynamicTextEmbeddingService]);
+    }
 
     for (const [name, EmbeddingFunction] of entries) {
         if (!knownEmbeddingFunctions.has(name)) {
@@ -104,7 +114,22 @@ export function registerNeoChromaEmbeddingFunctions() {
     return registered
 }
 
-registerNeoChromaEmbeddingFunctions();
+/**
+ * @param {Object} embeddingFunction
+ * @param {String} label
+ * @returns {void}
+ * @throws {TypeError} When the value is not a Chroma embedding-function duck-type.
+ */
+function assertEmbeddingFunction(embeddingFunction, label) {
+    if (
+        !embeddingFunction ||
+        typeof embeddingFunction.name !== 'string' ||
+        typeof embeddingFunction.getConfig !== 'function' ||
+        typeof embeddingFunction.generate !== 'function'
+    ) {
+        throw new TypeError(`[ChromaClientPrimitives] ${label} must provide name, getConfig(), and generate().`)
+    }
+}
 
 /**
  * @summary Stateless helpers for the Chroma-client connection lifecycle, shared between the
@@ -143,9 +168,8 @@ registerNeoChromaEmbeddingFunctions();
  *   `Neo.ai.services.knowledge-base.ChromaManager#resolveKnowledgeBaseCollection`) and MC
  *   (plain `getOrCreateCollection` for three named collections). Sharing would either flatten
  *   KB's swap safety or balloon the primitive with KB-specific phase awareness MC doesn't need.
- * - `ensureDummyEmbedding` — KB uses `aiConfig.dummyEmbeddingFunction` (static); MC instantiates
- *   a `TextEmbeddingService`-backed dynamic function per-call. Neither is shareable at the
- *   client-wrapper layer.
+ * - `ensureDummyEmbedding` — the dummy EF remains the Tier-1 `AiConfig.dummyEmbeddingFunction`
+ *   leaf. This module only registers that leaf with Chroma when a config owner passes it in.
  * - `disconnect()` — neither consumer currently has a disconnect path; the chromadb client is
  *   GC-managed. Speculative substrate per `feedback_truth_in_code`.
  *
@@ -262,6 +286,8 @@ export function createSilentExecutor() {
  * @see https://github.com/neomjs/neo/issues/11652
  */
 export async function chromaDeleteCollection({client, name, subsystem, confirmation} = {}) {
+    const {assertCanonicalCollectionDeleteAllowed} = await import('../../../mcp/server/shared/services/DestructiveOperationGuard.mjs');
+
     assertCanonicalCollectionDeleteAllowed({name, subsystem, confirmation});
     return await client.deleteCollection({name})
 }

--- a/test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs
@@ -153,6 +153,20 @@ test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556, #
         expect(scriptUserIds).toEqual(CORE_SWARM_USER_IDS);
     });
 
+    test('migration runner uses the lightweight Chroma registry instead of suppressing schema warnings', async () => {
+        const fs   = await import('fs');
+        const path = await import('path');
+
+        const repoRoot   = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../../../../../..');
+        const scriptPath = path.join(repoRoot, 'ai/scripts/migrations/backfillChromaSharedUserId.mjs');
+        const source     = fs.readFileSync(scriptPath, 'utf-8');
+
+        expect(source).toContain('createDynamicTextEmbeddingFunction');
+        expect(source).toContain('registerNeoChromaEmbeddingFunctions');
+        expect(source).not.toContain('console.warn = () => {}');
+        expect(source).not.toContain('origWarn');
+    });
+
     test('CORE_SWARM_AGENT_IDS mirrors user ids in AgentIdentity form', () => {
         expect(CORE_SWARM_AGENT_IDS).toEqual(CORE_SWARM_USER_IDS.map(userId => `@${userId}`));
     });
@@ -197,7 +211,7 @@ test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556, #
     });
 
     test('canonical-form invariant — both prefix forms collapse to the same value', () => {
-        // The load-bearing assertion for #10556: any code path that ever produces both forms
+        // The load-bearing assertion: any code path that ever produces both forms
         // must converge on a single canonical comparison value at boundary time. Without this
         // invariant, a write tagging `userId: 'x'` would be invisible to a read filtering
         // `userId: '@x'` — the silent-self-filter trap.

--- a/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
@@ -164,6 +164,7 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
     });
 
     test('registers Neo Chroma embedding functions before defrag collection hydration', async () => {
+        const {default: AiConfig} = await import('../../../../../../ai/config.mjs');
         const warnings     = [];
         const originalWarn = console.warn;
 
@@ -185,6 +186,7 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
             });
 
             expect(dummy?.name).toBe('dummy_embedding_function');
+            expect(dummy).toBe(AiConfig.dummyEmbeddingFunction);
             expect(dynamic?.name).toBe('dynamic_text_embedding_service');
             expect(warnings).toEqual([]);
         } finally {

--- a/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs
@@ -21,6 +21,7 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import {execSync}     from 'child_process';
 import fs             from 'fs-extra';
 import path           from 'path';
+import {getEmbeddingFunction, knownEmbeddingFunctions} from 'chromadb';
 
 /**
  * Verifies the unified-store-safe physical orphan cleanup in
@@ -160,6 +161,35 @@ test.describe('defragChromaDB segment cleanup — unified-store-safe keep-set (#
             'neo-agent-sessions',
             'neo-native-graph'
         ]);
+    });
+
+    test('registers Neo Chroma embedding functions before defrag collection hydration', async () => {
+        const warnings     = [];
+        const originalWarn = console.warn;
+
+        console.warn = (...args) => warnings.push(args.join(' '));
+
+        try {
+            expect(knownEmbeddingFunctions.has('dummy_embedding_function')).toBe(true);
+            expect(knownEmbeddingFunctions.has('dynamic_text_embedding_service')).toBe(true);
+
+            const dummy = await getEmbeddingFunction({
+                collectionName: 'schema deserialization',
+                client        : {},
+                efConfig      : {type: 'known', name: 'dummy_embedding_function', config: {}}
+            });
+            const dynamic = await getEmbeddingFunction({
+                collectionName: 'schema deserialization',
+                client        : {},
+                efConfig      : {type: 'known', name: 'dynamic_text_embedding_service', config: {}}
+            });
+
+            expect(dummy?.name).toBe('dummy_embedding_function');
+            expect(dynamic?.name).toBe('dynamic_text_embedding_service');
+            expect(warnings).toEqual([]);
+        } finally {
+            console.warn = originalWarn;
+        }
     });
 
     test('skips UUID-named entries that are files, not directories', async () => {


### PR DESCRIPTION
Resolves #12156

Authored by GPT-5 (Codex Desktop). Session 79e8a897-794c-4ffd-bfb1-3408093d0e33.

FAIR-band: over-target [21/30] — taking this lane despite over-target because this was an operator-triggered incident-response repair for live Chroma / Knowledge Base defrag breakage.

Registers Neo-local Chroma embedding functions in the SDK process registry so Chroma 3.x schema hydration resolves Neo-owned embedding functions locally instead of falling through to nonexistent `@chroma-core/*` packages. The registry now keeps `dummy_embedding_function` anchored to the Tier-1 `AiConfig.dummyEmbeddingFunction` leaf, centralizes the Memory Core `dynamic_text_embedding_service` wrapper in the shared Chroma primitive, and uses explicit entry-point registration for defrag, KB, MC, and the metadata-only migration path.

Evidence: L2 (focused unit coverage + direct Chroma SDK hydration probes; destructive live defrag not run) → L4 required (operator-run live `npm run ai:defrag-kb`). Residual: post-merge operator retry of the live defrag path [#12156].

## Deltas from ticket

The core unified-store target mapping was already present on `dev`; the live incident exposed a remaining Chroma 3.x registry gap in the same operator defrag path. This PR closes that hydration gap, removes stale ticket refs from durable comments in touched shared primitives so the pre-commit archaeology hook can pass, and addresses review cycle 2 by consolidating duplicate embedding-function definitions instead of introducing a parallel registry-only copy.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/defrag-segment-cleanup.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/services/memory-core/managers/ChromaManager.canonicalGuard.spec.mjs` — 48 passed at rebased head `94df5bcd9`.
- Direct SDK probe after defrag import: `{"hasDummy":true,"hasDynamic":true,"dummyIsConfig":true,"dynamicName":"dynamic_text_embedding_service","warnings":[]}`.
- `node ai/scripts/migrations/backfillChromaSharedUserId.mjs --help` — passed; validates the standalone migration can load the lightweight registry path without touching Chroma.
- `git diff --check origin/dev..HEAD` — passed after rebase on `origin/dev@54296bb6f`.
- Pre-commit hook — passed (`check-whitespace`, `check-shorthand`, `check-ticket-archaeology`).

Not counted as failure evidence for this PR: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs` still fails in this checkout because the ignored local `ai/config.mjs` overlay is stale and lacks `engines.chroma.database`; the tracked template has that leaf. The observed failures are the existing local-overlay assertions expecting `neo-unit-test` but receiving `undefined` from the ignored overlay.

## Post-Merge Validation

- [ ] Restart the affected KB/ProcessSupervisor process so it loads the registry patch.
- [ ] Re-run `npm run ai:defrag-kb` on the operator store and confirm no `@chroma-core/dummy_embedding_function` stderr.

## Commits

- `73cf8e6a7` — register local Chroma embedding functions for schema hydration.
- `94df5bcd9` — consolidate Chroma embedding registry definitions.
