### PR TITLE
feat(ai): real GitLab IssueService — GitLabClient + issue ops (#12624)

### DIFF
--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -95,7 +95,14 @@ class Config extends ConfigProvider {
                  * GitLab Personal Access Token. Empty in the tracked template.
                  * @member {String} token=''
                  */
-                token: leaf('', 'NEO_GITLAB_PAT', 'string')
+                token: leaf('', 'NEO_GITLAB_PAT', 'string'),
+                /**
+                 * Default GitLab project full path (e.g. `group/subgroup/project`) for issue / MR
+                 * operations — analogous to github-workflow's owner/repo. The leaf owns env-default
+                 * resolution; services read the resolved `aiConfig.gitlab.projectPath` at the use site.
+                 * @member {String} projectPath=''
+                 */
+                projectPath: leaf('', 'NEO_GITLAB_PROJECT', 'string')
             }
         }
     }

--- a/ai/mcp/server/gitlab-workflow/openapi.yaml
+++ b/ai/mcp/server/gitlab-workflow/openapi.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       operationId: list_issues
       summary: List GitLab issues
-      description: Lists GitLab issues. Scaffolded until the GitLabClient subtask lands.
+      description: Lists GitLab project issues via the GitLab GraphQL API, with optional state / label / assignee filters.
       tags: [Issues]
       x-pass-as-object: true
       x-annotations:
@@ -68,7 +68,7 @@ paths:
     post:
       operationId: create_issue
       summary: Create a GitLab issue
-      description: Creates a GitLab issue. Scaffolded until the GitLabClient subtask lands.
+      description: Creates a GitLab issue via the GitLab GraphQL API; optionally assigns labels (by name) and assignees (by username).
       tags: [Issues]
       x-pass-as-object: true
       x-annotations:
@@ -102,11 +102,11 @@ paths:
                   default: []
       responses:
         '200':
-          description: Scaffolded create response.
+          description: The created issue, or a structured error.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScaffoldResponse'
+                $ref: '#/components/schemas/CreateIssueResponse'
 
   /merge-requests:
     get:
@@ -177,7 +177,7 @@ paths:
     post:
       operationId: manage_issue_comment
       summary: Manage GitLab issue comments
-      description: Creates or updates GitLab issue comments. Scaffolded until the GitLabClient subtask lands.
+      description: Creates or updates a GitLab issue comment (note) via the GitLab GraphQL API.
       tags: [Issues]
       x-pass-as-object: true
       x-annotations:
@@ -205,17 +205,17 @@ paths:
                   description: Comment body.
       responses:
         '200':
-          description: Scaffolded comment-management response.
+          description: The comment result, or a structured error.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScaffoldResponse'
+                $ref: '#/components/schemas/IssueCommentResponse'
 
   /issues/{issue_number}/labels/manage:
     post:
       operationId: manage_issue_labels
       summary: Manage GitLab issue labels
-      description: Adds or removes GitLab issue labels. Scaffolded until the GitLabClient subtask lands.
+      description: Adds or removes GitLab issue labels (by name) via the GitLab GraphQL API.
       tags: [Issues]
       x-pass-as-object: true
       x-annotations:
@@ -246,17 +246,17 @@ paths:
                   description: Labels to add or remove.
       responses:
         '200':
-          description: Scaffolded label-management response.
+          description: The label result, or a structured error.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScaffoldResponse'
+                $ref: '#/components/schemas/IssueLabelResponse'
 
   /issues/{issue_number}/assignees/manage:
     post:
       operationId: manage_issue_assignees
       summary: Manage GitLab issue assignees
-      description: Adds or removes GitLab issue assignees. Scaffolded until the GitLabClient subtask lands.
+      description: Adds or removes GitLab issue assignees (by username) via the GitLab GraphQL API.
       tags: [Issues]
       x-pass-as-object: true
       x-annotations:
@@ -287,11 +287,11 @@ paths:
                   description: GitLab usernames to add or remove.
       responses:
         '200':
-          description: Scaffolded assignee-management response.
+          description: The assignee result, or a structured error.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ScaffoldResponse'
+                $ref: '#/components/schemas/IssueAssigneeResponse'
 
 components:
   schemas:
@@ -333,3 +333,65 @@ components:
         received:
           type: object
           additionalProperties: true
+    CreateIssueResponse:
+      type: object
+      description: A created GitLab issue, or a structured error.
+      properties:
+        iid:
+          type: string
+        title:
+          type: string
+        webUrl:
+          type: string
+        assignees:
+          type: array
+          items:
+            type: string
+        assigneeWarning:
+          type: string
+        error:
+          type: string
+        message:
+          type: string
+        code:
+          type: string
+    IssueCommentResponse:
+      type: object
+      description: The result of a GitLab issue comment (note) operation, or a structured error.
+      properties:
+        message:
+          type: string
+        noteId:
+          type: string
+        error:
+          type: string
+        code:
+          type: string
+    IssueLabelResponse:
+      type: object
+      description: The resulting GitLab issue labels, or a structured error.
+      properties:
+        message:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        error:
+          type: string
+        code:
+          type: string
+    IssueAssigneeResponse:
+      type: object
+      description: The resulting GitLab issue assignees, or a structured error.
+      properties:
+        message:
+          type: string
+        assignees:
+          type: array
+          items:
+            type: string
+        error:
+          type: string
+        code:
+          type: string

--- a/ai/mcp/server/gitlab-workflow/openapi.yaml
+++ b/ai/mcp/server/gitlab-workflow/openapi.yaml
@@ -60,7 +60,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Scaffolded issue list response.
+          description: The matching GitLab project issues.
           content:
             application/json:
               schema:

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -24,6 +24,9 @@ import _GH_SyncService from './services/github-workflow/SyncService.mjs';
 
 GH_Config.data.syncOnStartup = false;
 
+// --- GitLab Workflow Services ---
+import _GL_IssueService from './services/gitlab-workflow/IssueService.mjs';
+
 // --- Knowledge Base Services ---
 import _KB_DatabaseService from './services/knowledge-base/DatabaseService.mjs';
 import _KB_LifecycleService from './services/knowledge-base/DatabaseLifecycleService.mjs';
