### PR TITLE
fix(ai): remove maintenance B3 config defenses (#12541)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -137,7 +137,7 @@ export function resolveBackupRetention({
     aiConfig = AiConfig,
     memoryCoreConfig = mcConfig
 } = {}) {
-    return aiConfig.maintenance?.backup?.retention || memoryCoreConfig.backupRetention || {};
+    return aiConfig.maintenance.backup.retention || memoryCoreConfig.backupRetention || {};
 }
 
 /**

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -127,17 +127,15 @@ export async function loadTopLevelAiConfig({
 }
 
 /**
- * Resolves atomic-bundle retention from Tier-1 AI config with Memory Core fallback.
+ * Resolves atomic-bundle retention from Tier-1 AI config.
  * @param {Object} [options]
  * @param {Object} [options.aiConfig=AiConfig] Tier-1 AI config.
- * @param {Object} [options.memoryCoreConfig=mcConfig] Memory Core config fallback.
  * @returns {Object}
  */
 export function resolveBackupRetention({
-    aiConfig = AiConfig,
-    memoryCoreConfig = mcConfig
+    aiConfig = AiConfig
 } = {}) {
-    return aiConfig.maintenance.backup.retention || memoryCoreConfig.backupRetention || {};
+    return aiConfig.maintenance.backup.retention;
 }
 
 /**

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -149,7 +149,7 @@ export async function loadTopLevelAiConfig({
 export function resolveDefragSnapshotRetention({
     aiConfig = AiConfig
 } = {}) {
-    return aiConfig.maintenance.defrag.snapshotRetention || {};
+    return aiConfig.maintenance.defrag.snapshotRetention;
 }
 
 /**

--- a/ai/scripts/maintenance/defragChromaDB.mjs
+++ b/ai/scripts/maintenance/defragChromaDB.mjs
@@ -149,7 +149,7 @@ export async function loadTopLevelAiConfig({
 export function resolveDefragSnapshotRetention({
     aiConfig = AiConfig
 } = {}) {
-    return aiConfig.maintenance?.defrag?.snapshotRetention || {};
+    return aiConfig.maintenance.defrag.snapshotRetention || {};
 }
 
 /**

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -22,16 +22,14 @@ import fs             from 'fs-extra';
 import path           from 'path';
 
 /**
- * Verifies the Phase 4 (#11663) configurable bundle retention policy in
+ * Verifies the configurable bundle retention policy in
  * `ai/scripts/maintenance/backup.mjs#cleanOldBackups`. Two-axis policy:
  *   - `keepMinimum` — newest N bundles retained unconditionally
  *   - `maxDays`     — bundles older than N days are eligible for deletion
  *
- * Default values (`K=3, N_DAYS=30`) match the pre-#11663 hardcoded constants
- * (byte-equivalence anchor — pre-#11663 deployments without `backupRetention`
+ * Default values (`K=3, N_DAYS=30`) match the previous hardcoded constants
+ * (byte-equivalence anchor — deployments without `backupRetention`
  * config behave identically).
- *
- * @see https://github.com/neomjs/neo/issues/11663
  */
 // Serial mode: this spec exercises a shared `cleanOldBackups` import + tmp filesystem
 // state. Running serially within the file avoids cross-test parallel-worker contention
@@ -39,7 +37,7 @@ import path           from 'path';
 // ordering. CI uses workers=1 in playwright.config.unit.mjs; this is a local-DX safeguard.
 test.describe.configure({mode: 'serial'});
 
