### PR TITLE
fix(theme): complete neo dialog and fieldset styling (#12565)

### DIFF
--- a/resources/scss/src/dialog/Base.scss
+++ b/resources/scss/src/dialog/Base.scss
@@ -66,6 +66,12 @@
         .neo-footer-toolbar {
             border    : none;
             border-top: 1px solid var(--dialog-border-color);
+
+            .neo-button {
+                border-radius: var(--dialog-footer-button-border-radius);
+                height       : var(--dialog-footer-button-height);
+                margin-left  : var(--dialog-footer-button-margin-left);
+            }
         }
 
         .neo-header-toolbar {

--- a/resources/scss/theme-dark/dialog/Base.scss
+++ b/resources/scss/theme-dark/dialog/Base.scss
@@ -1,6 +1,9 @@
 :root .neo-theme-dark { // .neo-dialog
-    --dialog-border-color: #3c3f41;
-    --dialog-box-shadow  : 0 5px 10px rgba(0,0,0,.4);
-    --dialog-header-color: floralwhite;
-    --dialog-icon-color  : floralwhite;
+    --dialog-border-color                : #3c3f41;
+    --dialog-box-shadow                  : 0 5px 10px rgba(0,0,0,.4);
+    --dialog-footer-button-border-radius: var(--button-border-radius);
+    --dialog-footer-button-height       : var(--button-height);
+    --dialog-footer-button-margin-left  : 0;
+    --dialog-header-color                : floralwhite;
+    --dialog-icon-color                  : floralwhite;
 }

--- a/resources/scss/theme-light/dialog/Base.scss
+++ b/resources/scss/theme-light/dialog/Base.scss
@@ -1,6 +1,9 @@
 :root .neo-theme-light { // .neo-dialog
-    --dialog-border-color: #ddd;
-    --dialog-box-shadow  : 0 5px 10px rgba(0,0,0,.4);
-    --dialog-header-color: #1c60a0;
-    --dialog-icon-color  : #1c60a0;
+    --dialog-border-color                : #ddd;
+    --dialog-box-shadow                  : 0 5px 10px rgba(0,0,0,.4);
+    --dialog-footer-button-border-radius: var(--button-border-radius);
+    --dialog-footer-button-height       : var(--button-height);
+    --dialog-footer-button-margin-left  : 0;
+    --dialog-header-color                : #1c60a0;
+    --dialog-icon-color                  : #1c60a0;
 }

--- a/resources/scss/theme-neo-dark/dialog/Base.scss
+++ b/resources/scss/theme-neo-dark/dialog/Base.scss
@@ -1,18 +1,13 @@
 :root .neo-theme-neo-dark { // .neo-dialog
-    --dialog-border-color: var(--purple-800);
-    --dialog-box-shadow  : 0 5px 10px rgba(17, 20, 28, .85);
-    --dialog-header-color: var(--sem-color-text-primary-default);
-    --dialog-icon-color  : var(--sem-color-icon-primary-default);
+    --dialog-border-color                : var(--purple-800);
+    --dialog-box-shadow                  : 0 5px 10px rgba(17, 20, 28, .85);
+    --dialog-footer-button-border-radius: 5px;
+    --dialog-footer-button-height       : 1.7em;
+    --dialog-footer-button-margin-left  : 0.3em;
+    --dialog-header-color                : var(--sem-color-text-primary-default);
+    --dialog-icon-color                  : var(--sem-color-icon-primary-default);
 
     .neo-dialog {
-        .neo-footer-toolbar {
-            .neo-button {
-                border-radius: 5px;
-                height       : 1.7em;
-                margin-left  : 0.3em;
-            }
-        }
-
         .neo-header-toolbar {
             .neo-button {
                 background-color: transparent;

--- a/resources/scss/theme-neo-dark/dialog/Base.scss
+++ b/resources/scss/theme-neo-dark/dialog/Base.scss
@@ -1,10 +1,18 @@
 :root .neo-theme-neo-dark { // .neo-dialog
-    --dialog-border-color: var(--sem-color-border-default);
-    --dialog-box-shadow  : 0 5px 10px rgba(0,0,0,.8);
+    --dialog-border-color: var(--purple-800);
+    --dialog-box-shadow  : 0 5px 10px rgba(17, 20, 28, .85);
     --dialog-header-color: var(--sem-color-text-primary-default);
     --dialog-icon-color  : var(--sem-color-icon-primary-default);
 
     .neo-dialog {
+        .neo-footer-toolbar {
+            .neo-button {
+                border-radius: 5px;
+                height       : 1.7em;
+                margin-left  : 0.3em;
+            }
+        }
+
         .neo-header-toolbar {
             .neo-button {
                 background-color: transparent;

--- a/resources/scss/theme-neo-dark/form/Fieldset.scss
+++ b/resources/scss/theme-neo-dark/form/Fieldset.scss
@@ -1,6 +1,6 @@
 :root .neo-theme-neo-dark { // .neo-fieldset
-    --fieldset-background-color : var(--sem-color-surface-neutral-highlighted);
-    --fieldset-border           : 1px solid var(--sem-color-border-default);
+    --fieldset-background-color : var(--sem-color-surface-primary-background);
+    --fieldset-border           : 1px solid var(--purple-800);
     --fieldset-legend-color     : var(--sem-color-text-primary-default);
     --fieldset-legend-icon-color: var(--sem-color-icon-primary-default);
 }

--- a/resources/scss/theme-neo-light/dialog/Base.scss
+++ b/resources/scss/theme-neo-light/dialog/Base.scss
@@ -1,18 +1,13 @@
 :root .neo-theme-neo-light { // .neo-dialog
-    --dialog-border-color: #ddd;
-    --dialog-box-shadow  : 0 5px 10px rgba(0,0,0,.4);
-    --dialog-header-color: var(--purple-500);
-    --dialog-icon-color  : var(--purple-500);
+    --dialog-border-color                : #ddd;
+    --dialog-box-shadow                  : 0 5px 10px rgba(0,0,0,.4);
+    --dialog-footer-button-border-radius: 5px;
+    --dialog-footer-button-height       : 1.7em;
+    --dialog-footer-button-margin-left  : 0.3em;
+    --dialog-header-color                : var(--purple-500);
+    --dialog-icon-color                  : var(--purple-500);
 
     .neo-dialog {
-        .neo-footer-toolbar {
-            .neo-button {
-                border-radius: 5px;
-                height       : 1.7em;
-                margin-left  : 0.3em;
-            }
-        }
-
         .neo-header-toolbar {
             .neo-button {
                 background-color: transparent;

--- a/resources/scss/theme-neo-light/dialog/Base.scss
+++ b/resources/scss/theme-neo-light/dialog/Base.scss
@@ -5,6 +5,14 @@
     --dialog-icon-color  : var(--purple-500);
 
     .neo-dialog {
+        .neo-footer-toolbar {
+            .neo-button {
+                border-radius: 5px;
+                height       : 1.7em;
+                margin-left  : 0.3em;
+            }
+        }
+
         .neo-header-toolbar {
             .neo-button {
                 background-color: transparent;


### PR DESCRIPTION
Resolves #12565

Authored by GPT-5.5 (Codex Desktop, extra-high thought budget). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Completes the neo light/dark dialog theme gaps surfaced by dogfooding while preserving Neo's source/theme split. The source layer now owns the dialog footer-toolbar button selector once, all dialog themes define footer-button variables, and the neo light/dark themes set the dogfooded compact footer-button values. The dark neo theme still maps the dialog border/shadow and fieldset surface/border to the dark purple palette.

Evidence: L3 (Sass theme builds for neo and classic light/dark themes + local Chromium render fixture from cycle 1 + source/theme split verification) -> L3 required (theme visual ACs are local-browser-verifiable). Residual: CI/re-review pending on current head.

## Deltas from ticket

- Moved the footer-toolbar button selector from the neo theme files into `resources/scss/src/dialog/Base.scss`, because selectors are structural source CSS; themes now only provide variable values for this new footer behavior.
- Added default footer-button variables to `theme-light` and `theme-dark` so the globally available source selector preserves existing classic-theme defaults.
- Kept dark dialog border/shadow and dark fieldset values as neo-dark theme variables, preserving the ticket's narrow blast radius.
- Did not add a separate dark form-container theme file because `resources/scss/src/form/Container.scss` only owns spacing; the actionable dark surface gap maps to `.neo-fieldset`.

## Test Evidence

- `npm run build-themes -- -n -e dev -t theme-neo-light`
- `npm run build-themes -- -n -e dev -t theme-neo-dark`
- `npm run build-themes -- -n -e dev -t theme-light`
- `npm run build-themes -- -n -e dev -t theme-dark`
- `git diff --check`
- `git diff --cached --check`
- Staged theme selector sweep before commit: no added `.neo-*` selectors in theme dialog files.
- Playwright render fixture computed in cycle 1:
  - light footer button: `border-radius=5px`, `height=22.6562px`, `margin-left=4px`
  - dark footer button: `border-radius=5px`, `height=22.6562px`, `margin-left=4px`
  - dark dialog border: `rgb(29, 46, 98)` (`--purple-800`)
  - dark dialog shadow: `rgba(17, 20, 28, 0.85) 0px 5px 10px 0px`
  - dark fieldset background/border: `rgb(24, 36, 73)` / `rgb(29, 46, 98)`
- Local screenshot sanity check of light dialog, dark dialog, and dark fieldset fixture passed in cycle 1.
- Branch freshness: rebased onto `origin/dev` at `a18271676`; current head is `d2390d27a`.

## Post-Merge Validation

- [ ] Dogfooding app can drop its local `.neo-footer-toolbar .neo-button` override while dialogs still render correctly in `theme-neo-light` and `theme-neo-dark`.

## Commits

- `623f534e7` - `fix(theme): complete neo dialog and fieldset styling (#12565)`
- `d2390d27a` - `fix(theme): move dialog footer structure to src (#12565)`

## Evolution

Cycle 1 corrected the PR from a theme-selector implementation to the source/theme split required by @tobiu's review: structural selector in `resources/scss/src/dialog/Base.scss`; theme files only define the new footer-button variable values.
