### PR TITLE
fix(ai): remove KB daemon B3 config defenses (#12529)

### DIFF
--- a/ai/daemons/kb-alerting/KbAlertingService.mjs
+++ b/ai/daemons/kb-alerting/KbAlertingService.mjs
@@ -224,15 +224,14 @@ class KbAlertingService extends Base {
     /**
      * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
      *
-     * Reads defensively: a stale gitignored `ai/config.mjs` deployment may lack the
-     * `knowledgeBase` key, so a naked `aiConfig.knowledgeBase.alertRules` would throw.
-     * Returns `{}` when the key is absent.
+     * Reads the resolved AiConfig Provider subtree directly; missing subtree shape must fail
+     * loud instead of being converted into a disabled alerting daemon.
      *
      * @returns {Object}
      * @protected
      */
     getKbConfig() {
-        return aiConfig.knowledgeBase || {}
+        return aiConfig.knowledgeBase
     }
 
     /**

--- a/ai/daemons/kb-alerting/KbAlertingService.mjs
+++ b/ai/daemons/kb-alerting/KbAlertingService.mjs
@@ -10,22 +10,9 @@ import RequestContextService          from '../../mcp/server/shared/services/Req
 import logger                         from '../../mcp/server/knowledge-base/logger.mjs';
 import {normalizeAgentIdentityNodeId} from '../../scripts/lifecycle/resumeHarness.mjs';
 import {
-    DEFAULT_COOLDOWN_MS,
     evaluateAlertRules,
     formatAlertMessage
 } from '../../services/knowledge-base/helpers/KbAlertRuleEngine.mjs';
-
-/**
- * @summary Poll interval fallback when `aiConfig.knowledgeBase.alertingIntervalMs` is unset.
- * @type {Number}
- */
-const DEFAULT_INTERVAL_MS = 15 * 60 * 1000;
-
-/**
- * @summary Rollup look-back fallback when `aiConfig.knowledgeBase.alertWindowMs` is unset.
- * @type {Number}
- */
-const DEFAULT_WINDOW_MS = 60 * 60 * 1000;
 
 /**
  * @summary Sender identity fallback for A2A alert dispatch when `NEO_AGENT_IDENTITY` is unset.
@@ -92,11 +79,12 @@ class KbAlertingService extends Base {
         pollHandle_: null,
         /**
          * Interval between alerting pulses in milliseconds.
-         * @member {Number} pollIntervalMs_=900000
+         * Populated from `aiConfig.knowledgeBase.alertingIntervalMs` when the daemon starts.
+         * @member {Number|null} pollIntervalMs_=null
          * @protected
          * @reactive
          */
-        pollIntervalMs_: DEFAULT_INTERVAL_MS
+        pollIntervalMs_: null
     }
 
     /**
@@ -130,7 +118,7 @@ class KbAlertingService extends Base {
             return;
         }
 
-        this.pollIntervalMs = pollIntervalMs || kbConfig.alertingIntervalMs || DEFAULT_INTERVAL_MS;
+        this.pollIntervalMs = pollIntervalMs ?? kbConfig.alertingIntervalMs;
         this.cooldownState  = {};
 
         await KBRecorderService.ready();
@@ -191,7 +179,7 @@ class KbAlertingService extends Base {
                 return // no rules configured → nothing to evaluate
             }
 
-            const windowMs = kbConfig.alertWindowMs || DEFAULT_WINDOW_MS;
+            const windowMs = kbConfig.alertWindowMs;
             const rollup   = await this.fetchRollup(windowMs);
 
             const {alerts, cooldownState, skippedRules} = evaluateAlertRules({
@@ -199,7 +187,7 @@ class KbAlertingService extends Base {
                 rollup,
                 cooldownState: this.cooldownState,
                 now          : Date.now(),
-                cooldownMs   : kbConfig.alertingCooldownMs || DEFAULT_COOLDOWN_MS
+                cooldownMs   : kbConfig.alertingCooldownMs
             });
 
             this.cooldownState = cooldownState;
@@ -332,4 +320,4 @@ class KbAlertingService extends Base {
 
 export default Neo.setupClass(KbAlertingService);
 
-export {DEFAULT_INTERVAL_MS, DEFAULT_WINDOW_MS, DEFAULT_SENDER};
+export {DEFAULT_SENDER};

--- a/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
+++ b/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
@@ -263,15 +263,14 @@ class KbGarbageCollectionService extends Base {
     /**
      * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
      *
-     * Reads defensively: a stale gitignored `ai/config.mjs` deployment may lack the `gc*`
-     * keys, so a naked `aiConfig.knowledgeBase.gcEnabled` would throw. Returns `{}` when
-     * the `knowledgeBase` key is absent.
+     * Reads the resolved AiConfig Provider subtree directly; missing subtree shape must fail
+     * loud instead of being converted into a disabled garbage-collection daemon.
      *
      * @returns {Object}
      * @protected
      */
     getKbConfig() {
-        return aiConfig.knowledgeBase || {}
+        return aiConfig.knowledgeBase
     }
 
     /**

--- a/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
+++ b/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
@@ -13,12 +13,6 @@ import {
 } from '../../services/knowledge-base/helpers/KbGarbageCollectionEngine.mjs';
 
 /**
- * @summary Poll-interval fallback when `aiConfig.knowledgeBase.gcIntervalMs` is unset.
- * @type {Number}
- */
-const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
-
-/**
  * @summary Chroma `collection.get` page size for the batched per-tenant rows fetch.
  * @type {Number}
  */
@@ -89,11 +83,12 @@ class KbGarbageCollectionService extends Base {
         pollHandle_: null,
         /**
          * Interval between GC pulses in milliseconds.
-         * @member {Number} pollIntervalMs_=86400000
+         * Populated from `aiConfig.knowledgeBase.gcIntervalMs` when the daemon starts.
+         * @member {Number|null} pollIntervalMs_=null
          * @protected
          * @reactive
          */
-        pollIntervalMs_: DEFAULT_INTERVAL_MS
+        pollIntervalMs_: null
     }
 
     /**
@@ -119,7 +114,7 @@ class KbGarbageCollectionService extends Base {
             return;
         }
 
-        this.pollIntervalMs = pollIntervalMs || kbConfig.gcIntervalMs || DEFAULT_INTERVAL_MS;
+        this.pollIntervalMs = pollIntervalMs ?? kbConfig.gcIntervalMs;
 
         await KBRecorderService.ready();
 
@@ -402,4 +397,4 @@ class KbGarbageCollectionService extends Base {
 
 export default Neo.setupClass(KbGarbageCollectionService);
 
-export {DEFAULT_INTERVAL_MS, ROWS_PAGE_SIZE};
+export {ROWS_PAGE_SIZE};

--- a/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
+++ b/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
@@ -247,15 +247,14 @@ class KbReconciliationService extends Base {
     /**
      * @summary Test-stubbable seam over `aiConfig.knowledgeBase`.
      *
-     * Reads defensively: a stale gitignored `ai/config.mjs` deployment may have no
-     * `knowledgeBase` key (or lack the reconciliation keys), so a naked
-     * `aiConfig.knowledgeBase.reconciliationEnabled` would throw. Returns `{}` when absent.
+     * Reads the resolved AiConfig Provider subtree directly; missing subtree shape must fail
+     * loud instead of being converted into a disabled reconciliation daemon.
      *
      * @returns {Object}
      * @protected
      */
     getKbConfig() {
-        return aiConfig.knowledgeBase || {}
+        return aiConfig.knowledgeBase
     }
 
     /**

--- a/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
+++ b/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
@@ -16,12 +16,6 @@ import {
 } from '../../services/knowledge-base/helpers/KbReconciliationEngine.mjs';
 
 /**
- * @summary Poll-interval fallback when `aiConfig.knowledgeBase.reconciliationIntervalMs` is unset.
- * @type {Number}
- */
-const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
-
-/**
  * @summary Chroma `collection.get` page size for the batched per-tenant rows fetch.
  * @type {Number}
  */
@@ -93,11 +87,12 @@ class KbReconciliationService extends Base {
         pollHandle_: null,
         /**
          * Interval between reconciliation pulses in milliseconds.
-         * @member {Number} pollIntervalMs_=3600000
+         * Populated from `aiConfig.knowledgeBase.reconciliationIntervalMs` when the daemon starts.
+         * @member {Number|null} pollIntervalMs_=null
          * @protected
          * @reactive
          */
-        pollIntervalMs_: DEFAULT_INTERVAL_MS
+        pollIntervalMs_: null
     }
 
     /**
@@ -123,7 +118,7 @@ class KbReconciliationService extends Base {
             return;
         }
 
-        this.pollIntervalMs = pollIntervalMs || kbConfig.reconciliationIntervalMs || DEFAULT_INTERVAL_MS;
+        this.pollIntervalMs = pollIntervalMs ?? kbConfig.reconciliationIntervalMs;
 
         await KBRecorderService.ready();
 
@@ -425,4 +420,4 @@ class KbReconciliationService extends Base {
 
 export default Neo.setupClass(KbReconciliationService);
 
-export {DEFAULT_INTERVAL_MS, ROWS_PAGE_SIZE};
+export {ROWS_PAGE_SIZE};

--- a/test/playwright/unit/ai/daemons/kb-alerting/KbAlertingService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/kb-alerting/KbAlertingService.spec.mjs
@@ -15,14 +15,14 @@ setup({
 
 // Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo` before
 // the dynamic KbAlertingService import below. Required because the class file no longer
-// imports Neo itself (#11058-style class+wrapper split). Mirrors SwarmHeartbeatService.spec.
+// imports Neo itself (class+wrapper split). Mirrors SwarmHeartbeatService.spec.
 import Neo       from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 
 import {test, expect} from '@playwright/test';
 
 /**
- * Phase 4D (#11642) — unit coverage for `ai/daemons/kb-alerting/KbAlertingService.mjs`, the KB
+ * Unit coverage for `ai/daemons/kb-alerting/KbAlertingService.mjs`, the KB
  * operator-alerting daemon.
  *
  * Stubbing strategy mirrors `SwarmHeartbeatService.spec.mjs`: the daemon exposes
@@ -32,7 +32,7 @@ import {test, expect} from '@playwright/test';
  * singletons (`MailboxService.addMessage`, `RequestContextService.run`, `logger`) are
  * saved + restored around each test for the `dispatchA2A` / `dispatchConsole` cases.
  *
- * Covers the #11642 Contract Ledger Evidence columns for channel dispatch (direct-DM,
+ * Covers the Contract Ledger Evidence columns for channel dispatch (direct-DM,
  * explicit broadcast, invalid-target rejection, wake vs. audit) and the daemon poll loop;
  * the pure threshold/cooldown logic is covered separately in `KbAlertRuleEngine.spec.mjs`.
  *
@@ -41,7 +41,7 @@ import {test, expect} from '@playwright/test';
  * @see test/playwright/unit/ai/daemons/SwarmHeartbeatService.spec.mjs — the sibling pattern.
  */
 test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
-    let KbAlertingService, DEFAULT_INTERVAL_MS;
+    let KbAlertingService;
     let MailboxService, RequestContextService, logger;
     let originals = {};
 
@@ -51,8 +51,17 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
     /** A one-tenant rollup whose errorRate (0.3) breaches RULE's 0.1 threshold. */
     const ROLLUP = [{tenantId: 'tenant-x', repoSlug: 'repo-x', eventCount: 10, errorEvents: 3, errorRate: 0.3}];
 
+    /** Resolved AiConfig subtree fixture — mirrors Provider-inherited template leaves. */
+    const defaultConfig = () => ({
+        alertingEnabled   : true,
+        alertRules        : [RULE],
+        alertingIntervalMs: 15 * 60 * 1000,
+        alertWindowMs     : 60 * 60 * 1000,
+        alertingCooldownMs: 60 * 60 * 1000
+    });
+
     test.beforeAll(async () => {
-        ({default: KbAlertingService, DEFAULT_INTERVAL_MS} =
+        ({default: KbAlertingService} =
             await import('../../../../../../ai/daemons/kb-alerting/KbAlertingService.mjs'));
 
         MailboxService        = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
@@ -83,7 +92,7 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
     test.afterEach(() => {
         KbAlertingService.stop();
         KbAlertingService.isPolling      = false;
-        KbAlertingService.pollIntervalMs = DEFAULT_INTERVAL_MS;
+        KbAlertingService.pollIntervalMs = null;
         KbAlertingService.cooldownState  = {};
 
         // Drop instance-method seam overrides so the real prototype methods resurface for
@@ -110,14 +119,14 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
      * `scheduleNext` is neutralized so tests never leave a real timer in the event loop.
      */
     function applyStubs({config, rollup} = {}) {
-        KbAlertingService.getKbConfig  = () => config || {alertingEnabled: true, alertRules: [RULE]};
+        KbAlertingService.getKbConfig  = () => config ?? defaultConfig();
         KbAlertingService.fetchRollup  = async () => rollup || ROLLUP;
         KbAlertingService.scheduleNext = function () {};
     }
 
     test.describe('start / stop', () => {
         test('start() is a no-op when alertingEnabled is false', async () => {
-            applyStubs({config: {alertingEnabled: false, alertRules: [RULE]}});
+            applyStubs({config: {...defaultConfig(), alertingEnabled: false}});
             let scheduled = 0;
             KbAlertingService.scheduleNext = () => { scheduled++ };
 
@@ -138,6 +147,14 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
 
             await KbAlertingService.start();
             expect(scheduled).toBe(1); // second start() is a no-op
+        });
+
+        test('start() honors a configured alertingIntervalMs', async () => {
+            applyStubs({config: {...defaultConfig(), alertingIntervalMs: 12345}});
+
+            await KbAlertingService.start();
+
+            expect(KbAlertingService.pollIntervalMs).toBe(12345);
         });
 
         test('start() resets cooldown state', async () => {
@@ -165,7 +182,7 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
 
     test.describe('pulse', () => {
         test('dispatches nothing when no rules are configured', async () => {
-            applyStubs({config: {alertingEnabled: true, alertRules: []}});
+            applyStubs({config: {...defaultConfig(), alertRules: []}});
             const dispatched = [];
             KbAlertingService.dispatchAlert = async (a) => { dispatched.push(a) };
 
@@ -206,7 +223,7 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
         });
 
         test('logs a warning for a malformed alert rule and still dispatches valid ones', async () => {
-            applyStubs({config: {alertingEnabled: true, alertRules: [{metric: 'bogus', threshold: 1, severity: 'warning', channels: ['console']}, RULE]}});
+            applyStubs({config: {...defaultConfig(), alertRules: [{metric: 'bogus', threshold: 1, severity: 'warning', channels: ['console']}, RULE]}});
             const warns = [];
             logger.warn = (msg) => { warns.push(msg) };
             const dispatched = [];
@@ -324,8 +341,8 @@ test.describe('Neo.ai.daemons.KbAlertingService (#11642)', () => {
         });
 
         test('skips an unresolvable A2A target before dispatch — no addMessage call', async () => {
-            // #11642 Contract Ledger / @neo-gpt PR #11709 review: an unresolvable target
-            // (not a registered @<identity>, not AGENT:*) must be rejected before dispatch.
+            // An unresolvable target (not a registered @<identity>, not AGENT:*) must be
+            // rejected before dispatch.
             const {sent} = captureA2A();
             MailboxService.isReachableTarget = () => false; // simulate an unregistered target
             const warns = [];

--- a/test/playwright/unit/ai/daemons/kb-gc/KbGarbageCollectionService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/kb-gc/KbGarbageCollectionService.spec.mjs
@@ -15,14 +15,14 @@ setup({
 
 // Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo` before the
 // dynamic KbGarbageCollectionService import below. Required because the class file no longer
-// imports Neo itself (#11058-style class+wrapper split). Mirrors KbReconciliationService.spec.
+// imports Neo itself (class+wrapper split). Mirrors KbReconciliationService.spec.
 import Neo       from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 
 import {test, expect} from '@playwright/test';
 
 /**
- * Phase 4C (#11641) — unit coverage for `ai/daemons/kb-gc/KbGarbageCollectionService.mjs`, the KB
+ * Unit coverage for `ai/daemons/kb-gc/KbGarbageCollectionService.mjs`, the KB
  * garbage-collection daemon.
  *
  * Stubbing strategy mirrors `KbReconciliationService.spec.mjs`: the daemon exposes
@@ -32,7 +32,7 @@ import {test, expect} from '@playwright/test';
  * Chroma I/O. The `collectTenant` tests keep the real method + the real pure
  * `KbGarbageCollectionEngine` so the retention-diff branching is genuinely exercised.
  *
- * Covers the #11641 Contract Ledger Evidence columns: the opt-in gate, the destructive
+ * Covers the Contract Ledger Evidence columns: the opt-in gate, the destructive
  * auto-delete gating, the clean-tenant telemetry suppression, the `defrag-recommended`
  * threshold signal, and pulse resilience. The pure retention logic is covered separately in
  * `KbGarbageCollectionEngine.spec.mjs`.
@@ -42,7 +42,7 @@ import {test, expect} from '@playwright/test';
  * @see test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs — the sibling pattern.
  */
 test.describe('Neo.ai.daemons.KbGarbageCollectionService (#11641)', () => {
-    let KbGarbageCollectionService, DEFAULT_INTERVAL_MS;
+    let KbGarbageCollectionService;
     let KBRecorderService, logger;
     let originals = {};
 
@@ -51,8 +51,14 @@ test.describe('Neo.ai.daemons.KbGarbageCollectionService (#11641)', () => {
         id, metadata: {ingestedAt, tenantId: 'tenant-x', repoSlug}
     });
 
+    /** Resolved AiConfig subtree fixture — mirrors Provider-inherited template leaves. */
+    const defaultConfig = () => ({
+        gcEnabled   : true,
+        gcIntervalMs: 24 * 60 * 60 * 1000
+    });
+
     test.beforeAll(async () => {
-        ({default: KbGarbageCollectionService, DEFAULT_INTERVAL_MS} =
+        ({default: KbGarbageCollectionService} =
             await import('../../../../../../ai/daemons/kb-gc/KbGarbageCollectionService.mjs'));
 
         KBRecorderService = (await import('../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
@@ -81,7 +87,7 @@ test.describe('Neo.ai.daemons.KbGarbageCollectionService (#11641)', () => {
     test.afterEach(() => {
         KbGarbageCollectionService.stop();
         KbGarbageCollectionService.isPolling      = false;
-        KbGarbageCollectionService.pollIntervalMs = DEFAULT_INTERVAL_MS;
+        KbGarbageCollectionService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for the
         // next test — an instance override otherwise leaks across tests in the worker.
@@ -101,13 +107,13 @@ test.describe('Neo.ai.daemons.KbGarbageCollectionService (#11641)', () => {
 
     /** Deterministic seam baseline — `scheduleNext` neutralized so no real timer leaks. */
     function applyStubs({config} = {}) {
-        KbGarbageCollectionService.getKbConfig  = () => config || {gcEnabled: true};
+        KbGarbageCollectionService.getKbConfig  = () => config ?? defaultConfig();
         KbGarbageCollectionService.scheduleNext = function () {};
     }
 
     test.describe('start / stop', () => {
         test('start() is a no-op when gcEnabled is false', async () => {
-            applyStubs({config: {gcEnabled: false}});
+            applyStubs({config: {...defaultConfig(), gcEnabled: false}});
             let scheduled = 0;
             KbGarbageCollectionService.scheduleNext = () => { scheduled++ };
 
@@ -131,7 +137,7 @@ test.describe('Neo.ai.daemons.KbGarbageCollectionService (#11641)', () => {
         });
 
         test('start() honors a configured gcIntervalMs', async () => {
-            applyStubs({config: {gcEnabled: true, gcIntervalMs: 54321}});
+            applyStubs({config: {...defaultConfig(), gcIntervalMs: 54321}});
 
             await KbGarbageCollectionService.start();
 

--- a/test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs
@@ -15,14 +15,14 @@ setup({
 
 // Test-side entry-point bootstrap: Neo + core/_export populate `globalThis.Neo` before
 // the dynamic KbReconciliationService import below. Required because the class file no
-// longer imports Neo itself (#11058-style class+wrapper split). Mirrors KbAlertingService.spec.
+// longer imports Neo itself (class+wrapper split). Mirrors KbAlertingService.spec.
 import Neo       from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 
 import {test, expect} from '@playwright/test';
 
 /**
- * Phase 4B (#11640) — unit coverage for `ai/daemons/kb-reconciliation/KbReconciliationService.mjs`, the KB
+ * Unit coverage for `ai/daemons/kb-reconciliation/KbReconciliationService.mjs`, the KB
  * reconciliation daemon.
  *
  * Stubbing strategy mirrors `KbAlertingService.spec.mjs`: the daemon exposes test-stubbable
@@ -32,7 +32,7 @@ import {test, expect} from '@playwright/test';
  * Chroma I/O. The orchestration tests keep the real `reconcileTenant` + the real pure
  * `KbReconciliationEngine` so the diff-driven branching is genuinely exercised.
  *
- * Covers the #11640 Contract Ledger Evidence columns: the opt-in gate, the destructive
+ * Covers the Contract Ledger Evidence columns: the opt-in gate, the destructive
  * auto-tombstone gating, the clean-tenant telemetry suppression, the tenant-scoped delete,
  * and pulse resilience. The pure diff logic is covered separately in
  * `KbReconciliationEngine.spec.mjs`.
@@ -42,7 +42,7 @@ import {test, expect} from '@playwright/test';
  * @see test/playwright/unit/ai/daemons/kb-alerting/KbAlertingService.spec.mjs — the sibling pattern.
  */
 test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
-    let KbReconciliationService, DEFAULT_INTERVAL_MS;
+    let KbReconciliationService;
     let KBRecorderService, logger;
     let originals = {};
 
@@ -59,8 +59,14 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
         }
     });
 
+    /** Resolved AiConfig subtree fixture — mirrors Provider-inherited template leaves. */
+    const defaultConfig = () => ({
+        reconciliationEnabled   : true,
+        reconciliationIntervalMs: 60 * 60 * 1000
+    });
+
     test.beforeAll(async () => {
-        ({default: KbReconciliationService, DEFAULT_INTERVAL_MS} =
+        ({default: KbReconciliationService} =
             await import('../../../../../../ai/daemons/kb-reconciliation/KbReconciliationService.mjs'));
 
         KBRecorderService = (await import('../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
@@ -88,7 +94,7 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
     test.afterEach(() => {
         KbReconciliationService.stop();
         KbReconciliationService.isPolling      = false;
-        KbReconciliationService.pollIntervalMs = DEFAULT_INTERVAL_MS;
+        KbReconciliationService.pollIntervalMs = null;
 
         // Drop instance-method seam overrides so the real prototype methods resurface for
         // the next test — an instance override otherwise leaks across tests in the worker.
@@ -107,14 +113,14 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
 
     /** Deterministic seam baseline — `scheduleNext` neutralized so no real timer leaks. */
     function applyStubs({config} = {}) {
-        KbReconciliationService.getKbConfig          = () => config || {reconciliationEnabled: true};
+        KbReconciliationService.getKbConfig          = () => config ?? defaultConfig();
         KbReconciliationService.fetchTenantManifests = async () => ({});
         KbReconciliationService.scheduleNext         = function () {};
     }
 
     test.describe('start / stop', () => {
         test('start() is a no-op when reconciliationEnabled is false', async () => {
-            applyStubs({config: {reconciliationEnabled: false}});
+            applyStubs({config: {...defaultConfig(), reconciliationEnabled: false}});
             let scheduled = 0;
             KbReconciliationService.scheduleNext = () => { scheduled++ };
 
@@ -138,7 +144,7 @@ test.describe('Neo.ai.daemons.KbReconciliationService (#11640)', () => {
         });
 
         test('start() honors a configured reconciliationIntervalMs', async () => {
-            applyStubs({config: {reconciliationEnabled: true, reconciliationIntervalMs: 12345}});
+            applyStubs({config: {...defaultConfig(), reconciliationIntervalMs: 12345}});
 
             await KbReconciliationService.start();
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Resolves #12529
Related: #12461
Related: #12456

Removes the `aiConfig.knowledgeBase || {}` B3 fallback from the three KB daemon helper seams and rewrites the helper JSDoc to document ADR 0019 fail-loud Provider semantics instead of stale gitignored `config.mjs` tolerance. The daemon opt-in behavior remains driven by the resolved `knowledgeBase` leaves.

Evidence: L2 (targeted unit specs + static guard + direct runtime leaf probe) → L2 required (close-target ACs are static/helper contract plus disabled-leaf behavior). No residuals.

## Deltas from ticket

None. Scope stayed to the three KB daemon service helpers.

## Test Evidence

- `rg -n 'aiConfig\\.knowledgeBase \\|\\| \\{\\}|stale gitignored `ai/config\\.mjs`|Returns \\{\\} when' ai/daemons/kb-alerting/KbAlertingService.mjs ai/daemons/kb-gc/KbGarbageCollectionService.mjs ai/daemons/kb-reconciliation/KbReconciliationService.mjs` → no matches.\n- `npm run ai:lint-config-template-ssot` → OK.\n- `npm run test-unit -- test/playwright/unit/ai/daemons/kb-alerting/KbAlertingService.spec.mjs test/playwright/unit/ai/daemons/kb-gc/KbGarbageCollectionService.spec.mjs test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs` → 57 passed.\n- Runtime probe: importing all three daemons and calling `getKbConfig()` against real resolved config returned `alertingEnabled:false`, `gcEnabled:false`, and `reconciliationEnabled:false`.\n\n## Post-Merge Validation\n\n- [ ] #12461 B3 cluster tracker can count the KB daemon `knowledgeBase || {}` cluster as removed.\n\n## Commits\n\n- `7e5a5e614` — `fix(ai): remove KB daemon B3 config defenses (#12529)`