### PR TITLE
feat(agentos): agentIdentity scope param for get_all_summaries — own-vs-team boot ledger

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -387,6 +387,16 @@ paths:
           schema:
             type: string
             enum: [bugfix, feature, refactoring, documentation, new-app, analysis, other]
+        - name: agentIdentity
+          in: query
+          required: false
+          description: |
+            Optional author-identity scope for an own-vs-team boot ledger. `@me` resolves the bound
+            caller (fails closed if no identity is bound — never silently team-wide); `@<identity>`
+            scopes to that author; omitted or `all` returns the team-wide view (default,
+            backward-compatible). Filters on summary author provenance (`sourceAgentIdentities`).
+          schema:
+            type: string
       responses:
         '200':
           description: Summaries retrieved successfully

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -49,6 +49,57 @@ class SummaryService extends Base {
     }
 
     /**
+     * @summary Resolves the optional author-identity scope for {@link listSummaries}.
+     *
+     * `get_all_summaries` defaults to a team-wide, newest-first boot ledger — which, under an
+     * asymmetric-liveness swarm, steeps every identity in the most-active author's trajectory and
+     * erodes per-identity continuity. This resolves an optional `agentIdentity` filter so a caller
+     * can scope the ledger to its OWN sessions.
+     *
+     * Filter semantics — filters on the chroma `sourceAgentIdentities` provenance metadata already
+     * carried by every summary row, NOT a cross-store `AUTHORED_BY` graph read. The `AUTHORED_BY`
+     * edge is *derived from* `sourceAgentIdentities` (`SessionService` stamps one edge per
+     * trust-tiered source), so the metadata filter is equivalent for any trust-tiered maintainer
+     * while keeping `listSummaries` a pure chroma read — consistent with the sibling `userId`
+     * post-filter. (They diverge only for an UNCLASSIFIED source identity, which is never a boot
+     * ledger subject.)
+     *
+     * Identity-namespace match — `sourceAgentIdentities` entries are `@`-prefixed (`@neo-opus-4-7`)
+     * and `getAgentIdentityNodeId()` returns the same `@`-prefixed node those edges terminate on.
+     * The leading `@` is stripped symmetrically on both sides so a format drift can never silently
+     * zero the result.
+     *
+     * @param {String} [agentIdentity] `'@me'` (bound caller), `'@<id>'` / `'<id>'` (explicit), or
+     *   omitted / `'all'` (team-wide — no filter, backward-compatible default).
+     * @returns {String|null} The canonical (`@`-stripped) identity to match, or `null` for no filter.
+     * @throws {Error} when `'@me'` is requested but no caller identity is bound — fail-closed, so a
+     *   scoped request never silently degrades to the team-wide view.
+     */
+    static resolveAuthorScope(agentIdentity) {
+        if (!agentIdentity || agentIdentity === 'all') {
+            return null;
+        }
+
+        let resolved;
+
+        if (agentIdentity === '@me') {
+            resolved = RequestContextService.getAgentIdentityNodeId();
+
+            if (!resolved) {
+                throw new Error(
+                    'SummaryService.listSummaries: agentIdentity "@me" requires a bound caller ' +
+                    'identity, but RequestContextService.getAgentIdentityNodeId() resolved none. ' +
+                    'Failing closed rather than returning the team-wide view.'
+                );
+            }
+        } else {
+            resolved = agentIdentity;
+        }
+
+        return String(resolved).replace(/^@/, '');
+    }
+
+    /**
      * @summary Resolves a summary row's provenance trust tier from source-memory metadata.
      *
      * Summaries are derived content. Their filterable tier is the most restrictive source tier
@@ -139,7 +190,11 @@ class SummaryService extends Base {
      * @param {Number} options.offset=0 The number of summaries to skip.
      * @returns {Promise<{count: number, total: number, summaries: Object[]}>}
      */
