### PR TITLE
fix(form): repair form field sizing regressions (#12566)

### DIFF
--- a/resources/scss/src/form/field/TextArea.scss
+++ b/resources/scss/src/form/field/TextArea.scss
@@ -2,6 +2,7 @@
     align-items   : stretch;
     display       : flex;
     flex-direction: column;
+    height        : auto;
 
     .neo-input-wrapper {
         flex: 1 0 auto;

--- a/src/form/field/Text.mjs
+++ b/src/form/field/Text.mjs
@@ -1576,12 +1576,13 @@ class Text extends Field {
      */
     updateInputWidth() {
         let me         = this,
+            inputEl    = me.vdom.cn[2],
             inputWidth = me.getInputWidth();
 
         if (inputWidth !== null && inputWidth !== me.width) {
-            me.vdom.cn[1].width = inputWidth
+            inputEl.width = inputWidth
         } else {
-            delete me.vdom.cn[1].width
+            delete inputEl.width
         }
 
         me.update()

--- a/test/playwright/component/form/field/ComboBox.spec.mjs
+++ b/test/playwright/component/form/field/ComboBox.spec.mjs
@@ -111,6 +111,30 @@ test.describe('Neo.form.field.ComboBox', () => {
         await expect(inputField).not.toBeFocused();
     });
 
+    test('Input wrapper fills remaining width after a left label', async ({page}) => {
+        componentId = await createComboBox(page, {
+            labelPosition: 'left',
+            labelWidth   : 100,
+            width        : 340
+        });
+
+        const sizes = await page.locator(`#${componentId}`).evaluate(element => {
+            const label   = element.querySelector('.neo-textfield-label'),
+                  wrapper = element.querySelector('.neo-input-wrapper'),
+                  input   = element.querySelector('input.neo-textfield-input:not(.neo-typeahead-input)');
+
+            return {
+                inputWidth  : input.getBoundingClientRect().width,
+                labelWidth  : label.getBoundingClientRect().width,
+                wrapperWidth: wrapper.getBoundingClientRect().width
+            };
+        });
+
+        expect(Math.round(sizes.labelWidth)).toBe(100);
+        expect(Math.round(sizes.wrapperWidth)).toBe(240);
+        expect(sizes.inputWidth).toBeGreaterThan(200);
+    });
+
     test('Keyboard navigation', async ({page}) => {
         componentId = await createComboBox(page);
         const comboBox = page.locator(`#${componentId}`);

--- a/test/playwright/component/form/field/TextArea.spec.mjs
+++ b/test/playwright/component/form/field/TextArea.spec.mjs
@@ -1,0 +1,77 @@
+import {test, expect} from '@playwright/test';
+
+let fieldsetId;
+
+async function createFieldsetWithTextArea(page, config={}) {
+    const result = await page.evaluate(async (config) => {
+        return Neo.worker.App.createNeoInstance({
+            importPath: '../form/Fieldset.mjs',
+            ntype     : 'fieldset',
+            parentId  : 'component-test-viewport',
+            title     : 'Details',
+            width     : 420,
+            items     : [{
+                importPath: '../form/field/TextArea.mjs',
+                ntype     : 'textarea',
+                labelText : 'Notes',
+                labelWidth: 80,
+                rows      : 5,
+                width     : 360,
+                ...config
+            }]
+        });
+    }, config);
+
+    if (!result.success) {
+        throw new Error(`Component creation failed: ${result.error.message}`);
+    }
+
+    return result.id;
+}
+
+test.describe('Neo.form.field.TextArea', () => {
+    test.beforeEach(async ({page}) => {
+        await page.goto('/test/playwright/component/apps/empty-viewport/index.html');
+        await page.waitForSelector('#component-test-viewport', { state: 'attached' });
+        await page.evaluate(async () => Neo.worker.App.loadModule({path: '../form/field/TextArea.mjs'}));
+    });
+
+    test.afterEach(async ({page}) => {
+        if (fieldsetId) {
+            await page.evaluate(async (id) => {
+                const result = await Neo.worker.App.destroyNeoInstance(id);
+
+                if (!result.success) {
+                    console.error(`Failed to destroy component ${id}:`, result.error);
+                }
+            }, fieldsetId);
+            fieldsetId = null;
+        }
+    });
+
+    test('Fieldset grows to fit TextArea rows', async ({page}) => {
+        fieldsetId = await createFieldsetWithTextArea(page);
+
+        const fieldset = page.locator(`#${fieldsetId}`);
+        const textArea = fieldset.locator('.neo-textarea');
+        const input    = textArea.locator('textarea.neo-textfield-input');
+
+        await expect(input).toHaveAttribute('rows', '5');
+
+        const sizes = await page.evaluate(id => {
+            const fieldset = document.getElementById(id),
+                  textArea = fieldset.querySelector('.neo-textarea'),
+                  input    = fieldset.querySelector('textarea.neo-textfield-input');
+
+            return {
+                fieldsetHeight: fieldset.getBoundingClientRect().height,
+                inputHeight   : input.getBoundingClientRect().height,
+                textAreaHeight: textArea.getBoundingClientRect().height
+            };
+        }, fieldsetId);
+
+        expect(sizes.textAreaHeight).toBeGreaterThan(sizes.inputHeight);
+        expect(sizes.fieldsetHeight).toBeGreaterThan(sizes.textAreaHeight);
+        expect(sizes.textAreaHeight).toBeGreaterThan(60);
+    });
+});

--- a/test/playwright/unit/form/field/InputWidth.spec.mjs
+++ b/test/playwright/unit/form/field/InputWidth.spec.mjs
@@ -1,0 +1,70 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'FormFieldInputWidthTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../src/manager/Instance.mjs';
+import Text           from '../../../../../src/form/field/Text.mjs';
+import ComboBox       from '../../../../../src/form/field/ComboBox.mjs';
+
+test.describe('Neo.form.field input width layout', () => {
+    test('Text writes calculated input width to the input node, not the sublabel', () => {
+        const field = Neo.create(Text, {
+            appName,
+            labelWidth: 80,
+            width     : 300
+        });
+
+        expect(field.vdom.cn[0].width).toBe(80);
+        expect(field.vdom.cn[1].width).toBeUndefined();
+        expect(field.vdom.cn[2].width).toBe(220);
+
+        field.width = 360;
+
+        expect(field.vdom.cn[1].width).toBeUndefined();
+        expect(field.vdom.cn[2].width).toBe(280);
+
+        field.destroy();
+    });
+
+    test('ComboBox applies calculated input width to the trigger wrapper', () => {
+        const field = Neo.create(ComboBox, {
+            appName,
+            labelWidth: 100,
+            width     : 340,
+            store     : {
+                data: [
+                    {id: 1, name: 'One'},
+                    {id: 2, name: 'Two'}
+                ]
+            }
+        });
+
+        expect(field.vdom.cn[1].width).toBeUndefined();
+        expect(field.vdom.cn[2].cls).toContain('neo-input-wrapper');
+        expect(field.vdom.cn[2].width).toBe(240);
+
+        field.labelWidth = 120;
+
+        expect(field.vdom.cn[1].width).toBeUndefined();
+        expect(field.vdom.cn[2].width).toBe(220);
+
+        field.destroy();
+    });
+});


### PR DESCRIPTION
Resolves #12566
Resolves #12567

Authored by GPT-5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Repairs two related form-field layout regressions surfaced by dogfooding: TextArea no longer inherits the one-line TextField root height when it is allowed to size from rows, and Text/ComboBox calculated input width now lands on the real input/input-wrapper node instead of the sublabel node.

Evidence: L3 (local Chromium component specs and one-off browser measurement) -> L3 required (browser-rendered layout ACs for both close targets). No residuals.

## Deltas from ticket (if any)
- Batched `#12566` and `#12567` because both are form-field sizing/layout regressions with the same verification surface; this keeps review and CI overhead proportional to the actual change.
- `#12567` was resolved as an implementation bug in `Text.updateInputWidth()`, not as a documentation-only contract update: the calculated input width is intended to apply to the actual input/input-wrapper, and historical form-field sizing fixes (`#3921`/`#4006`) support flexing the input surface rather than squeezing it.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/form/field/InputWidth.spec.mjs` - 2/2 passed.
- `npm run test-unit -- test/playwright/unit/form/field/InputWidth.spec.mjs test/playwright/unit/form/field/IdSync.spec.mjs test/playwright/unit/form/field/ComboBoxInternalId.spec.mjs test/playwright/unit/form/field/TimeFieldInternalId.spec.mjs test/playwright/unit/form/field/AfterSetValueSequence.spec.mjs` - 9/9 passed.
- Focused component specs against a local webpack dev server on port 8091 because localhost:8080 was occupied by an unrelated static server: ComboBox/TextArea regression specs both passed, 2/2.
- One-off Playwright measurement on local Chromium: ComboBox label `100`, wrapper `240`, input `215`; Fieldset `363.8`, TextArea `318.2`, textarea input `92`, rows `5`.
- `git diff --check` and `git diff --cached --check` passed.
- Commit hook checks passed during commit: whitespace, shorthand, ticket archaeology.

## Post-Merge Validation
- [ ] Verify the dogfooding dialog/form view that surfaced these tickets now shows the TextArea unclipped and the status ComboBox input with usable width.

## Decision Record impact
None. This is a Body/form-field layout bugfix; no ADR or Agent OS substrate mutation.

## Commits
- `43c1a376b` - `fix(form): repair text field sizing regressions (#12566)`