### PR TITLE
feat(agentos): add optional pr-review premise snapshot anchors (#12448)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-followup-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-followup-template.md
@@ -8,6 +8,16 @@
 
 ---
 
+### Patch-Blind Premise Snapshot
+
+*For follow-ups, ground the expected shape in the prior review anchor plus the current delta. Do not let the author's response framing replace the source-of-authority substrate.*
+
+*   **Inputs Read Before Patch:** [Prior review anchor / author response / changed-file list / current `dev` source / source-of-authority substrate checked before treating the delta as evidence.]
+*   **Expected Solution Shape:** [1-3 sentences naming the expected delta shape, what boundary this must NOT hardcode, and what test isolation should exist.]
+*   **Patch Verdict:** [Matches / improves / contradicts the expected shape, with the evidence that confirmed or changed your premise.]
+
+---
+
 ### Strategic-Fit Decision
 
 Per §9 Strategic-Fit Step-Back:

--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -18,6 +18,16 @@ Per §9 Strategic-Fit Step-Back:
 
 ---
 
+### 🧭 Patch-Blind Premise Snapshot
+
+*Source this from the ticket, changed-file list, current `dev` source, sibling precedent, and source-of-authority substrate — not from the PR's own self-description as the primary premise.*
+
+*   **Inputs Read Before Patch:** [Ticket / issue, changed-file list, current `dev` source, sibling precedent, source-of-authority substrate read before treating the patch as evidence.]
+*   **Expected Solution Shape:** [1-3 sentences: expected surface, simplest acceptable shape, what boundary this must NOT hardcode, and what test isolation should exist.]
+*   **Patch Verdict:** [Matches / improves / contradicts the expected shape, with the specific diff/source evidence that confirmed or changed your premise.]
+
+---
+
 ### 🕸️ Context & Graph Linking
 *   **Target Epic / Issue ID:** Resolves #[Issue Number]
 *   **Related Graph Nodes:** [Any other related node IDs or conceptual tags]

--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -78,10 +78,23 @@ jobs:
               "Strategic-Fit Decision"
             ];
 
-            const missingVisible   = VISIBLE_PR_REVIEW_ANCHORS  .filter(a => !body.includes(a));
-            const missingInvisible = INVISIBLE_PR_REVIEW_ANCHORS.filter(a => !body.includes(a));
+            // OPTIONAL-FIRST migration anchors for #12442/#12448. Old reviews without a
+            // premise snapshot still pass; reviews that start emitting the snapshot must emit
+            // the complete three-field shape so partial back-rationalized snapshots do not pass.
+            const OPTIONAL_PR_REVIEW_PREMISE_ANCHORS = [
+              "Inputs Read Before Patch",
+              "Expected Solution Shape",
+              "Patch Verdict"
+            ];
 
