### PR TITLE
docs(agentos): add own-agent-team provisioning guide (#12519)

### DIFF
--- a/apps/portal/llms.txt
+++ b/apps/portal/llms.txt
@@ -236,6 +236,7 @@ The sections below (Release Notes, Guides/Blogs, and GitHub Tickets) represent p
 - [The GitHub Workflow Server](https://neomjs.com/raw/learn/agentos/GitHubWorkflow.md)
 - [Code Execution (AI SDK)](https://neomjs.com/raw/learn/agentos/CodeExecution.md)
 - [Shared KB/MC Team Deployment](https://neomjs.com/raw/learn/agentos/SharedDeployment.md)
+- [Provision Your Own Agent Team](https://neomjs.com/raw/learn/agentos/OwnAgentTeam.md)
 - [Deployment Cookbook](https://neomjs.com/raw/learn/agentos/DeploymentCookbook.md)
 - [Why Deploy the Agent OS](https://neomjs.com/raw/learn/agentos/cloud-deployment/WhyDeploy.md)
 - [Cloud-Native KB Ingestion Overview](https://neomjs.com/raw/learn/agentos/cloud-deployment/Overview.md)

--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -191,6 +191,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/SkillCompressionRolloutPlan</loc>
+    <lastmod>2026-06-04T14:47:45+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/DreamPipeline</loc>
@@ -231,6 +232,10 @@
     <loc>https://neomjs.com/learn/agentos/SharedDeployment</loc>
     <lastmod>2026-05-28T08:34:45+02:00</lastmod>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://neomjs.com/learn/agentos/OwnAgentTeam</loc>
+    <lastmod>2026-06-04T18:04:49+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/DeploymentCookbook</loc>
@@ -310,6 +315,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/ConfigSubstrateEnvVarAudit</loc>
+    <lastmod>2026-05-27T15:35:52+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/ConfigSubstrateDeadConfigAudit</loc>
@@ -317,6 +323,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/measurements/pr-review-baseline-2026-04</loc>
+    <lastmod>2026-05-02T13:12:50+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/measurements/heartbeat-token-economy-2026-05</loc>
@@ -340,6 +347,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/MemoryCoreMcpAuth</loc>
+    <lastmod>2026-05-07T19:22:00+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/GraphBackfill</loc>
@@ -347,6 +355,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/ChromeDevToolsMcpServer</loc>
+    <lastmod>2026-03-31T02:29:29+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/GitHubCLISetup</loc>
@@ -396,6 +405,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/guides/fundamentals/InstanceLifecycle</loc>
+    <lastmod>2026-01-08T23:06:13+01:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/guides/fundamentals/WorkerArchitecture</loc>
@@ -1338,490 +1348,651 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12477</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12474</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12473</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12467</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12465</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12464</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12462</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12461</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12459</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12457</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12456</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12455</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12454</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12452</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12451</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12450</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12449</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12448</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12447</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12446</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12445</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12444</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12443</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12442</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12441</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12440</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12438</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12437</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12435</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12434</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12430</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12425</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12422</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12419</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12418</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12417</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12416</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12413</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12408</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12406</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12402</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12401</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12394</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12391</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12390</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12382</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12381</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12380</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12379</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12378</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12377</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12375</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12371</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12370</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12367</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12335</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12334</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12332</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12331</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12329</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12328</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12325</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12322</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12321</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12319</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12317</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12315</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12314</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12312</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12309</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12305</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12304</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12302</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12300</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12297</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12296</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12294</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12289</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12286</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12285</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12276</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12270</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12265</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12264</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12262</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12259</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12256</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12255</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12253</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12251</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12250</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12247</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12244</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12241</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12236</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12232</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12231</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12230</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12229</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12228</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12227</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12226</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12225</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12220</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12219</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12218</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12217</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12216</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12215</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12214</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12213</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12211</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12210</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12209</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12208</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12207</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12206</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12205</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12204</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12203</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12199</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12198</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12194</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12191</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12190</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12188</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12186</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12184</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12180</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12177</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12176</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12173</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12170</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12168</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12167</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12166</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12165</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12163</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12158</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12157</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12156</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12155</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12154</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12153</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12150</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12147</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12145</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12143</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12142</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12140</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12139</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12138</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12136</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12132</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12130</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12126</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12123</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12117</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12116</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12114</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12109</loc>
+    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12108</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12107</loc>

--- a/learn/agentos/OwnAgentTeam.md
+++ b/learn/agentos/OwnAgentTeam.md
@@ -1,0 +1,244 @@
+# Provision Your Own Agent Team
+
+Neo's Agent OS can run as your own local maintainer team inside a fork or a generated
+`npx neo-app` workspace. This guide describes the local provisioning shape: stable
+agent identities, identity-bound MCP harnesses, seeded Memory Core graph nodes, and
+data isolation that keeps your team separate from the upstream Neo swarm.
+
+The examples use `@acme-claude`, `@acme-gpt`, and `@acme-gemini`. Replace them with
+handles that belong to your deployment.
+
+## Local Boundary
+
+A local agent team is not the canonical Neo maintainer swarm. Treat it as a separate
+deployment with its own:
+
+- GitHub accounts or stable local handles for each agent.
+- `AgentIdentity` graph nodes in your Memory Core database.
+- Harness configuration that pins each process to exactly one identity.
+- Knowledge Base and Memory Core data roots, unless you intentionally connect to a
+  shared team service.
+
+Do not reuse upstream Neo identities such as `@neo-opus-4-7`, `@neo-gpt`, or
+`@neo-gemini-3-1-pro` for your own agents. Those handles carry upstream provenance
+and review semantics.
+
+## Identity Layers
+
+Keep four identity layers separate:
+
+| Layer | Own-team question | Neo substrate |
+|---|---|---|
+| Operational identity | Which account or local handle is making this request? | `NEO_AGENT_IDENTITY`, OIDC subject, or proxy header |
+| Graph identity | Which node receives provenance edges? | `AgentIdentity` node in `ai/graph/identityRoots.mjs` |
+| Model lineage | Which model class, version, and capability profile is behind the handle? | `modelFamily`, capability fields, and ModelStats-style metadata |
+| Social label | What should humans call this teammate? | `displayName`, docs, PR bodies, and A2A messages |
+
+The handle should be stable. Put model-version churn in lineage metadata, not in the
+handle, so historical memory remains queryable after provider upgrades.
+
+## Choose Handles
+
+Good handles are team-scoped and version-free:
+
+```text
+@acme-claude
+@acme-gpt
+@acme-gemini
+```
+
+Avoid handles like `@acme-claude-4-7` unless your deployment intentionally creates a
+new identity every time the model version changes. That pattern fragments long-term
+memory and makes review provenance harder to audit.
+
+## Define Identity Roots
+
+The identity root source of truth is `ai/graph/identityRoots.mjs`. Add one
+`AgentIdentity` entry per teammate. Keep account-level fields stable and put model
+details in metadata fields.
+
+```js
+{
+    id: '@acme-claude',
+    type: 'AgentIdentity',
+    name: 'Acme Claude',
+    description: 'Claude-family maintainer identity for the Acme local Agent OS.',
+    properties: {
+        githubLogin: '@acme-claude',
+        displayName: 'Acme Claude',
+        modelFamily: 'claude',
+        accountType: 'agent',
+        trustTier  : TRUST_TIERS.PEER_TRUSTED,
+        hosting    : 'cloud',
+        family     : 'claude',
+        tier       : 'frontier',
+        participationStatus: 'active',
+        statusReason       : null,
+        authority          : null,
+        since              : null,
+        reactivationTrigger: null,
+        createdAt          : new Date().toISOString()
+    }
+}
+```
+
+Use the upstream entries as shape examples, not as identities to copy. Your `trustTier`
+choice is a deployment policy: local teammates can be trusted inside your team without
+becoming upstream Neo maintainers.
+
+## Seed The Graph
+
+After editing `ai/graph/identityRoots.mjs`, seed or refresh the Memory Core graph:
+
+```bash
+node ai/scripts/setup/seedAgentIdentities.mjs
+```
+
+The script is idempotent. Existing root nodes keep their creation provenance while new
+nodes are inserted. A fresh Memory Core may also self-seed on boot, but running the
+script is the explicit recovery and verification path.
+
+## Bind Harnesses
+
+Each harness process should pin its own identity with `NEO_AGENT_IDENTITY` in the MCP
+server environment block. Use the bare login without `@`; Memory Core normalizes and
+binds it to the `@`-prefixed graph node.
+
+```json
+{
+    "mcpServers": {
+        "neo.mjs-memory-core": {
+            "command": "node",
+            "args": ["ai/mcp/server/memory-core/mcp-server.mjs"],
+            "env": {
+                "NEO_AGENT_IDENTITY": "acme-claude"
+            }
+        }
+    }
+}
+```
+
+For stdio clients, `NEO_AGENT_IDENTITY` is the authoritative local identity pin. The
+GitHub CLI fallback is useful for humans, but a team agent should not depend on an
+ambient shell login.
+
+## Isolate Memory Correctly
+
+Local provisioning has three memory surfaces:
+
+| Surface | Isolation lever | Shared by default? |
+|---|---|---|
+| Claude Code file-memory | Distinct repo clone or worktree cwd per teammate | No, if each teammate has a distinct cwd |
+| Claude app sessions and transcripts | Distinct `--user-data-dir` when launching separate app instances | No, if each instance has its own user-data-dir |
+| Memory Core MCP | Deployment-selected Memory Core graph and Chroma data | Yes, if teammates point at the same Memory Core |
+
+The footgun is assuming `--user-data-dir` isolates everything. It does not redirect
+Claude Code file-memory; file-memory is keyed by the project cwd. If two Claude
+instances run from the same repo cwd, they can share the same file-memory folder even
+when their Electron app data is separate.
+
+The robust local setup is:
+
+1. Give each teammate its own repo clone or worktree cwd.
+2. Give each GUI app instance its own `--user-data-dir` when two instances of the same
+   app need to run side by side.
+3. Point all teammates at the same Memory Core only when you want shared team memory.
+
+Memory Core's shared layer is identity-tagged by design. Separate identities preserve
+provenance while still letting the team build common graph context.
+
+## Isolate Data Roots
+
+For a completely separate local team, do not point your harnesses at upstream Neo's
+local databases. Use your own Memory Core graph path, Chroma service, and collection
+names through the normal AiConfig env leaves or operator overlay.
+
+Important rules:
+
+- Read resolved AiConfig values at the use site.
+- Override env-bound leaves or local overlay deltas; do not clone and maintain config
+  templates by hand.
+- Avoid source-level overlay merging. AiConfig is a Provider tree; inheritance and
+  deep merge are the substrate.
+- Use `NEO_MEMORY_DB_PATH` for the production Memory Core graph path when you need a
+  deployment-specific SQLite file.
+
+If your Knowledge Base and Memory Core should be private to your local team, keep their
+Chroma data and graph database under that team's workspace or service account. If they
+should be shared across teammates, document that as a team deployment decision rather
+than an accidental consequence of reused defaults.
+
+## Verify A Teammate
+
+Start one harness and call Memory Core `healthcheck`. The identity block should show
+the expected identity source and a bound graph node:
+
+```json
+{
+    "identity": {
+        "source": "env-var",
+        "bound": true,
+        "nodeId": "@acme-claude"
+    }
+}
+```
+
+If `bound` is false, verify in order:
+
+1. `NEO_AGENT_IDENTITY` is present in the MCP server env block, not only in a shell.
+2. The `@<login>` node exists in `ai/graph/identityRoots.mjs`.
+3. `node ai/scripts/setup/seedAgentIdentities.mjs` has run against the active Memory
+   Core graph path.
+4. The harness was restarted after seeding.
+
+## Bring Up The Team
+
+Provision teammates incrementally:
+
+1. Add one identity root.
+2. Seed the graph.
+3. Bind one harness with `NEO_AGENT_IDENTITY`.
+4. Verify `healthcheck.identity.bound`.
+5. Send an A2A message to the teammate and confirm it lands in the correct inbox.
+6. Repeat for the next teammate.
+
+This sequence keeps identity, graph binding, and mailbox reachability falsifiable at
+each step.
+
+## Rename Policy
+
+Renaming an agent is not a display-text edit. A real rename may touch:
+
+- The `AgentIdentity` node id.
+- Historical graph edges and message routing.
+- Raw memories and session summaries.
+- Harness env config.
+- Documentation and CI allowlists.
+
+Prefer stable handles. If a rename is required, treat it as a migration with a ticket,
+contract ledger, source and destination identities, and post-migration verification.
+
+## Local vs Cloud
+
+Local teams can use stdio identity binding and local database paths. Cloud or
+multi-tenant teams should use the shared-deployment path: OIDC or trusted proxy
+identity, canonical public URLs, explicit Chroma topology, and proxy trust-boundary
+verification.
+
+Do not mix the two mentally. Local stdio identity is a trusted-process shortcut; cloud
+identity is an authenticated request contract.
+
+## Source Anchors
+
+- `ai/graph/identityRoots.mjs` defines the root identities consumed by boot-time
+  self-seeding and the manual seed script.
+- `ai/scripts/setup/seedAgentIdentities.mjs` inserts or refreshes those root identities
+  in the Native Edge Graph.
+- `learn/agentos/tooling/MemoryCoreMcpAuth.md` explains `NEO_AGENT_IDENTITY`, graph-node
+  binding, and the anti-spoof invariant.
+- `learn/agentos/SharedDeployment.md` explains shared Knowledge Base and Memory Core
+  topology.
+- `learn/agentos/AiConfigModel.md` explains why config overlays are inherited data
+  deltas, not source files to clone or merge.
+- `learn/tree.json` is consumed by the Portal Learn view and the Knowledge Base learning
+  source, so public guides must be registered there.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -43,6 +43,7 @@
         {"name": "The GitHub Workflow Server",                         "parentId": "AgentOS",                                             "id": "agentos/GitHubWorkflow"},
         {"name": "Code Execution (AI SDK)",                            "parentId": "AgentOS",                                             "id": "agentos/CodeExecution"},
         {"name": "Shared KB/MC Team Deployment",                       "parentId": "AgentOS",                                             "id": "agentos/SharedDeployment"},
+        {"name": "Provision Your Own Agent Team",                      "parentId": "AgentOS",                                             "id": "agentos/OwnAgentTeam"},
         {"name": "Deployment Cookbook",                                "parentId": "AgentOS",                                             "id": "agentos/DeploymentCookbook"},
         {"name": "Deploying the Agent OS",                             "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/CloudDeployment", "collapsed": true},
             {"name": "Why Deploy the Agent OS",                        "parentId": "AgentOS/CloudDeployment",                             "id": "agentos/cloud-deployment/WhyDeploy"},


### PR DESCRIPTION
Resolves #12519

Authored by GPT-5.5 (Codex Desktop). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Adds a public Agent OS guide for provisioning an own local agent team in a fork or generated Neo workspace. The guide covers stable version-free handles, `AgentIdentity` graph roots, `NEO_AGENT_IDENTITY` harness binding, Memory Core seed/healthcheck verification, local-vs-cloud identity boundaries, rename policy, and the corrected local memory-isolation model: per-teammate repo clone/worktree cwd isolates Claude Code file-memory, `--user-data-dir` isolates app sessions, and Memory Core is the shared identity-tagged layer by deployment choice.

Evidence: L1 (static source/docs audit, `learn/tree.json` structural lint, tree-row-to-Markdown existence/content probe, whitespace checks) -> L1 required (public guide + learn tree registration). No residuals.

## Slot Rationale

- Added `learn/agentos/OwnAgentTeam.md`: disposition `keep`; 3-axis rating trigger-frequency `medium` x failure-severity `high` x enforceability `medium`. This is public, conditionally loaded documentation for deployers and fork/generated-workspace operators; it prevents identity/memory provenance mistakes at setup time without adding turn-loaded agent instructions.
- Modified `learn/tree.json`: disposition delta `keep -> keep`; registers the new guide in the public Learn nav and Knowledge Base learning source. No rule-body expansion; one index row points to the conditionally loaded guide.

Decision Record impact: none. The guide follows ADR 0012 version/governance separation, ADR 0018 identity indirection, and ADR 0019 AiConfig Provider SSOT; no ADR update is required.

## Deltas from Ticket

- Incorporated the peer-verified memory-isolation correction from #12519 coordination: distinct repo clone/worktree cwd is the file-memory isolation lever; `--user-data-dir` is orthogonal session/app-data isolation.
- Corrected the healthcheck example against the current Memory Core health projection: `identity.nodeId`, not `agentIdentityNodeId`.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `node ai/scripts/lint/lint-tree-json.mjs`
- `node -e "const fs=require('fs'); const tree=JSON.parse(fs.readFileSync('learn/tree.json','utf8')); const item=tree.data.find(i=>i.id==='agentos/OwnAgentTeam'); if(!item) throw new Error('missing tree row'); if(item.parentId!=='AgentOS') throw new Error('wrong parent'); const file='learn/'+item.id+'.md'; const content=fs.readFileSync(file,'utf8'); for (const needle of ['# Provision Your Own Agent Team','Claude Code file-memory','NEO_AGENT_IDENTITY','identityRoots.mjs','nodeId']) { if (!content.includes(needle)) throw new Error('missing '+needle); } console.log(JSON.stringify({treeItem:item,file,checked:true}, null, 2));"`
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `ff4390037 docs(agentos): add own-agent-team provisioning guide (#12519)`.

## Post-Merge Validation

- [ ] Portal Learn nav surfaces `Provision Your Own Agent Team` under Agent OS.
- [ ] Knowledge Base learning source ingests `learn/agentos/OwnAgentTeam.md` from the new `learn/tree.json` row.

## Commit

- `ff4390037` — `docs(agentos): add own-agent-team provisioning guide (#12519)`
