### PR TITLE
fix(orchestrator): fail loud on AiConfig subtree reads (#12515)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -386,7 +386,7 @@ export class Orchestrator extends Base {
      * @returns {String[]|null}
      */
     get swarmHeartbeatExplicitTargets() {
-        const raw = AiConfig.orchestrator.swarmHeartbeat?.targets;
+        const raw = AiConfig.orchestrator.swarmHeartbeat.targets;
         if (!raw) return null;
         const list = String(raw).split(',').map(s => s.trim()).filter(Boolean);
         return list.length > 0 ? list : null;
@@ -403,8 +403,8 @@ export class Orchestrator extends Base {
 
     // MLX + LM Studio CLI inference-server lane config. Canonical defaults + env overrides
     // live in `ai/config.template.mjs::orchestrator.{mlx,lms}` + `envBindings.orchestrator.{mlx,lms}`.
-    get mlxEnabled() { return !!AiConfig.orchestrator.mlx?.enabled; }
-    get lmsEnabled() { return !!AiConfig.orchestrator.lms?.enabled; }
+    get mlxEnabled() { return !!AiConfig.orchestrator.mlx.enabled; }
+    get lmsEnabled() { return !!AiConfig.orchestrator.lms.enabled; }
     get lmsPreloadConfig() { return buildLmsPreloadConfig(AiConfig); }
     get lmsModels()        { return this.lmsPreloadConfig.models;      }
 
@@ -444,15 +444,15 @@ export class Orchestrator extends Base {
         this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
             nodeBin   : options.nodeBin || process.argv[0],
-            chromaPort: AiConfig.engines.chroma?.port,
+            chromaPort: AiConfig.engines.chroma.port,
             mlxEnabled: this.mlxEnabled,
-            mlxModel  : AiConfig.orchestrator.mlx?.model,
-            mlxPort   : AiConfig.orchestrator.mlx?.port,
+            mlxModel  : AiConfig.orchestrator.mlx.model,
+            mlxPort   : AiConfig.orchestrator.mlx.port,
             lmsEnabled: this.lmsEnabled,
-            lmsModel  : AiConfig.orchestrator.lms?.model,
+            lmsModel  : AiConfig.orchestrator.lms.model,
             lmsModels : lmsPreloadConfig.models,
-            lmsHost   : AiConfig.openAiCompatible?.host,
-            lmsPort   : AiConfig.orchestrator.lms?.port,
+            lmsHost   : AiConfig.openAiCompatible.host,
+            lmsPort   : AiConfig.orchestrator.lms.port,
             lmsContextLengths: lmsPreloadConfig.contextLengths,
             providerReadiness: AiConfig.orchestrator.providerReadiness,
             graphLogCompactionVacuum: AiConfig.orchestrator.graphLogCompaction.vacuum
@@ -508,7 +508,7 @@ export class Orchestrator extends Base {
                 // is sufficient. Order matches the JSDoc contract on the service class.
                 this.swarmHeartbeatService.identity        = this.swarmHeartbeatIdentity;
                 this.swarmHeartbeatService.pollIntervalMs  = AiConfig.orchestrator.intervals.swarmHeartbeatMs;
-                this.swarmHeartbeatService.targetSource    = AiConfig.orchestrator.swarmHeartbeat?.targetSource ?? null;
+                this.swarmHeartbeatService.targetSource    = AiConfig.orchestrator.swarmHeartbeat.targetSource ?? null;
                 this.swarmHeartbeatService.explicitTargets = this.swarmHeartbeatExplicitTargets;
                 await this.swarmHeartbeatService.ready();
             } catch (e) {
@@ -599,7 +599,7 @@ export class Orchestrator extends Base {
      * @returns {Boolean}
      */
     isChromaRecycleDue(state, now) {
-        const maxRuntimeMs = AiConfig.orchestrator.chroma?.maxRuntimeMs;
+        const maxRuntimeMs = AiConfig.orchestrator.chroma.maxRuntimeMs;
         const lastRunAt    = state?.lastRunAt || 0;
         // lastRunAt === 0 means no recorded spawn (uninitialized / never started): uptime is
         // undefined, so never recycle. A genuinely running daemon always carries a real start
@@ -617,7 +617,7 @@ export class Orchestrator extends Base {
      */
     probeChromaReady({timeoutMs = 2000} = {}) {
         return new Promise(resolve => {
-            const socket = net.connect({host: 'localhost', port: AiConfig.engines.chroma?.port});
+            const socket = net.connect({host: 'localhost', port: AiConfig.engines.chroma.port});
             const finish = result => { socket.destroy(); resolve(result); };
             socket.setTimeout(timeoutMs);
             socket.once('connect', () => finish(true));
@@ -657,7 +657,7 @@ export class Orchestrator extends Base {
             // once the fresh daemon is connection-ready. Implicitly gated by chromaDaemonEnabled
             // (chroma is only a continuousTask when that lane is enabled).
             if (taskName === 'chroma' && this.isChromaRecycleDue(state, now)) {
-                this.processSupervisorService.killTask('chroma', `max-runtime:${now - (state.lastRunAt || 0)}ms>${AiConfig.orchestrator.chroma?.maxRuntimeMs}ms`);
+                this.processSupervisorService.killTask('chroma', `max-runtime:${now - (state.lastRunAt || 0)}ms>${AiConfig.orchestrator.chroma.maxRuntimeMs}ms`);
                 this._chromaDefragPending = true;
                 continue;
             }

--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -184,7 +184,7 @@ export async function startOrchestrator(options = {}) {
 
     return Orchestrator.start({
         dataDir: DAEMON_DATA_DIR,
-        primaryDevSyncRootsConfig: AiConfig.orchestrator?.devSyncRoots,
+        primaryDevSyncRootsConfig: AiConfig.orchestrator.devSyncRoots,
         ...options
     });
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -5,7 +5,6 @@ import {fileURLToPath} from 'url';
 import Neo       from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 import AiConfig from '../../../../../../ai/config.mjs';
-import BaseConfig, {createConfigProxy} from '../../../../../../ai/BaseConfig.mjs';
 import {
     Orchestrator
 } from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
@@ -20,6 +19,7 @@ const __dirname  = path.dirname(__filename);
 const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
 
 const ORCHESTRATOR_MJS_PATH    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
+const ORCHESTRATOR_DAEMON_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
 const TASK_DEFINITIONS_MJS_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/TaskDefinitions.mjs');
 
 let invariantSeq         = 0;
@@ -106,7 +106,7 @@ test.afterEach(() => {
     AiConfig.orchestrator.deploymentMode = savedDeploymentMode;
 
     // Restore the full mlx/lms objects (overwrites every leaf on the still-healthy parent).
-    // Post-#12101 these leaves are data-seeded and always present on the singleton, so
+    // These leaves are data-seeded and always present on the singleton, so
     // there is no `delete`-to-absent branch — the verbatim tests above only swap object
     // values, never null the parent.
     if (savedMlxConfig !== undefined) {
@@ -203,7 +203,7 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
         expect(AiConfig.orchestrator.localOnly.kbSyncEnabled).toBe(!baselineLocalKbs);
     });
 
-    // === mlx + lms supervised-server lane getters (#12005) ===
+    // === mlx + lms supervised-server lane getters ===
     // AiConfig.orchestrator.mlx + .lms + the 6 NEO_ORCHESTRATOR_{MLX,LMS}_{ENABLED,MODEL,PORT}
     // env vars are saved/restored by the file-level beforeEach/afterEach hooks above —
     // individual tests can mutate freely without leak risk.
@@ -214,38 +214,6 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
 
         AiConfig.orchestrator.mlx = {enabled: false, model: 'm', port: '11435'};
         expect(createMinimalOrchestrator().mlxEnabled).toBe(false);
-    });
-
-    // Post-#12101 the AiConfig singleton is a reactive `Neo.state.Provider`, so its
-    // `orchestrator.mlx`/`.lms` leaves are seeded from the data tree at construction and ALWAYS
-    // exist on the singleton. A fresh BaseConfig instance whose data tree omits the namespace is the
-    // faithful "config missing" state — BUT `BaseConfig.getParent()` makes every instance
-    // inherit the registered realm root (`Neo.ai.Config`), so the fresh instance would otherwise
-    // resolve the namespace UP the chain. Detach the root for the duration so it resolves in
-    // isolation, exercising the same undefined-safe `?.` delegation the Orchestrator `mlx*`/`lms*`
-    // getters use against `AiConfig.orchestrator.{mlx,lms}`.
-    test('mlx getter delegation is undefined-safe when AiConfig.orchestrator.mlx is missing', () => {
-        const prevRoot = Neo.ai?.Config;
-        if (Neo.ai) {delete Neo.ai.Config}
-
-        try {
-            const config = Neo.create(BaseConfig, {data: {
-                      orchestrator: {intervals: {pollMs: {default: 3000}}}
-                  }}),
-                  cfg    = createConfigProxy(config);
-
-            // mlx absent locally + no realm root → resolves undefined, not a stale default.
-            expect(cfg.orchestrator.mlx).toBeUndefined();
-
-            // Mirror of the keeper mlxEnabled getter + the inline AiConfig.orchestrator.mlx?.{model,port} reads.
-            expect(!!cfg.orchestrator.mlx?.enabled).toBe(false);
-            expect(cfg.orchestrator.mlx?.model).toBeUndefined();
-            expect(cfg.orchestrator.mlx?.port).toBeUndefined();
-
-            config.destroy();
-        } finally {
-            if (prevRoot !== undefined) {Neo.ai.Config = prevRoot}
-        }
     });
 
     test('lmsEnabled coerces to boolean + lmsModels follow state-provider role selectors (model/port/host inlined at call sites)', () => {
@@ -310,31 +278,6 @@ test.describe('Orchestrator config getters delegate to AiConfig (data env/parse 
     });
 
 
-    // See the mlx-missing test above: a fresh instance inherits the realm root via
-    // getParent(), so the root is detached here to simulate a genuinely-missing namespace.
-    test('lms getter delegation is undefined-safe when AiConfig.orchestrator.lms is missing', () => {
-        const prevRoot = Neo.ai?.Config;
-        if (Neo.ai) {delete Neo.ai.Config}
-
-        try {
-            const config = Neo.create(BaseConfig, {data: {
-                      orchestrator: {intervals: {pollMs: {default: 3000}}}
-                  }}),
-                  cfg    = createConfigProxy(config);
-
-            // lms absent locally + no realm root → resolves undefined, not a stale default.
-            expect(cfg.orchestrator.lms).toBeUndefined();
-
-            // Mirror of the keeper lmsEnabled getter + the inline AiConfig.orchestrator.lms?.{model,port} reads.
-            expect(!!cfg.orchestrator.lms?.enabled).toBe(false);
-            expect(cfg.orchestrator.lms?.model).toBeUndefined();
-            expect(cfg.orchestrator.lms?.port).toBeUndefined();
-
-            config.destroy();
-        } finally {
-            if (prevRoot !== undefined) {Neo.ai.Config = prevRoot}
-        }
-    });
 });
 
 test.describe('Orchestrator parent-prop propagation (#11834 AC3)', () => {
@@ -436,6 +379,32 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
         const matches = codeLines.match(/processSupervisorService\.set\s*\(\s*\{\s*\.\.\.this/g) || [];
 
         expect(matches, 'Orchestrator.mjs must NOT spread `this` into `processSupervisorService.set({...})` (Sub-1 anti-pattern; `afterSetX` parent-prop propagation hooks supersede the start()-time context replay).').toHaveLength(0);
+    });
+
+    test('orchestrator AiConfig reads are fail-loud direct reads on declared subtrees (#12515)', async () => {
+        const orchestratorSource = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_MJS_PATH, 'utf8'));
+        const daemonSource       = stripCommentsAndStrings(await fs.readFile(ORCHESTRATOR_DAEMON_PATH, 'utf8'));
+
+        for (const snippet of [
+            'AiConfig.orchestrator.swarmHeartbeat?.',
+            'AiConfig.orchestrator.mlx?.',
+            'AiConfig.orchestrator.lms?.',
+            'AiConfig.orchestrator.chroma?.',
+            'AiConfig.engines.chroma?.',
+            'AiConfig.openAiCompatible?.'
+        ]) {
+            expect(orchestratorSource, `Orchestrator.mjs must not defend declared AiConfig subtree ${snippet}`).not.toContain(snippet);
+        }
+
+        expect(daemonSource, 'daemon.mjs must read AiConfig.orchestrator.devSyncRoots directly').not.toContain('AiConfig.orchestrator?.devSyncRoots');
+
+        expect(orchestratorSource).toContain('AiConfig.orchestrator.swarmHeartbeat.targets');
+        expect(orchestratorSource).toContain('AiConfig.orchestrator.mlx.enabled');
+        expect(orchestratorSource).toContain('AiConfig.orchestrator.lms.enabled');
+        expect(orchestratorSource).toContain('AiConfig.engines.chroma.port');
+        expect(orchestratorSource).toContain('AiConfig.openAiCompatible.host');
+        expect(orchestratorSource).toContain('AiConfig.orchestrator.chroma.maxRuntimeMs');
+        expect(daemonSource).toContain('AiConfig.orchestrator.devSyncRoots');
     });
 
     test('Orchestrator.mjs has no `_`-suffix reactive config slot without a corresponding `beforeSet*` or `afterSet*` hook', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -21,7 +21,7 @@ let savedGraphLogCompactionMissing = false;
 let savedDeploymentMode = null;
 
 /**
- * Test helper updated per Epic #11831 Sub 1 (#11833) Orchestrator refactor:
+ * Test helper for the Orchestrator refactor shape:
  * - Operator policy values (intervals + booleans) are now Class D lazy getters reading
  *   from AiConfig — Neo.create config can't reach them. Helper injects via AiConfig.data
  *   mutation with restore-in-afterEach.
@@ -723,7 +723,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     test('resolves default paths correctly without configuration overrides', () => {
-        // Post Sub 1 #11833: configure() removed; path resolution is direct instance-field
+        // With configure() removed, path resolution is direct instance-field
         // assignment + buildTaskDefinitions(), mirroring the substrate-correct shape used
         // in `start()`. No side-effecting orchestrator.start() needed for path tests.
         const orchestrator = Neo.create(Orchestrator);
@@ -898,14 +898,14 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     // ─────────────────────────────────────────────────────────────────────────────
-    // Lane A of #11503 — per #11513:
-    //   1. AC2: pin DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES contents so future refactors
+    // Heavy-maintenance classification coverage:
+    //   1. Pin DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES contents so future refactors
     //      can't silently drop a heavy class.
-    //   2. AC3-AC6: cross-poll deferral coverage for backup / dream / primary-dev-sync
+    //   2. Cross-poll deferral coverage for backup / dream / primary-dev-sync
     //      and proof that `backup` is now ALSO a valid blocker (previously: only
     //      summary↔kbSync pair was pinned at line 184).
     //
-    // Golden-path is intentionally NOT in this set (light-classified per #11511 / PR #11512).
+    // Golden-path is intentionally NOT in this set: it is light-classified maintenance.
     // Its dream-dependency backpressure is covered separately at line ~242.
     // ─────────────────────────────────────────────────────────────────────────────
 
@@ -922,7 +922,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             'summary'
         ].sort());
         expect(Object.isFrozen(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)).toBe(true);
-        // Defensive: golden-path is intentionally OUT per #11511 / #11512 (light maintenance).
+        // Defensive: golden-path is intentionally OUT as light maintenance.
         expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain('golden-path');
     });
 
@@ -1015,8 +1015,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             }
         });
 
-        // backup is now the blocker (only meaningful AFTER backup is in the heavy set —
-        // before #11513 this test would have observed kbSync running despite backup active).
+        // backup is now the blocker because it belongs to the heavy set; without that
+        // classification this test would observe kbSync running despite backup active.
         TaskStateService.taskState.backup.running = true;
         orchestrator.processSupervisorService = {
             runTask(taskName, reason) {
@@ -1171,9 +1171,9 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         //      wrapper tries to acquire lease → sees A's active lease → 'held' → defers
         //      with reasonCode='heavy-maintenance-lease-held'.
         //
-        // This is the substrate gap PR #11514 (Lane A in-process check) could not close —
-        // in-process activeHeavyTask is per-process; the file lease is the only cross-process
-        // mutex. Without this test the cross-daemon coverage gap would regress silently.
+        // In-process activeHeavyTask is per-process; the file lease is the only
+        // cross-process mutex. Without this test the cross-daemon coverage gap would
+        // regress silently.
         const sharedLeasePath = `/tmp/orchestrator-test/heavy-maintenance-lease-cross-daemon-${process.pid}-${++testOrchestratorSeq}.json`;
 
         const outcomesA = [];
@@ -1237,7 +1237,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     });
 
     // ─────────────────────────────────────────────────────────────────────────────
-    // #11766 — swarm-heartbeat lane. The standalone swarm-heartbeat daemon is folded
+    // Swarm-heartbeat lane. The standalone swarm-heartbeat daemon is folded
     // into the Orchestrator as a config-gated scheduled lane. The lane runs
     // `SwarmHeartbeatService.pulse()` per cadence tick and is skipped when disabled.
     // It is NOT a heavy-maintenance task — it runs directly without backpressure.
@@ -1441,14 +1441,11 @@ test.describe('Neo.ai.daemons.Orchestrator — chroma max-runtime recycle (#1213
         expect(orchestrator._chromaDefragPending).toBeFalsy();
     });
 
-    test('isChromaRecycleDue: false when the ceiling is 0 or absent (recycling disabled)', () => {
+    test('isChromaRecycleDue: false when the ceiling is 0 (recycling disabled)', () => {
         const orchestrator = createTestOrchestrator();
         const now          = Date.now();
 
         AiConfig.orchestrator.chroma = {maxRuntimeMs: 0};
-        expect(orchestrator.isChromaRecycleDue({running: true, lastRunAt: now - 999999}, now)).toBe(false);
-
-        AiConfig.orchestrator.chroma = undefined;
         expect(orchestrator.isChromaRecycleDue({running: true, lastRunAt: now - 999999}, now)).toBe(false);
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Resolves #12515
Related: #12461

Drops the remaining orchestrator-cluster B3 defensive optional chains on declared AiConfig subtrees. The orchestrator now reads `orchestrator.swarmHeartbeat`, `orchestrator.mlx`, `orchestrator.lms`, `orchestrator.chroma`, `engines.chroma`, `openAiCompatible`, and daemon `orchestrator.devSyncRoots` directly, preserving nullable leaf semantics where the leaf itself is nullable.

Evidence: L2 (focused Playwright unit coverage + static source-grep proof + pre-commit hooks) → L2 required (contract is unit/static-verifiable). No residuals.

## Deltas from ticket

- Removed stale durable ticket references in touched orchestrator test comments because the repository ticket-archaeology hook now enforces behavior-only comments on touched files.
- Preserved the `orchestrator.swarmHeartbeat.targetSource ?? null` leaf-value normalization; only the declared subtree defense was removed.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` → 75 passed.
- `git diff --check` → passed.
- `git diff --cached --check` → passed.
- `node ./buildScripts/util/check-ticket-archaeology.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` → 0 violations.
- `rg -n "AiConfig\.(orchestrator\.swarmHeartbeat|orchestrator\.mlx|orchestrator\.lms|orchestrator\.chroma|engines\.chroma|openAiCompatible)\?\.|AiConfig\.orchestrator\?\.devSyncRoots" ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/daemon.mjs` → no matches.
- Pre-commit hook passed: check-whitespace, check-shorthand, check-ticket-archaeology.

## Post-Merge Validation

- [ ] Confirm #12515 auto-closes and #12461 remains open for the remaining non-orchestrator B3 cleanup clusters.

## Commits

- `9caf53c26` — `fix(orchestrator): fail loud on AiConfig subtree reads (#12515)`