### PR TITLE
docs(core): capture setupClass rationale and benchmark (#10107)

### DIFF
--- a/ai/scripts/benchmark/setupClass-cold-start.mjs
+++ b/ai/scripts/benchmark/setupClass-cold-start.mjs
@@ -1,0 +1,259 @@
+import {Command} from 'commander';
+import {mkdir, writeFile} from 'fs/promises';
+import path from 'path';
+import {fileURLToPath} from 'url';
+import Neo from '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import {median, percentile} from './helpers/stats.mjs';
+
+/**
+ * @module ai/scripts/benchmark/setupClass-cold-start
+ * @summary Cold-start benchmark for `Neo.setupClass()` class-registration cost.
+ *
+ * `Neo.setupClass()` is the mixed-runtime gatekeeper for every Neo class module:
+ * it merges config along the prototype chain, applies overwrites, creates reactive
+ * getters/setters, registers ntypes, applies mixins, maps classes into
+ * `globalThis.Neo`, and records hierarchy metadata. That makes it a cold-start hot
+ * path. Any future readability refactor must prove it does not regress boot-time
+ * cost or heap pressure.
+ *
+ * This benchmark creates synthetic subclasses of `Neo.core.Base` with unique
+ * className / ntype pairs, runs them through `Neo.setupClass()`, and records
+ * elapsed time plus heap deltas. It intentionally avoids constructing instances:
+ * the measured surface is class registration, not component lifecycle work.
+ *
+ * @see src/Neo.mjs - `setupClass()` gatekeeper
+ * @see src/core/Base.mjs - base class config inherited by every synthetic class
+ * @see learn/agentos/measurements/setupClass-cold-start.md - baseline protocol
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../../..');
+
+/**
+ * Parse a positive integer CLI option.
+ *
+ * @param {string|number} value Incoming CLI value
+ * @param {number} fallback Fallback when parsing fails
+ * @returns {number}
+ */
+function parsePositiveInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * Parse a non-negative integer CLI option.
+ *
+ * @param {string|number} value Incoming CLI value
+ * @param {number} fallback Fallback when parsing fails
+ * @returns {number}
+ */
+function parseNonNegativeInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/**
+ * Round numeric output so small sample summaries do not expose floating-point noise.
+ *
+ * @param {number} value
+ * @param {number} [decimals=3]
+ * @returns {number}
+ */
+function roundMetric(value, decimals = 3) {
+    const factor = 10 ** decimals;
+    return Math.round(value * factor) / factor;
+}
+
+/**
+ * Build one synthetic class with configurable reactive and non-reactive config load.
+ *
+ * @param {string} className Unique className
+ * @param {string} ntype Unique ntype
+ * @param {number} reactiveConfigs Number of trailing-underscore configs
+ * @param {number} prototypeConfigs Number of prototype configs
+ * @returns {typeof Neo.core.Base}
+ */
+function createSyntheticClass(className, ntype, reactiveConfigs, prototypeConfigs) {
+    class SyntheticSetupClassBenchmark extends Neo.core.Base {}
+
+    const config = {className, ntype};
+
+    for (let i = 0; i < reactiveConfigs; i++) {
+        config[`reactive${i}_`] = i;
+    }
+
+    for (let i = 0; i < prototypeConfigs; i++) {
+        config[`prototype${i}`] = {
+            index: i,
+            value: `static-${i}`
+        };
+    }
+
+    SyntheticSetupClassBenchmark.config = config;
+
+    return SyntheticSetupClassBenchmark;
+}
+
+/**
+ * Run one benchmark pass.
+ *
+ * @param {Object} options
+ * @param {number} options.classCount Number of synthetic classes to register
+ * @param {number} options.reactiveConfigs Reactive configs per class
+ * @param {number} options.prototypeConfigs Prototype configs per class
+ * @param {string} options.runId Unique namespace suffix
+ * @returns {{classCount: number, reactiveConfigs: number, prototypeConfigs: number, elapsedMs: number, msPerClass: number, heapDeltaBytes: number, heapDeltaPerClassBytes: number}}
+ */
+function runBenchmark({classCount, reactiveConfigs, prototypeConfigs, runId}) {
+    if (globalThis.gc) {
+        globalThis.gc();
+    }
+
+    const beforeHeap = process.memoryUsage().heapUsed;
+    const t0 = performance.now();
+
+    for (let i = 0; i < classCount; i++) {
+        const
+            className = `Neo.benchmark.SetupClass.${runId}.Class${i}`,
+            ntype     = `setup-class-${runId}-${i}`;
+
+        Neo.setupClass(createSyntheticClass(className, ntype, reactiveConfigs, prototypeConfigs));
+    }
+
+    const elapsedMs = performance.now() - t0;
+
+    if (globalThis.gc) {
+        globalThis.gc();
+    }
+
+    const heapDeltaBytes = process.memoryUsage().heapUsed - beforeHeap;
+
+    return {
+        classCount,
+        reactiveConfigs,
+        prototypeConfigs,
+        elapsedMs              : Math.round(elapsedMs * 100) / 100,
+        msPerClass             : Math.round((elapsedMs / classCount) * 1000) / 1000,
+        heapDeltaBytes,
+        heapDeltaPerClassBytes : Math.round(heapDeltaBytes / classCount)
+    };
+}
+
+/**
+ * Summarize benchmark runs.
+ *
+ * @param {Array} runs
+ * @returns {Object}
+ */
+function summarizeRuns(runs) {
+    const
+        elapsed = runs.map(run => run.elapsedMs),
+        perClass = runs.map(run => run.msPerClass),
+        heapDelta = runs.map(run => run.heapDeltaBytes),
+        heapPerClass = runs.map(run => run.heapDeltaPerClassBytes);
+
+    return {
+        n                          : runs.length,
+        elapsedMs_median           : roundMetric(median(elapsed), 2),
+        elapsedMs_p95              : runs.length >= 5 ? roundMetric(percentile(elapsed, 0.95), 2) : undefined,
+        msPerClass_median          : roundMetric(median(perClass), 3),
+        heapDeltaBytes_median         : roundMetric(median(heapDelta), 0),
+        heapDeltaPerClassBytes_median : roundMetric(median(heapPerClass), 0)
+    };
+}
+
+async function main() {
+    const program = new Command();
+    program
+        .name('setupClass-cold-start')
+        .description('Benchmark Neo.setupClass cold-start class-registration cost')
+        .option('-c, --classes <n>', 'Synthetic classes per measured run', '500')
+        .option('-r, --runs <n>', 'Measured runs', '5')
+        .option('-w, --warmup <n>', 'Warmup runs (discarded)', '1')
+        .option('--reactive-configs <n>', 'Reactive trailing-underscore configs per class', '3')
+        .option('--prototype-configs <n>', 'Non-reactive prototype configs per class', '3')
+        .option('-o, --output <path>', 'Output JSON path (default: .neo-ai-data/benchmarks/setupClass-cold-start-{ts}.json)');
+
+    program.parse();
+
+    const opts = program.opts();
+    const config = {
+        classCount      : parsePositiveInt(opts.classes, 500),
+        runs            : parsePositiveInt(opts.runs, 5),
+        warmup          : parseNonNegativeInt(opts.warmup, 1),
+        reactiveConfigs : parseNonNegativeInt(opts.reactiveConfigs, 3),
+        prototypeConfigs: parseNonNegativeInt(opts.prototypeConfigs, 3)
+    };
+
+    const timestamp = new Date().toISOString();
+    const namespaceSeed = timestamp.replace(/[^0-9]/g, '');
+
+    console.log('[setupClass-cold-start] Benchmarking Neo.setupClass()');
+    console.log(`[setupClass-cold-start] Classes/run: ${config.classCount}`);
+    console.log(`[setupClass-cold-start] Runs: ${config.runs} (+${config.warmup} warmup discarded)`);
+    console.log(`[setupClass-cold-start] Configs/class: reactive=${config.reactiveConfigs}, prototype=${config.prototypeConfigs}`);
+    console.log(`[setupClass-cold-start] GC exposed: ${Boolean(globalThis.gc)}`);
+    console.log('');
+
+    for (let i = 0; i < config.warmup; i++) {
+        process.stdout.write(`  warmup ${i + 1}/${config.warmup}...`);
+        const warmup = runBenchmark({
+            ...config,
+            runId: `${namespaceSeed}Warmup${i}`
+        });
+        console.log(` ${warmup.elapsedMs}ms (${warmup.msPerClass}ms/class)`);
+    }
+
+    const runs = [];
+    for (let i = 0; i < config.runs; i++) {
+        process.stdout.write(`  run ${i + 1}/${config.runs}...`);
+        const run = runBenchmark({
+            ...config,
+            runId: `${namespaceSeed}Run${i}`
+        });
+        runs.push(run);
+        console.log(
+            ` ${run.elapsedMs}ms (${run.msPerClass}ms/class), ` +
+            `heapDelta=${run.heapDeltaBytes} bytes`
+        );
+    }
+
+    const results = {
+        meta: {
+            timestamp,
+            nodeVersion: process.version,
+            platform   : process.platform,
+            arch       : process.arch,
+            gcExposed  : Boolean(globalThis.gc),
+            command    : process.argv.join(' ')
+        },
+        config,
+        runs,
+        summary: summarizeRuns(runs)
+    };
+
+    console.log('\n=== Summary ===');
+    console.log(`elapsedMs median: ${results.summary.elapsedMs_median}`);
+    if (results.summary.elapsedMs_p95 !== undefined) {
+        console.log(`elapsedMs p95   : ${results.summary.elapsedMs_p95}`);
+    }
+    console.log(`ms/class median : ${results.summary.msPerClass_median}`);
+    console.log(`heap/class median bytes: ${results.summary.heapDeltaPerClassBytes_median}`);
+
+    const outputPath = opts.output || path.join(
+        projectRoot,
+        '.neo-ai-data/benchmarks',
+        `setupClass-cold-start-${timestamp.replace(/[:.]/g, '-')}.json`
+    );
+    await mkdir(path.dirname(outputPath), {recursive: true});
+    await writeFile(outputPath, JSON.stringify(results, null, 2), 'utf8');
+    console.log(`\nWritten: ${outputPath}`);
+}
+
+main().catch(error => {
+    console.error('[setupClass-cold-start] FATAL:', error);
+    process.exit(1);
+});

--- a/learn/agentos/measurements/setupClass-cold-start.md
+++ b/learn/agentos/measurements/setupClass-cold-start.md
@@ -1,0 +1,103 @@
+# setupClass Cold-Start Benchmark
+
+> **Status (2026-06-06):** baseline committed for #10107.
+> **Scope:** `Neo.setupClass()` class-registration cost only; no instance construction.
+
+## Why this exists
+
+`Neo.setupClass()` is the gatekeeper for every Neo class module. It merges inherited
+config, applies overwrites, creates reactive getters/setters, registers ntypes,
+applies mixins, maps classes into `globalThis.Neo`, and records class-hierarchy
+metadata. That work happens once per class during application cold start.
+
+The function is intentionally centralized because it protects mixed-runtime loading:
+bundled production classes, dynamically loaded ESM classes, workers, and test entry
+points all meet at the same `globalThis.Neo` registry. Readability refactors are
+allowed only when they preserve that registry behavior and do not regress cold-start
+time or allocation pressure.
+
+## Script
+
+```bash
+npm run ai:benchmark-setup-class
+```
+
+Equivalent direct form:
+
+```bash
+node --expose-gc ai/scripts/benchmark/setupClass-cold-start.mjs \
+    --classes 500 \
+    --runs 5 \
+    --warmup 1
+```
+
+Output: console summary plus JSON at
+`.neo-ai-data/benchmarks/setupClass-cold-start-{timestamp}.json` unless `--output`
+is supplied.
+
+## Method
+
+The script creates synthetic subclasses of `Neo.core.Base` with unique
+`className` / `ntype` pairs, three reactive configs, and three prototype configs
+per class. It then runs each generated class through `Neo.setupClass()` and records:
+
+- elapsed wall time
+- elapsed time per class
+- heap delta
+- heap delta per class
+
+The benchmark intentionally avoids constructing instances. Instance lifecycle,
+rendering, component configs, and worker remoting are separate performance surfaces.
+
+## Baseline Measurements
+
+Run captured on 2026-06-06T14:07:43.219Z.
+
+| Field | Value |
+| --- | --- |
+| Node | `v25.9.0` |
+| Platform | `darwin arm64` |
+| GC exposed | `true` |
+| Classes per run | `500` |
+| Measured runs | `5` |
+| Warmups discarded | `1` |
+| Reactive configs per class | `3` |
+| Prototype configs per class | `3` |
+
+| Run | Elapsed ms | ms/class | Heap delta bytes | Heap/class bytes |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 9.19 | 0.018 | 1,343,048 | 2,686 |
+| 2 | 9.14 | 0.018 | 1,384,976 | 2,770 |
+| 3 | 10.12 | 0.020 | 1,283,240 | 2,566 |
+| 4 | 10.07 | 0.020 | 1,271,768 | 2,544 |
+| 5 | 10.64 | 0.021 | 1,484,288 | 2,969 |
+
+| Summary | Value |
+| --- | ---: |
+| Median elapsed | 10.07 ms |
+| p95 elapsed | 10.64 ms |
+| Median ms/class | 0.020 |
+| Median heap delta | 1,343,048 bytes |
+| Median heap/class | 2,686 bytes |
+
+## Refactor Gate
+
+Any future `Neo.setupClass()` decomposition or helper extraction should run this
+benchmark before and after the change, with the same class/config counts. A valid
+refactor PR needs to document:
+
+- before/after median elapsed time
+- before/after heap delta
+- whether the class namespace, ntype map, reactive-config, and hierarchy outputs
+  remain byte-for-byte equivalent for the benchmark class shape
+- why any regression is acceptable, if a regression is proposed
+
+If the refactor changes benchmark shape, commit the new protocol first and explain
+why the old baseline no longer covers the relevant hot path.
+
+## Related
+
+- #10107 - core.Base + Neo.mjs rationale and benchmark baseline.
+- #10108 - separate `me = this` policy decision.
+- `src/Neo.mjs` - `setupClass()` implementation and registry rationale.
+- `src/core/Base.mjs` - shared class identity config rationale.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "ai:audit-integrity"           : "node ./ai/scripts/maintenance/auditGraphIntegrity.mjs",
         "ai:backup"                    : "node ./ai/scripts/maintenance/backup.mjs",
         "ai:benchmark-gemma4"          : "node ./ai/scripts/benchmark/gemma4-rem-benchmark.mjs",
+        "ai:benchmark-setup-class"     : "node --expose-gc ./ai/scripts/benchmark/setupClass-cold-start.mjs",
         "ai:bootstrap-codex-sandbox"   : "node ./ai/scripts/diagnostics/bootstrapCodexSandbox.mjs",
         "ai:check-identity-facts"      : "node ./ai/scripts/diagnostics/check-identity-facts.mjs",
         "ai:check-retired-primitives"  : "node ./ai/scripts/diagnostics/check-retired-primitives.mjs",

--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -49,6 +49,16 @@ const
 /**
  * The base module to enhance classes, create instances and the Neo namespace.
  *
+ * `Neo` deliberately exists as both an ES module export and the shared `globalThis.Neo`
+ * registry. The dual role is the class-system boundary that lets bundled production code,
+ * dynamically loaded ESM modules, workers, and unit-test entry points meet at one namespace.
+ * `setupClass()` is the gatekeeper for that registry: the first loaded class wins, later loads
+ * resolve to the existing namespace entry, and `unitTestMode` turns accidental duplicate loads
+ * into explicit failures. Do not split this registry or decompose `setupClass()` without first
+ * proving cold-start neutrality with `ai/scripts/benchmark/setupClass-cold-start.mjs`; it runs
+ * once per class during application boot, so helper extraction must account for wall time,
+ * allocation pressure, descriptor churn, and mixed-runtime namespace behavior.
+ *
  * **Note:** The `Neo` namespace is explicitly augmented by core modules like `src/core/Util.mjs`
  * and `src/core/Compare.mjs`. Global utility methods (e.g. `Neo.isArray`, `Neo.isEqual`) are defined
  * there and mapped here. To ensure these methods are available, make sure to import the core package:

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -13,6 +13,15 @@ const configSymbol       = Symbol.for('configSymbol'),
 /**
  * The base class for (almost) all classes inside the Neo namespace
  * Exceptions are e.g. core.IdGenerator, vdom.VNode
+ *
+ * `className` and `ntype` intentionally live on instances as well as on static class config.
+ * This costs a few prototype slots, but it keeps Chrome DevTools and Neural Link inspection
+ * direct: expanding an instance immediately reveals its framework identity and creation
+ * shortcut without walking the constructor or prototype chain. That ergonomics choice is part
+ * of the core debugging contract; do not demote these values to static-only metadata without
+ * measuring the runtime/debugging trade-off and updating every consumer that serializes,
+ * routes, or instantiates by class identity.
+ *
  * @class Neo.core.Base
  */
 class Base {
@@ -946,7 +955,7 @@ class Base {
      *
      * **[CRITICAL]** This is the correct, architecture-compliant way to wait for an instance to spin up externally.
      * Never call `initAsync()` externally!
-     * 
+     *
      * @example await ChromaManager.ready();
      * @example await orchestrator.ready();
      * @returns {Promise<void>}


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Resolves #10107

Captures the architectural rationale for keeping `Neo.setupClass()` as the central class-system gatekeeper, documents why `Neo.core.Base` keeps `className` / `ntype` visible on instances, and adds a repeatable cold-start benchmark so future decomposition work has a measured baseline instead of relying on readability-only arguments.

Evidence: L3 (real Node benchmark CLI executed with synthetic `Neo.setupClass()` class registrations) -> L3 required (benchmark baseline plus source rationale). No residuals.

## Deltas from Ticket

The ticket proposed `buildScripts/benchmarks/`; the current repo-local benchmark substrate is `ai/scripts/benchmark/`, so the implementation follows the existing `ai:benchmark-*` package-script pattern instead.

## Test Evidence

- `git diff --check`
- `rg -n "[^\\x00-\\x7F]" ai/scripts/benchmark/setupClass-cold-start.mjs learn/agentos/measurements/setupClass-cold-start.md src/Neo.mjs src/core/Base.mjs package.json` returned no matches
- `node --check ai/scripts/benchmark/setupClass-cold-start.mjs`
- `node --input-type=module -e "import fs from 'fs'; JSON.parse(fs.readFileSync('package.json','utf8')); console.log('package.json valid');"`
- `node --expose-gc ai/scripts/benchmark/setupClass-cold-start.mjs --classes 500 --runs 5 --warmup 1 --output /private/tmp/setupClass-cold-start-baseline-current.json`
- `npm run ai:benchmark-setup-class -- --classes 50 --runs 2 --warmup 0 --output /private/tmp/setupClass-cold-start-smoke.json`
- `npm run ai:benchmark-setup-class -- --classes 20 --runs 1 --warmup 0 --reactive-configs 0 --prototype-configs 0 --output /private/tmp/setupClass-cold-start-zero-config-smoke.json`
- `node ./buildScripts/util/check-whitespace.mjs`
- `node ./buildScripts/util/check-shorthand.mjs`
- Commit hook passed `node ./buildScripts/util/check-ticket-archaeology.mjs`

## Post-Merge Validation

- [ ] Future `Neo.setupClass()` decomposition PRs compare before/after benchmark output against `learn/agentos/measurements/setupClass-cold-start.md`.

## Commit

- `ae7217847` - `docs(core): capture setupClass rationale and benchmark (#10107)`
