### PR TITLE
fix(lint): validate named skill section refs (#12582)

### DIFF
--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -296,14 +296,34 @@ function normalizeRelPath(filePath) {
     return path.normalize(filePath).replace(/\\/g, '/').replace(/^\.\//, '');
 }
 
+const NAMED_SECTION_REF_SOURCE   = '[A-Za-z](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?';
+const NUMERIC_SECTION_REF_SOURCE = '\\d+\\.\\d+(?:\\.\\d+)*';
+const SECTION_REF_SOURCE         = `${NUMERIC_SECTION_REF_SOURCE}|${NAMED_SECTION_REF_SOURCE}`;
+const SECTION_REF_TARGET_SOURCE  = [
+    '\\.agents\\/skills\\/[A-Za-z0-9_.\\/-]+',
+    '(?:\\.{1,2}\\/|references\\/)[A-Za-z0-9_.\\/-]+',
+    '[A-Za-z0-9_.\\/-]+\\.md',
+    '[A-Za-z0-9_.-]+'
+].join('|');
+
+function isNumericSectionRef(sectionRef) {
+    return new RegExp(`^${NUMERIC_SECTION_REF_SOURCE}$`).test(sectionRef);
+}
+
 function extractHeadingAnchors(text) {
     const anchors = new Set();
 
     for (const line of text.split('\n')) {
-        const match = line.match(/^#{1,6}\s+(?:§)?(\d+(?:\.\d+)*)(?:\b|[^\d.])/);
+        const numericMatch = line.match(/^#{1,6}\s+(?:§)?(\d+(?:\.\d+)*)(?:\b|[^\d.])/);
 
-        if (match) {
-            anchors.add(match[1]);
+        if (numericMatch) {
+            anchors.add(numericMatch[1]);
+        }
+
+        const namedMatch = line.match(new RegExp(`^#{1,6}\\s+§(${NAMED_SECTION_REF_SOURCE})(?:\\b|[^A-Za-z0-9_.-])`));
+
+        if (namedMatch) {
+            anchors.add(namedMatch[1]);
         }
     }
 
@@ -391,6 +411,25 @@ function collectMarkdownPointerTargets(line) {
     }
 
     return [...targets];
+}
+
+function collectMarkdownSectionRefs(line) {
+    const refs = [];
+    const markdownLinkSectionRefPattern = new RegExp(`\\[[^\\]]*?§(${SECTION_REF_SOURCE})[^\\]]*?\\]\\(([^)\\s]+\\.md(?:#[^)]+)?)\\)`, 'g');
+    let match;
+
+    while ((match = markdownLinkSectionRefPattern.exec(line))) {
+        refs.push({
+            sectionRef: match[1],
+            target    : match[2]
+        });
+    }
+
+    return refs;
+}
+
+function stripMarkdownLinks(line) {
+    return line.replace(/\[[^\]]+\]\([^)]+\)/g, '');
 }
 
 function ensureChangedLineSet(changedLinesByRelPath, relPath) {
@@ -601,8 +640,29 @@ function shouldScanReferenceLine(sourceRelPath, lineNo, changedLinesByRelPath) {
     return changedLines.has(lineNo);
 }
 
+function validateSectionRef({sourceRelPath, lineNo, target, sectionRef, index, errors}) {
+    const targetRelPath = target
+        ? resolveSkillMarkdownTarget(target, sourceRelPath, index)
+        : sourceRelPath.endsWith('.md')
+            ? sourceRelPath
+            : null;
+
+    if (!targetRelPath) return;
+    if (!index.byRelPath.has(targetRelPath)) {
+        errors.push(`${sourceRelPath}:${lineNo} → broken section-ref target ${target} for §${sectionRef}`);
+        return;
+    }
+
+    const anchors = index.headingIndex.get(targetRelPath);
+    if (!anchors) return;
+    if (!anchors.has(sectionRef)) {
+        const targetLabel = target ? `${target} ` : '';
+        errors.push(`${sourceRelPath}:${lineNo} → dangling section ref ${targetLabel}§${sectionRef} (target lacks matching heading)`);
+    }
+}
+
 /**
- * @summary Checks changed skill substrate text for resolvable Markdown pointers and numeric section references.
+ * @summary Checks changed skill substrate text for resolvable Markdown pointers and section references.
  *
  * Manifest prose can be a source of references, but target anchors intentionally stay Markdown-only.
  *
@@ -635,28 +695,32 @@ function checkSkillReferenceIntegrity(changedRelPaths, allMarkdownFiles, {change
                 }
             }
 
-            const sectionRefPattern = /(?:(\.agents\/skills\/[A-Za-z0-9_.\/-]+|(?:\.{1,2}\/|references\/)[A-Za-z0-9_.\/-]+|[A-Za-z0-9_.-]+(?:\.md)?)\s+)?§(\d+\.\d+(?:\.\d+)*)/g;
+            for (const sectionRef of collectMarkdownSectionRefs(line)) {
+                validateSectionRef({
+                    sourceRelPath,
+                    lineNo,
+                    target: sectionRef.target,
+                    sectionRef: sectionRef.sectionRef,
+                    index,
+                    errors
+                });
+            }
+
+            const sectionRefPattern = new RegExp(`(?:(${SECTION_REF_TARGET_SOURCE})\\s+)?§(${SECTION_REF_SOURCE})`, 'g');
+            const lineWithoutMarkdownLinks = stripMarkdownLinks(line);
             let match;
 
-            while ((match = sectionRefPattern.exec(line))) {
-                const targetRelPath = match[1]
-                    ? resolveSkillMarkdownTarget(match[1], sourceRelPath, index)
-                    : sourceRelPath.endsWith('.md')
-                        ? sourceRelPath
-                        : null;
+            while ((match = sectionRefPattern.exec(lineWithoutMarkdownLinks))) {
+                if (!match[1] && !isNumericSectionRef(match[2])) continue;
 
-                if (!targetRelPath) continue;
-                if (!index.byRelPath.has(targetRelPath)) {
-                    errors.push(`${sourceRelPath}:${lineNo} → broken section-ref target ${match[1]} for §${match[2]}`);
-                    continue;
-                }
-
-                const anchors = index.headingIndex.get(targetRelPath);
-                if (!anchors) continue;
-                if (!anchors.has(match[2])) {
-                    const targetLabel = match[1] ? `${match[1]} ` : '';
-                    errors.push(`${sourceRelPath}:${lineNo} → dangling section ref ${targetLabel}§${match[2]} (target lacks matching heading)`);
-                }
+                validateSectionRef({
+                    sourceRelPath,
+                    lineNo,
+                    target: match[1],
+                    sectionRef: match[2],
+                    index,
+                    errors
+                });
             }
         });
     }
@@ -693,7 +757,7 @@ function checkRemovedSkillFileReferences(removedRelPaths, allTextFiles) {
                 }
             }
 
-            const sectionRefPattern = /(\.agents\/skills\/[A-Za-z0-9_.\/-]+|(?:\.{1,2}\/|references\/)[A-Za-z0-9_.\/-]+|[A-Za-z0-9_.-]+(?:\.md)?)\s+§\d+\.\d+(?:\.\d+)*/g;
+            const sectionRefPattern = new RegExp(`(${SECTION_REF_TARGET_SOURCE})\\s+§(?:${SECTION_REF_SOURCE})`, 'g');
             let match;
 
             while ((match = sectionRefPattern.exec(line))) {

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -501,6 +501,34 @@ ${padding}
         expect(errors[1]).toContain('dangling section ref pr-review-guide §10.4');
     });
 
+    test('checkSkillReferenceIntegrity validates targeted named section refs (#12582)', () => {
+        const files = [{
+            relPath: '.agents/skills/ideation-sandbox/audits/consensus-mandate.md',
+            text   : [
+                '## §template-block — Graduated-Artifact Required Sections',
+                '## §same-family-aggregation — Multi-Identity Family Resolution'
+            ].join('\n')
+        }, {
+            relPath: '.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md',
+            text   : [
+                'Valid linked ref: [`audits/consensus-mandate.md §template-block`](../audits/consensus-mandate.md).',
+                'Valid prose ref: consensus-mandate §same-family-aggregation.',
+                'Invalid linked ref: [`audits/consensus-mandate.md §missing-template`](../audits/consensus-mandate.md).',
+                'Invalid prose ref: consensus-mandate §missing-aggregation.'
+            ].join('\n')
+        }];
+
+        const errors = checkSkillReferenceIntegrity([
+            '.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md'
+        ], files);
+
+        expect(errors).toHaveLength(2);
+        expect(errors[0]).toContain('ideation-sandbox-workflow.md:3');
+        expect(errors[0]).toContain('dangling section ref ../audits/consensus-mandate.md §missing-template');
+        expect(errors[1]).toContain('ideation-sandbox-workflow.md:4');
+        expect(errors[1]).toContain('dangling section ref consensus-mandate §missing-aggregation');
+    });
+
     test('parseUnifiedDiffChangedLines maps base diffs to current-file line numbers (#12557)', () => {
         const diffText = [
             'diff --git a/.agents/skills/pr-review/references/pr-review-guide.md b/.agents/skills/pr-review/references/pr-review-guide.md',
@@ -541,6 +569,32 @@ ${padding}
         expect(errors).toHaveLength(1);
         expect(errors[0]).toContain('pr-review-guide.md:4');
         expect(errors[0]).toContain('dangling section ref §9.2');
+    });
+
+    test('checkSkillReferenceIntegrity only scans changed named section refs when base ownership is provided (#12582)', () => {
+        const relPath = '.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md';
+        const files = [{
+            relPath: '.agents/skills/ideation-sandbox/audits/consensus-mandate.md',
+            text   : '## §template-block — Graduated-Artifact Required Sections'
+        }, {
+            relPath,
+            text: [
+                'Valid changed ref: consensus-mandate §template-block.',
+                'Pre-existing stale ref: consensus-mandate §missing-template.'
+            ].join('\n')
+        }];
+
+        expect(checkSkillReferenceIntegrity([relPath], files, {
+            changedLinesByRelPath: new Map([[relPath, new Set([1])]])
+        })).toEqual([]);
+
+        const errors = checkSkillReferenceIntegrity([relPath], files, {
+            changedLinesByRelPath: new Map([[relPath, new Set([2])]])
+        });
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('ideation-sandbox-workflow.md:2');
+        expect(errors[0]).toContain('dangling section ref consensus-mandate §missing-template');
     });
 
     test('downstream docs skip only applies to link-path-only skill diffs whose docs omit the moved target (#12557)', () => {
@@ -624,7 +678,9 @@ ${padding}
                 'Ticket #12488 and ADR 0019 §A4 are descriptive refs.',
                 'External [doc](https://example.com/a.md) is out of scope.',
                 'Wildcard authoring prose like `references/*.md` is not a concrete pointer.',
-                'Generic guide §7 wording has no resolvable target and is ignored.'
+                'Generic guide §7 wording has no resolvable target and is ignored.',
+                'External named anchors like AGENTS.md §verify_before_assert are ignored when the file target is outside skill substrate.',
+                'Standalone named prose like §contributions_over_commits stays descriptive without a markdown target.'
             ].join('\n')
         }];
 
@@ -639,6 +695,7 @@ ${padding}
             text   : [
                 'Deleted relative pointer: [old](./removed-rule.md).',
                 'Deleted basename section ref: removed-rule §2.1.',
+                'Deleted named section ref: removed-rule §legacy-anchor.',
                 'Live pointer: [response](./review-response-protocol.md).'
             ].join('\n')
         }, {
@@ -650,10 +707,12 @@ ${padding}
             '.agents/skills/pull-request/references/removed-rule.md'
         ], files);
 
-        expect(errors).toHaveLength(2);
+        expect(errors).toHaveLength(3);
         expect(errors[0]).toContain('pull-request-workflow.md:1');
         expect(errors[0]).toContain('reference to deleted file ./removed-rule.md');
         expect(errors[1]).toContain('pull-request-workflow.md:2');
         expect(errors[1]).toContain('reference to deleted file removed-rule');
+        expect(errors[2]).toContain('pull-request-workflow.md:3');
+        expect(errors[2]).toContain('reference to deleted file removed-rule');
     });
 });