-test.describe('cleanOldBackups — configurable retention (#11663)', () => {
+test.describe('cleanOldBackups — configurable retention', () => {
     let cleanOldBackups;
     let loadTopLevelAiConfig;
     let resolveBackupRetention;
@@ -87,10 +85,10 @@ test.describe('cleanOldBackups — configurable retention (#11663)', () => {
         return entries.filter(name => name.startsWith('backup-'));
     }
 
-    test('default config (K=3, N=30 days) matches pre-#11663 hardcoded behavior — byte-equivalence anchor', async () => {
+    test('default config (K=3, N=30 days) matches previous hardcoded behavior — byte-equivalence anchor', async () => {
         // Seed 5 bundles spanning the retention thresholds:
         //   1d, 10d, 25d, 40d, 60d old
-        // Pre-#11663 expected outcome: newest 3 (1d, 10d, 25d) retained unconditionally;
+        // Previous hardcoded expected outcome: newest 3 (1d, 10d, 25d) retained unconditionally;
         // 40d + 60d eligible for deletion (both > 30 days AND outside newest-3 window).
         await seedBackup(1);
         await seedBackup(10);
@@ -235,8 +233,8 @@ test.describe('cleanOldBackups — configurable retention (#11663)', () => {
         });
     });
 
-    test('falls back to legacy Memory Core backupRetention when top-level maintenance is absent', () => {
-        expect(resolveBackupRetention({
+    test('fails loud when top-level maintenance subtree is absent', () => {
+        expect(() => resolveBackupRetention({
             aiConfig: {},
             memoryCoreConfig: {
                 backupRetention: {
@@ -244,10 +242,7 @@ test.describe('cleanOldBackups — configurable retention (#11663)', () => {
                     maxDays    : 20
                 }
             }
-        })).toEqual({
-            keepMinimum: 5,
-            maxDays    : 20
-        });
+        })).toThrow('backup');
     });
 
     test('loads gitignored top-level AI config only when present', async () => {
@@ -285,7 +280,7 @@ test.describe('cleanOldBackups — configurable retention (#11663)', () => {
     });
 });
 
-test.describe('defragChromaDB cleanOldBackups — configurable snapshot retention (#11722)', () => {
+test.describe('defragChromaDB cleanOldBackups — configurable snapshot retention', () => {
     let cleanOldDefragBackups;
     let resolveDefragSnapshotRetention;
     let tmpRoot;
@@ -324,7 +319,7 @@ test.describe('defragChromaDB cleanOldBackups — configurable snapshot retentio
         return entries.filter(name => name.startsWith('backup-'));
     }
 
-    test('default snapshot config (K=3, N=7 days) matches pre-#11722 hardcoded behavior', async () => {
+    test('default snapshot config (K=3, N=7 days) matches previous hardcoded behavior', async () => {
         await seedDefragBackup(1);
         await seedDefragBackup(3);
         await seedDefragBackup(5);

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -209,7 +209,7 @@ test.describe('cleanOldBackups — configurable retention', () => {
         expect(remaining).toHaveLength(0);
     });
 
-    test('resolves backup retention from top-level maintenance config before legacy Memory Core fallback', () => {
+    test('resolves backup retention from top-level maintenance config', () => {
         expect(resolveBackupRetention({
             aiConfig: {
                 maintenance: {
@@ -220,12 +220,6 @@ test.describe('cleanOldBackups — configurable retention', () => {
                         }
                     }
                 }
-            },
-            memoryCoreConfig: {
-                backupRetention: {
-                    keepMinimum: 3,
-                    maxDays    : 30
-                }
             }
         })).toEqual({
             keepMinimum: 7,
@@ -235,13 +229,7 @@ test.describe('cleanOldBackups — configurable retention', () => {
 
     test('fails loud when top-level maintenance subtree is absent', () => {
         expect(() => resolveBackupRetention({
-            aiConfig: {},
-            memoryCoreConfig: {
-                backupRetention: {
-                    keepMinimum: 5,
-                    maxDays    : 20
-                }
-            }
+            aiConfig: {}
         })).toThrow('backup');
     });
 


### PR DESCRIPTION
Resolves #12541
Related: #12461

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Removes the maintenance-script B3 optional-chain defenses from the Tier-1 AiConfig reads in `backup.mjs` and `defragChromaDB.mjs`. The focused retention spec now also asserts that an absent top-level maintenance subtree fails loud instead of silently falling back through a stale plain-object test seam.

Evidence: L1 (focused unit/static verification) -> L1 required (all #12541 ACs are read-site and unit-contract verifiable). No residuals.

## Deltas from ticket

The first focused test run exposed a stale unit expectation: `resolveBackupRetention({aiConfig: {}})` expected the legacy Memory Core fallback. That contradicted ADR 0019 B3 fail-loud semantics for a missing AiConfig subtree, so the test was updated to expect the fail-loud path.

The pre-commit archaeology hook also required removing durable ticket numbers from comments/test names in the touched spec. No runtime behavior changed from that cleanup.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs` -> 14 passed.
- `npm run ai:lint-config-template-ssot` -> OK.
- `rg -n "aiConfig\.maintenance\?\.|AiConfig\.maintenance\?\." ai/scripts/maintenance/backup.mjs ai/scripts/maintenance/defragChromaDB.mjs test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs` -> no matches.
- `git diff --check` -> clean.
- Pre-commit hooks passed: whitespace, shorthand, ticket archaeology.

## Post-Merge Validation

- [ ] #12461 B3 parent burndown can subtract the maintenance-script cluster.

## Commits

- `8e9c50d5a` — `fix(ai): remove maintenance B3 config defenses (#12541)`