### PR TITLE
test(learn): guard SEO output sync (#12522)

### DIFF
--- a/.github/workflows/tree-json-lint.yml
+++ b/.github/workflows/tree-json-lint.yml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Lint learn/tree.json against the learn/ folder structure
         run: node ai/scripts/lint/lint-tree-json.mjs

--- a/.github/workflows/tree-json-lint.yml
+++ b/.github/workflows/tree-json-lint.yml
@@ -5,12 +5,18 @@ on:
     branches: [dev]
     paths:
       - 'learn/**'
+      - 'apps/portal/llms.txt'
+      - 'apps/portal/sitemap.xml'
+      - 'buildScripts/docs/seo/generate.mjs'
       - 'ai/scripts/lint/lint-tree-json.mjs'
       - '.github/workflows/tree-json-lint.yml'
   push:
     branches: [dev]
     paths:
       - 'learn/**'
+      - 'apps/portal/llms.txt'
+      - 'apps/portal/sitemap.xml'
+      - 'buildScripts/docs/seo/generate.mjs'
       - 'ai/scripts/lint/lint-tree-json.mjs'
       - '.github/workflows/tree-json-lint.yml'
 

--- a/ai/scripts/lint/lint-tree-json.mjs
+++ b/ai/scripts/lint/lint-tree-json.mjs
@@ -11,7 +11,7 @@
  * `id` referenced by its children's `parentId`.
  *
  * Because it is hand-edited JSON with no schema enforcement, drift is silent until it
- * breaks portal nav / SEO. This lint enforces five mechanical invariants:
+ * breaks portal nav / SEO. This lint enforces six mechanical invariants:
  *
  *   1. LEAF_FILE        — every leaf `id` resolves to an existing `learn/<id>.md`.
  *   2. PARENT_INTEGRITY — every non-null `parentId` references an existing group node.
@@ -23,6 +23,9 @@
  *                         (`*Audit`/`*Plan`/`*Sweep`/`*Census`/`*Forensics`/`*Benchmark`);
  *                         learn/ is public docs, so these belong in a non-published subfolder
  *                         or the owning ticket, never the portal nav.
+ *   6. SEO_SYNC         — checked-in `apps/portal/llms.txt` + `sitemap.xml` expose the
+ *                         same learn/ URL sets as the SEO generator would emit now
+ *                         (ignoring sitemap lastmod).
  *
  * (3) + (4) together assert a group ↔ folder bijection for leaf-bearing groups: the
  * mechanical form of "the nav tree mirrors the folder layout." (1) transitively covers
@@ -39,11 +42,20 @@ import path             from 'node:path';
 import process          from 'node:process';
 import {fileURLToPath}  from 'node:url';
 
+import {
+    getLlmsTxt,
+    getSitemapXml
+} from '../../../buildScripts/docs/seo/generate.mjs';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const ROOT_DIR   = path.resolve(__dirname, '../../..');
 const LEARN_DIR  = path.join(ROOT_DIR, 'learn');
 const TREE_PATH  = path.join(LEARN_DIR, 'tree.json');
+const PORTAL_DIR = path.join(ROOT_DIR, 'apps/portal');
+const LLMS_PATH  = path.join(PORTAL_DIR, 'llms.txt');
+const SITEMAP_PATH      = path.join(PORTAL_DIR, 'sitemap.xml');
+const DEFAULT_BASE_URL = 'https://neomjs.com';
 
 // Invariant 5: exploration/process-artifact basename suffixes that must never be published.
 // `learn/` is public docs; these are tracking/process outputs whose home is a non-published
@@ -75,6 +87,131 @@ function folderPrefix(id) {
  */
 function isGroup(node) {
     return node.isLeaf === false;
+}
+
+/**
+ * Returns leaf ids from parsed tree data, preserving `tree.json` semantics.
+ * @param {{data: Array<object>}} treeData Parsed `tree.json`.
+ * @returns {String[]}
+ */
+function getLeafIds(treeData) {
+    const nodes = Array.isArray(treeData?.data) ? treeData.data : [];
+
+    return nodes
+        .filter(node => !isGroup(node) && node?.id != null)
+        .map(node => node.id);
+}
+
+/**
+ * Extracts checked-in learn/ URLs from `llms.txt`.
+ * @param {String} llmsTxt The checked-in `apps/portal/llms.txt` content.
+ * @param {String} [baseUrl] The canonical site base URL.
+ * @returns {Set<String>}
+ */
+function getLlmsLearnUrls(llmsTxt, baseUrl=DEFAULT_BASE_URL) {
+    const normalizedBase = baseUrl.replace(/\/$/, '');
+    const urls = new Set();
+    const escapedBase = normalizedBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const urlRegex = new RegExp(`${escapedBase}/raw/learn/([^\\s)]+?\\.md)`, 'g');
+
+    for (const match of llmsTxt.matchAll(urlRegex)) {
+        urls.add(match[1].replace(/\.md$/, ''));
+    }
+
+    return urls;
+}
+
+/**
+ * Extracts checked-in learn/ URLs from `sitemap.xml`.
+ * @param {String} sitemapXml The checked-in `apps/portal/sitemap.xml` content.
+ * @param {String} [baseUrl] The canonical site base URL.
+ * @returns {Set<String>}
+ */
+function getSitemapLearnUrls(sitemapXml, baseUrl=DEFAULT_BASE_URL) {
+    const normalizedBase = baseUrl.replace(/\/$/, '');
+    const urls = new Set();
+    const escapedBase = normalizedBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const urlRegex = new RegExp(`<loc>${escapedBase}/learn/([^<]+)</loc>`, 'g');
+
+    for (const match of sitemapXml.matchAll(urlRegex)) {
+        urls.add(match[1]);
+    }
+
+    return urls;
+}
+
+/**
+ * Compares expected generated learn URLs against one checked-in SEO surface.
+ * @param {String} surfaceName Human-readable surface name.
+ * @param {ReadonlySet<String>} expectedIds Expected generated learn ids.
+ * @param {ReadonlySet<String>} actualIds IDs parsed from the checked-in output.
+ * @returns {Array<{code: string, message: string}>}
+ */
+function compareSeoSurface(surfaceName, expectedIds, actualIds) {
+    const violations = [];
+    const missing = [...expectedIds].filter(id => !actualIds.has(id)).sort();
+    const extra   = [...actualIds].filter(id => !expectedIds.has(id)).sort();
+
+    if (missing.length > 0) {
+        violations.push({
+            code   : 'SEO_OUTPUT_MISSING',
+            message: `${surfaceName} is missing ${missing.length} generated learn route(s): ${missing.join(', ')}. Regenerate apps/portal/llms.txt and apps/portal/sitemap.xml from the SEO prepare step.`
+        });
+    }
+
+    if (extra.length > 0) {
+        violations.push({
+            code   : 'SEO_OUTPUT_EXTRA',
+            message: `${surfaceName} contains ${extra.length} stale learn/ route(s) not present in generated output: ${extra.join(', ')}. Regenerate apps/portal/llms.txt and apps/portal/sitemap.xml from the SEO prepare step.`
+        });
+    }
+
+    return violations;
+}
+
+/**
+ * Pure SEO-output validator. It compares expected generated learn routes against
+ * checked-in SEO/LLM outputs and deliberately ignores sitemap `lastmod` values. Tests can
+ * omit explicit expectations to fall back to tree-derived sets.
+ * @param {{data: Array<object>}} treeData Parsed `tree.json`.
+ * @param {{llmsTxt: string, sitemapXml: string, baseUrl?: string, expectedLlmsIds?: Set<String>, expectedSitemapIds?: Set<String>}} options
+ * @returns {Array<{code: string, message: string}>}
+ */
+function lintSeoOutputs(treeData, {
+    llmsTxt,
+    sitemapXml,
+    baseUrl = DEFAULT_BASE_URL,
+    expectedLlmsIds,
+    expectedSitemapIds
+}) {
+    const expectedIds = new Set(getLeafIds(treeData));
+    const llmsIds     = getLlmsLearnUrls(llmsTxt, baseUrl);
+    const sitemapIds  = getSitemapLearnUrls(sitemapXml, baseUrl);
+
+    return [
+        ...compareSeoSurface('apps/portal/llms.txt', expectedLlmsIds ?? expectedIds, llmsIds),
+        ...compareSeoSurface('apps/portal/sitemap.xml', expectedSitemapIds ?? expectedIds, sitemapIds)
+    ];
+}
+
+/**
+ * Regenerates the SEO outputs in memory and extracts their learn/ URL sets.
+ * @param {{baseUrl?: string, sitemapPath?: string}} [options]
+ * @returns {Promise<{expectedLlmsIds: Set<String>, expectedSitemapIds: Set<String>}>}
+ */
+async function getGeneratedSeoLearnUrls({
+    baseUrl = DEFAULT_BASE_URL,
+    sitemapPath = SITEMAP_PATH
+} = {}) {
+    const [llmsTxt, sitemapXml] = await Promise.all([
+        getLlmsTxt({baseUrl}),
+        getSitemapXml({baseUrl, existingSitemapPath: sitemapPath})
+    ]);
+
+    return {
+        expectedLlmsIds   : getLlmsLearnUrls(llmsTxt, baseUrl),
+        expectedSitemapIds: getSitemapLearnUrls(sitemapXml, baseUrl)
+    };
 }
 
 /**
@@ -179,12 +316,19 @@ function lintTree(treeData, {fileExists} = {}) {
 
 /**
  * CLI entry. Reads + parses `tree.json`, runs `lintTree` with a real fs-backed probe,
- * prints a report, and returns a numeric exit code (so tests can drive it without
- * triggering `process.exit`).
- * @param {{treePath?: string, learnDir?: string}} [options]
- * @returns {{exitCode: number, violations: Array<{code: string, message: string}>}}
+ * verifies generated SEO outputs by URL set, prints a report, and returns a numeric exit
+ * code (so tests can drive it without triggering `process.exit`).
+ * @param {{treePath?: string, learnDir?: string, llmsPath?: string, sitemapPath?: string, baseUrl?: string, checkSeo?: boolean}} [options]
+ * @returns {Promise<{exitCode: number, violations: Array<{code: string, message: string}>}>}
  */
-function runLint({treePath = TREE_PATH, learnDir = LEARN_DIR} = {}) {
+async function runLint({
+    treePath = TREE_PATH,
+    learnDir = LEARN_DIR,
+    llmsPath = LLMS_PATH,
+    sitemapPath = SITEMAP_PATH,
+    baseUrl = DEFAULT_BASE_URL,
+    checkSeo = true
+} = {}) {
     let treeData;
 
     try {
@@ -197,21 +341,57 @@ function runLint({treePath = TREE_PATH, learnDir = LEARN_DIR} = {}) {
     const fileExists = relPath => fs.existsSync(path.join(learnDir, relPath));
     const violations = lintTree(treeData, {fileExists});
 
+    if (checkSeo) {
+        let generatedSeoLearnUrls;
+
+        try {
+            generatedSeoLearnUrls = await getGeneratedSeoLearnUrls({
+                baseUrl,
+                sitemapPath
+            });
+        } catch (error) {
+            violations.push({
+                code   : 'SEO_OUTPUT_GENERATE',
+                message: `Cannot regenerate SEO outputs in memory: ${error.message}`
+            });
+        }
+
+        if (generatedSeoLearnUrls) {
+            try {
+                const llmsTxt    = fs.readFileSync(llmsPath, 'utf8');
+                const sitemapXml = fs.readFileSync(sitemapPath, 'utf8');
+
+                violations.push(...lintSeoOutputs(treeData, {
+                    baseUrl,
+                    ...generatedSeoLearnUrls,
+                    llmsTxt,
+                    sitemapXml
+                }));
+            } catch (error) {
+                violations.push({
+                    code   : 'SEO_OUTPUT_READ',
+                    message: `Cannot read checked-in SEO outputs (${path.relative(ROOT_DIR, llmsPath)}, ${path.relative(ROOT_DIR, sitemapPath)}): ${error.message}`
+                });
+            }
+        }
+    }
+
     if (violations.length === 0) {
-        console.log(`[lint-tree-json] OK — learn/tree.json mirrors the learn/ folder structure (${treeData.data.length} nodes).`);
+        console.log(`[lint-tree-json] OK — learn/tree.json mirrors the learn/ folder structure and checked-in SEO outputs (${treeData.data.length} nodes).`);
         return {exitCode: 0, violations};
     }
 
-    console.error(`[lint-tree-json] FAILED — ${violations.length} structural violation(s) in learn/tree.json:\n`);
+    console.error(`[lint-tree-json] FAILED — ${violations.length} violation(s) across learn/tree.json and generated SEO outputs:\n`);
     for (const violation of violations) {
         console.error(`- [${violation.code}] ${violation.message}`);
     }
     console.error('\nlearn/tree.json must mirror the on-disk learn/ folder: every leaf id maps to learn/<id>.md,');
     console.error('every parentId references a real group, and each folder maps to exactly one nav group.');
+    console.error('apps/portal/llms.txt and apps/portal/sitemap.xml must also match the in-memory generated learn URL sets.');
     return {exitCode: 1, violations};
 }
 
-function main() {
+async function main() {
     const arg = process.argv[2];
 
     if (arg === '--help' || arg === '-h') {
@@ -223,20 +403,29 @@ function main() {
         console.log('  3. GROUP_COHESION    a group\'s direct leaves share one folder');
         console.log('  4. FOLDER_UNIQUENESS each folder maps to one group (phantom-group guard)');
         console.log('  5. EXPLORATION_ARTIFACT no audit/plan/sweep/census/forensics/benchmark leaf in nav');
+        console.log('  6. SEO_SYNC          checked-in llms.txt + sitemap.xml match generated learn URLs');
         process.exit(0);
     }
 
-    const {exitCode} = runLint();
+    const {exitCode} = await runLint();
     process.exit(exitCode);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
-    main();
+    main().catch(error => {
+        console.error(`[lint-tree-json] FAILED — unexpected error: ${error.message}`);
+        process.exit(1);
+    });
 }
 
 export {
     folderPrefix,
+    getGeneratedSeoLearnUrls,
+    getLeafIds,
+    getLlmsLearnUrls,
+    getSitemapLearnUrls,
     isGroup,
+    lintSeoOutputs,
     lintTree,
     runLint
 };

--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -51,7 +51,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/benefits/AgentMemory</loc>
-    <lastmod>2026-05-31T06:13:39+02:00</lastmod>
+    <lastmod>2026-06-02T13:41:00+02:00</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
@@ -190,7 +190,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/ProgressiveDisclosureSkills</loc>
-    <lastmod>2026-05-31T04:00:12+02:00</lastmod>
+    <lastmod>2026-06-04T10:23:25+02:00</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
@@ -243,7 +243,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/DeploymentCookbook</loc>
-    <lastmod>2026-05-28T08:34:45+02:00</lastmod>
+    <lastmod>2026-05-31T22:44:07+02:00</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
@@ -257,68 +257,68 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Overview</loc>
-    <lastmod>2026-05-26T19:43:05+02:00</lastmod>
+    <lastmod>2026-06-01T12:41:43+02:00</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Day0Tutorial</loc>
-    <lastmod>2026-05-28T23:33:21+02:00</lastmod>
+    <lastmod>2026-06-02T17:39:05+02:00</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Troubleshooting</loc>
-    <lastmod>2026-05-28T22:13:31+02:00</lastmod>
+    <lastmod>2026-06-02T17:39:05+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/LlamaCppProfile</loc>
-    <lastmod>2026-05-28T22:13:31+02:00</lastmod>
+    <lastmod>2026-06-01T12:41:43+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/McpInspectorCompatibility</loc>
-    <lastmod>2026-05-28T22:13:31+02:00</lastmod>
+    <lastmod>2026-06-02T17:53:03+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/TenantIngestionModel</loc>
-    <lastmod>2026-05-21T23:57:03+02:00</lastmod>
+    <lastmod>2026-05-28T22:13:31+02:00</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Configuration</loc>
-    <lastmod>2026-05-25T09:46:58+02:00</lastmod>
+    <lastmod>2026-06-01T12:41:43+02:00</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/CustomSources</loc>
-    <lastmod>2026-05-22T20:41:49+02:00</lastmod>
+    <lastmod>2026-05-31T22:44:07+02:00</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/CustomParsers</loc>
-    <lastmod>2026-05-22T17:03:24+02:00</lastmod>
+    <lastmod>2026-05-31T22:44:07+02:00</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/HookWiring</loc>
-    <lastmod>2026-05-28T22:13:31+02:00</lastmod>
+    <lastmod>2026-05-31T22:44:07+02:00</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/PipelineWiring</loc>
-    <lastmod>2026-05-27T15:35:52+02:00</lastmod>
+    <lastmod>2026-06-01T08:02:43+02:00</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/Security</loc>
-    <lastmod>2026-05-09T16:33:29+02:00</lastmod>
+    <lastmod>2026-06-01T08:02:43+02:00</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/ClientAuthentication</loc>
-    <lastmod>2026-05-02T13:12:50+02:00</lastmod>
+    <lastmod>2026-06-02T21:34:35+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/cloud-deployment/MigrationPath</loc>
-    <lastmod>2026-05-22T19:28:26+02:00</lastmod>
+    <lastmod>2026-05-28T22:13:31+02:00</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
@@ -327,23 +327,23 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/measurements/heartbeat-token-economy-2026-05</loc>
-    <lastmod>2026-05-07T19:22:00+02:00</lastmod>
+    <lastmod>2026-05-22T19:28:26+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/Authorization</loc>
-    <lastmod>2026-03-31T02:29:29+02:00</lastmod>
-  </url>
-  <url>
-    <loc>https://neomjs.com/learn/agentos/tooling/GoogleAuthDemo</loc>
-    <lastmod>2026-03-31T02:29:29+02:00</lastmod>
-  </url>
-  <url>
-    <loc>https://neomjs.com/learn/agentos/tooling/AgentAgnosticMcpConfig</loc>
     <lastmod>2026-05-07T19:22:00+02:00</lastmod>
   </url>
   <url>
+    <loc>https://neomjs.com/learn/agentos/tooling/GoogleAuthDemo</loc>
+    <lastmod>2026-05-07T19:22:00+02:00</lastmod>
+  </url>
+  <url>
+    <loc>https://neomjs.com/learn/agentos/tooling/AgentAgnosticMcpConfig</loc>
+    <lastmod>2026-03-31T02:29:29+02:00</lastmod>
+  </url>
+  <url>
     <loc>https://neomjs.com/learn/agentos/tooling/MemoryCoreMcpApi</loc>
-    <lastmod>2026-05-09T12:33:18+02:00</lastmod>
+    <lastmod>2026-03-31T02:29:29+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/MemoryCoreMcpAuth</loc>
@@ -351,7 +351,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/GraphBackfill</loc>
-    <lastmod>2026-03-31T02:29:29+02:00</lastmod>
+    <lastmod>2026-05-09T12:33:18+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/ChromeDevToolsMcpServer</loc>
@@ -379,7 +379,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/RestorationRunbook</loc>
-    <lastmod>2026-05-17T23:59:00+02:00</lastmod>
+    <lastmod>2026-06-01T08:02:43+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/tooling/WakeSubstrateIncidentProtocol</loc>
@@ -391,16 +391,16 @@
   </url>
   <url>
     <loc>https://neomjs.com/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot</loc>
-    <lastmod>2026-05-31T04:00:12+02:00</lastmod>
+    <lastmod>2026-06-04T02:12:19+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/learn/guides/fundamentals/CodebaseOverview</loc>
-    <lastmod>2026-01-08T23:14:01+01:00</lastmod>
+    <lastmod>2026-06-04T10:23:25+02:00</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://neomjs.com/learn/guides/fundamentals/ApplicationBootstrap</loc>
-    <lastmod>2026-01-08T23:06:13+01:00</lastmod>
+    <lastmod>2026-01-08T23:14:01+01:00</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
@@ -824,7 +824,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/apps/portal/index.html</loc>
-    <lastmod>2026-06-04T09:14:36Z</lastmod>
+    <lastmod>2026-06-04T16:48:34Z</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/apps/realworld/index.html</loc>
@@ -864,7 +864,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/examples/calendar/weekview/index.html</loc>
-    <lastmod>2025-07-11T21:54:21+02:00</lastmod>
+    <lastmod>2026-06-01T19:32:56+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/examples/charts/index.html</loc>
@@ -1340,11 +1340,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12480</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12479</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12477</loc>
@@ -1996,31 +1996,31 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12107</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12106</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12105</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12104</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12103</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12102</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12101</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12097</loc>
@@ -2028,7 +2028,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12094</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12091</loc>
@@ -2036,15 +2036,15 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12090</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12089</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12088</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12087</loc>
@@ -2052,7 +2052,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12080</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12078</loc>
@@ -2060,7 +2060,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12075</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12074</loc>
@@ -2068,7 +2068,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12073</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12072</loc>
@@ -2088,7 +2088,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12068</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12067</loc>
@@ -2100,7 +2100,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12065</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12063</loc>
@@ -2124,7 +2124,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12047</loc>
-    <lastmod>2026-05-28T00:03:07+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12042</loc>
@@ -2236,7 +2236,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11993</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11990</loc>
@@ -2260,7 +2260,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11976</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11973</loc>
@@ -2312,11 +2312,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11925</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11924</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11923</loc>
@@ -2324,11 +2324,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11922</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11912</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11909</loc>
@@ -2472,7 +2472,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11837</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11836</loc>
@@ -2496,7 +2496,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11831</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11830</loc>
@@ -2516,11 +2516,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11822</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11821</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11819</loc>
@@ -2532,7 +2532,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11812</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11811</loc>
@@ -2580,7 +2580,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11791</loc>
-    <lastmod>2026-05-27T01:15:47+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11790</loc>
@@ -2664,7 +2664,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11731</loc>
-    <lastmod>2026-05-27T01:15:47+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11730</loc>
@@ -2920,19 +2920,19 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11605</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11604</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11603</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11602</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11601</loc>
@@ -2940,7 +2940,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11599</loc>
-    <lastmod>2026-05-21T20:04:56+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11596</loc>
@@ -2956,11 +2956,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11593</loc>
-    <lastmod>2026-05-18T22:58:02+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11591</loc>
-    <lastmod>2026-05-18T22:58:02+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11590</loc>
@@ -3300,7 +3300,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11404</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11402</loc>
@@ -3352,7 +3352,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11377</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11373</loc>
@@ -3360,11 +3360,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11372</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11370</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11367</loc>
@@ -3372,7 +3372,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11365</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11364</loc>
@@ -3584,7 +3584,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11236</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11235</loc>
@@ -3656,7 +3656,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11195</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11192</loc>
@@ -3688,7 +3688,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11179</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11177</loc>
@@ -3824,7 +3824,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11110</loc>
-    <lastmod>2026-05-21T20:04:56+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/11108</loc>
@@ -4448,7 +4448,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10788</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10787</loc>
@@ -4480,7 +4480,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10777</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10776</loc>
@@ -4488,7 +4488,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10775</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10774</loc>
@@ -4528,15 +4528,15 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10758</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10757</loc>
-    <lastmod>2026-05-22T15:48:05+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10756</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10755</loc>
@@ -4628,7 +4628,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10714</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10708</loc>
@@ -4720,7 +4720,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10671</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10669</loc>
@@ -4752,7 +4752,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10651</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10650</loc>
@@ -4864,7 +4864,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10601</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10599</loc>
@@ -5012,7 +5012,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10517</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10515</loc>
@@ -5076,7 +5076,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10484</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10478</loc>
@@ -5116,7 +5116,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10462</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10461</loc>
@@ -5156,7 +5156,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10442</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10440</loc>
@@ -5200,11 +5200,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10422</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10420</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10419</loc>
@@ -5240,11 +5240,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10399</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10396</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10395</loc>
@@ -5272,7 +5272,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10384</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10383</loc>
@@ -5312,7 +5312,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10364</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10363</loc>
@@ -5424,7 +5424,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10316</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10314</loc>
@@ -5436,7 +5436,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10311</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10310</loc>
@@ -5452,7 +5452,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10304</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10302</loc>
@@ -5492,11 +5492,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10288</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10285</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10284</loc>
@@ -5520,7 +5520,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10275</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10274</loc>
@@ -5536,7 +5536,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10271</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10270</loc>
@@ -5544,7 +5544,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10267</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10260</loc>
@@ -5648,7 +5648,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10219</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10218</loc>
@@ -5660,15 +5660,15 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10216</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10215</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10214</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10212</loc>
@@ -5676,7 +5676,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10210</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10209</loc>
@@ -5708,7 +5708,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10194</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10192</loc>
@@ -5768,7 +5768,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10172</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10169</loc>
@@ -5788,7 +5788,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10158</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10156</loc>
@@ -5840,7 +5840,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10143</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10141</loc>
@@ -5864,7 +5864,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10134</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10132</loc>
@@ -5924,7 +5924,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10106</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10104</loc>
@@ -5940,7 +5940,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10096</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10095</loc>
@@ -5960,7 +5960,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10089</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10088</loc>
@@ -6024,7 +6024,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10063</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10061</loc>
@@ -6056,7 +6056,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10050</loc>
-    <lastmod>2026-05-18T03:07:13+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10049</loc>
@@ -6100,7 +6100,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10030</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/10028</loc>
@@ -6376,15 +6376,15 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9920</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9919</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9915</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9914</loc>
@@ -6552,15 +6552,15 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9848</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9847</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9846</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9845</loc>
@@ -8608,19 +8608,19 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9298</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9297</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9296</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9295</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9294</loc>
@@ -8944,11 +8944,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9209</loc>
-    <lastmod>2026-05-21T20:04:56+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9208</loc>
-    <lastmod>2026-05-21T20:04:56+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9207</loc>
@@ -9040,7 +9040,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9185</loc>
-    <lastmod>2026-05-18T22:58:02+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9184</loc>
@@ -9140,11 +9140,11 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9160</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9159</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/9158</loc>
@@ -17272,7 +17272,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/6983</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/6982</loc>
@@ -17316,7 +17316,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/6972</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/6971</loc>
@@ -19316,7 +19316,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/6468</loc>
-    <lastmod>2026-05-16T20:39:28+02:00</lastmod>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/6467</loc>

--- a/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs
@@ -4,7 +4,11 @@ import path             from 'node:path';
 
 import {
     folderPrefix,
+    getLeafIds,
+    getLlmsLearnUrls,
+    getSitemapLearnUrls,
     isGroup,
+    lintSeoOutputs,
     lintTree,
     runLint
 } from '../../../../../../ai/scripts/lint/lint-tree-json.mjs';
@@ -13,10 +17,10 @@ import {
  * @summary Coverage for `ai/scripts/lint/lint-tree-json.mjs` — the structural lint that
  * verifies `learn/tree.json` mirrors the on-disk `learn/` folder structure.
  *
- * Empirical drift this lint mechanizes: a phantom nav group was added over files that were
- * flat in `learn/benefits/` (PHANTOM_GROUP), and a parent label outgrew its contents. Both
- * were caught by human / cross-family review, not tooling — this spec proves the five
- * invariants now catch the mechanical cases at CI time.
+ * Empirical anchors (the drift this lint mechanizes): a phantom `BenefitsBrain` nav group
+ * once sat over files that were flat in `learn/benefits/` (PHANTOM_GROUP), and another
+ * parent label outgrew its contents. Both were caught by human / cross-family review, not
+ * tooling — this spec proves the invariants now catch the mechanical cases at CI time.
  *
  * Test axes:
  *   - LEAF_FILE          leaf id with no backing learn/<id>.md
@@ -26,12 +30,14 @@ import {
  *   - PHANTOM_GROUP      >1 nav group owning the same folder (the phantom-group reproducer)
  *   - EXPLORATION_ARTIFACT a published leaf whose basename is an audit/plan/sweep/census/
  *                          forensics/benchmark artifact (learn/ is public docs)
+ *   - SEO_OUTPUT_MISSING generated learn URL missing from checked-in llms.txt / sitemap.xml
+ *   - SEO_OUTPUT_EXTRA   stale checked-in llms.txt / sitemap.xml learn URL
  *   - DUP_ID / MISSING_ID / STRUCTURE  malformed input guards
  *   - happy path: a well-formed fixture + the real learn/tree.json both pass
  *
  * The `lintTree` core is pure (injectable `fileExists`), so the bulk runs without a shell-out.
  */
-test.describe('ai/scripts/lint-tree-json (#12247 — learn/tree.json mirrors learn/ folder structure)', () => {
+test.describe('ai/scripts/lint-tree-json (learn/tree.json mirrors learn/ folder structure)', () => {
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-tree-json.mjs');
 
     /** Convenience: run lintTree and return the sorted set of violation codes. */
@@ -48,6 +54,7 @@ test.describe('ai/scripts/lint-tree-json (#12247 — learn/tree.json mirrors lea
         expect(result.stdout).toContain('LEAF_FILE');
         expect(result.stdout).toContain('FOLDER_UNIQUENESS');
         expect(result.stdout).toContain('EXPLORATION_ARTIFACT');
+        expect(result.stdout).toContain('SEO_SYNC');
     });
 
     test('CLI: the real learn/tree.json passes (mirrors the folder structure)', () => {
@@ -95,7 +102,7 @@ test.describe('ai/scripts/lint-tree-json (#12247 — learn/tree.json mirrors lea
         ])).toEqual(['GROUP_SPANS_FOLDERS']);
     });
 
-    test('PHANTOM_GROUP: two nav groups owning the same folder are flagged (#12238 reproducer)', () => {
+    test('PHANTOM_GROUP: two nav groups owning the same folder are flagged', () => {
         expect(codes([
             {id: 'Benefits', isLeaf: false, parentId: null},
             {id: 'BenefitsBrain', isLeaf: false, parentId: null},
@@ -156,8 +163,113 @@ test.describe('ai/scripts/lint-tree-json (#12247 — learn/tree.json mirrors lea
         expect(isGroup({id: 'L', isLeaf: true})).toBe(false);
     });
 
-    test('runLint: exported entry returns a numeric exit code on the real tree', () => {
-        const {exitCode, violations} = runLint();
+    test('SEO helpers: extract learn ids from checked-in URL shapes', () => {
+        expect(getLlmsLearnUrls(`
+            - [A](https://neomjs.com/raw/learn/agentos/OwnAgentTeam.md)
+            - [B](https://neomjs.com/raw/learn/Glossary.md)
+        `)).toEqual(new Set(['agentos/OwnAgentTeam', 'Glossary']));
+
+        expect(getSitemapLearnUrls(`
+            <url><loc>https://neomjs.com/learn/agentos/OwnAgentTeam</loc></url>
+            <url><loc>https://neomjs.com/learn/Glossary</loc></url>
+        `)).toEqual(new Set(['agentos/OwnAgentTeam', 'Glossary']));
+    });
+
+    test('getLeafIds: returns tree leaf ids and skips explicit groups', () => {
+        expect(getLeafIds({
+            data: [
+                {id: 'AgentOS', isLeaf: false, parentId: null},
+                {id: 'agentos/OwnAgentTeam', parentId: 'AgentOS'}
+            ]
+        })).toEqual(['agentos/OwnAgentTeam']);
+    });
+
+    test('lintSeoOutputs: matching llms.txt + sitemap.xml URL sets pass', () => {
+        const treeData = {
+            data: [
+                {id: 'AgentOS', isLeaf: false, parentId: null},
+                {id: 'agentos/OwnAgentTeam', parentId: 'AgentOS'},
+                {id: 'Glossary', parentId: null}
+            ]
+        };
+
+        expect(lintSeoOutputs(treeData, {
+            llmsTxt: `
+                - [Provision Your Own Agent Team](https://neomjs.com/raw/learn/agentos/OwnAgentTeam.md)
+                - [Glossary](https://neomjs.com/raw/learn/Glossary.md)
+            `,
+            sitemapXml: `
+                <url>
+                    <loc>https://neomjs.com/learn/agentos/OwnAgentTeam</loc>
+                    <lastmod>2026-06-03T00:00:00Z</lastmod>
+                </url>
+                <url>
+                    <loc>https://neomjs.com/learn/Glossary</loc>
+                    <lastmod>2024-01-01T00:00:00Z</lastmod>
+                </url>
+            `
+        })).toEqual([]);
+    });
+
+    test('lintSeoOutputs: accepts generator-specific llms.txt and sitemap.xml expected sets', () => {
+        const treeData = {
+            data: [
+                {id: 'AgentOS', isLeaf: false, parentId: null},
+                {id: 'agentos/OwnAgentTeam', parentId: 'AgentOS'},
+                {id: 'Glossary', parentId: null}
+            ]
+        };
+
+        expect(lintSeoOutputs(treeData, {
+            expectedLlmsIds   : new Set(['agentos/OwnAgentTeam']),
+            expectedSitemapIds: new Set(['agentos/OwnAgentTeam', 'Glossary']),
+            llmsTxt           : '- [Provision Your Own Agent Team](https://neomjs.com/raw/learn/agentos/OwnAgentTeam.md)',
+            sitemapXml        : `
+                <url><loc>https://neomjs.com/learn/agentos/OwnAgentTeam</loc></url>
+                <url><loc>https://neomjs.com/learn/Glossary</loc></url>
+            `
+        })).toEqual([]);
+    });
+
+    test('lintSeoOutputs: missing tree routes are flagged on both SEO surfaces', () => {
+        const treeData = {
+            data: [
+                {id: 'AgentOS', isLeaf: false, parentId: null},
+                {id: 'agentos/OwnAgentTeam', parentId: 'AgentOS'}
+            ]
+        };
+
+        expect(lintSeoOutputs(treeData, {
+            llmsTxt   : '',
+            sitemapXml: ''
+        }).map(v => v.code)).toEqual(['SEO_OUTPUT_MISSING', 'SEO_OUTPUT_MISSING']);
+    });
+
+    test('lintSeoOutputs: stale generated routes are flagged on both SEO surfaces', () => {
+        const treeData = {data: []};
+
+        expect(lintSeoOutputs(treeData, {
+            llmsTxt   : '- [Gone](https://neomjs.com/raw/learn/agentos/Gone.md)',
+            sitemapXml: '<url><loc>https://neomjs.com/learn/agentos/Gone</loc></url>'
+        }).map(v => v.code)).toEqual(['SEO_OUTPUT_EXTRA', 'SEO_OUTPUT_EXTRA']);
+    });
+
+    test('lintSeoOutputs: sitemap lastmod changes are ignored when URLs match', () => {
+        const treeData = {data: [{id: 'Glossary', parentId: null}]};
+
+        expect(lintSeoOutputs(treeData, {
+            llmsTxt: '- [Glossary](https://neomjs.com/raw/learn/Glossary.md)',
+            sitemapXml: `
+                <url>
+                    <loc>https://neomjs.com/learn/Glossary</loc>
+                    <lastmod>1999-01-01T00:00:00Z</lastmod>
+                </url>
+            `
+        })).toEqual([]);
+    });
+
+    test('runLint: exported entry returns a numeric exit code on the real tree', async () => {
+        const {exitCode, violations} = await runLint();
 
         expect(exitCode).toBe(0);
         expect(violations).toEqual([]);


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Resolves #12522

Adds a CI-backed SEO sync guard to `ai/scripts/lint/lint-tree-json.mjs`. The lint still validates the structural `learn/tree.json` invariants, and now also regenerates `apps/portal/llms.txt` and `apps/portal/sitemap.xml` in memory through the existing SEO generator, compares the checked-in learn URL sets, and ignores sitemap `lastmod` churn.

Evidence: L1 (static lint + focused unit spec) -> L1 required (CI guard over checked-in generated URL sets). No residuals.

## Deltas from ticket
- Implemented by extending the existing `lint-tree-json` guard rather than adding a sibling lint.
- Expected URL sets come from `buildScripts/docs/seo/generate.mjs`, not a second hand-coded projection of `tree.json`; this preserves the generator's curated `llms.txt` shape while still catching stale generated outputs.
- Expanded the Tree JSON Lint workflow path filters to run when the SEO generator or checked-in SEO outputs change.
- Added `npm ci` to the Tree JSON Lint workflow because the generator-backed guard imports repo dependencies such as `fs-extra`.
- Regenerated `apps/portal/sitemap.xml` on the rebased branch; `apps/portal/llms.txt` was already current on the updated `origin/dev`.

## Test Evidence
- `node ai/scripts/lint/lint-tree-json.mjs` -> OK, 197 nodes.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs` -> 19 passed.
- `git diff --check origin/dev..HEAD` -> clean.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev` -> Safe to push.
- CI log for first head identified missing workflow dependencies (`ERR_MODULE_NOT_FOUND: fs-extra`); fixed by `96adf45d2`.

## Post-Merge Validation
- [ ] Tree JSON Lint workflow runs on `dev` and reports the checked-in SEO outputs in sync.

## Commits
- `bce847d94` — `test(learn): guard SEO output sync (#12522)`
- `96adf45d2` — `ci(learn): install deps for SEO sync lint (#12522)`