### PR TITLE
refactor(ai): resolve memory-core graph DB-path declaratively via a config formula (#12491)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -117,9 +117,30 @@ class Config extends BaseConfig {
             engine: leaf('hybrid'),
             /**
              * Physical file paths for embedded/local datasets.
+             *
+             * `graph` (the active path consumers read) is a reactive formula (see `formulas` below) that
+             * resolves `graphProd` / `graphTest` by construction from `useTestDatabase` — no inline
+             * `process.env` in a leaf default. Test-mode is resolved in the config, so
+             * the ~10 `storagePaths.graph` consumers (GraphService open, DatabaseService guard, Server
+             * diagnostic, maintenance scripts) read one value unchanged.
              */
             storagePaths: {
-                graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string')
+                /**
+                 * Production graph SQLite path. Declarative leaf; env override via `NEO_MEMORY_DB_PATH`.
+                 * @type {string}
+                 */
+                graphProd      : leaf(path.resolve(cwd, '.neo-ai-data/sqlite/memory-core-graph.sqlite'), 'NEO_MEMORY_DB_PATH', 'string'),
+                /**
+                 * Unit-test graph path: in-memory SQLite (ephemeral, per-process). Declarative leaf.
+                 * @type {string}
+                 */
+                graphTest      : leaf(':memory:', 'NEO_MEMORY_DB_PATH_TEST', 'string'),
+                /**
+                 * Test-mode toggle (env-driven via `UNIT_TEST_MODE`). The `storagePaths.graph` formula
+                 * reads this to select `graphTest` (true) or `graphProd` (false) — safe-by-construction.
+                 * @type {boolean}
+                 */
+                useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean')
             },
             /**
              * Durable wake-daemon watermarks consumed by GraphLog maintenance.
@@ -322,6 +343,20 @@ class Config extends BaseConfig {
              * @type {string}
              */
             lazyEdgesQueuePath: leaf(path.resolve(cwd, 'ai/data/memory-core/lazy-edges.jsonl'), 'NEO_LAZY_EDGES_QUEUE_PATH', 'string')
+        },
+        /**
+         * Reactive computed config values (`Neo.state.Provider` formulas — recompute when a dependency changes).
+         */
+        formulas: {
+            /**
+             * The active graph SQLite path, resolved BY CONSTRUCTION from the test-mode toggle.
+             * Consumers read `AiConfig.storagePaths.graph` (this) unchanged — the single resolution
+             * point, reactive on `storagePaths.useTestDatabase`. Replaces the prior inline-`process.env`
+             * leaf ternary so test isolation is by construction, not per-consumer.
+             * @param {Object} data Hierarchical data proxy.
+             * @returns {String}
+             */
+            'storagePaths.graph': data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest : data.storagePaths.graphProd
         }
     }
 }

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -56,14 +56,6 @@ const SCAN_ROOT_REL            = 'ai';
 export const BASELINE = Object.freeze([
     Object.freeze({
         file   : 'ai/mcp/server/memory-core/config.template.mjs',
-        env    : 'NEO_MEMORY_DB_PATH',
-        ticket : '#12451',
-        reshape: 'Static. Fold the sqlite path as the leaf default; the unit suite sets NEO_MEMORY_DB_PATH=:memory:. ' +
-                 'Verify a UNIT_TEST_MODE guard on the graph store before relocating — unlike Chroma, a missed ' +
-                 'override here may write the real graph db rather than fail loud.'
-    }),
-    Object.freeze({
-        file   : 'ai/mcp/server/memory-core/config.template.mjs',
         env    : 'NEO_MEMORY_COLLECTION_NAME',
         ticket : '#12451',
         reshape: 'Dynamic (harder sub-case). The per-worker-unique test collection name (Date.now()/Math.random()) ' +

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -207,4 +207,16 @@ test.describe('Memory Core Config (#10010)', () => {
             /\[Config\] Invalid NEO_MEMORY_SHARING_DEFAULT_POLICY value: "public"\. Must be one of: legacy, private, team/
         );
     });
+
+    test('storagePaths.graph resolves by construction from the useTestDatabase toggle (ADR 0019 §A4/A8; #12491)', () => {
+        // The reshape replaced the inline `process.env.UNIT_TEST_MODE ? ':memory:' : prod` leaf ternary
+        // with two declarative leaves + a formula. Under the unit suite (UNIT_TEST_MODE=true) the toggle
+        // resolves true and the `storagePaths.graph` formula returns `graphTest` — self-validating
+        // safe-by-construction isolation (the ~10 graph-path consumers read this one resolved value).
+        expect(config.storagePaths.useTestDatabase).toBe(true);
+        expect(config.storagePaths.graphTest).toBe(':memory:');
+        expect(config.storagePaths.graphProd).toContain('.neo-ai-data/sqlite/memory-core-graph.sqlite');
+        expect(config.storagePaths.graph).toBe(':memory:');
+        expect(config.storagePaths.graph).toBe(config.storagePaths.graphTest);
+    });
 });

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -65,9 +65,12 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
     const fileOf = (file, source) => ({file, source});
 
     test('a baselined violation is suppressed (no new violations)', () => {
+        // Derive the fixture from a live BASELINE row so this test does not churn each time a
+        // specific env is reshaped + dropped (it broke on NEO_CHROMA_DATABASE, then NEO_MEMORY_DB_PATH).
+        const [baselined] = BASELINE;
         const files = [fileOf(
-            'ai/mcp/server/memory-core/config.template.mjs',
-            `graph: leaf(process.env.UNIT_TEST_MODE === 'true' ? ':memory:' : '/x.sqlite', 'NEO_MEMORY_DB_PATH', 'string')`
+            baselined.file,
+            `x: leaf(process.env.UNIT_TEST_MODE === 'true' ? 'a' : 'b', '${baselined.env}', 'string')`
         )];
 
         const {violations, newViolations} = lintConfigTemplateSsot({files});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), /lead-role. MC session `f5432f03-d2b6-4bc0-a7b5-9fbdafe4b7b9`.

Resolves #12491

Refs #12451
Refs #12456

Second declarative-reshape burndown of #12451 (chroma was #12480 / #12481). Makes the memory-core `storagePaths.graph` leaf declarative + safe-by-construction, replacing the inline `process.env.UNIT_TEST_MODE ? ':memory:' : prod` ternary.

Evidence: L2 (unit specs + SSOT lint) → L2 required (the config-contract + formula-resolution ACs are unit-coverable). No residuals.

## What shipped — declarative leaves + a config-resolved formula
The graph DB-path has **~10 consumers** (GraphService open, DatabaseService destructive-op guard, Server diagnostic, 5 maintenance scripts, analyzeNlTelemetry) — unlike chroma's single consumer (`ChromaManager`). So the selection lives **in the config**, not per-consumer:
```js
storagePaths: {
    graphProd      : leaf('<prod sqlite path>', 'NEO_MEMORY_DB_PATH', 'string'),
    graphTest      : leaf(':memory:', 'NEO_MEMORY_DB_PATH_TEST', 'string'),
    useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean')
}
formulas: {
    'storagePaths.graph': data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest : data.storagePaths.graphProd
}
```
All ~10 consumers keep reading `AiConfig.storagePaths.graph` (now the formula result) **unchanged** — test isolation is by construction, no inline `process.env` in a leaf default. Maintenance scripts run without `UNIT_TEST_MODE` → resolve `graphProd` (the real DB — correct).

Design per **ADR 0019** §3 (A4: inline-`process.env` leaf ternary; A8: the `storagePaths.graph` tangle → "test-mode by construction") + §5.3 (formulas for genuine reactive computed values). This is the **first `ai/`-config formula** — `config.template.spec` proves it resolves; the regenerated overlay (`config.mjs`) carries the formula + leaves directly, so runtime consumers reading `AiConfig.storagePaths.graph` get the resolved value (see Test Evidence).

## Contract Ledger
| Surface | Type | Contract |
| :--- | :--- | :--- |
| `storagePaths.graphProd` | config leaf | Prod graph sqlite path. Literal default; env `NEO_MEMORY_DB_PATH`. |
| `storagePaths.graphTest` | config leaf | Test path `:memory:`. Literal default; env `NEO_MEMORY_DB_PATH_TEST`. |
| `storagePaths.useTestDatabase` | config leaf | Toggle. Default `false`; env `UNIT_TEST_MODE` (boolean). |
| `storagePaths.graph` | formula | `useTestDatabase ? graphTest : graphProd`. The single resolution point; consumers read it unchanged. |

## Test Evidence
- `config.template.spec.mjs` — **9 passed**, incl. the new self-validating test: under the unit suite `storagePaths.graph === ':memory:'` (=== `graphTest`), `useTestDatabase === true`, `graphProd` = the prod path.
- `GraphService.spec.mjs` — **26 passed**: a consumer-boundary **health** check (the runtime consumer reads the `storagePaths.graph` slot fine). *Per @neo-gpt's review:* this spec overrides `aiConfig.storagePaths.graph` before importing GraphService (a pre-existing B4 mutation, #12435's domain), so it does **not** exercise the formula — it is not formula-propagation proof. The formula proof is `config.template.spec` above; runtime propagation is verified by the regenerated overlay (`config.mjs`) carrying the formula directly (lines 132-143 + the `formulas` block).
- SSOT lint — `OK - 2 inline-env leaf default(s), all baselined` (the graph leaf is now declarative; only the deferred dynamic collection-names remain).

## Deltas
Resolves #12491 fully — the static graph DB-path is declarative + safe-by-construction. Two AC items deferred by design (see Scope): the optional fail-closed guard (the formula is the primary safe-by-construction) and the dynamic collection-names (separate baselined leaf). Follow-up commit `d2b9c7d8c` derived the `lintConfigTemplateSsot` baselined-fixture from `BASELINE[0]` so dropping the `NEO_MEMORY_DB_PATH` baseline row didn't break the lint's own spec (recurring reshape churn, now fixed). The CI `WriteSideInvariant` failure (`@neo-test-receiver` identity-format) reads as a pre-existing flake — unrelated to this change, passes locally.

## Scope + deferred
- **STATIC graph DB-path only.** The **dynamic** collection-names (`NEO_MEMORY_COLLECTION_NAME` / `NEO_SESSION_COLLECTION_NAME`, `${Date.now()}-${Math.random()}` per-run uniqueness) need a per-worker bootstrap → separate harder leaf, still baselined.
- **Fail-closed guard deferred (optional).** The formula provides safe-by-construction (under `UNIT_TEST_MODE` → `:memory:`); a GraphService connect-time guard (refuse `graphProd` under the toggle) would be defense-in-depth parity with chroma — deferred as optional (the baseline note's "verify a guard" concern was about env-relocation, which this formula avoids). Reviewer's call if it should land here.

## Rollout Note (existing checkouts / worktrees)
Existing checkouts/worktrees with a stale gitignored `ai/config.mjs` must refresh before the new leaves/formula resolve at runtime: `npm run prepare -- --migrate-config` (or `node ai/scripts/setup/initServerConfigs.mjs --migrate-config`); worktrees via `ai/scripts/migrations/bootstrapWorktree.mjs`. CI regenerates via `prepare`. (Verified locally: `--migrate-config` refreshed the overlay + GraphService.spec passed.)

## Post-Merge Validation
- [ ] Unit + integration suites green (the formula propagates to all graph-path consumers).
- [ ] `#12451` umbrella body updated: the env-relocation reshape note is superseded by by-construction config resolution (this PR's precedent).
- [ ] (friction→gold) `check-ticket-archaeology` false-positives on durable `ADR NNNN` refs (it flagged my ADR-0019 citations as ticket-archaeology) — consider exempting `ADR \d+`.
