### PR TITLE
fix(ai): guard SQLite graph schema resets (#10233)

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -1,6 +1,10 @@
 import Base from './Base.mjs';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE } from './constants.mjs';
 
+const GRAPH_SCHEMA_VERSION = 1;
+const GRAPH_SCHEMA_VERSION_ID = 'graph';
+const GRAPH_SCHEMA_WIPE_ENV = 'NEO_ALLOW_SCHEMA_WIPE';
+
 /**
  * Native Write-Ahead Logging (WAL) SQLite engine proxy driving memory graph persistence logic.
  * Bounded uniquely inside backend Node.js domains, this integration leverages dynamic imports natively,
@@ -60,24 +64,16 @@ class SQLite extends Base {
     }
 
     /**
+     * @summary Initializes or migrates the persisted graph schema without silently dropping graph data.
+     *
      * Evaluates current disk schemas, verifying universal JSON mapping configurations.
      * Injects strict Graph relational maps internally mitigating corrupted Edge cascade cascades cleanly.
      */
     initSchema() {
         if (!this.db) return;
         if (!this.db.open) throw new Error('SQLite connection is closed (lifecycle violation).');
-        let upgradeRequired = false;
 
-        try {
-            this.db.prepare('SELECT log_id FROM GraphLog LIMIT 1').get();
-        } catch (e) {
-            upgradeRequired = true;
-        }
-
-        if (upgradeRequired) {
-            this.db.exec('DROP TABLE IF EXISTS Edges');
-            this.db.exec('DROP TABLE IF EXISTS Nodes');
-        }
+        this.assertSupportedSchemaVersion();
 
         this.db.exec(`
             CREATE TABLE IF NOT EXISTS Nodes (
@@ -103,17 +99,7 @@ class SQLite extends Base {
             CREATE INDEX IF NOT EXISTS idx_edges_target ON Edges(target);
         `);
 
-        // Add user_id when migrating from older graph schemas.
-        try {
-            this.db.prepare('SELECT user_id FROM Nodes LIMIT 1').get();
-        } catch (e) {
-            try {
-                this.db.exec('ALTER TABLE Nodes ADD COLUMN user_id TEXT');
-                this.db.exec('ALTER TABLE Edges ADD COLUMN user_id TEXT');
-            } catch (alterErr) {
-                console.error('--- Migration failed ---', alterErr);
-            }
-        }
+        this.migrateLegacyGraphColumns();
 
         // The Delta Log Hardware Mechanism mimicking Global Broadcast matrices securely natively without network payloads cleanly!
         this.db.exec(`
@@ -144,6 +130,155 @@ class SQLite extends Base {
                 retry_count INTEGER DEFAULT 0
             );
         `);
+
+        this.stampSchemaVersion();
+    }
+
+    /**
+     * @summary Refuses unsupported persisted schemas unless the operator explicitly opts into a destructive reset.
+     * @protected
+     */
+    assertSupportedSchemaVersion() {
+        const schemaVersion = this.readGraphSchemaVersion();
+
+        if (schemaVersion === null || schemaVersion === GRAPH_SCHEMA_VERSION) {
+            return;
+        }
+
+        this.resetGraphSchemaOrThrow(
+            `Unsupported SQLite graph schema version ${schemaVersion}; expected ${GRAPH_SCHEMA_VERSION}.`
+        );
+    }
+
+    /**
+     * @summary Reads the current graph schema version row, treating absent version metadata as legacy v1-compatible.
+     * @returns {Number|null}
+     * @protected
+     */
+    readGraphSchemaVersion() {
+        if (!this.hasTable('SchemaVersion')) {
+            return null;
+        }
+
+        let row;
+
+        try {
+            row = this.db.prepare('SELECT version FROM SchemaVersion WHERE id = ? LIMIT 1').get(GRAPH_SCHEMA_VERSION_ID);
+        } catch (e) {
+            this.resetGraphSchemaOrThrow(`Unreadable SQLite graph SchemaVersion table: ${e.message}`);
+            return null;
+        }
+
+        if (!row) {
+            return null;
+        }
+
+        const version = Number(row.version);
+
+        if (!Number.isInteger(version) || version < 1) {
+            this.resetGraphSchemaOrThrow(`Invalid SQLite graph schema version value: ${String(row.version)}.`);
+            return null;
+        }
+
+        return version;
+    }
+
+    /**
+     * @summary Adds backward-compatible columns to legacy graph tables without deleting existing rows.
+     * @protected
+     */
+    migrateLegacyGraphColumns() {
+        if (!this.hasColumn('Nodes', 'user_id')) {
+            this.db.exec('ALTER TABLE Nodes ADD COLUMN user_id TEXT');
+        }
+
+        if (!this.hasColumn('Edges', 'user_id')) {
+            this.db.exec('ALTER TABLE Edges ADD COLUMN user_id TEXT');
+        }
+    }
+
+    /**
+     * @summary Writes the current graph schema version row after successful schema creation/migration.
+     * @protected
+     */
+    stampSchemaVersion() {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS SchemaVersion (
+                id TEXT PRIMARY KEY,
+                version INTEGER NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+        `);
+
+        this.db.prepare(`
+            INSERT INTO SchemaVersion (id, version, updated_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(id) DO UPDATE SET
+                version = excluded.version,
+                updated_at = excluded.updated_at
+        `).run(GRAPH_SCHEMA_VERSION_ID, GRAPH_SCHEMA_VERSION);
+    }
+
+    /**
+     * @summary Resets graph schema tables only under the explicit schema-wipe environment gate.
+     * @param {String} reason Operator-facing reset reason.
+     * @protected
+     */
+    resetGraphSchemaOrThrow(reason) {
+        if (process.env[GRAPH_SCHEMA_WIPE_ENV] !== 'true') {
+            throw new Error(
+                `${reason} Refusing destructive graph schema reset for ${this.dbPath || ':memory:'}. ` +
+                `Set ${GRAPH_SCHEMA_WIPE_ENV}=true only for deliberate maintenance.`
+            );
+        }
+
+        console.warn(
+            `[SQLite] ${GRAPH_SCHEMA_WIPE_ENV}=true; resetting graph schema at ` +
+            `${this.dbPath || ':memory:'}. Reason: ${reason}`
+        );
+
+        this.db.exec(`
+            DROP TRIGGER IF EXISTS node_insert;
+            DROP TRIGGER IF EXISTS node_update;
+            DROP TRIGGER IF EXISTS node_delete;
+            DROP TRIGGER IF EXISTS edge_insert;
+            DROP TRIGGER IF EXISTS edge_update;
+            DROP TRIGGER IF EXISTS edge_delete;
+            DROP TABLE IF EXISTS SummarizationJobs;
+            DROP TABLE IF EXISTS GraphLog;
+            DROP TABLE IF EXISTS Edges;
+            DROP TABLE IF EXISTS Nodes;
+            DROP TABLE IF EXISTS SchemaVersion;
+        `);
+    }
+
+    /**
+     * @summary Checks whether a persisted SQLite table exists.
+     * @param {String} tableName
+     * @returns {Boolean}
+     * @protected
+     */
+    hasTable(tableName) {
+        return Boolean(this.db.prepare(`
+            SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name = ?
+            LIMIT 1
+        `).get(tableName));
+    }
+
+    /**
+     * @summary Checks whether a persisted SQLite table contains a column.
+     * @param {String} tableName
+     * @param {String} columnName
+     * @returns {Boolean}
+     * @protected
+     */
+    hasColumn(tableName, columnName) {
+        if (!this.hasTable(tableName)) {
+            return false;
+        }
+
+        return this.db.prepare(`PRAGMA table_info(${tableName})`).all().some(column => column.name === columnName);
     }
 
     /**

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -18,6 +18,7 @@ import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
 import Database       from '../../../../../ai/graph/Database.mjs';
 import SQLite         from '../../../../../ai/graph/storage/SQLite.mjs';
+import BetterSqlite   from 'better-sqlite3';
 import fs             from 'fs-extra';
 import path           from 'path';
 
@@ -39,6 +40,55 @@ test.describe('Neo.ai.graph.Database', () => {
             id: 'my-graph-db-' + testRun
         });
     });
+
+    function seedLegacyGraphFile({schemaVersion} = {}) {
+        const legacyDb = new BetterSqlite(dbPath);
+
+        try {
+            legacyDb.exec(`
+                CREATE TABLE Nodes (
+                    id TEXT PRIMARY KEY,
+                    data TEXT NOT NULL
+                );
+                CREATE TABLE Edges (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    target TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    data TEXT NOT NULL
+                );
+            `);
+
+            legacyDb.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(
+                'legacy-source',
+                JSON.stringify({id: 'legacy-source', label: 'Legacy', properties: {name: 'Source'}})
+            );
+            legacyDb.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(
+                'legacy-target',
+                JSON.stringify({id: 'legacy-target', label: 'Legacy', properties: {name: 'Target'}})
+            );
+            legacyDb.prepare('INSERT INTO Edges (id, source, target, type, data) VALUES (?, ?, ?, ?, ?)').run(
+                'legacy-edge',
+                'legacy-source',
+                'legacy-target',
+                'LEGACY',
+                JSON.stringify({id: 'legacy-edge', source: 'legacy-source', target: 'legacy-target', type: 'LEGACY'})
+            );
+
+            if (schemaVersion !== undefined) {
+                legacyDb.exec(`
+                    CREATE TABLE SchemaVersion (
+                        id TEXT PRIMARY KEY,
+                        version INTEGER NOT NULL,
+                        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                    );
+                `);
+                legacyDb.prepare('INSERT INTO SchemaVersion (id, version) VALUES (?, ?)').run('graph', schemaVersion);
+            }
+        } finally {
+            legacyDb.close();
+        }
+    }
 
     test.afterEach(() => {
         db?.destroy();
@@ -158,6 +208,79 @@ test.describe('Neo.ai.graph.Database', () => {
             expect(() => storage.addNodes([{ id: null, label: 'Broken', properties: {} }])).toThrow(/non-empty string id/);
             expect(() => storage.addNodes([{ label: 'Broken', properties: {} }])).toThrow(/non-empty string id/);
         } finally {
+            storage.destroy();
+        }
+    });
+
+    test('SQLite initSchema preserves legacy graph rows when GraphLog is missing (#10233)', async () => {
+        seedLegacyGraphFile();
+
+        let storage = Neo.create(SQLite, { dbPath });
+        await storage.initAsync();
+
+        try {
+            expect(storage.db.prepare('SELECT COUNT(*) as c FROM Nodes').get().c).toBe(2);
+            expect(storage.db.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(1);
+            expect(storage.db.prepare('SELECT version FROM SchemaVersion WHERE id = ?').get('graph').version).toBe(1);
+            expect(storage.db.prepare('PRAGMA table_info(Nodes)').all().map(column => column.name)).toContain('user_id');
+            expect(storage.db.prepare('PRAGMA table_info(Edges)').all().map(column => column.name)).toContain('user_id');
+            expect(storage.db.prepare('SELECT COUNT(*) as c FROM GraphLog').get().c).toBe(0);
+        } finally {
+            if (storage.db?.open) storage.db.close();
+            storage.destroy();
+        }
+    });
+
+    test('SQLite initSchema refuses unsupported graph schema versions without wipe opt-in (#10233)', async () => {
+        seedLegacyGraphFile({schemaVersion: 999});
+
+        let storage = Neo.create(SQLite, { dbPath });
+
+        try {
+            await expect(storage.initAsync()).rejects.toThrow(/Unsupported SQLite graph schema version 999/);
+        } finally {
+            if (storage.db?.open) storage.db.close();
+            storage.destroy();
+        }
+
+        const verifyDb = new BetterSqlite(dbPath);
+
+        try {
+            expect(verifyDb.prepare('SELECT COUNT(*) as c FROM Nodes').get().c).toBe(2);
+            expect(verifyDb.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(1);
+            expect(verifyDb.prepare('SELECT version FROM SchemaVersion WHERE id = ?').get('graph').version).toBe(999);
+        } finally {
+            verifyDb.close();
+        }
+    });
+
+    test('SQLite initSchema resets unsupported graph schema only with explicit wipe opt-in (#10233)', async () => {
+        seedLegacyGraphFile({schemaVersion: 999});
+
+        const previousWipeOptIn = process.env.NEO_ALLOW_SCHEMA_WIPE;
+        const originalWarn      = console.warn;
+        const warnings          = [];
+        let storage             = Neo.create(SQLite, { dbPath });
+
+        try {
+            process.env.NEO_ALLOW_SCHEMA_WIPE = 'true';
+            console.warn = message => warnings.push(String(message));
+
+            await storage.initAsync();
+
+            expect(storage.db.prepare('SELECT COUNT(*) as c FROM Nodes').get().c).toBe(0);
+            expect(storage.db.prepare('SELECT COUNT(*) as c FROM Edges').get().c).toBe(0);
+            expect(storage.db.prepare('SELECT version FROM SchemaVersion WHERE id = ?').get('graph').version).toBe(1);
+            expect(warnings.join('\n')).toContain('NEO_ALLOW_SCHEMA_WIPE=true');
+            expect(warnings.join('\n')).toContain('Unsupported SQLite graph schema version 999');
+        } finally {
+            console.warn = originalWarn;
+            if (previousWipeOptIn === undefined) {
+                delete process.env.NEO_ALLOW_SCHEMA_WIPE;
+            } else {
+                process.env.NEO_ALLOW_SCHEMA_WIPE = previousWipeOptIn;
+            }
+            if (storage.db?.open) storage.db.close();
             storage.destroy();
         }
     });


### PR DESCRIPTION
Resolves #10233

Authored by GPT-5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Replaces `SQLite.initSchema()`'s catch-all `GraphLog` probe -> drop `Edges`/`Nodes` fallback with an explicit graph schema-version guard. Compatible legacy graph files that are missing `GraphLog` now keep their persisted rows, get the `user_id` column migration, create `GraphLog`/triggers, and stamp `SchemaVersion(graph)=1`. Unsupported or malformed schema-version states refuse to reset unless the operator explicitly sets `NEO_ALLOW_SCHEMA_WIPE=true`, and that opt-in emits a warning before dropping graph tables.

Evidence: L2 (focused Playwright unit regression coverage for preserve/refuse/opt-in reset plus existing SQLite graph tests) -> L2 required (schema behavior is unit-observable). No residuals.

Related: #12435

## Deltas from ticket

- Added `SchemaVersion` as the graph schema marker table with row id `graph`.
- Preserved v1-compatible unversioned legacy databases instead of treating missing `GraphLog` as a destructive upgrade trigger.
- Shaped the reset path as reusable `SQLite.mjs` guard helpers so the adjacent `#12435` test-runner/prod-graph guard can align to the same idiom without taking that lane here.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/graph/Database.spec.mjs` -> 21 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; branch history contains only `ce46fd063 fix(ai): guard SQLite graph schema resets (#10233)`.

## Post-Merge Validation

- [ ] Confirm CI unit shard including `test/playwright/unit/ai/graph/Database.spec.mjs` remains green on GitHub-hosted runners.

## Commits

- `ce46fd063` — `fix(ai): guard SQLite graph schema resets (#10233)`
