### PR TITLE
fix(memory): retry embedding contention (#12487)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -175,14 +175,19 @@ class Config extends BaseConfig {
              * @type {Object}
              */
             openAiCompatible: {
-                host                 : leaf('http://127.0.0.1:11434', 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
-                model                : leaf('gemma-4-31b-it', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
-                embeddingModel       : leaf('text-embedding-qwen3-embedding-8b', 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
-                apiKey               : leaf('', 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
-                unloadRetryCount     : leaf(3, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
-                unloadRetryDelayMs   : leaf(500, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', 'number'),
-                keep_alive           : leaf(-1, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
-                requireParallelModels: leaf(2, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')
+                host                    : leaf('http://127.0.0.1:11434', 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
+                model                   : leaf('gemma-4-31b-it', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
+                embeddingModel          : leaf('text-embedding-qwen3-embedding-8b', 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
+                apiKey                  : leaf('', 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
+                unloadRetryCount        : leaf(3, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
+                unloadRetryDelayMs      : leaf(500, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', 'number'),
+                contentionRetryCount    : leaf(2, 'NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT', 'number'),
+                contentionRetryDelayMs  : leaf(1000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS', 'number'),
+                contentionTimeoutMs     : leaf(15000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS', 'number'),
+                batchEmbeddingChunkSize: leaf(5, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE', 'number'),
+                batchEmbeddingYieldMs   : leaf(0, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS', 'number'),
+                keep_alive              : leaf(-1, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
+                requireParallelModels   : leaf(2, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')
             },
             /**
              * @summary Local-model role-keyed context limits.

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1574,6 +1574,32 @@ components:
                 dimensions:
                   type: integer
                   example: 4096
+                writeCanary:
+                  type: object
+                  description: "Write-side embedding canary result used to detect add_memory embedding-path degradation."
+                  properties:
+                    status:
+                      type: string
+                      enum: ["healthy", "failed"]
+                      example: "healthy"
+                    provider:
+                      type: string
+                      example: "openAiCompatible"
+                    dimensions:
+                      type: integer
+                      nullable: true
+                      example: 4096
+                    expectedDimensions:
+                      type: integer
+                      nullable: true
+                      example: 4096
+                    durationMs:
+                      type: integer
+                      example: 42
+                    error:
+                      type: string
+                      nullable: true
+                      example: null
                 error:
                   type: string
                   nullable: true

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -193,6 +193,83 @@ export function buildEmbeddingProviderBlock(cfg) {
 }
 
 /**
+ * @summary Probes the active embedding write path used by Memory Core writes.
+ *
+ * Memory writes fail before ChromaDB insertion when the active embedding provider cannot return a
+ * vector. The provider observability block confirms configured routing; this canary verifies the
+ * write-side embedding call itself so healthcheck does not report `healthy` while `add_memory`
+ * would starve or fail at the embedding step.
+ *
+ * @param {Object} options
+ * @param {Object} [options.cfg=aiConfig] aiConfig-shaped input.
+ * @param {Function} [options.embedText] Optional test seam matching `TextEmbeddingService.embedText`.
+ * @param {String} [options.input='neo-healthcheck-embedding-write-canary'] Probe text.
+ * @param {Function} [options.now=Date.now] Time source for deterministic tests.
+ * @returns {Promise<{status: String, provider: String, dimensions: Number|null,
+ *     expectedDimensions: Number|null, durationMs: Number, error: String|undefined}>}
+ */
+export async function buildEmbeddingWriteCanaryBlock({
+    cfg       = aiConfig,
+    embedText = null,
+    input     = 'neo-healthcheck-embedding-write-canary',
+    now       = Date.now
+} = {}) {
+    const readNow            = typeof now === 'function' ? now : () => (typeof now === 'number' ? now : now.getTime()),
+          startedAt          = readNow(),
+          provider           = cfg.embeddingProvider || 'openAiCompatible',
+          expectedDimensions = cfg.vectorDimension ?? null;
+
+    try {
+        const probe = embedText || (async (text, explicitProvider) => {
+            const {default: TextEmbeddingService} = await import('./TextEmbeddingService.mjs');
+            return TextEmbeddingService.embedText(text, explicitProvider);
+        });
+        const embedding = await probe(input, provider),
+              dimensions = Array.isArray(embedding) ? embedding.length : null,
+              durationMs = Math.max(0, readNow() - startedAt);
+
+        if (!Array.isArray(embedding) || embedding.length === 0) {
+            return {
+                status: 'failed',
+                provider,
+                dimensions,
+                expectedDimensions,
+                durationMs,
+                error : 'Embedding write canary returned no vector.'
+            };
+        }
+
+        if (expectedDimensions && dimensions !== expectedDimensions) {
+            return {
+                status: 'failed',
+                provider,
+                dimensions,
+                expectedDimensions,
+                durationMs,
+                error : `Embedding write canary returned ${dimensions} dimensions; expected ${expectedDimensions}.`
+            };
+        }
+
+        return {
+            status: 'healthy',
+            provider,
+            dimensions,
+            expectedDimensions,
+            durationMs
+        };
+    } catch (error) {
+        return {
+            status    : 'failed',
+            provider,
+            dimensions: null,
+            expectedDimensions,
+            durationMs: Math.max(0, readNow() - startedAt),
+            error     : error.message
+        };
+    }
+}
+
+/**
  * Projects one embedding provider selector into the common healthcheck sub-block shape.
  * @param {Object} cfg aiConfig-shaped input.
  * @param {String} active The selected provider key.
@@ -920,7 +997,7 @@ class HealthService extends Base {
         const database   = cachedHealth.database || {};
         const connection = database.connection || {};
 
-        return {
+        const freshPayload = {
             ...cachedHealth,
             timestamp: new Date(now).toISOString(),
             database : {
@@ -934,6 +1011,8 @@ class HealthService extends Base {
                 }
             }
         };
+
+        return this.#applyEmbeddingWriteCanary(freshPayload);
     }
 
     /**
@@ -1109,6 +1188,31 @@ class HealthService extends Base {
     }
 
     /**
+     * @summary Adds the embedding write canary to a healthcheck payload and degrades on failure.
+     * @param {Object} payload Mutable healthcheck payload under construction.
+     * @returns {Promise<Object>}
+     * @private
+     */
+    async #applyEmbeddingWriteCanary(payload) {
+        const canary = await buildEmbeddingWriteCanaryBlock();
+
+        payload.providers.embedding = {
+            ...payload.providers.embedding,
+            writeCanary: canary
+        };
+
+        if (canary.status !== 'healthy') {
+            payload.status = payload.status === 'unhealthy' ? 'unhealthy' : 'degraded';
+            payload.details = (payload.details || [])
+                .filter(detail => detail !== 'All features are operational')
+                .filter(detail => !detail.startsWith('Embedding write canary failed:'));
+            payload.details.push(`Embedding write canary failed: ${canary.error || 'unknown error'}`);
+        }
+
+        return payload;
+    }
+
+    /**
      * Performs a comprehensive health check without using the cache.
      *
      * Intent: This is the core health check logic, separated from the caching layer
@@ -1209,6 +1313,8 @@ class HealthService extends Base {
             payload.details.push('One or more required collections are missing');
             return payload;
         }
+
+        await this.#applyEmbeddingWriteCanary(payload);
 
         // Step 3: Check API key for summarization feature
         const apiKeyConfigured = this.#checkApiKeyConfigured();

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -4,6 +4,9 @@ import Base                 from '../../../src/core/Base.mjs';
 import logger               from '../../mcp/server/memory-core/logger.mjs';
 import OllamaProvider       from '../../provider/Ollama.mjs';
 
+const DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS = 60 * 60 * 1000;
+const OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE   = /openAiCompatible embedding error HTTP (408|429|503|504):/;
+
 /**
  * Determines whether TextEmbeddingService needs a Gemini embedding client for the active provider.
  * Kept pure so config-consolidation tests can pin the single-provider gate without
@@ -13,6 +16,48 @@ import OllamaProvider       from '../../provider/Ollama.mjs';
  */
 export function shouldInitializeGeminiEmbeddingClient(cfg = aiConfig) {
     return cfg.embeddingProvider === 'gemini';
+}
+
+/**
+ * @summary Detects OpenAI-compatible embedding failures that indicate request contention or timeout.
+ *
+ * The existing unload retry handles LM Studio JIT-unload cases. This helper isolates the distinct
+ * busy/queued request class so interactive single embeddings can retry without treating ordinary
+ * model-load or malformed-request failures as contention.
+ *
+ * @param {Error} error The request error to classify.
+ * @returns {Boolean}
+ */
+export function isOpenAiCompatibleContentionTimeoutError(error) {
+    const message = error?.message || '',
+          code    = error?.code    || '';
+
+    return code === 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT' ||
+        code === 'ETIMEDOUT' ||
+        code === 'ESOCKETTIMEDOUT' ||
+        OPENAI_COMPATIBLE_CONTENTION_HTTP_ERROR_RE.test(message);
+}
+
+/**
+ * @summary Formats the timeout value used in OpenAI-compatible embedding timeout errors.
+ * @param {Number} requestTimeoutMs The timeout in milliseconds.
+ * @returns {String}
+ */
+function describeOpenAiCompatibleTimeout(requestTimeoutMs) {
+    return requestTimeoutMs === DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS ? '1 hour' : `${requestTimeoutMs}ms`;
+}
+
+/**
+ * @summary Waits before the next OpenAI-compatible batch chunk.
+ *
+ * Even a zero-millisecond timeout yields the event loop, letting already-arrived interactive
+ * single-embedding calls send their provider request before the next batch sub-request.
+ *
+ * @param {Number} delayMs Delay in milliseconds.
+ * @returns {Promise<void>}
+ */
+function waitForOpenAiCompatibleBatchYield(delayMs) {
+    return new Promise(resolve => setTimeout(resolve, Math.max(0, delayMs || 0)));
 }
 
 /**
@@ -74,16 +119,35 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * Executes OpenAI-compatible /v1/embeddings POST requests with retry semantics for unloaded models.
+     * @summary Executes OpenAI-compatible /v1/embeddings POST requests with bounded retry semantics.
+     *
+     * Retries unloaded-model failures for both single and batch embeddings. Single interactive
+     * embeddings can additionally opt into a shorter contention timeout + retry budget, preventing
+     * `add_memory` from waiting behind a serialized batch until the MCP client times out.
      * The same endpoint shape is used by LM Studio desktop, `lms server start`, MLX, llama.cpp,
      * and other local OpenAI-format embedding servers.
+     *
      * @param {String|String[]} inputData The text or array of texts to embed.
-     * @param {Number} retriesLeft Number of retries remaining.
+     * @param {Object} options
+     * @param {Number} options.unloadRetriesLeft Number of unload retries remaining.
+     * @param {Number} [options.contentionRetriesLeft=0] Number of contention-timeout retries remaining.
+     * @param {Number} [options.requestTimeoutMs=3600000] Request timeout in milliseconds.
      * @returns {Promise<Object>}
      * @private
      */
-    async #postOpenAiCompatible(inputData, retriesLeft) {
-        const { host, embeddingModel, apiKey, unloadRetryCount = 3, unloadRetryDelayMs = 500 } = aiConfig.openAiCompatible;
+    async #postOpenAiCompatible(inputData, options) {
+        const {
+            unloadRetriesLeft,
+            contentionRetriesLeft = 0,
+            requestTimeoutMs      = DEFAULT_OPENAI_COMPATIBLE_REQUEST_TIMEOUT_MS
+        } = options;
+        const {
+            host,
+            embeddingModel,
+            apiKey,
+            unloadRetryDelayMs    = 500,
+            contentionRetryDelayMs = 1000
+        } = aiConfig.openAiCompatible;
 
         try {
             const parsedUrl = new URL(`${host}/v1/embeddings`);
@@ -103,7 +167,7 @@ class TextEmbeddingService extends Base {
             const req = httpModule.request(parsedUrl, {
                 method : 'POST',
                 headers: reqHeaders,
-                timeout: 60 * 60 * 1000 // 1 hour timeout natively
+                timeout: requestTimeoutMs
             }, (res) => {
                 let body = '';
                 res.on('data', chunk => body += chunk);
@@ -123,8 +187,10 @@ class TextEmbeddingService extends Base {
 
             req.on('error', (err) => rejectFunc(err));
             req.on('timeout', () => {
+                const err = new Error(`openAiCompatible request timed out after ${describeOpenAiCompatibleTimeout(requestTimeoutMs)}`);
+                err.code = 'OPENAI_COMPATIBLE_REQUEST_TIMEOUT';
                 req.destroy();
-                rejectFunc(new Error('openAiCompatible request timed out after 1 hour'));
+                rejectFunc(err);
             });
 
             req.write(JSON.stringify({ model: embeddingModel, input: inputData }));
@@ -138,10 +204,24 @@ class TextEmbeddingService extends Base {
                  err.message.includes('Operation canceled'))
             );
 
-            if (retriesLeft > 0 && isModelLoadError) {
-                logger.log(`[TextEmbeddingService] embedding-provider model-load failure detected (Shape ${err.message.includes('Model was unloaded') ? 'A' : 'B'}), retrying (remaining retries: ${retriesLeft})`);
+            if (unloadRetriesLeft > 0 && isModelLoadError) {
+                logger.log(`[TextEmbeddingService] embedding-provider model-load failure detected (Shape ${err.message.includes('Model was unloaded') ? 'A' : 'B'}), retrying (remaining retries: ${unloadRetriesLeft})`);
                 await new Promise(r => setTimeout(r, unloadRetryDelayMs));
-                return this.#postOpenAiCompatible(inputData, retriesLeft - 1);
+                return this.#postOpenAiCompatible(inputData, {
+                    unloadRetriesLeft: unloadRetriesLeft - 1,
+                    contentionRetriesLeft,
+                    requestTimeoutMs
+                });
+            }
+
+            if (contentionRetriesLeft > 0 && isOpenAiCompatibleContentionTimeoutError(err)) {
+                logger.log(`[TextEmbeddingService] embedding-provider contention timeout detected, retrying (remaining contention retries: ${contentionRetriesLeft})`);
+                await new Promise(r => setTimeout(r, contentionRetryDelayMs));
+                return this.#postOpenAiCompatible(inputData, {
+                    unloadRetriesLeft,
+                    contentionRetriesLeft: contentionRetriesLeft - 1,
+                    requestTimeoutMs
+                });
             }
             logger.error(`[TextEmbeddingService] Failed to generate embedding from openAiCompatible:`, err.message);
             throw err;
@@ -173,7 +253,52 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * Creates an embedding vector for the provided text.
+     * @summary Embeds a text array through OpenAI-compatible chunked batch requests.
+     *
+     * Local OpenAI-compatible embedding servers often serialize model requests. Sending the whole
+     * KB-sync batch as one provider call can monopolize that server for minutes. Chunking keeps
+     * batch ingestion moving while yielding between chunks so interactive single embeddings can
+     * enter the provider queue before the next batch chunk.
+     *
+     * @param {String[]} texts The texts to embed.
+     * @returns {Promise<number[][]>}
+     * @private
+     */
+    async #embedOpenAiCompatibleBatch(texts) {
+        const {
+            unloadRetryCount        = 3,
+            batchEmbeddingChunkSize = 5,
+            batchEmbeddingYieldMs   = 0
+        } = aiConfig.openAiCompatible;
+        const chunkSize = Math.max(1, Math.floor(batchEmbeddingChunkSize || texts.length)),
+              data      = [];
+
+        for (let offset = 0; offset < texts.length; offset += chunkSize) {
+            const chunk = texts.slice(offset, offset + chunkSize),
+                  result = await this.#postOpenAiCompatible(chunk, {
+                      unloadRetriesLeft: unloadRetryCount
+                  });
+
+            data.push(...(result.data || []).map(item => ({
+                ...item,
+                index: offset + item.index
+            })));
+
+            if (offset + chunkSize < texts.length) {
+                await waitForOpenAiCompatibleBatchYield(batchEmbeddingYieldMs);
+            }
+        }
+
+        return data.sort((a, b) => a.index - b.index).map(d => d.embedding);
+    }
+
+    /**
+     * @summary Creates one embedding vector for interactive write/query paths.
+     *
+     * The OpenAI-compatible branch uses the contention retry budget because single embeddings are
+     * latency-sensitive (`add_memory`, query, frontier) and must fail/retry inside the service before
+     * the MCP request envelope times out.
+     *
      * @param {String} text The text to embed.
      * @param {String} explicitProvider The embedding provider to use.
      * @returns {Promise<number[]>}
@@ -182,8 +307,16 @@ class TextEmbeddingService extends Base {
         if (!explicitProvider) throw new Error('TextEmbeddingService.embedText requires an explicit provider argument');
 
         if (explicitProvider === 'openAiCompatible') {
-            const { unloadRetryCount = 3 } = aiConfig.openAiCompatible;
-            const result = await this.#postOpenAiCompatible(text, unloadRetryCount);
+            const {
+                unloadRetryCount          = 3,
+                contentionRetryCount      = 2,
+                contentionTimeoutMs       = 15000
+            } = aiConfig.openAiCompatible;
+            const result = await this.#postOpenAiCompatible(text, {
+                unloadRetriesLeft    : unloadRetryCount,
+                contentionRetriesLeft: contentionRetryCount,
+                requestTimeoutMs     : contentionTimeoutMs
+            });
             return result.data?.[0]?.embedding;
         } else if (explicitProvider === 'ollama') {
             // Native Ollama returns `{embeddings: [[...]]}` even for single-input;
@@ -209,7 +342,11 @@ class TextEmbeddingService extends Base {
     }
 
     /**
-     * Creates embedding vectors for an array of texts.
+     * @summary Creates embedding vectors for batch ingestion paths.
+     *
+     * The OpenAI-compatible branch preserves the long request timeout and only applies unload retry,
+     * so legitimate KB-sync batches are not cut short by the interactive contention timeout.
+     *
      * @param {String[]} texts The texts to embed.
      * @param {String} explicitProvider The embedding provider to use.
      * @returns {Promise<number[][]>}
@@ -218,9 +355,7 @@ class TextEmbeddingService extends Base {
         if (!explicitProvider) throw new Error('TextEmbeddingService.embedTexts requires an explicit provider argument');
 
         if (explicitProvider === 'openAiCompatible') {
-            const { unloadRetryCount = 3 } = aiConfig.openAiCompatible;
-            const result = await this.#postOpenAiCompatible(texts, unloadRetryCount);
-            return result.data.sort((a, b) => a.index - b.index).map(d => d.embedding);
+            return this.#embedOpenAiCompatibleBatch(texts);
         } else if (explicitProvider === 'ollama') {
             // Ollama's `/api/embed` accepts array-of-strings natively + returns
             // a parallel embeddings array — no per-text fan-out needed.

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -31,8 +31,8 @@ const neoRootDir = path.resolve(__dirname, '../../..');
  *   into another spec's assertion against the snapshot.
  * - Recursively frozen via the local `deepFreeze()` helper. Neo doesn't ship
  *   a recursive freeze counterpart to `Neo.clone`, so this helper stays
- *   in-fixture; the shallow `Object.freeze({...x})` failure mode caught in
- *   #11978 cycle-1 is the regression-anchor for why deep freeze is required.
+ *   in-fixture; the shallow `Object.freeze({...x})` failure mode is the
+ *   regression anchor for why deep freeze is required.
  *
  * **Why not import the template directly here?**
  * Importing `ai/config.template.mjs` registers `Neo.ai.Config`. This fixture is
@@ -108,14 +108,19 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         requireParallelModels: Number(process.env.NEO_OLLAMA_REQUIRE_PARALLEL_MODELS) || 2
     },
     openAiCompatible: {
-        host                 : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-        model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
-        embeddingModel       : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
-        apiKey               : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
-        unloadRetryCount     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
-        unloadRetryDelayMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-        keep_alive           : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1),
-        requireParallelModels: Number(process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS) || 2
+        host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+        model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+        embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+        apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+        unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+        unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+        contentionRetryCount    : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT) || 2,
+        contentionRetryDelayMs  : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS) || 1000,
+        contentionTimeoutMs     : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS) || 15000,
+        batchEmbeddingChunkSize: Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE) || 5,
+        batchEmbeddingYieldMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS) || 0,
+        keep_alive              : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1),
+        requireParallelModels   : Number(process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS) || 2
     },
     localModels: {
         chat: {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -75,14 +75,19 @@ test.describe('Tier 1 Config Immutability', () => {
             requireParallelModels: TIER1_DEFAULTS.ollama.requireParallelModels
         });
         expect(Config.openAiCompatible).toMatchObject({
-            host                 : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-            model                : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
-            embeddingModel       : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
-            apiKey               : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
-            unloadRetryCount     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
-            unloadRetryDelayMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-            keep_alive           : TIER1_DEFAULTS.openAiCompatible.keep_alive,
-            requireParallelModels: TIER1_DEFAULTS.openAiCompatible.requireParallelModels
+            host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+            model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+            embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+            apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+            unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+            unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+            contentionRetryCount    : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT) || 2,
+            contentionRetryDelayMs  : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS) || 1000,
+            contentionTimeoutMs     : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS) || 15000,
+            batchEmbeddingChunkSize: Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE) || 5,
+            batchEmbeddingYieldMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS) || 0,
+            keep_alive              : TIER1_DEFAULTS.openAiCompatible.keep_alive,
+            requireParallelModels   : TIER1_DEFAULTS.openAiCompatible.requireParallelModels
         });
         expect(Config.localModels).toMatchObject({
             chat: {

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -213,8 +213,10 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     test.describe.configure({mode: 'serial'});
 
     let HealthService;
+    let TextEmbeddingService;
     let memoryCount;
     let originalDateNow;
+    let originalEmbedText;
     let originalGeminiApiKey;
     let originals;
     let summaryCount;
@@ -228,10 +230,12 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
     test.beforeAll(async () => {
         HealthService = (await import('../../../../../../ai/services/memory-core/HealthService.mjs')).default;
+        TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
     });
 
     test.beforeEach(() => {
         originalDateNow    = Date.now;
+        originalEmbedText  = TextEmbeddingService.embedText;
         originalGeminiApiKey = process.env.GEMINI_API_KEY;
         memoryCount        = 10;
         summaryCount       = 20;
@@ -266,6 +270,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         ChromaLifecycleService.getDatabaseStatus = () => ({running: true});
         MailboxService.getHealthcheckPreview     = async () => ({unreadCount: 0, latestPreview: null});
+        TextEmbeddingService.embedText            = async () => new Array(4096).fill(0.1);
         process.env.GEMINI_API_KEY               = 'unit-test-key';
 
         HealthService.setStdioIdentityState(null);
@@ -288,6 +293,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         StorageRouter.getSummaryCollection     = originals.getSummaryCollection;
         ChromaLifecycleService.getDatabaseStatus = originals.getDatabaseStatus;
         MailboxService.getHealthcheckPreview     = originals.getHealthcheckPreview;
+        TextEmbeddingService.embedText            = originalEmbedText;
 
         HealthService.setStdioIdentityState(null);
         HealthService.clearCache();
@@ -360,6 +366,23 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(refreshed).not.toBe(cached);
         expect(refreshed.database.connection.collections.memories.count).toBe(12);
         expect(refreshed.database.connection.collections.summaries.count).toBe(22);
+    });
+
+    test('embedding write canary failure degrades healthcheck status', async () => {
+        TextEmbeddingService.embedText = async () => {
+            throw new Error('embedding provider busy');
+        };
+
+        const result = await HealthService.healthcheck();
+
+        expect(result.status).toBe('degraded');
+        expect(result.providers.embedding.writeCanary).toMatchObject({
+            status  : 'failed',
+            provider: 'openAiCompatible',
+            error   : 'embedding provider busy'
+        });
+        expect(result.details).toContain('Embedding write canary failed: embedding provider busy');
+        expect(result.details).not.toContain('All features are operational');
     });
 });
 
@@ -590,6 +613,107 @@ test.describe('HealthService #10723/#10773/#10804 — buildEmbeddingProviderBloc
             const result = buildEmbeddingProviderBlock(cfg);
             expect(result.dimensions).toBe(768);
         }
+    });
+});
+
+/**
+ * @summary Coverage for the embedding write canary in the healthcheck payload.
+ *
+ * The provider block reports configured routing; the write canary probes the write-side
+ * embedding call that `add_memory` needs before it can insert into ChromaDB.
+ *
+ * @see Neo.ai.services.memory-core.HealthService#buildEmbeddingWriteCanaryBlock
+ */
+test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
+    let buildEmbeddingWriteCanaryBlock;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
+        buildEmbeddingWriteCanaryBlock = mod.buildEmbeddingWriteCanaryBlock;
+    });
+
+    test('reports healthy when the active provider returns a vector', async () => {
+        let nowCalls = 0;
+        const result = await buildEmbeddingWriteCanaryBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 3
+            },
+            embedText: async (input, provider) => {
+                expect(input).toBe('neo-healthcheck-embedding-write-canary');
+                expect(provider).toBe('openAiCompatible');
+                return [0.1, 0.2, 0.3];
+            },
+            now: () => nowCalls++ ? 125 : 100
+        });
+
+        expect(result).toEqual({
+            status            : 'healthy',
+            provider          : 'openAiCompatible',
+            dimensions        : 3,
+            expectedDimensions: 3,
+            durationMs        : 25
+        });
+    });
+
+    test('reports failed when the active provider throws', async () => {
+        const result = await buildEmbeddingWriteCanaryBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 4096
+            },
+            embedText: async () => {
+                throw new Error('embedding provider busy');
+            },
+            now: () => 100
+        });
+
+        expect(result).toMatchObject({
+            status            : 'failed',
+            provider          : 'openAiCompatible',
+            dimensions        : null,
+            expectedDimensions: 4096,
+            durationMs        : 0,
+            error             : 'embedding provider busy'
+        });
+    });
+
+    test('reports failed when the provider returns no vector', async () => {
+        const result = await buildEmbeddingWriteCanaryBlock({
+            cfg: {
+                embeddingProvider: 'ollama',
+                vectorDimension  : 4096
+            },
+            embedText: async () => [],
+            now: () => 100
+        });
+
+        expect(result).toMatchObject({
+            status            : 'failed',
+            provider          : 'ollama',
+            dimensions        : 0,
+            expectedDimensions: 4096,
+            error             : 'Embedding write canary returned no vector.'
+        });
+    });
+
+    test('reports failed when the provider returns a wrong-sized vector', async () => {
+        const result = await buildEmbeddingWriteCanaryBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 4096
+            },
+            embedText: async () => [0.1, 0.2, 0.3],
+            now: () => 100
+        });
+
+        expect(result).toMatchObject({
+            status            : 'failed',
+            provider          : 'openAiCompatible',
+            dimensions        : 3,
+            expectedDimensions: 4096,
+            error             : 'Embedding write canary returned 3 dimensions; expected 4096.'
+        });
     });
 });
 

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -19,13 +19,16 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import http           from 'http';
 import aiConfig       from '../../../../../../ai/mcp/server/memory-core/config.mjs';
 
-test.describe.serial('TextEmbeddingService #11393/#11402 — openAiCompatible retry and lms server start support', () => {
+test.describe.serial('TextEmbeddingService #11393/#11402/#12487 — openAiCompatible retry and lms server start support', () => {
     let SDK, TextEmbeddingService, server;
     let requestCount = 0;
     let serverBehavior = 'succeed';
     let lastRequest;
+    let allRequests;
     let testPort;
     let originalHost, originalRetryCount, originalRetryDelay;
+    let originalContentionRetryCount, originalContentionRetryDelay, originalContentionTimeout;
+    let originalBatchEmbeddingChunkSize, originalBatchEmbeddingYieldMs;
 
     test.beforeAll(async () => {
         SDK = await import('../../../../../../ai/services.mjs');
@@ -43,6 +46,7 @@ test.describe.serial('TextEmbeddingService #11393/#11402 — openAiCompatible re
                     url   : req.url,
                     body  : body ? JSON.parse(body) : null
                 };
+                allRequests.push(lastRequest);
 
                 if (serverBehavior === 'succeed') {
                     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -85,6 +89,42 @@ test.describe.serial('TextEmbeddingService #11393/#11402 — openAiCompatible re
                 } else if (serverBehavior === 'fail-other') {
                     res.writeHead(400, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify({ error: 'Some other bad request error' }));
+                } else if (serverBehavior === 'timeout-then-succeed') {
+                    if (requestCount === 1) {
+                        return;
+                    }
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ data: [{ embedding: [1.4, 1.5, 1.6] }] }));
+                } else if (serverBehavior === 'timeout-all') {
+                    return;
+                } else if (serverBehavior === 'http-timeout-then-succeed') {
+                    if (requestCount === 1) {
+                        res.writeHead(503, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({ error: 'Embedding server busy while prior batch is queued' }));
+                        return;
+                    }
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ data: [{ embedding: [1.7, 1.8, 1.9] }] }));
+                } else if (serverBehavior === 'delayed-batch-succeed') {
+                    setTimeout(() => {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({
+                            data: [
+                                {index: 0, embedding: [3.1, 3.2, 3.3]},
+                                {index: 1, embedding: [4.1, 4.2, 4.3]}
+                            ]
+                        }));
+                    }, 50);
+                } else if (serverBehavior === 'chunked-batch-succeed') {
+                    const inputs = lastRequest.body.input;
+
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({
+                        data: inputs.map((_, index) => ({
+                            index,
+                            embedding: [requestCount, index]
+                        })).reverse()
+                    }));
                 }
             });
         });
