### PR TITLE
fix(ai): remove residual AiConfig B3 defenses (#12461)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -123,7 +123,7 @@ function resolveDeploymentEnabled(key) {
  * @returns {Boolean}
  */
 function resolveCloudOnlyEnabled(key) {
-    const cfg = AiConfig.orchestrator.cloudOnly?.[key];
+    const cfg = AiConfig.orchestrator.cloudOnly[key];
     if (cfg !== null && cfg !== undefined) return cfg;
     return AiConfig.orchestrator.deploymentMode === 'cloud';
 }

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -906,7 +906,7 @@ class HealthService extends Base {
      */
     async #checkDatabaseConnections() {
         try {
-            const engine = aiConfig.engine || 'hybrid';
+            const engine = aiConfig.engine;
             const engines = { chroma: false };
 
             // 2. Vector Chroma DB (Hybrid & Standalone Chroma)
@@ -1196,7 +1196,7 @@ class HealthService extends Base {
 
     #checkApiKeyConfigured() {
         const providers = [aiConfig.modelProvider];
-        const engine = aiConfig.engine || 'hybrid';
+        const engine = aiConfig.engine;
 
         if (engine === 'chroma' || engine === 'hybrid') {
             providers.push(aiConfig.embeddingProvider);
@@ -1246,7 +1246,7 @@ class HealthService extends Base {
      */
     async #getEmbeddingWriteCanary() {
         const now = Date.now(),
-              key = `${aiConfig.embeddingProvider || 'openAiCompatible'}:${aiConfig.vectorDimension ?? ''}`,
+              key = `${aiConfig.embeddingProvider}:${aiConfig.vectorDimension}`,
               cached = this.#embeddingWriteCanaryCache;
 
         if (cached &&

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -384,7 +384,7 @@ class MemoryService extends Base {
             // the filter reduces to sessionId alone — single-tenant fallthrough preserved.
             // normalizeUserId strips `@`-prefix at the AgentIdentity ↔ userId boundary.
             const userId = normalizeUserId(RequestContextService.getUserId());
-            const policy = memorySharing || aiConfig?.memorySharing?.defaultPolicy || 'legacy';
+            const policy = memorySharing || aiConfig.memorySharing.defaultPolicy;
 
             let tenantScope = null;
             if (userId) {
@@ -485,7 +485,7 @@ class MemoryService extends Base {
             // Tenant-scoped where clause with additive shared-commons access.
             // normalizeUserId handles the AgentIdentity ↔ userId boundary.
             const userId = normalizeUserId(RequestContextService.getUserId());
-            const policy = memorySharing || aiConfig?.memorySharing?.defaultPolicy || 'legacy';
+            const policy = memorySharing || aiConfig.memorySharing.defaultPolicy;
 
             let tenantScope = null;
             if (userId) {

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -204,7 +204,7 @@ class SummaryService extends Base {
             // normalizeUserId strips `@`-prefix so AgentIdentity nodeId vs ChromaDB userId never
             // self-filters.
             const userId = normalizeUserId(RequestContextService.getUserId());
-            const policy = aiConfig?.memorySharing?.defaultPolicy || 'legacy';
+            const policy = aiConfig.memorySharing.defaultPolicy;
 
             // See querySummaries: 'private' restricts via DB-where; 'team'/'legacy' are additive
             // (own + 'shared' + untagged commons) and rely on the JS post-filter below.
@@ -377,7 +377,7 @@ class SummaryService extends Base {
             // Tenant-scoped where clause with additive shared-commons access.
             // normalizeUserId handles the AgentIdentity-vs-userId namespace boundary.
             const userId = normalizeUserId(RequestContextService.getUserId());
-            const policy = memorySharing || aiConfig?.memorySharing?.defaultPolicy || 'legacy';
+            const policy = memorySharing || aiConfig.memorySharing.defaultPolicy;
 
             // 'private' restricts to the caller's own records via a DB-where. 'team' and 'legacy' are
             // additive (caller-owned + 'shared' + untagged commons): the team commons is currently


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Resolves #12461

Related: #12456

Removes the remaining direct raw-SSOT B3 defenses that survived the stale 62-instance census: the `cloudOnly` optional-chain read, `memorySharing.defaultPolicy` optional-chain/legacy fallbacks, and direct `HealthService` singleton fallbacks for `engine` / `embeddingProvider` / `vectorDimension`. Parameterized projection and injected config-shaped receiver guards remain untouched because they are not raw `AiConfig` SSOT reads.

Evidence: L2 (focused unit specs + config SSOT lint + direct-pattern source sweep) -> L2 required (production-source B3 cleanup against ADR 0019). No residuals for #12461; non-B3 parameterized receiver cases remain intentionally out of scope.

## Deltas from ticket
The ticket body's original "62 B3 instances across 30 files" census is stale after the merged B3 slice PRs and #12532. Intake classified #12461 as positive-ROI only after narrowing it to current-source residuals. This PR therefore closes the live raw-SSOT residuals rather than re-running a blanket grep-shaped sweep.

Decision Record impact: aligned-with ADR 0019.

## Test Evidence
- `npm run ai:lint-config-template-ssot` — passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs` — 16 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SummaryService.TenantIsolation.spec.mjs` — 16 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` — 56 passed; rerun after the `vectorDimension` review fix.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 45 passed.
- Direct residual sweep passed: `rg -n "aiConfig\\.vectorDimension \\?\\?|aiConfig\\.engine \\|\\||aiConfig\\.embeddingProvider \\|\\||aiConfig\\?\\.memorySharing|memorySharing\\?\\.defaultPolicy|defaultPolicy \\|\\| 'legacy'|cloudOnly\\?\\." ai` returned no matches.
- `git diff --check` passed.

## Post-Merge Validation
- [ ] Re-run #12456 epic-resolution after #12435 and #11976 resolve; #12461 should no longer block the B3 row.

## Commits
- `261005b59` — `fix(ai): remove residual AiConfig B3 defenses (#12461)`

## Evolution
The implementation started from Claude's same-day re-census and live source V-B-A rather than the original issue body. During final validation, direct `HealthService` singleton fallbacks proved to be raw B3 too, while `ChromaManager`/backup/projection helper shapes stayed out of scope because their receivers are injected or serialized config-shaped inputs rather than direct SSOT reads.
