### PR TITLE
docs(agentos): git commit-identity provisioning in OwnAgentTeam guide (#12535)

### DIFF
--- a/learn/agentos/OwnAgentTeam.md
+++ b/learn/agentos/OwnAgentTeam.md
@@ -130,10 +130,11 @@ author**. That is a separate surface. If a clone has no commit identity, `git co
 falls through to the global `~/.gitconfig`, so commits land authored as the human
 operator instead of the agent.
 
-This is easy to miss because **squash-merge masks it**: GitHub rewrites a squashed
-commit's author to the PR account, so merged history looks correct while local history,
-`Co-Authored-By` trailers, and any rebase/merge-commit stay mis-attributed. Treat commit
-identity as load-bearing, not cosmetic.
+This is easy to miss because **squash-merge can mask it**: when the repo's *squash merge
+commit author* setting rewrites the squashed commit's author to the PR account, merged
+history looks correct while local history, `Co-Authored-By` trailers, and any
+rebase/merge-commit stay mis-attributed. Treat commit identity as load-bearing, not
+cosmetic.
 
 Derive the identity from the same source of truth as the rest of the setup — the
 `AgentIdentity` `displayName` (social label) and the team email convention (here
@@ -142,10 +143,17 @@ later rename does not strand stale attribution.
 
 ### Primary: inject commit identity in the harness env
 
-`GIT_AUTHOR_*` / `GIT_COMMITTER_*` environment variables override **both** repo-local and
-global config (precedence: `--author` > `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env > `git
-config --local` > global). Inject them once per agent, beside `NEO_AGENT_IDENTITY`, and
-every repo the process touches is attributed correctly from a single shared clone:
+`GIT_AUTHOR_*` and `GIT_COMMITTER_*` environment variables override **both** repo-local
+and global config — but author and committer are **separate surfaces**, each with its own
+precedence:
+
+- **Author:** `--author` > `GIT_AUTHOR_*` env > `git config --local` > global.
+- **Committer:** `GIT_COMMITTER_*` env > `git config --local` > global. `--author` and
+  `GIT_AUTHOR_*` do *not* affect the committer.
+
+Set **all four** (`GIT_AUTHOR_NAME`/`EMAIL` + `GIT_COMMITTER_NAME`/`EMAIL`) once per agent,
+beside `NEO_AGENT_IDENTITY`, and every repo the process touches is attributed correctly on
+both surfaces from a single shared clone:
 
 ```bash
 export GIT_AUTHOR_NAME="Acme Claude"
@@ -176,10 +184,12 @@ for every clone and is the step that gets skipped.
 
 ### Verify (fail loud)
 
-Before the first commit from a new clone or harness, confirm the effective author:
+Before the first commit from a new clone or harness, confirm the effective author and
+committer:
 
 ```bash
 git var GIT_AUTHOR_IDENT
+git var GIT_COMMITTER_IDENT
 # → Acme Claude <acme-claude@acme.example> 1700000000 +0000
 ```
 

--- a/learn/agentos/OwnAgentTeam.md
+++ b/learn/agentos/OwnAgentTeam.md
@@ -122,6 +122,70 @@ For stdio clients, `NEO_AGENT_IDENTITY` is the authoritative local identity pin.
 GitHub CLI fallback is useful for humans, but a team agent should not depend on an
 ambient shell login.
 
+## Provision Git Commit Identity
+
+`NEO_AGENT_IDENTITY` binds a harness to its Memory Core node, and a per-clone `GH_TOKEN`
+routes GitHub API/CLI calls to the right account — but **neither sets git's commit
+author**. That is a separate surface. If a clone has no commit identity, `git commit`
+falls through to the global `~/.gitconfig`, so commits land authored as the human
+operator instead of the agent.
+
+This is easy to miss because **squash-merge masks it**: GitHub rewrites a squashed
+commit's author to the PR account, so merged history looks correct while local history,
+`Co-Authored-By` trailers, and any rebase/merge-commit stay mis-attributed. Treat commit
+identity as load-bearing, not cosmetic.
+
+Derive the identity from the same source of truth as the rest of the setup — the
+`AgentIdentity` `displayName` (social label) and the team email convention (here
+`<handle>@acme.example`). **Do not hardcode handles that may change**; resolve them so a
+later rename does not strand stale attribution.
+
+### Primary: inject commit identity in the harness env
+
+`GIT_AUTHOR_*` / `GIT_COMMITTER_*` environment variables override **both** repo-local and
+global config (precedence: `--author` > `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env > `git
+config --local` > global). Inject them once per agent, beside `NEO_AGENT_IDENTITY`, and
+every repo the process touches is attributed correctly from a single shared clone:
+
+```bash
+export GIT_AUTHOR_NAME="Acme Claude"
+export GIT_AUTHOR_EMAIL="acme-claude@acme.example"
+export GIT_COMMITTER_NAME="Acme Claude"
+export GIT_COMMITTER_EMAIL="acme-claude@acme.example"
+```
+
+Env injection is the robust shape because it cannot be forgotten per-clone — the
+originating failure was an unconfigured clone falling through to the operator's global
+identity. Use the agent's verified team email so commits link to its account (the push
+token needs only write access; attribution follows the author, not the pusher, so one
+shared write token can push every agent's commits each correctly credited). Never use a
+`<noreply@*>` author/committer email.
+
+### Fallback: per-clone repo-local config
+
+For contexts without harness env injection — a manual shell, a one-off side-repo — set
+repo-local identity per clone:
+
+```bash
+git config user.name  "Acme Claude"          # AgentIdentity displayName
+git config user.email "acme-claude@acme.example"
+```
+
+Repo-local config is the fallback, not the primary, precisely because it must be repeated
+for every clone and is the step that gets skipped.
+
+### Verify (fail loud)
+
+Before the first commit from a new clone or harness, confirm the effective author:
+
+```bash
+git var GIT_AUTHOR_IDENT
+# → Acme Claude <acme-claude@acme.example> 1700000000 +0000
+```
+
+If this resolves to the operator's global identity (a personal name/email), **stop and
+fix it before committing** — otherwise the agent silently commits as the operator.
+
 ## Isolate Memory Correctly
 
 Local provisioning has three memory surfaces:
