### PR TITLE
feat(agentos): add skill reference integrity lint (#12493)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -138,6 +138,7 @@ Map vs World Atlas applies **recursively**. A workflow file (`references/<workfl
 - Default: 25,000 bytes (25 KB) — empirical-floor for clean skills
 - Temporary per-skill overrides for migration-period monoliths (e.g., `pr-review` at 66000, `pull-request` at 38000) — to be tightened as Sub-B+ migrations land
 - `checkSectionTriggers` heuristic: sections larger than 5,000 bytes declaring a rare-firing trigger (e.g., 'openapi', 'audit', 'deprecation', 'edge-case') are flagged for extraction to a sibling file.
+- Skill reference integrity: changed skill text surfaces (Markdown plus manifest prose) must not leave dangling numeric section refs to sibling skill files, broken relative Markdown pointers, or refs to files deleted in the same diff. Fix the reference in the same PR instead of relying on review cycles to catch anchor churn.
 
 **Empirical precedent:**
 - `pull-request` skill: workflow + 4 sub-rule siblings (`env-var-rename-rule.md`, `mcp-config-template-change-guide.md`, `sync-all-constraints.md`, `review-response-protocol.md`) — each conditionally loaded per workflow body trigger pointer

--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -279,6 +279,225 @@ function checkSectionTriggers(filePath, text, rarePatterns = []) {
     return {errors, index};
 }
 
+function stripFencedCodeBlocks(text) {
+    let inFence = false;
+
+    return text.split('\n').map(line => {
+        if (/^\s*```/.test(line)) {
+            inFence = !inFence;
+            return '';
+        }
+
+        return inFence ? '' : line;
+    }).join('\n');
+}
+
+function normalizeRelPath(filePath) {
+    return path.normalize(filePath).replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function extractHeadingAnchors(text) {
+    const anchors = new Set();
+
+    for (const line of text.split('\n')) {
+        const match = line.match(/^#{1,6}\s+(?:§)?(\d+(?:\.\d+)*)(?:\b|[^\d.])/);
+
+        if (match) {
+            anchors.add(match[1]);
+        }
+    }
+
+    return anchors;
+}
+
+function addBasenameIndexEntry(index, relPath) {
+    const basename = path.basename(relPath, '.md');
+    const current  = index.get(basename);
+
+    if (current === undefined) {
+        index.set(basename, relPath);
+    } else if (current !== relPath) {
+        index.set(basename, null);
+    }
+}
+
+function buildSkillReferenceIndex(files, extraMarkdownRelPaths = []) {
+    const byRelPath     = new Map();
+    const basenameIndex = new Map();
+    const headingIndex  = new Map();
+
+    for (const file of files) {
+        const relPath = normalizeRelPath(file.relPath);
+
+        byRelPath.set(relPath, file.text);
+
+        if (!relPath.endsWith('.md')) continue;
+
+        headingIndex.set(relPath, extractHeadingAnchors(file.text));
+
+        addBasenameIndexEntry(basenameIndex, relPath);
+    }
+
+    for (const relPath of extraMarkdownRelPaths.map(normalizeRelPath)) {
+        if (relPath.endsWith('.md')) {
+            addBasenameIndexEntry(basenameIndex, relPath);
+        }
+    }
+
+    return {basenameIndex, byRelPath, headingIndex};
+}
+
+function resolveSkillMarkdownTarget(rawTarget, sourceRelPath, index) {
+    if (!rawTarget || /^(https?:|mailto:|#)/.test(rawTarget)) return null;
+    if (rawTarget.includes('*')) return null;
+    if (/[<>{}[\]]/.test(rawTarget)) return null;
+
+    const target = rawTarget.replace(/^`|`$/g, '').replace(/[#?].*$/, '');
+    let relPath  = null;
+
+    if (target.startsWith('.agents/skills/')) {
+        relPath = target;
+    } else if (target.startsWith('./') || target.startsWith('../') || target.startsWith('references/')) {
+        relPath = path.join(path.dirname(sourceRelPath), target);
+    } else if (target.endsWith('.md') && target.includes('/')) {
+        relPath = target;
+    } else {
+        const basename = target.endsWith('.md') ? path.basename(target, '.md') : target;
+        relPath = index.basenameIndex.get(basename);
+    }
+
+    if (!relPath) return null;
+
+    relPath = normalizeRelPath(relPath);
+
+    return relPath.startsWith('.agents/skills/') ? relPath : null;
+}
+
+function collectMarkdownPointerTargets(line) {
+    const targets = new Set();
+    const patterns = [
+        /\[[^\]]+\]\(([^)\s]+\.md(?:#[^)]+)?)\)/g,
+        /<!--\s*trigger:[\s\S]*?\bread\s+([^\s]+\.md)\s*-->/g,
+        /`((?:\.agents\/skills\/|references\/|\.\/|\.\.\/)[^`\s]+\.md(?:#[^`]*)?)`/g,
+        /(?:^|[\s(])((?:references\/|\.\/|\.\.\/)[^\s)`]+\.md(?:#[^\s)`]+)?)/g
+    ];
+
+    for (const pattern of patterns) {
+        let match;
+
+        while ((match = pattern.exec(line))) {
+            targets.add(match[1]);
+        }
+    }
+
+    return [...targets];
+}
+
+/**
+ * @summary Checks changed skill substrate text for resolvable Markdown pointers and numeric section references.
+ *
+ * Manifest prose can be a source of references, but target anchors intentionally stay Markdown-only.
+ *
+ * @param {String[]} changedRelPaths
+ * @param {Array<{relPath: String, text: String}>} allMarkdownFiles
+ * @returns {String[]}
+ */
+function checkSkillReferenceIntegrity(changedRelPaths, allMarkdownFiles) {
+    const errors = [];
+    const index  = buildSkillReferenceIndex(allMarkdownFiles);
+
+    for (const sourceRelPath of changedRelPaths.map(normalizeRelPath).sort()) {
+        const sourceText = index.byRelPath.get(sourceRelPath);
+
+        if (!sourceText) continue;
+
+        const lines = stripFencedCodeBlocks(sourceText).split('\n');
+
+        lines.forEach((line, lineIndex) => {
+            const lineNo = lineIndex + 1;
+
+            for (const target of collectMarkdownPointerTargets(line)) {
+                const targetRelPath = resolveSkillMarkdownTarget(target, sourceRelPath, index);
+
+                if (targetRelPath && !index.byRelPath.has(targetRelPath)) {
+                    errors.push(`${sourceRelPath}:${lineNo} → broken file pointer ${target}`);
+                }
+            }
+
+            const sectionRefPattern = /(?:(\.agents\/skills\/[A-Za-z0-9_.\/-]+|(?:\.{1,2}\/|references\/)[A-Za-z0-9_.\/-]+|[A-Za-z0-9_.-]+(?:\.md)?)\s+)?§(\d+\.\d+(?:\.\d+)*)/g;
+            let match;
+
+            while ((match = sectionRefPattern.exec(line))) {
+                const targetRelPath = match[1]
+                    ? resolveSkillMarkdownTarget(match[1], sourceRelPath, index)
+                    : sourceRelPath.endsWith('.md')
+                        ? sourceRelPath
+                        : null;
+
+                if (!targetRelPath) continue;
+                if (!index.byRelPath.has(targetRelPath)) {
+                    errors.push(`${sourceRelPath}:${lineNo} → broken section-ref target ${match[1]} for §${match[2]}`);
+                    continue;
+                }
+
+                const anchors = index.headingIndex.get(targetRelPath);
+                if (!anchors) continue;
+                if (!anchors.has(match[2])) {
+                    const targetLabel = match[1] ? `${match[1]} ` : '';
+                    errors.push(`${sourceRelPath}:${lineNo} → dangling section ref ${targetLabel}§${match[2]} (target lacks matching heading)`);
+                }
+            }
+        });
+    }
+
+    return errors;
+}
+
+function checkRemovedSkillFileReferences(removedRelPaths, allTextFiles) {
+    const removed = new Set(removedRelPaths
+        .map(normalizeRelPath)
+        .filter(relPath => relPath.startsWith('.agents/skills/') && relPath.endsWith('.md')));
+
+    if (removed.size === 0) return [];
+
+    const errors = [];
+    const index  = buildSkillReferenceIndex(allTextFiles, [...removed]);
+
+    for (const sourceRelPath of allTextFiles.map(file => normalizeRelPath(file.relPath)).sort()) {
+        if (removed.has(sourceRelPath)) continue;
+
+        const sourceText = index.byRelPath.get(sourceRelPath);
+        if (!sourceText) continue;
+
+        const lines = stripFencedCodeBlocks(sourceText).split('\n');
+
+        lines.forEach((line, lineIndex) => {
+            const lineNo = lineIndex + 1;
+
+            for (const target of collectMarkdownPointerTargets(line)) {
+                const targetRelPath = resolveSkillMarkdownTarget(target, sourceRelPath, index);
+
+                if (targetRelPath && removed.has(targetRelPath)) {
+                    errors.push(`${sourceRelPath}:${lineNo} → reference to deleted file ${target}`);
+                }
+            }
+
+            const sectionRefPattern = /(\.agents\/skills\/[A-Za-z0-9_.\/-]+|(?:\.{1,2}\/|references\/)[A-Za-z0-9_.\/-]+|[A-Za-z0-9_.-]+(?:\.md)?)\s+§\d+\.\d+(?:\.\d+)*/g;
+            let match;
+
+            while ((match = sectionRefPattern.exec(line))) {
+                const targetRelPath = resolveSkillMarkdownTarget(match[1], sourceRelPath, index);
+
+                if (targetRelPath && removed.has(targetRelPath)) {
+                    errors.push(`${sourceRelPath}:${lineNo} → reference to deleted file ${match[1]}`);
+                }
+            }
+        });
+    }
+
+    return errors;
+}
+
 function validateManifestSchema(manifest, schema) {
     const errors = [];
     const rootKeys = new Set([...schema.required, '$schema']);
@@ -452,6 +671,33 @@ function changedFiles(base) {
     }
 }
 
+function removedFiles(base) {
+    if (!base) return [];
+
+    try {
+        const output = execFileSync('git', ['diff', '--name-status', `${base}...HEAD`], {
+            cwd     : ROOT_DIR,
+            encoding: 'utf8'
+        });
+        const removed = [];
+
+        for (const line of output.split('\n').filter(Boolean)) {
+            const parts  = line.split('\t');
+            const status = parts[0];
+
+            if (status === 'D') {
+                removed.push(parts[1]);
+            } else if (/^R\d+/.test(status)) {
+                removed.push(parts[1]);
+            }
+        }
+
+        return removed.sort();
+    } catch (error) {
+        throw new Error(`Unable to compute removed files${base ? ` against ${base}` : ''}: ${error.message}`);
+    }
+}
+
 function getBaseFileSize(base, filePath) {
     try {
         const output = execFileSync('git', ['cat-file', '-s', `${base}:${filePath}`], {
@@ -598,6 +844,32 @@ async function lint({base = null} = {}) {
         }
     }
 
+    if (base) {
+        const allSkillTextFiles = (await walkFiles(SKILLS_DIR))
+            .filter(filePath => filePath.endsWith('.md'))
+            .map(filePath => ({
+                relPath: path.relative(ROOT_DIR, filePath),
+                text   : requireText(filePath)
+            }));
+        const manifestPath = path.join(SKILLS_DIR, 'skills.manifest.json');
+
+        if (existsSync(manifestPath)) {
+            allSkillTextFiles.push({
+                relPath: path.relative(ROOT_DIR, manifestPath),
+                text   : requireText(manifestPath)
+            });
+        }
+
+        const changedSkillTextFiles = [...changed]
+            .filter(filePath => filePath === '.agents/skills/skills.manifest.json' ||
+                                (filePath.startsWith('.agents/skills/') && filePath.endsWith('.md')));
+        const removedSkillMarkdownFiles = removedFiles(base)
+            .filter(filePath => filePath.startsWith('.agents/skills/') && filePath.endsWith('.md'));
+
+        errors.push(...checkSkillReferenceIntegrity(changedSkillTextFiles, allSkillTextFiles));
+        errors.push(...checkRemovedSkillFileReferences(removedSkillMarkdownFiles, allSkillTextFiles));
+    }
+
     return errors;
 }
 
@@ -632,7 +904,9 @@ if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
 export {
     checkOversizedWorkflowMaps,
     checkPerFileBudgets,
+    checkRemovedSkillFileReferences,
     checkSectionTriggers,
+    checkSkillReferenceIntegrity,
     classifySizeReportRow,
     formatSkillMarkdownSizeReport,
     parseSectionTriggers,

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -5,7 +5,9 @@ import path                      from 'path';
 import {
     checkOversizedWorkflowMaps,
     checkPerFileBudgets,
+    checkRemovedSkillFileReferences,
     checkSectionTriggers,
+    checkSkillReferenceIntegrity,
     classifySizeReportRow,
     formatSkillMarkdownSizeReport,
     parseArgs,
@@ -465,5 +467,120 @@ ${padding}
 
         const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
         expect(errors).toEqual([]);
+    });
+
+    test('checkSkillReferenceIntegrity flags dangling numeric section refs (#12493)', () => {
+        const files = [{
+            relPath: '.agents/skills/pr-review/references/pr-review-guide.md',
+            text   : [
+                '## 9. Strategic Fit',
+                '### 9.0 Premise Pre-Flight',
+                'Valid same-file ref: §9.0.',
+                'Invalid same-file ref: §9.2.'
+            ].join('\n')
+        }, {
+            relPath: '.agents/skills/pull-request/references/review-response-protocol.md',
+            text   : [
+                'Valid: pr-review-guide §9.0.',
+                'Invalid: pr-review-guide §10.4.'
+            ].join('\n')
+        }];
+
+        const errors = checkSkillReferenceIntegrity([
+            '.agents/skills/pr-review/references/pr-review-guide.md',
+            '.agents/skills/pull-request/references/review-response-protocol.md'
+        ], files);
+
+        expect(errors).toHaveLength(2);
+        expect(errors[0]).toContain('pr-review-guide.md:4');
+        expect(errors[0]).toContain('dangling section ref §9.2');
+        expect(errors[1]).toContain('review-response-protocol.md:2');
+        expect(errors[1]).toContain('dangling section ref pr-review-guide §10.4');
+    });
+
+    test('checkSkillReferenceIntegrity scans manifest prose refs as source text (#12493)', () => {
+        const files = [{
+            relPath: '.agents/skills/pr-review/references/pr-review-guide.md',
+            text   : '## 10. A2A Comment-ID Hand-off\n'
+        }, {
+            relPath: '.agents/skills/skills.manifest.json',
+            text   : '{"description":"Review handoff per pr-review-guide §10.5"}'
+        }];
+
+        const errors = checkSkillReferenceIntegrity([
+            '.agents/skills/skills.manifest.json'
+        ], files);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('skills.manifest.json:1');
+        expect(errors[0]).toContain('dangling section ref pr-review-guide §10.5');
+    });
+
+    test('checkSkillReferenceIntegrity flags broken relative markdown pointers (#12493)', () => {
+        const files = [{
+            relPath: '.agents/skills/pull-request/references/pull-request-workflow.md',
+            text   : [
+                'Valid: [response](./review-response-protocol.md).',
+                'Broken: [missing](./missing-rule.md).',
+                'Broken bare relative pointer: ./also-missing.md',
+                'Example fence ignored:',
+                '```md',
+                '[template](./fenced-missing.md)',
+                '```'
+            ].join('\n')
+        }, {
+            relPath: '.agents/skills/pull-request/references/review-response-protocol.md',
+            text   : '# Review Response Protocol\n'
+        }];
+
+        const errors = checkSkillReferenceIntegrity([
+            '.agents/skills/pull-request/references/pull-request-workflow.md'
+        ], files);
+
+        expect(errors).toHaveLength(2);
+        expect(errors[0]).toContain('pull-request-workflow.md:2');
+        expect(errors[0]).toContain('broken file pointer ./missing-rule.md');
+        expect(errors[1]).toContain('pull-request-workflow.md:3');
+        expect(errors[1]).toContain('broken file pointer ./also-missing.md');
+    });
+
+    test('checkSkillReferenceIntegrity ignores external refs, ticket refs, and unresolved prose (#12493)', () => {
+        const files = [{
+            relPath: '.agents/skills/example/references/example-workflow.md',
+            text   : [
+                'Ticket #12488 and ADR 0019 §A4 are descriptive refs.',
+                'External [doc](https://example.com/a.md) is out of scope.',
+                'Wildcard authoring prose like `references/*.md` is not a concrete pointer.',
+                'Generic guide §7 wording has no resolvable target and is ignored.'
+            ].join('\n')
+        }];
+
+        expect(checkSkillReferenceIntegrity([
+            '.agents/skills/example/references/example-workflow.md'
+        ], files)).toEqual([]);
+    });
+
+    test('checkRemovedSkillFileReferences flags surviving refs to deleted skill files (#12493)', () => {
+        const files = [{
+            relPath: '.agents/skills/pull-request/references/pull-request-workflow.md',
+            text   : [
+                'Deleted relative pointer: [old](./removed-rule.md).',
+                'Deleted basename section ref: removed-rule §2.1.',
+                'Live pointer: [response](./review-response-protocol.md).'
+            ].join('\n')
+        }, {
+            relPath: '.agents/skills/pull-request/references/review-response-protocol.md',
+            text   : '# Review Response Protocol\n'
+        }];
+
+        const errors = checkRemovedSkillFileReferences([
+            '.agents/skills/pull-request/references/removed-rule.md'
+        ], files);
+
+        expect(errors).toHaveLength(2);
+        expect(errors[0]).toContain('pull-request-workflow.md:1');
+        expect(errors[0]).toContain('reference to deleted file ./removed-rule.md');
+        expect(errors[1]).toContain('pull-request-workflow.md:2');
+        expect(errors[1]).toContain('reference to deleted file removed-rule');
     });
 });


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Resolves #12493

Adds base-scoped skill reference-integrity checks folded into `lint-skill-manifest`: changed skill text now catches dangling decimal section refs, broken relative Markdown pointers, manifest-prose refs, and surviving references to deleted or renamed skill Markdown targets.

Evidence: L1 (static lint plus focused unit coverage for the deterministic reference resolver) → L1 required (CI-scoped skill reference guard). No residuals.

## Slot Rationale
- `.agents/skills/create-skill/references/skill-authoring-guide.md`: disposition `keep -> keep` inside conditional `create-skill` payload; rating medium trigger-frequency x medium failure-severity x high enforceability. The delta is one mechanical-enforcement note documenting the new lint, with no always-loaded router expansion.
- `ai/scripts/lint/lint-skill-manifest.mjs` and its unit coverage add mechanical enforcement outside turn-loaded instruction substrate.

Decision Record impact: `none`.

## Deltas from ticket
- Folded the check into `lint-skill-manifest` instead of adding a separate command, so the existing CI path covers `.agents/skills/**` diffs.
- Includes same-file decimal refs like `§9.0`, named target refs like `pr-review-guide §10.4`, Markdown links, bare `./*.md` prose pointers, manifest prose refs, and deleted/renamed target survivor refs.
- Narrows bare same-file detection to decimal `§N.x` and deeper to avoid false positives on measurement citations such as `§7`; named decimal refs remain validated against target headings.

## Test Evidence
- `node --check ai/scripts/lint/lint-skill-manifest.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` passed: 30/30.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` passed.
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` passed.
- `git diff --check` passed.
- Pre-push freshness check passed after rebase: `merge-base HEAD origin/dev == origin/dev`; outgoing branch history contains only `4e83c27f1 feat(agentos): add skill reference integrity lint (#12493)`.

## Post-Merge Validation
- [ ] CI `lint-skill-manifest` rejects a future `.agents/skills/**` PR that leaves a dangling decimal section ref, broken relative Markdown pointer, or surviving reference to a deleted skill Markdown file.

## Commit
- `4e83c27f1` — `feat(agentos): add skill reference integrity lint (#12493)`