### PR TITLE
fix(ai): handle non-sse OpenAI-compatible JSON (#10484)

### DIFF
--- a/ai/provider/OpenAiCompatible.mjs
+++ b/ai/provider/OpenAiCompatible.mjs
@@ -50,9 +50,9 @@ class OpenAiCompatibleProvider extends Base {
 
     /**
      * Helper to prepare the payload for the OpenAI compatible format.
-     * @param {String|Array} input 
-     * @param {Object} options 
-     * @param {Boolean} stream 
+     * @param {String|Array} input
+     * @param {Object} options
+     * @param {Boolean} stream
      * @returns {Object}
      * @protected
      */
@@ -133,7 +133,7 @@ class OpenAiCompatibleProvider extends Base {
         let fullContent = '';
 
         try {
-            // Internally delegate to the streaming API to bypass LM Studio/llama.cpp 
+            // Internally delegate to the streaming API to bypass LM Studio/llama.cpp
             // monolithic buffer serialization penalties (~30% faster on Apple Silicon)
             for await (const chunk of this.stream(input, options)) {
                 fullContent += chunk;
@@ -146,6 +146,74 @@ class OpenAiCompatibleProvider extends Base {
             };
         } catch (error) {
             throw error;
+        }
+    }
+
+    /**
+     * @summary Extracts generated content from OpenAI-compatible chat completion chunks.
+     *
+     * Streaming SSE frames expose text as `choices[0].delta.content`; non-SSE
+     * JSON chat-completions responses expose the final text as
+     * `choices[0].message.content`.
+     *
+     * @param {Object} data Parsed OpenAI-compatible response payload.
+     * @returns {String|null}
+     * @private
+     */
+    #getChoiceContent(data) {
+        const choice = data?.choices?.[0],
+              deltaContent = choice?.delta?.content,
+              messageContent = choice?.message?.content;
+
+        if (typeof deltaContent === 'string') {
+            return deltaContent;
+        }
+
+        return typeof messageContent === 'string' ? messageContent : null;
+    }
+
+    /**
+     * @summary Parses one streaming line or a complete single-line JSON response.
+     *
+     * @param {String} line SSE `data:` line or JSON response line.
+     * @returns {String|null}
+     * @private
+     */
+    #parseCompletionLine(line) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') {
+            return null;
+        }
+
+        try {
+            const jsonStr = trimmed.replace(/^data:\s*/, '');
+            return jsonStr ? this.#getChoiceContent(JSON.parse(jsonStr)) : null;
+        } catch (e) {
+            // Safe to ignore if JSON.parse fails on malformed LLM outputs.
+            return null;
+        }
+    }
+
+    /**
+     * @summary Parses a plain JSON chat-completions body after the stream ends.
+     *
+     * Pretty-printed JSON can span multiple lines, so this fallback operates on
+     * the full body only when no content has already been yielded.
+     *
+     * @param {String} bodyText Full decoded response body.
+     * @returns {String|null}
+     * @private
+     */
+    #parseCompletionBody(bodyText) {
+        const trimmed = bodyText.trim();
+        if (!trimmed || trimmed.startsWith('data:')) {
+            return null;
+        }
+
+        try {
+            return this.#getChoiceContent(JSON.parse(trimmed));
+        } catch (e) {
+            return null;
         }
     }
 
@@ -179,35 +247,47 @@ class OpenAiCompatibleProvider extends Base {
 
             const reader = response.body.getReader();
             const decoder = new TextDecoder('utf-8');
-            let buffer = '';
+            let buffer = '',
+                bodyText = '',
+                yieldedContent = false;
 
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) break;
 
-                buffer += decoder.decode(value, { stream: true });
+                const chunkText = decoder.decode(value, { stream: true });
+                bodyText += chunkText;
+                buffer += chunkText;
                 const lines = buffer.split('\n');
 
                 // Keep the last partial line in the buffer for the next chunk
                 buffer = lines.pop();
 
                 for (const line of lines) {
-                    const trimmed = line.trim();
-                    if (!trimmed || trimmed === 'data: [DONE]') continue;
-
-                    try {
-                        const jsonStr = trimmed.replace(/^data:\s*/, '');
-                        if (!jsonStr) continue;
-
-                        const data = JSON.parse(jsonStr);
-                        const delta = data.choices?.[0]?.delta;
-                        if (typeof delta?.content === 'string') {
-                            yield delta.content;
-                        }
-                    } catch (e) {
-                        // Safe to ignore if JSON.parse fails on malformed LLM outputs
-                        // We have handled TCP boundaries via the buffer!
+                    const content = this.#parseCompletionLine(line);
+                    if (content) {
+                        yieldedContent = true;
+                        yield content;
                     }
+                }
+            }
+
+            const flushText = decoder.decode();
+            if (flushText) {
+                bodyText += flushText;
+                buffer += flushText;
+            }
+
+            const finalContent = this.#parseCompletionLine(buffer);
+            if (finalContent) {
+                yieldedContent = true;
+                yield finalContent;
+            }
+
+            if (!yieldedContent) {
+                const bodyContent = this.#parseCompletionBody(bodyText);
+                if (bodyContent) {
+                    yield bodyContent;
                 }
             }
         } catch (error) {

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -290,6 +290,40 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         expect(capturedPayload.num_ctx).toBeUndefined();
     });
 