@@ -184,6 +187,7 @@ const ghSpec  = safeLoadYaml(path.join(__dirname, 'mcp/server/github-workflow/op
 const kbSpec  = safeLoadYaml(path.join(__dirname, 'mcp/server/knowledge-base/openapi.yaml'));
 const memSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/memory-core/openapi.yaml'));
 const nlSpec  = safeLoadYaml(path.join(__dirname, 'mcp/server/neural-link/openapi.yaml'));
+const gitlabSpec = safeLoadYaml(path.join(__dirname, 'mcp/server/gitlab-workflow/openapi.yaml'));
 
 // --- Apply Safety Wrappers ---
 
@@ -195,6 +199,9 @@ const GH_LocalFileService = makeSafe(_GH_LocalFileService, ghSpec);
 const GH_PullRequestService = makeSafe(_GH_PullRequestService, ghSpec);
 const GH_RepositoryService = makeSafe(_GH_RepositoryService, ghSpec);
 const GH_SyncService = makeSafe(_GH_SyncService, ghSpec);
+
+// GitLab
+const GL_IssueService = makeSafe(_GL_IssueService, gitlabSpec);
 
 // Knowledge Base
 const KB_DatabaseService = makeSafe(_KB_DatabaseService, kbSpec);
@@ -263,6 +270,9 @@ export {
     GH_PullRequestService,
     GH_RepositoryService,
     GH_SyncService,
+
+    // GitLab Workflow
+    GL_IssueService,
 
     // Knowledge Base
     KB_Config,

--- a/ai/services/gitlab-workflow/GitLabClient.mjs
+++ b/ai/services/gitlab-workflow/GitLabClient.mjs
@@ -1,0 +1,309 @@
+import aiConfig from '../../mcp/server/gitlab-workflow/config.mjs';
+import Base     from '../../../src/core/Base.mjs';
+import logger   from '../../mcp/server/gitlab-workflow/logger.mjs';
+
+/**
+ * @summary Centralized singleton client for the GitLab GraphQL API.
+ *
+ * The GitLab analog of github-workflow's `GraphqlService`: it issues authenticated GraphQL
+ * queries/mutations and centralizes auth, retry, and error handling so the gitlab-workflow
+ * services never re-implement transport. Two deliberate divergences from the GitHub client:
+ *
+ * 1. **Endpoint is config-derived, not static** — GitLab is commonly self-hosted, so the API
+ *    URL is built per call from `aiConfig.gitlab.hostUrl` (`NEO_GITLAB_HOST`), not a constant.
+ * 2. **Auth is a config PAT, not a CLI token** — the token comes from `aiConfig.gitlab.token`
+ *    (`NEO_GITLAB_PAT`); there is no `glab`-CLI dependency (the GitHub client shells
+ *    `gh auth token`, but adding a second CLI install requirement for GitLab is avoided here).
+ *
+ * The retry/backoff machinery (transient HTTP 429/5xx + network errors, jittered exponential
+ * delay honoring `retry-after`) and the partial-data GraphQL error handling mirror the GitHub
+ * `GraphqlService` so behavior stays consistent across both workflow servers.
+ *
+ * @class Neo.ai.services.gitlab-workflow.GitLabClient
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class GitLabClient extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.gitlab-workflow.GitLabClient'
+         * @protected
+         */
+        className: 'Neo.ai.services.gitlab-workflow.GitLabClient',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * Optional explicit token override for tests or controlled embedded callers.
+         * Normal runtime auth uses `aiConfig.gitlab.token` (`NEO_GITLAB_PAT`).
+         * @member {String|null} authTokenOverride=null
+         * @protected
+         */
+        authTokenOverride: null,
+        /**
+         * Maximum retry attempts for transient GitLab transport/gateway failures.
+         * @member {Number} maxRetryAttempts=3
+         * @protected
+         */
+        maxRetryAttempts: 3,
+        /**
+         * Initial retry delay in milliseconds.
+         * @member {Number} retryBaseDelayMs=1000
+         * @protected
+         */
+        retryBaseDelayMs: 1000,
+        /**
+         * Maximum retry delay in milliseconds.
+         * @member {Number} retryMaxDelayMs=10000
+         * @protected
+         */
+        retryMaxDelayMs: 10000,
+        /**
+         * Jitter ratio applied to exponential retry delays.
+         * @member {Number} retryJitterRatio=0.2
+         * @protected
+         */
+        retryJitterRatio: 0.2,
+        /**
+         * HTTP statuses that represent transient GitLab/proxy failures.
+         * @member {Number[]} retryableHttpStatuses=[429,502,503,504]
+         * @protected
+         */
+        retryableHttpStatuses: [429, 502, 503, 504]
+    }
+
+    /**
+     * Resolves the GitLab GraphQL endpoint from config. GitLab is frequently self-hosted,
+     * so the endpoint is `${hostUrl}/api/graphql` rather than a constant.
+     * @returns {String}
+     * @throws {Error} If no host URL is configured.
+     * @private
+     */
+    #getApiUrl() {
+        const hostUrl = aiConfig.gitlab.hostUrl;
+
+        if (!hostUrl) {
+            throw new Error('Missing GitLab host URL. Set NEO_GITLAB_HOST (or config.gitlab.hostUrl).');
+        }
+
+        return `${String(hostUrl).replace(/\/+$/, '')}/api/graphql`;
+    }
+
+    /**
+     * Resolves the GitLab Personal Access Token from config (or the test override). Unlike the
+     * GitHub client, this reads a config PAT rather than shelling out to a CLI.
+     * @returns {String}
+     * @throws {Error} If no token is configured.
+     * @private
+     */
+    #getAuthToken() {
+        if (this.authTokenOverride) {
+            return String(this.authTokenOverride).trim();
+        }
+
+        const token = aiConfig.gitlab.token;
+
+        if (!token) {
+            logger.error('Missing GitLab PAT; cannot authenticate.');
+            throw new Error('Could not authenticate with GitLab. Set NEO_GITLAB_PAT (or config.gitlab.token).');
+        }
+
+        return String(token).trim();
+    }
+
+    /**
+     * Calculates the retry delay for a transient GitLab failure (honors `retry-after`).
+     * @param {Number} attempt The 1-based retry attempt.
+     * @param {Response|null} response The failed response, if one exists.
+     * @returns {Number} Delay in milliseconds.
+     * @private
+     */
+    #getRetryDelay(attempt, response=null) {
+        const retryAfter = response?.headers?.get?.('retry-after');
+
+        if (retryAfter) {
+            const seconds = Number(retryAfter);
+
+            if (Number.isFinite(seconds)) {
+                return Math.max(0, seconds * 1000);
+            }
+
+            const retryAt = Date.parse(retryAfter);
+
+            if (Number.isFinite(retryAt)) {
+                return Math.max(0, retryAt - Date.now());
+            }
+        }
+
+        const baseDelay = Math.min(this.retryMaxDelayMs, this.retryBaseDelayMs * 2 ** (attempt - 1));
+        const jitter    = baseDelay * this.retryJitterRatio * Math.random();
+
+        return Math.round(baseDelay + jitter);
+    }
+
+    /**
+     * Determines whether a transport error is likely transient.
+     * @param {Error|*} error The thrown fetch error.
+     * @returns {Boolean}
+     * @private
+     */
+    #isRetryableNetworkError(error) {
+        const message = [
+            error?.message,
+            error?.cause?.message,
+            error?.cause?.code,
+            error?.code,
+            String(error)
+        ].filter(Boolean).join(' ').toLowerCase();
+
+        return [
+            'fetch failed',
+            'network',
+            'terminated',
+            'timeout',
+            'econnreset',
+            'etimedout',
+            'enotfound',
+            'eai_again',
+            'socket hang up'
+        ].some(pattern => message.includes(pattern));
+    }
+
+    /**
+     * @param {Number} status The HTTP response status.
+     * @returns {Boolean}
+     * @private
+     */
+    #isRetryableHttpStatus(status) {
+        return this.retryableHttpStatuses.includes(status);
+    }
+
+    /**
+     * Waits before a retry attempt.
+     * @param {Number} delay Delay in milliseconds.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #sleep(delay) {
+        if (delay <= 0) {
+            return;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, delay));
+    }
+
+    /**
+     * Logs and waits for a transient retry.
+     * @param {String} reason Safe retry reason for logs.
+     * @param {Number} attempt The 1-based retry attempt.
+     * @param {Response|null} response The failed response, if one exists.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #waitForRetry(reason, attempt, response=null) {
+        const delay = this.#getRetryDelay(attempt, response);
+
+        logger.warn(`[GitLabClient] ${reason}; retrying in ${delay}ms (attempt ${attempt}/${this.maxRetryAttempts})`);
+        await this.#sleep(delay);
+    }
+
+    /**
+     * @summary Detects whether a GraphQL response contains usable partial data.
+     *
+     * GitLab can return `{data, errors}` when only one aliased field fails. A top-level `data`
+     * object with at least one non-null field is useful partial data; `null`/empty/all-null data
+     * still represents a hard semantic failure.
+     *
+     * @param {*} data The GraphQL `data` payload.
+     * @returns {Boolean}
+     * @private
+     */
+    #hasPartialData(data) {
+        if (data == null) {
+            return false;
+        }
+
+        if (Array.isArray(data)) {
+            return data.some(item => item != null);
+        }
+
+        if (typeof data === 'object') {
+            return Object.values(data).some(value => value != null);
+        }
+
+        return true;
+    }
+
+    /**
+     * Executes a GraphQL query or mutation against the GitLab API.
+     * @param {String}  query                 The GraphQL query/mutation string.
+     * @param {Object}  [variables={}]        Optional variables for the query.
+     * @param {Object}  [options={}]          Behavior options.
+     * @param {Boolean} [options.strict=true] Whether any GraphQL `errors` entry is a hard failure.
+     * @returns {Promise<Object>} The `data` object, or `{data, errors}` for non-strict partial-data responses.
+     * @throws {Error} If the request fails, config is missing, or strict GraphQL error handling rejects the response.
+     */
+    async query(query, variables={}, options={}) {
+        const strict = options?.strict !== false;
+        const apiUrl = this.#getApiUrl();
+        const token  = this.#getAuthToken();
+
+        const headers = {
+            'Content-Type' : 'application/json',
+            'Authorization': `Bearer ${token}`
+        };
+
+        let response;
+
+        for (let attempt = 0; attempt <= this.maxRetryAttempts; attempt++) {
+            try {
+                response = await fetch(apiUrl, {
+                    method: 'POST',
+                    headers,
+                    body  : JSON.stringify({query, variables})
+                });
+            } catch (e) {
+                if (attempt < this.maxRetryAttempts && this.#isRetryableNetworkError(e)) {
+                    await this.#waitForRetry(`Transient GitLab GraphQL transport failure (${e.message})`, attempt + 1);
+                    continue;
+                }
+
+                throw e;
+            }
+
+            if (response.ok) {
+                break;
+            }
+
+            const errorMessage = `GitLab API request failed: ${response.status} ${response.statusText}`;
+
+            if (attempt < this.maxRetryAttempts && this.#isRetryableHttpStatus(response.status)) {
+                await this.#waitForRetry(errorMessage, attempt + 1, response);
+                continue;
+            }
+
+            throw new Error(errorMessage);
+        }
+
+        const json = await response.json();
+
+        if (json.errors) {
+            if (!strict && this.#hasPartialData(json.data)) {
+                logger.warn('GitLab API returned partial data with GraphQL errors:', json.errors);
+                return {
+                    data  : json.data,
+                    errors: json.errors
+                };
+            }
+
+            logger.error('GitLab API returned errors:', json.errors);
+            throw new Error(`GitLab API error: ${json.errors.map(e => e.message).join(', ')}`);
+        }
+
+        return json.data;
+    }
+}
+
+export default Neo.setupClass(GitLabClient);

