### PR TITLE
fix(ai): remove GitLab B3 config defenses (#12526)

### DIFF
--- a/ai/services/gitlab-workflow/HealthService.mjs
+++ b/ai/services/gitlab-workflow/HealthService.mjs
@@ -4,7 +4,7 @@ import Base     from '../../../src/core/Base.mjs';
 /**
  * @summary Scaffold health service for the GitLab Workflow MCP server.
  *
- * The initial #11768 lane only registers the MCP surface. It validates that the
+ * The initial scaffold only registers the MCP surface. It validates that the
  * server has a GitLab host configuration and reports whether a PAT is configured,
  * without pretending that real API connectivity exists before GitLabClient lands.
  *
@@ -31,7 +31,7 @@ class HealthService extends Base {
      * @returns {Promise<Object>}
      */
     async healthcheck() {
-        const hostUrl = aiConfig.gitlab?.hostUrl || '';
+        const hostUrl = aiConfig.gitlab.hostUrl;
         const details = [];
 
         if (!hostUrl) {
@@ -42,7 +42,7 @@ class HealthService extends Base {
             status: details.length ? 'unhealthy' : 'healthy',
             gitlab: {
                 hostUrl,
-                tokenConfigured: Boolean(aiConfig.gitlab?.token)
+                tokenConfigured: Boolean(aiConfig.gitlab.token)
             },
             details
         };


### PR DESCRIPTION
Resolves #12526
Related: #12461
Related: #12456

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Removes the GitLab workflow healthcheck B3 defensive reads around the AiConfig Provider SSOT. `HealthService.healthcheck()` now reads the resolved `gitlab.hostUrl` and `gitlab.token` leaves directly, preserving the health payload shape while letting broken config trees fail loud per ADR 0019.

Evidence: L1 (static B3 grep + SSOT lint + pre-commit archaeology/shorthand/whitespace hooks) plus L2-lite (direct runtime import/call of `HealthService.healthcheck()`) -> L1/L2 required (single-service config-read cleanup). No residuals.

## Deltas from ticket
- Also removed the stale `#11768` token from the touched JSDoc because the repo pre-commit `check-ticket-archaeology` hook rejects durable ticket references in comments. The comment still describes the same scaffold behavior.

## Test Evidence
- `npm run ai:lint-config-template-ssot` -> OK
- `node --input-type=module -e "import './src/Neo.mjs'; import './src/core/_export.mjs'; const HealthService = (await import('./ai/services/gitlab-workflow/HealthService.mjs')).default; const result = await HealthService.healthcheck(); console.log(JSON.stringify({status: result.status, hostUrl: result.gitlab.hostUrl, tokenConfigured: result.gitlab.tokenConfigured, details: result.details}));"` -> `{"status":"healthy","hostUrl":"https://gitlab.com","tokenConfigured":false,"details":[]}`
- `rg -n "aiConfig\.gitlab\?\.|aiConfig\.gitlab\.hostUrl\s*\|\||#11768" ai/services/gitlab-workflow/HealthService.mjs` -> no matches
- `git diff --check` -> clean
- pre-commit hooks passed: whitespace, shorthand, ticket archaeology

## Post-Merge Validation
- [ ] #12461 B3 workstream can count the GitLab workflow cluster as complete while leaving other B3 clusters untouched.

## Commits
- `f2ab108b8` — `fix(ai): remove GitLab B3 config defenses (#12526)`