### PR TITLE
fix(agentos): bound VALIDATES edge precision (#12639)

### DIFF
--- a/ai/services/graph/GapInferenceEngine.mjs
+++ b/ai/services/graph/GapInferenceEngine.mjs
@@ -26,10 +26,10 @@ const ISO_VERIFIED_AT_PATTERN = /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}\.\d{3}Z
  *
  * Operates in two passes per REM cycle:
  *
- * 1. **TEST_GAP inference (regex, session-scoped):** iterates session-artifact structural nodes
- *    (CLASS / METHOD / COMPONENT) and matches tokenized node names against `test/*` file-path
- *    entries in the graph. This legacy regex path is still acceptable because testing
- *    discipline maps 1:1 to source file names and the test-file namespace is small and flat.
+ * 1. **TEST_GAP inference (session-scoped):** iterates session-artifact structural nodes
+ *    (CLASS / METHOD / COMPONENT) and matches tokenized node names against precise `test/*`
+ *    file evidence in the graph. Multi-token structural names require all name tokens to be
+ *    present in the test path before a `VALIDATES` edge is created.
  *
  * 2. **Concept-graph inference (edge traversal, cycle-scoped):** iterates CONCEPT nodes ingested
  *    by `ConceptIngestor` and emits deterministic signals via metadata + outbound-edge checks:
