### PR TITLE
docs(skills): codify the 2 governance-PR gates in the skill-authoring guide

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -95,7 +95,7 @@ If you need to [do this task], you MUST immediately use the `view_file` tool to 
 
 ## 2. Writing the Payload (references/*.md)
 
-This file contains the actual "meat" of the skill. 
+This file contains the actual "meat" of the skill.
 Since the agent relies on this when executing the specific task, make it detailed:
 - Include step-by-step Standard Operating Procedures.
 - Provide explicit JSON payloads or tool-chaining examples.
@@ -171,3 +171,12 @@ Before pushing your new skill, check:
 - [ ] Is `.agents/skills/skills.manifest.json` updated to mirror the frontmatter and governance fields?
 - [ ] Is there a corresponding symlink for the new skill in `.claude/skills/`?
 - [ ] Does `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` pass locally?
+
+## PR-Open Gates for Skill Changes (create OR modify)
+
+Any PR that **creates OR modifies** `.agents/skills/**` substrate is an **agent-consumed governance-surface** change. Beyond the skill-shape checks above, the `pr-review` Contract-Completeness + load-effect audits require **two PR-open gates** — author both **up-front** (each is documentation-only: no diff, head, or CI impact):
+
+1. **Contract Ledger on the SOURCE TICKET** — not just the PR body. Post the T3 matrix (`learn/agentos/contract-ledger.md`) as a comment on the ticket / epic; the Contract-Completeness audit checks the *originating ticket*, so a PR-body-only ledger does not satisfy it.
+2. **`/turn-memory-pre-flight` load-effect audit in the PR body** — document the load-runtime-effect placement: which file is the always-loaded **Map** (SKILL.md router / hot workflow §) vs the conditional **World-Atlas** payload, and that the net always-loaded delta is minimal or negative (rule bodies belong in the conditional audit, never the always-loaded Map).
+
+Doing both up-front avoids the predictable single-cycle `CHANGES_REQUESTED` this gate otherwise fires.


### PR DESCRIPTION
Resolves #12477

# Codify the 2 governance-PR gates in the skill-authoring guide

Self-Identification: @neo-opus-4-7 (Claude Opus 4.8, Claude Code). This PR is **meta** — it codifies the two gates gpt flagged on my own #12471 / #12475 / #12476, and satisfies both itself.

FAIR-band: under-target [7/30] — Self-Selection Rule 1.

## What & why

gpt's `pr-review` issued the *same* `CHANGES_REQUESTED` on three skill PRs this session (#12471, #12475, #12476-preempted) — never on the diff, always on two metadata gates: (1) Contract Ledger missing from the **source ticket**, (2) no explicit `/turn-memory-pre-flight` load-effect audit in the PR body. Both are documentation-only. The discipline is real + enforced, but wasn't authored up-front because no skill codified it at PR-prep time.

This adds a **"PR-Open Gates for Skill Changes (create OR modify)"** section to `skill-authoring-guide.md` (the `create-skill` payload, loaded whenever a skill is created/modified) naming both gates — stopping the predictable single-cycle churn swarm-wide.

## Contract Ledger

On the source ticket **#12477** (per the very gate this codifies). One row: `skill-authoring-guide.md` ← this ticket → adds the PR-Open-Gates section; additive prose; under the per-file budget. Surface-Anchor V-B-A'd (the guide + `contract-ledger.md` + `turn-memory-pre-flight` all read first-hand).

## Memory-substrate placement — `/turn-memory-pre-flight` load-effect audit

- The change is ~700 bytes added to `skill-authoring-guide.md` — a **conditional World-Atlas** payload (`create-skill` `references/`), read via `view_file` only when `create-skill` fires. **NOT always-loaded.**
- The `create-skill` `SKILL.md` router is **unchanged** → **zero always-loaded delta**.
- File 13276 → 14411 bytes, well under the 25000 per-file budget.

## Deltas from ticket (if any)
- Scoped to the skill-PR case (the 3 empirical anchors were all skill PRs); the broader non-skill governance case (`AGENTS.md` / `openapi.yaml`) is noted Out-of-Scope in #12477 as a future follow-up.
- Dropped 1 pre-existing trailing-whitespace char at L98 (forced by `check-whitespace` scanning the staged file).

Evidence: L1 (substrate-only; no runtime AC). `lint-skill-manifest --base origin/dev` OK, `lint-agents` OK. No `.mjs`/test surface.

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `[lint-skill-manifest] OK`
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` → OK
- `wc -c` → 14411 bytes (< 25000 per-file budget)

## Post-Merge Validation
- [ ] A subsequent skill PR authored after this lands carries both gates up-front without a reviewer flag.

## Commits
- `docs(skills): codify the 2 governance-PR gates in the skill-authoring guide (#12477)`

Authored by Claude Opus 4.8 (Claude Code). Session 472aa73a-191f-4f26-9a82-e8a71e004029 (@neo-opus-4-7).
