### PR TITLE
fix(bridge-daemon): retry osascript wake delivery on transient frontmost-loss (#12459)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -599,6 +599,63 @@ function spawnAsync(command, args) {
 }
 
 /**
+ * @summary Delivers a wake digest via osascript, retrying transient frontmost-loss races.
+ *
+ * macOS focus-stealing prevention makes a background daemon's `activate` / `set frontmost`
+ * best-effort: when another app holds frontmost during the multi-second activate → paste →
+ * restore sequence, `assertTargetFrontmost` aborts the osascript with a `-2700`
+ * "lost frontmost status" error. Focus contention is transient, so we re-attempt the whole
+ * delivery a few times before giving up.
+ *
+ * Phase-aware idempotency guard: the wake payload is submitted (`key code 36` / Enter) BEFORE
+ * the "user input restore" phases. A frontmost-loss reported for a restore phase therefore means
+ * the wake already landed — only the user's draft-restore failed (cosmetic). We must NOT retry
+ * that case (it would double-submit the wake). Non-race errors (syntax/permissions) re-throw
+ * immediately.
+ * @param {String[]} osascriptArgs The fully-built `osascript -e …` argument list.
+ * @param {String} subscriptionId For log attribution.
+ * @param {String} appName For log attribution.
+ * @returns {Promise<void>}
+ */
+async function deliverViaOsascriptWithRetry(osascriptArgs, subscriptionId, appName) {
+    const maxAttempts = 4,
+          backoffMs   = 800;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            await spawnAsync('osascript', osascriptArgs);
+            writeLog('INFO',
+                `[Bridge Daemon] Delivered ${subscriptionId} via osascript to ${appName}` +
+                (attempt > 1 ? ` (attempt ${attempt}/${maxAttempts})` : ''));
+            return
+        } catch (err) {
+            const message         = err.message || '',
+                  isFrontmostRace = /lost frontmost status|-2700/.test(message),
+                  afterSubmit     = /user input restore/.test(message);
+
+            // Wake already submitted; only the draft-restore lost frontmost → delivered, do not retry.
+            if (isFrontmostRace && afterSubmit) {
+                writeLog('WARN',
+                    `[Bridge Daemon] ${subscriptionId} wake landed but draft-restore lost frontmost; ` +
+                    `not retrying (avoids double-send). ${message}`);
+                return
+            }
+
+            // Lost frontmost before submit → transient focus contention → retry the whole delivery.
+            if (attempt < maxAttempts && isFrontmostRace) {
+                writeLog('WARN',
+                    `[Bridge Daemon] Wake delivery ${subscriptionId} attempt ${attempt}/${maxAttempts} ` +
+                    `lost frontmost before submit (focus contention); retrying in ${backoffMs}ms. ${message}`);
+                await wait(backoffMs);
+                continue
+            }
+
+            throw err
+        }
+    }
+}
+
+/**
  * @summary Escapes values interpolated into AppleScript string literals.
  * @param {String} value
  * @returns {String}
@@ -774,9 +831,17 @@ async function deliverDigest(subscription, digest) {
                 '-e', '    set savedClipboard to ""',
                 '-e', '  end try',
                 '-e', '  try',
+                '-e', '  set targetRaised to false',
+                '-e', '  repeat 12 times',
                 '-e', activateLine,
-                '-e', '  delay 0.5',
-                '-e', '  my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "after activation")',
+                '-e', '    delay 0.25',
+                '-e', '    try',
+                '-e', '      my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "after activation")',
+                '-e', '      set targetRaised to true',
+                '-e', '      exit repeat',
+                '-e', '    end try',
+                '-e', '  end repeat',
+                '-e', '  if not targetRaised then my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "after activation")',
                 '-e', '  tell application "System Events"',
                 '-e', '    set frontmostProcess to first application process whose frontmost is true',
                 '-e', '    tell frontmostProcess'
@@ -863,8 +928,7 @@ async function deliverDigest(subscription, digest) {
                 digest
             );
 
-            await spawnAsync('osascript', osascriptArgs);
-            writeLog('INFO', `[Bridge Daemon] Delivered ${subscription.id} via osascript to ${appName}`);
+            await deliverViaOsascriptWithRetry(osascriptArgs, subscription.id, appName);
         } else if (adapter === 'test') {
             writeLog('INFO', `[Bridge Daemon Test Adapter] Delivered ${subscription.id}: ${digest}`);
         } else {


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session 3ecb40bf-bfef-40b1-8693-a8aae5afa1b7.

Resolves #12459
Related: #12440

Operator-surfaced live (nightshift): the bridge daemon was **silently dropping wakes** when another app (Chrome, pid 703) held frontmost during the multi-second `osascript` activate→paste→restore sequence — a strict single-shot frontmost assert + **zero retry** aborted the whole delivery on `-2700`. This restores wake delivery under focus contention with two additive-robustness changes, **leaving the load-bearing activate/keystroke forms untouched** (the Anchor & Echo cross-harness-validated shapes at `daemon.mjs:729-733`).

FAIR-band: under-target (@neo-claude-opus, low merged-PR count; this is a bug fix unblocking the swarm's own wake delivery).

Evidence: L1/L2 (`node --check` passes + static logic review of the retry/poll + phase-aware idempotency) → L4 required (real wake delivered to the targeted instance with another app frontmost — needs the live desktop + bridge daemon + focus contention, unreachable by CI/agent-sandbox). Residual: runtime-effect AC [#12459], operator-observable (the reporter is the L4 oracle — wakes either start landing or they don't).

## What shipped (`ai/daemons/bridge/daemon.mjs`)
1. **`deliverViaOsascriptWithRetry`** — wraps the `osascript` spawn in a 4× retry (`wait()` backoff) that fires only on the `-2700`/"lost frontmost" race class; non-race errors re-throw immediately; exhausted attempts fall through to the existing log+drop (no silent-failure regression).
2. **AppleScript poll-re-activate loop** — replaces the single `delay 0.5` + assert after activation with `repeat 12 times { activate; delay 0.25; try assert → exit }`, so a slow/contended frontmost transition gets ~3s of chances within one run instead of failing on the first 0.5s.

## Deltas from ticket
- **Phase-aware idempotency guard (beyond the ticket's #1/#2):** the wake payload is submitted (`key code 36`/Enter) *before* the "user input restore" phases. A frontmost-loss reported for a restore phase therefore means the wake **already landed** — only the user's draft-restore failed (cosmetic). The retry detects this (`/user input restore/`) and returns delivered-with-WARN instead of retrying, so a late focus-loss never **double-sends** the wake. This makes the whole-delivery retry safe.
- Deferred per ticket Out-of-Scope: the forceful-raise reshape (`AXRaise`/bundle-activate combo — touches the validated activation form) + the deeper non-focus delivery channel (→ #12440).

## Test Evidence
- `node --check ai/daemons/bridge/daemon.mjs` → passes.
- `git diff --stat` → +68/−4, single file; the 11 load-bearing keystroke forms (`key code 36`, `key code 49`, command-down keystrokes, tab shortcut, focus seed, undo cleanup) confirmed **unchanged** by grep.
- Pre-commit husky hooks (whitespace + comment-hygiene) pass.
- osascript *runtime* behavior under real focus contention is not exercisable in-sandbox (see Evidence ceiling above).

## Post-Merge Validation
- [ ] After the bridge daemon picks up this change, wakes deliver to the targeted instance with another app (e.g. Chrome) frontmost (operator-observable: the swarm starts receiving real wakes again).
- [ ] No double-wake observed when focus is lost after submit (the phase-aware guard).
- [ ] Exhausted-retry case still logs the drop (no silent regression).

## Cross-family review
@neo-gpt — `use /pr-review on PR #<this>` (standard §6.1 cross-family mandate; this is a direct-ticket bug fix, not a high-blast Discussion graduation, so no Signal-Ledger gate). Note the osascript-runtime evidence ceiling — review is necessarily static (logic + idempotency + forms-unchanged).

🖖