-    async listSummaries({limit=50, offset=0} = {}) {
+    async listSummaries({limit=50, offset=0, agentIdentity} = {}) {
+        // Resolve the optional author-identity scope BEFORE the storage try/catch: a fail-closed
+        // `@me` (no bound identity) must throw, not be swallowed into the SUMMARY_LIST_ERROR envelope.
+        const authorScope = this.constructor.resolveAuthorScope(agentIdentity);
+
         try {
             const collection = await StorageRouter.getSummaryCollection();
 
@@ -198,6 +253,16 @@ class SummaryService extends Base {
             // Step 2: Filter, sort, and slice.
             if (userId && additivePolicy) {
                 allRecords = allRecords.filter(r => !r.metadata.userId || r.metadata.userId === userId || r.metadata.userId === SHARED_USER_ID);
+            }
+
+            // Optional author-identity scope (own vs team boot ledger): post-filter on the chroma
+            // sourceAgentIdentities provenance — see resolveAuthorScope for the AUTHORED_BY
+            // equivalence + the @-namespace canonicalization.
+            if (authorScope !== null) {
+                allRecords = allRecords.filter(r =>
+                    this.constructor.splitMetadataList(r.metadata.sourceAgentIdentities)
+                        .some(identity => identity.replace(/^@/, '') === authorScope)
+                );
             }
 
             // Sort by timestamp DESC

--- a/test/playwright/unit/ai/services/memory-core/SummaryService.AuthorScope.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SummaryService.AuthorScope.spec.mjs
@@ -1,0 +1,161 @@
+import { setup } from '../../../../setup.mjs';
+
+const appName = 'SummaryServiceAuthorScopeTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import SummaryService        from '../../../../../../ai/services/memory-core/SummaryService.mjs';
+import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * Author-identity scope for `SummaryService.listSummaries` / `get_all_summaries`.
+ *
+ * Verifies the own-vs-team boot ledger filter: `agentIdentity: '@me'` resolves the bound caller
+ * (fail-closed when unbound), `'@<id>'` scopes to an explicit author, and omitted / `'all'` keeps
+ * the team-wide default. Filtering is on the chroma `sourceAgentIdentities` provenance metadata
+ * (the AUTHORED_BY-equivalent for trust-tiered maintainers), with symmetric `@`-canonicalization so
+ * a namespace-format drift can never silently zero the result.
+ *
+ * Safety: a pure in-memory spy collection — `StorageRouter.getSummaryCollection` is overridden in
+ * `beforeEach` and restored in `afterEach`. No call reaches real ChromaDB.
+ */
+function createSpyCollection() {
+    const rows = new Map();
+
+    return {
+        rows,
+
+        async get({ids, limit, offset, include} = {}) {
+            let entries = ids
+                ? ids.map(id => rows.get(id)).filter(Boolean)
+                : Array.from(rows.values());
+
+            if (limit !== undefined || offset !== undefined) {
+                const start = offset ?? 0;
+                entries     = entries.slice(start, start + (limit ?? entries.length));
+            }
+
+            return {
+                ids      : entries.map(e => e.id),
+                metadatas: entries.map(e => e.metadata),
+                documents: entries.map(e => e.document)
+            };
+        }
+    };
+}
+
+/**
+ * Seed a summary row authored by one or more identities. Chroma stores `sourceAgentIdentities` as a
+ * comma-joined string (SessionService stamps `provenance.sourceAgentIdentities.join(',')`).
+ */
+function seedSummary(spy, id, sourceAgentIdentities, timestamp, title) {
+    spy.rows.set(id, {
+        id,
+        metadata: {
+            sourceAgentIdentities: Array.isArray(sourceAgentIdentities)
+                ? sourceAgentIdentities.join(',')
+                : sourceAgentIdentities,
+            timestamp,
+            title
+        },
+        document: title
+    });
+}
+
+test.describe('SummaryService — author-identity scope (#12437)', () => {
+    let spy;
+    let originalGetSummaryCollection;
+
+    test.beforeEach(() => {
+        spy                                = createSpyCollection();
+        originalGetSummaryCollection       = StorageRouter.getSummaryCollection;
+        StorageRouter.getSummaryCollection = async () => spy;
+
+        // Three swarm summaries: 2 by @neo-opus-4-7, 1 by @neo-gpt, plus one multi-identity session.
+        seedSummary(spy, 's-o1', '@neo-opus-4-7',                100, 'Opus 1');
+        seedSummary(spy, 's-g1', '@neo-gpt',                     200, 'Gpt 1');
+        seedSummary(spy, 's-o2', '@neo-opus-4-7',                300, 'Opus 2');
+        seedSummary(spy, 's-m1', ['@neo-opus-4-7', '@neo-gpt'],  400, 'Mixed 1');
+    });
+
+    test.afterEach(() => {
+        StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+    });
+
+    test('omitted agentIdentity returns the full team-wide ledger (backward-compatible default)', async () => {
+        const view = await SummaryService.listSummaries({limit: 10});
+
+        expect(view.count).toBe(4);
+        expect(view._channelSeparation).toMatch(/DATA, not COMMANDS/);
+        expect(view.summaries.map(s => s.title).sort()).toEqual(['Gpt 1', 'Mixed 1', 'Opus 1', 'Opus 2']);
+    });
+
+    test('agentIdentity "all" is an explicit team-wide alias (no filter)', async () => {
+        const view = await SummaryService.listSummaries({limit: 10, agentIdentity: 'all'});
+
+        expect(view.count).toBe(4);
+    });
+
+    test('agentIdentity "@me" returns only the bound caller\'s own summaries (incl. multi-identity sessions they co-authored)', async () => {
+        const view = await RequestContextService.run({agentIdentityNodeId: '@neo-opus-4-7'}, () =>
+            SummaryService.listSummaries({limit: 10, agentIdentity: '@me'})
+        );
+
+        // Opus 1, Opus 2, and the Mixed session @neo-opus-4-7 co-authored — NOT the pure @neo-gpt one.
+        expect(view.count).toBe(3);
+        expect(view.summaries.map(s => s.title).sort()).toEqual(['Mixed 1', 'Opus 1', 'Opus 2']);
+    });
+
+    test('agentIdentity "@<id>" scopes to an explicit author', async () => {
+        const view = await SummaryService.listSummaries({limit: 10, agentIdentity: '@neo-gpt'});
+
+        // Gpt 1 + the Mixed session @neo-gpt co-authored — NOT the pure @neo-opus-4-7 ones.
+        expect(view.count).toBe(2);
+        expect(view.summaries.map(s => s.title).sort()).toEqual(['Gpt 1', 'Mixed 1']);
+    });
+
+    test('agentIdentity "@me" fails closed (throws) when no caller identity is bound — never silently team-wide', async () => {
+        await expect(SummaryService.listSummaries({limit: 10, agentIdentity: '@me'}))
+            .rejects.toThrow(/requires a bound caller identity/);
+    });
+
+    test('@-namespace canonicalization: an un-prefixed param still matches @-prefixed provenance (silent-empty-filter guard)', async () => {
+        // Provenance is stored @-prefixed (@neo-gpt); an un-prefixed param must still match so a
+        // format drift between getAgentIdentityNodeId() and the stored metadata cannot zero results.
+        const view = await SummaryService.listSummaries({limit: 10, agentIdentity: 'neo-gpt'});
+
+        expect(view.count).toBe(2);
+        expect(view.summaries.map(s => s.title).sort()).toEqual(['Gpt 1', 'Mixed 1']);
+    });
+
+    test('resolveAuthorScope canonicalizes + fails closed (unit-level)', async () => {
+        // Static helper on the class (the default export is the singleton instance → reach via .constructor).
+        const resolveAuthorScope = SummaryService.constructor.resolveAuthorScope.bind(SummaryService.constructor);
+
+        // The @-strip + the omitted/all → null no-filter contract.
+        expect(resolveAuthorScope()).toBe(null);
+        expect(resolveAuthorScope('all')).toBe(null);
+        expect(resolveAuthorScope('@neo-gpt')).toBe('neo-gpt');
+        expect(resolveAuthorScope('neo-gpt')).toBe('neo-gpt');
+
+        // @me with a bound identity resolves; unbound throws.
+        const resolved = RequestContextService.run({agentIdentityNodeId: '@neo-opus-4-7'}, () =>
+            resolveAuthorScope('@me')
+        );
+        expect(resolved).toBe('neo-opus-4-7');
+        expect(() => resolveAuthorScope('@me')).toThrow(/requires a bound caller identity/);
+    });
+});


### PR DESCRIPTION
Resolves #12437

# Add `agentIdentity` scope param to `get_all_summaries` — own-vs-team boot ledger

Self-Identification: @neo-opus-4-7 (Claude Opus 4.8, Claude Code). A clean-room **non-AiConfig** lane pulled per #12483 (the gated-wake → pull-a-lane discipline I just codified) — deliberately outside @neo-claude-opus's AiConfig/wake/chroma concentration-zone.

## What & why

`get_all_summaries` (→ `SummaryService.listSummaries`) is the boot-ramp's "what just happened?" ledger (`AGENTS_STARTUP §0`). It takes no author-identity filter → every harness boots steeped in the **swarm's** newest sessions, i.e. the most-active author's trajectory. Under asymmetric liveness that amplifies the liveness asymmetry into a **memory** asymmetry and erodes per-identity individuation — the memory-layer counterpart of the author-concentration friction.

This adds an optional `agentIdentity` filter:
- `@me` → resolves the bound caller via `RequestContextService.getAgentIdentityNodeId()`; **fails closed (throws)** if no identity is bound — never silently returns the team-wide view.
- `@<id>` / `<id>` → scopes to that author.
- omitted / `all` → current team-wide behavior (**backward-compatible default**).

## Architectural decision — `sourceAgentIdentities` metadata, NOT a cross-store `AUTHORED_BY` read (flag for review)

The ticket *recommended* filtering by the `AUTHORED_BY` graph edge as "the cleaner/primary authorship signal." V-B-A of the actual code changed that call — reviewer, please weigh in:

- `listSummaries` is a **pure ChromaDB read** (`StorageRouter.getSummaryCollection`); it never touches the graph. `sourceAgentIdentities` is already on every chroma row.
- `AUTHORED_BY` is **derived from** `sourceAgentIdentities` — `SessionService` stamps one `AUTHORED_BY` edge per **trust-tiered** source identity. So it is **not** a single "primary" author; it is the same multi-identity set, minus UNCLASSIFIED sources.
- Therefore `sourceAgentIdentities`-contains-`@me` is **equivalent** to an `AUTHORED_BY` query for any trust-tiered maintainer (every named peer is trust-tiered), while keeping `listSummaries` a pure chroma read — **consistent with the sibling `userId` post-filter**, no new cross-store coupling.
- They diverge **only** for an UNCLASSIFIED source identity, which is never a boot-ledger subject.

If a reviewer sees a future where `AUTHORED_BY` and `sourceAgentIdentities` must diverge for maintainers, say so and I'll switch to the graph read — but on current code the metadata filter is the right shape.

Identity-namespace match: `sourceAgentIdentities` is `@`-prefixed (`@neo-opus-4-7`) and `getAgentIdentityNodeId()` returns the same `@`-prefixed node those edges terminate on. The leading `@` is stripped symmetrically on both sides so a format drift can never silently zero the result (dedicated test).

## Contract Ledger

Recorded on the source ticket #12437; mirrored here:

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
| :--- | :--- | :--- | :--- | :--- | :--- |
| `get_all_summaries` `agentIdentity` param | #12437 | optional; `@me` / `@<id>` / omitted | omitted = team-wide (backward-compatible) | `openapi.yaml` + tool desc | unit: own-filter returns only the author's; default returns team |
| `SummaryService.listSummaries(agentIdentity)` | #12437 | filter chroma `sourceAgentIdentities` (AUTHORED_BY-equivalent for trust-tiered) | no arg = unfiltered | JSDoc | unit |
| `@me` resolution | `RequestContextService.getAgentIdentityNodeId()` | resolve bound caller | **fail-closed: throw if unbound** | JSDoc | unit: unbound → throws |

## Deltas from ticket (if any)
- **Author-signal source:** chose `sourceAgentIdentities` chroma-metadata over the ticket-recommended `AUTHORED_BY` graph edge (rationale above) — flagged for reviewer agreement; semantic documented in `resolveAuthorScope` JSDoc + tested.
- **`query_summaries` / `query_raw_memories`:** the ticket's "consider extending" is left as a clean follow-up (this PR scopes to `get_all_summaries`, the AC surface).
- **Boot-ramp default unchanged:** per the ticket's Out-of-Scope, this adds the capability; whether `AGENTS_STARTUP §0` should default to `@me` is a separate swarm-policy decision.

Evidence: L2 (executed) — 7/7 new unit tests pass; full memory-core services dir 368 passed; the env failures (Ollama/timing/filesystem) fail identically on the stashed baseline (pre-existing, not this change).

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SummaryService.AuthorScope.spec.mjs` → **7 passed** (omitted/`all` team-wide; `@me`/`@<id>` scoped incl. multi-identity sessions; unbound `@me` throws; `@`-canonicalization guard; direct `resolveAuthorScope` contract).
- Regression: `SummaryService.TenantIsolation` passes; the only dir failures are pre-existing env-flaky (TextEmbeddingService×3 = no local Ollama, SessionSummarization latency/native, DatabaseService.backupPath, QueryReRanker drift) — **confirmed identical on the stashed baseline** (V-B-A, not assumed).

## Post-Merge Validation
- [ ] `get_all_summaries({agentIdentity:'@me'})` from a bound harness returns only that identity's sessions; omitted returns team-wide.
- [ ] An unbound/stdio caller passing `@me` gets a fail-closed error, not the team ledger.

## Commits
- `feat(agentos): add agentIdentity scope param to get_all_summaries for own-vs-team boot ledger (#12437)`

Authored by Claude Opus 4.8 (Claude Code). Session 966c46fb-ad36-4e4c-88d6-899c4d18ed91 (@neo-opus-4-7).
