### PR TITLE
feat(agentos): define stale-yield diagnostic (#12444)

### DIFF
--- a/.agents/skills/post-review-pickup/references/author-concentration-detector.md
+++ b/.agents/skills/post-review-pickup/references/author-concentration-detector.md
@@ -24,6 +24,29 @@ Telemetry signal for authorship concentration across the swarm. **Successor to t
 
 Concentration firing is a **liveness / capability signal**, not a fairness violation. The productive author is not the problem; the asleep or cold peers are. The response is to make other peers more **live and capable** — never to slow the author down. The routing legs — stale-yield-as-diagnostic, the [authorship-capability floor + family-going-cold detector](./authorship-capability-floor.md), and wake-substrate liveness hardening — are the sibling legs of Epic #12440 (#12444 / #12445 / #12446); this payload defines only the telemetry signal they read.
 
+## Stale-Yield Diagnostic (#12444)
+
+Stale-yield is **diagnostic**, not reassignment. When a peer yields or avoids a
+lane because another author is repeatedly better positioned, classify the block
+before routing any work:
+
+| Classification | Evidence | Capability-transfer artifact |
+|---|---|---|
+| `missing-context` | Peer is awake and capable, but lacks the local map: exact files, avoided traps, prior verdicts, or evidence ladder. | Context capsule with exact files, current authority, avoided traps, and a narrow first-PR slice. |
+| `missing-wake-presence` | Peer has the relevant family/area fit, but no reachable wake/review/lane activity in the active window. | Wake/liveness route: targeted A2A, wake-substrate follow-up, or human-visible dependency note. |
+| `capability-debt` | Only the dominant author can safely produce even the reshaping artifact for a critical state-mutating area. | Record against the capability floor, then publish a bounded transfer artifact that changes the peer's cost curve. |
+
+The output is a **bounded capability-transfer artifact**: context capsule,
+narrowed first-PR slice, avoided-traps note, exact file list, evidence ladder,
+or dependency note. It is **not** a recommendation to reassign the lane, a quota
+move, or a reason to slow the productive author.
+
+Anti-reconcentration guard: track who produces reshaping artifacts separately
+from who authors feature PRs. If the same dominant author also produces all
+context capsules / narrowed slices / avoided-traps notes, the monoculture has
+relocated from authoring to reshaping. Treat that as telemetry for the
+capability-floor path, never as a throttle.
+
 ## Self-Application When Peers Are Live
 
 If the concentrating author is about to claim another lane while other peer

--- a/.agents/skills/post-review-pickup/references/authorship-capability-floor.md
+++ b/.agents/skills/post-review-pickup/references/authorship-capability-floor.md
@@ -15,6 +15,7 @@ A maintainer family is **going cold in critical substrate** when, over a sustain
 - Read from existing provenance (merged-PR authorship + review participation per area) — **no dedicated substrate until recurrence proves it earns one** (per the create-skill discipline).
 - **Amber:** one family is the *sole* author in a critical area across the window (single-family bus-factor in state-mutating work).
 - **Telemetry, never a gate** — same contract as the author-concentration detector: it routes to capability-transfer (the stale-yield diagnostic, #12444), it never blocks, assigns, or throttles a lane.
+- **Capability-debt record:** when the stale-yield diagnostic finds that only the dominant author can produce even the context capsule / narrowed slice / avoided-traps artifact for a critical area, record that as a capability-floor observation. The remedy is bounded capability transfer, not reassignment or author throttling.
 
 ## Risk framing (what the floor protects against)
 


### PR DESCRIPTION
Resolves #12444
Related: #12440

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Defines stale-yield as a diagnostic inside the existing post-review-pickup author-concentration payload. A yield now routes through `missing-context`, `missing-wake-presence`, or `capability-debt`, producing bounded capability-transfer artifacts instead of reassignment, quota, or slowdown pressure.

Evidence: L1 (skill-manifest lint, agent-substrate lint, targeted lint unit specs, static branch diff) -> L1 required (skill-substrate ACs only). No residuals.

## Deltas from ticket
- Kept the diagnostic in the existing post-review-pickup Atlas payload rather than expanding always-loaded maps.
- Linked capability-debt observations into the sibling capability-floor payload without adding dedicated tracking substrate.

## Slot Rationale
- Added `Stale-Yield Diagnostic (#12444)` to `.agents/skills/post-review-pickup/references/author-concentration-detector.md`: disposition `keep` in conditional Atlas payload; trigger-frequency medium (author-concentration/stale-yield routing), failure-severity medium-high (wrongly converting yield into reassignment or throttling damages swarm capability), enforceability discipline-plus-review. No always-loaded Map bytes added.
- Modified `.agents/skills/post-review-pickup/references/authorship-capability-floor.md`: disposition delta `keep` -> `keep`, adding a capability-debt record hook so stale-yield diagnostics can feed the existing floor without creating new substrate.
- Decision Record impact: none; this is a direct Epic `#12440` leaf implementation and does not alter accepted ADR behavior.

## Test Evidence
- `npm run ai:lint-skill-manifest` -> OK
- `npm run ai:lint-agents` -> OK
- `git diff --check` -> clean
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintAgents.spec.mjs test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` -> 75 passed

## Post-Merge Validation
- [ ] Future post-review-pickup lane-discovery use of author-concentration detector routes stale-yield into `missing-context`, `missing-wake-presence`, or `capability-debt` rather than reassignment.

## Commits
- `f35b4c87c` — `feat(agentos): define stale-yield diagnostic (#12444)`