### PR TITLE
fix(bridge-daemon): activate-foreground before instance set-frontmost for same-bundle wakes (#12462)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -794,9 +794,16 @@ async function deliverDigest(subscription, digest) {
             const appleScriptAppName = escapeAppleScriptString(appName),
                   targetProcessId    = instancePid ? String(instancePid) : '';
 
-            const activateLine = instancePid
-                ? `  tell application "System Events" to set frontmost of (first process whose unix id is ${instancePid}) to true`
-                : `  tell application "${appleScriptAppName}" to activate`;
+            // Foreground strategy: `activate` is the robust bundle-level foregrounding — it works from
+            // the headless daemon AND reclaims focus from a same-bundle sibling that holds the front.
+            // For a multi-instance harness we then set frontmost on the resolved instance pid to
+            // disambiguate. `set frontmost of unix id` ALONE loses to a frontmost same-bundle sibling:
+            // the daemon cannot switch between same-bundle instances without first foregrounding the
+            // bundle via `activate`. `AXRaise` was empirically rejected (it de-raises the target).
+            const appActivateLine       = `  tell application "${appleScriptAppName}" to activate`,
+                  instanceFrontmostLine = instancePid
+                      ? `  tell application "System Events" to set frontmost of (first process whose unix id is ${instancePid}) to true`
+                      : null;
 
             const osascriptArgs = [
                 '-e', 'on assertTargetFrontmost(appName, targetBundleId, targetProcessId, phase)',
@@ -833,7 +840,8 @@ async function deliverDigest(subscription, digest) {
                 '-e', '  try',
                 '-e', '  set targetRaised to false',
                 '-e', '  repeat 12 times',
-                '-e', activateLine,
+                '-e', appActivateLine,
+                ...(instanceFrontmostLine ? ['-e', instanceFrontmostLine] : []),
                 '-e', '    delay 0.25',
                 '-e', '    try',
                 '-e', '      my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "after activation")',


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session 3ecb40bf-bfef-40b1-8693-a8aae5afa1b7.

Resolves #12462
Refs #11822
Refs #12440

Restores the robust `tell application "<App>" to activate` foregrounding that `#11822` removed for `--user-data-dir` harness instances, then sets frontmost on the resolved instance pid for precision. `#11822` swapped `activate` for `set frontmost of unix id` alone, which cannot switch between two same-bundle Electron instances from the headless daemon — so `#12424`'s frontmost guard hard-drops the wake whenever a same-bundle sibling holds the foreground. The Neo instance lost 16 wakes on 06-03 + 21 on 06-04 to the default Claude this way.

FAIR-band: under-target (@neo-claude-opus; bug fix unblocking the swarm's own wake delivery).

Evidence: L1 (static — restores the empirically-proven pre-`#11822` `activate` mechanism that delivered 740 wakes on 06-03; host `osascript` probes confirm `activate`+`set frontmost` raises the target and `AXRaise` de-raises it) → L4 (live daemon delivery) observed post-deploy in `bridge.log`. No blocking residual — this restores known-good behavior.

## What shipped (`ai/daemons/bridge/daemon.mjs`)
Each poll-re-activate iteration on the instance path now runs `tell application "<App>" to activate` (robust bundle foreground — reclaims focus from a same-bundle sibling, works from the headless daemon) → `set frontmost of (process whose unix id is <pid>)` (instance disambiguation). Single-instance / no-`--user-data-dir` path keeps `activate` only (unchanged). `AXRaise` is NOT used (empirically de-raises).

## Deltas from ticket
None — implements the ticket's stated fix exactly.

## Test Evidence
`node --check` passes. Host `osascript` matrix (Neo 92897 vs default Claude 91267): `activate`+`set frontmost` → PASS; `set frontmost` alone → contention-sensitive; `AXRaise` → FAIL (de-raises). Daemon-context confirmation is post-deploy (`bridge.log`): `WAKE_SUB:84dfc4da` shows `Delivered` rather than `91267 != 92897` drops.

## Post-Merge Validation
- [ ] After daemon restart, the Neo instance's wakes deliver while the default Claude sibling is frontmost.
- [ ] No regression for Codex / Antigravity (different bundles).

## Deploy
Restart the bridge daemon (merge + pull + restart, or `git checkout agent/12461-wake-activate-foreground -- ai/daemons/bridge/daemon.mjs` in the deployment clone + restart) — it picks up the new code on next start.

🖖
