### PR TITLE
feat(memory-core): add harness presence address dispatch (#12422)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -46,7 +46,9 @@ import {
     getGraphLogEntries,
     getNodesData,
     getEdgesData,
-    getDbNode
+    getDbNode,
+    getActiveHarnessPresence,
+    isHarnessPresenceFresh
 } from './queries.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
@@ -675,6 +677,7 @@ let deliveryPromise = Promise.resolve();
  */
 async function deliverDigest(subscription, digest) {
     const meta = subscription.properties?.harnessTargetMetadata || {};
+    const {instanceAddress, addressType} = resolveInstanceAddress(meta);
     // Fall back to osascript on macOS by default, tmux otherwise
     const defaultAdapter = process.platform === 'darwin' ? 'osascript' : 'tmux';
     const adapter = meta.adapter || defaultAdapter;
@@ -683,8 +686,19 @@ async function deliverDigest(subscription, digest) {
     deliveryPromise = deliveryPromise.then(async () => {
 
     try {
+        if (addressType && instanceAddress && !assertFreshTargetPresence(subscription, {addressType})) {
+            return;
+        }
+
+        if (addressType === 'webhookUrl') {
+            await deliverViaWebhookUrl(subscription, digest, instanceAddress);
+            return;
+        }
+
         if (adapter === 'tmux') {
-            const tmuxSession = meta.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';
+            const tmuxSession = addressType === 'tmuxSession' && instanceAddress
+                ? instanceAddress
+                : meta.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';
             await spawnAsync('tmux', ['send-keys', '-t', tmuxSession, digest, 'C-m']);
             writeLog('INFO', `[Bridge Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}`);
         } else if (adapter === 'osascript') {
@@ -733,11 +747,10 @@ async function deliverDigest(subscription, digest) {
                 return;
             }
 
-            // Instance-addressable wake — LOCAL deployment only. When the subscription carries a
-            // userDataDir, two same-bundle GUI harnesses may be running; resolve the intended
-            // instance's pid and raise THAT process — never the ambiguous app-activate / frontmost
-            // guess. Fail closed (skip the wake) if the instance cannot be located, so a targeted
-            // wake never lands in the wrong one.
+            // Instance-addressable wake — LOCAL deployment only. When the subscription carries an
+            // addressType, route through that address instead of falling back to ambiguous
+            // app-activate/frontmost guessing. Fail closed (skip the wake) if the instance cannot
+            // be located, so a targeted wake never lands in the wrong one.
             //
             // Instance addressing is a local-only primitive: this daemon delivers desktop-harness
             // wakes via osascript/tmux, which a headless cloud deployment has no GUI harness to
@@ -747,7 +760,24 @@ async function deliverDigest(subscription, digest) {
             // app-activate — a targeted wake must never silently degrade to an untargeted one. Uses
             // the canonical AiConfig.orchestrator.deploymentMode signal.
             let instancePid = null;
-            if (meta.userDataDir) {
+            if (addressType === 'pid') {
+                if (AiConfig.orchestrator.deploymentMode === 'cloud') {
+                    writeLog('ERROR',
+                        `[Bridge Daemon] Instance wake refused for ${subscription.id}: ` +
+                        `pid targeting requires local deployment (deploymentMode='cloud'). ` +
+                        `Failing closed — instance-addressed GUI wakes are local-only (ADR 0014).`
+                    );
+                    return;
+                }
+                instancePid = normalizePid(instanceAddress);
+                if (!instancePid) {
+                    writeLog('ERROR',
+                        `[Bridge Daemon] Instance wake refused for ${subscription.id}: ` +
+                        `invalid pid instanceAddress='${instanceAddress}'. Failing closed.`
+                    );
+                    return;
+                }
+            } else if (addressType === 'userDataDir' && instanceAddress) {
                 if (AiConfig.orchestrator.deploymentMode === 'cloud') {
                     writeLog('ERROR',
                         `[Bridge Daemon] Instance wake refused for ${subscription.id}: ` +
@@ -756,11 +786,11 @@ async function deliverDigest(subscription, digest) {
                     );
                     return;
                 }
-                instancePid = await getInstancePid({userDataDir: meta.userDataDir});
+                instancePid = await getInstancePid({userDataDir: instanceAddress});
                 if (!instancePid) {
                     writeLog('ERROR',
                         `[Bridge Daemon] Instance wake refused for ${subscription.id}: ` +
-                        `no running process found for userDataDir='${meta.userDataDir}'. ` +
+                        `no running process found for userDataDir='${instanceAddress}'. ` +
                         `Failing closed to avoid misrouting to another ${appName} instance.`
                     );
                     return;
@@ -954,6 +984,94 @@ async function deliverDigest(subscription, digest) {
     });
 
     return deliveryPromise;
+}
+
+/**
+ * @summary Resolves generic instance-address metadata with legacy field compatibility.
+ * @param {Object} meta Subscription harnessTargetMetadata.
+ * @returns {{instanceAddress:String|null,addressType:String|null}}
+ */
+function resolveInstanceAddress(meta = {}) {
+    const addressType = meta.addressType
+        || (meta.userDataDir ? 'userDataDir' : null);
+
+    const instanceAddress = meta.instanceAddress
+        || (addressType === 'userDataDir' ? meta.userDataDir : null);
+
+    return {
+        instanceAddress: instanceAddress || null,
+        addressType    : addressType || null
+    };
+}
+
+/**
+ * @summary Requires fresh HarnessPresence before immediate address-specific dispatch.
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @param {Object} address Resolved address tuple.
+ * @returns {Boolean}
+ */
+function assertFreshTargetPresence(subscription, {addressType}) {
+    const presence = getActiveHarnessPresence(db, {
+        subscriptionId: subscription.id,
+        agentIdentity : subscription.properties?.agentIdentity
+    });
+
+    if (isHarnessPresenceFresh(presence)) return true;
+
+    writeLog('WARN',
+        `[Bridge Daemon] Targeted wake refused for ${subscription.id}: ` +
+        `addressType='${addressType}' requires fresh HarnessPresence. ` +
+        `Failing closed; recipient will pick up the unread event on next turn.`
+    );
+    return false;
+}
+
+/**
+ * @summary Normalizes a pid string for direct-pid address dispatch.
+ * @param {*} pid Process id candidate.
+ * @returns {Number|null}
+ */
+function normalizePid(pid) {
+    const numericPid = Number(pid);
+
+    return Number.isInteger(numericPid) && numericPid > 0 ? numericPid : null;
+}
+
+/**
+ * @summary Posts a wake digest to a bridge-dispatchable webhook address.
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @param {String} digest Wake digest body.
+ * @param {String} webhookUrl Target webhook URL.
+ * @returns {Promise<void>}
+ */
+async function deliverViaWebhookUrl(subscription, digest, webhookUrl) {
+    let url;
+    try {
+        url = new URL(webhookUrl);
+    } catch (error) {
+        writeLog('ERROR',
+            `[Bridge Daemon] Webhook wake refused for ${subscription.id}: ` +
+            `invalid webhookUrl instanceAddress. Failing closed.`
+        );
+        return;
+    }
+
+    const response = await fetch(url, {
+        method : 'POST',
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+            subscriptionId: subscription.id,
+            digest
+        })
+    });
+
+    if (!response.ok) {
+        throw new Error(`webhookUrl POST failed with HTTP ${response.status}`);
+    }
+
+    writeLog('INFO', `[Bridge Daemon] Delivered ${subscription.id} via webhookUrl POST`);
 }
 
 // Start loop

--- a/ai/daemons/bridge/queries.mjs
+++ b/ai/daemons/bridge/queries.mjs
@@ -38,6 +38,85 @@ export function getActiveShapeCSubscriptions(db) {
     return collapseDuplicateShapeCRoutes(stmt.all().map(row => JSON.parse(row.data)));
 }
 
+export const HARNESS_PRESENCE_STALE_AFTER_MS = 5 * 60 * 1000;
+
+/**
+ * @summary Loads the newest active HarnessPresence row for a bridge-daemon subscription.
+ *
+ * Presence is a volatile overlay keyed by subscription and identity. The bridge daemon consumes it
+ * only as a freshness guard for targeted delivery; missing or stale presence must fail closed for
+ * address-specific dispatch instead of falling through to the legacy untargeted activate path.
+ *
+ * @param {Database} db SQLite database handle.
+ * @param {Object} opts
+ * @param {String} opts.subscriptionId WAKE_SUBSCRIPTION id.
+ * @param {String} opts.agentIdentity AgentIdentity node id.
+ * @returns {Object|null} Parsed HARNESS_PRESENCE node.
+ */
+export function getActiveHarnessPresence(db, {subscriptionId, agentIdentity} = {}) {
+    if (!subscriptionId && !agentIdentity) return null;
+
+    if (subscriptionId) {
+        return getNewestHarnessPresence(db, {
+            where : "json_extract(data, '$.properties.subscriptionId') = ?",
+            params: [subscriptionId]
+        });
+    }
+
+    if (!agentIdentity) return null;
+
+    return getNewestHarnessPresence(db, {
+        where : "json_extract(data, '$.properties.agentIdentity') = ?",
+        params: [agentIdentity]
+    });
+}
+
+function getNewestHarnessPresence(db, {where, params}) {
+    const rows = db.prepare(`
+        SELECT data FROM Nodes
+        WHERE json_extract(data, '$.label') = 'HARNESS_PRESENCE'
+          AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+          AND ${where}
+        ORDER BY COALESCE(
+            json_extract(data, '$.properties.lastSeenAt'),
+            json_extract(data, '$.properties.updatedAt'),
+            ''
+        ) DESC
+        LIMIT 1
+    `).all(...params);
+
+    for (const row of rows) {
+        try {
+            return JSON.parse(row.data);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @summary Checks whether a HarnessPresence row is fresh enough for immediate targeted delivery.
+ * @param {Object|null} presence Parsed HARNESS_PRESENCE node.
+ * @param {Object} [opts]
+ * @param {Number} [opts.now=Date.now()] Current timestamp in ms.
+ * @param {Number} [opts.staleAfterMs=HARNESS_PRESENCE_STALE_AFTER_MS] Staleness threshold.
+ * @returns {Boolean}
+ */
+export function isHarnessPresenceFresh(presence, {
+    now = Date.now(),
+    staleAfterMs = HARNESS_PRESENCE_STALE_AFTER_MS
+} = {}) {
+    const props = presence?.properties || {};
+    if ((props.status || 'active') !== 'active') return false;
+
+    const lastSeenAt = props.lastSeenAt ? new Date(props.lastSeenAt).getTime() : NaN;
+    if (!Number.isFinite(lastSeenAt)) return false;
+
+    return now - lastSeenAt <= staleAfterMs;
+}
+
 /**
  * @summary Collapses duplicate active Shape C wake routes before bridge-daemon dispatch.
  *

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1351,7 +1351,7 @@ paths:
                   description: Required for subscribe; specifies how wake events are delivered.
                 harnessTargetMetadata:
                   type: object
-                  description: Channel-specific metadata. appName is required so fresh agents always provide the bridge-daemon/osascript routing target; url is required for a2a-webhook; coalesceWindow is an optional override. userDataDir (local bridge-daemon only) addresses one specific same-bundle GUI instance when two harnesses of the same app run in parallel — the daemon resolves that instance's pid from its --user-data-dir and raises only that process.
+                  description: Channel-specific metadata. appName is required so fresh agents always provide the bridge-daemon/osascript routing target; url is required for a2a-webhook; coalesceWindow is an optional override. instanceAddress + addressType (local bridge-daemon only) target a specific receiver instance; userDataDir is a legacy compatibility field for existing subscriptions.
                   required: [appName]
                   properties:
                     url:              {type: string}
@@ -1359,6 +1359,8 @@ paths:
                     daemonSocketPath: {type: string}
                     adapter:          {type: string, enum: [osascript, tmux]}
                     appName:          {type: string}
+                    instanceAddress:  {type: string, nullable: true}
+                    addressType:      {type: string, enum: [userDataDir, pid, tmuxSession, webhookUrl], nullable: true}
                     userDataDir:      {type: string, nullable: true}
                     tabShortcut:      {type: string, nullable: true}
                     focusSeedKey:     {type: string, nullable: true}

--- a/ai/mcp/server/shared/services/BootEnvelopeResolver.mjs
+++ b/ai/mcp/server/shared/services/BootEnvelopeResolver.mjs
@@ -33,12 +33,11 @@ import Base from '../../../../../src/core/Base.mjs';
  *
  * ## Dispatch coverage
  *
- * The bridge daemon currently dispatches the `userDataDir` address kind. The `pid`, `tmuxSession`,
- * and `webhookUrl` kinds are recognized envelope values reserved for the forthcoming generic
- * address-type dispatch; until that lands they fail closed here rather than produce a subscription
- * the daemon would misroute. For `userDataDir`, the address is also mirrored onto the legacy
- * `userDataDir` metadata field the daemon reads today; that mirror is a transitional bridge and is
- * retired once dispatch reads the generic `addressType` directly.
+ * The bridge daemon dispatches the generic `{instanceAddress, addressType}` pair directly:
+ * `userDataDir` resolves to a same-bundle GUI process, `pid` targets that process directly,
+ * `tmuxSession` sends to tmux, and `webhookUrl` posts the wake digest. The earlier transitional
+ * `userDataDir` mirror is retired here; legacy subscriptions that already carry that field remain
+ * a bridge-daemon compatibility read concern, not a boot-envelope output.
  *
  * Pure resolution is intentionally side-effect-free (reads `process.env` only) so the mapping is
  * unit-testable with injected environments.
@@ -65,8 +64,7 @@ class BootEnvelopeResolver extends Base {
 
     /**
      * @member {String[]} validAddressTypes
-     * The recognized instance-address kinds. `userDataDir` is dispatched today; the remainder are
-     * reserved for generic address-type dispatch and currently fail closed.
+     * The recognized instance-address kinds.
      */
     validAddressTypes = ['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']
 
@@ -74,7 +72,7 @@ class BootEnvelopeResolver extends Base {
      * @member {String[]} dispatchableAddressTypes
      * The subset of {@link validAddressTypes} the bridge daemon can route today.
      */
-    dispatchableAddressTypes = ['userDataDir']
+    dispatchableAddressTypes = ['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']
 
     /**
      * Resolves the boot instance-address envelope into wake-subscription `overrideMetadata`.
@@ -123,16 +121,7 @@ class BootEnvelopeResolver extends Base {
             );
         }
 
-        const overrideMetadata = {instanceAddress, addressType};
-
-        // Transitional daemon-compat: the live bridge daemon resolves the target instance from the
-        // `userDataDir` metadata field. Mirror the address there so wake routing is functional now;
-        // the mirror is retired once dispatch reads `addressType` directly.
-        if (addressType === 'userDataDir') {
-            overrideMetadata.userDataDir = instanceAddress;
-        }
-
-        return overrideMetadata;
+        return {instanceAddress, addressType};
     }
 }
 

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -92,6 +92,45 @@ class WakeSubscriptionService extends Base {
     subscriptionCache = new Map()
 
     /**
+     * @member {String[]} validHarnessPresenceStates
+     * @protected
+     */
+    validHarnessPresenceStates = ['unknown', 'idle', 'active', 'waitingOnApproval', 'userTyping']
+
+    /**
+     * @member {String[]} validWakePolicies
+     * @protected
+     */
+    validWakePolicies = ['silent', 'next_turn', 'immediate']
+
+    /**
+     * @member {String[]} validAddressTypes
+     * @protected
+     */
+    validAddressTypes = ['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']
+
+    /**
+     * @member {Number} harnessPresenceFreshMs
+     * Presence older than one heartbeat is not fresh enough for immediate targeted delivery.
+     * @protected
+     */
+    harnessPresenceFreshMs = 5 * 60 * 1000
+
+    /**
+     * @member {Number} harnessPresenceTtlMs
+     * TTL backstop for stale HarnessPresence records, approximately 2x swarm heartbeat.
+     * @protected
+     */
+    harnessPresenceTtlMs = 10 * 60 * 1000
+
+    /**
+     * @member {String} bootId
+     * Per-process boot identity used to supersede stale HarnessPresence rows.
+     * @protected
+     */
+    bootId = crypto.randomUUID()
+
+    /**
      * @member {Number} liveCursor=0
      * @protected
      */
@@ -273,10 +312,15 @@ class WakeSubscriptionService extends Base {
      * agent even while mailbox storage remains healthy.
      *
      * @param {Object} [opts]
-     * @param {Object} [opts.overrideMetadata] Optional metadata to override template defaults
+     * @param {Object} [opts.overrideMetadata] Optional metadata to override template defaults.
+     * @param {Object} [opts.presence] Optional HarnessPresence state override, used by tests and
+     *     future native-control-plane adapters.
+     * @param {String} [opts.bootId] Optional boot id override for deterministic tests.
+     * @param {Number} [opts.pid] Optional process id override for deterministic tests.
+     * @param {Date|String|Number} [opts.now] Optional clock override for deterministic tests.
      * @returns {Promise<Object>} {subscriptionId, harnessTarget, status: 'existing'|'created'}
      */
-    async bootstrap({overrideMetadata} = {}) {
+    async bootstrap({overrideMetadata, presence = {}, bootId = this.bootId, pid = process.pid, now = new Date()} = {}) {
         const owner = RequestContextService.getAgentIdentityNodeId();
         if (!owner) throw new Error('Cannot bootstrap subscription: no agent identity context bound.');
 
@@ -316,6 +360,8 @@ class WakeSubscriptionService extends Base {
                 harnessTargetMetadata: mergedMetadata
             });
 
+            this.upsertHarnessPresence({owner, subscriptionId: refreshed.id, metadata: mergedMetadata, presence, bootId, pid, now});
+
             return {subscriptionId: refreshed.id, harnessTarget: refreshed.harnessTarget, status: 'existing'};
         }
 
@@ -327,7 +373,138 @@ class WakeSubscriptionService extends Base {
             harnessTargetMetadata: mergedMetadata
         });
 
+        this.upsertHarnessPresence({owner, subscriptionId: result.subscriptionId, metadata: mergedMetadata, presence, bootId, pid, now});
+
         return {...result, status: result.status === 'existing' ? 'existing' : 'created'};
+    }
+
+    /**
+     * @summary Upserts the volatile HarnessPresence overlay for a bootstrapped wake route.
+     *
+     * The durable WAKE_SUBSCRIPTION node records interest in a wake channel. HarnessPresence records
+     * the currently booted receiver's live routing input: receiver state vocabulary plus the
+     * boot-envelope address tuple. Presence is intentionally separate from subscription metadata so
+     * stale receiver state can retire without deleting the durable subscription.
+     *
+     * @param {Object} opts
+     * @param {String} opts.owner AgentIdentity node id.
+     * @param {String} opts.subscriptionId Durable WAKE_SUBSCRIPTION id this presence overlays.
+     * @param {Object} [opts.metadata={}] Merged harnessTargetMetadata.
+     * @param {Object} [opts.presence={}] Presence state overrides.
+     * @param {String} [opts.bootId=this.bootId] Per-process boot id.
+     * @param {Number} [opts.pid=process.pid] Process id used for stale-pid probes.
+     * @param {Date|String|Number} [opts.now=new Date()] Clock source.
+     * @returns {Object} Persisted HarnessPresence properties.
+     */
+    upsertHarnessPresence({
+        owner,
+        subscriptionId,
+        metadata = {},
+        presence = {},
+        bootId = this.bootId,
+        pid = process.pid,
+        now = new Date()
+    } = {}) {
+        if (!owner || !subscriptionId) return null;
+
+        const nowDate = this._coerceDate(now),
+              nowIso  = nowDate.toISOString();
+
+        this.retireStaleHarnessPresence({owner, bootId, now: nowDate});
+
+        const {instanceAddress, addressType} = this._resolvePresenceAddress(metadata);
+        const presencePid = this._normalizePresencePid(presence.pid ?? (addressType === 'pid' ? instanceAddress : pid));
+        const state       = this.validHarnessPresenceStates.includes(presence.state) ? presence.state : 'unknown';
+        const wakePolicy  = this.validWakePolicies.includes(presence.wakePolicy) ? presence.wakePolicy : 'next_turn';
+
+        const properties = {
+            agentIdentity: owner,
+            subscriptionId,
+            state,
+            activeTurnId   : presence.activeTurnId || null,
+            wakePolicy,
+            source         : presence.source || 'mcp-client',
+            instanceAddress: instanceAddress || null,
+            addressType    : addressType || null,
+            pid            : presencePid,
+            bootId,
+            lastSeenAt     : nowIso,
+            capabilities   : Array.isArray(presence.capabilities) ? presence.capabilities : [],
+            freshUntil     : new Date(nowDate.getTime() + this.harnessPresenceFreshMs).toISOString(),
+            expiresAt      : new Date(nowDate.getTime() + this.harnessPresenceTtlMs).toISOString(),
+            updatedAt      : nowIso,
+            status         : 'active',
+            userId         : owner,
+            sharedEntity   : false
+        };
+
+        GraphService.upsertNode({
+            id         : this._buildHarnessPresenceId(owner, bootId),
+            type       : 'HARNESS_PRESENCE',
+            name       : `HarnessPresence ${owner}`,
+            description: 'Volatile wake-routing presence overlay for a booted harness instance.',
+            properties
+        });
+
+        return properties;
+    }
+
+    /**
+     * @summary Retires stale HarnessPresence rows for an identity.
+     *
+     * Primary stale signal: a prior boot id plus a dead pid. TTL is a backstop for harnesses whose
+     * pid cannot be trusted or was never recorded.
+     *
+     * @param {Object} opts
+     * @param {String} opts.owner AgentIdentity node id.
+     * @param {String} opts.bootId Current boot id.
+     * @param {Date|String|Number} [opts.now=new Date()] Clock source.
+     * @returns {Number} Count of retired rows.
+     */
+    retireStaleHarnessPresence({owner, bootId, now = new Date()} = {}) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite || !owner) return 0;
+
+        const nowMs = this._coerceDate(now).getTime();
+        const rows = sqlite.prepare(`
+            SELECT id, data FROM Nodes
+            WHERE json_extract(data, '$.label') = 'HARNESS_PRESENCE'
+              AND json_extract(data, '$.properties.agentIdentity') = ?
+              AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+        `).all(owner);
+
+        let retired = 0;
+
+        for (const row of rows) {
+            let node;
+            try {
+                node = JSON.parse(row.data);
+            } catch (error) {
+                logger.warn(`[WakeSubscription] Failed to parse HarnessPresence row ${row.id}: ${error.message}`);
+                continue;
+            }
+
+            const props        = node.properties || {};
+            const bootMismatch = props.bootId && props.bootId !== bootId;
+            const ttlExpired   = this._isPresenceTtlExpired(props, nowMs);
+            const pidDead      = props.pid ? !this._isPidAlive(props.pid) : false;
+
+            if (!ttlExpired && !(bootMismatch && pidDead)) continue;
+
+            GraphService.upsertNode({
+                id        : row.id || node.id,
+                type      : 'HARNESS_PRESENCE',
+                properties: {
+                    ...props,
+                    status      : 'retired',
+                    retiredAt   : new Date(nowMs).toISOString(),
+                    retireReason: ttlExpired ? 'ttl-expired' : 'boot-mismatch-pid-dead'
+                }
+            });
+            retired++;
+        }
+
+        return retired;
     }
 
     /**
@@ -422,9 +599,10 @@ class WakeSubscriptionService extends Base {
      * @param {Object} [opts.filters] taggedConcepts | priority | senderFilter | inReplyToFilter
      * @param {String} opts.harnessTarget One of validHarnessTargets
      * @param {Object} [opts.harnessTargetMetadata] appName | url | coalesceWindow |
-     *     daemonSocketPath | adapter | tabShortcut | focusSeedKey | tmuxSession | userDataDir
-     *     (userDataDir: instance address for a same-bundle GUI harness — the bridge daemon resolves
-     *     it to that instance's pid and raises that process, instead of the ambiguous frontmost guess)
+     *     daemonSocketPath | adapter | tabShortcut | focusSeedKey | tmuxSession |
+     *     instanceAddress | addressType | userDataDir
+     *     (`instanceAddress` + `addressType`: boot-envelope instance address for bridge-daemon
+     *     dispatch; `userDataDir` remains a legacy compatibility field for existing subscriptions)
      * @returns {Promise<Object>} {subscriptionId, harnessTarget, signingKey?}
      */
     async subscribe({trigger, filters = {}, harnessTarget, harnessTargetMetadata = {}} = {}) {
@@ -612,6 +790,14 @@ class WakeSubscriptionService extends Base {
         }
         if (metadata.appName && !this.validAppNames.includes(metadata.appName)) {
             throw new Error(`Invalid appName '${metadata.appName}'. Must be one of: ${this.validAppNames.join(', ')}`);
+        }
+        if (metadata.instanceAddress || metadata.addressType) {
+            if (!metadata.instanceAddress || !metadata.addressType) {
+                throw new Error('Shape C generic instance addressing requires both harnessTargetMetadata.instanceAddress and harnessTargetMetadata.addressType.');
+            }
+            if (!this.validAddressTypes.includes(metadata.addressType)) {
+                throw new Error(`Invalid addressType '${metadata.addressType}'. Must be one of: ${this.validAddressTypes.join(', ')}`);
+            }
         }
     }
 
@@ -1446,6 +1632,93 @@ class WakeSubscriptionService extends Base {
         this.subscriptionCache.set(id, refreshed);
 
         return refreshed;
+    }
+
+    /**
+     * @summary Builds a deterministic HarnessPresence node id for one identity boot.
+     * @param {String} owner AgentIdentity node id.
+     * @param {String} bootId Per-process boot id.
+     * @returns {String}
+     * @protected
+     */
+    _buildHarnessPresenceId(owner, bootId) {
+        return `HARNESS_PRESENCE:${owner}:${bootId}`;
+    }
+
+    /**
+     * @summary Resolves generic and legacy route metadata into a presence address tuple.
+     * @param {Object} metadata Merged harnessTargetMetadata.
+     * @returns {{instanceAddress:String|null,addressType:String|null}}
+     * @protected
+     */
+    _resolvePresenceAddress(metadata = {}) {
+        const addressType = metadata.addressType
+            || (metadata.userDataDir ? 'userDataDir' : null);
+
+        const instanceAddress = metadata.instanceAddress
+            || (addressType === 'userDataDir' ? metadata.userDataDir : null);
+
+        return {
+            instanceAddress: instanceAddress || null,
+            addressType    : addressType || null
+        };
+    }
+
+    /**
+     * @summary Normalizes a process id candidate for HarnessPresence storage.
+     * @param {*} pid Process id candidate.
+     * @returns {Number|null}
+     * @protected
+     */
+    _normalizePresencePid(pid) {
+        const numericPid = Number(pid);
+
+        return Number.isInteger(numericPid) && numericPid > 0 ? numericPid : null;
+    }
+
+    /**
+     * @summary Coerces test-injected and production clock values to a valid Date.
+     * @param {Date|String|Number} value Clock value.
+     * @returns {Date}
+     * @protected
+     */
+    _coerceDate(value) {
+        const date = value instanceof Date ? value : new Date(value);
+
+        return Number.isNaN(date.getTime()) ? new Date() : date;
+    }
+
+    /**
+     * @summary Tests whether a HarnessPresence row has exceeded its TTL backstop.
+     * @param {Object} props HarnessPresence properties.
+     * @param {Number} nowMs Current timestamp in milliseconds.
+     * @returns {Boolean}
+     * @protected
+     */
+    _isPresenceTtlExpired(props, nowMs) {
+        const expiresAt = props.expiresAt ? new Date(props.expiresAt).getTime() : NaN;
+        if (Number.isFinite(expiresAt)) return expiresAt <= nowMs;
+
+        const lastSeenAt = props.lastSeenAt ? new Date(props.lastSeenAt).getTime() : NaN;
+        return Number.isFinite(lastSeenAt) && nowMs - lastSeenAt > this.harnessPresenceTtlMs;
+    }
+
+    /**
+     * @summary Checks pid liveness for stale HarnessPresence retirement.
+     * @param {Number|String} pid Process id candidate.
+     * @returns {Boolean}
+     * @protected
+     */
+    _isPidAlive(pid) {
+        const numericPid = this._normalizePresencePid(pid);
+        if (!numericPid) return false;
+
+        try {
+            process.kill(numericPid, 0);
+            return true;
+        } catch (error) {
+            return error.code === 'EPERM';
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -4,8 +4,9 @@ import path from 'path';
 import Database from 'better-sqlite3';
 import { spawn } from 'child_process';
 import crypto from 'crypto';
+import http from 'http';
 import os from 'os';
-import { collapseDuplicateShapeCRoutes, getNodesData, getEdgesData } from '../../../../../../ai/daemons/bridge/queries.mjs';
+import { collapseDuplicateShapeCRoutes, getActiveHarnessPresence, getNodesData, getEdgesData } from '../../../../../../ai/daemons/bridge/queries.mjs';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../../../../../ai/graph/storage/constants.mjs';
 
 /**
@@ -25,6 +26,82 @@ function writeMockPs(binDir, psOutput = '') {
 
     fs.writeFileSync(mockPsPath, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(psOutput)});\n`);
     fs.chmodSync(mockPsPath, 0o755);
+}
+
+function insertBridgeSubscription(db, {
+    subId = 'sub_' + crypto.randomUUID(),
+    agentId,
+    harnessTargetMetadata
+}) {
+    db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+        id: agentId,
+        label: 'AGENT',
+        properties: { name: agentId }
+    }));
+
+    db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+        id: subId,
+        label: 'WAKE_SUBSCRIPTION',
+        properties: {
+            agentIdentity: agentId,
+            harnessTarget: 'bridge-daemon',
+            status: 'active',
+            trigger: 'SENT_TO_ME',
+            harnessTargetMetadata
+        }
+    }));
+
+    db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+    return subId;
+}
+
+function insertHarnessPresence(db, {
+    presenceId = 'presence_' + crypto.randomUUID(),
+    subId,
+    agentId,
+    lastSeenAt = new Date().toISOString()
+}) {
+    db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(presenceId, JSON.stringify({
+        id: presenceId,
+        label: 'HARNESS_PRESENCE',
+        properties: {
+            agentIdentity: agentId,
+            subscriptionId: subId,
+            state: 'idle',
+            wakePolicy: 'immediate',
+            source: 'mcp-client',
+            bootId: 'test-boot',
+            pid: process.pid,
+            lastSeenAt,
+            status: 'active'
+        }
+    }));
+}
+
+function insertMessageWake(db, {agentId, subject = 'Addressed Wake Event'}) {
+    const msgId = 'msg_' + crypto.randomUUID();
+    db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+        id: msgId,
+        label: 'MESSAGE',
+        properties: {
+            from: '@sender',
+            subject,
+            priority: 'normal'
+        }
+    }));
+    db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+    const edgeId = 'edge_' + crypto.randomUUID();
+    db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
+        id: edgeId,
+        source: msgId,
+        target: agentId,
+        type: 'SENT_TO'
+    }), msgId, agentId, 'SENT_TO');
+    db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+
+    return {msgId, edgeId};
 }
 
 test.describe('Bridge Daemon', () => {
@@ -835,6 +912,214 @@ test.describe('Bridge Daemon', () => {
         expect(scriptContent).not.toContain('key code 49');
     });
 
+    test('addressType pid dispatch targets the resolved process id when HarnessPresence is fresh (#12422)', async () => {
+        const agentId = '@test-agent-pid-address';
+        const subId = insertBridgeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter: 'osascript',
+                appName: 'Antigravity',
+                coalesceWindow: 1,
+                instanceAddress: '4242',
+                addressType: 'pid'
+            }
+        });
+        insertHarnessPresence(db, {subId, agentId});
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_pid_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver pid-addressed event within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Bridge Daemon] Delivered ' + subId)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'PID Address Wake'});
+        await deliveryPromise;
+
+        const args = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        const scriptContent = args.filter((_, i) => args[i - 1] === '-e').join('\n');
+
+        expect(scriptContent).toContain('set targetProcessId to "4242"');
+        expect(scriptContent).toContain('first process whose unix id is 4242');
+    });
+
+    test('stale HarnessPresence refuses targeted GUI delivery instead of falling through to app activate (#12422)', async () => {
+        const agentId = '@test-agent-stale-presence';
+        const subId = insertBridgeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter: 'osascript',
+                appName: 'Antigravity',
+                coalesceWindow: 1,
+                instanceAddress: '4242',
+                addressType: 'pid'
+            }
+        });
+        insertHarnessPresence(db, {
+            subId,
+            agentId,
+            lastSeenAt: new Date(Date.now() - 20 * 60 * 1000).toISOString()
+        });
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_stale_presence_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const refusalPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not refuse stale targeted wake within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes(`Targeted wake refused for ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+                if (out.includes(`[Bridge Daemon] Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    reject(new Error('Daemon delivered targeted wake despite stale HarnessPresence'));
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Stale Presence Wake'});
+        await refusalPromise;
+
+        expect(fs.existsSync(mockOutPath)).toBe(false);
+    });
+
+    test('addressType tmuxSession dispatch sends the digest to the instanceAddress session (#12422)', async () => {
+        const agentId = '@test-agent-tmux-address';
+        const subId = insertBridgeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter: 'tmux',
+                appName: 'Antigravity',
+                coalesceWindow: 1,
+                instanceAddress: 'neo-gpt-session',
+                addressType: 'tmuxSession'
+            }
+        });
+        insertHarnessPresence(db, {subId, agentId});
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        const mockTmuxPath = path.join(binDir, 'tmux');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_tmux_out.json');
+        fs.writeFileSync(mockTmuxPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockTmuxPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver tmux-addressed event within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes(`Delivered ${subId} via tmux to session neo-gpt-session`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Tmux Address Wake'});
+        await deliveryPromise;
+
+        const args = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        expect(args[0]).toBe('send-keys');
+        expect(args[1]).toBe('-t');
+        expect(args[2]).toBe('neo-gpt-session');
+        expect(args.at(-1)).toBe('C-m');
+    });
+
+    test('addressType webhookUrl dispatch POSTs the wake digest to the instanceAddress (#12422)', async () => {
+        const received = new Promise((resolve, reject) => {
+            const server = http.createServer((req, res) => {
+                let body = '';
+                req.on('data', chunk => body += chunk.toString());
+                req.on('end', () => {
+                    res.writeHead(204);
+                    res.end();
+                    resolve({server, req, body});
+                });
+            });
+            server.on('error', reject);
+            server.listen(0, '127.0.0.1', () => {
+                const {port} = server.address();
+                const agentId = '@test-agent-webhook-address';
+                const subId = insertBridgeSubscription(db, {
+                    agentId,
+                    harnessTargetMetadata: {
+                        adapter: 'tmux',
+                        appName: 'Antigravity',
+                        coalesceWindow: 1,
+                        instanceAddress: `http://127.0.0.1:${port}/wake`,
+                        addressType: 'webhookUrl'
+                    }
+                });
+                insertHarnessPresence(db, {subId, agentId});
+
+                daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
+                    stdio: 'pipe',
+                    env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+                });
+
+                setTimeout(() => insertMessageWake(db, {agentId, subject: 'Webhook Address Wake'}), 1000);
+            });
+        });
+
+        const timeout = new Promise((_, reject) => {
+            setTimeout(() => reject(new Error('Daemon failed to POST webhook-addressed event within timeout')), 10000);
+        });
+
+        const {server, req, body} = await Promise.race([received, timeout]);
+        server.close();
+
+        const payload = JSON.parse(body);
+        expect(req.method).toBe('POST');
+        expect(req.url).toBe('/wake');
+        expect(payload.digest).toContain('Webhook Address Wake');
+        expect(payload.subscriptionId).toMatch(/^sub_/);
+    });
+
     test('Codex UI wake fails closed when no validated focusSeedKey is configured (#10664)', async () => {
         // An earlier hypothesis — that a Codex Space-seed could mirror the Claude focus-seed fix —
         // was empirically falsified by manual matrix validation 2026-05-03. Space and Enter
@@ -1109,6 +1394,23 @@ test.describe('Bridge Daemon', () => {
         const result = collapseDuplicateShapeCRoutes([oldGemini, claude, newGemini]);
 
         expect(result.map(sub => sub.id).sort()).toEqual(['WAKE_SUB:claude', 'WAKE_SUB:new-gemini']);
+    });
+
+    test('getActiveHarnessPresence does not fall back from a missing subscription row to another fresh identity row (#12422)', () => {
+        const agentId      = '@test-agent-route-specific-presence';
+        const missingSubId = 'sub_missing_route_specific_presence';
+        const freshSubId   = 'sub_fresh_route_specific_presence';
+
+        insertHarnessPresence(db, {subId: freshSubId, agentId});
+
+        const missingRoutePresence = getActiveHarnessPresence(db, {
+            subscriptionId: missingSubId,
+            agentIdentity : agentId
+        });
+        const identityFallbackPresence = getActiveHarnessPresence(db, {agentIdentity: agentId});
+
+        expect(missingRoutePresence).toBeNull();
+        expect(identityFallbackPresence.properties.subscriptionId).toBe(freshSubId);
     });
 
     test('suppresses wake for sender of AGENT:* broadcast and delivers to peers (#10668)', async () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -25,13 +25,13 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
     test.beforeAll(async () => {
         // Import the config and apply any required setup
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        
+
         // Setup temporary directory for db paths to avoid crashing
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
         }
-        
+
         aiConfig.storagePaths.graph = path.join(tmpDir, `tool-limits-test-${Date.now()}.sqlite`);
 
         const ToolServiceModule = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs');
@@ -66,16 +66,19 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
         expect(metadata.required).toContain('appName');
         expect(Object.keys(metadata.properties)).toEqual(expect.arrayContaining([
+            'addressType',
             'adapter',
             'appName',
             'coalesceWindow',
             'daemonSocketPath',
             'focusSeedKey',
+            'instanceAddress',
             'tabShortcut',
             'tmuxSession',
             'url'
         ]));
         expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux']);
+        expect(metadata.properties.addressType.enum).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
     });
 
     test('get_neighbors output schema exposes semanticVectorId contract (#11680)', async () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs
@@ -24,9 +24,9 @@ import BootEnvelopeResolver from '../../../../../../../../ai/mcp/server/shared/s
  * The resolver maps the boot instance-address envelope (`NEO_HARNESS_INSTANCE_ADDRESS` +
  * `NEO_HARNESS_INSTANCE_ADDRESS_TYPE`) into wake-subscription `overrideMetadata`. The critical
  * behaviors: a fully-omitted envelope is the default instance (null, routed by absence); a complete
- * `userDataDir` envelope yields the address override the bridge daemon reads; and every degenerate
- * shape (partial config, unknown type, recognized-but-not-yet-dispatchable type) fails closed so a
- * non-default instance can never silently fall back to the default route and misroute its wakes.
+ * `userDataDir` envelope yields the generic address override the bridge daemon reads; and every
+ * degenerate shape (partial config, unknown type) fails closed so a non-default instance can never
+ * silently fall back to the default route and misroute its wakes.
  */
 
 test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)', () => {
@@ -43,7 +43,7 @@ test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)',
         })).toBeNull();
     });
 
-    test('userDataDir envelope yields the address override the daemon reads', () => {
+    test('userDataDir envelope yields the generic address override the daemon reads', () => {
         const result = BootEnvelopeResolver.resolveOverrideMetadata({
             NEO_HARNESS_INSTANCE_ADDRESS     : NEO_DIR,
             NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'userDataDir'
@@ -51,8 +51,7 @@ test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)',
 
         expect(result).toEqual({
             instanceAddress: NEO_DIR,
-            addressType    : 'userDataDir',
-            userDataDir    : NEO_DIR
+            addressType    : 'userDataDir'
         });
     });
 
@@ -64,8 +63,7 @@ test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)',
 
         expect(result).toEqual({
             instanceAddress: NEO_DIR,
-            addressType    : 'userDataDir',
-            userDataDir    : NEO_DIR
+            addressType    : 'userDataDir'
         });
     });
 
@@ -88,19 +86,25 @@ test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)',
         })).toThrow(/Invalid NEO_HARNESS_INSTANCE_ADDRESS_TYPE/);
     });
 
