### PR TITLE
test(ai): add REM Phase A regression anchors (#12617)

### DIFF
--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs
@@ -37,6 +37,15 @@ let originals;
 let configOriginals;
 let tmpDir;
 
+async function readOnlyRunStateEntry() {
+    const files = await readdir(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^rem-.*\.jsonl$/);
+
+    const lines = (await readFile(path.join(tmpDir, files[0]), 'utf8')).trim().split('\n');
+    return JSON.parse(lines[0]);
+}
+
 test.beforeEach(async () => {
     originals = Object.fromEntries(ORIGINAL_KEYS.map(key => [key, DreamService[key]]));
     configOriginals = {
@@ -72,7 +81,7 @@ test.afterEach(async () => {
 });
 
 test.describe('DreamService.executeRemCycle typed outcome contract', () => {
-    test('returns failed status with diagnostic when provider readiness gate rejects', async () => {
+    test('Sub 9 hypotheses 2, 6, 8: provider readiness failure writes failed providerReady state (#12617)', async () => {
         DreamService.checkProviderReadiness = async () => ({
             ready     : false,
             diagnostic: {
@@ -97,6 +106,23 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
         expect(outcome.runId).toMatch(/^rem-/);
         expect(outcome.completedAt).toBeTruthy();
         expect(outcome.durationMs).toBeGreaterThanOrEqual(0);
+
+        const entry = await readOnlyRunStateEntry();
+        expect(entry.outcome).toBe('failed');
+        expect(entry.reasonCode).toBe('provider-unreachable');
+        expect(entry.failurePhase).toBe('providerReady');
+        expect(entry.failureReason).toBe('PROVIDER_READINESS_TIMEOUT');
+        expect(entry.cycleScopePhases).toEqual(['providerReady']);
+        expect(entry.perPhaseStates[0]).toMatchObject({
+            phase : 'providerReady',
+            status: 'failed',
+            details: {
+                diagnostic: {
+                    provider     : 'openAiCompatible',
+                    graphProvider: 'openAiCompatible'
+                }
+            }
+        });
     });
 
     test('returns failed status when provider-readiness config validation throws', async () => {
@@ -131,6 +157,28 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
         expect(outcome.skipReason).toContain('dreamService.isProcessing already true');
     });
 
+    test('Sub 9 hypotheses 1 and 3: already-processing skip is durable typed cycle state (#12617)', async () => {
+        DreamService.isProcessing = true;
+
+        const outcome = await DreamService.executeRemCycle({reason: 'already-processing-state-test'});
+
+        expect(outcome.status).toBe('skipped');
+        expect(outcome.skipReason).toContain('already true');
+
+        const entry = await readOnlyRunStateEntry();
+        expect(entry.outcome).toBe('skipped');
+        expect(entry.reasonCode).toBe('already-processing');
+        expect(entry.failurePhase).toBeNull();
+        expect(entry.lastSuccessfulPhase).toBe('providerReady');
+        expect(entry.cycleScopePhases).toEqual(['providerReady', 'concurrentGuard']);
+        expect(entry.perPhaseStates[1]).toMatchObject({
+            phase : 'concurrentGuard',
+            status: 'skipped',
+            details: {reasonCode: 'already-processing'}
+        });
+        expect(entry.perSessionStates).toEqual([]);
+    });
+
     test('returns skipped with sessionsProcessed=0 when no undigested sessions exist', async () => {
         DreamService.findUndigestedSessions = async () => [];
 
@@ -157,6 +205,97 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
         expect(outcome.sessionsProcessed).toBe(2);
         expect(outcome.error).toBeNull();
         expect(outcome.skipReason).toBeNull();
+    });
+
+    test('Sub 9 hypotheses 10 and 11: failed phase from processing is persisted into REM run state (#12617)', async () => {
+        const failedSessionState = {
+            sessionId          : 'session-topology-failure',
+            payloadSizeTokens  : 42,
+            memorySessionIngest: {status: 'completed', errorReasons: []},
+            triVector          : {status: 'completed', attempts: 1},
+            topology           : {status: 'failed', conflictCount: 0},
+            gapSession         : {status: 'skipped'},
+            graphDigestedFlag  : false,
+            failureReasons     : ['topology provider failed']
+        };
+        const error = new Error('topology provider failed');
+        error.remState = {
+            perPhaseStates: [{
+                phase      : 'topology',
+                startedAt  : 100,
+                completedAt: 150,
+                wallClockMs: 50,
+                status     : 'failed',
+                details    : {
+                    sessionId: 'session-topology-failure',
+                    error    : 'topology provider failed'
+                }
+            }],
+            perSessionStates: [failedSessionState]
+        };
+
+        DreamService.findUndigestedSessions = async () => [{id: 'session-a'}];
+        DreamService.processUndigestedSessions = async () => {
+            throw error;
+        };
+
+        const outcome = await DreamService.executeRemCycle({
+            reason      : 'topology-failure-state-test',
+            includeDecay: false
+        });
+
+        expect(outcome.status).toBe('failed');
+        expect(outcome.sessionsProcessed).toBe(1);
+
+        const entry = await readOnlyRunStateEntry();
+        expect(entry.outcome).toBe('failed');
+        expect(entry.reasonCode).toBe('extraction-failed');
+        expect(entry.failurePhase).toBe('topology');
+        expect(entry.failureReason).toBe('topology provider failed');
+        expect(entry.cycleScopePhases).toContain('topology');
+        expect(entry.perSessionStates).toEqual([failedSessionState]);
+    });
+
+    test('Sub 9 hypotheses 11 and 12: non-throwing per-session failures remain visible without graphDigested (#12617)', async () => {
+        const failedSessionState = {
+            sessionId          : 'session-null-result',
+            payloadSizeTokens  : 100000,
+            memorySessionIngest: {status: 'completed', errorReasons: []},
+            triVector          : {status: 'failed', attempts: 3, errorKind: 'null-result'},
+            topology           : {status: 'completed', conflictCount: 0},
+            gapSession         : {status: 'completed'},
+            graphDigestedFlag  : false,
+            failureReasons     : ['tri-vector extraction returned null']
+        };
+
+        DreamService.findUndigestedSessions = async () => [{id: 'session-a'}];
+        DreamService.processUndigestedSessions = async () => ({
+            perPhaseStates: [{
+                phase      : 'triVector',
+                startedAt  : 200,
+                completedAt: 275,
+                wallClockMs: 75,
+                status     : 'failed',
+                details    : {sessionId: 'session-null-result'}
+            }],
+            perSessionStates: [failedSessionState]
+        });
+
+        const outcome = await DreamService.executeRemCycle({
+            reason      : 'null-result-session-state-test',
+            includeDecay: false
+        });
+
+        // Current-dev Phase A boundary: the cycle outcome is still completed, but the
+        // per-session state exposes the null-result and prevents graphDigested overclaim.
+        expect(outcome.status).toBe('completed');
+
+        const entry = await readOnlyRunStateEntry();
+        expect(entry.reasonCode).toBe('ok');
+        expect(entry.cycleScopePhases).toContain('triVector');
+        expect(entry.perSessionStates).toEqual([failedSessionState]);
+        expect(entry.perSessionStates[0].graphDigestedFlag).toBe(false);
+        expect(entry.perSessionStates[0].failureReasons).toEqual(['tri-vector extraction returned null']);
     });
 
     test('returns failed status when processUndigestedSessions throws', async () => {
@@ -217,12 +356,7 @@ test.describe('DreamService.executeRemCycle typed outcome contract', () => {
             dryRun: true
         });
 
-        const files = await readdir(tmpDir);
-        expect(files).toHaveLength(1);
-        expect(files[0]).toMatch(/^rem-.*\.jsonl$/);
-
-        const lines = (await readFile(path.join(tmpDir, files[0]), 'utf8')).trim().split('\n');
-        const entry = JSON.parse(lines[0]);
+        const entry = await readOnlyRunStateEntry();
 
         expect(outcome.stateWriteError).toBeUndefined();
         expect(entry.runId).toBe(outcome.runId);

--- a/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs
@@ -109,7 +109,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         });
     });
 
-    test('#12264: dead owner pid makes a wall-clock-active lease stale', async () => {
+    test('Sub 9 hypothesis 5: dead owner pid makes a wall-clock-active lease stale (#12617, #12264)', async () => {
         const leasePath = createLeasePath('dead-owner-pid');
         const now       = new Date('2026-05-16T20:00:00.000Z');
 
@@ -250,7 +250,7 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
         });
     });
 
-    test('malformed leases recover at acquisition time', async () => {
+    test('Sub 9 hypothesis 5: malformed leases recover at acquisition time (#12617)', async () => {
         const leasePath = createLeasePath('malformed');
         await fs.writeFile(leasePath, '{not-json', 'utf8');
 
@@ -324,8 +324,8 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
     });
 
     test('withLease release-timing invariant: task inner finally runs INSIDE the lease window (#11515)', async () => {
-        // Empirical anchor: PR #11509 cycles 1 + 2 surfaced the same root failure-mode at two
-        // different surfaces — substrate mutation placed AFTER `await withHeavyMaintenanceLease(...)`
+        // Empirical anchor: prior review cycles surfaced the same root failure-mode at two
+        // different surfaces: substrate mutation placed AFTER `await withHeavyMaintenanceLease(...)`
         // runs OUTSIDE the lease window because the helper's own `finally` (release) fires before
         // the awaited promise settles.
         //
@@ -351,8 +351,8 @@ test.describe('Neo.ai.daemons.services.HeavyMaintenanceLeaseService (#11505)', (
                 // Primary "heavy work" stand-in
                 await Promise.resolve();
             } finally {
-                // Substrate-protected side effect (canonical inner-finally pattern from
-                // ai/scripts/runners/runSandman.mjs post-PR #11509).
+                // Substrate-protected side effect matching the canonical inner-finally pattern
+                // from ai/scripts/runners/runSandman.mjs.
                 order.push('task-finally');
                 leaseDuringFinally = await inspectHeavyMaintenanceLease({leasePath, now});
             }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -63,7 +63,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             'summary'
         ].sort());
         expect(Object.isFrozen(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES)).toBe(true);
-        // Golden Path is light maintenance per #11511 / PR #11512 — must NOT be in heavy set
+        // Golden Path is light maintenance and must NOT be in the heavy-maintenance set.
         expect(DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES).not.toContain('golden-path');
     });
 
@@ -322,7 +322,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(activeHeavyTask.name).toBeNull();
     });
 
-    test('acquireLeaseAndExecute defers intra-process when another heavy task is running', () => {
+    test('Sub 9 hypothesis 4: acquireLeaseAndExecute records intra-process backpressure as skipped (#12617)', () => {
         const outcomeCalls = [];
         const service      = buildService({
             taskStateService: buildTaskStateService({summary: {running: true}}),
@@ -345,7 +345,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(outcomeCalls[0].p.blockingTaskName).toBe('summary');
     });
 
-    test('acquireLeaseAndExecute defers cross-daemon when lease is held', () => {
+    test('Sub 9 hypotheses 4 and 5: acquireLeaseAndExecute records held lease as skipped (#12617)', () => {
         const outcomeCalls = [];
         const service      = buildService({
             taskStateService: buildTaskStateService({}),

--- a/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
+++ b/test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs
@@ -106,6 +106,56 @@ test.describe('runSandman.mjs provider readiness diagnostics (#10587)', () => {
         expect(() => runSandmanModule.checkProvider({config: {graphProvider: 'openAiCompatible'}})).toThrow(/timeoutMs.*required/);
     });
 
+    test('Sub 9 hypothesis 7: manual CLI delegates to canonical REM cycle without autoDream coupling (#12617)', async () => {
+        const calls = [];
+        const output = {
+            log  : message => calls.push({type: 'log', message}),
+            error: message => calls.push({type: 'error', message}),
+            write: message => calls.push({type: 'write', message})
+        };
+        const lifecycleService = {
+            ready: async () => calls.push({type: 'lifecycle-ready'})
+        };
+        const dreamService = {
+            ready: async () => calls.push({type: 'dream-ready'}),
+            executeRemCycle: async options => {
+                calls.push({type: 'execute-rem-cycle', options});
+                return {
+                    status           : 'skipped',
+                    skipReason       : 'no undigested sessions',
+                    sessionsProcessed: 0,
+                    durationMs       : 5
+                };
+            }
+        };
+        let leaseOptions;
+
+        const exitCode = await runSandmanModule.runSandman({
+            dreamService,
+            lifecycleService,
+            output,
+            withLease: async (fn, options) => {
+                leaseOptions = options;
+                return {status: 'completed', result: await fn()};
+            },
+            exit: code => code
+        });
+
+        expect(exitCode).toBe(0);
+        expect(leaseOptions).toEqual({
+            owner   : 'sandman',
+            reason  : 'manual-cli',
+            metadata: {script: 'ai/scripts/runners/runSandman.mjs'}
+        });
+        expect(calls.find(call => call.type === 'execute-rem-cycle').options).toEqual({
+            reason      : 'manual-cli',
+            mode        : 'cli',
+            includeDecay: true
+        });
+        expect(calls.map(call => call.type)).toContain('lifecycle-ready');
+        expect(calls.map(call => call.type)).toContain('dream-ready');
+    });
+
     test('extracts OpenAI-compatible model ids from provider variants', () => {
         expect(providerReadinessHelper.getOpenAiCompatibleModelIds({
             data: [

--- a/test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs
@@ -197,7 +197,7 @@ test.describe('Neo.ai.daemons.services.LazyEdgeDrainer', () => {
         expect(remaining).toContain('memory:dryrun-m');
     });
 
-    test('drainQueue recovers orphaned .draining file from a prior-run SIGKILL', async () => {
+    test('Sub 9 hypothesis 13: drainQueue recovers orphaned .draining file from a prior-run SIGKILL (#12617)', async () => {
         // Simulate a prior drain that was SIGKILL'd between rename and completion: the
         // `.draining` file exists with queued edges but the live queue may or may not have
         // fresh appends from a concurrent producer.
@@ -227,7 +227,7 @@ test.describe('Neo.ai.daemons.services.LazyEdgeDrainer', () => {
         expect(fs.existsSync(queuePath)).toBe(false);
     });
 
-    test('drainQueue handles thrown exceptions from linkNodesAsync as failures', async () => {
+    test('Sub 9 hypothesis 13: drainQueue retains link failures for retry (#12617)', async () => {
         fs.writeFileSync(queuePath, JSON.stringify({source: 'a', target: 'memory:throw', relationship: 'RELATES_TO'}) + '\n');
 
         const originalWarn = logger.warn;

--- a/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs
@@ -105,7 +105,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
     });
 
-    test('should normalize Memory/Session provenance targets before lazy queue (#10172)', async () => {
+    test('Sub 9 hypothesis 12: provenance Memory/Session edges are lazy-queued, not silently culled (#12617, #10172)', async () => {
         const baseGenerate = OpenAiCompatible.prototype.generate;
 
         try {
@@ -289,7 +289,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         }
     });
 
-    test('detects silent empty-response as context-overflow + aborts retry amplification (#12091)', async () => {
+    test('Sub 9 hypotheses 9 and 11: empty-response overflow records friction and aborts retry amplification (#12617, #12091)', async () => {
         const baseGenerate = OpenAiCompatible.prototype.generate;
         let invocationCount = 0;
 
@@ -339,7 +339,7 @@ test.describe('Neo.ai.daemons.services.SemanticGraphExtractor', () => {
         }
     });
 
-    test('uses configured graph-provider model for consumer friction telemetry (#12059)', async () => {
+    test('Sub 9 hypotheses 2, 8, 9: guardrail telemetry uses configured graph-provider model (#12617, #12059)', async () => {
         const originalGraphProvider                  = aiConfig.graphProvider;
         const originalOllamaModel                    = aiConfig.ollama?.model;
         const originalContextLimitTokens             = aiConfig.localModels.chat.contextLimitTokens;


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Resolves #12617

Related: #12075 #12065 #12073 #12423 #12439 #12077 #12087 #12088

Adds a non-micro Phase A regression batch for the current-dev REM/Sandman silent-failure surface. The patch anchors all Sub 9 hypotheses 1-13 across six existing unit suites: durable REM run-state failures, already-processing skip state, provider readiness state, backpressure/lease skips, manual CLI delegation to the canonical REM cycle, graph-provider guardrail telemetry, oversized empty-response friction, non-throwing per-session failure visibility, provenance lazy-queue behavior, and lazy-drainer retry/recovery behavior.

Evidence: L2 (focused Playwright unit regression batch over current-dev REM/Sandman service contracts) -> L2 required (leaf ticket ACs require unit-test regression coverage). No residuals for #12617.

## Source Traceability

The hypothesis numbering comes from Discussion #12062 §2.4 and the Sub 1 runbook at `learn/agentos/incidents/sandman-silent-failure-forensics.md`. That runbook's `Sub 9 Test Mapping` is the archaeology-safe source bridge for the six unit suites in this PR.

## Deltas from ticket

Extended existing sibling specs rather than adding a new spec, keeping each hypothesis anchor beside the consumed behavior.

Hypothesis 9 is covered only as current-dev guardrail / empty-response telemetry. This PR does not claim chunk activation, chunk recomposition, or semantic-fidelity completion; #12075 remains open for the Phase B / full closeout path.

The pre-commit archaeology hook also forced behavior-first comment hygiene in two already-touched specs. Those comment edits remove stale durable ticket citations without changing assertions.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.executeRemCycle.spec.mjs test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/HeavyMaintenanceLeaseService.spec.mjs test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs` -> 110 passed.
- `git diff --cached --check` -> passed before commit.
- `node ./buildScripts/util/check-ticket-archaeology.mjs <six staged files>` -> 6 files scanned, 0 violations.
- Commit hook passed `check-whitespace`, `check-shorthand`, and staged-file `check-ticket-archaeology`.

## Post-Merge Validation

- [ ] Confirm #12617 auto-closes.
- [ ] Confirm #12075 remains open until Phase B / chunking-dependent full closeout coverage lands.

## Commits

- e792fa678 — `test(ai): add REM Phase A regression anchors (#12617)`
