### PR TITLE
test(ai): stub bridge daemon ps resolver (#12425)

### DIFF
--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -8,6 +8,25 @@ import os from 'os';
 import { collapseDuplicateShapeCRoutes, getNodesData, getEdgesData } from '../../../../../../ai/daemons/bridge/queries.mjs';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../../../../../ai/graph/storage/constants.mjs';
 
+/**
+ * @summary Stubs `ps` for subprocess daemon tests so instance-resolution branches do not depend
+ * on the host machine's live GUI process list.
+ *
+ * The bridge daemon resolves same-bundle harness instances by shelling out to `ps`. Unit tests that
+ * assert the default app-activate AppleScript path must force the resolver to return `null`,
+ * otherwise a developer machine with Claude.app already running can take the PID-targeted branch
+ * while CI takes the activate branch.
+ *
+ * @param {String} binDir
+ * @param {String} [psOutput='']
+ */
+function writeMockPs(binDir, psOutput = '') {
+    const mockPsPath = path.join(binDir, 'ps');
+
+    fs.writeFileSync(mockPsPath, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(psOutput)});\n`);
+    fs.chmodSync(mockPsPath, 0o755);
+}
+
 test.describe('Bridge Daemon', () => {
     let db;
     let daemonProcess;
@@ -643,6 +662,7 @@ test.describe('Bridge Daemon', () => {
         // Create mock osascript to capture args without actually running AppleScript
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
         const mockOutPath = path.join(DAEMON_DIR, 'mock_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
@@ -731,6 +751,7 @@ test.describe('Bridge Daemon', () => {
 
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
         const mockOutPath = path.join(DAEMON_DIR, 'mock_claude_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
@@ -847,6 +868,7 @@ test.describe('Bridge Daemon', () => {
 
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
         const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_failclosed_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
@@ -939,6 +961,7 @@ test.describe('Bridge Daemon', () => {
 
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
         const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_cleanup_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 79e8a897-794c-4ffd-bfb1-3408093d0e33.

FAIR-band: over-target [20/30] — this is a narrow test-determinism fix surfaced from the active #12424 review path. It removes host-process dependence from a daemon unit spec without adding runtime surface.

Resolves #12425

## Summary

`daemon.spec` subprocess tests already prepend a fake `bin` directory for `osascript`. This PR adds a deterministic fake `ps` executable in the same test bin so bridge-daemon instance resolution returns `null` during default-instance AppleScript assertions.

That keeps the unit tests on the legacy app-activate path regardless of whether the developer machine has Claude.app / same-bundle instances running.

## Deltas From Ticket

- Uses the existing subprocess PATH seam instead of import mocking, because the daemon is spawned as a separate Node process.
- Current `origin/dev` has no instance-addressed daemon spec cases, so the fake `ps` returns empty stdout for every fake-`osascript` subprocess path. Future instance-addressed tests can pass fixture `ps` output through the helper.
- Test-only change. No daemon runtime behavior changed.

## Test Evidence

- `git diff --check`
- `node ./buildScripts/util/check-shorthand.mjs test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs`
- `node ./buildScripts/util/check-whitespace.mjs test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs -g "Claude default focus seed"` -> 1 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs` -> 15 passed

Evidence: L2 (unit, subprocess daemon spec with deterministic `ps` seam) -> L2 required for a test-only determinism fix.

## Post-Merge Validation

- [ ] On a harness machine with Claude.app running, rerun `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs` and confirm the default focus-seed case remains on the activate-path assertion.

## Commit

- `5ed2a097c` — `test(ai): stub bridge daemon ps resolver (#12425)`