-    test('fails closed on a recognized-but-not-yet-dispatchable type (pid)', () => {
-        expect(() => BootEnvelopeResolver.resolveOverrideMetadata({
+    test('pid envelope yields the generic address override', () => {
+        expect(BootEnvelopeResolver.resolveOverrideMetadata({
             NEO_HARNESS_INSTANCE_ADDRESS     : '20001',
             NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'pid'
-        })).toThrow(/not yet implemented/);
+        })).toEqual({
+            instanceAddress: '20001',
+            addressType    : 'pid'
+        });
     });
 
-    test('fails closed on the remaining reserved types (tmuxSession, webhookUrl)', () => {
+    test('remaining graduated address types yield generic address overrides', () => {
         for (const addressType of ['tmuxSession', 'webhookUrl']) {
-            expect(() => BootEnvelopeResolver.resolveOverrideMetadata({
+            expect(BootEnvelopeResolver.resolveOverrideMetadata({
                 NEO_HARNESS_INSTANCE_ADDRESS     : 'reserved-value',
                 NEO_HARNESS_INSTANCE_ADDRESS_TYPE: addressType
-            })).toThrow(/not yet implemented/);
+            })).toEqual({
+                instanceAddress: 'reserved-value',
+                addressType
+            });
         }
     });
 
@@ -114,8 +118,7 @@ test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)',
 
             expect(BootEnvelopeResolver.resolveOverrideMetadata()).toEqual({
                 instanceAddress: NEO_DIR,
-                addressType    : 'userDataDir',
-                userDataDir    : NEO_DIR
+                addressType    : 'userDataDir'
             });
         } finally {
             if (prevAddress === undefined) delete process.env.NEO_HARNESS_INSTANCE_ADDRESS;
@@ -128,6 +131,6 @@ test.describe('Neo.ai.mcp.server.shared.services.BootEnvelopeResolver (#12418)',
 
     test('validAddressTypes documents the graduated address-kind set', () => {
         expect(BootEnvelopeResolver.validAddressTypes).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
-        expect(BootEnvelopeResolver.dispatchableAddressTypes).toEqual(['userDataDir']);
+        expect(BootEnvelopeResolver.dispatchableAddressTypes).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -182,6 +182,55 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
         });
 
+        test('bootstraps a volatile HarnessPresence overlay from boot address metadata (#12422)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                const res = await WakeSubscriptionService.manage({
+                    action          : 'bootstrap',
+                    bootId          : 'boot-addressed',
+                    pid             : 12345,
+                    now             : '2026-06-04T00:00:00.000Z',
+                    overrideMetadata: {
+                        instanceAddress: '/Users/example/.antigravity-instances/Neo',
+                        addressType    : 'userDataDir'
+                    },
+                    presence: {
+                        state       : 'idle',
+                        wakePolicy  : 'immediate',
+                        capabilities: ['turn/start']
+                    }
+                });
+
+                const presenceNode = GraphService.db.nodes.get('HARNESS_PRESENCE:@alice:boot-addressed');
+                expect(presenceNode.label).toBe('HARNESS_PRESENCE');
+                expect(presenceNode.properties.agentIdentity).toBe('@alice');
+                expect(presenceNode.properties.subscriptionId).toBe(res.subscriptionId);
+                expect(presenceNode.properties.state).toBe('idle');
+                expect(presenceNode.properties.wakePolicy).toBe('immediate');
+                expect(presenceNode.properties.source).toBe('mcp-client');
+                expect(presenceNode.properties.instanceAddress).toBe('/Users/example/.antigravity-instances/Neo');
+                expect(presenceNode.properties.addressType).toBe('userDataDir');
+                expect(presenceNode.properties.pid).toBe(12345);
+                expect(presenceNode.properties.bootId).toBe('boot-addressed');
+                expect(presenceNode.properties.lastSeenAt).toBe('2026-06-04T00:00:00.000Z');
+                expect(presenceNode.properties.freshUntil).toBe('2026-06-04T00:05:00.000Z');
+                expect(presenceNode.properties.expiresAt).toBe('2026-06-04T00:10:00.000Z');
+                expect(presenceNode.properties.capabilities).toEqual(['turn/start']);
+            });
+        });
+
         test('returns existing subscription if it matches template (idempotent)', async () => {
             // Give Alice a template
             GraphService.upsertNode({
@@ -205,6 +254,100 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 expect(second.status).toBe('existing');
                 expect(second.subscriptionId).toBe(first.subscriptionId);
             });
+        });
+
+        test('bootId mismatch plus dead pid retires stale HarnessPresence before upsert (#12422)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            GraphService.upsertNode({
+                id  : 'HARNESS_PRESENCE:@alice:old-boot',
+                type: 'HARNESS_PRESENCE',
+                name: 'HarnessPresence @alice',
+                properties: {
+                    agentIdentity: '@alice',
+                    subscriptionId: 'WAKE_SUB:old',
+                    state        : 'idle',
+                    wakePolicy   : 'immediate',
+                    source       : 'mcp-client',
+                    bootId       : 'old-boot',
+                    pid          : 999999,
+                    lastSeenAt   : '2026-06-04T00:00:00.000Z',
+                    expiresAt    : '2026-06-04T00:10:00.000Z',
+                    status       : 'active'
+                }
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.manage({
+                    action: 'bootstrap',
+                    bootId: 'new-boot',
+                    now   : '2026-06-04T00:01:00.000Z',
+                    pid   : process.pid
+                });
+            });
+
+            const oldPresence = GraphService.db.nodes.get('HARNESS_PRESENCE:@alice:old-boot');
+            const newPresence = GraphService.db.nodes.get('HARNESS_PRESENCE:@alice:new-boot');
+
+            expect(oldPresence.properties.status).toBe('retired');
+            expect(oldPresence.properties.retireReason).toBe('boot-mismatch-pid-dead');
+            expect(newPresence.properties.status).toBe('active');
+        });
+
+        test('TTL backstop retires HarnessPresence even without a pid (#12422)', async () => {
+            GraphService.upsertNode({
+                id: '@alice',
+                type: 'AGENT',
+                name: 'Alice',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: { appName: 'Antigravity' }
+                    }
+                }
+            });
+
+            GraphService.upsertNode({
+                id  : 'HARNESS_PRESENCE:@alice:expired-boot',
+                type: 'HARNESS_PRESENCE',
+                name: 'HarnessPresence @alice',
+                properties: {
+                    agentIdentity: '@alice',
+                    subscriptionId: 'WAKE_SUB:expired',
+                    state        : 'idle',
+                    wakePolicy   : 'immediate',
+                    source       : 'mcp-client',
+                    bootId       : 'expired-boot',
+                    lastSeenAt   : '2026-06-04T00:00:00.000Z',
+                    expiresAt    : '2026-06-04T00:10:00.000Z',
+                    status       : 'active'
+                }
+            });
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.manage({
+                    action: 'bootstrap',
+                    bootId: 'ttl-boot',
+                    now   : '2026-06-04T00:11:00.000Z',
+                    pid   : process.pid
+                });
+            });
+
+            const expiredPresence = GraphService.db.nodes.get('HARNESS_PRESENCE:@alice:expired-boot');
+            expect(expiredPresence.properties.status).toBe('retired');
+            expect(expiredPresence.properties.retireReason).toBe('ttl-expired');
         });
 
         test('recovers template from durable AgentIdentity row when cache is stale', async () => {
@@ -563,6 +706,33 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 harnessTarget: 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'antigravity'}
             })).rejects.toThrow("Invalid appName 'antigravity'. Must be one of: Antigravity, Claude, Codex");
