### PR TITLE
fix(skills): correct relative section-ref paths in audit files (#12588)

### DIFF
--- a/.agents/skills/ideation-sandbox/audits/consensus-mandate.md
+++ b/.agents/skills/ideation-sandbox/audits/consensus-mandate.md
@@ -1,28 +1,28 @@
 # Consensus-Mandate Audit Reference
 
-*(Sub-rule extraction from `ideation-sandbox-workflow.md §6` per #11319 / #11320 byte-budget discipline. Load this file when you need the graduated-artifact template block, two-axis substrate details, empirical anchors for the §6 consensus mandate, or the 30-day post-merge validation framing. The main `references/ideation-sandbox-workflow.md §6` carries the operational rule; this file carries reference-grade context that loads on-demand.)*
+*(Sub-rule extraction from `ideation-sandbox-workflow.md §6` per #11319 / #11320 byte-budget discipline. Load this file when you need the graduated-artifact template block, two-axis substrate details, empirical anchors for the §6 consensus mandate, or the 30-day post-merge validation framing. The main `../references/ideation-sandbox-workflow.md §6` carries the operational rule; this file carries reference-grade context that loads on-demand.)*
 
 ## §quorum-rule — Family-Keyed Quorum Rule (full rationale)
 
-`references/ideation-sandbox-workflow.md §6.2` carries the operational rule; this section carries the full rationale + background.
+`../references/ideation-sandbox-workflow.md §6.2` carries the operational rule; this section carries the full rationale + background.
 
 **Quorum rule** (per Epic #11796 / Discussion #11793 — family-keyed, membership-derived):
 
 - **(a) Floor-2 (all tiers):** ≥ 2 distinct *active* families (per `AgentIdentity.participationStatus` in `ai/graph/identityRoots.mjs`) carry ANY signal type (`AUTHOR_SIGNAL` or `[GRADUATION_APPROVED]`).
 - **(b) Non-author endorsement (all tiers):** ≥ 1 *non-author* active family carries `[GRADUATION_APPROVED]`. `AUTHOR_SIGNAL` from the author's family is necessary for family coverage but never sufficient on its own.
-- **(c) Tier 2** (core-value / §critical_gates / consensus-gate mutations) additionally requires explicit `## Unresolved Liveness` entry for any benched family + capability-grounded `revalidationTrigger` AC in the graduating Epic (per `references/ideation-sandbox-workflow.md §6.6`).
+- **(c) Tier 2** (core-value / §critical_gates / consensus-gate mutations) additionally requires explicit `## Unresolved Liveness` entry for any benched family + capability-grounded `revalidationTrigger` AC in the graduating Epic (per `../references/ideation-sandbox-workflow.md §6.6`).
 
-Family-keying replaces the prior hardcoded "3× cross-family signals" — the count was a snapshot of fixed swarm membership, while the active membership is variable (operator-benched families, same-family siblings). Same-family aggregation (`references/ideation-sandbox-workflow.md §6.4`) determines a family's contributed signal when multiple identities of one family are active.
+Family-keying replaces the prior hardcoded "3× cross-family signals" — the count was a snapshot of fixed swarm membership, while the active membership is variable (operator-benched families, same-family siblings). Same-family aggregation (`../references/ideation-sandbox-workflow.md §6.4`) determines a family's contributed signal when multiple identities of one family are active.
 
 ## §same-family-aggregation — Multi-Identity Family Resolution (full rule)
 
-`references/ideation-sandbox-workflow.md §6.4` codifies a one-line summary; this section carries the full rule.
+`../references/ideation-sandbox-workflow.md §6.4` codifies a one-line summary; this section carries the full rule.
 
 When a family has multiple active identities (e.g., `claude` with both `@neo-opus-4-7` and a future `@neo-claude-opus`), that family contributes `APPROVED` when **(a) ≥ 1 active identity in the family has posted `[GRADUATION_APPROVED]` at the current body anchor**, AND **(b) no active identity in that family holds an unresolved `[GRADUATION_DEFERRED]` or `[GRADUATION_VETO]` at the same anchor**. Any unresolved same-family `DEFERRED`/`VETO` blocks that family until reconciled. The `§6.4` burden-of-convergence clause applies to same-family APPROVED-signalers as well as cross-family ones. This preserves same-family challenge pressure without double-counting the family.
 
 ## §template-block — Graduated-Artifact Required Sections (canonical markdown)
 
-The graduated Issue / Epic / PR body MUST include the four `## Signal Ledger` + `## Unresolved Dissent` + `## Unresolved Liveness` + `## Discussion Criteria Mapping` sections per `references/ideation-sandbox-workflow.md §6.6`. Canonical template (post-Epic #11796 family-keyed rule):
+The graduated Issue / Epic / PR body MUST include the four `## Signal Ledger` + `## Unresolved Dissent` + `## Unresolved Liveness` + `## Discussion Criteria Mapping` sections per `../references/ideation-sandbox-workflow.md §6.6`. Canonical template (post-Epic #11796 family-keyed rule):
 
 ```markdown
 ## Signal Ledger
@@ -49,7 +49,7 @@ The graduated Issue / Epic / PR body MUST include the four `## Signal Ledger` + 
 
 ## §signal-patterns-table — Full Signal Pattern Definitions (§6.2 reference)
 
-The four signal patterns recognized at high-blast graduation (`references/ideation-sandbox-workflow.md §6.2` carries the inline bullet summary):
+The four signal patterns recognized at high-blast graduation (`../references/ideation-sandbox-workflow.md §6.2` carries the inline bullet summary):
 
 | Signal | Effect on graduation | Definition |
 |--------|----------------------|------------|
@@ -98,11 +98,11 @@ Per #11195 30-day Step 2.5 validation tracker, the consensus-mandate substrate's
 
 When the Signal Ledger reaches the §6.2 quorum (floor-2 + non-author-APPROVED ≥ 1; Tier 2 also requires `## Unresolved Liveness` + `revalidationTrigger` AC), the author executes the following sequence:
 
-1. Add `[GRADUATED_TO_TICKET: #N]` marker near top of Discussion body (per `references/ideation-sandbox-workflow.md §4` OQ-resolution-tag pattern).
+1. Add `[GRADUATED_TO_TICKET: #N]` marker near top of Discussion body (per `../references/ideation-sandbox-workflow.md §4` OQ-resolution-tag pattern).
 2. Update body with `## Signal Ledger` + `## Unresolved Dissent` + `## Unresolved Liveness` + `## Discussion Criteria Mapping` sections (template per §template-block above).
 3. File resulting Epic / ticket / PR with cross-references back to Discussion + each peer's GRADUATION signal commentId.
 4. Formally close Discussion via GraphQL `closeDiscussion(reason: RESOLVED)`.
 
 The closed Discussion remains the archaeological source; the linked artifact becomes actionable. **The cycle-comments archive as the divergence-trail.**
 
-**Precondition for the sequence** (codified in `references/ideation-sandbox-workflow.md §6.7`): if the author's family has no other active identity, the author posts `[AUTHOR_SIGNAL]` at the current body anchor BEFORE the final non-author-APPROVED poll. Without it, floor-2 cannot be reached when only one non-author family is active.
+**Precondition for the sequence** (codified in `../references/ideation-sandbox-workflow.md §6.7`): if the author's family has no other active identity, the author posts `[AUTHOR_SIGNAL]` at the current body anchor BEFORE the final non-author-APPROVED poll. Without it, floor-2 cannot be reached when only one non-author family is active.

--- a/.agents/skills/ideation-sandbox/audits/tier-2-revalidation.md
+++ b/.agents/skills/ideation-sandbox/audits/tier-2-revalidation.md
@@ -1,6 +1,6 @@
 # Tier-2 Revalidation Sweep — Audit Reference
 
-*(Substrate extracted from `references/ideation-sandbox-workflow.md §6.5` per #11319 / #11320 per-file byte-budget discipline. Load this file when you need the full Tier-2 Revalidation Sweep mechanism description, invocation, reconciliation semantics, or MVP scope boundaries. The main `references/ideation-sandbox-workflow.md §6.5` carries the operational rule with an inline pointer to this audit.)*
+*(Substrate extracted from `../references/ideation-sandbox-workflow.md §6.5` per #11319 / #11320 per-file byte-budget discipline. Load this file when you need the full Tier-2 Revalidation Sweep mechanism description, invocation, reconciliation semantics, or MVP scope boundaries. The main `../references/ideation-sandbox-workflow.md §6.5` carries the operational rule with an inline pointer to this audit.)*
 
 ## §mechanism — Tier-2 Revalidation Sweep (Option c sweep-script-notifies-only)
 

--- a/.agents/skills/pull-request/audits/consensus-gate-mirror.md
+++ b/.agents/skills/pull-request/audits/consensus-gate-mirror.md
@@ -1,6 +1,6 @@
 # Consensus-Gate Mirror Reference (§6.1.1 family-keyed shape, post Epic #11796)
 
-*(Sub-rule extraction from `references/pull-request-workflow.md §6.1.1` per #11319 / #11320 byte-budget discipline. Load when authoring a substrate PR from a high-blast Discussion or reviewing one. The main `references/pull-request-workflow.md §6.1.1` carries the operational rule; this file carries the full template + Tier-2 reviewer step detail + reviewer-step quorum check + rejection-mode enumeration.)*
+*(Sub-rule extraction from `../references/pull-request-workflow.md §6.1.1` per #11319 / #11320 byte-budget discipline. Load when authoring a substrate PR from a high-blast Discussion or reviewing one. The main `../references/pull-request-workflow.md §6.1.1` carries the operational rule; this file carries the full template + Tier-2 reviewer step detail + reviewer-step quorum check + rejection-mode enumeration.)*
 
 ## §quorum-citation — Axis 2 quorum semantics (post Epic #11796)
 


### PR DESCRIPTION
Resolves #12588

Authored by Claude Opus 4.8 (Claude Code). Session 0f6d0fa0-327f-42ec-b970-e32f388699b4.

Corrects relative section-ref paths in three skill `audits/`-resident files. They referenced the sibling `references/` directory as `references/<file>.md §N` (skill-root-relative), but from `audits/` the resolvable path is `../references/<file>.md §N`. ~13 refs across 3 files; a pure relative-path correction — no anchor or prose-content change. This is the legitimate path-fix PR #12581 originally attempted (dropped pre-merge when its bundled §-ref restyle was flagged in review).

Evidence: L1 (static lint audit — `lint-skill-manifest --base HEAD~1` → OK; every rewritten target + numeric anchor resolves) → L1 required (doc-path correctness, no runtime ACs). No residuals.

**Micro-change exemption (§6.1):** pure documentation, no runtime impact — cross-family review welcome but not merge-gating.

## Deltas from ticket
None — implements #12588 one-to-one.

## Slot-Rationale (Substrate-Mutation Pre-Flight — AGENTS.md §13)
Touches `.agents/skills/ideation-sandbox/audits/consensus-mandate.md`, `.agents/skills/ideation-sandbox/audits/tier-2-revalidation.md`, `.agents/skills/pull-request/audits/consensus-gate-mirror.md` — conditionally-loaded World-Atlas audit files (read-on-demand, **not** always-loaded turn substrate).
- **Modified (all 3 files):** disposition `rewrite` — corrected the relative path of existing section-refs (`references/` → `../references/`). No section added or removed; no prose/anchor change; **zero always-loaded substrate growth** (+3 chars `../` per ref). Reason for the shift: the paths were file-relative-incorrect from `audits/`; the #12584 named-section-ref lint flags them on next edit, so this pre-empts CI breakage.

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base HEAD~1` → `[lint-skill-manifest] OK` (exit 0).
- Seam grep: 0 broken `references/…§` refs remain in the three `audits/` files; the 13 refs now use `../references/…§`, all targets + numeric anchors resolving.
- Pure docs — no unit/e2e tests apply.

## Post-Merge Validation
- [ ] `lint-skill-manifest` + `lint-pr-body` green on the PR head.

## Commits
- `535772e3d` — fix(skills): correct relative section-ref paths in audit files (#12588)
