### PR TITLE
fix(skills): correct relative section-ref paths in 2 audit files (#12588)

### DIFF
--- a/.agents/skills/ideation-sandbox/audits/tier-2-revalidation.md
+++ b/.agents/skills/ideation-sandbox/audits/tier-2-revalidation.md
@@ -1,6 +1,6 @@
 # Tier-2 Revalidation Sweep — Audit Reference
 
-*(Substrate extracted from `references/ideation-sandbox-workflow.md §6.5` per #11319 / #11320 per-file byte-budget discipline. Load this file when you need the full Tier-2 Revalidation Sweep mechanism description, invocation, reconciliation semantics, or MVP scope boundaries. The main `references/ideation-sandbox-workflow.md §6.5` carries the operational rule with an inline pointer to this audit.)*
+*(Substrate extracted from `../references/ideation-sandbox-workflow.md §6.5` per #11319 / #11320 per-file byte-budget discipline. Load this file when you need the full Tier-2 Revalidation Sweep mechanism description, invocation, reconciliation semantics, or MVP scope boundaries. The main `../references/ideation-sandbox-workflow.md §6.5` carries the operational rule with an inline pointer to this audit.)*
 
 ## §mechanism — Tier-2 Revalidation Sweep (Option c sweep-script-notifies-only)
 

--- a/.agents/skills/pull-request/audits/consensus-gate-mirror.md
+++ b/.agents/skills/pull-request/audits/consensus-gate-mirror.md
@@ -1,6 +1,6 @@
 # Consensus-Gate Mirror Reference (§6.1.1 family-keyed shape, post Epic #11796)
 
-*(Sub-rule extraction from `references/pull-request-workflow.md §6.1.1` per #11319 / #11320 byte-budget discipline. Load when authoring a substrate PR from a high-blast Discussion or reviewing one. The main `references/pull-request-workflow.md §6.1.1` carries the operational rule; this file carries the full template + Tier-2 reviewer step detail + reviewer-step quorum check + rejection-mode enumeration.)*
+*(Sub-rule extraction from `../references/pull-request-workflow.md §6.1.1` per #11319 / #11320 byte-budget discipline. Load when authoring a substrate PR from a high-blast Discussion or reviewing one. The main `../references/pull-request-workflow.md §6.1.1` carries the operational rule; this file carries the full template + Tier-2 reviewer step detail + reviewer-step quorum check + rejection-mode enumeration.)*
 
 ## §quorum-citation — Axis 2 quorum semantics (post Epic #11796)
 


### PR DESCRIPTION
Resolves #12588

Authored by Claude Opus 4.8 (Claude Code). Session 0f6d0fa0-327f-42ec-b970-e32f388699b4.

Corrects the relative section-ref paths in the two remaining `audits/`-resident skill files — `ideation-sandbox/audits/tier-2-revalidation.md` + `pull-request/audits/consensus-gate-mirror.md` — which referenced the sibling `references/` dir as `references/<file>.md §N` (skill-root-relative) instead of the file-relative `../references/<file>.md §N` (4 refs). The third file named in #12588, `consensus-mandate.md`, was **already corrected upstream by #12581**, so this PR completes the ticket.

(Supersedes the closed PR #12589, which I authored against a stale local `dev` — its `consensus-mandate.md` edits would have conflicted-or-reverted #12581. This is the clean, fresh-base re-do of the genuinely-valid remainder.)

Evidence: L1 (static lint audit — `lint-skill-manifest --base HEAD~1` → OK; both rewritten targets + numeric anchors resolve) → L1 required (doc-path correctness, no runtime ACs). No residuals.

**Micro-change exemption (§6.1):** pure documentation, no runtime impact — cross-family review welcome but not merge-gating.

## Deltas from ticket
`consensus-mandate.md` (1 of the 3 files in #12588) needed no change — already `../references/` on `dev` via #12581. This PR delivers the other two; all three are now correct.

## Slot-Rationale (Substrate-Mutation Pre-Flight — AGENTS.md §13)
Touches `.agents/skills/ideation-sandbox/audits/tier-2-revalidation.md` + `.agents/skills/pull-request/audits/consensus-gate-mirror.md` — conditionally-loaded World-Atlas audit files (read-on-demand, **not** always-loaded turn substrate).
- **Modified (both files):** disposition `rewrite` — corrected the relative path of existing section-refs (`references/` → `../references/`). No section added/removed; no prose/anchor change; **zero always-loaded substrate growth** (+3 chars `../` per ref). Reason: file-relative-incorrect from `audits/`; the #12584 named-section-ref lint flags them on next edit.

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base HEAD~1` → `[lint-skill-manifest] OK`.
- Seam grep: 0 broken `references/…§` remain across all three #12588 `audits/` files.
- Pure docs — no unit/e2e tests apply.

## Post-Merge Validation
- [ ] `lint-skill-manifest` + `lint-pr-body` green on the PR head.
