### PR TITLE
refactor(ai): make config.template chroma database leaf declarative (#12480)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -287,17 +287,22 @@ class Config extends BaseConfig {
                     host    : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
                     port    : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
                     /**
-                     * Chroma database the client connects to. Production is `'default_database'` verbatim —
-                     * the declarative default, defined inline here (config.template is the SSOT; it imports
-                     * no config values). The unit suite overrides via `NEO_CHROMA_DATABASE` (set to the
-                     * dedicated, droppable test database in the `test-unit` npm script) so test collections
-                     * never enter the production namespace. `ChromaManager` fails loud if the production
-                     * database is ever resolved under `UNIT_TEST_MODE` (an independent defense-in-depth guard),
-                     * so this leaf carries no test-branch itself. Consumed by the Memory Core `ChromaManager`;
-                     * the Knowledge Base ChromaManager reads only host/port, so this field is inert for it
-                     * until separately migrated.
+                     * Chroma database selection — three declarative leaves, all SSOT-inline (config.template
+                     * imports no config values):
+                     *   - `database`        — the production DB name (literal).
+                     *   - `databaseTest`    — the dedicated, droppable unit-test DB name (literal).
+                     *   - `useTestDatabase` — the toggle, resolved from `UNIT_TEST_MODE` via the leaf's
+                     *                         env-var argument (declarative — NOT an inline `process.env` read).
+                     * The consumer (`ChromaManager`) reads the resolved toggle and picks `databaseTest` when
+                     * true, else `database`. Both NAMES live in config, so the test path needs no env var the
+                     * runner must remember to set — `npx playwright` without `npm run test-unit` still toggles
+                     * to the test DB and CANNOT bleed unit collections into production by construction.
+                     * `ChromaManager` additionally fails loud if the resolved DB equals `database` while the
+                     * toggle is on (independent defense-in-depth). KB ChromaManager reads only host/port.
                      */
-                    database: leaf('default_database', 'NEO_CHROMA_DATABASE', 'string')
+                    database       : leaf('default_database', 'NEO_CHROMA_DATABASE', 'string'),
+                    databaseTest   : leaf('neo-unit-test', 'NEO_CHROMA_DATABASE_TEST', 'string'),
+                    useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean')
                 }
             },
             /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,10 +1,7 @@
 import path                                  from 'path';
 import {fileURLToPath}                       from 'url';
 import BaseConfig, {createConfigProxy, leaf} from './BaseConfig.mjs';
-import {
-    CHROMA_PRODUCTION_DATABASE,
-    CHROMA_TEST_DATABASE
-}                                            from './services/shared/vector/chromaTestIsolation.mjs';
+import {CHROMA_PRODUCTION_DATABASE}          from './services/shared/vector/chromaTestIsolation.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -291,14 +288,16 @@ class Config extends BaseConfig {
                     host    : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
                     port    : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
                     /**
-                     * Chroma database the client connects to. Under `UNIT_TEST_MODE` this resolves to a
-                     * dedicated, droppable test database so unit-test collections never enter the
-                     * production `default_database` by construction (the prevention half of the
-                     * store-isolation cluster); production is `default_database` verbatim. Consumed by
-                     * the Memory Core `ChromaManager`. The Knowledge Base ChromaManager currently reads
+                     * Chroma database the client connects to. Production is `CHROMA_PRODUCTION_DATABASE`
+                     * (`default_database`) verbatim — the declarative default. The unit suite overrides via
+                     * `NEO_CHROMA_DATABASE` (set to the dedicated, droppable test database in the `test-unit`
+                     * npm script) so test collections never enter the production namespace. `ChromaManager`
+                     * fails loud if the production database is ever resolved under `UNIT_TEST_MODE` — the
+                     * by-construction store-isolation backstop, so this leaf carries no test-branch itself.
+                     * Consumed by the Memory Core `ChromaManager`; the Knowledge Base ChromaManager reads
                      * only host/port, so this field is inert for it until separately migrated.
                      */
-                    database: leaf(process.env.UNIT_TEST_MODE === 'true' ? CHROMA_TEST_DATABASE : CHROMA_PRODUCTION_DATABASE, 'NEO_CHROMA_DATABASE', 'string')
+                    database: leaf(CHROMA_PRODUCTION_DATABASE, 'NEO_CHROMA_DATABASE', 'string')
                 }
             },
             /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,7 +1,6 @@
 import path                                  from 'path';
 import {fileURLToPath}                       from 'url';
 import BaseConfig, {createConfigProxy, leaf} from './BaseConfig.mjs';
