### PR TITLE
fix(memory): skip externally active drift summaries (#9959)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -122,13 +122,6 @@ class Config extends ConfigProvider {
              */
             summarizationConcurrency: leaf(5),
             /**
-             * Freshness window for graph-backed externally-active session detection during
-             * opportunistic drift summarization. Consumers read the resolved value from
-             * AiConfig instead of parsing process env at the use site.
-             * @type {number}
-             */
-            activeSessionIdleThresholdMs: leaf(10 * 60 * 1000, 'NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS', 'number'),
-            /**
              * The target Storage Architecture to use.
              * Note: Chroma is the only supported Vector DB.
              * Options: 'hybrid' (Chroma vectors + SQLite graph), 'chroma' (Chroma vectors only).

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -122,6 +122,13 @@ class Config extends ConfigProvider {
              */
             summarizationConcurrency: leaf(5),
             /**
+             * Freshness window for graph-backed externally-active session detection during
+             * opportunistic drift summarization. Consumers read the resolved value from
+             * AiConfig instead of parsing process env at the use site.
+             * @type {number}
+             */
+            activeSessionIdleThresholdMs: leaf(10 * 60 * 1000, 'NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS', 'number'),
+            /**
              * The target Storage Architecture to use.
              * Note: Chroma is the only supported Vector DB.
              * Options: 'hybrid' (Chroma vectors + SQLite graph), 'chroma' (Chroma vectors only).

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -305,18 +305,16 @@ class SessionService extends Base {
      *
      * @param {Object} [options]
      * @param {Number|Date|String} [options.now=Date.now()] Clock source for tests.
-     * @param {Number} [options.idleThresholdMs] Explicit test seam; production reads
-     *     `aiConfig.activeSessionIdleThresholdMs`.
      * @returns {Set<String>} Session ids considered active outside the current process.
      */
-    getExternallyActiveSessionIds({now = Date.now(), idleThresholdMs} = {}) {
+    getExternallyActiveSessionIds({now = Date.now()} = {}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) return new Set();
 
         const nowMs = typeof now === 'number' ? now : new Date(now).getTime();
         if (!Number.isFinite(nowMs)) return new Set();
 
-        const thresholdMs = idleThresholdMs ?? aiConfig.activeSessionIdleThresholdMs;
+        const thresholdMs = aiConfig.orchestrator.swarmHeartbeat.idleThresholdMs;
         const cutoffMs = nowMs - thresholdMs;
 
         try {

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -299,7 +299,7 @@ class SessionService extends Base {
      *
      * The spawned `summarize-sessions.mjs` child has its own `currentSessionId`, so drift detection
      * cannot rely on `this.currentSessionId` alone. `AGENT_MEMORY` graph nodes already carry the
-     * source identity, session id, and timestamp; pairing the latest fresh rows with an active
+     * source identity, session id, and timestamp; pairing fresh rows with an active
      * `WAKE_SUBSCRIPTION` gives the drift sweep a cross-process exclusion predicate without
      * introducing a second session registry.
      *
@@ -352,26 +352,14 @@ class SessionService extends Base {
                   )
             `).all();
 
-            const latestByIdentity = new Map();
             const activeSessionIds = new Set();
 
             for (const row of rows) {
                 const timestampMs = this.resolveGraphTimestampMs(row.timestampField, row.nameField);
                 if (timestampMs === null) continue;
 
-                const current = latestByIdentity.get(row.agentIdentity);
-
-                if (!current || timestampMs > current.timestampMs) {
-                    latestByIdentity.set(row.agentIdentity, {
-                        sessionId: row.sessionId,
-                        timestampMs
-                    });
-                }
-            }
-
-            for (const {sessionId, timestampMs} of latestByIdentity.values()) {
                 if (timestampMs >= cutoffMs) {
-                    activeSessionIds.add(sessionId);
+                    activeSessionIds.add(row.sessionId);
                 }
             }
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -305,8 +305,8 @@ class SessionService extends Base {
      *
      * @param {Object} [options]
      * @param {Number|Date|String} [options.now=Date.now()] Clock source for tests.
-     * @param {Number} [options.idleThresholdMs] Freshness window; defaults to `IDLE_THRESHOLD_MS`
-     *     or 10 minutes to match the heartbeat idle detectors.
+     * @param {Number} [options.idleThresholdMs] Explicit test seam; production reads
+     *     `aiConfig.activeSessionIdleThresholdMs`.
      * @returns {Set<String>} Session ids considered active outside the current process.
      */
     getExternallyActiveSessionIds({now = Date.now(), idleThresholdMs} = {}) {
@@ -316,10 +316,7 @@ class SessionService extends Base {
         const nowMs = typeof now === 'number' ? now : new Date(now).getTime();
         if (!Number.isFinite(nowMs)) return new Set();
 
-        const configuredThresholdMs = Number(idleThresholdMs);
-        const thresholdMs = Number.isFinite(configuredThresholdMs) && configuredThresholdMs > 0
-            ? configuredThresholdMs
-            : (parseInt(process.env.IDLE_THRESHOLD_MS, 10) || 10 * 60 * 1000);
+        const thresholdMs = idleThresholdMs ?? aiConfig.activeSessionIdleThresholdMs;
         const cutoffMs = nowMs - thresholdMs;
 
         try {
@@ -347,8 +344,8 @@ class SessionService extends Base {
                             json_extract(memory.data, '$.properties.agentIdentity'),
                             json_extract(memory.data, '$.properties.userId')
                         )
-                        AND COALESCE(json_extract(subscription.data, '$.properties.status'), 'active') = 'active'
-                        AND COALESCE(json_extract(subscription.data, '$.properties.harnessTarget'), '') != 'disabled'
+                        AND json_extract(subscription.data, '$.properties.status') = 'active'
+                        AND json_extract(subscription.data, '$.properties.harnessTarget') != 'disabled'
                   )
             `).all();
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -557,7 +557,12 @@ class SessionService extends Base {
 
             // Explicitly exclude sessions that are still active in this process or another
             // live harness. Stale/crashed sessions fall back into the self-healing drift path.
-            if (sessionId === this.currentSessionId || externallyActiveSessionIds.has(sessionId)) {
+            if (sessionId === this.currentSessionId) {
+                return;
+            }
+
+            if (externallyActiveSessionIds.has(sessionId)) {
+                logger.info(`[SessionService] Skipping externally active session ${sessionId} during drift detection.`);
                 return;
             }
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -125,10 +125,9 @@ import RequestContextService, {
  *
  * **Parallel Sessions Trade-off:**
  * In a scenario where multiple sessions are running in parallel (e.g., Session A and Session B),
- * they may continuously update the memory count. This strategy accepts the overhead of
- * potentially re-summarizing an active session multiple times to ensure that if any session
- * crashes or ends abruptly, its context is preserved and up-to-date for the next agent.
- * Data integrity and context availability are prioritized over minimizing LLM token usage.
+ * the drift sweep skips sessions whose latest graph-backed `AGENT_MEMORY` is still inside the
+ * active-agent idle threshold. Stale/crashed sessions remain eligible for self-healing, and
+ * explicit disconnect markers still summarize through the `SummarizationJobs.pending` path.
  *
  * @class Neo.ai.services.memory-core.SessionService
  * @extends Neo.core.Base
@@ -296,6 +295,122 @@ class SessionService extends Base {
     }
 
     /**
+     * @summary Resolves session ids that are still externally active in another harness/process.
+     *
+     * The spawned `summarize-sessions.mjs` child has its own `currentSessionId`, so drift detection
+     * cannot rely on `this.currentSessionId` alone. `AGENT_MEMORY` graph nodes already carry the
+     * source identity, session id, and timestamp; pairing the latest fresh rows with an active
+     * `WAKE_SUBSCRIPTION` gives the drift sweep a cross-process exclusion predicate without
+     * introducing a second session registry.
+     *
+     * @param {Object} [options]
+     * @param {Number|Date|String} [options.now=Date.now()] Clock source for tests.
+     * @param {Number} [options.idleThresholdMs] Freshness window; defaults to `IDLE_THRESHOLD_MS`
+     *     or 10 minutes to match the heartbeat idle detectors.
+     * @returns {Set<String>} Session ids considered active outside the current process.
+     */
+    getExternallyActiveSessionIds({now = Date.now(), idleThresholdMs} = {}) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) return new Set();
+
+        const nowMs = typeof now === 'number' ? now : new Date(now).getTime();
+        if (!Number.isFinite(nowMs)) return new Set();
+
+        const configuredThresholdMs = Number(idleThresholdMs);
+        const thresholdMs = Number.isFinite(configuredThresholdMs) && configuredThresholdMs > 0
+            ? configuredThresholdMs
+            : (parseInt(process.env.IDLE_THRESHOLD_MS, 10) || 10 * 60 * 1000);
+        const cutoffMs = nowMs - thresholdMs;
+
+        try {
+            const rows = sqlite.prepare(`
+                SELECT DISTINCT
+                       COALESCE(
+                           json_extract(memory.data, '$.properties.agentIdentity'),
+                           json_extract(memory.data, '$.properties.userId')
+                       ) as agentIdentity,
+                       json_extract(memory.data, '$.properties.sessionId') as sessionId,
+                       json_extract(memory.data, '$.properties.timestamp') as timestampField,
+                       json_extract(memory.data, '$.properties.name')      as nameField
+                FROM Nodes memory
+                WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
+                  AND json_extract(memory.data, '$.properties.sessionId') IS NOT NULL
+                  AND COALESCE(
+                      json_extract(memory.data, '$.properties.agentIdentity'),
+                      json_extract(memory.data, '$.properties.userId')
+                  ) IS NOT NULL
+                  AND EXISTS (
+                      SELECT 1
+                      FROM Nodes subscription
+                      WHERE json_extract(subscription.data, '$.label') = 'WAKE_SUBSCRIPTION'
+                        AND json_extract(subscription.data, '$.properties.agentIdentity') = COALESCE(
+                            json_extract(memory.data, '$.properties.agentIdentity'),
+                            json_extract(memory.data, '$.properties.userId')
+                        )
+                        AND COALESCE(json_extract(subscription.data, '$.properties.status'), 'active') = 'active'
+                        AND COALESCE(json_extract(subscription.data, '$.properties.harnessTarget'), '') != 'disabled'
+                  )
+            `).all();
+
+            const latestByIdentity = new Map();
+            const activeSessionIds = new Set();
+
+            for (const row of rows) {
+                const timestampMs = this.resolveGraphTimestampMs(row.timestampField, row.nameField);
+                if (timestampMs === null) continue;
+
+                const current = latestByIdentity.get(row.agentIdentity);
+
+                if (!current || timestampMs > current.timestampMs) {
+                    latestByIdentity.set(row.agentIdentity, {
+                        sessionId: row.sessionId,
+                        timestampMs
+                    });
+                }
+            }
+
+            for (const {sessionId, timestampMs} of latestByIdentity.values()) {
+                if (timestampMs >= cutoffMs) {
+                    activeSessionIds.add(sessionId);
+                }
+            }
+
+            return activeSessionIds;
+        } catch (error) {
+            logger.warn(`[SessionService] Failed to resolve externally active sessions: ${error.message}`);
+            return new Set();
+        }
+    }
+
+    /**
+     * @summary Normalizes graph-memory timestamp fields into epoch milliseconds.
+     * @param {String|Number|null} timestampField Structured `AGENT_MEMORY.properties.timestamp`.
+     * @param {String|null} [nameField] Legacy `Memory: <iso>` fallback.
+     * @returns {Number|null}
+     */
+    resolveGraphTimestampMs(timestampField, nameField) {
+        let value = timestampField;
+
+        if (!value && typeof nameField === 'string') {
+            value = nameField.match(/^Memory:\s+(.+)$/)?.[1] || null;
+        }
+
+        if (typeof value === 'number') {
+            return Number.isFinite(value) ? value : null;
+        }
+
+        if (typeof value === 'string' && value.trim() !== '') {
+            const numeric = Number(value);
+            if (Number.isFinite(numeric)) return numeric;
+
+            const parsed = Date.parse(value);
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+
+        return null;
+    }
+
+    /**
      * Finds sessions that need summarization by detecting "Drift" between the database state
      * and the summary metadata.
      *
@@ -433,17 +548,16 @@ class SessionService extends Base {
         });
 
         // 4. Determine candidates
+        const externallyActiveSessionIds = this.getExternallyActiveSessionIds();
         const sessionsToUpdate = [];
 
         Object.keys(sessions).forEach(sessionId => {
             const sessionData = sessions[sessionId];
             const summaryCount = summaryMap[sessionId];
 
-            // Explicitly exclude the current active session from both cases.
-            // It is still accumulating memories, so summarizing it mid-flight is wasteful and
-            // produces incomplete summaries. It will be correctly summarized on the next startup
-            // when a new session takes over.
-            if (sessionId === this.currentSessionId) {
+            // Explicitly exclude sessions that are still active in this process or another
+            // live harness. Stale/crashed sessions fall back into the self-healing drift path.
+            if (sessionId === this.currentSessionId || externallyActiveSessionIds.has(sessionId)) {
                 return;
             }
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -89,28 +89,6 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.memorySharing.defaultPolicy).toBe('team');
     });
 
-    test('activeSessionIdleThresholdMs resolves through AiConfig, not service env parsing (#9959)', () => {
-        expect(config.activeSessionIdleThresholdMs).toBe(10 * 60 * 1000);
-
-        const originalThreshold = process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS;
-        process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS = '12345';
-
-        try {
-            const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
-            try {
-                expect(freshCfg.activeSessionIdleThresholdMs).toBe(12345);
-            } finally {
-                freshCfg.destroy();
-            }
-        } finally {
-            if (originalThreshold === undefined) {
-                delete process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS;
-            } else {
-                process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS = originalThreshold;
-            }
-        }
-    });
-
     test('inherits deployment-wide Tier-1 defaults (provider, auth, ollama, openAiCompatible, storage) via the realm chain', () => {
         // MC declares none of these locally — they resolve UP the getParent() chain to the
         // Tier-1 realm root. Read KEYED, never whole-namespace: `toEqual(config.ollama)` would
@@ -142,6 +120,10 @@ test.describe('Memory Core Config (#10010)', () => {
         // Was the stale `.neo-ai-data/chroma/memory-core` — the bug.
         expect(config.engines.chroma.dataDir).toBe(TIER1_DEFAULTS.engines.chroma.dataDir);
         expect(config.engines.chroma.dataDir).toContain('.neo-ai-data/chroma/unified');
+    });
+
+    test('inherits the Tier-1 active-session idle threshold (#9959)', () => {
+        expect(config.orchestrator.swarmHeartbeat.idleThresholdMs).toBe(10 * 60 * 1000);
     });
 
     test('inherits concrete graphProvider defaults from Tier-1 config', () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -89,6 +89,28 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.memorySharing.defaultPolicy).toBe('team');
     });
 
+    test('activeSessionIdleThresholdMs resolves through AiConfig, not service env parsing (#9959)', () => {
+        expect(config.activeSessionIdleThresholdMs).toBe(10 * 60 * 1000);
+
+        const originalThreshold = process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS;
+        process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS = '12345';
+
+        try {
+            const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+            try {
+                expect(freshCfg.activeSessionIdleThresholdMs).toBe(12345);
+            } finally {
+                freshCfg.destroy();
+            }
+        } finally {
+            if (originalThreshold === undefined) {
+                delete process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS;
+            } else {
+                process.env.NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS = originalThreshold;
+            }
+        }
+    });
+
     test('inherits deployment-wide Tier-1 defaults (provider, auth, ollama, openAiCompatible, storage) via the realm chain', () => {
         // MC declares none of these locally — they resolve UP the getParent() chain to the
         // Tier-1 realm root. Read KEYED, never whole-namespace: `toEqual(config.ollama)` would

--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -324,6 +324,47 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         expect(sessionsToSummarize).not.toContain(activeSessionId);
     });
 
+    test('#9959: externally active detection should protect parallel sessions for the same identity', async () => {
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        const firstSessionId  = `external-active-a-${crypto.randomUUID()}`;
+        const secondSessionId = `external-active-b-${crypto.randomUUID()}`;
+        const agentIdentity   = `@parallel-active-${crypto.randomUUID()}`;
+        const now             = Date.now();
+
+        insertActiveWakeSubscription(sqlite, agentIdentity);
+        insertAgentMemoryNode(sqlite, {sessionId: firstSessionId,  agentIdentity, timestampMs: now - 1000});
+        insertAgentMemoryNode(sqlite, {sessionId: secondSessionId, agentIdentity, timestampMs: now});
+
+        const collection = await SDK.Memory_ChromaManager.getMemoryCollection();
+        await collection.add({
+            ids      : [
+                `external-parallel-memory-a-${crypto.randomUUID()}`,
+                `external-parallel-memory-b-${crypto.randomUUID()}`
+            ],
+            documents: [
+                'First parallel externally active session memory',
+                'Second parallel externally active session memory'
+            ],
+            metadatas: [
+                {sessionId: firstSessionId,  timestamp: now - 1000, type: 'agent-interaction'},
+                {sessionId: secondSessionId, timestamp: now,        type: 'agent-interaction'}
+            ]
+        });
+
+        const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({now});
+        expect(externallyActiveSessionIds.has(firstSessionId)).toBe(true);
+        expect(externallyActiveSessionIds.has(secondSessionId)).toBe(true);
+
+        const sessionsToSummarize = await SDK.Memory_SessionService.findSessionsToSummarize(false);
+        expect(sessionsToSummarize).not.toContain(firstSessionId);
+        expect(sessionsToSummarize).not.toContain(secondSessionId);
+    });
+
     test('#9959: explicit named-session summarization should bypass the externally active drift filter', async () => {
         const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         await GraphService.ready();

--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -324,6 +324,68 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         expect(sessionsToSummarize).not.toContain(activeSessionId);
     });
 
+    test('#9959: explicit named-session summarization should bypass the externally active drift filter', async () => {
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        const activeSessionId = `explicit-active-${crypto.randomUUID()}`;
+        const agentIdentity   = `@explicit-active-${crypto.randomUUID()}`;
+        const now             = Date.now();
+
+        insertActiveWakeSubscription(sqlite, agentIdentity);
+        insertAgentMemoryNode(sqlite, {sessionId: activeSessionId, agentIdentity, timestampMs: now});
+
+        const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({now});
+        expect(externallyActiveSessionIds.has(activeSessionId)).toBe(true);
+
+        const originalClaim     = SDK.Memory_SessionService.claimSummarizationJob;
+        const originalSummarize = SDK.Memory_SessionService.summarizeSession;
+        const originalComplete  = SDK.Memory_SessionService.completeSummarizationJob;
+        const originalFail      = SDK.Memory_SessionService.failSummarizationJob;
+
+        const calls = [];
+
+        SDK.Memory_SessionService.claimSummarizationJob = (sessionId) => {
+            calls.push({type: 'claim', sessionId});
+            return true;
+        };
+        SDK.Memory_SessionService.summarizeSession = async (sessionId) => {
+            calls.push({type: 'summarize', sessionId});
+            return {
+                sessionId,
+                summaryId   : `summary_${sessionId}`,
+                title       : 'Explicit Active Summary',
+                memoryCount : 1
+            };
+        };
+        SDK.Memory_SessionService.completeSummarizationJob = (sessionId) => {
+            calls.push({type: 'complete', sessionId});
+        };
+        SDK.Memory_SessionService.failSummarizationJob = (sessionId) => {
+            calls.push({type: 'fail', sessionId});
+        };
+
+        try {
+            const result = await SDK.Memory_SessionService.summarizeSessions({sessionId: activeSessionId});
+
+            expect(result.processed).toBe(1);
+            expect(result.sessions[0].sessionId).toBe(activeSessionId);
+            expect(calls).toEqual([
+                {type: 'claim', sessionId: activeSessionId},
+                {type: 'summarize', sessionId: activeSessionId},
+                {type: 'complete', sessionId: activeSessionId}
+            ]);
+        } finally {
+            SDK.Memory_SessionService.claimSummarizationJob     = originalClaim;
+            SDK.Memory_SessionService.summarizeSession          = originalSummarize;
+            SDK.Memory_SessionService.completeSummarizationJob  = originalComplete;
+            SDK.Memory_SessionService.failSummarizationJob      = originalFail;
+        }
+    });
+
     test('#9959: findSessionsToSummarize should keep stale peer sessions eligible for self-healing', async () => {
         const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         await GraphService.ready();

--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -28,6 +28,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 dotenv.config({path: path.resolve(__dirname, '../../../../../../.env'), quiet: true});
 
+let cleanupSDK;
+
+test.afterAll(async () => {
+    if (!cleanupSDK) return;
+
+    const { cleanupChromaManager } = await import('./util.mjs');
+    await cleanupChromaManager(cleanupSDK);
+});
+
 test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
     test.skip(skipCiSubstrateData, 'CI-skip: Memory Core substrate data not seeded - bucket C (#10903)');
 
@@ -36,16 +45,8 @@ test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
     const testTs  = Date.now();
 
     test.beforeAll(async () => {
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        const path = await import("path");
-        const tmpDir = path.resolve(process.cwd(), "tmp");
-        aiConfig.storagePaths.graph = path.join(tmpDir, "test-graph-" + Date.now() + "-" + Math.random().toString(36).substring(7) + ".db");
-
-        // Isolate collections to prevent pollution
-        aiConfig.collections.memory  = `test-reranker-mem-${testPid}-${testTs}`;
-        aiConfig.collections.session = `test-reranker-sum-${testPid}-${testTs}`;
-
         SDK                  = await import('../../../../../../ai/services.mjs');
+        cleanupSDK           = SDK;
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
 
         // Force offline mode — mock embeddings with deterministic 4096D vectors
@@ -81,11 +82,6 @@ test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
                 model    : 'test-model'
             });
         }
-    });
-
-    test.afterAll(async () => {
-        const { cleanupChromaManager } = await import('./util.mjs');
-        await cleanupChromaManager(SDK);
     });
 
     test('StorageRouter re-ranker should NOT crash when ChromaDB returns empty/malformed query results', async () => {
@@ -175,19 +171,16 @@ test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
 test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
     test.skip(skipCiSubstrateData, 'CI-skip: Memory Core substrate data not seeded - bucket C (#10903)');
 
-    let SDK, TextEmbeddingService, driftSessionId;
+    let SDK, TextEmbeddingService, RequestContextService, callTool, driftSessionId;
     const testPid = process.pid;
     const testTs  = Date.now();
 
     test.beforeAll(async () => {
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-
-        // Use SEPARATE isolated collections from the previous describe block
-        aiConfig.collections.memory  = `test-drift-mem-${testPid}-${testTs}`;
-        aiConfig.collections.session = `test-drift-sum-${testPid}-${testTs}`;
-
-        SDK                  = await import('../../../../../../ai/services.mjs');
-        TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
+        SDK                   = await import('../../../../../../ai/services.mjs');
+        cleanupSDK            = SDK;
+        TextEmbeddingService  = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
+        RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+        ({callTool}           = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs'));
 
         SDK.Memory_Config.data.embeddingProvider       = 'openAiCompatible';
         SDK.Memory_Config.data.autoSummarize           = false;
@@ -204,43 +197,49 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         await SDK.Memory_ChromaManager.ready();
     });
 
-    test.afterAll(async () => {
-        const { cleanupChromaManager } = await import('./util.mjs');
-        await cleanupChromaManager(SDK);
-    });
+    function callToolAs(agentIdentity, toolName, args) {
+        const userId = agentIdentity.startsWith('@') ? agentIdentity.slice(1) : agentIdentity;
 
-    function insertGraphNode(sqlite, {id, label, userId, properties}) {
-        sqlite.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)').run(id, userId || null, JSON.stringify({
-            id,
-            label,
-            properties
-        }));
+        return RequestContextService.run({
+            agentIdentityNodeId: agentIdentity,
+            source             : 'unit-test',
+            userId
+        }, () => callTool(toolName, args));
     }
 
-    function insertActiveWakeSubscription(sqlite, agentIdentity) {
-        insertGraphNode(sqlite, {
-            id        : `WAKE_SUB:${crypto.randomUUID()}`,
-            label     : 'WAKE_SUBSCRIPTION',
-            userId    : agentIdentity,
-            properties: {
-                agentIdentity,
-                harnessTarget: 'bridge-daemon',
-                status       : 'active'
+    function subscribeActiveWakeRoute(agentIdentity) {
+        return callToolAs(agentIdentity, 'manage_wake_subscription', {
+            action               : 'subscribe',
+            trigger              : 'SENT_TO_ME',
+            filters              : {taggedConcepts: [`unit-${crypto.randomUUID()}`]},
+            harnessTarget        : 'bridge-daemon',
+            harnessTargetMetadata: {
+                appName: 'Codex'
             }
         });
     }
 
-    function insertAgentMemoryNode(sqlite, {sessionId, agentIdentity, timestampMs}) {
-        insertGraphNode(sqlite, {
-            id        : crypto.randomUUID(),
-            label     : 'AGENT_MEMORY',
-            userId    : agentIdentity,
-            properties: {
-                agentIdentity,
-                sessionId,
-                timestamp: new Date(timestampMs).toISOString()
-            }
+    async function addToolMemory({sessionId, agentIdentity, prompt = 'Externally active session memory'}) {
+        const result = await callToolAs(agentIdentity, 'add_memory', {
+            prompt,
+            thought: 'Unit test active-session fixture.',
+            response: 'Stored through the MCP add_memory tool shape.',
+            sessionId,
+            agent: agentIdentity,
+            model: 'unit-test-model',
+            amountToolCalls: 0,
+            toolsUsed: ['unit-test']
         });
+
+        expect(result.error).toBeUndefined();
+        expect(result.sessionId).toBe(sessionId);
+
+        return result;
+    }
+
+    async function seedExternallyActiveSession({sessionId, agentIdentity, prompt}) {
+        await subscribeActiveWakeRoute(agentIdentity);
+        return addToolMemory({sessionId, agentIdentity, prompt});
     }
 
     test('findSessionsToSummarize should detect unsummarized sessions with epoch timestamps', async () => {
@@ -297,24 +296,13 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
     });
 
     test('#9959: findSessionsToSummarize should exclude externally active peer sessions from drift detection', async () => {
-        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        await GraphService.ready();
-
-        const sqlite = GraphService.db?.storage?.db;
-        expect(sqlite).toBeTruthy();
-
         const activeSessionId = `external-active-${crypto.randomUUID()}`;
-        const agentIdentity   = `@external-active-${crypto.randomUUID()}`;
+        const agentIdentity   = '@neo-gpt';
         const now             = Date.now();
 
-        insertActiveWakeSubscription(sqlite, agentIdentity);
-        insertAgentMemoryNode(sqlite, {sessionId: activeSessionId, agentIdentity, timestampMs: now});
-
-        const collection = await SDK.Memory_ChromaManager.getMemoryCollection();
-        await collection.add({
-            ids      : [`external-active-memory-${crypto.randomUUID()}`],
-            documents: ['Externally active session memory'],
-            metadatas: [{sessionId: activeSessionId, timestamp: now, type: 'agent-interaction'}]
+        await seedExternallyActiveSession({
+            sessionId: activeSessionId,
+            agentIdentity
         });
 
         const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({now});
@@ -325,35 +313,21 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
     });
 
     test('#9959: externally active detection should protect parallel sessions for the same identity', async () => {
-        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        await GraphService.ready();
-
-        const sqlite = GraphService.db?.storage?.db;
-        expect(sqlite).toBeTruthy();
-
         const firstSessionId  = `external-active-a-${crypto.randomUUID()}`;
         const secondSessionId = `external-active-b-${crypto.randomUUID()}`;
-        const agentIdentity   = `@parallel-active-${crypto.randomUUID()}`;
+        const agentIdentity   = '@neo-opus-ada';
         const now             = Date.now();
 
-        insertActiveWakeSubscription(sqlite, agentIdentity);
-        insertAgentMemoryNode(sqlite, {sessionId: firstSessionId,  agentIdentity, timestampMs: now - 1000});
-        insertAgentMemoryNode(sqlite, {sessionId: secondSessionId, agentIdentity, timestampMs: now});
-
-        const collection = await SDK.Memory_ChromaManager.getMemoryCollection();
-        await collection.add({
-            ids      : [
-                `external-parallel-memory-a-${crypto.randomUUID()}`,
-                `external-parallel-memory-b-${crypto.randomUUID()}`
-            ],
-            documents: [
-                'First parallel externally active session memory',
-                'Second parallel externally active session memory'
-            ],
-            metadatas: [
-                {sessionId: firstSessionId,  timestamp: now - 1000, type: 'agent-interaction'},
-                {sessionId: secondSessionId, timestamp: now,        type: 'agent-interaction'}
-            ]
+        await subscribeActiveWakeRoute(agentIdentity);
+        await addToolMemory({
+            sessionId: firstSessionId,
+            agentIdentity,
+            prompt   : 'First parallel externally active session memory'
+        });
+        await addToolMemory({
+            sessionId: secondSessionId,
+            agentIdentity,
+            prompt   : 'Second parallel externally active session memory'
         });
 
         const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({now});
@@ -366,18 +340,14 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
     });
 
     test('#9959: explicit named-session summarization should bypass the externally active drift filter', async () => {
-        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        await GraphService.ready();
-
-        const sqlite = GraphService.db?.storage?.db;
-        expect(sqlite).toBeTruthy();
-
         const activeSessionId = `explicit-active-${crypto.randomUUID()}`;
-        const agentIdentity   = `@explicit-active-${crypto.randomUUID()}`;
+        const agentIdentity   = '@neo-claude-opus';
         const now             = Date.now();
 
-        insertActiveWakeSubscription(sqlite, agentIdentity);
-        insertAgentMemoryNode(sqlite, {sessionId: activeSessionId, agentIdentity, timestampMs: now});
+        await seedExternallyActiveSession({
+            sessionId: activeSessionId,
+            agentIdentity
+        });
 
         const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({now});
         expect(externallyActiveSessionIds.has(activeSessionId)).toBe(true);
@@ -428,46 +398,30 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
     });
 
     test('#9959: findSessionsToSummarize should keep stale peer sessions eligible for self-healing', async () => {
-        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
-        await GraphService.ready();
-
-        const sqlite = GraphService.db?.storage?.db;
-        expect(sqlite).toBeTruthy();
-
         const staleSessionId = `external-stale-${crypto.randomUUID()}`;
-        const agentIdentity  = `@external-stale-${crypto.randomUUID()}`;
-        const now            = Date.now();
-        const staleTimestamp = now - 60_000;
-        const idleThreshold  = 10_000;
+        const agentIdentity  = '@neo-opus-vega';
+        const memoryTs       = Date.now();
+        const futureNow      = memoryTs + (11 * 60 * 1000);
 
-        insertActiveWakeSubscription(sqlite, agentIdentity);
-        insertAgentMemoryNode(sqlite, {sessionId: staleSessionId, agentIdentity, timestampMs: staleTimestamp});
-
-        const collection = await SDK.Memory_ChromaManager.getMemoryCollection();
-        await collection.add({
-            ids      : [`external-stale-memory-${crypto.randomUUID()}`],
-            documents: ['Externally stale session memory'],
-            metadatas: [{sessionId: staleSessionId, timestamp: staleTimestamp, type: 'agent-interaction'}]
+        await seedExternallyActiveSession({
+            sessionId: staleSessionId,
+            agentIdentity,
+            prompt: 'Externally stale session memory'
         });
 
         const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({
-            idleThresholdMs: idleThreshold,
-            now
+            now: futureNow
         });
         expect(externallyActiveSessionIds.has(staleSessionId)).toBe(false);
 
-        const originalIdleThreshold = process.env.IDLE_THRESHOLD_MS;
-        process.env.IDLE_THRESHOLD_MS = String(idleThreshold);
+        const originalDateNow = Date.now;
+        Date.now = () => futureNow;
 
         try {
             const sessionsToSummarize = await SDK.Memory_SessionService.findSessionsToSummarize(false);
             expect(sessionsToSummarize).toContain(staleSessionId);
         } finally {
-            if (originalIdleThreshold === undefined) {
-                delete process.env.IDLE_THRESHOLD_MS;
-            } else {
-                process.env.IDLE_THRESHOLD_MS = originalIdleThreshold;
-            }
+            Date.now = originalDateNow;
         }
     });
 

--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -209,6 +209,40 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         await cleanupChromaManager(SDK);
     });
 
+    function insertGraphNode(sqlite, {id, label, userId, properties}) {
+        sqlite.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)').run(id, userId || null, JSON.stringify({
+            id,
+            label,
+            properties
+        }));
+    }
+
+    function insertActiveWakeSubscription(sqlite, agentIdentity) {
+        insertGraphNode(sqlite, {
+            id        : `WAKE_SUB:${crypto.randomUUID()}`,
+            label     : 'WAKE_SUBSCRIPTION',
+            userId    : agentIdentity,
+            properties: {
+                agentIdentity,
+                harnessTarget: 'bridge-daemon',
+                status       : 'active'
+            }
+        });
+    }
+
+    function insertAgentMemoryNode(sqlite, {sessionId, agentIdentity, timestampMs}) {
+        insertGraphNode(sqlite, {
+            id        : crypto.randomUUID(),
+            label     : 'AGENT_MEMORY',
+            userId    : agentIdentity,
+            properties: {
+                agentIdentity,
+                sessionId,
+                timestamp: new Date(timestampMs).toISOString()
+            }
+        });
+    }
+
     test('findSessionsToSummarize should detect unsummarized sessions with epoch timestamps', async () => {
         driftSessionId = crypto.randomUUID();
 
@@ -260,6 +294,78 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
 
         // The active session should NOT be in the list
         expect(sessionsToSummarize).not.toContain(activeSessionId);
+    });
+
+    test('#9959: findSessionsToSummarize should exclude externally active peer sessions from drift detection', async () => {
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        const activeSessionId = `external-active-${crypto.randomUUID()}`;
+        const agentIdentity   = `@external-active-${crypto.randomUUID()}`;
+        const now             = Date.now();
+
+        insertActiveWakeSubscription(sqlite, agentIdentity);
+        insertAgentMemoryNode(sqlite, {sessionId: activeSessionId, agentIdentity, timestampMs: now});
+
+        const collection = await SDK.Memory_ChromaManager.getMemoryCollection();
+        await collection.add({
+            ids      : [`external-active-memory-${crypto.randomUUID()}`],
+            documents: ['Externally active session memory'],
+            metadatas: [{sessionId: activeSessionId, timestamp: now, type: 'agent-interaction'}]
+        });
+
+        const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({now});
+        expect(externallyActiveSessionIds.has(activeSessionId)).toBe(true);
+
+        const sessionsToSummarize = await SDK.Memory_SessionService.findSessionsToSummarize(false);
+        expect(sessionsToSummarize).not.toContain(activeSessionId);
+    });
+
+    test('#9959: findSessionsToSummarize should keep stale peer sessions eligible for self-healing', async () => {
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        const staleSessionId = `external-stale-${crypto.randomUUID()}`;
+        const agentIdentity  = `@external-stale-${crypto.randomUUID()}`;
+        const now            = Date.now();
+        const staleTimestamp = now - 60_000;
+        const idleThreshold  = 10_000;
+
+        insertActiveWakeSubscription(sqlite, agentIdentity);
+        insertAgentMemoryNode(sqlite, {sessionId: staleSessionId, agentIdentity, timestampMs: staleTimestamp});
+
+        const collection = await SDK.Memory_ChromaManager.getMemoryCollection();
+        await collection.add({
+            ids      : [`external-stale-memory-${crypto.randomUUID()}`],
+            documents: ['Externally stale session memory'],
+            metadatas: [{sessionId: staleSessionId, timestamp: staleTimestamp, type: 'agent-interaction'}]
+        });
+
+        const externallyActiveSessionIds = SDK.Memory_SessionService.getExternallyActiveSessionIds({
+            idleThresholdMs: idleThreshold,
+            now
+        });
+        expect(externallyActiveSessionIds.has(staleSessionId)).toBe(false);
+
+        const originalIdleThreshold = process.env.IDLE_THRESHOLD_MS;
+        process.env.IDLE_THRESHOLD_MS = String(idleThreshold);
+
+        try {
+            const sessionsToSummarize = await SDK.Memory_SessionService.findSessionsToSummarize(false);
+            expect(sessionsToSummarize).toContain(staleSessionId);
+        } finally {
+            if (originalIdleThreshold === undefined) {
+                delete process.env.IDLE_THRESHOLD_MS;
+            } else {
+                process.env.IDLE_THRESHOLD_MS = originalIdleThreshold;
+            }
+        }
     });
 
     test('ChromaDB $gt filter should correctly compare epoch timestamps', async () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop, extra-high thought budget). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Resolves #9959

Adds a graph-backed active-session exclusion to `SessionService` opportunistic drift sweep so the spawned summary child skips sessions with fresh `AGENT_MEMORY` rows for active wake subscriptions. Stale/crashed sessions remain eligible for self-healing, explicit disconnect jobs still travel through the existing `SummarizationJobs.pending` path, and explicit named-session summarization remains intentional.

Evidence: L2 (unit-level Memory Core drift fixture using Memory Core MCP tool shapes plus Chroma/session coverage) -> L2 required (service predicate and unit coverage). No #9959 residuals.

## Latest-Reality Reconciliation
- Rebased on current `origin/dev`, after the lifecycle idle scripts moved to `AiConfig.orchestrator.swarmHeartbeat.idleThresholdMs`.
- Removed the transient `activeSessionIdleThresholdMs` Memory Core leaf and `NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS` env surface from this PR.
- `SessionService.getExternallyActiveSessionIds()` now reads the existing Tier-1 `orchestrator.swarmHeartbeat.idleThresholdMs` leaf (`NEO_IDLE_THRESHOLD_MS`) at the use site, matching ADR 0019's reactive Provider SSOT rule.
- `bridge-daemon` remains the current harness target enum on `dev`; this PR keeps the wake-subscription tool-shape fixture aligned with that current contract.

## Deltas from ticket
- Uses existing `AGENT_MEMORY` and `WAKE_SUBSCRIPTION` graph nodes instead of adding a new session registry.
- Treats every fresh session for an active identity as externally active, so parallel same-identity sessions are both protected while stale sessions from that identity remain eligible.
- Leaves explicit pending summarization markers untouched; only the opportunistic drift sweep gets the active-session filter.
- Reads the external-active idle threshold from `AiConfig.orchestrator.swarmHeartbeat.idleThresholdMs` (`NEO_IDLE_THRESHOLD_MS`) instead of parsing `process.env` inside `SessionService` or adding a Memory Core duplicate leaf.
- Consumes explicit wake-subscription tool output: `status` must be `active` and `harnessTarget` must not be `disabled`; missing fields are not silently defaulted active.
- Logs externally-active drift skips for operator diagnosis.

## Test Evidence
- `git diff --check`
- `rg -n "activeSessionIdleThresholdMs|NEO_ACTIVE_SESSION_IDLE_THRESHOLD_MS|process\\.env\\.IDLE_THRESHOLD_MS|parseInt\\(process\\.env\\.IDLE_THRESHOLD_MS|Number\\.isFinite\\(configuredThresholdMs\\)|idleThresholdMs \\?\\?" ai/services/memory-core/SessionService.mjs ai/mcp/server/memory-core/config.template.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs ai/scripts/lifecycle/checkSunsetted.mjs ai/scripts/lifecycle/checkAllAgentIdle.mjs` (no matches)
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs --workers=1` (18 passed)

## Local Verification Gap
- Chroma-backed Memory Core tests could not be re-run locally after the latest-reality fix because the local Chroma server could not bind (`Address 127.0.0.1:8001 is not available`) and `localhost:8000` was not serving Chroma heartbeat. CI should be treated as the Chroma-backed verification source for the pushed head.

## Post-Merge Validation
- [ ] Periodic summary child no longer summarizes a peer session while that peer is still producing fresh `AGENT_MEMORY`.

## Commits
- `f78d0ac4f` — `fix(memory): skip externally active drift summaries (#9959)`
- `b33a9c368` — `test(memory): cover explicit active session summaries (#9959)`
- `2bc91b96d` — `fix(memory): protect parallel active sessions (#9959)`
- `683382210` — `fix(memory): align active-session config (#9959)`
- `6f415dbcc` — `fix(memory): reuse swarm idle threshold (#9959)`
