### PR TITLE
fix(ai): reconcile wake digest against read-status, dropping already-read messages (#12479)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -527,6 +527,35 @@ function getHighestWakePriority(messages) {
 }
 
 /**
+ * @summary Whether `messageId` is already read by `recipient` — for reconciling the wake digest
+ * against actual mailbox read-status. Mirrors `MailboxService.getReadAtForMessage`: the per-recipient
+ * `DELIVERED_TO` edge's `readAt` when that edge exists (broadcasts + delivered DMs), else the MESSAGE
+ * node's own `readAt` (direct DM). Read-status is independent of the GraphLog delta that fires the wake,
+ * so a large delta (resync / data-sync jump) otherwise re-counts already-read rows as "new".
+ * @param {Object} db better-sqlite3 handle (the bridge daemon's graph store).
+ * @param {String} messageId
+ * @param {String} recipient The agent identity the wake targets.
+ * @returns {Boolean} true when the message has been read by the recipient.
+ * @private
+ */
+function isMessageReadFor(db, messageId, recipient) {
+    const edge = db.prepare(
+        `SELECT json_extract(data, '$.properties.readAt') AS readAt
+         FROM Edges WHERE source = ? AND target = ? AND type = 'DELIVERED_TO' LIMIT 1`
+    ).get(messageId, recipient);
+
+    if (edge !== undefined) {
+        return edge.readAt != null;
+    }
+
+    const node = db.prepare(
+        `SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ? LIMIT 1`
+    ).get(messageId);
+
+    return node ? node.readAt != null : false;
+}
+
+/**
  * @summary Flushes the coalesced wake queue into a priority-tagged digest.
  *
  * The digest header carries the highest coalesced message priority so agent policy can
@@ -542,7 +571,6 @@ async function flushSubscription(subId) {
 
     if (queue.length === 0) return;
 
-    const N = queue.length;
     const identity = subscription.properties?.agentIdentity;
 
     let messages = [], tasks = [], permissions = [], heartbeats = [];
@@ -552,6 +580,19 @@ async function flushSubscription(subId) {
         else if (ev.type === 'permission') permissions.push(ev);
         else if (ev.type === 'heartbeat') heartbeats.push(ev);
     }
+
+    // A large GraphLog delta (resync / data-sync jump) re-includes already-read message rows, so the raw
+    // delta over-counts "new messages" and can spoof a HIGH digest priority. Reconcile against actual
+    // read-status: keep only genuinely-unread messages for the count / preview / priority — without
+    // dropping real wakes (unread messages, tasks, permissions, and heartbeats all still fire).
+    messages = messages.filter(ev => !isMessageReadFor(db, ev.messageId, identity));
+
+    // Nothing genuinely-new survived (the delta was entirely already-read messages) → suppress the stale wake.
+    if (messages.length === 0 && tasks.length === 0 && permissions.length === 0 && heartbeats.length === 0) {
+        return;
+    }
+
+    const N = messages.length + tasks.length + permissions.length + heartbeats.length;
 
     let breakdown = '';
     const digestPriority = getHighestWakePriority(messages);

--- a/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
@@ -259,6 +259,86 @@ test.describe('Bridge Daemon', () => {
         expect(logContents).toContain('[Bridge Daemon Test Adapter] Delivered');          // Same delivery line as stdout
     });
 
+    test('filters already-read messages out of the wake digest, counting only genuinely-unread (#12479)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-readfilter';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent ReadFilter' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: { adapter: 'test', coalesceWindow: 1 }
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/bridge/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver event within timeout')), 10000);
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Bridge Daemon Test Adapter] Delivered')) {
+                    clearTimeout(timeout);
+                    resolve(out);
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Inject a MESSAGE addressable to the agent: SENT_TO is the routing/detection edge the wake fires on;
+        // DELIVERED_TO carries the per-recipient readAt the daemon must reconcile against. Only SENT_TO + the
+        // node go into GraphLog (the wake trigger) — DELIVERED_TO is read live at flush time, not a trigger.
+        const injectMessage = (subject, readAt) => {
+            const msgId = 'msg_' + crypto.randomUUID();
+            db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+                id: msgId,
+                label: 'MESSAGE',
+                properties: { from: '@sender', subject, priority: 'normal' }
+            }));
+            db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+            const sentId = 'edge_' + crypto.randomUUID();
+            db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(
+                sentId, JSON.stringify({ id: sentId, source: msgId, target: agentId, type: 'SENT_TO' }),
+                msgId, agentId, 'SENT_TO'
+            );
+            db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(sentId, 'edges');
+
+            const delId = 'edge_' + crypto.randomUUID();
+            db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(
+                delId, JSON.stringify({ id: delId, source: msgId, target: agentId, type: 'DELIVERED_TO', properties: { readAt } }),
+                msgId, agentId, 'DELIVERED_TO'
+            );
+            return msgId;
+        };
+
+        // One already-read message (readAt set) and one genuinely-unread (readAt null), in the same coalesce window.
+        injectMessage('Already Read Noise',   '2026-06-06T00:00:00.000Z');
+        injectMessage('Genuinely New Signal', null);
+
+        const output = await deliveryPromise;
+        expect(output).toContain('[Bridge Daemon Test Adapter] Delivered');
+        expect(output).toContain('1 new messages');         // only the unread one is counted
+        expect(output).toContain('Genuinely New Signal');    // ...and previewed as the latest
+        expect(output).not.toContain('Already Read Noise');  // the already-read one is reconciled out
+    });
+
     test('delivers GraphLog-only heartbeat pulses via test adapter', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-heartbeat';


### PR DESCRIPTION
Resolves #12479

The bridge daemon's wake digest now reconciles against actual mailbox read-status before counting. Previously `flushSubscription` counted *every* message row in the GraphLog delta as "new" — a large delta (resync / the hourly data-sync jump) re-includes already-read rows, over-counting "N new messages" and spoofing a **HIGH** wake priority off stale mail. It now filters the delta to genuinely-unread messages via `isMessageReadFor(db, messageId, recipient)` (the per-recipient `DELIVERED_TO` edge `readAt` if that edge exists, else the `MESSAGE` node `readAt` — mirroring `MailboxService.getReadAtForMessage`), recomputes the event count over the filtered set, and suppresses the wake entirely when nothing genuine survives. Unread messages, tasks, permissions, and heartbeats all still fire — only already-read message noise is dropped.

Evidence: L3 (real spawned `daemon.mjs` + real SQLite; the test-adapter digest asserts a read-filtered count over injected read/unread messages) → L3 sufficient: the defect lives in `flushSubscription`'s count/filter logic, fully exercised by the spawned-daemon integration path. No residuals.

## Deltas from ticket

None — the fix matches the ticket's documented root cause (the digest counts unfiltered GraphLog-delta message-events with no read-status reconciliation). The read-model (`DELIVERED_TO`-edge `readAt`, else node `readAt`) is lifted directly from `MailboxService.getReadAtForMessage` rather than re-derived, and the `json_extract(data, '$.properties.readAt')` path matches what the graph RLS clause already uses.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/bridge/daemon.spec.mjs
→ 24 passed (15.9s)
```

- **New case** — injects one already-read message (`DELIVERED_TO` `readAt` set) and one unread message into the same coalesce window; asserts the digest reports `1 new messages` previewing only the unread one, and never names the read one.
- **Regression guard** — the full bridge-daemon wake-delivery suite (genuine-message, heartbeat-only, self-DM, broadcast-suppression) stays green, proving the filter does not drop real wakes.

## Post-Merge Validation

- [ ] On the live deployment, confirm the bridge daemon no longer emits wake digests that count already-read messages after a large GraphLog delta (resync / data-sync jump) — i.e. no spurious "N new messages" / HIGH-priority wakes off stale mail.

## Commits

- `959972df8` — reconcile wake digest against read-status (helper + filter/suppress/recount in `flushSubscription` + integration test).

---
Authored by Claude Opus 4.8 (Claude Code). Session c4f7dff5-d871-420e-ab99-7b736f0fe39d.
