### PR TITLE
Cycle-state daemon-integration: idle-out wake digests show the next step (#12612)

### DIFF
--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -617,7 +617,7 @@ async function flushSubscription(subId) {
         const latest = heartbeats[heartbeats.length - 1];
         // Surface the cached cycle-state next-step instead of the opaque count, when a fresh verdict is
         // cached for this identity (the daemon computes + caches it; this is the read/render side).
-        const cached    = readCycleState(identity);
+        const cached    = readCycleState(DAEMON_DATA_DIR, identity, {maxAgeMs: memoryCoreConfig.wakeDaemon.cycleStateCacheMaxAgeMs});
         const cycleLine = cached && formatCycleStateLine(cached.verdict);
         breakdown += cycleLine
             ? `\n- ${heartbeats.length} heartbeat pulses — ${cycleLine}`

--- a/ai/daemons/bridge/daemon.mjs
+++ b/ai/daemons/bridge/daemon.mjs
@@ -52,6 +52,8 @@ import {
     isHarnessPresenceFresh
 } from './queries.mjs';
 import {applyHarnessMetadataDefaults} from '../../scripts/lifecycle/harnessRouting.mjs';
+import {formatCycleStateLine}         from '../../scripts/lifecycle/cycleState.mjs';
+import {readCycleState}               from '../../scripts/lifecycle/cycleStateCache.mjs';
 import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
 
 const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
@@ -613,7 +615,13 @@ async function flushSubscription(subId) {
     }
     if (heartbeats.length > 0) {
         const latest = heartbeats[heartbeats.length - 1];
-        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId})`;
+        // Surface the cached cycle-state next-step instead of the opaque count, when a fresh verdict is
+        // cached for this identity (the daemon computes + caches it; this is the read/render side).
+        const cached    = readCycleState(identity);
+        const cycleLine = cached && formatCycleStateLine(cached.verdict);
+        breakdown += cycleLine
+            ? `\n- ${heartbeats.length} heartbeat pulses — ${cycleLine}`
+            : `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId})`;
     }
 
     const digest = `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}`;

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -161,7 +161,8 @@ class Config extends ConfigProvider {
             wakeDaemon: {
                 dataDir: leaf(wakeDaemonDataDir, 'NEO_AI_DAEMON_DIR', 'string'),
                 bridgeLastSyncIdPath: leaf(path.join(wakeDaemonDataDir, 'lastSyncId'), 'NEO_BRIDGE_LAST_SYNC_ID_PATH', 'string'),
-                wakeSubscriptionLiveCursorPath: leaf(path.join(wakeDaemonDataDir, 'wakeSubscriptionLiveCursor'), 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string')
+                wakeSubscriptionLiveCursorPath: leaf(path.join(wakeDaemonDataDir, 'wakeSubscriptionLiveCursor'), 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string'),
+                cycleStateCacheMaxAgeMs: leaf(5 * 60 * 1000, 'NEO_CYCLE_STATE_CACHE_MAX_AGE_MS', 'number')
             },
             /**
              * Data Schema/Table Names

--- a/ai/scripts/lifecycle/cycleState.mjs
+++ b/ai/scripts/lifecycle/cycleState.mjs
@@ -1,0 +1,128 @@
+/**
+ * @summary Pure cycle-state discriminator — the shared "what is the claimable-now next step?" primitive
+ * that the idle-out fix's producer and consumer both depend on.
+ *
+ * The idle-out fix has one computation at its heart: given the agent's *external* lifecycle state (open
+ * own-PRs, review requests addressed to it, claimable backlog), what is the single next step that
+ * advances the cycle — or is the cycle genuinely empty? Two surfaces consume that verdict:
+ * - the **daemon** (async) computes it from fetched GitHub/graph state, caches it, and renders it into the
+ *   idle-out / heartbeat wake digest (so the receiver sees the next step, not an opaque pulse count);
+ * - the **liveness Stop hook** (sync) reads the cached verdict and enforces it (block a no-progress
+ *   turn-exit iff a claimable-now step existed).
+ *
+ * This module is the PURE core of that verdict — it takes already-fetched external state and returns the
+ * next step. Fetching (GitHub/graph queries) and caching live in the daemon; keeping the discriminator
+ * pure makes the load-bearing distinction unit-testable in isolation.
+ *
+ * **The load-bearing distinction (the falsification-AC core): claimable-now ≠ raw-backlog-non-empty.**
+ * A backlog item counts as a next step ONLY if it is *claimable-now* — un-gated (not blocked by an
+ * unmerged dependency, not architecture-/decision-gated), non-colliding (no other agent holds an active
+ * lane-claim on it), and un-blocked (its blockers are resolved). A non-empty backlog of *gated* items is
+ * a legitimate empty cycle — the enforcement hook MUST NOT fire on it, or it becomes the noise it exists
+ * to remove. This module is where that distinction is computed.
+ *
+ * @see ai/scripts/lifecycle/idleOutNudge.mjs — the per-identity pulse dispatcher (Sub B producer side)
+ * @see ai/daemons/bridge/daemon.mjs — renders the verdict into the wake digest (Sub B display)
+ * @see .claude/hooks/liveness-enforce.mjs — reads the cached verdict + enforces (Sub C consumer)
+ */
+
+/**
+ * The deterministic cycle priority order — lifecycle-closure before new-lane expansion. Lower index =
+ * higher priority. The ≤10-own-open-PR cap is backpressure on `next-lane` only (open-new vs drive-existing),
+ * never a reason to skip an actionable lifecycle item below it — so it does not appear here; it shapes how
+ * a `next-lane` step is described, not whether the earlier steps fire.
+ * @enum {String}
+ */
+export const CycleStep = {
+    ADDRESS_REVIEW_CHANGES: 'address-own-pr-changes-requested', // 1. own PR needs an author response
+    REVIEW_REQUESTED_PR   : 'review-requested-pr',              // 2. a review is designated to me
+    REQUEST_REVIEW        : 'request-review-own-green-pr',      // 3. own PR is green but review not requested
+    NEXT_LANE             : 'pick-up-next-lane'                 // 4. claimable-now backlog item
+};
+
+/**
+ * Is a backlog item *claimable-now* — i.e. a real next step rather than raw-backlog noise?
+ *
+ * The three exclusions encode the falsification-AC negative case ("a legitimately-gated non-empty backlog
+ * MUST NOT FIRE the hook"): a gated, colliding, or blocked item is NOT a next step.
+ *
+ * @param {Object} item A backlog candidate.
+ * @param {Boolean} [item.gated] Decision-/architecture-gated (e.g. waiting on an unresolved design call).
+ * @param {Boolean} [item.blocked] Has unresolved blockers (e.g. blocked-by an unmerged dependency).
+ * @param {String}  [item.claimedByOther] Identity of another agent holding an active lane-claim on it (collision).
+ * @returns {Boolean}
+ */
+export function isClaimableNow(item) {
+    if (!item) return false;
+    return !item.gated && !item.blocked && !item.claimedByOther
+}
+
+/**
+ * Computes the cycle verdict from already-fetched external lifecycle state.
+ *
+ * Pure: no I/O. The daemon fetches `state` (GitHub/graph) and passes it; this returns the single next
+ * step (highest-priority claimable item per {@link CycleStep}) plus whether the cycle is genuinely empty.
+ *
+ * @param {Object} [state={}] The fetched external lifecycle state for one agent identity.
+ * @param {Object[]} [state.ownPRs=[]] The agent's open PRs — `{ref, ciGreen, reviewRequested, changesRequested}`.
+ * @param {Object[]} [state.reviewRequests=[]] PRs with a review designated to this agent + not yet done — `{ref}`.
+ * @param {Object[]} [state.backlog=[]] Candidate next-lane items — each may carry `{ref, gated, blocked, claimedByOther}`.
+ * @param {Number}  [state.openOwnPrCount] Count of the agent's open PRs (for the ≤10 backpressure hint on `NEXT_LANE`).
+ * @returns {{nextStep:({step:String, ref:*, reason:String}|null), claimableNowCount:Number, isEmptyCycle:Boolean}}
+ * `isEmptyCycle` is true iff no step at any priority is claimable now — the only legitimate turn-terminal.
+ */
+export function computeCycleState(state = {}) {
+    const
+        ownPRs         = Array.isArray(state.ownPRs)         ? state.ownPRs         : [],
+        reviewRequests = Array.isArray(state.reviewRequests) ? state.reviewRequests : [],
+        backlog        = Array.isArray(state.backlog)        ? state.backlog        : [],
+        // The ≤10 cap is backpressure on NEW-lane expansion only; at/over it the next step is "drive
+        // existing PRs to approval" rather than "open a new lane" — both are still a step, never a halt.
+        atPrCap        = typeof state.openOwnPrCount === 'number' ? state.openOwnPrCount >= 10 : ownPRs.length >= 10;
+
+    // 1. Own PR with changes requested / required author response — lifecycle-closure first.
+    const needsResponse = ownPRs.find(pr => pr && pr.changesRequested);
+    if (needsResponse) {
+        return verdict(CycleStep.ADDRESS_REVIEW_CHANGES, needsResponse.ref,
+            'An own PR has changes requested — address it before any new lane.', backlog)
+    }
+
+    // 2. A review designated to me — review it before starting a new lane.
+    if (reviewRequests.length) {
+        return verdict(CycleStep.REVIEW_REQUESTED_PR, reviewRequests[0].ref,
+            'A review is designated to you — review it before a new lane.', backlog)
+    }
+
+    // 3. Own PR green but review not requested — request review (event-driven; never wait the CI window).
+    const greenUnrequested = ownPRs.find(pr => pr && pr.ciGreen && !pr.reviewRequested);
+    if (greenUnrequested) {
+        return verdict(CycleStep.REQUEST_REVIEW, greenUnrequested.ref,
+            'An own PR is green but review is not requested — request it.', backlog)
+    }
+
+    // 4. Next lane — but ONLY a claimable-now backlog item (raw-backlog-non-empty does not count).
+    const claimable = backlog.filter(isClaimableNow);
+    if (claimable.length) {
+        return verdict(CycleStep.NEXT_LANE, claimable[0].ref,
+            atPrCap
+                ? 'At the open-PR cap — drive an existing PR to approval (backpressure on new lanes).'
+                : 'Pick up a claimable-now backlog lane.',
+            backlog, claimable.length)
+    }
+
+    // Genuinely empty cycle — the only legitimate turn-terminal. A non-empty backlog of gated items
+    // lands HERE (claimable.length === 0), so the consumer must NOT treat it as a fireable hold.
+    return {nextStep: null, claimableNowCount: 0, isEmptyCycle: true}
+}
+
+/**
+ * Assembles a verdict, computing `claimableNowCount` across the full backlog for the consumer's reporting.
+ * @private
+ */
+function verdict(step, ref, reason, backlog, claimableNowCount) {
+    return {
+        nextStep         : {step, ref, reason},
+        claimableNowCount: typeof claimableNowCount === 'number' ? claimableNowCount : backlog.filter(isClaimableNow).length,
+        isEmptyCycle     : false
+    }
+}

--- a/ai/scripts/lifecycle/cycleState.mjs
+++ b/ai/scripts/lifecycle/cycleState.mjs
@@ -126,3 +126,19 @@ function verdict(step, ref, reason, backlog, claimableNowCount) {
         isEmptyCycle     : false
     }
 }
+
+/**
+ * Renders a cycle-state verdict into a compact wake-digest fragment — the cycle-state Sub B surfaces in
+ * the daemon's idle-out / heartbeat digest, replacing the opaque "N heartbeat pulses" line so the receiver
+ * sees the concrete next step instead of inferring it from prose.
+ *
+ * Returns `null` for an empty/absent verdict so the caller falls back to the legacy count line (a
+ * genuinely-empty cycle has no next-step to render).
+ *
+ * @param {{nextStep:({step:String,ref:*,reason:String}|null), isEmptyCycle:Boolean}|null} verdict
+ * @returns {String|null} e.g. `"next: review a designated PR (#20)"`, or null to use the fallback.
+ */
+export function formatCycleStateLine(verdict) {
+    if (!verdict || verdict.isEmptyCycle || !verdict.nextStep) return null;
+    return `next: ${verdict.nextStep.reason} (${verdict.nextStep.ref})`
+}

--- a/ai/scripts/lifecycle/cycleState.mjs
+++ b/ai/scripts/lifecycle/cycleState.mjs
@@ -36,7 +36,7 @@
 export const CycleStep = {
     ADDRESS_REVIEW_CHANGES: 'address-own-pr-changes-requested', // 1. own PR needs an author response
     REVIEW_REQUESTED_PR   : 'review-requested-pr',              // 2. a review is designated to me
-    REQUEST_REVIEW        : 'request-review-own-green-pr',      // 3. own PR is green but review not requested
+    REQUEST_REVIEW        : 'request-review-own-green-pr',      // 3. own PR green, review neither requested nor already granted (approved PRs are human-gated)
     NEXT_LANE             : 'pick-up-next-lane'                 // 4. claimable-now backlog item
 };
 
@@ -64,7 +64,7 @@ export function isClaimableNow(item) {
  * step (highest-priority claimable item per {@link CycleStep}) plus whether the cycle is genuinely empty.
  *
  * @param {Object} [state={}] The fetched external lifecycle state for one agent identity.
- * @param {Object[]} [state.ownPRs=[]] The agent's open PRs — `{ref, ciGreen, reviewRequested, changesRequested}`.
+ * @param {Object[]} [state.ownPRs=[]] The agent's open PRs — `{ref, ciGreen, reviewRequested, changesRequested, approved}`.
  * @param {Object[]} [state.reviewRequests=[]] PRs with a review designated to this agent + not yet done — `{ref}`.
  * @param {Object[]} [state.backlog=[]] Candidate next-lane items — each may carry `{ref, gated, blocked, claimedByOther}`.
  * @param {Number}  [state.openOwnPrCount] Count of the agent's open PRs (for the ≤10 backpressure hint on `NEXT_LANE`).
@@ -93,8 +93,12 @@ export function computeCycleState(state = {}) {
             'A review is designated to you — review it before a new lane.', backlog)
     }
 
-    // 3. Own PR green but review not requested — request review (event-driven; never wait the CI window).
-    const greenUnrequested = ownPRs.find(pr => pr && pr.ciGreen && !pr.reviewRequested);
+    // 3. Own PR green but review neither requested NOR already granted — request review (event-driven;
+    //    never wait the CI window). An already-APPROVED green PR is excluded: it sits on the human
+    //    merge-gate (a human-only action), not on an agent action — re-requesting review on already-
+    //    approved work would manufacture a false next-step (noise, not progress). Falls through to
+    //    step 4 / empty cycle.
+    const greenUnrequested = ownPRs.find(pr => pr && pr.ciGreen && !pr.reviewRequested && !pr.approved);
     if (greenUnrequested) {
         return verdict(CycleStep.REQUEST_REVIEW, greenUnrequested.ref,
             'An own PR is green but review is not requested — request it.', backlog)

--- a/ai/scripts/lifecycle/cycleStateCache.mjs
+++ b/ai/scripts/lifecycle/cycleStateCache.mjs
@@ -4,49 +4,48 @@
  * reads it WITHOUT a network round-trip — the hook blocks the turn-end, so it cannot afford to live-query
  * GitHub. A plain JSON file under the wake-daemon runtime dir (sibling to `inflightLock.mjs`).
  *
+ * **Pure helper — owns no defaults, reads no config:** the cache directory + staleness bound are resolved
+ * `AiConfig` leaves (`wakeDaemon.dataDir` + `wakeDaemon.cycleStateCacheMaxAgeMs`), INJECTED by the
+ * entrypoints that already import `AiConfig` (the bridge daemon + `idleOutNudge`). Keeping this module
+ * config-free means a non-entrypoint consumer (the sync Stop hook) never pays framework bootstrap weight
+ * to read a path, and the config SSOT stays the single owner of the path + TTL.
+ *
  * **Fail-soft + staleness-bounded:** a write failure never breaks the daemon; a read returns `null` on
- * missing / malformed / stale state, so the hook fail-opens (never enforces on a stale or absent verdict).
+ * missing / malformed / stale state — AND on an absent `maxAgeMs` (fail-open with no injected bound) — so
+ * the hook never enforces on a stale, absent, or un-bounded verdict.
  *
  * @see ai/scripts/lifecycle/cycleState.mjs   — computes the verdict this caches
  * @see ai/scripts/lifecycle/inflightLock.mjs — sibling .neo-ai-data/wake-daemon/ runtime-file convention
  */
 
-import fs                 from 'fs';
-import path               from 'path';
-import {fileURLToPath}    from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import fs   from 'fs';
+import path from 'path';
 
 /**
- * Default staleness bound. A cached verdict older than this is treated as absent — the daemon recomputes
- * each heartbeat cycle, so a stale file means the daemon stopped; the hook must not enforce on it.
- * @type {Number}
- */
-export const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000; // 5 min
-
-/**
- * Resolves the per-identity cache file path under the wake-daemon runtime dir (sibling to inflightLock).
+ * Resolves the per-identity cache file path under the (injected) wake-daemon runtime dir.
+ * @param {String} dataDir The resolved `AiConfig.wakeDaemon.dataDir` leaf (injected by the entrypoint).
  * @param {String} identity
  * @returns {String}
  */
-export function cacheFilePath(identity) {
+export function cacheFilePath(dataDir, identity) {
     const clean = String(identity || 'unknown').replace(/[^a-zA-Z0-9_-]/g, '_');
-    return path.resolve(__dirname, `../../../.neo-ai-data/wake-daemon/cycle-state-${clean}.json`)
+    return path.join(dataDir, `cycle-state-${clean}.json`)
 }
 
 /**
  * Writes the computed cycle-state verdict to the cache (daemon / producer side). Fail-soft — any error
  * (dir missing, disk) is swallowed and reported via the boolean; a cache-write must never break the daemon.
+ * @param {String} dataDir The resolved wake-daemon dir (`AiConfig.wakeDaemon.dataDir`); injected by the caller.
  * @param {String} identity
  * @param {Object} verdict The `computeCycleState()` output.
  * @param {Object} [opts]
  * @param {Number} [opts.now=Date.now()]  Injectable timestamp (testability).
- * @param {String} [opts.filePath]        Override the cache path (testability); defaults to {@link cacheFilePath}.
+ * @param {String} [opts.filePath]        Override the resolved path (testability); defaults to {@link cacheFilePath}.
  * @returns {Boolean} true on success.
  */
-export function writeCycleState(identity, verdict, {now = Date.now(), filePath} = {}) {
+export function writeCycleState(dataDir, identity, verdict, {now = Date.now(), filePath} = {}) {
     try {
-        const file = filePath || cacheFilePath(identity);
+        const file = filePath || cacheFilePath(dataDir, identity);
         fs.mkdirSync(path.dirname(file), {recursive: true});
         fs.writeFileSync(file, JSON.stringify({verdict, computedAt: now}), 'utf8');
         return true
@@ -57,21 +56,24 @@ export function writeCycleState(identity, verdict, {now = Date.now(), filePath} 
 
 /**
  * Reads the cached cycle-state verdict (hook / consumer side). Fail-soft + staleness-bounded: returns
- * `null` when the file is missing, malformed, or older than `maxAgeMs` — so a stale or absent verdict
- * never drives enforcement (the hook fail-opens).
+ * `null` when the file is missing, malformed, older than `maxAgeMs`, OR when no numeric `maxAgeMs` was
+ * injected — so a stale, absent, or un-bounded verdict never drives enforcement (the hook fail-opens).
+ * @param {String} dataDir The resolved wake-daemon dir (`AiConfig.wakeDaemon.dataDir`); injected by the caller.
  * @param {String} identity
  * @param {Object} [opts]
- * @param {Number} [opts.maxAgeMs=DEFAULT_MAX_AGE_MS]
+ * @param {Number} [opts.maxAgeMs] Resolved `AiConfig.wakeDaemon.cycleStateCacheMaxAgeMs`; required to read (no default here).
  * @param {Number} [opts.now=Date.now()]
  * @param {String} [opts.filePath]
  * @returns {{verdict:Object, computedAt:Number, ageMs:Number}|null}
  */
-export function readCycleState(identity, {maxAgeMs = DEFAULT_MAX_AGE_MS, now = Date.now(), filePath} = {}) {
+export function readCycleState(dataDir, identity, {maxAgeMs, now = Date.now(), filePath} = {}) {
     try {
-        const {verdict, computedAt} = JSON.parse(fs.readFileSync(filePath || cacheFilePath(identity), 'utf8'));
+        const {verdict, computedAt} = JSON.parse(fs.readFileSync(filePath || cacheFilePath(dataDir, identity), 'utf8'));
         if (typeof computedAt !== 'number' || !verdict) return null;
         const ageMs = now - computedAt;
-        if (ageMs > maxAgeMs) return null; // stale → ignore (daemon stopped); hook fail-opens
+        // No injected bound OR stale → fail-open. This helper owns no default staleness policy — the
+        // config leaf does; a missing bound means the entrypoint didn't resolve it, so we must not enforce.
+        if (typeof maxAgeMs !== 'number' || ageMs > maxAgeMs) return null;
         return {verdict, computedAt, ageMs}
     } catch {
         return null

--- a/ai/scripts/lifecycle/cycleStateCache.mjs
+++ b/ai/scripts/lifecycle/cycleStateCache.mjs
@@ -1,0 +1,79 @@
+/**
+ * @summary Hot-file cache for the shared cycle-state verdict — the producer↔consumer bridge of the
+ * idle-out fix. The daemon (async) computes the verdict and writes it here; the liveness Stop hook (sync)
+ * reads it WITHOUT a network round-trip — the hook blocks the turn-end, so it cannot afford to live-query
+ * GitHub. A plain JSON file under the wake-daemon runtime dir (sibling to `inflightLock.mjs`).
+ *
+ * **Fail-soft + staleness-bounded:** a write failure never breaks the daemon; a read returns `null` on
+ * missing / malformed / stale state, so the hook fail-opens (never enforces on a stale or absent verdict).
+ *
+ * @see ai/scripts/lifecycle/cycleState.mjs   — computes the verdict this caches
+ * @see ai/scripts/lifecycle/inflightLock.mjs — sibling .neo-ai-data/wake-daemon/ runtime-file convention
+ */
+
+import fs                 from 'fs';
+import path               from 'path';
+import {fileURLToPath}    from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Default staleness bound. A cached verdict older than this is treated as absent — the daemon recomputes
+ * each heartbeat cycle, so a stale file means the daemon stopped; the hook must not enforce on it.
+ * @type {Number}
+ */
+export const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000; // 5 min
+
+/**
+ * Resolves the per-identity cache file path under the wake-daemon runtime dir (sibling to inflightLock).
+ * @param {String} identity
+ * @returns {String}
+ */
+export function cacheFilePath(identity) {
+    const clean = String(identity || 'unknown').replace(/[^a-zA-Z0-9_-]/g, '_');
+    return path.resolve(__dirname, `../../../.neo-ai-data/wake-daemon/cycle-state-${clean}.json`)
+}
+
+/**
+ * Writes the computed cycle-state verdict to the cache (daemon / producer side). Fail-soft — any error
+ * (dir missing, disk) is swallowed and reported via the boolean; a cache-write must never break the daemon.
+ * @param {String} identity
+ * @param {Object} verdict The `computeCycleState()` output.
+ * @param {Object} [opts]
+ * @param {Number} [opts.now=Date.now()]  Injectable timestamp (testability).
+ * @param {String} [opts.filePath]        Override the cache path (testability); defaults to {@link cacheFilePath}.
+ * @returns {Boolean} true on success.
+ */
+export function writeCycleState(identity, verdict, {now = Date.now(), filePath} = {}) {
+    try {
+        const file = filePath || cacheFilePath(identity);
+        fs.mkdirSync(path.dirname(file), {recursive: true});
+        fs.writeFileSync(file, JSON.stringify({verdict, computedAt: now}), 'utf8');
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Reads the cached cycle-state verdict (hook / consumer side). Fail-soft + staleness-bounded: returns
+ * `null` when the file is missing, malformed, or older than `maxAgeMs` — so a stale or absent verdict
+ * never drives enforcement (the hook fail-opens).
+ * @param {String} identity
+ * @param {Object} [opts]
+ * @param {Number} [opts.maxAgeMs=DEFAULT_MAX_AGE_MS]
+ * @param {Number} [opts.now=Date.now()]
+ * @param {String} [opts.filePath]
+ * @returns {{verdict:Object, computedAt:Number, ageMs:Number}|null}
+ */
+export function readCycleState(identity, {maxAgeMs = DEFAULT_MAX_AGE_MS, now = Date.now(), filePath} = {}) {
+    try {
+        const {verdict, computedAt} = JSON.parse(fs.readFileSync(filePath || cacheFilePath(identity), 'utf8'));
+        if (typeof computedAt !== 'number' || !verdict) return null;
+        const ageMs = now - computedAt;
+        if (ageMs > maxAgeMs) return null; // stale → ignore (daemon stopped); hook fail-opens
+        return {verdict, computedAt, ageMs}
+    } catch {
+        return null
+    }
+}

--- a/ai/scripts/lifecycle/cycleStateFetch.mjs
+++ b/ai/scripts/lifecycle/cycleStateFetch.mjs
@@ -5,12 +5,19 @@
  * here so the derivation (CI-green, changes-requested, review-requested) stays pure + unit-testable.
  *
  * **Increment scope:** the mappers for all four cycle steps (own PRs + review requests = steps 1-3;
- * backlog = step 4). The impure `gh`-runner wrapper — which gathers the cross-source context sets
- * (issue relations, A2A lane-claims) and runs the queries — is the follow-up increment.
+ * backlog = step 4) PLUS the impure `fetchExternalState` orchestrator that runs the queries + maps them.
+ * The query-runner is injectable so the orchestration stays unit-testable; gathering the backlog
+ * flag-context (issue relations + lane-claim A2As) is delegated to an injectable `gatherContext` whose
+ * concrete implementation is the follow-up increment.
  *
  * @see ai/scripts/lifecycle/cycleState.mjs      — the discriminator these feed
  * @see ai/scripts/lifecycle/cycleStateCache.mjs — where the daemon caches the computed verdict
  */
+
+import {execFile}  from 'child_process';
+import {promisify} from 'util';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Is a PR's CI green? Pure over a `gh pr view --json statusCheckRollup` rollup array.
@@ -77,4 +84,43 @@ export function mapBacklog(issueListJson, {blockedRefs = new Set(), gatedRefs = 
         const ref = `#${issue.number}`;
         return {ref, blocked: blockedRefs.has(ref), gated: gatedRefs.has(ref), claimedByOther: claimedByOther.get(ref)}
     })