-import {CHROMA_PRODUCTION_DATABASE}          from './services/shared/vector/chromaTestIsolation.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -288,16 +287,17 @@ class Config extends BaseConfig {
                     host    : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
                     port    : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
                     /**
-                     * Chroma database the client connects to. Production is `CHROMA_PRODUCTION_DATABASE`
-                     * (`default_database`) verbatim — the declarative default. The unit suite overrides via
-                     * `NEO_CHROMA_DATABASE` (set to the dedicated, droppable test database in the `test-unit`
-                     * npm script) so test collections never enter the production namespace. `ChromaManager`
-                     * fails loud if the production database is ever resolved under `UNIT_TEST_MODE` — the
-                     * by-construction store-isolation backstop, so this leaf carries no test-branch itself.
-                     * Consumed by the Memory Core `ChromaManager`; the Knowledge Base ChromaManager reads
-                     * only host/port, so this field is inert for it until separately migrated.
+                     * Chroma database the client connects to. Production is `'default_database'` verbatim —
+                     * the declarative default, defined inline here (config.template is the SSOT; it imports
+                     * no config values). The unit suite overrides via `NEO_CHROMA_DATABASE` (set to the
+                     * dedicated, droppable test database in the `test-unit` npm script) so test collections
+                     * never enter the production namespace. `ChromaManager` fails loud if the production
+                     * database is ever resolved under `UNIT_TEST_MODE` (an independent defense-in-depth guard),
+                     * so this leaf carries no test-branch itself. Consumed by the Memory Core `ChromaManager`;
+                     * the Knowledge Base ChromaManager reads only host/port, so this field is inert for it
+                     * until separately migrated.
                      */
