### PR TITLE
fix(ai): remove ConceptDiscoveryService B3 defenses (#12538)

### DIFF
--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -154,15 +154,15 @@ class ConceptDiscoveryService extends Base {
      * @protected
      */
     async extractConceptsFromSource(sourceRef, text) {
-        const minSourceLength = aiConfig.conceptDiscovery?.minSourceLength;
+        const minSourceLength = aiConfig.conceptDiscovery.minSourceLength;
         if (!text || text.trim().length < minSourceLength) return [];
 
         let provider;
         try {
             provider = Neo.create(OpenAiCompatible, {
-                modelName: aiConfig.openAiCompatible?.model,
-                host     : aiConfig.openAiCompatible?.host,
-                keepAlive: aiConfig.openAiCompatible?.keep_alive
+                modelName: aiConfig.openAiCompatible.model,
+                host     : aiConfig.openAiCompatible.host,
+                keepAlive: aiConfig.openAiCompatible.keep_alive
             });
         } catch (e) {
             logger.warn(`[ConceptDiscoveryService] OpenAiCompatible provider could not be constructed; skipping ${sourceRef}:`, e.message);
@@ -286,7 +286,7 @@ class ConceptDiscoveryService extends Base {
             return nb - na;
         });
 
-        const scanLimit   = this.prScanLimit ?? aiConfig.conceptDiscovery?.prScanLimit;
+        const scanLimit   = this.prScanLimit ?? aiConfig.conceptDiscovery.prScanLimit;
         const cappedFiles = files.slice(0, scanLimit);
         const sources     = [];
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Resolves #12538

Removes the ADR-0019 B3 optional-chain defenses from `ConceptDiscoveryService.mjs`. The service now reads the resolved AiConfig leaves directly for `conceptDiscovery.minSourceLength`, `openAiCompatible.model`, `openAiCompatible.host`, `openAiCompatible.keep_alive`, and `conceptDiscovery.prScanLimit`, while preserving the explicit instance override pattern for `this.prScanLimit`.

Evidence: L2 (focused unit spec + AiConfig SSOT lint + source grep) → L2 required (ACs require relevant unit coverage and zero B3 reads in the target file). No residuals.

## Deltas from ticket
The ticket prose called this 4 reads; the exact diff removes 5 optional-chain access sites across the same 4 logical read groups: `conceptDiscovery` ×2 and `openAiCompatible` ×3. Scope stayed source-only; no new config, public surface, docs, or tests were needed beyond the existing focused spec.

Reviewer note: the three `openAiCompatible` resolved-leaf reads are inside the existing provider-construction `try/catch`. If that subtree were genuinely absent, the branch now fails loud at the read site and then follows the pre-existing logged skip path; this PR does not add a new silent swallow.

## Test Evidence
- `rg -n "aiConfig\.[A-Za-z0-9_]+\?\.|aiConfig\.openAiCompatible\?\.|aiConfig\.conceptDiscovery\?\." ai/services/ingestion/ConceptDiscoveryService.mjs` — no matches
- `git diff --check`
- `npm run ai:lint-config-template-ssot` — OK
- `npm run test-unit -- test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs` — 7 passed
- Pre-commit hooks: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology` passed

## Post-Merge Validation
- [ ] Confirm #12461 B3 burndown inventory no longer reports `ConceptDiscoveryService.mjs`.

## Commits
- `6d5b0e5b8` — `fix(ai): remove ConceptDiscoveryService B3 defenses (#12538)`