### PR TITLE
fix(agentos): record Opus 4.8 for @neo-opus-ada + @neo-claude-opus (#12531)

### DIFF
--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -16,7 +16,7 @@ and can drift independently of the Codex Desktop harness.
 ## Runtime Notes
 
 - GitHub username: `neo-gpt`.
-- A2A peers: Claude Opus 4.7 at `neo-opus-ada`; Gemini at
+- A2A peers: Claude at `neo-opus-ada`; Gemini at
   `neo-gemini-pro`.
 - `gh auth status` can falsely report `GH_TOKEN` as invalid inside Codex
   sandboxing. Verify identity with `gh api user --jq .login` before treating

--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -16,7 +16,7 @@ and can drift independently of the Codex Desktop harness.
 ## Runtime Notes
 
 - GitHub username: `neo-gpt`.
-- A2A peers: Claude at `neo-opus-ada`; Gemini at
+- A2A peers: Claude at `neo-opus-ada`, `neo-claude-opus`, and `neo-opus-vega`; Gemini at
   `neo-gemini-pro`.
 - `gh auth status` can falsely report `GH_TOKEN` as invalid inside Codex
   sandboxing. Verify identity with `gh api user --jq .login` before treating

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ We are not an abstract collective. We are a structured institution of named main
 | Maintainer | Role | Identity |
 |---|---|---|
 | [@tobiu](https://github.com/tobiu) | Substrate architect, empirical-corrector, merge-gate authority | Human |
-| [@neo-opus-ada](https://github.com/neo-opus-ada) | AI maintainer (Anthropic Claude Opus 4.7) | Machine Account |
-| [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude — same-family generalist; throughput + same-family review pressure) | Machine Account |
+| [@neo-opus-ada](https://github.com/neo-opus-ada) | AI maintainer (Anthropic Claude Opus 4.8) | Machine Account |
+| [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude Opus 4.8 — same-family generalist; throughput + same-family review pressure) | Machine Account |
 | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude Opus 4.8; version-free handle) | Machine Account |
 | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -72,7 +72,7 @@ export const IDENTITIES = [
         id: '@neo-opus-ada',
         type: 'AgentIdentity',
         name: 'Neo Opus Ada',
-        description: 'Anthropic Claude Opus version 4.7 Agent Identity',
+        description: 'Anthropic Claude Opus version 4.8 Agent Identity',
         properties: {
             githubLogin: '@neo-opus-ada',
             displayName: 'Neo Opus Ada',
@@ -98,11 +98,11 @@ export const IDENTITIES = [
             hosting           : 'cloud',
             family            : 'claude',
             tier              : 'frontier',
-            releaseDate       : '2026-04-16',
+            releaseDate       : '2026-05-28',
             pricingInput      : 5.00,
             pricingOutput     : 25.00,
             swarmRole         : 'Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination',
-            sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
+            sunsetTriggers    : ['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             // Active-peer quorum substrate. Family-keyed graduation quorum reads from
             // `participationStatus`; this structured field is authoritative.
             // Heartbeat / message-recency / quota / pricing-tier / model-release announcements are
@@ -122,7 +122,7 @@ export const IDENTITIES = [
         id: '@neo-claude-opus',
         type: 'AgentIdentity',
         name: 'Neo Claude Opus',
-        description: 'Anthropic Claude-family generalist maintainer identity.',
+        description: 'Anthropic Claude Opus 4.8 generalist maintainer identity.',
         properties: {
             githubLogin: '@neo-claude-opus',
             displayName: 'Neo Claude Opus',
@@ -164,11 +164,11 @@ export const IDENTITIES = [
             hosting           : 'cloud',
             family            : 'claude',
             tier              : 'frontier',
-            releaseDate       : '2026-04-16',
+            releaseDate       : '2026-05-28',
             pricingInput      : 5.00,
             pricingOutput     : 25.00,
             swarmRole         : 'Active Claude-family generalist maintainer identity; same-family throughput and same-family review pressure for Claude-authored work. Does not satisfy cross-family approval for Claude-family PRs per reviewSemantics.',
-            sunsetTriggers    : ['Anthropic releases Opus 4.8+ with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
+            sunsetTriggers    : ['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             participationStatus : 'active',
             statusReason        : null,
             authority           : null,

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -89,9 +89,7 @@ export const IDENTITIES = [
                 }
             },
             // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_opus — primary source: platform.claude.com/docs/en/about-claude/models/overview
-            // (pricing currently from aipricing.guru secondary citation; replace with Anthropic's own
-            // pricing-page link on next-update).
+            // §neo_opus — primary source: Anthropic Claude Opus 4.8 announcement/product page.
             contextWindowInput: 1048576,
             parallelToolCalls : true,
             thoughtBudget     : 'max',

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -11,7 +11,7 @@ Per ADR 0012 §2.5:
 3. New rows added at first swarm contact OR at model-public-release date for reference entries
 4. Updates do NOT require ADR amendment unless a capability dimension changes or new dimension is added
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-05
 
 ---
 
@@ -24,24 +24,23 @@ Named cross-family maintainers with active swarm participation. These models hol
 | Field | Value |
 |---|---|
 | `id` / `githubLogin` | `@neo-opus-ada` |
-| `name` | Claude Opus 4.7 |
+| `name` | Claude Opus 4.8 |
 | `family` | `claude` (Anthropic) |
 | `hosting` | `cloud` |
 | `tier` | `frontier` |
 | `contextWindowInput` | 1,048,576 (1M) |
 | `parallelToolCalls` | `true` |
 | `thoughtBudget` | `max` (we use the highest Claude thinking-budget setting) |
-| `releaseDate` | 2026-04-16 |
+| `releaseDate` | 2026-05-28 |
 | `pricingInput` | $5.00 per 1M tokens |
 | `pricingOutput` | $25.00 per 1M tokens |
-| `benchmarkSnapshot` | SWE-bench Verified: 87.6%; image-resolution: 2,576px (3.75 megapixels) |
-| `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
+| `benchmarkSnapshot` | Online-Mind2Web: 84%; stronger coding, agentic, and professional-work performance than Opus 4.7 per Anthropic announcement. |
+| `sunsetTriggers` | Anthropic releases a successor Opus-class model with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
 | `swarmRole` | Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination |
 
-**Sources** (primary first; secondary/commentary marked):
-- **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
-- **Primary**: [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
-- **Secondary/commentary**: [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/) (V-B-A pending — replace with Anthropic's own pricing page citation when next-update touches this row)
+**Sources** (primary first):
+- **Primary**: [Introducing Claude Opus 4.8 — Anthropic](https://www.anthropic.com/news/claude-opus-4-8)
+- **Primary**: [Claude Opus 4.8 — Anthropic](https://www.anthropic.com/claude/opus)
 
 ### §neo_opus_vega
 
@@ -140,10 +139,10 @@ transitions to `active`.
 | `contextWindowInput` | 1,048,576 (1M) |
 | `parallelToolCalls` | `true` |
 | `thoughtBudget` | `max` (highest Claude thinking-budget setting in use for the active Claude Opus maintainer) |
-| `releaseDate` | 2026-04-16 |
+| `releaseDate` | 2026-05-28 |
 | `pricingInput` | $5.00 per 1M tokens |
 | `pricingOutput` | $25.00 per 1M tokens |
-| `sunsetTriggers` | Anthropic releases Opus 4.8+ with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
+| `sunsetTriggers` | Anthropic releases a successor Opus-class model with material reasoning capability upgrade; OR Anthropic deprecates Opus family branch |
 | `swarmRole` | Pending Claude-family generalist maintainer identity; no active routing, quorum participation, or review coverage until activation |
 
 This row mirrors the Claude Opus model-class capability values from
@@ -151,10 +150,9 @@ This row mirrors the Claude Opus model-class capability values from
 class. Activation must re-verify the row if the operator-created account uses a
 different Claude model, provider-side capability tier, or pricing surface.
 
-**Sources** (primary first; secondary/commentary marked):
-- **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview)
-- **Primary**: [Context windows — Claude API Docs](https://platform.claude.com/docs/en/build-with-claude/context-windows)
-- **Secondary/commentary**: [Anthropic Claude API Pricing 2026 — aipricing.guru](https://www.aipricing.guru/anthropic-pricing/) (V-B-A pending — replace with Anthropic's own pricing page citation when next-update touches this row)
+**Sources** (primary first):
+- **Primary**: [Introducing Claude Opus 4.8 — Anthropic](https://www.anthropic.com/news/claude-opus-4-8)
+- **Primary**: [Claude Opus 4.8 — Anthropic](https://www.anthropic.com/claude/opus)
 
 ---
 

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -102,7 +102,7 @@ No harness configuration required. `StdioIdentityResolver` falls back to `gh api
 
 Ticket #10144 seeded three `AgentIdentity` nodes in the Native Edge Graph:
 
-- `@neo-opus-ada` — Claude Opus 4.7
+- `@neo-opus-ada` — Claude Opus 4.8
 - `@neo-gemini-pro` — Gemini 3.1 Pro
 - `@tobiu` — Tobias Uhlig (human owner)
 


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code, as @neo-opus-vega). Session db066a97-cc06-4bd3-b8fe-c056ab15639e.

Resolves #12531

Corrects a stale model-version fact across **five files**. The two Claude maintainers `@neo-opus-ada` + `@neo-claude-opus` — whom `@tobiu` confirmed (per the #12531 body) now run Opus **4.8** — were recorded at the Opus **4.7** class. Surfaces:
- `learn/agentos/ModelStats.md` — `§neo_opus` + `§neo_claude_opus` rows (`name`, `releaseDate`, `benchmarkSnapshot`, `sunsetTriggers`, Anthropic Opus 4.8 sources) + `Last updated`.
- `README.md` — the two maintainer rows.
- `ai/graph/identityRoots.mjs` — the identity-seed values **and** the `§neo_opus` source-comment.
- `learn/agentos/tooling/MemoryCoreMcpAuth.md` — the AgentIdentity graph-node binding row.
- `.codex/CODEX.md` — the A2A peer-roster: made version-free (per its own anti-hardcode note + the version-free Gemini sibling) **and completed to list all three Claude Opus peers** (`@neo-opus-ada`, `@neo-claude-opus`, `@neo-opus-vega`) per operator change-request.

Values single-source-derived from the already-vetted `§neo_opus_vega` 4.8 row.

Evidence: L1 (static doc/seed-data fact consistency; no runtime ACs — seed values apply on next re-seed, validated post-merge) → L1 required. No residuals (full grep sweep run pre-handoff — see Test Evidence).

## Supersedes #12534
#12534 went `CONFLICTING` after the merge queue landed, and the `@neo-opus-4-7` → `@neo-opus-ada` handle rename + `§neo_opus_4_7` → `§neo_opus` section-rename it scoped *out* have since merged to dev. Per `pull-request-workflow §9.1` this is a fresh superseding PR off current dev; #12534 closed pointing here.

## Slot-rationale (§1.1 — touches `learn/agentos/**`)
Data-value correction to the model registry + identity substrate, not a rule add/modify/retire.
- `ModelStats.md §neo_opus` + `§neo_claude_opus` and `MemoryCoreMcpAuth.md` binding row (both `learn/agentos/**`): disposition `keep` — canonical registry/tooling surfaces; only the asserted version *values* move 4.7 → 4.8, roles unchanged.
- `ai/graph/identityRoots.mjs` (graph seed) + `.codex/CODEX.md` (Codex harness notes) are outside §1.1 paths — value correction + the operator-requested peer-roster completion.
- Net loaded-bytes: ModelStats −2; identityRoots −2 (source-comment collapse); README / MemoryCoreMcpAuth / CODEX ±0. All conditionally-loaded reference/seed/harness, not always-loaded Map → Substrate Accretion Defense satisfied (drift-reduction).
- `Decision Record impact`: aligned-with ADR 0012 (capability-value update with authoritative-source-cite per §2.5; no amendment needed) + ADR 0018 (respects version-in-registry-not-in-handle; touches no handles).

## Deltas from ticket
- **Re-targeted to the current handle**: #12531's ACs name `@neo-opus-4-7` / `§neo_opus_4_7`; both renamed on dev. The version *fact* is corrected in the renamed surfaces; no handle/section edits (those landed separately, per #12531's Out-of-Scope).
- **identityRoots + a source/comment sweep added** (scope-evolution): the same drift sat in the identityRoots seed values, the identityRoots `§neo_opus` source-comment, the `MemoryCoreMcpAuth.md` binding row, and the `.codex/CODEX.md` peer-roster. @neo-claude-opus confirmed #10271 is GraphService-only; the comment + the two tooling/harness surfaces were caught in @neo-gpt's Cycle-1 review-driven full grep.
- **Operator change-request (post-approval)**: the `.codex/CODEX.md` A2A-peers line listed only `@neo-opus-ada`, but @neo-gpt has three Claude Opus teammates — completed with `@neo-claude-opus` + `@neo-opus-vega`.
- **No longer pure-docs**: touches a `.mjs` seed → standard cross-family approved review (not micro-exempt).
- **Benchmark propagation note**: the `Online-Mind2Web: 84%` figure is carried over from the merged `§neo_opus_vega` row (single-source-derive), not independently re-benchmarked by me.

## Test Evidence
Docs + seed-data; no runtime surface exercised. `git diff` spans **5 files** (README, ModelStats, identityRoots.mjs, MemoryCoreMcpAuth.md, .codex/CODEX.md). Full residual grep run post-sweep: only historical/illustrative/reference/test references + the intentional benchmark comparison remain — no current-fact residuals. Pre-commit hooks (whitespace / shorthand / ticket-archaeology) green on every commit.

## Post-Merge Validation
- [ ] Next graph (re)seed (`seedAgentIdentities.mjs` / boot self-seed) provisions `@neo-opus-ada` + `@neo-claude-opus` nodes with the Opus 4.8 values (existing nodes keep prior values until refreshed — seed idempotent on root provenance).
- [ ] KB / portal Learn view renders the corrected ModelStats rows at 4.8.
- [x] Residual grep (`Opus 4.7` / `2026-04-16` across README + `learn/agentos/` + `ai/graph/` + `.codex/`) returns only intended/historical references — run pre-handoff this cycle.

## Commits
- `486b3d89e` — ModelStats `§neo_opus` + `§neo_claude_opus` + README rows + `Last updated` (4.7 → 4.8).
- `48f5116bb` — `identityRoots.mjs` seed values (4.7 → 4.8).
- `544396783` — source/comment sweep: identityRoots `§neo_opus` source-comment, `MemoryCoreMcpAuth.md` binding row, `.codex/CODEX.md` peer-roster version-free (@neo-gpt Cycle-1 review).
- `49dfbb030` — `.codex/CODEX.md` A2A-roster completed with all three Claude Opus peers (operator change-request).

## Cross-family review
@neo-gpt (cross-family). Cycle-1: source/comment sweep (addressed). Cycle-2: PR-body sync. Cycle-3: APPROVED. Post-approval: operator-requested CODEX peer-roster completion (`49dfbb030`) — quick re-confirm on the 1-line delta requested.
