### PR TITLE
refactor(agentos): derive harness routing from identity roots (#12434)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -48,6 +48,7 @@ import {
     getEdgesData,
     getDbNode
 } from './queries.mjs';
+import {applyHarnessMetadataDefaults} from '../../scripts/lifecycle/harnessRouting.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
 const DB_PATH                  = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
@@ -699,22 +700,10 @@ async function deliverDigest(subscription, digest) {
                 );
                 return;
             }
-            let tabShortcut = meta.tabShortcut;
-            // Default tab/focus shortcuts are harness-specific. Claude uses Cmd+3 for
-            // its Code tab; Antigravity uses Cmd+Shift+I for the verified focus route.
-            // Note: If tabShortcut is explicitly null, it is treated as a deliberate opt-out (no keystroke).
-            if (tabShortcut === undefined) {
-                if (appName === 'Claude') tabShortcut = '3';
-                else if (appName === 'Antigravity') tabShortcut = 'shift+i';
-            }
-            let focusSeedKey      = meta.focusSeedKey;
-            let focusSeedSequence = meta.focusSeedSequence;
-            // Claude tab switching does not always focus the prompt. Use the
-            // probe-and-undo sequence before the destructive Cmd+A/Cmd+X clear path.
-            // Keep this per harness; Antigravity owns an idempotent Cmd+Shift+I route.
-            if (focusSeedSequence === undefined && focusSeedKey === undefined && appName === 'Claude') {
-                focusSeedSequence = 'r-undo';
-            }
+            const metadataWithDefaults = applyHarnessMetadataDefaults(meta);
+            let tabShortcut            = metadataWithDefaults.tabShortcut;
+            let focusSeedKey           = metadataWithDefaults.focusSeedKey;
+            let focusSeedSequence      = metadataWithDefaults.focusSeedSequence;
 
             // Codex Desktop fail-closed guard. The bridge must not drive the destructive
             // Cmd+A/Cmd+X clear path unless subscription metadata provides a verified,

--- a/ai/scripts/lifecycle/harnessRouting.mjs
+++ b/ai/scripts/lifecycle/harnessRouting.mjs
@@ -1,0 +1,97 @@
+/**
+ * @summary Lightweight harness-routing primitives for wake/resume delivery.
+ *
+ * The AgentIdentity roster lives in `identityRoots.mjs`; lifecycle dispatchers should derive
+ * routable identities from that registry instead of mirroring Neo's maintainer handles. Host-app
+ * shortcut defaults live here as well so bridge wake delivery and fresh-session recovery consume
+ * one fact table.
+ *
+ * @see ai/graph/identityRoots.mjs
+ * @see ai/scripts/lifecycle/resumeHarness.mjs
+ * @see ai/daemons/bridge/daemon.mjs
+ */
+import {IDENTITIES} from '../../graph/identityRoots.mjs';
+
+const FAMILY_HARNESS_TARGETS = Object.freeze({
+    claude: Object.freeze({
+        adapter             : 'osascript',
+        appName             : 'Claude',
+        freshSessionShortcut: 'n'
+    }),
+    gemini: Object.freeze({
+        adapter: 'antigravity-cli'
+    }),
+    gpt: Object.freeze({
+        adapter: 'codex-app-server'
+    })
+});
+
+const APP_HARNESS_DEFAULTS = Object.freeze({
+    Antigravity: Object.freeze({
+        tabShortcut: 'shift+i'
+    }),
+    Claude: Object.freeze({
+        tabShortcut      : '3',
+        focusSeedSequence: 'r-undo'
+    })
+});
+
+/**
+ * @summary Normalize a GitHub-login-style identity into AgentIdentity node-id form.
+ * @param {String} identity Raw identity from env/config/CLI.
+ * @returns {String} Canonical AgentIdentity node id, or an empty string for empty input.
+ */
+export function normalizeAgentIdentityNodeId(identity) {
+    const value = String(identity ?? '').trim();
+    return value && !value.startsWith('@') ? `@${value}` : value;
+}
+/**
+ * @summary Apply host-app default shortcuts while preserving explicit metadata.
+ *
+ * `undefined` means "use the known app default"; `null` remains a deliberate opt-out.
+ *
+ * @param {Object} metadata Harness target metadata.
+ * @returns {Object} Copy of metadata with host-app defaults applied.
+ */
+export function applyHarnessMetadataDefaults(metadata = {}) {
+    const result   = {...metadata};
+    const defaults = APP_HARNESS_DEFAULTS[result.appName] || {};
+
+    if (result.tabShortcut === undefined && Object.hasOwn(defaults, 'tabShortcut')) {
+        result.tabShortcut = defaults.tabShortcut;
+    }
+
+    if (
+        result.focusSeedSequence === undefined &&
+        result.focusSeedKey === undefined &&
+        Object.hasOwn(defaults, 'focusSeedSequence')
+    ) {
+        result.focusSeedSequence = defaults.focusSeedSequence;
+    }
+
+    return result;
+}
+
+/**
+ * @summary Resolve the fresh-session harness target for an AgentIdentity.
+ *
+ * This intentionally derives from `modelFamily`, not `subscriptionTemplate`: same-app Claude
+ * identities can be active before their mailbox wake route is individually addressable, but they
+ * still share the Claude Desktop fresh-session recovery target.
+ *
+ * @param {String} identity Agent identity id or GitHub login.
+ * @param {Object} [options]
+ * @param {Object[]} [options.identities=IDENTITIES] Identity-root-shaped registry for tests.
+ * @returns {Object|null} Harness target with app defaults applied, or `null` for unknown identities.
+ */
+export function resolveHarnessTargetForIdentity(identity, {identities = IDENTITIES} = {}) {
+    const nodeId = normalizeAgentIdentityNodeId(identity);
+    const entry  = identities.find(candidate => candidate.type === 'AgentIdentity' && candidate.id === nodeId);
+
+    if (!entry) return null;
+
+    const family = entry.properties?.modelFamily || entry.properties?.family;
+    const target = FAMILY_HARNESS_TARGETS[family];
+
+    return target ? applyHarnessMetadataDefaults(target) : null;
+}

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -21,6 +21,12 @@ import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
 import { createSpawnRequest } from './windowsBatchSpawn.mjs';
