### PR TITLE
feat(build): scope check-ticket-archaeology pre-commit to the staged diff (#12609)

### DIFF
--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -187,25 +187,37 @@ export function filterToAddedLines(hits, addedLines) {
 }
 
 /**
- * @summary Returns the staged added-line set for a file, or null when git cannot be consulted.
- *
- * Runs `git diff --cached --unified=0` for the path and parses it; an empty diff yields an empty set
- * (nothing added → nothing to flag), while a git error (e.g. no repo / no HEAD on the first commit)
- * returns null so the caller falls back to a full-file scan rather than passing blindly.
+ * @summary Default git-diff runner: argv-based `spawnSync` (never a shell string — staged filenames are
+ * untrusted hook input), comparing staged content against HEAD with zero context lines.
  * @param {String} file
  * @param {String} gitRoot
+ * @returns {Object} The `spawnSync` result (`{status, stdout, error}`).
+ */
+function defaultGitDiff(file, gitRoot) {
+    return spawnSync('git', ['diff', '--cached', '--unified=0', '--no-color', '--', file], {cwd: gitRoot, encoding: 'utf-8'})
+}
+
+/**
+ * @summary Returns the staged added-line set for a file, or null when git cannot be consulted.
+ *
+ * Parses the injected git-diff result: an empty diff yields an empty set (nothing added → nothing to
+ * flag), while a git failure (spawn error, non-zero status, or missing stdout — git absent / not a repo)
+ * returns null so the caller falls back to a full-file scan rather than passing blindly. The runner is
+ * argv-based (no shell string built from the staged filename) and injectable so the fallback branch is
+ * unit-testable without a live repo.
+ * @param {String} file
+ * @param {String} gitRoot
+ * @param {Function} [runGitDiff=defaultGitDiff] (file, gitRoot) → spawnSync-shaped result.
  * @returns {Set<Number>|null}
  */
-function stagedAddedLines(file, gitRoot) {
-    let diff;
+export function stagedAddedLines(file, gitRoot, runGitDiff = defaultGitDiff) {
+    const result = runGitDiff(file, gitRoot);
 
-    try {
-        diff = execSync(`git diff --cached --unified=0 --no-color -- "${file}"`, {cwd: gitRoot, encoding: 'utf-8'})
-    } catch (e) {
+    if (!result || result.error || result.status !== 0 || typeof result.stdout !== 'string') {
         return null
     }
 
-    return parseAddedLines(diff)
+    return parseAddedLines(result.stdout)
 }
 
 function main() {

--- a/buildScripts/util/check-ticket-archaeology.mjs
+++ b/buildScripts/util/check-ticket-archaeology.mjs
@@ -129,6 +129,85 @@ export function findTicketRefs(content) {
     return hits
 }
 
+/**
+ * @summary Extracts the set of new-side line numbers added by a `git diff --unified=0` patch.
+ *
+ * Walks each hunk header `@@ -old +new[,count] @@` and the following `+` lines so every added line maps to
+ * its line number in the post-image (new) file; `-` (removed) lines do not advance the new-side counter, and
+ * `--unified=0` emits no context lines. Lets the per-commit scan target only what a commit actually adds.
+ * @param {String} diffOutput Raw `git diff --cached --unified=0` text for a single file.
+ * @returns {Set<Number>} 1-based new-file line numbers that were added (empty when the diff adds nothing).
+ */
+export function parseAddedLines(diffOutput) {
+    const added = new Set();
+
+    let newLine = 0,
+        inHunk  = false;
+
+    for (const line of diffOutput.split('\n')) {
+        const header = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+
+        if (header) {
+            newLine = parseInt(header[1], 10);
+            inHunk  = true;
+            continue
+        }
+
+        if (!inHunk) {
+            continue
+        }
+
+        // `+` adds a new-side line (advance the counter); `+++` is the file header, not content.
+        if (line.startsWith('+') && !line.startsWith('+++')) {
+            added.add(newLine);
+            newLine++
+        }
+        // `-` removes an old-side line — absent from the new file, so the new-side counter holds.
+    }
+
+    return added
+}
+
+/**
+ * @summary Scopes archaeology hits to the lines a commit actually adds (per-commit / lint-staged mode).
+ *
+ * Full-file `findTicketRefs` preserves block-comment context; this then keeps only hits on staged-added
+ * lines so a clean diff is never blocked by pre-existing legacy refs in untouched regions. A null
+ * `addedLines` (git unavailable) returns every hit — the safe full-file fallback, never a blind pass.
+ * @param {Object[]} hits `[{line, text}]` from findTicketRefs.
+ * @param {Set<Number>|null} addedLines Staged added line numbers, or null to fall back to all hits.
+ * @returns {Object[]} The retained hits.
+ */
+export function filterToAddedLines(hits, addedLines) {
+    if (addedLines === null) {
+        return hits
+    }
+
+    return hits.filter(hit => addedLines.has(hit.line))
+}
+
+/**
+ * @summary Returns the staged added-line set for a file, or null when git cannot be consulted.
+ *
+ * Runs `git diff --cached --unified=0` for the path and parses it; an empty diff yields an empty set
+ * (nothing added → nothing to flag), while a git error (e.g. no repo / no HEAD on the first commit)
+ * returns null so the caller falls back to a full-file scan rather than passing blindly.
+ * @param {String} file
+ * @param {String} gitRoot
+ * @returns {Set<Number>|null}
+ */
+function stagedAddedLines(file, gitRoot) {
+    let diff;
+
+    try {
+        diff = execSync(`git diff --cached --unified=0 --no-color -- "${file}"`, {cwd: gitRoot, encoding: 'utf-8'})
+    } catch (e) {
+        return null
+    }
+
+    return parseAddedLines(diff)
+}
+
 function main() {
     let gitRoot;
     try {
@@ -173,9 +252,11 @@ function main() {
         return result.stdout.trim().split('\n').filter(Boolean);
     }
 
-    const files = argvFiles.length > 0
-        ? argvFiles.filter(f => f.endsWith('.mjs'))
-        : collectDefaultFiles();
+    // Per-commit mode: lint-staged passes explicit staged paths. Sweep mode: no args → scan --dirs whole.
+    const perCommit = argvFiles.length > 0,
+          files     = perCommit
+              ? argvFiles.filter(f => f.endsWith('.mjs'))
+              : collectDefaultFiles();
 
     if (files.length === 0) {
         console.log('check-ticket-archaeology: 0 .mjs files in scope, nothing to check.');
@@ -192,7 +273,13 @@ function main() {
             continue;
         }
 
-        findTicketRefs(content).forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
+        // Full scan preserves block-comment context; in per-commit mode, scope hits to the lines this
+        // commit adds so a clean diff is never blocked by pre-existing legacy refs it never touched. The
+        // no-args sweep keeps full-file scanning for deliberate cleanup runs.
+        const hits   = findTicketRefs(content),
+              scoped = perCommit ? filterToAddedLines(hits, stagedAddedLines(file, gitRoot)) : hits;
+
+        scoped.forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
     }
 
     if (violations.length > 0) {

--- a/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                    from '@playwright/test';
-import {extractComment, filterToAddedLines, findTicketRefs, parseAddedLines} from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
+import {extractComment, filterToAddedLines, findTicketRefs, parseAddedLines, stagedAddedLines} from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
 
 /**
  * Self-test for the ticket-archaeology guard: the mechanical replacement for the discipline-only
@@ -144,5 +144,18 @@ test.describe('check-ticket-archaeology diff-aware scoping (#12609)', () => {
 
         expect(hits.map(h => h.line)).toEqual([1, 3]);
         expect(filterToAddedLines(hits, added).map(h => h.line)).toEqual([3])
+    });
+
+    test('stagedAddedLines parses a successful diff, empties on no-change, and falls back to null on git failure', () => {
+        // Happy path: a spawnSync-shaped success result is parsed to the added-line set.
+        const ok = stagedAddedLines('x.mjs', '/repo', () => ({status: 0, stdout: '@@ -0,0 +1,2 @@\n+a\n+b'}));
+        expect([...ok]).toEqual([1, 2]);
+
+        // File staged with no changes → empty diff → empty set (nothing added), NOT a fallback.
+        expect(stagedAddedLines('x.mjs', '/repo', () => ({status: 0, stdout: ''})).size).toBe(0);
+
+        // Git-failure boundary → null, so the caller does the full-file fallback (never a blind pass).
+        expect(stagedAddedLines('x.mjs', '/repo', () => ({error: new Error('spawn ENOENT')}))).toBeNull(); // git absent
+        expect(stagedAddedLines('x.mjs', '/repo', () => ({status: 128, stdout: ''}))).toBeNull();          // not a repo / no HEAD
     });
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                    from '@playwright/test';
-import {extractComment, findTicketRefs}  from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
+import {extractComment, filterToAddedLines, findTicketRefs, parseAddedLines} from '../../../../../../buildScripts/util/check-ticket-archaeology.mjs';
 
 /**
  * Self-test for the ticket-archaeology guard: the mechanical replacement for the discipline-only
@@ -67,5 +67,82 @@ test.describe('check-ticket-archaeology guard', () => {
         const state = {inBlock: false};
         extractComment('/** opens */', state);
         expect(state.inBlock).toBe(false)
+    });
+});
+
+/**
+ * Diff-aware scoping: the per-commit (lint-staged) path scans only lines a commit ADDS, so a clean diff
+ * is never blocked by pre-existing legacy refs in untouched regions — while NEW refs in the staged diff
+ * still hard-block. The no-args sweep keeps full-file scanning (covered by the guard suite above).
+ */
+test.describe('check-ticket-archaeology diff-aware scoping (#12609)', () => {
+    test('parseAddedLines maps + lines to their new-file line numbers', () => {
+        const diff = [
+            'diff --git a/x.mjs b/x.mjs',
+            '--- a/x.mjs',
+            '+++ b/x.mjs',
+            '@@ -4,0 +5,2 @@',
+            '+// added line 5 — see #12345',
+            '+const y = 2;'
+        ].join('\n');
+
+        expect([...parseAddedLines(diff)]).toEqual([5, 6])
+    });
+
+    test('parseAddedLines counts only + lines; - lines do not advance the new-side counter', () => {
+        const diff = [
+            '@@ -5,2 +5,3 @@',
+            '-const old = 1;',
+            '-const gone = 2;',
+            '+const a = 1;',
+            '+const b = 2;',
+            '+const c = 3;'
+        ].join('\n');
+
+        expect([...parseAddedLines(diff)]).toEqual([5, 6, 7])
+    });
+
+    test('parseAddedLines returns an empty set for a pure deletion and for an empty diff', () => {
+        const deletion = ['@@ -5,2 +4,0 @@', '-const a = 1;', '-const b = 2;'].join('\n');
+
+        expect(parseAddedLines(deletion).size).toBe(0);
+        expect(parseAddedLines('').size).toBe(0)
+    });
+
+    test('parseAddedLines unions multiple hunks', () => {
+        const diff = [
+            '@@ -1,0 +2,1 @@',
+            '+const a = 1;',
+            '@@ -10,0 +12,2 @@',
+            '+const b = 2;',
+            '+const c = 3;'
+        ].join('\n');
+
+        expect([...parseAddedLines(diff)].sort((a, b) => a - b)).toEqual([2, 12, 13])
+    });
+
+    test('filterToAddedLines keeps only hits on added lines, empties on empty set, and falls back on null', () => {
+        const hits = [{line: 2, text: 'legacy'}, {line: 9, text: 'fresh'}];
+
+        // Only the newly-added line 9 is retained — line 2 is a pre-existing legacy ref.
+        expect(filterToAddedLines(hits, new Set([9]))).toEqual([{line: 9, text: 'fresh'}]);
+        // Empty added-set → nothing blocked.
+        expect(filterToAddedLines(hits, new Set())).toEqual([]);
+        // null (git unavailable) → safe full-file fallback, every hit returned.
+        expect(filterToAddedLines(hits, null)).toEqual(hits)
+    });
+
+    test('end-to-end: a legacy ref in an untouched region is not flagged; a newly-added ref is', () => {
+        const content = [
+            '// legacy ref from an old commit — see #11111',
+            'const stable = 1;',
+            '// freshly added this commit — see #22222'
+        ].join('\n');
+
+        const hits  = findTicketRefs(content), // full scan finds both comment refs
+              added = new Set([3]);            // only line 3 is in the staged diff
+
+        expect(hits.map(h => h.line)).toEqual([1, 3]);
+        expect(filterToAddedLines(hits, added).map(h => h.line)).toEqual([3])
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code, as @neo-opus-vega). Session a54e89a3-4259-4b41-9e26-561f665de744.

Resolves #12609

Makes the `check-ticket-archaeology` pre-commit hook **diff-aware** in its lint-staged (per-commit) path: it scans only the lines a commit actually **adds**, so a clean commit is never blocked by pre-existing legacy ticket-refs in untouched regions of a file it happens to touch. New refs in the staged diff still hard-block; the no-args sweep keeps full-file scanning.

This removes the **first-touch tax** that forced a documented `--no-verify` on #12608 (the `MailboxService.spec.mjs` carried 19 legacy refs, zero from that diff).

Evidence: L2 (focused unit coverage — hunk-parsing / filter / end-to-end — plus a real-file proof on `check-branch-discipline.mjs`) → L2 required (build-tooling logic, unit-verifiable). No residuals.

## How
- `parseAddedLines(diffOutput)` — pure: parses `git diff --unified=0` hunk headers (`@@ -old +new @@`) → Set of new-side added line numbers (`-` lines do not advance the counter; `--unified=0` has no context lines).
- `filterToAddedLines(hits, addedLines)` — pure: keeps `findTicketRefs` hits whose line is in the added set; `null` → returns all (the full-file fallback).
- `stagedAddedLines(file, gitRoot, runGitDiff?)` — runs git via **argv-based `spawnSync`** (no shell string built from the staged filename); empty diff → empty set (nothing added), git failure (spawn error / non-zero status) → `null` (full-file fallback, never a blind pass). The runner is injectable so the fallback boundary is unit-testable.
- `main()` — per-commit mode (`argvFiles` present) scopes hits to added lines; the no-args sweep (`collectDefaultFiles`) keeps full-file scanning. Full-file `findTicketRefs` is **always** run first so block-comment state stays correct; only the *reporting* is scoped.

## Contract Ledger (§5.4 — the hook's commit-gate behavior)
| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
|---|---|---|---|---|---|
| `check-ticket-archaeology` per-commit exit (args path) | #12609 / lint-staged `package.json` | Non-zero only when the **staged diff** adds a ref in comment context | empty diff → empty set; git error / no HEAD → full-file scan (never blind-pass) | hook JSDoc | spec: parse/filter/end-to-end + real-file proof |
| no-args sweep (`collectDefaultFiles`) | existing behavior | Unchanged — full-file scan | n/a | hook JSDoc | sweep flagged 4 refs in a sibling file during verification |

## Deltas from ticket
- Implemented the **recommended** option (diff-aware), not the ratchet alternative — the PR review is the venue to redirect to ratchet if preferred (per the #12609 `[lane-claim]`). The full-file sweep mode is preserved, so the boy-scout convergence capability is intact (just not forced per-commit).
- Block-comment context preserved by scanning the full file then filtering hits by added-line — avoids the false-negatives a naive "scan only the added lines" would hit on multi-line comments.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-ticket-archaeology.spec.mjs --workers=1` → **14/14** (7 existing + 7 new: `parseAddedLines` hunk-parsing incl. mixed add/remove, pure-deletion, empty, multi-hunk; `filterToAddedLines` incl. the `null` full-file fallback; `stagedAddedLines` git-failure → `null` boundary via an injected runner (@neo-gpt RA2); end-to-end legacy-excluded / new-included).
Real-file proof: staged an unrelated clean line into `check-branch-discipline.mjs` (4 pre-existing legacy refs) → per-commit diff-aware = **0 violations**; sweep (full-file) = **4** (still caught). `node --check` clean. This very commit (`d5be03ca8`) passed the pre-commit hook with **no `--no-verify`**.

## Post-Merge Validation
- [ ] Re-commit the #12608 `MailboxService.spec.mjs` change without `--no-verify` (regression anchor — should now pass).
- [ ] Confirm a NEW ticket-ref added in a comment in a future commit still hard-blocks (the core guarantee).

## Commits
- `d5be03ca8` — `feat(build)`: diff-aware lint-staged path (`parseAddedLines` + `filterToAddedLines` + `stagedAddedLines` + `main` wiring) + 6 spec tests.
- `c80e5a3b6` — `fix(build)`: argv-based `spawnSync` git runner (no shell-string footgun) + injectable runner so the git-failure fallback is unit-tested (@neo-gpt cycle-1 RA1 + RA2).

## Cross-family review
@neo-gpt (cross-family). **Cycle 1 (`c80e5a3b6`):** RA1 (command boundary) → argv-based `spawnSync` so staged filenames are never interpolated into a shell string; RA2 (fallback proof) → the `stagedAddedLines` git-failure → `null` boundary is now unit-tested via an injected runner (spawn-error + non-zero-status → `null`). The diff-aware vs ratchet design call remains open — flag if you prefer the ratchet shape. Re-review when CI greens.
