### PR TITLE
feat(ci): enforce MCP test location lint (#10210)

### DIFF
--- a/.github/workflows/mcp-test-location-lint.yml
+++ b/.github/workflows/mcp-test-location-lint.yml
@@ -1,0 +1,40 @@
+name: MCP Test Location Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'test/playwright/mcp/**'
+      - 'test/playwright/unit/ai/mcp/server/**'
+      - 'ai/scripts/lint/lint-mcp-test-locations.mjs'
+      - 'test/playwright/unit/ai/scripts/lint/lintMcpTestLocations.spec.mjs'
+      - '.github/workflows/mcp-test-location-lint.yml'
+      - 'package.json'
+  push:
+    branches: [dev]
+    paths:
+      - 'test/playwright/mcp/**'
+      - 'test/playwright/unit/ai/mcp/server/**'
+      - 'ai/scripts/lint/lint-mcp-test-locations.mjs'
+      - 'test/playwright/unit/ai/scripts/lint/lintMcpTestLocations.spec.mjs'
+      - '.github/workflows/mcp-test-location-lint.yml'
+      - 'package.json'
+
+concurrency:
+  group: mcp-test-location-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Lint MCP test locations
+        run: npm run ai:lint-mcp-test-locations

--- a/ai/scripts/lint/lint-mcp-test-locations.mjs
+++ b/ai/scripts/lint/lint-mcp-test-locations.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * @summary Enforces canonical MCP server test placement.
+ *
+ * MCP server unit tests belong under `test/playwright/unit/ai/mcp/server/`.
+ * The legacy `test/playwright/mcp/` tree is deprecated and may contain only
+ * explicitly grandfathered files until they are migrated. This lint makes that
+ * convention mechanical so new tests cannot silently land in the old tree.
+ */
+import fs              from 'node:fs';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __filename                    = fileURLToPath(import.meta.url);
+const __dirname                     = path.dirname(__filename);
+const ROOT_DIR                      = path.resolve(__dirname, '../../..');
+const DEPRECATED_MCP_TEST_DIR       = path.join(ROOT_DIR, 'test/playwright/mcp');
+const CANONICAL_MCP_SERVER_TEST_DIR = path.join(ROOT_DIR, 'test/playwright/unit/ai/mcp/server');
+const GRANDFATHERED_MCP_TEST_FILES  = Object.freeze([
+    'github-workflow/OpenapiIssues.spec.mjs'
+]);
+
+function toPosixRelative(rootDir, filePath) {
+    return path.relative(rootDir, filePath).split(path.sep).join('/');
+}
+
+function normalizeRelPath(relPath) {
+    return relPath.split(path.sep).join('/');
+}
+
+function walkFiles(dir) {
+    if (!fs.existsSync(dir)) return [];
+
+    const entries = fs.readdirSync(dir, {withFileTypes: true});
+    const files   = [];
+
+    for (const entry of entries) {
+        const filePath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            files.push(...walkFiles(filePath));
+        } else {
+            files.push(filePath);
+        }
+    }
+
+    return files.sort();
+}
+
+/**
+ * Returns all files in the deprecated MCP test tree that are not grandfathered.
+ * @param {Object} [options]
+ * @param {String} [options.deprecatedDir]
+ * @param {String[]} [options.grandfatheredFiles]
+ * @returns {{files: String[], violations: String[]}}
+ */
+function lintMcpTestLocations({
+    deprecatedDir      = DEPRECATED_MCP_TEST_DIR,
+    grandfatheredFiles = GRANDFATHERED_MCP_TEST_FILES
+} = {}) {
+    const allowed = new Set(grandfatheredFiles.map(normalizeRelPath));
+    const files   = walkFiles(deprecatedDir).map(filePath => toPosixRelative(deprecatedDir, filePath));
+
+    return {
+        files,
+        violations: files.filter(file => !allowed.has(file))
+    };
+}
+
+/**
+ * CLI entry. Scans the deprecated tree and returns an exit code for tests.
+ * @param {Object} [options]
+ * @param {String} [options.deprecatedDir]
+ * @param {String[]} [options.grandfatheredFiles]
+ * @returns {{exitCode: Number, files: String[], violations: String[]}}
+ */
+function runLint(options = {}) {
+    const result = lintMcpTestLocations(options);
+
+    if (result.violations.length === 0) {
+        console.log(`[lint-mcp-test-locations] OK - ${result.files.length} deprecated-tree file(s) are grandfathered or the tree is empty.`);
+        return {exitCode: 0, ...result};
+    }
+
+    const deprecatedRel = toPosixRelative(ROOT_DIR, options.deprecatedDir || DEPRECATED_MCP_TEST_DIR);
+    const canonicalRel  = toPosixRelative(ROOT_DIR, CANONICAL_MCP_SERVER_TEST_DIR);
+
+    console.error(`[lint-mcp-test-locations] FAILED - ${result.violations.length} non-grandfathered file(s) found under ${deprecatedRel}:\n`);
+
+    for (const file of result.violations) {
+        console.error(`- ${deprecatedRel}/${file}`);
+    }
+
+    console.error(`\nNew MCP server tests must live under ${canonicalRel}/.`);
+    console.error('Only these legacy files are currently grandfathered:');
+    for (const file of GRANDFATHERED_MCP_TEST_FILES) {
+        console.error(`- ${deprecatedRel}/${file}`);
+    }
+
+    return {exitCode: 1, ...result};
+}
+
+function main() {
+    const arg = process.argv[2];
+
+    if (arg === '--help' || arg === '-h') {
+        console.log('Usage: node ai/scripts/lint/lint-mcp-test-locations.mjs');
+        console.log('');
+        console.log('Fails when non-grandfathered files exist under test/playwright/mcp/.');
+        console.log('Place new MCP server tests under test/playwright/unit/ai/mcp/server/.');
+        process.exit(0);
+    }
+
+    const {exitCode} = runLint();
+    process.exit(exitCode);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main();
+}
+
+export {
+    GRANDFATHERED_MCP_TEST_FILES,
+    lintMcpTestLocations,
+    runLint
+};

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:purge-test-collections"    : "node ./ai/scripts/maintenance/purgeTestCollections.mjs",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
+        "ai:lint-mcp-test-locations"   : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"            : "node ./ai/scripts/lint/lint-tree-json.mjs",
         "ai:skill-size-report"         : "node ./ai/scripts/lint/lint-skill-manifest.mjs --report-sizes",

