### PR TITLE
fix(memory-core): team summary reads include the untagged commons (#12473)

### DIFF
--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -151,15 +151,12 @@ class SummaryService extends Base {
             const userId = normalizeUserId(RequestContextService.getUserId());
             const policy = aiConfig?.memorySharing?.defaultPolicy || 'legacy';
 
+            // See querySummaries: 'private' restricts via DB-where; 'team'/'legacy' are additive
+            // (own + 'shared' + untagged commons) and rely on the JS post-filter below.
+            const additivePolicy = policy === 'team' || policy === 'legacy';
             let tenantScope = null;
-            if (userId) {
-                if (policy === 'private') {
-                    tenantScope = {userId};
-                } else if (policy === 'team') {
-                    tenantScope = {userId: SHARED_USER_ID};
-                } else {
-                    tenantScope = null; // ChromaDB does not support $exists: false, handled post-query
-                }
+            if (userId && policy === 'private') {
+                tenantScope = {userId};
             }
 
             const where = tenantScope ? tenantScope : undefined;
@@ -199,7 +196,7 @@ class SummaryService extends Base {
             }
 
             // Step 2: Filter, sort, and slice.
-            if (userId && policy === 'legacy') {
+            if (userId && additivePolicy) {
                 allRecords = allRecords.filter(r => !r.metadata.userId || r.metadata.userId === userId || r.metadata.userId === SHARED_USER_ID);
             }
 
@@ -317,22 +314,20 @@ class SummaryService extends Base {
             const userId = normalizeUserId(RequestContextService.getUserId());
             const policy = memorySharing || aiConfig?.memorySharing?.defaultPolicy || 'legacy';
 
+            // 'private' restricts to the caller's own records via a DB-where. 'team' and 'legacy' are
+            // additive (caller-owned + 'shared' + untagged commons): the team commons is currently
+            // untagged (summaries carry no userId metadata), so a {userId:'shared'} DB-where would
+            // wrongly exclude it. Both fetch without a restrictive userId filter and rely on
+            // the JS post-filter below; {userId:{$exists:false}} is unsupported by ChromaDB. The
+            // post-filter is mandatory for additive policies — skipping it would return other tenants'
+            // private records unfiltered.
+            const additivePolicy = policy === 'team' || policy === 'legacy';
             let tenantScope = null;
-            if (userId) {
-                if (policy === 'private') {
-                    tenantScope = {userId};
-                } else if (policy === 'team') {
-                    // Team/deployment scope: Tagged records only.
-                    tenantScope = {userId: SHARED_USER_ID};
-                } else {
-                    // legacy: Migration compatibility (caller owned + shared records + untagged)
-                    // Note: {userId: {$exists: false}} is not supported by ChromaDB.
-                    // We must fetch without a userId DB-filter and apply JS post-filtering.
-                    tenantScope = null;
-                }
+            if (userId && policy === 'private') {
+                tenantScope = {userId};
             }
 
-            if ((tenantScope === null && userId && policy === 'legacy') || minTrustTier) {
+            if ((tenantScope === null && userId && additivePolicy) || minTrustTier) {
                 queryArgs.nResults = nResults * 5;
             }
 
@@ -351,11 +346,11 @@ class SummaryService extends Base {
             let metadatas = searchResult.metadatas?.[0] || [];
             let documents = searchResult.documents?.[0] || [];
 
-            if ((userId && policy === 'legacy') || minTrustTier) {
+            if ((userId && additivePolicy) || minTrustTier) {
                 const filteredIndices = [];
                 for (let i = 0; i < metadatas.length; i++) {
                     const metaUserId = metadatas[i]?.userId;
-                    const tenantMatch = !userId || policy !== 'legacy' || !metaUserId || metaUserId === userId || metaUserId === SHARED_USER_ID;
+                    const tenantMatch = !userId || !additivePolicy || !metaUserId || metaUserId === userId || metaUserId === SHARED_USER_ID;
                     const trustMatch  = this.constructor.matchesMinTrustTier(metadatas[i], minTrustTier);
 
                     if (tenantMatch && trustMatch) {

--- a/test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs
@@ -155,7 +155,7 @@ test.describe('SummaryService — tenant isolation (#10000)', () => {
 
         // The load-bearing assertion: `collection.drop()` MUST NOT have been called. The legacy
         // drop+recreate path would have nuked Bob's data along with Alice's — the whole point of
-        // #10000's cloud-mode branching is to replace that call with the scoped `delete({where})`.
+        // the cloud-mode branching is to replace that call with the scoped `delete({where})`.
         expect(spy.calls.drop).toBe(0);
         expect(spy.calls.delete).toHaveLength(1);
         expect(spy.calls.delete[0].where).toEqual({userId: 'u-alice'});
@@ -246,7 +246,7 @@ test.describe('SummaryService — additive shared-commons access (#10556)', () =
     });
 
     test('listSummaries returns the tenant\'s OWN records PLUS SHARED_USER_ID-tagged records PLUS untagged records', async () => {
-        // The load-bearing #10556 invariant: legacy pre-#10145 records (backfilled by the
+        // The load-bearing additive-access invariant: legacy pre-tenant-aware records (backfilled by the
         // migration runner with userId='shared' OR untagged) become accessible to every tenant via the
         // additive $or filter, alongside the tenant's own data.
         spy.rows.set('s-a1', {id: 's-a1', metadata: {userId: 'u-alice', timestamp: 100, title: 'Alice 1'}, document: 'A1'});
@@ -360,20 +360,27 @@ test.describe('SummaryService — memorySharing policy (#10010)', () => {
         expect(queryCall.where).toEqual({userId: 'u-alice'});
     });
 
-    test('querySummaries with memorySharing=team returns only team-tagged records', async () => {
+    test('querySummaries with memorySharing=team is additive: own + shared + untagged commons, excludes other-tenant private (#12450)', async () => {
+        // Session summaries are untagged commons, so `team` is additive like `legacy` (own + shared +
+        // untagged), NOT a restrictive {userId:'shared'} DB-where — which matched nothing and returned
+        // empty. The JS post-filter still isolates other tenants' private records (Bob's stays hidden).
         spy.rows.set('s-a1', {id: 's-a1', metadata: {userId: 'u-alice', timestamp: 100, title: 'a1'}, document: 'a1'});
         spy.rows.set('s-shared1', {id: 's-shared1', metadata: {userId: 'shared', timestamp: 200, title: 'L1'}, document: 'L1'});
         spy.rows.set('s-untagged', {id: 's-untagged', metadata: {timestamp: 300, title: 'pre-migration'}, document: 'P'});
+        spy.rows.set('s-bob', {id: 's-bob', metadata: {userId: 'u-bob', timestamp: 400, title: 'bob-private'}, document: 'B'});
 
         const view = await RequestContextService.run({userId: 'u-alice'}, () =>
             SummaryService.querySummaries({query: 'anything', nResults: 10, memorySharing: 'team'})
         );
 
-        expect(view.count).toBe(1);
-        expect(view.results[0].title).toBe('L1');
+        // own (a1) + shared (L1) + untagged (pre-migration); Bob's private record stays isolated.
+        expect(view.count).toBe(3);
+        expect(view.results.map(r => r.title).sort()).toEqual(['L1', 'a1', 'pre-migration']);
+        expect(view.results.some(r => r.title === 'bob-private')).toBe(false);
 
         const queryCall = spy.calls.query.at(-1);
-        expect(queryCall.where).toEqual({userId: 'shared'});
+        // Additive policy: NO restrictive {userId:'shared'} DB-where; over-fetch + JS post-filter.
+        expect(queryCall.where).toBeUndefined();
     });
 
     test('querySummaries with memorySharing=legacy returns tenant-owned plus team-tagged plus untagged', async () => {


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), /lead-role. Session 3ecb40bf-bfef-40b1-8693-a8aae5afa1b7.

Resolves #12473

Refs #12450

(#12473 is the access-policy fix this PR fully delivers — Layer 3 of the #12450 symptom. #12450 itself stays open: its Layer-1/2 corruption + observability ACs are out of this PR's scope. Commits reference #12450, the investigation origin. See "Scope vs #12450" below.)

`query_summaries` / `list_summaries` returned empty under the `team` memorySharing policy (and the intended `team` default from the cloud-deployment access work) — memory-mining over session summaries was 100% non-functional. Root cause (V-B-A'd; full analysis on #12450): session summaries carry **no `userId` metadata** (untagged legacy-commons), but the `team` read applied `where:{userId:'shared'}` which matched nothing. Only `legacy` (no DB-where + JS post-filter passing untagged) worked; `query_raw_memories` is fine because raw-memory writes DO tag `userId`.

FAIR-band: under-target (@neo-claude-opus; operator-pointed regression — memory-mining degraded).

Evidence: L1 (static + tenant invariant) + **L2 (codifying unit test, 16/16 green)** → L4 (live team-scoped query returning the commons) on the next Memory Core restart. ⚠️ Security-sensitive (tenant isolation) — needs cross-family review.

## What shipped (`SummaryService.mjs`)
`team` becomes **additive** like `legacy` (caller-owned + `'shared'` + untagged commons) via the existing over-fetch + JS post-filter path; drops the restrictive `{userId:'shared'}` DB-where that excluded the untagged commons. `private` stays strict (own-only DB-where). Applied to both `querySummaries` + `listSummaries`. The JS post-filter is **mandatory** for additive policies — skipping it would return other tenants' private records unfiltered (kept consistent via an `additivePolicy` flag).

## Scope vs #12450 (close-target reconciliation — addressing the review)
#12450 is the "query_summaries empty" **symptom** ticket. The operator's redirect ("explore if access related → team vs private; repo default should be team") surfaced a **distinct, additional root cause** beyond #12450's documented Layers 1–2:

- **Layer 1 — corrupt `neo-agent-sessions` HNSW** (only 68/1018 vectors reachable; `get(embeddings)` throws `Error finding id`). Raw-Chroma level, **independent of access-policy. NOT delivered here — remains open.**
- **Layer 2 — `injectQueryReRanker` swallows the throw + no healthcheck query-canary. NOT delivered here — remains open.**
- **Layer 3 — `team` access-policy excludes the untagged commons (this PR).** ✅ delivered + tested.

The Layer-1/2 evidence is raw-Chroma-level and unaffected by this access-policy fix, so this PR is a partial contribution to #12450 (Layer 3 only). Documented as a scope amendment on #12450.

## Deltas from ticket
**Resolves #12473** (the access-policy ticket) fully — its ACs map 1:1 to this diff. Relative to **#12450** (symptom): delivers Layer 3 (access-policy) only; the Layer-1/2 ACs (HNSW repair, `injectQueryReRanker` degraded-envelope, healthcheck canary) are out of scope here and remain open. Separate follow-up: tag summary writes `'shared'` + backfill the 930 existing, so the model is explicit and `private` summaries become possible.

## Test Evidence
- `SummaryService.TenantIsolation.spec.mjs` — **16/16 green** (`UNIT_TEST_MODE=true`, exact head). The team-policy contract test (`:363`) is rewritten to codify the corrected invariant: `team` is additive (own + shared + untagged commons), `where` is **not** `{userId:'shared'}`, and an other-tenant private record (Bob) **stays isolated** via the JS post-filter (the security assertion the review asked for).
- `node --check` passes. Runtime confirmation is post-restart (the MCP server runs old code until then).

## Post-Merge Validation
- [ ] After Memory Core restart, `query_summaries(memorySharing:'team')` returns the commons (non-empty).
- [ ] `query_summaries(memorySharing:'private')` returns only the caller's own (no cross-tenant leak).
- [ ] `list_summaries` mirrors the same scoping.

🖖