+        });
+    });
+
+    test('subscribe rejects partial generic instance addressing (#12422)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.subscribe({
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName: 'Antigravity',
+                    instanceAddress: '4242'
+                }
+            })).rejects.toThrow('requires both harnessTargetMetadata.instanceAddress and harnessTargetMetadata.addressType');
+        });
+    });
+
+    test('subscribe rejects unknown generic addressType (#12422)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.subscribe({
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName: 'Antigravity',
+                    instanceAddress: 'frontmost',
+                    addressType: 'frontmost'
+                }
+            })).rejects.toThrow("Invalid addressType 'frontmost'. Must be one of: userDataDir, pid, tmuxSession, webhookUrl");
         });
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Resolves #12422
Related: #12416
Related: #12536

Adds the volatile HarnessPresence overlay for bootstrapped wake routes and graduates bridge delivery to the generic `{instanceAddress,addressType}` contract. Targeted bridge wakes now require fresh route-specific presence before immediate delivery, dispatch `userDataDir`, `pid`, `tmuxSession`, and `webhookUrl` address types, and keep legacy `userDataDir` reads only for already-existing subscriptions while new boot envelopes emit the generic pair.

Evidence: L2 (unit-covered boot registry/stale-retire behavior, mock bridge dispatch, and OpenAPI/tool-schema validation) → L2 required (AC1-AC5 are unit-coverable registry/dispatch contract changes). No residuals.

