### PR TITLE
fix(ai): remove memory-core + MCP/runtime B3 AiConfig defensive reads (#12550)

### DIFF
--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -259,7 +259,7 @@ class TransportService extends Base {
             await RequestContextService.run(requestContext, () => transport.handleRequest(req, res, req.body));
         });
 
-        const port = aiConfig.mcpHttpPort || 3000;
+        const port = aiConfig.mcpHttpPort;
         await new Promise((resolve, reject) => {
             this.httpServer = app.listen(port, () => {
                 logger.info(`[${resourceName}] Server started on SSE transport (Port: ${port})`);

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -323,7 +323,7 @@ class SessionService extends Base {
         // Override: All time (if includeAll is true).
         const ONE_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
         const minTimestamp = Date.now() - ONE_MONTH_MS;
-        const limit = aiConfig.summarizationBatchLimit || 2000;
+        const limit = aiConfig.summarizationBatchLimit;
         const maxIterations = 1000; // Safety break: max 2M records (2000 * 1000)
 
         let allMetadatas = [];

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -218,7 +218,7 @@ class SummaryService extends Base {
 
             // Step 1: Fetch ALL metadata (lightweight).
             let allRecords = [];
-            const batchSize  = aiConfig.summarizationBatchLimit || 2000;
+            const batchSize  = aiConfig.summarizationBatchLimit;
 
             let batchOffset = 0,
                 hasMore     = true;

--- a/ai/services/memory-core/TextEmbeddingService.mjs
+++ b/ai/services/memory-core/TextEmbeddingService.mjs
@@ -242,11 +242,11 @@ class TextEmbeddingService extends Base {
     #getOllamaProvider() {
         if (this.ollamaProvider) return this.ollamaProvider;
 
-        const config = aiConfig.ollama || {};
+        const config = aiConfig.ollama;
         const provider = Neo.create(OllamaProvider, {
-            host          : config.host           || 'http://127.0.0.1:11434',
-            modelName     : config.model          || 'gemma4',
-            embeddingModel: config.embeddingModel || null
+            host          : config.host,
+            modelName     : config.model,
+            embeddingModel: config.embeddingModel
         });
         this.ollamaProvider = provider;
         return provider;

--- a/ai/services/memory-core/managers/CollectionProxy.mjs
+++ b/ai/services/memory-core/managers/CollectionProxy.mjs
@@ -20,7 +20,7 @@ class CollectionProxy extends Base {
     }
 
     async getManagers() {
-        const architecture = aiConfig.engine || 'hybrid';
+        const architecture = aiConfig.engine;
         const managers = [];
 
         // In Hybrid RAG, vectors exclusively live in ChromaDB
@@ -97,7 +97,7 @@ class CollectionProxy extends Base {
                     await manager.getSummaryCollection();
             }
 
-            const chromaCoordinates = aiConfig.engines?.chroma || {};
+            const chromaCoordinates = aiConfig.engines.chroma;
             const chromaPath        = chromaCoordinates.path || chromaCoordinates.dataDir;
 
             await DestructiveOperationGuard.assertDestructiveTargetAllowed({


### PR DESCRIPTION
Authored by @neo-opus-4-7 (Claude Opus 4.8, Claude Code). Session c2800781-b204-4883-a52f-2979a560718b.

Resolves #12550
Related: #12461
Related: #12456

Cluster A of the consolidated #12461 B3 cleanup (memory-core + MCP/runtime), per ADR 0019 — the 2-cluster reshape that replaced the per-leaf sweep after @tobiu flagged ticket-proliferation friction. Removes B3 hidden-default defensive reads of the AiConfig SSOT; each stripped read resolves through the Provider chain (confirmed via @neo-gpt's parent-chain V-B-A on the sibling #12551).

Evidence: L2 (memory-core unit specs, 16 passed) → L2 required (pure-refactoring leaf reads under ADR 0019; no public/consumed-surface change). Residual: `engines.chroma` + `mcpHttpPort` have no dedicated local spec — CI-verified (see Test Evidence).

## Deltas from ticket

The #12550 ledger's read classification was **refined during a config-source V-B-A** (the per-file MailboxService-lesson check), which is exactly why this is a cluster PR and not a per-leaf strip:

- **Stripped (B3 hidden-defaults, leaf resolves):** `SessionService`/`SummaryService` `summarizationBatchLimit || 2000`; `CollectionProxy` `engine || 'hybrid'` + `engines?.chroma || {}`; `TextEmbeddingService` `ollama || {}` and its inner `config.host/model/embeddingModel || <literal>` (the leaf provides `host`/`model`/`embeddingModel` defaults — note the code's `'gemma4'` *diverged* from the template's `'gemma4:31b'`, a drift this fixes); `TransportService` `mcpHttpPort || 3000` (already bare-read at line 160, so this makes the file consistent).
- **Excluded — NOT B3 (rationale):** `BaseServer this.aiConfig?.load/.transport` — `aiConfig=null` is a genuinely-nullable instance property (legit guard); `Logger aiConfig?.data ?? aiConfig ?? {}` — an intentional dual-shape (BaseConfig-proxy vs plain-object) adapter per its JSDoc.
- **Deferred behind #12532:** `SummaryService.memorySharing.defaultPolicy` reads + `MemoryService` entirely (memorySharing overlap).

## Test Evidence

- `npm run test-unit -- …/TextEmbeddingService.spec.mjs …/SummaryService.spec.mjs …/SessionService.spec.mjs` → **16 passed**. Covers the stripped `ollama`, `summarizationBatchLimit` reads with the bare-resolution.
- `CollectionProxy` (`engines.chroma`, `engine`) and `TransportService` (`mcpHttpPort`) have no dedicated local spec, and the local env is missing `parse5`/`marked` (known gap) — these two reads are **CI-verified** here. V-B-A basis: `engines` is a top-level Tier-1 config object (same inheritance mechanism gpt confirmed for `ollama`/`graphProvider`/`openAiCompatible`/`localModels`); `mcpHttpPort` is already bare-read at `TransportService:160`.
- Residue grep: stripped reads no longer carry `|| {}` / `|| <literal>` defenses.

## Post-Merge Validation

- [ ] Epic #12461 B3 cluster tracker counts the memory-core + MCP/runtime reads as cleaned.
- [ ] Confirm `engines.chroma` + `mcpHttpPort` resolve under CI integration (no runtime `undefined`).

## Commits

- `a2274cc7d` — `fix(ai): remove memory-core + MCP/runtime B3 AiConfig defensive reads (#12550)`
