### PR TITLE
fix(ai): guard osascript frontmost delivery (#10422)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -599,6 +599,15 @@ function spawnAsync(command, args) {
 }
 
 /**
+ * @summary Escapes values interpolated into AppleScript string literals.
+ * @param {String} value
+ * @returns {String}
+ */
+function escapeAppleScriptString(value) {
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
  * Global mutex for serializing adapter deliveries.
  * Prevents concurrent osascript calls from colliding when multiple agents wake simultaneously.
  */
@@ -725,20 +734,49 @@ async function deliverDigest(subscription, digest) {
             // Instance-addressed wake raises the resolved pid's process to frontmost (verified
             // addressable via System Events `whose unix id`); single-instance wakes keep the
             // app-activate path unchanged.
+            const appleScriptAppName = escapeAppleScriptString(appName),
+                  targetProcessId    = instancePid ? String(instancePid) : '';
+
             const activateLine = instancePid
                 ? `  tell application "System Events" to set frontmost of (first process whose unix id is ${instancePid}) to true`
-                : `  tell application "${appName}" to activate`;
+                : `  tell application "${appleScriptAppName}" to activate`;
 
             const osascriptArgs = [
+                '-e', 'on assertTargetFrontmost(appName, targetBundleId, targetProcessId, phase)',
+                '-e', '  tell application "System Events"',
+                '-e', '    set frontmostProcess to first application process whose frontmost is true',
+                '-e', '    if targetProcessId is not "" then',
+                '-e', '      set currentPid to (unix id of frontmostProcess) as string',
+                '-e', '      if currentPid is not targetProcessId then error "Target app lost frontmost status " & phase & " (pid " & currentPid & " != " & targetProcessId & ")"',
+                '-e', '    else if targetBundleId is not "" then',
+                '-e', '      set currentBundleId to ""',
+                '-e', '      try',
+                '-e', '        set currentBundleId to (bundle identifier of frontmostProcess) as string',
+                '-e', '      end try',
+                '-e', '      if currentBundleId is not targetBundleId then error "Target app lost frontmost status " & phase & " (bundle " & currentBundleId & " != " & targetBundleId & ")"',
+                '-e', '    else',
+                '-e', '      set currentApp to name of frontmostProcess',
+                '-e', '      if currentApp is not appName then error "Target app lost frontmost status " & phase & " (" & currentApp & " != " & appName & ")"',
+                '-e', '    end if',
+                '-e', '  end tell',
+                '-e', 'end assertTargetFrontmost',
                 '-e', 'on run argv',
                 '-e', '  set wakePayload to (item 1 of argv)',
+                '-e', `  set targetAppName to "${appleScriptAppName}"`,
+                '-e', '  set targetBundleId to ""',
+                '-e', '  try',
+                '-e', `    set targetBundleId to id of application "${appleScriptAppName}"`,
+                '-e', '  end try',
+                '-e', `  set targetProcessId to "${targetProcessId}"`,
                 '-e', '  try',
                 '-e', '    set savedClipboard to the clipboard as string',
                 '-e', '  on error',
                 '-e', '    set savedClipboard to ""',
                 '-e', '  end try',
+                '-e', '  try',
                 '-e', activateLine,
                 '-e', '  delay 0.5',
+                '-e', '  my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "after activation")',
                 '-e', '  tell application "System Events"',
                 '-e', '    set frontmostProcess to first application process whose frontmost is true',
                 '-e', '    tell frontmostProcess'
@@ -777,6 +815,7 @@ async function deliverDigest(subscription, digest) {
             }
 
             osascriptArgs.push(
+                '-e', '      my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before prompt clear")',
                 '-e', '      set the clipboard to ""',
                 '-e', '      keystroke "a" using command down',
                 '-e', '      delay 0.2',
@@ -789,8 +828,10 @@ async function deliverDigest(subscription, digest) {
                 '-e', '  on error',
                 '-e', '    set userInput to ""',
                 '-e', '  end try',
+                '-e', '  my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before wake clipboard set")',
                 '-e', '  set the clipboard to wakePayload',
                 '-e', '  delay 0.2',
+                '-e', '  my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before wake paste")',
                 '-e', '  tell application "System Events"',
                 '-e', '    set frontmostProcess to first application process whose frontmost is true',
                 '-e', '    tell frontmostProcess',
@@ -801,8 +842,10 @@ async function deliverDigest(subscription, digest) {
                 '-e', '    end tell',
                 '-e', '  end tell',
                 '-e', '  if userInput is not "" then',
+                '-e', '    my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before user input restore clipboard set")',
                 '-e', '    set the clipboard to userInput',
                 '-e', '    delay 0.2',
+                '-e', '    my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before user input restore paste")',
                 '-e', '    tell application "System Events"',
                 '-e', '      set frontmostProcess to first application process whose frontmost is true',
                 '-e', '      tell frontmostProcess',
@@ -812,6 +855,10 @@ async function deliverDigest(subscription, digest) {
                 '-e', '  end if',
                 '-e', '  delay 0.5',
                 '-e', '  set the clipboard to savedClipboard',
+                '-e', '  on error errMsg',
+                '-e', '    set the clipboard to savedClipboard',
+                '-e', '    error errMsg',
+                '-e', '  end try',
                 '-e', 'end run',
                 digest
             );

--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -701,7 +701,7 @@ test.describe('Bridge Daemon', () => {
         expect(args.join(' ')).not.toContain('key code 49');
     });
 
-    test('Claude default focus seed emits r -> Cmd+Z before prompt clear (#10987)', async () => {
+    test('Claude default focus seed emits r -> Cmd+Z before prompt clear and guards frontmost (#10987, #10422)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-claude';
 
@@ -787,12 +787,30 @@ test.describe('Bridge Daemon', () => {
         const rIndex        = scriptContent.indexOf('keystroke "r"');
         const zIndex        = scriptContent.indexOf('keystroke "z" using command down');
         const clearIndex    = scriptContent.indexOf('keystroke "a" using command down');
+        const guardAfterActivationIndex = scriptContent.indexOf('my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "after activation")');
+        const guardBeforeClearIndex     = scriptContent.indexOf('my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before prompt clear")');
+        const guardBeforeWakeSetIndex   = scriptContent.indexOf('my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before wake clipboard set")');
+        const wakePayloadIndex          = scriptContent.indexOf('set the clipboard to wakePayload');
+        const guardBeforeWakePasteIndex = scriptContent.indexOf('my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before wake paste")');
+        const pasteIndex                = scriptContent.indexOf('keystroke "v" using command down');
 
         expect(activateIndex).toBeGreaterThan(-1);
+        expect(scriptContent).toContain('on assertTargetFrontmost(appName, targetBundleId, targetProcessId, phase)');
+        expect(scriptContent).toContain('set targetBundleId to id of application "Claude"');
+        expect(scriptContent).toContain('bundle identifier of frontmostProcess');
+        expect(scriptContent).toContain('set the clipboard to savedClipboard\n    error errMsg');
         expect(tabIndex).toBeGreaterThan(activateIndex);
+        expect(guardAfterActivationIndex).toBeGreaterThan(activateIndex);
+        expect(guardAfterActivationIndex).toBeLessThan(tabIndex);
         expect(rIndex).toBeGreaterThan(tabIndex);
         expect(zIndex).toBeGreaterThan(rIndex);
+        expect(guardBeforeClearIndex).toBeGreaterThan(zIndex);
+        expect(guardBeforeClearIndex).toBeLessThan(clearIndex);
         expect(clearIndex).toBeGreaterThan(zIndex);
+        expect(guardBeforeWakeSetIndex).toBeGreaterThan(clearIndex);
+        expect(guardBeforeWakeSetIndex).toBeLessThan(wakePayloadIndex);
+        expect(guardBeforeWakePasteIndex).toBeGreaterThan(wakePayloadIndex);
+        expect(guardBeforeWakePasteIndex).toBeLessThan(pasteIndex);
         expect(scriptContent).not.toContain('key code 49');
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 79e8a897-794c-4ffd-bfb1-3408093d0e33.
FAIR-band: over-target [20/30] — taking this lane despite over-target because #10422 is a safety-critical wake-delivery bug, already self-assigned/claimed, and the wake-routing author confirmed it should land before #12401 to avoid rename-sweep churn.

Resolves #10422

Restores the frontmost-target safety guard in the current Agent-OS wake daemon path. The daemon now emits an AppleScript `assertTargetFrontmost` helper and checks the target after activation, before prompt clearing, before writing the wake payload to the clipboard, before paste/submit, and before restoring user input. The guard uses the resolved instance pid when present, bundle id for the app-activate fallback, and process name only as a last fallback so newer Electron/frontmost routing remains intact. On failure, the script restores the saved clipboard and aborts instead of typing into the wrong app.

Evidence: L2 (mocked osascript argv generation + bridge daemon unit coverage) → L4 required (AC3 wrong-app bleed prevention under live macOS focus-steal block). Residual: AC3 live blocked-focus verification [#10422].

## Deltas from ticket
- Current source moved from the original ticket path `ai/scripts/bridge-daemon.mjs` to `ai/daemons/bridge/daemon.mjs`; this PR fixes the live daemon path.
- Uses pid/bundle-id/name assertions instead of only `currentApp is appName`, preserving #12399/#12407 instance routing and Electron process-name compatibility.
- #12401 bridge→wake-daemon rename is deliberately out of scope; @neo-opus-4-7 confirmed #10422 should land first and #12401 will sweep the final guarded state.

## Test Evidence
- `git diff --check`
- `node ./buildScripts/util/check-shorthand.mjs ai/daemons/bridge/daemon.mjs test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs`
- `node ./buildScripts/util/check-whitespace.mjs ai/daemons/bridge/daemon.mjs test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs`
- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/daemons/bridge/daemon.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs -g "Claude default focus seed"` — 1 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs` — 15 passed

## Post-Merge Validation
- [ ] On a macOS host with Accessibility permission, trigger an osascript wake while focus-steal is blocked/denied and verify the wake payload does not paste into the currently active non-target app.
- [ ] When #12401 lands, confirm the rename sweep preserves the `assertTargetFrontmost` guard in the renamed wake-daemon path.

## Commit
- `2630e65b4` — `fix(ai): guard osascript frontmost delivery (#10422)`