### PR TITLE
fix(ai): remove mailbox B3 config defense (#12543)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -421,7 +421,7 @@ class MailboxService extends Base {
         // `CAN_READ_SESSIONS_OF`) is NOT affected by this setting — reading someone's
         // inbox is categorically different from sending them a message; asymmetric treatment
         // is intentional.
-        const strictReplyPolicy = aiConfig.mailbox?.defaultReplyPolicy === 'blocked';
+        const strictReplyPolicy = aiConfig.mailbox.defaultReplyPolicy === 'blocked';
 
         // @summary Defensive guard enforcing the "Block Wins" negative-intent primitive.
         // Fires in BOTH reply-policy modes ('open' and 'blocked').


### PR DESCRIPTION
Resolves #12543

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Removes the defensive optional-chain read from `MailboxService.addMessage()` so the reply-policy gate consumes the ADR-0019-resolved `aiConfig.mailbox.defaultReplyPolicy` leaf directly. Missing mailbox config now fails loudly instead of silently weakening strict reply enforcement.

Evidence: L1 direct source/grep proved the B3 residue and its removal; L3 focused unit coverage was required for the consumed mailbox reply-policy behavior.

Related: #12461, #12456

## Deltas from ticket

None. This PR keeps the scope to the one-line B3 read-shape cleanup and does not touch B4 test singleton mutation cleanup or other #12461 clusters.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` -> 62 passed
- `npm run ai:lint-config-template-ssot` -> OK
- `git diff --check` -> passed
- `rg -n "aiConfig\\.mailbox\\?\\.|aiConfig\\.mailbox\\s*\\|\\||aiConfig\\.mailbox\\s*\\?\\?" ai/services/memory-core/MailboxService.mjs` -> no matches

## Post-Merge Validation

- [ ] #12543 closes on merge while #12461 remains open for the remaining B3 cluster leaves.

## Commit

- `7c0e9ca11` — `fix(ai): remove mailbox B3 config defense (#12543)`