### PR TITLE
feat(agent): record Golden Path outcomes (#9920)

### DIFF
--- a/ai/agent/AgentOrchestrator.mjs
+++ b/ai/agent/AgentOrchestrator.mjs
@@ -1,10 +1,26 @@
 import Base  from '../../src/core/Base.mjs';
 import Agent from '../Agent.mjs';
+import crypto from 'crypto';
 import fs    from 'fs';
 import path  from 'path';
 
+const OUTCOME_STATUSES = new Set(['completed', 'failed', 'blocked', 'expired', 'exhausted', 'crashed']),
+      REASON_CODES      = new Set([
+          'agent-uncaught-error',
+          'productive-failure-tripwire',
+          'turn-limit',
+          'context-limit',
+          'tool-failure',
+          'blocked-task-state',
+          'queue-exhausted',
+          'unknown'
+      ]),
+      RETRY_POLICIES    = new Set(['preserve-urgency', 'demote-next-cycle', 'blocked-handoff', 'no-retry']);
+
 /**
  * Parses sandman_handoff.md and injects the resulting directives into a headless agent loop.
+ * Golden Path scoring remains owned by graph synthesis; this runner only records
+ * terminal issue-task outcomes so later cycles can reason from durable evidence.
  * @class Neo.ai.agent.AgentOrchestrator
  * @extends Neo.core.Base
  */
@@ -23,7 +39,37 @@ class AgentOrchestrator extends Base {
          * Wait interval before checking if the scheduler is exhausted natively.
          * @member {Number} monitorIntervalMs=5000
          */
-        monitorIntervalMs: 5000
+        monitorIntervalMs: 5000,
+        /**
+         * Optional factory seam for tests or host runtimes that need a custom agent.
+         * @member {Function|null} agentFactory=null
+         */
+        agentFactory: null,
+        /**
+         * Optional HealthService-compatible projection sink.
+         * @member {Object|null} healthService=null
+         */
+        healthService: null,
+        /**
+         * Optional handoff/A2A emitter for crashed, blocked, expired, or repeated-failed outcomes.
+         * @member {Function|null} handoffEmitter=null
+         */
+        handoffEmitter: null,
+        /**
+         * Append-only Golden Path issue outcome file.
+         * @member {String} outcomePath=path.resolve(process.cwd(), '.neo-ai-data/agent-orchestrator/golden-path-outcomes.jsonl')
+         */
+        outcomePath: path.resolve(process.cwd(), '.neo-ai-data/agent-orchestrator/golden-path-outcomes.jsonl'),
+        /**
+         * Injectable exit hook. Defaults to process.exit for CLI runner compatibility.
+         * @member {Function} exitHandler=(code) => process.exit(code)
+         */
+        exitHandler: code => process.exit(code),
+        /**
+         * Injectable clock for deterministic outcome timestamps.
+         * @member {Function} now=() => new Date()
+         */
+        now: () => new Date()
     }
 
     /**
@@ -60,12 +106,259 @@ class AgentOrchestrator extends Base {
     }
 
     /**
+     * Creates the underlying autonomous agent. Kept as a seam so issue-outcome
+     * tests can drive execute() without booting real MCP servers.
+     * @returns {Neo.ai.Agent|Object}
+     */
+    createAgent() {
+        if (this.agentFactory) {
+            return this.agentFactory();
+        }
+
+        return Neo.create(Agent, {
+            maxSubAgentLifespan: 20,
+            servers            : ['knowledge-base', 'file-system', 'github-workflow']
+        });
+    }
+
+    /**
+     * @param {Error|*} error
+     * @returns {Object|null}
+     */
+    serializeError(error) {
+        if (!error) return null;
+
+        return {
+            message: error.message || String(error),
+            name   : error.name || 'Error',
+            stack  : error.stack || null
+        };
+    }
+
+    /**
+     * @param {String} status Golden Path outcome status.
+     * @returns {String} Coarse HealthService status.
+     */
+    getHealthStatus(status) {
+        return status === 'completed' || status === 'exhausted' ? 'completed' : 'failed';
+    }
+
+    /**
+     * @param {Object} outcome
+     * @returns {Boolean}
+     */
+    shouldEmitHandoff(outcome) {
+        return outcome.status === 'blocked' ||
+            outcome.status === 'expired' ||
+            outcome.status === 'crashed' ||
+            (outcome.status === 'failed' && outcome.reasonCode === 'productive-failure-tripwire');
+    }
+
+    /**
+     * @param {Object} agent Agent-like instance with a loop scheduler.
+     * @returns {Boolean}
+     */
+    hasPendingAgentTasks(agent) {
+        const scheduler = agent.loop?.scheduler;
+
+        if (!scheduler) {
+            return false;
+        }
+        if (typeof scheduler.isEmpty === 'function') {
+            return !scheduler.isEmpty();
+        }
+        if (Array.isArray(scheduler.queue)) {
+            return scheduler.queue.length > 0;
+        }
+
+        return Object.values(scheduler.queues || {}).some(queue => queue.length > 0);
+    }
+
+    /**
+     * @param {Object} agent Agent-like instance with a loop dead-letter queue.
+     * @param {Object} directive Golden Path directive.
+     * @returns {Object|null}
+     */
+    getFailedEventForDirective(agent, directive) {
+        const failedEvents = agent.loop?.failedEvents || [];
+
+        return failedEvents.find(entry => {
+            const data = entry.event?.data || {};
+            return entry.event?.type === 'system:golden-path' &&
+                String(data.issueId) === String(directive.issueId);
+        }) || null;
+    }
+
+    /**
+     * Emits an optional peer-visible handoff and returns its stable identifier.
+     * @param {Object} outcome
+     * @returns {Promise<String|null>}
+     */
+    async emitHandoff(outcome) {
+        if (!this.shouldEmitHandoff(outcome) || !this.handoffEmitter) {
+            return null;
+        }
+
+        try {
+            const result = await this.handoffEmitter(outcome);
+            return typeof result === 'string' ? result : result?.messageId || result?.id || null;
+        } catch (err) {
+            console.warn(`[AgentOrchestrator] Handoff emitter failed: ${err.message}`);
+            return null;
+        }
+    }
+
+    /**
+     * @param {Object} options
+     * @param {String} options.runId Stable execution run id.
+     * @param {Object} options.directive Golden Path directive.
+     * @param {String} options.startedAt ISO start time.
+     * @param {String} options.completedAt ISO completion time.
+     * @param {String} options.status Terminal issue-task status.
+     * @param {String} options.reasonCode Terminal reason code.
+     * @param {String} options.retryPolicy Conservative retry policy.
+     * @param {Error|*} [options.error=null]
+     * @returns {Object}
+     */
+    createOutcome({
+        runId,
+        directive,
+        startedAt,
+        completedAt,
+        status,
+        reasonCode,
+        retryPolicy,
+        error = null
+    }) {
+        if (!OUTCOME_STATUSES.has(status)) {
+            throw new TypeError(`AgentOrchestrator: unsupported outcome status '${status}'`);
+        }
+        if (!REASON_CODES.has(reasonCode)) {
+            throw new TypeError(`AgentOrchestrator: unsupported reason code '${reasonCode}'`);
+        }
+        if (!RETRY_POLICIES.has(retryPolicy)) {
+            throw new TypeError(`AgentOrchestrator: unsupported retry policy '${retryPolicy}'`);
+        }
+
+        return {
+            runId,
+            issueId         : directive.issueId,
+            description     : directive.description,
+            startedAt,
+            completedAt,
+            status,
+            reasonCode,
+            retryPolicy,
+            error           : this.serializeError(error),
+            handoffMessageId: null
+        };
+    }
+
+    /**
+     * @param {Object} outcome
+     */
+    appendOutcome(outcome) {
+        fs.mkdirSync(path.dirname(this.outcomePath), {recursive: true});
+        fs.appendFileSync(this.outcomePath, `${JSON.stringify(outcome)}\n`, 'utf-8');
+
+        try {
+            this.healthService?.recordTaskOutcome?.(
+                'agent-orchestrator',
+                this.getHealthStatus(outcome.status),
+                outcome
+            );
+        } catch (err) {
+            console.warn(`[AgentOrchestrator] Health projection failed: ${err.message}`);
+        }
+    }
+
+    /**
+     * Records one durable outcome per Golden Path directive.
+     * @param {Object} options
+     * @param {String} options.runId
+     * @param {Array<{issueId: String, description: String}>} options.directives
+     * @param {String} options.startedAt
+     * @param {String} options.status
+     * @param {String} options.reasonCode
+     * @param {String} options.retryPolicy
+     * @param {Error|*} [options.error=null]
+     * @returns {Promise<Object[]>}
+     */
+    async recordDirectiveOutcomes({
+        runId,
+        directives,
+        startedAt,
+        status,
+        reasonCode,
+        retryPolicy,
+        error = null
+    }) {
+        const completedAt = this.now().toISOString(),
+              outcomes    = [];
+
+        for (const directive of directives) {
+            const outcome = this.createOutcome({
+                runId,
+                directive,
+                startedAt,
+                completedAt,
+                status,
+                reasonCode,
+                retryPolicy,
+                error
+            });
+
+            outcome.handoffMessageId = await this.emitHandoff(outcome);
+            this.appendOutcome(outcome);
+            outcomes.push(outcome);
+        }
+
+        return outcomes;
+    }
+
+    /**
+     * Records completed or dead-lettered outcomes after the agent loop exhausts.
+     * @param {Object} options
+     * @param {String} options.runId
+     * @param {Array<{issueId: String, description: String}>} options.directives
+     * @param {String} options.startedAt
+     * @param {Object} options.agent Agent-like instance.
+     * @returns {Promise<Object[]>}
+     */
+    async recordExhaustedDirectiveOutcomes({
+        runId,
+        directives,
+        startedAt,
+        agent
+    }) {
+        const outcomes = [];
+
+        for (const directive of directives) {
+            const failedEvent = this.getFailedEventForDirective(agent, directive),
+                  recorded    = await this.recordDirectiveOutcomes({
+                      runId,
+                      directives : [directive],
+                      startedAt,
+                      status     : failedEvent ? 'failed' : 'completed',
+                      reasonCode : failedEvent ? 'productive-failure-tripwire' : 'queue-exhausted',
+                      retryPolicy: failedEvent ? 'demote-next-cycle' : 'no-retry',
+                      error      : failedEvent?.error || null
+                  });
+
+            outcomes.push(recorded[0]);
+        }
+
+        return outcomes;
+    }
+
+    /**
      * Executes the orchestration pipeline.
      * @param {Object} [options]
      * @param {Boolean} [options.dryRun=false] Logs directives without agent execution.
+     * @param {String} [options.runId] Stable execution run id.
      * @returns {Promise<void>}
      */
-    async execute({ dryRun = false } = {}) {
+    async execute({ dryRun = false, runId = `agent-orchestrator-${crypto.randomUUID()}` } = {}) {
         console.log('⏳ Initializing Neo AgentOrchestrator...');
 
         const directives = this.parseGoldenPath();
@@ -84,18 +377,17 @@ class AgentOrchestrator extends Base {
             return;
         }
 
+        const startedAt = this.now().toISOString();
+
         try {
             console.log(`   Found ${directives.length} prioritized tasks. Booting underlying agent instance...`);
 
-            const agent = Neo.create(Agent, {
-                maxSubAgentLifespan: 20,
-                servers: ['knowledge-base', 'file-system', 'github-workflow']
-            });
+            const agent = this.createAgent();
 
             await agent.initAsync();
-            
+
             console.log('   Injecting Golden Path Directives into Scheduler...');
-            
+
             for (const directive of directives) {
                 agent.schedule({
                     type    : 'system:golden-path',
@@ -110,21 +402,45 @@ class AgentOrchestrator extends Base {
 
             console.log('✅ Directives injected. Engaging Autonomous Loop.\n====================================');
             agent.start();
-            
+
             // Monitor loop exhaustion safely
-            const monitorInterval = setInterval(() => {
-                const hasPendingTasks = agent.loop.scheduler.queue.length > 0;
-                const hasActiveJobs   = agent.loop.processing; 
-                
-                if (!hasPendingTasks && !hasActiveJobs && Object.keys(agent.activeSubAgents).length === 0) {
-                     clearInterval(monitorInterval);
-                     console.log('\n====================================\n✅ Autonomous Loop Exhausted. Exiting cleanly.');
-                     agent.disconnect();
-                     process.exit(0); // Optional depending on daemon runner structure
-                }
-            }, this.monitorIntervalMs);
+            await new Promise((resolve, reject) => {
+                const monitorInterval = setInterval(async () => {
+                    const hasPendingTasks = this.hasPendingAgentTasks(agent),
+                          hasActiveJobs   = agent.loop.processing;
+
+                    if (!hasPendingTasks && !hasActiveJobs && Object.keys(agent.activeSubAgents).length === 0) {
+                        clearInterval(monitorInterval);
+
+                        try {
+                            await this.recordExhaustedDirectiveOutcomes({
+                                runId,
+                                directives,
+                                startedAt,
+                                agent
+                            });
+
+                            console.log('\n====================================\n✅ Autonomous Loop Exhausted. Exiting cleanly.');
+                            agent.disconnect();
+                            this.exitHandler(0);
+                            resolve();
+                        } catch (err) {
+                            reject(err);
+                        }
+                    }
+                }, this.monitorIntervalMs);
+            });
 
         } catch (err) {
+            await this.recordDirectiveOutcomes({
+                runId,
+                directives,
+                startedAt,
+                status     : 'crashed',
+                reasonCode : 'agent-uncaught-error',
+                retryPolicy: 'preserve-urgency',
+                error      : err
+            });
             console.error('❌ AgentOrchestrator failed:', err);
             throw err;
         }

--- a/ai/agent/AgentOrchestrator.mjs
+++ b/ai/agent/AgentOrchestrator.mjs
@@ -41,6 +41,12 @@ class AgentOrchestrator extends Base {
          */
         monitorIntervalMs: 5000,
         /**
+         * Maximum execution window before pending directives are recorded as expired.
+         * A value of `0` disables the timeout for current CLI compatibility.
+         * @member {Number} executionTimeoutMs=0
+         */
+        executionTimeoutMs: 0,
+        /**
          * Optional factory seam for tests or host runtimes that need a custom agent.
          * @member {Function|null} agentFactory=null
          */
@@ -190,6 +196,20 @@ class AgentOrchestrator extends Base {
     }
 
     /**
+     * @param {Object} failedEvent Loop dead-letter entry.
+     * @returns {String}
+     */
+    getFailedEventReasonCode(failedEvent) {
+        if (REASON_CODES.has(failedEvent?.reasonCode)) {
+            return failedEvent.reasonCode;
+        }
+
+        return String(failedEvent?.error || '').includes('blocked-task-state') ?
+            'blocked-task-state' :
+            'productive-failure-tripwire';
+    }
+
+    /**
      * Emits an optional peer-visible handoff and returns its stable identifier.
      * @param {Object} outcome
      * @returns {Promise<String|null>}
@@ -335,13 +355,15 @@ class AgentOrchestrator extends Base {
 
         for (const directive of directives) {
             const failedEvent = this.getFailedEventForDirective(agent, directive),
+                  reasonCode  = failedEvent ? this.getFailedEventReasonCode(failedEvent) : 'queue-exhausted',
+                  isBlocked   = reasonCode === 'blocked-task-state',
                   recorded    = await this.recordDirectiveOutcomes({
                       runId,
                       directives : [directive],
                       startedAt,
-                      status     : failedEvent ? 'failed' : 'completed',
-                      reasonCode : failedEvent ? 'productive-failure-tripwire' : 'queue-exhausted',
-                      retryPolicy: failedEvent ? 'demote-next-cycle' : 'no-retry',
+                      status     : failedEvent ? (isBlocked ? 'blocked' : 'failed') : 'completed',
+                      reasonCode,
+                      retryPolicy: failedEvent ? (isBlocked ? 'blocked-handoff' : 'demote-next-cycle') : 'no-retry',
                       error      : failedEvent?.error || null
                   });
 
@@ -405,14 +427,33 @@ class AgentOrchestrator extends Base {
 
             // Monitor loop exhaustion safely
             await new Promise((resolve, reject) => {
-                const monitorInterval = setInterval(async () => {
+                let finished = false,
+                    monitorInterval,
+                    timeoutTimer;
+
+                const finish = async callback => {
+                    if (finished) {
+                        return;
+                    }
+
+                    finished = true;
+                    clearInterval(monitorInterval);
+                    clearTimeout(timeoutTimer);
+
+                    try {
+                        await callback();
+                        resolve();
+                    } catch (err) {
+                        reject(err);
+                    }
+                };
+
+                monitorInterval = setInterval(async () => {
                     const hasPendingTasks = this.hasPendingAgentTasks(agent),
                           hasActiveJobs   = agent.loop.processing;
 
                     if (!hasPendingTasks && !hasActiveJobs && Object.keys(agent.activeSubAgents).length === 0) {
-                        clearInterval(monitorInterval);
-
-                        try {
+                        await finish(async () => {
                             await this.recordExhaustedDirectiveOutcomes({
                                 runId,
                                 directives,
@@ -423,12 +464,31 @@ class AgentOrchestrator extends Base {
                             console.log('\n====================================\n✅ Autonomous Loop Exhausted. Exiting cleanly.');
                             agent.disconnect();
                             this.exitHandler(0);
-                            resolve();
-                        } catch (err) {
-                            reject(err);
-                        }
+                        });
                     }
                 }, this.monitorIntervalMs);
+
+                if (this.executionTimeoutMs > 0) {
+                    timeoutTimer = setTimeout(async () => {
+                        await finish(async () => {
+                            const error = new Error(`AgentOrchestrator execution exceeded ${this.executionTimeoutMs}ms`);
+
+                            await this.recordDirectiveOutcomes({
+                                runId,
+                                directives,
+                                startedAt,
+                                status     : 'expired',
+                                reasonCode : 'turn-limit',
+                                retryPolicy: 'preserve-urgency',
+                                error
+                            });
+
+                            console.error(`❌ ${error.message}`);
+                            agent.disconnect();
+                            this.exitHandler(1);
+                        });
+                    }, this.executionTimeoutMs);
+                }
             });
 
         } catch (err) {

--- a/ai/agent/AgentOrchestrator.mjs
+++ b/ai/agent/AgentOrchestrator.mjs
@@ -9,6 +9,7 @@ const OUTCOME_STATUSES = new Set(['completed', 'failed', 'blocked', 'expired', '
           'agent-uncaught-error',
           'productive-failure-tripwire',
           'turn-limit',
+          'execution-timeout',
           'context-limit',
           'tool-failure',
           'blocked-task-state',
@@ -478,7 +479,7 @@ class AgentOrchestrator extends Base {
                                 directives,
                                 startedAt,
                                 status     : 'expired',
-                                reasonCode : 'turn-limit',
+                                reasonCode : 'execution-timeout',
                                 retryPolicy: 'preserve-urgency',
                                 error
                             });

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -5,6 +5,46 @@ import Neo               from '../../../../src/Neo.mjs';
 import * as core       from '../../../../src/core/_export.mjs';
 import AgentOrchestrator from '../../../../ai/agent/AgentOrchestrator.mjs';
 
+const createTestHandoff = (filename, content) => {
+          const filePath = path.resolve(process.cwd(), filename);
+          fs.writeFileSync(filePath, content, 'utf-8');
+          return filePath;
+      },
+      readJsonl = filePath => fs.readFileSync(filePath, 'utf-8')
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map(line => JSON.parse(line)),
+      createFakeAgent = ({failedEvents = [], initError = null, onSchedule = null} = {}) => {
+          const agent = {
+              activeSubAgents: {},
+              disconnected   : false,
+              loop           : {
+                  failedEvents,
+                  processing: false,
+                  scheduler : {
+                      isEmpty: () => true
+                  }
+              },
+              scheduled: [],
+              async initAsync() {
+                  if (initError) {
+                      throw initError;
+                  }
+              },
+              schedule(event) {
+                  this.scheduled.push(event);
+                  onSchedule?.(event);
+              },
+              start() {},
+              disconnect() {
+                  this.disconnected = true;
+              }
+          };
+
+          return agent;
+      };
+
 test.describe('Neo.ai.agent.AgentOrchestrator', () => {
     test('Golden Path regex correctly extracts issue IDs and descriptions', async () => {
         const content = `
@@ -23,8 +63,7 @@ Based on priorities, the following tasks are mathematically recommended:
 > Pivot memory synthesis.
 `;
 
-        const testHandoffPath = path.resolve(process.cwd(), '.neo-test-handoff.md');
-        fs.writeFileSync(testHandoffPath, content, 'utf-8');
+        const testHandoffPath = createTestHandoff('.neo-test-handoff.md', content);
 
         try {
             const orchestrator = Neo.create(AgentOrchestrator, {
@@ -59,8 +98,7 @@ Based on priorities, the following tasks are mathematically recommended:
    - *docs: restructure CodebaseOverview "Query Entry Points" to lead with ask_knowledge_base*
 `;
 
-        const testHandoffPath = path.resolve(process.cwd(), '.neo-test-handoff-silent.md');
-        fs.writeFileSync(testHandoffPath, content, 'utf-8');
+        const testHandoffPath = createTestHandoff('.neo-test-handoff-silent.md', content);
 
         try {
             const orchestrator = Neo.create(AgentOrchestrator, {
@@ -78,5 +116,274 @@ Based on priorities, the following tasks are mathematically recommended:
                 fs.unlinkSync(testHandoffPath);
             }
         }
+    });
+
+    test('execute records completed outcomes for exhausted Golden Path directives', async () => {
+        const content = `
+# Autonomous Handoff
+
+## Computed Golden Path (Strategic Recommendation)
+
+1. **issue-9900**: Score 3.25 (Semantic: 1.12, Structural: 1.00)
+   - *docs: restructure CodebaseOverview "Query Entry Points" to lead with ask_knowledge_base*
+2. **issue-9844**: Score 2.08 (Semantic: 1.04, Structural: 0.00)
+   - *feat: Implement Safe Commit Pipeline for Autonomous Agent Execution*
+`;
+
+        const testHandoffPath = createTestHandoff('.neo-test-handoff-outcomes.md', content),
+              outcomePath     = path.resolve(process.cwd(), '.neo-test-agent-orchestrator/completed.jsonl'),
+              fakeAgent       = createFakeAgent(),
+              healthCalls     = [],
+              exitCodes       = [],
+              times           = [
+                  '2026-06-06T08:00:00.000Z',
+                  '2026-06-06T08:00:03.000Z'
+              ];
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {
+                agentFactory     : () => fakeAgent,
+                exitHandler      : code => exitCodes.push(code),
+                handoffPath      : testHandoffPath,
+                healthService    : {
+                    recordTaskOutcome: (...args) => healthCalls.push(args)
+                },
+                monitorIntervalMs: 1,
+                now              : () => new Date(times.shift() || '2026-06-06T08:00:03.000Z'),
+                outcomePath
+            });
+
+            await orchestrator.execute({runId: 'run-completed'});
+
+            const outcomes = readJsonl(outcomePath);
+
+            test.expect(fakeAgent.scheduled).toHaveLength(2);
+            test.expect(fakeAgent.scheduled[0]).toMatchObject({
+                type    : 'system:golden-path',
+                priority: 'high',
+                data    : {
+                    issueId: '9900'
+                }
+            });
+            test.expect(fakeAgent.disconnected).toBe(true);
+            test.expect(exitCodes).toEqual([0]);
+            test.expect(outcomes).toHaveLength(2);
+            test.expect(outcomes[0]).toMatchObject({
+                runId           : 'run-completed',
+                issueId         : '9900',
+                startedAt       : '2026-06-06T08:00:00.000Z',
+                completedAt     : '2026-06-06T08:00:03.000Z',
+                status          : 'completed',
+                reasonCode      : 'queue-exhausted',
+                retryPolicy     : 'no-retry',
+                error           : null,
+                handoffMessageId: null
+            });
+            test.expect(outcomes[1].issueId).toBe('9844');
+            test.expect(healthCalls).toHaveLength(2);
+            test.expect(healthCalls[0][0]).toBe('agent-orchestrator');
+            test.expect(healthCalls[0][1]).toBe('completed');
+            test.expect(healthCalls[0][2]).toMatchObject({issueId: '9900'});
+        } finally {
+            if (fs.existsSync(testHandoffPath)) {
+                fs.unlinkSync(testHandoffPath);
+            }
+            fs.rmSync(path.dirname(outcomePath), {recursive: true, force: true});
+        }
+    });
+
+    test('execute records failed outcomes for Golden Path dead-letter events', async () => {
+        const content = `
+# Autonomous Handoff
+
+## Computed Golden Path (Strategic Recommendation)
+
+1. **issue-9900**: Score 3.25 (Semantic: 1.12, Structural: 1.00)
+   - *docs: restructure CodebaseOverview "Query Entry Points" to lead with ask_knowledge_base*
+`;
+
+        const testHandoffPath = createTestHandoff('.neo-test-handoff-failed.md', content),
+              outcomePath     = path.resolve(process.cwd(), '.neo-test-agent-orchestrator/failed.jsonl'),
+              handoffCalls    = [],
+              healthCalls     = [],
+              failedEvents    = [{
+                  error: 'tool failed after max retries',
+                  event: {
+                      type: 'system:golden-path',
+                      data: {
+                          issueId: '9900'
+                      }
+                  }
+              }];
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {
+                agentFactory     : () => createFakeAgent({failedEvents}),
+                exitHandler      : () => {},
+                handoffEmitter   : outcome => {
+                    handoffCalls.push(outcome);
+                    return 'MESSAGE:failed';
+                },
+                handoffPath      : testHandoffPath,
+                healthService    : {
+                    recordTaskOutcome: (...args) => healthCalls.push(args)
+                },
+                monitorIntervalMs: 1,
+                outcomePath
+            });
+
+            await orchestrator.execute({runId: 'run-failed'});
+
+            const outcomes = readJsonl(outcomePath);
+
+            test.expect(outcomes).toHaveLength(1);
+            test.expect(outcomes[0]).toMatchObject({
+                runId           : 'run-failed',
+                issueId         : '9900',
+                status          : 'failed',
+                reasonCode      : 'productive-failure-tripwire',
+                retryPolicy     : 'demote-next-cycle',
+                handoffMessageId: 'MESSAGE:failed'
+            });
+            test.expect(outcomes[0].error).toMatchObject({
+                message: 'tool failed after max retries',
+                name   : 'Error'
+            });
+            test.expect(handoffCalls).toHaveLength(1);
+            test.expect(healthCalls[0][1]).toBe('failed');
+        } finally {
+            if (fs.existsSync(testHandoffPath)) {
+                fs.unlinkSync(testHandoffPath);
+            }
+            fs.rmSync(path.dirname(outcomePath), {recursive: true, force: true});
+        }
+    });
+
+    test('execute records crashed outcome and handoff id when agent bootstrap fails', async () => {
+        const content = `
+# Autonomous Handoff
+
+## Computed Golden Path (Strategic Recommendation)
+
+1. **issue-9920**: Score 4.00 (Semantic: 1.00, Structural: 1.00)
+   - *Golden Path issue-task failure envelope and requeue policy*
+`;
+
+        const testHandoffPath = createTestHandoff('.neo-test-handoff-crashed.md', content),
+              outcomePath     = path.resolve(process.cwd(), '.neo-test-agent-orchestrator/crashed.jsonl'),
+              initError       = new Error('boot failed'),
+              handoffCalls    = [],
+              times           = [
+                  '2026-06-06T09:00:00.000Z',
+                  '2026-06-06T09:00:01.000Z'
+              ];
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {
+                agentFactory     : () => createFakeAgent({initError}),
+                handoffEmitter   : outcome => {
+                    handoffCalls.push(outcome);
+                    return {messageId: 'MESSAGE:crash'};
+                },
+                handoffPath      : testHandoffPath,
+                monitorIntervalMs: 1,
+                now              : () => new Date(times.shift() || '2026-06-06T09:00:01.000Z'),
+                outcomePath
+            });
+
+            await test.expect(orchestrator.execute({runId: 'run-crashed'})).rejects.toThrow('boot failed');
+
+            const outcomes = readJsonl(outcomePath);
+
+            test.expect(outcomes).toHaveLength(1);
+            test.expect(outcomes[0]).toMatchObject({
+                runId           : 'run-crashed',
+                issueId         : '9920',
+                startedAt       : '2026-06-06T09:00:00.000Z',
+                completedAt     : '2026-06-06T09:00:01.000Z',
+                status          : 'crashed',
+                reasonCode      : 'agent-uncaught-error',
+                retryPolicy     : 'preserve-urgency',
+                handoffMessageId: 'MESSAGE:crash'
+            });
+            test.expect(outcomes[0].error).toMatchObject({
+                message: 'boot failed',
+                name   : 'Error'
+            });
+            test.expect(handoffCalls).toHaveLength(1);
+            test.expect(handoffCalls[0]).toMatchObject({
+                issueId   : '9920',
+                status    : 'crashed',
+                reasonCode: 'agent-uncaught-error'
+            });
+        } finally {
+            if (fs.existsSync(testHandoffPath)) {
+                fs.unlinkSync(testHandoffPath);
+            }
+            fs.rmSync(path.dirname(outcomePath), {recursive: true, force: true});
+        }
+    });
+
+    test('health projection failures do not block JSONL outcome persistence', async () => {
+        const content = `
+# Autonomous Handoff
+
+## Computed Golden Path (Strategic Recommendation)
+
+1. **issue-9900**: Score 3.25 (Semantic: 1.12, Structural: 1.00)
+   - *docs: restructure CodebaseOverview "Query Entry Points" to lead with ask_knowledge_base*
+`;
+
+        const testHandoffPath = createTestHandoff('.neo-test-handoff-health-fallback.md', content),
+              outcomePath     = path.resolve(process.cwd(), '.neo-test-agent-orchestrator/health-fallback.jsonl'),
+              exitCodes       = [];
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {
+                agentFactory     : () => createFakeAgent(),
+                exitHandler      : code => exitCodes.push(code),
+                handoffPath      : testHandoffPath,
+                healthService    : {
+                    recordTaskOutcome: () => {
+                        throw new Error('health down');
+                    }
+                },
+                monitorIntervalMs: 1,
+                outcomePath
+            });
+
+            await orchestrator.execute({runId: 'run-health-fallback'});
+
+            const outcomes = readJsonl(outcomePath);
+
+            test.expect(outcomes).toHaveLength(1);
+            test.expect(outcomes[0]).toMatchObject({
+                runId : 'run-health-fallback',
+                status: 'completed'
+            });
+            test.expect(exitCodes).toEqual([0]);
+        } finally {
+            if (fs.existsSync(testHandoffPath)) {
+                fs.unlinkSync(testHandoffPath);
+            }
+            fs.rmSync(path.dirname(outcomePath), {recursive: true, force: true});
+        }
+    });
+
+    test('createOutcome rejects unsupported outcome vocabulary', async () => {
+        const orchestrator = Neo.create(AgentOrchestrator, {});
+
+        test.expect(() => orchestrator.createOutcome({
+            runId      : 'run-invalid',
+            directive  : {
+                issueId    : '1',
+                description: 'invalid vocabulary'
+            },
+            startedAt  : '2026-06-06T09:00:00.000Z',
+            completedAt: '2026-06-06T09:00:01.000Z',
+            status     : 'complete',
+            reasonCode : 'queue-exhausted',
+            retryPolicy: 'no-retry'
+        })).toThrow('unsupported outcome status');
     });
 });

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -15,7 +15,12 @@ const createTestHandoff = (filename, content) => {
           .split('\n')
           .filter(Boolean)
           .map(line => JSON.parse(line)),
-      createFakeAgent = ({failedEvents = [], initError = null, onSchedule = null} = {}) => {
+      createFakeAgent = ({
+          failedEvents = [],
+          initError = null,
+          onSchedule = null,
+          schedulerEmpty = true
+      } = {}) => {
           const agent = {
               activeSubAgents: {},
               disconnected   : false,
@@ -23,7 +28,7 @@ const createTestHandoff = (filename, content) => {
                   failedEvents,
                   processing: false,
                   scheduler : {
-                      isEmpty: () => true
+                      isEmpty: () => schedulerEmpty
                   }
               },
               scheduled: [],
@@ -251,6 +256,111 @@ Based on priorities, the following tasks are mathematically recommended:
             });
             test.expect(handoffCalls).toHaveLength(1);
             test.expect(healthCalls[0][1]).toBe('failed');
+        } finally {
+            if (fs.existsSync(testHandoffPath)) {
+                fs.unlinkSync(testHandoffPath);
+            }
+            fs.rmSync(path.dirname(outcomePath), {recursive: true, force: true});
+        }
+    });
+
+    test('execute records blocked outcomes for blocked-task-state dead-letter events', async () => {
+        const content = `
+# Autonomous Handoff
+
+## Computed Golden Path (Strategic Recommendation)
+
+1. **issue-9900**: Score 3.25 (Semantic: 1.12, Structural: 1.00)
+   - *docs: restructure CodebaseOverview "Query Entry Points" to lead with ask_knowledge_base*
+`;
+
+        const testHandoffPath = createTestHandoff('.neo-test-handoff-blocked.md', content),
+              outcomePath     = path.resolve(process.cwd(), '.neo-test-agent-orchestrator/blocked.jsonl'),
+              failedEvents    = [{
+                  error     : 'blocked-task-state: credentials required',
+                  event     : {
+                      type: 'system:golden-path',
+                      data: {
+                          issueId: '9900'
+                      }
+                  },
+                  reasonCode: 'blocked-task-state'
+              }];
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {
+                agentFactory     : () => createFakeAgent({failedEvents}),
+                exitHandler      : () => {},
+                handoffPath      : testHandoffPath,
+                monitorIntervalMs: 1,
+                outcomePath
+            });
+
+            await orchestrator.execute({runId: 'run-blocked'});
+
+            const outcomes = readJsonl(outcomePath);
+
+            test.expect(outcomes).toHaveLength(1);
+            test.expect(outcomes[0]).toMatchObject({
+                runId      : 'run-blocked',
+                issueId    : '9900',
+                status     : 'blocked',
+                reasonCode : 'blocked-task-state',
+                retryPolicy: 'blocked-handoff'
+            });
+        } finally {
+            if (fs.existsSync(testHandoffPath)) {
+                fs.unlinkSync(testHandoffPath);
+            }
+            fs.rmSync(path.dirname(outcomePath), {recursive: true, force: true});
+        }
+    });
+
+    test('execute records expired outcomes when execution timeout fires', async () => {
+        const content = `
+# Autonomous Handoff
+
+## Computed Golden Path (Strategic Recommendation)
+
+1. **issue-9900**: Score 3.25 (Semantic: 1.12, Structural: 1.00)
+   - *docs: restructure CodebaseOverview "Query Entry Points" to lead with ask_knowledge_base*
+`;
+
+        const testHandoffPath = createTestHandoff('.neo-test-handoff-expired.md', content),
+              outcomePath     = path.resolve(process.cwd(), '.neo-test-agent-orchestrator/expired.jsonl'),
+              exitCodes       = [],
+              handoffCalls    = [];
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {
+                agentFactory      : () => createFakeAgent({schedulerEmpty: false}),
+                executionTimeoutMs: 1,
+                exitHandler       : code => exitCodes.push(code),
+                handoffEmitter    : outcome => {
+                    handoffCalls.push(outcome);
+                    return 'MESSAGE:expired';
+                },
+                handoffPath       : testHandoffPath,
+                monitorIntervalMs : 50,
+                outcomePath
+            });
+
+            await orchestrator.execute({runId: 'run-expired'});
+
+            const outcomes = readJsonl(outcomePath);
+
+            test.expect(outcomes).toHaveLength(1);
+            test.expect(outcomes[0]).toMatchObject({
+                runId           : 'run-expired',
+                issueId         : '9900',
+                status          : 'expired',
+                reasonCode      : 'turn-limit',
+                retryPolicy     : 'preserve-urgency',
+                handoffMessageId: 'MESSAGE:expired'
+            });
+            test.expect(outcomes[0].error.message).toContain('execution exceeded 1ms');
+            test.expect(exitCodes).toEqual([1]);
+            test.expect(handoffCalls).toHaveLength(1);
         } finally {
             if (fs.existsSync(testHandoffPath)) {
                 fs.unlinkSync(testHandoffPath);

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -354,7 +354,7 @@ Based on priorities, the following tasks are mathematically recommended:
                 runId           : 'run-expired',
                 issueId         : '9900',
                 status          : 'expired',
-                reasonCode      : 'turn-limit',
+                reasonCode      : 'execution-timeout',
                 retryPolicy     : 'preserve-urgency',
                 handoffMessageId: 'MESSAGE:expired'
             });


### PR DESCRIPTION
Resolves #9920

Authored by GPT-5.5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

`AgentOrchestrator` now records a durable per-directive Golden Path outcome envelope instead of treating scheduler exhaustion as the only observable terminal state. The implementation writes append-only JSONL rows under the configured outcome path, projects the same rich details into `HealthService.recordTaskOutcome('agent-orchestrator', <coarse-status>, details)` when a health service is available, and exposes optional seams for agent creation, handoff emission, time, exit, health, and timeout behavior.

Evidence: L2 (unit-exercised orchestrator seams covering completed, failed, blocked, expired, crashed, health-fallback, handoff-id, and vocabulary validation) -> L2 required (local outcome persistence/projection contract). No residuals.

## Deltas from ticket

- Uses the real `Scheduler.isEmpty()` contract instead of the stale `.queue.length` assumption, with a queue fallback for agent-like test doubles.
- Keeps Golden Path scoring untouched; outcome recording lives only in `AgentOrchestrator`.
- Does not add a daemon task or MCP/healthcheck schema expansion. Health remains a projection sink; JSONL remains source of truth.
- Adds `executionTimeoutMs` as an opt-in timeout, defaulting to `0` to preserve current CLI compatibility.

## Test Evidence

- `node --check ai/agent/AgentOrchestrator.mjs`
- `npm run test-unit -- test/playwright/unit/ai/AgentOrchestrator.spec.mjs --workers=1` -> 9 passed
- `git diff --check`
- Pre-commit hook passed on both commits: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`

## Post-Merge Validation

- [ ] Run a real Golden Path cycle with a non-empty handoff and verify `.neo-ai-data/agent-orchestrator/golden-path-outcomes.jsonl` appends one row per directive.

## Commits

- `98b0d1a2f` — `feat(agent): record Golden Path outcomes (#9920)`
- `7bb7c5462` — `feat(agent): map Golden Path blocked and timeout outcomes (#9920)`

## Evolution

During implementation, source verification showed the live scheduler exposes `isEmpty()` / `queues`, not the stale `.queue.length` field the old monitor used. The branch corrects that runtime contract and expands the unit coverage accordingly.
