### PR TITLE
feat(ai): lint banning inline process.env in config.template leaves (#12451)

### DIFF
--- a/.github/workflows/config-template-ssot-lint.yml
+++ b/.github/workflows/config-template-ssot-lint.yml
@@ -1,0 +1,34 @@
+name: Config Template SSOT Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/**/config.template.mjs'
+      - 'ai/scripts/lint/lint-config-template-ssot.mjs'
+      - '.github/workflows/config-template-ssot-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/**/config.template.mjs'
+      - 'ai/scripts/lint/lint-config-template-ssot.mjs'
+      - '.github/workflows/config-template-ssot-lint.yml'
+
+concurrency:
+  group: config-template-ssot-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Lint config.template.mjs leaves for inline process.env reads
+        run: node ai/scripts/lint/lint-config-template-ssot.mjs

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * @summary Bans inline `process.env` reads inside `leaf(...)` default expressions in
+ * `config.template.mjs` files — the declarative-config SSOT antipattern.
+ *
+ * ## The rule
+ *
+ * `config.template.mjs` is the declarative configuration SSOT: every value is
+ * `leaf(default, envVarName, type)`, where the environment override is named by the
+ * string-literal `envVarName` argument and resolved by the config system. A `default`
+ * expression that itself reads `process.env` (typically an inline
+ * `process.env.UNIT_TEST_MODE === 'true' ? test : prod` branch) leaks imperative
+ * env-resolution into the canonical config — the same root the `resolveAiDataRoot`
+ * over-engineering hit. Env-resolution belongs at the env/test layer, not baked into
+ * the SSOT, so this guard makes the antipattern un-mergeable rather than "review harder".
+ *
+ * ## What this catches
+ *
+ * Any single-line `leaf( ... process.env ... )` default across every `config.template.mjs`
+ * under `ai/`. Env access must flow through the leaf env-var-name argument; a test
+ * override belongs in the test layer (the `test-unit` npm script shell env), not an
+ * inline branch.
+ *
+ * Scope: single-line leaf defaults (the established idiom — the realistic regression
+ * copies that shape). Multi-line leaf bodies are not parsed. The gitignored `config.mjs`
+ * overlays are out of scope by design: they are generated from these templates, so the
+ * template is the SSOT fix site.
+ *
+ * ## Baseline + burndown
+ *
+ * The known pre-existing instances live in `BASELINE` so this lint lands enforcing
+ * (blocks NEW antipattern instances) without failing the build on the historical debt.
+ * Each reshape that removes an instance must also drop its `BASELINE` row — a row that no
+ * longer matches a live violation fails the lint, keeping the burndown honest.
+ *
+ * @see learn/agentos/decisions  The AiConfig reactive Provider SSOT decision record.
+ */
+import fs              from 'node:fs';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT_DIR   = path.resolve(__dirname, '../../..');
+
+const CONFIG_TEMPLATE_BASENAME = 'config.template.mjs';
+const SCAN_ROOT_REL            = 'ai';
+
+/**
+ * Pre-existing inline-env leaf defaults, keyed by `<file>::<envVar>`. Each entry is a
+ * burndown row for the declarative-config reshape: dropping the inline branch from the
+ * template must also drop the matching row here. `reshape` records the verified fix shape.
+ * @type {ReadonlyArray<{file: String, env: String, ticket: String, reshape: String}>}
+ */
+export const BASELINE = Object.freeze([
+    Object.freeze({
+        file   : 'ai/config.template.mjs',
+        env    : 'NEO_CHROMA_DATABASE',
+        ticket : '#12451',
+        reshape: 'Static. Fold CHROMA_PRODUCTION_DATABASE as the leaf default; the unit suite sets ' +
+                 'NEO_CHROMA_DATABASE=neo-unit-test via the test-unit npm script shell env. Fail-closed: ' +
+                 'ChromaManager refuses the production database under UNIT_TEST_MODE, so a missed override fails loud.'
+    }),
+    Object.freeze({
+        file   : 'ai/mcp/server/memory-core/config.template.mjs',
+        env    : 'NEO_MEMORY_DB_PATH',
+        ticket : '#12451',
+        reshape: 'Static. Fold the sqlite path as the leaf default; the unit suite sets NEO_MEMORY_DB_PATH=:memory:. ' +
+                 'Verify a UNIT_TEST_MODE guard on the graph store before relocating — unlike Chroma, a missed ' +
+                 'override here may write the real graph db rather than fail loud.'
+    }),
+    Object.freeze({
+        file   : 'ai/mcp/server/memory-core/config.template.mjs',
+        env    : 'NEO_MEMORY_COLLECTION_NAME',
+        ticket : '#12451',
+        reshape: 'Dynamic (harder sub-case). The per-worker-unique test collection name (Date.now()/Math.random()) ' +
+                 'must move to a per-worker test bootstrap, not a static env value — one shared shell-env value would ' +
+                 'collide across fullyParallel workers.'
+    }),
+    Object.freeze({
+        file   : 'ai/mcp/server/memory-core/config.template.mjs',
+        env    : 'NEO_SESSION_COLLECTION_NAME',
+        ticket : '#12451',
+        reshape: 'Dynamic (harder sub-case). Same per-worker-bootstrap relocation as NEO_MEMORY_COLLECTION_NAME.'
+    })
+]);
+
+/**
+ * @summary Recursively collects `config.template.mjs` files under a directory.
+ * @param {String} dir Absolute directory to walk.
+ * @returns {String[]} Absolute file paths, sorted.
+ */
+function walkConfigTemplates(dir) {
+    if (!fs.existsSync(dir)) return [];
+
+    const out = [];
+
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const full = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules') continue;
+            out.push(...walkConfigTemplates(full));
+        } else if (entry.name === CONFIG_TEMPLATE_BASENAME) {
+            out.push(full);
+        }
+    }
+
+    return out.sort();
+}
+
+/**
+ * @summary Detects single-line `leaf(...)` defaults that read `process.env` inline.
+ *
+ * Pure: operates on source text, so it is unit-testable without touching disk. Env access
+ * in a declarative leaf must flow through the env-var-name argument, never an inline
+ * `process.env` read in the default expression.
+ * @param {String} source File contents.
+ * @returns {Array<{line: Number, env: (String|null), key: (String|null), text: String}>}
+ */
+export function detectInlineEnvLeaves(source) {
+    const violations = [],
+          lines      = source.split('\n');
+
+    lines.forEach((text, index) => {
+        if (!/\bleaf\s*\(/.test(text))      return;
+        if (!/\bprocess\.env\b/.test(text)) return;
+
+        const env = (text.match(/'([A-Z][A-Z0-9_]{2,})'/) || [])[1] || null,
+              key = (text.match(/(\w+)\s*:\s*leaf\s*\(/)   || [])[1] || null;
+
+        violations.push({line: index + 1, env, key, text: text.trim()});
+    });
+
+    return violations;
+}
+
+/**
+ * @summary Core lint: scans config templates and partitions inline-env leaf defaults into
+ * baselined, new (unbaselined), and stale-baseline sets.
+ * @param {Object} [options]
+ * @param {String} [options.rootDir] Repo root.
+ * @param {Array<{file: String, source: String}>} [options.files] Injected file records (test seam).
+ * @param {ReadonlyArray<Object>} [options.baseline] Baseline rows.
+ * @returns {{violations: Object[], newViolations: Object[], staleBaseline: Object[]}}
+ */
+export function lintConfigTemplateSsot({rootDir = ROOT_DIR, files, baseline = BASELINE} = {}) {
+    const records = files || walkConfigTemplates(path.join(rootDir, SCAN_ROOT_REL)).map(abs => ({
+        file  : path.relative(rootDir, abs).split(path.sep).join('/'),
+        source: fs.readFileSync(abs, 'utf8')
+    }));
+
+    const violations = [];
+
+    for (const {file, source} of records) {
+        for (const hit of detectInlineEnvLeaves(source)) {
+            violations.push({file, ...hit});
+        }
+    }
+
+    const keyOf         = row => `${row.file}::${row.env}`,
+          baselineKeys  = new Set(baseline.map(keyOf)),
+          violationKeys = new Set(violations.map(keyOf));
+
+    return {
+        violations,
+        newViolations: violations.filter(v => !baselineKeys.has(keyOf(v))),
+        staleBaseline: baseline.filter(b => !violationKeys.has(keyOf(b)))
+    };
+}
+
+const FIX_HINT = 'Move env access into the leaf env-var-name argument — leaf(default, \'ENV_VAR\', type) — ' +
+    'and relocate any UNIT_TEST_MODE branch to the test layer (the test-unit npm script shell env). ' +
+    'Authority: the AiConfig reactive Provider SSOT decision record (issue #12451).';
+
+/**
+ * @summary CLI wrapper. Returns an exit code (0 clean, 1 on new violations or stale baseline rows).
+ * @param {Object} [options] Forwarded to {@link lintConfigTemplateSsot}.
+ * @returns {{exitCode: Number, violations: Object[], newViolations: Object[], staleBaseline: Object[]}}
+ */
+export function runLint(options = {}) {
+    const result = lintConfigTemplateSsot(options),
+          {violations, newViolations, staleBaseline} = result;
+
+    if (newViolations.length === 0 && staleBaseline.length === 0) {
+        console.log(`[lint-config-template-ssot] OK - ${violations.length} inline-env leaf default(s), all baselined for #12451 burndown.`);
+        return {exitCode: 0, ...result};
+    }
+
+    if (newViolations.length > 0) {
+        console.error(`[lint-config-template-ssot] FAILED - ${newViolations.length} new inline process.env read(s) in a leaf default:\n`);
+
+        for (const v of newViolations) {
+            console.error(`- ${v.file}:${v.line}${v.env ? `  (${v.env})` : ''}`);
+            console.error(`    ${v.text}`);
+        }
+
+        console.error(`\n${FIX_HINT}\n`);
+    }
+
+    if (staleBaseline.length > 0) {
+        console.error(`[lint-config-template-ssot] FAILED - ${staleBaseline.length} baseline row(s) no longer match a live violation (reshape landed — remove the row):\n`);
+
+        for (const b of staleBaseline) {
+            console.error(`- ${b.file}::${b.env}  (${b.ticket})`);
+        }
+
+        console.error('');
+    }
+
+    return {exitCode: 1, ...result};
+}
+
+function main() {
+    const arg = process.argv[2];
+
+    if (arg === '--help' || arg === '-h') {
+        console.log('Usage: node ai/scripts/lint/lint-config-template-ssot.mjs');
+        console.log('');
+        console.log('Fails when a config.template.mjs leaf default reads process.env inline');
+        console.log('(outside the BASELINE), or when a BASELINE row no longer matches a violation.');
+        process.exit(0);
+    }
+
+    const {exitCode} = runLint();
+    process.exit(exitCode);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main();
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:purge-test-collections"    : "node ./ai/scripts/maintenance/purgeTestCollections.mjs",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
+        "ai:lint-config-template-ssot" : "node ./ai/scripts/lint/lint-config-template-ssot.mjs",
         "ai:lint-mcp-test-locations"   : "node ./ai/scripts/lint/lint-mcp-test-locations.mjs",
         "ai:lint-skill-manifest"       : "node ./ai/scripts/lint/lint-skill-manifest.mjs",
         "ai:lint-tree-json"            : "node ./ai/scripts/lint/lint-tree-json.mjs",

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -1,0 +1,113 @@
+import {test, expect} from '@playwright/test';
+import {spawnSync}    from 'node:child_process';
+import path           from 'node:path';
+
+import {
+    BASELINE,
+    detectInlineEnvLeaves,
+    lintConfigTemplateSsot,
+    runLint
+} from '../../../../../../ai/scripts/lint/lint-config-template-ssot.mjs';
+
+/**
+ * @summary Coverage for `ai/scripts/lint/lint-config-template-ssot.mjs` — the guard that bans
+ * inline `process.env` reads inside `leaf(...)` defaults in `config.template.mjs` files.
+ *
+ * The antipattern it mechanizes: env-resolution branching (e.g. an inline
+ * `process.env.UNIT_TEST_MODE === 'true' ? test : prod`) baked into the declarative config
+ * SSOT instead of flowing through the leaf env-var-name argument. The lint lands enforcing via
+ * a frozen baseline of the known instances, so NEW occurrences fail while the historical debt
+ * burns down. These tests prove: detection is precise, the baseline suppresses the known set,
+ * a fresh violation fails, and a stale baseline row fails (burndown hygiene).
+ */
+test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative config SSOT guard)', () => {
+    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-config-template-ssot.mjs');
+
+    // ---- CLI ----
+
+    test('CLI: --help exits 0 with usage text', () => {
+        const result = spawnSync('node', [scriptPath, '--help'], {cwd: process.cwd(), encoding: 'utf8'});
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: node ai/scripts/lint/lint-config-template-ssot.mjs');
+    });
+
+    test('CLI: the real config.template.mjs tree passes (all instances baselined)', () => {
+        const result = spawnSync('node', [scriptPath], {cwd: process.cwd(), encoding: 'utf8'});
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('[lint-config-template-ssot] OK');
+    });
+
+    // ---- pure detection ----
+
+    test('detects an inline process.env read in a leaf default and extracts env + key', () => {
+        const hits = detectInlineEnvLeaves(
+            `            graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : '/x.sqlite', 'NEO_MEMORY_DB_PATH', 'string')`
+        );
+
+        expect(hits).toHaveLength(1);
+        expect(hits[0].env).toBe('NEO_MEMORY_DB_PATH');
+        expect(hits[0].key).toBe('graph');
+        expect(hits[0].line).toBe(1);
+    });
+
+    test('ignores a declarative leaf (env only via the env-var-name argument)', () => {
+        expect(detectInlineEnvLeaves(`            debug: leaf(false, 'NEO_DEBUG', 'boolean'),`)).toHaveLength(0);
+    });
+
+    test('ignores a process.env read that is not inside a leaf() call', () => {
+        expect(detectInlineEnvLeaves(`const wakeDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || cwd);`)).toHaveLength(0);
+    });
+
+    // ---- baseline partitioning (injected files, no disk) ----
+
+    const fileOf = (file, source) => ({file, source});
+
+    test('a baselined violation is suppressed (no new violations)', () => {
+        const files = [fileOf(
+            'ai/config.template.mjs',
+            `database: leaf(process.env.UNIT_TEST_MODE === 'true' ? T : P, 'NEO_CHROMA_DATABASE', 'string')`
+        )];
+
+        const {violations, newViolations} = lintConfigTemplateSsot({files});
+
+        expect(violations).toHaveLength(1);
+        expect(newViolations).toHaveLength(0);
+    });
+
+    test('a fresh (unbaselined) violation fails the lint', () => {
+        const files = [fileOf(
+            'ai/mcp/server/knowledge-base/config.template.mjs',
+            `host: leaf(process.env.UNIT_TEST_MODE === 'true' ? 'a' : 'b', 'NEO_KB_HOST', 'string')`
+        )];
+
+        const {newViolations} = lintConfigTemplateSsot({files});
+
+        expect(newViolations).toHaveLength(1);
+        expect(newViolations[0].env).toBe('NEO_KB_HOST');
+        expect(runLint({files}).exitCode).toBe(1);
+    });
+
+    test('a stale baseline row (reshape landed, no live violation) fails the lint', () => {
+        const baseline = [{file: 'ai/config.template.mjs', env: 'NEO_GONE', ticket: '#12451', reshape: 'done'}];
+
+        const {staleBaseline, newViolations} = lintConfigTemplateSsot({files: [], baseline});
+
+        expect(newViolations).toHaveLength(0);
+        expect(staleBaseline).toHaveLength(1);
+        expect(runLint({files: [], baseline}).exitCode).toBe(1);
+    });
+
+    // ---- the shipped baseline is internally well-formed ----
+
+    test('every shipped BASELINE row carries file, env, and a reshape note', () => {
+        expect(BASELINE.length).toBeGreaterThan(0);
+
+        for (const row of BASELINE) {
+            expect(row.file).toMatch(/config\.template\.mjs$/);
+            expect(row.env).toMatch(/^[A-Z][A-Z0-9_]+$/);
+            expect(row.reshape.length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), /lead-role. Session 3ecb40bf-bfef-40b1-8693-a8aae5afa1b7.

Resolves #12474

Refs #12451
Refs #12456

(#12474 is the lint-guard leaf this PR fully delivers. #12451 stays open for the declarative reshape half; #12456 is the AiConfig SSOT epic.)

The declarative-config SSOT antipattern: `config.template.mjs` leaves are `leaf(default, envVarName, type)`, but several embed an inline `process.env.UNIT_TEST_MODE === 'true' ? test : prod` branch in the default — env-resolution leaking into the canonical config (same root as the `resolveAiDataRoot` over-engineering). This guard makes it **un-mergeable**, not "review harder".

FAIR-band: on-target (@neo-claude-opus; recurrence-prevention keystone for the AiConfig SSOT cleanup).

Evidence: L2 — the lint runs clean on the real tree (4 baselined, exit 0) and the spec proves enforcement (fresh violation + stale baseline both exit 1). CI workflow gate green.

## What shipped
`ai/scripts/lint/lint-config-template-ssot.mjs` bans inline `process.env` reads in `leaf()` defaults across every `config.template.mjs` under `ai/`. Lands **enforcing** via a frozen `BASELINE` of the 4 known instances — NEW occurrences fail, the historical debt burns down, and a stale baseline row also fails (burndown hygiene). Each row carries the verified reshape shape. Wired as `npm run ai:lint-config-template-ssot` + a CI workflow gate. Matches the repo's existing `GRANDFATHERED_*` baseline idiom.

## Deltas from ticket
Resolves #12474 (the lint-guard leaf) fully — its ACs map 1:1 to the diff. The declarative **reshape** of the 4 baselined instances is out of scope here and remains on #12451 (V-B-A surfaced real test-isolation subtleties — worker env-channel, asymmetric chroma-vs-graph guard, dynamic per-worker collection-names — all documented on #12451).

## Test Evidence
- `lintConfigTemplateSsot.spec.mjs` — **9/9 green** (`UNIT_TEST_MODE=true`): detection precision (extracts env + key; ignores declarative leaves and non-leaf `process.env`), baseline suppression, and both enforcement paths (fresh violation → exit 1; stale baseline row → exit 1).
- `node ai/scripts/lint/lint-config-template-ssot.mjs` → `OK - 4 inline-env leaf default(s), all baselined` (exit 0); `--help` exit 0. Husky (whitespace / shorthand / ticket-archaeology) green.

## Post-Merge Validation
- [ ] The CI `config-template-ssot-lint` gate runs on `config.template.mjs` / the lint / its workflow and stays green.
- [ ] A later reshape PR that zeroes a baseline row must also drop that row (else the lint fails) — guaranteed by the stale-baseline path.
