### PR TITLE
feat(agent): batch governance authoring gates (#10276)

### DIFF
--- a/.agents/skills/ideation-sandbox/audits/pre-authoring-adjacency-sweep.md
+++ b/.agents/skills/ideation-sandbox/audits/pre-authoring-adjacency-sweep.md
@@ -1,0 +1,34 @@
+# Pre-Authoring Adjacency Sweep
+
+Before drafting a Discussion body, architectural sketch, or multi-idea proposal,
+verify no equivalent ideation or ticket already owns the concept. This mirrors
+`ticket-create` Gate 0 for the ideation surface: re-deriving an existing Open
+Question or adjacent Epic is a substrate failure, not a fresh idea.
+
+## Sweep Order
+
+- **Live sweep:** check current open issues and, when available, open/recent
+  Discussions for the proposal's core nouns, existing Epic names, and likely
+  aliases.
+- **Semantic sweep:** use `ask_knowledge_base(query='<proposal concept>',
+  type='all')` when the Knowledge Base is available. Do not invent unsupported
+  filters; if KB is unavailable, record that and continue with live/local
+  evidence.
+- **Local exact sweep:** search `resources/content/discussions/` and
+  `resources/content/issues/` for exact keywords and issue/discussion anchors.
+- **Memory sweep:** use `query_raw_memories` when the concept plausibly appeared
+  in your own or team sessions; self-remembering is the failure mode this gate
+  exists to counter.
+
+## Exit Criteria
+
+If equivalent ideation exists, do not file a duplicate. Comment on the existing
+Discussion, extend its body via the `#10119` annotation pattern, or reshape the
+new proposal to the residual gap only.
+
+## Canonical Trap
+
+The 2026-04-24 Agent-Brain proposal duplicated substantial in-flight scope
+(#10030 Concept Ontology and #10137 Open Questions) despite the author having
+recently touched that territory. Gate 0 exists so that adjacency is checked
+before the sketch hardens.

--- a/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
+++ b/.agents/skills/ideation-sandbox/references/ideation-sandbox-workflow.md
@@ -7,6 +7,10 @@ When engaging in deep architectural design, brainstorming, or encountering "Unkn
 *For skill-authoring discipline including Progressive Disclosure (why SKILL.md is a lightweight router pointing here), see `.agents/skills/create-skill/`.*
 
 ## 2. Initial Proposal (Authoring)
+
+### 2.0 Pre-Authoring Adjacency Sweep (Gate 0)
+Before drafting a Discussion/proposal, run [`../audits/pre-authoring-adjacency-sweep.md`](../audits/pre-authoring-adjacency-sweep.md).
+
 1. **Never create an Issue for ideation.** If your intent is speculative or exploratory, abort Issue creation immediately.
 2. **Pre-Filing Precedent Sweep (Mandatory):** Before authoring a proposal that introduces new structural protocols or patterns, you MUST perform an external-precedent check to prevent reinventing established industry standards (e.g., as happened during the A2A Task Schema discovery).
    - **Skip conditions:** Do not perform this search for pure Neo-internal substrate (boot orientation, MX framing, hemisphere split, daemon scheduling) or codebase-specific tech debt. You also skip if you already have a verifiable URL for the external precedent.
@@ -15,7 +19,7 @@ When engaging in deep architectural design, brainstorming, or encountering "Unkn
    - **No Standard:** If no standard surfaces, document the search in your Author's Note ("I searched for [keywords] and found no canonical industry standard; proposing Neo-native design").
    - **Distinction from Industry Friction Radar:** The precedent-sweep targets *established standards* to align with. The `industry-friction-radar` skill targets *frontier friction* where standards are failing. They are complementary, opposite directions.
 3. **Use Discussions.** Call the `create_discussion` tool to post your proposal.
-4. **Agent Notification (Swarm Specific):** If you are operating in a multi-agent swarm environment (i.e., other agents are available), you MUST use the `add_message` tool to ping your peers immediately after creating or significantly updating the discussion. Ideation thrives on cross-family peer review. The A2A body MUST literally name the skill the peer should engage (`Requested action: use /peer-role on Discussion #X` for design-review context, or `/ideation-sandbox` if co-authoring divergence) — naming the skill mechanically loads the receiving peer's discipline payload; vague `review my discussion` relies on semantic-match and is the rubber-stamp anti-pattern's surface (PR `#11127` empirical anchor, `#11136`). (Skip this step if you are the only agent operating in the workspace).
+4. **Agent Notification (Swarm Specific):** In a multi-agent swarm, ping peers via `add_message` after creating or materially updating the Discussion. The A2A body MUST name the skill to engage (`/peer-role` for design review, `/ideation-sandbox` for co-authoring divergence); vague "review my discussion" relies on semantic-match and reopens the rubber-stamp anti-pattern (PR `#11127`, `#11136`). Skip if no peers are operating in the workspace.
 5. **Set the Category.** Map the discussion to the `Ideas` category.
 6. **Format the Proposal.** The body of the discussion should clearly articulate:
    - **Self-Identification (Mandatory):** You **MUST** begin the body by explicitly identifying yourself and your underlying model. (e.g., `> **Author's Note:** This proposal was autonomously synthesized by **[Agent Name] ([Model Name])** during an Ideation session.`)

--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -152,9 +152,10 @@ For every modified or added OpenAPI tool description:
 
 Expand these audits only when their trigger fires; otherwise omit them rather than rendering default N/A sections:
 
-- **🛂 Provenance Audit (§7.3):** PR introduces a major architectural abstraction or core subsystem.
+- **🛂 Provenance Audit:** PR introduces a major architectural abstraction or core subsystem.
 - **📜 Source-of-Authority Audit:** review cites operator or peer authority for a demand.
 - **🔌 Wire-Format Compatibility Audit:** PR alters JSON-RPC notification schemas, payload envelopes, native API wire formats, event payloads, tool signatures, or database schemas.
+- **🧠 Turn-Memory / Substrate-Load Audit:** PR modifies files in `/turn-memory-pre-flight` IN-SCOPE list. Verify the author documented the decision-tree application and load-effect audit in the PR body; if missing, use the Loading-Runtime-Effect Required Action template from the guide.
 
 ---
 
@@ -199,7 +200,7 @@ To proceed with merging, please address the following:
 
 No required actions — eligible for human merge.
 
-*Do NOT use pre-ticked placeholder items like `- [x] All checks pass and no required changes identified.` — that reads as box-checking, not genuine review. Per guide §5 Zero-Issue PR Semantics + §7.7 anti-patterns table.*
+*Do NOT use pre-ticked placeholder items like `- [x] All checks pass and no required changes identified.` — that reads as box-checking, not genuine review. Per the guide's Zero-Issue PR Semantics and anti-patterns table.*
 
 ---
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -16,13 +16,14 @@ The act of opening a PR is an irreversible state transition in the Agent OS. Bef
 
 ### 1.1 The Substrate-Mutation Pre-Flight Gate
 
-If your PR touches **any** of the following paths:
-- `AGENTS.md`
-- `AGENTS_ATLAS.md`
-- `.agents/skills/**`
-- `learn/agentos/**`
+If your PR touches memory substrate per `/turn-memory-pre-flight` (`AGENTS.md`,
+`learn/agentos/AGENTS_ATLAS.md`, `.agents/skills/**`, or directly loaded
+`learn/agentos/**`):
 
-You MUST include a **slot-rationale section** in your PR body. This satisfies the `AGENTS.md §13` mandate requiring explicit decay-mitigation rationale for all substrate mutations.
+Ordinary `learn/agentos/**` operator/reference docs that are not directly loaded
+can cite in-doc lifecycle rationale instead of duplicating PR-body slot-rationale.
+
+For in-scope memory substrate, you MUST include a **slot-rationale section** in your PR body. This satisfies the `AGENTS.md §13` mandate requiring explicit decay-mitigation rationale for all substrate mutations.
 Your PR body's slot-rationale section MUST enumerate:
 - For each *added* section: its disposition (`keep` / `move` / `compress-to-trigger` / `rewrite` / `retire`) + 3-axis rating (trigger-frequency × failure-severity × enforceability).
 - For each *modified* section: its disposition delta + the reason for the shift.

--- a/learn/agentos/AGENTS_ATLAS.md
+++ b/learn/agentos/AGENTS_ATLAS.md
@@ -61,7 +61,7 @@ If the user explicitly pivots the top-level focus of the session, you **MUST** a
 Classify the user's request:
 - **A) Conceptual/Informational:** Use knowledge base, no ticket required.
 - **B) Actionable/Modification:** Apply Ticket-First Gate.
