### PR TITLE
fix(memory-core): stamp global system/identity graph nodes userId:null for cross-tenant RLS (#10271)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -104,7 +104,7 @@ class GraphService extends Base {
             try {
                 this.db.getAdjacentNodes('frontier', 'both'); // trigger lazy load
                 if (!this.db.nodes.has('frontier')) {
-                    this.upsertNode({
+                    this.upsertGlobalNode({
                         id         : 'frontier',
                         type       : 'SYSTEM_ANCHOR',
                         name       : 'Active Context Frontier',
@@ -122,7 +122,7 @@ class GraphService extends Base {
             try {
                 this.db.getAdjacentNodes('Neo-Master-Architecture', 'both');
                 if (!this.db.nodes.has('Neo-Master-Architecture')) {
-                    this.upsertNode({
+                    this.upsertGlobalNode({
                         id         : 'Neo-Master-Architecture',
                         type       : 'System',
                         name       : 'Global System Primer',
@@ -143,7 +143,7 @@ class GraphService extends Base {
                     this.db.getAdjacentNodes(identity.id, 'both');
 
                     if (!this.db.nodes.has(identity.id)) {
-                        this.upsertNode(identity);
+                        this.upsertGlobalNode(identity);
                     } else {
                         // Defensive createdAt retention: Peek SQLite to preserve original timestamp
                         const row = storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(identity.id);
@@ -151,11 +151,11 @@ class GraphService extends Base {
                             const rawData = JSON.parse(row.data);
                             if (rawData.properties?.createdAt) {
                                 const preserved = {...identity, properties: {...identity.properties, createdAt: rawData.properties.createdAt}};
-                                this.upsertNode(preserved);
+                                this.upsertGlobalNode(preserved);
                                 continue;
                             }
                         }
-                        this.upsertNode(identity);
+                        this.upsertGlobalNode(identity);
                     }
                 }
             } catch (error) {
@@ -257,6 +257,20 @@ class GraphService extends Base {
             });
             // logger.debug(`Successfully added node to Database RAM: ${id}`);
         }
+    }
+
+    /**
+     * Upserts a globally-visible system node, forcing `userId: null` so it stays
+     * reachable to every tenant under RLS regardless of which boot harness creates
+     * it first. Plain {@link GraphService#upsertNode} stamps the active request's
+     * bound identity, which would isolate these shared sentinels (`frontier`, the
+     * `Neo-Master-Architecture` primer, `_SYSTEM_STATE`, and the identity roots) to
+     * a single tenant — they would then vanish from the graph for all others.
+     * @param {Object} spec See {@link GraphService#upsertNode}; `properties.userId`
+     * is forced to `null`.
+     */
+    upsertGlobalNode(spec) {
+        this.upsertNode({...spec, properties: {...spec.properties, userId: null}});
     }
 
     /**
@@ -508,7 +522,7 @@ class GraphService extends Base {
         // Initialize or fetch the global _SYSTEM_STATE node for cycle tracking
         let systemNode = this.db.nodes.get('_SYSTEM_STATE');
         if (!systemNode) {
-            this.upsertNode({
+            this.upsertGlobalNode({
                 id: '_SYSTEM_STATE',
                 type: 'SYSTEM_CLOCK',
                 name: 'Global System Clock',
@@ -548,7 +562,7 @@ class GraphService extends Base {
         const info      = pruneStmt.run(pruningThreshold);
 
         // Commit global clock update
-        this.upsertNode({
+        this.upsertGlobalNode({
             id        : '_SYSTEM_STATE',
             type      : systemNode.isRecord ? systemNode.get('label') : systemNode.label,
             properties: {
@@ -913,7 +927,7 @@ class GraphService extends Base {
     mutateFrontier({targetNodeId, weight = 1.0, relationship = 'STRATEGIC_PIVOT'}) {
         let frontierNode = this.db.nodes.get('frontier');
         if (!frontierNode) {
-            this.upsertNode({
+            this.upsertGlobalNode({
                 id         : 'frontier',
                 type       : 'SYSTEM_ANCHOR',
                 name       : 'Active Context Frontier',

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -129,7 +129,7 @@ class GraphService extends Base {
                         description: 'Core framework tenets: 1. All Playwright tests must be run using "npm run test-unit -- [file]". No npx. 2. UI debugging and application state inspection must use the Neural Link MCP tools. 3. Look at .agents/skills for reusable agent workflows.'
                     });
                 }
-                this.linkNodes('frontier', 'Neo-Master-Architecture', 'SYSTEM_TENET', 1.0);
+                this.linkGlobalNodes('frontier', 'Neo-Master-Architecture', 'SYSTEM_TENET', 1.0);
             } catch (error) {
                 logger.warn(`[GraphService] Non-fatal DB contention during Master Architecture seed: ${error.message}`);
             }
@@ -271,6 +271,23 @@ class GraphService extends Base {
      */
     upsertGlobalNode(spec) {
         this.upsertNode({...spec, properties: {...spec.properties, userId: null}});
+    }
+
+    /**
+     * Links two globally-visible system nodes, forcing the edge's `userId: null` so the
+     * **connection itself** stays visible to every tenant under RLS. {@link GraphService#getContextFrontier}
+     * and {@link GraphService#getNeighbors} / {@link GraphService#queryNodeTopology} require BOTH the node
+     * AND the edge to be RLS-visible, so a global sentinel reached only through a tenant-stamped edge
+     * (the default {@link GraphService#linkNodes} stamps the active request's identity) would still vanish
+     * from topology traversal for non-booting tenants — even when {@link GraphService#upsertGlobalNode}
+     * already made the node itself global.
+     * @param {String} source
+     * @param {String} target
+     * @param {String} relationship
+     * @param {Number} [weight=1.0]
+     */
+    linkGlobalNodes(source, target, relationship, weight = 1.0) {
+        this.linkNodes(source, target, relationship, weight, {userId: null});
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
@@ -18,7 +18,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * #10011 — graph RLS read-side return boundary.
+ * Graph RLS read-side return boundary.
  *
  * `getNode` / `getNeighbors` / `queryNodeTopology` / `getContextFrontier` return graph nodes
  * AND edges read from `GraphService.db` — process-wide in-memory Stores. The SQL RLS clause in
@@ -245,5 +245,78 @@ test.describe('GraphService — RLS read-side return boundary (#10011)', () => {
         requester.value = '@tenant-b';
 
         expect(GraphService.getContextFrontier({depth: 2}).strategicNeighbors).toEqual([]);
+    });
+});
+
+/**
+ * Write-side complement to the read-side RLS boundary above.
+ *
+ * The read side correctly treats a null-owned node as visible to every tenant. The bug was
+ * purely on the write side: `GraphService` provisions shared sentinels (`frontier`, the
+ * `Neo-Master-Architecture` primer, `_SYSTEM_STATE`, identity roots) via plain `upsertNode`,
+ * which stamps `properties.userId` with the *first boot harness's* bound identity. Under strict
+ * RLS that isolates these operational nodes to a single tenant — they vanish from the graph for
+ * everyone else. `upsertGlobalNode` forces `userId: null` so they stay globally reachable.
+ */
+function makeWritableDb() {
+    const nodeMap = new Map();
+    return {
+        getAdjacentNodes() {},
+        nodes: nodeMap,
+        edges  : {getByIndex() { return []; }},
+        addNode(spec) { nodeMap.set(spec.id, {id: spec.id, label: spec.label, properties: spec.properties}); },
+        autoSave: false,
+        storage : {RequestContextService: {getAgentIdentityNodeId: () => requester.value}}
+    };
+}
+
+test.describe('GraphService — global system-node provisioning (write-side null-owner) (#10271)', () => {
+    let GraphService, originalDb;
+
+    test.beforeAll(async () => {
+        GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalDb      = GraphService.db;
+        requester.value = null;
+    });
+
+    test.afterEach(() => {
+        GraphService.db = originalDb;
+        requester.value = null;
+    });
+
+    test('upsertGlobalNode forces userId:null even under an active request context', () => {
+        GraphService.db = makeWritableDb();
+        requester.value = '@tenant-a';
+
+        GraphService.upsertGlobalNode({id: 'sys-x', type: 'System', name: 'Sys X'});
+
+        // Null-owned, NOT stamped with the booting tenant — so RLS keeps it visible to all.
+        expect(GraphService.db.nodes.get('sys-x').properties.userId).toBeNull();
+    });
+
+    test('a global node provisioned under tenant-A stays visible to tenant-B', () => {
+        GraphService.db = makeWritableDb();
+
+        requester.value = '@tenant-a';  // the first boot harness
+        GraphService.upsertGlobalNode({id: 'Neo-Master-Architecture', type: 'System', name: 'Primer'});
+
+        requester.value = '@tenant-b';  // a different tenant must still see the global primer
+        expect(GraphService.getNode({id: 'Neo-Master-Architecture'})?.id).toBe('Neo-Master-Architecture');
+    });
+
+    test('plain upsertNode stamps the active tenant — the isolation the helper prevents', () => {
+        GraphService.db = makeWritableDb();
+
+        requester.value = '@tenant-a';
+        GraphService.upsertNode({id: 'leaky', type: 'System', name: 'Leaky'});
+
+        // Baseline: without the helper the node is bound to @tenant-a and hidden from @tenant-b.
+        expect(GraphService.db.nodes.get('leaky').properties.userId).toBe('@tenant-a');
+
+        requester.value = '@tenant-b';
+        expect(GraphService.getNode({id: 'leaky'})).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
@@ -270,6 +270,42 @@ function makeWritableDb() {
     };
 }
 
+/**
+ * Writable fake `GraphService.db` that ALSO supports the edge-write path (`linkNodes` →
+ * `storage.db.prepare` FK-verify + existing-edge check + `addEdge`) and the topology read
+ * (`edges.getByIndex` consumed by `getContextFrontier`). Lets a spec provision + link global
+ * sentinels end-to-end, then read them back as a different tenant — the path the global-edge gap lived in.
+ */
+function makeTopologyDb() {
+    const nodeMap = new Map(),
+          edges   = [];
+    const sqliteDb = {
+        prepare(sql) {
+            return {
+                get(...args) {
+                    // linkNodes FK pre-check: both endpoints must exist in Nodes.
+                    if (sql.includes('FROM Nodes')) {
+                        const [a, b] = args;
+                        return {count: (nodeMap.has(a) ? 1 : 0) + (a === b ? 0 : (nodeMap.has(b) ? 1 : 0))};
+                    }
+                    // linkNodes existing-edge lookup: none → a fresh edge is written.
+                    return undefined;
+                }
+            };
+        }
+    };
+    return {
+        getAdjacentNodes() {},
+        nodes: nodeMap,
+        edges: {getByIndex(field, id) { return edges.filter(e => e[field] === id); }},
+        addNode(spec) { nodeMap.set(spec.id, {id: spec.id, label: spec.label, properties: spec.properties}); },
+        addEdge(spec) { edges.push({id: spec.id, source: spec.source, target: spec.target, type: spec.type, properties: spec.properties}); },
+        transaction(fn) { return fn(); },  // linkNodes wraps executeLink in a transaction when not already in one
+        autoSave: false,
+        storage : {db: sqliteDb, dbPath: '/tmp/neo-graph.db', RequestContextService: {getAgentIdentityNodeId: () => requester.value}}
+    };
+}
+
 test.describe('GraphService — global system-node provisioning (write-side null-owner) (#10271)', () => {
     let GraphService, originalDb;
 
@@ -318,5 +354,40 @@ test.describe('GraphService — global system-node provisioning (write-side null
 
         requester.value = '@tenant-b';
         expect(GraphService.getNode({id: 'leaky'})).toBeNull();
+    });
+
+    // Edge ownership: a global node reached only through a tenant-stamped edge still vanishes from
+    // topology traversal (getContextFrontier RLS-filters edges AND nodes). linkGlobalNodes closes that.
+    test('a global sentinel linked under tenant-A is reachable via getContextFrontier for tenant-B', () => {
+        GraphService.db = makeTopologyDb();
+
+        requester.value = '@tenant-a';  // the booting harness
+        GraphService.upsertGlobalNode({id: 'frontier', type: 'SYSTEM_ANCHOR', name: 'Frontier'});
+        GraphService.upsertGlobalNode({id: 'Neo-Master-Architecture', type: 'System', name: 'Primer'});
+        GraphService.linkGlobalNodes('frontier', 'Neo-Master-Architecture', 'SYSTEM_TENET', 1.0);
+
+        // The SYSTEM_TENET edge must itself be null-owned, not just the node.
+        expect(GraphService.db.edges.getByIndex('source', 'frontier')[0].properties.userId).toBeNull();
+
+        // A non-booting tenant reaches the primer through topology, not only a direct getNode.
+        requester.value = '@tenant-b';
+        const ids = GraphService.getContextFrontier({depth: 2}).strategicNeighbors.map(n => n.id);
+        expect(ids).toContain('Neo-Master-Architecture');
+    });
+
+    test('plain linkNodes tenant-stamps the edge — the topology gap the global-edge helper closes', () => {
+        GraphService.db = makeTopologyDb();
+
+        requester.value = '@tenant-a';
+        GraphService.upsertGlobalNode({id: 'frontier', type: 'SYSTEM_ANCHOR', name: 'Frontier'});
+        GraphService.upsertGlobalNode({id: 'Neo-Master-Architecture', type: 'System', name: 'Primer'});
+        GraphService.linkNodes('frontier', 'Neo-Master-Architecture', 'SYSTEM_TENET', 1.0);  // plain → edge stamped @tenant-a
+
+        // Baseline: the node is global, but the tenant-stamped edge hides the primer from topology.
+        expect(GraphService.db.edges.getByIndex('source', 'frontier')[0].properties.userId).toBe('@tenant-a');
+
+        requester.value = '@tenant-b';
+        const ids = GraphService.getContextFrontier({depth: 2}).strategicNeighbors.map(n => n.id);
+        expect(ids).not.toContain('Neo-Master-Architecture');
     });
 });


### PR DESCRIPTION
Resolves #10271

Authored by Claude Opus 4.8 (Claude Code). Session 0f6d0fa0-327f-42ec-b970-e32f388699b4.

Global graph sentinels (`frontier`, the `Neo-Master-Architecture` primer, `_SYSTEM_STATE`) and the identity roots were provisioned via plain `upsertNode`, which stamps `properties.userId` with the **first boot harness's bound identity** (`RequestContextService.getAgentIdentityNodeId()`). Under strict multi-tenant RLS that isolates these operational nodes to a single tenant — `isRlsVisible` then hides them from every *other* tenant, so the global onboarding primer / system clock / identity roster **vanish from the graph for all but the booting tenant**.

`isRlsVisible` filters **edges as well as nodes**, and the topology readers (`getContextFrontier` / `getNeighbors` / `queryNodeTopology`) require *both* to be visible — so making the nodes global is necessary but not sufficient. The `SYSTEM_TENET` edge that anchors the primer to `frontier` must be global too, or the primer stays unreachable through topology traversal for non-booting tenants.

Fix: two symmetric helpers force `userId: null` — `GraphService#upsertGlobalNode` for the sentinel **nodes**, `GraphService#linkGlobalNodes` for the sentinel **edges** — and all global provisioning + linking routes through them.

Evidence: L2 (write-side tenant-isolation + topology unit tests — a node provisioned and linked under `@tenant-a` is reachable via `getContextFrontier` for `@tenant-b`; baselines prove plain `upsertNode`/`linkNodes` isolate. 41 passed locally across TenantIsolation + GraphService specs). No blocking residuals.

## Intent-validity V-B-A (ticket is from April's RLS-stabilization phase — confirmed live on `origin/dev`, not stale)
- **Write side:** `upsertNode`/`linkNodes` stamp `userId = currentUserId` when a provisioned node/edge passes no `userId` (`GraphService.mjs` 222-223 / 249-250 / 337-338); every system-node provisioning + the boot link omitted it.
- **Read side:** `isRlsVisible` returns false for a non-null owner that isn't the requester / shared / team — for both nodes and edges; `getContextFrontier` (803) requires `isRlsVisible(node) && isRlsVisible(edge)`.
- **Independent of the #12532 team-default:** that governs the memory/summary `tenantScope` filter, a different layer; these carry a concrete `userId`, not `visibility:'team'`.

## Sites changed (all in `ai/services/memory-core/GraphService.mjs`)
- New `upsertGlobalNode` helper + **6 node-provisioning sites** routed through it: `frontier` boot seed + the `mutateFrontier` re-seed (the site the ticket never catalogued), `Neo-Master-Architecture` primer, `_SYSTEM_STATE` init **and** the decay-clock update, and the identity-root upsert loop.
- New `linkGlobalNodes` helper + the boot `SYSTEM_TENET` edge (`frontier → Neo-Master-Architecture`) routed through it.
- Left request-scoped (correctly): the dynamic `CONTEXT_NODE` pivot target and the `STRATEGIC_PIVOT` edges in `mutateFrontier` — the agent's working context, not global sentinels.

## Deltas from ticket
- **Approach — symmetric helpers, not per-site stamps.** The ticket catalogued 4 node sites and didn't mention edge ownership at all. A 6th uncatalogued node site (`mutateFrontier`) plus the cross-family-surfaced edge gap proved hand-stamping is drift-prone, so the `userId: null` invariant is centralized in `upsertGlobalNode` (nodes) + `linkGlobalNodes` (edges) — the "global sentinel" abstraction across both graph entity kinds. Embodies the #12456 epic's "mechanically prevent recurrence" principle.
- **Edge ownership added in review (cross-family catch by @neo-gpt).** Cycle-1 review flagged that globalizing the nodes left the `SYSTEM_TENET` edge tenant-stamped, so the primer still failed topology traversal for non-booting tenants. Fixed via `linkGlobalNodes` + two topology regressions. This is the cross-family review model working: gpt's family caught the edge blind spot.
- **Existing-deployment heal.** Identity roots, the `_SYSTEM_STATE` decay-clock, and the unconditional boot `linkGlobalNodes` re-run every boot (self-correct existing deployments). The create-guarded `frontier`/primer nodes are correct on fresh provisioning; a live deployment that already stamped them re-provisions on next delete/reseed (prevention-vs-purge split, mirrors #12180).
- **Incidental hook compliance.** Dropped a pre-existing decay-prone `#10011` ref from a spec JSDoc comment to satisfy the whole-file `check-ticket-archaeology` gate; behavior description preserved, ticket linkage in the `describe` title + history (same pattern as #12532).

## Test Evidence
- `GraphService.TenantIsolation.spec.mjs` — write-side null-owner block (5 tests): `upsertGlobalNode` forces `userId:null` under an active request context; a global node provisioned under `@tenant-a` resolves for `@tenant-b` via `getNode`; **a sentinel linked under `@tenant-a` is reachable via `getContextFrontier` for `@tenant-b`** (the topology path); baselines confirm plain `upsertNode`/`linkNodes` stamp `@tenant-a` and hide the node/primer.
- Regression: `GraphService.spec.mjs` (incl. `auto-provision all identity roots at boot`, `decayGlobalTopology … _SYSTEM_STATE`, and the `getContextFrontier` topology tests) green — the provisioning + linking paths I touched are exercised. **41 passed.**

## Post-Merge Validation
- [ ] On a live multi-tenant deployment, confirm a non-booting tenant can read `Neo-Master-Architecture` / `_SYSTEM_STATE` / the identity roster AND reach the primer through `getContextFrontier` topology.
- [ ] If a deployment already stamped `frontier` / `Neo-Master-Architecture` (node) with a tenant id before this fix, re-provision those two seed nodes (delete + reboot, or a small backfill) — the create-guard means they don't auto-rewrite. Identity roots, the system clock, and the `SYSTEM_TENET` edge self-heal on the next boot / decay cycle.

## Decision Record impact
`aligned-with` the graph RLS model (`isRlsVisible` / the SQL RLS clause) — global sentinel nodes **and edges** are `userId: null` by construction, the sanctioned "visible to all tenants" shape.
