### PR TITLE
feat(agents): auto-persist turn memories via Claude Code Stop hook (#10063)

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -44,6 +44,7 @@ extended-thinking over plain narration:
 | `amountToolCalls` | Total `tool_use` block count. |
 | `sessionId` | From the hook stdin `session_id` (groups the turn under the session). |
 | `model` | The assistant entry's `message.model` (optional). |
+| `agent` | The harness-owner identity from `NEO_AGENT_IDENTITY`, canonicalized by `MemoryService` into a trusted `agentIdentity`. **Required for trusted provenance** — without it, hook-written memories fall to `unclassified` trust (see Provenance below). |
 
 **Why Option B over the alternatives:** **A** loses extended-thinking blocks (the richest reasoning
 signal — verified present in real transcripts). **C** uses an empty `thought`, which would require a
@@ -61,6 +62,10 @@ spans **many** assistant entries (`text`/`thinking` → `tool_use` → `tool_res
 2. reverse-scans for the real turn-start — the last `user` entry that is an actual prompt, **not** a
    `tool_result` continuation;
 3. folds every assistant entry from there to EOF into the mapping above.
+
+### Provenance — set `NEO_AGENT_IDENTITY`
+
+The hook runs standalone and bypasses MCP, so there is no `RequestContextService` to derive the author from. It reads the harness-owner identity from the `NEO_AGENT_IDENTITY` env var (the same source `Orchestrator.swarmHeartbeatIdentity` / `KbAlertingService` use) and passes it as `addMemory`'s `agent`, which `MemoryService` canonicalizes into `metadata.agentIdentity` and resolves to a trust tier. **Set `NEO_AGENT_IDENTITY` (e.g. `@neo-opus-vega`) in the harness environment** so hook-written memories carry trusted author provenance. If unset, persistence still works but the memories are `unclassified` — queryable by session, not by trusted author identity.
 
 ### Wiring
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,118 @@
+# Claude Code Hooks
+
+Harness-level automation for the Neo Agent OS, wired through Claude Code's
+[hook system](https://code.claude.com/docs/en/hooks.md).
+
+## `persist-memory.mjs` — auto-persist turn memories (#10063)
+
+### Why
+
+`AGENTS.md §memory_core_protocol` mandates an `add_memory` call at the end of **every** turn. Under
+cognitive load this is forgotten — empirically, session `f018be49-…` ran ~25 turns with **zero** manual
+saves, breaking every downstream `query_raw_memories(sessionId)` self-detection (e.g. `pr-review`'s
+own-session check returned 0 matches and needed manual override).
+
+"Always do X at end of turn" is a **harness** responsibility, not an agent-discipline one. Claude Code's
+`Stop` hook fires after each turn — wiring it to the Memory Core makes per-turn persistence deterministic
+and removes the human/agent from the loop.
+
+### How it works
+
+```
+turn ends → Claude Code runs the Stop hook → pipes {session_id, transcript_path, …} on stdin
+          → persist-memory.mjs tails the transcript JSONL, extracts the last turn
+          → imports ai/services.mjs (direct SDK — no MCP subprocess, no HTTP)
+          → await Memory_LifecycleService.ready(); Memory_Service.addMemory({…})
+```
+
+**Fail-soft by contract:** every error path (chroma down, malformed transcript, services cold-start
+failure) logs to `stderr` and `exit(0)`. A persistence failure must never block the user's next turn.
+Wired `async: true` so the ~500 ms–1 s `services.mjs` cold-start stays off the interactive path.
+
+### Transcript → `add_memory` mapping (Option B)
+
+Claude Code has no discrete "thought" field, so the turn is projected onto `add_memory`'s
+`{prompt, thought, response}` triad. **Option B** (resolved at #10063 ticket-intake) prefers
+extended-thinking over plain narration:
+
+| `add_memory` field | Source |
+| --- | --- |
+| `prompt` | The last **real** user prompt (string content, or joined `text` blocks). |
+| `thought` | Concatenated `thinking` blocks across the turn; **fallback** → pre-response narration text; **final fallback** → an explicit placeholder (the field is schema-required). |
+| `response` | The final user-facing `text` block of the turn. |
+| `toolsUsed` | Deduped `tool_use` block names (names only — never arguments/payloads). |
+| `amountToolCalls` | Total `tool_use` block count. |
+| `sessionId` | From the hook stdin `session_id` (groups the turn under the session). |
+| `model` | The assistant entry's `message.model` (optional). |
+
+**Why Option B over the alternatives:** **A** loses extended-thinking blocks (the richest reasoning
+signal — verified present in real transcripts). **C** uses an empty `thought`, which would require a
+memory-core schema change (`thought` is required) — strictly more coupling for less signal.
+
+### The real transcript is messier than "tail = last turn"
+
+A naive parser that reads the final JSONL entry fails. Real Claude Code transcripts interleave **8+
+entry types** — `user`, `assistant`, plus `queue-operation`, `last-prompt`, `ai-title`, `pr-link`,
+`attachment`, `system` bookkeeping that routinely **trails** the final assistant text. And a single turn
+spans **many** assistant entries (`text`/`thinking` → `tool_use` → `tool_result` (a `user`-role entry!)
+→ assistant continues → … → final text). `parseLastTurn` therefore:
+
+1. filters to `user`/`assistant` entries, dropping `isSidechain` (sub-agent) entries;
+2. reverse-scans for the real turn-start — the last `user` entry that is an actual prompt, **not** a
+   `tool_result` continuation;
+3. folds every assistant entry from there to EOF into the mapping above.
+
+### Wiring
+
+Add this to your Claude Code settings (see the gitignore note below for *which* file):
+
+```json
+{
+  "hooks": {
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/persist-memory.mjs",
+        "async": true,
+        "timeout": 30
+      }]
+    }]
+  }
+}
+```
+
+#### ⚠️ Opt-in today — `.claude/settings.json` is gitignored
+
+The #10063 ticket's plan was to commit this hook into a **project-tracked** `.claude/settings.json` so
+every contributor gets it without opt-in. **That file is gitignored** (`.gitignore:116` — *"Per-user
+Claude Code permissions allowlist (not shared)"*), ignored by PR #10060 itself. So today the hook is
+**per-user opt-in**: paste the snippet into your own `.claude/settings.json` (Claude Code reads it) or
+`.claude/settings.local.json`.
+
+Making it the **default for all contributors** (the ticket's original intent) requires un-ignoring
+`.claude/settings.json` so a shared copy can be tracked — with per-user permission grants living in
+`.claude/settings.local.json` (the standard Claude Code split, where they already are). That reverses a
+deliberate infra decision and touches every contributor's harness config, so it is **flagged to @tobiu
+on #10063** rather than changed unilaterally.
+
+### Testing
+
+```bash
+npm run test-unit -- test/playwright/unit/ai/claude-hooks/persist-memory.spec.mjs
+```
+
+The spec exercises `parseLastTurn` (the pure, exported parser) against the real-transcript edge cases:
+trailing bookkeeping, `tool_result`-vs-prompt detection, Option-B thinking/narration fallback,
+sidechain filtering, dedup, and malformed lines. The `Stop`-hook → live `addMemory` wiring is covered by
+post-merge integration (open a fresh session, run N turns, then `query_raw_memories({sessionId})` → N
+matches).
+
+### Known limitations / future work
+
+- **Large compaction-continuation turns** store a big `prompt` (the full summary). Acceptable (rare);
+  truncation policy belongs in the Memory Core, not the hook.
+- **Cold-start cost** — `ai/services.mjs` boots the full service graph (~500 ms–1 s). A lean
+  `Memory_Service`-only entrypoint is a future optimization once the cost is measurable (not a
+  prerequisite — masked by `async: true`).
+- **Harness parity** — Gemini CLI / Antigravity have their own lifecycle mechanisms; extending this
+  pattern to them is out of scope here.

--- a/.claude/hooks/persist-memory.mjs
+++ b/.claude/hooks/persist-memory.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * @summary Claude Code `Stop`-hook that auto-persists the just-completed turn into the Neo Memory Core,
+ * removing the manually-forgotten `add_memory` call mandated by AGENTS.md §memory_core_protocol.
+ *
+ * The empirical failure this closes: session `f018be49-...` ran ~25 turns with ZERO manual
+ * saves under cognitive load, breaking every downstream `query_raw_memories(sessionId)` self-detection.
+ * The correct layer for "always do X at end of turn" is the harness, not agent discipline.
+ *
+ * Flow: Claude Code pipes `{session_id, transcript_path, ...}` on stdin when a turn ends → this script
+ * tails the transcript JSONL, extracts the last turn (see {@link parseLastTurn}), and writes it via the
+ * direct-SDK `ai/services.mjs` (`Memory_Service.addMemory`) — no MCP subprocess, no HTTP endpoint.
+ *
+ * **Fail-soft by contract:** EVERY error path logs to stderr and `exit(0)`. A memory-save failure (chroma
+ * down, malformed transcript, services cold-start error) must NEVER block the user's next turn. Wired
+ * `async: true` in settings so the ~500ms-1s `services.mjs` cold-start is off the interactive path.
+ *
+ * Transcript-field → `add_memory` mapping = **Option B** (resolved at ticket-intake): prefer
+ * extended-thinking blocks for `thought`, fall back to pre-response narration. Full rationale +
+ * wiring instructions: `.claude/hooks/README.md`.
+ *
+ * @see .claude/hooks/README.md
+ */
+
+import fs                            from 'fs';
+import path                          from 'path';
+import {fileURLToPath, pathToFileURL} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+
+/**
+ * Claude Code threads tool outputs back into the transcript as `user`-role entries whose content is
+ * entirely `tool_result` blocks. Those are continuations, NOT prompts — so a "real" user prompt is a
+ * `user` entry carrying string content or at least one non-empty `text` block.
+ * @param {Object} entry A parsed transcript entry (`type === 'user'`).
+ * @returns {Boolean}
+ */
+export function isRealUserPrompt(entry) {
+    const content = entry?.message?.content;
+    if (typeof content === 'string') return content.trim().length > 0;
+    if (Array.isArray(content))      return content.some(block => block.type === 'text' && (block.text || '').trim().length > 0);
+    return false
+}
+
+/**
+ * Extracts the human-readable prompt text from a user entry (string content, or the joined `text`
+ * blocks of an array content — attachments / tool_result blocks are ignored).
+ * @param {Object} entry A parsed transcript `user` entry.
+ * @returns {String}
+ */
+export function userPromptText(entry) {
+    const content = entry?.message?.content;
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content))      return content.filter(block => block.type === 'text').map(block => block.text || '').join('\n');
+    return ''
+}
+
+/**
+ * Parses raw transcript JSONL into the just-completed turn, mapped onto the `add_memory` triad.
+ *
+ * Robust to the REAL Claude Code transcript shape (empirically 8 entry types — `user`, `assistant`,
+ * plus `queue-operation` / `last-prompt` / `ai-title` / `pr-link` / `attachment` / `system` bookkeeping
+ * that routinely TRAILS the final assistant text). It therefore does NOT trust "tail entry === turn":
+ * it filters to `user`/`assistant` non-sidechain entries, reverse-scans for the real turn-start prompt,
+ * then folds the turn's assistant blocks into `{prompt, thought, response, toolsUsed, amountToolCalls}`.
+ *
+ * @param {String} jsonl Raw transcript file contents (newline-delimited JSON).
+ * @returns {{prompt:String, thought:String, response:String, toolsUsed:String[], amountToolCalls:Number, model:(String|null)}|null}
+ * `null` when no persistable turn exists (no real user prompt in the transcript).
+ */
+export function parseLastTurn(jsonl) {
+    const entries = String(jsonl).split('\n')
+        .filter(Boolean)
+        .map(line => { try { return JSON.parse(line) } catch { return null } })
+        // Only conversational entries carry turn content; sub-agent sidechains belong to nested loops.
+        .filter(entry => entry && (entry.type === 'user' || entry.type === 'assistant') && !entry.isSidechain);
+
+    // Turn-start = the LAST `user` entry that is a real prompt (not a tool_result continuation).
+    let startIdx = -1;
+    for (let i = entries.length - 1; i >= 0; i--) {
+        if (entries[i].type === 'user' && isRealUserPrompt(entries[i])) { startIdx = i; break }
+    }
+    if (startIdx === -1) return null;
+
+    const prompt = userPromptText(entries[startIdx]).trim();
+    if (!prompt) return null;
+
+    const thinking = [], textBlocks = [], toolNames = [];
+    let amountToolCalls = 0, model = null;
+
+    // Fold every assistant entry from the prompt to end-of-file (a single turn spans many entries:
+    // assistant text/thinking → tool_use → tool_result → assistant continues → … → final text).
+    for (let i = startIdx + 1; i < entries.length; i++) {
+        const entry = entries[i];
+        if (entry.type !== 'assistant') continue;
+        model = entry.message?.model || model;
+        const content = Array.isArray(entry.message?.content) ? entry.message.content : [];
+        for (const block of content) {
+            if (block.type === 'thinking' && typeof block.thinking === 'string' && block.thinking.trim()) {
+                thinking.push(block.thinking)
+            } else if (block.type === 'text' && typeof block.text === 'string' && block.text.trim()) {
+                textBlocks.push(block.text)
+            } else if (block.type === 'tool_use') {
+                amountToolCalls++;
+                block.name && toolNames.push(block.name)
+            }
+        }
+    }
+
+    // response = the final user-facing text block (the answer, after all reasoning + tool work).
+    const response  = (textBlocks.length ? textBlocks[textBlocks.length - 1] : '').trim();
+    // Option B: thought = extended-thinking blocks; else the assistant's narration EXCLUDING the
+    // response (so a no-thinking single-text turn never duplicates response into thought).
+    const narration = textBlocks.slice(0, -1);
+    let   thought   = (thinking.length ? thinking : narration).join('\n\n').trim();
+
+    // `thought` and `response` are schema-required (AddMemoryRequest); an unusual turn shape must never
+    // fail the save on a missing field — substitute an explicit placeholder instead.
+    if (!thought) thought = '(No discrete reasoning blocks were recorded for this turn.)';
+
+    return {
+        prompt,
+        thought,
+        response       : response || '(No final text response was recorded for this turn.)',
+        toolsUsed      : [...new Set(toolNames)],
+        amountToolCalls,
+        model
+    }
+}
+
+/**
+ * Hook entrypoint: read stdin → parse the turn → persist via the direct Memory Core SDK. Never throws;
+ * always exits 0.
+ * @returns {Promise<void>}
+ */
+export async function main() {
+    let hookInput;
+    try {
+        hookInput = JSON.parse(await readStdin())
+    } catch (error) {
+        console.error('[persist-memory] Could not parse hook stdin JSON:', error.message);
+        return process.exit(0)
+    }
+
+    const transcriptPath = hookInput.transcript_path;
+    const sessionId      = hookInput.session_id;
+
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+        console.error(`[persist-memory] transcript_path missing or not found: ${transcriptPath}`);
+        return process.exit(0)
+    }
+
+    let turn;
+    try {
+        turn = parseLastTurn(fs.readFileSync(transcriptPath, 'utf8'))
+    } catch (error) {
+        console.error('[persist-memory] Failed to read/parse transcript:', error.message);
+        return process.exit(0)
+    }
+
+    if (!turn) {
+        console.error('[persist-memory] No persistable turn found (no user prompt) — skipping.');
+        return process.exit(0)
+    }
+
+    try {
+        // Lazy import so a parse failure above never pays the heavy services.mjs cold-start. The import
+        // itself eagerly boots the Memory Core singletons (Neo.create auto-triggers initAsync).
+        const {Memory_Service, Memory_LifecycleService} = await import(
+            pathToFileURL(path.resolve(__dirname, '../../ai/services.mjs')).href
+        );
+
+        // ALWAYS await ready(); NEVER call initAsync() externally — core.Base documents that an external
+        // initAsync() double-executes and causes fatal duplication bugs (src/core/Base.mjs).
+        await Memory_LifecycleService.ready();
+
+        await Memory_Service.addMemory({
+            prompt         : turn.prompt,
+            thought        : turn.thought,
+            response       : turn.response,
+            sessionId,
+            model          : turn.model || undefined,
+            toolsUsed      : turn.toolsUsed,
+            amountToolCalls: turn.amountToolCalls
+        });
+
+        console.error(`[persist-memory] ✅ Persisted turn for session ${sessionId} — ${turn.amountToolCalls} tool call(s), ${turn.toolsUsed.length} distinct tool(s).`)
+    } catch (error) {
+        console.error('[persist-memory] addMemory failed (non-blocking):', error.message)
+    }
+
+    process.exit(0)
+}
+
+/**
+ * Drains process stdin to a string. Resolves '' if stdin is closed with no data.
+ * @returns {Promise<String>}
+ */
+function readStdin() {
+    return new Promise(resolve => {
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data', chunk => { data += chunk });
+        process.stdin.on('end', () => resolve(data));
+        process.stdin.on('error', () => resolve(data))
+    })
+}
+
+// Run main() only when executed directly (`node persist-memory.mjs`), NOT when imported by the unit
+// test — importing must expose the pure parser without booting the Memory Core services.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main()
+}

--- a/.claude/hooks/persist-memory.mjs
+++ b/.claude/hooks/persist-memory.mjs
@@ -130,6 +130,19 @@ export function parseLastTurn(jsonl) {
 }
 
 /**
+ * Resolves the harness-owner agent identity for provenance stamping, from `NEO_AGENT_IDENTITY` — the
+ * canonical Agent OS harness-identity env var (`Orchestrator.swarmHeartbeatIdentity`, `KbAlertingService`
+ * et al. read the same source). Threaded into `addMemory` as `agent` so hook-written memories carry a
+ * trusted `agentIdentity` instead of falling to `unclassified`: the `Stop` hook runs standalone and
+ * bypasses MCP, so `RequestContextService` provenance is absent — this env identity is the only source.
+ * @param {Object} [env=process.env]
+ * @returns {String|undefined} The trimmed identity, or `undefined` when unset (graceful single-tenant fallthrough).
+ */
+export function resolveHarnessIdentity(env = process.env) {
+    return env.NEO_AGENT_IDENTITY?.trim() || undefined
+}
+
+/**
  * Hook entrypoint: read stdin → parse the turn → persist via the direct Memory Core SDK. Never throws;
  * always exits 0.
  * @returns {Promise<void>}
@@ -180,6 +193,9 @@ export async function main() {
             thought        : turn.thought,
             response       : turn.response,
             sessionId,
+            // Provenance: thread the harness identity so the memory carries a trusted `agentIdentity`
+            // rather than `unclassified` — the standalone hook has no MCP request context to derive it.
+            agent          : resolveHarnessIdentity(),
             model          : turn.model || undefined,
             toolsUsed      : turn.toolsUsed,
             amountToolCalls: turn.amountToolCalls

--- a/test/playwright/unit/ai/claude-hooks/persist-memory.spec.mjs
+++ b/test/playwright/unit/ai/claude-hooks/persist-memory.spec.mjs
@@ -1,0 +1,158 @@
+import {test, expect}                                  from '@playwright/test';
+import {isRealUserPrompt, parseLastTurn, userPromptText} from '../../../../../.claude/hooks/persist-memory.mjs';
+
+/**
+ * Self-test for the Claude Code `Stop`-hook turn parser. The hook auto-persists each turn into
+ * the Memory Core; correctness hinges entirely on `parseLastTurn` mapping the REAL (messy, 8-entry-type)
+ * Claude Code transcript onto the `add_memory` {prompt, thought, response} triad — Option B mapping.
+ *
+ * These cases encode the empirical findings that a naive "tail entry === turn" parser gets wrong:
+ * bookkeeping entries trail the final assistant text, tool outputs arrive as `user` entries, a turn
+ * spans many assistant entries, and extended-thinking is the preferred `thought` source.
+ */
+
+// --- mock-transcript builders (shapes verified against a real session JSONL) ---
+const think     = thinking            => ({type: 'thinking', thinking, signature: 'sig'});
+const text      = t                   => ({type: 'text', text: t});
+const toolUse   = (name, id = 'tu1')  => ({type: 'tool_use', id, name, input: {}});
+const userMsg   = (content, extra={}) => ({type: 'user',      isSidechain: false, message: {role: 'user',      content}, ...extra});
+const asstMsg   = (content, extra={}) => ({type: 'assistant', isSidechain: false, message: {role: 'assistant', model: 'claude-opus-4-8', content}, ...extra});
+const toolResult= (id, txt)           => userMsg([{type: 'tool_result', tool_use_id: id, content: txt}]);
+const jsonl     = (...entries)        => entries.map(e => JSON.stringify(e)).join('\n');
+
+test.describe('persist-memory hook — helpers', () => {
+    test('isRealUserPrompt: string content is a prompt; tool_result-only array is not', () => {
+        expect(isRealUserPrompt(userMsg('Real prompt'))).toBe(true);
+        expect(isRealUserPrompt(userMsg([{type: 'text', text: 'Hi'}]))).toBe(true);
+        expect(isRealUserPrompt(toolResult('tu1', 'output'))).toBe(false);
+        expect(isRealUserPrompt(userMsg(''))).toBe(false);             // empty string is not a prompt
+        expect(isRealUserPrompt(userMsg([{type: 'text', text: '  '}]))).toBe(false)
+    });
+
+    test('userPromptText: joins text blocks, ignores non-text (attachments / tool_result)', () => {
+        expect(userPromptText(userMsg('plain'))).toBe('plain');
+        expect(userPromptText(userMsg([{type: 'text', text: 'a'}, {type: 'image'}, {type: 'text', text: 'b'}]))).toBe('a\nb')
+    });
+});
+
+test.describe('persist-memory hook — parseLastTurn (Option B)', () => {
+    test('maps a normal turn: thinking → thought, final text → response, tools counted + deduped', () => {
+        const turn = parseLastTurn(jsonl(
+            userMsg('Add the feature'),
+            asstMsg([think('I should read the file first.'), toolUse('Read')]),
+            toolResult('tu1', 'file contents'),
+            asstMsg([think('Now I edit it.'), toolUse('Edit'), toolUse('Edit')]),
+            toolResult('tu1', 'edited'),
+            asstMsg([text('Done — the feature is added.')])
+        ));
+
+        expect(turn.prompt).toBe('Add the feature');
+        expect(turn.thought).toBe('I should read the file first.\n\nNow I edit it.');
+        expect(turn.response).toBe('Done — the feature is added.');
+        expect(turn.toolsUsed).toEqual(['Read', 'Edit']);   // deduped
+        expect(turn.amountToolCalls).toBe(3);                // counted (Read + Edit + Edit)
+        expect(turn.model).toBe('claude-opus-4-8')
+    });
+
+    test('ignores trailing bookkeeping entries (last-prompt / ai-title / pr-link) — tail is NOT the turn', () => {
+        const turn = parseLastTurn(jsonl(
+            userMsg('Question?'),
+            asstMsg([think('reasoning'), text('Answer.')]),
+            {type: 'last-prompt', lastPrompt: 'Question?', leafUuid: 'x'},
+            {type: 'ai-title',    aiTitle: 'A title'},
+            {type: 'pr-link',     url: 'https://...'}
+        ));
+
+        expect(turn.response).toBe('Answer.');
+        expect(turn.thought).toBe('reasoning')
+    });
+
+    test('treats tool_result user-entries as continuations, not prompts (turn-start detection)', () => {
+        // Two turns; only the LAST real prompt + its assistant work must be extracted.
+        const turn = parseLastTurn(jsonl(
+            userMsg('First turn prompt'),
+            asstMsg([text('First answer.')]),
+            userMsg('Second turn prompt'),
+            asstMsg([toolUse('Bash')]),
+            toolResult('tu1', 'bash output'),     // a user-role entry that is NOT a prompt
+            asstMsg([text('Second answer.')])
+        ));
+
+        expect(turn.prompt).toBe('Second turn prompt');
+        expect(turn.response).toBe('Second answer.');
+        expect(turn.toolsUsed).toEqual(['Bash'])
+    });
+
+    test('Option B fallback: no thinking → thought = narration (text before the final response)', () => {
+        const turn = parseLastTurn(jsonl(
+            userMsg('Do it'),
+            asstMsg([text('Let me check a few things.'), toolUse('Grep')]),
+            toolResult('tu1', 'matches'),
+            asstMsg([text('All set.')])
+        ));
+
+        expect(turn.thought).toBe('Let me check a few things.');  // pre-response narration
+        expect(turn.response).toBe('All set.')
+    });
+
+    test('no-thinking single-text turn: thought = placeholder (never duplicates response)', () => {
+        const turn = parseLastTurn(jsonl(
+            userMsg('Hi'),
+            asstMsg([text('Hello!')])
+        ));
+
+        expect(turn.response).toBe('Hello!');
+        expect(turn.thought).toBe('(No discrete reasoning blocks were recorded for this turn.)');
+        expect(turn.thought).not.toBe(turn.response);
+        expect(turn.amountToolCalls).toBe(0);
+        expect(turn.toolsUsed).toEqual([])
+    });
+
+    test('filters sidechain (sub-agent) entries from the main turn', () => {
+        const turn = parseLastTurn(jsonl(
+            userMsg('Run the agent'),
+            asstMsg([think('main reasoning'), toolUse('Agent')]),
+            asstMsg([text('subagent step')], {isSidechain: true}),   // must be excluded
+            {type: 'user', isSidechain: true, message: {role: 'user', content: 'subagent prompt'}},
+            asstMsg([text('Main thread done.')])
+        ));
+
+        expect(turn.prompt).toBe('Run the agent');
+        expect(turn.response).toBe('Main thread done.');
+        expect(turn.thought).toBe('main reasoning')
+    });
+
+    test('skips malformed JSONL lines without throwing', () => {
+        const raw  = [
+            JSON.stringify(userMsg('Solid prompt')),
+            '{ this is not json',
+            '',
+            JSON.stringify(asstMsg([think('ok'), text('Reply.')]))
+        ].join('\n');
+        const turn = parseLastTurn(raw);
+
+        expect(turn.prompt).toBe('Solid prompt');
+        expect(turn.response).toBe('Reply.')
+    });
+
+    test('returns null when there is no real user prompt to persist', () => {
+        expect(parseLastTurn(jsonl(
+            asstMsg([text('orphan assistant text')]),
+            toolResult('tu1', 'only tool output')
+        ))).toBeNull();
+        expect(parseLastTurn('')).toBeNull()
+    });
+
+    test('multi-block final response uses the last text block as the answer', () => {
+        const turn = parseLastTurn(jsonl(
+            userMsg('Explain'),
+            asstMsg([think('t1')]),
+            asstMsg([text('Intermediate note.'), toolUse('Read')]),
+            toolResult('tu1', 'x'),
+            asstMsg([text('Final explanation here.')])
+        ));
+
+        expect(turn.response).toBe('Final explanation here.');
+        expect(turn.thought).toBe('t1')   // thinking wins over narration text
+    });
+});

--- a/test/playwright/unit/ai/claude-hooks/persist-memory.spec.mjs
+++ b/test/playwright/unit/ai/claude-hooks/persist-memory.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                                  from '@playwright/test';
-import {isRealUserPrompt, parseLastTurn, userPromptText} from '../../../../../.claude/hooks/persist-memory.mjs';
+import {isRealUserPrompt, parseLastTurn, resolveHarnessIdentity, userPromptText} from '../../../../../.claude/hooks/persist-memory.mjs';
 
 /**
  * Self-test for the Claude Code `Stop`-hook turn parser. The hook auto-persists each turn into
@@ -32,6 +32,15 @@ test.describe('persist-memory hook — helpers', () => {
     test('userPromptText: joins text blocks, ignores non-text (attachments / tool_result)', () => {
         expect(userPromptText(userMsg('plain'))).toBe('plain');
         expect(userPromptText(userMsg([{type: 'text', text: 'a'}, {type: 'image'}, {type: 'text', text: 'b'}]))).toBe('a\nb')
+    });
+
+    test('resolveHarnessIdentity: reads NEO_AGENT_IDENTITY (trimmed) for provenance; undefined when unset/blank', () => {
+        // Threaded into addMemory as `agent` → canonicalized to a trusted `agentIdentity`, not `unclassified`.
+        expect(resolveHarnessIdentity({NEO_AGENT_IDENTITY: '@neo-opus-vega'})).toBe('@neo-opus-vega');
+        expect(resolveHarnessIdentity({NEO_AGENT_IDENTITY: '  neo-opus-vega  '})).toBe('neo-opus-vega');
+        expect(resolveHarnessIdentity({NEO_AGENT_IDENTITY: ''})).toBeUndefined();
+        expect(resolveHarnessIdentity({NEO_AGENT_IDENTITY: '   '})).toBeUndefined();
+        expect(resolveHarnessIdentity({})).toBeUndefined()
     });
 });
 


### PR DESCRIPTION
Authored by Claude Opus 4.8 (@neo-opus-vega, Claude Desktop). Session a54e89a3-4259-4b41-9e26-561f665de744.

Resolves #10063

A Claude Code `Stop` hook now auto-persists each completed turn into the Memory Core via the direct `ai/services.mjs` SDK — closing the empirically-recurring "agent forgets the end-of-turn `add_memory`" failure (session `f018be49-…` ran ~25 turns with zero manual saves, breaking every `query_raw_memories(sessionId)` self-detection). Per-turn persistence becomes a harness guarantee instead of an agent-discipline obligation.

Evidence: L2 (pure parser unit-tested + validated against a real 4214-entry transcript — correct prompt/thought/response/toolsUsed/model extraction; Option B confirmed sourcing `thought` from real extended-thinking blocks) → L4 required (live `Stop`-fire → `addMemory` → `query_raw_memories(sessionId)` round-trip). Residual: live-wiring ACs [#10063] + the settings.json sharing decision (below).

## What shipped
- `.claude/hooks/persist-memory.mjs` — the hook. Exported pure `parseLastTurn(jsonl)` (unit-testable) + a fail-soft `main()` that reads the hook stdin, tails the transcript, and writes via `Memory_Service.addMemory` after `await Memory_LifecycleService.ready()`. Every error path logs to stderr and `exit(0)` — a save failure must never block the user's next turn.
- `test/playwright/unit/ai/claude-hooks/persist-memory.spec.mjs` — 11 cases over the real-transcript edge surface.
- `.claude/hooks/README.md` — the Option B mapping spec, wiring snippet, and the gitignore note.

## Deltas from ticket
1. **`thought` mapping = Option B** (resolved at ticket-intake): extended-thinking blocks → fallback to pre-response narration → placeholder (the field is schema-required). Verified extended-thinking is present *and* captured in real transcripts — the whole advantage over Option A.
2. **The transcript is far messier than "tail = last turn."** Real Claude Code transcripts interleave 8+ entry types — `queue-operation` / `last-prompt` / `ai-title` / `pr-link` / `attachment` / `system` bookkeeping routinely *trails* the final assistant text, and a single turn spans many assistant entries (`tool_result`s arrive as `user`-role entries). The parser filters to `user`/`assistant`, drops sidechains, and reverse-scans for the real turn-start (a string prompt, not a `tool_result` continuation). This empirical messiness is exactly why the ticket demanded a fresh-context implementation.
3. **`await Memory_LifecycleService.ready()`, NOT `initAsync()`** — `src/core/Base.mjs` documents that calling `initAsync()` externally double-executes (fatal duplication bug). The ticket's `.ready()` recommendation is correct; verifying it against `core.Base` caught a trap a naive read would have hit.

## ⚠️ Open operator decision: `.claude/settings.json` is gitignored
The ticket's Artifact 2 plan was to commit the `Stop` hook into a **project-tracked** `.claude/settings.json` so every contributor gets it without opt-in. Empirically that file is **gitignored** — `.gitignore:116`, *"Per-user Claude Code permissions allowlist (not shared)"* — and it was ignored by PR #10060 itself (the PR the ticket cites as having *tracked* it; commit `1e738c962`). The per-user permissions actually live in `.claude/settings.local.json`. So:

- **Today (this PR):** the hook is **opt-in** — the README documents pasting the snippet into your own `.claude/settings.json` / `settings.local.json`. Functional immediately for any contributor who opts in.
- **To make it default-for-all** (the ticket's original intent): `.claude/settings.json` must be un-ignored so a shared copy can be tracked, with per-user permission grants staying in `.claude/settings.local.json` (where they already are — the standard Claude Code split). That **reverses a deliberate infra decision** and starts tracking every contributor's currently-personal settings.json → flagged to @tobiu (ticket author + merge authority) on #10063 rather than changed unilaterally. The human merge gate is the natural decision point.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/claude-hooks/persist-memory.spec.mjs` → **11 passed** (594ms).
- Real-transcript validation: `parseLastTurn` on a live 4214-entry session → correct `{prompt, thought, response}`; `toolsUsed` = the exact distinct tools used; `amountToolCalls` + `model` (`claude-opus-4-8`) correct; Option B sourced `thought` from 19 real extended-thinking blocks (not narration fallback).
- Pre-commit hooks (whitespace, shorthand, ticket-archaeology) pass clean — no decay-prone ticket-refs in code comments; ticket linkage lives in this body + the commit subject.

## Post-Merge Validation
- [ ] Wire the `Stop` hook per the operator decision above, open a fresh Claude Code session, run 3–5 turns, then `query_raw_memories({query, sessionId})` → expect 3–5 matches (one per turn).
- [ ] Failure-mode: stop chroma mid-session → the hook logs to stderr + exits 0; the next turn proceeds normally.
