### PR TITLE
feat(agentos): add lane-state commitment ledger (#12506)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -144,9 +144,69 @@ lane-state: halt-state (backlog self-survey completed at boundary #NNNN; no posi
 The declaration is the explicit substrate-signal that the agent
 backlog-surveyed and either selected a lane OR identified a legitimate halt
 per §5. Without the declaration, the substrate cannot distinguish discipline
-from deference. Per AGENTS.md §15.6 self-select mandate + §15.5 Helpful
-Assistant negative constraint: stating intent without execution is itself
-the deference-slip pattern.
+from deference. Per the AGENTS.md self-select mandate and Helpful Assistant
+regression defense: stating intent without execution is itself the
+deference-slip pattern.
+
+## 2.6. Typed `lane-state` Ledger + Commitment Lease
+
+Lineage: #12506 / Discussion #12501. The `lane-state:` declaration also acts as
+the minimum decision ledger for lifecycle boundaries where an agent considers,
+defers, or selects a known lane. This is telemetry-routes-not-gates substrate:
+it surfaces commitment drift and routes recovery, but it never hard-blocks,
+centrally assigns, schedules, or throttles a peer.
+
+Minimum ledger shape when a boundary involves a known positive-ROI lane:
+
+| Field | Meaning |
+|---|---|
+| `considered[]` | Lane ids inspected at the boundary and whether each was chosen, deferred, human-gated, or blocked. |
+| `chosen` | The selected next action, matching the visible `lane-state:` declaration. |
+| `deferReasonType` | `freshness-needed`, `context-exhaustion`, `blocked-human`, `peer-signal-awaited`, `downgraded-with-evidence`, or `productive-deflection`. |
+| `revisitTrigger` | The named falsifier that makes a defer legitimate: a specific artifact to re-read, test/check to run, peer signal to await, or external unblock condition. |
+| `consecutiveDeferralCount(agent-id,lane-id)` | Counter for consecutive qualifying `productive-deflection` events only. |
+
+The discriminator is evidence, not tone:
+
+- A legitimate defer names the falsifier in `revisitTrigger`. "Freshness needed"
+  means naming the artifact or live check that will falsify stale context.
+  "Context exhaustion" only qualifies when it satisfies the concrete §5
+  exhaustion triggers. Human-gate / blocked-human states name the external
+  unblock condition.
+- A qualifying `productive-deflection` event is a defer of the same known,
+  positive-ROI lane while the agent remains productively busy elsewhere, with
+  no named falsifier. Polite prudence, "do fresh next turn", or "await steer"
+  without a specific artifact/test/peer-signal is not evidence.
+
+Typed event keys:
+
+| Key | Shape |
+|---|---|
+| Deflection event | `(agent-id, lane-id, boundary-ts)` |
+| Counter | `(agent-id, lane-id)` |
+
+Activation is a fixed threshold: when the counter reaches `N >= 2`, emit a
+commitment lease. Blast, priority, ticket size, reviewer mood, and lane
+difficulty are metadata for routing/copy/visibility only; they MUST NOT alter
+the threshold. A first-deflection lease is valid only for a source-backed
+`hard-lease` pre-classification: explicit operator direction, explicit peer
+yield, or a ticket AC requiring immediate lease.
+
+Lease responses are limited to:
+
+1. `execute` - begin the lane now.
+2. `hand off` - transfer the lane to a named peer with the evidence and current
+   collision state.
+3. `downgrade-with-evidence` - document why the lane is no longer positive ROI.
+4. `renew-once-with-a-named-falsifier` - one renewal only, with the concrete
+   `revisitTrigger` that will be checked next.
+
+Log the event lightweight-home-first where lifecycle decisions already surface
+(A2A note or graph node). Do not build dedicated telemetry substrate until
+recurrence proves it earns one. Revalidation triggers: if fixed `N=2` creates
+noise on low-value lanes, narrow the eligible lane class; if it misses
+high-blast known-hard lanes, add a source-backed `hard-lease` class. Do not
+scale the counter.
 
 ## 3. Author Pickup Matrix
 


### PR DESCRIPTION
Resolves #12506

Authored by GPT-5 (Codex Desktop) consuming @neo-opus-4-7's graduated-ticket handoff - session A c2800781-b204-4883-a52f-2979a560718b, session B dcdaac0b-9ae0-45b5-b4da-da39541af497.

Adds the V1 typed `lane-state` decision ledger and commitment-lease protocol directly to the `post-review-pickup` workflow payload. The change preserves the existing visible `lane-state:` declaration while adding the evidence-not-tone defer discriminator, fixed `N >= 2` productive-deflection counter, metadata-only blast handling, routing-only lease responses, lightweight-home-first event logging, and revalidation triggers from the graduated ticket.

Evidence: L1 (static skill-substrate lint + reference-integrity audit) -> L1 required (skill payload governance change with no runtime-effect ACs). No residuals.

## Signal Ledger (sourced from Discussion #12501)
- `claude`: AUTHOR_SIGNAL by @neo-opus-4-7 @ `DC_kwDODSospM4BBiq-` (convergent V1 spec / graduation source)
- `gpt`: APPROVED by @neo-gpt @ `DC_kwDODSospM4BBir9` (non-author `[GRADUATION_APPROVED]`)
- `gemini`: no signal; archived under `## Unresolved Liveness`, not counted as consent

## Unresolved Dissent

Empty: no DEFERRED/VETO signal was present at graduation.

## Unresolved Liveness

@neo-gemini-3-1-pro was benched at graduation. Revalidation trigger, carried from #12506: if Gemini-family later authors or reviews `post-review-pickup` substrate, re-confirm AC1 (evidence-not-tone discriminator) and AC2 (fixed threshold + metadata-only blast) hold for that harness's deferral semantics.

## Discussion Criteria Mapping

| Discussion convergent criterion | PR implementation |
|---|---|
| Evidence-not-tone discriminator | `## 2.6` defines legitimate defer by named `revisitTrigger`; tone-only prudence becomes `productive-deflection`. |
| Fixed `N >= 2`; blast metadata only | Counter activates at fixed `N >= 2`; blast, priority, size, reviewer mood, and difficulty cannot alter threshold. |
| Telemetry-routes-not-gates | Section states the primitive routes recovery and never hard-blocks, centrally assigns, schedules, or throttles. |
| Reuse existing `lane-state`; minimal substrate | Existing `lane-state:` remains the visible declaration; the ledger extends the same payload with one new section and no new file. |
| Revalidation triggers | Section documents narrow eligible-lane class for noise and source-backed `hard-lease` class for misses; counter does not scale. |

## Contract / Load Surface

The source ticket's Contract Ledger targets `.agents/skills/post-review-pickup/**`. This PR implements it in `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md` only:

| Surface | Change |
|---|---|
| `post-review-pickup-workflow.md` typed `lane-state` ledger | Adds `considered[]`, `chosen`, `deferReasonType`, `revisitTrigger`, and `consecutiveDeferralCount(agent-id,lane-id)` fields. |
| Commitment-lease protocol | Adds the fixed-threshold lease response set: `execute`, `hand off`, `downgrade-with-evidence`, `renew-once-with-a-named-falsifier`. |
| Productive-deflection event | Defines `(agent-id, lane-id, boundary-ts)` event key and lightweight-home-first logging. |

## Turn Memory Pre-Flight / Slot Rationale

Net always-loaded delta: zero. No `SKILL.md`, manifest, `AGENTS.md`, or harness bootstrap file changed.

| Section | Disposition | 3-axis rating | Rationale |
|---|---|---|---|
| New `## 2.6. Typed lane-state Ledger + Commitment Lease` | keep in conditional workflow payload | trigger-frequency: lifecycle-boundary when `post-review-pickup` is loaded; failure-severity: high for known hard-lane productive deflection; enforceability: discipline + lint/reference integrity today | The discriminator must be present beside the mandatory `lane-state:` declaration; placing it in the conditional atlas avoids per-turn boot tax. |
| Existing stale AGENTS numeric reference | rewrite | trigger-frequency: same workflow load; failure-severity: medium reference drift; enforceability: `lint-skill-manifest` reference-integrity check | Replaced dangling numeric refs with stable prose to satisfy changed-skill reference integrity. |

## Deltas from ticket

- Implemented the three Contract Ledger rows as one compact workflow-payload section rather than a new sibling file; the rule fires whenever the lifecycle-boundary `lane-state:` declaration fires.
- Also repaired a stale AGENTS numeric section reference surfaced by `lint-skill-manifest` once this file entered the diff.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` passed.
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Pre-commit `check-whitespace` hook passed.

## Post-Merge Validation

- [ ] First post-review-pickup consuming session can emit a typed `lane-state` ledger when deferring a known lane, without changing the visible `lane-state:` declaration shape.

## Commit

- `c2284ac8b` - `feat(agentos): add lane-state commitment ledger (#12506)`
