### PR TITLE
fix(ai): remove existing-leaf B3 fallbacks (#12568)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -508,7 +508,7 @@ export class Orchestrator extends Base {
                 // is sufficient. Order matches the JSDoc contract on the service class.
                 this.swarmHeartbeatService.identity        = this.swarmHeartbeatIdentity;
                 this.swarmHeartbeatService.pollIntervalMs  = AiConfig.orchestrator.intervals.swarmHeartbeatMs;
-                this.swarmHeartbeatService.targetSource    = AiConfig.orchestrator.swarmHeartbeat.targetSource ?? null;
+                this.swarmHeartbeatService.targetSource    = AiConfig.orchestrator.swarmHeartbeat.targetSource;
                 this.swarmHeartbeatService.explicitTargets = this.swarmHeartbeatExplicitTargets;
                 await this.swarmHeartbeatService.ready();
             } catch (e) {

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -253,7 +253,7 @@ class SessionService extends Base {
         if (aiConfig.modelProvider === 'openAiCompatible') {
             logger.info(`[SessionService] Initializing generation model via OpenAI-Compatible API (${aiConfig.openAiCompatible.model})`);
         } else if (aiConfig.modelProvider === 'ollama') {
-            logger.info(`[SessionService] Initializing generation model via native Ollama (${aiConfig.ollama?.model || '<unset>'})`);
+            logger.info(`[SessionService] Initializing generation model via native Ollama (${aiConfig.ollama.model})`);
         } else if (aiConfig.modelProvider === 'gemini') {
             logger.info(`[SessionService] Initializing generation model via Gemini (${aiConfig.modelName})`);
         }
@@ -575,9 +575,9 @@ ${aggregatedContent}
         // Consumer model naming covers all three active providers for
         // guardrail/log surfaces.
         const consumerModel =
-            aiConfig.modelProvider === 'openAiCompatible' ? (aiConfig.openAiCompatible.model || 'openAiCompatible') :
-            aiConfig.modelProvider === 'ollama'           ? (aiConfig.ollama?.model           || 'ollama') :
-            (aiConfig.modelName || 'gemini');
+            aiConfig.modelProvider === 'openAiCompatible' ? aiConfig.openAiCompatible.model :
+            aiConfig.modelProvider === 'ollama'           ? aiConfig.ollama.model :
+            aiConfig.modelName;
         const consumerContextTokens = aiConfig.localModels.chat.contextLimitTokens;
         const consumerSafeTokens    = aiConfig.localModels.chat.safeProcessingLimitTokens;
         const guardrailed           = await invokeWithGuardrail({
@@ -589,7 +589,7 @@ ${aggregatedContent}
             contextLimitTokens       : consumerContextTokens,
             safeProcessingLimitTokens: consumerSafeTokens,
             serviceDomain            : 'memory-core',
-            note                     : `summarizationBatchLimit=${aiConfig.summarizationBatchLimit || 'unset'}`
+            note                     : `summarizationBatchLimit=${aiConfig.summarizationBatchLimit}`
         });
 
         if (!guardrailed.result) {

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -306,7 +306,7 @@ class ChromaManager extends AbstractVectorManager {
      */
     async getUndigestedSessionCount() {
         const collection = await this.getSummaryCollection();
-        const limit      = aiConfig.summarizationBatchLimit || 2000;
+        const limit      = aiConfig.summarizationBatchLimit;
         const batch      = await collection.get({include: ['metadatas'], limit});
 
         if (!batch || !batch.ids?.length) return 0;
@@ -345,7 +345,7 @@ class ChromaManager extends AbstractVectorManager {
      */
     async getGraphDigestedCount() {
         const collection = await this.getSummaryCollection();
-        const limit      = aiConfig.summarizationBatchLimit || 2000;
+        const limit      = aiConfig.summarizationBatchLimit;
         const batch      = await collection.get({include: ['metadatas'], limit});
 
         if (!batch || !batch.ids?.length) return 0;


### PR DESCRIPTION
Resolves #12568

Related: #12461
Related: #12456

Authored by GPT-5.5 (Codex Desktop). Session dcdaac0b-9ae0-45b5-b4da-da39541af497.

Removes a narrow existing-leaf B3 fallback slice from AI production consumers: Orchestrator `swarmHeartbeat.targetSource`, ChromaManager `summarizationBatchLimit`, and SessionService provider-model / guardrail metadata reads now use the imported AiConfig authority directly.

Evidence: L1 (diff hygiene + static B3 sweeps; focused unit command blocked before tests by ignored local `ai/config.mjs` overlay) -> L1 required (direct-read cleanup ACs). Residual: broader `#12461` remains open.

## Deltas from Ticket

No implementation delta from #12568. This PR deliberately uses #12568 as the close target instead of broad `#12461`, because `#12461` still has verified residuals: memorySharing fallbacks blocked by red PR `#12532`, HealthService conflict-adjacent to open self PR `#12562`, and GitHub Workflow `pullFilenamePrefix` requiring a ledgered missing-leaf follow-up.

## Test Evidence

- `git diff --check origin/dev...HEAD` passed.
- Focused static sweep over `ai/daemons/orchestrator/Orchestrator.mjs`, `ai/services/memory-core/managers/ChromaManager.mjs`, and `ai/services/memory-core/SessionService.mjs` returned no matches for this slice's B3 patterns.
- Broad B3 sweep still reports only out-of-scope/blocked/false-positive surfaces called out in #12568: `HealthService`, `SummaryService` / `MemoryService` memorySharing, `PullRequestSyncer` `pullFilenamePrefix`, normalized plain-object `KnowledgeBaseIngestionService`, and generic local config helpers.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs` failed before test execution: local ignored `ai/config.mjs` imports missing `ai/ConfigProvider.mjs`.
- Overlay blocker verified without inspecting the local config body: `git check-ignore -v ai/config.mjs` confirms it is ignored, `git ls-files --error-unmatch ai/config.mjs` confirms it is untracked, and `git ls-files ai/ConfigProvider.mjs ai/BaseConfig.mjs ai/config.template.mjs` confirms the tracked branch has `BaseConfig.mjs` / `config.template.mjs` but no `ConfigProvider.mjs`.

## Post-Merge Validation

- [ ] Confirm #12568 auto-closes while #12461 remains open for its residual B3 work.
- [ ] After #12532 resolves, re-check the memorySharing residuals under #12461 or fold cleanup into that lane.

## Commits

- `9c4cec6a8` - `fix(ai): remove existing-leaf B3 fallbacks (#12568)`

## Evolution

During pre-PR reflection, the original #12461 commit target was corrected to #12568 so the PR can satisfy close-target hygiene without prematurely closing the broader B3 cleanup ticket.