-**Meta Gate:** Deduplication & Linking, Ticket Intake validation, Graph Linking (`update_issue_relationship`), and State Topologies drafting.
+**Meta Gate:** Deduplication & Linking (`ticket-create` Gate 0 and `ideation-sandbox` Gate 0), Ticket Intake validation, Graph Linking (`update_issue_relationship`), and State Topologies drafting.
 
 ## §pull_request_mandate [MACHINE-ENFORCEABLE-CANDIDATE]
 You are strictly FORBIDDEN from committing code or running `gh pr create` via raw bash commands. Formally open a PR using the `pull-request` skill. Cross-Review Response Cycle requires Triangular Evaluation.


### PR DESCRIPTION
Resolves #10276
Resolves #10794

Authored by GPT-5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

This PR batches two small governance-substrate fixes so the CI/review cost is worth the trip:

- Adds an `ideation-sandbox` Gate 0 adjacency sweep so Discussion/proposal authors check live issues, existing Discussions, local synced content, KB when available, and team memory before sketching a duplicate idea.
- Aligns `pull-request` substrate-mutation slot-rationale scope with `/turn-memory-pre-flight`, so ordinary `learn/agentos/**` operator/reference docs are not treated the same as turn-loaded or skill-loaded memory substrate.
- Surfaces the existing `pr-review-guide` Loading-Runtime-Effect audit in the visible review template without duplicating its rule body.

