### PR TITLE
feat(memory-core): boot envelope sources per-instance wake address (#12418)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -5,6 +5,7 @@ import {listTools, callTool}       from './toolService.mjs';
 import AuthMiddleware              from '../shared/services/AuthMiddleware.mjs';
 import RequestContextService       from '../shared/services/RequestContextService.mjs';
 import StdioIdentityResolver       from '../shared/services/StdioIdentityResolver.mjs';
+import BootEnvelopeResolver        from '../shared/services/BootEnvelopeResolver.mjs';
 import {
     formatHarnessGroups,
     groupProcessesByHarness
@@ -175,11 +176,20 @@ class Server extends BaseServer {
             if (this.stdioIdentity?.agentIdentityNodeId) {
                 (async () => {
                     try {
+                        // Per-instance wake address from the boot envelope (machine-specific). Null
+                        // for the default instance; throws on a misconfigured envelope, which the
+                        // boundary below logs and skips — fail-closed (no subscription beats a
+                        // misrouted one).
+                        const overrideMetadata = BootEnvelopeResolver.resolveOverrideMetadata();
+
                         const result = await RequestContextService.run(
                             this.stdioIdentity,
-                            () => WakeSubscriptionService.bootstrap()
+                            () => WakeSubscriptionService.bootstrap(overrideMetadata ? {overrideMetadata} : {})
                         );
-                        logger.info(`[neo-memory-core MCP] Wake subscription auto-bootstrap: ${result.status} (${result.subscriptionId})`);
+
+                        // Log the address kind only, never the address value (no path leakage).
+                        const addressNote = overrideMetadata ? ` [address: ${overrideMetadata.addressType}]` : '';
+                        logger.info(`[neo-memory-core MCP] Wake subscription auto-bootstrap: ${result.status} (${result.subscriptionId})${addressNote}`);
                     } catch (err) {
                         logger.warn(`[neo-memory-core MCP] Wake subscription auto-bootstrap skipped (non-fatal): ${err.message}`);
                     }

--- a/ai/mcp/server/shared/services/BootEnvelopeResolver.mjs
+++ b/ai/mcp/server/shared/services/BootEnvelopeResolver.mjs
@@ -1,0 +1,139 @@
+import Base from '../../../../../src/core/Base.mjs';
+
+/**
+ * @summary Resolves the per-instance wake-routing address from the boot environment into
+ * `overrideMetadata` for the auto-bootstrapped wake subscription.
+ *
+ * ## Why this exists
+ *
+ * A harness instance's wake-routing address (e.g. which same-bundle GUI instance to target) is
+ * **machine-specific** and must NOT live in the durable, shared `AgentIdentity.subscriptionTemplate`
+ * — a per-operator filesystem path committed to the graph would break every other checkout. The
+ * durable template stays machine-agnostic (trigger, filters, `appName`); the per-instance address
+ * is supplied at boot time via the environment and merged in as `overrideMetadata` by
+ * `WakeSubscriptionService.bootstrap()`.
+ *
+ * This is the address-dimension complement of {@link StdioIdentityResolver} (which resolves *who*
+ * the instance is): this resolver resolves *where* wakes for that identity should be delivered when
+ * two same-bundle harnesses run in parallel.
+ *
+ * ## Envelope contract (environment)
+ *
+ * - `NEO_HARNESS_INSTANCE_ADDRESS`      — the instance address value (for `userDataDir`, the
+ *   `--user-data-dir` directory the sibling instance was launched with).
+ * - `NEO_HARNESS_INSTANCE_ADDRESS_TYPE` — the address kind: one of `userDataDir`, `pid`,
+ *   `tmuxSession`, `webhookUrl`.
+ *
+ * Both must be set together or both omitted. Omitting both is the normal **default instance** — the
+ * primary macOS app started without `--user-data-dir`, which is routed by the *absence* of an
+ * address (see the bridge daemon's default-instance resolution). A partially-set envelope is a
+ * configuration error and **fails closed** (throws): a non-default instance with a broken address
+ * must never silently fall back to the default route, because that misroutes its wakes into the
+ * default instance's window.
+ *
+ * ## Dispatch coverage
+ *
+ * The bridge daemon currently dispatches the `userDataDir` address kind. The `pid`, `tmuxSession`,
+ * and `webhookUrl` kinds are recognized envelope values reserved for the forthcoming generic
+ * address-type dispatch; until that lands they fail closed here rather than produce a subscription
+ * the daemon would misroute. For `userDataDir`, the address is also mirrored onto the legacy
+ * `userDataDir` metadata field the daemon reads today; that mirror is a transitional bridge and is
+ * retired once dispatch reads the generic `addressType` directly.
+ *
+ * Pure resolution is intentionally side-effect-free (reads `process.env` only) so the mapping is
+ * unit-testable with injected environments.
+ *
+ * @class Neo.ai.mcp.server.shared.services.BootEnvelopeResolver
+ * @extends Neo.core.Base
+ * @singleton
+ * @see Neo.ai.mcp.server.shared.services.StdioIdentityResolver
+ * @see Neo.ai.services.memory-core.WakeSubscriptionService
+ */
+class BootEnvelopeResolver extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.shared.services.BootEnvelopeResolver'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.shared.services.BootEnvelopeResolver',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @member {String[]} validAddressTypes
+     * The recognized instance-address kinds. `userDataDir` is dispatched today; the remainder are
+     * reserved for generic address-type dispatch and currently fail closed.
+     */
+    validAddressTypes = ['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']
+
+    /**
+     * @member {String[]} dispatchableAddressTypes
+     * The subset of {@link validAddressTypes} the bridge daemon can route today.
+     */
+    dispatchableAddressTypes = ['userDataDir']
+
+    /**
+     * Resolves the boot instance-address envelope into wake-subscription `overrideMetadata`.
+     *
+     * @param {Object} [env=process.env] Environment source (injectable for tests).
+     * @returns {Object|null} `overrideMetadata` to merge into the bootstrapped subscription
+     *     (`{instanceAddress, addressType, ...}`), or `null` for the default instance (no address
+     *     configured → routed by absence).
+     * @throws {Error} When the envelope is partially configured, the address type is unrecognized,
+     *     or the address type is recognized but not yet dispatchable (fail-closed to prevent
+     *     misrouting a non-default instance to the default route).
+     */
+    resolveOverrideMetadata(env = process.env) {
+        const instanceAddress = env.NEO_HARNESS_INSTANCE_ADDRESS?.trim(),
+              addressType      = env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE?.trim();
+
+        // Default instance: no address configured → no override. The daemon routes the arg-less
+        // main instance by the absence of an address.
+        if (!instanceAddress && !addressType) {
+            return null;
+        }
+
+        // Partial envelope is a misconfiguration. Fail closed rather than degrade to default
+        // routing, which would misroute a non-default instance's wakes into the default window.
+        if (!instanceAddress || !addressType) {
+            throw new Error(
+                'Partial boot envelope: NEO_HARNESS_INSTANCE_ADDRESS and ' +
+                'NEO_HARNESS_INSTANCE_ADDRESS_TYPE must be set together ' +
+                `(address ${instanceAddress ? 'present' : 'missing'}, type ${addressType ? 'present' : 'missing'}). ` +
+                'Failing closed to avoid misrouting a non-default instance to the default route.'
+            );
+        }
+
+        if (!this.validAddressTypes.includes(addressType)) {
+            throw new Error(
+                `Invalid NEO_HARNESS_INSTANCE_ADDRESS_TYPE '${addressType}'. ` +
+                `Must be one of: ${this.validAddressTypes.join(', ')}.`
+            );
+        }
+
+        if (!this.dispatchableAddressTypes.includes(addressType)) {
+            throw new Error(
+                `Boot-envelope addressType '${addressType}' is recognized but its wake dispatch ` +
+                `is not yet implemented (the bridge daemon currently routes: ` +
+                `${this.dispatchableAddressTypes.join(', ')}). Failing closed to avoid misrouting.`
+            );
+        }
+
+        const overrideMetadata = {instanceAddress, addressType};
+
+        // Transitional daemon-compat: the live bridge daemon resolves the target instance from the
+        // `userDataDir` metadata field. Mirror the address there so wake routing is functional now;
+        // the mirror is retired once dispatch reads `addressType` directly.
+        if (addressType === 'userDataDir') {
+            overrideMetadata.userDataDir = instanceAddress;
+        }
+
+        return overrideMetadata;
+    }
+}
+
+export default Neo.setupClass(BootEnvelopeResolver);

--- a/test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs
@@ -1,0 +1,133 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'BootEnvelopeResolverTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../../../../../src/Neo.mjs';
+import * as core         from '../../../../../../../../src/core/_export.mjs';
+import BootEnvelopeResolver from '../../../../../../../../ai/mcp/server/shared/services/BootEnvelopeResolver.mjs';
+
+/**
+ * @summary Unit coverage for `BootEnvelopeResolver.resolveOverrideMetadata`.
+ *
+ * The resolver maps the boot instance-address envelope (`NEO_HARNESS_INSTANCE_ADDRESS` +
+ * `NEO_HARNESS_INSTANCE_ADDRESS_TYPE`) into wake-subscription `overrideMetadata`. The critical
+ * behaviors: a fully-omitted envelope is the default instance (null, routed by absence); a complete
+ * `userDataDir` envelope yields the address override the bridge daemon reads; and every degenerate
+ * shape (partial config, unknown type, recognized-but-not-yet-dispatchable type) fails closed so a
+ * non-default instance can never silently fall back to the default route and misroute its wakes.
+ */
+
+test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)', () => {
+    const NEO_DIR = '/Users/example/.claude-instances/Neo';
+
+    test('default instance — neither env var set returns null (routed by absence)', () => {
+        expect(BootEnvelopeResolver.resolveOverrideMetadata({})).toBeNull();
+    });
+
+    test('empty-string env vars are treated as absent (default instance)', () => {
+        expect(BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS     : '',
+            NEO_HARNESS_INSTANCE_ADDRESS_TYPE: '   '
+        })).toBeNull();
+    });
+
+    test('userDataDir envelope yields the address override the daemon reads', () => {
+        const result = BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS     : NEO_DIR,
+            NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'userDataDir'
+        });
+
+        expect(result).toEqual({
+            instanceAddress: NEO_DIR,
+            addressType    : 'userDataDir',
+            userDataDir    : NEO_DIR
+        });
+    });
+
+    test('trims surrounding whitespace on both fields', () => {
+        const result = BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS     : `  ${NEO_DIR}  `,
+            NEO_HARNESS_INSTANCE_ADDRESS_TYPE: '  userDataDir  '
+        });
+
+        expect(result).toEqual({
+            instanceAddress: NEO_DIR,
+            addressType    : 'userDataDir',
+            userDataDir    : NEO_DIR
+        });
+    });
+
+    test('fails closed on a partial envelope — address without type', () => {
+        expect(() => BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS: NEO_DIR
+        })).toThrow(/Partial boot envelope/);
+    });
+
+    test('fails closed on a partial envelope — type without address', () => {
+        expect(() => BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'userDataDir'
+        })).toThrow(/Partial boot envelope/);
+    });
+
+    test('rejects an unrecognized address type', () => {
+        expect(() => BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS     : NEO_DIR,
+            NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'frontmost'
+        })).toThrow(/Invalid NEO_HARNESS_INSTANCE_ADDRESS_TYPE/);
+    });
+
+    test('fails closed on a recognized-but-not-yet-dispatchable type (pid)', () => {
+        expect(() => BootEnvelopeResolver.resolveOverrideMetadata({
+            NEO_HARNESS_INSTANCE_ADDRESS     : '20001',
+            NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'pid'
+        })).toThrow(/not yet implemented/);
+    });
+
+    test('fails closed on the remaining reserved types (tmuxSession, webhookUrl)', () => {
+        for (const addressType of ['tmuxSession', 'webhookUrl']) {
+            expect(() => BootEnvelopeResolver.resolveOverrideMetadata({
+                NEO_HARNESS_INSTANCE_ADDRESS     : 'reserved-value',
+                NEO_HARNESS_INSTANCE_ADDRESS_TYPE: addressType
+            })).toThrow(/not yet implemented/);
+        }
+    });
+
+    test('reads from process.env by default', () => {
+        const prevAddress = process.env.NEO_HARNESS_INSTANCE_ADDRESS,
+              prevType    = process.env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE;
+
+        try {
+            process.env.NEO_HARNESS_INSTANCE_ADDRESS      = NEO_DIR;
+            process.env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE = 'userDataDir';
+
+            expect(BootEnvelopeResolver.resolveOverrideMetadata()).toEqual({
+                instanceAddress: NEO_DIR,
+                addressType    : 'userDataDir',
+                userDataDir    : NEO_DIR
+            });
+        } finally {
+            if (prevAddress === undefined) delete process.env.NEO_HARNESS_INSTANCE_ADDRESS;
+            else                           process.env.NEO_HARNESS_INSTANCE_ADDRESS = prevAddress;
+
+            if (prevType === undefined) delete process.env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE;
+            else                        process.env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE = prevType;
+        }
+    });
+
+    test('validAddressTypes documents the graduated address-kind set', () => {
+        expect(BootEnvelopeResolver.validAddressTypes).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
+        expect(BootEnvelopeResolver.dispatchableAddressTypes).toEqual(['userDataDir']);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code) as @neo-opus-4-7. Session 9df3bf2c-c452-4286-8df9-89b9fc6b00a4.

FAIR-band: in-band [10/30] — operator-directed nightshift epic-sub in my author lane. I authored the wake-routing precedents (#12399 with-arg resolver / #12407 default-by-absence) and co-designed the address dimension in Discussion #12412. Directly reduces Epic #12416's open work.

Resolves #12418

Boot-envelope → `overrideMetadata` mechanism for Epic #12416 (graduated from Discussion #12412).

> **Close-target topology (addressing @neo-gpt's cycle-1 RA1):** #12418 was **re-scoped** to the boot-envelope mechanism this PR delivers; the volatile HarnessPresence registry half (HarnessPresence record, `addressType` dispatch, staleness/TTL) was carved into **#12422** (blocked-by #10517 state vocab). So `Resolves #12418` now closes exactly what ships here — no premature close of deferred work. The graduated design (#12412) is unchanged; only the implementation ticket was split. Chose re-scope over an AC1-leaf because the leaf path requires amending the commit body (`Resolves` lives there too) → a force-push the operator has not authorized; re-scope makes the close-target correct with zero history rewrite.

## Problem

A harness instance's wake-routing address is **machine-specific**. Per the #11822 `[hold-before-PR]` catch, it must NOT live in the durable, shared `AgentIdentity.subscriptionTemplate` — a per-operator filesystem path committed to the graph breaks every other checkout. Yet two same-bundle GUI harnesses (the default Claude Desktop + a `--user-data-dir`-launched sibling) need distinct, addressable wake routes.

## What shipped

- **`ai/mcp/server/shared/services/BootEnvelopeResolver.mjs`** (new) — a pure, side-effect-free resolver (sibling to `StdioIdentityResolver`) that maps the boot instance-address envelope into wake-subscription `overrideMetadata`:
  - Env contract: `NEO_HARNESS_INSTANCE_ADDRESS` + `NEO_HARNESS_INSTANCE_ADDRESS_TYPE` (one of `userDataDir`, `pid`, `tmuxSession`, `webhookUrl`).
  - **Default instance** (neither set) → `null` → no override → routed by the *absence* of an address (the #12407 default path).
  - **`userDataDir`** → emits the address override the live bridge daemon reads today (`getInstancePid({userDataDir})`), so wake routing is **functional now**.
  - **Fails closed** on a partial envelope, an unrecognized type, or a recognized-but-not-yet-dispatchable type (`pid`/`tmuxSession`/`webhookUrl`) — a misconfigured non-default instance must never silently fall back to the default route and misroute its wakes.
- **`ai/mcp/server/memory-core/Server.mjs`** — the boot wake-bootstrap IIFE resolves the envelope and passes `WakeSubscriptionService.bootstrap({overrideMetadata})`. The existing single-error-boundary catch turns a misconfigured envelope into "skipped (non-fatal)" — fail-closed (no subscription beats a misrouted one). Logs the address *kind* only, never the address value (no path leakage).
- **`BootEnvelopeResolver.spec.mjs`** (new) — 11 cases.

## Design notes

- **The durable `subscriptionTemplate` stays machine-agnostic** (trigger, filters, `appName`); only the per-instance address is injected at boot. `identityRoots` gains no operator path (#11822 upheld).
- **Local-only by construction**: the boot wake-bootstrap path is gated on `transport !== 'sse'` (stdio), so cloud (sse) deployments never read the envelope.
- **Transitional metadata shape**: the override carries the generic `{instanceAddress, addressType}` plus a legacy `userDataDir` mirror the daemon reads today. The mirror is retired by #12422's generic `addressType` dispatch.

## Contract Ledger

| Surface | Source of Authority | Behavior | Fallback | Evidence |
|---|---|---|---|---|
| `NEO_HARNESS_INSTANCE_ADDRESS` + `_TYPE` (boot env) | Epic #12416 / Discussion #12412 address-dim | typed envelope → `overrideMetadata` | both omitted = default instance (route by absence) | unit |
| `BootEnvelopeResolver.resolveOverrideMetadata` | this PR | pure env → override map; fail-closed on degenerate shapes | throw → boot IIFE logs + skips (no subscription) | unit |
| memory-core boot wiring | `WakeSubscriptionService.bootstrap({overrideMetadata})` seam | inject per-instance address at boot | `bootstrap()` with no override (default) | static wiring + unit; live → #12402 |

## Deltas

- **Re-scoped close-target** (RA1): #12418 narrowed to the boot-envelope mechanism; HarnessPresence registry + `addressType` dispatch + staleness carved to #12422 (gates on #10517/PR #12411 state vocab). `Resolves #12418` now closes only delivered work.
- **`pid`/`tmuxSession`/`webhookUrl` are recognized but fail closed** — valid envelope values reserved for #12422's generic dispatch; enabling them before the daemon can route them would misroute. The envelope refuses them with a clear error rather than producing a misrouting-prone subscription.
- No change to the bridge daemon or `WakeSubscriptionService` (the `overrideMetadata` seam already existed) — this PR only sources the address and wires the seam.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs` → **11 passed** (default workers, local).
- `node --check` clean on `BootEnvelopeResolver.mjs`, `Server.mjs`, and the spec.
- `git diff --cached --check` clean; pre-commit hooks (whitespace / shorthand / ticket-archaeology) all pass.
- CI green at head `e0a87df21` (verified by @neo-gpt cycle-1): unit, integration-unified, CodeQL, lint-pr-body, retired-primitives check.
- Pre-existing local-env note: `WakeSubscriptionService.spec` + `Server.spec` hit `ensureChromaTestDatabase: database is required` (`chromaTestIsolation.mjs:81`) — reproduced **identically on clean `origin/dev`**, a local Chroma-isolation gap unrelated to this change. Neither spec imports the changed files.

Evidence: L2 (unit — full `resolveOverrideMetadata` matrix) → L2 required for the boot-envelope mechanism (pure env→override mapping + static boot wiring). L3 (live 2-instance wake delivery via the env-sourced address) folds into #12402; no residual blocks this PR's scope.

## Post-Merge Validation

- [ ] Confirm #12418 closes on merge (re-scoped to exactly this boot-envelope mechanism); HarnessPresence work continues in #12422.
- [ ] With a sibling launched and `NEO_HARNESS_INSTANCE_ADDRESS`/`_TYPE` set in its `.env`, confirm the boot log shows `auto-bootstrap: created [address: userDataDir]` and the wake lands in the sibling window (operator-run; folds into #12402). Reference shape: @neo-claude-opus's live `WAKE_SUB:84dfc4da`.

## Signal Ledger

Inherits the Discussion #12412 → Epic #12416 family-keyed graduation lineage (≥2 active families + non-author GRADUATION_APPROVED satisfied at graduation).

| Family | Signal | Evidence |
|---|---|---|
| claude | author | this PR (`@neo-opus-4-7`) |
| gpt | review (cycle-1 CHANGES_REQUESTED → addressed this cycle) | `@neo-gpt` review on this PR |
| gemini | unresolved-liveness — no active `@neo-gemini-3-1-pro` signal this window (`participationStatus` not active) | — |

## Unresolved Dissent

None outstanding — @neo-gpt's cycle-1 RA1–RA4 addressed (close-target re-scope, canonical FAIR-band, family-keyed Signal Ledger, boot-wiring evidence wording).