@@ -80,10 +80,9 @@ class GapInferenceEngine extends Base {
 
     /**
      * Session-scoped TEST_GAP inference entry point. Iterates CLASS / METHOD / COMPONENT nodes
-     * from the session artifact and checks for a matching test file via tokenized regex scan.
-     * The legacy regex path is retained for test-file discovery. Internal-config lifecycle
-     * hooks (`beforeSet*`, `afterSet*`, `beforeGet*`) are excluded since they're structurally
-     * shared and not individually testable.
+     * from the session artifact and checks for precise matching test-file evidence.
+     * Internal-config lifecycle hooks (`beforeSet*`, `afterSet*`, `beforeGet*`) are excluded
+     * since they're structurally shared and not individually testable.
      *
      * Gaps are persisted as a JSON-array-encoded string on `node.properties.capabilityGap` with
      * `[TEST_GAP]` prefix so `GoldenPathSynthesizer` can categorize them into the correct
@@ -128,16 +127,14 @@ class GapInferenceEngine extends Base {
             let matchingTestFiles = [];
 
             if (!isInternalConfigHook) {
-                const nodeTokens = node.name.replace(/([A-Z])/g, ' $1').toLowerCase().split(/[^a-z0-9]+/).filter(t => t.length > 2);
-                if (nodeTokens.length === 0) nodeTokens.push(node.name.toLowerCase());
+                const nodeTokens = this.getStructuralNameTokens(node.name);
 
-                matchingTestFiles = testFileNodes.filter(({pathLower}) => nodeTokens.some(term => {
-                    const regex = new RegExp('\\b' + term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'i');
-                    return regex.test(pathLower);
-                }));
+                matchingTestFiles = testFileNodes.filter(testFile =>
+                    this.doesTestFileValidateStructuralNode(testFile, node, nodeTokens)
+                );
 
                 if (matchingTestFiles.length === 0) {
-                    testGap = `[TEST_GAP] The ${node.type} '${node.name}' lacks corresponding automated validation suites (Playwright) covering its tokens within the test/ directory.`;
+                    testGap = `[TEST_GAP] The ${node.type} '${node.name}' lacks corresponding automated validation suites (Playwright) with precise test-file evidence within the test/ directory.`;
                 } else {
                     this.linkTestEvidenceToStructuralNode(matchingTestFiles, dbNode, node);
                 }
@@ -145,6 +142,67 @@ class GapInferenceEngine extends Base {
 
             this.applyGapsToNode(dbNode, testGap ? [testGap] : []);
         }
+    }
+
+    /**
+     * @summary Tokenizes a structural name for deterministic test-file evidence matching.
+     *
+     * CamelCase boundaries and non-alphanumeric separators are normalized into lower-case
+     * tokens. Short connective tokens are ignored to keep evidence matching focused on semantic
+     * names rather than path noise.
+     * @param {String} name Structural node name or test-path fragment
+     * @returns {String[]} Unique lower-case evidence tokens
+     * @protected
+     */
+    getStructuralNameTokens(name = '') {
+        const
+            raw    = String(name || ''),
+            tokens = raw
+                .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+                .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+                .toLowerCase()
+                .split(/[^a-z0-9]+/)
+                .filter(token => token.length > 2);
+
+        return tokens.length > 0 ? [...new Set(tokens)] : (raw ? [raw.toLowerCase()] : []);
+    }
+
+    /**
+     * @summary Extracts comparable evidence tokens from a test-file path.
+     *
+     * Test suffixes are stripped before tokenization so `ButtonFeature.spec.mjs` contributes
+     * `button` + `feature`, while directory segments can still satisfy split evidence paths
+     * such as `button/Feature.spec.mjs`.
+     * @param {String} filePath Test-file path from a graph `FILE` node
+     * @returns {String[]} Unique lower-case evidence tokens
+     * @protected
+     */
+    getTestFileEvidenceTokens(filePath = '') {
+        const pathWithoutTestSuffix = String(filePath || '')
+            .replace(/\.(spec|test)\.[cm]?[jt]sx?$/i, '')
+            .replace(/\.[cm]?[jt]sx?$/i, '');
+
+        return this.getStructuralNameTokens(pathWithoutTestSuffix);
+    }
+
+    /**
+     * @summary Determines whether a test file is strong enough evidence for a structural node.
+     *
+     * A `VALIDATES` edge is only written when the test path contains every semantic token from
+     * the structural node name. This preserves single-token matches while preventing sibling
+     * false positives such as `ButtonFeature` being validated by `ButtonStore.spec.mjs`.
+     * @param {Object}   testFile   Test-file node descriptor
+     * @param {Object}   sourceNode Session-artifact structural node
+     * @param {String[]} nodeTokens Pre-tokenized structural-node name
+     * @returns {Boolean} `true` when the file is precise validation evidence
+     * @protected
+     */
+    doesTestFileValidateStructuralNode(testFile, sourceNode, nodeTokens = this.getStructuralNameTokens(sourceNode?.name)) {
+        if (nodeTokens.length === 0) return false;
+
+        const evidenceTokens = this.getTestFileEvidenceTokens(testFile?.path);
+
+        return nodeTokens.every(token => evidenceTokens.includes(token));
     }
 
     /**

--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -125,7 +125,7 @@ and checks three coverage dimensions:
 
 | Gap Type | Detection Method |
 |---|---|
-| `[TEST_GAP]` | No test file paths in `test/` contain tokens matching the node name; matching test `FILE` nodes create `VALIDATES` edges to the structural source node |
+| `[TEST_GAP]` | No test file paths in `test/` provide precise evidence for the structural node name; matching test `FILE` nodes create `VALIDATES` edges only when all semantic name tokens are present |
 | `[GUIDE_GAP]` | No guide paths in `learn/guides/` match the node name (with LLM verification fallback) |
 
 The `[GUIDE_GAP]` detection has a two-stage pipeline:

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -299,7 +299,7 @@ flowchart TD
 
 4. **Capability Gap Inference:** This phase is **deterministic** — it does not use an LLM.
    It cross-references graph nodes directly against the filesystem:
-   - Does `test/` contain files matching this class's tokens? If not: **TEST_GAP**; if yes, add a `VALIDATES` edge from the test `FILE` node to the structural source node.
+   - Does `test/` contain files with precise evidence for this class's semantic name tokens? If not: **TEST_GAP**; if yes, add a `VALIDATES` edge from the test `FILE` node to the structural source node.
    - Does `learn/guides/` have a matching guide? If not: **GUIDE_GAP**
 
 5. **Hebbian Decay:** Universal edge weight fade and garbage collection of stale nodes,

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -266,6 +266,67 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         expect(edge.properties.validatedNodeType).toBe('CLASS');
     });
 
+    test('inferTestGapsFromSession does not link sibling token matches via VALIDATES edges (#12639)', async () => {
+        GraphService.upsertNode({
+            id        : 'button-feature-class',
+            type      : 'CLASS',
+            name      : 'ButtonFeature',
+            properties: {}
+        });
+        GraphService.upsertNode({
+            id        : 'button-store-class',
+            type      : 'CLASS',
+            name      : 'ButtonStore',
+            properties: {}
+        });
+        GraphService.upsertNode({
+            id        : 'test-file-button-store',
+            type      : 'FILE',
+            name      : 'ButtonStore.spec.mjs',
+            properties: {path: 'test/playwright/unit/button/ButtonStore.spec.mjs'}
+        });
+
+        const payload = {
+            session_artifact: {
+                graph: {
+                    nodes: [{
+                        id        : 'button-feature-class',
+                        type      : 'CLASS',
+                        name      : 'ButtonFeature',
+                        confidence: 0.9
+                    }, {
+                        id        : 'button-store-class',
+                        type      : 'CLASS',
+                        name      : 'ButtonStore',
+                        confidence: 0.9
+                    }],
+                    edges: []
+                }
+            }
+        };
+
+        await DreamService.inferTestGapsFromSession(payload);
+
+        const
+            featureNode = GraphService.db.nodes.get('button-feature-class'),
+            storeNode   = GraphService.db.nodes.get('button-store-class'),
+            featureEdge = GraphService.db.edges.items.find(e =>
+                e.source === 'test-file-button-store' &&
+                e.target === 'button-feature-class' &&
+                e.type === 'VALIDATES'
+            ),
+            storeEdge = GraphService.db.edges.items.find(e =>
+                e.source === 'test-file-button-store' &&
+                e.target === 'button-store-class' &&
+                e.type === 'VALIDATES'
+            );
+
+        expect(featureNode.properties.capabilityGap).toContain('[TEST_GAP]');
+        expect(featureEdge).toBeUndefined();
+        expect(storeNode.properties.capabilityGap).toBeUndefined();
+        expect(storeEdge).toBeTruthy();
+    });
+
     test('findUndigestedSessions fails loud when remSleepBatchLimit is malformed in the imported config', async () => {
         const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
               originalRemSleepBatchLimit = aiConfig.remSleepBatchLimit;


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Resolves #12639

Tightens the Dream Pipeline test-evidence predicate before downstream reward or gap-downgrade consumers treat `VALIDATES` as durable graph proof. The implementation extracts named matching helpers on `GapInferenceEngine`, requires every semantic structural-name token to appear in the test path before writing a `VALIDATES` edge, preserves the existing positive exact-match edge, and documents the stricter contract in the Dream Pipeline overview surfaces.

Evidence: L2 (focused unit fixture plus existing positive `VALIDATES` coverage) → L2 required (close-target ACs are fully covered by unit tests and static docs). No residuals.

## Deltas from ticket

- Implemented all-token evidence matching across the normalized test path rather than basename-only matching, preserving split-path evidence such as `button/Feature.spec.mjs`.
- Kept existing `VALIDATES` metadata unchanged; the precision bound lives in the predicate, so downstream consumers do not need a new match-kind field for this ticket.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs --workers=1` — 18 passed
- Commit hook during `git commit`: whitespace, shorthand, and ticket-archaeology checks passed

## Post-Merge Validation

- [ ] Confirm `#12639` auto-closes on merge.
- [ ] Confirm downstream reward / gap consumers rely on `VALIDATES` only after this precision bound is present on `dev`.

## Commit

- `557bbeae2` — `fix(agentos): bound validates edge precision (#12639)`