### PR TITLE
feat(ai): add extraction_metadata to ConceptDiscoveryService output schema (#10106)

### DIFF
--- a/ai/services/ingestion/ConceptDiscoveryService.mjs
+++ b/ai/services/ingestion/ConceptDiscoveryService.mjs
@@ -50,10 +50,17 @@ A concept exists if:
       "reasoning": "Why this passes the Teaching Test — cite the semantic dimension it teaches.",
       "aliases": ["alternative phrasing 1", "alternative phrasing 2"]
     }
-  ]
+  ],
+  "extraction_metadata": {
+    "missing_fields": ["candidate field you could not populate confidently, e.g. 'reasoning'"],
+    "ambiguous_references": ["a source phrase with more than one referent, e.g. 'the module' when three modules exist"],
+    "confidence_score": 0.0
+  }
 }
 
-If nothing qualifies, return \`{"candidates": []}\`. Err on the side of quality over quantity — 0 high-confidence candidates beats 10 noisy ones. The ontology has ~60 concepts today; proposing 3-5 genuinely architectural ones per source is the sweet spot.`;
+**\`extraction_metadata\`** reports OBJECTIVE markers about THIS extraction pass — not subjective difficulty (which you cannot self-report reliably): \`missing_fields\` are candidate fields the source did not let you populate confidently; \`ambiguous_references\` are specific source-text phrases pointing to more than one referent (a verifiable linguistic fact); \`confidence_score\` is your calibrated 0.0–1.0 confidence in this candidate set. Always emit \`extraction_metadata\`.
+
+If nothing qualifies, return \`{"candidates": [], "extraction_metadata": {"missing_fields": [], "ambiguous_references": [], "confidence_score": 0.0}}\`. Err on the side of quality over quantity — 0 high-confidence candidates beats 10 noisy ones. The ontology has ~60 concepts today; proposing 3-5 genuinely architectural ones per source is the sweet spot.`;
 
 /**
  * Default tier / validation state for a newly-discovered candidate concept. Tier 3 + the
@@ -140,6 +147,36 @@ class ConceptDiscoveryService extends Base {
     prScanLimit = null
 
     /**
+     * Normalizes the envelope-level `extraction_metadata` block the LLM emits alongside
+     * `candidates` — objective self-report markers: `missing_fields` (candidate fields
+     * the source did not support), `ambiguous_references` (source phrases with more than one
+     * referent), `confidence_score` (0-1). Returns `null` when the block is absent or not a
+     * plain object, so candidate rows stay additive (legacy `{candidates}`-only responses
+     * produce rows without the field).
+     *
+     * @summary Anchor & Echo: validates + defaults the extraction-pass self-report block;
+     * non-array / out-of-range fields coerce to safe defaults rather than propagating malformed shapes.
+     * @param {Object} [meta] Raw `extraction_metadata` from the LLM envelope
+     * @returns {Object|null} `{missing_fields, ambiguous_references, confidence_score}` or `null`
+     * @protected
+     */
+    normalizeExtractionMetadata(meta) {
+        if (!meta || typeof meta !== 'object' || Array.isArray(meta)) return null;
+
+        const
+            missingFields       = Array.isArray(meta.missing_fields)       ? meta.missing_fields.filter(f => typeof f === 'string')       : [],
+            ambiguousReferences = Array.isArray(meta.ambiguous_references) ? meta.ambiguous_references.filter(r => typeof r === 'string') : [],
+            rawScore            = meta.confidence_score,
+            confidenceScore     = typeof rawScore === 'number' && rawScore >= 0 && rawScore <= 1 ? rawScore : null;
+
+        return {
+            missing_fields      : missingFields,
+            ambiguous_references: ambiguousReferences,
+            confidence_score    : confidenceScore
+        };
+    }
+
+    /**
      * Invokes the configured LLM provider on a single source and parses the response as the
      * candidate schema. Returns `[]` on any failure (provider offline, malformed JSON, no
      * candidates) — failure to extract is never fatal to `runDiscoveryCycle`, just a skip.
@@ -185,6 +222,11 @@ class ConceptDiscoveryService extends Base {
             return [];
         }
 
+        // Envelope-level extraction_metadata describes THIS extraction pass; it is denormalized
+        // onto each candidate row below so nodes.jsonl stays the single store, and is null for
+        // legacy candidates-only responses so the candidate-row schema stays additive.
+        const extractionMetadata = this.normalizeExtractionMetadata(payload.extraction_metadata);
+
         const accepted = [];
         for (const raw of payload.candidates) {
             if (!raw || typeof raw !== 'object' || !raw.id || !raw.name) continue;
@@ -200,7 +242,8 @@ class ConceptDiscoveryService extends Base {
                 aliases    : Array.isArray(raw.aliases) ? raw.aliases : [],
                 source     : sourceRef,
                 reasoning  : raw.reasoning || '',
-                ...CANDIDATE_DEFAULTS
+                ...CANDIDATE_DEFAULTS,
+                ...(extractionMetadata ? {extraction_metadata: extractionMetadata} : {})
             });
         }
 
@@ -405,7 +448,8 @@ class ConceptDiscoveryService extends Base {
      * the graph. The next `ConceptIngestor.syncConceptsToGraph` picks them up.
      *
      * Each candidate serializes one per line matching the established schema
-     * (`{id, name, tier, description, uniqueToNeo, tags, aliases, validated, verifiedAt, source, reasoning}`).
+     * (`{id, name, tier, description, uniqueToNeo, tags, aliases, validated, verifiedAt, source, reasoning}`),
+     * plus the optional `extraction_metadata` block when the LLM envelope carried one.
      * File is flush-written via `fs.promises.appendFile` which is atomic at the per-line level
      * on POSIX filesystems — safe for the single-writer REM pipeline pattern.
      * @param {Object[]} candidates

--- a/learn/agentos/ConceptOntology.md
+++ b/learn/agentos/ConceptOntology.md
@@ -97,9 +97,11 @@ Each line in `nodes.jsonl` is a JSON object:
 | `tags` | string[] | ✅ | Categorization tags for search and filtering |
 | `aliases` | string[] | ❌ | Alternative terms that refer to the exact same concept (O(1) lookup) |
 | `verifiedAt` | string \| null | ❌ | ISO date string for the last source-grounded verification, or `null` / missing when never explicitly verified |
+| `extraction_metadata` | object \| null | ❌ | Present only on **LLM-mined candidate rows** (written by `ConceptDiscoveryService`): the extraction pass's objective self-report `{missing_fields, ambiguous_references, confidence_score}`, denormalized onto each candidate it produced. **JSONL-only** — not projected to graph node `properties` or the `ConceptIngestor` payload hash; legacy rows without it load unchanged. |
 
 ```jsonl
 {"id":"off-main-thread","name":"Off-Main-Thread Execution","tier":1,"description":"Application business logic runs inside a dedicated App Worker.","uniqueToNeo":true,"tags":["architecture","workers"],"aliases":["off the main thread","OMT"],"verifiedAt":null}
+{"id":"mined-example","name":"Mined Example","tier":3,"description":"An LLM-mined candidate awaiting curator review.","uniqueToNeo":false,"tags":["mined-candidate"],"aliases":[],"verifiedAt":null,"extraction_metadata":{"missing_fields":[],"ambiguous_references":["'the module' — three modules exist"],"confidence_score":0.7}}
 ```
 
 > [!IMPORTANT]

--- a/test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs
@@ -305,4 +305,67 @@ test.describe('Neo.ai.daemons.services.ConceptDiscoveryService', () => {
         expect(sharedLine).toContain('from-epic');
         expect(sharedLine).not.toContain('from-pr');
     });
+
+    test('runDiscoveryCycle captures envelope extraction_metadata, denormalizes onto each candidate, and persists it (#10106)', async () => {
+        writeEmptyConceptGraph();
+        writeIssueFile('issue-900.md', {labels: ['epic'], id: 900});
+
+        llmResponses = [{
+            candidates: [
+                {id: 'persisted-a', name: 'Persisted A', description: 'a', reasoning: 'y', aliases: []},
+                {id: 'persisted-b', name: 'Persisted B', description: 'b', reasoning: 'y', aliases: []}
+            ],
+            extraction_metadata: {
+                missing_fields      : ['reasoning'],
+                ambiguous_references: ['the module — three modules exist'],
+                confidence_score    : 0.7
+            }
+        }];
+
+        const result = await ConceptDiscoveryService.runDiscoveryCycle();
+        expect(result.candidatesAdded).toBe(2);
+
+        // Envelope metadata describes the extraction pass → denormalized onto EACH candidate it produced
+        for (const c of result.candidates) {
+            expect(c.extraction_metadata).toEqual({
+                missing_fields      : ['reasoning'],
+                ambiguous_references: ['the module — three modules exist'],
+                confidence_score    : 0.7
+            });
+        }
+
+        // ...and persisted to nodes.jsonl as the additive optional field
+        const nodesContent = fs.readFileSync(path.join(tmpConceptsDir, 'nodes.jsonl'), 'utf8');
+        const row          = JSON.parse(nodesContent.split('\n').find(l => l.includes('"persisted-a"')));
+        expect(row.extraction_metadata.confidence_score).toBe(0.7);
+        expect(row.extraction_metadata.missing_fields).toEqual(['reasoning']);
+    });
+
+    test('extractConceptsFromSource omits extraction_metadata for legacy responses and coerces malformed blocks (#10106)', async () => {
+        writeEmptyConceptGraph();
+        ConceptService.loadGraph();
+
+        llmResponses = [
+            // Legacy: no extraction_metadata envelope at all
+            {candidates: [{id: 'legacy-c', name: 'Legacy C', description: 'x', reasoning: 'y', aliases: []}]},
+            // Malformed: non-array fields + out-of-range score → coerced to safe defaults
+            {
+                candidates         : [{id: 'malformed-c', name: 'Malformed C', description: 'x', reasoning: 'y', aliases: []}],
+                extraction_metadata: {missing_fields: 'not-an-array', ambiguous_references: null, confidence_score: 5}
+            }
+        ];
+
+        const body = 'Enough content to exceed MIN_SOURCE_LENGTH. '.repeat(20);
+
+        const legacy = await ConceptDiscoveryService.extractConceptsFromSource('legacy-source', body);
+        expect(legacy.length).toBe(1);
+        expect(legacy[0].extraction_metadata).toBeUndefined(); // additive — legacy rows carry no field
+
+        const malformed = await ConceptDiscoveryService.extractConceptsFromSource('malformed-source', body);
+        expect(malformed[0].extraction_metadata).toEqual({
+            missing_fields      : [],   // 'not-an-array' → []
+            ambiguous_references: [],   // null → []
+            confidence_score    : null  // 5 (outside [0,1]) → null
+        });
+    });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code, as @neo-opus-vega). Session db066a97-cc06-4bd3-b8fe-c056ab15639e.

Resolves #10106
Related: #10105

Adds the objective `extraction_metadata` self-report block to `ConceptDiscoveryService`'s LLM output schema — `missing_fields`, `ambiguous_references`, `confidence_score` (the schema gemma itself proposed for *verifiable* markers, not the unreliable subjective "felt slowed down" it explicitly refused). The envelope-level block describes the extraction pass; it is denormalized onto each candidate row in `nodes.jsonl`, kept JSONL-only, and documented in the canonical `ConceptOntology.md` node schema.

Evidence: L2 (focused unit coverage for parser capture / denormalize / coerce + persistence) → L2 required (Contract Ledger rows are unit/source-verifiable). No residuals.

## Slot-rationale (§1.1 — touches `learn/agentos/**`)
- `learn/agentos/ConceptOntology.md` (canonical `nodes.jsonl` node-schema doc): disposition `keep` — adds one optional-field table row + a sample line documenting `extraction_metadata`. Net +3 lines; drift-reduction (closes the stale-schema gap a reviewer would otherwise inherit via KB/RAG). Conditionally-loaded reference doc, not always-loaded Map.
- `Decision Record impact`: none — additive schema documentation, no ADR challenged.

## Contract Ledger (resolving the intake ambiguities)
gpt's 2026-05-28 intake parked this `needs-contract-alignment` over the envelope-vs-row + JSONL-vs-graph choices. Resolved here:

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
|---|---|---|---|---|---|
| `CONCEPT_EXTRACTION_SYSTEM_PROMPT` envelope | #10106 / #10105 probe | `{candidates, extraction_metadata: {missing_fields, ambiguous_references, confidence_score}}` — **envelope-level** | Absent/malformed → `null` / coerced defaults | prompt schema + instruction | spec: capture test |
| `extractConceptsFromSource()` parser | #10106 | Captured once, **denormalized onto each candidate row** | Legacy `{candidates}`-only → rows without field (additive) | `normalizeExtractionMetadata` JSDoc | spec: legacy + malformed tests |
| `nodes.jsonl` candidate row schema | Concept Ontology JSONL contract | Optional `extraction_metadata` field per row | Legacy rows load unchanged | **`ConceptOntology.md` Node Schema table + sample** | spec: persistence test |
| `ConceptService` / `ConceptIngestor` projection | `loadGraph()` + `computePayloadHash()` | **JSONL-only** — NOT in graph `properties` or payload hash | Graph contract + hash untouched | `ConceptOntology.md` note | no `ConceptIngestor` diff |

## Deltas from ticket
- **Resolved the parked Contract Ledger in-lane** rather than re-parking — design call (envelope-level + denormalized + JSONL-only) documented here + commented on #10106.
- **Denormalized-per-candidate** over single-per-extraction: `nodes.jsonl` is the per-candidate store, and per-row metadata lets a curator see which extraction's confidence/ambiguities produced each candidate. AC3 ("per candidate row") satisfied.
- **Cycle-1 review (@neo-gpt)**: closed the canonical-schema-doc gap — `ConceptOntology.md` now documents `extraction_metadata` (the inline `appendCandidates` comment is the use-site pointer; the guide is the durable schema source).
- Downstream consumers (confidence-prioritized review, `ambiguous_references` surfacing) stay Out-of-Scope per the ticket.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/services/ingestion/ConceptDiscoveryService.spec.mjs --workers=1` → **9/9 passed** (2 new + 7 existing). Single-worker is the deterministic mode: the default parallel run shows unrelated module-load races (`identityRoots.mjs` / `knowledge-base/logger.mjs` — the `--workers=1` isolation class tracked in #12597 / #12143). The `ConceptOntology.md` follow-up is doc-only (no test impact). Pre-commit hooks green on every commit.

## Post-Merge Validation
- [ ] On the next manual `DreamService.runConceptDiscovery`, confirm mined candidate rows in `nodes.jsonl` carry `extraction_metadata` from a real gemma response.
- [ ] Confirm `ConceptIngestor.syncConceptsToGraph` still hashes/projects candidates unchanged (metadata stays JSONL-only — no graph drift).

## Commits
- `5a873852a` — `feat(ai)`: prompt schema + instruction, `normalizeExtractionMetadata` helper, parser denormalize, `appendCandidates` comment, 2 spec tests.
- `57d16d2a5` — `docs(agentos)`: document `extraction_metadata` in the `ConceptOntology.md` node schema (Cycle-1 review).

## Cross-family review
@neo-gpt (cross-family) — you did the #10106 intake. Cycle-1: canonical-schema-doc gap (addressed, `57d16d2a5`). Re-review requested once CI greens.