@@ -100,19 +140,35 @@ test.describe.serial('TextEmbeddingService #11393/#11402 — openAiCompatible re
     test.beforeEach(() => {
         requestCount = 0;
         lastRequest  = null;
+        allRequests  = [];
         originalHost = aiConfig.openAiCompatible.host;
         originalRetryCount = aiConfig.openAiCompatible.unloadRetryCount;
         originalRetryDelay = aiConfig.openAiCompatible.unloadRetryDelayMs;
+        originalContentionRetryCount = aiConfig.openAiCompatible.contentionRetryCount;
+        originalContentionRetryDelay = aiConfig.openAiCompatible.contentionRetryDelayMs;
+        originalContentionTimeout = aiConfig.openAiCompatible.contentionTimeoutMs;
+        originalBatchEmbeddingChunkSize = aiConfig.openAiCompatible.batchEmbeddingChunkSize;
+        originalBatchEmbeddingYieldMs = aiConfig.openAiCompatible.batchEmbeddingYieldMs;
 
         aiConfig.openAiCompatible.host = `http://127.0.0.1:${testPort}`;
         aiConfig.openAiCompatible.unloadRetryCount = 3;
         aiConfig.openAiCompatible.unloadRetryDelayMs = 10; // fast for tests
+        aiConfig.openAiCompatible.contentionRetryCount = 2;
+        aiConfig.openAiCompatible.contentionRetryDelayMs = 10;
+        aiConfig.openAiCompatible.contentionTimeoutMs = 25;
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 5;
+        aiConfig.openAiCompatible.batchEmbeddingYieldMs = 0;
     });
 
     test.afterEach(() => {
         aiConfig.openAiCompatible.host = originalHost;
         aiConfig.openAiCompatible.unloadRetryCount = originalRetryCount;
         aiConfig.openAiCompatible.unloadRetryDelayMs = originalRetryDelay;
+        aiConfig.openAiCompatible.contentionRetryCount = originalContentionRetryCount;
+        aiConfig.openAiCompatible.contentionRetryDelayMs = originalContentionRetryDelay;
+        aiConfig.openAiCompatible.contentionTimeoutMs = originalContentionTimeout;
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = originalBatchEmbeddingChunkSize;
+        aiConfig.openAiCompatible.batchEmbeddingYieldMs = originalBatchEmbeddingYieldMs;
     });
 
     test('first-call-succeeds-no-retry path', async () => {
@@ -202,5 +258,71 @@ test.describe.serial('TextEmbeddingService #11393/#11402 — openAiCompatible re
             .rejects.toThrow(/Some other bad request error/);
 
         expect(requestCount).toBe(1); // No retries
+    });
+
+    test('contention-timeout single embedding retries and succeeds', async () => {
+        serverBehavior = 'timeout-then-succeed';
+        aiConfig.openAiCompatible.contentionRetryCount = 1;
+
+        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
+
+        expect(result).toEqual([1.4, 1.5, 1.6]);
+        expect(requestCount).toBe(2);
+    });
+
+    test('contention-timeout single embedding fails after bounded retries', async () => {
+        serverBehavior = 'timeout-all';
+        aiConfig.openAiCompatible.contentionRetryCount = 1;
+
+        await expect(TextEmbeddingService.embedText('hello', 'openAiCompatible'))
+            .rejects.toThrow(/openAiCompatible request timed out/);
+
+        // Initial request + 1 contention retry = 2 total requests
+        expect(requestCount).toBe(2);
+    });
+
+    test('HTTP contention status single embedding retries and succeeds', async () => {
+        serverBehavior = 'http-timeout-then-succeed';
+        aiConfig.openAiCompatible.contentionRetryCount = 1;
+
+        const result = await TextEmbeddingService.embedText('hello', 'openAiCompatible');
+
+        expect(result).toEqual([1.7, 1.8, 1.9]);
+        expect(requestCount).toBe(2);
+    });
+
+    test('batch embeddings preserve the long batch timeout instead of using the interactive contention timeout', async () => {
+        serverBehavior = 'delayed-batch-succeed';
+        aiConfig.openAiCompatible.contentionTimeoutMs = 1;
+
+        const result = await TextEmbeddingService.embedTexts(['first', 'second'], 'openAiCompatible');
+
+        expect(result).toEqual([
+            [3.1, 3.2, 3.3],
+            [4.1, 4.2, 4.3]
+        ]);
+        expect(requestCount).toBe(1);
+    });
+
+    test('batch embeddings split large requests into yieldable chunks and preserve global ordering', async () => {
+        serverBehavior = 'chunked-batch-succeed';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 2;
+        aiConfig.openAiCompatible.batchEmbeddingYieldMs = 0;
+
+        const result = await TextEmbeddingService.embedTexts(['a', 'b', 'c', 'd', 'e'], 'openAiCompatible');
+
+        expect(requestCount).toBe(3);
+        expect(allRequests.map(item => item.body.input)).toEqual([
+            ['a', 'b'],
+            ['c', 'd'],
+            ['e']
+        ]);
+        expect(result).toEqual([
+            [1, 0],
+            [1, 1],
+            [2, 0],
+            [2, 1],
+            [3, 0]
+        ]);
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Resolves #12487

Adds V1 resilience for OpenAI-compatible embedding contention: interactive single embeddings now use a shorter contention timeout with bounded retry/backoff, batch embeddings are split into yieldable chunks so they do not monopolize serialized local embedders as one long request, and healthcheck now reports a write-side embedding canary instead of declaring the embedding write path healthy by configuration alone.

Evidence: L2 (mock OpenAI-compatible timeout/503 contention, chunked batch-yield, and healthcheck canary unit coverage) -> L4 required (interactive add_memory during a live heavy KB-sync embedding batch). Residual: AC1 [#12487].

## Deltas from ticket
- Implements the V1 resilience path from the Contract Ledger: contention-timeout retry plus explicit config leaves alongside the existing unload retry.
- Adds minimal batch chunk/yield behavior in TextEmbeddingService.embedTexts so retry is not defeated by one minutes-long provider batch request.
- Does not add a full priority scheduler or pause-on-interactive queue. That remains the V2 true-QoS shape from the Contract Ledger.
- The healthcheck canary probes the embedding write path. It does not perform a Chroma insert/delete canary.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` passed: 117 tests.
- `npm run ai:lint-config-template-ssot` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed.
- Pre-commit lint-staged hooks passed: check-whitespace, check-shorthand, check-ticket-archaeology.
- Branch freshness passed: `merge-base HEAD origin/dev == origin/dev` at `5bc93d0dcb7671ae3d2052996bd0487a13224703`; outgoing log contained only `6822412e8 fix(memory): retry embedding contention (#12487)`.

## Post-Merge Validation
- [ ] During a live KB-sync embedding batch, call `add_memory` from an agent harness and confirm it completes inside the MCP envelope.
- [ ] Force active embedder outage/contention and confirm healthcheck degrades via `providers.embedding.writeCanary`.

## Commits
- `6822412e8` — `fix(memory): retry embedding contention (#12487)`