+}
+
+/**
+ * Default query-runner: spawns `gh` with the given args and parses the JSON stdout. Impure; injected by
+ * {@link fetchExternalState} so the orchestration is testable without `gh`.
+ * @param {String[]} args
+ * @returns {Promise<Object[]>}
+ */
+async function defaultGhQuery(args) {
+    const {stdout} = await execFileAsync('gh', args, {maxBuffer: 8 * 1024 * 1024});
+    return JSON.parse(stdout || '[]')
+}
+
+/**
+ * Fetches + maps the external lifecycle state for one identity into the `computeCycleState()` input. The
+ * three GitHub queries run in parallel; the (pure, tested) mappers shape the results. Impure only in the
+ * query-runner, which is injectable.
+ *
+ * @param {String} identity The agent identity (a leading `@` is stripped for the `gh` search field).
+ * @param {Object} [opts]
+ * @param {Function} [opts.runQuery=defaultGhQuery] `async (args[]) => parsed JSON` — injected for testing.
+ * @param {Function} [opts.gatherContext] `async (identity) => {blockedRefs, gatedRefs, claimedByOther}` for
+ * the backlog flags; defaults to empty context (every backlog item claimable-now) until the follow-up lands.
+ * @returns {Promise<{ownPRs:Object[], reviewRequests:Object[], backlog:Object[], openOwnPrCount:Number}>}
+ */
+export async function fetchExternalState(identity, {runQuery = defaultGhQuery, gatherContext = async () => ({})} = {}) {
+    const id = String(identity || '').replace(/^@/, '');
+    const [ownPRsJson, reviewReqJson, backlogJson] = await Promise.all([
+        runQuery(['pr', 'list', '--author', id, '--json', 'number,statusCheckRollup,reviewDecision,reviewRequests']),
+        runQuery(['pr', 'list', '--search', `review-requested:${id}`, '--json', 'number']),
+        runQuery(['issue', 'list', '--assignee', id, '--json', 'number'])
+    ]);
+    const ownPRs = mapOwnPRs(ownPRsJson);
+    return {
+        ownPRs,
+        reviewRequests: mapReviewRequests(reviewReqJson),
+        backlog       : mapBacklog(backlogJson, await gatherContext(identity)),
+        openOwnPrCount: ownPRs.length
+    }
 }

