### PR TITLE
fix(ai): drop orphaned backupRetention config leaf (#12545)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -262,18 +262,6 @@ class Config extends BaseConfig {
                 minSourceLength: leaf(200, 'NEO_CONCEPT_DISCOVERY_MIN_SOURCE_LENGTH', 'number')
             },
             /**
-             * Bundle retention policy for `ai/scripts/maintenance/backup.mjs`. Bundles older
-             * than `maxDays` are eligible for deletion, but the newest `keepMinimum` bundles
-             * are retained unconditionally regardless of age. Defaults preserve the historical
-             * `K=3, N_DAYS=30` behavior so existing deployments are unaffected without
-             * operator action.
-             * @type {{keepMinimum: number, maxDays: number}}
-             */
-            backupRetention: leaf({
-                keepMinimum: 3,
-                maxDays    : 30
-            }),
-            /**
              * Directory for the always-on Memory Core diagnostic log files. The MC server's
              * `logger.mjs` writes daily-rotated entries here regardless of `debug`, so long-
              * running operations (summarization, ingestion sweeps, ChromaDB lifecycle) leave

--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -207,8 +207,8 @@ export async function runBackup({
 
     logger.log('[7/7] Applying retention sweep...');
     await loadTopLevelAiConfig();
-    // Operator-configurable retention comes from Tier-1 AI maintenance policy when
-    // available. Missing keys fall through to Memory Core config/defaults.
+    // Retention comes from Tier-1 AI maintenance policy; missing keys fail loud
+    // at the direct resolved-leaf read site.
     await cleanOldBackups(DEFAULT_BACKUP_ROOT, logger, resolveBackupRetention());
 
     logger.log('Verifying bundle integrity (row-count parity)...');

--- a/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs
@@ -27,9 +27,9 @@ import path           from 'path';
  *   - `keepMinimum` — newest N bundles retained unconditionally
  *   - `maxDays`     — bundles older than N days are eligible for deletion
  *
- * Default values (`K=3, N_DAYS=30`) match the previous hardcoded constants
- * (byte-equivalence anchor — deployments without `backupRetention`
- * config behave identically).
+ * Default values (`K=3, N_DAYS=30`) are now owned by the top-level
+ * `aiConfig.maintenance.backup.retention` subtree and match the previous
+ * hardcoded constants.
  */
 // Serial mode: this spec exercises a shared `cleanOldBackups` import + tmp filesystem
 // state. Running serially within the file avoids cross-test parallel-worker contention
@@ -162,7 +162,7 @@ test.describe('cleanOldBackups — configurable retention', () => {
         expect(remaining).toHaveLength(24);
     });
 
-    test('missing retention config (undefined) falls through to defaults — preserves zero-config deployments', async () => {
+    test('missing cleanOldBackups retention argument uses function defaults', async () => {
         await seedBackup(1);
         await seedBackup(40);
         await seedBackup(60);
@@ -170,11 +170,12 @@ test.describe('cleanOldBackups — configurable retention', () => {
         await cleanOldBackups(tmpRoot, {log: () => {}}, undefined);
 
         const remaining = await listBackups();
-        // K=3 default — all 3 backups retained unconditionally despite 40d + 60d being >30d
+        // Function-level K=3 default — all 3 backups retained unconditionally despite
+        // 40d + 60d being >30d.
         expect(remaining).toHaveLength(3);
     });
 
-    test('empty retention config object ({}) falls through to defaults', async () => {
+    test('empty cleanOldBackups retention object uses property defaults', async () => {
         await seedBackup(1);
         await seedBackup(40);
         await seedBackup(60);


### PR DESCRIPTION
Authored by GPT-5 (Codex). Session 019e9274-0ecf-7d91-9fc3-b3e3fe64bb85.

Resolves #12545
Related: #12461

Removes the stale Memory Core `backupRetention` template leaf after maintenance backup retention moved to `aiConfig.maintenance.backup.retention`. Updates runtime and test commentary so operator-facing source no longer suggests ignored `memoryCoreConfig.backupRetention` controls bundle retention.

Evidence: L1 (static config-shape audit + focused unit/lint verification) -> L1 required (config leaf removal, commentary cleanup, focused tests, SSOT lint). No residuals.

## Deltas from ticket
- `ai/mcp/server/memory-core/config.mjs` is a gitignored local operator overlay; per MCP config-template workflow, I did not commit it. The checked-out local overlay was updated for runtime verification, while tracked source changes the SSOT `config.template.mjs`.
- No fallback, alias, or migration shim added.

## Config Template Sync
- Changed key: removed `memoryCore.data.backupRetention` from `ai/mcp/server/memory-core/config.template.mjs`.
- Local `config.mjs` follow-up: existing clones with pre-generated `ai/mcp/server/memory-core/config.mjs` may still contain the dead local key until refreshed. It is no longer read by backup retention; run `npm run prepare -- --migrate-config` or manually remove the key after merge if clone-shape hygiene matters.
- Harness restart: unnecessary for this PR because no live Memory Core runtime reader consumes the removed key.

## Test Evidence
- `node --check ai/scripts/maintenance/backup.mjs`
- `node --check ai/mcp/server/memory-core/config.mjs`
- `node --check ai/mcp/server/memory-core/config.template.mjs`
- `node --check test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs`
- `rg -n "backupRetention|memoryCoreConfig\.backupRetention|zero-config deployments|falls through to Memory Core" ai/scripts/maintenance/backup.mjs ai/mcp/server/memory-core/config.mjs ai/mcp/server/memory-core/config.template.mjs test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs learn --glob "!resources/content/**"` returned no matches
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backup-retention.spec.mjs` — 14 passed
- `npm run ai:lint-config-template-ssot` — OK
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation
- [ ] Fresh clone/server config materialization no longer advertises `memoryCore.data.backupRetention`.
- [ ] Existing local clones can remove the stale gitignored config key or run `npm run prepare -- --migrate-config` when convenient.

## Commit
- `2616a1a00` — `fix(ai): drop orphaned backupRetention config leaf (#12545)`