-                    database: leaf(CHROMA_PRODUCTION_DATABASE, 'NEO_CHROMA_DATABASE', 'string')
+                    database: leaf('default_database', 'NEO_CHROMA_DATABASE', 'string')
                 }
             },
             /**

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -55,14 +55,6 @@ const SCAN_ROOT_REL            = 'ai';
  */
 export const BASELINE = Object.freeze([
     Object.freeze({
-        file   : 'ai/config.template.mjs',
-        env    : 'NEO_CHROMA_DATABASE',
-        ticket : '#12451',
-        reshape: 'Static. Fold CHROMA_PRODUCTION_DATABASE as the leaf default; the unit suite sets ' +
-                 'NEO_CHROMA_DATABASE=neo-unit-test via the test-unit npm script shell env. Fail-closed: ' +
-                 'ChromaManager refuses the production database under UNIT_TEST_MODE, so a missed override fails loud.'
-    }),
-    Object.freeze({
         file   : 'ai/mcp/server/memory-core/config.template.mjs',
         env    : 'NEO_MEMORY_DB_PATH',
         ticket : '#12451',

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -10,7 +10,7 @@ import {
     createSilentExecutor,
     registerNeoChromaEmbeddingFunctions
 } from '../../shared/vector/chromaClientPrimitives.mjs';
-import {CHROMA_PRODUCTION_DATABASE, ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
+import {ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
 
 /**
  * Predicate suppression filter for MC: the four Chroma library messages that surface noisily
@@ -111,15 +111,19 @@ class ChromaManager extends AbstractVectorManager {
             throw new Error(message);
         }
 
-        const database = chroma.database;
+        // Select the test database via the config-owned `useTestDatabase` toggle (a declarative env-driven
+        // leaf resolved from UNIT_TEST_MODE). Both DB names are config literals, so the test path depends on
+        // no env var the runner must remember to set — `npx playwright` without `npm run test-unit` still
+        // toggles to the test DB and cannot bleed unit collections into production by construction.
+        const useTestDatabase = chroma.useTestDatabase === true;
+        const database        = useTestDatabase ? chroma.databaseTest : chroma.database;
 
-        // Fail-closed test-isolation guard: under UNIT_TEST_MODE the client must never resolve to the
-        // production database, even via a NEO_CHROMA_DATABASE override — refuse to construct/connect
-        // rather than risk a unit run touching the production namespace. Production override behavior
-        // remains intact outside UNIT_TEST_MODE.
-        if (process.env.UNIT_TEST_MODE === 'true' && database === CHROMA_PRODUCTION_DATABASE) {
-            const message = `ChromaManager: refusing the production database "${CHROMA_PRODUCTION_DATABASE}" under ` +
-                `UNIT_TEST_MODE — unit-test isolation must not be overridable into the production namespace.`;
+        // Fail-closed defense-in-depth: when the test toggle is on, the resolved DB must never equal the
+        // production database (e.g. a misconfigured databaseTest) — refuse rather than risk a unit run
+        // touching the production namespace.
+        if (useTestDatabase && database === chroma.database) {
+            const message = `ChromaManager: refusing the production database "${chroma.database}" under ` +
+                `the test-database toggle — unit-test isolation must not resolve into the production namespace.`;
 
             logger.error(`[ChromaManager] Test-isolation guard: ${message}`);
 
@@ -149,11 +153,11 @@ class ChromaManager extends AbstractVectorManager {
     async connect() {
         this.connected = await chromaConnect({client: this.client, logger});
 
-        // Under UNIT_TEST_MODE the client targets a dedicated test database. chromadb 3.x has no
-        // getOrCreateDatabase and the ChromaClient constructor does not create the database, so it
+        // When the test-database toggle is on, the client targets a dedicated test database. chromadb 3.x
+        // has no getOrCreateDatabase and the ChromaClient constructor does not create the database, so it
         // must be ensured-to-exist here — after the heartbeat proves the server is reachable, before the
-        // first lazy getOrCreateCollection. Idempotent; the production path (default_database) is untouched.
-        if (this.connected && process.env.UNIT_TEST_MODE === 'true') {
+        // first lazy getOrCreateCollection. Idempotent; the production path is untouched.
+        if (this.connected && aiConfig.engines.chroma.useTestDatabase === true) {
             const {host, port, database} = this.resolveChromaClientConfig(aiConfig);
             await ensureChromaTestDatabase({host, port, database});
         }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "test-components"              : "playwright test -c test/playwright/playwright.config.component.mjs",
         "test-e2e"                     : "playwright test -c test/playwright/playwright.config.e2e.mjs",
         "test-integration-unified"     : "playwright test -c test/playwright/playwright.config.integration.mjs",
-        "test-unit"                    : "UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs",
+        "test-unit"                    : "UNIT_TEST_MODE=true NEO_CHROMA_DATABASE=neo-unit-test playwright test -c test/playwright/playwright.config.unit.mjs",
         "watch-themes"                 : "node ./buildScripts/helpers/watchThemes.mjs"
     },
     "keywords"       : [

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "test-components"              : "playwright test -c test/playwright/playwright.config.component.mjs",
         "test-e2e"                     : "playwright test -c test/playwright/playwright.config.e2e.mjs",
         "test-integration-unified"     : "playwright test -c test/playwright/playwright.config.integration.mjs",
-        "test-unit"                    : "UNIT_TEST_MODE=true NEO_CHROMA_DATABASE=neo-unit-test playwright test -c test/playwright/playwright.config.unit.mjs",
+        "test-unit"                    : "UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs",
         "watch-themes"                 : "node ./buildScripts/helpers/watchThemes.mjs"
     },
     "keywords"       : [

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -95,10 +95,12 @@ test.describe('Tier 1 Config Immutability', () => {
             }
         });
         expect(Config.engines.chroma).toEqual({
-            dataDir : expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
-            host    : process.env.NEO_CHROMA_HOST || 'localhost',
-            port    : Number(process.env.NEO_CHROMA_PORT) || 8000,
-            database: process.env.NEO_CHROMA_DATABASE || CHROMA_TEST_DATABASE
+            dataDir        : expect.stringMatching(/\.neo-ai-data[/\\]chroma[/\\]unified$/),
+            host           : process.env.NEO_CHROMA_HOST || 'localhost',
+            port           : Number(process.env.NEO_CHROMA_PORT) || 8000,
+            database       : process.env.NEO_CHROMA_DATABASE || 'default_database',
+            databaseTest   : process.env.NEO_CHROMA_DATABASE_TEST || CHROMA_TEST_DATABASE,
+            useTestDatabase: true
         });
     });
 

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -66,8 +66,8 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
 
     test('a baselined violation is suppressed (no new violations)', () => {
         const files = [fileOf(
-            'ai/config.template.mjs',
-            `database: leaf(process.env.UNIT_TEST_MODE === 'true' ? T : P, 'NEO_CHROMA_DATABASE', 'string')`
+            'ai/mcp/server/memory-core/config.template.mjs',
+            `graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : '/x.sqlite', 'NEO_MEMORY_DB_PATH', 'string')`
         )];
 
         const {violations, newViolations} = lintConfigTemplateSsot({files});

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -58,32 +58,36 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         // The spec runs with unitTestMode:true, so the config leaf must resolve to the dedicated
         // test database — never default_database — by construction. No crashed/npx-bypassed run can
         // create collections in the production namespace because the client never points there.
-        expect(aiConfig.engines.chroma.database).toBe(CHROMA_TEST_DATABASE);
-        expect(aiConfig.engines.chroma.database).not.toBe(CHROMA_PRODUCTION_DATABASE);
+        // The test-database toggle is ON (declaratively resolved from UNIT_TEST_MODE), so the resolver
+        // selects the dedicated test database — never default_database — by construction. Both NAMES are
+        // config literals; the toggle (not an env var the runner must remember to set) drives selection.
+        expect(aiConfig.engines.chroma.useTestDatabase).toBe(true);
+        expect(aiConfig.engines.chroma.databaseTest).toBe(CHROMA_TEST_DATABASE);
+        expect(aiConfig.engines.chroma.database).toBe(CHROMA_PRODUCTION_DATABASE);
 
-        // …and the resolver carries that isolated namespace through to the client coordinates.
+        // …and the resolver carries the isolated namespace (databaseTest) through to the client coordinates.
         const {database} = ChromaManager.resolveChromaClientConfig(aiConfig);
         expect(database).toBe(CHROMA_TEST_DATABASE);
+        expect(database).not.toBe(CHROMA_PRODUCTION_DATABASE);
     });
 
     test('the constructed ChromaClient targets the isolated test database', () => {
-        // construct() wires resolveChromaClientConfig(...).database into `new ChromaClient({database})`,
-        // so the live client's database getter reflects the isolated namespace, not default_database.
-        expect(ChromaManager.client.database).toBe(aiConfig.engines.chroma.database);
+        // construct() wires resolveChromaClientConfig(...).database (the toggle-selected test DB) into
+        // `new ChromaClient({database})`, so the live client targets the isolated namespace, not prod.
+        expect(ChromaManager.client.database).toBe(aiConfig.engines.chroma.databaseTest);
         expect(ChromaManager.client.database).not.toBe(CHROMA_PRODUCTION_DATABASE);
     });
 
-    test('resolveChromaClientConfig fails closed: refuses the production database under UNIT_TEST_MODE (#12335 AC1)', () => {
-        // The spec runs with UNIT_TEST_MODE=true. Even an inherited NEO_CHROMA_DATABASE=default_database
-        // override must not let a unit run resolve into the production namespace — the resolver throws
-        // fail-closed before any ChromaClient construct/connect, so no test can touch production.
+    test('resolveChromaClientConfig fails closed: refuses the production database under the test toggle (#12335 AC1)', () => {
+        // With the test toggle ON, a misconfigured databaseTest that resolves into the production namespace
+        // must fail closed before any ChromaClient construct/connect — so no unit run can touch production.
         expect(() => ChromaManager.resolveChromaClientConfig({
-            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_PRODUCTION_DATABASE}}
-        })).toThrow(/refusing the production database .* under\s+UNIT_TEST_MODE/);
+            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_PRODUCTION_DATABASE, databaseTest: CHROMA_PRODUCTION_DATABASE, useTestDatabase: true}}
+        })).toThrow(/refusing the production database .* test-database toggle/);
 
-        // A normal isolated test database resolves cleanly (the guard only fires for the production name).
+        // A correctly isolated test database resolves cleanly (the guard fires only when the resolved DB is prod).
         expect(ChromaManager.resolveChromaClientConfig({
-            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_TEST_DATABASE}}
+            engines: {chroma: {host: 'localhost', port: 8000, database: CHROMA_PRODUCTION_DATABASE, databaseTest: CHROMA_TEST_DATABASE, useTestDatabase: true}}
         }).database).toBe(CHROMA_TEST_DATABASE);
     });
 


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), /lead-role. Session 3ecb40bf-bfef-40b1-8693-a8aae5afa1b7.

Resolves #12480

Refs #12451
Refs #12456

(First reshape burndown of #12451's declarative-reshape half — the lint guard landed via #12474/#12472.)

Make Chroma DB selection a **declarative, safe-by-construction** config shape (replacing the inline `process.env.UNIT_TEST_MODE ? TEST : PROD` branch that imported the names). Design steered by @tobiu (SSOT + KISS).

Evidence: L2 — 53 specs pass (ChromaManager + config.template + the SSOT-lint spec + chromaTestIsolation + purge + canonical-guard); SSOT lint green at 3 baselined.

## What shipped — three declarative leaves + a consumer toggle
`ai/config.template.mjs` `engines.chroma` (config.template imports **zero** config values — it IS the SSOT):
```js
database       : leaf('default_database', 'NEO_CHROMA_DATABASE', 'string'),      // prod name, literal
databaseTest   : leaf('neo-unit-test', 'NEO_CHROMA_DATABASE_TEST', 'string'),    // test name, literal
useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean')                        // env-driven toggle (env-arg form — lint-clean)
```
`ChromaManager` (the consumer) reads the resolved toggle and selects `databaseTest` when on, else `database` — **pure config reads, no inline `process.env`**. The fail-closed guard now reads config (refuse if the resolved DB equals `database` while the toggle is on). `package.json` reverted (no env-var dependency). `chromaTestIsolation.mjs` keeps its constants as an independent defense-in-depth guard invariant.

A formal **Contract Ledger** for the 3-leaf surface is backfilled on #12480 (per @neo-gpt's review).

## Why it's safe-by-construction (the bleed fix)
Both DB **names are config values**, not an npm-script-only env var. So `npx playwright` *without* `npm run test-unit` still resolves the toggle (from `UNIT_TEST_MODE`) and points at `databaseTest` — it **cannot** bleed unit collections into production. (My earlier env-var cut moved the test-DB *name* into the `test-unit` script → bare `npx` lost it → the bleed @tobiu caught. This shape removes that fragility entirely.)

## Rollout Note (existing checkouts / worktrees) — per @neo-gpt review
The safe-by-construction claim applies to the **tracked template + a current generated overlay**. An existing checkout/worktree whose gitignored `ai/config.mjs` is **stale** (predating the new `databaseTest` / `useTestDatabase` leaves) imports that stale overlay at runtime — the new leaves are absent until refreshed, so the toggle/guard cannot apply to that local process yet. Refresh before relying on the toggle:
- **Checkout:** `npm run prepare -- --migrate-config` (or `node ai/scripts/setup/initServerConfigs.mjs --migrate-config`) — regenerates/migrates the gitignored overlay.
- **Worktree:** `ai/scripts/migrations/bootstrapWorktree.mjs` copies the overlay.

CI regenerates via `prepare`, so the merge-gate is unaffected. (@neo-gpt reproduced the stale-overlay failure locally + confirmed `--migrate-config` repairs it — the same trap that surfaced `ensureChromaTestDatabase: database is required` during development.)

## Deltas from ticket
Resolves #12480 fully (the chroma leaf is now declarative + safe). The graph (`NEO_MEMORY_DB_PATH`) + dynamic collection-name reshapes remain on #12451 (distinct risk).

## Test Evidence
- **53 specs pass** (`npm run test-unit`): `ChromaManager.spec` + `config.template.spec` + `lintConfigTemplateSsot.spec` (22) and `chromaTestIsolation` + `purgeTestCollections` + `ChromaManager.canonicalGuard` (31).
- **Self-validating** (your "check the toggle matches the test DB name"): under `UNIT_TEST_MODE`, `useTestDatabase === true` AND the resolver returns `databaseTest` (never `default_database`).
- Fail-closed guard test: toggle-on + a misconfigured `databaseTest`→prod throws. `node --check` passes; SSOT lint `OK - 3 baselined`; husky green.

## Post-Merge Validation
- [ ] Unit suite resolves `neo-unit-test` via the toggle (no prod-DB refusal); production path uses `default_database`.
- [ ] No new inline-`process.env` config-leaf default reintroduced (the SSOT lint guards this).
- [ ] Existing checkouts/worktrees refreshed the gitignored `ai/config.mjs` overlay (`--migrate-config`) before relying on the toggle (Rollout Note).
