### PR TITLE
feat(memory-core): on-demand graph lifecycle census method + script, off the healthcheck hot path (#10158)

### DIFF
--- a/ai/scripts/maintenance/graphLifecycleReport.mjs
+++ b/ai/scripts/maintenance/graphLifecycleReport.mjs
@@ -1,0 +1,146 @@
+import 'dotenv/config';
+import {Command}       from 'commander';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+import {
+    Memory_GraphService as GraphService,
+    Memory_LifecycleService
+} from '../../services.mjs';
+
+/**
+ * @summary On-demand Memory/Session graph lifecycle report (storage-growth observability).
+ *
+ * Thin operator entrypoint over {@link GraphService#getLifecycleCensus}. This lives in a script —
+ * NOT the healthcheck payload and NOT an MCP tool — because the optional incident-edge count is an
+ * `O(edges)` scan that grows linearly with the graph (multi-second at millions of edges), and because
+ * an MCP-tool response schema would load into every agent's context unconditionally. Run it when an
+ * operator wants a census; nothing pays the cost otherwise. Node counts + file sizes are cheap;
+ * `--edges` opts into the slow incident-edge scan.
+ *
+ * @module ai/scripts/maintenance/graphLifecycleReport
+ */
+
+/**
+ * @summary Build the Commander parser for the report runner.
+ * @param {Object} env Environment source.
+ * @returns {Command}
+ */
+function createArgParser(env = process.env) {
+    const program = new Command();
+
+    program
+        .name('ai:graph-lifecycle-report')
+        .description('On-demand Memory/Session graph lifecycle census (storage-growth observability).')
+        .exitOverride()
+        .configureOutput({writeErr: () => {}, writeOut: () => {}})
+        .helpOption(false)
+        .allowExcessArguments(false)
+        .option('--edges', 'Include the O(edges) incident-edge counts (slow at scale).', false)
+        .option('--json', 'Emit the raw census JSON only.', false)
+        .option('-h, --help', 'Show help');
+
+    return program;
+}
+
+/**
+ * @summary Parse CLI argv for the report runner.
+ * @param {String[]} argv CLI argv slice.
+ * @param {Object} env Environment source.
+ * @returns {Object}
+ */
+export function parseArgs(argv, env = process.env) {
+    const program = createArgParser(env);
+
+    program.parse(argv, {from: 'user'});
+
+    const options = program.opts(),
+          args    = {includeIncidentEdges: options.edges === true, json: options.json === true};
+
+    if (options.help) args.help = true;
+
+    return args;
+}
+
+/**
+ * @summary Format a census payload as a human-readable report.
+ * @param {Object} census The {@link GraphService#getLifecycleCensus} payload.
+ * @returns {String}
+ */
+export function formatCensus(census) {
+    if (!census.available) {
+        return `[graphLifecycleReport] graph storage unavailable: ${census.error || 'unknown'}`;
+    }
+
+    const mib   = bytes => (bytes / (1024 * 1024)).toFixed(2),
+          lines = [
+              `[graphLifecycleReport] measured ${census.measuredAt}`,
+              `  MEMORY nodes  : ${census.memoryNodes}`,
+              `  SESSION nodes : ${census.sessionNodes}`,
+              `  SQLite main   : ${mib(census.sqliteBytes)} MiB`,
+              `  SQLite WAL    : ${mib(census.sqliteWalBytes)} MiB`,
+              `  SQLite SHM    : ${mib(census.sqliteShmBytes)} MiB`
+          ];
+
+    if (census.memoryIncidentEdges !== undefined) {
+        lines.push(`  MEMORY incident edges  : ${census.memoryIncidentEdges}`);
+        lines.push(`  SESSION incident edges : ${census.sessionIncidentEdges}`);
+    } else {
+        lines.push('  (incident-edge counts omitted — rerun with --edges for the O(edges) scan)');
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * @summary Run the report against live Memory Core services and print it.
+ * @param {Object} options
+ * @param {Object} [options.graphService] GraphService singleton or test double.
+ * @param {Object} [options.lifecycle] LifecycleService used to await readiness.
+ * @param {Boolean} [options.includeIncidentEdges=false] Run the O(edges) incident-edge scan.
+ * @param {Boolean} [options.json=false] Emit raw JSON instead of the formatted report.
+ * @param {Object} [options.logger=console] Output sink.
+ * @returns {Promise<Object>} The census payload.
+ */
+export async function runReport({
+    graphService         = GraphService,
+    lifecycle            = Memory_LifecycleService,
+    includeIncidentEdges = false,
+    json                 = false,
+    logger               = console
+} = {}) {
+    await lifecycle.ready();
+    await graphService.initAsync();
+
+    const census = await graphService.getLifecycleCensus({includeIncidentEdges});
+
+    logger.log(json ? JSON.stringify(census, null, 2) : formatCensus(census));
+
+    return census;
+}
+
+function printHelp() {
+    console.log(createArgParser().helpInformation().trimEnd());
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.help) {
+        printHelp();
+        return {exitCode: 0};
+    }
+
+    const census = await runReport(args);
+
+    return {exitCode: census.available ? 0 : 1};
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+    main()
+        .then(({exitCode}) => process.exit(exitCode))
+        .catch(error => {
+            console.error('[graphLifecycleReport] Fatal:', error);
+            process.exit(2);
+        });
+}

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -5,6 +5,7 @@ import Base         from '../../../src/core/Base.mjs';
 import CoreDatabase from '../../../ai/graph/Database.mjs';
 import SQLite       from '../../../ai/graph/storage/SQLite.mjs';
 import { IDENTITIES } from '../../../ai/graph/identityRoots.mjs';
+import fsExtra       from 'fs-extra';
 
 /**
  * Row-level-security visibility predicate for an in-memory graph **node or edge**, mirroring
@@ -1012,6 +1013,85 @@ class GraphService extends Base {
         }
 
         return orphaned;
+    }
+
+    /**
+     * @summary On-demand Memory/Session graph lifecycle census for storage-growth observability.
+     *
+     * Returns counts of durable `MEMORY` / `SESSION` provenance-anchor nodes plus the graph SQLite
+     * file sizes (main / WAL / SHM). Deliberately **not** a healthcheck field and **not** an MCP tool:
+     * the optional incident-edge count is an `O(edges)` scan (multi-second at millions of edges, growing
+     * linearly with the graph), so this is invoked on demand via the maintenance report script, never on
+     * the healthcheck hot path or in an always-loaded tool-response schema. The node counts + file sizes
+     * are cheap (sub-second); the incident-edge counts are opt-in via `includeIncidentEdges`.
+     *
+     * @param {Object} [options]
+     * @param {Boolean} [options.includeIncidentEdges=false] Also count edges incident to MEMORY/SESSION
+     *     nodes — an `O(edges)` scan, off by default so the census stays cheap at scale.
+     * @returns {Promise<{available: Boolean, memoryNodes: Number, sessionNodes: Number, sqliteBytes: Number,
+     *     sqliteWalBytes: Number, sqliteShmBytes: Number, measuredAt: String,
+     *     memoryIncidentEdges?: Number, sessionIncidentEdges?: Number, error?: String}>}
+     */
+    async getLifecycleCensus({includeIncidentEdges = false} = {}) {
+        const measuredAt = new Date().toISOString(),
+              storage    = this.db?.storage,
+              sqliteDb   = storage?.db,
+              dbPath     = storage?.dbPath;
+
+        if (!sqliteDb || !dbPath) {
+            return {
+                available: false, memoryNodes: 0, sessionNodes: 0,
+                sqliteBytes: 0, sqliteWalBytes: 0, sqliteShmBytes: 0,
+                measuredAt, error: 'Graph SQLite storage is unavailable.'
+            };
+        }
+
+        try {
+            const countNodes = label => Number(sqliteDb.prepare(`
+                SELECT COUNT(*) AS count FROM Nodes WHERE json_extract(data, '$.label') = ?
+            `).get(label)?.count || 0);
+
+            const fileSize = async filePath => {
+                try {
+                    return Number((await fsExtra.stat(filePath)).size || 0);
+                } catch (e) {
+                    return 0;
+                }
+            };
+
+            const [sqliteBytes, sqliteWalBytes, sqliteShmBytes] = await Promise.all([
+                fileSize(dbPath),
+                fileSize(`${dbPath}-wal`),
+                fileSize(`${dbPath}-shm`)
+            ]);
+
+            const census = {
+                available   : true,
+                memoryNodes : countNodes('MEMORY'),
+                sessionNodes: countNodes('SESSION'),
+                sqliteBytes, sqliteWalBytes, sqliteShmBytes,
+                measuredAt
+            };
+
+            if (includeIncidentEdges) {
+                const countIncidentEdges = label => Number(sqliteDb.prepare(`
+                    SELECT COUNT(*) AS count FROM Edges e
+                    WHERE EXISTS (SELECT 1 FROM Nodes n WHERE n.id = e.source AND json_extract(n.data, '$.label') = ?)
+                       OR EXISTS (SELECT 1 FROM Nodes n WHERE n.id = e.target AND json_extract(n.data, '$.label') = ?)
+                `).get(label, label)?.count || 0);
+
+                census.memoryIncidentEdges  = countIncidentEdges('MEMORY');
+                census.sessionIncidentEdges = countIncidentEdges('SESSION');
+            }
+
+            return census;
+        } catch (e) {
+            return {
+                available: false, memoryNodes: 0, sessionNodes: 0,
+                sqliteBytes: 0, sqliteWalBytes: 0, sqliteShmBytes: 0,
+                measuredAt, error: e?.message || String(e)
+            };
+        }
     }
 
     /**

--- a/learn/agentos/measurements/MemorySessionGraphLifecycle.md
+++ b/learn/agentos/measurements/MemorySessionGraphLifecycle.md
@@ -1,0 +1,95 @@
+# Memory/Session Graph Lifecycle
+
+`MEMORY` and `SESSION` graph nodes are durable provenance anchors. They connect
+raw agent turns, session summaries, mailbox threads, authorship edges, and
+future recovery queries back to the Native Edge Graph. Their lifecycle policy is
+therefore stricter than ordinary extracted concept nodes.
+
+## Lifecycle Telemetry (on-demand)
+
+Memory/Session graph storage-growth observability is exposed by
+`GraphService.getLifecycleCensus()` and run on demand via the maintenance
+script:
+
+```bash
+npm run ai:graph-lifecycle-report            # cheap: node counts + SQLite file sizes
+npm run ai:graph-lifecycle-report -- --edges # also the O(edges) incident-edge counts
+npm run ai:graph-lifecycle-report -- --json  # raw census JSON
+```
+
+The census payload:
+
+```json
+{
+  "available": true,
+  "memoryNodes": 3,
+  "sessionNodes": 2,
+  "sqliteBytes": 4096,
+  "sqliteWalBytes": 512,
+  "sqliteShmBytes": 0,
+  "measuredAt": "2026-06-05T20:00:00.000Z",
+  "memoryIncidentEdges": 7,
+  "sessionIncidentEdges": 5
+}
+```
+
+`memoryNodes` / `sessionNodes` count SQLite `Nodes` rows whose JSON label is
+`MEMORY` / `SESSION`. The SQLite byte fields report the configured graph
+database file and its `-wal` / `-shm` siblings (`0` for missing siblings). The
+`memoryIncidentEdges` / `sessionIncidentEdges` fields appear only with `--edges`.
+If the graph store is not mounted, the census returns `available:false` with
+zero counts and an `error` string instead of throwing.
+
+### Why on-demand, not healthcheck / MCP tool
+
+This census is deliberately **not** a `HealthService.healthcheck()` field and
+**not** an MCP tool. The incident-edge count is an `O(edges)` scan — benchmarked
+at ~5.3s for 2.5M edges and growing linearly — so it cannot sit on the
+healthcheck hot path. And an MCP-tool response schema loads into every agent's
+tool surface unconditionally (a permanent per-agent context tax), independent of
+graph size or whether the tool is ever called. Keeping the census in a
+`GraphService` method behind an on-demand script means nothing pays the runtime
+or context cost unless an operator explicitly asks for the report.
+
+## Retention Policy
+
+`MEMORY` and `SESSION` nodes remain protected from
+`GraphService.getOrphanedNodes()` and vector apoptosis by default. This is
+intentional even when a node is temporarily edgeless:
+
+- Freshly ingested memories and sessions can be created before all downstream
+  provenance edges are attached.
+- Empty sessions still need stable anchors for later summary, handoff, and
+  recovery edges.
+- Mailbox, identity, and authorship edges may be created after the original
+  memory/session row exists.
+
+`GraphMaintenanceService.runGarbageCollection()` must continue to delete only
+the node IDs returned by `GraphService.getOrphanedNodes()`. Broadening apoptosis
+to include `MEMORY` or `SESSION` requires a separate ticket with a Contract
+Ledger and explicit evidence that memory recovery, mailbox threading, provenance
+queries, and agent identity edge creation remain safe.
+
+## Future Archival Gate
+
+This guide does not introduce archival, default-query exclusion, or hard
+deletion. Future retention pressure must first be proven by sustained lifecycle
+census evidence. A follow-up archival proposal must define:
+
+- exact marker names and reversible semantics;
+- include-archived query behavior;
+- tenant/user visibility effects;
+- migration behavior for existing nodes without the marker;
+- recovery evidence for memory search, session summaries, mailbox threads, and
+  identity/provenance edge creation.
+
+Hard deletion of `MEMORY` or `SESSION` graph nodes remains out of scope unless a
+future ticket proves safety across all of those recovery paths.
+
+## Initial Baseline
+
+Capture the baseline by running `npm run ai:graph-lifecycle-report -- --json`
+against the target Memory Core graph store after deployment, and record the
+payload here. Until a live baseline is captured, the unit-pinned reference shape
+is `memoryNodes: 3 / sessionNodes: 2 / sqliteBytes: 4096` (from
+`GraphService — getLifecycleCensus` fixtures); live counts replace it.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "ai:defrag-memory"             : "node ./ai/scripts/maintenance/defragChromaDB.mjs --target memory-core",
         "ai:defrag-sqlite"             : "node ./ai/scripts/maintenance/defragSQLiteDB.mjs",
         "ai:download-kb"               : "node ./ai/scripts/maintenance/downloadKnowledgeBase.mjs",
+        "ai:graph-lifecycle-report"    : "node ./ai/scripts/maintenance/graphLifecycleReport.mjs",
         "ai:ingest-tenant"             : "node ./ai/scripts/maintenance/ingestTenant.mjs",
         "ai:kb-push-client"            : "node ./ai/scripts/maintenance/kbPushClient.mjs",
         "ai:mcp-healthcheck"           : "node ./ai/scripts/diagnostics/mcpHealthcheck.mjs",

--- a/test/playwright/unit/ai/scripts/maintenance/graphLifecycleReport.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/graphLifecycleReport.spec.mjs
@@ -1,0 +1,80 @@
+import {setup} from '../../../../setup.mjs';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+
+const appName = 'GraphLifecycleReportTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+
+test.describe('graphLifecycleReport.mjs (#10158)', () => {
+    let mod;
+
+    test.beforeAll(async () => {
+        mod = await import('../../../../../../ai/scripts/maintenance/graphLifecycleReport.mjs');
+    });
+
+    test('parseArgs defaults to the cheap census; --edges + --json opt in', () => {
+        expect(mod.parseArgs([])).toEqual({includeIncidentEdges: false, json: false});
+        expect(mod.parseArgs(['--edges', '--json'])).toEqual({includeIncidentEdges: true, json: true});
+    });
+
+    test('formatCensus renders the cheap fields and flags the omitted edge scan', () => {
+        const out = mod.formatCensus({
+            available     : true,
+            memoryNodes   : 3,
+            sessionNodes  : 2,
+            sqliteBytes   : 4096,
+            sqliteWalBytes: 0,
+            sqliteShmBytes: 0,
+            measuredAt    : '2026-06-05T20:00:00.000Z'
+        });
+
+        expect(out).toContain('MEMORY nodes  : 3');
+        expect(out).toContain('SESSION nodes : 2');
+        expect(out).toContain('--edges');  // tells the operator the O(edges) scan was skipped
+    });
+
+    test('formatCensus surfaces an unavailable graph', () => {
+        const out = mod.formatCensus({available: false, error: 'Graph SQLite storage is unavailable.'});
+        expect(out).toContain('unavailable');
+    });
+
+    test('runReport awaits readiness, calls getLifecycleCensus, and prints', async () => {
+        const calls  = [],
+              lines  = [],
+              census = {
+                  available: true, memoryNodes: 1, sessionNodes: 1,
+                  sqliteBytes: 0, sqliteWalBytes: 0, sqliteShmBytes: 0, measuredAt: 'x'
+              };
+
+        const result = await mod.runReport({
+            lifecycle   : {ready: async () => { calls.push('ready'); }},
+            graphService: {
+                initAsync         : async () => { calls.push('init'); },
+                getLifecycleCensus: async opts => { calls.push(['census', opts.includeIncidentEdges]); return census; }
+            },
+            includeIncidentEdges: true,
+            json                : true,
+            logger              : {log: line => lines.push(line)}
+        });
+
+        expect(result).toBe(census);
+        // Readiness + init happen before the census query; the opt-in flag threads through.
+        expect(calls).toEqual(['ready', 'init', ['census', true]]);
+        expect(lines[0]).toContain('"memoryNodes": 1');  // --json emits raw payload
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -883,3 +883,70 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         }
     });
 });
+
+test.describe('GraphService — getLifecycleCensus (#10158)', () => {
+    let GraphService, originalDb;
+
+    test.beforeAll(async () => {
+        GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+    });
+
+    test.beforeEach(() => { originalDb = GraphService.db; });
+    test.afterEach(()  => { GraphService.db = originalDb; });
+
+    // Fake the better-sqlite3 handle: route the Nodes/Edges COUNT queries to fixed values by SQL shape.
+    function fakeSqliteDb({nodes = {}, edges = {}} = {}) {
+        return {
+            prepare(sql) {
+                return {
+                    get(...args) {
+                        const label = args[0];
+                        if (sql.includes('FROM Edges')) return {count: edges[label]};
+                        if (sql.includes('FROM Nodes')) return {count: nodes[label]};
+                        return undefined;
+                    }
+                };
+            }
+        };
+    }
+
+    test('counts MEMORY/SESSION nodes + SQLite file size; omits incident edges by default', async () => {
+        const tmpFile = path.join(os.tmpdir(), `neo-census-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+        await fs.writeFile(tmpFile, 'x'.repeat(4096));
+        try {
+            GraphService.db = {storage: {db: fakeSqliteDb({nodes: {MEMORY: 3, SESSION: 2}}), dbPath: tmpFile}};
+
+            const census = await GraphService.getLifecycleCensus();
+
+            expect(census.available).toBe(true);
+            expect(census.memoryNodes).toBe(3);
+            expect(census.sessionNodes).toBe(2);
+            expect(census.sqliteBytes).toBe(4096);
+            expect(census.sqliteWalBytes).toBe(0);  // sibling absent → 0, not throw
+            expect(census.sqliteShmBytes).toBe(0);
+            expect(census.memoryIncidentEdges).toBeUndefined();  // O(edges) scan is opt-in only
+        } finally {
+            await fs.remove(tmpFile);
+        }
+    });
+
+    test('includeIncidentEdges runs the O(edges) incident-edge counts', async () => {
+        GraphService.db = {storage: {db: fakeSqliteDb({nodes: {MEMORY: 1, SESSION: 1}, edges: {MEMORY: 7, SESSION: 5}}), dbPath: '/no/such/graph.db'}};
+
+        const census = await GraphService.getLifecycleCensus({includeIncidentEdges: true});
+
+        expect(census.memoryIncidentEdges).toBe(7);
+        expect(census.sessionIncidentEdges).toBe(5);
+        expect(census.sqliteBytes).toBe(0);  // absent dbPath → stat fails → 0, not throw
+    });
+
+    test('returns available:false when the graph SQLite store is unmounted', async () => {
+        GraphService.db = {storage: {db: null, dbPath: null}};
+
+        const census = await GraphService.getLifecycleCensus();
+
+        expect(census.available).toBe(false);
+        expect(census.memoryNodes).toBe(0);
+        expect(census.error).toContain('unavailable');
+    });
+});


### PR DESCRIPTION
Resolves #10158

Authored by Claude Opus 4.8 (Claude Code). Session 0f6d0fa0-327f-42ec-b970-e32f388699b4.

**Operator-directed reshape of the Memory/Session graph-lifecycle telemetry. Supersedes #12595.**

The original #10158 contract (and #12595) put the census in `HealthService.healthcheck()` as an exported `buildGraphLifecycleBlock` + a `graphLifecycle` block on the `HealthCheckResponse` OpenAPI schema. @tobiu challenged that shape on cost; I benchmarked it, and two independent costs make it the wrong home:

1. **Runtime — `O(edges)` on the hot path.** The incident-edge count is a full `Edges` scan with a per-edge `json_extract` node lookup. Benchmarked against real `better-sqlite3` at the projected scale (50k nodes / 2.5M edges): node counts 15ms, **incident-edge counts ~5.3s**, and it grows linearly — at 20×-team / multi-repo scale it's minutes. `healthcheck` is a callable tool with no throttle; it can't carry that.
2. **Context — a permanent per-agent tool-shape tax.** `ai/mcp/ToolService.mjs:145-146` publishes each operation's `outputSchema` into `allToolsForListing`, so the `graphLifecycle` fields (~500 tokens) loaded into **every agent's context at tool-enumeration, unconditionally** — even agents that never call healthcheck, even on a tiny graph.

## The reshape
- **`GraphService.getLifecycleCensus({includeIncidentEdges})`** — a method on the schema owner (reuses the live SQLite connection; no standalone service export, no healthcheck coupling). Default census = `MEMORY`/`SESSION` node counts + SQLite main/WAL/SHM file sizes (sub-second). The `O(edges)` incident-edge counts are **opt-in** via `includeIncidentEdges`.
- **`ai/scripts/maintenance/graphLifecycleReport.mjs`** (npm: `ai:graph-lifecycle-report`) — thin on-demand entrypoint, sibling to `auditGraphIntegrity.mjs`. `--edges` runs the slow scan; `--json` emits raw payload.
- **Not** a healthcheck field, **not** an MCP tool → zero hot-path cost, zero context tax.
- Retention-policy guide carried forward to `learn/agentos/measurements/MemorySessionGraphLifecycle.md` (telemetry section rewritten for the script; durable-anchor / archival-gate sections preserved).

Evidence: L2 (focused unit tests for the census method + the script's parse/format/run logic, + a `--help` entrypoint smoke) → L2 required (the census shape is fully unit-coverable; the live-store baseline is an operator post-merge run). No blocking residuals.

## Deltas from ticket
- **Shape revision (operator-directed).** #10158's Contract Ledger prescribed the healthcheck-payload shape; @tobiu revised it to a `GraphService` method + on-demand script after the cost benchmark. I'm posting the revised Contract Ledger as a comment on #10158.
- **Precedent considered.** `auditGraphIntegrity.mjs`'s `listGraphSessions` deliberately reads `graphService.db` *directly in the script* "without adding a public service method before the report contract has empirical mileage." I flagged this; per operator direction the census is a `GraphService` method, with the contract kept minimal (cheap default + `--edges` opt-in) to mitigate the premature-contract risk that precedent guards against.
- **Edge count gated.** Even on-demand, the `O(edges)` count is opt-in (`--edges`) so the default report stays cheap at 20× scale — the node counts + file sizes are the actual storage-growth signal.
- **HealthService export debt (separate).** @tobiu flagged *all* of `HealthService`'s `export function buildXBlock` helpers as debt (a service is its singleton; module-level exports are the smell). Out of scope here; I'm filing a narrow tech-debt ticket for the conversion.

## Test Evidence
- `GraphService.spec.mjs` — `getLifecycleCensus`: cheap default (node counts + real-temp-file `sqliteBytes`, edges omitted), `--edges` opt-in incident counts, and `available:false` on an unmounted store.
- `graphLifecycleReport.spec.mjs` — `parseArgs` (cheap default; `--edges`/`--json` opt-in), `formatCensus` (rendered fields + omitted-edge note + unavailable error), `runReport` (readiness→init→census order + JSON output).
- **33 passed** (`GraphService.spec` + `graphLifecycleReport.spec`); `--help` smoke green; lint-staged + tree-json (195 nodes) clean.

## Post-Merge Validation
- [ ] Operator captures the live baseline: `npm run ai:graph-lifecycle-report -- --json` against the target Memory Core store; record it in `learn/agentos/measurements/MemorySessionGraphLifecycle.md`.
- [ ] Confirm `--edges` completes acceptably on the real graph at current size (it is `O(edges)` by design).

## Decision Record impact
`aligned-with` the substrate-accretion-defense principle — moves expensive, on-demand telemetry off the always-loaded MCP tool surface (net context-budget reduction) and off the healthcheck hot path.
