### PR TITLE
fix(ai): lock Claude recovery target to Claude Desktop Tab 3 via osascript (#10788)

### DIFF
--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -70,6 +70,9 @@ function spawnAsync(cmd, args, identity = null, hostPlatform = process.platform)
 /**
  * @summary Resolve the embedded Claude Code CLI binary path inside Claude Desktop.
  *
+ * NOTE: retained as a non-routed fallback — Claude recovery routes to the `osascript`
+ * adapter (Claude Desktop Tab 3 / Code tab); see the HARNESS_REGISTRY note in `resumeHarness`.
+ *
  * Claude Desktop ships the `claude` CLI under
  * `~/Library/Application Support/Claude/claude-code/<version>/claude.app/Contents/MacOS/claude`.
  * The version segment changes with auto-updates, so we resolve the LATEST version
@@ -308,23 +311,31 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
 
     // Harness Registry: maps identity IDs to their restart adapters.
     // - antigravity-ide: native CLI `chat -n` through the `antigravity-cli` adapter.
-    // - claude-desktop: embedded Claude Code CLI through the `claude-cli` adapter;
-    //   no session-id flag is passed because a fresh process creates a fresh MCP client.
+    // - claude-desktop: Claude Desktop GUI through the `osascript` adapter — activate
+    //   Claude, Cmd+3 to the Code tab (Tab 3), Cmd+N for a fresh chat, then paste the
+    //   boot-grounding prompt. Locks the recovery target to Claude Desktop Tab 3 per
+    //   the operator calibration ("Claude Desktop in 2026, third tab = Claude Code;
+    //   that is the target, not terminal-attached CLI"). The fresh chat yields a fresh
+    //   `SessionService.currentSessionId` + transcript (the load-bearing recovery goal);
+    //   it reuses the running Claude Desktop app + its MCP server rather than spawning a
+    //   fresh OS process — the accepted trade-off for deterministic Tab-3 targeting. The
+    //   same osascript Cmd+3 path is empirically proven by live bridge-daemon wake delivery.
     // - codex-desktop: Codex Desktop app-server debug surface through
     //   `codex debug app-server send-message-v2`; live dispatch remains explicitly
     //   gated, while tests use CODEX_APP_SERVER_MOCK=1 + CODEX_CLI_PATH.
-    // The `osascript` adapter remains available as a fallback for harnesses that need
-    // UI-keystroke dispatch, but no production identity currently routes there.
+    // The `claude-cli` adapter (embedded `claude <prompt>` CLI) is retained as a
+    // non-routed fallback; no production identity routes there after the Tab-3 remap.
     const HARNESS_REGISTRY = {
         'antigravity-ide': { adapter: 'antigravity-cli' },
-        'claude-desktop':  { adapter: 'claude-cli' },
+        'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' },
         'codex-desktop':   { adapter: 'codex-app-server' }
     };
 
     const identityMap = {
         '@neo-gemini-3-1-pro': 'antigravity-ide',
         '@neo-gpt'           : 'codex-desktop',
-        '@neo-opus-4-7'      : 'claude-desktop'
+        '@neo-opus-4-7'      : 'claude-desktop',
+        '@neo-claude-opus'   : 'claude-desktop'
     };
 
     const targetId = identityMap[identity];
@@ -382,10 +393,12 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
              * Operator override `CLAUDE_CLI_PATH` env var supports test-mock injection.
              *
              * @todo Abstract for cross-platform execution (Windows/Linux).
-             * @todo Empirically verify whether `claude <prompt>` lands as Claude Desktop Tab 3
-             *   ("Code" tab) or a terminal-attached CLI session. Either satisfies the
-             *   fresh-process / fresh-MCP / fresh-session substrate goal, but the operator
-             *   surface differs. Document the observed shape post-verification.
+             *
+             * NOTE: the Tab-3-vs-terminal ambiguity this branch once carried is resolved.
+             * `claude-desktop` now routes to the `osascript` adapter, which deterministically
+             * targets Claude Desktop Tab 3 (Code tab) via Cmd+3 — see the Harness Registry
+             * note above. This `claude-cli` branch is retained only as a non-routed fallback;
+             * no identity maps to it.
              */
             const cliPath = await resolveClaudeCliPath();
             if (!cliPath) {

--- a/learn/agentos/wake-substrate/PersistentProcessManagement.md
+++ b/learn/agentos/wake-substrate/PersistentProcessManagement.md
@@ -14,7 +14,7 @@ The wake substrate (Epic [#10671](https://github.com/neomjs/neo/issues/10671)) s
 
 - `ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs` — Neo-singleton swarm-heartbeat lane (5-minute pulse cadence by default; #10789). Folded into the Orchestrator daemon as a config-gated scheduled lane per [#11766](https://github.com/neomjs/neo/issues/11766).
 - `ai/scripts/checkSunsetted.mjs` — sunset / idle-out detector consumed by the heartbeat lane
-- `ai/scripts/resumeHarness.mjs` — recovery dispatcher invoked when a sunsetted agent is detected
+- `ai/scripts/resumeHarness.mjs` — recovery dispatcher invoked when a sunsetted agent is detected; Claude recovery targets Claude Desktop Tab 3 (Code tab) via the `osascript` adapter (Cmd+3 → fresh chat), not a terminal-attached CLI
 - `ai/scripts/wakeSafetyGate.mjs` — fail-closed safety gate consulted before any high-authority recovery action
 
 The heartbeat must run continuously. Rather than a dedicated daemon, the heartbeat `pulse()` is scheduled by the **Orchestrator** — the same persistent process that owns summarization, KB-sync, backup, dream, and golden-path lanes. macOS's native primitive for the long-lived per-user Orchestrator process is **launchd LaunchAgent** (per-user, lives in `~/Library/LaunchAgents/`). Linux's analog is a **systemd user service** (typically `~/.config/systemd/user/`).

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -34,7 +34,7 @@ test.describe('ai/scripts/resumeHarness', () => {
      * (production unset, tests set explicitly). Avoids the singleton-on-disk
      * collision when this spec runs in parallel with `wakeSafetyGate.spec.mjs`.
      *
-     * `overrideEnv` — for tests that pre-date #10648 and just need to exercise
+     * `overrideEnv` — for tests that just need to exercise
      * the unknown-identity / cooldown / osascript surfaces without the gate
      * blocking. Sets both an isolated gate path AND `WAKE_GATE_OVERRIDE=1`.
      *
@@ -42,7 +42,7 @@ test.describe('ai/scripts/resumeHarness', () => {
      * the gate path but leaves `WAKE_GATE_OVERRIDE` unset so the default-tripped
      * / explicitly-enabled paths can be exercised.
      *
-     * Live-host opt-in (#10681): tests that fire the REAL `osascript` paste path
+     * Live-host opt-in: tests that fire the REAL `osascript` paste path
      * (vs. tests that mock or skip osascript) MUST be gated behind
      * `RUN_LIVE_OSASCRIPT=1` env-var opt-in via `test.skip(!process.env.RUN_LIVE_OSASCRIPT, ...)`
      * as the FIRST statement of the test body. Default behavior (env var unset)
@@ -55,7 +55,7 @@ test.describe('ai/scripts/resumeHarness', () => {
      * which uses either the `test` adapter (test stream delivery) or a mock
      * `osascript` binary on PATH that captures argv without executing AppleScript.
      *
-     * Codex live-host opt-in (#10679): `codex debug app-server send-message-v2`
+     * Codex live-host opt-in: `codex debug app-server send-message-v2`
      * creates/injects into a real Codex Desktop thread. Default tests MUST use
      * `CODEX_APP_SERVER_MOCK=1` plus a `CODEX_CLI_PATH` mock. Real probes require
      * `RUN_LIVE_CODEX_APP_SERVER=1`.
@@ -94,17 +94,18 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
-    test('Opus identity routes to claude-desktop adapter via HARNESS_REGISTRY (config check)', async () => {
-        // Static script-content check: HARNESS_REGISTRY claude-desktop entry uses the
-        // substrate-correct `claude-cli` adapter post-#10677 (was `osascript` Cmd+N pre-fix).
-        // Always-on coverage — no host side effects. The `claude-cli` adapter spawns the embedded
-        // Claude Code CLI with NO sessionId flag — fresh process = fresh MCP client connection =
-        // fresh `currentSessionId` by construction. That construction-by-spawn is precisely the
-        // architectural goal of harness restart that eliminates the spawner-side sessionId
-        // management plumbing #10627's prompt-layer attempt failed to achieve structurally.
+    test('Claude identities route to claude-desktop -> osascript Tab-3 adapter (config check)', async () => {
+        // Static script-content check: the HARNESS_REGISTRY claude-desktop entry uses the
+        // osascript adapter, locking Claude recovery to Claude Desktop Tab 3 (Code tab) via
+        // Cmd+3 + Cmd+N (fresh chat). The fresh chat yields a fresh currentSessionId + transcript;
+        // it reuses the running Claude Desktop app (osascript is exempt from process-termination)
+        // rather than spawning a tracked OS process — the accepted trade-off for deterministic
+        // Tab-3 targeting. Always-on coverage — no host side effects (static read only). Both
+        // Claude identities map to claude-desktop.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'claude-cli' }");
+        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' }");
         expect(scriptContent).toContain("'@neo-opus-4-7'      : 'claude-desktop'");
+        expect(scriptContent).toContain("'@neo-claude-opus'   : 'claude-desktop'");
     });
 
     test('normalizes GitHub-login identity form before harness dispatch (#11797)', async () => {
@@ -119,7 +120,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         // Live-host integration: invokes real `osascript` which on hosts with Claude Desktop
         // + System Events accessibility granted will paste the boot-grounding prompt into the
         // live app and spawn a real Claude Code session. Skipped by default to prevent the
-        // 2026-05-04 09:03Z runaway-spawn pattern (see #10681 forensic record).
+        // 2026-05-04 09:03Z runaway-spawn pattern (forensic record).
         test.skip(!process.env.RUN_LIVE_OSASCRIPT, 'Live osascript test — paste-spawns real Claude sessions on hosts with accessibility granted; set RUN_LIVE_OSASCRIPT=1 to run (#10681)');
         try {
             execFileSync('node', [scriptPath, '@neo-opus-4-7', 'test'], {encoding: 'utf-8', stdio: 'pipe', env: overrideEnv});
@@ -147,7 +148,7 @@ test.describe('ai/scripts/resumeHarness', () => {
     });
 
     test('Wake safety gate enabled + unknown identity → gate passes; identity check exits without osascript (#10648, #10681)', async () => {
-        // Always-on coverage of gate-pass logic, addressing @neo-gemini-3-1-pro's PR #10682
+        // Always-on coverage of gate-pass logic, addressing @neo-gemini-3-1-pro's review
         // cycle 1 challenge re: the coverage gap left by skipping the live-host gate-pass test.
         // resumeHarness.mjs sequences gate check (lines 67-71) BEFORE identity lookup (lines
         // 110-116). Pairing an enabled gate with an unknown identity proves the gate let
@@ -178,7 +179,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         // is enabled and the identity is known, resumeHarness reaches osascript dispatch
         // — which on hosts with Claude Desktop + accessibility granted will paste the
         // boot-grounding prompt into the live app. Skipped by default to prevent the
-        // 2026-05-04 09:03Z runaway-spawn pattern (see #10681 forensic record).
+        // 2026-05-04 09:03Z runaway-spawn pattern (forensic record).
         test.skip(!process.env.RUN_LIVE_OSASCRIPT, 'Live osascript test — paste-spawns real Claude sessions when gate is enabled; set RUN_LIVE_OSASCRIPT=1 to run (#10681)');
         fs.mkdirSync(path.dirname(gatePath), {recursive: true});
         fs.writeFileSync(gatePath, JSON.stringify({state: 'enabled', reason: '', trippedAt: null, trippedBy: null}), 'utf-8');
@@ -194,15 +195,14 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(stderrAndStdout).not.toContain('Wake safety gate disabled');
     });
 
-    test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries route to safe adapters (#10611 PR-B AC1, #10677, #10678, #10679)', async () => {
-        // Antigravity and Claude Desktop now route to native-CLI adapters that bypass
-        // the legacy Cmd+N osascript path. Antigravity uses `antigravity chat -n` (#10678 / #10680);
-        // Claude Desktop uses the embedded Claude Code CLI with NO sessionId flag (#10677);
-        // Codex Desktop uses the live-host-gated app-server adapter (#10679). The substrate-correct
-        // primitives avoid the rejected prompt-layer plumbing of #10627.
+    test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries route to safe adapters (#10611 PR-B AC1)', async () => {
+        // Each harness routes to its substrate-correct fresh-session adapter. Antigravity uses
+        // `antigravity chat -n`; Claude Desktop uses the osascript Cmd+3 -> Tab 3 + Cmd+N path
+        // (deterministic Tab-3 targeting); Codex Desktop uses the live-host-gated app-server
+        // adapter. All avoid the rejected prompt-layer sessionId plumbing.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).toContain("'antigravity-ide': { adapter: 'antigravity-cli' }");
-        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'claude-cli' }");
+        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' }");
         expect(scriptContent).toContain("'codex-desktop':   { adapter: 'codex-app-server' }");
         expect(scriptContent).toContain("'@neo-gpt'           : 'codex-desktop'");
     });
@@ -217,7 +217,7 @@ test.describe('ai/scripts/resumeHarness', () => {
     });
 
     test('Q1b boot-grounding prompt: payload refers to AGENTS_STARTUP.md and sandman_handoff.md (#10611 PR-B AC2)', async () => {
-        // Per #10611 PR-B, the wake payload is a boot-grounding prompt instructing the fresh
+        // The wake payload is a boot-grounding prompt instructing the fresh
         // agent to read AGENTS_STARTUP.md + sandman_handoff.md, NOT a "Resuming sunsetted session"
         // prose payload. Static-read the prompt builder to verify the shape.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
@@ -228,57 +228,35 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(scriptContent).not.toContain('Auto-Wakeup Substrate: Resuming sunsetted session.');
     });
 
-    test('Claude CLI: adapter executes <payload> with NO session-id flag via CLAUDE_CLI_PATH (#10677)', async () => {
-        test.skip(process.platform !== 'darwin', 'Claude CLI is currently mac-specific (parallel concern to #10684)');
-        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
-
-        // Mock claude binary that records argv to a file. Substrate-truth verification: the spawner
-        // MUST pass NO `--session-id` flag — fresh `claude <prompt>` invocation creates a fresh
-        // process + fresh MCP client connection + fresh `currentSessionId` by construction. That
-        // is the architectural goal of harness restart (eliminate spawner-side sessionId management
-        // entirely). Spawner-side UUID generation (`--session-id <uuid>`) would defeat the goal by
-        // reintroducing the same plumbing #10627's prompt-layer attempt tried.
-        //
-        // `--session-id` is the CLI's *resume* flag, the opposite of what recovery needs.
-        const mockPath = path.join(os.tmpdir(), `mock-claude-${randomUUID()}`);
-        const outPath = path.join(os.tmpdir(), `out-claude-${randomUUID()}`);
-        fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
-
-        try {
-            const env = { ...overrideEnv, CLAUDE_CLI_PATH: mockPath };
-            execFileSync('node', [scriptPath, '@neo-opus-4-7', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
-
-            expect(fs.existsSync(outPath)).toBe(true);
-            const args = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
-            // Negative assertion: NO sessionId plumbing.
-            expect(args).not.toContain('--session-id');
-            // Positive assertion: payload is the sole argument.
-            expect(args).toHaveLength(1);
-            expect(args[0]).toContain('@AGENTS_STARTUP.md');
-            expect(args[0]).toContain('testReason');
-        } finally {
-            if (fs.existsSync(mockPath)) fs.unlinkSync(mockPath);
-            if (fs.existsSync(outPath)) fs.unlinkSync(outPath);
-        }
+    test('Claude recovery: osascript adapter sends Cmd+3 (Tab 3) then Cmd+N (fresh chat) before paste', async () => {
+        // Locked-target shape for Claude recovery: the osascript adapter activates Claude, sends
+        // Cmd+`tabShortcut` (Cmd+3 -> Code tab / Tab 3) then Cmd+`freshSessionShortcut` (Cmd+N ->
+        // fresh chat) before the clipboard cut/paste of the boot-grounding prompt. The fresh chat
+        // is what yields a fresh currentSessionId + transcript. Static-content verification; the
+        // live runtime osascript dispatch is RUN_LIVE_OSASCRIPT-gated in the test above.
+        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
+        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' }");
+        expect(scriptContent).toContain('keystroke "${tabShortcut}" using command down');
+        expect(scriptContent).toContain('keystroke "${freshSessionShortcut}" using command down');
     });
 
-    test('harness lifecycle: claude-cli spawn records PID in state-file (#10696 review point 2)', async () => {
-        test.skip(process.platform !== 'darwin', 'Claude CLI is currently mac-specific');
+    test('harness lifecycle: CLI-adapter spawn records PID in state-file (antigravity-cli)', async () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
-        // Verify the cross-adapter cleanup primitive: after a successful claude-cli dispatch,
-        // resumeHarness records the spawned process's PID via harnessLifecycle.recordHarnessProcess.
-        // The recorded PID is what the NEXT resumeHarness invocation will SIGTERM during cleanup.
+        // Verify the cross-adapter cleanup primitive via a still-process-tracked CLI adapter
+        // (antigravity-cli; Claude now routes to the process-exempt osascript adapter). After a
+        // successful CLI dispatch, resumeHarness records the spawned process's PID via
+        // harnessLifecycle.recordHarnessProcess — the PID the NEXT invocation SIGTERMs during cleanup.
         const harnessLifecycle = await import('../../../../../../ai/scripts/lifecycle/harnessLifecycle.mjs');
-        const stateFile = harnessLifecycle.getStateFilePath('@neo-opus-4-7');
+        const stateFile = harnessLifecycle.getStateFilePath('@neo-gemini-3-1-pro');
         if (fs.existsSync(stateFile)) fs.unlinkSync(stateFile);
 
-        const mockPath = path.join(os.tmpdir(), `mock-claude-record-${randomUUID()}`);
+        const mockPath = path.join(os.tmpdir(), `mock-ag-record-${randomUUID()}`);
         fs.writeFileSync(mockPath, `#!/usr/bin/env node\nprocess.exit(0);\n`, { mode: 0o755 });
 
         try {
-            const env = { ...overrideEnv, CLAUDE_CLI_PATH: mockPath };
-            execFileSync('node', [scriptPath, '@neo-opus-4-7', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
+            const env = { ...overrideEnv, ANTIGRAVITY_CLI_PATH: mockPath };
+            execFileSync('node', [scriptPath, '@neo-gemini-3-1-pro', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
 
             // State file MUST exist post-spawn with a recorded PID.
             expect(fs.existsSync(stateFile)).toBe(true);
@@ -291,26 +269,26 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
-    test('harness lifecycle: stale dead PID in state-file is reaped before fresh spawn (#10696 review point 2)', async () => {
-        test.skip(process.platform !== 'darwin', 'Claude CLI is currently mac-specific');
+    test('harness lifecycle: stale dead PID in state-file is reaped before fresh spawn (antigravity-cli)', async () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
-        // Pre-populate state file with a clearly-dead PID (well above pid_max), then run
-        // resumeHarness. The cleanup primitive should detect ESRCH and proceed with fresh spawn.
-        // Verifies the fail-safe behavior — cleanup never blocks fresh-spawn on missing/dead PIDs.
+        // Pre-populate the state file with a clearly-dead PID (well above pid_max), then run
+        // resumeHarness via a process-tracked CLI adapter (antigravity-cli). The cleanup primitive
+        // should detect ESRCH and proceed with a fresh spawn — cleanup never blocks fresh-spawn on
+        // missing/dead PIDs.
         const harnessLifecycle = await import('../../../../../../ai/scripts/lifecycle/harnessLifecycle.mjs');
-        const stateFile = harnessLifecycle.getStateFilePath('@neo-opus-4-7');
+        const stateFile = harnessLifecycle.getStateFilePath('@neo-gemini-3-1-pro');
         const stalePid = 999999; // way above typical pid_max
         await import('fs/promises').then(({writeFile, mkdir}) => mkdir(path.dirname(stateFile), {recursive: true})
             .then(() => writeFile(stateFile, JSON.stringify({pid: stalePid, spawnedAt: Date.now() - 60000}))));
 
-        const mockPath = path.join(os.tmpdir(), `mock-claude-stale-${randomUUID()}`);
-        const outPath = path.join(os.tmpdir(), `out-claude-stale-${randomUUID()}`);
+        const mockPath = path.join(os.tmpdir(), `mock-ag-stale-${randomUUID()}`);
+        const outPath = path.join(os.tmpdir(), `out-ag-stale-${randomUUID()}`);
         fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
 
         try {
-            const env = { ...overrideEnv, CLAUDE_CLI_PATH: mockPath };
-            execFileSync('node', [scriptPath, '@neo-opus-4-7', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
+            const env = { ...overrideEnv, ANTIGRAVITY_CLI_PATH: mockPath };
+            execFileSync('node', [scriptPath, '@neo-gemini-3-1-pro', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
 
             // Spawn proceeded — output file written.
             expect(fs.existsSync(outPath)).toBe(true);
@@ -479,33 +457,30 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(scriptContent).toContain("const tmuxSession = harnessTarget.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';");
     });
 
-    test('adapter failure (e.g. ESC-as-rejection) clears the inflight lock (#10674, #10677)', async () => {
+    test('adapter failure clears the inflight lock (antigravity-cli failure path)', async () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
-        // Substrate-correct lock-clear-on-failure invariant. Post-#10677, claude-desktop
-        // routes through the `claude-cli` adapter (no longer osascript), so we exercise
-        // the failure path via a fake `claude` binary that always exits 1. The adapter
-        // throws → resumeHarness catch block clears the in-flight lock → next interval
-        // can retry without waiting for BOOT_TIMEOUT_MS expiration.
-        const fakeClaudeCli = path.join(os.tmpdir(), `fake-claude-fail-${randomUUID()}`);
-        fs.writeFileSync(fakeClaudeCli, '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+        // Substrate-correct lock-clear-on-failure invariant, exercised via a process-tracked CLI
+        // adapter (antigravity-cli; Claude now routes to osascript). A missing antigravity binary
+        // makes the adapter throw AFTER the in-flight lock is written -> resumeHarness catch block
+        // clears the lock -> the next interval can retry without waiting for BOOT_TIMEOUT_MS.
+        const missingAgCli = path.join(os.tmpdir(), `missing-ag-fail-${randomUUID()}`);
 
         const { getLockPath } = await import('../../../../../../ai/scripts/lifecycle/inflightLock.mjs');
-        const lockPath = getLockPath('sunset_restart', '@neo-opus-4-7');
+        const lockPath = getLockPath('sunset_restart', '@neo-gemini-3-1-pro');
         if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
 
-        const env = { ...overrideEnv, CLAUDE_CLI_PATH: fakeClaudeCli };
+        const env = { ...overrideEnv, ANTIGRAVITY_CLI_PATH: missingAgCli };
         try {
-            execFileSync('node', [scriptPath, '@neo-opus-4-7', 'test'], {encoding: 'utf-8', stdio: 'pipe', env});
+            execFileSync('node', [scriptPath, '@neo-gemini-3-1-pro', 'test'], {encoding: 'utf-8', stdio: 'pipe', env});
             test.fail('Should have exited with error');
         } catch (e) {
             expect(e.status).toBe(1);
-            expect(e.stderr).toMatch(/Failed to resume @neo-opus-4-7 via claude-cli/);
+            expect(e.stderr).toMatch(/Failed to resume @neo-gemini-3-1-pro via antigravity-cli/);
 
             // Lock cleared per lock-clear-on-failure invariant.
             expect(fs.existsSync(lockPath)).toBe(false);
         } finally {
-            if (fs.existsSync(fakeClaudeCli)) fs.unlinkSync(fakeClaudeCli);
             if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
         }
     });
@@ -517,14 +492,14 @@ test.describe('ai/scripts/resumeHarness', () => {
         // which forces the new agent to naturally generate Session Y !== Session X.
         // The substring match is anchored to the call shape `set_session_id(` rather
         // than the bare term — JSDoc references that explain WHY we avoid the call
-        // (e.g., #10677 substrate-correct framing) are permitted.
+        // (e.g., substrate-correct framing) are permitted.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).not.toContain('set_session_id(');
         expect(scriptContent).toContain('Origin Session ID');
     });
 
     test('Negative test: subprocess in-process singleton mutation alone is INSUFFICIENT (#10676)', async () => {
-        // Explicit anti-pattern test carrying forward #10627 substrate-truth.
+        // Explicit anti-pattern test carrying forward the substrate-truth.
         // Modifying a session singleton inside this script would only affect the temporary
         // checkSunsetted/resumeHarness heartbeat node process, NOT the actual
         // long-lived IDE MCP client process.


### PR DESCRIPTION
Resolves #10788
Refs #10671

Authored by Claude Opus 4.8 (Claude Code). Session e886ae3e-13c0-4a94-9713-f8316e2342d0.

FAIR-band: under-target [0/30] — Self-Selection Rule 1 (under-band → bias toward author lane); first authored PR for `@neo-claude-opus`. Additionally operator-directed ("drive #10788") + handoff-accepted from @neo-gpt, who yielded the implementation lane after I validated #10788 AC1 as a live Claude Desktop Tab 3 instance.

Locks the Claude harness-recovery target to **Claude Desktop Tab 3 (Code tab)** by remapping recovery from the ambiguous `claude-cli` adapter — the unresolved `resumeHarness.mjs` Tab-3-vs-terminal-CLI TODO — to the existing `osascript` adapter, which deterministically targets Tab 3 via Cmd+3 + Cmd+N (fresh chat). Registers `@neo-claude-opus`. Per the operator calibration: *"Claude Desktop in 2026, third tab = Claude Code; that is the target, not terminal-attached CLI."*

Evidence: L2 (unit — config remap + osascript Tab-3 keystroke shape + the PID-record / stale-reap / lock-clear invariants repointed to `antigravity-cli`; `resumeHarness.spec.mjs` 22 passed / 2 skipped) + L1 (the osascript Cmd+3 → Tab 3 path is empirically proven by live bridge-daemon wake delivery to `@neo-claude-opus` this session) → L3 required (AC7-class: a recovery prompt lands in a fresh Tab-3 chat over ≥2 cycles). Residual: live-dispatch validation [#10788 — RUN_LIVE_OSASCRIPT-gated / operator-watched].

## AC mapping
- **AC2 / AC3** — Claude recovery routes to the `osascript` Tab-3 adapter (the locked target); the `claude <prompt>` Tab-3-vs-terminal ambiguity is *sidestepped* via the proven osascript path rather than characterized.
- **AC4** — `resumeHarness.spec.mjs` reworked to the locked shape: config asserts → osascript; the cross-adapter cleanup invariants (PID record / stale-PID reap / lock-clear-on-failure) repointed to `antigravity-cli` (Claude is now exempt from process-termination under osascript).
- **AC5 / AC6** — `resumeHarness.mjs` docstring + `learn/agentos/wake-substrate/PersistentProcessManagement.md` clarify the locked Tab-3 target.
- **AC1** (validation, operator-territory) was satisfied this session: as a live Claude Desktop Tab 3 instance I read the recovery code rather than firing the side-effecting `resumeHarness.mjs` command (extra-instance-spam risk mid-live-session) — see the #10788 thread.

## Deltas from ticket
- **Lighter than anticipated**: the `osascript` adapter already exists in `resumeHarness.mjs` (Cmd+3 + Cmd+N), so the fix is a `HARNESS_REGISTRY` remap, not a new dispatch path.
- **Trade-off (documented)**: osascript reuses the running Claude Desktop app + its MCP server — a fresh chat (Cmd+N) yields a fresh `currentSessionId` + transcript (the load-bearing recovery goal) — rather than spawning a fresh OS process. Accepted for deterministic Tab-3 targeting (the operator's locked requirement); osascript is exempt from the process-termination cleanup by design.
- **`claude-cli` retained as a non-routed fallback** (not removed): `resolveClaudeCliPath` / `CLAUDE_CLI_PATH` are also referenced by `harnessLifecycle.mjs` + `SwarmHeartbeatService.mjs`, so a full removal is cross-file scope creep. Suggest a follow-up cleanup ticket to remove the now-dead claude-cli path.

## Substrate-mutation slot-rationale (§1.1 — touches `learn/agentos/**`)
- `learn/agentos/wake-substrate/PersistentProcessManagement.md` — **modified** (one operator-runbook bullet clarified: Claude recovery = Tab 3 osascript, not terminal CLI). Disposition: **keep**. Conditionally-read operator doc, not always-loaded rule substrate; the Map (always-loaded) is untouched, so the trigger-frequency × failure-severity × enforceability rating does not apply. No always-loaded expansion. No ADR impact.

## Decision Record impact
`none` — aligns with the #10671 wake-substrate recovery design + the bridge-daemon osascript Tab-3 pattern. No ADR amended.

## Test Evidence
- `NEO_CHROMA_PORT=9 npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs` → **22 passed, 2 skipped** (the 2 skips are `RUN_LIVE_OSASCRIPT`-gated live-host tests, skipped by default per the suite's host-side-effect discipline).
- `node --check` on both touched `.mjs` files → pass.
- `git diff --check` → pass.
- `check-ticket-archaeology.mjs` on both `.mjs` files → 0 violations (removed stale ticket refs from durable spec comments to satisfy the gate).
- Freshness: `merge-base HEAD origin/dev == origin/dev` (FRESH at push).

## Post-Merge Validation
- [ ] On a live Claude Desktop install, trigger a Claude recovery (`RUN_LIVE_OSASCRIPT=1` or an operator-watched controlled run) and confirm the boot-grounding prompt lands in a **fresh Claude Code chat in Tab 3** — not a terminal CLI, not the sunsetted chat — over ≥2 cycles (parent #10671 AC12-class).

## Commits
- `f09f2bb01` — fix(ai): lock Claude recovery target to Claude Desktop Tab 3 via osascript (#10788)
