### PR TITLE
fix(ai): remove ProtoSource defensive sourcePaths read (#12504)

### DIFF
--- a/ai/examples/cloud-deployment/minimal-external-workspace/src/ProtoSource.mjs
+++ b/ai/examples/cloud-deployment/minimal-external-workspace/src/ProtoSource.mjs
@@ -7,7 +7,7 @@ import aiConfig            from 'neo.mjs/ai/mcp/server/knowledge-base/config.mjs
 /**
  * @summary Example custom Source — indexes a tenant's `.proto` schema files in the full-corpus build.
  *
- * Demonstrates the Source contract for Epic #11624: `extract(writeStream, createHashFn)`
+ * Demonstrates the Source contract: `extract(writeStream, createHashFn)`
  * writes one JSONL chunk record per file and returns the count. Registered via
  * `aiConfig.customSources` or `SourceRegistry.registerSource`; the territory path is read
  * from `aiConfig.sourcePaths.ProtoSource`. See learn/agentos/cloud-deployment/CustomSources.md.
@@ -38,9 +38,8 @@ class ProtoSource extends Base {
      */
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // `sourcePaths.ProtoSource` is an absolute path when set; the fallback resolves
-        // `proto` against the deployment root for a co-located workspace.
-        const dir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ProtoSource ?? 'proto');
+        // `sourcePaths.ProtoSource` defaults to `proto` and can be overridden per deployment.
+        const dir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths.ProtoSource);
 
         if (existsSync(dir)) {
             for (const file of (await readdir(dir)).sort()) {

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -224,6 +224,7 @@ class Config extends BaseConfig {
                 SkillSource       : '.agents/skills',
                 TestSource        : 'test/playwright',
                 LearningSource    : 'learn/tree.json',
+                ProtoSource       : 'proto',
                 DiscussionSource  : ['resources/content/discussions',
                                      'resources/content/archive/discussions'],
                 PullRequestSource : ['resources/content/pulls',

--- a/learn/agentos/cloud-deployment/CustomSources.md
+++ b/learn/agentos/cloud-deployment/CustomSources.md
@@ -59,8 +59,8 @@ class ProtoSource extends Base {
 
     async extract(writeStream, createHashFn) {
         let count = 0;
-        // Path resolves from aiConfig.sourcePaths — falls through to a default when unset.
-        const dir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.ProtoSource ?? 'proto');
+        // Path resolves from aiConfig.sourcePaths; the config leaf owns the default.
+        const dir = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths.ProtoSource);
 
         if (await fs.pathExists(dir)) {
             for (const file of (await fs.readdir(dir)).sort()) {
@@ -120,7 +120,7 @@ Graduate from `RawRepoSource` to a custom Source when a tenant needs semantic ch
 
 ## Path conventions
 
-A Source should not hard-code its territory path. Resolve it from `aiConfig.sourcePaths` keyed by the Source's registry name — `aiConfig.sourcePaths?.ProtoSource ?? '<fallback>'` — so a deployment whose layout differs overrides only that key. Each Source interprets its own entry shape (a string, a string-array, or a path→type object — see the built-in Source defaults in `config.template.mjs`).
+A Source should not hard-code its territory path. Resolve it from `aiConfig.sourcePaths` keyed by the Source's registry name — `aiConfig.sourcePaths.ProtoSource` — so a deployment whose layout differs overrides only that key. Defaults belong in `config.template.mjs`, not in consumer-side optional chains. Each Source interprets its own entry shape (a string, a string-array, or a path→type object — see the built-in Source defaults in `config.template.mjs`).
 
 ## Identity-tuple semantics
 


### PR DESCRIPTION
Resolves #12504
Refs #12461

Removes the remaining `sourcePaths?.ProtoSource ?? 'proto'` B3 defensive read from the ProtoSource custom-source example, moves the `proto` default into the knowledge-base config template leaf, and updates the matching cloud-deployment guide snippet so future custom Source authors copy the direct `AiConfig` read pattern.

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Evidence: L1 (static source/config/docs audit) -> L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket (if any)

- Added `sourcePaths.ProtoSource: 'proto'` to `ai/mcp/server/knowledge-base/config.template.mjs` so the prior consumer-side fallback is owned by the config leaf.
- Updated `learn/agentos/cloud-deployment/CustomSources.md` because it taught the same optional-chain fallback pattern as the example source.
- Removed a pre-existing durable ticket reference from the touched `ProtoSource` JSDoc after the pre-commit archaeology hook flagged it.

## Config Template Change

Changed key: `sourcePaths.ProtoSource` in `ai/mcp/server/knowledge-base/config.template.mjs`.

Local `config.mjs` follow-up: clones that run the minimal external workspace example from an older gitignored knowledge-base `config.mjs` should refresh/migrate that local config or add `sourcePaths.ProtoSource: 'proto'` manually. No byte-identical local config is required.

Harness restart: not required for general Agent OS operation. Restart the knowledge-base MCP server only if a clone updates its local config and wants the running server to pick up the new key immediately.

## Test Evidence

- `node --check ai/examples/cloud-deployment/minimal-external-workspace/src/ProtoSource.mjs` -> passed
- `node --check ai/mcp/server/knowledge-base/config.template.mjs` -> passed
- `git diff --check` -> passed
- `rg -n "sourcePaths\\?\\.|\\?\\? 'proto'|\\?\\? \"proto\"" ai learn/agentos/cloud-deployment/CustomSources.md` -> no matches
- Pre-commit hook passed: whitespace, shorthand, and ticket-archaeology checks for staged files

## Post-Merge Validation

- [ ] If a local clone uses the minimal external workspace example with a stale gitignored knowledge-base `config.mjs`, refresh/migrate the local config before running that example.

## Commits

- `aabdec91a` - `fix(ai): remove ProtoSource defensive sourcePaths read (#12504)`
