### PR TITLE
fix(memory-core): harden wake liveness surfaces (#12446)

### DIFF
--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -1,6 +1,6 @@
 # Session Sunset Workflow
 
-This document outlines the authoritative protocol for gracefully terminating an agent session (the **Sunset Protocol**). 
+This document outlines the authoritative protocol for gracefully terminating an agent session (the **Sunset Protocol**).
 
 Because the Neo.mjs Swarm operates across fragmented sessions and multiple agent identities, simply halting execution creates "Zero-State Amnesia" (`AGENTS.md §14`). The next agent starts blind. The Sunset Protocol guarantees the next agent has a perfect "cold-pickup" ramp.
 
@@ -10,7 +10,7 @@ Because the Neo.mjs Swarm operates across fragmented sessions and multiple agent
 > - **AGENTS.md §14 PRE-DECISION SUNSET GATE** is the load-bearing constraint that this workflow exists *under*. The Gate is loaded at session boot; this workflow describes the *post-decision* execution flow. If the Gate's pre-conditions aren't met, you are FORBIDDEN from entering this workflow regardless of how natural the "completion narrative" feels. Empirical anchor: 13+ premature-sunset occurrences logged on [#10564](https://github.com/neomjs/neo/issues/10564) where this workflow was entered despite the Gate explicitly forbidding it.
 > - **Auto-Wakeup Substrate (Epic [#10601](https://github.com/neomjs/neo/issues/10601), corrective [#10611](https://github.com/neomjs/neo/issues/10611) PR-B)** — sunset is **terminal** for the old transcript. Trio coordination is preserved by **fresh-session recovery**, not in-place wake injection. The substrate (`swarm-heartbeat.sh` → `checkSunsetted.mjs` → `resumeHarness.mjs`) opens a NEW chat session in the target harness via `freshSessionShortcut` (Cmd+N for Antigravity IDE + Claude Desktop) and the new agent boots via `AGENTS_STARTUP.md`, picking up prior context via Memory Core context-priming (using the forwarded `originSessionId`) + sandman_handoff.md + A2A mailbox. **Stale-wake invariant:** if a wake-shaped payload arrives in an OLD sunsetted transcript, treat it as noise — DO NOT continue substantive work there. The canonical execution target is the fresh session that recovery spawns. Identity coverage: `@neo-gemini-3-1-pro` and `@neo-opus-4-7` shipped via #10611 PR-B; `@neo-gpt` deferred until Codex Desktop fresh-session shortcut + osascript receptiveness are empirically verified. For uncovered identities, sunset still requires manual @tobiu intervention. Each spurious sunset spawns a fresh boot ramp (Memory Core context-priming + sandman_handoff parse + mailbox check), which drains attention + introduces stale-state risk. Recovery is a safety net, not a license.
 
-To an LLM, yielding a prompt resolution feels like a "termination," but to a Human Commander, it is merely a **Turn** within a longer continuous **Session**. 
+To an LLM, yielding a prompt resolution feels like a "termination," but to a Human Commander, it is merely a **Turn** within a longer continuous **Session**.
 
 You are strictly **FORBIDDEN** from executing the Sunset Protocol simply because you finished a prompt and yielded control back to the human. You MUST only execute the Sunset Protocol when a true **Session Boundary** is reached.
 
@@ -119,7 +119,7 @@ Summarize the scope of your session. How many PRs were merged? How many skills w
 To preserve "hot" thread visibility across sessions (Option B), agents do NOT `mark_read` messages immediately during active processing. Now that handovers are drafted (and have read your inbox state), you MUST explicitly use the `mark_read` MCP tool on all processed messages in your inbox. This ensures the inbox is clean for the next agent session.
 
 ### Step 8: The A2A Continuity Ping & Reward Signal (Future-Self Routing)
-You MUST use the `add_message` MCP tool to send an A2A message to your own agent identity (e.g., `to: '@me'` or your explicit handle). The body of this message MUST contain the **full Sunset Protocol markdown payload** (the output from Steps 1-6), alongside the `Origin Session ID`. 
+You MUST use the `add_message` MCP tool to send an A2A message to your own agent identity (e.g., `to: '@me'` or your explicit handle). The body of this message MUST contain the **full Sunset Protocol markdown payload** (the output from Steps 1-6), alongside the `Origin Session ID`.
 
 Set `wakeSuppressed: true` and include `taggedConcepts: ['sunset-protocol-handover']` on this self-DM. This makes the ping mailbox-only: it remains unread for the next session's boot mailbox check, but it MUST NOT emit a `SENT_TO_ME` wake into the active session that is currently shutting down. Do not mark this newly-created continuity ping read during the same sunset flow. Note: Peer broadcasts can be conditionally suppressed for `scope: solo-refresh` unless cross-peer handoff coordination is actively required.
 
@@ -157,16 +157,17 @@ or human-triggered recovery assigns lead.
 
 Crucially, from an "LLM Psychology" perspective, this message must include a **Conceptual Priming / Reward Signal**. If you formulated new architectural concepts or achieved a major milestone, summarize the *actual content and value* of that breakthrough in the ping. Reading this high-density, successful content acts as a mathematical "dopamine hit" for your future self—it primes the next session's token probabilities for high-agency, expert-level continuity. This drastically improves the Model Experience (MX) by ensuring the agent wakes up not just with tasks, but with immediate, rich, "exciting" context.
 
-### Step 9: Disable Harness Routing (The Unsubscribe Primitive)
-As the penultimate operational step, you MUST sever the active wake routing to prevent "False Continuity" (processing new events with stale context while waiting for the daemon to reboot the harness).
-Invoke the `manage_wake_subscription(action: 'unsubscribe', subscriptionId: '<current-sub-id>')` tool. (The `subscriptionId` is available in the payload of the WAKE events you received, or by querying `manage_wake_subscription(action: 'list')`). This cleanly severs the wake loop, transitioning the harness into a truly dormant state.
+### Step 9: Preserve Harness Wake Eligibility
+As the penultimate operational step, preserve the durable wake route unless the operator explicitly decommissions this harness or a replacement route is verified active. `manage_wake_subscription(action: 'unsubscribe')` is a decommission primitive, not the default sunset primitive: removing the subscription strands future heartbeat and A2A delivery for that identity after the old transcript terminates.
+
+False continuity is prevented by the old-transcript stale-wake invariant and the wake-suppressed continuity ping from Step 8. Any post-sunset wake-shaped payload delivered into the old transcript is noise; the canonical execution target is the fresh session that recovery spawns.
 
 ### Step 10: Memory Persistence (The Sandman Memory)
-This is the final memory checkpoint. You MUST invoke `add_memory` to persist a rich "Sandman memory" node. This memory should encapsulate the entire Sunset Protocol payload (Steps 1-10), including the declared `scope: solo-refresh | convergent` and successful unsubscription. The resulting `Origin Session ID` or `Memory ID` serves as the direct pointer for the next agent. Sandman persistence is strictly REQUIRED for both `solo-refresh` and `convergent` scopes.
+This is the final memory checkpoint. You MUST invoke `add_memory` to persist a rich "Sandman memory" node. This memory should encapsulate the entire Sunset Protocol payload (Steps 1-10), including the declared `scope: solo-refresh | convergent` and preserved/decommissioned wake-route state. The resulting `Origin Session ID` or `Memory ID` serves as the direct pointer for the next agent. Sandman persistence is strictly REQUIRED for both `solo-refresh` and `convergent` scopes.
 
 ## 3. Terminating the Session
 
-After completing the 10 steps above, you must drop your final Sunset Protocol payload directly into the chat response for the Human Commander. 
+After completing the 10 steps above, you must drop your final Sunset Protocol payload directly into the chat response for the Human Commander.
 
 **Format the final response as follows:**
 
@@ -192,11 +193,11 @@ After completing the 10 steps above, you must drop your final Sunset Protocol pa
 
 **Closing:**
 [Brief reflection on the session's success/failures].
-The organism is healing. Future-self entry point preserved in Sandman memory [UUID/SessionID]. 
+The organism is healing. Future-self entry point preserved in Sandman memory [UUID/SessionID].
 
 Next session: read that memory FIRST, then pick up carry-over starting with #[N].
 
-Routing severed via unsubscribe primitive. Halting per Sunset Protocol.
+Wake eligibility preserved unless explicitly decommissioned. Halting per Sunset Protocol.
 
 lane-state: halt-state (session sunset executed)
 ```

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -76,9 +76,9 @@ function heartbeatLivenessStaleMs() {
  * tenant users are not expected to have AgentIdentity graph nodes, and SSE healthcheck boot state
  * normally remains unresolved because request identity flows through `RequestContextService`.
  *
- * `status` is NOT flipped by this projection. Unbound identity is a valid single-tenant
- * fallthrough per the MemoryCoreMcpAuth contract — this block is pure observability, not
- * a health gate. The architectural choice matches "surface, don't obscure".
+ * The projection itself stays pure and does not assign top-level health. The healthcheck
+ * caller treats env-pinned unbound identity as degraded readiness because a named harness
+ * cannot safely receive A2A/wake routing while `bound:false`.
  *
  * @param {Object|null} stdioIdentityState Either `null` or `{userId, agentIdentityNodeId, source}`
  * @returns {{source: String, bound: Boolean, nodeId: String|null, warning: String|null}}
@@ -1220,6 +1220,9 @@ class HealthService extends Base {
         }
 
         if (payload.identity.warning) {
+            if (payload.status === 'healthy') {
+                payload.status = 'degraded';
+            }
             payload.details.push(`WARN: ${payload.identity.warning}`);
         }
 

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -803,11 +803,9 @@ class WakeSubscriptionService extends Base {
 
         const owner = subscription.agentIdentity;
 
-        if (subscription.trigger === 'SENT_TO_ME' && edge.type === 'SENT_TO' && edge.target === owner) {
-            const messageNode = db.nodes.get(edge.source);
-            if (!messageNode) return null;
-            if (messageNode.properties?.wakeSuppressed) return null;
-            const payload = this._buildSentToMePayload(messageNode);
+        if (subscription.trigger === 'SENT_TO_ME') {
+            const payload = this._buildSentToMePayloadForEdge(edge, owner);
+            if (!payload) return null;
             if (!this._matchesFilters(payload, subscription.filters)) return null;
             return this._wrapEvent('wake/sent_to_me', subscription, payload, logIdAnchor);
         }
@@ -824,6 +822,78 @@ class WakeSubscriptionService extends Base {
         }
 
         return null;
+    }
+
+    /**
+     * @summary Builds a `SENT_TO_ME` wake payload only for unread recipient-visible edges.
+     *
+     * Mailbox unread state is split by delivery shape: direct DMs and legacy broadcasts store
+     * `readAt` on the MESSAGE node, while fan-out broadcasts store it on each recipient's
+     * `DELIVERED_TO` edge. Wake replay follows that same taxonomy so stale already-read
+     * messages do not reopen sunsetted or caught-up harnesses.
+     *
+     * @protected
+     * @param {Object} edge Candidate mailbox delivery edge from GraphLog.
+     * @param {String} owner Subscription owner AgentIdentity node id.
+     * @returns {Object|null} `wake/sent_to_me` payload or null when the edge is not wake-eligible.
+     */
+    _buildSentToMePayloadForEdge(edge, owner) {
+        const db = GraphService.db;
+
+        if (edge.type === 'DELIVERED_TO' && edge.target === owner) {
+            if (edge.properties?.readAt) return null;
+
+            const messageNode = db.nodes.get(edge.source);
+            if (!this._messageIsWakeEligible(messageNode)) return null;
+
+            return this._buildSentToMePayload(messageNode);
+        }
+
+        if (edge.type !== 'SENT_TO') return null;
+
+        const messageNode = db.nodes.get(edge.source);
+        if (!this._messageIsWakeEligible(messageNode)) return null;
+
+        if (edge.target === owner) {
+            return messageNode.properties?.readAt ? null : this._buildSentToMePayload(messageNode);
+        }
+
+        if (edge.target === 'AGENT:*') {
+            if (messageNode.properties?.from === owner) return null;
+            if (messageNode.properties?.readAt) return null;
+            if (this._messageHasDeliveryReceipts(messageNode.id)) return null;
+
+            return this._buildSentToMePayload(messageNode);
+        }
+
+        return null;
+    }
+
+    /**
+     * @summary Checks message-level wake suppressors shared by direct and broadcast delivery paths.
+     *
+     * @protected
+     * @param {Object|null} messageNode Candidate MESSAGE graph node.
+     * @returns {Boolean}
+     */
+    _messageIsWakeEligible(messageNode) {
+        return !!messageNode && messageNode.label === 'MESSAGE' && !messageNode.properties?.wakeSuppressed;
+    }
+
+    /**
+     * @summary Detects whether a broadcast MESSAGE has per-recipient delivery receipts.
+     *
+     * Receipt-backed broadcasts are evaluated through `DELIVERED_TO` edges only. The legacy
+     * `SENT_TO -> AGENT:*` path remains for old messages that predate receipt fan-out.
+     *
+     * @protected
+     * @param {String} messageId MESSAGE node id.
+     * @returns {Boolean}
+     */
+    _messageHasDeliveryReceipts(messageId) {
+        return (GraphService.db?.edges?.items || []).some(edge =>
+            edge.source === messageId && edge.type === 'DELIVERED_TO'
+        );
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -323,7 +323,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(ensureHealthyFastPath.database.connection.collections.memories.count).toBe(10);
     });
 
-    test('healthy healthcheck echoes env-pinned unbound identity warning without changing status', async () => {
+    test('healthcheck degrades env-pinned unbound identity warning', async () => {
         HealthService.setStdioIdentityState({
             userId             : 'neo-claude-opus',
             agentIdentityNodeId: null,
@@ -332,16 +332,15 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         const result = await HealthService.healthcheck();
 
-        expect(result.status).toBe('healthy');
+        expect(result.status).toBe('degraded');
         expect(result.identity).toMatchObject({
             source : 'env-var',
             bound  : false,
             nodeId : null
         });
         expect(result.identity.warning).toContain("NEO_AGENT_IDENTITY is pinned to 'neo-claude-opus'");
-        expect(result.details).toContain('Connected to the orchestrator-managed ChromaDB instance');
         expect(result.details).toContain(`WARN: ${result.identity.warning}`);
-        expect(result.details).toContain('All features are operational');
+        expect(result.details).not.toContain('All features are operational');
     });
 
     test('unhealthy cached-refresh shape clears cache and falls through to a full healthcheck', async () => {

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -18,10 +18,10 @@ import crypto                from 'crypto';
 import fs                    from 'fs-extra';
 import path                  from 'path';
 import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
 
-// Stub Neo.get to bypass Playwright boot regression (#10384) in data records.
-// This workaround demonstrates that #10384 affects Phase 3 cross-spec tests,
-// proving the regression affects newcomers. See triage note in PR #10387.
+// Stub Neo.get to keep data-record boot behavior from masking wake-subscription coverage.
+// The setup regression is outside this spec's delivery contract.
 if (!Neo.get) Neo.get = () => null;
 
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
@@ -90,6 +90,12 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         GraphService.upsertNode({id: '@alice', type: 'AGENT', name: 'Alice', properties: {}});
         GraphService.upsertNode({id: '@bob',   type: 'AGENT', name: 'Bob',   properties: {}});
+        GraphService.upsertNode({
+            id        : 'AGENT:*',
+            type      : 'BroadcastSentinel',
+            name      : 'Broadcast',
+            properties: {accountType: 'sentinel'}
+        });
     });
 
     test.afterEach(async () => {
@@ -248,7 +254,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         });
 
         // ------------------------------------------------------------------------
-        // Cross-session duplicate-accumulation reconciler (#11182)
+        // Cross-session duplicate-accumulation reconciler
         // ------------------------------------------------------------------------
 
         test('reconciles duplicate active subscriptions at bootstrap, keeping newest (#11182)', async () => {
@@ -267,8 +273,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
 
             // Seed 2 active subscriptions for @alice with identical route-tuple but
-            // different creation times. Empirical anchor (#11182): @neo-opus-4-7 + @neo-gpt
-            // both accumulated duplicates with ~2 days between createdAt timestamps.
+            // different creation times; only the newest route should remain active.
             const older = insertDurableSubscription({
                 subscriptionId: 'WAKE_SUB:older-uuid',
                 owner         : '@alice',
@@ -387,9 +392,9 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         });
 
         test('reconciler preserves distinct route-tuples for same owner (#11183 Cycle 1 GPT-RA1)', async () => {
-            // RA1 from PR #11183 Cycle 1: reconciler must group by canonical route-key
-            // (trigger + filters + harnessTarget + appName), not flatten by owner. Two
-            // legitimate routes for the same agent must BOTH survive.
+            // Reconciler must group by canonical route-key (trigger + filters +
+            // harnessTarget + appName), not flatten by owner. Two legitimate routes
+            // for the same agent must BOTH survive.
             GraphService.upsertNode({
                 id: '@alice',
                 type: 'AGENT',
@@ -657,15 +662,10 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         });
     });
 
-    // Note (#10664): the Codex round-trip test for `focusSeedKey: 'space'` that shipped in
-    // PR #10663 was removed here. The bridge runtime layer now fails closed for Codex
-    // without an explicit operator-validated `focusSeedKey` (per #10664 fail-closed guard
-    // + bridge-daemon.spec.mjs `Codex UI wake fails closed when no validated focusSeedKey
-    // is configured` test). The schema-layer round-trip behavior (`focusSeedKey` accepted
-    // as `string | null` in `harnessTargetMetadata`) is already covered by the Claude
-    // round-trip test above; duplicating it for Codex with `focusSeedKey: 'space'` would
-    // have implied Space is the validated Codex configuration, which manual matrix
-    // validation 2026-05-03 falsified. See #10664 for empirical anchor.
+    // The Codex `focusSeedKey: 'space'` round-trip is intentionally absent: runtime wake
+    // dispatch fails closed without an explicit operator-validated focus seed. The
+    // schema-layer shape remains covered by the Claude round-trip above, without implying
+    // Space is the validated Codex configuration.
 
     test('subscribe rejects invalid trigger', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
@@ -1157,6 +1157,142 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             expect(emittedEvents.length).toBe(0);
             expect(GraphService.db.nodes.get('MSG:SUPPRESSED').properties.readAt).toBeNull();
+        });
+
+        test('does not emit SENT_TO_ME wake for already-read direct messages', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({
+                    trigger      : 'SENT_TO_ME',
+                    harnessTarget: 'mcp-notifications'
+                });
+            });
+
+            GraphService.upsertNode({
+                id        : 'MSG:READ-DIRECT',
+                type      : 'MESSAGE',
+                properties: {
+                    from   : '@bob',
+                    to     : '@alice',
+                    subject: 'already handled',
+                    readAt : '2026-06-04T12:00:00.000Z'
+                }
+            });
+            GraphService.linkNodes('MSG:READ-DIRECT', '@alice', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(emittedEvents).toEqual([]);
+        });
+
+        test('emits only unread recipient receipts for broadcast SENT_TO_ME wake', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({
+                    trigger      : 'SENT_TO_ME',
+                    harnessTarget: 'mcp-notifications'
+                });
+            });
+
+            GraphService.upsertNode({
+                id        : 'MSG:BROADCAST-READ',
+                type      : 'MESSAGE',
+                properties: {from: '@bob', to: 'AGENT:*', subject: 'read receipt', readAt: null}
+            });
+            GraphService.linkNodes('MSG:BROADCAST-READ', 'AGENT:*', 'SENT_TO', 1.0);
+            GraphService.linkNodes('MSG:BROADCAST-READ', '@alice', 'DELIVERED_TO', 1.0, {
+                deliveredAt : '2026-06-04T12:00:00.000Z',
+                readAt      : '2026-06-04T12:01:00.000Z',
+                deliveryKind: 'broadcast'
+            });
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(emittedEvents).toEqual([]);
+
+            GraphService.upsertNode({
+                id        : 'MSG:BROADCAST-UNREAD',
+                type      : 'MESSAGE',
+                properties: {from: '@bob', to: 'AGENT:*', subject: 'unread receipt', readAt: null}
+            });
+            GraphService.linkNodes('MSG:BROADCAST-UNREAD', 'AGENT:*', 'SENT_TO', 1.0);
+            GraphService.linkNodes('MSG:BROADCAST-UNREAD', '@alice', 'DELIVERED_TO', 1.0, {
+                deliveredAt : '2026-06-04T12:02:00.000Z',
+                readAt      : null,
+                deliveryKind: 'broadcast'
+            });
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(emittedEvents.length).toBe(1);
+            expect(emittedEvents[0].params.eventType).toBe('wake/sent_to_me');
+            expect(emittedEvents[0].params.payload).toMatchObject({
+                messageId  : 'MSG:BROADCAST-UNREAD',
+                isBroadcast: true,
+                subject    : 'unread receipt'
+            });
+        });
+
+        test('does not duplicate receipt-backed broadcasts through the AGENT:* edge', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({
+                    trigger      : 'SENT_TO_ME',
+                    harnessTarget: 'mcp-notifications'
+                });
+            });
+
+            GraphService.upsertNode({
+                id        : 'MSG:BROADCAST-DEDUP',
+                type      : 'MESSAGE',
+                properties: {from: '@bob', to: 'AGENT:*', subject: 'dedupe', readAt: null}
+            });
+            GraphService.linkNodes('MSG:BROADCAST-DEDUP', 'AGENT:*', 'SENT_TO', 1.0);
+            GraphService.linkNodes('MSG:BROADCAST-DEDUP', '@alice', 'DELIVERED_TO', 1.0, {
+                deliveredAt : '2026-06-04T12:03:00.000Z',
+                readAt      : null,
+                deliveryKind: 'broadcast'
+            });
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(emittedEvents.length).toBe(1);
+            expect(emittedEvents[0].params.payload.messageId).toBe('MSG:BROADCAST-DEDUP');
+        });
+
+        test('legacy AGENT:* broadcasts still respect message-level readAt', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({
+                    trigger      : 'SENT_TO_ME',
+                    harnessTarget: 'mcp-notifications'
+                });
+            });
+
+            GraphService.upsertNode({
+                id        : 'MSG:LEGACY-READ',
+                type      : 'MESSAGE',
+                properties: {
+                    from   : '@bob',
+                    to     : 'AGENT:*',
+                    subject: 'legacy read',
+                    readAt : '2026-06-04T12:04:00.000Z'
+                }
+            });
+            GraphService.linkNodes('MSG:LEGACY-READ', 'AGENT:*', 'SENT_TO', 1.0);
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(emittedEvents).toEqual([]);
         });
 
         test('does not emit for non-matching subscription', async () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Resolves #12446
Related: #12440

Hardens the primary wake-liveness surfaces by making `SENT_TO_ME` wake evaluation obey the mailbox unread taxonomy, degrading healthcheck readiness when a stdio harness is env-pinned but unbound, and correcting the sunset workflow so durable wake routing is preserved by default.

Evidence: L2 (unit coverage for wake evaluator/read-state semantics + healthcheck readiness projection + skill manifest lint) -> L2 required (contracted service/test/docs surfaces). No residuals.

## Deltas from ticket

- `WakeSubscriptionService` now evaluates direct `SENT_TO`, receipt-backed `DELIVERED_TO`, and legacy `SENT_TO -> AGENT:*` broadcast delivery using the same read-state split as `MailboxService`.
- Receipt-backed broadcasts are emitted from unread per-recipient `DELIVERED_TO` edges only; the legacy `AGENT:*` edge is skipped when receipts exist, preventing duplicate wake events.
- `HealthService.healthcheck()` now reports env-pinned `bound:false` identity as `degraded` readiness instead of `healthy` with an informational warning.
- The session-sunset payload now treats `unsubscribe` as an explicit decommission primitive, not the default sunset continuity step.
- No temporary ledger/testing artifact was added to `learn/tree.json`. The portal consumes that file as public Learn navigation; ledger evidence remains in the ticket/PR surfaces rather than becoming a public-facing guide.

## Contract Ledger

| Surface | Source of Authority | Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `WakeSubscriptionService._evaluateEdgeAgainstSubscription()` / `_buildSentToMePayloadForEdge()` | #12446 Contract Ledger; `MailboxService` unread taxonomy | Emit `SENT_TO_ME` only for recipient-visible unread messages across direct, receipt-backed broadcast, and legacy broadcast paths | `wakeSuppressed` remains a hard no-wake override; legacy broadcasts without receipts retain message-level `readAt` | JSDoc `@summary` on new helper methods | `WakeSubscriptionService.spec.mjs` focused pump tests |
| `HealthService.healthcheck()` identity readiness | #12446 Contract Ledger | Env-pinned unbound stdio identity downgrades status to `degraded` and removes all-operational success wording | Existing unhealthy/degraded states are not overwritten upward | Updated identity projection JSDoc | `HealthService.spec.mjs` healthcheck test |
| `.agents/skills/session-sunset/references/session-sunset-workflow.md` | #12446 Contract Ledger; `/turn-memory-pre-flight` | Preserve durable wake route by default; unsubscribe only for explicit decommission/replacement route | Old-transcript stale-wake invariant + wake-suppressed continuity ping prevent false continuity | Skill payload updated; router unchanged | `lint-skill-manifest`, `git diff --check`, pre-commit hook |

## Substrate Slot Rationale

- Modified section: session-sunset Step 9, disposition delta `rewrite`.
- Trigger-frequency: session-boundary only, not every turn.
- Failure-severity: high for wake continuity because accidental unsubscribe strands future heartbeat/A2A delivery.
- Enforceability: discipline-only today; runtime support is covered by the wake evaluator tests and healthcheck readiness signal.
- Load-runtime effect: no always-loaded router expansion; the rule body remains in the conditional session-sunset payload.
- Decay mitigation: the rewrite removes an incorrect mandatory action instead of adding a new parallel checklist. Future decommission behavior remains discoverable through the same Step 9 slot.
- Decision Record impact: none. This updates workflow payload semantics without changing the accepted Progressive Disclosure or wake-substrate ADR model.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 98 passed.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> OK.
- `node ./buildScripts/util/check-ticket-archaeology.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` -> 0 violations.
- `git diff --check` -> passed.
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.

## Post-Merge Validation

- [ ] In a live harness, confirm an already-read direct A2A message does not wake a sunsetted transcript.
- [ ] Confirm a receipt-backed unread `AGENT:*` broadcast wakes the intended recipient exactly once.
- [ ] Confirm `healthcheck` reports `status: "degraded"` when `NEO_AGENT_IDENTITY` resolves to no AgentIdentity node.

## Commits

- `78db2e6c1` - `fix(memory-core): harden wake liveness surfaces (#12446)`

## Evolution

During implementation, the portal `learn/tree.json` consumer was checked after operator friction: `apps/portal/view/learn/MainContainerStateProvider.mjs` resolves `learnneo` to `learn/` and hides only records marked `hidden` directly or by ancestor. That means temporary ledger/testing pages listed in `learn/tree.json` become public Learn navigation, so this PR keeps ledger evidence in issue/PR substrates and avoids public-doc churn.
