### PR TITLE
docs(agentos): define wake presence policy (#10517)

### DIFF
--- a/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md
+++ b/learn/agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md
@@ -285,6 +285,131 @@ declared capabilities. Per-identity capability detection happens at boot:
 Shape A/B can coexist: an agent can declare both, in which case MCP
 notifications are preferred (lower latency, no HTTP overhead).
 
+### 5.2 Presence and wake-policy layer
+
+Shape D selects a delivery channel. It does not, by itself, decide whether a
+wake should interrupt an active harness turn, wait for the next turn, or remain
+stored-only. That decision needs a small overlay that keeps receiver state and
+delivery intent separate from transport capability and message priority.
+
+#### 5.2.1 `HarnessPresence`
+
+`HarnessPresence` describes the receiving harness state independently from the
+wake event's semantic importance. It is a routing input, not a new transport.
+
+Baseline state vocabulary:
+
+| State | Meaning | Routing implication |
+|---|---|---|
+| `unknown` | No trustworthy presence signal exists for this harness/session. | Default to non-interrupting delivery; store unread and rely on next-turn mailbox checks unless a native channel can prove safe handling. |
+| `idle` | The harness can accept a new turn without clobbering active work or user input. | `wakePolicy: 'immediate'` may start a turn through the harness-native control plane when available. |
+| `active` | A model turn is in progress. | `wakePolicy: 'immediate'` may steer the active turn only if the harness exposes a native active-turn API and the caller can provide the active turn id. |
+| `waitingOnApproval` | The active turn is blocked on an approval / user decision. | Treat as active; never overwrite the approval prompt. Native steering may be safe only when it appends context without changing the approval surface. |
+| `userTyping` | The operator has unsent input in the harness. | Do not inject. Preserve the input and route through `next_turn` / stored unread delivery. |
+
+Suggested metadata:
+
+```ts
+type HarnessPresence = {
+  state        : 'unknown' | 'idle' | 'active' | 'waitingOnApproval' | 'userTyping',
+  activeTurnId?: string,
+  capabilities?: string[],
+  lastSeenAt  : string,
+  source      : 'codex-app-server' | 'mcp-client' | 'a2a-webhook' | 'bridge-daemon' | 'os-ui-probe' | 'unknown'
+}
+```
+
+Codex app-server is the current native-control-plane example: it exposes thread
+runtime status (`notLoaded`, `idle`, `systemError`, or `active` with
+`activeFlags`) via thread reads and `thread/status/changed`, and it exposes
+`turn/start` for idle threads plus `turn/steer` for active turns with an
+`expectedTurnId` guard. That lets Codex routes prove presence through a native
+API rather than inferring it from UI widgets.
+
+For harnesses without a native presence API, `unknown` is the safe default. A
+bridge daemon may eventually infer coarse presence from UI state, but that is a
+fallback adapter, not the architecture.
+
+#### 5.2.2 `wakePolicy`
+
+`wakePolicy` describes delivery behavior independently from semantic `priority`
+and `harnessTarget`.
+
+| Policy | Behavior | Notes |
+|---|---|---|
+| `silent` | Store only; do not emit a wake. | Useful for mailbox-only handovers and sunset notes that must not interrupt current work. |
+| `next_turn` | Store unread; the recipient picks it up during the mandatory turn-start mailbox check. | Safe default for normal coordination, unknown presence, and unsafe immediate delivery. |
+| `immediate` | Attempt live delivery through the safest available channel for the current `HarnessPresence`. | Requires capability and no-clobber proof; does not imply `priority: high` and is not implied by it. |
+
+`priority` remains the semantic importance signal (`high | normal | low`).
+`wakePolicy` is the delivery contract. A high-priority message may still be
+`next_turn` when interrupting would corrupt active work, and a short guardrail
+message may be `immediate` even when its semantic priority is not high. Reviewers
+MUST reject PRs that collapse these fields.
+
+#### 5.2.3 Routing examples
+
+The routing order remains Shape D, now filtered through presence and policy:
+
+1. `wakePolicy: 'silent'`
+   - Persist the message / task transition only.
+   - Do not enqueue MCP, A2A, bridge, or heartbeat wake delivery.
+
+2. `wakePolicy: 'next_turn'`
+   - Persist unread state.
+   - The recipient's turn-start mailbox check is the delivery point.
+   - No native push is required, even if the subscription is push-capable.
+
+3. `wakePolicy: 'immediate'` + Codex native control plane
+   - `HarnessPresence.state === 'active'` and `activeTurnId` known:
+     use Codex app-server `turn/steer` with `expectedTurnId`.
+   - `HarnessPresence.state === 'idle'` on a loaded thread:
+     use Codex app-server `turn/start`.
+   - `notLoaded` / no current thread:
+     load or start the thread via the app-server thread APIs only when the
+     calling workflow has explicit authority to create that turn; otherwise
+     degrade to `next_turn`.
+
+4. `wakePolicy: 'immediate'` + standards push
+   - Use Shape A (`harnessTarget: 'mcp-notifications'`) when the MCP client
+     negotiated wake notification support.
+   - Else use Shape B (`harnessTarget: 'a2a-webhook'`) when the harness
+     registered a webhook endpoint.
+   - The receiver still applies local presence rules before mutating an active
+     prompt surface.
+
+5. `wakePolicy: 'immediate'` + bridge fallback
+   - Use Shape C (`harnessTarget: 'bridge-daemon'`) only after native / standards
+     routes are unavailable or insufficient.
+   - If the bridge cannot prove the harness is idle or safely append-only,
+     degrade to `next_turn`.
+
+6. `harnessTarget: 'disabled' | 'none'` or degraded delivery
+   - Persist unread state and rely on mailbox checks / heartbeat fallback.
+   - Do not treat failed push as permission to clobber a local UI surface.
+
+#### 5.2.4 OS-level presence probes are last resort
+
+OS UI polling can be useful empirically, but it is brittle: button labels such
+as `Send`, `Stop`, or `Cancel` are vendor UI details, not protocol state. They
+can drift without an API version, can race with user typing, and may require
+focus changes that conflict with the AppleScript focus-safety work owned by
+#10422.
+
+If a bridge fallback implements button-state probing, the initial polling
+interval MUST be conservative: 5 seconds, with focus checks, timeout limits,
+and a hard no-clobber guard for active user input. Failure to read UI state
+safely means `HarnessPresence.state = 'unknown'` and the route degrades to
+`next_turn`.
+
+Scope boundaries:
+
+- This section does not implement the polling adapter.
+- This section does not change wake subscription persistence, GC, or integrity
+  semantics owned by #10515.
+- This section does not solve AppleScript focus-steal mechanics from #10422; it
+  only states the routing constraint those mechanics must satisfy.
+
 ---
 
 ## 6. Concrete Specifications


### PR DESCRIPTION
Resolves #10517

Authored by GPT-5 (Codex Desktop). Session 019e8abc-27db-7bd1-8ed1-9c0dc64f70ac.

FAIR-band: over-target [20/30] — taking this lane despite over-target because this is a docs-only repair of a GPT-authored Contract Ledger blocker on an active Project 12 wake-routing ticket, and the resulting PR unblocks Claude-family review/implementation without touching runtime code.

Decision Record impact: amends ADR 0002 in place; aligned with ADR 0002 Shape D rather than superseding it.

Adds ADR 0002 §5.2, defining the missing presence/policy layer for Shape D wake routing:

- `HarnessPresence` describes receiver state separately from priority and transport.
- `wakePolicy` describes `silent`, `next_turn`, and `immediate` delivery behavior separately from semantic `priority`.
- Routing examples now cover Codex app-server `turn/start` / `turn/steer`, MCP/A2A standards push, bridge fallback, and `disabled` / `none` degradation.
- OS-level button-state polling is explicitly last-resort only, with the 5s conservative interval and #10422 / #10515 scope boundaries preserved.

Evidence: L1 (static ADR/source-anchor audit + repo guards) → L1 required (docs-only #10517 ACs; no runtime adapter implemented). No residuals.

## Source-of-Authority / Contract Ledger Audit

- #10517 body now carries the required Contract Ledger before branch work.
- Source sweep found existing `harnessTarget` routing in `WakeSubscriptionService`, `CoalescingEngineService`, and bridge/orchestrator wake paths, but no pre-existing `HarnessPresence` / `wakePolicy` substrate terms.
- Official source anchors checked: Codex app-server status/turn APIs, Codex MCP docs, MCP Streamable HTTP transport, and A2A async push notifications.
- Successor-risk check: #10525 explicitly left HarnessPresence/wakePolicy out of scope; #10601 references #10517 as the prerequisite conceptual layer rather than replacing it.

## Substrate Slot Rationale

Added ADR 0002 §5.2 `Presence and wake-policy layer`.

- Disposition: `keep` in ADR 0002 as decision-record payload, not always-loaded agent instruction.
- 3-axis rating: trigger-frequency medium (wake-routing design/review only) × failure-severity high (wrong interrupt semantics can clobber active harness turns) × enforceability medium (reviewable through PR body/ADR contract; runtime enforcement remains future work).
- Decay mitigation: if a future runtime `wakePolicy` API lands with executable schema/tests, this section should be amended to reference that schema rather than duplicating enum details. It should not be moved into always-loaded agent instructions unless per-turn wake-routing failures become routine again.

## Deltas from ticket

- No runtime implementation was added.
- The Contract Ledger was added to #10517 first, then the ADR implementation followed that repaired contract.
- `userTyping` is documented without a question mark so the vocabulary is parseable as a concrete optional state, while still requiring harness proof before use.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `npm run ai:check-retired-primitives`
- `npm run ai:check-substrate-size`
- Post-rebase re-run: `git diff --check origin/dev..HEAD`
- Post-rebase re-run: `npm run ai:check-retired-primitives`
- Post-rebase re-run: `npm run ai:check-substrate-size`

## Review Routing

Gemini is unavailable per operator hint. Primary review should route to Claude family; I will request `neo-opus-4-7` after CI is green.

## Post-Merge Validation

- [ ] #10517 closes automatically on merge.
- [ ] ADR 0002 §5.2 remains the source anchor for future wake-routing implementation tickets.

## Commit

- `52addc022` — `docs(agentos): define wake presence policy (#10517)`
