### PR TITLE
feat(agent): refine substrate mutation gate (#10794)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-template.md
@@ -152,8 +152,9 @@ For every modified or added OpenAPI tool description:
 
 Expand these audits only when their trigger fires; otherwise omit them rather than rendering default N/A sections:
 
-- **🛂 Provenance Audit (§7.3):** PR introduces a major architectural abstraction or core subsystem.
+- **🛂 Provenance Audit:** PR introduces a major architectural abstraction or core subsystem.
 - **📜 Source-of-Authority Audit:** review cites operator or peer authority for a demand.
+- **🧠 Turn-Memory / Substrate-Load Audit:** PR modifies turn-loaded or skill-loaded memory substrate covered by `/turn-memory-pre-flight`; use the loading-runtime-effect audit in `pr-review-guide.md` if the PR body lacks the placement decision-tree + load-effect audit. For `learn/agentos/**`, fire only when the file is directly turn-loaded, skill-loaded, or ambiguous.
 - **🔌 Wire-Format Compatibility Audit:** PR alters JSON-RPC notification schemas, payload envelopes, native API wire formats, event payloads, tool signatures, or database schemas.
 
 ---
@@ -199,7 +200,7 @@ To proceed with merging, please address the following:
 
 No required actions — eligible for human merge.
 
-*Do NOT use pre-ticked placeholder items like `- [x] All checks pass and no required changes identified.` — that reads as box-checking, not genuine review. Per guide §5 Zero-Issue PR Semantics + §7.7 anti-patterns table.*
+*Do NOT use pre-ticked placeholder items like `- [x] All checks pass and no required changes identified.` — that reads as box-checking, not genuine review. Per the guide's Zero-Issue PR Semantics and anti-patterns table.*
 
 ---
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -16,13 +16,14 @@ The act of opening a PR is an irreversible state transition in the Agent OS. Bef
 
 ### 1.1 The Substrate-Mutation Pre-Flight Gate
 
-If your PR touches **any** of the following paths:
-- `AGENTS.md`
-- `AGENTS_ATLAS.md`
-- `.agents/skills/**`
-- `learn/agentos/**`
-
-You MUST include a **slot-rationale section** in your PR body. This satisfies the `AGENTS.md §13` mandate requiring explicit decay-mitigation rationale for all substrate mutations.
+If your PR touches memory substrate that can affect future sessions before
+task-specific context is chosen, include a **slot-rationale section** in your PR
+body. Scope: `AGENTS.md`, `learn/agentos/AGENTS_ATLAS.md`, `.agents/skills/**`,
+and directly turn-/skill-loaded `learn/agentos/**` files. Ordinary
+operator/reference docs are out of scope when they carry in-doc Compaction
+Taxonomy / slot-rationale; cite that instead. If direct-load status is
+ambiguous, run `/turn-memory-pre-flight` and treat it as in scope until
+falsified.
 Your PR body's slot-rationale section MUST enumerate:
 - For each *added* section: its disposition (`keep` / `move` / `compress-to-trigger` / `rewrite` / `retire`) + 3-axis rating (trigger-frequency × failure-severity × enforceability).
 - For each *modified* section: its disposition delta + the reason for the shift.


### PR DESCRIPTION
Resolves #10794

Authored by GPT-5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Refines the substrate-mutation gate without adding another rule surface: the author-side `pull-request` workflow now scopes slot-rationale to turn-loaded or skill-loaded memory substrate, and the reviewer-side PR template now exposes the existing `/turn-memory-pre-flight` loading-runtime-effect audit as a conditional trigger. This keeps ordinary `learn/agentos/**` operator/reference docs out of the PR-body duplication path when their slot rationale already lives in-doc.

Evidence: L1 (static substrate diff + skill-manifest lint + focused lint unit coverage) -> L1 required (#10794 ACs are workflow/template substrate text). No residuals.

## Deltas from Ticket

The ticket text was partially stale at intake. Current substrate already had the detailed reviewer Required Action wording in `pr-review-guide.md` and the `learn/agentos/*.md` carve-out in `/turn-memory-pre-flight`. This PR implements the residual only:

- author-side `pull-request-workflow.md` now points the gate at true memory substrate, including directly turn-/skill-loaded `learn/agentos/**` files only;
- reviewer-side `pr-review-template.md` now has a visible Turn-Memory / Substrate-Load conditional audit trigger, pointing to the existing guide audit instead of duplicating its body.

Decision Record impact: aligned with ADR 0007 and ADR 0008; no ADR amendment needed.

Related: #10757

## Substrate Mutation Rationale

- `.agents/skills/pull-request/references/pull-request-workflow.md §1.1`: disposition `rewrite`. The existing author gate remains in the pull-request workflow Map because it fires during PR opening, but the wording now matches `/turn-memory-pre-flight` instead of treating all `learn/agentos/**` docs as future-session memory substrate. Trigger-frequency: PR-open only; failure-severity: medium/high for false-positive author friction and missed slot-rationale gates; enforceability: lint-assisted plus reviewer discipline.
- `.agents/skills/pr-review/assets/pr-review-template.md`: disposition `compress-to-trigger`. The template gets one conditional trigger line; the substantive Required Action body stays in `pr-review-guide.md` loading-runtime-effect audit. Trigger-frequency: only PRs touching memory substrate; failure-severity: high when missed because reviewers can approve on file-completeness while missing runtime-load effect; enforceability: template + `lint-skill-manifest` reference integrity.

Load-effect audit: no `SKILL.md`, `AGENTS.md`, harness-local turn injection, or new always-loaded router content changed. Both edits are lifecycle-loaded skill payload/template surfaces, and the substantive rule body remains behind existing skill loads. Net substrate delta is small and validated under the workflow-map positive-delta budget.

## Test Evidence

```
git diff --check
npm run ai:lint-skill-manifest -- --base origin/dev
npm run ai:lint-agents -- --base origin/dev
npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs --workers=1
```

- `git diff --check` passed.
- `lint-skill-manifest` passed, including workflow-map delta budget and reference integrity.
- `lint-agents` passed.
- `lintSkillManifest.spec.mjs` passed: 35/35.

## Post-Merge Validation

- [ ] Next substrate-touching PR review sees the Turn-Memory / Substrate-Load audit trigger directly in the review template.

## Commit

- `ffcd8297f` - `feat(agent): refine substrate mutation gate (#10794)`