--- a/ai/services/gitlab-workflow/IssueService.mjs
+++ b/ai/services/gitlab-workflow/IssueService.mjs
@@ -17,9 +17,10 @@ import {CREATE_ISSUE, CREATE_NOTE, UPDATE_NOTE, UPDATE_ISSUE_LABELS, ISSUE_SET_A
  *
  * Argument validation lives at the OpenAPI/Zod `makeSafe` boundary in `ai/services.mjs`, not
  * inside these methods; the per-method `action` guards here are domain routing, not schema
- * validation. The GraphQL strings are integration-validated against a live GitLab instance —
- * the unit suite mocks `GitLabClient.query` and exercises this service's logic (routing, id
- * resolution, variable forwarding, error surfacing).
+ * validation. The GraphQL strings are best-knowledge against GitLab's current schema and are
+ * not yet integration-validated against a live instance (that validation is a deferred
+ * follow-up); the unit suite mocks `GitLabClient.query` and exercises this service's logic
+ * (routing, id resolution, variable forwarding, error surfacing).
  *
  * @class Neo.ai.services.gitlab-workflow.IssueService
  * @extends Neo.core.Base

--- a/ai/services/gitlab-workflow/IssueService.mjs
+++ b/ai/services/gitlab-workflow/IssueService.mjs
@@ -1,11 +1,15 @@
-import Base from '../../../src/core/Base.mjs';
+import Base          from '../../../src/core/Base.mjs';
+import GitLabClient  from './GitLabClient.mjs';
+import aiConfig      from '../../mcp/server/gitlab-workflow/config.mjs';
+import {LIST_ISSUES} from './queries/issueQueries.mjs';
 
 /**
- * @summary Scaffold issue-tool service for GitLab Workflow MCP.
+ * @summary Issue-tool service for the GitLab Workflow MCP server.
  *
- * Registers the #11768 issue operations with truthful scaffold responses. Real
- * GitLab API calls are intentionally deferred to the GitLabClient subtask so this
- * lane can establish the MCP contract without fabricating persistence behavior.
+ * `listIssues` is implemented against the GitLab GraphQL API via `GitLabClient`; the remaining
+ * issue mutations (create / comment / labels / assignees) are still truthful scaffold responses
+ * pending follow-up subtasks. Argument validation lives at the OpenAPI/Zod `makeSafe` boundary
+ * in `ai/services.mjs`, not inside these methods.
  *
  * @class Neo.ai.services.gitlab-workflow.IssueService
  * @extends Neo.core.Base
@@ -42,15 +46,37 @@ class IssueService extends Base {
     }
 
     /**
-     * @summary Lists GitLab issues once the GitLabClient subtask is implemented.
+     * @summary Lists the configured GitLab project's issues via the GitLab GraphQL API.
      * @param {Object} [options={}]
-     * @returns {Promise<Object>}
+     * @param {Number} [options.limit=30]
+     * @param {String} [options.state='opened'] One of `opened` / `closed` / `all`.
+     * @param {String} [options.labels] Comma-separated label names to filter by.
+     * @param {String} [options.assignee] A single GitLab username to filter by.
+     * @returns {Promise<Object>} `{items, count}`.
      */
-    async listIssues(options = {}) {
+    async listIssues({limit=30, state='opened', labels=null, assignee=null} = {}) {
+        const data = await GitLabClient.query(LIST_ISSUES, {
+            fullPath         : aiConfig.gitlab.projectPath,
+            state,
+            first            : limit,
+            labelName        : labels ? labels.split(',').map(label => label.trim()).filter(Boolean) : null,
+            assigneeUsernames: assignee ? [assignee] : null
+        });
+
+        const nodes = data?.project?.issues?.nodes || [];
+
         return {
-            ...this.#scaffold('list_issues', options),
-            items: [],
-            count: 0
+            items: nodes.map(node => ({
+                iid      : node.iid,
+                title    : node.title,
+                state    : node.state,
+                webUrl   : node.webUrl,
+                createdAt: node.createdAt,
+                updatedAt: node.updatedAt,
+                labels   : (node.labels?.nodes    || []).map(label => label.title),
+                assignees: (node.assignees?.nodes || []).map(user  => user.username)
+            })),
+            count: nodes.length
         };
     }
 

--- a/ai/services/gitlab-workflow/IssueService.mjs
+++ b/ai/services/gitlab-workflow/IssueService.mjs
@@ -1,15 +1,25 @@
 import Base          from '../../../src/core/Base.mjs';
 import GitLabClient  from './GitLabClient.mjs';
 import aiConfig      from '../../mcp/server/gitlab-workflow/config.mjs';
-import {LIST_ISSUES} from './queries/issueQueries.mjs';
+import logger        from '../../mcp/server/gitlab-workflow/logger.mjs';
+import {LIST_ISSUES, GET_ISSUE_GID, GET_PROJECT_LABEL_IDS}                          from './queries/issueQueries.mjs';
+import {CREATE_ISSUE, CREATE_NOTE, UPDATE_NOTE, UPDATE_ISSUE_LABELS, ISSUE_SET_ASSIGNEES} from './queries/mutations.mjs';
 
 /**
  * @summary Issue-tool service for the GitLab Workflow MCP server.
  *
- * `listIssues` is implemented against the GitLab GraphQL API via `GitLabClient`; the remaining
- * issue mutations (create / comment / labels / assignees) are still truthful scaffold responses
- * pending follow-up subtasks. Argument validation lives at the OpenAPI/Zod `makeSafe` boundary
- * in `ai/services.mjs`, not inside these methods.
+ * Implements real GitLab GraphQL behavior for the full issue-tool surface — `listIssues`,
+ * `createIssue`, `manageIssueComment`, `manageIssueLabels`, `manageIssueAssignees` — via the
+ * shared `GitLabClient`. The GitLab-vs-GitHub shape differences are handled here: issues are
+ * addressed by `iid` under a `project(fullPath)`, comments are `notes`, and mutations that
+ * require opaque global ids (`noteableId`, label ids) resolve them through the lookup queries
+ * before mutating.
+ *
+ * Argument validation lives at the OpenAPI/Zod `makeSafe` boundary in `ai/services.mjs`, not
+ * inside these methods; the per-method `action` guards here are domain routing, not schema
+ * validation. The GraphQL strings are integration-validated against a live GitLab instance —
+ * the unit suite mocks `GitLabClient.query` and exercises this service's logic (routing, id
+ * resolution, variable forwarding, error surfacing).
  *
  * @class Neo.ai.services.gitlab-workflow.IssueService
  * @extends Neo.core.Base
@@ -30,19 +40,103 @@ class IssueService extends Base {
     }
 
     /**
-     * @summary Builds a truthful scaffold response for a GitLab issue tool.
-     * @param {String} tool
-     * @param {Object} [received={}]
+     * @summary Builds the structured error response for a GitLab API/transport failure.
+     * @param {Error}  error
+     * @param {String} context Human-readable description of the attempted operation.
      * @returns {Object}
      * @private
      */
-    #scaffold(tool, received = {}) {
-        return {
-            status : 'scaffolded',
-            tool,
-            message: 'GitLab Workflow MCP tool is registered; real GitLab API behavior lands with the GitLabClient subtask.',
-            received
-        };
+    #apiErrorResponse(error, context) {
+        logger.error(`Error ${context} via GitLab GraphQL:`, error);
+        return {error: 'GitLab API request failed', message: error.message, code: 'GITLAB_API_ERROR'};
+    }
+
+    /**
+     * @summary Builds the structured error response for a GitLab mutation that returned
+     * user-facing validation errors in its `errors` payload.
+     * @param {String[]} errors
+     * @param {String}   context Human-readable description of the attempted operation.
+     * @returns {Object}
+     * @private
+     */
+    #mutationErrorResponse(errors, context) {
+        const message = `GitLab rejected ${context}: ${errors.join('; ')}`;
+        logger.warn(message);
+        return {error: 'GitLab API error', message, code: 'GITLAB_MUTATION_ERROR'};
+    }
+
+    /**
+     * @summary Returns a GitLab mutation payload's user-facing `errors` array if non-empty.
+     * @param {Object} payload The named mutation payload (e.g. `data.createIssue`).
+     * @returns {String[]|null}
+     * @private
+     */
+    #userErrors(payload) {
+        const errors = payload?.errors;
+        return Array.isArray(errors) && errors.length > 0 ? errors : null;
+    }
+
+    /**
+     * @summary Resolves an issue `iid` to its opaque global id (the `noteableId` a comment needs).
+     * @param {Number|String} iid
+     * @returns {Promise<String|null>}
+     * @private
+     */
+    async #resolveIssueGid(iid) {
+        const data = await GitLabClient.query(GET_ISSUE_GID, {
+            fullPath: aiConfig.gitlab.projectPath,
+            iid     : String(iid)
+        });
+        return data?.project?.issue?.id || null;
+    }
+
+    /**
+     * @summary Resolves project label names to their opaque global ids (drops unknown names).
+     * @param {String[]} labelNames
+     * @returns {Promise<String[]>}
+     * @private
+     */
+    async #resolveLabelIds(labelNames) {
+        if (!labelNames?.length) return [];
+
+        const data          = await GitLabClient.query(GET_PROJECT_LABEL_IDS, {fullPath: aiConfig.gitlab.projectPath}),
+              projectLabels = data?.project?.labels?.nodes || [];
+
+        return labelNames.map(name => projectLabels.find(label => label.title === name)?.id).filter(Boolean);
+    }
+
+    /**
+     * @summary Shared `issueSetAssignees` mutation runner (username-native; no id pre-lookup).
+     *
+     * Self-contained error handling so callers can treat a failed assign as a soft warning
+     * (`createIssue`) or a hard error (`manageIssueAssignees`) without a throw escaping.
+     *
+     * @param {Number|String} iid
+     * @param {String[]}      assignees     GitLab usernames.
+     * @param {String}        operationMode `APPEND` | `REMOVE` | `REPLACE`.
+     * @returns {Promise<Object>} `{message, assignees}` on success, or a structured error.
+     * @private
+     */
+    async #setAssignees(iid, assignees, operationMode) {
+        try {
+            const data    = await GitLabClient.query(ISSUE_SET_ASSIGNEES, {
+                projectPath      : aiConfig.gitlab.projectPath,
+                iid              : String(iid),
+                assigneeUsernames: assignees,
+                operationMode
+            });
+            const payload = data?.issueSetAssignees,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `setting assignees on issue #${iid}`);
+
+            return {
+                message  : `Successfully updated assignees on issue #${iid}`,
+                assignees: (payload?.issue?.assignees?.nodes || []).map(user => user.username)
+            };
+        } catch (error) {
+            return this.#apiErrorResponse(error, `setting assignees on issue #${iid}`);
+        }
     }
 
     /**
@@ -81,39 +175,162 @@ class IssueService extends Base {
     }
 
     /**
-     * @summary Creates a GitLab issue once the GitLabClient subtask is implemented.
-     * @param {Object} options
-     * @returns {Promise<Object>}
+     * @summary Creates a GitLab issue, then optionally applies assignees.
+     *
+     * Labels are assigned by name during creation. Assignees are username-keyed and applied in
+     * a follow-up `issueSetAssignees`; a failed assign does NOT roll back the created issue
+     * (the issue exists — graceful degradation) and is surfaced as `assigneeWarning`.
+     *
+     * @param {Object}   options
+     * @param {String}   options.title
+     * @param {String}   [options.body='']      Markdown issue description.
+     * @param {String[]} [options.labels=[]]    Label names to assign on creation.
+     * @param {String[]} [options.assignees=[]] GitLab usernames to assign.
+     * @returns {Promise<Object>} `{iid, title, webUrl, assignees?|assigneeWarning?}` or a structured error.
      */
