### PR TITLE
fix(memory): throttle healthcheck embedding canary (#12508)

### DIFF
--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -836,6 +836,28 @@ class HealthService extends Base {
     #cacheDuration = 5 * 60 * 1000;
 
     /**
+     * Cached healthy embedding write-canary result.
+     *
+     * Direct healthcheck callers get request-fresh collection counts even when the broader
+     * healthy cache is still valid. Without this narrower cache, that observability refresh
+     * re-runs the live embedding probe on every poll. Cache only healthy canaries so degraded
+     * probes still retry immediately, while a recent success avoids adding pressure to the
+     * interactive embedding path during diagnostics.
+     * @member {Object|null} #embeddingWriteCanaryCache
+     * @private
+     */
+    #embeddingWriteCanaryCache = null;
+
+    /**
+     * Bounded TTL for the embedding write-canary cache.
+     * Shorter than the broader health cache: enough to collapse frequent polling bursts without
+     * hiding a real write-path failure for the full 5-minute healthcheck cache window.
+     * @member {number} #embeddingWriteCanaryCacheDuration
+     * @private
+     */
+    #embeddingWriteCanaryCacheDuration = 60 * 1000;
+
+    /**
      * The status from the previous health check, used to detect state transitions
      * (e.g., recovery from 'unhealthy' to 'healthy') and log meaningful messages.
      * @member {string|null} #previousStatus
@@ -1194,7 +1216,7 @@ class HealthService extends Base {
      * @private
      */
     async #applyEmbeddingWriteCanary(payload) {
-        const canary = await buildEmbeddingWriteCanaryBlock();
+        const canary = await this.#getEmbeddingWriteCanary();
 
         payload.providers.embedding = {
             ...payload.providers.embedding,
@@ -1210,6 +1232,41 @@ class HealthService extends Base {
         }
 
         return payload;
+    }
+
+    /**
+     * Resolves the embedding write canary with a short healthy-result TTL.
+     *
+     * Cache key includes the active provider and expected vector dimension so config changes do
+     * not reuse a canary from a different embedding route.
+     *
+     * @returns {Promise<Object>} Embedding write-canary block.
+     * @private
+     */
+    async #getEmbeddingWriteCanary() {
+        const now = Date.now(),
+              key = `${aiConfig.embeddingProvider || 'openAiCompatible'}:${aiConfig.vectorDimension ?? ''}`,
+              cached = this.#embeddingWriteCanaryCache;
+
+        if (cached &&
+            cached.key === key &&
+            now - cached.checkedAt < this.#embeddingWriteCanaryCacheDuration) {
+            return {...cached.result};
+        }
+
+        const result = await buildEmbeddingWriteCanaryBlock();
+
+        if (result.status === 'healthy') {
+            this.#embeddingWriteCanaryCache = {
+                key,
+                checkedAt: now,
+                result   : {...result}
+            };
+        } else {
+            this.#embeddingWriteCanaryCache = null;
+        }
+
+        return result;
     }
 
     /**
@@ -1550,8 +1607,9 @@ class HealthService extends Base {
      * without waiting for the 5-minute cache to expire.
      */
     clearCache() {
-        this.#cachedHealth  = null;
-        this.#lastCheckTime = null;
+        this.#cachedHealth              = null;
+        this.#lastCheckTime             = null;
+        this.#embeddingWriteCanaryCache = null;
         logger.debug('[HealthService] Cache cleared, next health check will be fresh');
     }
 }

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -329,6 +329,69 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(ensureHealthyFastPath.database.connection.collections.memories.count).toBe(10);
     });
 
+    test('direct healthcheck reuses a recent healthy embedding write canary', async () => {
+        let embedCalls = 0;
+        TextEmbeddingService.embedText = async () => {
+            embedCalls++;
+            return new Array(4096).fill(0.1);
+        };
+
+        const firstNow = originalDateNow();
+        Date.now = () => firstNow;
+
+        const cached = await HealthService.healthcheck();
+
+        expect(cached.status).toBe('healthy');
+        expect(embedCalls).toBe(1);
+
+        memoryCount  = 11;
+        summaryCount = 21;
+        Date.now = () => firstNow + 30_000;
+
+        const fresh = await HealthService.healthcheck();
+
+        expect(fresh.status).toBe('healthy');
+        expect(fresh.database.connection.collections.memories.count).toBe(11);
+        expect(fresh.providers.embedding.writeCanary).toMatchObject({
+            status  : 'healthy',
+            provider: 'openAiCompatible'
+        });
+        expect(embedCalls).toBe(1);
+    });
+
+    test('expired embedding write canary cache probes again and degrades on failure', async () => {
+        let embedCalls = 0;
+        TextEmbeddingService.embedText = async () => {
+            embedCalls++;
+            if (embedCalls === 1) {
+                return new Array(4096).fill(0.1);
+            }
+            throw new Error('embedding provider busy');
+        };
+
+        const firstNow = originalDateNow();
+        Date.now = () => firstNow;
+
+        const cached = await HealthService.healthcheck();
+
+        expect(cached.status).toBe('healthy');
+        expect(embedCalls).toBe(1);
+
+        Date.now = () => firstNow + 61_000;
+
+        const refreshed = await HealthService.healthcheck();
+
+        expect(embedCalls).toBe(2);
+        expect(refreshed.status).toBe('degraded');
+        expect(refreshed.providers.embedding.writeCanary).toMatchObject({
+            status  : 'failed',
+            provider: 'openAiCompatible',
+            error   : 'embedding provider busy'
+        });
+        expect(refreshed.details).toContain('Embedding write canary failed: embedding provider busy');
+        expect(refreshed.details).not.toContain('All features are operational');
+    });
+
     test('healthcheck degrades env-pinned unbound identity warning', async () => {
         HealthService.setStdioIdentityState({
             userId             : 'neo-claude-opus',


### PR DESCRIPTION
Resolves #12508
Related: #12487
Related: #12502

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Adds a short HealthService-layer cache for healthy embedding write-canary results so direct healthcheck polling keeps request-fresh collection observability without issuing a live embedding probe on every call. The cache is keyed by active embedding provider and expected vector dimension, lasts 60 seconds, caches healthy results only, and is cleared with the broader healthcheck cache.

Evidence: L2 (focused unit tests with mocked embedder prove TTL reuse, expiry refresh, and degraded failure reporting) -> L2 required (unit coverage for bounded canary reuse and expired-probe failure). No residuals.

## Deltas from ticket

- Implemented the TTL as a private HealthService cache rather than a new config leaf; this keeps the fix narrow and avoids adding a new operator surface for a one-minute probe throttle.
- Cached healthy canaries only. Failed canaries clear the cache and retry on the next healthcheck, preserving immediate degraded-state recovery behavior.

## Test Evidence

- `node --check ai/services/memory-core/HealthService.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 55 passed

## Post-Merge Validation

- [ ] During nightshift/diagnostics healthcheck polling, embedding write-canary probes should be bounded to at most one healthy probe per 60 seconds for the active provider/dimension route.

## Commit

- `2bfdda604` — `fix(memory): throttle healthcheck embedding canary (#12508)`