## Deltas from ticket
- Tightened presence lookup to exact subscription rows when a targeted subscription id is available; identity-only fallback remains available only for callers that explicitly ask without a subscription id.
- Kept #12536 as the downstream `resumeHarness` / resume-activate consumer of this substrate instead of folding that consumer path into this PR.
- Removed the transitional `userDataDir` mirror from new boot-envelope output while preserving daemon compatibility for legacy metadata that already carries `userDataDir`.

## Test Evidence
- `node --check ai/mcp/server/shared/services/BootEnvelopeResolver.mjs && node --check ai/services/memory-core/WakeSubscriptionService.mjs && node --check ai/daemons/bridge/queries.mjs && node --check ai/daemons/bridge/daemon.mjs`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/BootEnvelopeResolver.spec.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 116 passed
- `npm run test-unit` — attempted full suite; 2757 passed, 35 failed, 44 did not run, 2 skipped. Failures are outside this branch surface across existing DreamService, lifecycle, KB/memory summarization, portal/news, and grid specs.
- `git diff --check`
- `git diff --cached --check`
- Pre-commit hook passed: check-whitespace, check-shorthand, check-ticket-archaeology.

## Post-Merge Validation
- [ ] Verify a live bridge-daemon targeted wake consumes fresh HarnessPresence in a multi-harness local session after the wake gate is re-enabled.
- [ ] Verify the #12536 `resumeHarness` downstream consumer can reuse the generic address substrate without adding a second resolver mechanism.

## Commit
- `ec987160b` — `feat(memory-core): add harness presence address dispatch (#12422)`