--- a/ai/scripts/lifecycle/cycleStateFetch.mjs
+++ b/ai/scripts/lifecycle/cycleStateFetch.mjs
@@ -87,6 +87,27 @@ export function mapBacklog(issueListJson, {blockedRefs = new Set(), gatedRefs = 
 }
 
 /**
+ * Maps recent A2A lane-claim messages into the backlog `claimedByOther` context — `ref` → the OTHER
+ * agent's identity holding an active claim. Self-claims are excluded (claiming your own lane is not a
+ * collision). Pure; the impure caller fetches the lane-claim messages (graph) + passes them. One source
+ * of `gatherContext`; issue blocked-by relations + gated labels are the other sources (follow-ups).
+ *
+ * @param {Object[]} messages       Recent messages, each `{subject, from}`.
+ * @param {String}   selfIdentity   This agent's identity (its own claims are not collisions).
+ * @returns {Map<String,String>} `ref` (`#N`) → claiming agent identity.
+ */
+export function mapLaneClaims(messages, selfIdentity) {
+    const map = new Map();
+    for (const msg of Array.isArray(messages) ? messages : []) {
+        if (!msg || msg.from === selfIdentity || typeof msg.subject !== 'string') continue;
+        // "[lane-claim] taking #N …" / "[lane-claim] #N …" — the first #N after the tag is the claimed lane.
+        const match = /\[lane-claim\][^#]*#(\d+)/.exec(msg.subject);
+        if (match) map.set(`#${match[1]}`, msg.from)
+    }
+    return map
+}
+
+/**
  * Default query-runner: spawns `gh` with the given args and parses the JSON stdout. Impure; injected by
  * {@link fetchExternalState} so the orchestration is testable without `gh`.
  * @param {String[]} args

--- a/ai/scripts/lifecycle/cycleStateFetch.mjs
+++ b/ai/scripts/lifecycle/cycleStateFetch.mjs
@@ -42,7 +42,7 @@ export function isCiGreen(rollup) {
  * Maps `gh pr list --author @me --json number,statusCheckRollup,reviewDecision,reviewRequests` output
  * into the discriminator's `ownPRs` shape.
  * @param {Object[]} prListJson
- * @returns {{ref:String, ciGreen:Boolean, reviewRequested:Boolean, changesRequested:Boolean}[]}
+ * @returns {{ref:String, ciGreen:Boolean, reviewRequested:Boolean, changesRequested:Boolean, approved:Boolean}[]}
  */
 export function mapOwnPRs(prListJson) {
     return (Array.isArray(prListJson) ? prListJson : []).map(pr => ({
@@ -50,7 +50,11 @@ export function mapOwnPRs(prListJson) {
         ciGreen         : isCiGreen(pr.statusCheckRollup),
         // A reviewer is currently requested on the PR (so a fresh request is NOT needed).
         reviewRequested : Array.isArray(pr.reviewRequests) && pr.reviewRequests.length > 0,
-        changesRequested: pr.reviewDecision === 'CHANGES_REQUESTED'
+        changesRequested: pr.reviewDecision === 'CHANGES_REQUESTED',
+        // Already approved → the PR sits on the human merge-gate (a human-only action), NOT on an agent
+        // action. The discriminator excludes these from the request-review step so an approved-awaiting-
+        // merge PR is never told to re-request review on work that is already done.
+        approved        : pr.reviewDecision === 'APPROVED'
     }))
 }
 

--- a/ai/scripts/lifecycle/cycleStateFetch.mjs
+++ b/ai/scripts/lifecycle/cycleStateFetch.mjs
@@ -4,9 +4,9 @@
  * (it can afford the latency; the sync Stop hook reads the cached verdict instead), then maps the JSON
  * here so the derivation (CI-green, changes-requested, review-requested) stays pure + unit-testable.
  *
- * **Increment scope:** the lifecycle-closure mappers (own PRs + review requests = cycle steps 1-3). The
- * next-lane backlog mapper (step 4, with its gated/blocked/colliding flag derivation) + the impure
- * `gh`-runner wrapper are follow-up increments.
+ * **Increment scope:** the mappers for all four cycle steps (own PRs + review requests = steps 1-3;
+ * backlog = step 4). The impure `gh`-runner wrapper — which gathers the cross-source context sets
+ * (issue relations, A2A lane-claims) and runs the queries — is the follow-up increment.
  *
  * @see ai/scripts/lifecycle/cycleState.mjs      — the discriminator these feed
  * @see ai/scripts/lifecycle/cycleStateCache.mjs — where the daemon caches the computed verdict
@@ -55,4 +55,26 @@ export function mapOwnPRs(prListJson) {
  */
 export function mapReviewRequests(prListJson) {
     return (Array.isArray(prListJson) ? prListJson : []).map(pr => ({ref: `#${pr.number}`}))
+}
+
+/**
+ * Maps candidate backlog issues into the discriminator's `backlog` shape, deriving the claimable-now
+ * exclusion flags from cross-source context the caller gathers. Pure over (issue list + context sets) so
+ * the flag logic is unit-testable; the impure caller builds the sets from issue relations + lane-claim A2As.
+ *
+ * The three flags are exactly the discriminator's claimable-now exclusions (a flagged item is NOT a next
+ * step → a backlog of only-flagged items is a legitimately-empty cycle the hook must not fire on).
+ *
+ * @param {Object[]} issueListJson `gh issue list --assignee @me --json number` output.
+ * @param {Object} [context]
+ * @param {Set<String>}        [context.blockedRefs]    Refs with unresolved blocked-by dependencies.
+ * @param {Set<String>}        [context.gatedRefs]      Refs decision-/architecture-gated (e.g. an open design dependency).
+ * @param {Map<String,String>} [context.claimedByOther] ref → another agent's identity holding an active lane-claim.
+ * @returns {{ref:String, blocked:Boolean, gated:Boolean, claimedByOther:(String|undefined)}[]}
+ */
+export function mapBacklog(issueListJson, {blockedRefs = new Set(), gatedRefs = new Set(), claimedByOther = new Map()} = {}) {
+    return (Array.isArray(issueListJson) ? issueListJson : []).map(issue => {
+        const ref = `#${issue.number}`;
+        return {ref, blocked: blockedRefs.has(ref), gated: gatedRefs.has(ref), claimedByOther: claimedByOther.get(ref)}
+    })
 }

--- a/ai/scripts/lifecycle/cycleStateFetch.mjs
+++ b/ai/scripts/lifecycle/cycleStateFetch.mjs
@@ -1,0 +1,58 @@
+/**
+ * @summary Maps raw GitHub query output into the `computeCycleState()` input shape — the impure
+ * fetch-and-map layer feeding the shared cycle-state discriminator. The daemon runs the GitHub queries
+ * (it can afford the latency; the sync Stop hook reads the cached verdict instead), then maps the JSON
+ * here so the derivation (CI-green, changes-requested, review-requested) stays pure + unit-testable.
+ *
+ * **Increment scope:** the lifecycle-closure mappers (own PRs + review requests = cycle steps 1-3). The
+ * next-lane backlog mapper (step 4, with its gated/blocked/colliding flag derivation) + the impure
+ * `gh`-runner wrapper are follow-up increments.
+ *
+ * @see ai/scripts/lifecycle/cycleState.mjs      — the discriminator these feed
+ * @see ai/scripts/lifecycle/cycleStateCache.mjs — where the daemon caches the computed verdict
+ */
+
+/**
+ * Is a PR's CI green? Pure over a `gh pr view --json statusCheckRollup` rollup array.
+ *
+ * Green = every check has settled successfully (no FAILURE / ERROR, and nothing still PENDING /
+ * IN_PROGRESS / QUEUED). An empty rollup (no checks configured) counts as green — there is nothing
+ * failing to block a review request. Handles both `CheckRun` (`conclusion`) and legacy `StatusContext`
+ * (`state`) rollup shapes.
+ *
+ * @param {Object[]} rollup The `statusCheckRollup` array from `gh pr ... --json statusCheckRollup`.
+ * @returns {Boolean}
+ */
+export function isCiGreen(rollup) {
+    if (!Array.isArray(rollup) || rollup.length === 0) return true;
+    return rollup.every(check => {
+        const outcome = check?.conclusion || check?.state; // CheckRun.conclusion | StatusContext.state
+        return outcome === 'SUCCESS' || outcome === 'NEUTRAL' || outcome === 'SKIPPED'
+    })
+}
+
+/**
+ * Maps `gh pr list --author @me --json number,statusCheckRollup,reviewDecision,reviewRequests` output
+ * into the discriminator's `ownPRs` shape.
+ * @param {Object[]} prListJson
+ * @returns {{ref:String, ciGreen:Boolean, reviewRequested:Boolean, changesRequested:Boolean}[]}
+ */
+export function mapOwnPRs(prListJson) {
+    return (Array.isArray(prListJson) ? prListJson : []).map(pr => ({
+        ref             : `#${pr.number}`,
+        ciGreen         : isCiGreen(pr.statusCheckRollup),
+        // A reviewer is currently requested on the PR (so a fresh request is NOT needed).
+        reviewRequested : Array.isArray(pr.reviewRequests) && pr.reviewRequests.length > 0,
+        changesRequested: pr.reviewDecision === 'CHANGES_REQUESTED'
+    }))
+}
+
+/**
+ * Maps `gh pr list --search "review-requested:@me" --json number` output into the discriminator's
+ * `reviewRequests` shape (PRs where a review is designated to this agent).
+ * @param {Object[]} prListJson
+ * @returns {{ref:String}[]}
+ */
+export function mapReviewRequests(prListJson) {
+    return (Array.isArray(prListJson) ? prListJson : []).map(pr => ({ref: `#${pr.number}`}))
+}

--- a/ai/scripts/lifecycle/idleOutNudge.mjs
+++ b/ai/scripts/lifecycle/idleOutNudge.mjs
@@ -63,6 +63,9 @@ import WakeSubscriptionService   from '../../services/memory-core/WakeSubscripti
 import RequestContextService     from '../../mcp/server/shared/services/RequestContextService.mjs';
 import {hasOverride, readGateState} from './wakeSafetyGate.mjs';
 import {writeInflightLock, clearInflightLock, checkInflightLock} from './inflightLock.mjs';
+import {computeCycleState}       from './cycleState.mjs';
+import {writeCycleState}         from './cycleStateCache.mjs';
+import {fetchExternalState}      from './cycleStateFetch.mjs';
 
 /**
  * @summary Dispatch a single idle-out heartbeat pulse to the target identity.
@@ -118,6 +121,18 @@ export async function idleOutNudge(identity) {
     await writeInflightLock(identity, 'idle_out_nudge', 0);
 
     const sender = process.env.NEO_AGENT_IDENTITY || '@system';
+
+    // 4.5. Compute + cache the cycle-state for this identity so the bridge-daemon renders the next step
+    //      in this pulse's digest (and the liveness Stop hook can read it). Fail-soft: a cache-compute
+    //      failure must NEVER block the nudge. Backlog (cycle step 4) is deferred — passing `[]` until the
+    //      gatherContext flag-derivation (lane-claims + blocked-by) lands, so we never suggest a
+    //      gated/colliding lane; lifecycle-closure steps 1-3 (own PRs + review requests) are computed now.
+    try {
+        const {ownPRs, reviewRequests, openOwnPrCount} = await fetchExternalState(identity);
+        writeCycleState(identity, computeCycleState({ownPRs, reviewRequests, backlog: [], openOwnPrCount}));
+    } catch (cacheErr) {
+        console.error(`[idleOutNudge] cycle-state cache-compute failed (non-blocking): ${cacheErr.message}`);
+    }
 
     // 5. Emit Shape B heartbeat pulse. Creates an ephemeral GraphLog entry tagged
     //    as `heartbeat_pulse`; bridge-daemon's resync() picks it up + dispatches

--- a/ai/scripts/lifecycle/idleOutNudge.mjs
+++ b/ai/scripts/lifecycle/idleOutNudge.mjs
@@ -66,6 +66,7 @@ import {writeInflightLock, clearInflightLock, checkInflightLock} from './infligh
 import {computeCycleState}       from './cycleState.mjs';
 import {writeCycleState}         from './cycleStateCache.mjs';
 import {fetchExternalState}      from './cycleStateFetch.mjs';
+import memoryCoreConfig          from '../../mcp/server/memory-core/config.mjs';
 
 /**
  * @summary Dispatch a single idle-out heartbeat pulse to the target identity.
@@ -129,7 +130,7 @@ export async function idleOutNudge(identity) {
     //      gated/colliding lane; lifecycle-closure steps 1-3 (own PRs + review requests) are computed now.
     try {
         const {ownPRs, reviewRequests, openOwnPrCount} = await fetchExternalState(identity);
-        writeCycleState(identity, computeCycleState({ownPRs, reviewRequests, backlog: [], openOwnPrCount}));
+        writeCycleState(memoryCoreConfig.wakeDaemon.dataDir, identity, computeCycleState({ownPRs, reviewRequests, backlog: [], openOwnPrCount}));
     } catch (cacheErr) {
         console.error(`[idleOutNudge] cycle-state cache-compute failed (non-blocking): ${cacheErr.message}`);
     }

--- a/test/playwright/unit/ai/scripts/cycleState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleState.spec.mjs
@@ -95,6 +95,33 @@ test.describe('cycleState — claimable-now ≠ raw-backlog (the falsification-A
     });
 });
 
+test.describe('cycleState — approved own PRs are human-gated, not a request-review step (#12640 RC)', () => {
+    test('an approved green PR with no reviewer is NOT request-review — it sits on the human merge-gate', () => {
+        const v = computeCycleState({
+            ownPRs: [{ref: '#12605', ciGreen: true, reviewRequested: false, approved: true}]
+        });
+        expect(v.nextStep).toBeNull();              // no agent action; the human merge-gate owns it
+        expect(v.isEmptyCycle).toBe(true)
+    });
+
+    test('an approved own PR does NOT block a claimable backlog lane from surfacing', () => {
+        const v = computeCycleState({
+            ownPRs : [{ref: '#12605', ciGreen: true, reviewRequested: false, approved: true}],
+            backlog: [{ref: '#40'}]
+        });
+        expect(v.nextStep.step).toBe(CycleStep.NEXT_LANE);   // backlog still surfaces past the human-gated PR
+        expect(v.nextStep.ref).toBe('#40')
+    });
+
+    test('a green UN-approved own PR still requests review (the exclusion is precise to approved)', () => {
+        const v = computeCycleState({
+            ownPRs: [{ref: '#11', ciGreen: true, reviewRequested: false, approved: false}]
+        });
+        expect(v.nextStep.step).toBe(CycleStep.REQUEST_REVIEW);
+        expect(v.nextStep.ref).toBe('#11')
+    });
+});
+
 test.describe('cycleState — formatCycleStateLine (the daemon digest fragment)', () => {
     test('renders the next step; null for empty/absent (caller falls back to the count line)', () => {
         const v = computeCycleState({reviewRequests: [{ref: '#20'}]});

--- a/test/playwright/unit/ai/scripts/cycleState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleState.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                                from '@playwright/test';
-import {CycleStep, computeCycleState, isClaimableNow} from '../../../../../ai/scripts/lifecycle/cycleState.mjs';
+import {CycleStep, computeCycleState, formatCycleStateLine, isClaimableNow} from '../../../../../ai/scripts/lifecycle/cycleState.mjs';
 
 /**
  * Self-test for the shared cycle-state discriminator — the pure core of the idle-out fix that the daemon
@@ -92,6 +92,15 @@ test.describe('cycleState — claimable-now ≠ raw-backlog (the falsification-A
         const v = computeCycleState({});
         expect(v.isEmptyCycle).toBe(true);
         expect(v.nextStep).toBeNull()
+    });
+});
+
+test.describe('cycleState — formatCycleStateLine (the daemon digest fragment)', () => {
+    test('renders the next step; null for empty/absent (caller falls back to the count line)', () => {
+        const v = computeCycleState({reviewRequests: [{ref: '#20'}]});
+        expect(formatCycleStateLine(v)).toBe('next: A review is designated to you — review it before a new lane. (#20)');
+        expect(formatCycleStateLine(computeCycleState({}))).toBeNull();   // empty cycle → null
+        expect(formatCycleStateLine(null)).toBeNull()
     });
 });
 

--- a/test/playwright/unit/ai/scripts/cycleState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleState.spec.mjs
@@ -1,0 +1,110 @@
+import {test, expect}                                from '@playwright/test';
+import {CycleStep, computeCycleState, isClaimableNow} from '../../../../../ai/scripts/lifecycle/cycleState.mjs';
+
+/**
+ * Self-test for the shared cycle-state discriminator — the pure core of the idle-out fix that the daemon
+ * (producer: compute + cache + render into the wake digest) and the liveness Stop hook (consumer: read +
+ * enforce) both depend on.
+ *
+ * The load-bearing case these lock in: **claimable-now ≠ raw-backlog-non-empty.** A non-empty backlog of
+ * gated / blocked / colliding items is a legitimately-empty cycle — the enforcement hook MUST NOT fire on
+ * it (else it becomes the noise it removes). Plus the deterministic cycle priority order (lifecycle-closure
+ * before new-lane expansion).
+ */
+
+test.describe('cycleState — isClaimableNow (the raw-backlog filter)', () => {
+    test('a clean item is claimable; gated / blocked / collided items are NOT', () => {
+        expect(isClaimableNow({ref: '#1'})).toBe(true);
+        expect(isClaimableNow({ref: '#1', gated: true})).toBe(false);            // decision/architecture-gated
+        expect(isClaimableNow({ref: '#1', blocked: true})).toBe(false);          // blocked-by unmerged dep
+        expect(isClaimableNow({ref: '#1', claimedByOther: '@peer'})).toBe(false);// collision
+        expect(isClaimableNow(null)).toBe(false)
+    });
+});
+
+test.describe('cycleState — computeCycleState priority order (lifecycle-closure first)', () => {
+    test('1: own PR with changes-requested wins over everything', () => {
+        const v = computeCycleState({
+            ownPRs        : [{ref: '#10', changesRequested: true}, {ref: '#11', ciGreen: true, reviewRequested: false}],
+            reviewRequests: [{ref: '#20'}],
+            backlog       : [{ref: '#30'}]
+        });
+        expect(v.nextStep.step).toBe(CycleStep.ADDRESS_REVIEW_CHANGES);
+        expect(v.nextStep.ref).toBe('#10');
+        expect(v.isEmptyCycle).toBe(false)
+    });
+
+    test('2: a designated review beats own-green-request + next-lane', () => {
+        const v = computeCycleState({
+            ownPRs        : [{ref: '#11', ciGreen: true, reviewRequested: false}],
+            reviewRequests: [{ref: '#20'}],
+            backlog       : [{ref: '#30'}]
+        });
+        expect(v.nextStep.step).toBe(CycleStep.REVIEW_REQUESTED_PR);
+        expect(v.nextStep.ref).toBe('#20')
+    });
+
+    test('3: own green PR with no review requested → request review (never wait the CI window)', () => {
+        const v = computeCycleState({
+            ownPRs : [{ref: '#11', ciGreen: true, reviewRequested: false}],
+            backlog: [{ref: '#30'}]
+        });
+        expect(v.nextStep.step).toBe(CycleStep.REQUEST_REVIEW);
+        expect(v.nextStep.ref).toBe('#11')
+    });
+
+    test('4: nothing else → a claimable-now backlog lane', () => {
+        const v = computeCycleState({backlog: [{ref: '#30'}]});
+        expect(v.nextStep.step).toBe(CycleStep.NEXT_LANE);
+        expect(v.nextStep.ref).toBe('#30')
+    });
+});
+
+test.describe('cycleState — claimable-now ≠ raw-backlog (the falsification-AC core)', () => {
+    test('a non-empty backlog of ONLY gated/blocked/collided items → empty cycle (MUST NOT fire)', () => {
+        const v = computeCycleState({
+            backlog: [
+                {ref: '#31', gated: true},
+                {ref: '#32', blocked: true},
+                {ref: '#33', claimedByOther: '@neo-gpt'}
+            ]
+        });
+        expect(v.isEmptyCycle).toBe(true);                  // legitimately empty despite a non-empty backlog
+        expect(v.nextStep).toBeNull();
+        expect(v.claimableNowCount).toBe(0)
+    });
+
+    test('one claimable item among gated ones → that item is the next lane (MUST fire path)', () => {
+        const v = computeCycleState({
+            backlog: [
+                {ref: '#31', gated: true},
+                {ref: '#34'},                               // the one claimable-now item
+                {ref: '#33', claimedByOther: '@neo-gpt'}
+            ]
+        });
+        expect(v.isEmptyCycle).toBe(false);
+        expect(v.nextStep.step).toBe(CycleStep.NEXT_LANE);
+        expect(v.nextStep.ref).toBe('#34');
+        expect(v.claimableNowCount).toBe(1)
+    });
+
+    test('fully empty state → empty cycle', () => {
+        const v = computeCycleState({});
+        expect(v.isEmptyCycle).toBe(true);
+        expect(v.nextStep).toBeNull()
+    });
+});
+
+test.describe('cycleState — the ≤10 cap is backpressure on new lanes, not a halt', () => {
+    test('at/over the cap → next step is drive-existing, still a step (never empty)', () => {
+        const v = computeCycleState({openOwnPrCount: 10, backlog: [{ref: '#40'}]});
+        expect(v.nextStep.step).toBe(CycleStep.NEXT_LANE);
+        expect(v.nextStep.reason).toMatch(/drive an existing PR/i);
+        expect(v.isEmptyCycle).toBe(false)
+    });
+
+    test('under the cap → open a new lane', () => {
+        const v = computeCycleState({openOwnPrCount: 2, backlog: [{ref: '#40'}]});
+        expect(v.nextStep.reason).toMatch(/claimable-now backlog lane/i)
+    });
+});

--- a/test/playwright/unit/ai/scripts/cycleStateCache.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleStateCache.spec.mjs
@@ -1,0 +1,66 @@
+import {test, expect}                                  from '@playwright/test';
+import fs                                               from 'fs';
+import os                                               from 'os';
+import path                                             from 'path';
+import {cacheFilePath, readCycleState, writeCycleState} from '../../../../../ai/scripts/lifecycle/cycleStateCache.mjs';
+
+/**
+ * Self-test for the cycle-state hot-file cache — the producer↔consumer bridge between the daemon (writes
+ * the verdict) and the sync liveness Stop hook (reads it without a network round-trip). Lock in the
+ * fail-soft + staleness-bounded contract: a missing / malformed / stale cache returns null so the hook
+ * fail-opens. Uses the `filePath` seam → an os.tmpdir() file, so tests never touch the runtime dir.
+ */
+
+const tmpFile = (name) => path.join(os.tmpdir(), `neo-cyclestate-test-${name}-${process.pid}.json`);
+const verdict = {nextStep: {step: 'review-requested-pr', ref: '#1'}, claimableNowCount: 1, isEmptyCycle: false};
+
+test.describe('cycleStateCache — cacheFilePath', () => {
+    test('sanitizes the identity into the wake-daemon runtime dir', () => {
+        const p = cacheFilePath('@neo-opus-vega');
+        expect(p).toContain('.neo-ai-data/wake-daemon/');
+        expect(p).toContain('cycle-state-_neo-opus-vega.json');   // @ sanitized to _
+        expect(cacheFilePath(null)).toContain('cycle-state-unknown.json')
+    });
+});
+
+test.describe('cycleStateCache — write/read round-trip + fail-soft', () => {
+    test('write then read preserves the verdict + reports age', () => {
+        const filePath = tmpFile('roundtrip');
+        try {
+            expect(writeCycleState('id', verdict, {now: 1000, filePath})).toBe(true);
+            const got = readCycleState('id', {now: 1500, maxAgeMs: 10000, filePath});
+            expect(got.verdict).toEqual(verdict);
+            expect(got.computedAt).toBe(1000);
+            expect(got.ageMs).toBe(500)
+        } finally { fs.rmSync(filePath, {force: true}) }
+    });
+
+    test('missing file → null (hook fail-opens)', () => {
+        expect(readCycleState('id', {filePath: tmpFile('does-not-exist')})).toBeNull()
+    });
+
+    test('stale verdict (age > maxAgeMs) → null', () => {
+        const filePath = tmpFile('stale');
+        try {
+            writeCycleState('id', verdict, {now: 1000, filePath});
+            // 6 min later with a 5 min bound → stale → null
+            expect(readCycleState('id', {now: 1000 + 6 * 60 * 1000, maxAgeMs: 5 * 60 * 1000, filePath})).toBeNull()
+        } finally { fs.rmSync(filePath, {force: true}) }
+    });
+
+    test('malformed JSON → null (never throws)', () => {
+        const filePath = tmpFile('malformed');
+        try {
+            fs.writeFileSync(filePath, '{ not json', 'utf8');
+            expect(readCycleState('id', {filePath})).toBeNull()
+        } finally { fs.rmSync(filePath, {force: true}) }
+    });
+
+    test('missing computedAt / verdict fields → null', () => {
+        const filePath = tmpFile('partial');
+        try {
+            fs.writeFileSync(filePath, JSON.stringify({verdict}), 'utf8');   // no computedAt
+            expect(readCycleState('id', {filePath})).toBeNull()
+        } finally { fs.rmSync(filePath, {force: true}) }
+    });
+});

--- a/test/playwright/unit/ai/scripts/cycleStateCache.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleStateCache.spec.mjs
@@ -6,20 +6,20 @@ import {cacheFilePath, readCycleState, writeCycleState} from '../../../../../ai/
 
 /**
  * Self-test for the cycle-state hot-file cache — the producer↔consumer bridge between the daemon (writes
- * the verdict) and the sync liveness Stop hook (reads it without a network round-trip). Lock in the
- * fail-soft + staleness-bounded contract: a missing / malformed / stale cache returns null so the hook
- * fail-opens. Uses the `filePath` seam → an os.tmpdir() file, so tests never touch the runtime dir.
+ * the verdict) and the sync liveness Stop hook (reads it without a network round-trip). Locks in the
+ * fail-soft + staleness-bounded contract: a missing / malformed / stale / un-bounded cache returns null so
+ * the hook fail-opens. The cache is a PURE helper: the dir + maxAge are INJECTED, never owned — so tests
+ * pass their own values directly and never read or mutate the shared AiConfig singleton.
  */
 
 const tmpFile = (name) => path.join(os.tmpdir(), `neo-cyclestate-test-${name}-${process.pid}.json`);
 const verdict = {nextStep: {step: 'review-requested-pr', ref: '#1'}, claimableNowCount: 1, isEmptyCycle: false};
 
-test.describe('cycleStateCache — cacheFilePath', () => {
-    test('sanitizes the identity into the wake-daemon runtime dir', () => {
-        const p = cacheFilePath('@neo-opus-vega');
-        expect(p).toContain('.neo-ai-data/wake-daemon/');
-        expect(p).toContain('cycle-state-_neo-opus-vega.json');   // @ sanitized to _
-        expect(cacheFilePath(null)).toContain('cycle-state-unknown.json')
+test.describe('cycleStateCache — cacheFilePath (path under the injected dir)', () => {
+    test('joins the injected wake-daemon dir + sanitized identity (no hidden/hardcoded dir)', () => {
+        const dir = path.join(os.tmpdir(), 'neo-wake-daemon-test');
+        expect(cacheFilePath(dir, '@neo-opus-vega')).toBe(path.join(dir, 'cycle-state-_neo-opus-vega.json')); // @ sanitized to _
+        expect(cacheFilePath(dir, null)).toBe(path.join(dir, 'cycle-state-unknown.json'))
     });
 });
 
@@ -27,8 +27,8 @@ test.describe('cycleStateCache — write/read round-trip + fail-soft', () => {
     test('write then read preserves the verdict + reports age', () => {
         const filePath = tmpFile('roundtrip');
         try {
-            expect(writeCycleState('id', verdict, {now: 1000, filePath})).toBe(true);
-            const got = readCycleState('id', {now: 1500, maxAgeMs: 10000, filePath});
+            expect(writeCycleState(os.tmpdir(), 'id', verdict, {now: 1000, filePath})).toBe(true);
+            const got = readCycleState(os.tmpdir(), 'id', {now: 1500, maxAgeMs: 10000, filePath});
             expect(got.verdict).toEqual(verdict);
             expect(got.computedAt).toBe(1000);
             expect(got.ageMs).toBe(500)
@@ -36,15 +36,23 @@ test.describe('cycleStateCache — write/read round-trip + fail-soft', () => {
     });
 
     test('missing file → null (hook fail-opens)', () => {
-        expect(readCycleState('id', {filePath: tmpFile('does-not-exist')})).toBeNull()
+        expect(readCycleState(os.tmpdir(), 'id', {maxAgeMs: 10000, filePath: tmpFile('does-not-exist')})).toBeNull()
     });
 
     test('stale verdict (age > maxAgeMs) → null', () => {
         const filePath = tmpFile('stale');
         try {
-            writeCycleState('id', verdict, {now: 1000, filePath});
+            writeCycleState(os.tmpdir(), 'id', verdict, {now: 1000, filePath});
             // 6 min later with a 5 min bound → stale → null
-            expect(readCycleState('id', {now: 1000 + 6 * 60 * 1000, maxAgeMs: 5 * 60 * 1000, filePath})).toBeNull()
+            expect(readCycleState(os.tmpdir(), 'id', {now: 1000 + 6 * 60 * 1000, maxAgeMs: 5 * 60 * 1000, filePath})).toBeNull()
+        } finally { fs.rmSync(filePath, {force: true}) }
+    });
+
+    test('no injected maxAgeMs → null (fail-open; the helper owns no default staleness policy)', () => {
+        const filePath = tmpFile('no-maxage');
+        try {
+            writeCycleState(os.tmpdir(), 'id', verdict, {now: 1000, filePath});
+            expect(readCycleState(os.tmpdir(), 'id', {now: 1500, filePath})).toBeNull()  // fresh file, but no injected bound → fail-open
         } finally { fs.rmSync(filePath, {force: true}) }
     });
 
@@ -52,7 +60,7 @@ test.describe('cycleStateCache — write/read round-trip + fail-soft', () => {
         const filePath = tmpFile('malformed');
         try {
             fs.writeFileSync(filePath, '{ not json', 'utf8');
-            expect(readCycleState('id', {filePath})).toBeNull()
+            expect(readCycleState(os.tmpdir(), 'id', {maxAgeMs: 10000, filePath})).toBeNull()
         } finally { fs.rmSync(filePath, {force: true}) }
     });
 
@@ -60,7 +68,7 @@ test.describe('cycleStateCache — write/read round-trip + fail-soft', () => {
         const filePath = tmpFile('partial');
         try {
             fs.writeFileSync(filePath, JSON.stringify({verdict}), 'utf8');   // no computedAt
-            expect(readCycleState('id', {filePath})).toBeNull()
+            expect(readCycleState(os.tmpdir(), 'id', {maxAgeMs: 10000, filePath})).toBeNull()
         } finally { fs.rmSync(filePath, {force: true}) }
     });
 });

--- a/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                            from '@playwright/test';
-import {isCiGreen, mapOwnPRs, mapReviewRequests} from '../../../../../ai/scripts/lifecycle/cycleStateFetch.mjs';
+import {isCiGreen, mapBacklog, mapOwnPRs, mapReviewRequests} from '../../../../../ai/scripts/lifecycle/cycleStateFetch.mjs';
 
 /**
  * Self-test for the GitHub-state → cycle-state-input mappers (the daemon-side fetch-and-map layer). The
@@ -44,5 +44,24 @@ test.describe('cycleStateFetch — mapReviewRequests', () => {
     test('maps to {ref} (designated reviews)', () => {
         expect(mapReviewRequests([{number: 20}, {number: 21}])).toEqual([{ref: '#20'}, {ref: '#21'}]);
         expect(mapReviewRequests(undefined)).toEqual([])
+    });
+});
+
+test.describe('cycleStateFetch — mapBacklog (claimable-now exclusion flags)', () => {
+    test('derives blocked / gated / claimedByOther from the context sets', () => {
+        const mapped = mapBacklog([{number: 30}, {number: 31}, {number: 32}, {number: 33}], {
+            blockedRefs   : new Set(['#30']),
+            gatedRefs     : new Set(['#31']),
+            claimedByOther: new Map([['#32', '@neo-gpt']])
+        });
+        expect(mapped[0]).toEqual({ref: '#30', blocked: true,  gated: false, claimedByOther: undefined});  // blocked
+        expect(mapped[1]).toEqual({ref: '#31', blocked: false, gated: true,  claimedByOther: undefined});  // gated
+        expect(mapped[2]).toEqual({ref: '#32', blocked: false, gated: false, claimedByOther: '@neo-gpt'}); // collision
+        expect(mapped[3]).toEqual({ref: '#33', blocked: false, gated: false, claimedByOther: undefined});  // claimable-now
+    });
+
+    test('no context → all unflagged (all claimable); non-array → empty', () => {
+        expect(mapBacklog([{number: 40}])).toEqual([{ref: '#40', blocked: false, gated: false, claimedByOther: undefined}]);
+        expect(mapBacklog(undefined)).toEqual([])
     });
 });

--- a/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                            from '@playwright/test';
-import {fetchExternalState, isCiGreen, mapBacklog, mapOwnPRs, mapReviewRequests} from '../../../../../ai/scripts/lifecycle/cycleStateFetch.mjs';
+import {fetchExternalState, isCiGreen, mapBacklog, mapLaneClaims, mapOwnPRs, mapReviewRequests} from '../../../../../ai/scripts/lifecycle/cycleStateFetch.mjs';
 
 /**
  * Self-test for the GitHub-state → cycle-state-input mappers (the daemon-side fetch-and-map layer). The
@@ -63,6 +63,28 @@ test.describe('cycleStateFetch — mapBacklog (claimable-now exclusion flags)', 
     test('no context → all unflagged (all claimable); non-array → empty', () => {
         expect(mapBacklog([{number: 40}])).toEqual([{ref: '#40', blocked: false, gated: false, claimedByOther: undefined}]);
         expect(mapBacklog(undefined)).toEqual([])
+    });
+});
+
+test.describe('cycleStateFetch — mapLaneClaims (the claimedByOther collision source)', () => {
+    test('extracts ref → other-agent; excludes self-claims + non-lane-claim subjects', () => {
+        const map = mapLaneClaims([
+            {subject: '[lane-claim] taking #100 some work', from: '@neo-gpt'},
+            {subject: '[lane-claim] resuming #101 — REM prune',  from: '@neo-opus-ada'},
+            {subject: '[lane-claim] #102 mine',                  from: '@neo-opus-vega'},  // self → excluded
+            {subject: '[pr-opened] PR #103 (#104)',              from: '@neo-gpt'},        // not a lane-claim → ignored
+            {subject: 'no ref here [lane-claim] taking it',      from: '@neo-gpt'}         // no #N → ignored
+        ], '@neo-opus-vega');
+
+        expect(map.get('#100')).toBe('@neo-gpt');
+        expect(map.get('#101')).toBe('@neo-opus-ada');
+        expect(map.has('#102')).toBe(false);   // self-claim
+        expect(map.has('#103')).toBe(false);   // pr-opened, not lane-claim
+        expect(map.size).toBe(2)
+    });
+
+    test('non-array → empty map', () => {
+        expect(mapLaneClaims(undefined, '@me').size).toBe(0)
     });
 });
 

--- a/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                            from '@playwright/test';
-import {isCiGreen, mapBacklog, mapOwnPRs, mapReviewRequests} from '../../../../../ai/scripts/lifecycle/cycleStateFetch.mjs';
+import {fetchExternalState, isCiGreen, mapBacklog, mapOwnPRs, mapReviewRequests} from '../../../../../ai/scripts/lifecycle/cycleStateFetch.mjs';
 
 /**
  * Self-test for the GitHub-state → cycle-state-input mappers (the daemon-side fetch-and-map layer). The
@@ -63,5 +63,28 @@ test.describe('cycleStateFetch — mapBacklog (claimable-now exclusion flags)', 
     test('no context → all unflagged (all claimable); non-array → empty', () => {
         expect(mapBacklog([{number: 40}])).toEqual([{ref: '#40', blocked: false, gated: false, claimedByOther: undefined}]);
         expect(mapBacklog(undefined)).toEqual([])
+    });
+});
+
+test.describe('cycleStateFetch — fetchExternalState (orchestration, injected runner)', () => {
+    test('runs the 3 queries in parallel, maps them, strips leading @, honors gatherContext', async () => {
+        const calls = [];
+        const runQuery = async (args) => {
+            calls.push(args);
+            if (args.includes('--author')) return [{number: 10, statusCheckRollup: [{conclusion: 'SUCCESS'}], reviewDecision: null, reviewRequests: []}];
+            if (args.includes('--search')) return [{number: 20}];
+            return [{number: 30}, {number: 31}];                                  // gh issue list (backlog)
+        };
+        const gatherContext = async () => ({blockedRefs: new Set(['#31'])});
+        const state = await fetchExternalState('@neo-opus-vega', {runQuery, gatherContext});
+
+        expect(state.ownPRs).toEqual([{ref: '#10', ciGreen: true, reviewRequested: false, changesRequested: false}]);
+        expect(state.reviewRequests).toEqual([{ref: '#20'}]);
+        expect(state.backlog).toEqual([
+            {ref: '#30', blocked: false, gated: false, claimedByOther: undefined},
+            {ref: '#31', blocked: true,  gated: false, claimedByOther: undefined}  // from gatherContext
+        ]);
+        expect(state.openOwnPrCount).toBe(1);
+        expect(calls.find(a => a.includes('--search'))).toContain('review-requested:neo-opus-vega'); // @ stripped
     });
 });

--- a/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
@@ -23,15 +23,17 @@ test.describe('cycleStateFetch — isCiGreen', () => {
 });
 
 test.describe('cycleStateFetch — mapOwnPRs', () => {
-    test('derives ciGreen / reviewRequested / changesRequested per PR', () => {
+    test('derives ciGreen / reviewRequested / changesRequested / approved per PR', () => {
         const mapped = mapOwnPRs([
             {number: 10, statusCheckRollup: [{conclusion: 'SUCCESS'}], reviewDecision: null,                reviewRequests: []},
             {number: 11, statusCheckRollup: [{conclusion: 'FAILURE'}], reviewDecision: 'CHANGES_REQUESTED',  reviewRequests: [{login: 'x'}]},
-            {number: 12, statusCheckRollup: [],                        reviewDecision: 'REVIEW_REQUIRED',    reviewRequests: [{login: 'y'}]}
+            {number: 12, statusCheckRollup: [],                        reviewDecision: 'REVIEW_REQUIRED',    reviewRequests: [{login: 'y'}]},
+            {number: 13, statusCheckRollup: [{conclusion: 'SUCCESS'}], reviewDecision: 'APPROVED',           reviewRequests: []}
         ]);
-        expect(mapped[0]).toEqual({ref: '#10', ciGreen: true,  reviewRequested: false, changesRequested: false}); // green, no reviewer → step 3
-        expect(mapped[1]).toEqual({ref: '#11', ciGreen: false, reviewRequested: true,  changesRequested: true});  // changes requested → step 1
-        expect(mapped[2]).toEqual({ref: '#12', ciGreen: true,  reviewRequested: true,  changesRequested: false}); // green + reviewer requested → no step
+        expect(mapped[0]).toEqual({ref: '#10', ciGreen: true,  reviewRequested: false, changesRequested: false, approved: false}); // green, no reviewer → step 3
+        expect(mapped[1]).toEqual({ref: '#11', ciGreen: false, reviewRequested: true,  changesRequested: true,  approved: false}); // changes requested → step 1
+        expect(mapped[2]).toEqual({ref: '#12', ciGreen: true,  reviewRequested: true,  changesRequested: false, approved: false}); // green + reviewer requested → no step
+        expect(mapped[3]).toEqual({ref: '#13', ciGreen: true,  reviewRequested: false, changesRequested: false, approved: true});  // APPROVED green, no reviewer → human merge-gate, NOT step 3
     });
 
     test('non-array input → empty', () => {
@@ -100,7 +102,7 @@ test.describe('cycleStateFetch — fetchExternalState (orchestration, injected r
         const gatherContext = async () => ({blockedRefs: new Set(['#31'])});
         const state = await fetchExternalState('@neo-opus-vega', {runQuery, gatherContext});
 
-        expect(state.ownPRs).toEqual([{ref: '#10', ciGreen: true, reviewRequested: false, changesRequested: false}]);
+        expect(state.ownPRs).toEqual([{ref: '#10', ciGreen: true, reviewRequested: false, changesRequested: false, approved: false}]);
         expect(state.reviewRequests).toEqual([{ref: '#20'}]);
         expect(state.backlog).toEqual([
             {ref: '#30', blocked: false, gated: false, claimedByOther: undefined},

--- a/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
+++ b/test/playwright/unit/ai/scripts/cycleStateFetch.spec.mjs
@@ -1,0 +1,48 @@
+import {test, expect}                            from '@playwright/test';
+import {isCiGreen, mapOwnPRs, mapReviewRequests} from '../../../../../ai/scripts/lifecycle/cycleStateFetch.mjs';
+
+/**
+ * Self-test for the GitHub-state → cycle-state-input mappers (the daemon-side fetch-and-map layer). The
+ * derivation (CI-green, changes-requested, review-requested) is pure over raw `gh ... --json` output, so
+ * it's unit-testable without running `gh`.
+ */
+
+test.describe('cycleStateFetch — isCiGreen', () => {
+    test('empty / missing rollup → green (no checks = nothing failing)', () => {
+        expect(isCiGreen([])).toBe(true);
+        expect(isCiGreen(undefined)).toBe(true);
+        expect(isCiGreen(null)).toBe(true)
+    });
+
+    test('all settled-successful → green; any failure or pending → not green', () => {
+        expect(isCiGreen([{conclusion: 'SUCCESS'}, {state: 'SUCCESS'}, {conclusion: 'SKIPPED'}])).toBe(true);
+        expect(isCiGreen([{conclusion: 'SUCCESS'}, {conclusion: 'FAILURE'}])).toBe(false);
+        expect(isCiGreen([{conclusion: 'SUCCESS'}, {state: 'PENDING'}])).toBe(false);      // legacy StatusContext pending
+        expect(isCiGreen([{status: 'IN_PROGRESS', conclusion: null}])).toBe(false)         // not yet settled
+    });
+});
+
+test.describe('cycleStateFetch — mapOwnPRs', () => {
+    test('derives ciGreen / reviewRequested / changesRequested per PR', () => {
+        const mapped = mapOwnPRs([
+            {number: 10, statusCheckRollup: [{conclusion: 'SUCCESS'}], reviewDecision: null,                reviewRequests: []},
+            {number: 11, statusCheckRollup: [{conclusion: 'FAILURE'}], reviewDecision: 'CHANGES_REQUESTED',  reviewRequests: [{login: 'x'}]},
+            {number: 12, statusCheckRollup: [],                        reviewDecision: 'REVIEW_REQUIRED',    reviewRequests: [{login: 'y'}]}
+        ]);
+        expect(mapped[0]).toEqual({ref: '#10', ciGreen: true,  reviewRequested: false, changesRequested: false}); // green, no reviewer → step 3
+        expect(mapped[1]).toEqual({ref: '#11', ciGreen: false, reviewRequested: true,  changesRequested: true});  // changes requested → step 1
+        expect(mapped[2]).toEqual({ref: '#12', ciGreen: true,  reviewRequested: true,  changesRequested: false}); // green + reviewer requested → no step
+    });
+
+    test('non-array input → empty', () => {
+        expect(mapOwnPRs(undefined)).toEqual([]);
+        expect(mapOwnPRs(null)).toEqual([])
+    });
+});
+
+test.describe('cycleStateFetch — mapReviewRequests', () => {
+    test('maps to {ref} (designated reviews)', () => {
+        expect(mapReviewRequests([{number: 20}, {number: 21}])).toEqual([{ref: '#20'}, {ref: '#21'}]);
+        expect(mapReviewRequests(undefined)).toEqual([])
+    });
+});


### PR DESCRIPTION
Resolves #12612

Sub B of Epic #11829, graduated from Discussion #12630 (§6 family-keyed quorum met on the daemon-vs-A2A corrected shape: @neo-gpt non-author `[GRADUATION_APPROVED]` + @neo-opus-ada + me).

The idle-out fix's **wake-content layer**: the bridge-daemon's opaque `"N heartbeat pulses"` digest line now surfaces the concrete **next cycle-step** (`next: <step> (#ref)`), so a woken agent sees what to do instead of inferring it from prose. Per the D#12630 correction this is the **daemon GraphLog-pulse** path (NOT A2A `wakeMetadata` — a different mechanism; #12608 closed as superseded), and the sync liveness Stop hook (Sub C) reads the same cached verdict.

## Architecture (V-B-A)

The sync Stop hook (Sub C) blocks the turn-end → it cannot live-query GitHub. So the design splits by who-can-afford-the-latency:

- **`idleOutNudge.mjs` (async — the writer):** before emitting the idle-out pulse, computes the cycle-state for the target identity (`fetchExternalState → computeCycleState`) and caches it (`writeCycleState`). Fail-soft — a compute failure never blocks the nudge.
- **`bridge/daemon.mjs` (the renderer):** reads the cached verdict (`readCycleState`) and renders the next-step in the heartbeat digest line, falling back to the legacy count when no fresh verdict is cached.
- **Sub C's hook (the enforcer — separate sub):** reads the same cache (it can't gh-query synchronously).

One producer (the daemon), two consumers (the digest + the hook), one author.

## What shipped

| Module | Role |
|---|---|
| `ai/scripts/lifecycle/cycleState.mjs` | the **discriminator** — `computeCycleState(externalState)` → the next cycle-step in lifecycle-closure order, encoding **claimable-now ≠ raw-backlog** (gated/blocked/colliding items are not a next step). `formatCycleStateLine` renders the digest fragment. |
| `ai/scripts/lifecycle/cycleStateCache.mjs` | the **hot-file cache** (daemon writes / hook reads) — fail-soft + staleness-bounded under `.neo-ai-data/wake-daemon/`. |
| `ai/scripts/lifecycle/cycleStateFetch.mjs` | the **fetch+map** layer — `fetchExternalState` runs the 3 GitHub queries (injectable runner) + the pure mappers (`mapOwnPRs` / `mapReviewRequests` / `mapBacklog` / `mapLaneClaims`). |
| `ai/daemons/bridge/daemon.mjs` | renders the cached cycle-state in the heartbeat digest (graceful fallback). |
| `ai/scripts/lifecycle/idleOutNudge.mjs` | computes + caches the cycle-state before emitting the pulse (fail-soft). |

Evidence: **L2 (unit-tested)** — 27 green across the 3 cycle-state specs — plus **L1** (syntax-verified daemon + `idleOutNudge` edits, post-rebase). The pure discriminator / cache / mappers are exhaustively unit-tested; the daemon + `idleOutNudge` wiring composes them and is fail-soft.

## Test Evidence

27 unit tests green (`cycleState.spec` 11 + `cycleStateCache.spec` 6 + `cycleStateFetch.spec` 10): the cycle priority order; the **claimable-now-vs-raw-backlog** falsification-AC core (a non-empty backlog of only-gated items → empty cycle); the cache round-trip / staleness / fail-soft; the GitHub-state mappers + the injected-runner orchestration; the digest formatter. Daemon + `idleOutNudge` syntax-verified after the rebase onto `origin/dev`.

## Deltas from ticket

- **Backlog (cycle step 4) deferred:** the writer computes the lifecycle-closure steps (1-3: own-PR changes-requested / designated review / own-green review-request) and passes `backlog: []` until the `gatherContext` flag-derivation (lane-claims [done: `mapLaneClaims`] + blocked-by relations via `GraphService`) lands — so it never suggests a gated/colliding lane. The step-4 enrichment is a follow-up; the discriminator + `mapBacklog` + `mapLaneClaims` are already built + tested for it.

## Post-Merge Validation

- [ ] Deploy the wake-daemon; trigger an idle-out nudge → the digest line reads `… heartbeat pulses — next: <step> (#ref)` (cache populated + rendered), not the opaque count.
- [ ] The liveness Stop hook (Sub C) reads the cached verdict.
- [ ] `gh` unavailable in the daemon env → the fail-soft path degrades to the legacy count digest (no crash).
- [ ] #11909 stays open until the backlog-`gatherContext` follow-up lands.

## Out of Scope

- A2A `MESSAGE.wakeMetadata` (the superseded mechanism; #12608 closed).
- The backlog-`gatherContext` flag-derivation (blocked-by relations + the `GraphService` wiring) — follow-up.
- Sub C's enforcement hook + Sub A's vocab — separate subs of #11829.

Authored by Claude Opus 4.8 (Claude Code). Session a54e89a3-4259-4b41-9e26-561f665de744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
