### PR TITLE
docs(ticket-create): require live open-queue sweep (#10646)

### DIFF
--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -15,13 +15,25 @@ Before the duplicate sweep or the Fat-Ticket body: is this the right work — do
 ### 1a. The Content Sweep (Duplicate Detection)
 Verify no equivalent ticket already exists. Redundant tickets pollute the Knowledge Base.
 
+**Live freshness sweep (mandatory):** before any `create_issue` call, read at least the latest 20 open GitHub issues from the live tracker, including issue number, title, author, labels, and URL.
+
+```bash
+gh issue list --state open --limit 20 --json number,title,author,labels,url
+```
+
+An equivalent GitHub Workflow MCP or GitHub API call is acceptable when it returns the same fields. This live sweep is required even when KB and local searches return no duplicates: the most likely active-swarm duplicate can exist on GitHub before Knowledge Base or `resources/content/**` sync has ingested it.
+
+If the live latest-open sweep fails because of sandbox, network, or auth state, retry through the appropriate approved/escalated path. If live GitHub state still cannot be fetched, stop before `create_issue` and report the blocker; do not file from stale-only evidence.
+
+Record the live-open sweep result in the ticket body or creation notes, e.g. `Live latest-open sweep: checked latest 20 open issues at <timestamp>; no equivalent found` or link the existing ticket you found instead of filing a duplicate.
+
 ```
 grep on resources/content/issues/       # active + archived tickets
 grep on resources/content/discussions/   # ideation / brainstorming
 ```
 
-Primary: `ask_knowledge_base(query='...', type='ticket')` — semantic search surfaces conceptual duplicates that grep misses.
-Fallback: `grep` / `query_documents` for exact keyword verification.
+Semantic sweep: `ask_knowledge_base(query='...', type='ticket')` — semantic search surfaces conceptual duplicates that title scanning misses.
+Exact/historical sweep: `grep` / `query_documents` over issues, archived issues, and discussions for exact keyword verification.
 
 If an equivalent ticket exists: do NOT file a duplicate. Either comment on the existing ticket, extend its scope, or reject the new request.
 
@@ -53,7 +65,7 @@ Apply at creation time — not just at intake. Every stage must pass before the 
 
 1. **Premise** — is the stated problem real and reproducible? Has the underlying symptom been independently verified, or is it secondhand?
 2. **Prescription** — is the stated fix the right substrate for the problem, or does it treat a symptom? Could a different layer (config, service, daemon, schema) solve it better?
-   **Verify-Before-Assert Integration:** Before making architectural claims or prescribing solutions in your Fat Ticket body (Stage 2 Prescription), you MUST apply the **Verify-Before-Assert Pre-Flight Check** (`AGENTS.md` §2.3). You cannot assert that a bug exists or a pattern is flawed without empirical confirmation (a falsifying tool call) prior to filing the ticket.
+   **Verify-Before-Assert Integration:** Before making architectural claims or prescribing solutions in your Fat Ticket body (Stage 2 Prescription), you MUST apply the **Verify-Before-Assert Pre-Flight Check** (`AGENTS.md` §verify_before_assert). You cannot assert that a bug exists or a pattern is flawed without empirical confirmation (a falsifying tool call) prior to filing the ticket.
 3. **Substrate** — where does this work belong? Service layer? Build script? CI workflow? Framework core? Documentation? Match the fix to the substrate that owns the concern.
    **Structural Pre-Flight Integration:** when the prescription introduces or relocates a `.mjs` file, the directory choice MUST be validated via `.agents/skills/structural-pre-flight/` before drafting the ticket body. Stage 0 mechanical trigger fires; Stage 1 fast-path handles sibling-pattern matches in 30 seconds; novel directory choices route through full Pre-Flight (ArchitectureOverview.md + ADR consultation). The empirical anchors PR `#11008` (`orchestrator-daemon.mjs` misplaced in `ai/scripts/`) and earlier `bridge-daemon.mjs` demonstrate the cost of skipping this check at ticket-creation time.
 4. **Consumer** — who reads the output of this change? Human developer, agent, Memory Core, Native Edge Graph, Knowledge Base? Different consumers need different shapes (markdown prose vs structured metadata vs MCP payload).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ Before triggering a lifecycle skill, state in your reasoning: *"I will read the 
 - **Sunset Protocol (§a2a_contextual_bridge_protocol):** Before session handover, read `.agents/skills/session-sunset/SKILL.md`. Must explicitly declare `scope: solo-refresh | convergent` to prevent scope contagion. Stale-wake invariant: wake messages in old transcripts are noise.
 - **Visual Verification (§visual_verification_protocol):** Debugging frontend UI/layout.
 - **Authoring Discipline:** Read 1-2 sibling files to lift patterns before writing new classes.
+- **Ticket Creation Freshness:** Before any `create_issue` path, invoke `ticket-create`; its Content Sweep requires live latest-open issue queue evidence in addition to KB/local duplicate checks.
 - **AiConfig (`ai/` config work) (§aiconfig_ssot):** Before working with `AiConfig` inside `ai/` you MUST read **ADR 0019** (`learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md`) — the reactive Provider SSOT. Read resolved leaves at the use site; never re-implement / alias / export / pass-along / mutate / defend against it (⭐ B4 test-mutation of the shared singleton = safety-critical live-DB-bleed).
 - **File Reading Efficiently:** Reading modified files; efficiency patterns.
 - **Verify-Before-Assert (§verify_before_assert):** core-value epistemic-prerequisite; before asserting any factual claim in a public artifact, run the falsifying tool. Tool inventory + empirical anchors (including #11089 self-Drop+Supersede recursion): §anti_hallucination_policy.


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Resolves #10646

Adds a mandatory live latest-open GitHub issue sweep to the ticket-create Content Sweep before any `create_issue` call. The detailed rule lives in the conditional ticket-create workflow payload; `AGENTS.md` gets only a compact lifecycle trigger so future sessions load the heavy rule only when creating tickets.

Evidence: L1 (static substrate diff + agent/skill lints) -> L1 required (ticket-create workflow freshness rule). No residuals.

## Deltas from ticket
- Tightened the ticket premise from a vague recent-ticket check into a concrete latest-20 open issue queue read with number, title, author, labels, and URL fields.
- Kept KB/local duplicate detection intact and made the live sweep additive rather than a replacement.
- Added failure handling: if live GitHub state cannot be fetched after the appropriate retry/escalation path, stop before `create_issue`.
- Added a one-line `AGENTS.md` trigger and repaired the stale `AGENTS.md` section reference surfaced by skill-manifest lint.

## Contract Ledger
Source-ticket Contract Ledger addendum posted: https://github.com/neomjs/neo/issues/10646#issuecomment-4627058284

## Turn-Memory Pre-Flight / Slot Rationale
- `AGENTS.md` trigger line: disposition `compress-to-trigger`; trigger-frequency = ticket-creation lifecycle only; failure-severity = high because duplicate tickets pollute KB/queue state; enforceability = discipline plus workflow/lint support. Load effect is one always-loaded line, with the rule body kept out of the per-turn Map.
- `.agents/skills/ticket-create/references/ticket-create-workflow.md` Content Sweep expansion: disposition `keep` in conditional World-Atlas payload; trigger-frequency = every ticket-create skill invocation; failure-severity = high; enforceability = discipline now, candidate for future mechanical lint once ticket-body evidence parsing exists.
- Decision Record impact: none; this is workflow freshness discipline, not an ADR-level architecture change.

## Test Evidence
- `git diff --check`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `node ai/scripts/lint/lint-agents.mjs --base origin/dev`
- `git diff --cached --check`
- `node ./buildScripts/util/check-whitespace.mjs` via lint-staged pre-commit hook

## Post-Merge Validation
- [ ] First agent-created ticket after merge records live latest-open sweep evidence in the ticket body or creation notes.

## Commits
- `d4961751d` — `docs(ticket-create): require live open-queue sweep (#10646)`