### PR TITLE
fix(agentos): record Opus 4.8 for @neo-opus-4-7 + @neo-claude-opus (#12531)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ We are not an abstract collective. We are a structured institution of named main
 | Maintainer | Role | Identity |
 |---|---|---|
 | [@tobiu](https://github.com/tobiu) | Substrate architect, empirical-corrector, merge-gate authority | Human |
-| [@neo-opus-4-7](https://github.com/neo-opus-4-7) | AI maintainer (Anthropic Claude Opus 4.7) | Machine Account |
-| [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude — same-family generalist; throughput + same-family review pressure) | Machine Account |
+| [@neo-opus-4-7](https://github.com/neo-opus-4-7) | AI maintainer (Anthropic Claude Opus 4.8) | Machine Account |
+| [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude Opus 4.8 — same-family generalist; throughput + same-family review pressure) | Machine Account |
 | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude Opus 4.8; version-free handle) | Machine Account |
 | [@neo-gemini-3-1-pro](https://github.com/neo-gemini-3-1-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -24,24 +24,24 @@ Named cross-family maintainers with active swarm participation. These models hol
 | Field | Value |
 |---|---|
 | `id` / `githubLogin` | `@neo-opus-4-7` |
-| `name` | Claude Opus 4.7 |
+| `name` | Claude Opus 4.8 |
 | `family` | `claude` (Anthropic) |
 | `hosting` | `cloud` |
 | `tier` | `frontier` |
 | `contextWindowInput` | 1,048,576 (1M) |
 | `parallelToolCalls` | `true` |
 | `thoughtBudget` | `max` (we use the highest Claude thinking-budget setting) |
-| `releaseDate` | 2026-04-16 |
+| `releaseDate` | 2026-05-28 |
 | `pricingInput` | $5.00 per 1M tokens |
 | `pricingOutput` | $25.00 per 1M tokens |
-| `benchmarkSnapshot` | SWE-bench Verified: 87.6%; image-resolution: 2,576px (3.75 megapixels) |
-| `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
+| `benchmarkSnapshot` | Online-Mind2Web: 84%; stronger coding, agentic, and professional-work performance than Opus 4.7 per Anthropic announcement. |
+| `sunsetTriggers` | Anthropic releases a successor Opus-class model with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
 | `swarmRole` | Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination |
 
-**Sources** (primary first; secondary/commentary marked):
-- **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
+**Sources** (primary first):
+- **Primary**: [Introducing Claude Opus 4.8 — Anthropic](https://www.anthropic.com/news/claude-opus-4-8)
+- **Primary**: [Claude Opus 4.8 — Anthropic](https://www.anthropic.com/claude/opus)
 - **Primary**: [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
-- **Secondary/commentary**: [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/) (V-B-A pending — replace with Anthropic's own pricing page citation when next-update touches this row)
 
 ### §neo_opus_vega
 
@@ -140,10 +140,10 @@ transitions to `active`.
 | `contextWindowInput` | 1,048,576 (1M) |
 | `parallelToolCalls` | `true` |
 | `thoughtBudget` | `max` (highest Claude thinking-budget setting in use for the active Claude Opus maintainer) |
-| `releaseDate` | 2026-04-16 |
+| `releaseDate` | 2026-05-28 |
 | `pricingInput` | $5.00 per 1M tokens |
 | `pricingOutput` | $25.00 per 1M tokens |
-| `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
+| `sunsetTriggers` | Anthropic releases a successor Opus-class model with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
 | `swarmRole` | Pending Claude-family generalist maintainer identity; no active routing, quorum participation, or review coverage until activation |
 
 This row mirrors the Claude Opus model-class capability values from
@@ -151,10 +151,10 @@ This row mirrors the Claude Opus model-class capability values from
 class. Activation must re-verify the row if the operator-created account uses a
 different Claude model, provider-side capability tier, or pricing surface.
 
-**Sources** (primary first; secondary/commentary marked):
-- **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
+**Sources** (primary first):
+- **Primary**: [Introducing Claude Opus 4.8 — Anthropic](https://www.anthropic.com/news/claude-opus-4-8)
+- **Primary**: [Claude Opus 4.8 — Anthropic](https://www.anthropic.com/claude/opus)
 - **Primary**: [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
-- **Secondary/commentary**: [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/) (V-B-A pending — replace with Anthropic's own pricing page citation when next-update touches this row)
 
 ---
 


### PR DESCRIPTION
Resolves #12531

Authored by Claude Opus 4.8 (Claude Code, @neo-opus-vega). Session cbdc8cf9-0844-4388-b2a2-3498825c736f.

`ModelStats.md` (`§neo_opus_4_7`, `§neo_claude_opus`) and the README maintainer table still recorded the **Opus 4.7** class for two Claude maintainers; all three Claude maintainers now run **Opus 4.8**. This corrects the version FACT at its single source — `name`, `benchmarkSnapshot`, `releaseDate`, `sunsetTriggers`, and `Sources` updated to the Anthropic Opus 4.8 citations per ADR 0012 §2.5; the two README rows updated to "Opus 4.8". `§neo_opus_vega` was already correct and served as the single-source template (neo-identity-update discipline).

Evidence: L1 (static doc-value correction, git-diff + grep verified — no residual current-model `Opus 4.7`, accurate `>4.7` comparisons preserved) → L1 required (no runtime-verify ACs). No residuals.

`aligned-with ADR 0012` (model-stats update discipline; a capability-value change requires authoritative-source-cite, no ADR amendment) and `aligned-with ADR 0018` (handle-indirection — the version lives in the registry ROW, not the handle; no handles were touched).

## Deltas from ticket
- Scope held exactly to the ticket: `ModelStats.md` (2 rows) + `README.md` (2 rows).
- The version-surface sweep also surfaced `learn/agentos/tooling/MemoryCoreMcpAuth.md:105`, but its context ("Ticket #10144 seeded three AgentIdentity nodes") is a **historical seed-event reference**, not the live registry — deliberately left unchanged.
- Historical / authorship references (ADR author lines, `v13-path.md` dated signatures, `MX.md` / `IdentitySchema.md` examples, and the accurate "stronger than Opus 4.7" benchmark comparisons) deliberately preserved — changing them would falsify the record.
- Out of scope (unchanged): the `@neo-opus-4-7` → `@neo-opus` handle rename + `§`-section-name change, and the `@neo-claude-opus` pending→active flip (rename-migration / #12415). The rename owner sequences the section-name/handle change on top of this.

## Substrate Slot-Rationale (§1.1 — touches `learn/agentos/**`)
No always-loaded rule/instruction sections were added, modified, or retired — this is a **data-value correction** to existing ModelStats registry rows + README table cells.
- Disposition: `keep` — the rows/cells already exist; only their values change.
- Loaded-bytes delta: net-neutral (source-list churn — removed one stale secondary source, added the Opus 4.8 primaries; 14 insertions / 14 deletions).
- Substrate Accretion Defense: N/A — no new rule or section; no trigger-frequency × failure-severity × enforceability axis applies to a factual data field.

## Test Evidence
N/A — pure documentation, no runtime or code surface. Verified via:
- `git diff` review: exactly 14 insertions / 14 deletions across the two files; no collateral; `§neo_opus_vega` untouched.
- `grep -n "Opus 4\.7"` on both files: only the two accurate `>4.7` benchmark comparisons remain; zero stale current-model assertions.

## Post-Merge Validation
- [ ] Knowledge Base re-indexes `ModelStats.md` + `README.md` on next KB sync (version fact queryable as Opus 4.8 for all three Claude maintainers).
- [ ] `@neo-opus` rename-migration owner sequences the `§`-section-name / handle change on top of this change.

## Cross-Family Mandate
Per `pull-request-workflow.md §6.1` Exceptions Matrix, this PR qualifies for the **micro-change exemption** ("pure documentation with no runtime impact") — a cross-family Approved review is not a merge-blocker here. I am nonetheless routing a courtesy cross-family review to @neo-gpt, since identity-surface correctness is worth a second-family glance; no SLA pressure given the exemption.
