### PR TITLE
fix(memory): canonicalize Memory/Session graph IDs (#10172)

### DIFF
--- a/ai/services/graph/SemanticGraphExtractor.mjs
+++ b/ai/services/graph/SemanticGraphExtractor.mjs
@@ -28,6 +28,36 @@ class SemanticGraphExtractor extends Base {
     }
 
     /**
+     * Tests whether a graph node ID references a row-backed Memory or Session node.
+     *
+     * @summary Anchor & Echo: Defines the producer-side provenance predicate for the
+     * Memory/Session lazy-edge queue. Matching is case-insensitive for compatibility
+     * with legacy uppercase inputs while non-row-backed prefixes remain untouched.
+     *
+     * @param {String} id Graph node ID candidate
+     * @returns {Boolean} `true` for Memory/Session graph node IDs
+     * @protected
+     */
+    isMemorySessionGraphNodeId(id) {
+        return typeof id === 'string' && /^(memory|session):/i.test(id);
+    }
+
+    /**
+     * Normalizes row-backed Memory/Session graph node IDs to canonical lowercase prefixes.
+     *
+     * @summary Anchor & Echo: Keeps `memory:` / `session:` as the producer canonical
+     * form while accepting `MEMORY:` / `SESSION:` as compatibility inputs. Semantic and
+     * identity prefixes such as `CONCEPT:`, `CLASS:`, and `AGENT:` pass through unchanged.
+     *
+     * @param {String} id Raw graph node ID
+     * @returns {String} Canonical Memory/Session ID, or the original ID for other prefixes
+     * @protected
+     */
+    normalizeMemorySessionGraphNodeId(id) {
+        return this.isMemorySessionGraphNodeId(id) ? GraphService.normalizeGraphNodeId(id) : id;
+    }
+
+    /**
      * Executes the Tri-Vector Synthesis (Semantic Graph, Open Deltas, Roadmap Strategy)
      * from the session memory log via JSON schema extraction.
      *
@@ -86,9 +116,13 @@ Enforce this STRICT JSON schema:
 
 PROVENANCE EDGES:
 When extracting entities, you MUST emit provenance edges linking them back to the source Memory or Session, for example:
-- MENTIONED_IN (Concept -> Memory:xyz)
-- DISCUSSED_IN (Class/Method -> Session:xyz)
-- REFERENCED_BY (Issue -> Memory:xyz)
+- MENTIONED_IN (Concept -> memory:xyz)
+- DISCUSSED_IN (Class/Method -> session:xyz)
+- REFERENCED_BY (Issue -> memory:xyz)
+
+Row-backed Memory and Session provenance targets MUST use lowercase canonical IDs (memory:<id> and session:<id>).
+Uppercase MEMORY: / SESSION: are compatibility input forms only; do not emit them.
+This does not recase semantic or identity prefixes such as CONCEPT:, CLASS:, or AGENT:.
 
 DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide purely the JSON object.`;
 
@@ -242,6 +276,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                     const cleanName = (node.name || nodeId).replace(/[^a-zA-Z0-9_\-\.]/g, '_');
                     nodeId = `${nodeType}:${cleanName}`;
                 }
+                nodeId = this.normalizeMemorySessionGraphNodeId(nodeId);
 
                 GraphService.upsertNode({
                     id: nodeId,
@@ -277,12 +312,15 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                 const targetNode = artifact.graph.nodes.find(n => n.id === edge.target);
                 if (targetNode && targetNode._resolvedId) resolvedTarget = targetNode._resolvedId;
 
+                resolvedSource = this.normalizeMemorySessionGraphNodeId(resolvedSource);
+                resolvedTarget = this.normalizeMemorySessionGraphNodeId(resolvedTarget);
+
                 const sourceExists = validNodeRefs.has(resolvedSource) || GraphService.db.nodes.has(resolvedSource);
                 const targetExists = validNodeRefs.has(resolvedTarget) || GraphService.db.nodes.has(resolvedTarget);
 
                 if (!sourceExists || !targetExists) {
                     const isProvenance = ['MENTIONED_IN', 'DISCUSSED_IN', 'REFERENCED_BY'].includes(edge.relationship);
-                    const targetsSessionOrMemory = resolvedTarget.startsWith('SESSION:') || resolvedTarget.startsWith('MEMORY:') || resolvedSource.startsWith('SESSION:') || resolvedSource.startsWith('MEMORY:');
+                    const targetsSessionOrMemory = this.isMemorySessionGraphNodeId(resolvedTarget) || this.isMemorySessionGraphNodeId(resolvedSource);
 
                     if (isProvenance && targetsSessionOrMemory) {
                         /**

--- a/learn/agentos/tooling/GraphBackfill.md
+++ b/learn/agentos/tooling/GraphBackfill.md
@@ -20,7 +20,7 @@ All three converge on the same primitive: `MemorySessionIngestor.ingestSingleRow
 
 ## Primitive: `ingestSingleRow`
 
-The per-row analog of `syncSessionToGraph`'s batch-per-session behavior. Given a graph node ID with the `memory:` or `session:` prefix (case-insensitive — accepts the uppercase `MEMORY:` / `SESSION:` form used by #10165's extractor without requiring a canonical-format migration), it fetches the corresponding Chroma row and upserts a graph node tagged `backfilled: true`.
+The per-row analog of `syncSessionToGraph`'s batch-per-session behavior. Given a graph node ID with the canonical `memory:` or `session:` prefix, it fetches the corresponding Chroma row and upserts a graph node tagged `backfilled: true`. Uppercase `MEMORY:` / `SESSION:` inputs remain accepted as compatibility forms and normalize to the canonical lowercase target before lookup.
 
 **Recursion:** a Memory's `sessionId` metadata points at its parent Session. If the Session node is absent when a Memory is back-filled, `ingestSingleRow` recursively back-fills the parent first so the `ORIGINATES_IN` edge doesn't dangle.
 
@@ -45,9 +45,9 @@ const ok = await GraphService.linkNodesAsync(source, target, relationship, weigh
 
 **Prefix normalization:** both endpoints are routed through `normalizeGraphNodeId` before the lookup. The edge lands on the canonical lowercase form regardless of input case. An edge passed as `MEMORY:xyz` lands in SQLite with `target = 'memory:xyz'`.
 
-## JSONL Lazy Queue (Producer/Consumer Contract with #10165)
+## JSONL Lazy Queue (Producer/Consumer Contract with #10165 / #10172)
 
-Gemini 3.1 Pro's [PR #10165](https://github.com/neomjs/neo/pull/10165) (ticket #10152) shipped the **producer** side: `SemanticGraphExtractor` writes provenance edges whose `MEMORY:` / `SESSION:` targets aren't yet in the graph to `aiConfig.lazyEdgesQueuePath` (default `ai/data/memory-core/lazy-edges.jsonl`) as one JSON object per line.
+Gemini 3.1 Pro's [PR #10165](https://github.com/neomjs/neo/pull/10165) (ticket #10152) shipped the **producer** side: `SemanticGraphExtractor` writes provenance edges whose `memory:` / `session:` targets aren't yet in the graph to `aiConfig.lazyEdgesQueuePath` (default `ai/data/memory-core/lazy-edges.jsonl`) as one JSON object per line. Pre-#10172 queue entries may still contain `MEMORY:` / `SESSION:` targets; the consumer path treats those as compatibility inputs and normalizes them before back-fill/linking.
 
 This ticket (#10153) ships the **consumer** side: `LazyEdgeDrainer.drainQueue()` reads the queue, retries each edge via `linkNodesAsync` (which triggers `ingestSingleRow` for missing endpoints), writes failures back for the next cycle, and deletes the queue when fully drained.
 
@@ -95,9 +95,14 @@ Use before mass cross-tenant operations (e.g. post-#10146 permission grant rollo
 
 ## Node-ID Canonical Format (Coordination Note)
 
-The ingestor writes node IDs in the form `memory:<chromaId>` and `session:<sessionId>` — lowercase prefix. Gemini's #10165 extractor emits edges referencing `MEMORY:<chromaId>` and `SESSION:<sessionId>` — uppercase prefix. `ingestSingleRow` and `linkNodesAsync` both normalize case-insensitively on the consumer side, so neither convention "wins" yet.
+Canonical row-backed Memory and Session graph IDs use lowercase prefixes:
 
-This is a known coordination seam. If the uppercase form becomes canonical, the ingestor's upsert path needs renaming. If lowercase wins, the extractor prompt and existing queued entries need updating. Current behavior: both forms resolve; the canonical-format decision is deferred to a follow-up.
+- `memory:<chromaId>`
+- `session:<sessionId>`
+
+This convention applies only to row-backed Memory/Session nodes. Semantic and identity prefixes such as `CONCEPT:`, `CLASS:`, and `AGENT:` remain outside this contract and are not recased by #10172.
+
+Uppercase `MEMORY:<chromaId>` and `SESSION:<sessionId>` remain compatibility input forms for historical lazy-queue lines, review artifacts, and manual operator probes. `GraphService.normalizeGraphNodeId`, `ingestSingleRow`, and `linkNodesAsync` normalize those inputs to the lowercase canonical form before storage/linking. New producer output should emit the lowercase canonical form directly.
 
 ## Chroma Collection Mapping
 
@@ -110,8 +115,8 @@ Tests inject stubs conforming to the same `collection.get({ids} | {where})` cont
 
 ## See Also
 
-- `ai/daemons/services/MemorySessionIngestor.mjs` — `ingestSingleRow` + `syncSessionToGraph`
-- `ai/daemons/services/LazyEdgeDrainer.mjs` — JSONL queue consumer
+- `ai/services/ingestion/MemorySessionIngestor.mjs` — `ingestSingleRow` + `syncSessionToGraph`
+- `ai/services/graph/LazyEdgeDrainer.mjs` — JSONL queue consumer
 - `ai/services/memory-core/GraphService.mjs` — `linkNodesAsync`, `ensureNodeExists`, `normalizeGraphNodeId`
 - `ai/scripts/priorityBackfill.mjs` — operator CLI
 - `learn/agentos/tooling/MemoryCoreMcpAuth.md` — identity propagation (orthogonal; user-tenant tagging happens at write time regardless of back-fill source)

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -49,12 +49,9 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         aiConfig.lazyEdgesQueuePath   = path.join(tmpDir, `lazy-edges-${process.pid}-${Date.now()}.jsonl`);
         aiConfig.autoIngestFileSystem = false;
 
-        // #11965 Sub-2 cycle-3: graph services now dispatch provider via
-        // aiConfig.modelProvider through buildGraphProvider. Memory Core's
-        // default modelProvider is 'gemini' which is out of Sub-2 graph scope
-        // (gemini-graph dispatch deferred to Sub-3 / follow-up). This test
-        // stubs OpenAiCompatible.prototype.generate, so force the dispatch
-        // path to 'openAiCompatible'.
+        // Graph services dispatch through buildGraphProvider using the configured
+        // modelProvider. This test stubs OpenAiCompatible.prototype.generate, so
+        // force that dispatch path for deterministic provider mocking.
         aiConfig.modelProvider = 'openAiCompatible';
 
         GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
@@ -108,88 +105,91 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
     });
 
-    test('should extract provenance edges and queue unresolved targets to lazy back-fill (#10152)', async () => {
+    test('should normalize Memory/Session provenance targets before lazy queue (#10172)', async () => {
         const baseGenerate = OpenAiCompatible.prototype.generate;
 
-        OpenAiCompatible.prototype.generate = async function(messages) {
-            return {
-                content: JSON.stringify({
-                    a2a_version: "1.0",
-                    agent_id: "Antigravity",
-                    session_artifact: {
-                        graph: {
-                            nodes: [
-                                {
-                                    id: "CONCEPT:TestConcept",
-                                    type: "CONCEPT",
-                                    name: "TestConcept",
-                                    description: "Test concept for provenance edges"
-                                }
-                            ],
-                            edges: [
-                                {
-                                    source: "CONCEPT:TestConcept",
-                                    target: "MEMORY:non-existent-memory",
-                                    relationship: "MENTIONED_IN",
-                                    weight: 1.0,
-                                    justification: "Provenance test"
-                                },
-                                {
-                                    source: "CONCEPT:TestConcept",
-                                    target: "SESSION:non-existent-session",
-                                    relationship: "DISCUSSED_IN",
-                                    weight: 1.0,
-                                    justification: "Provenance test 2"
-                                },
-                                {
-                                    source: "CONCEPT:TestConcept",
-                                    target: "frontier",
-                                    relationship: "RELATES_TO"
-                                }
-                            ]
+        try {
+            OpenAiCompatible.prototype.generate = async function(messages) {
+                return {
+                    content: JSON.stringify({
+                        a2a_version: "1.0",
+                        agent_id: "Antigravity",
+                        session_artifact: {
+                            graph: {
+                                nodes: [
+                                    {
+                                        id: "CONCEPT:TestConcept",
+                                        type: "CONCEPT",
+                                        name: "TestConcept",
+                                        description: "Test concept for provenance edges"
+                                    }
+                                ],
+                                edges: [
+                                    {
+                                        source: "CONCEPT:TestConcept",
+                                        target: "MEMORY:non-existent-memory",
+                                        relationship: "MENTIONED_IN",
+                                        weight: 1.0,
+                                        justification: "Uppercase compatibility provenance test"
+                                    },
+                                    {
+                                        source: "CONCEPT:TestConcept",
+                                        target: "session:non-existent-session",
+                                        relationship: "DISCUSSED_IN",
+                                        weight: 1.0,
+                                        justification: "Canonical lowercase provenance test"
+                                    },
+                                    {
+                                        source: "CONCEPT:TestConcept",
+                                        target: "frontier",
+                                        relationship: "RELATES_TO"
+                                    }
+                                ]
+                            }
                         }
-                    }
-                })
+                    })
+                };
             };
-        };
 
-        const session = {
-            id: 'mock-semantic-vector-id',
-            meta: { sessionId: 'playwright-provenance-test' },
-            document: "Mock episodic history for provenance"
-        };
+            const session = {
+                id: 'mock-semantic-vector-id',
+                meta: { sessionId: 'playwright-provenance-test' },
+                document: "Mock episodic history for provenance"
+            };
 
-        const lazyQueueFile = aiConfig.lazyEdgesQueuePath;
-        if (fs.existsSync(lazyQueueFile)) {
-            fs.unlinkSync(lazyQueueFile);
-        }
+            const lazyQueueFile = aiConfig.lazyEdgesQueuePath;
+            if (fs.existsSync(lazyQueueFile)) {
+                fs.unlinkSync(lazyQueueFile);
+            }
 
-        const result = await SemanticGraphExtractor.executeTriVectorExtraction(session);
+            const result = await SemanticGraphExtractor.executeTriVectorExtraction(session);
 
-        expect(result).not.toBeNull();
-        expect(result.session_artifact.graph.edges.length).toBe(3);
+            expect(result).not.toBeNull();
+            expect(result.session_artifact.graph.edges.length).toBe(3);
 
-        // Check if the lazy queue file was created and contains the edge
-        expect(fs.existsSync(lazyQueueFile)).toBe(true);
-        const queueContent = fs.readFileSync(lazyQueueFile, 'utf8');
-        expect(queueContent).toContain('"relationship":"MENTIONED_IN"');
-        expect(queueContent).toContain('"target":"MEMORY:non-existent-memory"');
-        expect(queueContent).toContain('"relationship":"DISCUSSED_IN"');
-        expect(queueContent).toContain('"target":"SESSION:non-existent-session"');
+            // Check if the lazy queue file was created and contains canonical endpoints.
+            expect(fs.existsSync(lazyQueueFile)).toBe(true);
+            const queueContent = fs.readFileSync(lazyQueueFile, 'utf8');
+            expect(queueContent).toContain('"relationship":"MENTIONED_IN"');
+            expect(queueContent).toContain('"target":"memory:non-existent-memory"');
+            expect(queueContent).toContain('"relationship":"DISCUSSED_IN"');
+            expect(queueContent).toContain('"target":"session:non-existent-session"');
+            expect(queueContent).not.toContain('"target":"MEMORY:non-existent-memory"');
+            expect(queueContent).not.toContain('"target":"SESSION:non-existent-session"');
 
-        // Check if RELATES_TO edge was added to the GraphService (since frontier exists)
-        const edges = GraphService.db.edges.items;
-        expect(edges.some(e => e.type === 'RELATES_TO' && e.source === 'CONCEPT:TestConcept')).toBe(true);
+            // Check if RELATES_TO edge was added to the GraphService (since frontier exists)
+            const edges = GraphService.db.edges.items;
+            expect(edges.some(e => e.type === 'RELATES_TO' && e.source === 'CONCEPT:TestConcept')).toBe(true);
 
-        // MENTIONED_IN shouldn't be in the DB directly because it targets a non-existent node
-        expect(edges.some(e => e.type === 'MENTIONED_IN')).toBe(false);
+            // MENTIONED_IN shouldn't be in the DB directly because it targets a non-existent node
+            expect(edges.some(e => e.type === 'MENTIONED_IN')).toBe(false);
 
-        // Restore global function
-        OpenAiCompatible.prototype.generate = baseGenerate;
-
-        // Cleanup
-        if (fs.existsSync(lazyQueueFile)) {
-            fs.unlinkSync(lazyQueueFile);
+            // Cleanup
+            if (fs.existsSync(lazyQueueFile)) {
+                fs.unlinkSync(lazyQueueFile);
+            }
+        } finally {
+            OpenAiCompatible.prototype.generate = baseGenerate;
         }
     });
     test('should extract concepts from message bodies', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Resolves #10172
Related: #10143

Canonicalizes the row-backed Memory/Session graph ID contract at the producer and operator-doc boundary. `SemanticGraphExtractor` now prompts for lowercase `memory:` / `session:` provenance targets, normalizes uppercase compatibility inputs before lazy-queue writes, and leaves semantic/identity prefixes such as `CONCEPT:`, `CLASS:`, and `AGENT:` unchanged. `GraphBackfill.md` now records lowercase as canonical and updates the current service paths.

Evidence: L2 (focused unit coverage for extractor lazy-queue output plus adjacent producer/consumer/ingestion suites) -> L2 required (unit/source verification for #10172 Contract Ledger rows). No residuals.

## Deltas from ticket

- Posted a retrospective #10143 epic-review gate before pickup because #10172 is still parented to the closed Graph-first Memory artifacts epic.
- Preserved uppercase `MEMORY:` / `SESSION:` as compatibility input forms for historical queue lines and manual probes.
- Rewrote an existing durable ticket-ref comment in the touched extractor spec because the pre-commit archaeology hook now enforces behavior-oriented comments on staged `.mjs` files.

## Slot Rationale

- Modified `learn/agentos/tooling/GraphBackfill.md` Node-ID Canonical Format: disposition delta `rewrite`; replaces deferred coordination wording with the accepted #10172 lowercase Memory/Session contract. Rating: trigger-frequency medium x failure-severity medium x enforceability high.
- Substrate accretion note: no new always-loaded rule substrate was added. This is conditionally-read operator guidance; retirement trigger is a future graph-wide prefix ADR or ticket that supersedes the Memory/Session-only contract.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs` -> 6/6 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs` -> 53/53 passed.
- `git diff --check` passed.
- `git diff --cached --check` passed.
- Pre-commit staged-file hooks passed: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`; branch history contains only `3440da847 fix(memory): canonicalize memory session graph ids (#10172)`.

## Post-Merge Validation

- [ ] Confirm #10172 auto-closes after merge and #10143 remains only referenced as the parent epic.
- [ ] On the next lazy-drain observation, verify any pre-#10172 uppercase queued Memory/Session edges still normalize and drain through the compatibility path.

## Commits

- `3440da847` — `fix(memory): canonicalize memory session graph ids (#10172)`