### PR TITLE
refactor(ai): read Memory Core path leaves directly (#12438)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -31,6 +31,7 @@ import Neo             from '../../../src/Neo.mjs';
 import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
 import AiConfig        from '../../config.mjs';
+import memoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
 
 import fs from 'fs-extra';
 import path from 'path';
@@ -53,8 +54,8 @@ import {
 import {applyHarnessMetadataDefaults} from '../../scripts/lifecycle/harnessRouting.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
-const DB_PATH                  = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
-const DAEMON_DATA_DIR          = process.env.NEO_AI_DAEMON_DIR || '.neo-ai-data/wake-daemon';
+const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
+const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
 const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');
 const LOG_FILE                 = path.join(DAEMON_DATA_DIR, 'bridge.log');
 const LOG_RETENTION_DAYS       = 30;

--- a/ai/scripts/diagnostics/analyzeNlTelemetry.mjs
+++ b/ai/scripts/diagnostics/analyzeNlTelemetry.mjs
@@ -20,7 +20,8 @@ const __dirname = path.dirname(__filename);
 const ROOT_DIR = path.resolve(__dirname, '../../../');
 import aiConfig from '../../mcp/server/memory-core/config.mjs';
 
-const DB_PATH = process.env.NEO_MEMORY_DB_PATH || aiConfig.storagePaths.graph;
+// The Memory Core config leaf owns the NEO_MEMORY_DB_PATH env override.
+const DB_PATH = aiConfig.storagePaths.graph;
 const RLAIF_PATH = aiConfig.datasets.rlaif.trajectories;
 
 const sessionId = process.argv[2];

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -19,14 +19,15 @@ import {readRecentRemRunStates} from './helpers/RemRunStateStore.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Heartbeat-liveness file path resolution. Mirrors `wakeSafetyGate.gateFilePath()` env-override
- * pattern so parallel test specs can isolate from the canonical on-disk path. Production
- * deployments leave `NEO_HEARTBEAT_ALIVE_PATH` unset; the canonical path under `.neo-ai-data/wake-daemon/`
- * applies. Counterpart producer: `SwarmHeartbeatService.touchLivenessFile()`, called once per
- * `pulse()` by the Orchestrator's swarm-heartbeat lane.
+ * @summary Heartbeat-liveness file path resolution shared with `SwarmHeartbeatService`.
+ *
+ * The Tier-1 config leaf owns `NEO_HEARTBEAT_ALIVE_PATH` env resolution, keeping the
+ * producer and consumer on one resolved path.
+ *
+ * @returns {String}
  */
-function heartbeatAlivePath() {
-    return process.env.NEO_HEARTBEAT_ALIVE_PATH || path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon/heartbeat.alive');
+export function heartbeatAlivePath() {
+    return aiConfig.wakeDaemonHeartbeatAlivePath;
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -122,6 +122,7 @@ test.describe('Bridge Daemon', () => {
         if (fs.existsSync(DB_PATH)) fs.unlinkSync(DB_PATH);
         if (fs.existsSync(`${DB_PATH}-wal`)) fs.unlinkSync(`${DB_PATH}-wal`);
         if (fs.existsSync(`${DB_PATH}-shm`)) fs.unlinkSync(`${DB_PATH}-shm`);
+        process.env.NEO_MEMORY_DB_PATH_TEST = DB_PATH;
 
         db = new Database(DB_PATH);
         db.pragma('journal_mode = WAL');
@@ -163,6 +164,7 @@ test.describe('Bridge Daemon', () => {
         if (fs.existsSync(`${DB_PATH}-wal`)) fs.unlinkSync(`${DB_PATH}-wal`);
         if (fs.existsSync(`${DB_PATH}-shm`)) fs.unlinkSync(`${DB_PATH}-shm`);
         fs.removeSync(DAEMON_DIR);
+        delete process.env.NEO_MEMORY_DB_PATH_TEST;
     });
 
     test('detects and delivers wake events via test adapter', async () => {
@@ -195,7 +197,7 @@ test.describe('Bridge Daemon', () => {
         // Start the daemon with environment overrides
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -286,7 +288,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -343,7 +345,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -400,7 +402,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let deliveryCount = 0;
@@ -476,7 +478,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let deliveryCount = 0;
@@ -570,7 +572,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -668,7 +670,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const errorLogPromise = new Promise((resolve, reject) => {
@@ -747,7 +749,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         // We know bridge-daemon will log INFO when it finishes osascript
@@ -836,7 +838,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -936,7 +938,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -991,7 +993,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const refusalPromise = new Promise((resolve, reject) => {
@@ -1042,7 +1044,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1099,7 +1101,7 @@ test.describe('Bridge Daemon', () => {
 
                 daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
                     stdio: 'pipe',
-                    env: { ...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+                    env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
                 });
 
                 setTimeout(() => insertMessageWake(db, {agentId, subject: 'Webhook Address Wake'}), 1000);
@@ -1179,7 +1181,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         // Wait for the fail-closed warning log line (proxy for the deliver-or-refuse decision).
@@ -1272,7 +1274,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1444,7 +1446,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env  : {...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+            env  : {...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
         });
 
         let senderDeliveryCount = 0;
@@ -1515,7 +1517,7 @@ test.describe('Bridge Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
             stdio: 'pipe',
-            env  : {...process.env, NEO_AI_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+            env  : {...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {

--- a/test/playwright/unit/ai/scripts/diagnostics/analyzeNlTelemetry.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/analyzeNlTelemetry.spec.mjs
@@ -91,7 +91,7 @@ test.describe('Neo.ai.scripts.analyzeNlTelemetry', () => {
     test('should extract Neural Link trajectories without mutating physical databases', () => {
         const env = {
             ...process.env,
-            NEO_MEMORY_DB_PATH: testDbPath,
+            NEO_MEMORY_DB_PATH_TEST: testDbPath,
             NEO_RLAIF_PATH: testRlaifPath
         };
 
@@ -104,7 +104,7 @@ test.describe('Neo.ai.scripts.analyzeNlTelemetry', () => {
     test('should gracefully exit if no trajectories are found', () => {
         const env = {
             ...process.env,
-            NEO_MEMORY_DB_PATH: testDbPath,
+            NEO_MEMORY_DB_PATH_TEST: testDbPath,
             NEO_RLAIF_PATH: testRlaifPath
         };
 
@@ -115,7 +115,7 @@ test.describe('Neo.ai.scripts.analyzeNlTelemetry', () => {
     test('should save to custom RLAIF path when --save is provided', () => {
         const env = {
             ...process.env,
-            NEO_MEMORY_DB_PATH: testDbPath,
+            NEO_MEMORY_DB_PATH_TEST: testDbPath,
             NEO_RLAIF_PATH: testRlaifPath
         };
 
@@ -141,5 +141,13 @@ test.describe('Neo.ai.scripts.analyzeNlTelemetry', () => {
         expect(maintenanceSource).toContain('aiConfig.storagePaths.graph');
         expect(diagnosticsSource).not.toContain(retiredPath);
         expect(maintenanceSource).not.toContain(retiredPath);
+    });
+
+    test('reads the resolved Memory Core graph leaf without a duplicate env fallback (#12438)', () => {
+        const diagnosticsSource = fs.readFileSync(scriptPath, 'utf8');
+
+        expect(diagnosticsSource).toContain('const DB_PATH = aiConfig.storagePaths.graph;');
+        expect(diagnosticsSource).not.toContain('process.env.NEO_MEMORY_DB_PATH ||');
+        expect(diagnosticsSource).not.toContain('process.env.NEO_MEMORY_DB_PATH ??');
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -17,6 +17,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+import AiConfig        from '../../../../../../ai/config.mjs';
 import ChromaManager   from '../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
 import StorageRouter   from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import ChromaLifecycleService from '../../../../../../ai/services/memory-core/lifecycle/ChromaLifecycleService.mjs';
@@ -1028,19 +1029,22 @@ test.describe('HealthService #10844 — buildBackupStateBlock', () => {
  * missing / malformed) × (liveness-file: fresh / stalled / missing) per AC5, plus the fully-degraded
  * defensive case.
  *
- * Test isolation: each test writes to a unique temp directory + sets `WAKE_GATE_FILE_PATH` and
- * `NEO_HEARTBEAT_ALIVE_PATH` env vars before importing the block; restores after. Mirrors the
- * `wakeSafetyGate` env-override pattern.
+ * Test isolation: each test writes to a unique temp directory, points `WAKE_GATE_FILE_PATH`
+ * at that fixture, and applies `NEO_HEARTBEAT_ALIVE_PATH` through the AiConfig env-override seam.
  *
  * @see Neo.ai.services.memory-core.HealthService#buildWakeFeaturesBlock
  */
 test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     let buildWakeFeaturesBlock;
+    let heartbeatAlivePath;
+    let originalHeartbeatAlivePath;
     let tmpDir;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
         buildWakeFeaturesBlock = mod.buildWakeFeaturesBlock;
+        heartbeatAlivePath     = mod.heartbeatAlivePath;
+        originalHeartbeatAlivePath = AiConfig.wakeDaemonHeartbeatAlivePath;
 
         const os   = await import('os');
         const path = await import('path');
@@ -1062,6 +1066,7 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
 
         process.env.WAKE_GATE_FILE_PATH      = path.join(tmpDir, `gate-${Date.now()}.json`);
         process.env.NEO_HEARTBEAT_ALIVE_PATH = path.join(tmpDir, `alive-${Date.now()}`);
+        AiConfig.setEnvOverride('NEO_HEARTBEAT_ALIVE_PATH', process.env.NEO_HEARTBEAT_ALIVE_PATH);
 
         // Ensure clean slate between tests (no carryover from prior writes)
         await fs.rm(process.env.WAKE_GATE_FILE_PATH,      {force: true}).catch(() => {});
@@ -1071,6 +1076,17 @@ test.describe('HealthService #10783 — buildWakeFeaturesBlock', () => {
     test.afterEach(() => {
         delete process.env.WAKE_GATE_FILE_PATH;
         delete process.env.NEO_HEARTBEAT_ALIVE_PATH;
+        AiConfig.setEnvOverride('NEO_HEARTBEAT_ALIVE_PATH', originalHeartbeatAlivePath);
+    });
+
+    test('heartbeatAlivePath() reads the resolved AiConfig leaf (#12438)', async () => {
+        const path = await import('path');
+        const overridePath = path.join(tmpDir, `alive-helper-${Date.now()}`);
+
+        AiConfig.setEnvOverride('NEO_HEARTBEAT_ALIVE_PATH', overridePath);
+
+        expect(heartbeatAlivePath()).toBe(AiConfig.wakeDaemonHeartbeatAlivePath);
+        expect(heartbeatAlivePath()).toBe(overridePath);
     });
 
     test('gate enabled + liveness fresh → daemonRunning true, gateState enabled', async () => {


### PR DESCRIPTION
Resolves #12438

Authored by GPT-5.5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Removes importable Memory Core path fallback re-derivations across the bridge daemon, Memory Core healthcheck wake liveness consumer, and NL telemetry diagnostic script. These consumers now read existing AiConfig / Memory Core config leaves directly, keeping env ownership in `leaf(...)` and preserving unit-mode DB isolation through `NEO_MEMORY_DB_PATH_TEST`.

Evidence: L2 (focused unit subprocess coverage + source invariants + residue grep) → L2 required (config leaf consumption and daemon delivery contract). No residuals for #12438.

## Deltas from ticket

- Re-scoped #12438 in place from an audit-wide tracker to the deliverable importable-consumer cluster. This avoids repeating the rejected #12464 one-line micro-split while keeping parent Epic #12456 responsible for remaining non-entrypoint / pure-default surfaces.
- Replaced the bridge daemon's stale `NEO_AI_DB_PATH` alias with the canonical Memory Core graph leaf. `NEO_AI_DAEMON_DIR` remains supported through `memoryCoreConfig.wakeDaemon.dataDir`.
- Left `TaskDefinitions.mjs`, orchestrator bootstrap defaults, lifecycle local state files, #12417, and #12461/B3 out of scope by design.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs` → 20 passed. Final run executed outside the sandbox because the webhook test binds `127.0.0.1`; the sandbox-only run had 19 passed + 1 `listen EPERM` sandbox failure, and the exact webhook test passed when rerun unsandboxed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` → 54 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/analyzeNlTelemetry.spec.mjs` → 5 passed.
- `git diff --check` → clean.
- Production residue check: no matches for direct `process.env.NEO_AI_DB_PATH`, `process.env.NEO_MEMORY_DB_PATH ||/??`, or `process.env.NEO_HEARTBEAT_ALIVE_PATH ||/??` in the three changed production consumers.

## Post-Merge Validation

- [ ] Operator custom wake-daemon runs still honor `NEO_AI_DAEMON_DIR` via the Memory Core config leaf.

## Commits

- `70d4d936d` — `refactor(ai): read Memory Core path leaves directly (#12438)`
