### PR TITLE
feat(agentos): surface Golden Path silent threads (#10275)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -219,6 +219,23 @@ class Config extends ConfigProvider {
              */
             goldenPathStaleAssignmentRenderLimit: leaf(20, 'NEO_GOLDEN_PATH_STALE_ASSIGNMENT_RENDER_LIMIT', 'number'),
             /**
+             * Idle threshold used by `GoldenPathSynthesizer` when rendering unassigned
+             * Silent Threads. Defaults to 14 days so the section surfaces longer-running
+             * atrophy than the 7-day stale-assignment lane.
+             * @type {number}
+             */
+            goldenPathSilentThreadThresholdMs: leaf(14 * DAY_MS, 'NEO_GOLDEN_PATH_SILENT_THREAD_THRESHOLD_MS', 'number'),
+            /**
+             * Minimum `daysIdle * max(structuralWeight, 1)` score required for Silent Threads.
+             * @type {number}
+             */
+            goldenPathSilentThreadMinScore: leaf(14, 'NEO_GOLDEN_PATH_SILENT_THREAD_MIN_SCORE', 'number'),
+            /**
+             * Maximum Silent Threads candidates rendered into the Sandman handoff.
+             * @type {number}
+             */
+            goldenPathSilentThreadRenderLimit: leaf(10, 'NEO_GOLDEN_PATH_SILENT_THREAD_RENDER_LIMIT', 'number'),
+            /**
              * Maximum recent open PR rows rendered inside `Active PR Cycle State`.
              * @type {number}
              */

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -15,9 +15,6 @@ import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const DAY_MS     = 24 * 60 * 60 * 1000;
-const DEFAULT_SILENT_THREAD_THRESHOLD_MS = 14 * DAY_MS;
-const DEFAULT_SILENT_THREAD_MIN_SCORE    = 14;
-const DEFAULT_SILENT_THREAD_RENDER_LIMIT = 10;
 
 const MAINTAINER_PROGRESS_PATTERN = /\b(?:in[-\s]?progress|picking up|taking|claim(?:ed|ing)?|lane-claim|lane-state:\s*next-lane|working|implement(?:ing)?|opened\s+(?:PR|pull request)|PR\s*#\d+)\b/i;
 
@@ -528,8 +525,8 @@ class GoldenPathSynthesizer extends Base {
         issuesDir,
         now = new Date(),
         goldenIds = new Set(),
-        thresholdMs = aiConfig.goldenPathSilentThreadThresholdMs ?? DEFAULT_SILENT_THREAD_THRESHOLD_MS,
-        minScore = aiConfig.goldenPathSilentThreadMinScore ?? DEFAULT_SILENT_THREAD_MIN_SCORE,
+        thresholdMs = aiConfig.goldenPathSilentThreadThresholdMs,
+        minScore = aiConfig.goldenPathSilentThreadMinScore,
         graphService = GraphService
     }) {
         const candidates = [];
@@ -627,7 +624,7 @@ class GoldenPathSynthesizer extends Base {
      */
     static renderSilentThreadCandidatesSection(candidates, {
         capturedAt = new Date(),
-        limit = aiConfig.goldenPathSilentThreadRenderLimit ?? DEFAULT_SILENT_THREAD_RENDER_LIMIT
+        limit = aiConfig.goldenPathSilentThreadRenderLimit
     } = {}) {
         let section = `\n## Silent Threads\n\n`;
         section += `*Captured at: ${capturedAt.toISOString()} (Source: local issue sync + Native Edge Graph; visibility-only, no routing)*\n\n`;

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -15,6 +15,9 @@ import {buildGraphProvider, resolveGraphModelProvider} from './providerDispatch.
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const DAY_MS     = 24 * 60 * 60 * 1000;
+const DEFAULT_SILENT_THREAD_THRESHOLD_MS = 14 * DAY_MS;
+const DEFAULT_SILENT_THREAD_MIN_SCORE    = 14;
+const DEFAULT_SILENT_THREAD_RENDER_LIMIT = 10;
 
 const MAINTAINER_PROGRESS_PATTERN = /\b(?:in[-\s]?progress|picking up|taking|claim(?:ed|ing)?|lane-claim|lane-state:\s*next-lane|working|implement(?:ing)?|opened\s+(?:PR|pull request)|PR\s*#\d+)\b/i;
 
@@ -404,6 +407,254 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Finds the latest reliable activity timestamp for an open issue.
+     *
+     * Silent Threads deliberately uses deterministic sync metadata rather than LLM triage:
+     * `updatedAt` first, then parsed timeline comments, then `createdAt` as the fallback.
+     *
+     * @param {Object} issue Parsed issue record.
+     * @param {String} issue.content Markdown body without frontmatter.
+     * @param {String} issue.createdAt Issue creation timestamp.
+     * @param {String} issue.updatedAt Issue update timestamp.
+     * @returns {{createdAt: Date, author: String, reason: String}|null}
+     */
+    static findLatestIssueActivity(issue) {
+        const candidates = [];
+
+        const updatedAt = new Date(issue.updatedAt);
+        if (!Number.isNaN(updatedAt.getTime())) {
+            candidates.push({createdAt: updatedAt, author: 'github-sync', reason: 'updatedAt'});
+        }
+
+        for (const comment of this.extractIssueCommentBlocks(issue.content || '')) {
+            const createdAt = new Date(comment.createdAt);
+            if (!Number.isNaN(createdAt.getTime())) {
+                candidates.push({createdAt, author: comment.author, reason: 'comment'});
+            }
+        }
+
+        const createdAt = new Date(issue.createdAt);
+        if (!Number.isNaN(createdAt.getTime())) {
+            candidates.push({createdAt, author: issue.author || 'unknown', reason: 'issue-created'});
+        }
+
+        candidates.sort((a, b) => b.createdAt - a.createdAt);
+
+        return candidates[0] || null
+    }
+
+    /**
+     * @summary Returns the Golden Path-style structural weight for an issue node.
+     *
+     * Uses the same inbound non-BLOCKS edge-weight shape as computed Golden Path scoring.
+     * Missing graph storage degrades to zero; Silent Threads then falls back to pure age.
+     *
+     * @param {String} issueId Canonical graph issue id (`issue-N`).
+     * @param {Object} [graphService=GraphService] Memory GraphService singleton or test double.
+     * @returns {Number}
+     */
+    static getIssueStructuralWeight(issueId, graphService = GraphService) {
+        try {
+            const sqliteDb = graphService?.db?.storage?.db;
+            if (!sqliteDb) return 0;
+
+            const row = sqliteDb.prepare(`
+                SELECT COALESCE(SUM(json_extract(e.data, '$.properties.weight')), 0.0) AS structuralWeight
+                FROM Edges e
+                WHERE e.target = ? AND e.type != 'BLOCKS'
+            `).get(issueId);
+
+            return Number(row?.structuralWeight || 0)
+        } catch (error) {
+            return 0
+        }
+    }
+
+    /**
+     * @summary Determines whether an issue has an open blocker.
+     *
+     * Prefer graph topology when available. If graph topology is not mounted, fall back to
+     * synced frontmatter `blockedBy` so a visibility-only signal does not resurface known
+     * blocked work.
+     *
+     * @param {Object} options
+     * @param {String} options.issueId Canonical graph issue id (`issue-N`).
+     * @param {Object} options.issue Parsed issue frontmatter.
+     * @param {Object} [options.graphService=GraphService] Memory GraphService singleton or test double.
+     * @returns {Boolean}
+     */
+    static hasOpenIssueBlocker({issueId, issue, graphService = GraphService}) {
+        let graphChecked = false;
+
+        try {
+            if (graphService?.db?.edges?.getByIndex) {
+                graphChecked = true;
+                graphService.db.getAdjacentNodes?.(issueId, 'both');
+
+                const blockers = graphService.db.edges.getByIndex('target', issueId).filter(edge => edge.type === 'BLOCKS');
+                for (const edge of blockers) {
+                    const blockerNode = graphService.db.nodes?.get?.(edge.source);
+                    if (blockerNode && (blockerNode.properties?.state === 'OPEN' || blockerNode.state === 'OPEN')) {
+                        return true
+                    }
+                }
+            }
+        } catch (error) {
+            graphChecked = false;
+        }
+
+        const frontmatterBlockers = Array.isArray(issue.blockedBy) ? issue.blockedBy.filter(Boolean) : [];
+
+        return !graphChecked && frontmatterBlockers.length > 0
+    }
+
+    /**
+     * @summary Builds visibility-only Silent Threads from local synced issue markdown.
+     *
+     * Candidates are open, unassigned, non-rejected issues outside the Computed Golden Path.
+     * They are sorted by `silenceScore = daysIdle * max(structuralWeight, 1)`, keeping this
+     * section as an operator/swarm reading surface without changing orchestrator routing.
+     *
+     * @param {Object} options
+     * @param {String} options.issuesDir Local synced issue directory.
+     * @param {Date} [options.now=new Date()] Current clock for deterministic tests.
+     * @param {Set<String>} [options.goldenIds=new Set()] Current Computed Golden Path issue ids.
+     * @param {Number} [options.thresholdMs=aiConfig.goldenPathSilentThreadThresholdMs] Idle threshold.
+     * @param {Number} [options.minScore=aiConfig.goldenPathSilentThreadMinScore] Minimum silence score.
+     * @param {Object} [options.graphService=GraphService] Memory GraphService singleton or test double.
+     * @returns {Array<Object>} Silent-thread candidates sorted by silence score.
+     */
+    static buildSilentThreadCandidates({
+        issuesDir,
+        now = new Date(),
+        goldenIds = new Set(),
+        thresholdMs = aiConfig.goldenPathSilentThreadThresholdMs ?? DEFAULT_SILENT_THREAD_THRESHOLD_MS,
+        minScore = aiConfig.goldenPathSilentThreadMinScore ?? DEFAULT_SILENT_THREAD_MIN_SCORE,
+        graphService = GraphService
+    }) {
+        const candidates = [];
+        const nowDate    = now instanceof Date ? now : new Date(now);
+        const goldenSet  = new Set([...goldenIds].map(id => String(id)));
+        const excludedLabels = new Set([
+            'needs-re-triage',
+            'no-auto-close',
+            'no auto close',
+            'duplicate',
+            'invalid',
+            'wontfix',
+            'wont fix'
+        ]);
+
+        for (const filePath of this.collectIssueMarkdownFiles(issuesDir)) {
+            let parsed;
+            try {
+                parsed = matter(fs.readFileSync(filePath, 'utf-8'));
+            } catch (error) {
+                logger.warn(`[GoldenPathSynthesizer] Failed to parse issue markdown for Silent Threads: ${filePath}`, error);
+                continue;
+            }
+
+            const meta      = parsed.data || {};
+            const labels    = Array.isArray(meta.labels) ? meta.labels.map(label => String(label).toLowerCase()) : [];
+            const assignees = Array.isArray(meta.assignees) ? meta.assignees.filter(Boolean) : [];
+            const fileId    = path.basename(filePath, '.md');
+            const rawId     = meta.id || fileId.replace(/^issue-/, '');
+            const issueId   = String(rawId).startsWith('issue-') ? String(rawId) : `issue-${rawId}`;
+
+            if (meta.state !== 'OPEN' ||
+                assignees.length > 0 ||
+                goldenSet.has(issueId) ||
+                labels.some(label => excludedLabels.has(label))) {
+                continue;
+            }
+
+            if (this.hasOpenIssueBlocker({issueId, issue: meta, graphService})) {
+                continue;
+            }
+
+            const lastActivity = this.findLatestIssueActivity({
+                author   : meta.author,
+                content  : parsed.content,
+                createdAt: meta.createdAt,
+                updatedAt: meta.updatedAt
+            });
+
+            if (!lastActivity) continue;
+
+            const idleMs = nowDate - lastActivity.createdAt;
+            if (idleMs < thresholdMs) continue;
+
+            const daysIdle        = Math.floor(idleMs / DAY_MS);
+            const structuralWeight = this.getIssueStructuralWeight(issueId, graphService);
+            const silenceScore     = daysIdle * Math.max(structuralWeight, 1);
+
+            if (silenceScore < minScore) continue;
+
+            candidates.push({
+                daysIdle,
+                filePath,
+                issueId,
+                labels,
+                lastActivityAt: lastActivity.createdAt.toISOString(),
+                lastActivityBy: lastActivity.author,
+                number        : Number(String(issueId).replace(/^issue-/, '')) || rawId,
+                reason        : lastActivity.reason,
+                silenceScore,
+                structuralWeight,
+                title         : meta.title || '(no title)',
+                url           : meta.githubUrl
+            });
+        }
+
+        candidates.sort((a, b) =>
+            b.silenceScore - a.silenceScore ||
+            b.daysIdle - a.daysIdle ||
+            b.structuralWeight - a.structuralWeight ||
+            Number(a.number) - Number(b.number)
+        );
+
+        return candidates
+    }
+
+    /**
+     * @summary Renders the Sandman handoff Silent Threads section.
+     *
+     * @param {Array<Object>} candidates Silent-thread candidates.
+     * @param {Object} options
+     * @param {Date} [options.capturedAt=new Date()] Capture timestamp.
+     * @param {Number} [options.limit=aiConfig.goldenPathSilentThreadRenderLimit] Maximum candidates to render.
+     * @returns {String}
+     */
+    static renderSilentThreadCandidatesSection(candidates, {
+        capturedAt = new Date(),
+        limit = aiConfig.goldenPathSilentThreadRenderLimit ?? DEFAULT_SILENT_THREAD_RENDER_LIMIT
+    } = {}) {
+        let section = `\n## Silent Threads\n\n`;
+        section += `*Captured at: ${capturedAt.toISOString()} (Source: local issue sync + Native Edge Graph; visibility-only, no routing)*\n\n`;
+
+        if (candidates.length === 0) {
+            section += `No silent thread candidates detected.\n`;
+            return section
+        }
+
+        const visibleCandidates = candidates.slice(0, limit);
+
+        if (candidates.length > visibleCandidates.length) {
+            section += `Showing ${visibleCandidates.length} of ${candidates.length} candidates, sorted by silence score.\n\n`;
+        }
+
+        for (const candidate of visibleCandidates) {
+            const issueRef = candidate.url ? `[#${candidate.number}](${candidate.url})` : `#${candidate.number}`;
+            section += `- **${issueRef}** — ${candidate.title} — ${candidate.daysIdle} days idle; ` +
+                `last activity ${candidate.lastActivityAt} by @${candidate.lastActivityBy}; ` +
+                `structural weight ${candidate.structuralWeight.toFixed(2)}; ` +
+                `silence score ${candidate.silenceScore.toFixed(2)} (${candidate.reason})\n`;
+        }
+
+        return section
+    }
+
+    /**
      * @summary Determines whether a PR has cross-family review coverage.
      *
      * @param {Object} pr GitHub PR payload from `gh pr list`.
@@ -629,6 +880,7 @@ class GoldenPathSynthesizer extends Base {
 
         // Remove mathematically rejected targets (Negative ROI), then slice
         const topNodes = scoredNodes.filter(n => n.score > -5000).slice(0, 5);
+        const goldenIds = new Set(topNodes.map(item => item.node.id));
 
         let markdownAppend = '';
 
@@ -832,6 +1084,23 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
+        // --- Silent Threads ---
+        let silentThreadsAppend = '';
+        if (repoEnrichmentEnabled) {
+            try {
+                const Synthesizer = this.constructor;
+                const silentThreadCandidates = Synthesizer.buildSilentThreadCandidates({
+                    issuesDir,
+                    now,
+                    goldenIds
+                });
+
+                silentThreadsAppend = Synthesizer.renderSilentThreadCandidatesSection(silentThreadCandidates, {capturedAt: now instanceof Date ? now : new Date(now)});
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to generate Silent Threads', e);
+            }
+        }
+
         // --- Active PR Cycle State ---
         let prStateAppend = '';
         if (repoEnrichmentEnabled) {
@@ -922,7 +1191,6 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
         }
 
         // --- Executive Priority Backlog ---
-        const goldenIds = new Set(topNodes.map(item => item.node.id));
         let backlogAppend = '';
         if (repoEnrichmentEnabled) {
             try {
@@ -961,7 +1229,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             }
         }
 
-        handoffContent += `${staleAssignmentAppend}${prStateAppend}${backlogAppend}${markdownAppend}`;
+        handoffContent += `${staleAssignmentAppend}${silentThreadsAppend}${prStateAppend}${backlogAppend}${markdownAppend}`;
 
         const handoffFile = aiConfig.handoffFilePath;
         fs.writeFileSync(handoffFile, handoffContent.trim() + '\n', 'utf-8');

--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -214,6 +214,18 @@ The Golden Path synthesis produces a markdown file divided into sections:
 ### 🗺️ Guide Disconnects (N items)
 - **`CLASS:MyComponent`**: lacks guide...
 
+## Stale Assignment Candidates
+
+No stale assignment candidates detected.
+
+## Silent Threads
+
+No silent thread candidates detected.
+
+## 📋 Latest Priority Backlog
+
+The following open tickets represent the most recently created structural objectives.
+
 ## Computed Golden Path (Strategic Recommendation)
 
 1. **issue-1234**: Score 5.42 (Semantic: 3.14, Structural: 2.28)
@@ -227,6 +239,12 @@ The Golden Path synthesis produces a markdown file divided into sections:
 The **Strategic Interpretation** is an optional LLM-generated brief that explains
 *why* the mathematical scores point to these specific tasks. If the LLM is offline,
 the system falls back to pure numerical output.
+
+`## Silent Threads` is visibility-only. It surfaces old, unassigned, non-rejected
+open issues that are outside the Computed Golden Path, sorted by
+`daysIdle * max(structuralWeight, 1)`. `AgentOrchestrator.parseGoldenPath()`
+continues to consume only `## Computed Golden Path`, so Silent Threads never
+becomes an automatic route or assignment source.
 
 ## Issue Ingestion Pipeline
 

--- a/learn/agentos/wake-substrate/sandman-handoff-format.md
+++ b/learn/agentos/wake-substrate/sandman-handoff-format.md
@@ -16,7 +16,23 @@ Detected structural mismatches within the codebase architecture, populated from 
 - `[KB_DEMAND_GAP]`
 - `[ARCHIVE_ANOMALY]`
 
-### 2. Active PR Cycle State
+### 2. Stale Assignment Candidates
+Assigned issues whose current assignee or maintainer progress signal has gone
+quiet past the configured stale-assignment threshold. This is the claimed-work
+counterpart to Silent Threads and is also visibility-only.
+
+### 3. Silent Threads
+Visibility-only candidates for open, unassigned, non-rejected issues that have
+gone quiet outside the Computed Golden Path. Candidates exclude assigned work,
+Golden Path entries, blocked issues, and tickets labeled `needs-re-triage`,
+`no auto close`, `duplicate`, `invalid`, or `wontfix`. The score is
+`daysIdle * max(structuralWeight, 1)`, capped by config and rendered only for
+swarm/operator reading.
+
+Silent Threads does **not** affect `AgentOrchestrator.parseGoldenPath()` routing.
+The orchestrator continues to consume only the `## Computed Golden Path` section.
+
+### 4. Active PR Cycle State
 A live extraction of active Pull Requests originated by the core Swarm agents (`@neo-opus-ada`, `@neo-gemini-pro`, `@neo-gpt`).
 Provides immediate visibility into cross-peer workflow, blocking states, and review cycles.
 
@@ -27,8 +43,8 @@ Each PR listing includes:
 - **Status:** Last known explicit approval/changes-requested state from comments or reviews.
 - **Head SHA:** Ensures agents operate on current branches without race conditions.
 
-### 3. Latest Priority Backlog
+### 5. Latest Priority Backlog
 A fallback queue of recent structurally significant tickets that are `OPEN` and not marked `needs-re-triage`. Used to guide execution when the Golden Path is fully blocked.
 
-### 4. Computed Golden Path
+### 6. Computed Golden Path
 The top 5 nodes mathematically recommended for execution, calculated via Hybrid GraphRAG (Semantic Vector Distance + Structural Edge Weight). A strategic brief synthesizing *why* these nodes represent the active frontier is appended to guide agent intuition.

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -44,5 +44,39 @@ Based on priorities, the following tasks are mathematically recommended:
             }
         }
     });
-});
 
+    test('Golden Path parser ignores visibility-only Silent Threads', async () => {
+        const content = `
+# Autonomous Handoff
+
+## Silent Threads
+
+- **[#7777](https://github.com/neomjs/neo/issues/7777)** — Quiet issue — 30 days idle; visibility-only, no routing
+
+## Computed Golden Path (Strategic Recommendation)
+
+1. **issue-9900**: Score 3.25 (Semantic: 1.12, Structural: 1.00)
+   - *docs: restructure CodebaseOverview "Query Entry Points" to lead with ask_knowledge_base*
+`;
+
+        const testHandoffPath = path.resolve(process.cwd(), '.neo-test-handoff-silent.md');
+        fs.writeFileSync(testHandoffPath, content, 'utf-8');
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {
+                handoffPath: testHandoffPath
+            });
+
+            const directives = orchestrator.parseGoldenPath();
+
+            test.expect(directives).not.toBeNull();
+            test.expect(directives.length).toBe(1);
+            test.expect(directives[0].issueId).toBe('9900');
+            test.expect(directives.map(directive => directive.issueId)).not.toContain('7777');
+        } finally {
+            if (fs.existsSync(testHandoffPath)) {
+                fs.unlinkSync(testHandoffPath);
+            }
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -32,6 +32,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let SystemLifecycleService;
     let buildStaleAssignmentCandidates;
     let renderStaleAssignmentCandidatesSection;
+    let buildSilentThreadCandidates;
+    let renderSilentThreadCandidatesSection;
 
     let StorageRouter;
     let TextEmbeddingService;
@@ -42,6 +44,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let originalGoldenPathRecentOpenPrRenderLimit;
     let originalGoldenPathStaleAssignmentRenderLimit;
     let originalGoldenPathStaleAssignmentThresholdMs;
+    let originalGoldenPathSilentThreadMinScore;
+    let originalGoldenPathSilentThreadRenderLimit;
+    let originalGoldenPathSilentThreadThresholdMs;
     let originalVectorDimension;
     let originalWarn;
 
@@ -64,6 +69,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         GoldenPathSynthesizer = GoldenPathSynthesizerModule.default;
         buildStaleAssignmentCandidates = GoldenPathSynthesizer.constructor.buildStaleAssignmentCandidates.bind(GoldenPathSynthesizer.constructor);
         renderStaleAssignmentCandidatesSection = GoldenPathSynthesizer.constructor.renderStaleAssignmentCandidatesSection.bind(GoldenPathSynthesizer.constructor);
+        buildSilentThreadCandidates = GoldenPathSynthesizer.constructor.buildSilentThreadCandidates.bind(GoldenPathSynthesizer.constructor);
+        renderSilentThreadCandidatesSection = GoldenPathSynthesizer.constructor.renderSilentThreadCandidatesSection.bind(GoldenPathSynthesizer.constructor);
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         StorageRouter = (await import('../../../../../../ai/services.mjs')).Memory_StorageRouter;
@@ -80,12 +87,18 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         originalGoldenPathRecentOpenPrRenderLimit       = aiConfig.goldenPathRecentOpenPrRenderLimit;
         originalGoldenPathStaleAssignmentRenderLimit    = aiConfig.goldenPathStaleAssignmentRenderLimit;
         originalGoldenPathStaleAssignmentThresholdMs    = aiConfig.goldenPathStaleAssignmentThresholdMs;
+        originalGoldenPathSilentThreadMinScore          = aiConfig.goldenPathSilentThreadMinScore;
+        originalGoldenPathSilentThreadRenderLimit       = aiConfig.goldenPathSilentThreadRenderLimit;
+        originalGoldenPathSilentThreadThresholdMs       = aiConfig.goldenPathSilentThreadThresholdMs;
         originalVectorDimension   = aiConfig.vectorDimension;
         originalWarn              = logger.warn;
 
         aiConfig.goldenPathRecentOpenPrRenderLimit       = 5;
         aiConfig.goldenPathStaleAssignmentRenderLimit    = 20;
         aiConfig.goldenPathStaleAssignmentThresholdMs    = 7 * 24 * 60 * 60 * 1000;
+        aiConfig.goldenPathSilentThreadMinScore          = 14;
+        aiConfig.goldenPathSilentThreadRenderLimit       = 10;
+        aiConfig.goldenPathSilentThreadThresholdMs       = 14 * 24 * 60 * 60 * 1000;
     });
 
     test.afterEach(() => {
@@ -94,6 +107,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         aiConfig.goldenPathRecentOpenPrRenderLimit       = originalGoldenPathRecentOpenPrRenderLimit;
         aiConfig.goldenPathStaleAssignmentRenderLimit    = originalGoldenPathStaleAssignmentRenderLimit;
         aiConfig.goldenPathStaleAssignmentThresholdMs    = originalGoldenPathStaleAssignmentThresholdMs;
+        aiConfig.goldenPathSilentThreadMinScore          = originalGoldenPathSilentThreadMinScore;
+        aiConfig.goldenPathSilentThreadRenderLimit       = originalGoldenPathSilentThreadRenderLimit;
+        aiConfig.goldenPathSilentThreadThresholdMs       = originalGoldenPathSilentThreadThresholdMs;
         aiConfig.vectorDimension   = originalVectorDimension;
         child_process.execSync     = originalExecSync;
         logger.warn                = originalWarn;
@@ -256,6 +272,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
         expect(handoffContent).not.toContain('## Active PR Cycle State');
         expect(handoffContent).not.toContain('## Stale Assignment Candidates');
+        expect(handoffContent).not.toContain('## Silent Threads');
         expect(handoffContent).not.toContain('## 📋 Latest Priority Backlog');
     });
 
@@ -356,6 +373,87 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain('last qualifying activity 2026-05-10T00:00:00.000Z by @neo-opus-ada');
         expect(handoffContent).not.toContain('Fresh assigned issue');
         expect(handoffContent).not.toContain('Rejected assigned issue');
+    });
+
+    test('synthesizeGoldenPath renders Silent Threads after stale assignments and before computed routing', async () => {
+        const originalGetGraphCollection = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText = TextEmbeddingService.embedText;
+        const originalFetchOpenPRs = GoldenPathSynthesizer.fetchOpenPRs;
+        const Synthesizer = GoldenPathSynthesizer.constructor;
+        const originalGetIssueStructuralWeight = Synthesizer.getIssueStructuralWeight;
+        const originalHasOpenIssueBlocker = Synthesizer.hasOpenIssueBlocker;
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-silent-render-issues-'));
+        const chunkDir  = path.join(issuesDir, 'chunk-1');
+        const now       = new Date('2026-05-28T00:00:00Z');
+        const goldenIssueId = `issue-silent-golden-${Date.now()}`;
+        aiConfig.vectorDimension = 2;
+
+        fs.mkdirSync(chunkDir, {recursive: true});
+        fs.writeFileSync(path.join(chunkDir, 'issue-9401.md'), [
+            '---',
+            'id: 9401',
+            "title: 'Quiet unassigned issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            "createdAt: '2026-04-01T00:00:00Z'",
+            "updatedAt: '2026-05-01T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9401'",
+            'author: neo-gpt',
+            '---',
+            '# Quiet unassigned issue'
+        ].join('\n'));
+        fs.writeFileSync(path.join(chunkDir, 'issue-9402.md'), [
+            '---',
+            'id: 9402',
+            "title: 'Fresh unassigned issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            "createdAt: '2026-05-27T00:00:00Z'",
+            "updatedAt: '2026-05-27T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9402'",
+            '---',
+            '# Fresh unassigned issue'
+        ].join('\n'));
+
+        GraphService.upsertNode({
+            id        : goldenIssueId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'Golden fixture'}
+        });
+
+        StorageRouter.getGraphCollection = async () => ({ query: async () => ({ ids: [[goldenIssueId]], distances: [[0.1]] }) });
+        StorageRouter.getSummaryCollection = async () => ({ get: async () => ({ documents: ['mock document'] }) });
+        TextEmbeddingService.embedText = async () => [0.1, 0.2];
+        GoldenPathSynthesizer.fetchOpenPRs = async () => [];
+        Synthesizer.getIssueStructuralWeight = issueId => issueId === 'issue-9401' ? 3 : 0;
+        Synthesizer.hasOpenIssueBlocker = () => false;
+
+        try {
+            await GoldenPathSynthesizer.synthesizeGoldenPath({issuesDir, now});
+        } finally {
+            GoldenPathSynthesizer.fetchOpenPRs = originalFetchOpenPRs;
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            Synthesizer.getIssueStructuralWeight = originalGetIssueStructuralWeight;
+            Synthesizer.hasOpenIssueBlocker = originalHasOpenIssueBlocker;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+        expect(handoffContent).toContain('## Stale Assignment Candidates');
+        expect(handoffContent).toContain('## Silent Threads');
+        expect(handoffContent).toContain('[#9401](https://github.com/neomjs/neo/issues/9401)');
+        expect(handoffContent).toContain('visibility-only, no routing');
+        expect(handoffContent).not.toContain('Fresh unassigned issue');
+        expect(handoffContent.indexOf('## Stale Assignment Candidates')).toBeLessThan(handoffContent.indexOf('## Silent Threads'));
+        expect(handoffContent.indexOf('## Silent Threads')).toBeLessThan(handoffContent.indexOf('## Computed Golden Path'));
     });
 
     test('synthesizeGoldenPath lists the 5 most recent open PRs with cross-family status', async () => {
@@ -459,6 +557,170 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(section).toContain('Candidate 1');
         expect(section).toContain('Candidate 2');
         expect(section).not.toContain('Candidate 3');
+    });
+
+    test('buildSilentThreadCandidates filters unassigned atrophying issues and sorts by silence score', () => {
+        const Synthesizer = GoldenPathSynthesizer.constructor;
+        const originalGetIssueStructuralWeight = Synthesizer.getIssueStructuralWeight;
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-silent-threads-'));
+        const chunkDir  = path.join(issuesDir, 'chunk-1');
+        fs.mkdirSync(chunkDir, {recursive: true});
+
+        function writeIssue(number, lines) {
+            fs.writeFileSync(path.join(chunkDir, `issue-${number}.md`), lines.join('\n'));
+        }
+
+        writeIssue(9301, [
+            '---',
+            'id: 9301',
+            "title: 'Old unassigned fallback-weight issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            "createdAt: '2026-04-01T00:00:00Z'",
+            "updatedAt: '2026-05-08T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9301'",
+            'author: neo-gpt',
+            '---',
+            '# Old unassigned fallback-weight issue'
+        ]);
+        writeIssue(9302, [
+            '---',
+            'id: 9302',
+            "title: 'Assigned issue is stale-assignment domain'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees:',
+            '  - neo-gpt',
+            "createdAt: '2026-04-01T00:00:00Z'",
+            "updatedAt: '2026-05-01T00:00:00Z'",
+            '---',
+            '# Assigned issue'
+        ]);
+        writeIssue(9303, [
+            '---',
+            'id: 9303',
+            "title: 'Rejected issue'",
+            'state: OPEN',
+            'labels:',
+            '  - needs-re-triage',
+            'assignees: []',
+            "createdAt: '2026-04-01T00:00:00Z'",
+            "updatedAt: '2026-05-01T00:00:00Z'",
+            '---',
+            '# Rejected issue'
+        ]);
+        writeIssue(9304, [
+            '---',
+            'id: 9304',
+            "title: 'Already golden issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            "createdAt: '2026-04-01T00:00:00Z'",
+            "updatedAt: '2026-05-01T00:00:00Z'",
+            '---',
+            '# Already golden issue'
+        ]);
+        writeIssue(9305, [
+            '---',
+            'id: 9305',
+            "title: 'Fresh unassigned issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            "createdAt: '2026-05-25T00:00:00Z'",
+            "updatedAt: '2026-05-25T00:00:00Z'",
+            '---',
+            '# Fresh issue'
+        ]);
+        writeIssue(9306, [
+            '---',
+            'id: 9306',
+            "title: 'Blocked unassigned issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            'blockedBy:',
+            '  - 9200',
+            "createdAt: '2026-04-01T00:00:00Z'",
+            "updatedAt: '2026-05-01T00:00:00Z'",
+            '---',
+            '# Blocked issue'
+        ]);
+        writeIssue(9307, [
+            '---',
+            'id: 9307',
+            "title: 'High-structure old issue'",
+            'state: OPEN',
+            'labels:',
+            '  - enhancement',
+            'assignees: []',
+            "createdAt: '2026-04-01T00:00:00Z'",
+            "updatedAt: '2026-05-13T00:00:00Z'",
+            "githubUrl: 'https://github.com/neomjs/neo/issues/9307'",
+            '---',
+            '# High-structure old issue'
+        ]);
+
+        Synthesizer.getIssueStructuralWeight = issueId => ({
+            'issue-9307': 4
+        })[issueId] || 0;
+
+        try {
+            const candidates = buildSilentThreadCandidates({
+                issuesDir,
+                now        : new Date('2026-05-28T00:00:00Z'),
+                goldenIds  : new Set(['issue-9304']),
+                graphService: null,
+                minScore   : 14,
+                thresholdMs: 14 * 24 * 60 * 60 * 1000
+            });
+
+            expect(candidates.map(candidate => candidate.number)).toEqual([9307, 9301]);
+            expect(candidates[0].silenceScore).toBe(60);
+            expect(candidates[1].silenceScore).toBe(20);
+        } finally {
+            Synthesizer.getIssueStructuralWeight = originalGetIssueStructuralWeight;
+            fs.rmSync(issuesDir, {recursive: true, force: true});
+        }
+    });
+
+    test('renderSilentThreadCandidatesSection renders empty and capped visibility-only output', () => {
+        const empty = renderSilentThreadCandidatesSection([], {
+            capturedAt: new Date('2026-05-28T00:00:00Z')
+        });
+
+        expect(empty).toContain('## Silent Threads');
+        expect(empty).toContain('No silent thread candidates detected.');
+
+        const candidates = Array.from({length: 3}, (_, index) => ({
+            daysIdle        : 20 + index,
+            lastActivityAt  : `2026-05-0${index + 1}T00:00:00.000Z`,
+            lastActivityBy  : 'github-sync',
+            number          : 9400 + index,
+            reason          : 'updatedAt',
+            silenceScore    : 40 + index,
+            structuralWeight: 2,
+            title           : `Silent Candidate ${index + 1}`,
+            url             : `https://github.com/neomjs/neo/issues/${9400 + index}`
+        }));
+
+        const capped = renderSilentThreadCandidatesSection(candidates, {
+            capturedAt: new Date('2026-05-28T00:00:00Z'),
+            limit     : 2
+        });
+
+        expect(capped).toContain('visibility-only, no routing');
+        expect(capped).toContain('Showing 2 of 3 candidates');
+        expect(capped).toContain('Silent Candidate 1');
+        expect(capped).toContain('Silent Candidate 2');
+        expect(capped).not.toContain('Silent Candidate 3');
     });
 
     test('synthesizeGoldenPath does not compose KB tenant telemetry into the handoff', () => {


### PR DESCRIPTION
Resolves #10275

Authored by GPT-5.5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Adds a visibility-only `## Silent Threads` section to Golden Path handoff generation so long-idle, unassigned, structurally weighted open tickets can surface without becoming route directives. The implementation keeps routing unchanged: `AgentOrchestrator.parseGoldenPath()` continues to consume only `## Computed Golden Path`.

Evidence: L2 (focused GoldenPathSynthesizer + AgentOrchestrator unit coverage, static syntax checks, branch diff whitespace check) -> L2 required (deterministic handoff-rendering and parser-boundary contract are fully unit-coverable). No residuals.

## Deltas from ticket

- Used the current committed handoff format guide path, `learn/agentos/wake-substrate/sandman-handoff-format.md`, instead of the stale ticket path `learn/agentos/sandman-handoff-format.md`.
- After review, removed duplicate runtime fallback constants for the new AiConfig leaves. `GoldenPathSynthesizer` now reads `goldenPathSilentThread*` leaves directly from `aiConfig` per ADR 0019; the tracked template owns the defaults.

## Config Template Impact

Changed `ai/mcp/server/memory-core/config.template.mjs` with these keys:

- `NEO_GOLDEN_PATH_SILENT_THREAD_THRESHOLD_MS`
- `NEO_GOLDEN_PATH_SILENT_THREAD_MIN_SCORE`
- `NEO_GOLDEN_PATH_SILENT_THREAD_RENDER_LIMIT`

Matching local `ai/mcp/server/memory-core/config.mjs` files should add the same `goldenPathSilentThread*` leaves after merge to stay shape-synced. The runtime no longer carries duplicate hidden fallbacks. Harness restart is recommended for long-lived MCP processes after syncing or changing local config values.

## Slot Rationale

- Modified `learn/agentos/DreamPipeline.md`: disposition `keep -> keep`; rating medium x medium x medium. Reason: this is the durable Dream Pipeline behavior guide, and the small text addition prevents future route-parser confusion by documenting that Silent Threads are visibility-only.
- Modified `learn/agentos/wake-substrate/sandman-handoff-format.md`: disposition `keep -> keep`; rating high x medium x high. Reason: this is the authoritative handoff format surface, and the section-order update keeps generated Sandman output and parser consumption rules aligned.

No always-loaded `.agents/**` or `AGENTS.md` substrate was expanded; these are conditionally consulted Agent OS reference docs. Net expansion is justified by preventing future silent-thread visibility from being mistaken for automatic work routing.

## Test Evidence

- `rg -n "DEFAULT_SILENT_THREAD|\\?\\? DEFAULT_SILENT_THREAD|runtime fallback constants|fallback constants" ai/services/graph/GoldenPathSynthesizer.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs ai/mcp/server/memory-core/config.template.mjs` -> no matches
- `node --check ai/services/graph/GoldenPathSynthesizer.mjs`
- `node --check test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs`
- `node --check test/playwright/unit/ai/AgentOrchestrator.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs test/playwright/unit/ai/AgentOrchestrator.spec.mjs` -> 17 passed after the ADR-0019 direct-read fix and rebase
- `git diff --check origin/dev..HEAD`

## Post-Merge Validation

- [ ] Run the Sandman/Golden Path handoff refresh against the live synced issue graph and confirm `## Silent Threads` renders candidates or the empty-state without adding parser directives.
- [ ] Sync any long-lived local `ai/mcp/server/memory-core/config.mjs` copies with the tracked template leaves before relying on local silent-thread tuning.

## Commit

- `df55a7d9c` - `feat(agentos): surface Golden Path silent threads (#10275)`
- `c73626d39` - `fix(agentos): read Silent Thread config leaves directly (#10275)`
