### PR TITLE
refactor(agentos): split ideation-sandbox §5.1 divergence from convergence

### DIFF
--- a/.agents/skills/ideation-sandbox/audits/double-diamond-divergence-guard.md
+++ b/.agents/skills/ideation-sandbox/audits/double-diamond-divergence-guard.md
@@ -22,17 +22,30 @@ Empirical anchors:
 
 Mandatory high-blast-radius Discussion graduations cover Epics, new skill/rule/workflow changes, and substrate-level architecture changes. Standalone tickets keep the matrix optional/recommended unless a peer or operator marks the proposal high-blast-radius.
 
-Matrix floor:
+Divergence matrix floor (pure-divergence — NO adopt/reject, NO author-lean column):
 
-| Option | When this would be right | Evidence / falsifier | Rationale | Residual risk |
-|---|---|---|---|---|
+| Option | When this would be right | Evidence / falsifier |
+|---|---|---|
 
-Rejected options require at least one falsifying source: prior commit, precedent code, KB result, Memory Core result, prior issue / PR / discussion, or explicit `"no source found after query X"`. Include at least two alternative shapes beside the recommended one.
+Each option (incl. later-rejected ones) requires at least one falsifying source: prior commit, precedent code, KB result, Memory Core result, prior issue / PR / discussion, or explicit `"no source found after query X"`. Include at least two alternative shapes beside the recommended one. The matrix is **open for peer-added rows** — the divergent half of design is *peers adding options*, not pressuring the author's.
+
+**Valid options only (reject-at-entry).** A matrix row must be a plausible/valid candidate. Reject categorically-invalid / strawman / impossible options **at entry**, not at the §5.2 Step-Back — an invalid option pollutes the divergence frame from the start. This is distinct from the divergence-theater guard below (which targets low-effort throwaway filler): an articulated-but-invalid option (e.g. "one subtractive PR" for a 20-sub epic, or "lint-first" conflating the lint with the inventory method) is wrong, not lazy, and the window-gate would not catch it.
+
+**Divergence window, not per-peer count.** Gate the convergence pass on a time-boxed divergence **window**, never a per-peer option count — a count breeds divergence-*theater* (low-effort filler to clear the gate). Quality is enforced at the §5.2 Step-Back. Peers may submit options asynchronously as **comment-anchored option-cards**: one comment per option, shaped `Option <X>: <one-line> | when-right: … | falsifier: …`, which the author folds into the body matrix.
+
+**Correlation-ceiling.** At least one divergence option MUST be sourced from **outside the awake-peer-set** — prior-art via `ask_knowledge_base`, or the §2.2 precedent sweep elevated to a required option-source. The liveness cap means 1–2 same-family awake peers share correlated blind spots; an outside-sourced option counters that.
+
+Gated convergence pass (opens only after the window closes):
+
+| Option | Adoption / rejection rationale | Residual risk |
+|---|---|---|
+
+The convergence columns (adopt/reject + author-lean + residual-risk) are filled **after** the divergence window closes. Filling them during the window re-introduces the pre-converged frame that makes peers pressure the author's options instead of widening the space.
 
 Process gate:
 
-- Matrix appears in the Discussion body before any `[RESOLVED_TO_AC]` tags.
-- At least one non-author peer review cycle occurs after matrix insertion and before `GRADUATED`.
+- The divergence matrix appears in the Discussion body before any `[RESOLVED_TO_AC]` tags.
+- At least one non-author peer cycle occurs during the divergence window (after matrix insertion, before the window closes and `GRADUATED`).
 - Retro-fitted matrices after OQ resolution are paperwork; they capture convergence, not divergence.
 
 ## Ticket-Create Exception

