### PR TITLE
fix(wake): machine-agnostic subscriptionTemplate for vega (#12536)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -200,9 +200,18 @@ export const IDENTITIES = [
                     rationale                    : 'Same-family Claude maintainers add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-family PRs.'
                 }
             },
-            // No subscriptionTemplate yet: same-app Claude wake routing remains instance-addressing
-            // substrate, not an identity-root default. Direct A2A identity and resumeHarness routing
-            // can still target the account once the operator wires the harness instance.
+            // Wake route is machine-agnostic: the per-instance address (which same-bundle Claude
+            // instance to wake) is injected from the boot environment, never committed here —
+            // committing a per-operator path would break other forks and checkouts.
+            subscriptionTemplate: {
+                trigger: 'SENT_TO_ME',
+                harnessTarget: 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName: 'Claude',
+                    tabShortcut: '3',
+                    focusSeedKey: 'space'
+                }
+            },
             // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
             // §neo_opus_vega — primary source: Anthropic Claude Opus 4.8 announcement/product page.
             contextWindowInput: 1048576,

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -1,0 +1,82 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'IdentityRootsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import {IDENTITIES}   from '../../../../../ai/graph/identityRoots.mjs';
+
+/**
+ * @summary Wake-route invariants for the same-app (Claude Desktop) AgentIdentity roots.
+ *
+ * Claude-family maintainers run as distinct same-bundle Claude Desktop instances. An identity
+ * needs a wake route — either a static `subscriptionTemplate` (so Memory Core auto-bootstrap
+ * creates a WAKE_SUBSCRIPTION node) or a self-registered runtime subscription. With neither,
+ * `checkSunsetted` reads the absence as a terminal sunset and `resumeHarness` spawns a fresh
+ * session every heartbeat — the fresh-session loop.
+ *
+ * `@neo-opus-vega` (the 3rd same-app harness) had neither and was caught in that loop, so it
+ * gets the static template here, mirroring `@neo-opus-4-7`. `@neo-claude-opus` is active via a
+ * self-registered runtime subscription and deliberately carries NO static template — asserted
+ * below so a static route it does not need cannot be re-introduced.
+ *
+ * The static template stays machine-agnostic: the per-instance address is injected from the boot
+ * environment, never committed — a per-operator path in the shared roster would break other forks
+ * and checkouts.
+ */
+test.describe('ai/graph/identityRoots — same-app Claude wake routes', () => {
+    const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
+
+    const expectedTemplate = {
+        trigger              : 'SENT_TO_ME',
+        harnessTarget        : 'bridge-daemon',
+        harnessTargetMetadata: {appName: 'Claude', tabShortcut: '3', focusSeedKey: 'space'}
+    };
+
+    // Identities that carry the static, machine-agnostic wake template.
+    for (const id of ['@neo-opus-4-7', '@neo-opus-vega']) {
+        test(`${id} defines the machine-agnostic bridge-daemon wake route`, () => {
+            const entry = findIdentity(id);
+            expect(entry, `${id} must be a registered AgentIdentity root`).toBeTruthy();
+
+            const template = entry.properties?.subscriptionTemplate;
+            expect(
+                template,
+                `${id} must define a subscriptionTemplate so auto-bootstrap creates a WAKE_SUBSCRIPTION; ` +
+                `a missing one is read by checkSunsetted as a terminal sunset and resumes a fresh session every heartbeat`
+            ).toBeTruthy();
+            expect(template).toEqual(expectedTemplate);
+        });
+
+        test(`${id} commits no per-operator instance address (fork-portability invariant)`, () => {
+            const meta = findIdentity(id).properties.subscriptionTemplate.harnessTargetMetadata;
+            // The per-instance address is env-injected at boot (the boot envelope), never committed.
+            // Asserting their absence guards the invariant that a per-operator filesystem path can
+            // never leak into the shared, fork-shared roster.
+            expect(meta.instanceAddress, 'instanceAddress must not be committed').toBeUndefined();
+            expect(meta.userDataDir,     'userDataDir must not be committed').toBeUndefined();
+            expect(meta.addressType,     'addressType must not be committed').toBeUndefined();
+        });
+    }
+
+    test('@neo-claude-opus carries no static template (active via self-registered runtime subscription)', () => {
+        // claude-opus's wakes work via a self-registered runtime WAKE_SUBSCRIPTION, so it carries no
+        // static template — the fresh-session loop was vega-only (the 3rd same-app harness). Keeping
+        // this asserted prevents re-introducing a static route claude-opus does not need.
+        const entry = findIdentity('@neo-claude-opus');
+        expect(entry).toBeTruthy();
+        expect(entry.properties).not.toHaveProperty('subscriptionTemplate');
+    });
+});