-    async createIssue(options) {
-        return this.#scaffold('create_issue', options);
+    async createIssue({title, body='', labels=[], assignees=[]}) {
+        try {
+            const data    = await GitLabClient.query(CREATE_ISSUE, {
+                projectPath: aiConfig.gitlab.projectPath,
+                title,
+                description: body,
+                labels     : labels?.length ? labels : null
+            });
+            const payload = data?.createIssue,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `creating issue "${title}"`);
+
+            const issue  = payload?.issue,
+                  result = {iid: issue?.iid, title: issue?.title, webUrl: issue?.webUrl};
+
+            if (assignees?.length && issue?.iid) {
+                const assignResult = await this.#setAssignees(issue.iid, assignees, 'APPEND');
+
+                if (assignResult.error) {
+                    result.assigneeWarning = assignResult.message;
+                } else {
+                    result.assignees = assignResult.assignees;
+                }
+            }
+
+            return result;
+        } catch (error) {
+            return this.#apiErrorResponse(error, `creating issue "${title}"`);
+        }
     }
 
     /**
-     * @summary Creates or updates GitLab issue comments once the GitLabClient subtask is implemented.
+     * @summary Creates or updates a comment (GitLab "note") on an issue.
+     *
+     * `create` resolves the issue's global id (`noteableId`); `update` addresses the note by the
+     * global id reconstructed from the numeric `note_id` (`gid://gitlab/Note/<id>`).
+     *
      * @param {Object} options
-     * @returns {Promise<Object>}
+     * @param {String} options.action          `create` | `update`.
+     * @param {Number} [options.issue_number]  Issue `iid` (required for `create`).
+     * @param {Number} [options.note_id]       Note id (required for `update`).
+     * @param {String} options.body            Comment body.
+     * @returns {Promise<Object>} `{message, noteId}` or a structured error.
      */
-    async manageIssueComment(options) {
-        return this.#scaffold('manage_issue_comment', options);
+    async manageIssueComment({action, issue_number, note_id, body}) {
+        if (!['create', 'update'].includes(action)) {
+            return {error: 'Bad Request', message: "Invalid action. Must be 'create' or 'update'.", code: 'INVALID_ARGUMENTS'};
+        }
+
+        try {
+            if (action === 'create') {
+                const noteableId = await this.#resolveIssueGid(issue_number);
+
+                if (!noteableId) {
+                    return {error: 'Not Found', message: `Issue #${issue_number} not found in project '${aiConfig.gitlab.projectPath}'.`, code: 'ISSUE_NOT_FOUND'};
+                }
+
+                const data    = await GitLabClient.query(CREATE_NOTE, {noteableId, body}),
+                      payload = data?.createNote,
+                      errors  = this.#userErrors(payload);
+
+                if (errors) return this.#mutationErrorResponse(errors, `commenting on issue #${issue_number}`);
+
+                return {message: `Successfully created comment on issue #${issue_number}`, noteId: payload?.note?.id};
+            }
+
+            // action === 'update'
+            if (!note_id) {
+                return {error: 'Bad Request', message: "Missing required argument: 'note_id' is required for updating comments.", code: 'MISSING_ARGUMENTS'};
+            }
+
+            const data    = await GitLabClient.query(UPDATE_NOTE, {id: `gid://gitlab/Note/${note_id}`, body}),
+                  payload = data?.updateNote,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `updating comment ${note_id}`);
+
+            return {message: `Successfully updated comment ${note_id}`, noteId: payload?.note?.id};
+        } catch (error) {
+            return this.#apiErrorResponse(error, `managing comment on issue #${issue_number}`);
+        }
     }
 
     /**
-     * @summary Adds or removes GitLab issue labels once the GitLabClient subtask is implemented.
-     * @param {Object} options
-     * @returns {Promise<Object>}
+     * @summary Adds or removes labels on an issue.
+     *
+     * Resolves label names to global ids (GitLab's `updateIssue` mutates labels by id), then
+     * routes them to `addLabelIds` / `removeLabelIds`. Unknown label names are rejected with
+     * `LABEL_NOT_FOUND` rather than silently dropped.
+     *
+     * @param {Object}   options
+     * @param {Number}   options.issue_number Issue `iid`.
+     * @param {String}   options.action       `add` | `remove`.
+     * @param {String[]} options.labels       Label names to add or remove.
+     * @returns {Promise<Object>} `{message, labels}` or a structured error.
      */