-            if (missingVisible.length === 0 && missingInvisible.length === 0) {
+            const missingVisible         = VISIBLE_PR_REVIEW_ANCHORS         .filter(a => !body.includes(a));
+            const missingInvisible       = INVISIBLE_PR_REVIEW_ANCHORS       .filter(a => !body.includes(a));
+            const presentPremiseSnapshot = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(a =>  body.includes(a));
+            const missingPremiseSnapshot = presentPremiseSnapshot.length === 0
+              ? []
+              : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(a => !body.includes(a));
+
+            if (missingVisible.length === 0 && missingInvisible.length === 0 && missingPremiseSnapshot.length === 0) {
               console.log("✅ Review body contains all required anchors.");
               return;
             }
@@ -90,7 +103,7 @@ jobs:
             // anchors. Even visible-list naming is bounded — at most ONE diagnostic
             // anchor in the prose (the full visible-miss list goes in the collapsed
             // details block for programmatic access; invisible misses are NEVER named).
-            const diagnosticAnchor = missingVisible[0] || null;
+            const diagnosticAnchor = missingVisible[0] || missingPremiseSnapshot[0] || null;
 
             const skillPath    = '.agents/skills/pr-review/SKILL.md';
             const templatePath = '.agents/skills/pr-review/assets/pr-review-template.md';
@@ -110,6 +123,10 @@ jobs:
               `Do NOT compose a substitute template or hallucinate section headings. The validator`,
               `checks more structural anchors than this comment names. The only reliable path to`,
               `passing is reading the actual template file and following its structure.`,
+              ``,
+              missingPremiseSnapshot.length > 0
+                ? `**Premise snapshot note**: the snapshot is optional during migration, but partial snapshots are invalid. Either omit it entirely or include all three fields.`
+                : ``,
               ``,
               diagnosticAnchor
                 ? `**Diagnostic hint**: at least one recognized anchor like \`${diagnosticAnchor}\` is missing.`

--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -81,18 +81,22 @@ jobs:
             // OPTIONAL-FIRST migration anchors for #12442/#12448. Old reviews without a
             // premise snapshot still pass; reviews that start emitting the snapshot must emit
             // the complete three-field shape so partial back-rationalized snapshots do not pass.
+            // Match the distinctive bold template labels, not bare prose, so incidental phrases
+            // like "Patch Verdict" do not activate the partial-snapshot gate.
             const OPTIONAL_PR_REVIEW_PREMISE_ANCHORS = [
-              "Inputs Read Before Patch",
-              "Expected Solution Shape",
-              "Patch Verdict"
+              {label: "Inputs Read Before Patch", token: "**Inputs Read Before Patch:**"},
+              {label: "Expected Solution Shape",  token: "**Expected Solution Shape:**"},
+              {label: "Patch Verdict",            token: "**Patch Verdict:**"}
             ];
 
             const missingVisible         = VISIBLE_PR_REVIEW_ANCHORS         .filter(a => !body.includes(a));
             const missingInvisible       = INVISIBLE_PR_REVIEW_ANCHORS       .filter(a => !body.includes(a));
-            const presentPremiseSnapshot = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(a =>  body.includes(a));
+            const presentPremiseSnapshot = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(a =>  body.includes(a.token));
             const missingPremiseSnapshot = presentPremiseSnapshot.length === 0
               ? []
-              : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(a => !body.includes(a));
+              : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS
+                .filter(a => !body.includes(a.token))
+                .map(a => a.label);
 
             if (missingVisible.length === 0 && missingInvisible.length === 0 && missingPremiseSnapshot.length === 0) {
               console.log("✅ Review body contains all required anchors.");

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -672,11 +672,11 @@ paths:
       x-annotations:
         readOnlyHint: false
       description: |
-        Atomic create or update of a formal PR review. Single call posts body + flips reviewDecision. create requires pr_number + state (APPROVED/REQUEST_CHANGES/COMMENT) + body. update requires review_id (PRR_*) + body; state cannot transition. Returns reviewId + state + url + submittedAt.
+        Atomic create/update of a formal PR review. `create` posts body + flips reviewDecision and requires `pr_number`, `state` (APPROVED/REQUEST_CHANGES/COMMENT), and `body`; `update` requires `review_id` (PRR_*) + `body` and cannot change state. Returns reviewId, state, url, and submittedAt.
 
-        **MANDATORY pre-step:** read `.agents/skills/pr-review/SKILL.md` — this skill contains the authoritative protocol and template structure for conducting pull request reviews. You MUST NOT execute a formal review without adhering to the depth floor and evidence audit guidelines outlined in the skill.
+        Mandatory pre-step: read `.agents/skills/pr-review/SKILL.md` and use the cycle-appropriate template.
 
-        **Mechanical body validation (#11491):** the `body` parameter is mechanically validated against two layers — visible 7 evaluation-metric anchor tags (`[ARCH_ALIGNMENT]`, `[CONTENT_COMPLETENESS]`, `[EXECUTION_QUALITY]`, `[PRODUCTIVITY]`, `[IMPACT]`, `[COMPLEXITY]`, `[EFFORT_PROFILE]`) AND additional structural-template anchors checked silently. The metric tags are the wire-format contract with the Retrospective-daemon graph ingestor (`ai/daemons/services/ConceptDiscoveryService.mjs`). On validation failure, error `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` points the caller at the canonical primitive (`.agents/skills/pr-review/SKILL.md` + `assets/pr-review-template.md`) — the **only** reliable path to passing is reading the actual template file. The validator deliberately does NOT enumerate every required anchor; do NOT compose a substitute template or hallucinate section headings. The agent can fix-and-resubmit in-turn before bad data reaches GitHub. This is the depth-floor enforcement; content quality remains the peer-V-B-A reviewer's responsibility.
+        Validation: `body` must include the 7 visible metric anchors plus silent structural template anchors; failures return `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` pointing at the skill/template. Do not synthesize substitute headings. #12448 premise-snapshot fields (`Inputs Read Before Patch`, `Expected Solution Shape`, `Patch Verdict`) are optional during migration: omit all three or include all three together.
       tags: [PullRequests]
       parameters:
         - name: pr_number

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -84,6 +84,20 @@ const INVISIBLE_PR_REVIEW_ANCHORS = [
 ];
 
 /**
+ * Optional-first premise-snapshot anchors for the patch-blind review migration.
+ *
+ * Absence of all three anchors is valid during the add-optional phase so in-flight reviews keep
+ * passing. If an author starts emitting the snapshot, all three fields must be present together;
+ * otherwise a partial snapshot reintroduces the same back-rationalized theater the snapshot is
+ * meant to expose. Later enforcement can promote these from optional-complete to required.
+ */
+const OPTIONAL_PR_REVIEW_PREMISE_ANCHORS = [
+    'Inputs Read Before Patch',
+    'Expected Solution Shape',
+    'Patch Verdict'
+];
+
+/**
  * @summary Service for interacting with GitHub Pull Requests via the `gh` CLI and GraphQL API.
  *
  * This service acts as a unified interface for Pull Request operations.
@@ -439,14 +453,18 @@ class PullRequestService extends Base {
         // Both layers point the agent at `.agents/skills/pr-review/SKILL.md` — the canonical
         // primitive for resolving any validation failure is to read the skill + template, not
         // to compose a substitute structure.
-        const missingVisible   = VISIBLE_PR_REVIEW_ANCHORS  .filter(anchor => !body.includes(anchor));
-        const missingInvisible = INVISIBLE_PR_REVIEW_ANCHORS.filter(anchor => !body.includes(anchor));
+        const missingVisible          = VISIBLE_PR_REVIEW_ANCHORS          .filter(anchor => !body.includes(anchor));
+        const missingInvisible        = INVISIBLE_PR_REVIEW_ANCHORS        .filter(anchor => !body.includes(anchor));
+        const presentPremiseSnapshot  = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS .filter(anchor =>  body.includes(anchor));
+        const missingPremiseSnapshot  = presentPremiseSnapshot.length === 0
+            ? []
+            : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(anchor => !body.includes(anchor));
 
-        if (missingVisible.length > 0 || missingInvisible.length > 0) {
+        if (missingVisible.length > 0 || missingInvisible.length > 0 || missingPremiseSnapshot.length > 0) {
             // Compose a message that guides toward the skill without enumerating invisible anchors.
             // Even the visible-list naming is bounded — at most ONE diagnostic example, not the
             // full list — to reduce the "stuff just these tags" attack surface further.
-            const diagnosticAnchor = missingVisible[0] ?? null;
+            const diagnosticAnchor = missingVisible[0] ?? missingPremiseSnapshot[0] ?? null;
 
             const skillPath    = '.agents/skills/pr-review/SKILL.md';
             const templatePath = '.agents/skills/pr-review/assets/pr-review-template.md';
@@ -462,6 +480,9 @@ class PullRequestService extends Base {
                 `Do NOT compose a substitute template or hallucinate section headings. The validator`,
                 `checks more structural anchors than this error names. The only reliable path to`,
                 `passing is reading the actual template file and following its structure.`,
+                missingPremiseSnapshot.length > 0
+                    ? `\nPremise snapshot note: the snapshot is optional during migration, but partial snapshots are invalid. Either omit it entirely or include all three fields.`
+                    : ``,
                 diagnosticAnchor
                     ? `\nDiagnostic hint: at least one recognized anchor like \`${diagnosticAnchor}\` is missing.`
                     : `\nDiagnostic hint: visible metric tags appear present but the structural template anchors do not.`
@@ -474,9 +495,10 @@ class PullRequestService extends Base {
                 // `missing_visible` lists the named-in-message visible misses. Invisible misses
                 // are intentionally NOT enumerated in the response body — even programmatic
                 // callers should be nudged toward the skill rather than the anchor list.
-                missing_visible: missingVisible,
-                skill          : skillPath,
-                template       : templatePath
+                missing_visible         : missingVisible,
+                missing_premise_snapshot: missingPremiseSnapshot,
+                skill                   : skillPath,
+                template                : templatePath
             };
         }
 

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -86,15 +86,16 @@ const INVISIBLE_PR_REVIEW_ANCHORS = [
 /**
  * Optional-first premise-snapshot anchors for the patch-blind review migration.
  *
- * Absence of all three anchors is valid during the add-optional phase so in-flight reviews keep
+ * Absence of all three labels is valid during the add-optional phase so in-flight reviews keep
  * passing. If an author starts emitting the snapshot, all three fields must be present together;
  * otherwise a partial snapshot reintroduces the same back-rationalized theater the snapshot is
- * meant to expose. Later enforcement can promote these from optional-complete to required.
+ * meant to expose. Match the distinctive bold template labels, not bare prose, so incidental
+ * phrases like "Patch Verdict" do not activate the partial-snapshot gate.
  */
 const OPTIONAL_PR_REVIEW_PREMISE_ANCHORS = [
-    'Inputs Read Before Patch',
-    'Expected Solution Shape',
-    'Patch Verdict'
+    {label: 'Inputs Read Before Patch',  token: '**Inputs Read Before Patch:**'},
+    {label: 'Expected Solution Shape',   token: '**Expected Solution Shape:**'},
+    {label: 'Patch Verdict',             token: '**Patch Verdict:**'}
 ];
 
 /**
@@ -455,10 +456,12 @@ class PullRequestService extends Base {
         // to compose a substitute structure.
         const missingVisible          = VISIBLE_PR_REVIEW_ANCHORS          .filter(anchor => !body.includes(anchor));
         const missingInvisible        = INVISIBLE_PR_REVIEW_ANCHORS        .filter(anchor => !body.includes(anchor));
-        const presentPremiseSnapshot  = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS .filter(anchor =>  body.includes(anchor));
+        const presentPremiseSnapshot  = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS .filter(anchor =>  body.includes(anchor.token));
         const missingPremiseSnapshot  = presentPremiseSnapshot.length === 0
             ? []
-            : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS.filter(anchor => !body.includes(anchor));
+            : OPTIONAL_PR_REVIEW_PREMISE_ANCHORS
+                .filter(anchor => !body.includes(anchor.token))
+                .map(anchor => anchor.label);
 
         if (missingVisible.length > 0 || missingInvisible.length > 0 || missingPremiseSnapshot.length > 0) {
             // Compose a message that guides toward the skill without enumerating invisible anchors.

--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -29,7 +29,7 @@ A concept exists if:
 
 **Where the gold is:**
 - Epic bodies: core architectural problem statements and phased solutions.
-- PR review comments: \`[ARCH_ALIGNMENT]\`, \`[RETROSPECTIVE]\`, \`[KB_GAP]\`, \`[TOOLING_GAP]\` sections; "Gold Standards Leveraged / Traps Avoided" lists; rationale prose explaining WHY a pattern was chosen.
+- PR review comments: \`[ARCH_ALIGNMENT]\`, \`[RETROSPECTIVE]\`, \`[KB_GAP]\`, \`[TOOLING_GAP]\` sections; "Inputs Read Before Patch" / "Expected Solution Shape" / "Patch Verdict" premise-snapshot fields; "Gold Standards Leveraged / Traps Avoided" lists; rationale prose explaining WHY a pattern was chosen.
 - Discussion about mid-term architecture direction, service boundaries, substrate choices.
 
 **DO NOT include:**

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -812,6 +812,35 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(graphqlCallCount).toBe(0);
     });
 
+    test('#12448: ignores incidental premise-snapshot prose without making it partial', async () => {
+        // Bare phrases in review prose must not activate the optional snapshot contract; only the
+        // distinctive bold template labels should require the full three-field snapshot.
+        let graphqlCallCount = 0;
+        GraphqlService.query = async (queryString) => {
+            graphqlCallCount++;
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
+            return null;
+        };
+
+        const body = [
+            'The Patch Verdict from the prior cycle still stands.',
+            '',
+            VALID_REVIEW_BODY
+        ].join('\n');
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 12448,
+            state    : 'APPROVED',
+            body
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.reviewId).toBe('PRR_kwDOABcD1111111111');
+        expect(graphqlCallCount).toBe(2);
+    });
+
     test('#11491: invisible-anchor enforcement is NOT discoverable from the error response', async () => {
         // Surface contract: the invisible-anchor strings MUST NOT appear in the error response
         // body (neither `message` prose nor programmatic field). Discovery from outside requires

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -20,12 +20,12 @@ import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 
 /**
- * @summary Contract coverage for `PullRequestService.getConversation` comment-selector params (#10272 §2.2).
+ * @summary Contract coverage for `PullRequestService.getConversation` comment-selector params.
  *
- * Prior to #10272, `getConversation(prNumber)` always returned the full PR conversation —
- * every review cycle N+1 paid context-fetch cost proportional to cumulative thread size.
- * This ticket added three optional selectors (`comment_id`, `since_comment_id`, `last_n`)
- * that narrow the returned comments array at the cost of one client-side filter pass.
+ * Before selector support, `getConversation(prNumber)` always returned the full PR conversation;
+ * every review cycle N+1 paid context-fetch cost proportional to cumulative thread size. The
+ * service now exposes three optional selectors (`comment_id`, `since_comment_id`, `last_n`) that
+ * narrow the returned comments array at the cost of one client-side filter pass.
  *
  * These tests pin the selector contract:
  * 1. No selectors → full conversation (backward-compat path).
@@ -84,7 +84,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getConvers
     });
 
     test('accepts legacy positional prNumber form (backward-compat migration path)', async () => {
-        // Existing callers predating #10272 may pass `prNumber` positionally. The new
+        // Existing callers may pass `prNumber` positionally. The object-form
         // signature must tolerate both forms to avoid a breaking change. Same result as
         // the object form, just demonstrating the calling convention still works.
         const result = await PullRequestService.getConversation(10272);
@@ -229,7 +229,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
     let fs;
     let path;
     let aiConfig;
-    
+
     test.beforeAll(async () => {
         PullRequestService = (await import('../../../../../../ai/services/github-workflow/PullRequestService.mjs')).default;
         aiConfig           = (await import('../../../../../../ai/mcp/server/github-workflow/config.mjs')).default;
@@ -242,7 +242,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
             pr_number : 10747,
             files_only: true
         });
-        
+
         expect(Array.isArray(result.files)).toBe(true);
         expect(result.files.some(f => f.path.includes('cognitive-load-baseline'))).toBe(true);
     });
@@ -252,7 +252,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
             pr_number: 10747,
             file     : 'learn/agentos/measurements/cognitive-load-baseline-2026-05.md'
         });
-        
+
         expect(typeof result.result).toBe('string');
         expect(result.result).toContain('Sub 4 Payload Audit Results');
     });
@@ -266,7 +266,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
 
         // 1. Capture baseline output
         const baseline = await PullRequestService.getPullRequestDiff(params);
-        
+
         // 2. Mutate local working tree
         const targetFilePath  = path.join(aiConfig.projectRoot, params.file);
         const originalContent = await fs.readFile(targetFilePath, 'utf-8');
@@ -276,7 +276,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
         try {
             // 3. Re-run
             const rerunning = await PullRequestService.getPullRequestDiff(params);
-            
+
             // 4. Assert byte-identical output
             expect(rerunning.result).toBe(baseline.result);
         } finally {
@@ -291,7 +291,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
             file     : 'some/file.md',
             sha      : 'invalid-sha-xyz; touch /tmp/pwned'
         });
-        
+
         expect(result.error).toBe('Bad Request');
         expect(result.code).toBe('INVALID_ARGUMENTS');
     });
@@ -301,7 +301,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
             pr_number: 10747,
             sha      : 'd8913f1fa89f585a237a5e54992b2d12865e4fb6'
         });
-        
+
         expect(result.error).toBe('Bad Request');
         expect(result.code).toBe('INVALID_ARGUMENTS');
     });
@@ -319,7 +319,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — getPullReq
 });
 
 /**
- * @summary Contract coverage for `PullRequestService.managePrReview` (#11273).
+ * @summary Contract coverage for `PullRequestService.managePrReview`.
  *
  * Closes the formal-state gap: atomic create or update of a formal pull request review
  * via the `addPullRequestReview` / `updatePullRequestReview` GraphQL mutations.
@@ -350,7 +350,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         databaseId : 12345
     };
 
-    // Minimal review body that passes BOTH layers of the #11491 tool-boundary template-anchor validator:
+    // Minimal review body that passes BOTH layers of the tool-boundary template-anchor validator:
     // - VISIBLE layer: the 7 evaluation-metric tags from pr-review-template.md / pr-review-followup-template.md
     // - INVISIBLE layer: structural anchors NOT enumerated in error responses; see
     //   `INVISIBLE_PR_REVIEW_ANCHORS` constant in `ai/services/github-workflow/PullRequestService.mjs`
@@ -597,19 +597,18 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     });
 
     // ────────────────────────────────────────────────────────────────────────
-    // #11491 — tool-boundary mechanical body-shape validation
+    // Tool-boundary mechanical body-shape validation
     //   Visible layer: 7 metric tags, misses named in error
     //   Invisible layer: structural anchors, checked but NOT named in error
     //                    (defeats Goodhart anchor-stuffing — operator-directed 2026-05-16)
     // ────────────────────────────────────────────────────────────────────────
 
     test('#11491: rejects body missing all 7 visible metric anchors AND structural anchors', async () => {
-        // The empirical recurrence: Gemini's PR #11488/#11489 reviews (2026-05-16T20:14Z) shipped
-        // a hallucinated "Structural Evaluation Matrix" with 5 invented metric names on a 1-10
-        // scale, completely bypassing the template's 7 evaluation-metric tags. The Retrospective
-        // daemon's regex parser (`ConceptDiscoveryService.mjs:32`) saw zero ingest signal — two
-        // PRs worth of review-substrate data silently lost from the Native Edge Graph. This test
-        // pins the new tool-boundary gate that prevents this class of substrate loss.
+        // The empirical recurrence: prior reviews shipped a hallucinated "Structural Evaluation
+        // Matrix" with 5 invented metric names on a 1-10 scale, completely bypassing the template's
+        // 7 evaluation-metric tags. The Retrospective daemon's regex parser saw zero ingest signal,
+        // losing review-substrate data from the Native Edge Graph. This test pins the tool-boundary
+        // gate that prevents this class of substrate loss.
         let graphqlCallCount = 0;
         GraphqlService.query = async () => {
             graphqlCallCount++;
@@ -648,12 +647,10 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     });
 
     test('#11491: Goodhart-stuffed body — all 7 metric tags present but missing structural anchors — still REJECTED', async () => {
-        // Empirical anchor: Gemini's review `4304287893` on PR #11499 (2026-05-16T21:16:25Z)
-        // contained ALL 7 metric tags but missed the structural template anchors. The pre-
-        // enhancement validator would have PASSED this body (the canonical Goodhart-stuffing
-        // failure mode the operator-directed invisible layer prevents). This test asserts that
-        // post-enhancement, structural-only-stuffing IS rejected — without naming the invisible
-        // anchors in test prose to preserve the safeguard surface.
+        // Empirical anchor: a prior review contained ALL 7 metric tags but missed the structural
+        // template anchors. The visible-only validator would have PASSED this body (the canonical
+        // Goodhart-stuffing failure mode the invisible layer prevents). This test asserts that
+        // structural-only-stuffing IS rejected without naming the invisible anchors in test prose.
         const stuffedBody = [
             'Approval granted.',
             '[ARCH_ALIGNMENT]: 100',
@@ -750,6 +747,69 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(result.reviewId).toBe('PRR_kwDOABcD1111111111');
         // Two GraphQL queries: GetPullRequestId + AddPullRequestReview
         expect(graphqlCallCount).toBe(2);
+    });
+
+    test('#12448: accepts complete optional premise snapshot during add-first migration', async () => {
+        // Premise-snapshot anchors are optional-first: old review bodies still pass,
+        // but migrated templates may emit all three fields together before a later enforcement PR.
+        let graphqlCallCount = 0;
+        GraphqlService.query = async (queryString) => {
+            graphqlCallCount++;
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
+            return null;
+        };
+
+        const body = [
+            '### Patch-Blind Premise Snapshot',
+            '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
+            '* **Expected Solution Shape:** optional validator recognition without hard enforcement.',
+            '* **Patch Verdict:** matches expected optional-first migration.',
+            '',
+            VALID_REVIEW_BODY
+        ].join('\n');
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 12448,
+            state    : 'APPROVED',
+            body
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.reviewId).toBe('PRR_kwDOABcD1111111111');
+        expect(graphqlCallCount).toBe(2);
+    });
+
+    test('#12448: rejects partial premise snapshot without making a GitHub call', async () => {
+        // Omit-all remains valid in the add-optional phase, but once the snapshot appears it must
+        // include the complete three-field shape. A partial snapshot is the exact theater risk the
+        // migration is meant to expose.
+        let graphqlCallCount = 0;
+        GraphqlService.query = async () => {
+            graphqlCallCount++;
+            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+        };
+
+        const body = [
+            '### Patch-Blind Premise Snapshot',
+            '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
+            '',
+            VALID_REVIEW_BODY
+        ].join('\n');
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 12448,
+            state    : 'APPROVED',
+            body
+        });
+
+        expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        expect(result.missing_visible).toEqual([]);
+        expect(result.missing_premise_snapshot).toEqual(['Expected Solution Shape', 'Patch Verdict']);
+        expect(result.message).toContain('Premise snapshot note');
+        expect(graphqlCallCount).toBe(0);
     });
 
     test('#11491: invisible-anchor enforcement is NOT discoverable from the error response', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 032b788b-aac0-40ae-9a48-f595ffb3e4e8.

Resolves #12448
Related: #12442

Adds the optional-first patch-blind premise snapshot to the pr-review Cycle 1 and follow-up templates, mirrors the complete-or-omit validator in both `PullRequestService.managePrReview` and the GitHub Actions review-body lint, and teaches graph ingestion to treat the new fields as review-signal material.

Evidence: L2 (focused unit coverage + static/lint checks + MCP tool-description budget audit) -> L2 required (mechanical review-body contract and skill-template substrate). No residuals after the follow-up hardening commit.

## Deltas
- Corrected the graph consumer path from the stale daemon path to `ai/services/ingestion/ConceptDiscoveryService.mjs`.
- Enforced the migration as optional-complete: old reviews may omit the snapshot; partial snapshots are rejected once any snapshot field appears.
- Hardened optional snapshot detection to match the template's bold labels, so incidental prose such as `Patch Verdict` does not activate the partial-snapshot gate.
- Compressed the `manage_pr_review` OpenAPI description from 1854 chars to 800 chars while preserving the validator contract and optional snapshot rule.
- Cleaned durable ticket IDs from comments in the touched `PullRequestService.spec.mjs` file because the repo hook now enforces behavior-first comments.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs -g "#12448|#11491|managePrReview"` -> 21 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs` -> 10 passed.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> OK.
- `node ai/scripts/lint/lint-agents.mjs` -> OK.
- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/services/github-workflow/PullRequestService.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` -> 2 files scanned, 0 violations.
- `git diff --cached --check` -> OK before each commit.
- Full `PullRequestService.spec.mjs` was attempted before the follow-up; the new tests passed, but three pre-existing live-GitHub diff tests failed on sandbox/network access to `gh pr view` / `gh pr diff`.

## Substrate Load-Effect Audit
- Source-ticket Contract Ledger: posted on #12448 before PR open.
- Always-loaded map delta: none. This PR does not edit `SKILL.md`, `AGENTS.md`, or the skill manifest.
- Conditional skill-template delta: `assets/pr-review-template.md` and `assets/pr-review-followup-template.md` gain the snapshot fields where reviewers already load the body templates.
- Disposition: keep in conditional templates; trigger-frequency is review-only, failure-severity is high for wrong-premise reviews, enforceability is partial through optional-complete service and CI validators.
- Net loaded-byte posture: no turn-loaded expansion; `manage_pr_review` OpenAPI tool description net-reduces below the MCP 1024-char budget.

## Post-Merge Validation
- [ ] First reviewer using the new template can submit a complete premise snapshot through `manage_pr_review` without validation drift.
- [ ] CI review-body lint rejects a partial snapshot and still accepts omit-all legacy reviews during migration.
- [ ] CI review-body lint ignores incidental prose containing a snapshot-field phrase unless the template label token is present.

## Commits
- `27b4c2f41` — `feat(agentos): add optional pr-review premise snapshot anchors (#12448)`
- `0ffb89b79` — `fix(agentos): harden premise snapshot label matching (#12448)`
