### PR TITLE
feat(memory-core): bound REM run JSONL store with write-side retention cap (#12123)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -564,7 +564,7 @@ class DreamService extends Base {
                     logger.warn(`[Orchestrator] REM cycle wall-clock ${stateEntry.wallClockMs}ms exceeded ${Math.round(AiConfig.orchestrator.intervals.dreamOverflowThreshold * 100)}% of configured cadence ${stateEntry.configuredCadenceMs}ms; back-to-back overlap risk`);
                 }
 
-                await appendRemRunState(stateEntry, {dir: aiConfig.remRunStateDir});
+                await appendRemRunState(stateEntry, {dir: aiConfig.remRunStateDir, retentionLimit: aiConfig.remRunRetentionLimit});
             } catch (e) {
                 logger.error('[DreamService] Failed to write REM run state:', e);
                 outcome.stateWriteError = toErrorMessage(e);

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -203,6 +203,13 @@ class Config extends ConfigProvider {
              */
             remRunRecentLimit: leaf(5, 'NEO_REM_RUN_RECENT_LIMIT', 'number'),
             /**
+             * Maximum per-cycle REM run/stage JSONL artifacts retained on disk. On each append the
+             * store prunes older artifacts beyond this bound, capping both the directory file count
+             * and the read-path stat fan-out so neither grows with deployment age.
+             * @type {number}
+             */
+            remRunRetentionLimit: leaf(200, 'NEO_REM_RUN_RETENTION_LIMIT', 'number'),
+            /**
              * Target markdown file used for autonomous agent-to-user reporting (offline jobs).
              * @type {string}
              */

--- a/ai/services/memory-core/helpers/RemRunStateStore.mjs
+++ b/ai/services/memory-core/helpers/RemRunStateStore.mjs
@@ -124,14 +124,66 @@ export function createRemRunStateEntry({
 }
 
 /**
- * @summary Appends one REM run state entry into its per-run JSONL artifact.
+ * @summary Prunes the REM run-state directory down to the most-recent `retentionLimit` artifacts.
+ *
+ * This is the write-side retention cap: bounding the on-disk artifact count on each append also
+ * bounds the read-path stat fan-out, because {@link readRecentRemRunStates} can never scan more
+ * files than the retained set. Choosing a write-side cap over an orchestrator cleanup lane avoids
+ * a cross-service boundary (the JSONL store stays self-contained, filesystem-durable). Retention
+ * sorts by `mtime` so it is robust to any run-id shape, and removes the oldest beyond the bound.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Directory for per-run state files.
+ * @param {Number} options.retentionLimit Maximum artifacts to retain; older ones are removed.
+ *   Non-positive / non-finite values disable pruning (no-op).
+ * @returns {Promise<Number>} Count of artifacts removed.
+ */
+export async function pruneRemRunStates({dir, retentionLimit} = {}) {
+    if (!dir || !Number.isFinite(retentionLimit) || retentionLimit <= 0) {
+        return 0;
+    }
+
+    let names;
+    try {
+        names = await fs.readdir(dir);
+    } catch (e) {
+        if (e?.code === 'ENOENT') return 0;
+        throw e;
+    }
+
+    const jsonlNames = names.filter(name => name.endsWith('.jsonl'));
+    if (jsonlNames.length <= retentionLimit) {
+        return 0;
+    }
+
+    const files = await Promise.all(jsonlNames.map(async name => {
+        const filePath = path.join(dir, name);
+        const stat     = await fs.stat(filePath);
+        return {filePath, mtimeMs: stat.mtimeMs};
+    }));
+
+    // Newest first; everything beyond the retention bound is the oldest and gets removed.
+    const toRemove = files
+        .sort((a, b) => b.mtimeMs - a.mtimeMs)
+        .slice(retentionLimit);
+
+    await Promise.all(toRemove.map(file => fs.rm(file.filePath, {force: true})));
+
+    return toRemove.length;
+}
+
+/**
+ * @summary Appends one REM run state entry into its per-run JSONL artifact, then applies a
+ * write-side retention cap when `retentionLimit` is supplied.
  *
  * @param {Object} entry JSONL-ready REM run state entry.
  * @param {Object} options
  * @param {String} options.dir Directory for per-run state files.
+ * @param {Number} [options.retentionLimit] Maximum artifacts to retain; older ones are pruned
+ *   after the append. Omitted / non-positive disables retention (no prune).
  * @returns {Promise<String>} Written file path.
  */
-export async function appendRemRunState(entry, {dir} = {}) {
+export async function appendRemRunState(entry, {dir, retentionLimit} = {}) {
     if (!dir) {
         throw new TypeError('appendRemRunState: dir is required');
     }
@@ -140,6 +192,12 @@ export async function appendRemRunState(entry, {dir} = {}) {
 
     const filePath = path.join(dir, getRemRunStateFileName(entry.runId));
     await fs.appendFile(filePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+    // Write-side retention cap: bound the artifact count (and thus the read-path stat fan-out)
+    // on each append, instead of relying on a separate orchestrator cleanup lane.
+    if (Number.isFinite(retentionLimit) && retentionLimit > 0) {
+        await pruneRemRunStates({dir, retentionLimit});
+    }
 
     return filePath;
 }

--- a/learn/agentos/rem-state-model.md
+++ b/learn/agentos/rem-state-model.md
@@ -113,6 +113,28 @@ projects only the recent cycle summary fields so operator dashboards stay small;
 inspect the JSONL artifact directly when phase-level or per-session failure
 reasons are needed.
 
+## Retention
+
+Each REM cycle appends one new `<runId>.jsonl` artifact, so the directory would grow
+without bound across a deployment's lifetime (~24 files/day at the default 1h dream
+cadence). `appendRemRunState` applies a **write-side retention cap** on every append:
+after writing, it prunes the oldest artifacts beyond `remRunRetentionLimit`
+(`NEO_REM_RUN_RETENTION_LIMIT`, default `200`). Retention sorts by `mtime`, removing the
+oldest and never the recent window.
+
+Bounding the artifact count on the write side also bounds the **read path**:
+`readRecentRemRunStates` — and therefore every `get_rem_pipeline_state` / healthcheck call
+— `readdir`s + `stat`s the directory, so its cost is capped by the retention bound rather
+than growing with the total number of cycles ever run.
+
+A write-side cap is preferred over an orchestrator cleanup lane: the JSONL store stays
+self-contained and filesystem-durable, with no cross-service boundary and no graph
+mutation during a REM run.
+
+**Disabled mode:** a non-positive or non-finite `remRunRetentionLimit` disables pruning —
+`appendRemRunState` then keeps every artifact (unbounded). Use this only for short-lived
+forensic captures where you want the full history and will clean the directory yourself.
+
 Set `NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD` to tune the overflow warning
 ratio against the configured dream cadence. The default is `0.8`, meaning a
 cycle that consumes more than 80% of its cadence is flagged as an overlap risk.

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -233,4 +233,20 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.collections.session).toBe(config.collections.sessionTest);
         expect(config.collections.graph).toBe('neo-native-graph');
     });
+
+    test('remRunRetentionLimit defaults to 200 and parses NEO_REM_RUN_RETENTION_LIMIT as a number (#12123)', () => {
+        expect(config.remRunRetentionLimit).toBe(200);
+
+        process.env.NEO_REM_RUN_RETENTION_LIMIT = '50';
+
+        // Fresh isolated instance picks up the env via #applyEnvLayer at construction —
+        // never mutate the shared singleton.
+        const freshCfg = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(freshCfg.remRunRetentionLimit).toBe(50);
+        } finally {
+            freshCfg.destroy();
+        }
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/helpers/RemRunStateStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/RemRunStateStore.spec.mjs
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 import Neo             from '../../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../../src/core/_export.mjs';
-import {mkdtemp, rm}   from 'fs/promises';
+import {mkdtemp, rm, readdir, utimes} from 'fs/promises';
 import os              from 'os';
 import path            from 'path';
 
@@ -10,6 +10,7 @@ import {
     createRemPhaseState,
     createRemRunStateEntry,
     getRemRunStateFileName,
+    pruneRemRunStates,
     readRecentRemRunStates
 } from '../../../../../../../ai/services/memory-core/helpers/RemRunStateStore.mjs';
 
@@ -98,5 +99,72 @@ test.describe('RemRunStateStore', () => {
         const recent = await readRecentRemRunStates({dir: tmpDir, limit: 1});
 
         expect(recent.map(entry => entry.runId)).toEqual(['rem-new']);
+    });
+
+    const makeEntry = (runId, completedAt) => createRemRunStateEntry({
+        runId,
+        reason             : 'manual',
+        startedAt          : completedAt - 100,
+        completedAt,
+        configuredCadenceMs: 1000,
+        overflowThreshold  : 0.8,
+        outcome            : 'completed',
+        reasonCode         : 'ok'
+    });
+
+    const jsonlCount = async dir => (await readdir(dir)).filter(name => name.endsWith('.jsonl')).length;
+
+    test('appendRemRunState without retentionLimit keeps every artifact (backward compatible)', async () => {
+        for (let i = 0; i < 8; i++) {
+            await appendRemRunState(makeEntry(`rem-${i}`, 1000 + i), {dir: tmpDir});
+        }
+        expect(await jsonlCount(tmpDir)).toBe(8);
+    });
+
+    test('appendRemRunState applies the write-side retention cap (AC2)', async () => {
+        for (let i = 0; i < 12; i++) {
+            await appendRemRunState(makeEntry(`rem-${String(i).padStart(2, '0')}`, 1000 + i), {dir: tmpDir, retentionLimit: 5});
+        }
+        expect(await jsonlCount(tmpDir)).toBe(5);
+    });
+
+    test('read fan-out is bounded by retention, not by lifetime cycle count (AC1/AC4)', async () => {
+        // 30 lifetime cycles, retentionLimit 5: the on-disk set — exactly what readRecentRemRunStates
+        // readdir/stats — stays at 5, independent of the 30 cycles run. The read no longer scales with age.
+        for (let i = 0; i < 30; i++) {
+            await appendRemRunState(makeEntry(`rem-${String(i).padStart(2, '0')}`, 1000 + i), {dir: tmpDir, retentionLimit: 5});
+        }
+        expect(await jsonlCount(tmpDir)).toBe(5);
+
+        const recent = await readRecentRemRunStates({dir: tmpDir, limit: 5});
+        expect(recent.length).toBe(5);
+    });
+
+    test('retention removes the oldest and never the recent window (AC6)', async () => {
+        for (let i = 0; i < 10; i++) {
+            const runId = `rem-${String(i).padStart(2, '0')}`;
+            await appendRemRunState(makeEntry(runId, 1000 + i), {dir: tmpDir});
+            // Deterministic age ordering: explicit mtime per artifact (oldest -> newest).
+            const filePath = path.join(tmpDir, getRemRunStateFileName(runId));
+            await utimes(filePath, new Date(1000 + i), new Date(1000 + i));
+        }
+
+        const removed = await pruneRemRunStates({dir: tmpDir, retentionLimit: 3});
+        expect(removed).toBe(7);
+
+        const survivors = (await readdir(tmpDir)).filter(name => name.endsWith('.jsonl')).sort();
+        expect(survivors).toEqual(['rem-07', 'rem-08', 'rem-09'].map(getRemRunStateFileName));
+
+        const recent = await readRecentRemRunStates({dir: tmpDir, limit: 3});
+        expect(recent.map(entry => entry.runId)).toEqual(['rem-09', 'rem-08', 'rem-07']);
+    });
+
+    test('pruneRemRunStates is a no-op below the bound or when disabled', async () => {
+        for (let i = 0; i < 3; i++) {
+            await appendRemRunState(makeEntry(`rem-${i}`, 1000 + i), {dir: tmpDir});
+        }
+        expect(await pruneRemRunStates({dir: tmpDir, retentionLimit: 5})).toBe(0);
+        expect(await pruneRemRunStates({dir: tmpDir, retentionLimit: 0})).toBe(0);
+        expect(await jsonlCount(tmpDir)).toBe(3);
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session 5f3fd8c4-ce8d-4a69-bbfe-336c5eeffdd3.

Resolves #12123
Related: #12065

`RemRunStateStore` shipped append + read but no prune, so the per-cycle `<runId>.jsonl` directory grew without bound (~24 files/day at the 1h dream cadence) and `readRecentRemRunStates` paid an `fs.stat` per file on every call — a read cost that scaled with deployment age, not the read limit. This adds a **write-side retention cap**: `appendRemRunState` prunes the oldest artifacts beyond `remRunRetentionLimit` on each append, bounding both the directory file count and the read-path stat fan-out.

Evidence: L2 (unit tests exercise the real prune against real filesystem artifacts via `mkdtemp` + `fs.readdir`/`utimes`) -> L2 required (the retention contract + the read-fan-out bound are filesystem-observable and fully unit-covered). No residuals here — the optional ops-side HNSW-segment repair is out of scope (tracked separately under the #12450 corruption layer).

## Deltas from ticket
- **Mechanism (AC1):** chose the **write-side cap** (prune-on-append in `RemRunStateStore`) over an orchestrator cleanup lane — the avoided-trap's preferred shape; it keeps the JSONL store self-contained with no cross-service boundary and no graph mutation during a REM run. The AC1 isolation test confirms the read fan-out is bounded by retention, not by lifetime cycle count.
- **Retention sort:** by `mtime` (robust to any run-id shape), removing the oldest and never the recent window (AC6).

## Config Template Change (per `mcp-config-template-change-guide.md`)
- **Changed key:** `remRunRetentionLimit` added to `ai/mcp/server/memory-core/config.template.mjs` — `leaf(200, 'NEO_REM_RUN_RETENTION_LIMIT', 'number')` (concrete template default + env binding, read verbatim, no fallback per AC3).
- **Local `config.mjs` follow-up:** not required for correctness — the deep-merge child-of-template inheritance resolves a missing leaf to the template default (200); regenerate via `bootstrapWorktree` to make it explicit. No gitignored `config.mjs` is committed.
- **Harness restart:** required to activate — the orchestrator's `DreamService` caller reads the new config, and the prune runs on the next REM cycle after a restart + dev pull.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/RemRunStateStore.spec.mjs` -> **9 passed (834ms)**: 4 existing + 5 new covering AC1/AC4 (read fan-out bounded by retention, not lifetime), AC2 (write-side prune caps the count), AC6 (oldest pruned, recent window intact), backward-compat (no `retentionLimit` -> no prune), and the no-op/disabled cases.
- `node --check` on `RemRunStateStore.mjs` + `DreamService.mjs`.
- Pre-commit hooks passed: whitespace, shorthand, ticket-archaeology.

## Post-Merge Validation
- [ ] After a confirmed post-merge deploy (orchestrator restart + dev pull), `.neo-ai-data/rem-runs/` stays bounded at `remRunRetentionLimit` artifacts across multiple REM cycles.
- [ ] `get_rem_pipeline_state.recentCycles` still returns the most-recent cycles after retention runs (the recent window is never pruned).
- [ ] Peer clones' local `config.mjs` understand the new key after their next `bootstrapWorktree` / restart.

## Commit
- `fb9fb809f` — feat(memory-core): bound REM run JSONL store with write-side retention cap (#12123)
