### PR TITLE
docs(readme): add neo-claude-opus maintainer (#12430)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ We are not an abstract collective. We are a structured institution of named main
 |---|---|---|
 | [@tobiu](https://github.com/tobiu) | Substrate architect, empirical-corrector, merge-gate authority | Human |
 | [@neo-opus-4-7](https://github.com/neo-opus-4-7) | AI maintainer (Anthropic Claude Opus 4.7) | Machine Account |
+| [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude — same-family generalist; throughput + same-family review pressure) | Machine Account |
 | [@neo-gemini-3-1-pro](https://github.com/neo-gemini-3-1-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
 
@@ -191,7 +192,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-4-7`, `@neo-claude-opus`, `@neo-gemini-3-1-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 


### PR DESCRIPTION
Resolves #12430

Authored by GPT-5 (Codex Desktop). Session 79e8a897-794c-4ffd-bfb1-3408093d0e33.

FAIR-band: over-target [20/30] — taking this lane despite over-target because #12430 is an operator-directed identity drift follow-up after #12415 activated `@neo-claude-opus`, and the fix is README-only with low collision risk.

Adds `@neo-claude-opus` to the public README maintainer institution surfaces after #12415 activated the identity in `ai/graph/identityRoots.mjs`. The row uses same-family Claude wording so the existing "rival labs — Claude, Gemini, GPT" cross-family framing remains correct.

Evidence: L1 documentation-only change with source V-B-A against `ai/graph/identityRoots.mjs`, README roster occurrences, and scoped identity-surface grep; no runtime code path changed.

## Deltas from ticket

The ticket scoped this to README only after the activation PR merged. Implementation follows that scope exactly: one README table row and one README Contributing paragraph list update. The broader sweep still finds `learn/agentos/ModelStats.md` pending-row text, but the ticket explicitly marks that adjacent surface out of scope.

## Identity Update Protocol

- Change material: FACT — public maintainer roster membership, sourced from `ai/graph/identityRoots.mjs`.
- Skill consulted: `neo-identity-update` + ADR 0018.
- Surfaces checked from the affected-areas map: README maintainer table, README Contributing paragraph, `ai/graph/identityRoots.mjs`, and scoped roster grep across `.github`, `learn/benefits`, `learn/agentos`, portal view/index, and `package.json`.
- Out of scope: `learn/agentos/ModelStats.md` pending-row text is explicitly tracked outside #12430; this PR does not change model capability registry semantics.
- External/Class-4 changes: none.

## Test Evidence

- `git diff --check origin/dev..HEAD` — passed.
- `rg -n "neo-claude-opus|rival labs|Claude, Gemini, GPT" README.md` — confirmed the new maintainer row + Contributing list entry, and that the cross-family rival-labs sentence remains unchanged.
- Scoped identity surface sweep: `rg -n "AI maintainer team|Institution Inside the Brain|@neo-claude-opus|@neo-opus-4-7|@neo-gemini-3-1-pro|@neo-gpt" README.md .github learn/benefits learn/agentos apps/portal/view apps/portal/index.html package.json ai/graph/identityRoots.mjs -g "*.*"` — confirmed the README roster surfaces and the identity root; other hits are agent-facing historical/tooling surfaces, not the public README roster sync targeted here.
- Pre-commit hook — passed (`check-whitespace`).

## Review Gate

Identity-surface PR: cross-family review required per ADR 0018 / `neo-identity-update`.

## Post-Merge Validation

- [ ] README institution table and Contributing paragraph both show `@neo-claude-opus` on `dev`.

## Commit

- `85c26e989` — add `@neo-claude-opus` to README maintainer surfaces.
