### PR TITLE
fix(ai): remove transport auth B3 defense (#12546)

### DIFF
--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -54,7 +54,7 @@ class TransportService extends Base {
     resolveAuthContext(req, aiConfig) {
         let baseAuth = req.auth;
 
-        if (!baseAuth && aiConfig.auth?.trustProxyIdentity) {
+        if (!baseAuth && aiConfig.auth.trustProxyIdentity) {
             const proxyUserId = req.headers['x-preferred-username'] || req.headers['x-auth-request-preferred-username'];
             if (proxyUserId) {
                 baseAuth = {


### PR DESCRIPTION
Resolves #12546

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Replaces the remaining TransportService B3 defensive auth read with the direct Provider-resolved `aiConfig.auth.trustProxyIdentity` leaf. The proxy-identity behavior is unchanged when the auth subtree is present, while a malformed missing subtree now fails loudly at the consumer read site instead of silently disabling proxy trust.

Evidence: L2 (focused unit coverage plus static residue audit) -> L2 required (close-target ACs fully coverable in CI). No residuals.

Related: #12461
Related: #12456

Decision Record impact: aligned with ADR 0019; no ADR update required.

## Deltas from ticket

None. The implementation is the one-line direct-leaf replacement described in #12546.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs` -> 16 passed.
- `npm run ai:lint-config-template-ssot` -> OK.
- `rg -n "aiConfig\.auth\?\.trustProxyIdentity|aiConfig\.auth\.trustProxyIdentity" ai/mcp/server/shared/services/TransportService.mjs` -> direct read only.
- `rg -n "aiConfig\.auth\?\.|aiConfig\.auth\s*\|\||aiConfig\.auth\s*\?\?" ai/mcp/server/shared/services/TransportService.mjs` -> no defensive auth fallback residues.
- `git diff --check` -> passed.

## Post-Merge Validation

- [ ] Confirm #12546 auto-closes after merge and #12461 remains open for remaining B3 leaves.

## Commit

- `6f67fe05c` - `fix(ai): remove transport auth B3 defense (#12546)`