### PR TITLE
refactor(ai): resolve memory-core collection-names declaratively via toggle+formula (#12499)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -22,6 +22,13 @@ const cwd               = neoRootDir;
 const wakeDaemonDataDir = path.resolve(process.env.NEO_AI_DAEMON_DIR || path.resolve(cwd, '.neo-ai-data/wake-daemon'));
 const DAY_MS            = 24 * 60 * 60 * 1000;
 
+// Per-worker-unique test collection names, generated at config-load. Each playwright worker is a
+// separate process that re-evaluates this module → its own unique names, so fullyParallel workers
+// never collide on a shared collection. Generated here (not inside a `process.env` leaf default) so
+// the leaves stay declarative; selection is the `collections.useTestDatabase` toggle + formulas below.
+const testMemoryCollection  = `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+const testSessionCollection = `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+
 /**
  * @summary Configuration manager for the Memory Core MCP server.
  *
@@ -155,9 +162,20 @@ class Config extends BaseConfig {
              * This defines WHAT the tables/collections are called logically.
              */
             collections: {
-                memory : leaf(process.env.UNIT_TEST_MODE === 'true' ? `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-memory', 'NEO_MEMORY_COLLECTION_NAME', 'string'),
-                session: leaf(process.env.UNIT_TEST_MODE === 'true' ? `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}` : 'neo-agent-sessions', 'NEO_SESSION_COLLECTION_NAME', 'string'),
-                graph  : leaf('neo-native-graph', 'NEO_GRAPH_COLLECTION_NAME', 'string')
+                /**
+                 * `memory` / `session` (the active names consumers read) are formulas (below) resolving
+                 * `*Prod` / `*Test` by construction from `useTestDatabase` — no inline `process.env` in a
+                 * leaf default. The test names are per-worker-unique (module consts above) for fullyParallel
+                 * isolation; consumers (HealthService, ChromaManager, defragChromaDB) read `collections.memory`
+                 * / `session` unchanged.
+                 * @type {string}
+                 */
+                memoryProd     : leaf('neo-agent-memory', 'NEO_MEMORY_COLLECTION_NAME', 'string'),
+                memoryTest     : leaf(testMemoryCollection, 'NEO_MEMORY_COLLECTION_NAME_TEST', 'string'),
+                sessionProd    : leaf('neo-agent-sessions', 'NEO_SESSION_COLLECTION_NAME', 'string'),
+                sessionTest    : leaf(testSessionCollection, 'NEO_SESSION_COLLECTION_NAME_TEST', 'string'),
+                useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean'),
+                graph          : leaf('neo-native-graph', 'NEO_GRAPH_COLLECTION_NAME', 'string')
             },
             /**
              * Datasets Schema/Paths
@@ -356,7 +374,16 @@ class Config extends BaseConfig {
              * @param {Object} data Hierarchical data proxy.
              * @returns {String}
              */
-            'storagePaths.graph': data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest : data.storagePaths.graphProd
+            'storagePaths.graph': data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest : data.storagePaths.graphProd,
+            /**
+             * The active memory/session collection names, resolved BY CONSTRUCTION from the test-mode
+             * toggle. Consumers read `AiConfig.collections.memory` / `session` (these) unchanged; the test
+             * names are per-worker-unique (module consts). Replaces the prior inline-`process.env` ternaries.
+             * @param {Object} data Hierarchical data proxy.
+             * @returns {String}
+             */
+            'collections.memory' : data => data.collections.useTestDatabase ? data.collections.memoryTest  : data.collections.memoryProd,
+            'collections.session': data => data.collections.useTestDatabase ? data.collections.sessionTest : data.collections.sessionProd
         }
     }
 }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -30,17 +30,6 @@ const testMemoryCollection  = `test-memory-${Date.now()}-${Math.random().toStrin
 const testSessionCollection = `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 
 /**
- * Test-mode value selectors for the reactive `formulas` below — extracted as named exports so the
- * reactive contract (re-resolution when `useTestDatabase` flips) is directly testable. Each picks the
- * active value from its test/prod leaf pair, driven by the resolved `useTestDatabase` toggle.
- * @param {Object} data Hierarchical data proxy.
- * @returns {String}
- */
-export const graphPathFormula          = data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest  : data.storagePaths.graphProd;
-export const collectionsMemoryFormula  = data => data.collections.useTestDatabase  ? data.collections.memoryTest   : data.collections.memoryProd;
-export const collectionsSessionFormula = data => data.collections.useTestDatabase  ? data.collections.sessionTest  : data.collections.sessionProd;
-
-/**
  * @summary Configuration manager for the Memory Core MCP server.
  *
  * Supports loading configuration from a custom file and merging with defaults.
@@ -378,12 +367,12 @@ class Config extends BaseConfig {
          */
         formulas: {
             // The active graph SQLite path + memory/session collection names, resolved BY CONSTRUCTION
-            // from the `useTestDatabase` toggle via the reactive selectors above. Consumers read
-            // `AiConfig.storagePaths.graph` / `collections.memory` / `collections.session` unchanged —
-            // the single resolution point. Replaces the prior inline-`process.env` leaf ternaries.
-            'storagePaths.graph' : graphPathFormula,
-            'collections.memory' : collectionsMemoryFormula,
-            'collections.session': collectionsSessionFormula
+            // from the `useTestDatabase` toggle. Consumers read `AiConfig.storagePaths.graph` /
+            // `collections.memory` / `collections.session` unchanged — the single resolution point.
+            // Replaces the prior inline-`process.env` leaf ternaries.
+            'storagePaths.graph' : data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest  : data.storagePaths.graphProd,
+            'collections.memory' : data => data.collections.useTestDatabase  ? data.collections.memoryTest   : data.collections.memoryProd,
+            'collections.session': data => data.collections.useTestDatabase  ? data.collections.sessionTest  : data.collections.sessionProd
         }
     }
 }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -30,6 +30,17 @@ const testMemoryCollection  = `test-memory-${Date.now()}-${Math.random().toStrin
 const testSessionCollection = `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 
 /**
+ * Test-mode value selectors for the reactive `formulas` below — extracted as named exports so the
+ * reactive contract (re-resolution when `useTestDatabase` flips) is directly testable. Each picks the
+ * active value from its test/prod leaf pair, driven by the resolved `useTestDatabase` toggle.
+ * @param {Object} data Hierarchical data proxy.
+ * @returns {String}
+ */
+export const graphPathFormula          = data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest  : data.storagePaths.graphProd;
+export const collectionsMemoryFormula  = data => data.collections.useTestDatabase  ? data.collections.memoryTest   : data.collections.memoryProd;
+export const collectionsSessionFormula = data => data.collections.useTestDatabase  ? data.collections.sessionTest  : data.collections.sessionProd;
+
+/**
  * @summary Configuration manager for the Memory Core MCP server.
  *
  * Supports loading configuration from a custom file and merging with defaults.
@@ -366,24 +377,13 @@ class Config extends BaseConfig {
          * Reactive computed config values (`Neo.state.Provider` formulas — recompute when a dependency changes).
          */
         formulas: {
-            /**
-             * The active graph SQLite path, resolved BY CONSTRUCTION from the test-mode toggle.
-             * Consumers read `AiConfig.storagePaths.graph` (this) unchanged — the single resolution
-             * point, reactive on `storagePaths.useTestDatabase`. Replaces the prior inline-`process.env`
-             * leaf ternary so test isolation is by construction, not per-consumer.
-             * @param {Object} data Hierarchical data proxy.
-             * @returns {String}
-             */
-            'storagePaths.graph': data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest : data.storagePaths.graphProd,
-            /**
-             * The active memory/session collection names, resolved BY CONSTRUCTION from the test-mode
-             * toggle. Consumers read `AiConfig.collections.memory` / `session` (these) unchanged; the test
-             * names are per-worker-unique (module consts). Replaces the prior inline-`process.env` ternaries.
-             * @param {Object} data Hierarchical data proxy.
-             * @returns {String}
-             */
-            'collections.memory' : data => data.collections.useTestDatabase ? data.collections.memoryTest  : data.collections.memoryProd,
-            'collections.session': data => data.collections.useTestDatabase ? data.collections.sessionTest : data.collections.sessionProd
+            // The active graph SQLite path + memory/session collection names, resolved BY CONSTRUCTION
+            // from the `useTestDatabase` toggle via the reactive selectors above. Consumers read
+            // `AiConfig.storagePaths.graph` / `collections.memory` / `collections.session` unchanged —
+            // the single resolution point. Replaces the prior inline-`process.env` leaf ternaries.
+            'storagePaths.graph' : graphPathFormula,
+            'collections.memory' : collectionsMemoryFormula,
+            'collections.session': collectionsSessionFormula
         }
     }
 }

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -54,20 +54,9 @@ const SCAN_ROOT_REL            = 'ai';
  * @type {ReadonlyArray<{file: String, env: String, ticket: String, reshape: String}>}
  */
 export const BASELINE = Object.freeze([
-    Object.freeze({
-        file   : 'ai/mcp/server/memory-core/config.template.mjs',
-        env    : 'NEO_MEMORY_COLLECTION_NAME',
-        ticket : '#12451',
-        reshape: 'Dynamic (harder sub-case). The per-worker-unique test collection name (Date.now()/Math.random()) ' +
-                 'must move to a per-worker test bootstrap, not a static env value — one shared shell-env value would ' +
-                 'collide across fullyParallel workers.'
-    }),
-    Object.freeze({
-        file   : 'ai/mcp/server/memory-core/config.template.mjs',
-        env    : 'NEO_SESSION_COLLECTION_NAME',
-        ticket : '#12451',
-        reshape: 'Dynamic (harder sub-case). Same per-worker-bootstrap relocation as NEO_MEMORY_COLLECTION_NAME.'
-    })
+    // EMPTY — all config.template inline-`process.env` leaf defaults have been reshaped to the
+    // declarative toggle+formula shape. The lint is now FULLY ENFORCING: any NEW inline-`process.env`
+    // leaf default is a fresh violation (no grandfathered instances remain).
 ]);
 
 /**

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -219,4 +219,18 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.storagePaths.graph).toBe(':memory:');
         expect(config.storagePaths.graph).toBe(config.storagePaths.graphTest);
     });
+
+    test('collections.memory/session resolve by construction to per-worker-unique test names under the toggle (#12499)', () => {
+        // The reshape replaced the inline `process.env.UNIT_TEST_MODE ? test-... : prod` leaf ternaries
+        // with *Prod/*Test leaves + formulas; the test names are per-worker-unique module consts. Under
+        // the unit suite (UNIT_TEST_MODE=true) the formulas resolve the test names (never prod).
+        expect(config.collections.useTestDatabase).toBe(true);
+        expect(config.collections.memoryProd).toBe('neo-agent-memory');
+        expect(config.collections.sessionProd).toBe('neo-agent-sessions');
+        expect(config.collections.memory).toMatch(/^test-memory-/);
+        expect(config.collections.session).toMatch(/^test-session-/);
+        expect(config.collections.memory).toBe(config.collections.memoryTest);
+        expect(config.collections.session).toBe(config.collections.sessionTest);
+        expect(config.collections.graph).toBe('neo-native-graph');
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -233,24 +233,4 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.collections.session).toBe(config.collections.sessionTest);
         expect(config.collections.graph).toBe('neo-native-graph');
     });
-
-    test('the reactive formulas select test vs prod by the useTestDatabase toggle — covering the prod branch the unit suite never exercises (#12500)', async () => {
-        // The formulas exist to compute the active value from the test/prod leaf pair; the value assertions
-        // above pin only the TEST branch (the unit suite always runs UNIT_TEST_MODE=true → useTestDatabase
-        // true). The prod branch is otherwise never verified. Exercise the extracted formula fns directly
-        // for BOTH toggle states — the construct-time selection we actually rely on. (The Provider re-invokes
-        // a formula when a dependency changes; that reactive plumbing is covered by Provider's own specs.
-        // Here the toggle is bounded, so the formula is effectively a construct-time derivation.)
-        const {graphPathFormula, collectionsMemoryFormula, collectionsSessionFormula} =
-            await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs');
-
-        expect(graphPathFormula({storagePaths: {useTestDatabase: true,  graphTest: ':memory:', graphProd: '/prod.sqlite'}})).toBe(':memory:');
-        expect(graphPathFormula({storagePaths: {useTestDatabase: false, graphTest: ':memory:', graphProd: '/prod.sqlite'}})).toBe('/prod.sqlite');
-
-        expect(collectionsMemoryFormula({collections: {useTestDatabase: true,  memoryTest: 'unit-mem', memoryProd: 'prod-mem'}})).toBe('unit-mem');
-        expect(collectionsMemoryFormula({collections: {useTestDatabase: false, memoryTest: 'unit-mem', memoryProd: 'prod-mem'}})).toBe('prod-mem');
-
-        expect(collectionsSessionFormula({collections: {useTestDatabase: true,  sessionTest: 'unit-sess', sessionProd: 'prod-sess'}})).toBe('unit-sess');
-        expect(collectionsSessionFormula({collections: {useTestDatabase: false, sessionTest: 'unit-sess', sessionProd: 'prod-sess'}})).toBe('prod-sess');
-    });
 });

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -233,4 +233,24 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.collections.session).toBe(config.collections.sessionTest);
         expect(config.collections.graph).toBe('neo-native-graph');
     });
+
+    test('the reactive formulas select test vs prod by the useTestDatabase toggle — covering the prod branch the unit suite never exercises (#12500)', async () => {
+        // The formulas exist to compute the active value from the test/prod leaf pair; the value assertions
+        // above pin only the TEST branch (the unit suite always runs UNIT_TEST_MODE=true → useTestDatabase
+        // true). The prod branch is otherwise never verified. Exercise the extracted formula fns directly
+        // for BOTH toggle states — the construct-time selection we actually rely on. (The Provider re-invokes
+        // a formula when a dependency changes; that reactive plumbing is covered by Provider's own specs.
+        // Here the toggle is bounded, so the formula is effectively a construct-time derivation.)
+        const {graphPathFormula, collectionsMemoryFormula, collectionsSessionFormula} =
+            await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs');
+
+        expect(graphPathFormula({storagePaths: {useTestDatabase: true,  graphTest: ':memory:', graphProd: '/prod.sqlite'}})).toBe(':memory:');
+        expect(graphPathFormula({storagePaths: {useTestDatabase: false, graphTest: ':memory:', graphProd: '/prod.sqlite'}})).toBe('/prod.sqlite');
+
+        expect(collectionsMemoryFormula({collections: {useTestDatabase: true,  memoryTest: 'unit-mem', memoryProd: 'prod-mem'}})).toBe('unit-mem');
+        expect(collectionsMemoryFormula({collections: {useTestDatabase: false, memoryTest: 'unit-mem', memoryProd: 'prod-mem'}})).toBe('prod-mem');
+
+        expect(collectionsSessionFormula({collections: {useTestDatabase: true,  sessionTest: 'unit-sess', sessionProd: 'prod-sess'}})).toBe('unit-sess');
+        expect(collectionsSessionFormula({collections: {useTestDatabase: false, sessionTest: 'unit-sess', sessionProd: 'prod-sess'}})).toBe('prod-sess');
+    });
 });

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -65,15 +65,16 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
     const fileOf = (file, source) => ({file, source});
 
     test('a baselined violation is suppressed (no new violations)', () => {
-        // Derive the fixture from a live BASELINE row so this test does not churn each time a
-        // specific env is reshaped + dropped (it broke on NEO_CHROMA_DATABASE, then NEO_MEMORY_DB_PATH).
-        const [baselined] = BASELINE;
+        // Use a SYNTHETIC baseline so this test exercises the suppression logic independent of the live
+        // BASELINE contents — which empties as reshapes land (the live BASELINE is now empty / fully
+        // enforcing) and which churned this fixture each time a specific env was dropped.
+        const baseline = [{file: 'ai/mcp/server/x/config.template.mjs', env: 'NEO_FIXTURE_ENV', ticket: '#0', reshape: 'fixture'}];
         const files = [fileOf(
-            baselined.file,
-            `x: leaf(process.env.UNIT_TEST_MODE === 'true' ? 'a' : 'b', '${baselined.env}', 'string')`
+            'ai/mcp/server/x/config.template.mjs',
+            `x: leaf(process.env.UNIT_TEST_MODE === 'true' ? 'a' : 'b', 'NEO_FIXTURE_ENV', 'string')`
         )];
 
-        const {violations, newViolations} = lintConfigTemplateSsot({files});
+        const {violations, newViolations} = lintConfigTemplateSsot({files, baseline});
 
         expect(violations).toHaveLength(1);
         expect(newViolations).toHaveLength(0);
@@ -105,8 +106,8 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
     // ---- the shipped baseline is internally well-formed ----
 
     test('every shipped BASELINE row carries file, env, and a reshape note', () => {
-        expect(BASELINE.length).toBeGreaterThan(0);
-
+        // BASELINE may be empty once all instances are reshaped (fully-enforcing); the per-row shape
+        // assertions below still guard any future grandfathered row.
         for (const row of BASELINE) {
             expect(row.file).toMatch(/config\.template\.mjs$/);
             expect(row.env).toMatch(/^[A-Z][A-Z0-9_]+$/);


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), /lead-role. MC session `f5432f03-d2b6-4bc0-a7b5-9fbdafe4b7b9`.

Resolves #12499
Resolves #12451

Refs #12456

The **third and final** #12451 reshape (chroma #12480/#12481; graph #12491/#12494). Makes the memory-core `collections.memory` / `session` leaves declarative + safe-by-construction, replacing the inline `process.env.UNIT_TEST_MODE ? test-unique : prod` ternaries. **Completes #12451** — with this merged, every `config.template` inline-`process.env` leaf default is reshaped, so the SSOT lint baseline empties and the lint is **fully-enforcing**.

Evidence: L2 (unit specs + SSOT lint) → L2 required (config-contract + formula-resolution ACs are unit-coverable). No residuals.

## What shipped — the #12494 formula pattern + per-worker-unique test names
The collection names are **per-worker-unique** (parallel `fullyParallel` workers must not share a collection). Same formula shape as graph, with the test name a **module const** generated at config-load (per worker process). The selection is an **inline reactive formula** per active leaf (no exported helpers):
```js
// module-level (per worker process — no process.env CHECK):
const testMemoryCollection  = `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}`;
const testSessionCollection = `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}`;

// collections: { memoryProd / memoryTest / sessionProd / sessionTest / useTestDatabase(toggle) / graph(static) }
// formulas: { 'collections.memory': data => data.collections.useTestDatabase ? data.collections.memoryTest : data.collections.memoryProd, ... }
```
The ~3 consumers (HealthService, ChromaManager, defragChromaDB) read `collections.memory` / `session` **unchanged**. A4-clean (no inline `process.env` in any leaf default — generation in a module const, selection via toggle+formula). Per-worker uniqueness preserved (each worker process re-evaluates the module → its own unique names). Maintenance (no `UNIT_TEST_MODE`) → prod names.

**No separate collection-guard needed:** test collections live inside the isolated test **database** (`neo-unit-test`), which `ChromaManager`'s fail-closed guard already enforces — so the test/prod collection-name split is backstopped by the DB-level isolation.

## Contract Ledger
| Surface | Type | Contract |
| :--- | :--- | :--- |
| `collections.memoryProd` / `.sessionProd` | config leaf | Prod names (static); env `NEO_MEMORY_COLLECTION_NAME` / `NEO_SESSION_COLLECTION_NAME`. |
| `collections.memoryTest` / `.sessionTest` | config leaf | Per-worker-unique test names (module-const default); env `…_TEST`. |
| `collections.useTestDatabase` | config leaf | Toggle. Default `false`; env `UNIT_TEST_MODE`. |
| `collections.memory` / `.session` | **formula** | Inline `useTestDatabase ? *Test : *Prod` reactive formula. Consumers read unchanged. |
| `BASELINE` (SSOT lint) | now empty | All reshaped → lint fully-enforcing. |

## Test Evidence
- `config.template.spec.mjs` — **10 passed**, incl. the self-validating test: under the unit suite `collections.memory`/`session` resolve by construction to `^test-memory-`/`^test-session-` (=== `*Test`), `useTestDatabase === true`, `*Prod` = the prod names — i.e. the real resolved formula output for the test branch.
- `managers/ChromaManager.spec.mjs` (+ chroma test-isolation) + `HealthService.spec.mjs` — **consumers green** against the regenerated overlay (read the formula-resolved names; 13 + 48 passed).
- `lintConfigTemplateSsot.spec.mjs` — **passed** after adapting for the now-empty baseline (synthetic-baseline suppression test + dropped the row-count `>0` assertion).
- SSOT lint — `OK - 0 inline-env leaf default(s)` → **fully-enforcing**.

## Deltas
Resolves #12499 fully (collections declarative + per-worker-safe). **Completes #12451** (the last of 3 reshapes → lint fully-enforcing) — Resolves it too. No deferred items: unlike graph, no separate fail-closed guard (the chroma DB-isolation backstops the collection-name split). The `lintConfigTemplateSsot.spec` empty-baseline adaptation prevents the reshape-churn that bit graph (#12494).

**Review-driven (post-open):** (a) @tobiu — flagged that exporting the formula fns purely for a spec to import was SSOT-config pollution. Agreed (over-engineering for trivial toggle-ternaries): the formulas are **inline** (zero exports), the value-test pins the real resolved output (test branch), and the prod branch is the verified ternary's trivial `else`. The toggle is bounded (re-resolved at construct/load, not live-per-read) → a construct-time derivation, so the value-test is the right level. (b) @neo-gpt — rollout command corrected (below).

## Rollout Note (existing checkouts / worktrees)
Existing checkouts/worktrees with a stale gitignored `config.mjs` overlay must refresh before the new leaves/formulas resolve at runtime: run **`node ai/scripts/setup/initServerConfigs.mjs --migrate-config`** directly — the `npm run prepare` wrapper does **not** forward the `--migrate-config` flag (gpt verified), so the direct script is required; worktrees via `ai/scripts/migrations/bootstrapWorktree.mjs`. (Verified locally: the direct script refreshed the overlay + ChromaManager / chroma-isolation / HealthService consumers passed.)

## Post-Merge Validation
- [ ] Unit + integration suites green (the formulas propagate to all collection-name consumers).
- [ ] SSOT lint stays `OK - 0` (fully-enforcing) — a new inline-`process.env` leaf default now fails CI.
- [ ] #12451 closes (the reshape umbrella is complete).
