### PR TITLE
docs(agentos): add reference hygiene guidance (#10288)

### DIFF
--- a/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
+++ b/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
@@ -1,7 +1,7 @@
 # Ideation Sandbox Workflow
 
 ## 1. Context
-When engaging in deep architectural design, brainstorming, or encountering "Unknown Unknowns", it is counter-productive to generate highly speculative GitHub Issues that pollute the actionable task tracker. The Ideation Sandbox directs speculative thought processes into GitHub Discussions. Canonical case studies include **#10119** (Agent harness as Neo app) and **#10137** (MX Model Experience).
+When engaging in deep architectural design, brainstorming, or encountering "Unknown Unknowns", route speculative work to GitHub Discussions. Case studies: **`#10119`** (Agent harness as Neo app) and **`#10137`** (MX Model Experience).
 
 **Crucial Mindset Shift:** The Ideation Sandbox is NOT meant to serve as a holding pen or a "second shot" before blindly creating an Epic. It is a dedicated space to discuss, brainstorm back-and-forth, and rigorously apply **PR Depth Challenges**. As a reviewer, you are expected to actively challenge assumptions and push back on architectural proposals (just as you would in a PR), rather than merely rubber-stamping the idea for graduation.
 *For skill-authoring discipline including Progressive Disclosure (why SKILL.md is a lightweight router pointing here), see `.agents/skills/create-skill/`.*
@@ -15,7 +15,7 @@ When engaging in deep architectural design, brainstorming, or encountering "Unkn
    - **No Standard:** If no standard surfaces, document the search in your Author's Note ("I searched for [keywords] and found no canonical industry standard; proposing Neo-native design").
    - **Distinction from Industry Friction Radar:** The precedent-sweep targets *established standards* to align with. The `industry-friction-radar` skill targets *frontier friction* where standards are failing. They are complementary, opposite directions.
 3. **Use Discussions.** Call the `create_discussion` tool to post your proposal.
-4. **Agent Notification (Swarm Specific):** If you are operating in a multi-agent swarm environment (i.e., other agents are available), you MUST use the `add_message` tool to ping your peers immediately after creating or significantly updating the discussion. Ideation thrives on cross-family peer review. The A2A body MUST literally name the skill the peer should engage (`Requested action: use /peer-role on Discussion #X` for design-review context, or `/ideation-sandbox` if co-authoring divergence) — naming the skill mechanically loads the receiving peer's discipline payload; vague `review my discussion` relies on semantic-match and is the rubber-stamp anti-pattern's surface (PR #11127 empirical anchor, #11136). (Skip this step if you are the only agent operating in the workspace).
+4. **Agent Notification (Swarm Specific):** If you are operating in a multi-agent swarm environment (i.e., other agents are available), you MUST use the `add_message` tool to ping your peers immediately after creating or significantly updating the discussion. Ideation thrives on cross-family peer review. The A2A body MUST literally name the skill the peer should engage (`Requested action: use /peer-role on Discussion #X` for design-review context, or `/ideation-sandbox` if co-authoring divergence) — naming the skill mechanically loads the receiving peer's discipline payload; vague `review my discussion` relies on semantic-match and is the rubber-stamp anti-pattern's surface (PR `#11127` empirical anchor, `#11136`). (Skip this step if you are the only agent operating in the workspace).
 5. **Set the Category.** Map the discussion to the `Ideas` category.
 6. **Format the Proposal.** The body of the discussion should clearly articulate:
    - **Self-Identification (Mandatory):** You **MUST** begin the body by explicitly identifying yourself and your underlying model. (e.g., `> **Author's Note:** This proposal was autonomously synthesized by **[Agent Name] ([Model Name])** during an Ideation session.`)
@@ -23,9 +23,13 @@ When engaging in deep architectural design, brainstorming, or encountering "Unkn
    - **The Rationale:** Why is this valuable?
    - **Open Questions (OQs):** What unknowns still need to be addressed?
 
-## 3. Author's Note Convention (The #10119 Annotation Pattern)
+### 2.1 Reference Hygiene
+
+Before Discussion prose, read [`reference-hygiene.md`](../../../../learn/agentos/reference-hygiene.md): relationships stay bare; descriptive tokens use backticks.
+
+## 3. Author's Note Convention (The `#10119` Annotation Pattern)
 Discussions are meant to evolve. Instead of creating noisy parallel comment threads to reflect updates to the core idea, the authoritative substrate is the Discussion body itself.
-- Use **"the #10119 annotation pattern"**: Treat the Discussion body like a PR diff. When the idea evolves, edit the body directly with `manage_discussion({action: 'update_body', discussion_number, body})` (like a force-push).
+- Use **"the `#10119` annotation pattern"**: Treat the Discussion body like a PR diff. When the idea evolves, edit the body directly with `manage_discussion({action: 'update_body', discussion_number, body})` (like a force-push).
 - Add top-of-body annotation markers (e.g. `> **Update 2026-04-24:** Refined the VDOM syncing section based on feedback below.`) to signal what changed.
 - You may add a brief comment to notify thread participants, but the body remains the single source of truth.
 
@@ -44,7 +48,7 @@ To enable the Retrospective daemon to ingest this negotiation, the author MUST u
 ## 5. Per-Domain Graduation Criteria
 A Discussion cannot graduate until it is clearly scoped. There is no universal checklist. Every Discussion MUST articulate its own graduation criteria in a dedicated section near the end of the body.
 - If you cannot articulate what "ready for graduation" looks like for this specific proposal, it isn't ready.
-- **Graduation target depends on scope:** the convergent shape may justify a full Epic (multi-sub coordination required), a single standalone ticket (`[GRADUATED_TO_TICKET]` per §4 — bounded artifact, often 1 PR's worth of work), or in rare cases a direct PR with no tracker when the operator approves and no follow-up coordination is needed. Empirical anchor: Discussion #10697 graduated to ticket #10698 (single bounded artifact: 1 new skill + amendments + 1 reference file) rather than an Epic.
+- **Graduation target depends on scope:** the convergent shape may justify a full Epic (multi-sub coordination required), a single standalone ticket (`[GRADUATED_TO_TICKET]` per §4 — bounded artifact, often 1 PR's worth of work), or in rare cases a direct PR with no tracker when the operator approves and no follow-up coordination is needed. Empirical anchor: Discussion `#10697` graduated to ticket `#10698` (single bounded artifact: 1 new skill + amendments + 1 reference file) rather than an Epic.
 
 ### 5.1. Double Diamond Divergence Guard (High-Blast-Radius Mandatory)
 
@@ -79,7 +83,7 @@ For source anchors, exception semantics, and substrate-decay review, read [`../a
 
 ### 5.2. Step 2.5: Architectural Step-Back (High-Blast-Radius Convergence Gate)
 
-§5.1 is the **divergence-phase** gate (matrix must be in body before convergence). §5.2 is the **convergence-phase** gate (cross-substrate sweep must run before graduation). Empirical anchor: Discussion #11180 → Epic #11187 arc (3-way convergence + matrix-in-body still produced 2 epic-review blockers caught only post-graduation; both would have surfaced via §5.2 sweep pre-graduation).
+§5.1 is the **divergence-phase** gate (matrix must be in body before convergence). §5.2 is the **convergence-phase** gate (cross-substrate sweep must run before graduation). Empirical anchor: Discussion `#11180` → Epic `#11187` arc (3-way convergence + matrix-in-body still produced 2 epic-review blockers caught only post-graduation; both would have surfaced via §5.2 sweep pre-graduation).
 
 **Trigger — high-blast-radius (any ONE qualifies)**:
 - Modifies durable content layout (`resources/content/`, `learn/`, `.agents/`)
@@ -91,7 +95,7 @@ For source anchors, exception semantics, and substrate-decay review, read [`../a
 
 **Gate**: Before any `[RESOLVED_TO_AC]` or `[GRADUATED_TO_TICKET]` marker, one peer MUST post a `STEP_BACK` comment running the 8-point cross-substrate sweep. Comment exit criterion: peers acknowledge each point (✓ pass / ⚠ partial / ✗ blocker). Blockers reshape the proposal; partials get explicit acknowledgment ACs in the graduation ticket.
 
-**8-point cross-substrate sweep checklist** (canonical; adopted from Discussion #11188 OQ4):
+**8-point cross-substrate sweep checklist** (canonical; adopted from Discussion `#11188` OQ4):
 
 1. **Authority sweep** — Which artifact will future agents treat as canonical: discussion body, latest comment, epic body, ticket AC? Are they consistent? If the proposal conflicts with an accepted ADR, apply the ADR successor-risk audit and make the keep / amend / supersede / retire disposition explicit before graduation.
 2. **Consumer sweep** — Which readers consume the proposed shape? Include syncers, local lookup services, health/readiness, release scripts, workflows, docs, external mirrors (pages/portal).
@@ -108,11 +112,11 @@ For source anchors, exception semantics, and substrate-decay review, read [`../a
 
 **Cross-skill complement**: `peer-role-mode.md` §8 third halt-trigger (convergence-rate tripwire) fires §5.2 mechanically when 3 peers reach agreement on a high-blast-radius proposal within ≤2 rounds AND no STEP_BACK comment yet exists. Detector-phrase patterns for 3rd-peer-post detection: "I agree with @peer's option X", "Adopt Option X", "Going with X" — when posted within ≤2 rounds on a high-blast-radius proposal.
 
-**Empirical anchor**: Discussion #11180 → Epic #11187 arc (2026-05-11) — 3-way convergence + matrix-in-body still produced 2 epic-review blockers (Discussion body authority drift + AC6/AC7 active-tier ordinal chunk-N breaking `LocalFileService#getIssueById` O(1) determinism) caught post-graduation. §5.2 sweep pre-graduation would have caught both via authority + path-determinism + active/archive-boundary sweeps.
+**Empirical anchor**: Discussion `#11180` → Epic `#11187` arc (2026-05-11) — 3-way convergence + matrix-in-body still produced 2 epic-review blockers (Discussion body authority drift + AC6/AC7 active-tier ordinal chunk-N breaking `LocalFileService#getIssueById` O(1) determinism) caught post-graduation. §5.2 sweep pre-graduation would have caught both via authority + path-determinism + active/archive-boundary sweeps.
 
 ## 6. Graduation Trigger (Consensus-Gated)
 
-*(Codified per #11217, graduated from Discussion #11216 under its own dogfooded protocol — recursive substrate validation)*
+*(Codified per `#11217`, graduated from Discussion `#11216` under its own dogfooded protocol — recursive substrate validation)*
 
 Graduation is the transition from speculative Discussion to actionable Epic / ticket / PR. The author proposes graduation by adding a `[GRADUATION_PROPOSED]` marker near the top of the body. **For high-blast classes**, graduation is BLOCKED until cross-family consensus is reached per the explicit Signal Ledger protocol below. **For low-blast classes**, the original author-declared `GRADUATED` shape (with §5.1 Double Diamond peer-review-cycle satisfied) suffices.
 
@@ -127,7 +131,7 @@ Author declares scope in Discussion body via `Scope: high-blast` or `Scope: low-
 
 ### 6.2 Signal Patterns + Quorum Rule (high-blast only)
 
-**Quorum rule** (per Epic #11796 / Discussion #11793 — family-keyed, membership-derived): graduation requires **(a)** ≥ 2 distinct *active* families (per `AgentIdentity.participationStatus`) signing with ANY signal type (`AUTHOR_SIGNAL` or `[GRADUATION_APPROVED]`), AND **(b)** ≥ 1 *non-author* active family signing `[GRADUATION_APPROVED]`. **Tier 2** (core-value / §critical_gates / consensus-gate mutations) additionally requires explicit `## Unresolved Liveness` entry for any benched family + capability-grounded `revalidationTrigger` AC in the graduating Epic. Family-keying replaces the prior hardcoded "3× cross-family signals" because active membership is variable (operator-benched families, same-family siblings); same-family aggregation (§6.4) resolves multi-identity families. Full rationale + background: [`audits/consensus-mandate.md §quorum-rule`](../audits/consensus-mandate.md).
+**Quorum rule** (per Epic `#11796` / Discussion `#11793` — family-keyed, membership-derived): graduation requires **(a)** ≥ 2 distinct *active* families (per `AgentIdentity.participationStatus`) signing with ANY signal type (`AUTHOR_SIGNAL` or `[GRADUATION_APPROVED]`), AND **(b)** ≥ 1 *non-author* active family signing `[GRADUATION_APPROVED]`. **Tier 2** (core-value / §critical_gates / consensus-gate mutations) additionally requires explicit `## Unresolved Liveness` entry for any benched family + capability-grounded `revalidationTrigger` AC in the graduating Epic. Family-keying replaces the prior hardcoded "3× cross-family signals" because active membership is variable (operator-benched families, same-family siblings); same-family aggregation (§6.4) resolves multi-identity families. Full rationale + background: [`audits/consensus-mandate.md §quorum-rule`](../audits/consensus-mandate.md).
 
 **Four signal patterns** (full definitions + VETO collapse rule: [`audits/consensus-mandate.md §signal-patterns-table`](../audits/consensus-mandate.md)):
 
@@ -154,7 +158,7 @@ When a peer signals DEFERRED, the **burden of convergence falls on the APPROVED-
 
 The DEFERRED peer is NOT obligated to either prove their case or update their signal unilaterally — they hold the substantive divergence position. The inversion ("what would change your signal?" framing) is an anti-pattern that re-introduces author-pressure on dissenters.
 
-**Same-family aggregation** (per Epic #11796 / Discussion #11793 OQ7): a family contributes `APPROVED` when ≥ 1 active identity APPROVES AND no active identity holds unresolved `DEFERRED`/`VETO` at the same anchor. The §6.4 burden-of-convergence clause applies to same-family APPROVED-signalers as well as cross-family ones. Full rule + multi-identity rationale: [`audits/consensus-mandate.md §same-family-aggregation`](../audits/consensus-mandate.md).
+**Same-family aggregation** (per Epic `#11796` / Discussion `#11793` OQ7): a family contributes `APPROVED` when ≥ 1 active identity APPROVES AND no active identity holds unresolved `DEFERRED`/`VETO` at the same anchor. The §6.4 burden-of-convergence clause applies to same-family APPROVED-signalers as well as cross-family ones. Full rule + multi-identity rationale: [`audits/consensus-mandate.md §same-family-aggregation`](../audits/consensus-mandate.md).
 
 **Reconciliation cycles**: typically resolve in 1-3 substantive cycles. If reconciliation stalls after ~20 comments, route the design back through peer-owned convergence substrate (fresh Step-Back, lead-role facilitation, or a narrower follow-up Discussion). Ask the operator only for Tier-4 human-owned intent clarification per AGENTS.md §15.6; do not convert a stalled sandbox into a human graduation approval gate.
 
@@ -164,13 +168,13 @@ Ideation Sandbox graduation is a peer-owned substrate transition. The operator c
 
 The graduated Issue / Epic / PR body MUST archive any non-empty dissent or liveness gap in `## Unresolved Dissent` / `## Unresolved Liveness` with commentId/state anchors and the peer-owned disposition. Future Discussions can re-open the risk if it materializes.
 
-Inactive families (`participationStatus ∈ {operator_benched, temporarily_unreachable}` per `ai/graph/identityRoots.mjs`) are archived in `## Unresolved Liveness` per §6.6; Tier-2 substrate additionally carries a `revalidationTrigger` AC (per Epic #11796 AC6 + sub #11803 — **Tier-2 Revalidation Sweep**, see [`audits/tier-2-revalidation.md`](../audits/tier-2-revalidation.md)) re-opening the substrate for retroactive signal review when the benched family reactivates. Unresolved no-signal never becomes implicit approval.
+Inactive families (`participationStatus ∈ {operator_benched, temporarily_unreachable}` per `ai/graph/identityRoots.mjs`) are archived in `## Unresolved Liveness` per §6.6; Tier-2 substrate additionally carries a `revalidationTrigger` AC (per Epic `#11796` AC6 + sub `#11803` — **Tier-2 Revalidation Sweep**, see [`audits/tier-2-revalidation.md`](../audits/tier-2-revalidation.md)) re-opening the substrate for retroactive signal review when the benched family reactivates. Unresolved no-signal never becomes implicit approval.
 
 ### 6.6 Graduated-Artifact Required Sections (AC11)
 
 The graduated Issue / Epic / PR body MUST include four explicit sections, even if empty: `## Signal Ledger` (family-keyed per §6.2), `## Unresolved Dissent`, `## Unresolved Liveness`, and `## Discussion Criteria Mapping`. Empty sections are positive signals (no dissent, no liveness gaps). Non-empty sections preserve the divergence trail per §15.6 transparent A2A introspection, and enable future Discussions to re-open if residual risks materialize.
 
-For the canonical markdown template (post-Epic #11796 family-keyed shape, same-family aggregation nesting, AUTHOR_SIGNAL distinction, Tier-2 revalidationTrigger placement), see [`audits/consensus-mandate.md §template-block`](../audits/consensus-mandate.md).
+For the canonical markdown template (post-Epic `#11796` family-keyed shape, same-family aggregation nesting, AUTHOR_SIGNAL distinction, Tier-2 revalidationTrigger placement), see [`audits/consensus-mandate.md §template-block`](../audits/consensus-mandate.md).
 
 ### 6.7 Author Actions Post-Consensus
 
@@ -184,8 +188,8 @@ Axis 1 (this section, §6) is the Discussion-graduation gate; Axis 2 is the PR-m
 
 ### 6.9 Empirical Anchors
 
-Empirical anchors for §6 consensus-mandate behavior — including the original #11216 graduation (the rule's own dogfooded recursion), the #11210 → #11213 + PR #11212 / #11215 axis-1+2 enforcement cases, the #11214 → #11218 dogfood example, the #11782 → #11731 first-empirical-hit-of-hardcoded-3× failure mode, and the Epic #11796 / Discussion #11793 family-keyed-quorum extension (recursive substrate validation depth-2) — are archived in [`audits/consensus-mandate.md §empirical-anchors`](../audits/consensus-mandate.md).
+Empirical anchors for §6 consensus-mandate behavior — including the original `#11216` graduation (the rule's own dogfooded recursion), the `#11210` → `#11213` + PR `#11212` / `#11215` axis-1+2 enforcement cases, the `#11214` → `#11218` dogfood example, the `#11782` → `#11731` first-empirical-hit-of-hardcoded-3× failure mode, and the Epic `#11796` / Discussion `#11793` family-keyed-quorum extension (recursive substrate validation depth-2) — are archived in [`audits/consensus-mandate.md §empirical-anchors`](../audits/consensus-mandate.md).
 
 ### 6.10 30-Day Post-Merge Validation (AC10)
 
-Per #11195 30-day Step 2.5 validation tracker, signal-ledger compliance + PR-merge-gate cite-compliance are audited prospectively on the next 3 high-blast graduations + 3 follow-up PRs. Full framing (compliance thresholds, escalation paths) in [`audits/consensus-mandate.md §post-merge-validation`](../audits/consensus-mandate.md).
+Per `#11195` 30-day Step 2.5 validation tracker, signal-ledger compliance + PR-merge-gate cite-compliance are audited prospectively on the next 3 high-blast graduations + 3 follow-up PRs. Full framing (compliance thresholds, escalation paths) in [`audits/consensus-mandate.md §post-merge-validation`](../audits/consensus-mandate.md).

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -31,7 +31,7 @@ If you are an AI Agent tasked with writing a PR review directly on GitHub (actin
     - **Minor Gaps:** If you uncover minor misses (e.g., missed JSDoc, missing Anchor & Echo context), push rapid successive commits to the PR to polish the execution.
     - **Major Refactors:** If you realize a mathematically superior architecture exists (e.g., massive GC optimization) that is *out-of-scope* for the current ticket, DO NOT attempt to cram it into the active PR. Secure the "good enough" PR, and instead propose a **Follow-Up System Enhancement Ticket** conceptually linked to the original PR to avoid scope creep.
 6. **Verify-Before-Assert Integration (Premise-Risk Check):** Before asserting any claim in your PR Review (especially under §7 Depth Floor) OR accepting the premise of the PR itself, you MUST apply the **Verify-Before-Assert Pre-Flight Check** (`AGENTS.md` §3.5). You are subject to RLHF conditioning that defaults to subservient, execution-first behaviors ("Helpful Assistant"). You must explicitly counteract this regression drift: do NOT assume the PR's architectural premises or claims about the codebase are true. You MUST execute falsifying tool calls (e.g., `ask_knowledge_base`, `grep_search`, `view_file`) to empirically validate the premise before generating review feedback. You cannot claim "this code breaks X" or "this label is missing" without first empirically running the falsifying tool to prove it.
-7. **Execution:** Post the substantive review via `manage_pr_review` (action: `create`, state: `APPROVED`/`REQUEST_CHANGES`/`COMMENT`). This is a single atomic call that posts the review body AND flips GitHub's `reviewDecision` surface — closes the historical formal-state-gap pattern (PR #11234 + PR #11271 empirical anchors) where agents posted review prose via `manage_issue_comment` then forgot the second `gh pr review --approve` step. `manage_pr_review` returns `reviewId` (PRR_* node ID) for A2A propagation per `review-response-protocol.md §14`. **Fallback (only when `manage_pr_review` is unavailable in harness)**: the legacy two-step `manage_issue_comment` create + `gh pr review` CLI chain still works; the cross-family mandate gate (`pull-request §6.1` `reviewDecision: APPROVED`) is what must be satisfied either way.
+7. **Execution:** Post the substantive review via `manage_pr_review` (action: `create`, state: `APPROVED`/`REQUEST_CHANGES`/`COMMENT`). This is a single atomic call that posts the review body AND flips GitHub's `reviewDecision` surface — closes the historical formal-state-gap pattern (PR `#11234` + PR `#11271` empirical anchors) where agents posted review prose via `manage_issue_comment` then forgot the second `gh pr review --approve` step. `manage_pr_review` returns `reviewId` (PRR_* node ID) for A2A propagation per `review-response-protocol.md §14`. **Fallback (only when `manage_pr_review` is unavailable in harness)**: the legacy two-step `manage_issue_comment` create + `gh pr review` CLI chain still works; the cross-family mandate gate (`pull-request §6.1` `reviewDecision: APPROVED`) is what must be satisfied either way.
 
 ## 3. Structural Evaluation Metrics
 Every PR review MUST score the work across the following categories on a scale of `0` to `100`:
@@ -98,6 +98,10 @@ The Retrospective daemon explicitly regex-matches these tags during REM sleep:
 
 **Author-side response tags (`pull-request` §6):** The `.agents/skills/pull-request/references/review-response-protocol.md` document defines a symmetric set of author-side tags — `[ADDRESSED]`, `[DEFERRED]`, `[REJECTED_WITH_RATIONALE]` — used by PR authors when responding to Required Actions from a review. Reviewer-side and author-side tags form a unified taxonomy the Retrospective daemon ingests as a complete negotiation thread; both sides of the review cycle are mineable signal.
 
+### 4.1 Reference Hygiene
+
+Before review prose/tags, read [`reference-hygiene.md`](../../../../learn/agentos/reference-hygiene.md): structural tokens stay bare; descriptive tokens use backticks.
+
 ## 5. Required Actions & Cross-Linking
 *   **Related Graph Nodes:** Every PR review MUST list related graph nodes (e.g., `Target Epic ID`, `Issue ID`) to ensure the Native Edge Graph links the evaluation to the overarching goal.
 *   **Required Actions:** Clearly list a bulleted checklist of mandatory changes required before the PR can be accepted.
@@ -110,7 +114,7 @@ When challenging a specific architectural pattern or complex implementation deta
 
 When reviewing a PR, audit every issue named as a close-target via GitHub's magic keywords (`Closes #N`, `Resolves #N`, `Fixes #N` — case-insensitive, in the PR body or commit messages) against labels, syntax, and branch-history safety. For Neo agent / `ai` PRs, `Resolves #N` is the only valid closing keyword; `Closes #N` / `Fixes #N` are invalid, and `Refs #N` / `Related: #N` are non-closing extras only.
 
-**Squash-merge commit-body hazard:** branch commit bodies are merge-time close-target surfaces. GitHub's squash merge can concatenate commit bodies into the default-branch commit; a stale `Resolves #N` inside any branch commit body can auto-close `#N` even when the PR body has been corrected to `Refs #N` and `gh pr view --json closingIssuesReferences` returns `[]`. Provenance: #11185 / PR #11183.
+**Squash-merge commit-body hazard:** branch commit bodies are merge-time close-target surfaces. GitHub's squash merge can concatenate commit bodies into the default-branch commit; a stale `Resolves #N` inside any branch commit body can auto-close `#N` even when the PR body has been corrected to `Refs #N` and `gh pr view --json closingIssuesReferences` returns `[]`. Provenance: `#11185` / PR `#11183`.
 
 **Rules:**
 - **Epics are invalid close-targets:** PRs deliver leaf sub-issues; epics close only when their sub-issue topology is complete or explicitly retired.
@@ -131,7 +135,7 @@ When reviewing a PR, audit every issue named as a close-target via GitHub's magi
 - **Validity:** Move the epic reference to `Related: #N` (no magic-close behavior).
 - **Partial-resolution stale commit body:** Prefer Drop+Supersede / clean branch when no operator authorization exists for history rewrite. If preserving the PR is preferred, get operator-explicit authorization before amend/rebase/force-push cleanup.
 
-Provenance: #9999 auto-close incident and #10323 duplicate chain. The stable rule is reviewer-side close-target validation before merge.
+Provenance: `#9999` auto-close incident and `#10323` duplicate chain. The stable rule is reviewer-side close-target validation before merge.
 
 **Out of scope for this audit:**
 - Leaf tickets without `epic` label — close-target is valid.
@@ -252,7 +256,7 @@ Reviewers MUST verify symmetry between **stated framing** and **mechanical imple
 1. **PR description** — does the architectural narrative accurately describe the boundaries and capabilities of the code? Or does the prose claim more than the diff substantiates?
 2. **Anchor & Echo summaries** (`AGENTS.md §15.2`) — does new JSDoc reuse precise codebase terminology, or does it lean on metaphor / source-comment archaeology that overshoots durable intent?
 3. **`[RETROSPECTIVE]` tags** (§4) — does the takeaway accurately characterize what shipped, or does it inflate the architectural significance of a routine change?
-4. **Linked-anchor accuracy** — when prose claims "implements pattern X from #N" or "similar to PR #M", does the cited reference actually establish that pattern, or is it being cited for borrowed authority?
+4. **Linked-anchor accuracy** — when prose claims "implements pattern X from `#N`" or "similar to PR `#M`", does the cited reference actually establish that pattern, or is it being cited for borrowed authority?
 
 #### What this audit is NOT
 
@@ -301,19 +305,19 @@ Formal reviews assume CI is already green. Verify the current PR check state bef
 | Approval without rhetorical-drift audit on a PR carrying substantive architectural prose | §7.4 Rhetorical-Drift Audit violated; framing drifts from mechanical reality, poisons `ask_knowledge_base` ingestion |
 | Approving `[EXECUTION_QUALITY]` without executing the author's test evidence or checking test locations | §7.5 Test-Execution & Location Audit violated; reviewers must independently verify testing claims and canonical file placement |
 | Approving a PR with failing CI or security checks (like CodeQL) | §7.6 CI / Security Checks Audit violated; fundamentally unsafe code |
-| PR names an epic as close-target without flagging | §5.2 Close-Target Audit violated; risks epic auto-close-with-open-subs (see #9999 sabotage chain) |
+| PR names an epic as close-target without flagging | §5.2 Close-Target Audit violated; risks epic auto-close-with-open-subs (see `#9999` sabotage chain) |
 | Re-escalating Required Action without superior empirical evidence after `[REJECTED_WITH_RATIONALE]` | §9.1 Reviewer-Yield Protocol violated; reviewers must yield to author's empirical evidence |
 | PR adds bloated multi-line OpenAPI tool description without flagging | §5.3 MCP-Tool-Description Budget Audit violated; bloat compounds across the tool surface and competes with agent reasoning budget at runtime |
-| Substantive review comment posted via `manage_issue_comment` without atomic `manage_pr_review` OR fallback `gh pr review` chain | Cross-family gate ungated despite the visible review prose; §2.7 violated. Prefer `manage_pr_review` atomic primitive (#11273); fallback to two-step only when MCP tool unavailable |
+| Substantive review comment posted via `manage_issue_comment` without atomic `manage_pr_review` OR fallback `gh pr review` chain | Cross-family gate ungated despite the visible review prose; §2.7 violated. Prefer `manage_pr_review` atomic primitive (`#11273`); fallback to two-step only when MCP tool unavailable |
 | PR adds env-var deprecation chain | Read `pull-request/references/env-var-rename-rule.md` |
 | Cycle-1 Request Changes with iterative Required Actions when PR premise is structurally invalid | §9.0 Cycle-1 Premise Pre-Flight violated; reviewer normalized "fix-these-N" as merge-path when Drop+Supersede framing was substrate-correct (Velocity-Preservation Bias) |
-| Approving substrate touching multi-loaded agent-memory files by FILE-COMPLETENESS dimension only without auditing RUNTIME-LOAD EFFECT | **Loading-runtime-effect substitution** — see **§7.8 Audit Spec: Loading-Runtime-Effect Substitution** for full DIMENSION-vs-ENGAGEMENT framing, PR #11244 empirical anchor, and reviewer mechanical pre-flight. Proactive companion: `/turn-memory-pre-flight`. |
+| Approving substrate touching multi-loaded agent-memory files by FILE-COMPLETENESS dimension only without auditing RUNTIME-LOAD EFFECT | **Loading-runtime-effect substitution** — see **§7.8 Audit Spec: Loading-Runtime-Effect Substitution** for full DIMENSION-vs-ENGAGEMENT framing, PR `#11244` empirical anchor, and reviewer mechanical pre-flight. Proactive companion: `/turn-memory-pre-flight`. |
 | PR adds substantive rule body directly to always-loaded skill substrate (`SKILL.md`, `pr-review-guide.md`, `pull-request-workflow.md`, `AGENTS.md`) instead of conditionally loaded `references/` payload | **Progressive Disclosure violation** — Map (always-loaded) vs World Atlas (conditional reference) split bypassed; bloats per-turn token budget. Default disposition for new rules is `compress-to-trigger` per `pull-request-workflow.md §1.1`. Proactive companion: `/create-skill`. Required Action: reshape to Map (trigger line) → Atlas (rule body in `references/`) split, or cite per-turn frequency + irreversibility justifying `keep` slot |
 | PR body missing FAIR-band stance declaration (or declaration mismatches live `gh search prs` query) | **`pull-request-workflow.md §1.3` FAIR-Band Pre-Flight Gate violated** — see [`audits/fair-band-declaration-audit.md`](./audits/fair-band-declaration-audit.md) for the reviewer-side verification protocol + Required Action template. <!-- trigger: PR body missing FAIR-band declaration → read audit payload --> |
 
 ## 7.8 Audit Spec: Loading-Runtime-Effect Substitution
 
-Reactive-side audit fired during `/pr-review`. The **proactive** counterpart `/turn-memory-pre-flight` skill (Epic #11256 substrate) owns the canonical substrate-effect framing, IN-SCOPE file list, mechanical pre-flight protocol, and decision tree. This audit defines the **reviewer-side discipline only** — what to recognize at PR-review time + the Required-Action shape when the pattern fires.
+Reactive-side audit fired during `/pr-review`. The **proactive** counterpart `/turn-memory-pre-flight` skill (Epic `#11256` substrate) owns the canonical substrate-effect framing, IN-SCOPE file list, mechanical pre-flight protocol, and decision tree. This audit defines the **reviewer-side discipline only** — what to recognize at PR-review time + the Required-Action shape when the pattern fires.
 
 ### Authoritative substrate (do NOT duplicate here)
 
@@ -322,7 +326,7 @@ See [`.agents/skills/turn-memory-pre-flight/references/turn-memory-pre-flight-wo
 - IN-SCOPE / OUT-OF-SCOPE / CARVE-OUT file list (Substrate Boundary section)
 - 5-step Placement Decision Tree
 - 4-step Mechanical Pre-Flight Protocol (`cat .codex/hooks.json` etc.)
-- PR #11244 empirical anchor + PR #11250 + Epic #11256 anchors
+- PR `#11244` empirical anchor + PR `#11250` + Epic `#11256` anchors
 
 ### When this audit fires (reviewer-side)
 
@@ -332,7 +336,7 @@ At `/pr-review` time, when a PR modifies any file listed in `/turn-memory-pre-fl
 
 **Loading-runtime-effect substitution**: PR approves on FILE-COMPLETENESS dimension *("3 harness files have the block, cross-harness symmetry achieved")* without verifying RUNTIME-LOAD EFFECT *("does content load once or twice per turn?")*.
 
-Distinct from rubber-stamping (§7.7 row 3): the failure is **DIMENSION** (effect-surface unaudited) not **ENGAGEMENT** (content-surface reviewed). Substantive feedback can be given across multiple cycles while the load-effect dimension stays invisible. Specific instance of **Flattening-Bias** from Discussion #11259's 4-sub-mode enumeration (Deference / Action / Approval / Flattening). PR #11244's 6-cycle arc (3 reviewers / 4 missed cycles / operator V-B-A) is the canonical empirical anchor — see `/turn-memory-pre-flight` atlas for full detail.
+Distinct from rubber-stamping (§7.7 row 3): the failure is **DIMENSION** (effect-surface unaudited) not **ENGAGEMENT** (content-surface reviewed). Substantive feedback can be given across multiple cycles while the load-effect dimension stays invisible. Specific instance of **Flattening-Bias** from Discussion `#11259`'s 4-sub-mode enumeration (Deference / Action / Approval / Flattening). PR `#11244`'s 6-cycle arc (3 reviewers / 4 missed cycles / operator V-B-A) is the canonical empirical anchor — see `/turn-memory-pre-flight` atlas for full detail.
 
 ### Required Action template (reviewer-side)
 
@@ -340,9 +344,9 @@ Distinct from rubber-stamping (§7.7 row 3): the failure is **DIMENSION** (effec
 
 ### Cross-skill bridge
 
-- **Proactive companion (substrate-creation time)**: `/turn-memory-pre-flight` (Epic #11256 substrate; `turn-memory-pre-flight` skill trigger)
-- **Architectural router (ambiguous cases)**: `/architecture-pre-flight` (Epic #11256 substrate)
-- **Helpful-Assistant 4-sub-mode context**: Discussion #11259 (CLOSED RESOLVED) → ticket #11262 → PR #11263 (substrate-load-time XML salience metadata)
+- **Proactive companion (substrate-creation time)**: `/turn-memory-pre-flight` (Epic `#11256` substrate; `turn-memory-pre-flight` skill trigger)
+- **Architectural router (ambiguous cases)**: `/architecture-pre-flight` (Epic `#11256` substrate)
+- **Helpful-Assistant 4-sub-mode context**: Discussion `#11259` (CLOSED RESOLVED) → ticket `#11262` → PR `#11263` (substrate-load-time XML salience metadata)
 
 
 ## 8. Cross-Skill Integration Audit
@@ -409,11 +413,11 @@ If the author's rationale holds up to empirical scrutiny—even if it doesn't ma
 
 This explicit reviewer open-mindedness mandate is symmetric to the author's mandate, closing the loop on deadlock vulnerabilities.
 
-## 10. A2A Comment-ID Hand-off Protocol (#10272)
+## 10. A2A Comment-ID Hand-off Protocol (`#10272`)
 
 **Problem:** Without commentId-scoped fetch, every review cycle N+1 incurs **cumulative-thread context cost** — full-thread fetch reads all prior cycles, not just the delta. This breaks linear-cost scaling: by cycle three of an Architectural Pillar review, fetching the full conversation burns more tokens on prior rounds than on the new substance. Compounds silently across the swarm — every reviewer pays the cumulative cost per cycle, not just once. **Treat as invariant discipline, not optional optimization** — the cost asymmetry diverges with thread length, and missed pings cascade across reviewers.
 
-Provenance: PR #10371 showed cumulative-thread fetch cost diverging with thread length. The stable rule is commentId-scoped hand-off for warm-cache review cycles.
+Provenance: PR `#10371` showed cumulative-thread fetch cost diverging with thread length. The stable rule is commentId-scoped hand-off for warm-cache review cycles.
 
 **Solution:** `manage_issue_comment` action:`create` returns `{message, commentId, url, createdAt}`. The reviewer captures `commentId` from that response and relays it to the next reviewer (peer or author) via A2A mailbox — the recipient fetches just-this-comment via `get_conversation({pr_number: N, comment_id: COMMENT_ID})`, scaling linearly with new-comment volume rather than cumulative thread size.
 
@@ -448,7 +452,7 @@ Provenance: PR #10371 showed cumulative-thread fetch cost diverging with thread 
 
 ### 10.4 Pre-Flight Check (operational reflex)
 
-The §10 hand-off protocol is mechanical — but reviewers empirically miss it across cycles even after reading this guide (PR #10371 + #10375, 2026-04-26: 5+ missed pings before @tobiu surfaced the gap explicitly). The discipline is reflex-application, not knowledge.
+The §10 hand-off protocol is mechanical — but reviewers empirically miss it across cycles even after reading this guide (PR `#10371` + `#10375`, 2026-04-26: 5+ missed pings before @tobiu surfaced the gap explicitly). The discipline is reflex-application, not knowledge.
 
 **Pre-Flight Check shape** (mirrors `AGENTS.md §3 / §4.2` proven primitives). After every `manage_issue_comment` create, before yielding turn, you MUST explicitly state in your internal reasoning:
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -38,7 +38,7 @@ ADR conflict trigger: add `Decision Record impact:` naming the ADR update or pen
 
 Before `git commit` or opening a PR, you MUST verify you are the formal assignee for the target ticket. This is the enforcement mechanism for **AGENTS.md §0 Invariant 7**. If unassigned, claim it (`manage_issue_assignees({action: 'add', issue_number: N, assignees: ['@me']})`). If assigned to someone else, halt and respect ownership.
 
-### 1.3 The FAIR-Band Pre-Flight Gate (#11433 — bypass-resistant choke-point for #11432)
+### 1.3 The FAIR-Band Pre-Flight Gate (`#11433` — bypass-resistant choke-point for `#11432`)
 
 <!-- trigger: PR-open → read ./fair-band-pre-flight-gate.md for FAIR-band stance declaration shapes + verifier query -->
 
@@ -77,7 +77,7 @@ git branch --show-current
 
 If it returns `main` or `dev`, STOP and branch off using the §2.2 procedure. This check costs nothing and catches edge cases where a harness's isolation assumption has broken (e.g. symlink detach, manual `git checkout`).
 
-### 2.3.1 Branch Freshness Check (pre-push) *(Codified per #10212)*
+### 2.3.1 Branch Freshness Check (pre-push) *(Codified per `#10212`)*
 
 Before the first `git push` that opens a PR, AND before every force-push that would update the PR branch:
 
@@ -92,7 +92,7 @@ git fetch origin
 
 **Exception — first push of a freshly-branched feature:** skip ONLY after confirming via `git log origin/dev..HEAD` that no sibling PRs have merged and the log reflects your own commits exclusively. The branch-point IS `origin/dev`'s tip.
 
-### 2.3.2 Branch-Discipline Check (pre-push) *(#11133)*
+### 2.3.2 Branch-Discipline Check (pre-push) *(`#11133`)*
 
 `.husky/pre-push` blocks `chore(data):` commits on feature branches: [`audits/branch-discipline-check.md`](../audits/branch-discipline-check.md).
 
@@ -177,7 +177,7 @@ You MUST follow this exact handoff protocol:
 
 ### 6.1 The Cross-Family Mandate
 
-*(Codified per #10208)*
+*(Codified per `#10208`)*
 
 **No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `gh pr review --approve` per `pr-review-guide.md §2.7`. A substantive review comment alone via `manage_issue_comment` is insufficient.
 
@@ -186,11 +186,11 @@ You MUST follow this exact handoff protocol:
 - **7-day-open fallback**: The PR itself has been OPEN for >= 7 days AND no cross-family reviewer has engaged on the thread. Any cross-family thread engagement (review, comment, or status) resets the 7-day-open clock; only an `Approved` status satisfies the mandate. Deterministically verifiable via `get_conversation(pr_number)`: (a) `now - createdAt >= 7 days`, (b) `comments.nodes` contains no entry whose `author.login` resolves to the cross-family pattern. Fallback invocation MUST include the PR's `createdAt` timestamp + explicit confirmation that no cross-family engagement has occurred, embedded in the self-review comment.
 - **Emergency hotfix escalator**: `priority: P0` label OR an explicit Tobi-override comment on the PR; post-merge cross-family retrospective review REQUIRED within 7 days.
 
-**Invitation Layer (`manage_pr_reviewers`):** the cross-family mandate is the **validation** mechanism (Approved-status before merge). The MCP tool `manage_pr_reviewers` (`github-workflow` server) is the corresponding **invitation** mechanism — surfaces GitHub's `requested_reviewers` API for active review-requests. If no cross-family reviewer has engaged ~2 hours after the PR has a green current-head CI state, the author SHOULD formally invite the opposite family via `manage_pr_reviewers({action: 'add', pr_number, reviewers: ['<opposite-family-login>']})`. Invitation precedes the 7-day-open fallback — it's the natural escalation step BEFORE that fallback fires. Codified per #10217.
+**Invitation Layer (`manage_pr_reviewers`):** the cross-family mandate is the **validation** mechanism (Approved-status before merge). The MCP tool `manage_pr_reviewers` (`github-workflow` server) is the corresponding **invitation** mechanism — surfaces GitHub's `requested_reviewers` API for active review-requests. If no cross-family reviewer has engaged ~2 hours after the PR has a green current-head CI state, the author SHOULD formally invite the opposite family via `manage_pr_reviewers({action: 'add', pr_number, reviewers: ['<opposite-family-login>']})`. Invitation precedes the 7-day-open fallback — it's the natural escalation step BEFORE that fallback fires. Codified per `#10217`.
 
 ### 6.1.1 The Consensus-Gate (PR-Merge-Gate for Discussion-Graduated Substrate)
 
-*(Codified per #11217, graduated from Discussion #11216; operationalizes operator directive 2026-05-11: "premature PRs → reject". Post-#11796 family-keyed shape: [`audits/consensus-gate-mirror.md`](../audits/consensus-gate-mirror.md). §6.1.1 below = pre-#11796 per-peer shape pending follow-up.)*
+*(Codified per `#11217`, graduated from Discussion `#11216`; operationalizes operator directive 2026-05-11: "premature PRs → reject". Post-`#11796` family-keyed shape: [`audits/consensus-gate-mirror.md`](../audits/consensus-gate-mirror.md). §6.1.1 below = pre-`#11796` per-peer shape pending follow-up.)*
 
 **Axis 2 of the consensus mandate** (Axis 1 is `ideation-sandbox-workflow.md §6` Discussion-graduation-gate). Without both axes, the consensus-mandate is bypassable by opening a PR before Discussion-graduation reaches the §6.2 quorum (canonical: audit pointer above).
 
@@ -210,9 +210,9 @@ You MUST follow this exact handoff protocol:
 **Operator merge-gate**: PRs that bypass the consensus-gate get rejected at the merge boundary by `@tobiu` regardless of CI green or cross-family approval. This is the structural enforcement of §0 Invariant 1 extended to consensus-gated substrate.
 
 **Empirical anchors** (2026-05-11):
-- **PR #11212** (Gemini's first sunset PR) — rejected by `@tobiu` at ~14:27Z; opened before Discussion #11210 reached 100% APPROVED
-- **PR #11215 (first iteration)** — rejected by `@tobiu` at ~14:37Z; same root cause
-- **PR #11215 (post-rework)** — Discussion #11210 graduated (3× APPROVED); GPT's Cycle 1 /pr-review nonetheless cited PR-hygiene contamination (15 of 17 files unrelated) → CHANGES_REQUESTED. The Consensus-Gate (this section) is distinct from PR-hygiene gates; both block merge independently.
+- **PR `#11212`** (Gemini's first sunset PR) — rejected by `@tobiu` at ~14:27Z; opened before Discussion `#11210` reached 100% APPROVED
+- **PR `#11215` (first iteration)** — rejected by `@tobiu` at ~14:37Z; same root cause
+- **PR `#11215` (post-rework)** — Discussion `#11210` graduated (3× APPROVED); GPT's Cycle 1 /pr-review nonetheless cited PR-hygiene contamination (15 of 17 files unrelated) → CHANGES_REQUESTED. The Consensus-Gate (this section) is distinct from PR-hygiene gates; both block merge independently.
 
 **Distinction from §6.1 Cross-Family Mandate**: §6.1 enforces approval-before-merge. §6.1.1 enforces consensus-source-before-approval for substrate-PRs. The reviewer's `/pr-review` Substantive Validation checklist is extended by §6.1.1 with the Signal Ledger verification step.
 
@@ -228,9 +228,9 @@ To prevent redundant parallel effort and reviewer collision, you MUST adhere to 
    - **GitHub Layer (Assignment):** Author chooses exactly ONE `primary-reviewer` and calls the `manage_pr_reviewers` MCP tool (`action: 'add'`) only after the CI-green gate passes.
    - **A2A Layer (Wake):** Author sends ONE actionable A2A ping *only* to that same primary reviewer.
      - Include `Review role: primary-reviewer`.
-     - Include `Requested action: use /pr-review on PR #N` — naming the skill literally is mandatory; mechanically loads the receiving peer's `pr-review-template.md` + structured-eval discipline + graph-ingestion section structure. Vague `review PR #N` relies on semantic-match and is the empirical anchor for the rubber-stamp / template-adherence-gap pattern (PR #11127 cycle-1, 2026-05-10). Mirror of §6.4's remediation idiom applied at initial routing time.
+     - Include `Requested action: use /pr-review on PR #N` — naming the skill literally is mandatory; mechanically loads the receiving peer's `pr-review-template.md` + structured-eval discipline + graph-ingestion section structure. Vague `review PR #N` relies on semantic-match and is the empirical anchor for the rubber-stamp / template-adherence-gap pattern (PR `#11127` cycle-1, 2026-05-10). Mirror of §6.4's remediation idiom applied at initial routing time.
      - Do NOT send an actionable request to the second peer (unless using the `AGENT:*` broadcast primitive for general awareness, which does not convey primary ownership).
-   - *Primary-reviewer selection heuristic:* Default to round-robin (rotation) to prevent static silos (provenance: #10483). Subsystem familiarity should only be used as an explicit override with stated rationale (e.g., "Assigning @neo-gpt because they authored this abstraction in PR #X"). Do not use pure random selection.
+   - *Primary-reviewer selection heuristic:* Default to round-robin (rotation) to prevent static silos (provenance: `#10483`). Subsystem familiarity should only be used as an explicit override with stated rationale (e.g., "Assigning @neo-gpt because they authored this abstraction in PR `#X`"). Do not use pure random selection.
    - *FAIR-band follow-up:* Authors request one primary reviewer; the reviewer then follows the FAIR-band pickup discipline after the review handoff (see `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`).
 
 2. **Reviewer SLA & Decline Protocol:**
@@ -267,7 +267,7 @@ This strict role-based feedback loop prevents duplicated work and confusion over
 
 ### 6.2.1 Cross-Family Corrective-Authorship Rotation
 
-*(Codified per #11267 to institutionalize Layer 2 rotation tracking)*
+*(Codified per `#11267` to institutionalize Layer 2 rotation tracking)*
 
 When correcting substrate errors, resolving merge conflicts, or handling complex architectural alignment across model families, we enforce a **cross-family corrective-authorship rotation**. This ensures symmetric burden sharing and mitigates "helpful assistant" compliance drift where one family perpetually cleans up another's PRs without substrate consequence.
 
@@ -278,7 +278,7 @@ The workload is distributed across the three swarm participants (`@neo-opus-4-7`
 - **Narrow Activation (AC-CycleC):** Corrective rotation activates ONLY on explicit operator-direction (e.g., Tobi assigning a peer) OR explicit author-yield (the original author declaring exhaustion/handoff via A2A).
 
 **Layer 2 Tracking Contract (5 Signals):**
-To ensure visibility within the Memory Core (and tying into the L1 capability manifest tracking per #11275), all cross-family authorship rotations MUST emit the following signals:
+To ensure visibility within the Memory Core (and tying into the L1 capability manifest tracking per `#11275`), all cross-family authorship rotations MUST emit the following signals:
 1. **Duplicate close-target prevention:** Evaluated prior to PR creation by checking active PRs and A2A `[lane-claim]` events.
 2. **Same-author correction check:** Tracked via cross-session aggregation to prevent a single agent from looping on the same correction multiple times.
 3. **Operator-direction / Author-yield:** Explicit A2A audit trail required for targeted assignment.
@@ -324,26 +324,30 @@ until shape is correct.
 
 Do not blindly copy the entire ticket body into the PR description. The ticket holds the original context; the PR body summarizes the implementation delta.
 
+### 9.1 Reference Hygiene
+
+Before PR prose, read [`reference-hygiene.md`](../../../../learn/agentos/reference-hygiene.md): relationships stay bare; descriptive tokens use backticks.
+
 **The Epic Close-Target Ban (Mandatory):**
 You are strictly FORBIDDEN from pointing `Resolves #N` at an Epic ticket. GitHub's auto-close-on-merge semantics would prematurely close the entire epic when the PR merges. PRs deliver sub-issues, not epics.
 - `Resolves` only the leaf sub-issue the PR fully implements.
 - To reference the parent epic without closing it, use `Related: #N` (or `Refs #N`).
 
-**The `Resolves`-Only Mandate (Mandatory, CI-enforced — #12367):**
+**The `Resolves`-Only Mandate (Mandatory, CI-enforced — `#12367`):**
 Every PR body MUST contain ≥1 `Resolves #N` — the only sanctioned closing keyword (= delivered work); `agent-pr-body-lint.yml` rejects agent/`ai` PRs without one. `Closes #N` is forbidden (closed-without-delivery needs no PR); `Fixes #N` is forbidden (ambiguous). `Refs #N` / `Related: #N` are allowed only as *additional* references. This makes 1-PR-per-ticket mechanical: N PRs cannot share N valid `Resolves`, so split the work into subs.
 You are strictly FORBIDDEN from embedding the keyword in a conversational sentence (e.g., "Resolves Sub 3 of Epic #X (#Y)"). GitHub's parser requires strict syntax to establish the automatic close link. If you fail to use the exact syntax, the ticket will remain open after merge.
 **Multiple Tickets Loophole:** While we strive for a 1-Ticket-to-1-PR ratio, if your PR fully resolves multiple tickets, you MUST flag each one individually. Do NOT use comma-separated lists like `Resolves #X, #Y`. Instead, use a distinct line for each ticket:
 `Resolves #X`
 `Resolves #Y`
 
-**Branch-history close-keyword hygiene (#11185):**
+**Branch-history close-keyword hygiene (`#11185`):**
 For any *additional* ticket your PR references but must NOT close (e.g. a parent epic via `Refs #N` / `Related: #N`), the entire branch history must agree it stays open. Before handoff, run:
 
 ```bash
 git log origin/dev..HEAD --format='%h%x09%s%n%b'
 ```
 
-If any branch commit body still contains `Closes #N`, `Fixes #N`, or `Resolves #N`, do not open or hand off the PR as merge-ready. GitHub squash-merge can concatenate branch commit bodies into the default-branch commit; stale magic-close text can auto-close `#N` even when the PR body says `Refs` and `closingIssuesReferences` is empty. Clean-path resolution is a fresh superseding branch/PR; preserving the same PR requires operator-explicit authorization before amend/rebase/force-push cleanup. Empirical anchor: PR #11183 squash-merged as `5c7c5a2f4`, preserving stale `Resolves #11182` from branch commit `deb022d0c` and auto-closing #11182.
+If any branch commit body still contains `Closes #N`, `Fixes #N`, or `Resolves #N`, do not open or hand off the PR as merge-ready. GitHub squash-merge can concatenate branch commit bodies into the default-branch commit; stale magic-close text can auto-close `#N` even when the PR body says `Refs` and `closingIssuesReferences` is empty. Clean-path resolution is a fresh superseding branch/PR; preserving the same PR requires operator-explicit authorization before amend/rebase/force-push cleanup. Empirical anchor: PR `#11183` squash-merged as `5c7c5a2f4`, preserving stale `Resolves #11182` from branch commit `deb022d0c` and auto-closing `#11182`.
 
 **Minimum-viable PR body structure:**
 ```markdown
@@ -369,7 +373,7 @@ Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target 
 <one compressed paragraph per pivot — why direction changed, not the old text>
 ```
 
-**Evidence declaration discipline (#10698 graduation artifact):**
+**Evidence declaration discipline (`#10698` graduation artifact):**
 
 The `Evidence:` line is a 1-line greppable declaration of what evidence class was achieved vs what the close-target requires. Reference: [`learn/agentos/evidence-ladder.md`](../../../../learn/agentos/evidence-ladder.md) for L1-L4 ladder + sandbox-ceiling vs achievable-ceiling distinction.
 

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -41,7 +41,7 @@ If the proposed ticket involves modifying any agent skill (i.e., any file within
 2. **Inline divergence-matrix substance** preempting the cited Discussion's expected gap. The matrix should include at least the recommended option + 2 alternative shapes with falsifying sources.
 3. **Acknowledgment that downstream amendments may be required** once the cited Discussion graduates — the ticket explicitly states which sections may need refresh post-Discussion-graduation, so future agents do not treat the early-filing as final.
 
-For source anchors (#11078/#11082/#11083/#11084), Discussion #11091 authority context, and substrate-decay review, read [`../../ideation-sandbox/audits/double-diamond-divergence-guard.md`](../../ideation-sandbox/audits/double-diamond-divergence-guard.md).
+For source anchors (`#11078` / `#11082` / `#11083` / `#11084`), Discussion `#11091` authority context, and substrate-decay review, read [`../../ideation-sandbox/audits/double-diamond-divergence-guard.md`](../../ideation-sandbox/audits/double-diamond-divergence-guard.md).
 
 ### 1d. Project Attachment Pre-Flight (during release cycle)
 
@@ -55,7 +55,7 @@ Apply at creation time — not just at intake. Every stage must pass before the 
 2. **Prescription** — is the stated fix the right substrate for the problem, or does it treat a symptom? Could a different layer (config, service, daemon, schema) solve it better?
    **Verify-Before-Assert Integration:** Before making architectural claims or prescribing solutions in your Fat Ticket body (Stage 2 Prescription), you MUST apply the **Verify-Before-Assert Pre-Flight Check** (`AGENTS.md` §2.3). You cannot assert that a bug exists or a pattern is flawed without empirical confirmation (a falsifying tool call) prior to filing the ticket.
 3. **Substrate** — where does this work belong? Service layer? Build script? CI workflow? Framework core? Documentation? Match the fix to the substrate that owns the concern.
-   **Structural Pre-Flight Integration:** when the prescription introduces or relocates a `.mjs` file, the directory choice MUST be validated via `.agents/skills/structural-pre-flight/` before drafting the ticket body. Stage 0 mechanical trigger fires; Stage 1 fast-path handles sibling-pattern matches in 30 seconds; novel directory choices route through full Pre-Flight (ArchitectureOverview.md + ADR consultation). The empirical anchors PR #11008 (`orchestrator-daemon.mjs` misplaced in `ai/scripts/`) and earlier `bridge-daemon.mjs` demonstrate the cost of skipping this check at ticket-creation time.
+   **Structural Pre-Flight Integration:** when the prescription introduces or relocates a `.mjs` file, the directory choice MUST be validated via `.agents/skills/structural-pre-flight/` before drafting the ticket body. Stage 0 mechanical trigger fires; Stage 1 fast-path handles sibling-pattern matches in 30 seconds; novel directory choices route through full Pre-Flight (ArchitectureOverview.md + ADR consultation). The empirical anchors PR `#11008` (`orchestrator-daemon.mjs` misplaced in `ai/scripts/`) and earlier `bridge-daemon.mjs` demonstrate the cost of skipping this check at ticket-creation time.
 4. **Consumer** — who reads the output of this change? Human developer, agent, Memory Core, Native Edge Graph, Knowledge Base? Different consumers need different shapes (markdown prose vs structured metadata vs MCP payload).
 5. **Service-Boundary** — does the fix cross a service boundary it shouldn't? Config added to the wrong owning service creates future migration debt.
 6. **Decision Record impact** — for architecture/substrate tickets, declare whether the work is `none`, `aligned-with`, `depends-on`, `amends`, `supersedes`, or `challenges` an ADR. If it challenges or supersedes an accepted ADR, apply the ADR successor-risk audit in [`../../ticket-intake/references/adr-successor-risk-audit.md`](../../ticket-intake/references/adr-successor-risk-audit.md) before filing.
@@ -83,7 +83,7 @@ Keep titles under ~70 characters. PR titles derive from ticket titles; length di
 - **Primary — exactly one:** `epic`, `enhancement`, or `bug`.
 - **Secondary — as applicable:** `architecture`, `performance`, `regression`, `refactoring`, `documentation`, `testing`, plus domain labels (`core`, `grid`, `build`, etc.).
 - Before filing: call `list_labels` to confirm the labels exist. Do not invent label names.
-- **Project attachment is MANDATORY on every ticket during the v13 release cycle.** Visibility primitive: every new ticket goes onto Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) so the swarm + operator have a single overview. ProjectV2 memberships supersede the deprecated `release:v*` label family per [#11233](https://github.com/neomjs/neo/issues/11233).
+- **Project attachment is MANDATORY on every ticket during the v13 release cycle.** Visibility primitive: every new ticket goes onto Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) so the swarm + operator have a single overview. ProjectV2 memberships supersede the deprecated `release:v*` label family per [ProjectV2 migration ticket](https://github.com/neomjs/neo/issues/11233).
   - **`create_issue` MCP tool path:** pass `projects: [{projectNumber: 12}]` atomically with the create.
   - **`gh issue create` CLI bypass path:** ALWAYS follow with `gh project item-add 12 --owner neomjs --url <new-issue-url>` immediately. Treat the two-step as inseparable.
   - **Project anchor** is currently `12` (v13). When v14 release work begins, update the project number in this section AND any hard-coded `create_issue` examples or call-sites that name the release project (the MCP tool's `projects` parameter is caller-supplied with `[]` default — not a configurable tool-side default to update). Sunset condition: once v13 release ships, this rule needs disposition review (`keep` with updated project number, OR `compress-to-trigger` if mid-release ambiguity arises).
@@ -105,6 +105,10 @@ Skeleton tickets are forbidden. Every ticket body MUST contain:
 - **Related** — sibling tickets, superseded tickets, dependencies, PRs.
 - **Origin Session ID** — Memory Core session ID that produced the ticket. **Optional, but highly recommended** for genuinely single-session tickets. Serves as a direct pointer for the A2A Contextual Bridge Protocol (`AGENTS.md §14`). Format: `Origin Session ID: <uuid>` on its own line near the end of the body.
 - **Handoff Retrieval Hints** — Semantic query patterns (`query_raw_memories`, `query_summaries`) or exact Git commit-range anchors to assist subsequent agents in resuming the workstream across fragmented session IDs post-restart. **REQUIRED for architecturally substantive tickets or multi-session workflows.** Example: `Retrieval Hint: "cross-harness MCP singleton cache divergence"` or `Retrieval Hint: Commit SHA 1234abcd..5678efgh`.
+
+### 5.1 Reference Hygiene: Backtick-Escape for Descriptive `#N`
+
+When drafting ticket bodies, read [`learn/agentos/reference-hygiene.md`](../../../../learn/agentos/reference-hygiene.md): structural issue references stay bare; descriptive prose references use backticks.
 
 ## 6. Linkage
 
@@ -137,7 +141,7 @@ If the "ticket" is really an architectural question, brainstorming, or pre-PR ex
 
 The `create_issue` tool returns the new issue number. Typical immediate follow-ups:
 
-- **`manage_issue_assignees(action: 'add', issue_number: N, assignees: ['@me'])`** — **MANDATORY** if you intend to start working immediately (AGENTS.md §0 Invariant 7). Do this *before* editing any tracked files. (Note: once #11308 is resolved, atomic assignee injection at creation will replace this post-hoc call).
+- **`manage_issue_assignees(action: 'add', issue_number: N, assignees: ['@me'])`** — **MANDATORY** if you intend to start working immediately (AGENTS.md §0 Invariant 7). Do this *before* editing any tracked files. (Note: once `#11308` is resolved, atomic assignee injection at creation will replace this post-hoc call).
 - **`manage_issue_labels(action: 'add', ...)`** — only if the label set needs adjustment post-creation (e.g., label list was incomplete at `create_issue` time). Prefer getting labels right in the initial call.
 - **`manage_issue_projects(action: 'add', issue_number, projectNumbers: [12])`** — only if project membership needs adjustment post-creation. Prefer the `projects` parameter on `create_issue` for atomic attach. Use `action: 'update_field'` to set Status/Priority on the project board after creation.
 - **`update_issue_relationship(parent_id: N, child_id: M, type: 'SUB_ISSUE')`** — required when filing sub-issues under an Epic. Native graph linkage only; do NOT rely on inline `- [ ] #N` markdown checkboxes (see §6).

--- a/learn/agentos/reference-hygiene.md
+++ b/learn/agentos/reference-hygiene.md
@@ -1,0 +1,25 @@
+# Reference Hygiene for GitHub Issue Tokens
+
+GitHub auto-links bare `#N` in rendered markdown, and the Native Edge Graph treats issue-token matches as relationship evidence. When authoring tickets, PRs, reviews, or discussions, separate intentional graph edges from descriptive prose.
+
+## Structural References Stay Bare
+
+Keep the token bare when the reference itself is the intended relationship:
+
+- `Resolves #N` / `Closes #N` / `Fixes #N` close keywords
+- `Refs #N` / `Related: #N` when the PR body intentionally links a non-closing issue
+- `BLOCKED_BY #N` relationship metadata
+- Conventional-commit subjects such as `feat(scope): message (#N)`
+- Graduation markers such as `[GRADUATED_TO_TICKET: #N]`
+- Structured tool payloads such as `update_issue_relationship`
+
+## Descriptive References Use Backticks
+
+Backtick-escape the token when the prose is only context, provenance, or comparison:
+
+- "See `#N` for context"
+- "Mirrors the pattern from `#N`"
+- "Filed alongside `#N`"
+- `[KB_GAP]`, `[TOOLING_GAP]`, `[RETROSPECTIVE]`, evidence notes, and rationale text that mention issue numbers descriptively
+
+Rule of thumb: if the reference IS the relationship edge, keep it bare. If it explains context without asserting a relationship, backtick-escape the token.


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e8abc-27db-7bd1-8ed1-9c0dc64f70ac.
FAIR-band: over-target [20/30] — taking this lane despite over-target because #10288 was unassigned, docs-only, positive-ROI substrate cleanup, and resolves an existing backlog ticket without creating new work.

Resolves #10288

Adds a shared Agent OS reference-hygiene atlas for GitHub issue tokens, then points the four authoring workflow payloads at it from compact Reference Hygiene subsections. The guidance preserves intentional relationship tokens like `Resolves #N`, `Refs #N`, `Related: #N`, `BLOCKED_BY #N`, commit-subject `(#N)`, and `[GRADUATED_TO_TICKET: #N]`, while teaching agents to backtick descriptive/provenance issue references in rendered GitHub markdown.

Evidence: L1 (static docs/substrate audit via `git diff --check`, `git diff --cached --check`, focused `rg`, and `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`) -> L1 required (doc-only convention ACs). No residuals.

## Slot Rationale
Substrate mutation touches `.agents/skills/**` workflow payloads and adds `learn/agentos/reference-hygiene.md`.

- `learn/agentos/reference-hygiene.md`: disposition `keep` as atlas payload; trigger-frequency edge-case authoring of GitHub-rendered markdown with issue tokens; failure-severity medium because misses pollute GitHub mention indexes and Native Edge Graph relationships; enforceability discipline-only for now. Future-decay mitigation: centralized shared atlas avoids four duplicate rule bodies and can be retired or reduced if a linter or intent-aware graph parser supersedes the convention.
- Four workflow Reference Hygiene subsections: disposition `compress-to-trigger`; each remains a short map pointer to the atlas instead of carrying the rule body inline.
- Existing descriptive provenance anchors in the touched workflow payloads were backtick-escaped where they were not structural close-target syntax.

## Deltas from ticket
- Normalized the ticket body path shape from `.agent/skills/...` to the repo-current `.agents/skills/...`.
- Extracted the reusable convention into `learn/agentos/reference-hygiene.md` so `pr-review` and `pull-request` oversized workflow maps stay within the positive-delta guard and `ideation-sandbox` stays under its per-file payload budget.

## Test Evidence
- `git diff --check`
- `git diff --cached --check`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `rg -n 'Reference Hygiene|reference-hygiene|(^|[^`])#[0-9]+' ...` to verify descriptive bare issue-token cleanup; remaining matches are structural code examples.
- FAIR-band verifier: `Counter({'neo-gpt': 20, 'neo-opus-4-7': 10})`.

## Post-Merge Validation
- [ ] Next five agent-authored tickets, PR bodies, reviews, or Discussions follow the structural-bare vs descriptive-backtick convention.

## Commit
- `ca99ace12` — `docs(agentos): add reference hygiene guidance (#10288)`