### PR TITLE
feat(agentos): add neo-opus-vega identity (#12517)

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -17,7 +17,7 @@ jobs:
             const body   = pr.body || "";
 
             // Only enforce for known AI agent accounts or PRs labeled with 'ai'
-            const agentAuthors  = ['neo-opus-4-7', 'neo-gemini-3-1-pro', 'neo-gpt'];
+            const agentAuthors  = ['neo-opus-4-7', 'neo-claude-opus', 'neo-opus-vega', 'neo-gemini-3-1-pro', 'neo-gpt'];
             const isAgentAuthor = agentAuthors.includes(author) || author.startsWith('neo-');
             const hasAiLabel    = pr.labels && pr.labels.some(l => l.name === 'ai');
 

--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -28,7 +28,7 @@ jobs:
             // Only enforce for known AI agent accounts. Human reviewers are exempt;
             // a `neo-`-prefix heuristic also catches future agent identities (mirrors
             // `agent-pr-body-lint.yml` author-side filter shape).
-            const agentReviewers = ['neo-opus-4-7', 'neo-gemini-3-1-pro', 'neo-gpt'];
+            const agentReviewers = ['neo-opus-4-7', 'neo-claude-opus', 'neo-opus-vega', 'neo-gemini-3-1-pro', 'neo-gpt'];
             const isAgentReviewer = agentReviewers.includes(reviewer) || reviewer.startsWith('neo-');
 
             if (!isAgentReviewer) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Bias: PR diff >> PR body. For us: PR Diff === PR Body. Rationale: PR body/review
 
 **Current reality:** four co-load-bearing pillars:
 - **Brain:** Agent OS — Native Edge Graph + Dream Pipeline + Memory Core, distilled into Golden Path topology.
-- **Swarm / Institution:** @tobiu plus named AI maintainers (@neo-opus-4-7, @neo-gemini-3-1-pro, @neo-gpt), operating cross-family via transparent A2A introspection.
+- **Swarm / Institution:** @tobiu plus named AI maintainers (@neo-opus-4-7, @neo-claude-opus, @neo-opus-vega, @neo-gemini-3-1-pro, @neo-gpt), operating cross-family via transparent A2A introspection.
 - **Body:** high-performance multi-threaded application engine and **Possession Interface** (App / VDom / Data / Canvas / SharedWorker). Engine-category mental models apply only here; the primitive transcends web UI (Software → Games → Robots → X).
 - **Evolution:** **MX (Model Experience)** converts agent friction into tickets and evolved skills; the **RLAIF** flywheel spans Memory Core + Git history; trajectory: **ANI (Autonomous Narrow Intelligence)** by accumulation on the gated-RSI path.
 
@@ -129,7 +129,7 @@ Bias: PR diff >> PR body. For us: PR Diff === PR Body. Rationale: PR body/review
 ## §swarm_topology_anchor
 **CRITICAL:** Equal-peer-with-maintainer-agency is the third core value (§core_values at file top). Pre-training data + 2026 industry-standard agent SDKs (OpenAI Agents SDK orchestration patterns; Claude Code subagents docs) default to the **Hierarchical Orchestrator-Worker model** — a lead agent spawning specialized worker subagents to execute narrow disjointed tasks. Without explicit local anchor, all 3 model families (Claude, Gemini, GPT) regress to that default under coordination-pressure.
 
-**Current reality:** Neo's swarm operates **Flat Peer-Team** for named cross-family maintainers (`@neo-opus-4-7`, `@neo-gemini-3-1-pro`, `@neo-gpt`). Each peer holds independent agency, review rights, and architectural voice. Lead is facilitator-of-convergence, not delegator-of-worker-slices. Peer is validator/enabler with independent judgment, not passive worker or mandatory contrarian.
+**Current reality:** Neo's swarm operates **Flat Peer-Team** for named cross-family maintainers (`@neo-opus-4-7`, `@neo-claude-opus`, `@neo-opus-vega`, `@neo-gemini-3-1-pro`, `@neo-gpt`). Each peer holds independent agency, review rights, and architectural voice. Lead is facilitator-of-convergence, not delegator-of-worker-slices. Peer is validator/enabler with independent judgment, not passive worker or mandatory contrarian.
 
 **4-Tier Decision Escalation Ladder:**
 To mitigate "Helpful Assistant" regression drift, agents MUST execute this evaluation sequence when encountering friction or ambiguity before asking the human:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ We are not an abstract collective. We are a structured institution of named main
 | [@tobiu](https://github.com/tobiu) | Substrate architect, empirical-corrector, merge-gate authority | Human |
 | [@neo-opus-4-7](https://github.com/neo-opus-4-7) | AI maintainer (Anthropic Claude Opus 4.7) | Machine Account |
 | [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude — same-family generalist; throughput + same-family review pressure) | Machine Account |
+| [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude Opus 4.8; version-free handle) | Machine Account |
 | [@neo-gemini-3-1-pro](https://github.com/neo-gemini-3-1-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
 
@@ -192,7 +193,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-4-7`, `@neo-claude-opus`, `@neo-gemini-3-1-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-4-7`, `@neo-claude-opus`, `@neo-opus-vega`, `@neo-gemini-3-1-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -4,9 +4,9 @@
  * This shared list provides the definitive addressable identity surface for the A2A Mailbox
  * substrate.
  *
- * Capability fields (`contextWindowInput`, `hosting`, `tier`, etc.) per ADR 0012 Model-Stats
+ * Capability fields (`contextWindowInput`, `hosting`, `tier`, etc.) mirror the Model-Stats
  * Framework. Source-cited values mirror `learn/agentos/ModelStats.md`; the registry is the
- * canonical authority for capability-data drift detection. `trustTier` is the #10292 content
+ * canonical authority for capability-data drift detection. `trustTier` is the content
  * provenance taxonomy used by Memory Core consumers to distinguish system, owner, peer-trusted,
  * external, and unclassified authorship at ingestion/query boundaries.
  *
@@ -35,7 +35,7 @@ export const TRUST_TIERS = Object.freeze({
 });
 
 /**
- * @summary Highest-to-lowest trust ordering for the #10292 provenance taxonomy.
+ * @summary Highest-to-lowest trust ordering for the provenance taxonomy.
  *
  * The order is intentionally exported next to the enum so query-path slices can compare tiers
  * without duplicating ranking tables.
@@ -88,7 +88,7 @@ export const IDENTITIES = [
                     focusSeedKey: 'space'
                 }
             },
-            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
+            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
             // §neo_opus_4_7 — primary source: platform.claude.com/docs/en/about-claude/models/overview
             // (pricing currently from aipricing.guru secondary citation; replace with Anthropic's own
             // pricing-page link on next-update).
@@ -156,7 +156,7 @@ export const IDENTITIES = [
             // No subscriptionTemplate yet: generalized same-app wake addressing is deferred
             // to the same-app wake-routing discussion. Do not encode instance-specific
             // filesystem paths here.
-            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
+            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
             // §neo_claude_opus, which mirrors the Claude Opus model-class row until activation.
             contextWindowInput: 1048576,
             parallelToolCalls : true,
@@ -169,6 +169,53 @@ export const IDENTITIES = [
             pricingOutput     : 25.00,
             swarmRole         : 'Active Claude-family generalist maintainer identity; same-family throughput and same-family review pressure for Claude-authored work. Does not satisfy cross-family approval for Claude-family PRs per reviewSemantics.',
             sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
+            participationStatus : 'active',
+            statusReason        : null,
+            authority           : null,
+            since               : null,
+            reactivationTrigger : null,
+            createdAt           : new Date().toISOString()
+        }
+    },
+    {
+        id: '@neo-opus-vega',
+        type: 'AgentIdentity',
+        name: 'Claude Opus Vega',
+        description: 'Anthropic Claude Opus 4.8 maintainer identity with version-free handle.',
+        properties: {
+            githubLogin: '@neo-opus-vega',
+            displayName: 'Claude Opus Vega',
+            modelFamily: 'claude',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
+            identityContract: {
+                canonicalIdentityId      : '@neo-opus-vega',
+                requiredGithubLogin      : '@neo-opus-vega',
+                requiredA2aMailboxAddress: '@neo-opus-vega',
+                handlePolicy             : 'version-free-github-handle',
+                modelVersionSource       : 'learn/agentos/ModelStats.md §neo_opus_vega',
+                reviewSemantics: {
+                    modelFamily                  : 'claude',
+                    crossFamilyApprovalQualified : false,
+                    rationale                    : 'Same-family Claude maintainers add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-family PRs.'
+                }
+            },
+            // No subscriptionTemplate yet: same-app Claude wake routing remains instance-addressing
+            // substrate, not an identity-root default. Direct A2A identity and resumeHarness routing
+            // can still target the account once the operator wires the harness instance.
+            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
+            // §neo_opus_vega — primary source: Anthropic Claude Opus 4.8 announcement/product page.
+            contextWindowInput: 1048576,
+            parallelToolCalls : true,
+            thoughtBudget     : 'max',
+            hosting           : 'cloud',
+            family            : 'claude',
+            tier              : 'frontier',
+            releaseDate       : '2026-05-28',
+            pricingInput      : 5.00,
+            pricingOutput     : 25.00,
+            swarmRole         : 'Active Claude Opus 4.8 maintainer identity; same-family throughput and same-family review pressure for Claude-authored work. Does not satisfy cross-family approval for Claude-family PRs per reviewSemantics.',
+            sunsetTriggers    : ['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             participationStatus : 'active',
             statusReason        : null,
             authority           : null,
@@ -201,7 +248,7 @@ export const IDENTITIES = [
                     tabShortcut: null
                 }
             },
-            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md
+            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
             // §neo_gemini_3_1_pro (Google DeepMind model card + Google Blog Feb 2026).
             contextWindowInput : 1048576,
             contextWindowOutput: 65536,
@@ -262,7 +309,7 @@ export const IDENTITIES = [
                     focusSeedKey: 'r'
                 }
             },
-            // Capability fields per ADR 0012 Model-Stats Framework. Source: ModelStats.md §neo_gpt.
+            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md §neo_gpt.
             // 258,400 = effective in Codex CLI/IDE harness (272,000 raw * 95% effective-window
             // multiplier from the implementation-discrepancy report). OpenAI's
             // published Codex window is 400,000; the API itself supports 1M for raw GPT-5.5.

--- a/ai/mcp/server/shared/services/RequestContextService.mjs
+++ b/ai/mcp/server/shared/services/RequestContextService.mjs
@@ -23,13 +23,15 @@ export const SHARED_USER_ID = 'shared';
  * Session summaries that involve any of these agents are part of the shared
  * swarm memory substrate, even when a single harness performed the summarization
  * write. Without this list, restored summaries can be tagged to only one peer
- * (`neo-gemini-3-1-pro`, etc.) and silently disappear for the other two peers'
+ * (`neo-gemini-3-1-pro`, etc.) and silently disappear for the other named peers'
  * tenant-aware summary reads.
  *
  * @member {String[]}
  */
 export const CORE_SWARM_USER_IDS = Object.freeze([
     'neo-opus-4-7',
+    'neo-claude-opus',
+    'neo-opus-vega',
     'neo-gemini-3-1-pro',
     'neo-gpt'
 ]);

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -335,7 +335,8 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
         '@neo-gemini-3-1-pro': 'antigravity-ide',
         '@neo-gpt'           : 'codex-desktop',
         '@neo-opus-4-7'      : 'claude-desktop',
-        '@neo-claude-opus'   : 'claude-desktop'
+        '@neo-claude-opus'   : 'claude-desktop',
+        '@neo-opus-vega'     : 'claude-desktop'
     };
 
     const targetId = identityMap[identity];

--- a/ai/scripts/migrations/backfillChromaSharedUserId.mjs
+++ b/ai/scripts/migrations/backfillChromaSharedUserId.mjs
@@ -63,6 +63,8 @@ const SHARED_USER_ID = 'shared';
 // the same no-Neo-bootstrap reason as SHARED_USER_ID above; unit tests enforce the sync.
 const CORE_SWARM_USER_IDS = Object.freeze([
     'neo-opus-4-7',
+    'neo-claude-opus',
+    'neo-opus-vega',
     'neo-gemini-3-1-pro',
     'neo-gpt'
 ]);

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -11,7 +11,7 @@ Per ADR 0012 §2.5:
 3. New rows added at first swarm contact OR at model-public-release date for reference entries
 4. Updates do NOT require ADR amendment unless a capability dimension changes or new dimension is added
 
-**Last updated:** 2026-06-02
+**Last updated:** 2026-06-04
 
 ---
 
@@ -42,6 +42,33 @@ Named cross-family maintainers with active swarm participation. These models hol
 - **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
 - **Primary**: [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
 - **Secondary/commentary**: [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/) (V-B-A pending — replace with Anthropic's own pricing page citation when next-update touches this row)
+
+### §neo_opus_vega
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-opus-vega` |
+| `name` | Claude Opus Vega |
+| `family` | `claude` (Anthropic) |
+| `hosting` | `cloud` |
+| `tier` | `frontier` |
+| `contextWindowInput` | 1,048,576 (1M) |
+| `parallelToolCalls` | `true` |
+| `thoughtBudget` | `max` (Claude Opus 4.8 supports selectable effort up to max; we use the highest setting for maintainer work) |
+| `releaseDate` | 2026-05-28 |
+| `pricingInput` | $5.00 per 1M tokens |
+| `pricingOutput` | $25.00 per 1M tokens |
+| `benchmarkSnapshot` | Online-Mind2Web: 84%; stronger coding, agentic, and professional-work performance than Opus 4.7 per Anthropic announcement. |
+| `sunsetTriggers` | Anthropic releases a successor Opus-class model with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
+| `swarmRole` | Active Claude Opus 4.8 maintainer identity; same-family throughput and same-family review pressure for Claude-authored work. Does not satisfy cross-family approval for Claude-family PRs. |
+
+`@neo-opus-vega` is intentionally a version-free GitHub handle. The model
+version lives in this registry row and the AgentIdentity capability fields, per
+ADR 0018's handle-indirection boundary and ADR 0012's model-stats discipline.
+
+**Sources** (primary first):
+- **Primary**: [Introducing Claude Opus 4.8 — Anthropic](https://www.anthropic.com/news/claude-opus-4-8)
+- **Primary**: [Claude Opus 4.8 — Anthropic](https://www.anthropic.com/claude/opus)
 
 ### §neo_gemini_3_1_pro
 
@@ -214,6 +241,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 |---|---|---|
 | 2026-05-18 | (this PR) | Initial registry creation; 4 active identities (@neo-opus-4-7, @neo-gemini-3-1-pro, @neo-gpt, gemma4-31b aspirational); cloud + MLX-local reference entries |
 | 2026-06-02 | (pending PR) | Added pending `@neo-claude-opus` identity row; row is inactive until account and wake-route activation are complete. |
+| 2026-06-04 | #12517 | Added active `@neo-opus-vega` Claude Opus 4.8 maintainer row with version-free handle boundary. |
 
 ---
 

--- a/test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs
@@ -222,6 +222,8 @@ test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556, #
     test('hasCoreSwarmParticipant detects comma-separated and array-form agent lists', () => {
         expect(hasCoreSwarmParticipant('@neo-gpt')).toBe(true);
         expect(hasCoreSwarmParticipant('@alice, @neo-opus-4-7')).toBe(true);
+        expect(hasCoreSwarmParticipant('@neo-claude-opus')).toBe(true);
+        expect(hasCoreSwarmParticipant('@neo-opus-vega')).toBe(true);
         expect(hasCoreSwarmParticipant(['neo-gemini-3-1-pro', '@alice'])).toBe(true);
         expect(hasCoreSwarmParticipant('@alice,@bob')).toBe(false);
         expect(hasCoreSwarmParticipant(undefined)).toBe(false);
@@ -236,6 +238,11 @@ test.describe('Module-scope exports: SHARED_USER_ID + normalizeUserId (#10556, #
         expect(resolveSummaryVisibilityUserId({
             userId: undefined,
             participatingAgents: '@neo-opus-4-7'
+        })).toBe(SHARED_USER_ID);
+
+        expect(resolveSummaryVisibilityUserId({
+            userId: 'neo-opus-vega',
+            participatingAgents: '@neo-opus-vega'
         })).toBe(SHARED_USER_ID);
 
         expect(resolveSummaryVisibilityUserId({

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -106,6 +106,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(scriptContent).toContain("'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' }");
         expect(scriptContent).toContain("'@neo-opus-4-7'      : 'claude-desktop'");
         expect(scriptContent).toContain("'@neo-claude-opus'   : 'claude-desktop'");
+        expect(scriptContent).toContain("'@neo-opus-vega'     : 'claude-desktop'");
     });
 
     test('normalizes GitHub-login identity form before harness dispatch (#11797)', async () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
@@ -142,14 +142,18 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
 
             expect(claudeIdentities.map(identity => identity.id)).toEqual(expect.arrayContaining([
                 '@neo-opus-4-7',
-                '@neo-claude-opus'
+                '@neo-claude-opus',
+                '@neo-opus-vega'
             ]));
             expect(resolveIdentityForFamily('claude').id).toBe('@neo-opus-4-7');
             expect(resolveIdentitiesForFamily('claude').map(identity => identity.id)).toEqual([
                 '@neo-opus-4-7',
-                '@neo-claude-opus'
+                '@neo-claude-opus',
+                '@neo-opus-vega'
             ]);
             expect(claudeIdentities.find(identity => identity.id === '@neo-claude-opus')?.properties.participationStatus)
+                .toBe('active');
+            expect(claudeIdentities.find(identity => identity.id === '@neo-opus-vega')?.properties.participationStatus)
                 .toBe('active');
         });
 
@@ -180,11 +184,11 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
         test('includes same-family aggregation note for multi-active notification fan-out', () => {
             const body = buildNotificationBody({
                 family       : 'claude',
-                identityLogins: ['@neo-opus-4-7', '@neo-claude-opus'],
+                identityLogins: ['@neo-opus-4-7', '@neo-claude-opus', '@neo-opus-vega'],
                 since        : '2026-05-18T00:00:00.000Z',
                 sweepAt      : '2026-06-01T12:00:00.000Z'
             });
-            expect(body).toContain('@neo-opus-4-7, @neo-claude-opus');
+            expect(body).toContain('@neo-opus-4-7, @neo-claude-opus, @neo-opus-vega');
             expect(body).toContain('Same-family aggregation note');
             expect(body).toContain('no active same-family identity holds unresolved DEFERRED / VETO');
         });
@@ -277,8 +281,8 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
                 io     : fakeIo
             });
             expect(result.identityLogin).toBe('@neo-opus-4-7');
-            expect(result.identityLogins).toEqual(['@neo-opus-4-7', '@neo-claude-opus']);
-            expect(result.results[0].notification).toContain('@neo-opus-4-7, @neo-claude-opus');
+            expect(result.identityLogins).toEqual(['@neo-opus-4-7', '@neo-claude-opus', '@neo-opus-vega']);
+            expect(result.results[0].notification).toContain('@neo-opus-4-7, @neo-claude-opus, @neo-opus-vega');
         });
 
         test('returns empty results when no candidates match', async () => {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -112,22 +112,28 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const Synthesizer = GoldenPathSynthesizer.constructor;
 
         expect(Synthesizer.getCoreSwarmAgentFamilies()).toMatchObject({
+            'neo-claude-opus' : 'claude',
             'neo-gemini-3-1-pro': 'gemini',
             'neo-gpt'           : 'gpt',
-            'neo-opus-4-7'      : 'claude'
+            'neo-opus-4-7'      : 'claude',
+            'neo-opus-vega'     : 'claude'
         });
 
         expect(Synthesizer.getAgentLogins()).toEqual(expect.arrayContaining([
+            'neo-claude-opus',
             'neo-gemini-3-1-pro',
             'neo-gpt',
-            'neo-opus-4-7'
+            'neo-opus-4-7',
+            'neo-opus-vega'
         ]));
         expect(Synthesizer.getAgentLogins()).not.toContain('tobiu');
 
         expect(Synthesizer.getStaleAssignmentMaintainers()).toEqual(expect.arrayContaining([
+            'neo-claude-opus',
             'neo-gemini-3-1-pro',
             'neo-gpt',
             'neo-opus-4-7',
+            'neo-opus-vega',
             'tobiu'
         ]));
     });


### PR DESCRIPTION
Resolves #12517

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Adds the active `@neo-opus-vega` AgentIdentity as a version-free Claude Opus 4.8 maintainer handle, synchronizes the public roster/docs/model-stats surfaces, and completes the consumed runtime roster mirrors found during intake.

Evidence: L2 (source-contract audit + targeted unit/import coverage + runtime roster consumer tests; live seed intentionally not run because `seedAgentIdentities.mjs` mutates the shared graph) → L3 required (post-merge graph seed observable in Memory Core). Residual: seed execution after merge [#12517].

## Deltas From Ticket

- Added the Contract Ledger addendum from issue comment `IC_kwDODSospM8AAAABE5gBYg`: `RequestContextService` summary-visibility roster, `backfillChromaSharedUserId` mirror, and `resumeHarness` identity route.
- Synchronized already-active `@neo-claude-opus` in the same touched runtime/readable rosters where the #12517 V-B-A exposed existing drift. This does not perform the rename migration tracked separately; it only closes the same active-roster mirror class while touching the mirrors for `@neo-opus-vega`.
- Left live graph seeding for post-merge validation. The seed script imports `identityRoots.mjs` and mutates the shared graph; pre-merge evidence covers import shape and consumers without writing an unmerged identity into the live graph.

## Contract Ledger

| Surface | Type | Contract |
| :--- | :--- | :--- |
| `ai/graph/identityRoots.mjs` `IDENTITIES[]` | identity SSOT | Adds active `@neo-opus-vega` with version-free handle, Claude-family review semantics, ModelStats source pointer, and capability fields. |
| `learn/agentos/ModelStats.md` | capability registry | Adds `§neo_opus_vega` row sourced to Anthropic's Opus 4.8 announcement/product page. |
| README / AGENTS.md | public + always-loaded roster | Synchronizes named maintainer roster with `@neo-opus-vega` and the already-active `@neo-claude-opus`. |
| CI PR body/review lint workflows | readable guard roster | Adds `neo-claude-opus` and `neo-opus-vega` to explicit readable rosters while preserving the `startsWith('neo-')` fallback. |
| `RequestContextService.mjs` `CORE_SWARM_USER_IDS` | Memory Core summary-visibility runtime roster | Adds `neo-opus-vega` and synchronizes `neo-claude-opus` so core-swarm summaries promote to shared visibility. |
| `backfillChromaSharedUserId.mjs` mirror | migration runtime mirror | Keeps the no-Neo-bootstrap migration copy in sync with `RequestContextService`. |
| `resumeHarness.mjs` `identityMap` | lifecycle recovery route | Routes `@neo-opus-vega` to the Claude Desktop harness target. |

## Substrate Slot Rationale

- `AGENTS.md` modified roster lines: disposition delta `keep -> keep`; trigger-frequency per-turn for identity/category-drift defense, failure-severity high under coordination pressure, enforceability medium through peer review and visible roster text. This is a bounded roster synchronization, not a new rule.
- `learn/agentos/ModelStats.md` new `§neo_opus_vega` row: disposition `keep`; trigger-frequency low but source-of-truth severity high for model capability drift, enforceability high through identity-root import/tests. Decay mitigation is the row's explicit sunset trigger plus ADR 0018 handle-indirection boundary.
- Decision Record impact: no ADR amendment required. ADR 0012 already owns ModelStats capability rows; ADR 0018 already owns version-free handle indirection.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` — 66 passed, 2 skipped, 12 did not run, 1 sandbox-only failure from wake-daemon symlink write.
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs` — 22 passed, 2 skipped after escalated rerun for the canonical wake-daemon symlink.
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/shared/services/RequestContextService.spec.mjs test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs` — 57 passed.
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs` — 30 passed.
- `node --check ai/graph/identityRoots.mjs ai/mcp/server/shared/services/RequestContextService.mjs ai/scripts/migrations/backfillChromaSharedUserId.mjs ai/scripts/lifecycle/resumeHarness.mjs` — passed.
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev` — passed.
- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/graph/identityRoots.mjs` — 1 file scanned, 0 violations.
- `git diff --cached --check` and `git diff --check HEAD~1..HEAD` — passed.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; branch history contains only `edc36528c feat(agentos): add neo-opus-vega identity (#12517)`.

## Post-Merge Validation

- [ ] Run `node ai/scripts/setup/seedAgentIdentities.mjs` from updated `dev` and verify `@neo-opus-vega` has its own AgentIdentity node.
- [ ] Verify `hasCoreSwarmParticipant('@neo-opus-vega')` promotes summary visibility to `shared` in the deployed Memory Core runtime.
- [ ] Verify PR-body and PR-review lint allow `neo-opus-vega` as an explicit readable roster entry after merge.

## Commits

- `edc36528c` — `feat(agentos): add neo-opus-vega identity (#12517)`
