### PR TITLE
fix(ai): remove ConceptDiscoveryService B3 AiConfig defensive reads (#12538)

### DIFF
--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -154,15 +154,15 @@ class ConceptDiscoveryService extends Base {
      * @protected
      */
     async extractConceptsFromSource(sourceRef, text) {
-        const minSourceLength = aiConfig.conceptDiscovery?.minSourceLength;
+        const minSourceLength = aiConfig.conceptDiscovery.minSourceLength;
         if (!text || text.trim().length < minSourceLength) return [];
 
         let provider;
         try {
             provider = Neo.create(OpenAiCompatible, {
-                modelName: aiConfig.openAiCompatible?.model,
-                host     : aiConfig.openAiCompatible?.host,
-                keepAlive: aiConfig.openAiCompatible?.keep_alive
+                modelName: aiConfig.openAiCompatible.model,
+                host     : aiConfig.openAiCompatible.host,
+                keepAlive: aiConfig.openAiCompatible.keep_alive
             });
         } catch (e) {
             logger.warn(`[ConceptDiscoveryService] OpenAiCompatible provider could not be constructed; skipping ${sourceRef}:`, e.message);
@@ -286,7 +286,7 @@ class ConceptDiscoveryService extends Base {
             return nb - na;
         });
 
-        const scanLimit   = this.prScanLimit ?? aiConfig.conceptDiscovery?.prScanLimit;
+        const scanLimit   = this.prScanLimit ?? aiConfig.conceptDiscovery.prScanLimit;
         const cappedFiles = files.slice(0, scanLimit);
         const sources     = [];
 


### PR DESCRIPTION
Authored by @neo-opus-4-7 (Claude Opus 4.8, Claude Code). Session c2800781-b204-4883-a52f-2979a560718b.

Resolves #12538
Related: #12461
Related: #12456

Removes the `aiConfig.<subtree>?.` B3 defensive reads from `ai/services/ingestion/ConceptDiscoveryService.mjs` — the graph/ingestion cluster of Epic #12461 — reading the resolved `conceptDiscovery` and `openAiCompatible` leaves directly per ADR 0019 §5. The reactive Provider SSOT guarantees the resolved subtree, so the optional-chaining masked fail-loud without adding any real safety. Continues the per-surface B3 cleanup after the KB-daemon (#12530), ProtoSource (#12504), and orchestrator (#12515) legs.

Evidence: L2 (dedicated unit spec, 7 tests, exercising the changed paths) → L2 required (pure-refactoring leaf-read; no public/consumed-surface change, governed by ADR 0019 + Epic #12461). No residuals.

## Deltas from ticket

The ticket AC said "4 reads"; the precise count is **5** `?.` removals across 2 subtrees — `conceptDiscovery` ×2 (`minSourceLength`, `prScanLimit`) and `openAiCompatible` ×3 (`model`, `host`, `keep_alive`). Scope otherwise unchanged. No Contract Ledger (pure refactoring under the existing ADR-0019 contract; trigger-exclusion per `contract-ledger.md`).

## Test Evidence

- `grep -nE 'aiConfig\.[a-zA-Z]+\?\.' ai/services/ingestion/ConceptDiscoveryService.mjs` → no matches (all defensive reads removed).
- `npx playwright test test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs --reporter=line` → **7 passed (3.1s)**. The spec exercises the changed paths: `extractConceptsFromSource` (provider construction via `openAiCompatible.*` + `minSourceLength` threshold) and `mineFromPullRequests` (`prScanLimit` cap).
- Behavior note for the reviewer: the three `openAiCompatible` reads sit inside an existing provider-construction `try/catch`. A genuinely-absent subtree now fails loud there and is logged + skipped — that is the pre-existing handler's behavior, not a new silent swallow introduced by this change. The `this.prScanLimit ?? aiConfig.conceptDiscovery.prScanLimit` explicit-override-else-SSOT pattern is unchanged (compliant).

## Post-Merge Validation

- [ ] Epic #12461 B3 cluster tracker can count the ConceptDiscoveryService (graph/ingestion) reads as removed.

## Commits

- `5a683ae51` — `fix(ai): remove ConceptDiscoveryService B3 AiConfig defensive reads (#12538)`
