### PR TITLE
fix(ai): remove KB graph B3 config defenses (#12549)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -136,8 +136,8 @@ class DreamService extends Base {
         // Since ChromaDB filtering on missing attributes can be tricky depending on version,
         // we'll fetch recent sessions and filter in memory if the dataset is reasonable.
         // For production, we will just query specifically.
-        const limit = aiConfig.summarizationBatchLimit || 2000;
-        const maxToProcess = aiConfig.remSleepBatchLimit || 10;
+        const limit = aiConfig.summarizationBatchLimit;
+        const maxToProcess = aiConfig.remSleepBatchLimit;
 
         try {
             const batch = await this.sessionsCollection.get({
@@ -194,7 +194,7 @@ class DreamService extends Base {
         if (aiConfig.modelProvider === 'openAiCompatible') {
             const providerStart = Date.now();
             try {
-                const url = new URL('/v1/models', aiConfig.openAiCompatible.host || 'http://127.0.0.1:8000');
+                const url = new URL('/v1/models', aiConfig.openAiCompatible.host);
                 const ping = await fetch(url.toString(), { method: 'GET', signal: AbortSignal.timeout(5000) });
                 if (!ping.ok) throw new Error('API provider not running');
                 perPhaseStates.push(finishPhase('legacyProviderProbe', providerStart, 'completed', {

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -72,6 +72,21 @@ function finishPhase(phase, startedAt, status, details = {}) {
 }
 
 /**
+ * @summary Reads a required numeric AiConfig leaf and fails loud when the imported config is stale.
+ * @param {String} leafName The AiConfig leaf name.
+ * @returns {Number}
+ */
+function readRequiredNumberLeaf(leafName) {
+    const value = aiConfig[leafName];
+
+    if (!Number.isFinite(value)) {
+        throw new Error(`[DreamService] Required AiConfig leaf "${leafName}" is missing or invalid. Update ai/mcp/server/memory-core/config.mjs from config.template.mjs.`);
+    }
+
+    return value;
+}
+
+/**
  * @summary Service for offline GraphRAG extraction ("REM Sleep").
  *
  * Scans recent session summaries from the `neo-agent-sessions` collection that have not
@@ -136,8 +151,8 @@ class DreamService extends Base {
         // Since ChromaDB filtering on missing attributes can be tricky depending on version,
         // we'll fetch recent sessions and filter in memory if the dataset is reasonable.
         // For production, we will just query specifically.
-        const limit = aiConfig.summarizationBatchLimit;
-        const maxToProcess = aiConfig.remSleepBatchLimit;
+        const limit = readRequiredNumberLeaf('summarizationBatchLimit');
+        const maxToProcess = readRequiredNumberLeaf('remSleepBatchLimit');
 
         try {
             const batch = await this.sessionsCollection.get({

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -110,6 +110,12 @@ class Config extends BaseConfig {
              */
             summarizationBatchLimit: leaf(2000),
             /**
+             * Maximum number of undigested sessions the REM pipeline processes per cycle.
+             * Keeps each sleep pass bounded even when the query batch is larger.
+             * @type {number}
+             */
+            remSleepBatchLimit: leaf(10, 'NEO_REM_SLEEP_BATCH_LIMIT', 'number'),
+            /**
              * Maximum number of concurrent session summarization requests.
              * Prevents hitting LLM/Embedding API rate limits during bulk operations.
              * @type {number}

--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -123,7 +123,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             // threshold (model-role axis, not provider-namespace — remote providers like
             // Gemini are API-bound and don't expose these knobs; local providers
             // share the same caps because the limit comes from the loaded model).
-            const consumerModel          = aiConfig[graphProvider]?.model;
+            const consumerModel          = aiConfig[graphProvider].model;
             const consumerContextTokens  = aiConfig.localModels.chat.contextLimitTokens;
             const consumerSafeTokens     = aiConfig.localModels.chat.safeProcessingLimitTokens;
 

--- a/ai/services/graph/TopologyInferenceEngine.mjs
+++ b/ai/services/graph/TopologyInferenceEngine.mjs
@@ -75,7 +75,7 @@ ${contextText}
                 emitConsumerFriction({
                     symptom                  : 'context-overflow',
                     consumer                 : 'TopologyInferenceEngine',
-                    model                    : aiConfig[graphProvider]?.model,
+                    model                    : aiConfig[graphProvider].model,
                     assetRef                 : sessionId,
                     serviceDomain            : 'dream-pipeline',
                     emissionPoint            : 'post-invocation-failure',
@@ -136,10 +136,9 @@ ${contextText}
 
     /**
      * @summary Count topological-conflict entries emitted to `sandman_handoff.md`.
-     * This is **Axis D** of the 5-axis REM observability model (per Discussion
-     * #12062 §2.6) — the count of conflicts the engine has actually written to
-     * the handoff file, which is the durable substrate consumers (next-session
-     * agents) read at boot.
+     * This is **Axis D** of the 5-axis REM observability model: the count of
+     * conflicts the engine has actually written to the handoff file, which is
+     * the durable substrate consumers (next-session agents) read at boot.
      *
      * Counts lines matching the canonical conflict-entry suffix `(Source Session:`
      * — each conflict entry in `sandman_handoff.md` follows the shape
@@ -148,22 +147,18 @@ ${contextText}
      * distinctive enough to avoid false positives from Golden Path or other
      * handoff sections.
      *
-     * **Important divergence semantic per Discussion #12062 §2.11 + PR #12077
-     * Sub 1 runbook hypothesis #10:** `extractTopology()` returns `undefined`
+     * **Important divergence semantic:** `extractTopology()` returns `undefined`
      * (void) on both no-conflicts AND provider-error paths — meaning a zero
      * count here does NOT distinguish "no conflicts detected" from "topology
-     * extraction silently failed for every session." Sub 3's unified REM cycle
-     * + Sub 2 Part B (state model) will close this distinction by tracking
-     * per-cycle topology outcome explicitly.
+     * extraction silently failed for every session." The unified REM cycle
+     * state model closes this distinction by tracking per-cycle topology outcome
+     * explicitly.
      *
      * Returns 0 on file-not-found, empty file, or read error — consistent with
      * sibling axis-count helpers' graceful-degradation contract.
      *
      * @returns {Promise<Number>} Count of conflict entries in `sandman_handoff.md`;
      *     0 if file absent / empty / unreadable
-     * @see Epic #12065 Sub 2 / #12068 — 5-axis observability primitive
-     * @see Discussion #12062 §2.6 — axis-divergence framing
-     * @see PR #12077 Sub 1 forensics runbook hypothesis #10 — TopologyInferenceEngine void-return silent failure
      */
     async getTopologyConflictCount() {
         const handoffFile = aiConfig.handoffFilePath;

--- a/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
+++ b/ai/services/knowledge-base/KnowledgeBaseIngestionService.mjs
@@ -167,8 +167,8 @@ class KnowledgeBaseIngestionService extends Base {
             summary.errors.push(this.createError({code: error.code || 'KB_INGEST_FAILED', message: error.message}));
             summary.durationMs = Date.now() - startedAt;
             this.recordMetric(summary, {
-                tenantId: summary.tenantId || aiConfig.defaultTenantId || 'neo-shared',
-                repoSlug: aiConfig.defaultRepoSlug || 'neo'
+                tenantId: summary.tenantId || aiConfig.defaultTenantId,
+                repoSlug: aiConfig.defaultRepoSlug
             });
             return summary;
         }
@@ -360,7 +360,7 @@ class KnowledgeBaseIngestionService extends Base {
             deleted            : 0,
             embeddingsGenerated: 0,
             errors             : [],
-            tenantId           : aiConfig.defaultTenantId || 'neo-shared',
+            tenantId           : aiConfig.defaultTenantId,
             durationMs         : Date.now() - startedAt
         };
     }
@@ -759,12 +759,12 @@ class KnowledgeBaseIngestionService extends Base {
             throw error;
         }
 
-        const tenantId = activeTenant || requestedTenant || aiConfig.defaultTenantId || 'neo-shared';
+        const tenantId = activeTenant || requestedTenant || aiConfig.defaultTenantId;
 
         return {
             tenantId,
-            repoSlug: payload.repoSlug || this.resolvePayloadRepoSlug(payload) || aiConfig.defaultRepoSlug || 'neo',
-            visibility: payload.visibility || aiConfig.defaultVisibility || 'team',
+            repoSlug: payload.repoSlug || this.resolvePayloadRepoSlug(payload) || aiConfig.defaultRepoSlug,
+            visibility: payload.visibility || aiConfig.defaultVisibility,
             originAgentIdentity: this.requestContextService.getAgentIdentityNodeId?.() || payload.originAgentIdentity
         };
     }
@@ -797,7 +797,7 @@ class KnowledgeBaseIngestionService extends Base {
      * @returns {Promise<{tenantId: String, source: String, version: Number, useDefaultSources: Boolean, rawRepoSource: Boolean, useDefaultParsers: Boolean, customSources: Array, customParsers: Array, sourcePaths: Object}>}
      */
     async getTenantConfig({tenantId} = {}) {
-        const resolvedTenant = normalizeUserId(tenantId) || aiConfig.defaultTenantId || 'neo-shared';
+        const resolvedTenant = normalizeUserId(tenantId) || aiConfig.defaultTenantId;
 
         await this.graphService.initAsync();
 

--- a/ai/services/knowledge-base/VectorService.mjs
+++ b/ai/services/knowledge-base/VectorService.mjs
@@ -591,11 +591,9 @@ class VectorService extends Base {
         // CLI invocations pass viaMcp: false and bypass.
         const mcpThreshold = aiConfig.mcpSyncMaxChunks;
         if (viaMcp && workVolume > mcpThreshold) {
-            // Defensive log-path resolution mirrors logger.mjs's lazy resolution — keeps
-            // the refusal message coherent even on existing gitignored config.mjs deployments
-            // that pre-date the `logPath` template key. Without the fallback, the rendered
-            // message would carry `undefined/kb-server-...`.
-            const logDir = aiConfig.logPath || `${aiConfig.neoRootDir}/.neo-ai-data/logs`;
+            // `logPath` is a Provider-owned leaf; read it directly so malformed config
+            // shape fails loud instead of silently re-deriving a local default.
+            const logDir = aiConfig.logPath;
             const errorPayload = {
                 error  : `KB sync work volume exceeds MCP-callable threshold`,
                 message: `${workVolume} chunks need re-embedding (threshold: ${mcpThreshold}). ` +

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -56,6 +56,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         aiConfig.storagePaths.graph = testDbPath;
         aiConfig.autoIngestFileSystem = false; // Prevent differential sync during DreamService tests
         aiConfig.handoffFilePath      = path.join(tmpDir, 'mock_sandman_handoff.md');
+        aiConfig.remSleepBatchLimit ??= 10;
         kbConfig.data.memoryCoreDbPath = testDbPath;
 
         GraphService = (await import('../../../../../../../ai/services/memory-core/GraphService.mjs')).default;
@@ -154,7 +155,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // Otherwise sibling specs (e.g. DreamServiceGoldenPath) hit
         //   `if (!_initPromise) initAsync() else ready()`
         // → take the `ready()` branch → never honor their own `aiConfig.storagePaths.graph`
-        // → real `getContextFrontier()` returns null. Empirically traced via #10946 bisection.
+        // → real `getContextFrontier()` returns null. Empirically traced via bisection.
         await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'destroy');
 
         if (KBRecorderService?.db) {
@@ -209,7 +210,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         // Suppress QueryService dynamic import execution during this deterministic test
         const originalImport = global.import;
-        // 3. Trigger session-scoped TEST_GAP inference (post-#10085 scope split)
+        // 3. Trigger session-scoped TEST_GAP inference after the cycle-scope split.
         await DreamService.inferTestGapsFromSession(payload);
 
         // Validate gaps are stored on the node correctly
@@ -219,8 +220,21 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         expect(updatedNode.properties.capabilityGap).toContain('[TEST_GAP]');
     });
 
+    test('findUndigestedSessions fails loud when remSleepBatchLimit is malformed in the imported config', async () => {
+        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+              originalRemSleepBatchLimit = aiConfig.remSleepBatchLimit;
+
+        aiConfig.remSleepBatchLimit = Number.NaN;
+
+        try {
+            await expect(DreamService.findUndigestedSessions()).rejects.toThrow(/Required AiConfig leaf "remSleepBatchLimit"/);
+        } finally {
+            aiConfig.remSleepBatchLimit = originalRemSleepBatchLimit ?? 10;
+        }
+    });
+
     test('should detect GUIDE_GAP via concept-graph edge traversal (no LLM verification)', async () => {
-        // #10035 rewrite: replaces the pre-refactor regex + LLM Boolean verification path with
+        // Capability-gap rewrite: replaces the pre-refactor regex + LLM Boolean verification path with
         // deterministic outbound-EXPLAINED_BY edge traversal. Two CONCEPT nodes planted in the
         // graph — one with EXPLAINED_BY (covered), one without (gap). Both above the tier-1
         // weight threshold (0.8) so threshold-filtering isn't what drives the asymmetry.
@@ -243,7 +257,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
 
         // Seed target stub nodes (SQLite FK constraint on edges.target → nodes.id) then the edges.
         // The "covered" concept needs EXPLAINED_BY (no guide gap), EXEMPLIFIED_BY (no example gap),
-        // AND IMPLEMENTED_BY (no orphan gap post-#10087) — otherwise it'd correctly emit one of
+        // AND IMPLEMENTED_BY (no orphan gap) — otherwise it'd correctly emit one of
         // those signals instead of being fully covered.
         GraphService.upsertNode({
             id        : 'file:learn/guides/Threading.md',
@@ -279,7 +293,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             type  : 'IMPLEMENTED_BY'
         });
 
-        // Concept-graph pass is session-independent (hoisted to cycle-scope in #10085).
+        // Concept-graph pass is session-independent and hoisted to cycle-scope.
         await DreamService.inferConceptGraphGaps();
 
         const covered     = GraphService.db.nodes.get('concept-covered');
@@ -334,7 +348,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('should detect EXAMPLE_GAP for concepts documented but lacking worked examples', async () => {
-        // #10035 new signal: EXPLAINED_BY edge present, EXEMPLIFIED_BY edge absent.
+        // New signal: EXPLAINED_BY edge present, EXEMPLIFIED_BY edge absent.
         // Lower-severity than a missing guide; surfaced in a separate handoff section.
         GraphService.upsertNode({
             id        : 'concept-no-example',
@@ -383,7 +397,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('threshold override via aiConfig.data.guideGapWeightThreshold changes emission behavior (#10086)', async () => {
-        // #10086: the weight gate lives in config (not a file-local constant). Verifying that
+        // The weight gate lives in config (not a file-local constant). Verifying that
         // GapInferenceEngine reads the live config value means curators can tune the handoff
         // silence level without code changes — the stated goal of the config-lift.
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
@@ -415,7 +429,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('should detect ORPHAN_CONCEPT for concepts with no IMPLEMENTED_BY edge (#10087)', async () => {
-        // #10087: concepts without source-code anchoring emit `[ORPHAN_CONCEPT]` via the durable
+        // Concepts without source-code anchoring emit `[ORPHAN_CONCEPT]` via the durable
         // `capabilityGap` channel rather than the deprecated per-orphan `logger.warn` in
         // `ConceptIngestor`. Shares the same `GUIDE_GAP_WEIGHT_THRESHOLD` weight gate as
         // `[GUIDE_GAP]` / `[EXAMPLE_GAP]` so low-priority concepts don't flood the handoff.
@@ -488,7 +502,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('unvalidated concepts (validated: false) should be silenced regardless of weight (#10036)', async () => {
-        // #10036: mined candidates from ConceptDiscoveryService carry `validated: false` until
+        // Mined candidates from ConceptDiscoveryService carry `validated: false` until
         // a curator promotes them via nodes.jsonl edit. Low weight is the primary silencing
         // mechanism (weight gate), but `validated: false` is the explicit override — even if
         // an unvalidated candidate had a high weight, it must stay silent until reviewed.
@@ -591,7 +605,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('processUndigestedSessions calls inferTestGapsFromSession per-session and inferConceptGraphGaps once per cycle (hoist contract — #10085)', async () => {
-        // Locks in the #10085 Item 1 contract: the concept-graph pass is ontology-scoped, so it
+        // Locks in the hoist contract: the concept-graph pass is ontology-scoped, so it
         // must fire exactly once per REM cycle regardless of session count — not N times inside
         // the per-session loop like the pre-refactor `executeCapabilityGapInference` wrapper did.
         // Guards against any future "simplification" that re-inlines the cycle-scope call back
@@ -681,7 +695,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
     });
 
     test('processUndigestedSessions does not set graphDigested when memory ingestion reports errors (#10460)', async () => {
-        // Regression guard for #10460: the Tri-Vector extractor can succeed from
+        // Regression guard: the Tri-Vector extractor can succeed from
         // `session.document` even when MemorySessionIngestor partially failed to upsert MEMORY
         // nodes. Keep such sessions undigested so the next REM cycle retries the missing graph
         // rows instead of permanently masking them behind `graphDigested: true`.
@@ -867,7 +881,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
              { id: 'blocker', properties: { state: 'OPEN' } },
              { id: 'weak-task', properties: { state: 'OPEN' } },
              { id: 'rejected-task', properties: { state: 'OPEN', labels: ['needs-re-triage'] } },
-             // #10087: planted CONCEPT with ORPHAN_CONCEPT gap to verify the ⚠️ section renders
+             // Planted CONCEPT with ORPHAN_CONCEPT gap to verify the ⚠️ section renders
              // in sandman_handoff.md alongside the existing TEST/GUIDE/EXAMPLE sections.
              { id: 'concept-orphan-render-test', properties: {
                  state        : 'OPEN',
@@ -936,7 +950,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             expect(finalContent.indexOf('- **[Codebase Gap]**')).toBeLessThan(finalContent.indexOf('## Computed Golden Path'));
             expect(finalContent).not.toContain('Old Path');
 
-            // #10087: planted CONCEPT with [ORPHAN_CONCEPT] must surface as a dedicated section
+            // Planted CONCEPT with [ORPHAN_CONCEPT] must surface as a dedicated section
             expect(finalContent).toContain('⚠️ Orphaned Concepts');
             expect(finalContent).toContain('Reactivity');
             expect(finalContent).toContain('Concept Reverification Queue');

--- a/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs
@@ -27,7 +27,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 /**
- * Work-volume branching coverage for `VectorService.embed` (#10572).
+ * Work-volume branching coverage for `VectorService.embed`.
  *
  * Verifies the post-delta-pre-embed gate at the four meaningful states:
  *
@@ -219,8 +219,8 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
     });
 
     test('zero-changes fast-path is unchanged (existing chunks dedup to empty queue)', async () => {
-        // Seed tenant-aware existing IDs that match the fixture exactly — chunksToProcess
-        // becomes empty under the Phase 0/1C write-side stamping contract (#11631).
+        // Seed tenant-aware existing IDs that match the fixture exactly so
+        // chunksToProcess becomes empty under the write-side stamping contract.
         const stamp = KB_VectorService.resolveTenantStamp();
         const ids   = ['chunk-0', 'chunk-1', 'chunk-2'].map((hash, i) => {
             return KB_VectorService.createTenantAwareChunkId({
@@ -450,13 +450,11 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         expect(result.message).toContain('npm run ai:sync-kb');
         expect(spy.calls.upsert).toBe(0); // no embedding work attempted under the gate
 
-        // Tail-progress reference (#10576 RA1 from @neo-gpt cycle 2): rendered message
-        // must point operators at a usable log path with no `undefined` interpolation.
-        // Defensive fallback in VectorService kicks in when `aiConfig.logPath` is absent
-        // — proven by the no-undefined assertion under the canonical-config setup, then
-        // by the dedicated fallback test below that simulates a stale operator overlay.
+        // Rendered tail-progress guidance must use the provider-owned logPath
+        // leaf with no `undefined` interpolation.
         expect(result.message).toContain('tail -f');
         expect(result.message).toContain('kb-server-');
+        expect(result.message).toContain(KB_Config.data.logPath);
         expect(result.message).not.toContain('undefined');
 
         // Wire-format boundary (RA2 per @neo-gpt cycle 1): the KB Server's adapter at
@@ -468,29 +466,6 @@ test.describe('VectorService.embed — work-volume branching (#10572)', () => {
         // before it reaches the gate — a test-env artifact, not a production path.)
         const isError = Neo.isObject(result) && 'error' in result;
         expect(isError).toBe(true);
-    });
-
-    test('above-threshold MCP gate-message renders fallback path when aiConfig.logPath unset (#10580 RA1)', async () => {
-        // Simulates an existing operator overlay without the new
-        // `logPath` template key. Naked `${aiConfig.logPath}` interpolation would
-        // render `undefined/kb-server-...`; the fallback in VectorService.embed should
-        // render `${neoRootDir}/.neo-ai-data/logs/kb-server-...` instead.
-        const spy = createSpyCollection({existingIds: []});
-        KB_ChromaManager.getKnowledgeBaseCollection = async () => spy;
-        writeFixtureJsonl(fixturePath, 10);
-
-        const wasLogPath       = KB_Config.data.logPath;
-        KB_Config.data.logPath = undefined;
-
-        try {
-            const result = await KB_VectorService.embed(fixturePath, {viaMcp: true});
-
-            expect(result.code).toBe('KB_SYNC_VOLUME_EXCEEDED');
-            expect(result.message).not.toContain('undefined');
-            expect(result.message).toContain('.neo-ai-data/logs');
-        } finally {
-            KB_Config.data.logPath = wasLogPath;
-        }
     });
 
     test('above-threshold CLI invocation bypasses the gate (explicit opt-in to long work)', async () => {


### PR DESCRIPTION
Resolves #12549

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Removes the Cluster B ADR-0019 B3 hidden-default reads across KB/vector/graph/daemon consumers. The code now reads Provider-owned AiConfig leaves directly for tenant defaults, graph provider models, vector log path, REM batch sizing, and OpenAI-compatible provider host, so stale or malformed config shape fails loud instead of silently re-deriving local defaults.

Evidence: L1 (static config-shape audit; focused unit tests exercised reachable behavior) -> L1 required (internal refactor with no host-only runtime ACs). No residuals.

Related: #12461
Related: #12456

## Changed Config Keys

- Added `remSleepBatchLimit` in `ai/mcp/server/memory-core/config.template.mjs`.
- Added env override `NEO_REM_SLEEP_BATCH_LIMIT`.
- Local `ai/mcp/server/memory-core/config.mjs` follow-up: required for active clones whose gitignored local config is a stale copy that lacks `remSleepBatchLimit`; add the key or re-copy the template while preserving local operator values.
- Runtime behavior before local follow-up: `DreamService.findUndigestedSessions()` fails loud with a config-shape error instead of silently slicing with `undefined`.
- Harness restart: required for long-running Memory Core MCP / REM daemon processes after local config shape update so the direct Provider-leaf read is present in runtime state.

## Deltas From Ticket

- Added the missing `remSleepBatchLimit` leaf after implementation V-B-A proved `DreamService` had a behavior fallback with no declared SSOT leaf.
- Added the imported-config fail-loud guard after peer V-B-A flagged that fresh template shape and stale gitignored `config.mjs` shape can diverge.
- Removed the stale VectorService unit test that encoded the old missing-`logPath` fallback contract.
- Cleaned pre-existing durable ticket archaeology in touched comments so the pre-commit guard passes without bypass.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/VectorService.WorkVolumeBranching.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBaseIngestionService.spec.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs test/playwright/unit/ai/services/rem-observability.spec.mjs` -> 102 passed. Initial sandbox run hit readonly symlinked SQLite; escalated rerun passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/services/rem-observability.spec.mjs` -> 59 passed for the fail-loud fixup.
- `npm run ai:lint-config-template-ssot` -> OK.
- Runtime imported-config probe: `Memory_Config` resolves inherited `graphProvider`, `ollama`, `openAiCompatible`, and `localModels` leaves through the Provider chain; stale local `remSleepBatchLimit` is absent until local config follow-up.
- Cluster B defensive-read residue grep -> no matches.
- `git diff --check` and `git diff --cached --check` -> clean.
- Pre-commit hook passed: whitespace, shorthand, ticket archaeology.

## Post-Merge Validation

- [ ] Update/re-copy stale gitignored `ai/mcp/server/memory-core/config.mjs` files in active clones so `remSleepBatchLimit` exists before REM sleep runs.
- [ ] Restart long-running Memory Core MCP / REM daemon processes after the local config shape update.

## Commits

- `4546ea2b5` - `fix(ai): remove KB graph B3 config defenses (#12549)`
- `17a5e47b4` - `fix(ai): fail loud on REM batch config drift (#12549)`