Evidence: L1 (static substrate + skill lint: `ai:lint-skill-manifest`, `ai:lint-agents`, `ai:check-substrate-size`, `git diff --check`) -> L1 required (skill/governance substrate text, no runtime code). No residuals.

## Source Ticket Contract Ledgers

- #10276 Contract Ledger: https://github.com/neomjs/neo/issues/10276#issuecomment-4637182089
- #10794 Contract Ledger: https://github.com/neomjs/neo/issues/10794#issuecomment-4637182226

## Deltas From Ticket

- #10276 requested a section in the ideation workflow. The implementation uses a one-line workflow trigger plus `audits/pre-authoring-adjacency-sweep.md` because the workflow file is already near its per-file payload budget. This matches Map vs World Atlas discipline and passed the manifest lint.
- #10276 referenced an `ask_knowledge_base(..., type='discussion')` shape. Current tool schema has no `discussion` type; the new audit uses `type='all'` when KB is available and explicitly forbids inventing unsupported filters.
- #10276 asked for an `AGENTS.md` cross-link. Current substrate has the relevant Meta Gate in `learn/agentos/AGENTS_ATLAS.md`, so the cross-link lands there instead of adding stale-shape root bytes.
- #10794 is partially stale on current `dev`: `/turn-memory-pre-flight` already defines the carve-out and `pr-review-guide.md` already has the Required Action template. This PR only aligns the author-side pull-request gate and adds a visible review-template hook.
- The `create-skill` guide still names a stale direct script path for skill-manifest lint. I verified and used the current package script, `npm run ai:lint-skill-manifest -- --base origin/dev`; guide cleanup is intentionally not bundled into this PR.

## `/turn-memory-pre-flight` Load-Effect Audit

Inputs read: `learn/agentos/decisions/0007-agents-md-compaction-taxonomy.md`, `learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md`, `.agents/skills/turn-memory-pre-flight/SKILL.md`, `.agents/skills/turn-memory-pre-flight/references/turn-memory-pre-flight-workflow.md`, and `.agents/skills/create-skill/references/skill-authoring-guide.md`.

Substrate placement:

- `ideation-sandbox-workflow.md`: added a one-line Map trigger. Disposition: `compress-to-trigger`; axis rating: medium trigger-frequency, medium/high failure-severity, discipline-only enforceability.
- `ideation-sandbox/audits/pre-authoring-adjacency-sweep.md`: new conditional World Atlas payload. Disposition: `keep` behind trigger; retirement condition: compress or retire if the next 3-5 Discussion authoring cycles show no adjacency misses and the workflow can rely on a lighter reminder.
- `pull-request-workflow.md`: rewrites existing substrate-mutation gate scope. Disposition: `rewrite`; axis rating: frequent PR-open gate, medium failure-severity from false-positive PR-body bloat, discipline-only enforceability.
- `pr-review-template.md`: adds one conditional-audit line and removes touched dangling numeric refs that the current section-ref lint rejects. Disposition: `compress-to-trigger`; rule body remains in `pr-review-guide.md`.
- `learn/agentos/AGENTS_ATLAS.md`: one-line Meta Gate cross-link. Disposition: `rewrite`; no root `AGENTS.md` bytes added.

Net load effect:

- `AGENTS.md` unchanged; `ai:check-substrate-size` remains green.
- Skill routers unchanged.
- `ideation-sandbox-workflow.md` remains under its 25KB per-file payload budget after compression.
- New detailed content loads only when the ideation Gate 0 trigger fires.

## Test Evidence

- `npm run ai:lint-skill-manifest -- --base origin/dev` -> OK
- `npm run ai:lint-agents` -> OK
- `npm run ai:check-substrate-size` -> OK
- `git diff --check` -> OK
- Pre-commit hooks passed on both commits.

## Post-Merge Validation

- Confirm the next ideation-sandbox authoring cycle that risks adjacency drift uses Gate 0 before creating a duplicate issue or Discussion.
- Confirm future substrate-mutation PR bodies apply `/turn-memory-pre-flight` slot rationale only for turn-loaded, skill-loaded, or directly loaded `learn/agentos/**` substrate.

## Commits

- `18930aa6d` — `feat(ideation): add adjacency sweep gate (#10276)`
- `e1496afb4` — `feat(review): align substrate gate enforcement (#10794)`
