### PR TITLE
feat(pull-request): add cross-pr overlap preflight (#10164)

### DIFF
--- a/.agents/skills/pull-request/references/cross-pr-overlap-check.md
+++ b/.agents/skills/pull-request/references/cross-pr-overlap-check.md
@@ -1,0 +1,72 @@
+# Cross-PR Overlap Check
+
+## Trigger
+
+Load this payload before the final commit / PR-open when your branch touches skill or workflow documentation, Agent OS substrate, or another surface where overlapping open PRs can create review-time rebase churn. Re-run it before a force-push when the changed-file set expands.
+
+This check is author-side. It complements:
+
+- `peer-role` lane-claim collision checks, which run before claiming a write lane.
+- `pr-review` Cross-Skill Integration Audit, which runs after a PR already exists.
+
+## Required Check
+
+1. List the branch write surface:
+
+   ```bash
+   git diff --cached --name-only
+   ```
+
+   If you have not staged yet, use the working-tree diff plus untracked files:
+
+   ```bash
+   git diff --name-only
+   git ls-files --others --exclude-standard
+   ```
+
+   If the branch already contains commits and you are re-checking before PR-open or force-push, use the feature branch diff:
+
+   ```bash
+   git diff --name-only origin/dev...HEAD
+   ```
+
+2. List open PR write surfaces:
+
+   ```bash
+   gh pr list --state open --json number,title,files
+   ```
+
+3. Compare paths exactly. Treat an exact path match as a collision. Treat same-directory / same-section proximity as a warning when the touched surface is skill or workflow documentation.
+
+4. If a collision exists, inspect the overlapping PR before opening yours:
+
+   ```bash
+   gh pr view <number> --json number,title,state,mergeStateStatus,reviewDecision,files,url
+   ```
+
+## PR Body Contract
+
+If overlaps exist, add this section to the PR body:
+
+```markdown
+## Known Collisions
+- PR #N touches `<path>`; intended merge order: <order>; rebase plan: <plan>.
+```
+
+If no overlaps exist, do not add a noisy section. Record the check in `## Test Evidence` or `## Deltas from ticket`, for example:
+
+```markdown
+- Cross-PR overlap check: `gh pr list --state open --json number,title,files` found no open PR touching this branch's files.
+```
+
+## Anti-Pattern
+
+| Anti-pattern | Why it harms |
+|---|---|
+| Opening or force-pushing a collision-prone skill/workflow PR without checking open PR file surfaces | Pushes predictable rebase and section-order conflicts into the review loop, where CI and cross-family review have already been spent. |
+
+## Boundaries
+
+- This is not a semantic-conflict detector. If file overlap exposes a content disagreement, document it and route the judgment through review or peer-role.
+- This is not a CI or pre-commit hook. Mechanical enforcement requires a separate ticket.
+- This is not a general merge-conflict oracle for all code PRs. Use it where concurrent PRs touching the same substrate are expensive to unwind.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -12,6 +12,8 @@ The act of opening a PR is an irreversible state transition in the Agent OS. Bef
 - **Minor Gaps:** If your reflection uncovers minor misses (e.g., missed JSDoc, missing Anchor & Echo context, logical edge cases, missing unit tests validating new logic, or incorrect test file placement per `unit-test.md`), you MUST fix them and add rapid successive commits to your local branch to polish the execution *before* opening the PR.
 - **Major Refactors:** If you realize a mathematically superior architecture exists (e.g., massive GC optimization) that is *out-of-scope* for the current ticket, DO NOT attempt to scope-creep and cram it into the active branch. Secure the "good enough" execution, and instead formally propose a **Follow-Up System Enhancement Ticket** conceptually linked to the original.
 
+<!-- trigger: branch touches skill/workflow docs or another collision-prone substrate while other PRs are open -> read ./cross-pr-overlap-check.md before final commit / PR-open -->
+
 *If and only if* you pass this reflection phase, proceed to the Git execution sequence.
 
 ### 1.1 The Substrate-Mutation Pre-Flight Gate


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Resolves #10164

Adds an author-side Cross-PR overlap preflight to the pull-request skill without growing the hot workflow map: `pull-request-workflow.md` gets a one-line trigger, and the actual mechanics live in a conditional sibling payload.

Evidence: L1 (static skill-substrate diff + manifest lint + live open-PR file-surface check) -> L1 required (workflow-doc / skill-payload ACs). No residuals.

## Deltas from ticket (if any)

- Preserves Option A, but applies the current Progressive Disclosure discipline: the workflow map gets only a trigger pointer; command details, PR-body contract, and anti-pattern live in `cross-pr-overlap-check.md`.
- Backfilled the source-ticket Contract Ledger before opening this PR: https://github.com/neomjs/neo/issues/10164#issuecomment-4636994233
- Current open-PR overlap check found no open PR touching `.agents/skills/pull-request/**`, so no `## Known Collisions` section is needed.

## Test Evidence

- `npm run ai:lint-skill-manifest -- --base origin/dev` -> passed.
- `git diff --cached --check` -> passed before commit.
- Cross-PR overlap check: staged files were `.agents/skills/pull-request/references/cross-pr-overlap-check.md` and `.agents/skills/pull-request/references/pull-request-workflow.md`; `gh pr list --state open --json number,title,files` found no open PR touching either path.
- Pre-commit hook ran `node ./buildScripts/util/check-whitespace.mjs` on the staged files -> passed.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `f29d13af9 feat(pull-request): add cross-pr overlap preflight (#10164)`.

## Post-Merge Validation

- [ ] Next skill/workflow-doc PR loads `cross-pr-overlap-check.md` during `/pull-request` and either records no overlap or adds a `## Known Collisions` section with merge order + rebase plan.

## Slot Rationale / Turn-Memory Pre-Flight

- Modified map section: `pull-request-workflow.md §1` adds a one-line trigger only. Disposition: `compress-to-trigger`; trigger-frequency = PR authoring only, failure-severity = medium/high for parallel skill-substrate PRs, enforceability = discipline-only for now. This keeps always-loaded payload growth minimal.
- Added payload: `cross-pr-overlap-check.md` is conditional World-Atlas content. It carries the command sequence, output classification, PR-body contract, anti-pattern, and boundaries.
- Decay mitigation: if this check proves too noisy or a mechanical guard lands, the map trigger can be retired or rewritten to point at the mechanical guard.

## Commits

- `f29d13af9` - `feat(pull-request): add cross-pr overlap preflight (#10164)`
