### PR TITLE
Drop redundant ?. on guaranteed sourcePaths SSOT in 11 KB source classes

### DIFF
--- a/ai/services/knowledge-base/source/AdrSource.mjs
+++ b/ai/services/knowledge-base/source/AdrSource.mjs
@@ -37,7 +37,7 @@ class AdrSource extends Base {
         let count = 0;
         // Per-source path from the `sourcePaths` config (SSOT — the leaf in the KB config template
         // defines every Source's default path).
-        const adrDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.AdrSource);
+        const adrDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths.AdrSource);
 
         if (await fs.pathExists(adrDir)) {
             const files = await fs.readdir(adrDir);

--- a/ai/services/knowledge-base/source/ApiSource.mjs
+++ b/ai/services/knowledge-base/source/ApiSource.mjs
@@ -41,7 +41,7 @@ class ApiSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         // Per-source sourceMap (path → type object) from the `sourcePaths` config (SSOT).
-        const sourceMap = aiConfig.sourcePaths?.ApiSource;
+        const sourceMap = aiConfig.sourcePaths.ApiSource;
 
         // Load the authoritative class hierarchy
         let hierarchy = {};
@@ -96,7 +96,7 @@ class ApiSource extends Base {
                 // Emit the neoRootDir-relative path as chunk metadata.source so the distributed
                 // Chroma zip shipped with each neo release stays portable across recipients'
                 // filesystems. SearchService resolves against its own neoRootDir at read time.
-                // See #10097 — absolute paths would hard-code tobi's FS layout into the zip.
+                // Absolute paths would hard-code the local FS layout into the distributed zip.
                 const chunks  = SourceParser.parse(content, relativeEntryPath, defaultType, hierarchy);
 
                 chunks.forEach(chunk => {

--- a/ai/services/knowledge-base/source/ConceptSource.mjs
+++ b/ai/services/knowledge-base/source/ConceptSource.mjs
@@ -37,7 +37,7 @@ class ConceptSource extends Base {
     async extract(writeStream, createHashFn) {
         let count = 0;
         // Per-source path from the `sourcePaths` config (SSOT).
-        const conceptsDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ConceptSource);
+        const conceptsDir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths.ConceptSource);
 
         if (await fs.pathExists(conceptsDir)) {
             const files = await fs.readdir(conceptsDir);

--- a/ai/services/knowledge-base/source/DiscussionSource.mjs
+++ b/ai/services/knowledge-base/source/DiscussionSource.mjs
@@ -60,7 +60,7 @@ class DiscussionSource extends Base {
         let count = 0;
         // Per-source paths (array) from the `sourcePaths` config (SSOT). Each entry is resolved
         // against `neoRootDir`.
-        const discussionPaths = aiConfig.sourcePaths?.DiscussionSource;
+        const discussionPaths = aiConfig.sourcePaths.DiscussionSource;
         const targetPaths = discussionPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
         const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'discussions');
@@ -87,7 +87,7 @@ class DiscussionSource extends Base {
                             kind   : 'discussion',
                             name   : `discussion-${id}`,
                             content,
-                            // Relative path keeps the distributed Chroma zip portable (#10097).
+                            // Relative path keeps the distributed Chroma zip portable.
                             source : path.relative(aiConfig.neoRootDir, filePath)
                         };
 

--- a/ai/services/knowledge-base/source/LearningSource.mjs
+++ b/ai/services/knowledge-base/source/LearningSource.mjs
@@ -42,7 +42,7 @@ class LearningSource extends Base {
         let count = 0;
         // Per-source path from the `sourcePaths` config (SSOT). The value points at the tree.json
         // file; the base directory containing the .md files is its containing directory.
-        const learnTreeRelative = aiConfig.sourcePaths?.LearningSource;
+        const learnTreeRelative = aiConfig.sourcePaths.LearningSource;
         const learnTreePath     = path.resolve(aiConfig.neoRootDir, learnTreeRelative);
         const learnBaseRelative = path.dirname(learnTreeRelative);
 
@@ -57,7 +57,7 @@ class LearningSource extends Base {
                     if (await fs.pathExists(filePath)) {
                         const content = await fs.readFile(filePath, 'utf-8');
                         // Pass the neoRootDir-relative path so stored chunk metadata stays
-                        // portable across distributed Chroma zips (#10097). fs.readFile above
+                        // portable across distributed Chroma zips. fs.readFile above
                         // still uses the absolute path internally.
                         const chunks  = DocumentationParser.parse(item, content, path.relative(aiConfig.neoRootDir, filePath));
 

--- a/ai/services/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/services/knowledge-base/source/PullRequestSource.mjs
@@ -62,7 +62,7 @@ class PullRequestSource extends Base {
     async extract(writeStream, createHashFn) {
         let count = 0;
         // Per-source paths (array) from the `sourcePaths` config (SSOT).
-        const pullRequestPaths = aiConfig.sourcePaths?.PullRequestSource;
+        const pullRequestPaths = aiConfig.sourcePaths.PullRequestSource;
         const targetPaths = pullRequestPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
         const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'pulls');
@@ -89,7 +89,7 @@ class PullRequestSource extends Base {
                             kind   : 'pull',
                             name   : `pr-${id}`,
                             content,
-                            // Relative path keeps the distributed Chroma zip portable (#10097).
+                            // Relative path keeps the distributed Chroma zip portable.
                             source : path.relative(aiConfig.neoRootDir, filePath)
                         };
 

--- a/ai/services/knowledge-base/source/RawRepoSource.mjs
+++ b/ai/services/knowledge-base/source/RawRepoSource.mjs
@@ -77,7 +77,7 @@ class RawRepoSource extends Base {
      * @returns {Promise<Number>} Number of file chunks extracted.
      */
     async extract(writeStream, createHashFn) {
-        const config   = this.normalizeConfig(aiConfig.sourcePaths?.RawRepoSource),
+        const config   = this.normalizeConfig(aiConfig.sourcePaths.RawRepoSource),
               rootPath = path.resolve(aiConfig.neoRootDir, config.root);
 
         if (!await fs.pathExists(rootPath)) {

--- a/ai/services/knowledge-base/source/ReleaseNotesSource.mjs
+++ b/ai/services/knowledge-base/source/ReleaseNotesSource.mjs
@@ -37,7 +37,7 @@ class ReleaseNotesSource extends Base {
     async extract(writeStream, createHashFn) {
         let count = 0;
         // Per-source path from the `sourcePaths` config (SSOT).
-        const releaseNotesPath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ReleaseNotesSource);
+        const releaseNotesPath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths.ReleaseNotesSource);
 
         if (await fs.pathExists(releaseNotesPath)) {
             const releaseFiles = await fs.readdir(releaseNotesPath);
@@ -52,7 +52,7 @@ class ReleaseNotesSource extends Base {
                         kind   : 'release',
                         name   : file.replace('.md', ''),
                         content,
-                        // Relative path keeps the distributed Chroma zip portable (#10097).
+                        // Relative path keeps the distributed Chroma zip portable.
                         source : path.relative(aiConfig.neoRootDir, filePath)
                     };
 

--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -39,7 +39,7 @@ class SkillSource extends Base {
     async extract(writeStream, createHashFn) {
         let count = 0;
         // Per-source path from the `sourcePaths` config (SSOT).
-        const skillsBasePath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.SkillSource);
+        const skillsBasePath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths.SkillSource);
 
         if (await fs.pathExists(skillsBasePath)) {
             // Using fast-glob to recursively find all .md files in the skills directory
@@ -99,7 +99,7 @@ class SkillSource extends Base {
                         name: chunkName,
                         content: section.trim(),
                         source: relativePath,
-                        // Sub-metadata for #11316 AC
+                        // Per-section skill sub-metadata (name, anchor, trigger).
                         skillName,
                         sectionAnchor,
                         triggerCondition,

--- a/ai/services/knowledge-base/source/TestSource.mjs
+++ b/ai/services/knowledge-base/source/TestSource.mjs
@@ -41,7 +41,7 @@ class TestSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         // Per-source path from the `sourcePaths` config (SSOT).
-        const testPath = aiConfig.sourcePaths?.TestSource;
+        const testPath = aiConfig.sourcePaths.TestSource;
         return await this.indexRawDirectory(writeStream, createHashFn, testPath, 'test', {
             include: ['.mjs'],
             exclude: ['node_modules', 'test-results', 'reports']

--- a/ai/services/knowledge-base/source/TicketSource.mjs
+++ b/ai/services/knowledge-base/source/TicketSource.mjs
@@ -62,7 +62,7 @@ class TicketSource extends Base {
     async extract(writeStream, createHashFn) {
         let count = 0;
         // Per-source paths (array) from the `sourcePaths` config (SSOT).
-        const ticketPaths = aiConfig.sourcePaths?.TicketSource;
+        const ticketPaths = aiConfig.sourcePaths.TicketSource;
         const targetPaths = ticketPaths.map(p => path.resolve(aiConfig.neoRootDir, p));
 
         const indexMap = await loadIndexMap(aiConfig.neoRootDir, 'issues');
@@ -90,7 +90,7 @@ class TicketSource extends Base {
                             kind   : 'ticket',
                             name   : `issue-${id}`,
                             content,
-                            // Relative path keeps the distributed Chroma zip portable (#10097).
+                            // Relative path keeps the distributed Chroma zip portable.
                             source : path.relative(aiConfig.neoRootDir, filePath)
                         };
 


### PR DESCRIPTION
Resolves #12467
Refs #12461
Refs #12456

Drops the redundant defensive `?.` on `aiConfig.sourcePaths` across the 11 Knowledge Base Source classes. `sourcePaths` is an SSOT leaf (`ai/mcp/server/knowledge-base/config.template.mjs:220`), always present (operator overlays inherit it), so `aiConfig.sourcePaths?.X` masked fail-loud — the ADR 0019 §3 **B3** antipattern. The change is behavior-equivalent (the `?.` never triggered; callers already assume the value, e.g. `.map`) and fail-loud-correct per the SSOT contract.

FAIR-band: under-target [5/30] — Self-Selection Rule 1 fires (under-band → bias toward author lane).

Evidence: L1 (static — behavior-equivalent `?.` removal verified via `node --check` on all 11 files; `sourcePaths` SSOT-guarantee V-B-A'd at `config.template.mjs:220`) → L1 required (no runtime-verify ACs; KB-source specs run in CI). No residuals.

## Deltas from ticket (if any)
- Beyond the pure B3 `?.`-removal, this also drops **7 bare ticket-refs** (`#10097` chroma-zip-portability ×6, `#11316` skill sub-metadata ×1) from comments in the touched files — required by the `check-ticket-archaeology` pre-commit guard (a touched file must be compliant). Each rationale is preserved; the refs move to this commit/PR per the guard's own remediation path.
- `ai/examples/.../ProtoSource.mjs` is **excluded**: it's a public external-workspace template whose `aiConfig.sourcePaths?.ProtoSource ?? 'proto'` fallback is an intentional default for custom-source authors.
- Scope held to **B3** — pre-existing `const X = aiConfig.sourcePaths.Y` aliases (B2, review-only) are left as-is, not introduced or expanded.

## Test Evidence
- `node --check` passes on all 11 edited files.
- No behavior change (the removed `?.` was a no-op on a guaranteed leaf), so existing KB-source specs are unaffected; CI runs them as the gate.

## Post-Merge Validation
- [ ] KB-source unit specs green in CI.

## Commits
- `d7189cd08` — drop redundant `?.` on guaranteed `sourcePaths` SSOT (11 files) + archaeology cleanup.

Authored by Claude Opus 4.8 (Claude Code). Session 966c46fb-ad36-4e4c-88d6-899c4d18ed91.