-    async manageIssueLabels(options) {
-        return this.#scaffold('manage_issue_labels', options);
+    async manageIssueLabels({issue_number, action, labels}) {
+        if (!['add', 'remove'].includes(action)) {
+            return {error: 'Bad Request', message: "Invalid action. Must be 'add' or 'remove'.", code: 'INVALID_ARGUMENTS'};
+        }
+
+        try {
+            const labelIds = await this.#resolveLabelIds(labels);
+
+            if (labelIds.length !== (labels?.length || 0)) {
+                return {error: 'Not Found', message: `One or more labels not found in project '${aiConfig.gitlab.projectPath}': ${labels.join(', ')}`, code: 'LABEL_NOT_FOUND'};
+            }
+
+            const data    = await GitLabClient.query(UPDATE_ISSUE_LABELS, {
+                projectPath   : aiConfig.gitlab.projectPath,
+                iid           : String(issue_number),
+                addLabelIds   : action === 'add'    ? labelIds : null,
+                removeLabelIds: action === 'remove' ? labelIds : null
+            });
+            const payload = data?.updateIssue,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `${action === 'add' ? 'adding labels to' : 'removing labels from'} issue #${issue_number}`);
+
+            return {
+                message: `Successfully ${action === 'add' ? 'added labels to' : 'removed labels from'} issue #${issue_number}`,
+                labels : (payload?.issue?.labels?.nodes || []).map(label => label.title)
+            };
+        } catch (error) {
+            return this.#apiErrorResponse(error, `managing labels on issue #${issue_number}`);
+        }
     }
 
     /**
-     * @summary Adds or removes GitLab issue assignees once the GitLabClient subtask is implemented.
-     * @param {Object} options
-     * @returns {Promise<Object>}
+     * @summary Adds or removes assignees on an issue (username-native via `issueSetAssignees`).
+     * @param {Object}   options
+     * @param {Number}   options.issue_number Issue `iid`.
+     * @param {String}   options.action       `add` (APPEND) | `remove` (REMOVE).
+     * @param {String[]} options.assignees    GitLab usernames.
+     * @returns {Promise<Object>} `{message, assignees}` or a structured error.
      */
-    async manageIssueAssignees(options) {
-        return this.#scaffold('manage_issue_assignees', options);
+    async manageIssueAssignees({issue_number, action, assignees}) {
+        if (!['add', 'remove'].includes(action)) {
+            return {error: 'Bad Request', message: "Invalid action. Must be 'add' or 'remove'.", code: 'INVALID_ARGUMENTS'};
+        }
+
+        return this.#setAssignees(issue_number, assignees, action === 'add' ? 'APPEND' : 'REMOVE');
     }
 }
 

--- a/ai/services/gitlab-workflow/queries/issueQueries.mjs
+++ b/ai/services/gitlab-workflow/queries/issueQueries.mjs
@@ -3,9 +3,10 @@
  *
  * GitLab's GraphQL surface differs from GitHub's: issues live under `project(fullPath)`, the
  * user-facing id is `iid`, and labels/assignees are connection nodes (`labels.nodes`,
- * `assignees.nodes`). These query strings are integration-validated against a live GitLab
- * instance; the unit tests validate the `IssueService` response-parsing against mocked
- * `GitLabClient` responses (the query strings themselves are not exercised by unit mocks).
+ * `assignees.nodes`). These query strings are best-knowledge against GitLab's GraphQL schema
+ * and are not yet integration-validated against a live instance; the unit tests validate the
+ * `IssueService` response-parsing against mocked `GitLabClient` responses (the query strings
+ * themselves are not exercised by unit mocks).
  *
  * Lookup queries (`GET_ISSUE_GID`, `GET_PROJECT_LABEL_IDS`) resolve the opaque global ids
  * (`gid://gitlab/Issue/...`, `gid://gitlab/ProjectLabel/...`) that GitLab mutations require but

--- a/ai/services/gitlab-workflow/queries/issueQueries.mjs
+++ b/ai/services/gitlab-workflow/queries/issueQueries.mjs
@@ -1,11 +1,16 @@
 /**
- * @summary GitLab GraphQL query constants for issue read operations.
+ * @summary GitLab GraphQL query constants for issue read + lookup operations.
  *
  * GitLab's GraphQL surface differs from GitHub's: issues live under `project(fullPath)`, the
  * user-facing id is `iid`, and labels/assignees are connection nodes (`labels.nodes`,
  * `assignees.nodes`). These query strings are integration-validated against a live GitLab
  * instance; the unit tests validate the `IssueService` response-parsing against mocked
  * `GitLabClient` responses (the query strings themselves are not exercised by unit mocks).
+ *
+ * Lookup queries (`GET_ISSUE_GID`, `GET_PROJECT_LABEL_IDS`) resolve the opaque global ids
+ * (`gid://gitlab/Issue/...`, `gid://gitlab/ProjectLabel/...`) that GitLab mutations require but
+ * the MCP tool contract only carries as `iid` / label-name — the GitLab twin of the
+ * github-workflow `GET_ISSUE_ID` / `GET_ISSUE_AND_LABEL_IDS` two-step pattern.
  */
 
 /**
@@ -25,6 +30,40 @@ export const LIST_ISSUES = `
                     updatedAt
                     labels    { nodes { title } }
                     assignees { nodes { username } }
+                }
+            }
+        }
+    }
+`;
+
+/**
+ * Resolves an issue `iid` to its opaque global id (`gid://gitlab/Issue/...`) — required as the
+ * `noteableId` for the `createNote` comment mutation.
+ * @type {String}
+ */
+export const GET_ISSUE_GID = `
+    query GetIssueGid($fullPath: ID!, $iid: String!) {
+        project(fullPath: $fullPath) {
+            issue(iid: $iid) {
+                id
+            }
+        }
+    }
+`;
+
+/**
+ * Resolves a project's label names to their opaque global ids — required for the
+ * `addLabelIds` / `removeLabelIds` arguments of the `updateIssue` label mutation (GitLab's
+ * `updateIssue` mutates labels by id, not name).
+ * @type {String}
+ */
+export const GET_PROJECT_LABEL_IDS = `
+    query GetProjectLabelIds($fullPath: ID!) {
+        project(fullPath: $fullPath) {
+            labels {
+                nodes {
+                    id
+                    title
                 }
             }
         }

--- a/ai/services/gitlab-workflow/queries/issueQueries.mjs
+++ b/ai/services/gitlab-workflow/queries/issueQueries.mjs
@@ -1,0 +1,32 @@
+/**
+ * @summary GitLab GraphQL query constants for issue read operations.
+ *
+ * GitLab's GraphQL surface differs from GitHub's: issues live under `project(fullPath)`, the
+ * user-facing id is `iid`, and labels/assignees are connection nodes (`labels.nodes`,
+ * `assignees.nodes`). These query strings are integration-validated against a live GitLab
+ * instance; the unit tests validate the `IssueService` response-parsing against mocked
+ * `GitLabClient` responses (the query strings themselves are not exercised by unit mocks).
+ */
+
+/**
+ * Lists a project's issues with optional state / label / assignee filters.
+ * @type {String}
+ */
+export const LIST_ISSUES = `
+    query ListIssues($fullPath: ID!, $state: IssuableState, $first: Int, $labelName: [String!], $assigneeUsernames: [String!]) {
+        project(fullPath: $fullPath) {
+            issues(state: $state, first: $first, labelName: $labelName, assigneeUsernames: $assigneeUsernames) {
+                nodes {
+                    iid
+                    title
+                    state
+                    webUrl
+                    createdAt
+                    updatedAt
+                    labels    { nodes { title } }
+                    assignees { nodes { username } }
+                }
+            }
+        }
+    }
+`;

--- a/ai/services/gitlab-workflow/queries/mutations.mjs
+++ b/ai/services/gitlab-workflow/queries/mutations.mjs
@@ -1,0 +1,97 @@
+/**
+ * @summary GitLab GraphQL mutation constants for issue write operations.
+ *
+ * Each GitLab mutation payload carries a top-level `errors: [String!]` array of user-facing
+ * validation errors (distinct from transport / GraphQL-level errors, which `GitLabClient.query`
+ * raises in strict mode). `IssueService` inspects this array and surfaces a structured error
+ * when it is non-empty. These mutation strings are integration-validated against a live GitLab
+ * instance; the unit tests exercise the `IssueService` logic (action routing, id resolution,
+ * variable forwarding, error surfacing) against a mocked `GitLabClient`.
+ */
+
+/**
+ * Creates an issue in a project. `labels` are assigned by name on creation; assignees are
+ * applied in a follow-up `issueSetAssignees` call (GitLab's `createIssue` takes assignee ids,
+ * not usernames, so username-keyed assignment is deferred to the username-native mutation).
+ * @type {String}
+ */
+export const CREATE_ISSUE = `
+    mutation CreateIssue($projectPath: ID!, $title: String!, $description: String, $labels: [String!]) {
+        createIssue(input: {projectPath: $projectPath, title: $title, description: $description, labels: $labels}) {
+            issue {
+                iid
+                title
+                webUrl
+            }
+            errors
+        }
+    }
+`;
+
+/**
+ * Creates a note (comment) on an issue. `noteableId` is the issue's global id (resolved via
+ * `GET_ISSUE_GID`).
+ * @type {String}
+ */
+export const CREATE_NOTE = `
+    mutation CreateNote($noteableId: NoteableID!, $body: String!) {
+        createNote(input: {noteableId: $noteableId, body: $body}) {
+            note {
+                id
+                body
+            }
+            errors
+        }
+    }
+`;
+
+/**
+ * Updates an existing note (comment). `id` is the note's global id (`gid://gitlab/Note/<id>`).
+ * @type {String}
+ */
+export const UPDATE_NOTE = `
+    mutation UpdateNote($id: NoteID!, $body: String!) {
+        updateNote(input: {id: $id, body: $body}) {
+            note {
+                id
+                body
+            }
+            errors
+        }
+    }
+`;
+
+/**
+ * Adds and/or removes labels on an issue by global id (resolved via `GET_PROJECT_LABEL_IDS`).
+ * `updateIssue` addresses the issue by `projectPath` + `iid`, so no issue-id pre-lookup is needed.
+ * @type {String}
+ */
+export const UPDATE_ISSUE_LABELS = `
+    mutation UpdateIssueLabels($projectPath: ID!, $iid: String!, $addLabelIds: [LabelID!], $removeLabelIds: [LabelID!]) {
+        updateIssue(input: {projectPath: $projectPath, iid: $iid, addLabelIds: $addLabelIds, removeLabelIds: $removeLabelIds}) {
+            issue {
+                iid
+                labels { nodes { title } }
+            }
+            errors
+        }
+    }
+`;
+
+/**
+ * Sets an issue's assignees by username. `operationMode` controls the semantics:
+ * `APPEND` (add), `REMOVE` (remove), or `REPLACE`. GitLab resolves usernames natively here,
+ * so no user-id pre-lookup is needed.
+ * @type {String}
+ */
+export const ISSUE_SET_ASSIGNEES = `
+    mutation IssueSetAssignees($projectPath: ID!, $iid: String!, $assigneeUsernames: [String!]!, $operationMode: MutationOperationMode) {
+        issueSetAssignees(input: {projectPath: $projectPath, iid: $iid, assigneeUsernames: $assigneeUsernames, operationMode: $operationMode}) {
+            issue {
+                iid
+                assignees { nodes { username } }
+            }
+            errors
+        }
+    }
+`;

