### PR TITLE
test(memory): reset lifecycle bindings between specs (#12597)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -21,8 +21,10 @@ import aiConfig       from '../../../../../../../ai/mcp/server/memory-core/confi
 import ChromaManager  from '../../../../../../../ai/services/memory-core/managers/ChromaManager.mjs';
 import {CHROMA_PRODUCTION_DATABASE, CHROMA_TEST_DATABASE} from '../../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 import logger         from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
+import StorageRouter  from '../../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import SystemLifecycleService from '../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import path           from 'path';
+import {resetMemoryCoreLifecycle} from '../util.mjs';
 
 const tmpDir = path.resolve(process.cwd(), 'tmp');
 aiConfig.storagePaths.graph = path.join(tmpDir, 'test-graph-' + Date.now() + '-' + Math.random().toString(36).substring(7) + '.db');
@@ -91,6 +93,30 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         }).database).toBe(CHROMA_TEST_DATABASE);
     });
 
+    test('resetMemoryCoreLifecycle clears singleton readiness and collection handles', async () => {
+        const stalePromise = Promise.resolve({name: 'stale-collection'});
+
+        SystemLifecycleService._initPromise   = stalePromise;
+        StorageRouter._initPromise            = stalePromise;
+        ChromaManager._memoryCollectionPromise  = stalePromise;
+        ChromaManager._summaryCollectionPromise = stalePromise;
+        ChromaManager._graphCollectionPromise   = stalePromise;
+        ChromaManager.memoryCollection  = {name: 'stale-memory'};
+        ChromaManager.summaryCollection = {name: 'stale-summary'};
+        ChromaManager.graphCollection   = {name: 'stale-graph'};
+
+        await resetMemoryCoreLifecycle();
+
+        expect(SystemLifecycleService._initPromise).toBeNull();
+        expect(StorageRouter._initPromise).toBeNull();
+        expect(ChromaManager._memoryCollectionPromise).toBeNull();
+        expect(ChromaManager._summaryCollectionPromise).toBeNull();
+        expect(ChromaManager._graphCollectionPromise).toBeNull();
+        expect(ChromaManager.memoryCollection).toBeNull();
+        expect(ChromaManager.summaryCollection).toBeNull();
+        expect(ChromaManager.graphCollection).toBeNull();
+    });
+
     test('should prevent console.warn global state theft during concurrent collection fetching', async () => {
         // Set up a custom warn logger to inspect leaks
         const warningLogs = [];
@@ -145,7 +171,7 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
             // Un-mock
             console.warn = originalWarn;
             if (originalClient) ChromaManager.client = originalClient;
-            SystemLifecycleService._initPromise = null;
+            await resetMemoryCoreLifecycle();
         }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -1,20 +1,59 @@
+/**
+ * @summary Clears process-singleton Memory Core lifecycle and collection bindings between specs.
+ *
+ * Memory Core specs mutate `aiConfig.collections.*` and `aiConfig.storagePaths.graph` per file.
+ * A graph-only cleanup must still clear the Memory Core lifecycle promise plus Chroma collection
+ * handles, otherwise the next `--workers=1` spec can reuse a collection binding resolved by an
+ * earlier spec while resolving config leaf names from the later spec.
+ *
+ * @param {Object} [SDK] Optional `ai/services.mjs` aggregate import for callers that already hold it.
+ */
+export async function resetMemoryCoreLifecycle(SDK) {
+    let ChromaManager, LifecycleService, StorageRouter;
+
+    if (SDK) {
+        ChromaManager    = SDK.Memory_ChromaManager;
+        LifecycleService = SDK.Memory_LifecycleService;
+        StorageRouter    = SDK.Memory_StorageRouter;
+    } else {
+        ChromaManager    = (await import('../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
+        LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+        StorageRouter    = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+    }
+
+    if (LifecycleService) {
+        LifecycleService._initPromise = null;
+    }
+
+    if (StorageRouter) {
+        StorageRouter._initPromise = null;
+    }
+
+    if (ChromaManager) {
+        ChromaManager._memoryCollectionPromise = null;
+        ChromaManager._summaryCollectionPromise = null;
+        ChromaManager._graphCollectionPromise = null;
+        ChromaManager.memoryCollection = null;
+        ChromaManager.summaryCollection = null;
+        ChromaManager.graphCollection = null;
+    }
+}
+
 export async function cleanupChromaManager(SDK) {
-    let ChromaManager, LifecycleService, collectionsConfig;
+    let ChromaManager, collectionsConfig;
 
     if (SDK) {
         ChromaManager = SDK.Memory_ChromaManager;
-        LifecycleService = SDK.Memory_LifecycleService;
         collectionsConfig = SDK.Memory_Config?.data?.collections;
     } else {
         ChromaManager = (await import('../../../../../../ai/services/memory-core/managers/ChromaManager.mjs')).default;
-        LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
         collectionsConfig = aiConfig?.collections;
     }
 
     if (ChromaManager?.client && collectionsConfig) {
-        // Defense-in-depth (#11652): refuse cleanup when `UNIT_TEST_MODE !== 'true'` regardless of
-        // collection name. The pre-#11652 guard checked only the name; under `npx playwright`
+        // Defense-in-depth: refuse cleanup when `UNIT_TEST_MODE !== 'true'` regardless of
+        // collection name. The earlier guard checked only the name; under `npx playwright`
         // without the unit-test config, `aiConfig.collections.*` falls through to canonical
         // names AND `UNIT_TEST_MODE` is unset — both invariants must hold for cleanup to proceed.
         // The substrate-level guard in `ChromaManager.deleteCollection` is the hard backstop;
@@ -26,7 +65,7 @@ export async function cleanupChromaManager(SDK) {
             throw new Error(`FATAL: Attempted to delete production Chroma collections! Aborting cleanup. memory=${collectionsConfig.memory}, session=${collectionsConfig.session}`);
         }
         try {
-            // Route through the guarded ChromaManager.deleteCollection (#11652) so the substrate-
+            // Route through the guarded ChromaManager.deleteCollection so the substrate-
             // level invariant fires uniformly. Test-prefixed names skip the guard cleanly under
             // UNIT_TEST_MODE; the bare `client.deleteCollection` access path is deprecated.
             try { await ChromaManager.deleteCollection({name: collectionsConfig.memory}); } catch(e) { if (!e.message.includes('not be found')) throw e; }
@@ -38,18 +77,7 @@ export async function cleanupChromaManager(SDK) {
         }
     }
 
-    if (LifecycleService) {
-        LifecycleService._initPromise = null;
-    }
-
-    if (ChromaManager) {
-        ChromaManager._memoryCollectionPromise = null;
-        ChromaManager._summaryCollectionPromise = null;
-        ChromaManager._graphCollectionPromise = null;
-        ChromaManager.memoryCollection = null;
-        ChromaManager.summaryCollection = null;
-        ChromaManager.graphCollection = null;
-    }
+    await resetMemoryCoreLifecycle(SDK);
 }
 
 export class TestLifecycleHelper {
@@ -65,6 +93,7 @@ export class TestLifecycleHelper {
                     }
                 }
             }
+            await resetMemoryCoreLifecycle();
             return;
         }
 
@@ -77,6 +106,8 @@ export class TestLifecycleHelper {
         if (SystemLifecycleService) {
             SystemLifecycleService._initPromise = null;
         }
+
+        await resetMemoryCoreLifecycle();
 
         if (fs && testDbPath) {
             try {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Resolves #12597

Adds a shared Memory Core test cleanup helper that clears process-singleton lifecycle promises and cached Chroma collection handles between specs, then wires both the Chroma cleanup path and graph-only cleanup path through it. This prevents a later `--workers=1` spec from reusing collection bindings resolved by an earlier spec while reading the later spec's `aiConfig.collections.*` leaf names.

Evidence: L2 (focused unit regression and single-worker affected-set runs) -> L2 required (test-isolation ACs). No residuals in the shipped current-dev lifecycle binding surface.

## Deltas from ticket

The ticket was created from the #12435 integration context, but #12435's snapshot/restore helper shape was later retracted under ADR 0019 B4. This PR targets the independent root cause visible on current `dev`: `cleanupChromaManager()` already reset Memory Core lifecycle and collection handles, while graph-only cleanup did not, and `ChromaManager.spec` could leave direct mock collection promises behind.

The complete #12435 affected-set should be repeated after #12435 is reshaped around isolation-by-construction on top of this lifecycle-reset substrate. During local reproduction on current `dev`, the QueryReRanker failure reproduced as described; two broader current-dev surfaces also timed out independently (`DreamServiceGoldenPath.spec.mjs` and `SessionSummarization.spec.mjs`) and were excluded from the final #12597 binary regression run.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs --workers=1` -> pre-patch reproduced QueryReRanker zero-result failure; post-patch 40/40 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs` -> 7/7 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs --workers=1` -> 96/96 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-commit hooks passed, including whitespace, shorthand, and ticket-archaeology checks.

## Post-Merge Validation

- [ ] Re-run the relevant #12435 affected-set `--workers=1` command after #12435 is reshaped around isolation-by-construction on top of this lifecycle-reset substrate. Do not use #12598's snapshot/restore helper as the validation basis.

## Commit

- `e0af02706` — `test(memory): reset lifecycle bindings between specs (#12597)`