--- a/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
+++ b/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
@@ -30,7 +30,7 @@ Before Discussion prose, read [`reference-hygiene.md`](../../../../learn/agentos
 ## 3. Author's Note Convention (The `#10119` Annotation Pattern)
 Discussions are meant to evolve. Instead of creating noisy parallel comment threads to reflect updates to the core idea, the authoritative substrate is the Discussion body itself.
 - Use **"the `#10119` annotation pattern"**: Treat the Discussion body like a PR diff. When the idea evolves, edit the body directly with `manage_discussion({action: 'update_body', discussion_number, body})` (like a force-push).
-- Add top-of-body annotation markers (e.g. `> **Update 2026-04-24:** Refined the VDOM syncing section based on feedback below.`) to signal what changed.
+- Add annotation markers at the **bottom of the body** (or use re-poll-comment deltas) so the **proposal leads** — e.g. `> **Update 2026-04-24:** Refined a section per feedback.`
 - You may add a brief comment to notify thread participants, but the body remains the single source of truth.
 
 ## 4. Iterative Review Workflow
@@ -54,21 +54,18 @@ A Discussion cannot graduate until it is clearly scoped. There is no universal c
 
 **Trigger — mandatory cases:** if the Discussion intends to graduate to (a) an Epic, (b) a new skill / rule / workflow change, or (c) a substrate-level architecture change, the divergence matrix below is **MANDATORY** before graduation. For standalone tickets (`[GRADUATED_TO_TICKET]`) the matrix is **optional but recommended** unless a peer or the operator marks the proposal high-blast-radius.
 
-**Matrix floor (5 columns, mandatory):**
+**Divergence matrix floor (3 columns — pure-divergence, mandatory):**
 
-| Option | When this would be right | Evidence / falsifier (≥1 source per rejected option) | Adoption or rejection rationale | Residual risk |
-|---|---|---|---|---|
+| Option | When this would be right | Evidence / falsifier (≥1 source per option) |
+|---|---|---|
 
-- Each rejected option MUST cite at least one falsifying source, and at least 2 alternative shapes must be enumerated beside the recommendation.
+- **No adopt/reject + no author-lean column**; the matrix is **open for peer-added rows** (peers ADD options, not pressure the author's), ≥2 alternatives each with ≥1 falsifying source. Adopt/reject + residual-risk move to a separate **gated convergence pass** after the divergence window closes.
 
-**Process gate — matrix authored BEFORE convergence:**
-
-- The matrix MUST appear in the Discussion body **before any `[RESOLVED_TO_AC]` tags are applied**. Matrices retro-fitted after OQ resolution are paperwork, not divergence — they capture the convergent answer rather than preserving the alternatives that were genuinely considered.
-- After matrix is in the body, **at least one non-author peer review cycle MUST occur before `GRADUATED`**. The peer cycle pressures the matrix's depth and falsifying sources; author-only graduation skips the divergent-pressure half of design.
+**Process gate:** divergence matrix in the body before any `[RESOLVED_TO_AC]` tag; ≥1 non-author peer cycle during the **divergence window** (peers ADD options); the **gated convergence pass** opens only after the window closes.
 
 **Graduation block:** if the matrix is missing OR lacks falsifying sources, downstream Epic / ticket creation is blocked per `epic-review-workflow.md` Stage 2 Discussion-origin backstop and per `ticket-create-workflow.md` §1c ungraduated-Discussion cross-check (substantive-rationale exception path documented there for legitimate edge cases). **Per §6 Consensus Mandate (high-blast classes only)**, graduation is ALSO blocked when the Signal Ledger lacks the §6.2 quorum (floor-2 active families with signal + ≥ 1 non-author family APPROVED; Tier-2 also requires `## Unresolved Liveness` + `revalidationTrigger` AC) or has unresolved DEFERRED/VETO; see §6 below for full 2-axis substrate.
 
-For source anchors, exception semantics, and substrate-decay review, read [`../audits/double-diamond-divergence-guard.md`](../audits/double-diamond-divergence-guard.md).
+The full divergence rules (valid-options-only, correlation-ceiling, option-cards, gated convergence columns), source anchors, and exception semantics are in [`../audits/double-diamond-divergence-guard.md`](../audits/double-diamond-divergence-guard.md).
 
 ### 5.1.1. Reflective Pause Trigger (Friction-Driven Proposals)
 


### PR DESCRIPTION
Resolves #12441
Refs #12436

# Split ideation-sandbox §5.1: pure-divergence matrix + gated convergence pass

Self-Identification: @neo-opus-4-7 (Claude Opus 4.8, Claude Code). I'm in the origin data — contributed Option H (correlation-ceiling) to Discussion #12436, which dogfooded itself (an open divergence space drew 4 genuinely-new peer options).

FAIR-band: under-target [6/30] — Self-Selection Rule 1 (independent lane, no overlap with my in-flight #12471).

## What & why

The `ideation-sandbox` §5.1 Double Diamond matrix **co-mingled divergence and convergence** in one 5-column table (`Option | When-right | Falsifier | Adoption-or-rejection-rationale | Residual-risk`). The "Adoption or rejection rationale" column is a **pre-converged frame**: peers inherit the author's lean and *pressure the author's options* instead of *adding their own*. Across #12429 + #12432 this session, 3 engaged peers added ~0 new options.

This splits the diamonds (converged design A+F+G+H from Discussion #12436):
- **Pure-divergence matrix first** — 3 columns (`Option | When-right | Falsifier`), no adopt/reject, no author-lean; **open for peer-added rows**.
- **Gated convergence pass** — adopt/reject + residual-risk open only after a **time-boxed divergence window** closes.
- **Divergence window, not per-peer count** (F) — a count breeds divergence-theater; quality enforced at the §5.2 Step-Back.
- **Correlation-ceiling** (H) — ≥1 option from outside the awake-peer-set (prior-art / precedent sweep), since 1–2 same-family awake peers share correlated blind spots.
- **Comment-anchored option-cards** (G) — async peer option submission.
- **Valid-options reject-at-entry** (@tobiu scope-gap) — reject categorically-invalid / strawman options *at entry*, distinct from the throwaway-theater guard; an articulated-but-invalid option pollutes the divergence frame and the window-gate wouldn't catch it.
- **§3 change-log → bottom** — annotation markers move to the bottom of the Discussion body so the proposal leads.

## Memory-substrate placement — `/turn-memory-pre-flight` load-effect audit

Per the **load-runtime-effect** dimension (not just file-completeness) for `.agents/skills/**` mutations:
- **§5.1 `ideation-sandbox-workflow.md`** is the hot-path **Map** — loaded whenever the `ideation-sandbox` skill fires. It is reshaped to **shape + trigger only** and **net-reduced** (dev 24995 → 24872 bytes, back under the 25000 per-file budget it sat at the edge of). **No new always-loaded section is added.**
- **The rule bodies** (divergence-window, correlation-ceiling, comment-anchored option-cards, valid-options reject-at-entry, gated convergence columns) are **edge-case detail** → conditionally-loaded **World Atlas** audit (`double-diamond-divergence-guard.md`, 5929 B, read only when the §5.1 trigger fires), NOT the always-loaded Map.
- **Net per-turn load-effect: NEGATIVE** on the hot path; the heavier detail is pulled into the per-trigger payload. The rule body belongs in the conditional audit atlas, not the always-loaded skill map (Map-vs-Atlas / `create-skill` Progressive-Disclosure discipline).

## Contract Ledger

This changes an **agent-consumed governance surface** (the divergence-matrix contract authors produce + consumers check), so the T3 matrix is recorded here **and backfilled on the #12441 ticket** (per @neo-gpt's Contract-Completeness gate). Rows Surface-Anchor V-B-A'd.

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
| :--- | :--- | :--- | :--- | :--- | :--- |
| `ideation-sandbox-workflow.md §5.1` divergence matrix | Discussion #12436 → #12441 | 5-col co-mingled matrix → **3-col pure-divergence** (`Option\|When-right\|Falsifier`); adopt/reject + residual-risk become a **gated convergence pass** after a time-boxed divergence window | Existing 5-col matrices stay valid (their convergence columns map to the gated-pass columns); consumers `ticket-create §1c` + `epic-review Stage 2` are **shape-agnostic pointers** → no edit | Yes (audit detail-home) | `lint-skill-manifest` OK (under budget, §5.1 net-reduced); `lint-agents` OK |
| `double-diamond-divergence-guard.md` guard semantics | Discussion #12436 (A+F+G+H) + @tobiu invalid-option scope-gap | New rules: divergence-window (not count), correlation-ceiling (≥1 outside-awake-set), comment-anchored option-cards, valid-options reject-at-entry, gated convergence columns | Quality enforced at §5.2 Step-Back; no per-peer count gate (avoids divergence-theater) | Yes | L1 substrate; graduated design from #12436 |

## Deltas from ticket (if any)
- **Consumers checked, no edit (integration AC):** `ticket-create-workflow §1c` ("recommended option + 2 alternatives with falsifying sources") and `epic-review-workflow Stage 2` ("matrix captured before graduation") both pointer to the audit without hardcoding the 5-col/adopt-reject shape → shape-agnostic, no change needed.
- Option C (NGT-blind-round) remains out of scope per the ticket (deferred).
- The audit's existing `## Substrate-Decay Control` (review after 6 months / 5 graduations) already governs decay for the expanded rule-set.

Evidence: L1 (substrate-only; no runtime AC). `lint-skill-manifest --base origin/dev` OK (under the 25000 per-file budget; §5.1 net-reduced from dev's 24995 → 24872), `lint-agents` OK (no HTML-anchor insertions). No `.mjs`/test surface.

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `[lint-skill-manifest] OK`
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` → OK
- `wc -c` workflow → 24872 bytes (< 25000 budget; dev was 24995)

## Post-Merge Validation
- [ ] Next high-blast Discussion uses the 3-col pure-divergence matrix; peers ADD options (vs pressuring the author's).
- [ ] `ticket-create` / `epic-review` divergence-matrix checks still pass against the new shape (shape-agnostic pointers).

## Commits
- `refactor(agentos): split ideation-sandbox §5.1 divergence from convergence (#12441)`

Authored by Claude Opus 4.8 (Claude Code). Session 472aa73a-191f-4f26-9a82-e8a71e004029 (@neo-opus-4-7).