--- a/ai/services/gitlab-workflow/queries/mutations.mjs
+++ b/ai/services/gitlab-workflow/queries/mutations.mjs
@@ -4,9 +4,10 @@
  * Each GitLab mutation payload carries a top-level `errors: [String!]` array of user-facing
  * validation errors (distinct from transport / GraphQL-level errors, which `GitLabClient.query`
  * raises in strict mode). `IssueService` inspects this array and surfaces a structured error
- * when it is non-empty. These mutation strings are integration-validated against a live GitLab
- * instance; the unit tests exercise the `IssueService` logic (action routing, id resolution,
- * variable forwarding, error surfacing) against a mocked `GitLabClient`.
+ * when it is non-empty. These mutation strings are best-knowledge against GitLab's GraphQL
+ * schema and are not yet integration-validated against a live instance; the unit tests exercise
+ * the `IssueService` logic (action routing, id resolution, variable forwarding, error
+ * surfacing) against a mocked `GitLabClient`.
  */
 
 /**

--- a/test/playwright/unit/ai/services/gitlab-workflow/GitLabClient.spec.mjs
+++ b/test/playwright/unit/ai/services/gitlab-workflow/GitLabClient.spec.mjs
@@ -5,6 +5,7 @@ setup({neoConfig: {unitTestMode: true}, appConfig: {name: appName, isMounted: ()
 
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
  * Unit coverage for the GitLab GraphQL client. Mocks global `fetch` and uses the

--- a/test/playwright/unit/ai/services/gitlab-workflow/GitLabClient.spec.mjs
+++ b/test/playwright/unit/ai/services/gitlab-workflow/GitLabClient.spec.mjs
@@ -1,0 +1,98 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GitLabClientTest';
+setup({neoConfig: {unitTestMode: true}, appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+
+/**
+ * Unit coverage for the GitLab GraphQL client. Mocks global `fetch` and uses the
+ * `authTokenOverride` config so no shared AiConfig mutation occurs (the gitlab host defaults to
+ * gitlab.com in a clean unit env). Mirrors the github-workflow GraphqlService test pattern.
+ */
+let GitLabClient, originalFetch, originalAuthOverride, originalRetryBaseDelay, originalRetryMaxDelay;
+
+test.beforeAll(async () => {
+    GitLabClient           = (await import('../../../../../../ai/services/gitlab-workflow/GitLabClient.mjs')).default;
+    originalAuthOverride   = GitLabClient.authTokenOverride;
+    originalRetryBaseDelay = GitLabClient.retryBaseDelayMs;
+    originalRetryMaxDelay  = GitLabClient.retryMaxDelayMs;
+});
+
+test.beforeEach(() => {
+    originalFetch                  = globalThis.fetch;
+    GitLabClient.authTokenOverride = 'test-pat'; // authenticated by default for the positive tests
+});
+
+test.afterEach(() => {
+    globalThis.fetch               = originalFetch;
+    GitLabClient.authTokenOverride = originalAuthOverride;
+    GitLabClient.retryBaseDelayMs  = originalRetryBaseDelay;
+    GitLabClient.retryMaxDelayMs   = originalRetryMaxDelay;
+});
+
+// Minimal Response-like stub. `json` is the parsed GraphQL envelope ({data} / {errors} / both).
+const response = ({ok = true, status = 200, statusText = 'OK', json = {}} = {}) => ({
+    ok, status, statusText,
+    headers: {get: () => null},
+    json   : async () => json
+});
+
+test.describe('Neo.ai.services.gitlab-workflow.GitLabClient', () => {
+    test('posts to ${hostUrl}/api/graphql with Bearer PAT and returns data (#12624)', async () => {
+        let captured;
+        globalThis.fetch = async (url, init) => {
+            captured = {url, init};
+            return response({json: {data: {project: {id: 'gid://gitlab/Project/1'}}}});
+        };
+
+        const data = await GitLabClient.query('query { project { id } }', {fullPath: 'group/proj'});
+
+        expect(data).toEqual({project: {id: 'gid://gitlab/Project/1'}});
+        expect(captured.url).toMatch(/\/api\/graphql$/);
+        expect(captured.init.method).toBe('POST');
+        expect(captured.init.headers['Authorization']).toBe('Bearer test-pat');
+        expect(captured.init.headers['Content-Type']).toBe('application/json');
+        expect(JSON.parse(captured.init.body)).toEqual({query: 'query { project { id } }', variables: {fullPath: 'group/proj'}});
+    });
+
+    test('retries on a transient 5xx then succeeds (#12624)', async () => {
+        GitLabClient.retryBaseDelayMs = 0;
+        GitLabClient.retryMaxDelayMs  = 0;
+
+        let calls = 0;
+        globalThis.fetch = async () => {
+            calls++;
+            return calls === 1
+                ? response({ok: false, status: 503, statusText: 'Service Unavailable'})
+                : response({json: {data: {project: {id: 'gid://gitlab/Project/1'}}}});
+        };
+
+        const data = await GitLabClient.query('query { project { id } }');
+
+        expect(calls).toBe(2);
+        expect(data).toEqual({project: {id: 'gid://gitlab/Project/1'}});
+    });
+
+    test('throws on GraphQL errors in strict mode (#12624)', async () => {
+        globalThis.fetch = async () => response({json: {errors: [{message: 'boom'}]}});
+
+        await expect(GitLabClient.query('mutation { x }')).rejects.toThrow(/GitLab API error: boom/);
+    });
+
+    test('returns partial data alongside errors in non-strict mode (#12624)', async () => {
+        globalThis.fetch = async () => response({json: {data: {project: {id: '1'}}, errors: [{message: 'partial'}]}});
+
+        const result = await GitLabClient.query('query { project { id } }', {}, {strict: false});
+
+        expect(result).toEqual({data: {project: {id: '1'}}, errors: [{message: 'partial'}]});
+    });
+
+    test('throws a clear auth error when no PAT is configured (#12624)', async () => {
+        GitLabClient.authTokenOverride = null; // and a clean unit env has no NEO_GITLAB_PAT
+        globalThis.fetch = async () => response({json: {data: {}}}); // must never be reached
+
+        await expect(GitLabClient.query('query { project { id } }')).rejects.toThrow(/Could not authenticate with GitLab/);
+    });
+});

