### PR TITLE
feat(memory-core): prioritize interactive embeddings (#12509)

### DIFF
--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -101,6 +101,9 @@ class TextEmbeddingService extends Base {
         ollamaProvider_: null
     }
 
+    #openAiCompatiblePostQueue       = [];
+    #openAiCompatiblePostQueueActive = false;
+
     /**
      * @param {Object} config The configuration object.
      */
@@ -116,6 +119,79 @@ class TextEmbeddingService extends Base {
                 this.embeddingModel = genAI.getGenerativeModel({model: aiConfig.embeddingModel});
             }
         }
+    }
+
+    /**
+     * @summary Queues OpenAI-compatible embedding posts behind an interactive-first scheduler.
+     *
+     * Local OpenAI-compatible embedding servers frequently serialize model requests. This queue
+     * keeps TextEmbeddingService from creating competing local-provider concurrency while allowing
+     * latency-sensitive single embeddings to run before subsequent KB-sync batch chunks.
+     *
+     * @param {String|String[]} inputData The text or array of texts to embed.
+     * @param {Object} options The `#postOpenAiCompatible` retry/timeout options.
+     * @param {'interactive'|'batch'} priority The request lane priority.
+     * @returns {Promise<Object>}
+     * @private
+     */
+    #enqueueOpenAiCompatiblePost(inputData, options, priority) {
+        return new Promise((resolve, reject) => {
+            this.#openAiCompatiblePostQueue.push({
+                inputData,
+                options,
+                priority,
+                reject,
+                resolve
+            });
+
+            this.#drainOpenAiCompatiblePostQueue();
+        });
+    }
+
+    /**
+     * @summary Runs queued OpenAI-compatible posts one at a time, preferring interactive work.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #drainOpenAiCompatiblePostQueue() {
+        if (this.#openAiCompatiblePostQueueActive) return;
+
+        this.#openAiCompatiblePostQueueActive = true;
+
+        try {
+            while (this.#openAiCompatiblePostQueue.length > 0) {
+                const taskIndex = this.#getNextOpenAiCompatiblePostQueueIndex(),
+                      task      = this.#openAiCompatiblePostQueue.splice(taskIndex, 1)[0];
+
+                try {
+                    task.resolve(await this.#postOpenAiCompatible(task.inputData, task.options));
+                } catch (err) {
+                    task.reject(err);
+                }
+            }
+        } finally {
+            this.#openAiCompatiblePostQueueActive = false;
+        }
+    }
+
+    /**
+     * @summary Selects the next OpenAI-compatible queue item, FIFO within each priority lane.
+     * @returns {Number}
+     * @private
+     */
+    #getNextOpenAiCompatiblePostQueueIndex() {
+        let bestIndex = 0;
+
+        for (let i = 1; i < this.#openAiCompatiblePostQueue.length; i++) {
+            const best = this.#openAiCompatiblePostQueue[bestIndex],
+                  item = this.#openAiCompatiblePostQueue[i];
+
+            if (best.priority === 'batch' && item.priority === 'interactive') {
+                bestIndex = i;
+            }
+        }
+
+        return bestIndex;
     }
 
     /**
@@ -275,9 +351,9 @@ class TextEmbeddingService extends Base {
 
         for (let offset = 0; offset < texts.length; offset += chunkSize) {
             const chunk = texts.slice(offset, offset + chunkSize),
-                  result = await this.#postOpenAiCompatible(chunk, {
+                  result = await this.#enqueueOpenAiCompatiblePost(chunk, {
                       unloadRetriesLeft: unloadRetryCount
-                  });
+                  }, 'batch');
 
             data.push(...(result.data || []).map(item => ({
                 ...item,
@@ -312,11 +388,11 @@ class TextEmbeddingService extends Base {
                 contentionRetryCount      = 2,
                 contentionTimeoutMs       = 15000
             } = aiConfig.openAiCompatible;
-            const result = await this.#postOpenAiCompatible(text, {
+            const result = await this.#enqueueOpenAiCompatiblePost(text, {
                 unloadRetriesLeft    : unloadRetryCount,
                 contentionRetriesLeft: contentionRetryCount,
                 requestTimeoutMs     : contentionTimeoutMs
-            });
+            }, 'interactive');
             return result.data?.[0]?.embedding;
         } else if (explicitProvider === 'ollama') {
             // Native Ollama returns `{embeddings: [[...]]}` even for single-input;

--- a/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs
@@ -19,12 +19,25 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import http           from 'http';
 import aiConfig       from '../../../../../../ai/mcp/server/memory-core/config.mjs';
 
-test.describe.serial('TextEmbeddingService #11393/#11402/#12487 — openAiCompatible retry and lms server start support', () => {
+async function waitForCondition(condition, message, timeoutMs = 250) {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        if (condition()) return;
+        await new Promise(resolve => setTimeout(resolve, 5));
+    }
+
+    throw new Error(`Timed out waiting for ${message}`);
+}
+
+test.describe.serial('TextEmbeddingService #11393/#11402/#12487/#12509 — openAiCompatible retry, QoS, and lms server start support', () => {
     let SDK, TextEmbeddingService, server;
     let requestCount = 0;
     let serverBehavior = 'succeed';
     let lastRequest;
     let allRequests;
+    let inFlightRequests;
+    let maxInFlightRequests;
     let testPort;
     let originalHost, originalRetryCount, originalRetryDelay;
     let originalContentionRetryCount, originalContentionRetryDelay, originalContentionTimeout;
@@ -125,6 +138,30 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487 — openAiCompat
                             embedding: [requestCount, index]
                         })).reverse()
                     }));
+                } else if (serverBehavior === 'qos-priority') {
+                    inFlightRequests++;
+                    maxInFlightRequests = Math.max(maxInFlightRequests, inFlightRequests);
+
+                    const inputs       = lastRequest.body.input,
+                          requestIndex = requestCount,
+                          respond      = () => {
+                              const data = Array.isArray(inputs) ?
+                                  inputs.map((_, index) => ({
+                                      index,
+                                      embedding: [requestIndex, index]
+                                  })) :
+                                  [{index: 0, embedding: [requestIndex, 0]}];
+
+                              res.writeHead(200, { 'Content-Type': 'application/json' });
+                              res.end(JSON.stringify({data}));
+                              inFlightRequests--;
+                          };
+
+                    if (Array.isArray(inputs) && inputs[0] === 'a') {
+                        setTimeout(respond, 25);
+                    } else {
+                        respond();
+                    }
                 }
             });
         });
@@ -141,6 +178,8 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487 — openAiCompat
         requestCount = 0;
         lastRequest  = null;
         allRequests  = [];
+        inFlightRequests = 0;
+        maxInFlightRequests = 0;
         originalHost = aiConfig.openAiCompatible.host;
         originalRetryCount = aiConfig.openAiCompatible.unloadRetryCount;
         originalRetryDelay = aiConfig.openAiCompatible.unloadRetryDelayMs;
@@ -323,6 +362,33 @@ test.describe.serial('TextEmbeddingService #11393/#11402/#12487 — openAiCompat
             [2, 0],
             [2, 1],
             [3, 0]
+        ]);
+    });
+
+    test('interactive single embeddings queue ahead of subsequent batch chunks and preserve completion', async () => {
+        serverBehavior = 'qos-priority';
+        aiConfig.openAiCompatible.batchEmbeddingChunkSize = 1;
+        aiConfig.openAiCompatible.batchEmbeddingYieldMs = 0;
+
+        const batchPromise = TextEmbeddingService.embedTexts(['a', 'b', 'c'], 'openAiCompatible');
+
+        await waitForCondition(() => allRequests.length === 1, 'first batch chunk request');
+
+        const interactivePromise = TextEmbeddingService.embedText('urgent', 'openAiCompatible');
+        const [batchResult, interactiveResult] = await Promise.all([batchPromise, interactivePromise]);
+
+        expect(maxInFlightRequests).toBe(1);
+        expect(allRequests.map(item => item.body.input)).toEqual([
+            ['a'],
+            'urgent',
+            ['b'],
+            ['c']
+        ]);
+        expect(interactiveResult).toEqual([2, 0]);
+        expect(batchResult).toEqual([
+            [1, 0],
+            [3, 0],
+            [4, 0]
         ]);
     });
 });


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Resolves #12509

Implements V2 embedding QoS for OpenAI-compatible embeddings by adding an interactive-first request queue inside `TextEmbeddingService`. Interactive `embedText` posts now run ahead of subsequent KB-sync batch chunks while batches remain chunked, yielded, ordered, and eventually completed. This is V2 true QoS, not V1 resilience: V1 retried after contention/timeouts, while this PR schedules request order before provider POSTs.

Evidence: L2 (mocked OpenAI-compatible provider contention unit coverage proving serialized provider posts, interactive priority, and batch completion) → L2 required (tests cover interactive-vs-batch contention with mocked providers). No residuals.

## Design Comparison
- Batch-yield/chunk-with-gaps/pause-on-interactive: kept existing batch chunking/yield and made the pause useful by letting pending interactive work enter the queue between chunks.
- Priority lane at embed-request layer: selected; smallest substrate that proves interactive priority without introducing an orchestrator scheduler.
- Orchestrator-level pause/resume: rejected for this leaf because it crosses #12508/#12533 canary/health scope and adds broader scheduling semantics not needed for #12509 ACs.

## Deltas from ticket
No new config leaf: the QoS behavior is intrinsic to `openAiCompatible` provider dispatch. Existing `batchEmbeddingChunkSize` and `batchEmbeddingYieldMs` remain the operator controls for batch granularity/yield cadence.

## Test Evidence
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` — 14 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs` — 23 passed
- Pre-commit hooks: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology` passed

## Post-Merge Validation
- [ ] During real KB sync, trigger an interactive `add_memory` against a local OpenAI-compatible embedding server and confirm it completes between batch chunks rather than relying on contention-timeout retry.

## Commits
- `6a21f7ff6` — `feat(memory-core): prioritize interactive embeddings (#12509)`