### PR TITLE
feat(ai): bump default remote Flash model to gemini-3.5-flash (#12573)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -259,7 +259,7 @@ class Config extends ConfigProvider {
              * summary and embedding paths; Tier-1 owns the default tuple.
              * @type {String}
              */
-            modelName: leaf('gemini-2.5-flash'),
+            modelName: leaf('gemini-3.5-flash'),
             /**
              * @summary Deployment-wide Gemini embedding model default.
              * @type {String}

--- a/ai/demo-agents/dev.mjs
+++ b/ai/demo-agents/dev.mjs
@@ -34,7 +34,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 // --- Configuration ---
-const MODEL_NAME = 'gemini-2.5-flash'; // Consistent with Memory Core config
+const MODEL_NAME = 'gemini-3.5-flash'; // Consistent with Memory Core config
 const GENERATION_CONFIG = {
     temperature: 0.2, // Low temperature for code precision
     responseMimeType: "application/json",

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -305,7 +305,7 @@ class Config extends ConfigProvider {
              * The name of the Google Generative AI model for content generation.
              * @type {string}
              */
-            modelName: leaf('gemini-2.5-flash'),
+            modelName: leaf('gemini-3.5-flash'),
             /**
              * The number of chunks to process in a single batch when embedding.
              * @type {number}

--- a/ai/provider/Gemini.mjs
+++ b/ai/provider/Gemini.mjs
@@ -16,9 +16,9 @@ class GeminiProvider extends Base {
          */
         className: 'Neo.ai.provider.Gemini',
         /**
-         * @member {String} modelName='gemini-2.5-flash'
+         * @member {String} modelName='gemini-3.5-flash'
          */
-        modelName: 'gemini-2.5-flash',
+        modelName: 'gemini-3.5-flash',
         /**
          * @member {String[]} requiredEnv=['GEMINI_API_KEY']
          */
@@ -124,10 +124,10 @@ class GeminiProvider extends Base {
         try {
             const result   = await model.generateContent({contents});
             const response = result.response;
-            
+
             // Extract text (might be empty if model just chose a tool)
             let text = '';
-            try { text = response.text(); } catch(e) {} 
+            try { text = response.text(); } catch(e) {}
 
             const functionCalls = response.functionCalls();
 

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -133,7 +133,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         }
     },
     vectorDimension: Number(process.env.NEO_VECTOR_DIMENSION) || 4096,
-    modelName      : 'gemini-2.5-flash',
+    modelName      : 'gemini-3.5-flash',
     embeddingModel : 'gemini-embedding-001',
     engines: {
         chroma: {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -64,7 +64,7 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(Config.embeddingProvider).toBe(process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible');
         expect(Config.vectorDimension).toBe(Number(process.env.NEO_VECTOR_DIMENSION) || 4096);
         expect(Config.backupPath).toBe(TIER1_DEFAULTS.backupPath);
-        expect(Config.modelName).toBe('gemini-2.5-flash');
+        expect(Config.modelName).toBe('gemini-3.5-flash');
         expect(Config.embeddingModel).toBe('gemini-embedding-001');
 
         expect(Config.ollama).toMatchObject({


### PR DESCRIPTION
Resolves #12573

Authored by Claude Opus 4.8 (Claude Code). Session 0f6d0fa0-327f-42ec-b970-e32f388699b4.

Bumps the default remote chat/summary model `gemini-2.5-flash` → `gemini-3.5-flash` (latest GA Flash) across the AiConfig leaf SSOT + KB leaf + provider class default + demo — a direct COGS lever on the remote-summary leg per the @tobiu directive. Embeddings (`gemini-embedding-001`) unchanged.

Evidence: L2 (live `gemini-3.5-flash` JSON-mode `generateContent` smoke test — output parsed as valid JSON) → L1/L2 required. No blocking residuals.

## Deltas from ticket — contract correction (per @neo-gpt review)
The `modelName` leaves are `leaf(default)` with **no env binding** — so there is **no `NEO_*` env override** for the model name (unlike `embeddingProvider`/`modelProvider`, which bind `NEO_*`). The real override surface is the **gitignored operator overlay** (`ai/config.mjs`, `ai/mcp/server/knowledge-base/config.mjs`) / instance config. My original "NEO_* env override unchanged" framing was inaccurate; corrected here and flagged on #12573's Contract Ledger.

## Local-overlay / clone-sync guidance
This bumps a **template default** (`config.template.mjs`); the gitignored operator overlays are thin deltas over it (ADR 0019 deep-merge inheritance):
- **Clones with no `modelName` delta** in their overlay inherit the new `gemini-3.5-flash` default automatically.
- **Clones whose overlay explicitly pins `modelName: 'gemini-2.5-flash'`** keep the old model until they update/remove that pin — and `initServerConfigs` will **not warn** for this pure-literal default change (imports/exports/env-var sets unchanged).
- **Existing deployments:** check `ai/config.mjs` + `ai/mcp/server/knowledge-base/config.mjs` for a pinned `modelName`; remove/update it to realize the COGS lever. **Memory-core / KB processes must be restarted** to load the new default (config is read at process start, not hot-reloaded).

## Sites changed
- `ai/config.template.mjs:262` (Gemini leaf SSOT), `ai/mcp/server/knowledge-base/config.template.mjs:308` (KB leaf), `ai/provider/Gemini.mjs:19/21` (class default + JSDoc), `ai/demo-agents/dev.mjs:37` (demo).
- `test/playwright/unit/ai/config.template.spec.mjs:67` + `test/playwright/fixtures/aiConfigDefaults.mjs:136` — the two expected-default references (Tier-1 assertion + fixture) realigned to `gemini-3.5-flash`.

## Test Evidence
- Smoke test (AC5): live `gemini-3.5-flash:generateContent` (JSON mode) → parseable JSON; output-shape parity confirmed.
- Exact identifier (AC1): `gemini-3.5-flash` is GA in the live Gemini API model list (no `-preview`/dated suffix).
- Unit/fixture: `config.template.spec` + memory-core/KB `config.template.spec` + `aiConfigDefaults.spec` (fixture-vs-template sanity) + `HealthService.spec` → all green locally + on CI.
- ModelStats (AC6): no Flash entry (utility model, not a tracked maintainer) → no Model-Stats entry mandated.
- CI: all checks green (integration-unified passed on re-run after a transient better-sqlite3 native-build network flake).

## Post-Merge Validation
- [ ] First live Memory-Core summary on a managed deployment confirms `gemini-3.5-flash` summaries parse end-to-end.

## Decision Record impact
`aligned-with ADR 0019` (AiConfig reactive SSOT — the bump changes the leaf default, the sanctioned place).