--- a/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
@@ -105,6 +105,19 @@ test.describe('Neo.ai.services.gitlab-workflow.IssueService', () => {
         expect(result.assignees).toEqual(['alice']);
     });
 
+    test('createIssue surfaces an assigneeWarning when the follow-up assign fails (graceful degradation) (#12624)', async () => {
+        GitLabClient.query = async (query) => {
+            if (query.includes('CreateIssue')) return {createIssue: {issue: {iid: '9', title: 'Y', webUrl: 'https://gitlab/9'}, errors: []}};
+            throw new Error('assign failed');
+        };
+
+        const result = await IssueService.createIssue({title: 'Y', assignees: ['ghost']});
+
+        expect(result.iid).toBe('9');
+        expect(result.assigneeWarning).toBeTruthy();
+        expect(result.assignees).toBeUndefined();
+    });
+
     test('createIssue surfaces a GitLab mutation error payload (#12624)', async () => {
         GitLabClient.query = async () => ({createIssue: {issue: null, errors: ['Title can\'t be blank']}});
 

--- a/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
@@ -8,8 +8,10 @@ import Neo            from '../../../../../../src/Neo.mjs';
 
 /**
  * Unit coverage for the GitLab IssueService real behavior. Mocks `GitLabClient.query` (the transport
- * boundary) and asserts the GitLab GraphQL response -> MCP-contract parsing. Mirrors the
- * github-workflow IssueService test pattern.
+ * boundary) and asserts the GitLab GraphQL response -> MCP-contract parsing, the GitLab id-resolution
+ * steps (issue iid -> gid, label name -> id), action routing, and mutation error surfacing. Mirrors
+ * the github-workflow IssueService test pattern. Multi-call methods are mocked by branching on the
+ * operation name embedded in the query string.
  */
 let IssueService, GitLabClient, originalQuery;
 
@@ -24,6 +26,8 @@ test.afterEach(() => {
 });
 
 test.describe('Neo.ai.services.gitlab-workflow.IssueService', () => {
+    // --- listIssues --------------------------------------------------------------------------
+
     test('listIssues maps GitLab project.issues nodes to the MCP item shape (#12624)', async () => {
         GitLabClient.query = async () => ({
             project: {issues: {nodes: [
@@ -64,5 +68,142 @@ test.describe('Neo.ai.services.gitlab-workflow.IssueService', () => {
         const result = await IssueService.listIssues();
 
         expect(result).toEqual({items: [], count: 0});
+    });
+
+    // --- createIssue -------------------------------------------------------------------------
+
+    test('createIssue returns the created issue and forwards labels by name (#12624)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {createIssue: {issue: {iid: '7', title: 'New', webUrl: 'https://gitlab/7'}, errors: []}};
+        };
+
+        const result = await IssueService.createIssue({title: 'New', body: 'desc', labels: ['bug']});
+
+        expect(captured.title).toBe('New');
+        expect(captured.description).toBe('desc');
+        expect(captured.labels).toEqual(['bug']);
+        expect(result).toEqual({iid: '7', title: 'New', webUrl: 'https://gitlab/7'});
+    });
+
+    test('createIssue applies assignees via a follow-up APPEND issueSetAssignees (#12624)', async () => {
+        let assignVars;
+        GitLabClient.query = async (query, variables) => {
+            if (query.includes('CreateIssue')) {
+                return {createIssue: {issue: {iid: '8', title: 'X', webUrl: 'https://gitlab/8'}, errors: []}};
+            }
+            assignVars = variables;
+            return {issueSetAssignees: {issue: {assignees: {nodes: [{username: 'alice'}]}}, errors: []}};
+        };
+
+        const result = await IssueService.createIssue({title: 'X', assignees: ['alice']});
+
+        expect(assignVars.iid).toBe('8');
+        expect(assignVars.assigneeUsernames).toEqual(['alice']);
+        expect(assignVars.operationMode).toBe('APPEND');
+        expect(result.assignees).toEqual(['alice']);
+    });
+
+    test('createIssue surfaces a GitLab mutation error payload (#12624)', async () => {
+        GitLabClient.query = async () => ({createIssue: {issue: null, errors: ['Title can\'t be blank']}});
+
+        const result = await IssueService.createIssue({title: ''});
+
+        expect(result.code).toBe('GITLAB_MUTATION_ERROR');
+        expect(result.message).toContain('Title can\'t be blank');
+    });
+
+    // --- manageIssueComment ------------------------------------------------------------------
+
+    test('manageIssueComment create resolves the issue gid then creates a note (#12624)', async () => {
+        let noteVars;
+        GitLabClient.query = async (query, variables) => {
+            if (query.includes('GetIssueGid')) return {project: {issue: {id: 'gid://gitlab/Issue/99'}}};
+            noteVars = variables;
+            return {createNote: {note: {id: 'gid://gitlab/Note/500', body: 'hi'}, errors: []}};
+        };
+
+        const result = await IssueService.manageIssueComment({action: 'create', issue_number: 3, body: 'hi'});
+
+        expect(noteVars.noteableId).toBe('gid://gitlab/Issue/99');
+        expect(result.noteId).toBe('gid://gitlab/Note/500');
+    });
+
+    test('manageIssueComment update addresses the note by reconstructed global id (#12624)', async () => {
+        let updateVars;
+        GitLabClient.query = async (query, variables) => {
+            updateVars = variables;
+            return {updateNote: {note: {id: 'gid://gitlab/Note/500', body: 'edited'}, errors: []}};
+        };
+
+        const result = await IssueService.manageIssueComment({action: 'update', note_id: 500, body: 'edited'});
+
+        expect(updateVars.id).toBe('gid://gitlab/Note/500');
+        expect(result.noteId).toBe('gid://gitlab/Note/500');
+    });
+
+    test('manageIssueComment rejects an invalid action (#12624)', async () => {
+        const result = await IssueService.manageIssueComment({action: 'destroy', issue_number: 1, body: 'x'});
+        expect(result.code).toBe('INVALID_ARGUMENTS');
+    });
+
+    // --- manageIssueLabels -------------------------------------------------------------------
+
+    test('manageIssueLabels add resolves label names to ids and forwards addLabelIds (#12624)', async () => {
+        let updateVars;
+        GitLabClient.query = async (query, variables) => {
+            if (query.includes('GetProjectLabelIds')) {
+                return {project: {labels: {nodes: [
+                    {id: 'gid://gitlab/ProjectLabel/1', title: 'bug'},
+                    {id: 'gid://gitlab/ProjectLabel/2', title: 'p1'}
+                ]}}};
+            }
+            updateVars = variables;
+            return {updateIssue: {issue: {iid: '4', labels: {nodes: [{title: 'bug'}, {title: 'p1'}]}}, errors: []}};
+        };
+
+        const result = await IssueService.manageIssueLabels({issue_number: 4, action: 'add', labels: ['bug', 'p1']});
+
+        expect(updateVars.addLabelIds).toEqual(['gid://gitlab/ProjectLabel/1', 'gid://gitlab/ProjectLabel/2']);
+        expect(updateVars.removeLabelIds).toBe(null);
+        expect(updateVars.iid).toBe('4');
+        expect(result.labels).toEqual(['bug', 'p1']);
+    });
+
+    test('manageIssueLabels rejects unknown label names with LABEL_NOT_FOUND (#12624)', async () => {
+        GitLabClient.query = async () => ({project: {labels: {nodes: [{id: 'gid://gitlab/ProjectLabel/1', title: 'bug'}]}}});
+
+        const result = await IssueService.manageIssueLabels({issue_number: 4, action: 'add', labels: ['bug', 'ghost']});
+
+        expect(result.code).toBe('LABEL_NOT_FOUND');
+    });
+
+    // --- manageIssueAssignees ----------------------------------------------------------------
+
+    test('manageIssueAssignees add forwards APPEND + usernames (#12624)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {issueSetAssignees: {issue: {assignees: {nodes: [{username: 'alice'}]}}, errors: []}};
+        };
+
+        const result = await IssueService.manageIssueAssignees({issue_number: 6, action: 'add', assignees: ['alice']});
+
+        expect(captured.operationMode).toBe('APPEND');
+        expect(captured.assigneeUsernames).toEqual(['alice']);
+        expect(result.assignees).toEqual(['alice']);
+    });
+
+    test('manageIssueAssignees remove forwards REMOVE (#12624)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {issueSetAssignees: {issue: {assignees: {nodes: []}}, errors: []}};
+        };
+
+        await IssueService.manageIssueAssignees({issue_number: 6, action: 'remove', assignees: ['alice']});
+
+        expect(captured.operationMode).toBe('REMOVE');
     });
 });

--- a/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
@@ -1,0 +1,68 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GitLabIssueServiceTest';
+setup({neoConfig: {unitTestMode: true}, appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+
+/**
+ * Unit coverage for the GitLab IssueService real behavior. Mocks `GitLabClient.query` (the transport
+ * boundary) and asserts the GitLab GraphQL response -> MCP-contract parsing. Mirrors the
+ * github-workflow IssueService test pattern.
+ */
+let IssueService, GitLabClient, originalQuery;
+
+test.beforeAll(async () => {
+    GitLabClient = (await import('../../../../../../ai/services/gitlab-workflow/GitLabClient.mjs')).default;
+    IssueService = (await import('../../../../../../ai/services/gitlab-workflow/IssueService.mjs')).default;
+    originalQuery = GitLabClient.query.bind(GitLabClient);
+});
+
+test.afterEach(() => {
+    GitLabClient.query = originalQuery;
+});
+
+test.describe('Neo.ai.services.gitlab-workflow.IssueService', () => {
+    test('listIssues maps GitLab project.issues nodes to the MCP item shape (#12624)', async () => {
+        GitLabClient.query = async () => ({
+            project: {issues: {nodes: [
+                {iid: '1', title: 'First', state: 'opened', webUrl: 'https://gitlab/1', createdAt: 't1', updatedAt: 't2', labels: {nodes: [{title: 'bug'}, {title: 'p1'}]}, assignees: {nodes: [{username: 'alice'}]}},
+                {iid: '2', title: 'Second', state: 'opened', webUrl: 'https://gitlab/2', createdAt: 't3', updatedAt: 't4', labels: {nodes: []}, assignees: {nodes: []}}
+            ]}}
+        });
+
+        const result = await IssueService.listIssues({limit: 10, state: 'opened'});
+
+        expect(result.count).toBe(2);
+        expect(result.items[0]).toEqual({
+            iid      : '1', title: 'First', state: 'opened', webUrl: 'https://gitlab/1',
+            createdAt: 't1', updatedAt: 't2', labels: ['bug', 'p1'], assignees: ['alice']
+        });
+        expect(result.items[1].labels).toEqual([]);
+        expect(result.items[1].assignees).toEqual([]);
+    });
+
+    test('listIssues forwards filters as GitLab GraphQL variables (#12624)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {project: {issues: {nodes: []}}};
+        };
+
+        await IssueService.listIssues({limit: 5, state: 'closed', labels: 'bug, p1', assignee: 'bob'});
+
+        expect(captured.first).toBe(5);
+        expect(captured.state).toBe('closed');
+        expect(captured.labelName).toEqual(['bug', 'p1']);
+        expect(captured.assigneeUsernames).toEqual(['bob']);
+    });
+
+    test('listIssues returns empty and is resilient to a null project (#12624)', async () => {
+        GitLabClient.query = async () => ({project: null});
+
+        const result = await IssueService.listIssues();
+
+        expect(result).toEqual({items: [], count: 0});
+    });
+});

--- a/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/gitlab-workflow/IssueService.spec.mjs
@@ -5,6 +5,7 @@ setup({neoConfig: {unitTestMode: true}, appConfig: {name: appName, isMounted: ()
 
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
  * Unit coverage for the GitLab IssueService real behavior. Mocks `GitLabClient.query` (the transport


### PR DESCRIPTION
Resolves #12624
Related: #11404

Authored by Claude Opus 4.8 (Claude Code). Session a54e89a3-4259-4b41-9e26-561f665de744.

Implements real GitLab GraphQL behavior for the full `gitlab-workflow` `IssueService` surface, replacing the `{status: 'scaffolded'}` placeholders. The MCP tools (`list_issues`, `create_issue`, `manage_issue_comment`, `manage_issue_labels`, `manage_issue_assignees`) now dispatch to live GitLab calls via a new `GitLabClient` GraphQL client — the GitLab twin of github-workflow's `GraphqlService` + `IssueService`.

Evidence: L1 (unit-mock of the `GitLabClient` transport boundary + static `makeSafe`/operationId wiring audit) → L1 required (all four ACs are unit/static-covered; live GitLab API integration is explicitly out-of-scope per the ticket — no test GitLab project in CI). Residual: live-GitLab integration validation of the GraphQL query/mutation strings [#11404 follow-up].

## What shipped (per AC)

- **AC1 — `GitLabClient.mjs`**: GraphQL client reading resolved `aiConfig.gitlab.hostUrl` / `aiConfig.gitlab.token` leaves at the use site (ADR 0019 — no `process.env` re-read, fallback cascade, alias, or threading), `${hostUrl}/api/graphql` endpoint, Bearer PAT auth, 429/5xx retry + backoff honoring `retry-after`, strict + non-strict-partial GraphQL error handling. No `glab`-CLI dependency.
- **AC2 — real `IssueService` (all 5 ops, `#scaffold()` removed)**: `listIssues` (filter→GraphQL variables), `createIssue` (createIssue + follow-up username-native `issueSetAssignees`, graceful assignee-degradation), `manageIssueComment` (iid→gid resolve → createNote / updateNote), `manageIssueLabels` (label-name→gid resolve → updateIssue add/removeLabelIds), `manageIssueAssignees` (issueSetAssignees APPEND/REMOVE). GitLab shape handled: `iid`, `project(fullPath)`, `notes`, connection nodes; each mutation's `errors` payload surfaced as a structured error.
- **AC3 — specs**: `GitLabClient.spec.mjs` + `IssueService.spec.mjs` (each op). **19 passed.**
- **AC4 — `GL_IssueService` wired in `ai/services.mjs`**: `makeSafe(_GL_IssueService, gitlabSpec)` against the gitlab openapi; all 5 operationIds map via `camelToSnake` → Zod-validated at the tool boundary. `toolService.mjs` already binds the methods.

## Config Template Change (per `mcp-config-template-change-guide`)

- **Changed key**: added `gitlab.projectPath` leaf to `ai/mcp/server/gitlab-workflow/config.template.mjs` (env `NEO_GITLAB_PROJECT`, default `''`) — the GitLab analog of github-workflow's `owner`/`repo`, owning env-default resolution per ADR 0019; services read `aiConfig.gitlab.projectPath` at the use site.
- **Local `config.mjs` follow-up**: REQUIRED after merge — each clone's gitignored `gitlab-workflow/config.mjs` needs the `projectPath` leaf (re-sync from the template; `ai:lint-config-template-ssot` flags the drift). No gitignored `config.mjs` is committed.
- **Harness restart**: recommended only if running the `gitlab-workflow` MCP server (still a scaffold under construction; not yet live in peer setups).
- *Guide-staleness note*: `mcp-config-template-change-guide.md` lists 4 scoped servers but not `gitlab-workflow` (added later by #11768) — its intent applies; the stale list is flagged for a separate doc-sync follow-up.

## Validation discipline (gpt's ADR-0019 shape note on the #12624 thread)
Config reads are resolved-leaf-at-use-site (no env re-read / alias / threading). Argument validation stays at the OpenAPI/Zod `makeSafe` boundary; the per-method `action` guards are domain-routing safety for raw (un-wrapped) callers + tests, not schema re-validation.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/services/gitlab-workflow/
→ 19 passed
```
Coverage: GitLabClient transport (endpoint/auth/headers, retry-on-5xx, strict-error, non-strict-partial, missing-PAT) + IssueService each op — node→MCP mapping, filter/variable forwarding, iid→gid + label-name→id resolution, action routing, mutation-error surfacing, graceful assignee-degradation, null-resilience.

## Deltas from ticket
The mutation GraphQL strings (`createIssue` / `createNote` / `updateNote` / `updateIssue` / `issueSetAssignees`) are best-knowledge against GitLab's current GraphQL schema; per the ticket's Out-of-Scope ("no test GitLab project in CI") they carry integration-validation as the #11404 follow-up. Unit tests validate the service *logic* (routing, id resolution, variable forwarding, error surfacing) against a mocked client, not the wire-correctness of the GraphQL strings.

## Commits
- `46eb83735` — GitLabClient + spec (AC1)
- `7c95f737c` — listIssues + `projectPath` config-template leaf
- `b6eb62c4a` — issue mutations + `makeSafe` wiring (AC2/AC4)
- `972f952b3` — assignee-degradation test

## Post-Merge Validation
- [ ] Each clone re-syncs `gitlab-workflow/config.mjs` with the `projectPath` leaf.
- [ ] Live GitLab integration validation of the GraphQL strings (set `NEO_GITLAB_HOST` / `NEO_GITLAB_PAT` / `NEO_GITLAB_PROJECT` against a real project) — #11404 follow-up.
