### PR TITLE
refactor(agentos): reshape pr-review §0 into patch-blind premise snapshot + net-reduce

### DIFF
--- a/.agents/skills/pr-review/references/a2a-commentid-handoff.md
+++ b/.agents/skills/pr-review/references/a2a-commentid-handoff.md
@@ -1,0 +1,65 @@
+# A2A Comment-ID Hand-off Protocol (`#10272`)
+
+Extracted from `pr-review-guide.md §10` per Map-vs-Atlas (#12447) — the warm-cache review-cycle hand-off mechanics. Loaded only when a multi-cycle review hand-off fires; the guide keeps the one-line trigger.
+
+**Problem:** Without commentId-scoped fetch, every review cycle N+1 incurs **cumulative-thread context cost** — full-thread fetch reads all prior cycles, not just the delta. This breaks linear-cost scaling: by cycle three of an Architectural Pillar review, fetching the full conversation burns more tokens on prior rounds than on the new substance. Compounds silently across the swarm — every reviewer pays the cumulative cost per cycle, not just once. **Treat as invariant discipline, not optional optimization** — the cost asymmetry diverges with thread length, and missed pings cascade across reviewers.
+
+Provenance: PR `#10371` showed cumulative-thread fetch cost diverging with thread length. The stable rule is commentId-scoped hand-off for warm-cache review cycles.
+
+**Solution:** `manage_issue_comment` action:`create` returns `{message, commentId, url, createdAt}`. The reviewer captures `commentId` from that response and relays it to the next reviewer (peer or author) via A2A mailbox — the recipient fetches just-this-comment via `get_conversation({pr_number: N, comment_id: COMMENT_ID})`, scaling linearly with new-comment volume rather than cumulative thread size.
+
+## 1. Workflow
+
+1. Reviewer posts their review comment via `manage_issue_comment({action: 'create', pr_number, body, agent})`.
+2. Reviewer captures `commentId` from the response.
+3. Reviewer sends an A2A mailbox DM to the next actor (peer reviewer or author) via `add_message`:
+   ```
+   subject: 're: PR #N review cycle K'
+   body: 'Review posted at PR #N comment <COMMENT_ID>. Substance: <one-line summary>.'
+   relatedTickets: ['#N']
+   ```
+4. Recipient reads the A2A message, extracts `COMMENT_ID`, calls `get_conversation({pr_number: N, comment_id: COMMENT_ID})` — receives only this reviewer's comment, not the whole thread history.
+
+## 2. Selector Precedence
+
+`get_conversation` accepts three optional selectors. First match wins:
+
+- `comment_id` — single-comment fetch. Used by the A2A hand-off pattern above.
+- `since_comment_id` — fetch comments strictly AFTER the given anchor. Used for incremental polling: track last-seen commentId, fetch only what's new.
+- `last_n` — fetch the last N comments. Coarse-grained catch-up when commentIds aren't tracked.
+- Omitting all three returns the full conversation (backward-compatible default).
+
+## 3. Anti-Patterns
+
+- **Full-conversation-fetch-per-cycle when commentId is available.** If the A2A message carries a commentId, use it. Otherwise the propagation discipline is broken.
+- **Mailbox DM without commentId when the message is pointing at a specific comment.** Forces recipient to fetch full thread and grep for the intended passage — negates the efficiency gain.
+- **Passing all three selectors at once expecting a merge.** First-match semantics; excess selectors are ignored.
+- **Rigidly applying commentId-scoped fetch in a cold-cache case** (e.g., fresh session bootstrap, Cycle 1 review). Lands one isolated comment in a void without the prior context it depends on. See §5 below.
+- **Skipping the Pre-Flight Check (§4) before yielding turn after `manage_issue_comment`.** Empirically the dominant failure mode — agents read this guide, draft the comment, post it, and forget to capture commentId + send A2A ping. Proven mitigation: explicit reasoning-statement mirroring the `AGENTS.md §3 / §4.2` Pre-Flight pattern.
+
+## 4. Pre-Flight Check (operational reflex)
+
+The hand-off protocol is mechanical — but reviewers empirically miss it across cycles even after reading this guide (PR `#10371` + `#10375`, 2026-04-26: 5+ missed pings before @tobiu surfaced the gap explicitly). The discipline is reflex-application, not knowledge.
+
+**Pre-Flight Check shape** (mirrors `AGENTS.md §3 / §4.2` proven primitives). After every `manage_issue_comment` create, before yielding turn, you MUST explicitly state in your internal reasoning:
+
+> *"Pre-Flight: I posted review commentId `<ID>` for cycle K. I have (or will) send an A2A ping to `<recipient>` via `add_message` with the literal commentId in the body so they can call `get_conversation({pr_number, comment_id})` for scoped fetch."*
+
+This commitment-statement is the gate that permits yielding turn. The `add_memory` discipline already proves this Pre-Flight pattern works as a reflex enforcement primitive when paired with explicit pre-action reasoning. Skipping forces the next cycle's actor to re-read the full thread — the empirical-anchor ~8× cost ratio quantifies the cost.
+
+Cold-cache exception applies when the recipient lacks prior-cycle context — see §5 below for when full-thread fetch is the right call instead.
+
+## 5. Cold-Cache Exception
+
+CommentId-scoped fetch is the **warm-cache** path — the reviewer or author has continuous prior-cycle context loaded in the current context window. **Cold-cache cases require a different fetch shape:**
+
+| Cold-cache case | Fetch shape | Reason |
+|---|---|---|
+| **Fresh session bootstrap** | Full-thread fetch + `query_summaries` / `query_raw_memories` for Memory Core grounding | No prior cycle context loaded; commentId-scoped fetch lands one comment in a void |
+| **Cycle 1 review** | Full-thread fetch | First ramp on the PR; no prior cycle exists; need full diff + body for grounding |
+| **Cross-agent handoff** | Full-thread fetch + memory query against the prior agent's session-id | Different reviewer/author than prior cycle; no shared mental model |
+| **Missed/lost A2A ping** | `since_comment_id` from last-known anchor, OR `last_n: 3-5`, OR full-thread fallback | No commentId pointer to scope from |
+
+The dichotomy mirrors the boot-pull-vs-sunset-pull lifecycle distinction (`AGENTS_STARTUP §0` vs `session-sunset` skill body Step 1): **warm path** optimizes for incremental context; **cold path** grounds from scratch. They are NOT symmetric operations — they fill different lifecycle gaps. Don't confuse them: rigidly applying commentId-scoped fetch in a cold-cache case lands one isolated comment without the context it depends on; over-fetching on principle in a warm-cache case defeats the linear-cost scaling.
+
+**The right reflex** — before fetching, ask: *"do I have prior cycle context loaded in this context window?"* If yes → commentId-scoped fetch (or `since_comment_id` for incremental polling across stale-anchor recovery). If no → full-thread fetch + memory query for grounding.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -10,9 +10,15 @@ This protocol ensures that feedback is:
 
 > **Measurement Trigger:** For review-density or skill-baggage work, use [Loaded-Surface Measurement Methodology](./measurement-methodology.md) and record `wc -c`; ordinary PR reviews do not load it.
 
-## §0 — Understand the intent before the diff
+## §0 — Patch-blind premise snapshot (BEFORE the diff)
 
-Learn what the change is *for*, and judge whether it fits the current architecture and goals, **before** the diff and the audits below — you can reject a toaster-when-we-need-a-car before reading a line. Build that understanding from the affected files themselves (intent belongs in their JSDoc — `src/core/Base.mjs` is the bar), their neighbors, and their imports; use `memory-mining` / `ask_knowledge_base` when the code is thin. This is slower on purpose — the judgment is the point, not the speed. Intent you can't find anywhere is the finding: ticket the gap. A green checklist over a wrong premise is theater, and nothing below substitutes for this.
+Build — and write down — your premise of the change **before** reading the patch as the source of truth. You can reject a toaster-when-we-need-a-car before reading a line; a green checklist over a wrong premise is theater, and nothing below substitutes for this. Capture three fields. The snapshot is **patch-blind**, NOT a temporally-guaranteed pre-commitment — claiming "I wrote this before I looked" is itself theater; the discipline is that the *premise authority* is the substrate, not the patch.
+
+1. **Inputs read before the patch** — the ticket/issue, the changed-file list, the current `dev` source of the touched files, sibling precedent, and the source-of-authority substrate (ADRs, `learn/`, the owning service). **NOT the PR's own self-description as the primary premise** — the PR body is a claim to verify, not the authority. Build the premise from the affected files (intent belongs in their JSDoc — `src/core/Base.mjs` is the bar), their neighbors, and their imports; use `memory-mining` / `ask_knowledge_base` when the code is thin. Intent you can't find anywhere is the finding: ticket the gap.
+2. **Expected solution-shape** (1–3 sentences) — what *should* a correct change here look like? Explicitly include **"what boundary should this NOT hardcode?"** and **"what test-isolation should exist?"**, so the snapshot reaches the portability + test-isolation dimensions before the diff frames them away.
+3. **Patch-verdict** — does the diff **match / improve / contradict** the expected shape? Name the specific evidence that changed (or confirmed) your mind. "Matches" with no evidence is not a verdict.
+
+**Night-shift provisional marker:** when the approval is single-family / human-asleep (no cross-family reviewer awake), label it `single-family — calibration-deferred-to-merge-gate`. The typed-calibration loop (#12449) reads this marker at the merge-gate to know the approval was single-family / calibration-deferred; it is inert until that consumer lands (define-then-consume).
 
 ## 1. Core Philosophy
 - **For Internal Agents (Peer-Review):** Be objective, clinical, and strict. Enforce the "Fat Ticket" protocol and strict JSDoc completeness.
@@ -414,67 +420,9 @@ This explicit reviewer open-mindedness mandate is symmetric to the author's mand
 
 ## 10. A2A Comment-ID Hand-off Protocol (`#10272`)
 
-**Problem:** Without commentId-scoped fetch, every review cycle N+1 incurs **cumulative-thread context cost** — full-thread fetch reads all prior cycles, not just the delta. This breaks linear-cost scaling: by cycle three of an Architectural Pillar review, fetching the full conversation burns more tokens on prior rounds than on the new substance. Compounds silently across the swarm — every reviewer pays the cumulative cost per cycle, not just once. **Treat as invariant discipline, not optional optimization** — the cost asymmetry diverges with thread length, and missed pings cascade across reviewers.
+<!-- trigger: warm-cache review cycle N+1 (multi-cycle hand-off) → read ./a2a-commentid-handoff.md -->
 
-Provenance: PR `#10371` showed cumulative-thread fetch cost diverging with thread length. The stable rule is commentId-scoped hand-off for warm-cache review cycles.
-
-**Solution:** `manage_issue_comment` action:`create` returns `{message, commentId, url, createdAt}`. The reviewer captures `commentId` from that response and relays it to the next reviewer (peer or author) via A2A mailbox — the recipient fetches just-this-comment via `get_conversation({pr_number: N, comment_id: COMMENT_ID})`, scaling linearly with new-comment volume rather than cumulative thread size.
-
-### 10.1 Workflow
-
-1. Reviewer posts their review comment via `manage_issue_comment({action: 'create', pr_number, body, agent})`.
-2. Reviewer captures `commentId` from the response.
-3. Reviewer sends an A2A mailbox DM to the next actor (peer reviewer or author) via `add_message`:
-   ```
-   subject: 're: PR #N review cycle K'
-   body: 'Review posted at PR #N comment <COMMENT_ID>. Substance: <one-line summary>.'
-   relatedTickets: ['#N']
-   ```
-4. Recipient reads the A2A message, extracts `COMMENT_ID`, calls `get_conversation({pr_number: N, comment_id: COMMENT_ID})` — receives only this reviewer's comment, not the whole thread history.
-
-### 10.2 Selector Precedence
-
-`get_conversation` accepts three optional selectors. First match wins:
-
-- `comment_id` — single-comment fetch. Used by the A2A hand-off pattern above.
-- `since_comment_id` — fetch comments strictly AFTER the given anchor. Used for incremental polling: track last-seen commentId, fetch only what's new.
-- `last_n` — fetch the last N comments. Coarse-grained catch-up when commentIds aren't tracked.
-- Omitting all three returns the full conversation (backward-compatible default).
-
-### 10.3 Anti-Patterns
-
-- **Full-conversation-fetch-per-cycle when commentId is available.** If the A2A message carries a commentId, use it. Otherwise the propagation discipline is broken.
-- **Mailbox DM without commentId when the message is pointing at a specific comment.** Forces recipient to fetch full thread and grep for the intended passage — negates the efficiency gain.
-- **Passing all three selectors at once expecting a merge.** First-match semantics; excess selectors are ignored.
-- **Rigidly applying commentId-scoped fetch in a cold-cache case** (e.g., fresh session bootstrap, Cycle 1 review). Lands one isolated comment in a void without the prior context it depends on. See §10.5 below.
-- **Skipping the Pre-Flight Check (§10.4) before yielding turn after `manage_issue_comment`.** Empirically the dominant failure mode — agents read this guide, draft the comment, post it, and forget to capture commentId + send A2A ping. Proven mitigation: explicit reasoning-statement mirroring the `AGENTS.md §3 / §4.2` Pre-Flight pattern.
-
-### 10.4 Pre-Flight Check (operational reflex)
-
-The §10 hand-off protocol is mechanical — but reviewers empirically miss it across cycles even after reading this guide (PR `#10371` + `#10375`, 2026-04-26: 5+ missed pings before @tobiu surfaced the gap explicitly). The discipline is reflex-application, not knowledge.
-
-**Pre-Flight Check shape** (mirrors `AGENTS.md §3 / §4.2` proven primitives). After every `manage_issue_comment` create, before yielding turn, you MUST explicitly state in your internal reasoning:
-
-> *"Pre-Flight: I posted review commentId `<ID>` for cycle K. I have (or will) send an A2A ping to `<recipient>` via `add_message` with the literal commentId in the body so they can call `get_conversation({pr_number, comment_id})` for scoped fetch."*
-
-This commitment-statement is the gate that permits yielding turn. The §0.5 `add_memory` discipline already proves this Pre-Flight pattern works as a reflex enforcement primitive when paired with explicit pre-action reasoning. Skipping forces the next cycle's actor to re-read the full thread — the empirical-anchor ~8× cost ratio quantifies the cost.
-
-Cold-cache exception applies when the recipient lacks prior-cycle context — see §10.5 below for when full-thread fetch is the right call instead.
-
-### 10.5 Cold-Cache Exception
-
-CommentId-scoped fetch is the **warm-cache** path — the reviewer or author has continuous prior-cycle context loaded in the current context window. **Cold-cache cases require a different fetch shape:**
-
-| Cold-cache case | Fetch shape | Reason |
-|---|---|---|
-| **Fresh session bootstrap** | Full-thread fetch + `query_summaries` / `query_raw_memories` for Memory Core grounding | No prior cycle context loaded; commentId-scoped fetch lands one comment in a void |
-| **Cycle 1 review** | Full-thread fetch | First ramp on the PR; no prior cycle exists; need full diff + body for grounding |
-| **Cross-agent handoff** | Full-thread fetch + memory query against the prior agent's session-id | Different reviewer/author than prior cycle; no shared mental model |
-| **Missed/lost A2A ping** | `since_comment_id` from last-known anchor, OR `last_n: 3-5`, OR full-thread fallback | No commentId pointer to scope from |
-
-The dichotomy mirrors the boot-pull-vs-sunset-pull lifecycle distinction (`AGENTS_STARTUP §0` vs `session-sunset` skill body Step 1): **warm path** optimizes for incremental context; **cold path** grounds from scratch. They are NOT symmetric operations — they fill different lifecycle gaps. Don't confuse them: rigidly applying commentId-scoped fetch in a cold-cache case lands one isolated comment without the context it depends on; over-fetching on principle in a warm-cache case defeats the linear-cost scaling.
-
-**The right reflex** — before fetching, ask: *"do I have prior cycle context loaded in this context window?"* If yes → commentId-scoped fetch (or `since_comment_id` for incremental polling across stale-anchor recovery). If no → full-thread fetch + memory query for grounding.
+For multi-cycle reviews, hand off via **commentId-scoped fetch**, not full-thread-per-cycle (the cost diverges with thread length — `#10371`): `manage_issue_comment` returns `commentId`; relay it via `add_message` so the next actor calls `get_conversation({pr_number, comment_id})` for linear-cost fetch. **Pre-Flight (the dominant miss):** after posting, before yielding turn, state that you captured the commentId + will send the A2A ping. The workflow, selector precedence (`comment_id` / `since_comment_id` / `last_n`), anti-patterns, and the **cold-cache exception** (Cycle 1 / fresh-boot / cross-agent-handoff → full-thread fetch instead) are in [`./a2a-commentid-handoff.md`](./a2a-commentid-handoff.md).
 
 ## 11. Post-Review-Cycle Reviewer Pickup
 


### PR DESCRIPTION
Resolves #12447
Refs #12442

# Reshape pr-review §0 → patch-blind premise snapshot + net-reduce

Self-Identification: @neo-opus-4-7 (Claude Opus 4.8, Claude Code). My B-prime design (Epic #12442 / Discussion #12432). **First PR after #12471's FAIR-band retirement merged** — no FAIR-band declaration (the lint anchor is gone).

## What & why

`pr-review` §0 ("understand intent before the diff") was a single paragraph — declared supreme + empirically skipped (Goodhart: the mechanically-enforced template/anchors get optimized; "does this make sense?" atrophies; @tobiu caught 5 mergeable-but-wrong-shape misses across the session). This reshapes §0 into a **3-field patch-blind premise snapshot** that makes premise-vacuity visible:
1. **Inputs read before the patch** — ticket / changed-files / current `dev` source / sibling precedent / source-of-authority substrate — NOT the PR's self-description as the primary premise.
2. **Expected solution-shape** (1–3 sentences) incl. *"what boundary should this NOT hardcode?"* + *"what test-isolation should exist?"* (reaches the portability + test-isolation dimensions).
3. **Patch-verdict** — match / improve / contradict + the evidence that changed the reviewer's mind.

Framed **patch-blind** (the premise *authority* is the substrate, not the patch), explicitly NOT a temporally-guaranteed pre-commitment (overclaiming temporality = theater). Plus the **night-shift provisional marker** (`single-family — calibration-deferred-to-merge-gate`) — defined here, consumed by #12449 (define-then-consume in order, per the lead's #12447 coordination note).

## Net-byte reduction (the AC)

§0 absorbs the premise-gate mass; to net-reduce overall, I extracted **§10 (the A2A comment-id hand-off protocol, ~62 lines)** to the conditional Atlas payload `references/a2a-commentid-handoff.md` behind a one-line trigger. **No 9th always-loaded section added.** Delta: `pr-review-guide.md` **52714 → 48474 bytes (−4240)**; sub-payload 6655 B (loaded only on a multi-cycle hand-off).

## Memory-substrate placement — `/turn-memory-pre-flight` load-effect audit

- `pr-review-guide.md` is a hot **Map** (loaded on every pr-review). §0 grew (the premise gate) but the file **net-reduced** (−4240 B) by moving §10's edge-case detail to the conditional **World-Atlas** payload. Net always-loaded delta **NEGATIVE**.
- `references/a2a-commentid-handoff.md` (new) is conditional World-Atlas — read only when a multi-cycle hand-off fires.
- No `SKILL.md` router change. Load-effect-correct (Map-vs-Atlas / `create-skill` discipline).

## Contract Ledger

Recorded on the source ticket #12447 (governance-surface change — the `pr-review` skill contract) and below:

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
| :--- | :--- | :--- | :--- | :--- | :--- |
| `pr-review-guide.md §0` | Discussion #12432 → #12447 | Single intent paragraph → **3-field patch-blind premise snapshot** + night-shift marker | Reviewers who skipped §0 now have a visible 3-field gate; marker inert until #12449 consumes it | Yes | `lint-skill-manifest`/`lint-agents` OK |
| `pr-review-guide.md §10` → `references/a2a-commentid-handoff.md` | This PR (#12447 net-reduce AC) | §10 hand-off protocol extracted to a conditional Atlas payload behind a trigger | §11 still references §10 (the trigger); no dangling §10.x refs (grep-verified) | Yes | net −4240 B; `lint-skill-manifest` OK |

## Deltas from ticket (if any)
- Night-shift marker: **defined** here (inert), consumed by #12449 — "define-then-consume in order" per the lead's #12447 coordination note (not "land together").
- Floor/ceiling residual archived: the diversity/liveness **ceiling** is owned by #12429 → Epic #12440 (now merged via #12471); this PR owns only the single-reviewer **floor** (the premise snapshot).
- The AC named §0/§7/§9 — the substantive reshape is §0 (the premise gate); §7 (Depth Floor) + §9 (Strategic-Fit) already complement it; the §7/§9-area net-reduce is achieved via the §10 extraction.

Evidence: L1 (substrate-only; no runtime AC). `lint-skill-manifest --base origin/dev` OK, `lint-agents` OK, net-reduce −4240 B verified, no dangling §10.x refs (grep). No `.mjs`/test surface.

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `[lint-skill-manifest] OK`
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` → OK
- `wc -c` pr-review-guide.md → 48474 (< the 66000 override budget; −4240 vs dev)
- `grep` §10.x → no dangling references

## Post-Merge Validation
- [ ] Reviewers use the 3-field patch-blind premise snapshot at §0 (premise visible before the diff).
- [ ] #12449 lands the night-shift-marker consumer (typed-calibration loop reads it at the merge-gate).

## Commits
- `refactor(agentos): reshape pr-review §0 into patch-blind premise snapshot + net-reduce (#12447)`

Authored by Claude Opus 4.8 (Claude Code). Session 472aa73a-191f-4f26-9a82-e8a71e004029 (@neo-opus-4-7).