+    test('OpenAiCompatible.stream() yields non-SSE JSON message content', async () => {
+        let capturedPayload;
+
+        globalThis.fetch = async (url, init) => {
+            expect(url).toBe('http://openai-compatible.test/v1/chat/completions');
+            capturedPayload = JSON.parse(init.body);
+
+            return {
+                ok  : true,
+                body: createReadableStream([
+                    JSON.stringify({choices: [{message: {content: 'json ok'}}]})
+                ])
+            };
+        };
+
+        const provider = Neo.create(OpenAiCompatibleProvider, {
+            host     : 'http://openai-compatible.test',
+            modelName: 'gemma4-test'
+        });
+        const chunks = [];
+
+        for await (const chunk of provider.stream('hello', {response_format: {type: 'json_object'}})) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toEqual(['json ok']);
+        expect(capturedPayload).toMatchObject({
+            model          : 'gemma4-test',
+            stream         : true,
+            keep_alive     : -1,
+            response_format: {type: 'json_object'}
+        });
+    });
+
     test('OpenAiCompatible.generate() defaults keep_alive through the streaming payload', async () => {
         let capturedPayload;
 
@@ -320,5 +354,51 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
             keep_alive : -1,
             temperature: 0.2
         });
+    });
+
+    test('OpenAiCompatible.generate() aggregates non-SSE JSON message content', async () => {
+        let capturedPayload;
+
+        globalThis.fetch = async (url, init) => {
+            expect(url).toBe('http://openai-compatible.test/v1/chat/completions');
+            capturedPayload = JSON.parse(init.body);
+
+            return {
+                ok  : true,
+                body: createReadableStream([
+                    JSON.stringify({
+                        choices: [{
+                            message: {
+                                role   : 'assistant',
+                                content: '{"status":"ok"}'
+                            }
+                        }]
+                    })
+                ])
+            };
+        };
+
+        const provider = Neo.create(OpenAiCompatibleProvider, {
+            host     : 'http://openai-compatible.test',
+            modelName: 'gemma4-test'
+        });
+
+        const result = await provider.generate('hello', {responseMimeType: 'application/json'});
+
+        expect(result).toEqual({
+            content: '{"status":"ok"}',
+            raw    : {
+                message: {
+                    content: '{"status":"ok"}'
+                }
+            }
+        });
+        expect(capturedPayload).toMatchObject({
+            model          : 'gemma4-test',
+            stream         : true,
+            keep_alive     : -1,
+            response_format: {type: 'json_object'}
+        });
+        expect(capturedPayload.responseMimeType).toBeUndefined();
     });
 });


### PR DESCRIPTION
Authored by GPT-5 Codex (Codex Desktop). Session 79e8a897-794c-4ffd-bfb1-3408093d0e33.

FAIR-band: over-target [20/30] — taking this lane despite over-target because #10484 was already live, unassigned, freshly re-triaged, narrowly scoped to one provider contract, and had no open PR or review-ready peer lane displaced.

Resolves #10484

Evidence: L2 (focused mocked-fetch stream unit coverage + static syntax/diff checks) -> L2 required (provider parser contract plus unit coverage ACs). No residuals.

## Summary

- Adds OpenAI-compatible response parsing for both streaming SSE `choices[0].delta.content` chunks and non-SSE JSON `choices[0].message.content` chat-completions bodies.
- Keeps `generate()` delegating through `stream()`, so non-SSE JSON content aggregates through the same provider path.
- Adds focused unit coverage for `stream()` and `generate()` against a mocked non-SSE JSON response body.

## Deltas from ticket (if any)

- Provider-only fix in `ai/provider/OpenAiCompatible.mjs`.
- No SQLite chunking, bridge-daemon, or unrelated Agent OS scope.
- No live external model probe; the close target asks for focused unit coverage, and the provider contract is covered at the mocked fetch stream boundary.

## Test Evidence

- `git diff --check`
- `node --check ai/provider/OpenAiCompatible.mjs`
- `node --check test/playwright/unit/ai/provider/KeepAlive.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs` — 9 passed

## Post-Merge Validation

- [ ] Optional operator smoke with an LM Studio / llama.cpp OpenAI-compatible endpoint returning a non-SSE JSON chat-completions body.

## Commit

- `97b134e3d` — `fix(ai): handle non-sse OpenAI-compatible JSON (#10484)`
