### PR TITLE
feat(memory): add graph lifecycle telemetry (#10158)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1547,6 +1547,52 @@ components:
                         count:
                           type: integer
                           example: 56
+        graphLifecycle:
+          type: object
+          description: "Memory/Session graph lifecycle telemetry. Observational only; does not alter REM state, pruning, archival, or deletion behavior."
+          properties:
+            available:
+              type: boolean
+              description: "True when the SQLite graph store was mounted and counted successfully."
+              example: true
+            memoryNodes:
+              type: integer
+              description: "Deployment-wide count of SQLite Nodes rows whose JSON label is MEMORY."
+              example: 3
+            sessionNodes:
+              type: integer
+              description: "Deployment-wide count of SQLite Nodes rows whose JSON label is SESSION."
+              example: 2
+            memoryIncidentEdges:
+              type: integer
+              description: "Count of SQLite Edges rows whose source or target is a MEMORY node."
+              example: 7
+            sessionIncidentEdges:
+              type: integer
+              description: "Count of SQLite Edges rows whose source or target is a SESSION node."
+              example: 5
+            sqliteBytes:
+              type: integer
+              description: "Byte size of the configured SQLite graph database file."
+              example: 4096
+            sqliteWalBytes:
+              type: integer
+              description: "Byte size of the sibling SQLite WAL file, or 0 when absent."
+              example: 512
+            sqliteShmBytes:
+              type: integer
+              description: "Byte size of the sibling SQLite SHM file, or 0 when absent."
+              example: 0
+            measuredAt:
+              type: string
+              format: date-time
+              description: "ISO 8601 timestamp for the graph lifecycle measurement."
+              example: "2026-06-05T20:00:00.000Z"
+            error:
+              type: string
+              nullable: true
+              description: "Optional defensive error when available is false."
+              example: null
         features:
           type: object
           properties:

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -542,6 +542,123 @@ export function buildDreamFeaturesBlock(taskOutcomes = {}) {
         lastGoldenPathRun: goldenPathState?.details?.completedAt || goldenPathState?.details?.failedAt || null
     };
 }