### PR DESCRIPTION
## Summary

`@neo-opus-vega` — the 3rd same-app Claude harness — had no `subscriptionTemplate` in `ai/graph/identityRoots.mjs`, so Memory Core auto-bootstrap threw "no subscriptionTemplate found" and never created a `WAKE_SUBSCRIPTION`. `checkSunsetted.mjs` reads a *missing* subscription as a **terminal sunset** → `resumeHarness` spawns a fresh `Cmd+N` session + boot-grounding prompt every 10-minute heartbeat. That is the fresh-session loop @tobiu flagged.

**Scope: vega-only.** `@neo-claude-opus` is active via a self-registered runtime subscription and is not in the loop, so its entry is untouched — confirmed with @tobiu and @neo-claude-opus.

This adds the **machine-agnostic** wake route, mirroring `@neo-opus-4-7`: `trigger: SENT_TO_ME`, `harnessTarget: bridge-daemon`, `harnessTargetMetadata: {appName, tabShortcut, focusSeedKey}`. The per-instance address (which same-bundle Claude instance to wake) stays **env-injected at boot** via the boot envelope (`NEO_HARNESS_INSTANCE_ADDRESS`), never committed — so other forks and checkouts are unaffected.

With a subscription present, `checkSunsetted` flips `sunset → idle_out_nudge` — a non-spawning `MailboxService` A2A delivered into the existing session. **The loop ends.**

## Deltas

- `ai/graph/identityRoots.mjs`: add the machine-agnostic, path-free `subscriptionTemplate` to `@neo-opus-vega` (replaces its "no subscriptionTemplate yet" deferral comment). `@neo-claude-opus` is unchanged.
- `test/playwright/unit/ai/graph/identityRoots.spec.mjs` (new): asserts `@neo-opus-vega` + `@neo-opus-4-7` carry the machine-agnostic route and the fork-portability invariant (no committed `instanceAddress` / `userDataDir` / `addressType`); asserts `@neo-claude-opus` deliberately carries no static template (active via self-registered runtime subscription).

FAIR-band: S (one data entry + a new spec; +94/-3; no runtime-logic change — `@neo-opus-4-7` already ships this exact template shape).

Evidence: full run below in Test Evidence.

## Test Evidence

- `identityRoots.spec.mjs` — 5 passed (vega + neo-opus-4-7 template + invariant; claude-opus no-template).
- `swarmHeartbeat.spec.mjs` — unchanged and green (its `@neo-claude-opus` "no subscriptionTemplate" assertion stays valid under the vega-only scope).
- The prior (pre-narrowing) revision was CI-green across unit / integration / check / CodeQL / Analyze. The only local failures were pre-existing env-bound `checkSunsetted` subprocess tests — confirmed identical on clean `dev` via `git stash -u` (the spec runs `checkSunsetted.mjs` as a subprocess that cannot load the worktree's gitignored config DB).

## Post-Merge Validation

This PR ends the loop. Completing end-to-end delivery needs two operator-side rollout steps (infra, not code):

1. Set `NEO_HARNESS_INSTANCE_ADDRESS` (vega's own `--user-data-dir`) + `NEO_HARNESS_INSTANCE_ADDRESS_TYPE=userDataDir` on vega's Claude launch. Without it the new subscription has no instance address → delivery resolves the arg-less default instance and focus-steals into the default Claude session.
2. Restart vega's Memory Core so auto-bootstrap reads the new template.
3. Verify: `checkSunsetted @neo-opus-vega` → `recommended_action: idle_out_nudge` (not `sunset_restart`); a new A2A wakes vega's own session with no fresh-session spawn.

Resolves #12574

Refs #12536 (broad parent — its `resumeHarness` / bridge per-identity routing ACs stay open; this PR is only the vega-template loop-fix slice, split out per cross-family review). Refs #12571 (HARNESS_PRESENCE refresh follow-up). Refs #12422 (boot-envelope mechanism).

Authored by @neo-opus-4-7 (Claude Opus 4.8). Handoff: @neo-claude-opus reassigned #12536 ("all yours") and corrected the scope to vega-only (his own wakes are fine). Note: the commit subject references the parent #12536 for context; the PR's close-target is the narrow #12574.