### PR DESCRIPTION
Resolves #12582

Authored by GPT-5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Extends `lint-skill-manifest` reference integrity so targeted named section refs are validated instead of silently escaping coverage. The lint now indexes named `## §anchor` headings, validates markdown-linked and prose file-target section refs such as `consensus-mandate §template-block`, keeps numeric `§N.N` behavior intact, and preserves #12557 changed-line ownership.

Evidence: L1 (focused unit coverage + static lint checks) → L1 required (lint contract and unit-test ACs). No residuals.

## Deltas from Ticket

- Implemented the preferred validation path rather than banning named refs.
- Scoped named-ref validation to refs with a resolvable skill markdown target. Standalone named prose such as external `AGENTS.md §...` anchors remains descriptive unless it points to a skill markdown file, avoiding false same-file failures.
- Extended removed-skill-file reference detection to catch named section refs to deleted skill files.

## Test Evidence

- `node --check ai/scripts/lint/lint-skill-manifest.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` — 35 passed
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `npm run ai:lint-skill-manifest`
- `npm run ai:lint-agents`
- `git diff --check`

## Post-Merge Validation

- [ ] Confirm GitHub Actions remain green at the merge candidate head.

## Commits

- `f19235b7f` — `fix(lint): validate named skill section refs (#12582)`