+
+function measuredAtIso(now) {
+    const value = typeof now === 'function' ? now() : now;
+    return (value instanceof Date ? value : new Date(value)).toISOString();
+}
+
+function emptyGraphLifecycleBlock(measuredAt, error) {
+    const block = {
+        available           : false,
+        memoryNodes         : 0,
+        sessionNodes        : 0,
+        memoryIncidentEdges : 0,
+        sessionIncidentEdges: 0,
+        sqliteBytes         : 0,
+        sqliteWalBytes      : 0,
+        sqliteShmBytes      : 0,
+        measuredAt
+    };
+
+    if (error) {
+        block.error = error;
+    }
+
+    return block;
+}
+
+/**
+ * @summary Projects Memory/Session graph lifecycle telemetry into the healthcheck payload.
+ *
+ * The block is observational only: it counts durable `MEMORY` / `SESSION` provenance anchors and
+ * their incident SQLite edges, then reports the graph database main/WAL/SHM file sizes. It does not
+ * mutate graph rows, alter REM freshness telemetry, or participate in vector apoptosis. Missing graph
+ * storage degrades to a typed `available:false` payload so healthcheck consumers can keep reading the
+ * rest of the response.
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.graphService] Optional GraphService-shaped object for tests.
+ * @param {Object} [options.fileSystem=fsExtra] Filesystem adapter exposing `stat(path)`.
+ * @param {Function|Number|Date} [options.now=Date.now] Time source for deterministic `measuredAt`.
+ * @returns {Promise<{available: Boolean, memoryNodes: Number, sessionNodes: Number,
+ *     memoryIncidentEdges: Number, sessionIncidentEdges: Number, sqliteBytes: Number,
+ *     sqliteWalBytes: Number, sqliteShmBytes: Number, measuredAt: String, error: String|undefined}>}
+ */
+export async function buildGraphLifecycleBlock({
+    graphService = null,
+    fileSystem   = fsExtra,
+    now          = Date.now
+} = {}) {
+    const measuredAt = measuredAtIso(now);
+
+    try {
+        if (!graphService) {
+            graphService = (await import('./GraphService.mjs')).default;
+        }
+
+        const storage  = graphService?.db?.storage,
+              sqliteDb = storage?.db,
+              dbPath   = storage?.dbPath;
+
+        if (!sqliteDb || !dbPath) {
+            return emptyGraphLifecycleBlock(measuredAt, 'Graph SQLite storage is unavailable.');
+        }
+
+        const countNodes = label => Number(sqliteDb.prepare(`
+            SELECT COUNT(*) AS count
+            FROM Nodes
+            WHERE json_extract(data, '$.label') = ?
+        `).get(label)?.count || 0);
+
+        const countIncidentEdges = label => Number(sqliteDb.prepare(`
+            SELECT COUNT(*) AS count
+            FROM Edges e
+            WHERE EXISTS (
+                SELECT 1 FROM Nodes n
+                WHERE n.id = e.source
+                  AND json_extract(n.data, '$.label') = ?
+            )
+               OR EXISTS (
+                SELECT 1 FROM Nodes n
+                WHERE n.id = e.target
+                  AND json_extract(n.data, '$.label') = ?
+            )
+        `).get(label, label)?.count || 0);
+
+        const fileSize = async filePath => {
+            try {
+                return Number((await fileSystem.stat(filePath)).size || 0);
+            } catch (e) {
+                return 0;
+            }
+        };
+
+        const [
+            sqliteBytes,
+            sqliteWalBytes,
+            sqliteShmBytes
+        ] = await Promise.all([
+            fileSize(dbPath),
+            fileSize(`${dbPath}-wal`),
+            fileSize(`${dbPath}-shm`)
+        ]);
+
+        return {
+            available           : true,
+            memoryNodes         : countNodes('MEMORY'),
+            sessionNodes        : countNodes('SESSION'),
+            memoryIncidentEdges : countIncidentEdges('MEMORY'),
+            sessionIncidentEdges: countIncidentEdges('SESSION'),
+            sqliteBytes,
+            sqliteWalBytes,
+            sqliteShmBytes,
+            measuredAt
+        };
+    } catch (e) {
+        return emptyGraphLifecycleBlock(measuredAt, e?.message || String(e));
+    }
+}
 /**
  * @summary Monitors and validates the ChromaDB dependency for the Memory Core MCP server.
  *
@@ -1323,6 +1440,7 @@ class HealthService extends Base {
             mailboxPreview: await MailboxService.getHealthcheckPreview(),
             identity : buildIdentityBlock(this.#stdioIdentityState),
             migration: await this.#checkMigrationState(),
+            graphLifecycle: await buildGraphLifecycleBlock(),
             providers: {
                 embedding: buildEmbeddingProviderBlock(aiConfig),
                 summary  : buildSummaryProviderBlock(aiConfig),

--- a/learn/agentos/measurements/MemorySessionGraphLifecycle.md
+++ b/learn/agentos/measurements/MemorySessionGraphLifecycle.md
@@ -1,0 +1,92 @@
+# Memory/Session Graph Lifecycle
+
+`MEMORY` and `SESSION` graph nodes are durable provenance anchors. They connect
+raw agent turns, session summaries, mailbox threads, authorship edges, and
+future recovery queries back to the Native Edge Graph. Their lifecycle policy is
+therefore stricter than ordinary extracted concept nodes.
+
+## Health Telemetry
+
+`HealthService.healthcheck()` exposes a top-level `graphLifecycle` block for
+cheap operator visibility into this anchor layer:
+
+```json
+{
+  "available": true,
+  "memoryNodes": 3,
+  "sessionNodes": 2,
+  "memoryIncidentEdges": 7,
+  "sessionIncidentEdges": 5,
+  "sqliteBytes": 4096,
+  "sqliteWalBytes": 512,
+  "sqliteShmBytes": 0,
+  "measuredAt": "2026-06-05T20:00:00.000Z"
+}
+```
+
+The counts are deployment-wide. `memoryNodes` and `sessionNodes` count SQLite
+`Nodes` rows whose JSON label is `MEMORY` or `SESSION`. Incident-edge counts
+count SQLite `Edges` rows whose `source` or `target` is one of those labeled
+nodes. The SQLite byte fields report the configured graph database file and its
+`-wal` / `-shm` siblings, returning `0` for missing siblings.
+
+If the graph store is not mounted, healthcheck returns `available:false` with
+zero counts and an `error` string instead of throwing. The rest of the
+healthcheck payload remains readable.
+
+## Retention Policy
+
+`MEMORY` and `SESSION` nodes remain protected from
+`GraphService.getOrphanedNodes()` and vector apoptosis by default. This is
+intentional even when a node is temporarily edgeless:
+
+- Freshly ingested memories and sessions can be created before all downstream
+  provenance edges are attached.
+- Empty sessions still need stable anchors for later summary, handoff, and
+  recovery edges.
+- Mailbox, identity, and authorship edges may be created after the original
+  memory/session row exists.
+
+`GraphMaintenanceService.runGarbageCollection()` must continue to delete only
+the node IDs returned by `GraphService.getOrphanedNodes()`. Broadening apoptosis
+to include `MEMORY` or `SESSION` requires a separate ticket with a Contract
+Ledger and explicit evidence that memory recovery, mailbox threading, provenance
+queries, and agent identity edge creation remain safe.
+
+## Future Archival Gate
+
+This guide does not introduce archival, default-query exclusion, or hard
+deletion. Future retention pressure must first be proven by sustained
+`graphLifecycle` telemetry. A follow-up archival proposal must define:
+
+- exact marker names and reversible semantics;
+- include-archived query behavior;
+- tenant/user visibility effects;
+- migration behavior for existing nodes without the marker;
+- recovery evidence for memory search, session summaries, mailbox threads, and
+  identity/provenance edge creation.
+
+Hard deletion of `MEMORY` or `SESSION` graph nodes remains out of scope unless a
+future ticket proves safety across all of those recovery paths.
+
+## Initial Baseline
+
+The #10158 implementation baseline is unit-equivalent telemetry from
+`HealthService #10158 - buildGraphLifecycleBlock`:
+
+```json
+{
+  "available": true,
+  "memoryNodes": 3,
+  "sessionNodes": 2,
+  "memoryIncidentEdges": 7,
+  "sessionIncidentEdges": 5,
+  "sqliteBytes": 4096,
+  "sqliteWalBytes": 512,
+  "sqliteShmBytes": 0,
+  "measuredAt": "2026-06-05T20:00:00.000Z"
+}
+```
+
+Live deployment baselines should replace fixture counts only after running a
+post-merge healthcheck against the target Memory Core graph store.

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -36,7 +36,7 @@ function findArraysWithoutItems(node, pathLabel = '') {
 
 /**
  * Walks a JSON Schema node and returns every dotted path where a `type: "object"` node
- * sets `additionalProperties: false`. For OUTPUT schemas this is the #9837 drift bug —
+ * sets `additionalProperties: false`. For OUTPUT schemas this is the #9837 drift bug — ticket-ref-ok: regression anchor for output-schema leniency
  * server implementations return fields the OpenAPI contract forgot to declare, and
  * strict MCP clients (GitHub Copilot) reject the payload with
  * "data/result/0 must NOT have additional properties". OUTPUT schemas should stay
@@ -61,7 +61,7 @@ function findStrictObjects(node, pathLabel = '') {
 
 /**
  * Walks a JSON Schema node looking for INPUT "open-bag" objects that would silently
- * strip their payload to `{}` — the #10070 regression. An open-bag is a `type: "object"`
+ * strip their payload to `{}` — the #10070 regression. ticket-ref-ok: regression anchor for open-bag payload preservation. An open-bag is a `type: "object"`
  * node that declares NO child `properties` (the author signaled "caller decides the
  * shape") AND strict `additionalProperties: false` (Zod then drops every unknown key).
  * The root of an input schema is excluded — top-level inputs with declared fields
@@ -112,6 +112,25 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         const lenient = zodToJsonSchema(z.object({a: z.string()}).passthrough());
         expect(strict.additionalProperties).toBe(false);
         expect(lenient.additionalProperties).toBe(true);
+    });
+
+    test('memory-core healthcheck schema declares graphLifecycle telemetry (#10158)', () => {
+        const doc = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'), 'utf8'));
+        const graphLifecycle = doc.components.schemas.HealthCheckResponse.properties.graphLifecycle;
+
+        expect(graphLifecycle.type).toBe('object');
+        expect(Object.keys(graphLifecycle.properties)).toEqual(expect.arrayContaining([
+            'available',
+            'memoryNodes',
+            'sessionNodes',
+            'memoryIncidentEdges',
+            'sessionIncidentEdges',
+            'sqliteBytes',
+            'sqliteWalBytes',
+            'sqliteShmBytes',
+            'measuredAt',
+            'error'
+        ]));
     });
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -1387,3 +1387,139 @@ test.describe('HealthService #10779, #11309 — buildDreamFeaturesBlock', () => 
         expect(result.lastGoldenPathRun).toBe('2026-05-13T20:06:00.000Z');
     });
 });
+
+/**
+ * @summary Coverage for Memory/Session graph lifecycle telemetry.
+ *
+ * Pins the pure-projection contract of `buildGraphLifecycleBlock`, the helper wired into
+ * `HealthService.healthcheck().graphLifecycle`. The tests inject a SQLite-shaped DB and filesystem
+ * adapter so the unit suite validates the payload semantics without mounting a live graph store.
+ *
+ * @see Neo.ai.services.memory-core.HealthService#buildGraphLifecycleBlock
+ */
+test.describe('HealthService #10158 — buildGraphLifecycleBlock', () => {
+    let buildGraphLifecycleBlock;
+
+    const fixedNow = () => new Date('2026-06-05T20:00:00.000Z');
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
+        buildGraphLifecycleBlock = mod.buildGraphLifecycleBlock;
+    });
+
+    test('counts Memory/Session nodes, incident edges, and SQLite main/WAL/SHM sizes', async () => {
+        const preparedSql = [];
+        const sqliteDb = {
+            prepare(sql) {
+                preparedSql.push(sql);
+
+                return {
+                    get(...args) {
+                        const label = args[0];
+
+                        if (sql.includes('FROM Nodes') && !sql.includes('FROM Edges')) {
+                            return {count: {MEMORY: 3, SESSION: 2}[label]};
+                        }
+
+                        if (sql.includes('FROM Edges')) {
+                            return {count: {MEMORY: 7, SESSION: 5}[label]};
+                        }
+
+                        throw new Error(`Unexpected SQL in test fixture: ${sql}`);
+                    }
+                };
+            }
+        };
+        const graphService = {
+            db: {
+                storage: {
+                    db    : sqliteDb,
+                    dbPath: '/tmp/neo-graph.db'
+                }
+            }
+        };
+        const fileSystem = {
+            stat: async filePath => {
+                if (filePath === '/tmp/neo-graph.db') return {size: 4096};
+                if (filePath === '/tmp/neo-graph.db-wal') return {size: 512};
+                throw new Error('missing file');
+            }
+        };
+
+        const result = await buildGraphLifecycleBlock({graphService, fileSystem, now: fixedNow});
+
+        expect(result).toEqual({
+            available           : true,
+            memoryNodes         : 3,
+            sessionNodes        : 2,
+            memoryIncidentEdges : 7,
+            sessionIncidentEdges: 5,
+            sqliteBytes         : 4096,
+            sqliteWalBytes      : 512,
+            sqliteShmBytes      : 0,
+            measuredAt          : '2026-06-05T20:00:00.000Z'
+        });
+
+        const incidentSql = preparedSql.find(sql => sql.includes('FROM Edges'));
+        expect(incidentSql).toContain('e.source');
+        expect(incidentSql).toContain('e.target');
+        expect(incidentSql).toContain("json_extract(n.data, '$.label') = ?");
+    });
+
+    test('returns available:false with zero counts when graph SQLite storage is unavailable', async () => {
+        let statCalls = 0;
+        const result = await buildGraphLifecycleBlock({
+            graphService: {db: {storage: {db: null, dbPath: null}}},
+            fileSystem  : {
+                stat: async () => {
+                    statCalls++;
+                    throw new Error('stat should not run');
+                }
+            },
+            now: fixedNow
+        });
+
+        expect(result).toMatchObject({
+            available           : false,
+            memoryNodes         : 0,
+            sessionNodes        : 0,
+            memoryIncidentEdges : 0,
+            sessionIncidentEdges: 0,
+            sqliteBytes         : 0,
+            sqliteWalBytes      : 0,
+            sqliteShmBytes      : 0,
+            measuredAt          : '2026-06-05T20:00:00.000Z'
+        });
+        expect(result.error).toContain('Graph SQLite storage is unavailable');
+        expect(statCalls).toBe(0);
+    });
+
+    test('surfaces SQL errors as defensive unavailable telemetry', async () => {
+        const graphService = {
+            db: {
+                storage: {
+                    db: {
+                        prepare() {
+                            throw new Error('Nodes table locked');
+                        }
+                    },
+                    dbPath: '/tmp/neo-graph.db'
+                }
+            }
+        };
+
+        const result = await buildGraphLifecycleBlock({
+            graphService,
+            fileSystem: {stat: async () => ({size: 1})},
+            now       : fixedNow
+        });
+
+        expect(result).toMatchObject({
+            available   : false,
+            memoryNodes : 0,
+            sessionNodes: 0,
+            measuredAt  : '2026-06-05T20:00:00.000Z'
+        });
+        expect(result.error).toBe('Nodes table locked');
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Resolves #10158

Adds Memory/Session graph lifecycle observability to the Memory Core healthcheck and documents the retention policy for those graph anchors. The new `graphLifecycle` block reports deployment-wide Memory/Session node counts, incident-edge counts, and SQLite main/WAL/SHM file sizes with a defensive `available:false` fallback when graph storage is unavailable.

Evidence: L2 (focused unit projection tests + MCP OpenAPI schema compliance + unit-equivalent baseline payload) -> L2 required (ticket explicitly accepts unit-equivalent baseline evidence for the healthcheck payload and retention-policy contract). No residuals.

## Deltas from ticket

- Added the `HealthCheckResponse.graphLifecycle` OpenAPI schema and a compliance assertion so the MCP response contract matches the runtime payload.
- Preserved `get_rem_pipeline_state`, graph query visibility, vector apoptosis, pruning, archival, and hard-deletion behavior unchanged.
- Added `ticket-ref-ok` markers to two existing OpenAPI compliance regression comments because touching that file made the pre-commit archaeology hook evaluate its durable comments.
- Placed the retention/lifecycle guide at `learn/agentos/measurements/MemorySessionGraphLifecycle.md`, matching the Agent OS tree lint contract for measurement artifacts.

## Baseline Evidence

Unit-equivalent `graphLifecycle` payload pinned by `HealthService #10158 - buildGraphLifecycleBlock`:

```json
{
  "available": true,
  "memoryNodes": 3,
  "sessionNodes": 2,
  "memoryIncidentEdges": 7,
  "sessionIncidentEdges": 5,
  "sqliteBytes": 4096,
  "sqliteWalBytes": 512,
  "sqliteShmBytes": 0,
  "measuredAt": "2026-06-05T20:00:00.000Z"
}
```

## Slot Rationale

Substrate mutation: added `learn/agentos/measurements/MemorySessionGraphLifecycle.md`.

- Disposition: `keep`.
- Rating: trigger-frequency medium x failure-severity high x enforceability medium.
- Rationale: this is not always-loaded instruction substrate; it is a conditionally consulted Agent OS measurement/reference guide for Memory/Session graph lifecycle and retention decisions. The guide prevents future archival/pruning lanes from treating durable provenance anchors as ordinary orphans while giving operators a concrete healthcheck telemetry contract.
- Retirement trigger: rewrite or move if a future accepted archival policy supersedes the retention boundary, or if `graphLifecycle` migrates from healthcheck to a dedicated lifecycle telemetry surface.

## Test Evidence

- `node ai/scripts/lint/lint-tree-json.mjs` -> OK after relocating the lifecycle guide under `learn/agentos/measurements/`.
- `git diff --cached --check` passed before commit.
- Pre-commit lint-staged passed: whitespace, shorthand, and touched-file ticket-archaeology checks.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 59/59 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 27/27 passed.
- Rebased on current `origin/dev`; final freshness check passed (`merge-base HEAD origin/dev == origin/dev`) before push.

## Post-Merge Validation

- [ ] After Memory Core restarts on the merged code, call `healthcheck` and compare the live `graphLifecycle` payload against the unit-equivalent baseline for deployment-specific counts.

## Commit

- `fe4928767` - `feat(memory): add graph lifecycle telemetry (#10158)`