+import {
+    normalizeAgentIdentityNodeId,
+    resolveHarnessTargetForIdentity
+} from './harnessRouting.mjs';
+
+export {normalizeAgentIdentityNodeId};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -71,7 +77,7 @@ function spawnAsync(cmd, args, identity = null, hostPlatform = process.platform)
  * @summary Resolve the embedded Claude Code CLI binary path inside Claude Desktop.
  *
  * NOTE: retained as a non-routed fallback — Claude recovery routes to the `osascript`
- * adapter (Claude Desktop Tab 3 / Code tab); see the HARNESS_REGISTRY note in `resumeHarness`.
+ * adapter (Claude Desktop Tab 3 / Code tab); see the harness routing note in `resumeHarness`.
  *
  * Claude Desktop ships the `claude` CLI under
  * `~/Library/Application Support/Claude/claude-code/<version>/claude.app/Contents/MacOS/claude`.
@@ -255,16 +261,6 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
 }
 
 /**
- * @summary Normalize a GitHub-login-style identity into the AgentIdentity node id form wake dispatchers require.
- * @param {String} identity Raw identity from env/config/CLI.
- * @returns {String} Canonical AgentIdentity node id, or an empty string for empty input.
- */
-export function normalizeAgentIdentityNodeId(identity) {
-    const value = String(identity ?? '').trim();
-    return value && !value.startsWith('@') ? `@${value}` : value
-}
-
-/**
  * @summary Resume a sunsetted agent by dispatching the configured fresh-session harness adapter.
  * @param {String} identity Agent identity to resume.
  * @param {String} reason Human-readable recovery reason.
@@ -309,7 +305,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
     // AGENTS_STARTUP.md and re-anchors prior context via Memory Core + sandman_handoff.
     const payload = buildBootGroundingPrompt(identity, reason, originSessionId);
 
-    // Harness Registry: maps identity IDs to their restart adapters.
+    // Harness routing derives identity IDs from `identityRoots.mjs` via `harnessRouting.mjs`.
     // - antigravity-ide: native CLI `chat -n` through the `antigravity-cli` adapter.
     // - claude-desktop: Claude Desktop GUI through the `osascript` adapter — activate
     //   Claude, Cmd+3 to the Code tab (Tab 3), Cmd+N for a fresh chat, then paste the
@@ -325,22 +321,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
     //   gated, while tests use CODEX_APP_SERVER_MOCK=1 + CODEX_CLI_PATH.
     // The `claude-cli` adapter (embedded `claude <prompt>` CLI) is retained as a
     // non-routed fallback; no production identity routes there after the Tab-3 remap.
-    const HARNESS_REGISTRY = {
-        'antigravity-ide': { adapter: 'antigravity-cli' },
-        'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' },
-        'codex-desktop':   { adapter: 'codex-app-server' }
-    };
-
-    const identityMap = {
-        '@neo-gemini-3-1-pro': 'antigravity-ide',
-        '@neo-gpt'           : 'codex-desktop',
-        '@neo-opus-4-7'      : 'claude-desktop',
-        '@neo-claude-opus'   : 'claude-desktop',
-        '@neo-opus-vega'     : 'claude-desktop'
-    };
-
-    const targetId = identityMap[identity];
-    const harnessTarget = targetId ? HARNESS_REGISTRY[targetId] : null;
+    const harnessTarget = resolveHarnessTargetForIdentity(identity);
 
     if (!harnessTarget) {
         throw new Error(`Unknown harness target for identity: ${identity}`);

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -22,6 +22,10 @@ import path                      from 'path';
 import fs                        from 'fs';
 import Neo                       from '../../../../../../src/Neo.mjs';
 import * as core                 from '../../../../../../src/core/_export.mjs';
+import {
+    applyHarnessMetadataDefaults,
+    resolveHarnessTargetForIdentity
+} from '../../../../../../ai/scripts/lifecycle/harnessRouting.mjs';
 
 test.describe('ai/scripts/resumeHarness', () => {
     test.describe.configure({mode: 'serial'});
@@ -94,19 +98,33 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
-    test('Claude identities route to claude-desktop -> osascript Tab-3 adapter (config check)', async () => {
-        // Static script-content check: the HARNESS_REGISTRY claude-desktop entry uses the
-        // osascript adapter, locking Claude recovery to Claude Desktop Tab 3 (Code tab) via
-        // Cmd+3 + Cmd+N (fresh chat). The fresh chat yields a fresh currentSessionId + transcript;
-        // it reuses the running Claude Desktop app (osascript is exempt from process-termination)
-        // rather than spawning a tracked OS process — the accepted trade-off for deterministic
-        // Tab-3 targeting. Always-on coverage — no host side effects (static read only). Both
-        // Claude identities map to claude-desktop.
+    test('Claude identities derive osascript Tab-3 routing from identityRoots modelFamily (#12434)', async () => {
+        // Static source check plus helper-level behavior: resumeHarness no longer mirrors Neo's
+        // identity roster. Claude-family identities derive the same Claude Desktop Tab-3 fresh
+        // session target from identityRoots, including active identities without a
+        // subscriptionTemplate.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' }");
-        expect(scriptContent).toContain("'@neo-opus-4-7'      : 'claude-desktop'");
-        expect(scriptContent).toContain("'@neo-claude-opus'   : 'claude-desktop'");
-        expect(scriptContent).toContain("'@neo-opus-vega'     : 'claude-desktop'");
+        expect(scriptContent).not.toContain('const identityMap =');
+        expect(scriptContent).toContain('resolveHarnessTargetForIdentity(identity)');
+
+        expect(resolveHarnessTargetForIdentity('@neo-opus-4-7')).toMatchObject({
+            adapter             : 'osascript',
+            appName             : 'Claude',
+            tabShortcut         : '3',
+            freshSessionShortcut: 'n'
+        });
+        expect(resolveHarnessTargetForIdentity('@neo-claude-opus')).toMatchObject({
+            adapter             : 'osascript',
+            appName             : 'Claude',
+            tabShortcut         : '3',
+            freshSessionShortcut: 'n'
+        });
+        expect(resolveHarnessTargetForIdentity('@neo-opus-vega')).toMatchObject({
+            adapter             : 'osascript',
+            appName             : 'Claude',
+            tabShortcut         : '3',
+            freshSessionShortcut: 'n'
+        });
     });
 
     test('normalizes GitHub-login identity form before harness dispatch (#11797)', async () => {
@@ -115,6 +133,51 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(normalizeAgentIdentityNodeId('neo-opus-4-7')).toBe('@neo-opus-4-7');
         expect(normalizeAgentIdentityNodeId('@neo-gpt')).toBe('@neo-gpt');
         expect(normalizeAgentIdentityNodeId('  neo-gemini-3-1-pro  ')).toBe('@neo-gemini-3-1-pro');
+    });
+
+    test('future identityRoots activation does not require resumeHarness identityMap edits (#12434)', () => {
+        const identities = [{
+            id        : '@neo-future-claude',
+            type      : 'AgentIdentity',
+            properties: {
+                modelFamily: 'claude',
+                accountType: 'agent'
+            }
+        }, {
+            id        : '@neo-future-gpt',
+            type      : 'AgentIdentity',
+            properties: {
+                modelFamily: 'gpt',
+                accountType: 'agent'
+            }
+        }];
+
+        expect(resolveHarnessTargetForIdentity('neo-future-claude', {identities})).toMatchObject({
+            adapter             : 'osascript',
+            appName             : 'Claude',
+            tabShortcut         : '3',
+            freshSessionShortcut: 'n'
+        });
+        expect(resolveHarnessTargetForIdentity('@neo-future-gpt', {identities})).toMatchObject({
+            adapter: 'codex-app-server'
+        });
+    });
+
+    test('host app defaults are shared and preserve explicit null opt-outs (#12434)', () => {
+        expect(applyHarnessMetadataDefaults({appName: 'Claude'})).toMatchObject({
+            appName          : 'Claude',
+            tabShortcut      : '3',
+            focusSeedSequence: 'r-undo'
+        });
+        expect(applyHarnessMetadataDefaults({appName: 'Antigravity'})).toMatchObject({
+            appName     : 'Antigravity',
+            tabShortcut : 'shift+i'
+        });
+        expect(applyHarnessMetadataDefaults({appName: 'Antigravity', tabShortcut: null})).toMatchObject({
+            appName     : 'Antigravity',
+            tabShortcut : null
+        });
+        expect(applyHarnessMetadataDefaults({appName: 'Claude', focusSeedKey: 'space'})).not.toHaveProperty('focusSeedSequence');
     });
 
     test('Opus identity osascript runtime dispatch (live host — RUN_LIVE_OSASCRIPT=1 required, #10681)', async () => {
@@ -196,16 +259,23 @@ test.describe('ai/scripts/resumeHarness', () => {
         expect(stderrAndStdout).not.toContain('Wake safety gate disabled');
     });
 
-    test('Q1b fresh-session-spawn: HARNESS_REGISTRY entries route to safe adapters (#10611 PR-B AC1)', async () => {
-        // Each harness routes to its substrate-correct fresh-session adapter. Antigravity uses
-        // `antigravity chat -n`; Claude Desktop uses the osascript Cmd+3 -> Tab 3 + Cmd+N path
-        // (deterministic Tab-3 targeting); Codex Desktop uses the live-host-gated app-server
-        // adapter. All avoid the rejected prompt-layer sessionId plumbing.
-        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-        expect(scriptContent).toContain("'antigravity-ide': { adapter: 'antigravity-cli' }");
-        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' }");
-        expect(scriptContent).toContain("'codex-desktop':   { adapter: 'codex-app-server' }");
-        expect(scriptContent).toContain("'@neo-gpt'           : 'codex-desktop'");
+    test('Q1b fresh-session-spawn: model-family routes use safe adapters (#10611 PR-B AC1)', async () => {
+        // Each model family routes to its substrate-correct fresh-session adapter. Antigravity uses
+        // `antigravity chat -n`; Claude Desktop uses the osascript Cmd+3 -> Tab 3 + Cmd+N path;
+        // Codex Desktop uses the live-host-gated app-server adapter. All avoid the rejected
+        // prompt-layer sessionId plumbing.
+        expect(resolveHarnessTargetForIdentity('@neo-gemini-3-1-pro')).toMatchObject({
+            adapter: 'antigravity-cli'
+        });
+        expect(resolveHarnessTargetForIdentity('@neo-opus-4-7')).toMatchObject({
+            adapter             : 'osascript',
+            appName             : 'Claude',
+            tabShortcut         : '3',
+            freshSessionShortcut: 'n'
+        });
+        expect(resolveHarnessTargetForIdentity('@neo-gpt')).toMatchObject({
+            adapter: 'codex-app-server'
+        });
     });
 
     test('Q1b fresh-session-spawn: osascript flow injects freshSessionShortcut keystroke before paste (#10611 PR-B AC1)', async () => {
@@ -235,10 +305,24 @@ test.describe('ai/scripts/resumeHarness', () => {
         // fresh chat) before the clipboard cut/paste of the boot-grounding prompt. The fresh chat
         // is what yields a fresh currentSessionId + transcript. Static-content verification; the
         // live runtime osascript dispatch is RUN_LIVE_OSASCRIPT-gated in the test above.
+        expect(resolveHarnessTargetForIdentity('@neo-opus-4-7')).toMatchObject({
+            adapter             : 'osascript',
+            appName             : 'Claude',
+            tabShortcut         : '3',
+            freshSessionShortcut: 'n'
+        });
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-        expect(scriptContent).toContain("'claude-desktop':  { adapter: 'osascript', appName: 'Claude', tabShortcut: '3', freshSessionShortcut: 'n' }");
         expect(scriptContent).toContain('keystroke "${tabShortcut}" using command down');
         expect(scriptContent).toContain('keystroke "${freshSessionShortcut}" using command down');
+    });
+
+    test('bridge daemon consumes shared host app defaults instead of duplicating shortcut literals (#12434)', async () => {
+        const bridgePath = path.resolve(process.cwd(), 'ai/daemons/bridge/daemon.mjs');
+        const bridgeContent = fs.readFileSync(bridgePath, 'utf-8');
+
+        expect(bridgeContent).toContain('applyHarnessMetadataDefaults(meta)');
+        expect(bridgeContent).not.toContain("if (appName === 'Claude') tabShortcut = '3'");
+        expect(bridgeContent).not.toContain("else if (appName === 'Antigravity') tabShortcut = 'shift+i'");
     });
 
     test('harness lifecycle: CLI-adapter spawn records PID in state-file (antigravity-cli)', async () => {
@@ -507,7 +591,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         // Therefore we strictly delegate to out-of-process harness adapters and ensure
         // no in-process session mutation exists.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
-        expect(scriptContent).toContain('adapter:');
+        expect(scriptContent).toContain('resolveHarnessTargetForIdentity(identity)');
         expect(scriptContent).not.toMatch(/currentSessionId\s*=/);
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Resolves #12434

Derives wake/restart harness routing from `identityRoots.mjs` so Claude-family identity activation no longer requires editing `resumeHarness.mjs`, and shares host-app shortcut defaults with the bridge daemon.

Evidence: L2 (identityRoots-backed unit coverage + static bridge/resume contract checks) → L2 required (runtime route table and duplicate-default contract covered by unit/static assertions). No residuals.

## Deltas from ticket
- Added `ai/scripts/lifecycle/harnessRouting.mjs` as the shared source for family-to-harness routing and host-app metadata defaults.
- Preserved same-app Claude identities without `subscriptionTemplate` by deriving from `modelFamily`, not wake subscription metadata.

## Test Evidence
- `NEO_TEST_SKIP_CI=1 npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs` → 18 passed, 9 skipped.
- `git diff --cached --check` → passed before commit.
- `git log origin/dev..HEAD` → outgoing history contains only `31a7ae641`.

## Post-Merge Validation
- [ ] Trigger or inspect a real wake/resume path for `@neo-opus-vega` once operator-side same-app routing is available.

## Commits
- `31a7ae641` — derive harness routing from identity roots and share bridge defaults
