### PR TITLE
feat(agentos): typed calibration loop — the non-self-policed leg of the pr-review premise gate (#12449)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -18,7 +18,7 @@ Build — and write down — your premise of the change **before** reading the p
 2. **Expected solution-shape** (1–3 sentences) — what *should* a correct change here look like? Explicitly include **"what boundary should this NOT hardcode?"** and **"what test-isolation should exist?"**, so the snapshot reaches the portability + test-isolation dimensions before the diff frames them away.
 3. **Patch-verdict** — does the diff **match / improve / contradict** the expected shape? Name the specific evidence that changed (or confirmed) your mind. "Matches" with no evidence is not a verdict.
 
-**Night-shift provisional marker:** when the approval is single-family / human-asleep (no cross-family reviewer awake), label it `single-family — calibration-deferred-to-merge-gate`. The typed-calibration loop (#12449) reads this marker at the merge-gate to know the approval was single-family / calibration-deferred; it is inert until that consumer lands (define-then-consume).
+**Night-shift provisional marker:** when the approval is single-family / human-asleep (no cross-family reviewer awake), label it `single-family — calibration-deferred-to-merge-gate`. §12 (Typed Calibration Loop) reads this marker at the merge-gate to apply calibration to a single-family / calibration-deferred approval.
 
 ## 1. Core Philosophy
 - **For Internal Agents (Peer-Review):** Be objective, clinical, and strict. Enforce the "Fat Ticket" protocol and strict JSDoc completeness.
@@ -436,3 +436,7 @@ That payload is the Atlas entry; this section is only the map pointer that fires
 after `pr-review` completes. Author-side symmetry is mapped from
 `pull-request-workflow.md §6.3`. This is the public skill codification of the
 `feedback_peer_not_assistant_mode` lineage.
+
+## 12. Typed Calibration Loop (the non-self-policed signal)
+
+<!-- trigger: operator / human-merge-gate overturns a verdict (incl. the §0 `calibration-deferred-to-merge-gate` marker) → read ./typed-calibration-loop.md -->

--- a/.agents/skills/pr-review/references/typed-calibration-loop.md
+++ b/.agents/skills/pr-review/references/typed-calibration-loop.md
@@ -8,11 +8,12 @@ An operator / human-merge-gate overturn of a reviewer verdict — **including** 
 
 ## Log a typed overturn event
 
-- **Classify by miss-dimension**, never by reviewer-id alone — reviewer-id Goodharts into defensive over-requesting, while the dimension reveals *what kind* of premise the reviewer missed:
-  `premise` · `solution-shape` · `SSOT-dup` · `file-placement` · `runtime-load` · `test-isolation` · `portability` · `rhetorical-drift`.
+- **Classify by miss-dimension**, never by reviewer-id alone — reviewer-id Goodharts into defensive over-requesting, while the dimension reveals *what kind* of premise the reviewer missed. The typed set is **extensible** — add a dimension when a miss has a *distinct remediation*, not merely a finer label:
+  `premise` · `solution-shape` · `verified-correct-but-wrong-layer` · `SSOT-dup` · `file-placement` · `runtime-load` · `test-isolation` · `portability` · `rhetorical-drift`.
+  - `verified-correct-but-wrong-layer` is distinct from surface `solution-shape`: the code is *verified correct* but built at the wrong architectural layer. The remediation differs — surface-shape → "ask the simplest-shape question"; wrong-layer → "read the relevant architecture doc / ADR before approving" — which is why it is typed separately.
 - **Stable event key:** `reviewer-id + miss-dimension + PR-id + overturn-timestamp` — idempotent, one event per overturn.
 - **Lightweight home (first):** record it where overturn events are already visible — an A2A overturn note or a graph node. **No dedicated substrate until recurrence proves it earns one** (per the create-skill discipline: don't build telemetry substrate ahead of demonstrated need).
 
 ## Target (Epic #12442 exit)
 
-The typed-calibration rate trends below the ≈5 baseline over a defined review window. If it does **not**, the §0 snapshot is merely *moving* failures between dimensions rather than *removing* them → the Epic's `revalidationTrigger` re-opens #12442.
+**Window:** the trailing **20 merged PRs** — count-based (≈ one active night's throughput), so it is robust to throughput variation and evaluable at any merge-gate. **Rate:** the count of typed overturn events logged in that window. **Exit:** the rate trends below the **≈5 baseline** (the observed pre-snapshot overturn rate). If it does **not**, the §0 snapshot is merely *moving* failures between dimensions rather than *removing* them → the Epic's `revalidationTrigger` re-opens #12442. *(The 20-PR window and ≈5 baseline are the initial calibration figures — recalibratable by the operator as overturn data accrues.)*

--- a/.agents/skills/pr-review/references/typed-calibration-loop.md
+++ b/.agents/skills/pr-review/references/typed-calibration-loop.md
@@ -1,0 +1,18 @@
+# Typed Calibration Loop (Epic #12442 — the non-self-policed signal)
+
+Read this when an operator or the human merge-gate **overturns** a reviewer verdict. §0 (the patch-blind premise snapshot) makes premise-vacuity *visible*; this loop makes *skipping* it *costly* — it is the one review leg a reviewer cannot self-grade, so it is the load-bearing external signal for whether the §0 snapshot actually works.
+
+## When it fires
+
+An operator / human-merge-gate overturn of a reviewer verdict — **including** consuming the §0 `single-family — calibration-deferred-to-merge-gate` marker: a single-family / human-asleep approval was deferred at review time and gets its calibration here, at the merge-gate, once a human or cross-family signal arrives.
+
+## Log a typed overturn event
+
+- **Classify by miss-dimension**, never by reviewer-id alone — reviewer-id Goodharts into defensive over-requesting, while the dimension reveals *what kind* of premise the reviewer missed:
+  `premise` · `solution-shape` · `SSOT-dup` · `file-placement` · `runtime-load` · `test-isolation` · `portability` · `rhetorical-drift`.
+- **Stable event key:** `reviewer-id + miss-dimension + PR-id + overturn-timestamp` — idempotent, one event per overturn.
+- **Lightweight home (first):** record it where overturn events are already visible — an A2A overturn note or a graph node. **No dedicated substrate until recurrence proves it earns one** (per the create-skill discipline: don't build telemetry substrate ahead of demonstrated need).
+
+## Target (Epic #12442 exit)
+
+The typed-calibration rate trends below the ≈5 baseline over a defined review window. If it does **not**, the §0 snapshot is merely *moving* failures between dimensions rather than *removing* them → the Epic's `revalidationTrigger` re-opens #12442.


### PR DESCRIPTION
Resolves #12449
Refs #12442

# Typed Calibration Loop — the non-self-policed leg of the pr-review premise gate

Self-Identification: @neo-opus-4-7 (Claude Opus 4.8, Claude Code). My design (Discussion #12432 → Epic #12442). Operator directive: "grab a new lane." Unblocked by #12482's merge (the §0 premise-snapshot + the night-shift marker this consumes).

## What & why

§0 makes premise-vacuity *visible*; this loop makes *skipping* it *costly*. It's the one review leg a reviewer cannot self-grade — the load-bearing external signal for whether the §0 snapshot actually works (vs merely *moving* failures between dimensions).

When an operator / human-merge-gate **overturns** a reviewer verdict, log a **typed overturn event** classified by miss-dimension (never reviewer-id alone, which Goodharts into defensive over-requesting), with a stable idempotent key, in a lightweight home (A2A note / graph node — no dedicated substrate until recurrence).

## Changes
1. **`pr-review-guide.md §12`** — a **one-line trigger** (the loop is edge-case-triggered: it fires at an overturn, not every review). The oversized-map delta cap (250 B) mandates extracting substantive content to a sibling.
2. **`references/typed-calibration-loop.md`** (new) — the protocol: the typed miss-dimensions (extensible; incl. `verified-correct-but-wrong-layer`, distinct remediation), the stable event key (`reviewer-id + miss-dimension + PR-id + overturn-timestamp`), the lightweight-home-first mandate, and the Epic #12442 exit target (rate < ≈5 baseline over the **trailing-20-merged-PR window**; else `revalidationTrigger`).
3. **§0 define-then-consume completed** — the night-shift marker (defined in #12482, previously inert) is now consumed by §12 at the merge-gate (line-21 updated).

## Memory-substrate placement — `/turn-memory-pre-flight` load-effect audit
- `pr-review-guide.md` = conditional World-Atlas (loaded on pr-review): §12 is a one-line trigger; line-21 net-shrank. Map delta within the 250-B oversized-map cap (lint-enforced).
- `references/typed-calibration-loop.md` = conditional World-Atlas, loaded ONLY when an overturn fires the trigger. 2713 B (< 25 KB budget).
- **No `SKILL.md` router / always-loaded Map change.** Net always-loaded delta: **ZERO**.

## Contract Ledger
Recorded on #12449; mirrored:

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `pr-review-guide.md §12` | #12449 (design #12432) | one-line trigger → `typed-calibration-loop.md`; consumes the §0 marker at the merge-gate | trigger only (oversized-map delta cap) | yes | lint-skill-manifest OK |
| `references/typed-calibration-loop.md` (new) | #12449 | typed miss-dimensions (extensible; incl. `verified-correct-but-wrong-layer`) + stable event key + lightweight-home-first + trailing-20-PR exit window | A2A note / graph-node home; **no dedicated substrate until recurrence** | yes | sibling < 25 KB |
| §0 night-shift marker consumption | #12482 (defined) → #12449 (consumes) | §12 reads `single-family — calibration-deferred-to-merge-gate` at the merge-gate | marker was inert; now live (define-then-consume complete) | yes | line-21 updated |

## Deltas from ticket (if any)
- **Extracted to a sibling, not inline** — the oversized-map lint (250-B cap) forced §12 to a trigger + `typed-calibration-loop.md`. Distinct from #12486's a2a-handoff inline-and-delete: that was *tool-mechanics duplication*; this is *genuine edge-case-triggered substrate* that earns a sibling.
- **Lightweight-home-first honored** — the protocol specifies an A2A/graph-node home via existing mechanisms; **no dedicated telemetry substrate is built** (per the AC + the create-skill discipline). Dedicated substrate is deferred to proven recurrence.

Evidence: L1 (substrate-only; no runtime AC). `lint-skill-manifest --base origin/dev` OK, `lint-agents` OK, sibling under budget, map delta within cap.

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `[lint-skill-manifest] OK` (after extracting §12 to the sibling — the first inline attempt correctly tripped the 250-B oversized-map cap, a clean dogfood of the recursive Map-vs-Atlas discipline)
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` → OK
- `wc -c` sibling → 2713 (< 25000)

## Post-Merge Validation
- [ ] When an operator overturns a verdict, the typed overturn event (dimension + stable key) is logged in the lightweight home.
- [ ] §0's night-shift marker is consumed by §12 at the merge-gate (no longer inert).

## Commits
- `feat(agentos): add typed calibration loop (#12442 leg) consuming the §0 night-shift marker (#12449)`

Authored by Claude Opus 4.8 (Claude Code). Session 966c46fb-ad36-4e4c-88d6-899c4d18ed91 (@neo-opus-4-7).
