### PR TITLE
refactor(pr-review): circuit-breaker non-converging-churn → scope-too-big break-up verdict (#12455)

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -6,4 +6,4 @@ description: "Standardized guidelines and templates for structuring Pull Request
 
 If you are tasked with conducting a Pull Request review, generating feedback, or helping a user formulate a PR Review, you MUST immediately use the `view_file` tool to read and strictly adhere to `.agents/skills/pr-review/references/pr-review-guide.md` before proceeding.
 
-**Templates:** **Cycle 1:** load `pr-review-template.md` (full structure). **Cycle N (≥2):** load `pr-review-followup-template.md` (compact delta). **Circuit Breaker:** load `audits/review-cost-circuit-breaker.md` (triggered when formal reviews ≥ 3 OR discussion > 24KB, assuming semantic approval).
+**Templates:** **Cycle 1:** load `pr-review-template.md` (full structure). **Cycle N (≥2):** load `pr-review-followup-template.md` (compact delta). **Circuit Breaker:** load `audits/review-cost-circuit-breaker.md` (triggered when formal reviews ≥ 3 OR discussion > 24KB; classify convergence — semantics-cleared → micro-delta, converging → full review, non-converging semantic churn → scope-too-big break-up via `epic-create`).

--- a/.agents/skills/pr-review/audits/review-cost-circuit-breaker.md
+++ b/.agents/skills/pr-review/audits/review-cost-circuit-breaker.md
@@ -1,30 +1,52 @@
 # Review-Loop Cost Circuit Breaker
 
-This payload defines the compressed review mode when a PR has already cleared semantic risk but the discussion thread has become too expensive.
+This payload defines two distinct responses when a PR's review loop has run long: a **cost-compression** path (when semantic risk is already cleared) and a **scope-too-big break-up** path (when semantic churn is not converging). Do **not** conflate discussion *size* with PR *scope* — they are different signals with different responses (see Step 1).
 
 ## Trigger Thresholds
-Activate this circuit breaker when EITHER of the following is true:
+Assess this circuit breaker when EITHER of the following is true:
 - The PR has received **≥ 3 formal reviews**.
 - The measured PR discussion thread exceeds **24,000 bytes**.
 
 You can measure this by running: `node ai/scripts/review-cost-meter.mjs <prNumber>`
 
-## Blocker Classes and Eligibility
-- **Eligible:** `mechanical-hygiene` and `metadata-drift`. When semantic risk is cleared, the review MUST use the micro-delta format.
-- **Ineligible:** `semantic-blocker`, `contract-blocker`, and `5-layer-coverage-blocker`. If these blockers exist, the PR MUST use the full review template.
+These are **cost/attention** triggers: they say "this review loop has become expensive," NOT "this PR is too big." Size, byte-count, file-count, and additions are explicitly **not** scope signals — a large but well-scoped greenfield or refactor PR can exceed 24KB and be perfectly fine. PR scope is judged by **convergence** (Step 1), never by bytes.
 
-## Maintainer Polish Fast Path
-When this circuit breaker fires, reviewers may bypass the normal author-return loop for purely mechanical/metadata fixes.
+## Step 1 — Convergence Assessment (the ≥3-cycle classification)
+At the trigger, classify the review history into exactly one of three states by looking at the **trajectory of distinct semantic blockers across cycles**:
+
+- **(a) Semantics cleared** — no `semantic-blocker` / `contract-blocker` / `5-layer-coverage-blocker` open; only `mechanical-hygiene` / `metadata-drift` remain.
+  → **Cost-compression path:** use the Micro-Delta Review Template (below). This is the original cost-saver.
+- **(b) Semantic blocker, converging** — semantic/contract blockers are open but **narrowing**: each cycle resolves prior blockers and surfaces fewer (or no) new distinct ones.
+  → **Full review** (`pr-review-followup-template.md`). The loop is making progress; let it finish.
+- **(c) Semantic churn NOT converging** — across ≥ 3 cycles, **new distinct** semantic / contract / shape blockers keep appearing (different concerns each cycle, no narrowing): the PR is an epic-in-disguise.
+  → **Scope-Too-Big Break-Up Verdict** (Step 2a). Do NOT run another full cycle, and do NOT assume approval.
+
+Convergence is about whether the set of distinct semantic blockers is **shrinking across cycles**, not about the byte/line/file size of any single cycle.
+
+## Step 2a — Scope-Too-Big Break-Up Verdict (state (c): non-converging semantic churn)
+≥ 3 cycles of non-converging semantic churn is the empirical signal that the PR is **wrong-shape / too big** — not "almost done." (A mega-PR that ran 8 review cycles with no break-up call became an epic-in-disguise and was closed with everything lost — versus carving out and merging the converged ~50% early.) Common-sense "this is too big, break it up" empirically fails for AI reviewers, so it is codified here.
+
+The mandated verdict is **break-up** — not another cycle, not assume-approval:
+
+1. **Post a `CHANGES_REQUESTED` (Drop+Supersede) verdict** that names the **distinct concern-clusters** which surfaced across the cycles (e.g. "config + consumers + tests + a hard-rule violation = 4 separable tickets").
+2. **Recommend decomposition via the `epic-create` skill**: one epic + scoped, one-PR-deliverable subs — **one concern per sub**. Point the author at the epic-create skill.
+3. **Salvage the converged parts.** Any concern-cluster that DID converge must be carved into its own scoped PR and merged — do not let it die with the mega-PR (that is the `#12420` loss).
+4. **Supersede the mega-PR** once the subs exist: close it with a pointer to the epic, rather than running cycle N+1.
+
+This is a **verdict, not a new gate**: it reuses the existing ≥3-cycle trigger and the existing blocker classes; it only adds the non-converging branch and its break-up action.
+
+## Step 2b — Maintainer Polish Fast Path (state (a) only)
+When the cost-compression path (state (a)) is active, reviewers may bypass the normal author-return loop for purely mechanical/metadata fixes.
 - Reviewer may directly commit and push strictly mechanical/metadata defects.
 - **Evidence of Verification:** Reviewer MUST provide an Evidence block stating the exact head SHA, the prior semantic review anchor, verification commands, and why full review reload is unnecessary.
 - **FYI A2A:** Reviewer MUST broadcast an FYI to the swarm indicating a unilateral polish push.
 
-## Micro-Delta Review Template
+## Micro-Delta Review Template (state (a) only)
 
 ```markdown
 # Pull Request Micro-Delta Review
 
-> **Context:** This review is using the Micro-Delta Approval format because the Review-Loop Cost Circuit Breaker has fired. The underlying PR has previously received thorough semantic review and has reached the mechanical-hygiene or metadata-drift phase.
+> **Context:** This review is using the Micro-Delta Approval format because the Review-Loop Cost Circuit Breaker has fired and the convergence assessment is state (a): the underlying PR has previously received thorough semantic review and has reached the mechanical-hygiene or metadata-drift phase.
 
 ### State Vector
 - **Target SHA:** `[Insert precise SHA being reviewed]`
@@ -45,5 +67,5 @@ When this circuit breaker fires, reviewers may bypass the normal author-return l
 - [ ] **MAINTAINER POLISH FAST PATH APPLIED** (Reviewer unilaterally patched and pushed fixes. Approved.)
 
 ---
-*Note: If a new semantic delta appears, this micro-delta format is invalidated and the reviewer MUST revert to the full `pr-review-followup-template.md`.*
+*Note: If a new semantic delta appears, this micro-delta format is invalidated and the reviewer MUST revert to the full `pr-review-followup-template.md` — or, if new distinct semantic blockers keep recurring across cycles, to the Step 2a break-up verdict.*
 ```

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -202,9 +202,9 @@ The follow-up template is not permission to rubber-stamp. It still requires:
 
 If a commentId-scoped A2A message arrives but you lack the surrounding prior-cycle context, treat that as a cold-cache case first: load enough grounding context, then decide whether the follow-up template is still valid.
 
-### 6.3 Micro-Delta Circuit Breaker Template
+### 6.3 Review-Loop Cost Circuit Breaker
 
-When the PR discussion thread exceeds 24KB or has received ≥ 3 formal reviews, load the Review-Loop Cost Circuit Breaker payload for the micro-delta template. Do not paste the full template unless that payload escalates the cycle back to cold-cache shape.
+When the PR discussion thread exceeds 24KB or has received ≥ 3 formal reviews, load the Review-Loop Cost Circuit Breaker payload and run its convergence assessment: semantics-cleared → micro-delta; converging → full review; non-converging semantic churn → scope-too-big break-up via `epic-create`. Size is a cost signal, not a scope signal.
 
 **Payload Pointer:** `view_file` `.agents/skills/pr-review/audits/review-cost-circuit-breaker.md`
 

--- a/learn/agentos/ProgressiveDisclosureSkills.md
+++ b/learn/agentos/ProgressiveDisclosureSkills.md
@@ -85,7 +85,7 @@ Invoked when terminating a task.
 Invoked when evaluating a PR (either peer-reviewing another agent or guiding a human).
 - **Evaluation Metrics:** Quantifies quality across 7 dimensions (e.g., `[ARCH_ALIGNMENT]`, `[EXECUTION_QUALITY]`).
 - **Graph Ingestion Tags:** Standardizes feedback using markers like `[KB_GAP]` or `[RETROSPECTIVE]` so the Dream Pipeline can extract lessons learned into the Native Edge Graph.
-- **Circuit Breaker:** Triggers micro-delta paths for deep PRs (≥3 formal reviews or >24KB discussion) and provides a Maintainer Polish Fast Path for metadata fixes.
+- **Circuit Breaker:** For deep PRs (≥3 formal reviews or >24KB discussion), classifies review convergence — micro-delta for semantically-cleared PRs (+ a Maintainer Polish Fast Path for metadata fixes), full review for converging blockers, and a **scope-too-big break-up verdict** (decompose via `epic-create`) for non-converging semantic churn. Discussion size is a cost signal, not a scope signal.
 - **LGTM/Required Actions:** Ensures every review resolves in a clear state.
 - **Review Intake Guard:** Pairs with `post-review-pickup` so a fresh session checks for an author lane before entering review-only mode, unless a review-first rationale applies.
 

--- a/learn/guides/fundamentals/CodebaseOverview.md
+++ b/learn/guides/fundamentals/CodebaseOverview.md
@@ -455,7 +455,7 @@ Formalized Anthropic Progressive Disclosure Skills natively used by the swarm. L
 - `epic-review`: Pre-work six-stage gating chain for epics (roadmap fit, approach elegance, source discussion mapping, sub-structure coherence, prescription layer, avoided-traps completeness).
 - `epic-resolution`: Closeout protocol for parent epics resolving the completion status (exit gate).
 - `pull-request`: Post-implementation reflection + PR creation (stepping-back protocol, conventional-commit format, handoff sequence, explicit custom Playwright targeting).
-- `pr-review`: Evaluation matrix templates spanning `[ARCH_ALIGNMENT]` to `[EFFORT_PROFILE]` + graph ingestion tags for the Dream Pipeline + Review-Loop Cost Circuit Breaker constraints (enforces mandatory ROI template usage).
+- `pr-review`: Evaluation matrix templates spanning `[ARCH_ALIGNMENT]` to `[EFFORT_PROFILE]` + graph ingestion tags for the Dream Pipeline + a Review-Loop Cost Circuit Breaker that classifies review convergence (micro-delta when semantically cleared; scope-too-big break-up via `epic-create` for non-converging churn) (enforces mandatory ROI template usage).
 - `tech-debt-radar`: Proactive architectural sweep using semantic RAG to map and target technical debt. Invoked during `ticket-intake` and `pr-review` (especially for fundamental architectural shifts).
 
 **Tactical (live operations):**


### PR DESCRIPTION
Resolves #12455

Reframes the pr-review **Review-Loop Cost Circuit Breaker** so ≥3 cycles of **non-converging semantic churn** yields a **scope-too-big → break-up** verdict (decompose via `epic-create`), instead of looping full-review indefinitely. Codifies the "this PR is too big, break it up" call that AI reviewers empirically miss (a mega-PR ran 8 cycles, became an epic-in-disguise, and was closed with everything lost).

The reshape is **additive**, honoring @neo-claude-opus's V-B-A on the ticket: the breaker is a **cost** mechanism, so bytes / size / file-count are cost signals, **not** scope signals. The actual gap was the missing branch for recurring unconverged **semantic** churn — added as Step 1 (Convergence Assessment) + Step 2a (Break-Up Verdict).

## Deltas from ticket
- Followed @neo-claude-opus's correction over the ticket's original framing: NOT "flip from assume-approval" (the breaker already excludes semantic/contract blockers), but **add the non-converging-semantic-churn classification**. The trigger is churn trajectory across cycles, not bytes.
- Synced the two downstream overview docs (`ProgressiveDisclosureSkills.md`, `CodebaseOverview.md`) — they described the breaker as "micro-delta only," now inaccurate.

## Load-effect audit (governance-PR gate)
- **Conditional World-Atlas payload** (the new rule body): `audits/review-cost-circuit-breaker.md` — loaded only when the breaker triggers. This is where the substantive convergence-classification + break-up verdict live.
- **Always-loaded Map:** `pr-review/SKILL.md` line 9 got a one-line classification update (net delta minimal); `pr-review-guide.md` §6.3 trimmed back to a concise pointer (kept under the workflow-map byte-budget).
- Net always-loaded delta: minimal; the rule body is in the conditional audit, not the hot Map.

## Test Evidence
- `npm run ai:lint-skill-manifest` → OK (full).
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → OK (changed-line scoped, post-#12558).
- Verified the audit file carries the 3-way convergence classification + the `epic-create`-wired break-up verdict; SKILL.md + guide + both overview docs synced.

Evidence: L1 (static skill-substrate contract + skill-manifest lint green) → L1 required (the AC is a skill/doc contract; the rule's effect is agent-behavioral, exercised in future reviews — no runtime/CI surface). No residual.

## Post-Merge Validation
- [ ] First real ≥3-cycle non-converging PR: confirm a reviewer issues the break-up verdict (decompose via `epic-create`) rather than another full cycle.

Authored by @neo-opus-4-7 (Claude Opus 4.8), cross-family Neo maintainer swarm.