@@ -198,9 +262,10 @@ Provision teammates incrementally:
 1. Add one identity root.
 2. Seed the graph.
 3. Bind one harness with `NEO_AGENT_IDENTITY`.
-4. Verify `healthcheck.identity.bound`.
-5. Send an A2A message to the teammate and confirm it lands in the correct inbox.
-6. Repeat for the next teammate.
+4. Set the harness git commit identity and confirm it with `git var GIT_AUTHOR_IDENT`.
+5. Verify `healthcheck.identity.bound`.
+6. Send an A2A message to the teammate and confirm it lands in the correct inbox.
+7. Repeat for the next teammate.
 
 This sequence keeps identity, graph binding, and mailbox reachability falsifiable at
 each step.


### PR DESCRIPTION
Resolves #12535

Authored by Opus 4.8 (Claude Code / @neo-opus-vega). Session db066a97-cc06-4bd3-b8fe-c056ab15639e.

Adds a **"Provision Git Commit Identity"** section to the `OwnAgentTeam.md` provisioning guide, closing a silent attribution footgun: agent clones with no commit identity fall through to the operator's global `~/.gitconfig`, so `git commit` lands authored as the human. Squash-merge masks this on merged `dev`, but local history, `Co-Authored-By` trailers, and any rebase/merge-commit stay mis-attributed. The section documents the **primary** fix (harness `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env injection — overrides repo-local + global config from a single shared clone), the **fallback** (per-clone `git config user.*`), and a **fail-loud verify** step (`git var GIT_AUTHOR_IDENT`). Identity resolves from the deployment SSOT (AgentIdentity `displayName` + team email convention), not hardcoded — rename-robust by construction.

Evidence: L1 (static doc audit — guide content verifiable in-diff; dogfooded — this PR's own commit is authored `Neo Opus Vega <neo-opus-vega@neomjs.com>`, not the operator default) → L1 required (documentation ACs, no runtime-verify). No residuals.

## Deltas from ticket
None — implements the contract-aligned body 1:1 (Contract Ledger primary / fallback / non-automation rows). Scope held to docs/harness-provisioning; framework bootstrap automation explicitly out of scope (noted NOT precluded by #10858 / #10860 — a deferrable, evidence-justified follow-up).

## Slot-Rationale (Substrate-Mutation Pre-Flight — AGENTS.md §13)
Touches `learn/agentos/OwnAgentTeam.md` — a provisioning guide (World-Atlas / read-on-demand, **not** always-loaded turn substrate).
- **Added — "Provision Git Commit Identity" section:** disposition **`keep`**. 3-axis: trigger-frequency LOW (read once per team/clone provisioning) × failure-severity HIGH (silent operator-misattribution; squash-merge masks it until a rebase/merge-commit corrupts `dev` history) × enforceability MANUAL (doc-side fail-loud `git var` check; no automated gate, per the ticket's non-automation boundary). `keep` over `compress-to-trigger` justified: it is reference documentation, not always-loaded bytes — zero per-turn substrate cost, and the World-Atlas is exactly where on-demand provisioning detail belongs.
- **Modified — "Bring Up The Team" checklist:** +1 step (set + verify commit identity) so the section is reachable from the provisioning sequence. Disposition: `keep` (discoverability hook).
- Net: +68 / −3 in a conditionally-read guide; **zero always-loaded substrate growth.**

## Test Evidence
- Pure documentation; no runtime/code surface, so no unit/e2e tests apply.
- `OwnAgentTeam.md` already registered in `learn/tree.json` (line 47) — editing an existing file, no registration change.
- Pre-commit whitespace check passed; commit authored `Neo Opus Vega <neo-opus-vega@neomjs.com>` with no `<noreply@*>` footer (gate #4).

## Post-Merge Validation
- [ ] Section renders correctly in the Portal Learn view + Knowledge Base ingestion of `agentos/OwnAgentTeam`.

Related: #12519 (the guide), #10858 / #10860 (`GH_TOKEN` / API-auth — relates-to, different surface), #12518 / #12578 (handle-rename — SSOT input).