--- a/test/playwright/unit/ai/scripts/lint/lintMcpTestLocations.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintMcpTestLocations.spec.mjs
@@ -1,0 +1,116 @@
+import {expect, test} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    GRANDFATHERED_MCP_TEST_FILES,
+    lintMcpTestLocations,
+    runLint
+} from '../../../../../../ai/scripts/lint/lint-mcp-test-locations.mjs';
+
+test.describe('ai/scripts/lint-mcp-test-locations (#10210)', () => {
+    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-mcp-test-locations.mjs');
+
+    function makeTempDir() {
+        return fs.mkdtempSync(path.join(os.tmpdir(), 'neo-mcp-test-locations-'));
+    }
+
+    function writeFixture(rootDir, relPath, content = 'test fixture') {
+        const filePath = path.join(rootDir, ...relPath.split('/'));
+        fs.mkdirSync(path.dirname(filePath), {recursive: true});
+        fs.writeFileSync(filePath, content, 'utf8');
+    }
+
+    function captureConsole(callback) {
+        const originalError = console.error;
+        const originalLog   = console.log;
+
+        try {
+            console.error = () => {};
+            console.log   = () => {};
+            return callback();
+        } finally {
+            console.error = originalError;
+            console.log   = originalLog;
+        }
+    }
+
+    test('CLI: --help exits 0 with placement guidance', () => {
+        const result = spawnSync('node', [scriptPath, '--help'], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: node ai/scripts/lint/lint-mcp-test-locations.mjs');
+        expect(result.stdout).toContain('test/playwright/unit/ai/mcp/server/');
+    });
+
+    test('CLI: the repository deprecated MCP test tree contains only grandfathered files', () => {
+        const result = spawnSync('node', [scriptPath], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('[lint-mcp-test-locations] OK');
+    });
+
+    test('pure lint: permits the current grandfathered file list', () => {
+        const deprecatedDir = makeTempDir();
+
+        try {
+            writeFixture(deprecatedDir, GRANDFATHERED_MCP_TEST_FILES[0]);
+
+            expect(lintMcpTestLocations({deprecatedDir}).violations).toEqual([]);
+        } finally {
+            fs.rmSync(deprecatedDir, {force: true, recursive: true});
+        }
+    });
+
+    test('pure lint: flags any non-grandfathered file in the deprecated tree', () => {
+        const deprecatedDir = makeTempDir();
+
+        try {
+            writeFixture(deprecatedDir, GRANDFATHERED_MCP_TEST_FILES[0]);
+            writeFixture(deprecatedDir, 'memory-core/NewServer.spec.mjs');
+
+            const result = lintMcpTestLocations({deprecatedDir});
+
+            expect(result.files).toEqual([
+                'github-workflow/OpenapiIssues.spec.mjs',
+                'memory-core/NewServer.spec.mjs'
+            ]);
+            expect(result.violations).toEqual(['memory-core/NewServer.spec.mjs']);
+        } finally {
+            fs.rmSync(deprecatedDir, {force: true, recursive: true});
+        }
+    });
+
+    test('runLint: missing deprecated tree passes so migration can remove it later', () => {
+        const deprecatedDir = path.join(os.tmpdir(), `neo-missing-mcp-tree-${Date.now()}`);
+        const result        = captureConsole(() => runLint({deprecatedDir}));
+
+        expect(result.exitCode).toBe(0);
+        expect(result.files).toEqual([]);
+        expect(result.violations).toEqual([]);
+    });
+
+    test('runLint: returns exit code 1 for placement violations', () => {
+        const deprecatedDir = makeTempDir();
+
+        try {
+            writeFixture(deprecatedDir, 'github-workflow/OpenapiIssues.spec.mjs');
+            writeFixture(deprecatedDir, 'github-workflow/Another.spec.mjs');
+
+            const result = captureConsole(() => runLint({deprecatedDir}));
+
+            expect(result.exitCode).toBe(1);
+            expect(result.violations).toEqual(['github-workflow/Another.spec.mjs']);
+        } finally {
+            fs.rmSync(deprecatedDir, {force: true, recursive: true});
+        }
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 1a18ef10-3f42-42ce-833a-9451be0eec6d.

FAIR-band: over-target [20/30] — taking this lane despite over-target because the live PR queue had no unapproved peer PR available for GPT review, #10210 was unassigned and recently re-triaged, and the change is a small mechanical CI guard that prevents future review churn without adding runtime scope.

Resolves #10210

Evidence: L2 (focused lint + unit verification) → L2 required (mechanical CI/test-location enforcement). Residual: none.

Adds a dedicated MCP test-location lint that keeps the deprecated `test/playwright/mcp/` tree closed to new files while preserving the current grandfathered file. The PR also wires a package script, a focused unit spec, and a path-scoped GitHub Actions workflow so placement drift is caught before review.

## Deltas from ticket

- Chose a dedicated Node lint script plus CI workflow, not ESLint or a pre-commit-only hook. This makes the enforcement deterministic in PRs while keeping local execution available through `npm run ai:lint-mcp-test-locations`.
- Kept the current grandfathered allow-list to `test/playwright/mcp/github-workflow/OpenapiIssues.spec.mjs`. Removing that file later is allowed; adding any other file under the deprecated tree fails the lint.

## Implementation Notes

- `ai/scripts/lint/lint-mcp-test-locations.mjs` scans `test/playwright/mcp/` and reports any non-grandfathered file.
- `test/playwright/unit/ai/scripts/lint/lintMcpTestLocations.spec.mjs` covers the real repo pass path, missing-tree migration path, and violation path.
- `.github/workflows/mcp-test-location-lint.yml` runs the lint on PR/push changes that touch the deprecated tree, canonical MCP server test tree, lint script/spec, workflow, or package script.

## Test Evidence

- `node --check ai/scripts/lint/lint-mcp-test-locations.mjs`
- `npm run ai:lint-mcp-test-locations`
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintMcpTestLocations.spec.mjs test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs` — 43 passed.
- `git diff --check`
- `git diff --cached --check`
- Pre-commit hook passed during commit: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.
- Branch freshness passed before push: `merge-base HEAD origin/dev == origin/dev`.

## Post-Merge Validation

- [ ] A future PR adding any non-grandfathered file under `test/playwright/mcp/` fails the `MCP Test Location Lint` workflow and directs the author to `test/playwright/unit/ai/mcp/server/`.
