### PR TITLE
feat(agentos): add shared AI data root (#12417)

### DIFF
--- a/AGENTS_STARTUP.md
+++ b/AGENTS_STARTUP.md
@@ -94,6 +94,10 @@ node ai/scripts/bootstrapWorktree.mjs --link-data --build-all
 
 It copies the four `config.mjs` files from the main checkout (resolved via `git worktree list --porcelain`) and — with `--link-data` — symlinks gitignored shared data substrates from the main checkout: `.neo-ai-data/` subdirs plus gitignored single-file handoffs such as `resources/content/sandman_handoff.md`. Independent sibling clones (Codex / Antigravity style) cannot infer the canonical checkout from `git worktree list`; pass `--canonical-root <canonical-checkout>` or set `NEO_AI_CANONICAL_ROOT`. Idempotent; no-op from the main checkout.
 
+`NEO_AI_DATA_ROOT` is the tracked config/runtime equivalent of the data symlink for independent clones: set it to the canonical checkout's `.neo-ai-data` directory to make Memory Core graph SQLite, Chroma, wake-daemon state, REM state, and shared Agent OS logs resolve against one durable substrate. Narrower path-specific overrides still win (`NEO_AI_DB_PATH`, `NEO_MEMORY_DB_PATH`, `NEO_AI_DAEMON_DIR`, `NEO_HEARTBEAT_ALIVE_PATH`, etc.). `--link-data` remains the default for true git worktrees; `NEO_AI_DATA_ROOT` covers clone layouts where symlinking the data directories is not practical.
+
+Identity root seeding is additive: Memory Core upserts identities present in the current checkout's `ai/graph/identityRoots.mjs`, but does not delete AgentIdentity nodes absent from that source. This makes a shared data root robust against stale clone seed sources after a canonical checkout has seeded a new identity. It also means identity-node cleanup is a separate reconcile/GC concern, not part of routine worktree bootstrap.
+
 **Per-task-class invocation guidance (per #10351):**
 - **Docs-only tickets** — `--link-data` is sufficient (no `node_modules` needed; the worktree filesystem itself + the data unification covers everything).
 - **Backend / MCP / unit-test tickets** — add `--install`. Empirical anchor: ~17s for `npm install` on a populated local cache (808 packages observed); `bundle-parse5` adds ~1-2s and IS required for the unit-test runner. Skips both if `node_modules/` already exists in the worktree.

--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -5,8 +5,7 @@ import Env      from '../src/util/Env.mjs';
 
 /**
  * Maps a {@link leaf} `type` token to the name-based `Neo.util.Env` parser that decodes its env
- * var. Reuses the Tier-1 Env primitive (Epic #12101 AC-Epic-1: extend, don't reinvent — no
- * parallel parser set).
+ * var. Reuses the Tier-1 Env primitive instead of maintaining a parallel parser set.
  * @type {Object<String,Function>}
  */
 const typeParsers = {
@@ -195,6 +194,9 @@ class BaseConfig extends Provider {
      * dangerous: e.g. a changed `NEO_CHROMA_PORT` would make new reads target a port the Chroma DB
      * is not actually listening on (the DB only moves on a coordinated restart). Live env that
      * drives coordinated restart/reconnection is a separate Body-tier concern, out of scope here.
+     *
+     * Subclasses may implement `afterApplyEnvLeaf(leafPath, value, meta)` to derive dependent
+     * defaults from a resolved env leaf without re-reading that env var through a second helper.
      * @param {Object} [env=process.env]
      * @param {Function} [warn=console.warn]
      */
@@ -214,7 +216,8 @@ class BaseConfig extends Provider {
             }
 
             if (value !== undefined) {
-                this.setData(leafPath, value)
+                this.setData(leafPath, value);
+                this.afterApplyEnvLeaf?.(leafPath, value, meta)
             }
         }
     }

--- a/ai/BaseConfig.mjs
+++ b/ai/BaseConfig.mjs
@@ -195,8 +195,6 @@ class BaseConfig extends Provider {
      * is not actually listening on (the DB only moves on a coordinated restart). Live env that
      * drives coordinated restart/reconnection is a separate Body-tier concern, out of scope here.
      *
-     * Subclasses may implement `afterApplyEnvLeaf(leafPath, value, meta)` to derive dependent
-     * defaults from a resolved env leaf without re-reading that env var through a second helper.
      * @param {Object} [env=process.env]
      * @param {Function} [warn=console.warn]
      */
@@ -217,7 +215,6 @@ class BaseConfig extends Provider {
 
             if (value !== undefined) {
                 this.setData(leafPath, value);
-                this.afterApplyEnvLeaf?.(leafPath, value, meta)
             }
         }
     }

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,7 +1,6 @@
 import path                                  from 'path';
 import {fileURLToPath}                       from 'url';
 import BaseConfig, {createConfigProxy, leaf} from './BaseConfig.mjs';
-import {resolveAiDataRoot}                  from './mcp/server/shared/helpers/DeploymentConfig.mjs';
 import {
     CHROMA_PRODUCTION_DATABASE,
     CHROMA_TEST_DATABASE
@@ -12,10 +11,14 @@ const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../');
 // Fallback to neoRootDir if cwd is root (e.g., container/daemon edge cases)
 const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
-const aiDataRoot  = resolveAiDataRoot({neoRootDir});
+const aiDataRoot  = path.join(neoRootDir, '.neo-ai-data');
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
+
+function hasEnvValue(name) {
+    return process.env[name] !== undefined && process.env[name] !== null && process.env[name] !== '';
+}
 
 /**
  * @class Neo.ai.Config
@@ -683,6 +686,32 @@ class Config extends BaseConfig {
                 }
             })
         }
+    };
+
+    /**
+     * @summary Keeps data-root-derived leaves aligned when `NEO_AI_DATA_ROOT`
+     * or an overlay changes the canonical Agent OS data root.
+     *
+     * `leaf(default, env, type)` owns env decoding for `aiDataRoot`; this hook
+     * derives sibling defaults from the resolved value without re-reading the
+     * same env var through a second helper path.
+     *
+     * @param {String} leafPath Env-applied leaf path.
+     * @param {String} value Resolved Agent OS data root.
+     * @returns {void}
+     */
+    afterApplyEnvLeaf(leafPath, value) {
+        if (leafPath !== 'aiDataRoot') return;
+        if (!value) return;
+
+        if (!hasEnvValue('NEO_BACKUP_PATH')) {
+            this.setData('backupPath', path.join(value, 'backups'));
+        }
+        if (!hasEnvValue('NEO_HEARTBEAT_ALIVE_PATH')) {
+            this.setData('wakeDaemonHeartbeatAlivePath', path.join(value, 'wake-daemon', 'heartbeat.alive'));
+        }
+
+        this.setData('engines.chroma.dataDir', path.join(value, 'chroma', 'unified'));
     }
 }
 

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -68,6 +68,16 @@ class Config extends BaseConfig {
              */
             wakeDaemonHeartbeatAlivePath: leaf(path.join(aiDataRoot, 'wake-daemon', 'heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string'),
             /**
+             * Path to the concurrency lock that suppresses overlapping swarm-heartbeat work.
+             * @type {string}
+             */
+            heartbeatConcurrencyLockPath: leaf(path.join(aiDataRoot, 'heartbeat-concurrency.lock'), 'NEO_HEARTBEAT_LOCK_PATH', 'string'),
+            /**
+             * Directory for per-identity harness lifecycle state files.
+             * @type {string}
+             */
+            harnessStateDir: leaf(path.join(aiDataRoot, 'harness-state'), 'NEO_HARNESS_STATE_DIR', 'string'),
+            /**
              * Global debug flag for all AI processes.
              * @type {boolean}
              */
@@ -321,6 +331,38 @@ class Config extends BaseConfig {
              * @type {Object}
              */
             orchestrator: {
+                /**
+                 * Orchestrator daemon state directory. Defaults below the shared Agent OS
+                 * data root; `NEO_AI_ORCHESTRATOR_DIR` isolates only this daemon-local
+                 * state without requiring consumers to rebuild the path.
+                 * @type {String}
+                 */
+                dataDir: leaf(path.join(aiDataRoot, 'orchestrator-daemon'), 'NEO_AI_ORCHESTRATOR_DIR', 'string'),
+                /**
+                 * Daemon singleton PID file.
+                 * @type {String}
+                 */
+                pidFile: leaf(path.join(aiDataRoot, 'orchestrator-daemon', 'orchestrator-daemon.pid')),
+                /**
+                 * Orchestrator process log file.
+                 * @type {String}
+                 */
+                logFile: leaf(path.join(aiDataRoot, 'orchestrator-daemon', 'orchestrator.log')),
+                /**
+                 * Persisted task-state file.
+                 * @type {String}
+                 */
+                stateFile: leaf(path.join(aiDataRoot, 'orchestrator-daemon', 'orchestrator-state.json')),
+                /**
+                 * Cross-process heavy-maintenance lease file.
+                 * @type {String}
+                 */
+                heavyMaintenanceLeasePath: leaf(path.join(aiDataRoot, 'orchestrator-daemon', 'heavy-maintenance-lease.json')),
+                /**
+                 * Orchestrator-local wake backoff state.
+                 * @type {String}
+                 */
+                wakeDecisionBackoffStateFile: leaf(path.join(aiDataRoot, 'wake-daemon', 'backoff.json')),
                 /**
                  * Deployment profile for Agent OS maintenance ownership.
                  * `local` preserves maintainer-checkout behavior; `cloud` disables local-only
@@ -685,34 +727,31 @@ class Config extends BaseConfig {
                     })
                 }
             })
+        },
+        formulas: {
+            backupPath: data => hasEnvValue('NEO_BACKUP_PATH')
+                ? data.backupPath
+                : path.join(data.aiDataRoot, 'backups'),
+            wakeDaemonHeartbeatAlivePath: data => hasEnvValue('NEO_HEARTBEAT_ALIVE_PATH')
+                ? data.wakeDaemonHeartbeatAlivePath
+                : path.join(data.aiDataRoot, 'wake-daemon', 'heartbeat.alive'),
+            heartbeatConcurrencyLockPath: data => hasEnvValue('NEO_HEARTBEAT_LOCK_PATH')
+                ? data.heartbeatConcurrencyLockPath
+                : path.join(data.aiDataRoot, 'heartbeat-concurrency.lock'),
+            harnessStateDir: data => hasEnvValue('NEO_HARNESS_STATE_DIR')
+                ? data.harnessStateDir
+                : path.join(data.aiDataRoot, 'harness-state'),
+            'engines.chroma.dataDir': data => path.join(data.aiDataRoot, 'chroma', 'unified'),
+            'orchestrator.dataDir': data => hasEnvValue('NEO_AI_ORCHESTRATOR_DIR')
+                ? data.orchestrator.dataDir
+                : path.join(data.aiDataRoot, 'orchestrator-daemon'),
+            'orchestrator.pidFile': data => path.join(data.orchestrator.dataDir, 'orchestrator-daemon.pid'),
+            'orchestrator.logFile': data => path.join(data.orchestrator.dataDir, 'orchestrator.log'),
+            'orchestrator.stateFile': data => path.join(data.orchestrator.dataDir, 'orchestrator-state.json'),
+            'orchestrator.heavyMaintenanceLeasePath': data => path.join(data.orchestrator.dataDir, 'heavy-maintenance-lease.json'),
+            'orchestrator.wakeDecisionBackoffStateFile': data => path.join(data.aiDataRoot, 'wake-daemon', 'backoff.json')
         }
     };
-
-    /**
-     * @summary Keeps data-root-derived leaves aligned when `NEO_AI_DATA_ROOT`
-     * or an overlay changes the canonical Agent OS data root.
-     *
-     * `leaf(default, env, type)` owns env decoding for `aiDataRoot`; this hook
-     * derives sibling defaults from the resolved value without re-reading the
-     * same env var through a second helper path.
-     *
-     * @param {String} leafPath Env-applied leaf path.
-     * @param {String} value Resolved Agent OS data root.
-     * @returns {void}
-     */
-    afterApplyEnvLeaf(leafPath, value) {
-        if (leafPath !== 'aiDataRoot') return;
-        if (!value) return;
-
-        if (!hasEnvValue('NEO_BACKUP_PATH')) {
-            this.setData('backupPath', path.join(value, 'backups'));
-        }
-        if (!hasEnvValue('NEO_HEARTBEAT_ALIVE_PATH')) {
-            this.setData('wakeDaemonHeartbeatAlivePath', path.join(value, 'wake-daemon', 'heartbeat.alive'));
-        }
-
-        this.setData('engines.chroma.dataDir', path.join(value, 'chroma', 'unified'));
-    }
 }
 
 const instance = Neo.setupClass(Config);

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -11,6 +11,7 @@ const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../');
 // Fallback to neoRootDir if cwd is root (e.g., container/daemon edge cases)
 const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
+const aiDataRoot  = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(neoRootDir, '.neo-ai-data'));
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
@@ -42,16 +43,26 @@ class Config extends BaseConfig {
             neoRootDir : leaf(neoRootDir),
             projectRoot: leaf(projectRoot),
             /**
+             * @summary Canonical Agent OS runtime data root.
+             *
+             * All local Agent OS runtime data that must survive across sibling worktrees
+             * resolves below this root unless a narrower path-specific env override is set.
+             * Operators can bind independent clones to one shared substrate by setting
+             * `NEO_AI_DATA_ROOT` to the canonical checkout's `.neo-ai-data` directory.
+             * @type {string}
+             */
+            aiDataRoot: leaf(aiDataRoot, 'NEO_AI_DATA_ROOT', 'string'),
+            /**
              * Universal JSONL backup/export directory for Agent OS databases.
              * @type {string}
              */
-            backupPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/backups'), 'NEO_BACKUP_PATH', 'string'),
+            backupPath: leaf(path.join(aiDataRoot, 'backups'), 'NEO_BACKUP_PATH', 'string'),
             /**
              * Path to the wake-daemon liveness sentinel touched on every swarm-heartbeat
              * pulse. Operators / tests can isolate the path via `NEO_HEARTBEAT_ALIVE_PATH`.
              * @type {string}
              */
-            wakeDaemonHeartbeatAlivePath: leaf(path.resolve(neoRootDir, '.neo-ai-data/wake-daemon/heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string'),
+            wakeDaemonHeartbeatAlivePath: leaf(path.join(aiDataRoot, 'wake-daemon', 'heartbeat.alive'), 'NEO_HEARTBEAT_ALIVE_PATH', 'string'),
             /**
              * Global debug flag for all AI processes.
              * @type {boolean}
@@ -287,7 +298,7 @@ class Config extends BaseConfig {
              */
             engines: {
                 chroma: {
-                    dataDir : leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
+                    dataDir : leaf(path.join(aiDataRoot, 'chroma', 'unified')),
                     host    : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
                     port    : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
                     /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,6 +1,7 @@
 import path                                  from 'path';
 import {fileURLToPath}                       from 'url';
 import BaseConfig, {createConfigProxy, leaf} from './BaseConfig.mjs';
+import {resolveAiDataRoot}                  from './mcp/server/shared/helpers/DeploymentConfig.mjs';
 import {
     CHROMA_PRODUCTION_DATABASE,
     CHROMA_TEST_DATABASE
@@ -11,7 +12,7 @@ const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../');
 // Fallback to neoRootDir if cwd is root (e.g., container/daemon edge cases)
 const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
-const aiDataRoot  = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(neoRootDir, '.neo-ai-data'));
+const aiDataRoot  = resolveAiDataRoot({neoRootDir});
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;

--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -31,7 +31,6 @@ import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
 import AiConfig        from '../../config.mjs';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 import fs from 'fs-extra';
 import path from 'path';
@@ -51,7 +50,7 @@ import {
 } from './queries.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
-const AI_DATA_ROOT             = resolveAiDataRoot({config: AiConfig});
+const AI_DATA_ROOT             = AiConfig.aiDataRoot;
 const DB_PATH                  = process.env.NEO_AI_DB_PATH || path.join(AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
 const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || path.join(AI_DATA_ROOT, 'wake-daemon');
 const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');

--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -50,8 +50,9 @@ import {
 } from './queries.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
-const DB_PATH                  = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
-const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || '.neo-ai-data/wake-daemon';
+const AI_DATA_ROOT             = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const DB_PATH                  = process.env.NEO_AI_DB_PATH || path.join(AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
+const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || path.join(AI_DATA_ROOT, 'wake-daemon');
 const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');
 const LOG_FILE                 = path.join(DAEMON_DATA_DIR, 'bridge.log');
 const LOG_RETENTION_DAYS       = 30;

--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -31,6 +31,7 @@ import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
 import AiConfig        from '../../config.mjs';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 import fs from 'fs-extra';
 import path from 'path';
@@ -50,7 +51,7 @@ import {
 } from './queries.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
-const AI_DATA_ROOT             = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const AI_DATA_ROOT             = resolveAiDataRoot({config: AiConfig});
 const DB_PATH                  = process.env.NEO_AI_DB_PATH || path.join(AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
 const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || path.join(AI_DATA_ROOT, 'wake-daemon');
 const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');

--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -30,7 +30,7 @@
 import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
-import AiConfig        from '../../config.mjs';
+import MemoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 
 import fs from 'fs-extra';
 import path from 'path';
@@ -50,11 +50,10 @@ import {
 } from './queries.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
-const AI_DATA_ROOT             = AiConfig.aiDataRoot;
-const DB_PATH                  = process.env.NEO_AI_DB_PATH || path.join(AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
-const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || path.join(AI_DATA_ROOT, 'wake-daemon');
-const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');
-const LOG_FILE                 = path.join(DAEMON_DATA_DIR, 'bridge.log');
+const DB_PATH                  = MemoryCoreConfig.storagePaths.graph;
+const DAEMON_DATA_DIR          = MemoryCoreConfig.wakeDaemon.dataDir;
+const STATE_FILE               = MemoryCoreConfig.wakeDaemon.bridgeLastSyncIdPath;
+const LOG_FILE                 = MemoryCoreConfig.wakeDaemon.logFile;
 const LOG_RETENTION_DAYS       = 30;
 const POLL_INTERVAL_MS         = 3000;
 const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
@@ -154,7 +153,7 @@ function writeLog(level, message) {
 // One-shot prune at startup; reaper for archived logs older than retention window
 pruneOldLogs();
 
-const PID_FILE = path.join(DAEMON_DATA_DIR, 'bridge-daemon.pid');
+const PID_FILE = MemoryCoreConfig.wakeDaemon.pidFile;
 const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 async function enforceSingleton() {

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -440,16 +440,17 @@ export class Orchestrator extends Base {
         const lmsPreloadConfig = this.lmsPreloadConfig;
         this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
-            nodeBin   : options.nodeBin || process.argv[0],
-            chromaPort: AiConfig.engines.chroma?.port,
-            mlxEnabled: this.mlxEnabled,
-            mlxModel  : AiConfig.orchestrator.mlx?.model,
-            mlxPort   : AiConfig.orchestrator.mlx?.port,
-            lmsEnabled: this.lmsEnabled,
-            lmsModel  : AiConfig.orchestrator.lms?.model,
-            lmsModels : lmsPreloadConfig.models,
-            lmsHost   : AiConfig.openAiCompatible?.host,
-            lmsPort   : AiConfig.orchestrator.lms?.port,
+            nodeBin      : options.nodeBin || process.argv[0],
+            chromaPort   : AiConfig.engines.chroma?.port,
+            chromaDataDir: AiConfig.engines.chroma?.dataDir,
+            mlxEnabled   : this.mlxEnabled,
+            mlxModel     : AiConfig.orchestrator.mlx?.model,
+            mlxPort      : AiConfig.orchestrator.mlx?.port,
+            lmsEnabled   : this.lmsEnabled,
+            lmsModel     : AiConfig.orchestrator.lms?.model,
+            lmsModels    : lmsPreloadConfig.models,
+            lmsHost      : AiConfig.openAiCompatible?.host,
+            lmsPort      : AiConfig.orchestrator.lms?.port,
             lmsContextLengths: lmsPreloadConfig.contextLengths,
             providerReadiness: AiConfig.orchestrator.providerReadiness
         });

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -1,14 +1,16 @@
 import path from 'path';
 import {fileURLToPath} from 'url';
+import '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import AiConfig from '../../config.mjs';
+import MemoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
-const neoRootDir = path.resolve(__dirname, '../../..');
 
-export const DEFAULT_AI_DATA_ROOT    = process.env.NEO_AI_DATA_ROOT || path.join(neoRootDir, '.neo-ai-data');
-export const DEFAULT_DB_PATH         = process.env.NEO_AI_DB_PATH || path.join(DEFAULT_AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
-export const DEFAULT_DATA_DIR        = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon');
-export const DEFAULT_CHROMA_DATA_DIR = path.join(DEFAULT_AI_DATA_ROOT, 'chroma', 'unified');
+export const DEFAULT_DB_PATH         = MemoryCoreConfig.storagePaths.graph;
+export const DEFAULT_DATA_DIR        = AiConfig.orchestrator.dataDir;
+export const DEFAULT_CHROMA_DATA_DIR = AiConfig.engines.chroma.dataDir;
 export const DEFAULT_SCRIPT_DIR      = path.resolve(__dirname, '../../scripts');
 
 /**
@@ -65,7 +67,6 @@ export function buildTaskDefinitions({
             label          : 'chroma daemon',
             command        : 'chroma',
             // The --path persist dir resolves to the same dir as AiConfig.engines.chroma.dataDir.
-            // The default preserves the historical relative path unless `NEO_AI_DATA_ROOT` is set;
             // Orchestrator passes the concrete config value after local config overlays are loaded.
             args           : ['run', '--path', chromaDataDir, '--port', String(chromaPort)],
             pidFileName    : 'chroma.pid',

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -1,12 +1,11 @@
 import path from 'path';
 import {fileURLToPath} from 'url';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-export const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT
-    ? path.resolve(process.env.NEO_AI_DATA_ROOT)
-    : '.neo-ai-data';
+export const DEFAULT_AI_DATA_ROOT    = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
 export const DEFAULT_DB_PATH         = process.env.NEO_AI_DB_PATH || path.join(DEFAULT_AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
 export const DEFAULT_DATA_DIR        = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon');
 export const DEFAULT_CHROMA_DATA_DIR = path.join(DEFAULT_AI_DATA_ROOT, 'chroma', 'unified');

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -4,9 +4,13 @@ import {fileURLToPath} from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
-export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
-export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
-export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
+export const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT
+    ? path.resolve(process.env.NEO_AI_DATA_ROOT)
+    : '.neo-ai-data';
+export const DEFAULT_DB_PATH         = process.env.NEO_AI_DB_PATH || path.join(DEFAULT_AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
+export const DEFAULT_DATA_DIR        = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon');
+export const DEFAULT_CHROMA_DATA_DIR = path.join(DEFAULT_AI_DATA_ROOT, 'chroma', 'unified');
+export const DEFAULT_SCRIPT_DIR      = path.resolve(__dirname, '../../scripts');
 
 /**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
@@ -28,6 +32,7 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
  * @param {String|Number} [options.chromaPort] Chroma daemon port — used for the `--port` arg and as the chroma task's `singletonPort` (the port the orchestrator reaps duplicate listeners on).
+ * @param {String} [options.chromaDataDir] Chroma persist directory.
  * @param {Boolean} [options.mlxEnabled=false] Whether to launch an orchestrator-owned mlx_lm.server.
  * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
  * @param {String|Number} [options.mlxPort] MLX OpenAI-compatible local inference port.
@@ -44,6 +49,7 @@ export function buildTaskDefinitions({
     scriptDir  = DEFAULT_SCRIPT_DIR,
     nodeBin    = process.argv[0],
     chromaPort,
+    chromaDataDir = DEFAULT_CHROMA_DATA_DIR,
     mlxEnabled = false,
     mlxModel,
     mlxPort,
@@ -59,12 +65,10 @@ export function buildTaskDefinitions({
         chroma: {
             label          : 'chroma daemon',
             command        : 'chroma',
-            // The --path persist dir resolves to the same dir as AiConfig.engines.chroma.dataDir
-            // — the SSOT that KB/MC configs + defragChromaDB read — under the standard
-            // cwd==repoRoot. Kept as a relative literal here (not SSOT-sourced) for daemon-launch
-            // resilience: a stale config.mjs lacking the SSOT key would otherwise launch the daemon
-            // with `--path undefined`. Keep this value in sync with engines.chroma.dataDir.
-            args           : ['run', '--path', '.neo-ai-data/chroma/unified', '--port', String(chromaPort)],
+            // The --path persist dir resolves to the same dir as AiConfig.engines.chroma.dataDir.
+            // The default preserves the historical relative path unless `NEO_AI_DATA_ROOT` is set;
+            // Orchestrator passes the concrete config value after local config overlays are loaded.
+            args           : ['run', '--path', chromaDataDir, '--port', String(chromaPort)],
             pidFileName    : 'chroma.pid',
             expectedCommand: 'chroma',
             singletonPort  : chromaPort

--- a/ai/daemons/orchestrator/TaskDefinitions.mjs
+++ b/ai/daemons/orchestrator/TaskDefinitions.mjs
@@ -1,11 +1,11 @@
 import path from 'path';
 import {fileURLToPath} from 'url';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
+const neoRootDir = path.resolve(__dirname, '../../..');
 
-export const DEFAULT_AI_DATA_ROOT    = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
+export const DEFAULT_AI_DATA_ROOT    = process.env.NEO_AI_DATA_ROOT || path.join(neoRootDir, '.neo-ai-data');
 export const DEFAULT_DB_PATH         = process.env.NEO_AI_DB_PATH || path.join(DEFAULT_AI_DATA_ROOT, 'sqlite', 'memory-core-graph.sqlite');
 export const DEFAULT_DATA_DIR        = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon');
 export const DEFAULT_CHROMA_DATA_DIR = path.join(DEFAULT_AI_DATA_ROOT, 'chroma', 'unified');

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -33,7 +33,8 @@ import {execSync} from 'child_process';
 import AiConfig from '../../config.mjs';
 import Orchestrator from './Orchestrator.mjs';
 
-const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
+const AI_DATA_ROOT    = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(AI_DATA_ROOT, 'orchestrator-daemon');
 const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
 const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
 const ORCHESTRATOR_DAEMON_PATH_TAIL = 'ai/daemons/orchestrator/daemon.mjs';

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -31,9 +31,10 @@ import fs from 'fs-extra';
 import path from 'path';
 import {execSync} from 'child_process';
 import AiConfig from '../../config.mjs';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 import Orchestrator from './Orchestrator.mjs';
 
-const AI_DATA_ROOT    = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const AI_DATA_ROOT    = resolveAiDataRoot({config: AiConfig});
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(AI_DATA_ROOT, 'orchestrator-daemon');
 const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
 const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -28,15 +28,13 @@ import InstanceManager from '../../../src/manager/Instance.mjs';
 
 import {fileURLToPath, pathToFileURL} from 'url';
 import fs from 'fs-extra';
-import path from 'path';
 import {execSync} from 'child_process';
 import AiConfig from '../../config.mjs';
 import Orchestrator from './Orchestrator.mjs';
 
-const AI_DATA_ROOT    = AiConfig.aiDataRoot;
-const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(AI_DATA_ROOT, 'orchestrator-daemon');
-const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
-const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');
+const DAEMON_DATA_DIR = AiConfig.orchestrator.dataDir;
+const PID_FILE        = AiConfig.orchestrator.pidFile;
+const LOG_FILE        = AiConfig.orchestrator.logFile;
 const ORCHESTRATOR_DAEMON_PATH_TAIL = 'ai/daemons/orchestrator/daemon.mjs';
 export const LOCAL_AI_CONFIG_FILE = fileURLToPath(new URL('../../config.mjs', import.meta.url));
 
@@ -185,6 +183,9 @@ export async function startOrchestrator(options = {}) {
 
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
+        logFile: LOG_FILE,
+        stateFile: AiConfig.orchestrator.stateFile,
+        heavyMaintenanceLeasePath: AiConfig.orchestrator.heavyMaintenanceLeasePath,
         primaryDevSyncRootsConfig: AiConfig.orchestrator?.devSyncRoots,
         ...options
     });

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -31,10 +31,9 @@ import fs from 'fs-extra';
 import path from 'path';
 import {execSync} from 'child_process';
 import AiConfig from '../../config.mjs';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 import Orchestrator from './Orchestrator.mjs';
 
-const AI_DATA_ROOT    = resolveAiDataRoot({config: AiConfig});
+const AI_DATA_ROOT    = AiConfig.aiDataRoot;
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || path.join(AI_DATA_ROOT, 'orchestrator-daemon');
 const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
 const LOG_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator.log');

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -1,14 +1,12 @@
 import crypto from 'crypto';
 import fs     from 'fs-extra';
 import path   from 'path';
-import {fileURLToPath} from 'url';
 import Neo    from '../../../../src/Neo.mjs';
+import '../../../../src/core/_export.mjs';
 import Base   from '../../../../src/core/Base.mjs';
+import AiConfig from '../../../config.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-export const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../../../'), '.neo-ai-data');
-export const DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH = path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon', 'heavy-maintenance-lease.json');
+export const DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH = AiConfig.orchestrator.heavyMaintenanceLeasePath;
 export const DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS = 6 * 60 * 60 * 1000;
 
 /**

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -1,10 +1,14 @@
 import crypto from 'crypto';
 import fs     from 'fs-extra';
 import path   from 'path';
+import {fileURLToPath} from 'url';
 import Neo    from '../../../../src/Neo.mjs';
 import Base   from '../../../../src/core/Base.mjs';
+import {resolveAiDataRoot} from '../../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
-export const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const DEFAULT_AI_DATA_ROOT = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../../../')});
 export const DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH = path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon', 'heavy-maintenance-lease.json');
 export const DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS = 6 * 60 * 60 * 1000;
 

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -4,11 +4,10 @@ import path   from 'path';
 import {fileURLToPath} from 'url';
 import Neo    from '../../../../src/Neo.mjs';
 import Base   from '../../../../src/core/Base.mjs';
-import {resolveAiDataRoot} from '../../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const DEFAULT_AI_DATA_ROOT = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../../../')});
+export const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../../../'), '.neo-ai-data');
 export const DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH = path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon', 'heavy-maintenance-lease.json');
 export const DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS = 6 * 60 * 60 * 1000;
 

--- a/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
+++ b/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs
@@ -4,7 +4,8 @@ import path   from 'path';
 import Neo    from '../../../../src/Neo.mjs';
 import Base   from '../../../../src/core/Base.mjs';
 
-export const DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH = '.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json';
+export const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+export const DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH = path.join(DEFAULT_AI_DATA_ROOT, 'orchestrator-daemon', 'heavy-maintenance-lease.json');
 export const DEFAULT_HEAVY_MAINTENANCE_LEASE_TTL_MS = 6 * 60 * 60 * 1000;
 
 /**
@@ -594,7 +595,7 @@ export class HeavyMaintenanceLeaseService extends Base {
          */
         singleton: true,
         /**
-         * @member {String} leasePath_='.neo-ai-data/orchestrator-daemon/heavy-maintenance-lease.json'
+         * @member {String} leasePath_=DEFAULT_HEAVY_MAINTENANCE_LEASE_PATH
          * @protected
          * @reactive
          */

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -51,8 +51,8 @@ const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhoo
  * `HealthService` reads the repo-root `.neo-ai-data/wake-daemon/heartbeat.alive`
  * mtime to project `features.wake.daemonRunning`. This producer must touch the
  * same path or health checks can remain stale while pulses execute. Tests and
- * operator probes can isolate the path via `NEO_HEARTBEAT_ALIVE_PATH`, matching
- * the consumer-side override contract.
+ * operator probes isolate the path through the Tier-1 AiConfig
+ * `wakeDaemonHeartbeatAlivePath` leaf.
  *
  * @returns {String}
  * @see ai/services/memory-core/HealthService.mjs
@@ -375,9 +375,9 @@ class SwarmHeartbeatService extends Base {
      * @summary Touch the heartbeat-liveness file `HealthService` reads for `daemonRunning`.
      *
      * Produces the `.neo-ai-data/wake-daemon/heartbeat.alive` mtime signal used by
-     * `HealthService`. Path resolution mirrors `HealthService.heartbeatAlivePath()`:
-     * `NEO_HEARTBEAT_ALIVE_PATH` override first, then the canonical path. A touch
-     * failure is swallowed because a missing liveness signal must never abort a pulse.
+     * `HealthService`. The Tier-1 AiConfig Provider owns the path formula and optional
+     * override; this consumer reads the resolved leaf. A touch failure is swallowed
+     * because a missing liveness signal must never abort a pulse.
      * @protected
      * @returns {Promise<void>}
      */

--- a/ai/daemons/orchestrator/services/WakeDecisionService.mjs
+++ b/ai/daemons/orchestrator/services/WakeDecisionService.mjs
@@ -2,9 +2,9 @@ import fs   from 'fs-extra';
 import path from 'path';
 import {fileURLToPath} from 'url';
 import Base from '../../../../src/core/Base.mjs';
-import {resolveAiDataRoot} from '../../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../../../'), '.neo-ai-data');
 
 /**
  * Default activity window (3h) within which any sent-or-received A2A keeps the
@@ -33,7 +33,7 @@ export const DEFAULT_IDLE_WINDOW_MS = 15 * 60 * 1000;
  * @type {String}
  */
 export const DEFAULT_BACKOFF_STATE_FILE = path.resolve(
-    resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../../../')}),
+    DEFAULT_AI_DATA_ROOT,
     'wake-daemon',
     'backoff.json'
 );

--- a/ai/daemons/orchestrator/services/WakeDecisionService.mjs
+++ b/ai/daemons/orchestrator/services/WakeDecisionService.mjs
@@ -1,10 +1,9 @@
 import fs   from 'fs-extra';
 import path from 'path';
-import {fileURLToPath} from 'url';
+import '../../../../src/Neo.mjs';
+import '../../../../src/core/_export.mjs';
 import Base from '../../../../src/core/Base.mjs';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DEFAULT_AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../../../'), '.neo-ai-data');
+import AiConfig from '../../../config.mjs';
 
 /**
  * Default activity window (3h) within which any sent-or-received A2A keeps the
@@ -32,11 +31,7 @@ export const DEFAULT_IDLE_WINDOW_MS = 15 * 60 * 1000;
  * substrate), NOT a new graph node type.
  * @type {String}
  */
-export const DEFAULT_BACKOFF_STATE_FILE = path.resolve(
-    DEFAULT_AI_DATA_ROOT,
-    'wake-daemon',
-    'backoff.json'
-);
+export const DEFAULT_BACKOFF_STATE_FILE = AiConfig.orchestrator.wakeDecisionBackoffStateFile;
 
 /**
  * @summary 3-signal wake-decision substrate for orchestrator-driven harness wakes.

--- a/ai/daemons/orchestrator/services/WakeDecisionService.mjs
+++ b/ai/daemons/orchestrator/services/WakeDecisionService.mjs
@@ -1,6 +1,10 @@
 import fs   from 'fs-extra';
 import path from 'path';
+import {fileURLToPath} from 'url';
 import Base from '../../../../src/core/Base.mjs';
+import {resolveAiDataRoot} from '../../../mcp/server/shared/helpers/DeploymentConfig.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Default activity window (3h) within which any sent-or-received A2A keeps the
@@ -29,7 +33,7 @@ export const DEFAULT_IDLE_WINDOW_MS = 15 * 60 * 1000;
  * @type {String}
  */
 export const DEFAULT_BACKOFF_STATE_FILE = path.resolve(
-    process.env.NEO_AI_DATA_ROOT || path.join(process.cwd(), '.neo-ai-data'),
+    resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../../../')}),
     'wake-daemon',
     'backoff.json'
 );

--- a/ai/daemons/orchestrator/services/WakeDecisionService.mjs
+++ b/ai/daemons/orchestrator/services/WakeDecisionService.mjs
@@ -29,8 +29,7 @@ export const DEFAULT_IDLE_WINDOW_MS = 15 * 60 * 1000;
  * @type {String}
  */
 export const DEFAULT_BACKOFF_STATE_FILE = path.resolve(
-    process.cwd(),
-    '.neo-ai-data',
+    process.env.NEO_AI_DATA_ROOT || path.join(process.cwd(), '.neo-ai-data'),
     'wake-daemon',
     'backoff.json'
 );

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -8,6 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
+const aiDataRoot = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(neoRootDir, '.neo-ai-data'));
 
 
 
@@ -38,6 +39,11 @@ class Config extends BaseConfig {
          */
         data: {
             neoRootDir: leaf(neoRootDir),
+            /**
+             * Canonical Agent OS runtime data root shared with Memory Core and the Chroma daemon.
+             * @type {string}
+             */
+            aiDataRoot: leaf(aiDataRoot, 'NEO_AI_DATA_ROOT', 'string'),
             /**
              * Global debug flag for all MCP servers.
              *
@@ -151,10 +157,10 @@ class Config extends BaseConfig {
              * Directory for the always-on KB server diagnostic log files. The KB server's
              * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-running
              * operations (sync, embedding loops, ChromaDB lifecycle) leave a tail-able diagnostic
-             * trail observable from the host shell. Default: `<neoRootDir>/.neo-ai-data/logs/`.
+             * trail observable from the host shell. Default: `<aiDataRoot>/logs/`.
              * @type {string}
              */
-            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
+            logPath: leaf(path.join(aiDataRoot, 'logs')),
             /**
              * @summary Shared MCP logger policy for Knowledge Base.
              *

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -2,14 +2,13 @@ import os              from 'os';
 import path            from 'path';
 import AiConfig        from '../../../config.template.mjs';
 import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
-import {resolveAiDataRoot}                     from '../shared/helpers/DeploymentConfig.mjs';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
-const aiDataRoot = resolveAiDataRoot({neoRootDir});
+const aiDataRoot = path.join(neoRootDir, '.neo-ai-data');
 
 
 
@@ -366,6 +365,18 @@ class Config extends BaseConfig {
                 inheritanceDecay : 0.6
             })
         }
+    };
+
+    /**
+     * @summary Keeps KB-local paths aligned with the resolved shared AI data root.
+     * @param {String} leafPath Env-applied leaf path.
+     * @param {String} value Resolved Agent OS data root.
+     * @returns {void}
+     */
+    afterApplyEnvLeaf(leafPath, value) {
+        if (leafPath !== 'aiDataRoot') return;
+        if (!value) return;
+        this.setData('logPath', path.join(value, 'logs'));
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -2,13 +2,14 @@ import os              from 'os';
 import path            from 'path';
 import AiConfig        from '../../../config.template.mjs';
 import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
+import {resolveAiDataRoot}                     from '../shared/helpers/DeploymentConfig.mjs';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
-const aiDataRoot = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(neoRootDir, '.neo-ai-data'));
+const aiDataRoot = resolveAiDataRoot({neoRootDir});
 
 
 

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -40,11 +40,6 @@ class Config extends BaseConfig {
         data: {
             neoRootDir: leaf(neoRootDir),
             /**
-             * Canonical Agent OS runtime data root shared with Memory Core and the Chroma daemon.
-             * @type {string}
-             */
-            aiDataRoot: leaf(aiDataRoot, 'NEO_AI_DATA_ROOT', 'string'),
-            /**
              * Global debug flag for all MCP servers.
              *
              * Operator env var: `NEO_DEBUG`.
@@ -364,19 +359,11 @@ class Config extends BaseConfig {
                 inheritanceBoost : 80,
                 inheritanceDecay : 0.6
             })
+        },
+        formulas: {
+            path: data => data.engines.chroma.dataDir,
+            logPath: data => path.join(data.aiDataRoot, 'logs')
         }
-    };
-
-    /**
-     * @summary Keeps KB-local paths aligned with the resolved shared AI data root.
-     * @param {String} leafPath Env-applied leaf path.
-     * @param {String} value Resolved Agent OS data root.
-     * @returns {void}
-     */
-    afterApplyEnvLeaf(leafPath, value) {
-        if (leafPath !== 'aiDataRoot') return;
-        if (!value) return;
-        this.setData('logPath', path.join(value, 'logs'));
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -3,6 +3,7 @@
 import '../../../config.template.mjs';
 import path                                  from 'path';
 import BaseConfig, {createConfigProxy, leaf} from '../../../BaseConfig.mjs';
+import {resolveAiDataRoot}                   from '../shared/helpers/DeploymentConfig.mjs';
 import {fileURLToPath}                       from 'url';
 
 function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
@@ -19,7 +20,7 @@ const __dirname  = path.dirname(__filename);
 
 const neoRootDir        = path.resolve(__dirname, '../../../../');
 const cwd               = neoRootDir;
-const aiDataRoot        = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(cwd, '.neo-ai-data'));
+const aiDataRoot        = resolveAiDataRoot({neoRootDir: cwd});
 const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.join(aiDataRoot, 'wake-daemon'));
 const DAY_MS            = 24 * 60 * 60 * 1000;
 

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -3,7 +3,6 @@
 import '../../../config.template.mjs';
 import path                                  from 'path';
 import BaseConfig, {createConfigProxy, leaf} from '../../../BaseConfig.mjs';
-import {resolveAiDataRoot}                   from '../shared/helpers/DeploymentConfig.mjs';
 import {fileURLToPath}                       from 'url';
 
 function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
@@ -20,9 +19,13 @@ const __dirname  = path.dirname(__filename);
 
 const neoRootDir        = path.resolve(__dirname, '../../../../');
 const cwd               = neoRootDir;
-const aiDataRoot        = resolveAiDataRoot({neoRootDir: cwd});
+const aiDataRoot        = path.join(cwd, '.neo-ai-data');
 const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.join(aiDataRoot, 'wake-daemon'));
 const DAY_MS            = 24 * 60 * 60 * 1000;
+
+function hasEnvValue(name) {
+    return process.env[name] !== undefined && process.env[name] !== null && process.env[name] !== '';
+}
 
 /**
  * @summary Configuration manager for the Memory Core MCP server.
@@ -334,6 +337,44 @@ class Config extends BaseConfig {
              */
             lazyEdgesQueuePath: leaf(path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl'), 'NEO_LAZY_EDGES_QUEUE_PATH', 'string')
         }
+    };
+
+    /**
+     * @summary Keeps Memory Core-owned path defaults aligned with the resolved
+     * shared AI data root while preserving narrower env overrides.
+     *
+     * @param {String} leafPath Env-applied leaf path.
+     * @param {String} value Resolved Agent OS data root.
+     * @returns {void}
+     */
+    afterApplyEnvLeaf(leafPath, value) {
+        if (leafPath !== 'aiDataRoot') return;
+        if (!value) return;
+
+        const wakeDataDir = path.resolve(hasEnvValue('NEO_AI_DAEMON_DIR')
+            ? process.env.NEO_AI_DAEMON_DIR
+            : path.join(value, 'wake-daemon'));
+
+        if (!hasEnvValue('NEO_MEMORY_DB_PATH') && process.env.UNIT_TEST_MODE !== 'true') {
+            this.setData('storagePaths.graph', path.join(value, 'sqlite', 'memory-core-graph.sqlite'));
+        }
+        if (!hasEnvValue('NEO_AI_DAEMON_DIR')) {
+            this.setData('wakeDaemon.dataDir', wakeDataDir);
+        }
+        if (!hasEnvValue('NEO_BRIDGE_LAST_SYNC_ID_PATH')) {
+            this.setData('wakeDaemon.bridgeLastSyncIdPath', path.join(wakeDataDir, 'lastSyncId'));
+        }
+        if (!hasEnvValue('NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE')) {
+            this.setData('wakeDaemon.wakeSubscriptionLiveCursorPath', path.join(wakeDataDir, 'wakeSubscriptionLiveCursor'));
+        }
+        if (!hasEnvValue('NEO_RLAIF_PATH')) {
+            this.setData('datasets.rlaif.trajectories', path.join(value, 'datasets', 'rlaif', 'trajectories.jsonl'));
+        }
+        if (!hasEnvValue('NEO_REM_RUN_STATE_DIR')) {
+            this.setData('remRunStateDir', path.join(value, 'rem-runs'));
+        }
+
+        this.setData('logPath', path.join(value, 'logs'));
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -19,7 +19,8 @@ const __dirname  = path.dirname(__filename);
 
 const neoRootDir        = path.resolve(__dirname, '../../../../');
 const cwd               = neoRootDir;
-const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.resolve(cwd, '.neo-ai-data/wake-daemon'));
+const aiDataRoot        = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(cwd, '.neo-ai-data'));
+const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.join(aiDataRoot, 'wake-daemon'));
 const DAY_MS            = 24 * 60 * 60 * 1000;
 
 /**
@@ -55,6 +56,15 @@ class Config extends BaseConfig {
              * @type {string}
              */
             neoRootDir: leaf(neoRootDir),
+            /**
+             * @summary Canonical Agent OS runtime data root for Memory Core-owned files.
+             *
+             * Defaults to `<neoRootDir>/.neo-ai-data`; setting `NEO_AI_DATA_ROOT` relocates
+             * graph SQLite, wake-daemon watermarks, REM state, logs, and datasets together
+             * without requiring each sibling path to be overridden separately.
+             * @type {string}
+             */
+            aiDataRoot: leaf(aiDataRoot, 'NEO_AI_DATA_ROOT', 'string'),
             /**
              * Global debug flag for all MCP servers.
              * @type {boolean}
@@ -119,7 +129,7 @@ class Config extends BaseConfig {
              * Physical file paths for embedded/local datasets.
              */
             storagePaths: {
-                graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string')
+                graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.join(aiDataRoot, 'sqlite', 'memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string')
             },
             /**
              * Durable wake-daemon watermarks consumed by GraphLog maintenance.
@@ -144,14 +154,14 @@ class Config extends BaseConfig {
              */
             datasets: {
                 rlaif: {
-                    trajectories: leaf(path.resolve(cwd, '.neo-ai-data/datasets/rlaif/trajectories.jsonl'), 'NEO_RLAIF_PATH', 'string')
+                    trajectories: leaf(path.join(aiDataRoot, 'datasets', 'rlaif', 'trajectories.jsonl'), 'NEO_RLAIF_PATH', 'string')
                 }
             },
             /**
              * Directory for per-cycle REM run/stage JSONL state artifacts.
              * @type {string}
              */
-            remRunStateDir: leaf(path.resolve(cwd, '.neo-ai-data/rem-runs'), 'NEO_REM_RUN_STATE_DIR', 'string'),
+            remRunStateDir: leaf(path.join(aiDataRoot, 'rem-runs'), 'NEO_REM_RUN_STATE_DIR', 'string'),
             /**
              * Number of recent REM cycles projected by `get_rem_pipeline_state`.
              * @type {number}
@@ -233,12 +243,12 @@ class Config extends BaseConfig {
              * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-
              * running operations (summarization, ingestion sweeps, ChromaDB lifecycle) leave
              * a tail-able diagnostic trail observable from the host shell.
-             * Default: `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Neural
+             * Default: `<aiDataRoot>/logs/` — shared with the KB and Neural
              * Link servers (each uses a distinct filename prefix: `mc-server-`, `kb-server-`,
              * `nl-server-`). Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: leaf(path.resolve(cwd, '.neo-ai-data/logs')),
+            logPath: leaf(path.join(aiDataRoot, 'logs')),
             /**
              * @summary Shared MCP logger policy for Memory Core.
              *

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -20,7 +20,7 @@ const __dirname  = path.dirname(__filename);
 const neoRootDir        = path.resolve(__dirname, '../../../../');
 const cwd               = neoRootDir;
 const aiDataRoot        = path.join(cwd, '.neo-ai-data');
-const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.join(aiDataRoot, 'wake-daemon'));
+const wakeDaemonDataDir = path.join(aiDataRoot, 'wake-daemon');
 const DAY_MS            = 24 * 60 * 60 * 1000;
 
 function hasEnvValue(name) {
@@ -60,15 +60,6 @@ class Config extends BaseConfig {
              * @type {string}
              */
             neoRootDir: leaf(neoRootDir),
-            /**
-             * @summary Canonical Agent OS runtime data root for Memory Core-owned files.
-             *
-             * Defaults to `<neoRootDir>/.neo-ai-data`; setting `NEO_AI_DATA_ROOT` relocates
-             * graph SQLite, wake-daemon watermarks, REM state, logs, and datasets together
-             * without requiring each sibling path to be overridden separately.
-             * @type {string}
-             */
-            aiDataRoot: leaf(aiDataRoot, 'NEO_AI_DATA_ROOT', 'string'),
             /**
              * Global debug flag for all MCP servers.
              * @type {boolean}
@@ -141,7 +132,9 @@ class Config extends BaseConfig {
             wakeDaemon: {
                 dataDir: leaf(wakeDaemonDataDir, 'NEO_AI_DAEMON_DIR', 'string'),
                 bridgeLastSyncIdPath: leaf(path.join(wakeDaemonDataDir, 'lastSyncId'), 'NEO_BRIDGE_LAST_SYNC_ID_PATH', 'string'),
-                wakeSubscriptionLiveCursorPath: leaf(path.join(wakeDaemonDataDir, 'wakeSubscriptionLiveCursor'), 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string')
+                wakeSubscriptionLiveCursorPath: leaf(path.join(wakeDaemonDataDir, 'wakeSubscriptionLiveCursor'), 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string'),
+                pidFile: leaf(path.join(wakeDaemonDataDir, 'bridge-daemon.pid')),
+                logFile: leaf(path.join(wakeDaemonDataDir, 'bridge.log'))
             },
             /**
              * Data Schema/Table Names
@@ -336,45 +329,39 @@ class Config extends BaseConfig {
              * @type {string}
              */
             lazyEdgesQueuePath: leaf(path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl'), 'NEO_LAZY_EDGES_QUEUE_PATH', 'string')
+        },
+        formulas: {
+            'storagePaths.graph': data => {
+                if (process.env.UNIT_TEST_MODE === 'true') {
+                    return ':memory:'
+                }
+                if (hasEnvValue('NEO_MEMORY_DB_PATH')) {
+                    return data.storagePaths.graph
+                }
+                if (hasEnvValue('NEO_AI_DB_PATH')) {
+                    return process.env.NEO_AI_DB_PATH
+                }
+                return path.join(data.aiDataRoot, 'sqlite', 'memory-core-graph.sqlite')
+            },
+            'wakeDaemon.dataDir': data => hasEnvValue('NEO_AI_DAEMON_DIR')
+                ? data.wakeDaemon.dataDir
+                : path.join(data.aiDataRoot, 'wake-daemon'),
+            'wakeDaemon.bridgeLastSyncIdPath': data => hasEnvValue('NEO_BRIDGE_LAST_SYNC_ID_PATH')
+                ? data.wakeDaemon.bridgeLastSyncIdPath
+                : path.join(data.wakeDaemon.dataDir, 'lastSyncId'),
+            'wakeDaemon.wakeSubscriptionLiveCursorPath': data => hasEnvValue('NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE')
+                ? data.wakeDaemon.wakeSubscriptionLiveCursorPath
+                : path.join(data.wakeDaemon.dataDir, 'wakeSubscriptionLiveCursor'),
+            'wakeDaemon.pidFile': data => path.join(data.wakeDaemon.dataDir, 'bridge-daemon.pid'),
+            'wakeDaemon.logFile': data => path.join(data.wakeDaemon.dataDir, 'bridge.log'),
+            'datasets.rlaif.trajectories': data => hasEnvValue('NEO_RLAIF_PATH')
+                ? data.datasets.rlaif.trajectories
+                : path.join(data.aiDataRoot, 'datasets', 'rlaif', 'trajectories.jsonl'),
+            remRunStateDir: data => hasEnvValue('NEO_REM_RUN_STATE_DIR')
+                ? data.remRunStateDir
+                : path.join(data.aiDataRoot, 'rem-runs'),
+            logPath: data => path.join(data.aiDataRoot, 'logs')
         }
-    };
-
-    /**
-     * @summary Keeps Memory Core-owned path defaults aligned with the resolved
-     * shared AI data root while preserving narrower env overrides.
-     *
-     * @param {String} leafPath Env-applied leaf path.
-     * @param {String} value Resolved Agent OS data root.
-     * @returns {void}
-     */
-    afterApplyEnvLeaf(leafPath, value) {
-        if (leafPath !== 'aiDataRoot') return;
-        if (!value) return;
-
-        const wakeDataDir = path.resolve(hasEnvValue('NEO_AI_DAEMON_DIR')
-            ? process.env.NEO_AI_DAEMON_DIR
-            : path.join(value, 'wake-daemon'));
-
-        if (!hasEnvValue('NEO_MEMORY_DB_PATH') && process.env.UNIT_TEST_MODE !== 'true') {
-            this.setData('storagePaths.graph', path.join(value, 'sqlite', 'memory-core-graph.sqlite'));
-        }
-        if (!hasEnvValue('NEO_AI_DAEMON_DIR')) {
-            this.setData('wakeDaemon.dataDir', wakeDataDir);
-        }
-        if (!hasEnvValue('NEO_BRIDGE_LAST_SYNC_ID_PATH')) {
-            this.setData('wakeDaemon.bridgeLastSyncIdPath', path.join(wakeDataDir, 'lastSyncId'));
-        }
-        if (!hasEnvValue('NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE')) {
-            this.setData('wakeDaemon.wakeSubscriptionLiveCursorPath', path.join(wakeDataDir, 'wakeSubscriptionLiveCursor'));
-        }
-        if (!hasEnvValue('NEO_RLAIF_PATH')) {
-            this.setData('datasets.rlaif.trajectories', path.join(value, 'datasets', 'rlaif', 'trajectories.jsonl'));
-        }
-        if (!hasEnvValue('NEO_REM_RUN_STATE_DIR')) {
-            this.setData('remRunStateDir', path.join(value, 'rem-runs'));
-        }
-
-        this.setData('logPath', path.join(value, 'logs'));
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -2,13 +2,12 @@ import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
-import {resolveAiDataRoot}                     from '../shared/helpers/DeploymentConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
 const cwd        = process.cwd();
-const aiDataRoot = resolveAiDataRoot({neoRootDir});
+const aiDataRoot = path.join(neoRootDir, '.neo-ai-data');
 
 
 
@@ -106,6 +105,18 @@ class Config extends BaseConfig {
              */
             pruneLogsAfterDays: leaf(14, 'NEO_NL_PRUNE_LOGS_AFTER_DAYS', 'number')
         }
+    };
+
+    /**
+     * @summary Keeps NL-local paths aligned with the resolved shared AI data root.
+     * @param {String} leafPath Env-applied leaf path.
+     * @param {String} value Resolved Agent OS data root.
+     * @returns {void}
+     */
+    afterApplyEnvLeaf(leafPath, value) {
+        if (leafPath !== 'aiDataRoot') return;
+        if (!value) return;
+        this.setData('logPath', path.join(value, 'logs'));
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -7,6 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
 const cwd        = process.cwd();
+const aiDataRoot = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(neoRootDir, '.neo-ai-data'));
 
 
 
@@ -44,6 +45,12 @@ class Config extends BaseConfig {
              */
             neoRootDir: leaf(neoRootDir),
             /**
+             * Canonical Agent OS runtime data root shared with Memory Core, Knowledge Base,
+             * and local daemon logs.
+             * @type {string}
+             */
+            aiDataRoot: leaf(aiDataRoot, 'NEO_AI_DATA_ROOT', 'string'),
+            /**
              * Automatically connect to the bridge on startup.
              * @type {boolean}
              */
@@ -73,12 +80,12 @@ class Config extends BaseConfig {
              * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so
              * long-running inspection chains and DOM/VDOM introspection sweeps leave a
              * tail-able diagnostic trail observable from the host shell. Default:
-             * `<neoRootDir>/.neo-ai-data/logs/` — shared with the KB and Memory Core servers
+             * `<aiDataRoot>/logs/` — shared with the KB and Memory Core servers
              * (each uses a distinct filename prefix: `nl-server-`, `kb-server-`, `mc-server-`).
              * Per-server file isolation, single tailable directory.
              * @type {string}
              */
-            logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
+            logPath: leaf(path.join(aiDataRoot, 'logs')),
             /**
              * @summary Shared MCP logger policy for Neural Link.
              *

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -2,12 +2,13 @@ import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
+import {resolveAiDataRoot}                     from '../shared/helpers/DeploymentConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
 const cwd        = process.cwd();
-const aiDataRoot = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(neoRootDir, '.neo-ai-data'));
+const aiDataRoot = resolveAiDataRoot({neoRootDir});
 
 
 

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,12 +1,12 @@
 import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
+import '../../../config.template.mjs';
 import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const neoRootDir = path.resolve(__dirname, '../../../../');
-const cwd        = process.cwd();
 const aiDataRoot = path.join(neoRootDir, '.neo-ai-data');
 
 
@@ -44,12 +44,6 @@ class Config extends BaseConfig {
              * @type {string}
              */
             neoRootDir: leaf(neoRootDir),
-            /**
-             * Canonical Agent OS runtime data root shared with Memory Core, Knowledge Base,
-             * and local daemon logs.
-             * @type {string}
-             */
-            aiDataRoot: leaf(aiDataRoot, 'NEO_AI_DATA_ROOT', 'string'),
             /**
              * Automatically connect to the bridge on startup.
              * @type {boolean}
@@ -104,19 +98,10 @@ class Config extends BaseConfig {
              * @type {number}
              */
             pruneLogsAfterDays: leaf(14, 'NEO_NL_PRUNE_LOGS_AFTER_DAYS', 'number')
+        },
+        formulas: {
+            logPath: data => path.join(data.aiDataRoot, 'logs')
         }
-    };
-
-    /**
-     * @summary Keeps NL-local paths aligned with the resolved shared AI data root.
-     * @param {String} leafPath Env-applied leaf path.
-     * @param {String} value Resolved Agent OS data root.
-     * @returns {void}
-     */
-    afterApplyEnvLeaf(leafPath, value) {
-        if (leafPath !== 'aiDataRoot') return;
-        if (!value) return;
-        this.setData('logPath', path.join(value, 'logs'));
     }
 }
 const instance = Neo.setupClass(Config);

--- a/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
+++ b/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
@@ -1,3 +1,30 @@
+import path from 'path';
+
+/**
+ * @summary Resolves the canonical Agent OS runtime data root from config + env.
+ *
+ * Centralizes the `.neo-ai-data` fallback so runtime consumers do not each rebuild the
+ * `NEO_AI_DATA_ROOT || <repo>/.neo-ai-data` contract. Pass an `AiConfig`-shaped config
+ * object when available; stale local config copies that predate `aiDataRoot` still inherit
+ * the env/default path from this single dependency-free helper.
+ *
+ * @param {Object} [options]
+ * @param {Object|null} [options.config=null] Config proxy carrying `aiDataRoot` / `neoRootDir`.
+ * @param {String|null} [options.neoRootDir=null] Repository root fallback.
+ * @param {Object} [options.env=process.env] Environment source.
+ * @returns {String}
+ */
+export function resolveAiDataRoot({
+    config     = null,
+    neoRootDir = null,
+    env        = process.env
+} = {}) {
+    const configuredRoot = config?.aiDataRoot;
+    const rootDir        = neoRootDir || config?.neoRootDir || process.cwd();
+
+    return path.resolve(configuredRoot || env.NEO_AI_DATA_ROOT || path.resolve(rootDir, '.neo-ai-data'));
+}
+
 /**
  * @summary Resolves the MCP server HTTP listening port.
  *

--- a/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
+++ b/ai/mcp/server/shared/helpers/DeploymentConfig.mjs
@@ -1,30 +1,3 @@
-import path from 'path';
-
-/**
- * @summary Resolves the canonical Agent OS runtime data root from config + env.
- *
- * Centralizes the `.neo-ai-data` fallback so runtime consumers do not each rebuild the
- * `NEO_AI_DATA_ROOT || <repo>/.neo-ai-data` contract. Pass an `AiConfig`-shaped config
- * object when available; stale local config copies that predate `aiDataRoot` still inherit
- * the env/default path from this single dependency-free helper.
- *
- * @param {Object} [options]
- * @param {Object|null} [options.config=null] Config proxy carrying `aiDataRoot` / `neoRootDir`.
- * @param {String|null} [options.neoRootDir=null] Repository root fallback.
- * @param {Object} [options.env=process.env] Environment source.
- * @returns {String}
- */
-export function resolveAiDataRoot({
-    config     = null,
-    neoRootDir = null,
-    env        = process.env
-} = {}) {
-    const configuredRoot = config?.aiDataRoot;
-    const rootDir        = neoRootDir || config?.neoRootDir || process.cwd();
-
-    return path.resolve(configuredRoot || env.NEO_AI_DATA_ROOT || path.resolve(rootDir, '.neo-ai-data'));
-}
-
 /**
  * @summary Resolves the MCP server HTTP listening port.
  *

--- a/ai/scripts/lifecycle/harnessLifecycle.mjs
+++ b/ai/scripts/lifecycle/harnessLifecycle.mjs
@@ -17,10 +17,10 @@
 import fs   from 'fs/promises';
 import path from 'path';
 import {fileURLToPath} from 'url';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STATE_DIR = path.join(resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')}), 'harness-state');
+const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
+const STATE_DIR = path.join(AI_DATA_ROOT, 'harness-state');
 
 function sanitize(identity) {
     return identity.replace(/[^a-zA-Z0-9_-]/g, '');

--- a/ai/scripts/lifecycle/harnessLifecycle.mjs
+++ b/ai/scripts/lifecycle/harnessLifecycle.mjs
@@ -16,11 +16,11 @@
  */
 import fs   from 'fs/promises';
 import path from 'path';
-import {fileURLToPath} from 'url';
+import '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import AiConfig from '../../config.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
-const STATE_DIR = path.join(AI_DATA_ROOT, 'harness-state');
+const STATE_DIR = AiConfig.harnessStateDir;
 
 function sanitize(identity) {
     return identity.replace(/[^a-zA-Z0-9_-]/g, '');

--- a/ai/scripts/lifecycle/harnessLifecycle.mjs
+++ b/ai/scripts/lifecycle/harnessLifecycle.mjs
@@ -16,10 +16,11 @@
  */
 import fs   from 'fs/promises';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import {fileURLToPath} from 'url';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STATE_DIR = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'), 'harness-state');
+const STATE_DIR = path.join(resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')}), 'harness-state');
 
 function sanitize(identity) {
     return identity.replace(/[^a-zA-Z0-9_-]/g, '');

--- a/ai/scripts/lifecycle/harnessLifecycle.mjs
+++ b/ai/scripts/lifecycle/harnessLifecycle.mjs
@@ -19,7 +19,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STATE_DIR = path.resolve(__dirname, '../../../.neo-ai-data/harness-state');
+const STATE_DIR = path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'), 'harness-state');
 
 function sanitize(identity) {
     return identity.replace(/[^a-zA-Z0-9_-]/g, '');

--- a/ai/scripts/lifecycle/heartbeatLock.mjs
+++ b/ai/scripts/lifecycle/heartbeatLock.mjs
@@ -20,8 +20,10 @@ import {spawn} from 'child_process';
 import fs      from 'fs-extra';
 import path    from 'path';
 import {fileURLToPath} from 'url';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
-const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const __dirname    = path.dirname(fileURLToPath(import.meta.url));
+const AI_DATA_ROOT = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
 
 export const HEARTBEAT_LOCK_PATH = path.join(AI_DATA_ROOT, 'heartbeat-concurrency.lock');
 export const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;

--- a/ai/scripts/lifecycle/heartbeatLock.mjs
+++ b/ai/scripts/lifecycle/heartbeatLock.mjs
@@ -20,12 +20,24 @@ import {spawn} from 'child_process';
 import fs      from 'fs-extra';
 import path    from 'path';
 import {fileURLToPath} from 'url';
+import '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import AiConfig from '../../config.mjs';
 
-const __dirname    = path.dirname(fileURLToPath(import.meta.url));
-const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
-
-export const HEARTBEAT_LOCK_PATH = path.join(AI_DATA_ROOT, 'heartbeat-concurrency.lock');
+export const HEARTBEAT_LOCK_PATH = AiConfig.heartbeatConcurrencyLockPath;
 export const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;
+
+/**
+ * @summary Reads the configured heartbeat concurrency lock path.
+ *
+ * The Tier-1 AiConfig Provider owns the shared-data-root formula and optional
+ * `NEO_HEARTBEAT_LOCK_PATH` override; consumers read the resolved leaf.
+ *
+ * @returns {String}
+ */
+export function heartbeatLockPath() {
+    return AiConfig.heartbeatConcurrencyLockPath;
+}
 
 /**
  * @summary Creates the heartbeat concurrency lock before expensive Agent OS work starts.
@@ -40,7 +52,7 @@ export const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;
  * @returns {Promise<string>} The created lock path.
  */
 export async function acquireHeartbeatLock({
-    lockPath = HEARTBEAT_LOCK_PATH,
+    lockPath = heartbeatLockPath(),
     metadata = {}
 } = {}) {
     await fs.ensureDir(path.dirname(lockPath));
@@ -63,7 +75,7 @@ export async function acquireHeartbeatLock({
  * @param {string} [options.lockPath=HEARTBEAT_LOCK_PATH] Lock file path to remove.
  * @returns {Promise<void>}
  */
-export async function releaseHeartbeatLock({lockPath = HEARTBEAT_LOCK_PATH} = {}) {
+export async function releaseHeartbeatLock({lockPath = heartbeatLockPath()} = {}) {
     await fs.remove(lockPath)
 }
 
@@ -80,7 +92,7 @@ export async function releaseHeartbeatLock({lockPath = HEARTBEAT_LOCK_PATH} = {}
  * @returns {Promise<{active: Boolean, stale: Boolean, ageMs: Number|null}>}
  */
 export async function inspectHeartbeatLock({
-    lockPath = HEARTBEAT_LOCK_PATH,
+    lockPath = heartbeatLockPath(),
     staleAfterMs = DEFAULT_STALE_LOCK_MS,
     now = new Date()
 } = {}) {

--- a/ai/scripts/lifecycle/heartbeatLock.mjs
+++ b/ai/scripts/lifecycle/heartbeatLock.mjs
@@ -20,10 +20,9 @@ import {spawn} from 'child_process';
 import fs      from 'fs-extra';
 import path    from 'path';
 import {fileURLToPath} from 'url';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname    = path.dirname(fileURLToPath(import.meta.url));
-const AI_DATA_ROOT = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
+const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
 
 export const HEARTBEAT_LOCK_PATH = path.join(AI_DATA_ROOT, 'heartbeat-concurrency.lock');
 export const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;

--- a/ai/scripts/lifecycle/heartbeatLock.mjs
+++ b/ai/scripts/lifecycle/heartbeatLock.mjs
@@ -21,7 +21,9 @@ import fs      from 'fs-extra';
 import path    from 'path';
 import {fileURLToPath} from 'url';
 
-export const HEARTBEAT_LOCK_PATH = '.neo-ai-data/heartbeat-concurrency.lock';
+const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+
+export const HEARTBEAT_LOCK_PATH = path.join(AI_DATA_ROOT, 'heartbeat-concurrency.lock');
 export const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;
 
 /**

--- a/ai/scripts/lifecycle/inflightLock.mjs
+++ b/ai/scripts/lifecycle/inflightLock.mjs
@@ -2,14 +2,13 @@ import fs from 'fs/promises';
 import path from 'path';
 import { writeGateState } from './wakeSafetyGate.mjs';
 import { fileURLToPath } from 'url';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const BOOT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 export const MAX_ABANDONED_ACTIONS = 3;
 
 function defaultAiDataRoot() {
-    return resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
+    return process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
 }
 
 /**

--- a/ai/scripts/lifecycle/inflightLock.mjs
+++ b/ai/scripts/lifecycle/inflightLock.mjs
@@ -7,6 +7,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const BOOT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 export const MAX_ABANDONED_ACTIONS = 3;
 
+function defaultAiDataRoot() {
+    return path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'));
+}
+
 /**
  * @summary Build the absolute in-flight lock-file path for one identity/mode pair.
  * @param {string} mode Recovery action mode.
@@ -15,7 +19,7 @@ export const MAX_ABANDONED_ACTIONS = 3;
  */
 export function getLockPath(mode, identity) {
     const cleanIdentity = identity.replace(/[^a-zA-Z0-9_-]/g, '');
-    return path.resolve(__dirname, `../../../.neo-ai-data/wake-daemon/inflight-${mode}-${cleanIdentity}.txt`);
+    return path.join(defaultAiDataRoot(), 'wake-daemon', `inflight-${mode}-${cleanIdentity}.txt`);
 }
 
 /**

--- a/ai/scripts/lifecycle/inflightLock.mjs
+++ b/ai/scripts/lifecycle/inflightLock.mjs
@@ -1,15 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { writeGateState } from './wakeSafetyGate.mjs';
-import { fileURLToPath } from 'url';
+import '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import MemoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const BOOT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 export const MAX_ABANDONED_ACTIONS = 3;
-
-function defaultAiDataRoot() {
-    return process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
-}
 
 /**
  * @summary Build the absolute in-flight lock-file path for one identity/mode pair.
@@ -19,7 +16,7 @@ function defaultAiDataRoot() {
  */
 export function getLockPath(mode, identity) {
     const cleanIdentity = identity.replace(/[^a-zA-Z0-9_-]/g, '');
-    return path.join(defaultAiDataRoot(), 'wake-daemon', `inflight-${mode}-${cleanIdentity}.txt`);
+    return path.join(MemoryCoreConfig.wakeDaemon.dataDir, `inflight-${mode}-${cleanIdentity}.txt`);
 }
 
 /**

--- a/ai/scripts/lifecycle/inflightLock.mjs
+++ b/ai/scripts/lifecycle/inflightLock.mjs
@@ -1,14 +1,15 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { writeGateState } from './wakeSafetyGate.mjs';
+import { fileURLToPath } from 'url';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const BOOT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 export const MAX_ABANDONED_ACTIONS = 3;
 
 function defaultAiDataRoot() {
-    return path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'));
+    return resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
 }
 
 /**

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -21,11 +21,10 @@ import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
 import { createSpawnRequest } from './windowsBatchSpawn.mjs';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
-const defaultAiDataRoot = () => resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
+const defaultAiDataRoot = () => process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
 
 /**
  * @summary Spawn a child process and (optionally) record its PID for later harness cleanup.

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -24,6 +24,7 @@ import { createSpawnRequest } from './windowsBatchSpawn.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
+const defaultAiDataRoot = () => path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'));
 
 /**
  * @summary Spawn a child process and (optionally) record its PID for later harness cleanup.
@@ -287,7 +288,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
 
     // Idempotency: resolve the cooldown beside this script so cron/launchd callers
     // share the same 600s re-fire window regardless of their current working directory.
-    const cooldownDir = path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon');
+    const cooldownDir = path.join(defaultAiDataRoot(), 'wake-daemon');
     const cooldownFile = path.resolve(cooldownDir, `cooldown-${identity.replace(/[^a-zA-Z0-9_-]/g, '')}.txt`);
 
     try {

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -21,10 +21,11 @@ import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
 import { createSpawnRequest } from './windowsBatchSpawn.mjs';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
-const defaultAiDataRoot = () => path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'));
+const defaultAiDataRoot = () => resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
 
 /**
  * @summary Spawn a child process and (optionally) record its PID for later harness cleanup.

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -21,10 +21,10 @@ import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
 import { createSpawnRequest } from './windowsBatchSpawn.mjs';
+import MemoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
-const defaultAiDataRoot = () => process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
 
 /**
  * @summary Spawn a child process and (optionally) record its PID for later harness cleanup.
@@ -288,7 +288,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
 
     // Idempotency: resolve the cooldown beside this script so cron/launchd callers
     // share the same 600s re-fire window regardless of their current working directory.
-    const cooldownDir = path.join(defaultAiDataRoot(), 'wake-daemon');
+    const cooldownDir = MemoryCoreConfig.wakeDaemon.dataDir;
     const cooldownFile = path.resolve(cooldownDir, `cooldown-${identity.replace(/[^a-zA-Z0-9_-]/g, '')}.txt`);
 
     try {

--- a/ai/scripts/lifecycle/trioWakeCooldown.mjs
+++ b/ai/scripts/lifecycle/trioWakeCooldown.mjs
@@ -16,10 +16,9 @@ import LifecycleService from '../../services/memory-core/lifecycle/SystemLifecyc
 import GraphService from '../../services/memory-core/GraphService.mjs';
 import MailboxService from '../../services/memory-core/MailboxService.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const AI_DATA_ROOT = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
+const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
 const COOLDOWN_STATE_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.json');
 const COOLDOWN_LOCK_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.lock');
 

--- a/ai/scripts/lifecycle/trioWakeCooldown.mjs
+++ b/ai/scripts/lifecycle/trioWakeCooldown.mjs
@@ -16,8 +16,10 @@ import LifecycleService from '../../services/memory-core/lifecycle/SystemLifecyc
 import GraphService from '../../services/memory-core/GraphService.mjs';
 import MailboxService from '../../services/memory-core/MailboxService.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
-const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const AI_DATA_ROOT = resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
 const COOLDOWN_STATE_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.json');
 const COOLDOWN_LOCK_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.lock');
 

--- a/ai/scripts/lifecycle/trioWakeCooldown.mjs
+++ b/ai/scripts/lifecycle/trioWakeCooldown.mjs
@@ -17,8 +17,9 @@ import GraphService from '../../services/memory-core/GraphService.mjs';
 import MailboxService from '../../services/memory-core/MailboxService.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 
-const COOLDOWN_STATE_PATH = '.neo-ai-data/wake-daemon/trio-wake-cooldown.json';
-const COOLDOWN_LOCK_PATH = '.neo-ai-data/wake-daemon/trio-wake-cooldown.lock';
+const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || '.neo-ai-data';
+const COOLDOWN_STATE_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.json');
+const COOLDOWN_LOCK_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.lock');
 
 /**
  * @summary Dispatch the cooldown-bounded swarm-wide wake for an all-agent-idle signal.

--- a/ai/scripts/lifecycle/trioWakeCooldown.mjs
+++ b/ai/scripts/lifecycle/trioWakeCooldown.mjs
@@ -10,6 +10,7 @@ import path from 'path';
 import {fileURLToPath} from 'url';
 import Neo from '../../../src/Neo.mjs';
 import * as core from '../../../src/core/_export.mjs';
+import MemoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 import { withHeartbeatLock } from './heartbeatLock.mjs';
 import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
 import LifecycleService from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
@@ -17,10 +18,8 @@ import GraphService from '../../services/memory-core/GraphService.mjs';
 import MailboxService from '../../services/memory-core/MailboxService.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const AI_DATA_ROOT = process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
-const COOLDOWN_STATE_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.json');
-const COOLDOWN_LOCK_PATH = path.join(AI_DATA_ROOT, 'wake-daemon', 'trio-wake-cooldown.lock');
+const COOLDOWN_STATE_PATH = path.join(MemoryCoreConfig.wakeDaemon.dataDir, 'trio-wake-cooldown.json');
+const COOLDOWN_LOCK_PATH = path.join(MemoryCoreConfig.wakeDaemon.dataDir, 'trio-wake-cooldown.lock');
 
 /**
  * @summary Dispatch the cooldown-bounded swarm-wide wake for an all-agent-idle signal.

--- a/ai/scripts/lifecycle/wakeSafetyGate.mjs
+++ b/ai/scripts/lifecycle/wakeSafetyGate.mjs
@@ -43,11 +43,11 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 function defaultAiDataRoot() {
-    return path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'));
+    return resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
 }
 
 /**

--- a/ai/scripts/lifecycle/wakeSafetyGate.mjs
+++ b/ai/scripts/lifecycle/wakeSafetyGate.mjs
@@ -43,11 +43,10 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import {resolveAiDataRoot} from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function defaultAiDataRoot() {
-    return resolveAiDataRoot({neoRootDir: path.resolve(__dirname, '../../..')});
+    return process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
 }
 
 /**

--- a/ai/scripts/lifecycle/wakeSafetyGate.mjs
+++ b/ai/scripts/lifecycle/wakeSafetyGate.mjs
@@ -46,6 +46,10 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function defaultAiDataRoot() {
+    return path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data'));
+}
+
 /**
  * Resolve the canonical state-file path under the wake-daemon data directory.
  * Resolved from `__dirname` rather than `process.cwd()` so the path is stable
@@ -59,7 +63,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * @returns {string} Absolute path to the gate state file.
  */
 export function gateFilePath() {
-    return process.env.WAKE_GATE_FILE_PATH || path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon/wake-safety-gate.json');
+    return process.env.WAKE_GATE_FILE_PATH || path.join(defaultAiDataRoot(), 'wake-daemon', 'wake-safety-gate.json');
 }
 
 /**

--- a/ai/scripts/lifecycle/wakeSafetyGate.mjs
+++ b/ai/scripts/lifecycle/wakeSafetyGate.mjs
@@ -43,17 +43,15 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-function defaultAiDataRoot() {
-    return process.env.NEO_AI_DATA_ROOT || path.join(path.resolve(__dirname, '../../..'), '.neo-ai-data');
-}
+import '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import MemoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 
 /**
  * Resolve the canonical state-file path under the wake-daemon data directory.
- * Resolved from `__dirname` rather than `process.cwd()` so the path is stable
- * under cron / launchd / sub-process invocations that don't inherit the
- * working directory of the operator's shell.
+ * Resolved from the Memory Core config Provider so the path follows the
+ * canonical wake-daemon data directory under cron / launchd / sub-process
+ * invocations that don't inherit the operator shell's working directory.
  *
  * Tests may override the path via the `WAKE_GATE_FILE_PATH` environment
  * variable so parallel specs don't collide on the singleton on-disk state.
@@ -62,7 +60,7 @@ function defaultAiDataRoot() {
  * @returns {string} Absolute path to the gate state file.
  */
 export function gateFilePath() {
-    return process.env.WAKE_GATE_FILE_PATH || path.join(defaultAiDataRoot(), 'wake-daemon', 'wake-safety-gate.json');
+    return process.env.WAKE_GATE_FILE_PATH || path.join(MemoryCoreConfig.wakeDaemon.dataDir, 'wake-safety-gate.json');
 }
 
 /**

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -3,6 +3,7 @@ import fsExtra                  from 'fs-extra';
 import path                     from 'path';
 import {fileURLToPath}          from 'url';
 import aiConfig                 from '../../mcp/server/memory-core/config.mjs';
+import {resolveAiDataRoot}      from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 import Base                     from '../../../src/core/Base.mjs';
 import ChromaManager            from './managers/ChromaManager.mjs';
 import StorageRouter            from './managers/StorageRouter.mjs';
@@ -28,7 +29,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function heartbeatAlivePath() {
     return process.env.NEO_HEARTBEAT_ALIVE_PATH
         || aiConfig.wakeDaemonHeartbeatAlivePath
-        || path.join(path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data')), 'wake-daemon', 'heartbeat.alive');
+        || path.join(resolveAiDataRoot({config: aiConfig, neoRootDir: path.resolve(__dirname, '../../..')}), 'wake-daemon', 'heartbeat.alive');
 }
 
 /**

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -26,7 +26,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * `pulse()` by the Orchestrator's swarm-heartbeat lane.
  */
 function heartbeatAlivePath() {
-    return process.env.NEO_HEARTBEAT_ALIVE_PATH || path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon/heartbeat.alive');
+    return process.env.NEO_HEARTBEAT_ALIVE_PATH
+        || aiConfig.wakeDaemonHeartbeatAlivePath
+        || path.join(path.resolve(process.env.NEO_AI_DATA_ROOT || path.resolve(__dirname, '../../../.neo-ai-data')), 'wake-daemon', 'heartbeat.alive');
 }
 
 /**

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -19,16 +19,12 @@ import {readRecentRemRunStates} from './helpers/RemRunStateStore.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Heartbeat-liveness file path resolution. Mirrors `wakeSafetyGate.gateFilePath()` env-override
- * pattern so parallel test specs can isolate from the canonical on-disk path. Production
- * deployments leave `NEO_HEARTBEAT_ALIVE_PATH` unset; the canonical path under `.neo-ai-data/wake-daemon/`
- * applies. Counterpart producer: `SwarmHeartbeatService.touchLivenessFile()`, called once per
- * `pulse()` by the Orchestrator's swarm-heartbeat lane.
+ * Heartbeat-liveness file path resolution. The Tier-1 AiConfig Provider owns the
+ * `NEO_HEARTBEAT_ALIVE_PATH` env layer and shared-data-root derivation; consumers
+ * read the resolved leaf instead of re-deriving the path.
  */
 function heartbeatAlivePath() {
-    return process.env.NEO_HEARTBEAT_ALIVE_PATH
-        || aiConfig.wakeDaemonHeartbeatAlivePath
-        || path.join(aiConfig.aiDataRoot, 'wake-daemon', 'heartbeat.alive');
+    return aiConfig.wakeDaemonHeartbeatAlivePath;
 }
 
 /**
@@ -389,6 +385,9 @@ export function buildAuthProviderBlock(cfg) {
  * Aligns with the "surface, don't obscure" principle.
  *
  * @param {Number|Date} [now=Date.now()] Time source for deterministic tests
+ * @param {Object} [options]
+ * @param {String} [options.livenessPath=aiConfig.wakeDaemonHeartbeatAlivePath]
+ *     Explicit heartbeat-liveness path for tests and callers with an already-resolved path.
  * @returns {Promise<{gateState: String, gateReason: String, gateTrippedAt: String|null,
  *     gateTrippedBy: String|null, daemonRunning: Boolean, lastPulseAt: String|null,
  *     secondsSinceLastPulse: Number|null}>}
@@ -396,7 +395,7 @@ export function buildAuthProviderBlock(cfg) {
  * @see ai/daemons/SwarmHeartbeatService.mjs — the swarm-heartbeat lane that touches the liveness file
  * @see learn/agentos/wake-substrate/PersistentProcessManagement.md
  */
-export async function buildWakeFeaturesBlock(now = Date.now()) {
+export async function buildWakeFeaturesBlock(now = Date.now(), {livenessPath = heartbeatAlivePath()} = {}) {
     const nowMs = typeof now === 'number' ? now : now.getTime();
 
     let gateBlock = {
@@ -428,7 +427,7 @@ export async function buildWakeFeaturesBlock(now = Date.now()) {
     };
 
     try {
-        const stat       = await fs.stat(heartbeatAlivePath());
+        const stat       = await fs.stat(livenessPath);
         const mtimeMs    = stat.mtime.getTime();
         const ageMs      = Math.max(0, nowMs - mtimeMs);
         livenessBlock = {

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -3,7 +3,6 @@ import fsExtra                  from 'fs-extra';
 import path                     from 'path';
 import {fileURLToPath}          from 'url';
 import aiConfig                 from '../../mcp/server/memory-core/config.mjs';
-import {resolveAiDataRoot}      from '../../mcp/server/shared/helpers/DeploymentConfig.mjs';
 import Base                     from '../../../src/core/Base.mjs';
 import ChromaManager            from './managers/ChromaManager.mjs';
 import StorageRouter            from './managers/StorageRouter.mjs';
@@ -29,7 +28,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function heartbeatAlivePath() {
     return process.env.NEO_HEARTBEAT_ALIVE_PATH
         || aiConfig.wakeDaemonHeartbeatAlivePath
-        || path.join(resolveAiDataRoot({config: aiConfig, neoRootDir: path.resolve(__dirname, '../../..')}), 'wake-daemon', 'heartbeat.alive');
+        || path.join(aiConfig.aiDataRoot, 'wake-daemon', 'heartbeat.alive');
 }
 
 /**

--- a/learn/agentos/AiConfigModel.md
+++ b/learn/agentos/AiConfigModel.md
@@ -22,6 +22,18 @@ Two properties fall out of "each layer owns only its slice":
 
 A config's `data` is a *meta-leaf tree* — each leaf is `leaf(default, env?, type?)`. `BaseConfig.compileMetaLeaves` walks it into (a) plain reactive data and (b) a metadata registry keyed by dotted path. A bounded **env layer** then overlays environment variables onto env-bound leaves — re-resolved at construction and on explicit refresh, never live-per-read (a port that silently moves without a coordinated restart is a footgun, not a feature). See `ai/BaseConfig.mjs`.
 
+## Runtime access and test seams
+
+The singleton configs are the source-of-truth providers, not mutable scratchpads. Runtime code must read resolved leaves from the relevant provider (`AiConfig`, `MemoryCoreConfig`, and other server configs) instead of recomputing template defaults or writing ad-hoc fallbacks next to each consumer. Derived paths belong in template leaves/formulas, so a changed Tier-1 root updates every consumer through the Provider chain.
+
+Tests follow the same boundary. Do **not** mutate config singletons to steer behavior (`AiConfig.somePath = ...`, `memoryCoreConfig.somePath = ...`, etc.); that hides stale consumers and leaks state across import order. Use one of the explicit seams instead:
+
+- construct a fresh config/provider under controlled env before import;
+- run a subprocess with the intended env envelope when singleton import order matters;
+- pass the value through a narrow constructor/method/test option when the code under test already has a runtime seam.
+
+If none of those seams exists, add the seam or model the value as a leaf/formula first. Mutating the singleton is evidence that the configurable boundary is in the wrong layer.
+
 ## Templates, overlays, and why advancement is *inheritance*
 
 Each config exists as a pair: a tracked `config.template.mjs` (the canonical defaults) and a gitignored `config.mjs` (the operator overlay). The overlay's job is to carry the operator's **deltas** — nothing more.

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,5 +1,8 @@
 import { test, expect } from '@playwright/test';
+import {execFileSync} from 'child_process';
 import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import Neo from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 import BaseConfig from '../../../../ai/BaseConfig.mjs';
@@ -99,6 +102,61 @@ test.describe('Tier 1 Config Immutability', () => {
             host    : process.env.NEO_CHROMA_HOST || 'localhost',
             port    : Number(process.env.NEO_CHROMA_PORT) || 8000,
             database: process.env.NEO_CHROMA_DATABASE || CHROMA_TEST_DATABASE
+        });
+    });
+
+    test('NEO_AI_DATA_ROOT relocates Tier-1 derived leaves through Provider formulas', async () => {
+        const aiDataRoot = path.join(os.tmpdir(), `neo-ai-data-root-${Date.now()}`);
+        const env = {
+            ...process.env,
+            NEO_AI_DATA_ROOT: aiDataRoot,
+            UNIT_TEST_MODE  : 'false'
+        };
+
+        delete env.NEO_BACKUP_PATH;
+        delete env.NEO_HEARTBEAT_ALIVE_PATH;
+        delete env.NEO_HEARTBEAT_LOCK_PATH;
+        delete env.NEO_HARNESS_STATE_DIR;
+        delete env.NEO_AI_ORCHESTRATOR_DIR;
+
+        const script = `
+            import './src/Neo.mjs';
+            import './src/core/_export.mjs';
+            const cfg = (await import('./ai/config.template.mjs')).default;
+            process.stdout.write(JSON.stringify({
+                aiDataRoot: cfg.aiDataRoot,
+                backupPath: cfg.backupPath,
+                heartbeat: cfg.wakeDaemonHeartbeatAlivePath,
+                heartbeatLockPath: cfg.heartbeatConcurrencyLockPath,
+                harnessStateDir: cfg.harnessStateDir,
+                chromaDataDir: cfg.engines.chroma.dataDir,
+                orchestratorDataDir: cfg.orchestrator.dataDir,
+                orchestratorPidFile: cfg.orchestrator.pidFile,
+                orchestratorLogFile: cfg.orchestrator.logFile,
+                orchestratorStateFile: cfg.orchestrator.stateFile,
+                heavyMaintenanceLeasePath: cfg.orchestrator.heavyMaintenanceLeasePath,
+                wakeDecisionBackoffStateFile: cfg.orchestrator.wakeDecisionBackoffStateFile
+            }));
+        `;
+        const actual = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+            cwd: path.resolve(process.cwd()),
+            env,
+            encoding: 'utf8'
+        }));
+
+        expect(actual).toEqual({
+            aiDataRoot,
+            backupPath                      : path.join(aiDataRoot, 'backups'),
+            heartbeat                       : path.join(aiDataRoot, 'wake-daemon', 'heartbeat.alive'),
+            heartbeatLockPath               : path.join(aiDataRoot, 'heartbeat-concurrency.lock'),
+            harnessStateDir                 : path.join(aiDataRoot, 'harness-state'),
+            chromaDataDir                   : path.join(aiDataRoot, 'chroma', 'unified'),
+            orchestratorDataDir             : path.join(aiDataRoot, 'orchestrator-daemon'),
+            orchestratorPidFile             : path.join(aiDataRoot, 'orchestrator-daemon', 'orchestrator-daemon.pid'),
+            orchestratorLogFile             : path.join(aiDataRoot, 'orchestrator-daemon', 'orchestrator.log'),
+            orchestratorStateFile           : path.join(aiDataRoot, 'orchestrator-daemon', 'orchestrator-state.json'),
+            heavyMaintenanceLeasePath       : path.join(aiDataRoot, 'orchestrator-daemon', 'heavy-maintenance-lease.json'),
+            wakeDecisionBackoffStateFile    : path.join(aiDataRoot, 'wake-daemon', 'backoff.json')
         });
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.externalConfig.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.externalConfig.spec.mjs
@@ -1,15 +1,15 @@
 import {test, expect} from '@playwright/test';
+import {execFileSync} from 'child_process';
 import fs   from 'fs/promises';
 import os   from 'os';
 import path from 'path';
-import {fileURLToPath, pathToFileURL} from 'url';
+import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
 
 const DAEMON_DIR = path.join(REPO_ROOT, 'ai/daemons');
-const TASK_DEFINITIONS_URL = pathToFileURL(path.join(REPO_ROOT, 'ai/daemons/orchestrator/TaskDefinitions.mjs')).href;
 
 const NEO_TEAM_IDENTITY_LITERAL_RE   = /['"`]@neo-(?:opus-4-7|gpt|gemini-3-1-pro)['"`]/g;
 const NEO_TEAM_PROJECT_LITERAL_RE    = /['"`]Project 12['"`]|['"`]v13['"`]|['"`]release:v\d+['"`]/g;
@@ -200,13 +200,28 @@ test.describe('Orchestrator shared data-root defaults (#12417)', () => {
         delete process.env.NEO_AI_DB_PATH;
         delete process.env.NEO_AI_ORCHESTRATOR_DIR;
 
-        const taskDefinitions = await import(`${TASK_DEFINITIONS_URL}?root=${Date.now()}`);
-        const tasks = taskDefinitions.buildTaskDefinitions({chromaPort: 9123});
+        const script = `
+            import './src/Neo.mjs';
+            import './src/core/_export.mjs';
+            const taskDefinitions = await import('./ai/daemons/orchestrator/TaskDefinitions.mjs');
+            const tasks = taskDefinitions.buildTaskDefinitions({chromaPort: 9123});
+            process.stdout.write(JSON.stringify({
+                dbPath: taskDefinitions.DEFAULT_DB_PATH,
+                dataDir: taskDefinitions.DEFAULT_DATA_DIR,
+                chromaDataDir: taskDefinitions.DEFAULT_CHROMA_DATA_DIR,
+                chromaArgs: tasks.chroma.args
+            }));
+        `;
+        const actual = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+            cwd: REPO_ROOT,
+            env: process.env,
+            encoding: 'utf8'
+        }));
 
-        expect(taskDefinitions.DEFAULT_DB_PATH).toBe(path.join(aiDataRoot, 'sqlite', 'memory-core-graph.sqlite'));
-        expect(taskDefinitions.DEFAULT_DATA_DIR).toBe(path.join(aiDataRoot, 'orchestrator-daemon'));
-        expect(taskDefinitions.DEFAULT_CHROMA_DATA_DIR).toBe(path.join(aiDataRoot, 'chroma', 'unified'));
-        expect(tasks.chroma.args).toEqual([
+        expect(actual.dbPath).toBe(path.join(aiDataRoot, 'sqlite', 'memory-core-graph.sqlite'));
+        expect(actual.dataDir).toBe(path.join(aiDataRoot, 'orchestrator-daemon'));
+        expect(actual.chromaDataDir).toBe(path.join(aiDataRoot, 'chroma', 'unified'));
+        expect(actual.chromaArgs).toEqual([
             'run',
             '--path',
             path.join(aiDataRoot, 'chroma', 'unified'),

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.externalConfig.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.externalConfig.spec.mjs
@@ -1,13 +1,15 @@
 import {test, expect} from '@playwright/test';
 import fs   from 'fs/promises';
+import os   from 'os';
 import path from 'path';
-import {fileURLToPath} from 'url';
+import {fileURLToPath, pathToFileURL} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
 
 const DAEMON_DIR = path.join(REPO_ROOT, 'ai/daemons');
+const TASK_DEFINITIONS_URL = pathToFileURL(path.join(REPO_ROOT, 'ai/daemons/orchestrator/TaskDefinitions.mjs')).href;
 
 const NEO_TEAM_IDENTITY_LITERAL_RE   = /['"`]@neo-(?:opus-4-7|gpt|gemini-3-1-pro)['"`]/g;
 const NEO_TEAM_PROJECT_LITERAL_RE    = /['"`]Project 12['"`]|['"`]v13['"`]|['"`]release:v\d+['"`]/g;
@@ -171,5 +173,45 @@ test.describe('Orchestrator external-config audit invariants (#11837 AC1-3)', ()
             findings,
             `Operator-specific absolute paths break on every external checkout (forks, CI runners, npx neo-app workspaces, cloud containers). All paths in daemon code MUST resolve relative to checkout root via existing Neo path helpers (path.resolve(...), path.join(neoRootDir, ...), etc.). Offending lines:\n${findings.map(f => `  ${f.file}:${f.line} — ${f.match}`).join('\n')}`
         ).toEqual([]);
+    });
+});
+
+test.describe('Orchestrator shared data-root defaults (#12417)', () => {
+    let originalEnv;
+
+    test.beforeEach(() => {
+        originalEnv = {...process.env};
+    });
+
+    test.afterEach(() => {
+        Object.keys(process.env).forEach(key => {
+            if (!(key in originalEnv)) {
+                delete process.env[key];
+            } else {
+                process.env[key] = originalEnv[key];
+            }
+        });
+    });
+
+    test('NEO_AI_DATA_ROOT relocates SQLite, orchestrator state, and Chroma task defaults', async () => {
+        const aiDataRoot = path.join(os.tmpdir(), `neo-ai-data-root-${Date.now()}`);
+
+        process.env.NEO_AI_DATA_ROOT = aiDataRoot;
+        delete process.env.NEO_AI_DB_PATH;
+        delete process.env.NEO_AI_ORCHESTRATOR_DIR;
+
+        const taskDefinitions = await import(`${TASK_DEFINITIONS_URL}?root=${Date.now()}`);
+        const tasks = taskDefinitions.buildTaskDefinitions({chromaPort: 9123});
+
+        expect(taskDefinitions.DEFAULT_DB_PATH).toBe(path.join(aiDataRoot, 'sqlite', 'memory-core-graph.sqlite'));
+        expect(taskDefinitions.DEFAULT_DATA_DIR).toBe(path.join(aiDataRoot, 'orchestrator-daemon'));
+        expect(taskDefinitions.DEFAULT_CHROMA_DATA_DIR).toBe(path.join(aiDataRoot, 'chroma', 'unified'));
+        expect(tasks.chroma.args).toEqual([
+            'run',
+            '--path',
+            path.join(aiDataRoot, 'chroma', 'unified'),
+            '--port',
+            '9123'
+        ]);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -324,8 +324,8 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
     });
 
     test('withLease release-timing invariant: task inner finally runs INSIDE the lease window (#11515)', async () => {
-        // Empirical anchor: PR #11509 cycles 1 + 2 surfaced the same root failure-mode at two
-        // different surfaces — substrate mutation placed AFTER `await withHeavyMaintenanceLease(...)`
+        // Empirical anchor: review cycles surfaced the same root failure-mode at two different
+        // surfaces — substrate mutation placed AFTER `await withHeavyMaintenanceLease(...)`
         // runs OUTSIDE the lease window because the helper's own `finally` (release) fires before
         // the awaited promise settles.
         //
@@ -352,7 +352,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
                 await Promise.resolve();
             } finally {
                 // Substrate-protected side effect (canonical inner-finally pattern from
-                // ai/scripts/runners/runSandman.mjs post-PR #11509).
+                // ai/scripts/runners/runSandman.mjs).
                 order.push('task-finally');
                 leaseDuringFinally = await inspectHeavyMaintenanceLease({leasePath, now});
             }
@@ -716,8 +716,8 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
     test('default singleton delegates to the reusable helpers', async () => {
         const leasePath = createLeasePath('service');
         const service   = Neo.create(HeavyMaintenanceLeaseService, {
-            leasePath_: leasePath,
-            staleAfterMs_: 60000
+            leasePath,
+            staleAfterMs: 60000
         });
 
         const acquired = await service.acquire({

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -37,16 +37,16 @@ test.describe('Memory Core Config (#10010)', () => {
             delete Neo.classHierarchyMap['Neo.ai.mcp.server.memory-core.Config'];
         }
 
-        config = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
-
         // Deterministic realm root: MC declares no realm leaves locally and inherits them
         // up the getParent() chain, so these tests need Neo.ai.Config present. The MC template's
         // side-effect import only registers it on FIRST module-eval — in a reused Playwright worker
-        // (cached module) that's a no-op — so install a fresh Tier-1 root built from the canonical
-        // template tree, making inheritance deterministic across workers.
+        // (cached module) that's a no-op. Install a fresh Tier-1 root before constructing the
+        // child template so formula leaves can resolve inherited paths during setupClass().
         const tier1Template = (await import('../../../../../../../ai/config.template.mjs')).default;
         Neo.ai = Neo.ai || {};
         Neo.ai.Config = Neo.create(BaseConfig, {data: tier1Template._data});
+
+        config = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
     });
 
     test.afterAll(() => {
@@ -159,6 +159,8 @@ test.describe('Memory Core Config (#10010)', () => {
                 wakeDataDir: cfg.wakeDaemon.dataDir,
                 bridgeLastSyncIdPath: cfg.wakeDaemon.bridgeLastSyncIdPath,
                 wakeSubscriptionLiveCursorPath: cfg.wakeDaemon.wakeSubscriptionLiveCursorPath,
+                bridgePidFile: cfg.wakeDaemon.pidFile,
+                bridgeLogFile: cfg.wakeDaemon.logFile,
                 trajectories: cfg.datasets.rlaif.trajectories,
                 remRunStateDir: cfg.remRunStateDir,
                 logPath: cfg.logPath
@@ -177,10 +179,37 @@ test.describe('Memory Core Config (#10010)', () => {
             wakeDataDir                       : path.join(aiDataRoot, 'wake-daemon'),
             bridgeLastSyncIdPath              : path.join(aiDataRoot, 'wake-daemon', 'lastSyncId'),
             wakeSubscriptionLiveCursorPath    : path.join(aiDataRoot, 'wake-daemon', 'wakeSubscriptionLiveCursor'),
+            bridgePidFile                     : path.join(aiDataRoot, 'wake-daemon', 'bridge-daemon.pid'),
+            bridgeLogFile                     : path.join(aiDataRoot, 'wake-daemon', 'bridge.log'),
             trajectories                      : path.join(aiDataRoot, 'datasets', 'rlaif', 'trajectories.jsonl'),
             remRunStateDir                    : path.join(aiDataRoot, 'rem-runs'),
             logPath                           : path.join(aiDataRoot, 'logs')
         });
+    });
+
+    test('legacy NEO_AI_DB_PATH alias resolves inside Memory Core config, not bridge consumers', () => {
+        const dbPath = path.join(os.tmpdir(), `neo-memory-core-${Date.now()}.sqlite`);
+        const env = {
+            ...process.env,
+            NEO_AI_DB_PATH: dbPath,
+            UNIT_TEST_MODE: 'false'
+        };
+
+        delete env.NEO_MEMORY_DB_PATH;
+
+        const script = `
+            import './src/Neo.mjs';
+            import './src/core/_export.mjs';
+            const cfg = (await import('./ai/mcp/server/memory-core/config.template.mjs')).default;
+            process.stdout.write(JSON.stringify({graph: cfg.storagePaths.graph}));
+        `;
+        const actual = JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+            cwd: path.resolve(process.cwd()),
+            env,
+            encoding: 'utf8'
+        }));
+
+        expect(actual.graph).toBe(dbPath);
     });
 
     test('env overrides GraphLog compaction watermark paths', () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -1,4 +1,6 @@
 import { test, expect } from '@playwright/test';
+import {execFileSync} from 'child_process';
+import os from 'os';
 import path from 'path';
 import Neo from '../../../../../../../src/Neo.mjs';
 import BaseConfig, {createConfigProxy} from '../../../../../../../ai/BaseConfig.mjs';
@@ -130,6 +132,55 @@ test.describe('Memory Core Config (#10010)', () => {
     test('declares GraphLog compaction watermark paths', () => {
         expect(config.wakeDaemon.bridgeLastSyncIdPath).toContain('.neo-ai-data/wake-daemon/lastSyncId');
         expect(config.wakeDaemon.wakeSubscriptionLiveCursorPath).toContain('.neo-ai-data/wake-daemon/wakeSubscriptionLiveCursor');
+    });
+
+    test('NEO_AI_DATA_ROOT relocates Memory Core graph, wake, REM, dataset, and log defaults at boot', () => {
+        const aiDataRoot = path.join(os.tmpdir(), `neo-ai-data-root-${Date.now()}`);
+        const env = {
+            ...process.env,
+            NEO_AI_DATA_ROOT: aiDataRoot,
+            UNIT_TEST_MODE  : 'false'
+        };
+
+        delete env.NEO_MEMORY_DB_PATH;
+        delete env.NEO_AI_DAEMON_DIR;
+        delete env.NEO_BRIDGE_LAST_SYNC_ID_PATH;
+        delete env.NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE;
+        delete env.NEO_RLAIF_PATH;
+        delete env.NEO_REM_RUN_STATE_DIR;
+
+        const script = `
+            import './src/Neo.mjs';
+            import './src/core/_export.mjs';
+            const cfg = (await import('./ai/mcp/server/memory-core/config.template.mjs')).default;
+            process.stdout.write(JSON.stringify({
+                aiDataRoot: cfg.aiDataRoot,
+                graph: cfg.storagePaths.graph,
+                wakeDataDir: cfg.wakeDaemon.dataDir,
+                bridgeLastSyncIdPath: cfg.wakeDaemon.bridgeLastSyncIdPath,
+                wakeSubscriptionLiveCursorPath: cfg.wakeDaemon.wakeSubscriptionLiveCursorPath,
+                trajectories: cfg.datasets.rlaif.trajectories,
+                remRunStateDir: cfg.remRunStateDir,
+                logPath: cfg.logPath
+            }));
+        `;
+        const output = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+            cwd: path.resolve(process.cwd()),
+            env,
+            encoding: 'utf8'
+        });
+        const actual = JSON.parse(output);
+
+        expect(actual).toEqual({
+            aiDataRoot,
+            graph                             : path.join(aiDataRoot, 'sqlite', 'memory-core-graph.sqlite'),
+            wakeDataDir                       : path.join(aiDataRoot, 'wake-daemon'),
+            bridgeLastSyncIdPath              : path.join(aiDataRoot, 'wake-daemon', 'lastSyncId'),
+            wakeSubscriptionLiveCursorPath    : path.join(aiDataRoot, 'wake-daemon', 'wakeSubscriptionLiveCursor'),
+            trajectories                      : path.join(aiDataRoot, 'datasets', 'rlaif', 'trajectories.jsonl'),
+            remRunStateDir                    : path.join(aiDataRoot, 'rem-runs'),
+            logPath                           : path.join(aiDataRoot, 'logs')
+        });
     });
 
     test('env overrides GraphLog compaction watermark paths', () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/wakeSafetyGate.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/wakeSafetyGate.spec.mjs
@@ -23,7 +23,7 @@ import Neo               from '../../../../../../src/Neo.mjs';
 import * as core         from '../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Validation for the Wake Safety Gate primitive (#10648, child of #10647).
+ * @summary Validation for the Wake Safety Gate primitive.
  *
  * Covers the deny-by-default discipline (missing file → tripped), state-file
  * round-trip (enable / disable / trip), CLI surface (check / reason / show),
@@ -97,6 +97,26 @@ test.describe('ai/scripts/wakeSafetyGate', () => {
         expect(written.state).toBe('enabled');
 
         expect(runCli(['check']).status).toBe(0);
+    });
+
+    test('NEO_AI_DATA_ROOT relocates the default gate file when no path-specific override is set', () => {
+        const aiDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-ai-data-root-'));
+        const env = {...process.env, NEO_AI_DATA_ROOT: aiDataRoot};
+        delete env.WAKE_GATE_FILE_PATH;
+
+        try {
+            execFileSync(process.execPath, [scriptPath, 'enable'], {
+                encoding: 'utf-8',
+                stdio   : 'pipe',
+                env
+            });
+
+            const rootedGatePath = path.join(aiDataRoot, 'wake-daemon', 'wake-safety-gate.json');
+            const written = JSON.parse(fs.readFileSync(rootedGatePath, 'utf-8'));
+            expect(written.state).toBe('enabled');
+        } finally {
+            fs.rmSync(aiDataRoot, {recursive: true, force: true});
+        }
     });
 
     test('CLI trip writes tripped state with reason and trippedBy', () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -41,6 +41,9 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         // Mock the SQLite target path to a safe pure temporary location
         if (!aiConfig.storagePaths) aiConfig.storagePaths = {};
         aiConfig.storagePaths.graph = testDbPath;
+        if (!aiConfig.engines) aiConfig.engines = {};
+        if (!aiConfig.engines.chroma) aiConfig.engines.chroma = {};
+        aiConfig.engines.chroma.database = aiConfig.engines.chroma.database || `graph-service-test-${process.pid}-${Date.now()}`;
         if (!aiConfig.collections) aiConfig.collections = {};
         aiConfig.collections.memory = `test-memory-${Date.now()}`;
         aiConfig.collections.session = `test-session-${Date.now()}`;
@@ -580,7 +583,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
     });
 
     // ----------------------------------------------------------------------------------------
-    // linkNodesAsync + ensureNodeExists + normalizeGraphNodeId (#10153) — lazy back-fill path.
+    // linkNodesAsync + ensureNodeExists + normalizeGraphNodeId — lazy back-fill path.
     // Sync `linkNodes` preserved unchanged for existing callers; these tests exercise the
     // async path that resolves missing endpoints via `MemorySessionIngestor.ingestSingleRow`.
     // ----------------------------------------------------------------------------------------
@@ -752,6 +755,39 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         const broadcast = await GraphService.getNode({id: 'AGENT:*'});
         expect(broadcast).toBeTruthy();
         expect(broadcast.type).toBe('BroadcastSentinel');
+    });
+
+    test('boot identity seeding is additive and does not garbage-collect existing AgentIdentity nodes (#12417)', async () => {
+        const legacyIdentityId = '@legacy-clone-only';
+
+        await GraphService.upsertNode({
+            id        : legacyIdentityId,
+            type      : 'AgentIdentity',
+            name      : 'Legacy Clone Only',
+            properties: {
+                githubLogin        : 'legacy-clone-only',
+                participationStatus: 'inactive',
+                createdAt          : '2026-06-03T00:00:00.000Z'
+            }
+        });
+
+        // Let the SQLite write land, then simulate a fresh Memory Core boot on the
+        // same shared DB from a checkout whose identityRoots source does not contain
+        // this legacy identity.
+        await new Promise(resolve => setTimeout(resolve, 50));
+        GraphService._initPromise = null;
+        GraphService.db = null;
+
+        await GraphService.initAsync();
+
+        const preserved = await GraphService.getNode({id: legacyIdentityId});
+        const row = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(legacyIdentityId);
+        const preservedRecord = JSON.parse(row.data);
+
+        expect(preserved).toBeTruthy();
+        expect(preserved.type).toBe('AgentIdentity');
+        expect(preservedRecord.properties.githubLogin).toBe('legacy-clone-only');
+        expect(preservedRecord.properties.createdAt).toBe('2026-06-03T00:00:00.000Z');
     });
 
     test('cross-tenant data isolation and identity stamping', async () => {

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -905,14 +905,14 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
  * missing / malformed) × (liveness-file: fresh / stalled / missing) per AC5, plus the fully-degraded
  * defensive case.
  *
- * Test isolation: each test writes to a unique temp directory + sets `WAKE_GATE_FILE_PATH` and
- * `NEO_HEARTBEAT_ALIVE_PATH` env vars before importing the block; restores after. Mirrors the
- * `wakeSafetyGate` env-override pattern.
+ * Test isolation: each test writes to a unique temp directory + sets `WAKE_GATE_FILE_PATH`;
+ * heartbeat liveness is isolated via the explicit `buildWakeFeaturesBlock()` path seam.
  *
  * @see Neo.ai.services.memory-core.HealthService#buildWakeFeaturesBlock
  */
 test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     let buildWakeFeaturesBlock;
+    let heartbeatAlivePath;
     let tmpDir;
 
     test.beforeAll(async () => {
@@ -938,17 +938,20 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         const fs   = await import('fs/promises');
 
         process.env.WAKE_GATE_FILE_PATH      = path.join(tmpDir, `gate-${Date.now()}.json`);
-        process.env.NEO_HEARTBEAT_ALIVE_PATH = path.join(tmpDir, `alive-${Date.now()}`);
+        heartbeatAlivePath = path.join(tmpDir, `alive-${Date.now()}`);
 
         // Ensure clean slate between tests (no carryover from prior writes)
         await fs.rm(process.env.WAKE_GATE_FILE_PATH,      {force: true}).catch(() => {});
-        await fs.rm(process.env.NEO_HEARTBEAT_ALIVE_PATH, {force: true}).catch(() => {});
+        await fs.rm(heartbeatAlivePath, {force: true}).catch(() => {});
     });
 
     test.afterEach(() => {
         delete process.env.WAKE_GATE_FILE_PATH;
-        delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
     });
+
+    function buildWakeFeaturesBlockForTest(now) {
+        return buildWakeFeaturesBlock(now, {livenessPath: heartbeatAlivePath});
+    }
 
     test('gate enabled + liveness fresh → daemonRunning true, gateState enabled', async () => {
         const fs = await import('fs/promises');
@@ -956,9 +959,9 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         await fs.writeFile(process.env.WAKE_GATE_FILE_PATH, JSON.stringify({
             state: 'enabled', reason: '', trippedAt: null, trippedBy: null
         }));
-        await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+        await fs.writeFile(heartbeatAlivePath, '');
 
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result.gateState).toBe('enabled');
         expect(result.gateReason).toBe('');
@@ -973,9 +976,9 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         await fs.writeFile(process.env.WAKE_GATE_FILE_PATH, JSON.stringify({
             state: 'disabled', reason: 'maintenance pause', trippedAt: '2026-05-07T10:00:00.000Z', trippedBy: 'cli'
         }));
-        await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+        await fs.writeFile(heartbeatAlivePath, '');
 
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result.gateState).toBe('disabled');
         expect(result.gateReason).toBe('maintenance pause');
@@ -992,9 +995,9 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
             trippedAt: '2026-05-03T22:53:09.450Z',
             trippedBy: 'wake-substrate-monitor'
         }));
-        await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+        await fs.writeFile(heartbeatAlivePath, '');
 
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result.gateState).toBe('tripped');
         expect(result.gateReason).toContain('orphan-spawn');
@@ -1010,9 +1013,9 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         const fs = await import('fs/promises');
 
         // No gate file write — leave path absent
-        await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+        await fs.writeFile(heartbeatAlivePath, '');
 
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result.gateState).toBe('unknown');
         expect(result.gateReason).toBe('');
@@ -1034,9 +1037,9 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         // because trippedBy !== 'default-on-missing-file'. Intentional: operator sees the data
         // corruption signal explicitly rather than swallowed-as-unknown.
         await fs.writeFile(process.env.WAKE_GATE_FILE_PATH, JSON.stringify({foo: 'bar'}));
-        await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+        await fs.writeFile(heartbeatAlivePath, '');
 
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result.gateState).toBe('tripped');
         expect(result.gateTrippedBy).toBe('malformed-state-file');
@@ -1050,7 +1053,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         }));
         // No liveness file write — leave path absent
 
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result.gateState).toBe('enabled');
         expect(result.daemonRunning).toBe(false);
@@ -1064,13 +1067,13 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         await fs.writeFile(process.env.WAKE_GATE_FILE_PATH, JSON.stringify({
             state: 'enabled', reason: '', trippedAt: null, trippedBy: null
         }));
-        await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+        await fs.writeFile(heartbeatAlivePath, '');
 
         // Backdate mtime to 11 minutes ago (past the 10min stale threshold)
         const elevenMinutesAgo = new Date(Date.now() - 11 * 60 * 1000);
-        await fs.utimes(process.env.NEO_HEARTBEAT_ALIVE_PATH, elevenMinutesAgo, elevenMinutesAgo);
+        await fs.utimes(heartbeatAlivePath, elevenMinutesAgo, elevenMinutesAgo);
 
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result.daemonRunning).toBe(false);
         expect(result.lastPulseAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
@@ -1080,7 +1083,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     test('both files missing → fully defensive defaults, no throw', async () => {
         // Worst-case observability: brand new install, daemon never started, gate never written.
         // Block must not throw; surfaces all-defensive shape.
-        const result = await buildWakeFeaturesBlock();
+        const result = await buildWakeFeaturesBlockForTest();
 
         expect(result).toEqual({
             gateState            : 'unknown',
@@ -1096,16 +1099,16 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     test('explicit `now` parameter overrides Date.now() for deterministic seconds-since calculation', async () => {
         const fs = await import('fs/promises');
 
-        await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+        await fs.writeFile(heartbeatAlivePath, '');
 
         // Backdate liveness mtime to a known epoch second
         const livenessTime = new Date('2026-05-07T20:00:00.000Z');
-        await fs.utimes(process.env.NEO_HEARTBEAT_ALIVE_PATH, livenessTime, livenessTime);
+        await fs.utimes(heartbeatAlivePath, livenessTime, livenessTime);
 
         // "Now" is exactly 5 seconds after the liveness mtime
         const fixedNow = livenessTime.getTime() + 5000;
 
-        const result = await buildWakeFeaturesBlock(fixedNow);
+        const result = await buildWakeFeaturesBlockForTest(fixedNow);
 
         expect(result.lastPulseAt).toBe('2026-05-07T20:00:00.000Z');
         expect(result.secondsSinceLastPulse).toBe(5);
@@ -1123,14 +1126,14 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
         process.env.POLL_INTERVAL = '900'; // 15 min cadence → 30 min stale threshold (2×)
 
         try {
-            await fs.writeFile(process.env.NEO_HEARTBEAT_ALIVE_PATH, '');
+            await fs.writeFile(heartbeatAlivePath, '');
 
             // Backdate liveness mtime to 11 min ago — past the default 10-min hardcoded threshold,
             // but well within the 30-min POLL_INTERVAL=900 stale window.
             const elevenMinAgo = new Date(Date.now() - 11 * 60 * 1000);
-            await fs.utimes(process.env.NEO_HEARTBEAT_ALIVE_PATH, elevenMinAgo, elevenMinAgo);
+            await fs.utimes(heartbeatAlivePath, elevenMinAgo, elevenMinAgo);
 
-            const result = await buildWakeFeaturesBlock();
+            const result = await buildWakeFeaturesBlockForTest();
 
             expect(result.daemonRunning).toBe(true); // 11 min < 30 min stale threshold
             expect(result.secondsSinceLastPulse).toBeGreaterThan(600);


### PR DESCRIPTION
Resolves #12417
Related: #12416
Related: https://github.com/neomjs/neo/discussions/12412

Authored by GPT-5 (Codex Desktop). Session 79e8a897-794c-4ffd-bfb1-3408093d0e33.

FAIR-band: over-target [20/30] - taking this lane despite over-target because #12417 is freshly graduated substrate from #12412/#12416, fixes an active multi-clone `bound:false` incident class, and was already claimed/implemented before the current approval-only wake traffic.

Evidence: L2 (config-shape, subprocess import, CLI path, targeted unit tests, and model-document update) -> L4 required (fresh independent clone using `NEO_AI_DATA_ROOT` shares live graph/chroma/wake state without symlinks). Residual: post-merge clone validation on #12417.

Adds `NEO_AI_DATA_ROOT` as the canonical Agent OS runtime data-root default across the shared graph/chroma/wake surfaces so fresh clones can point at one shared `.neo-ai-data` directory without relying on `bootstrapWorktree --link-data` symlinks. Existing narrower overrides still win when explicitly set.

## Signal Ledger

- Source: Discussion #12412, graduated into Epic #12416 and this leaf ticket #12417.
- GPT family signal: discussion approval at https://github.com/neomjs/neo/discussions/12412#discussioncomment-17159800 and epic review at https://github.com/neomjs/neo/issues/12416#issuecomment-4608960764.
- Claude family signal: OQ1 V-B-A at https://github.com/neomjs/neo/discussions/12412#discussioncomment-17159985, graduation at https://github.com/neomjs/neo/discussions/12412#discussioncomment-17160020, and lived #12417 empirical evidence via A2A during implementation.
- Active-family quorum: GPT + Claude are active for this lane; Gemini is unavailable per operator note in the #12412 work window.

## Unresolved Dissent

None observed.

## Unresolved Liveness

Gemini-family signal is benched by availability, not by dissent. Revalidation trigger: if Gemini returns with a conflicting multi-instance bring-up model or fresh evidence that `NEO_AI_DATA_ROOT` cannot replace symlink dependence for graph/chroma/wake, reopen Discussion #12412 before extending the root contract.

## Deltas from ticket

- Extended the root beyond the three named AC surfaces into sibling daemon/script defaults that store wake, cooldown, heartbeat, harness, REM, dataset, backup, and log state under the same root.
- Replaced the previous imperative config-hook repair with declarative `Neo.state.Provider` formulas. Dependent leaves now derive from resolved Provider data rather than consumer-side `config || env || path.join(...)` fallbacks.
- Moved bridge/orchestrator/wake lifecycle consumers to resolved `AiConfig` / `MemoryCoreConfig` leaves. The legacy `NEO_AI_DB_PATH` alias remains inside Memory Core config only, not bridge consumers.
- Documented the AiConfig model boundary in `learn/agentos/AiConfigModel.md`: singleton configs are source-of-truth providers, tests must not mutate them, and runtime/test overrides should use fresh providers, subprocess env envelopes, or explicit seams.
- Left KB/Neural Link `memoryCoreDbPath` defaults unchanged because those keys are telemetry/action-log sinks (`kb_query_log`, `nl_action_log`), not the Memory Core graph SQLite named in AC1. `NEO_MEMORY_DB_PATH` remains the explicit override for those telemetry sinks.
- Removed two stale ticket-number references from durable comments in touched test files because the staged-file archaeology hook blocked the commit; the behavior descriptions remain intact.

## Config Template / Local Config Follow-Up

Changed config keys and defaults:
- `ai/config.template.mjs`: `aiDataRoot` is the Tier-1 root. `backupPath`, `wakeDaemonHeartbeatAlivePath`, `heartbeatConcurrencyLockPath`, `harnessStateDir`, `engines.chroma.dataDir`, and orchestrator daemon/state/lease/backoff leaves derive through Provider formulas.
- `ai/mcp/server/memory-core/config.template.mjs`: graph SQLite, wake-daemon watermarks/pid/log leaves, REM run state, RLAIF dataset path, and Memory Core logs inherit Tier-1 `aiDataRoot` and derive through Provider formulas.
- `ai/mcp/server/knowledge-base/config.template.mjs`: Chroma path follows top-level `AiConfig.engines.chroma.dataDir`; KB logs derive from the shared logs directory.
- `ai/mcp/server/neural-link/config.template.mjs`: Neural Link logs derive from the shared logs directory.
- Runtime consumers: orchestrator task definitions, bridge daemon, wake decision/backoff, maintenance lease, wake gate, inflight lock, heartbeat lock, trio cooldown, resume cooldown, harness lifecycle state, and heartbeat liveness lookup read resolved config leaves.

Local gitignored `config.mjs` copies need manual shape/key refresh after merge in each active clone if they are copied from older templates. At minimum, set `NEO_AI_DATA_ROOT` in the harness/daemon environment and refresh local config copies that currently hard-code `engines.chroma.dataDir`, Memory Core `storagePaths.graph`, or wake-daemon paths. Narrower overrides such as `NEO_MEMORY_DB_PATH`, `NEO_AI_DAEMON_DIR`, `NEO_CHROMA_DATA_DIR`, `NEO_BACKUP_PATH`, `NEO_HEARTBEAT_ALIVE_PATH`, `NEO_HEARTBEAT_LOCK_PATH`, and `NEO_HARNESS_STATE_DIR` still override the shared-root defaults.

Harness restart is required for running MCP servers and daemons to pick up the new env/config shape.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs` -> 18 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs` -> 65 passed.
- `NEO_AI_DATA_ROOT=/tmp/neo-root-check UNIT_TEST_MODE=false node --input-type=module -e "<template smoke>"` -> Tier-1, Memory Core, KB, and Neural Link template paths all resolved under `/tmp/neo-root-check`.
- `rg -n "AiConfig\\.[A-Za-z0-9_.$]+\\s*=|aiConfig\\.[A-Za-z0-9_.$]+\\s*=|MemoryCoreConfig\\.[A-Za-z0-9_.$]+\\s*=|memoryCoreConfig\\.[A-Za-z0-9_.$]+\\s*=" <changed spec set>` -> no config singleton mutations in changed tests.
- `git diff --check` -> clean.
- Pre-commit hook passed: whitespace, shorthand, and staged-file ticket-archaeology checks.

Local note: the broader lifecycle-script focused set still cannot be fully run in this sandbox without refreshing ignored local config copies because `.neo-ai-data/wake-daemon` in this checkout is a symlink to `/Users/Shared/github/neomjs/neo/.neo-ai-data/wake-daemon`, outside the writable roots. The committed templates and CI-generated config copies are the authority for this PR.

## Post-Merge Validation

- [ ] In a fresh independent clone without `.neo-ai-data` symlinks, set `NEO_AI_DATA_ROOT` to the canonical clone's data root, restart Memory Core / Knowledge Base / Neural Link / wake daemons, and confirm graph binding reports `bound:true`.
- [ ] Confirm Chroma launches with the shared root-derived `chroma/unified` path when no narrower `NEO_CHROMA_DATA_DIR` override is set.
- [ ] Confirm wake-daemon heartbeat and cursor files are read/written under the shared root.

## Commits

- `bcb362020` - `feat(agentos): add shared AI data root (#12417)`
- `9ff74e46f` - fallback-helper repair, later superseded by review cycle.
- `fd362fd77` - `fix(agentos): simplify ai data root resolution (#12417)`
- `fe234d6f5` - `fix(agentos): centralize data-root path leaves (#12417)`
- `bae64ce24` - `docs(agentos): clarify AiConfig mutation boundary (#12417)`
