### PR TITLE
refactor(ai): rename BaseConfig to ConfigProvider (#12452)

### DIFF
--- a/ai/ConfigProvider.mjs
+++ b/ai/ConfigProvider.mjs
@@ -5,8 +5,8 @@ import Env      from '../src/util/Env.mjs';
 
 /**
  * Maps a {@link leaf} `type` token to the name-based `Neo.util.Env` parser that decodes its env
- * var. Reuses the Tier-1 Env primitive (Epic #12101 AC-Epic-1: extend, don't reinvent — no
- * parallel parser set).
+ * var. Reuses the Tier-1 Env primitive: extend the shared parser set, don't introduce a parallel
+ * parser set.
  * @type {Object<String,Function>}
  */
 const typeParsers = {
@@ -66,7 +66,7 @@ export function leaf(defaultValue, env = null, type = null) {
 }
 
 /**
- * @summary Reactive base configuration manager for Neo MCP servers.
+ * @summary Reactive configuration Provider for Neo MCP servers.
  *
  * Extends the Body-tier reactive state Provider. A subclass assigns its meta-leaf tree to the
  * inherited `data` config — each leaf is `{env?, default, parse?, type?}`, typically produced by
@@ -87,17 +87,17 @@ export function leaf(defaultValue, env = null, type = null) {
  * child* of its template, never a clone, and bringing it up to a newer template is inheritance, not
  * a source-level merge.
  *
- * @class Neo.ai.BaseConfig
+ * @class Neo.ai.ConfigProvider
  * @extends Neo.state.Provider
  * @see learn/agentos/AiConfigModel.md — the hierarchical-nested-data model + its rationale
  */
-class BaseConfig extends Provider {
+class ConfigProvider extends Provider {
     static config = {
         /**
-         * @member {String} className='Neo.ai.BaseConfig'
+         * @member {String} className='Neo.ai.ConfigProvider'
          * @protected
          */
-        className: 'Neo.ai.BaseConfig'
+        className: 'Neo.ai.ConfigProvider'
     }
 
     /**
@@ -177,7 +177,7 @@ class BaseConfig extends Provider {
             return
         }
 
-        const {plainData, registry} = BaseConfig.compileMetaLeaves(value);
+        const {plainData, registry} = ConfigProvider.compileMetaLeaves(value);
 
         this.#leafMetadataRegistry = registry;
         super.afterSetData(plainData, oldValue);
@@ -244,7 +244,7 @@ class BaseConfig extends Provider {
             const validator = typeValidators[meta.type];
 
             if (validator && !validator(value)) {
-                console.warn(`[Neo.ai.BaseConfig] "${leafPath}" expected ${meta.type}, got ${Neo.typeOf(value)}; keeping value.`)
+                console.warn(`[Neo.ai.ConfigProvider] "${leafPath}" expected ${meta.type}, got ${Neo.typeOf(value)}; keeping value.`)
             }
         }
 
@@ -277,7 +277,7 @@ class BaseConfig extends Provider {
      * {@link Neo.state.Provider#getOwnerOfDataProperty}. A cross-tier write — a child writing a
      * Tier-1-owned leaf — is therefore validated against the parent's metadata instead of bypassing
      * validation on both tiers. The `#leafMetadataRegistry in owner` brand check guards
-     * the cross-instance private access (every chain member is a BaseConfig).
+     * the cross-instance private access (every chain member is a ConfigProvider).
      * @param {String} key
      * @param {*} value
      * @returns {*}
@@ -347,7 +347,7 @@ class BaseConfig extends Provider {
         const ownerDetails = this.getOwnerOfDataProperty(leafPath);
 
         if (!ownerDetails) {
-            console.warn(`[Neo.ai.BaseConfig] observeData: no data leaf at "${leafPath}".`);
+            console.warn(`[Neo.ai.ConfigProvider] observeData: no data leaf at "${leafPath}".`);
             return () => {}
         }
 
@@ -400,20 +400,20 @@ class BaseConfig extends Provider {
 
             this.#applyEnvLayer();
 
-            console.error(`[Neo.ai.BaseConfig] Loaded overlay configuration from ${absolutePath}`)
+            console.error(`[Neo.ai.ConfigProvider] Loaded overlay configuration from ${absolutePath}`)
         } catch (error) {
-            console.error(`[Neo.ai.BaseConfig] Failed to load configuration from ${filePath}:`, error.message);
+            console.error(`[Neo.ai.ConfigProvider] Failed to load configuration from ${filePath}:`, error.message);
             throw error
         }
     }
 }
 
 /**
- * Wraps a BaseConfig instance in a Proxy so consumers read leaf values directly
+ * Wraps a ConfigProvider instance in a Proxy so consumers read leaf values directly
  * (`config.namespace.leaf`) and assign top-level keys (`config.key = value`). Instance members
  * win; unknown keys delegate to the reactive data tree, whose own hierarchical proxy resolves
  * nested paths and routes nested assignments through `setData`.
- * @param {Neo.ai.BaseConfig} instance
+ * @param {Neo.ai.ConfigProvider} instance
  * @returns {Proxy}
  */
 export function createConfigProxy(instance) {
@@ -439,4 +439,4 @@ export function createConfigProxy(instance) {
     })
 }
 
-export default Neo.setupClass(BaseConfig);
+export default Neo.setupClass(ConfigProvider);

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,6 +1,6 @@
 import path                                  from 'path';
 import {fileURLToPath}                       from 'url';
-import BaseConfig, {createConfigProxy, leaf} from './BaseConfig.mjs';
+import ConfigProvider, {createConfigProxy, leaf} from './ConfigProvider.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -13,10 +13,10 @@ const DAY_MS  = 24 * HOUR_MS;
 
 /**
  * @class Neo.ai.Config
- * @extends Neo.ai.BaseConfig
+ * @extends Neo.ai.ConfigProvider
  * @singleton
  */
-class Config extends BaseConfig {
+class Config extends ConfigProvider {
     static config = {
         /**
          * @member {String} className='Neo.ai.Config'

--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -1,6 +1,6 @@
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
+import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';
 
 const __filename  = fileURLToPath(import.meta.url);
 const __dirname   = path.dirname(__filename);
@@ -31,10 +31,10 @@ function parseLogLevel(envVarName, {env = process.env, warn = console.warn} = {}
  * The configuration handles GitHub repository details, sync settings, and server behavior options.
  *
  * @class Neo.ai.mcp.server.github-workflow.Config
- * @extends Neo.ai.BaseConfig
+ * @extends Neo.ai.ConfigProvider
  * @singleton
  */
-class Config extends BaseConfig {
+class Config extends ConfigProvider {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.github-workflow.Config'

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -1,6 +1,6 @@
 import path                                       from 'path';
 import {fileURLToPath}                            from 'url';
-import BaseConfig, {createConfigProxy, leaf}      from '../../../BaseConfig.mjs';
+import ConfigProvider, {createConfigProxy, leaf}      from '../../../ConfigProvider.mjs';
 
 const __filename     = fileURLToPath(import.meta.url);
 const __dirname      = path.dirname(__filename);
@@ -32,9 +32,9 @@ function parseLogLevel(envVarName, {env = process.env, warn = console.warn} = {}
  * @summary GitLab Workflow MCP configuration singleton.
  *
  * @class Neo.ai.mcp.server.gitlab-workflow.Config
- * @extends Neo.ai.BaseConfig
+ * @extends Neo.ai.ConfigProvider
  */
-class Config extends BaseConfig {
+class Config extends ConfigProvider {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.gitlab-workflow.Config'

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -1,7 +1,7 @@
 import os              from 'os';
 import path            from 'path';
 import AiConfig        from '../../../config.template.mjs';
-import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
+import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -18,10 +18,10 @@ const neoRootDir = path.resolve(__dirname, '../../../../');
  * Supports loading configuration from a custom file and merging with defaults.
  *
  * @class Neo.ai.mcp.server.knowledge-base.Config
- * @extends Neo.ai.BaseConfig
+ * @extends Neo.ai.ConfigProvider
  * @singleton
  */
-class Config extends BaseConfig {
+class Config extends ConfigProvider {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.knowledge-base.Config'

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -2,7 +2,7 @@
 // MC reads no AiConfig values directly — they resolve via the chain, not a binding.
 import '../../../config.template.mjs';
 import path                                  from 'path';
-import BaseConfig, {createConfigProxy, leaf} from '../../../BaseConfig.mjs';
+import ConfigProvider, {createConfigProxy, leaf} from '../../../ConfigProvider.mjs';
 import {fileURLToPath}                       from 'url';
 
 function parseMemorySharingPolicy(envVarName, {env = process.env} = {}) {
@@ -35,10 +35,10 @@ const testSessionCollection = `test-session-${Date.now()}-${Math.random().toStri
  * Supports loading configuration from a custom file and merging with defaults.
  *
  * @class Neo.ai.mcp.server.memory-core.Config
- * @extends Neo.ai.BaseConfig
+ * @extends Neo.ai.ConfigProvider
  * @singleton
  */
-class Config extends BaseConfig {
+class Config extends ConfigProvider {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.memory-core.Config'

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -1,7 +1,7 @@
 import os              from 'os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import BaseConfig, { createConfigProxy, leaf } from '../../../BaseConfig.mjs';
+import ConfigProvider, { createConfigProxy, leaf } from '../../../ConfigProvider.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -16,10 +16,10 @@ const cwd        = process.cwd();
  * Supports loading configuration from a custom file and merging with defaults.
  *
  * @class Neo.ai.mcp.server.neural-link.Config
- * @extends Neo.ai.BaseConfig
+ * @extends Neo.ai.ConfigProvider
  * @singleton
  */
-class Config extends BaseConfig {
+class Config extends ConfigProvider {
     static config = {
         /**
          * @member {String} className='Neo.ai.mcp.server.neural-link.Config'

--- a/ai/mcp/server/shared/Logger.mjs
+++ b/ai/mcp/server/shared/Logger.mjs
@@ -19,7 +19,7 @@ const DEFAULT_LOGGER_CONFIG = {
 };
 
 /**
- * @summary Extracts the live config data from either a BaseConfig proxy or a plain object.
+ * @summary Extracts the live config data from either a ConfigProvider proxy or a plain object.
  *
  * MCP server configs are mutable during tests and after config-file loading, so the shared
  * logger resolves config lazily per write instead of freezing options at module import time.

--- a/ai/scripts/maintenance/compactGraphLog.mjs
+++ b/ai/scripts/maintenance/compactGraphLog.mjs
@@ -1,4 +1,4 @@
-// Bootstrap Neo namespace BEFORE importing runtime config; `BaseConfig` consumes core utilities
+// Bootstrap Neo namespace BEFORE importing runtime config; `ConfigProvider` consumes core utilities
 // through `Neo.gatekeep()` / `Neo.isObject()` once the config module is loaded.
 import Neo                            from '../../../src/Neo.mjs';
 import * as core                      from '../../../src/core/_export.mjs';

--- a/learn/agentos/AiConfigModel.md
+++ b/learn/agentos/AiConfigModel.md
@@ -4,12 +4,12 @@
 
 ## The shape
 
-`Neo.ai.BaseConfig extends Neo.state.Provider`, so every config *is* a reactive state provider, and they compose into one tree:
+`Neo.ai.ConfigProvider extends Neo.state.Provider`, so every config *is* a reactive state provider, and they compose into one tree:
 
 - **Tier-1 — `Neo.ai.Config`** (singleton): the *realm root*. It owns the deployment-wide leaves — model providers, `auth`, `ollama` / `openAiCompatible`, storage, the orchestrator intervals.
 - **Per-server configs — `Neo.ai.mcp.server.<name>.Config`**: children of the realm root. Each owns only the leaves that are genuinely server-local — the Knowledge Base's `collectionName`, the Memory Core's `memorySharing`, and so on.
 
-A child resolves a leaf it does not own by walking **up** to the owner: `getOwnerOfDataProperty` checks the local data first, then delegates to `getParent()`. The Brain has no component tree, so `ai/BaseConfig.mjs` overrides `getParent()` to return the Tier-1 singleton — that override is what roots the realm chain.
+A child resolves a leaf it does not own by walking **up** to the owner: `getOwnerOfDataProperty` checks the local data first, then delegates to `getParent()`. The Brain has no component tree, so `ai/ConfigProvider.mjs` overrides `getParent()` to return the Tier-1 singleton — that override is what roots the realm chain.
 
 This is the same hierarchy the Body uses for component state providers. The canonical illustration lives in [examples/stateProvider/advanced](../../examples/stateProvider/advanced/MainContainer.mjs): a `Panel` reads `button1Text` that only the top-level `Viewport` owns (the lookup walks up), and a write to `button1Text` *initiated on the Panel* bubbles up and lands on the `Viewport`'s provider, which owns it.
 
@@ -20,7 +20,7 @@ Two properties fall out of "each layer owns only its slice":
 
 ## Leaves and the env layer
 
-A config's `data` is a *meta-leaf tree* — each leaf is `leaf(default, env?, type?)`. `BaseConfig.compileMetaLeaves` walks it into (a) plain reactive data and (b) a metadata registry keyed by dotted path. A bounded **env layer** then overlays environment variables onto env-bound leaves — re-resolved at construction and on explicit refresh, never live-per-read (a port that silently moves without a coordinated restart is a footgun, not a feature). See `ai/BaseConfig.mjs`.
+A config's `data` is a *meta-leaf tree* — each leaf is `leaf(default, env?, type?)`. `ConfigProvider.compileMetaLeaves` walks it into (a) plain reactive data and (b) a metadata registry keyed by dotted path. A bounded **env layer** then overlays environment variables onto env-bound leaves — re-resolved at construction and on explicit refresh, never live-per-read (a port that silently moves without a coordinated restart is a footgun, not a feature). See `ai/ConfigProvider.mjs`.
 
 ## Templates, overlays, and why advancement is *inheritance*
 
@@ -44,5 +44,5 @@ The one-line test: **if you are parsing or rewriting config *source* to reconcil
 
 - [examples/stateProvider/advanced](../../examples/stateProvider/advanced/MainContainer.mjs) — the canonical hierarchical-state illustration (read up, write-to-owner).
 - [src/state/Provider.mjs](../../src/state/Provider.mjs) — `getOwnerOfDataProperty`, owner-routed `setData` / `internalSetData`, and the `data_` `merge: 'deep'` descriptor.
-- [ai/BaseConfig.mjs](../../ai/BaseConfig.mjs) — the meta-leaf compile, the bounded env layer, and the `getParent()` override that roots the realm chain.
+- [ai/ConfigProvider.mjs](../../ai/ConfigProvider.mjs) — the meta-leaf compile, the bounded env layer, and the `getParent()` override that roots the realm chain.
 - [Cloud-Native KB Ingestion — Configuration](./cloud-deployment/Configuration.md) — the operator-facing config keys this model carries.

--- a/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+++ b/learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
@@ -17,7 +17,7 @@
 
 ## 1. Context
 
-We made `AiConfig` a `Neo.state.Provider` (`ai/BaseConfig.mjs`) to **simplify** Agent OS config — one reactive hierarchical SSOT instead of scattered env-reads and hand-rolled cascades. Then PR #12420 re-implemented, aliased, threaded, and **mutated** it across `ai/`, and a careful reviewer (@neo-claude-opus) approved it **twice, catching 0 of the 4 real defects** @tobiu then found (cycle-3 over-engineering · cycle-4 wrong-layer · the −90 formulas · a test→live-DB bleed).
+We made `AiConfig` a `Neo.state.Provider` (`ai/ConfigProvider.mjs`) to **simplify** Agent OS config — one reactive hierarchical SSOT instead of scattered env-reads and hand-rolled cascades. Then PR #12420 re-implemented, aliased, threaded, and **mutated** it across `ai/`, and a careful reviewer (@neo-claude-opus) approved it **twice, catching 0 of the 4 real defects** @tobiu then found (cycle-3 over-engineering · cycle-4 wrong-layer · the −90 formulas · a test→live-DB bleed).
 
 The empirical lesson is not "be more careful" — that is **falsified** (4/4 missed across 2 doc-prepared reviews). It is the **broken-window root**: a pattern-matcher with no grasp of the sanctioned mechanism has only the broken code to match. This ADR is that mechanism, made readable; the turn-loaded trigger makes reading it un-skippable; the lint (sub #2) makes the mechanical subset un-bypassable.
 
@@ -27,10 +27,10 @@ The empirical lesson is not "be more careful" — that is **falsified** (4/4 mis
 
 ### 2.1 How the primitive works (read this instead of the 3 code files)
 
-`ai/BaseConfig.mjs extends Neo.state.Provider` — every config **is** a reactive state provider; they compose into one tree. (Primitive line-anchors below are for someone changing the *primitive itself*; consumers do not need them.)
+`ai/ConfigProvider.mjs extends Neo.state.Provider` — every config **is** a reactive state provider; they compose into one tree. (Primitive line-anchors below are for someone changing the *primitive itself*; consumers do not need them.)
 
-- **`leaf(default, env, type)`** declares one value (`ai/BaseConfig.mjs:52`). `BaseConfig.#applyEnvLayer` (`:201`) already reads `process.env[env]`, decodes it by `type` (via `Neo.util.Env` parsers), and applies it when set — **the leaf owns env-override-with-default.** A manual `hasEnvValue('NEO_X')` check re-implements the leaf's *internal* env-resolution: it is the fingerprint of not understanding `leaf()`.
-- **Hierarchy / realm chain.** Tier-1 `Neo.ai.Config` is the realm root; each per-server config is a child — `ai/BaseConfig.mjs` overrides `getParent()` (`:268`) to return the Tier-1 singleton (the Brain has no component tree). `Provider#getOwnerOfDataProperty` (`src/state/Provider.mjs:376`) checks local `#dataConfigs` first, then walks up the parent chain: **reads resolve override-else-inherit; writes bubble to the owner.** No layer holds a copy of another's data. (The same hierarchy the Body uses for component state — see [examples/stateProvider/advanced](../../examples/stateProvider/advanced/MainContainer.mjs): read-up, write-to-owner.)
+- **`leaf(default, env, type)`** declares one value (`ai/ConfigProvider.mjs:52`). `ConfigProvider.#applyEnvLayer` (`:201`) already reads `process.env[env]`, decodes it by `type` (via `Neo.util.Env` parsers), and applies it when set — **the leaf owns env-override-with-default.** A manual `hasEnvValue('NEO_X')` check re-implements the leaf's *internal* env-resolution: it is the fingerprint of not understanding `leaf()`.
+- **Hierarchy / realm chain.** Tier-1 `Neo.ai.Config` is the realm root; each per-server config is a child — `ai/ConfigProvider.mjs` overrides `getParent()` (`:268`) to return the Tier-1 singleton (the Brain has no component tree). `Provider#getOwnerOfDataProperty` (`src/state/Provider.mjs:376`) checks local `#dataConfigs` first, then walks up the parent chain: **reads resolve override-else-inherit; writes bubble to the owner.** No layer holds a copy of another's data. (The same hierarchy the Body uses for component state — see [examples/stateProvider/advanced](../../examples/stateProvider/advanced/MainContainer.mjs): read-up, write-to-owner.)
 - **`formulas`** are lazy `Effect`s (`src/state/Provider.mjs:177` → first run in `onConstructed`) for **genuine reactive computed values** — re-run when a dependency accessed via the hierarchical proxy changes. They are NOT a place to re-derive a leaf with env-checks.
 - **The hierarchical data proxy** (`src/state/createHierarchicalDataProxy.mjs`) resolves nested paths; its get-trap registers `EffectManager.getActiveEffect()?.addDependency(config)` (`:58`, automatic dependency tracking) and its set-trap routes assignments to the owning provider's `setData` (`:99`). **Consumers read `AiConfig.engines.chroma.dataDir`** — the Provider resolves; you read. (This routing is *why* B4 writes are mechanically dangerous — see §4.)
 - **`data_` is a `merge: 'deep'` descriptor** (`src/state/Provider.mjs:61`). An operator overlay (`config.mjs`) is a *thin child of deltas* over the canonical template (`config.template.mjs`); advancing to a newer template is **inheritance, not a source-level merge** — never parse/splice config *source* to reconcile them.
@@ -103,7 +103,7 @@ aiConfig.engines.chroma.database = `graph-service-test-${process.pid}-${Date.now
 
 Before authoring or reviewing any `ai/` config work, you MUST:
 1. Read **this ADR** (the AGENTS.md turn-loaded trigger makes this un-skippable).
-2. If you are changing the *primitive itself* (not just consuming it), additionally read `src/state/Provider.mjs` + `src/state/createHierarchicalDataProxy.mjs` + `ai/BaseConfig.mjs` and cite them.
+2. If you are changing the *primitive itself* (not just consuming it), additionally read `src/state/Provider.mjs` + `src/state/createHierarchicalDataProxy.mjs` + `ai/ConfigProvider.mjs` and cite them.
 3. V-B-A your diff against §3/§5's sanctioned forms — not against the surrounding (possibly broken) code.
 
 ## 7. Codification stack & sequencing
@@ -122,9 +122,9 @@ Before authoring or reviewing any `ai/` config work, you MUST:
 - **Discussion #12453** — full archaeology trail + the divergence matrix (incl. @neo-opus-4-7's OQ3 C1=bootstrap-weight V-B-A, `DC_kwDODSospM4BBgm5`).
 - **Epic #12456** — workstream coordination; **#12457** — this sub.
 - **#12420** — superseded empirical anchor (do-not-merge). **#12335** — orphan incident (the B4 danger).
-- Folded subs: **#12435** (B4), **#12438** (A1), **#11976** (C3), **#12452** (`BaseConfig → ConfigProvider` rename), **#12451** (config-leaf lint → sub #2).
+- Folded subs: **#12435** (B4), **#12438** (A1), **#11976** (C3), **#12452** (config primitive rename), **#12451** (config-leaf lint → sub #2).
 - **ADR 0005** (ADR-at-graduation), **ADR 0007** (compaction taxonomy).
-- `ai/BaseConfig.mjs`, `src/state/Provider.mjs`, `src/state/createHierarchicalDataProxy.mjs` — the primitive.
+- `ai/ConfigProvider.mjs`, `src/state/Provider.mjs`, `src/state/createHierarchicalDataProxy.mjs` — the primitive.
 - `learn/agentos/AiConfigModel.md` — the **public configuration-model guide** (docs-reader audience). This ADR is the **maintainer-facing complement** (antipattern catalog + safety-critical danger + read-gate); the two cross-reference and neither replaces the other.
 
 Origin Session ID: `3ecb40bf-bfef-40b1-8693-a8aae5afa1b7`

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -372,7 +372,7 @@ Post-M6 ([#10986](https://github.com/neomjs/neo/issues/10986)) the per-MCP-serve
 |---|---|---|---|
 | `ai/Agent.mjs` | Agent base class | `Agent` | — |
 | `ai/agent/` | Cognitive runtime | `Loop`, `Orchestrator`, `Scheduler` | — |
-| `ai/config.template.mjs`, `ai/BaseConfig.mjs` | Tier-1 Agent OS config template and shared config base consumed by top-level and MCP server configs | `Config`, `BaseConfig` | — |
+| `ai/config.template.mjs`, `ai/ConfigProvider.mjs` | Tier-1 Agent OS config template and shared config provider consumed by top-level and MCP server configs | `Config`, `ConfigProvider` | — |
 | `ai/context/` | Context window management | `Assembler` | — |
 | `ai/provider/` | LLM abstraction | `Gemini`, `Ollama`, `OpenAiCompatible` | — |
 | `ai/services.mjs` | SDK with Zod validation aggregator | — | — |

--- a/src/util/Env.mjs
+++ b/src/util/Env.mjs
@@ -1,11 +1,11 @@
 /**
- * Internal typed-parser registry for `Neo.ai.BaseConfig`.
+ * Internal typed-parser registry for `Neo.ai.ConfigProvider`.
  *
  * Each parser reads `env[envVarName]` and decodes it to a typed value, answering exactly one
  * question: "env var absent (undefined) / decoded value / invalid (warn + undefined)". The
  * decoders know NOTHING about specific configs, defaults, or domain consumers.
  *
- * **Not consumer-facing.** These parsers are the env-decode layer that `BaseConfig` wires into
+ * **Not consumer-facing.** These parsers are the env-decode layer that `ConfigProvider` wires into
  * its meta-leaf registry: a `leaf(default, 'NEO_X', type)` resolves its env override through the
  * `type`-keyed parser here. Application code does NOT call `Env.parseX` directly — it reads the
  * resolved value via the Provider-extending aiConfig substrate (`AiConfig.<path>`), which layers

--- a/test/playwright/unit/ai/ConfigProvider.spec.mjs
+++ b/test/playwright/unit/ai/ConfigProvider.spec.mjs
@@ -5,7 +5,7 @@ setup({
         unitTestMode: true
     },
     appConfig: {
-        name             : 'AiBaseConfigTest',
+        name             : 'AiConfigProviderTest',
         isMounted        : () => true,
         vnodeInitialising: false
     }
@@ -15,10 +15,10 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 
-let BaseConfig, createConfigProxy, leaf, Env, originalEnv;
+let ConfigProvider, createConfigProxy, leaf, Env, originalEnv;
 
 /**
- * Fresh meta-leaf tree per test, assigned to the `data` config (the new #12168 shape).
+ * Fresh meta-leaf tree per test, assigned to the Provider-backed `data` config.
  * Mixes env-bound + env-free leaves, multiple `leaf()` types, a null-default-with-type leaf,
  * a nested namespace, and an object leaf whose value carries an own `constructor` key
  * (the dummy-EF duck-type that breaks `Neo.typeOf` inference — guarded by `leaf()`).
@@ -43,9 +43,9 @@ function buildTree() {
     }
 }
 
-test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', () => {
+test.describe('Neo.ai.ConfigProvider (data + afterSetData seam + leaf() factory)', () => {
     test.beforeAll(async () => {
-        ({default: BaseConfig, createConfigProxy, leaf} = await import('../../../../ai/BaseConfig.mjs'));
+        ({default: ConfigProvider, createConfigProxy, leaf} = await import('../../../../ai/ConfigProvider.mjs'));
         Env         = (await import('../../../../src/util/Env.mjs')).default;
         originalEnv = {...process.env}
     });
@@ -89,7 +89,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('afterSetData compiles reactive data from leaf defaults', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         expect(config.getDataConfig('debug').get()).toBe(false);
         expect(config.getDataConfig('port').get()).toBe(3000);
@@ -103,7 +103,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('object leaf with an own constructor key survives compile (typeOf guard)', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()}),
+        const config = Neo.create(ConfigProvider, {data: buildTree()}),
               ef     = config.getDataConfig('ef').get();
 
         expect(ef.name).toBe('dummy_embedding_function');
@@ -119,7 +119,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
         process.env.NEO_TEST_NAMES   = 'neo-gpt, neo-opus-4-7';
         process.env.NEO_TEST_TIMEOUT = '1234';
 
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         expect(config.getDataConfig('port').get()).toBe(8080);
         expect(config.getDataConfig('debug').get()).toBe(true);
@@ -134,7 +134,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('setData() writes a value through the reactive pipeline', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         config.setData('server.timeout', 9999);
         expect(config.getDataConfig('server.timeout').get()).toBe(9999);
@@ -143,7 +143,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('setEnvOverride() is keyed by env var name and wins over the default', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         config.setEnvOverride('NEO_TEST_DEBUG', true);
         expect(config.getDataConfig('debug').get()).toBe(true);
@@ -152,7 +152,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('refreshEnv() re-resolves env; runtime override persists', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         config.setEnvOverride('NEO_TEST_DEBUG', true);
         process.env.NEO_TEST_PORT = '9090';
@@ -165,7 +165,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('direct assignment via createConfigProxy routes through setData', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()}),
+        const config = Neo.create(ConfigProvider, {data: buildTree()}),
               proxy  = createConfigProxy(config);
 
         expect(proxy.name).toBe('neo');
@@ -181,7 +181,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('observeData fires on change and stops after cleanup', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         let calls     = 0;
         const cleanup = config.observeData('name', () => {calls++});
@@ -198,7 +198,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('internalSetData validates ANY value at a known leaf path (object leaves included)', () => {
-        const config   = Neo.create(BaseConfig, {data: buildTree()}),
+        const config   = Neo.create(ConfigProvider, {data: buildTree()}),
               warnings = [],
               origWarn = console.warn;
 
@@ -226,7 +226,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('nested namespaces are preserved as a deep structure', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         expect(config.data.server.host).toBe('localhost');
         expect(config.data.server.timeout).toBe(5000);
@@ -236,7 +236,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('createConfigProxy: .data getter + method calls bind to the real instance', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()}),
+        const config = Neo.create(ConfigProvider, {data: buildTree()}),
               proxy  = createConfigProxy(config);
 
         expect(proxy.data.server.host).toBe('localhost');
@@ -249,7 +249,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('destroy() releases observeData subscriptions (no manual cleanup needed)', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         let calls = 0;
         config.observeData('name', () => {calls++}); // intentionally not cleaned up manually
@@ -261,7 +261,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('observeData resolves leaves via getOwnerOfDataProperty (hierarchy-aware)', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         const {owner, propertyName} = config.getOwnerOfDataProperty('server.host');
         expect(owner).toBe(config);
@@ -277,7 +277,7 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('does not shadow core.Base set() / observeConfig()', () => {
-        const config = Neo.create(BaseConfig, {data: buildTree()});
+        const config = Neo.create(ConfigProvider, {data: buildTree()});
 
         // core.Base#observeConfig(publisher, configName, fn) — Provider#createBinding depends on it.
         let calls     = 0;
@@ -292,8 +292,8 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('getParent() resolves the Tier-1 root; root self-parents to null; bare instance resolves locally', () => {
-        const root     = Neo.create(BaseConfig, {data: {sharedRealmLeaf: leaf('root-owned')}}),
-              child    = Neo.create(BaseConfig, {data: {own: leaf('child-owned')}}),
+        const root     = Neo.create(ConfigProvider, {data: {sharedRealmLeaf: leaf('root-owned')}}),
+              child    = Neo.create(ConfigProvider, {data: {own: leaf('child-owned')}}),
               prevRoot = Neo.ai?.Config;
 
         Neo.ai = Neo.ai || {};
@@ -320,8 +320,8 @@ test.describe('Neo.ai.BaseConfig (data + afterSetData seam + leaf() factory)', (
     });
 
     test('cross-tier write validates against the OWNER registry', () => {
-        const root     = Neo.create(BaseConfig, {data: {sharedPort: leaf(3000, null, 'port')}}),
-              child    = Neo.create(BaseConfig, {data: {own: leaf('x')}}),
+        const root     = Neo.create(ConfigProvider, {data: {sharedPort: leaf(3000, null, 'port')}}),
+              child    = Neo.create(ConfigProvider, {data: {own: leaf('x')}}),
               warnings = [],
               origWarn = console.warn,
               prevRoot = Neo.ai?.Config;

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'fs/promises';
 import Neo from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
-import BaseConfig from '../../../../ai/BaseConfig.mjs';
+import ConfigProvider from '../../../../ai/ConfigProvider.mjs';
 import {TIER1_DEFAULTS} from '../../fixtures/aiConfigDefaults.mjs';
 import {CHROMA_TEST_DATABASE} from '../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
@@ -48,7 +48,7 @@ test.describe('Tier 1 Config Immutability', () => {
 
         // A fresh instance built from the same meta-leaf tree (`_data`) gets the clean default —
         // the instance write touched the reactive Config value, not the leaf `default`.
-        const fresh = Neo.create(BaseConfig, {data: Config._data});
+        const fresh = Neo.create(ConfigProvider, {data: Config._data});
         expect(fresh.getDataConfig('mcpHttpPort').get()).not.toBe(9999);
         expect(fresh.getDataConfig('mcpHttpPort').get()).toBe(initialPort);
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
@@ -260,7 +260,7 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
 
     test('surfaces stale config overlay errors without hiding the typed outcome', async () => {
         // Simulate a stale / malformed config overlay that leaves dreamOverflowThreshold
-        // present-but-invalid. The reactive config tree (BaseConfig extends Neo.state.Provider)
+        // present-but-invalid. The reactive config tree (ConfigProvider extends Neo.state.Provider)
         // routes leaf writes through core.Config#set, which intentionally treats `undefined`
         // as a no-op (preserves the prior value) — so a defined-but-invalid sentinel like `null`
         // is the faithful stale-overlay simulant. It propagates to `finalize()`, where

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs
@@ -50,10 +50,10 @@ async function importTemplateConfig() {
 }
 
 test.describe('GitHub Workflow MCP Server Config Completeness', () => {
-    let BaseConfig, originalEnv;
+    let ConfigProvider, originalEnv;
 
     test.beforeAll(async () => {
-        BaseConfig  = (await import('../../../../../../../ai/BaseConfig.mjs')).default;
+        ConfigProvider  = (await import('../../../../../../../ai/ConfigProvider.mjs')).default;
         originalEnv = {...process.env};
     });
 
@@ -117,7 +117,7 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
 
         process.env.NEO_MCP_GITHUB_ARCHIVE_ROOT = '/custom/archive/path';
 
-        const config = Neo.create(BaseConfig, {data: _data});
+        const config = Neo.create(ConfigProvider, {data: _data});
 
         try {
             expect(config.getDataConfig('issueSync.archiveRoot').get()).toBe('/custom/archive/path');
@@ -141,7 +141,7 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
 
         // Valid value: parsed + normalized to lower-case.
         process.env.NEO_LOG_LEVEL = 'DEBUG';
-        const validConfig = Neo.create(BaseConfig, {data: _data});
+        const validConfig = Neo.create(ConfigProvider, {data: _data});
 
         try {
             expect(validConfig.getDataConfig('logLevel').get()).toBe('debug');
@@ -158,7 +158,7 @@ test.describe('GitHub Workflow MCP Server Config Completeness', () => {
 
         let invalidConfig;
         try {
-            invalidConfig = Neo.create(BaseConfig, {data: _data});
+            invalidConfig = Neo.create(ConfigProvider, {data: _data});
         } finally {
             console.warn = originalWarn;
         }

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -1,6 +1,6 @@
 import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../../../../src/Neo.mjs';
-import BaseConfig, {createConfigProxy} from '../../../../../../../ai/BaseConfig.mjs';
+import ConfigProvider, {createConfigProxy} from '../../../../../../../ai/ConfigProvider.mjs';
 import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
 
 test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
@@ -40,7 +40,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         // deterministic across reused Playwright workers.
         const tier1Template = (await import('../../../../../../../ai/config.template.mjs')).default;
         Neo.ai = Neo.ai || {};
-        Neo.ai.Config = Neo.create(BaseConfig, {data: tier1Template._data});
+        Neo.ai.Config = Neo.create(ConfigProvider, {data: tier1Template._data});
     });
 
     test.afterAll(() => {
@@ -111,13 +111,13 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         // KB-LOCAL leaves (Chroma host/port) — env applies at the CHILD instance directly.
         // Fresh isolated instance (not the module-cached singleton, whose reactive state is
         // contaminated by sibling specs). config._data carries the raw KB meta-leaf tree.
-        const freshKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        const freshKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
         // TIER-1-OWNED leaves (auth.*, backupPath) — post-split the child no longer declares them,
         // so env precedence lives at the OWNER. Build a fresh realm root WITH the env set and
         // register it so the child inherits the override up the getParent() chain.
         const prevRoot  = Neo.ai?.Config;
-        const freshRoot = Neo.create(BaseConfig, {data: Neo.ai.Config._data});
+        const freshRoot = Neo.create(ConfigProvider, {data: Neo.ai.Config._data});
         Neo.ai.Config   = freshRoot;
 
         try {
@@ -134,7 +134,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
     });
 
     test('keeps debug off by default and accepts NEO_DEBUG as a KB-local override', () => {
-        const defaultKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        const defaultKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
         try {
             expect(defaultKB.debug).toBe(false);
@@ -144,7 +144,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
 
         process.env.NEO_DEBUG = 'true';
 
-        const freshKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        const freshKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
         try {
             expect(freshKB.debug).toBe(true);
@@ -165,7 +165,7 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         console.warn = message => warnings.push(message);
 
         try {
-            freshKB = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+            freshKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
             expect(freshKB.debug).toBe(false);
             expect(warnings.some(message => message.includes('Invalid NEO_DEBUG'))).toBe(true);

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import path from 'path';
 import Neo from '../../../../../../../src/Neo.mjs';
-import BaseConfig, {createConfigProxy} from '../../../../../../../ai/BaseConfig.mjs';
+import ConfigProvider, {createConfigProxy} from '../../../../../../../ai/ConfigProvider.mjs';
 import {TIER1_DEFAULTS} from '../../../../../fixtures/aiConfigDefaults.mjs';
 
 test.describe('Memory Core Config (#10010)', () => {
@@ -44,7 +44,7 @@ test.describe('Memory Core Config (#10010)', () => {
         // template tree, making inheritance deterministic across workers.
         const tier1Template = (await import('../../../../../../../ai/config.template.mjs')).default;
         Neo.ai = Neo.ai || {};
-        Neo.ai.Config = Neo.create(BaseConfig, {data: tier1Template._data});
+        Neo.ai.Config = Neo.create(ConfigProvider, {data: tier1Template._data});
     });
 
     test.afterAll(() => {
@@ -136,7 +136,7 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_BRIDGE_LAST_SYNC_ID_PATH = '/tmp/neo-bridge-last-sync-id';
         process.env.NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE = '/tmp/neo-wake-live-cursor';
 
-        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
         try {
             expect(freshCfg.wakeDaemon.bridgeLastSyncIdPath).toBe('/tmp/neo-bridge-last-sync-id');
@@ -164,9 +164,9 @@ test.describe('Memory Core Config (#10010)', () => {
         // a fresh MC child inherits the overrides up the getParent() chain. (config._data is the raw
         // MC meta-leaf tree; Neo.ai.Config._data is the Tier-1 realm tree, loaded via MC's import.)
         const prevRoot  = Neo.ai?.Config;
-        const freshRoot = Neo.create(BaseConfig, {data: Neo.ai.Config._data});
+        const freshRoot = Neo.create(ConfigProvider, {data: Neo.ai.Config._data});
         Neo.ai.Config   = freshRoot;
-        const freshMC   = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        const freshMC   = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
         try {
             expect(freshMC.modelProvider).toBe('openAiCompatible');
@@ -191,7 +191,7 @@ test.describe('Memory Core Config (#10010)', () => {
         process.env.NEO_MEMORY_SHARING_DEFAULT_POLICY = 'team';
 
         // Fresh isolated instance picks up the env via #applyEnvLayer at construction.
-        const freshCfg = createConfigProxy(Neo.create(BaseConfig, {data: config._data}));
+        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
 
         expect(freshCfg.memorySharing.defaultPolicy).toBe('team');
 
@@ -203,7 +203,7 @@ test.describe('Memory Core Config (#10010)', () => {
 
         // The leaf `parse` fn (parseMemorySharingPolicy) runs inside #applyEnvLayer at
         // construction; a throwing parser propagates out of Neo.create.
-        expect(() => Neo.create(BaseConfig, {data: config._data})).toThrow(
+        expect(() => Neo.create(ConfigProvider, {data: config._data})).toThrow(
             /\[Config\] Invalid NEO_MEMORY_SHARING_DEFAULT_POLICY value: "public"\. Must be one of: legacy, private, team/
         );
     });

--- a/test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs
@@ -28,18 +28,15 @@ const __dirname  = path.dirname(__filename);
 const TEMPLATE_PATH = path.resolve(__dirname, '../../../../../../../ai/mcp/server/knowledge-base/config.template.mjs');
 
 /**
- * Verifies the Phase 0/1B-β (#11660) `aiConfig.sourcePaths` config-driven override + legacy
- * hardcoded-fallback contract across all 10 default Neo Source classes. Each test exercises
+ * Verifies the `aiConfig.sourcePaths` config-driven override + legacy hardcoded-fallback contract
+ * across all 10 default Neo Source classes. Each test exercises
  * the same `path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths?.<SourceName> ?? '<fallback>')`
  * pattern that each Source class uses at its extract-path-resolution point.
  *
- * Byte-equivalence anchor: the hardcoded fallback inside `??` MUST match the pre-#11660
+ * Byte-equivalence anchor: the hardcoded fallback inside `??` MUST match the pre-config
  * hardcoded path so deployments without the new `sourcePaths` config key still resolve
  * to the legacy Neo layout. This spec is the regression guard against that fallback
  * drifting away from the legacy default.
- *
- * @see https://github.com/neomjs/neo/issues/11660
- * @see https://github.com/neomjs/neo/issues/11658 (sibling — registry foundation)
  */
 
 // Serial mode: tests mutate the shared `aiConfig.sourcePaths` singleton via per-test
@@ -49,8 +46,6 @@ const TEMPLATE_PATH = path.resolve(__dirname, '../../../../../../../ai/mcp/serve
 // mode within this file forces non-overlapping mutation windows. CI uses workers=1 so
 // this primarily defends local-DX correctness; the singleton-mutation pattern is inherent
 // to the test shape, not a workers=1 vs workers=9 distinction.
-// @neo-gpt PR #11661 Cycle 1 review (commentId IC_kwDODSospM8AAAABC9dlIg, formal
-// review PRR_kwDODSospM8AAAABAcNngw, Required Action 1).
 test.describe.configure({mode: 'serial'});
 
 test.describe('aiConfig.sourcePaths config-driven path resolution (#11660)', () => {
@@ -83,8 +78,7 @@ test.describe('aiConfig.sourcePaths config-driven path resolution (#11660)', () 
         }
 
         aiConfig = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
-        // Phase 0/1B-β #11660 + Cycle 1 RA from @neo-gpt commentId IC_kwDODSospM8AAAABC9gB_A:
-        // the byte-equivalence anchor MUST assert against the canonical git-tracked template,
+        // The byte-equivalence anchor MUST assert against the canonical git-tracked template,
         // not any per-clone operator overlay (which may be stale on clones that pulled
         // the template change without re-running `bootstrapWorktree.mjs` to refresh local config).
         // Read the template file as text and verify the expected fallback strings appear inside
@@ -256,7 +250,7 @@ test.describe('aiConfig.sourcePaths config-driven path resolution (#11660)', () 
         });
 
         test('override sourceMap takes precedence over fallback', () => {
-            // Reactive-config semantics (epic #12101: BaseConfig extends Neo.state.Provider):
+            // Reactive-config semantics (ConfigProvider extends Neo.state.Provider):
             // assigning an OBJECT to a config leaf routes through the Provider's `setData`, which
             // drills into the supplied nested keys and MERGES them onto the existing sub-keys —
             // override values WIN on a conflicting key; keys the override omits keep their default.
@@ -313,8 +307,8 @@ test.describe('aiConfig.sourcePaths config-driven path resolution (#11660)', () 
                 delete aiConfig.sourcePaths;
 
                 // Verify each Source class's resolution path still works via the `??` fallback.
-                // This is the byte-equivalence guarantee for pre-#11660 deployments whose
-                // the local operator overlay was generated from a config.template.mjs that didn't have
+                // This is the byte-equivalence guarantee for deployments whose local operator
+                // overlay was generated from a config.template.mjs that didn't have
                 // the `sourcePaths` key.
                 expect(aiConfig.sourcePaths?.AdrSource          ?? 'learn/agentos/decisions').toBe('learn/agentos/decisions');
                 expect(aiConfig.sourcePaths?.ConceptSource      ?? 'resources/content/concepts').toBe('resources/content/concepts');
@@ -337,7 +331,7 @@ test.describe('aiConfig.sourcePaths config-driven path resolution (#11660)', () 
             // Read from KB_DEFAULTS fixture (frozen snapshot of KB-template defaults) rather
             // than the live overlay-merged singleton — operator-customized
             // `sourcePaths.LearningSource` would otherwise break this canonical-default check.
-            // #11981 / Sub-2 of #11976 (1-spec drift-migration scope).
+            // This remains a one-spec drift-migration scope.
             const treePath = KB_DEFAULTS.sourcePaths?.LearningSource ?? 'learn/tree.json';
             const basePath = path.dirname(treePath);
             expect(basePath).toBe('learn');


### PR DESCRIPTION
Resolves #12452

Authored by GPT-5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Renames the Provider-backed Agent OS config primitive from `Neo.ai.BaseConfig` / `ai/BaseConfig.mjs` to `Neo.ai.ConfigProvider` / `ai/ConfigProvider.mjs`, while preserving the `AiConfig` singleton, `leaf`, and `createConfigProxy` contracts. All live template imports, runtime labels, JSDoc, focused tests, and live docs now use the Provider-framed name.

Evidence: L2 (focused unit/import runtime + static residue/lint sweeps) -> L2 required (rename/import contract and docs surface). Residual: full-suite run still has unrelated pre-existing/out-of-scope failures; see Test Evidence.

## Deltas From Ticket

- Preserved the ticket-requested hard rename with no compatibility shim.
- Updated local ignored `config.mjs` overlays in this checkout so the working clone can continue importing the renamed primitive, but did not commit any ignored overlay.
- Pre-commit surfaced ticket-archaeology debt in comments on touched `.mjs` files; this PR removes those durable comment ticket refs as mechanical hygiene required by the current hook.

## MCP Config Template Sync

- Changed config keys: none. This is an import/class-name rename only.
- Local `config.mjs` follow-up: required after merge for active clones whose ignored overlays still import `BaseConfig.mjs`. Re-run the worktree bootstrap/config hydration path or update the ignored overlay import/class extension to `ConfigProvider`.
- Harness restart: recommended after local overlay rehydration, because long-running MCP processes may hold the old module graph.
- Committed ignored overlays: none.

## Slot Rationale

This PR modifies existing conditional documentation/decision-record substrate under `learn/agentos/**` only to replace the stale primitive name with the new one. No new rule, trigger, or always-loaded substrate is added. Disposition remains `keep` for the public AiConfig model guide and ADR 0019 as existing authority surfaces; the decay mitigation is removing a category-error name that the ticket identifies as reviewer-friction.

Decision Record impact: ADR 0019 references are updated in place to the new primitive name; no decision semantics change.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/ConfigProvider.spec.mjs test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs` -> 44 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs test/playwright/unit/ai/services/knowledge-base/source/SourcePathsConfig.spec.mjs` -> 49 passed.
- `npm run ai:lint-config-template-ssot` -> OK.
- `git diff --check` -> OK.
- `node ./buildScripts/util/check-ticket-archaeology.mjs ...` over the staged `.mjs` set -> 17 files scanned, 0 violations.
- `rg -n "\bBaseConfig\b|Neo\.ai\.BaseConfig|BaseConfig\.mjs" ai src test/playwright/unit/ai learn/agentos learn/benefits -g "*.mjs" -g "*.md"` -> no live-source matches.
- `npm run test-unit` -> 2749 passed, 5 skipped, 60 failed, 49 did not run. Failures are outside the rename surface (AI infra/Chroma/health/lifecycle plus grid/VDOM specs); focused config-provider suites above are green.

## Post-Merge Validation

- [ ] Rehydrate/update ignored `config.mjs` overlays in active agent clones so they import `ConfigProvider.mjs`.
- [ ] Restart long-running MCP/harness processes after overlay rehydration.
- [ ] Confirm CI on the PR head.

## Commits

- `84fff735e` — rename `BaseConfig` to `ConfigProvider` and update live import/docs/test surfaces.
