### PR TITLE
feat(agentos): link test evidence with validates edges (#9906)

### DIFF
--- a/ai/services/graph/GapInferenceEngine.mjs
+++ b/ai/services/graph/GapInferenceEngine.mjs
@@ -110,32 +110,69 @@ class GapInferenceEngine extends Base {
         // INTERNAL MAPPING NOTE: The native SQLite items iterate over `Neo.ai.graph.NodeModel`
         // instances. To align with formal Graph Database taxonomy, the DTO `.type` property
         // is mapped to `.label` on Nodes (while Edges retain `.type`).
-        const testFilePaths = GraphService.db.nodes.items.filter(n =>
+        const testFileNodes = GraphService.db.nodes.items.filter(n =>
             n.label === 'FILE' && n.properties?.path?.startsWith('test/')
-        ).map(n => n.properties?.path || '').map(p => p.toLowerCase());
+        ).map(n => ({
+            id       : n.id,
+            path     : n.properties?.path || '',
+            pathLower: (n.properties?.path || '').toLowerCase()
+        }));
 
         for (const node of structuralNodes) {
             const isInternalConfigHook = node.type === 'METHOD' && /^(beforeGet|beforeSet|afterSet)[A-Z]/.test(node.name);
-            let testGap = null;
+            const dbNode = GraphService.db.nodes.get(node.id) || GraphService.db.nodes.get(node._resolvedId);
+
+            if (!dbNode) continue;
+
+            let testGap           = null;
+            let matchingTestFiles = [];
 
             if (!isInternalConfigHook) {
                 const nodeTokens = node.name.replace(/([A-Z])/g, ' $1').toLowerCase().split(/[^a-z0-9]+/).filter(t => t.length > 2);
                 if (nodeTokens.length === 0) nodeTokens.push(node.name.toLowerCase());
 
-                const hasTest = testFilePaths.some(p => nodeTokens.some(term => {
+                matchingTestFiles = testFileNodes.filter(({pathLower}) => nodeTokens.some(term => {
                     const regex = new RegExp('\\b' + term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'i');
-                    return regex.test(p);
+                    return regex.test(pathLower);
                 }));
 
-                if (!hasTest) {
+                if (matchingTestFiles.length === 0) {
                     testGap = `[TEST_GAP] The ${node.type} '${node.name}' lacks corresponding automated validation suites (Playwright) covering its tokens within the test/ directory.`;
+                } else {
+                    this.linkTestEvidenceToStructuralNode(matchingTestFiles, dbNode, node);
                 }
             }
 
-            const dbNode = GraphService.db.nodes.get(node.id) || GraphService.db.nodes.get(node._resolvedId);
-            if (!dbNode) continue;
-
             this.applyGapsToNode(dbNode, testGap ? [testGap] : []);
+        }
+    }
+
+    /**
+     * @summary Links durable test-file evidence to a structural graph node.
+     *
+     * `FILE` nodes whose `properties.path` starts with `test/` are the canonical evidence node
+     * for this first relation contract. The edge metadata keeps downstream reward / gap-downgrade
+     * consumers from re-parsing `capabilityGap` strings once a matching test file exists.
+     * @param {Object[]} testFileNodes Matching test-file node descriptors
+     * @param {Object}   dbNode        SQLite-persisted structural graph node
+     * @param {Object}   sourceNode    Session-artifact structural node
+     * @protected
+     */
+    linkTestEvidenceToStructuralNode(testFileNodes, dbNode, sourceNode) {
+        const linkedIds = new Set();
+
+        for (const testFile of testFileNodes) {
+            if (!testFile.id || linkedIds.has(testFile.id)) continue;
+
+            linkedIds.add(testFile.id);
+
+            GraphService.linkNodes(testFile.id, dbNode.id, 'VALIDATES', 1.0, {
+                evidenceKind      : 'permanent-test-file',
+                evidencePath      : testFile.path,
+                inferredBy        : 'GapInferenceEngine.inferTestGapsFromSession',
+                validatedNodeName : sourceNode.name,
+                validatedNodeType : sourceNode.type
+            });
         }
     }
 

--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -125,7 +125,7 @@ and checks three coverage dimensions:
 
 | Gap Type | Detection Method |
 |---|---|
-| `[TEST_GAP]` | No test file paths in `test/` contain tokens matching the node name |
+| `[TEST_GAP]` | No test file paths in `test/` contain tokens matching the node name; matching test `FILE` nodes create `VALIDATES` edges to the structural source node |
 | `[GUIDE_GAP]` | No guide paths in `learn/guides/` match the node name (with LLM verification fallback) |
 
 The `[GUIDE_GAP]` detection has a two-stage pipeline:

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -299,7 +299,7 @@ flowchart TD
 
 4. **Capability Gap Inference:** This phase is **deterministic** — it does not use an LLM.
    It cross-references graph nodes directly against the filesystem:
-   - Does `test/` contain files matching this class's tokens? If not: **TEST_GAP**
+   - Does `test/` contain files matching this class's tokens? If not: **TEST_GAP**; if yes, add a `VALIDATES` edge from the test `FILE` node to the structural source node.
    - Does `learn/guides/` have a matching guide? If not: **GUIDE_GAP**
 
 5. **Hebbian Decay:** Universal edge weight fade and garbage collection of stale nodes,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -220,6 +220,52 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         expect(updatedNode.properties.capabilityGap).toContain('[TEST_GAP]');
     });
 
+    test('inferTestGapsFromSession links matching test files via VALIDATES edges (#9906)', async () => {
+        GraphService.upsertNode({
+            id        : 'covered-class',
+            type      : 'CLASS',
+            name      : 'ButtonFeature',
+            properties: {}
+        });
+        GraphService.upsertNode({
+            id        : 'test-file-button-feature',
+            type      : 'FILE',
+            name      : 'ButtonFeature.spec.mjs',
+            properties: {path: 'test/playwright/unit/button/ButtonFeature.spec.mjs'}
+        });
+
+        const payload = {
+            session_artifact: {
+                graph: {
+                    nodes: [{
+                        id        : 'covered-class',
+                        type      : 'CLASS',
+                        name      : 'ButtonFeature',
+                        confidence: 0.9
+                    }],
+                    edges: []
+                }
+            }
+        };
+
+        await DreamService.inferTestGapsFromSession(payload);
+
+        const coveredNode = GraphService.db.nodes.get('covered-class');
+        const edge = GraphService.db.edges.items.find(e =>
+            e.source === 'test-file-button-feature' &&
+            e.target === 'covered-class' &&
+            e.type === 'VALIDATES'
+        );
+
+        expect(coveredNode.properties.capabilityGap).toBeUndefined();
+        expect(edge).toBeTruthy();
+        expect(edge.properties.evidenceKind).toBe('permanent-test-file');
+        expect(edge.properties.evidencePath).toBe('test/playwright/unit/button/ButtonFeature.spec.mjs');
+        expect(edge.properties.inferredBy).toBe('GapInferenceEngine.inferTestGapsFromSession');
+        expect(edge.properties.validatedNodeName).toBe('ButtonFeature');
+        expect(edge.properties.validatedNodeType).toBe('CLASS');
+    });
+
     test('findUndigestedSessions fails loud when remSleepBatchLimit is malformed in the imported config', async () => {
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
               originalRemSleepBatchLimit = aiConfig.remSleepBatchLimit;


### PR DESCRIPTION
Resolves #9906

Authored by GPT-5.5 (Codex Desktop). Session 019e98ad-5af5-7981-be15-dfc740a81d46.

Adds the first structural test-evidence relation for #9904's useful core: when deterministic `TEST_GAP` inference finds matching durable test-file evidence, `GapInferenceEngine` now creates `FILE -> VALIDATES -> CLASS/METHOD/COMPONENT` edges through `GraphService.linkNodes()`. Missing coverage still emits `[TEST_GAP]`; internal config hooks remain excluded; the old synthetic Playwright runner and reward propagation body text remain out of scope.

Evidence: L2 (in-process graph edge unit coverage for `VALIDATES` creation + `TEST_GAP` suppression) -> L2 required (#9906 relation contract). No residuals.

Related: #9904
Related: #9890

## Deltas from Ticket

- Re-scoped the stale April body before implementation, based on the #9904 epic-review artifact: https://github.com/neomjs/neo/issues/9904#issuecomment-4639343479
- Uses existing test-path `FILE` nodes as canonical durable test evidence for this first increment, avoiding duplicate `TEST` node identity until a later ticket proves an alias rule is needed.
- Leaves #9905 and #9907 as later producer / consumer follow-ups after this relation contract exists.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` -> 17 passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Pre-commit hooks passed: whitespace, shorthand, ticket archaeology.

## Post-Merge Validation

- [ ] Future #9905 / #9907 work consumes the `VALIDATES` relation instead of inventing a parallel gap state.
- [ ] #9890 keeps Neural Link action evidence distinct from permanent Playwright coverage unless a later contract explicitly promotes it.

## Commit

- `d67437b2d` - `feat(agentos): link test evidence with validates edges (#9906)`
