### PR TITLE
fix(memory-core): protect PR RESOLVES edges (#12644)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -44,6 +44,13 @@ function isValidGraphNodeId(id) {
     return typeof id === 'string' && id.length > 0;
 }
 
+const PROTECTED_EDGE_TYPES = Object.freeze([
+    'IMPLEMENTS',
+    'EXTENDS',
+    'SYSTEM_TENET',
+    'RESOLVES'
+]);
+
 /**
  * @summary Service that manages the SQLite Knowledge Graph (Nodes and Edges).
  *
@@ -562,22 +569,25 @@ class GraphService extends Base {
 
         logger.info(`[GraphService] Running ambient topology decay (factor: ${decayFactor})...`);
 
-        // Shield structural edges completely from decay
+        const protectedEdgePlaceholders = PROTECTED_EDGE_TYPES.map(() => '?').join(', ');
+
+        // Shield durable structural/provenance edges completely from decay and pruning.
         const decayStmt = this.db.storage.db.prepare(`
             UPDATE Edges
             SET data = json_set(data, '$.properties.weight',
                                 MAX(COALESCE(CAST(json_extract(data, '$.properties.weight') AS REAL), 1.0) * ?, 0.1))
-            WHERE type NOT IN ('IMPLEMENTS', 'EXTENDS', 'SYSTEM_TENET')
+            WHERE type NOT IN (${protectedEdgePlaceholders})
         `);
-        decayStmt.run(decayFactor);
+        decayStmt.run(decayFactor, ...PROTECTED_EDGE_TYPES);
 
         // Prune dead pathways permanently mapping via physical SQL
         const pruneStmt = this.db.storage.db.prepare(`
             DELETE
             FROM Edges
-            WHERE COALESCE(CAST(json_extract(data, '$.properties.weight') AS REAL), 1.0) < ?
+            WHERE type NOT IN (${protectedEdgePlaceholders})
+              AND COALESCE(CAST(json_extract(data, '$.properties.weight') AS REAL), 1.0) < ?
         `);
-        const info      = pruneStmt.run(pruningThreshold);
+        const info      = pruneStmt.run(...PROTECTED_EDGE_TYPES, pruningThreshold);
 
         // Commit global clock update
         this.upsertGlobalNode({

--- a/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
@@ -23,18 +23,24 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
     let StorageRouter;
     let _originalExistsSync;
     let _originalReaddir;
+    let _originalReaddirSync;
     let _originalReadFile;
+    let _originalReadFileSync;
     let _originalGetGraphCollection;
     let GraphService;
     let _originalGraphDb;
+    let _originalUpsertNode;
+    let _originalLinkNodes;
     let graphNodes;
+    let graphEdges;
 
     // We will use a mock index.json and mock markdown files
     const mockIndexMap = [
         { type: 'issues', id: 2001, path: 'issues/issue-2001.md' },
         { type: 'issues', id: 2002, path: 'archive/issues/v1.0.0/issue-2002.md' },
         { type: 'discussions', id: 3001, path: 'discussions/discussion-3001.md' },
-        { type: 'discussions', id: 3002, path: 'discussions/discussion-3002.md' }
+        { type: 'discussions', id: 3002, path: 'discussions/discussion-3002.md' },
+        { type: 'pulls', id: 4001, path: 'pulls/pr-4001.md' }
     ];
 
     const mockFiles = {
@@ -63,6 +69,19 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
             '---',
             '# Closed Discussion Body'
         ].join('\n'),
+        'resources/content/pulls/pr-4001.md': [
+            '---',
+            'number: 4001',
+            'title: Resolve graph ticket',
+            'state: MERGED',
+            "createdAt: '2026-06-06T10:00:00Z'",
+            "updatedAt: '2026-06-06T11:00:00Z'",
+            '---',
+            'Resolves #2001',
+            '',
+            '## Summary',
+            'Hardens the PR resolution graph path.'
+        ].join('\n'),
         'resources/content/_index.json': JSON.stringify(mockIndexMap)
     };
 
@@ -84,7 +103,27 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
 
         _originalExistsSync = fs.existsSync;
         _originalReaddir = fs.promises.readdir;
+        _originalReaddirSync = fs.readdirSync;
         _originalReadFile = fs.promises.readFile;
+        _originalReadFileSync = fs.readFileSync;
+        _originalUpsertNode = GraphService.upsertNode;
+        _originalLinkNodes = GraphService.linkNodes;
+        GraphService.upsertNode = nodeData => {
+            graphNodes.push({
+                id        : nodeData.id,
+                label     : nodeData.type || 'NODE',
+                properties: {
+                    name       : nodeData.name,
+                    description: nodeData.description,
+                    state      : nodeData.state,
+                    updatedAt  : nodeData.updatedAt,
+                    ...(nodeData.properties || {})
+                }
+            });
+        };
+        GraphService.linkNodes = (source, target, relationship, weight = 1.0, properties = {}) => {
+            graphEdges.push({source, target, relationship, weight, properties});
+        };
 
         fs.existsSync = (p) => {
             if (typeof p === 'string' && p.includes('resources/content')) {
@@ -118,6 +157,16 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
             return _originalReaddir.call(fs.promises, dirPath, options);
         };
 
+        fs.readdirSync = (dirPath, options) => {
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/archive/pulls')) {
+                return [];
+            }
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/pulls')) {
+                return ['pr-4001.md'];
+            }
+            return _originalReaddirSync.call(fs, dirPath, options);
+        };
+
         fs.promises.readFile = async (filePath, encoding) => {
             if (typeof filePath === 'string') {
                 const normPath = filePath.replace(/\\/g, '/');
@@ -130,21 +179,38 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
             }
             return _originalReadFile.call(fs.promises, filePath, encoding);
         };
+
+        fs.readFileSync = (filePath, encoding) => {
+            if (typeof filePath === 'string') {
+                const normPath = filePath.replace(/\\/g, '/');
+                for (const key of Object.keys(mockFiles)) {
+                    if (normPath.endsWith(key)) {
+                        return mockFiles[key];
+                    }
+                }
+            }
+            return _originalReadFileSync.call(fs, filePath, encoding);
+        };
     });
 
     test.beforeEach(() => {
         graphNodes = [];
+        graphEdges = [];
     });
 
     test.afterAll(() => {
         fs.existsSync = _originalExistsSync;
         fs.promises.readdir = _originalReaddir;
+        fs.readdirSync = _originalReaddirSync;
         fs.promises.readFile = _originalReadFile;
+        fs.readFileSync = _originalReadFileSync;
         if (StorageRouter) {
             StorageRouter.getGraphCollection = _originalGetGraphCollection;
         }
         if (GraphService) {
             GraphService.db = _originalGraphDb;
+            GraphService.upsertNode = _originalUpsertNode;
+            GraphService.linkNodes = _originalLinkNodes;
         }
     });
 
@@ -205,6 +271,26 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
             closed  : true,
             closedAt: '2026-05-20T12:00:00Z',
             category: 'Q&A'
+        });
+    });
+
+    test('ingestPullRequestFeedback() creates PR nodes and RESOLVES edges from PR markdown (#12644)', async () => {
+        await IssueIngestor.ingestPullRequestFeedback();
+
+        expect(graphNodes.find(node => node.id === 'pr-4001')).toMatchObject({
+            id   : 'pr-4001',
+            label: 'PULL_REQUEST'
+        });
+
+        expect(graphEdges.find(edge =>
+            edge.source === 'pr-4001' &&
+            edge.target === 'issue-2001' &&
+            edge.relationship === 'RESOLVES'
+        )).toMatchObject({
+            weight    : 1.0,
+            properties: {
+                justification: 'PR #4001 explicitly resolves Issue #2001.'
+            }
         });
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -66,6 +66,11 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         } else {
             await SystemLifecycleService.ready();
         }
+
+        if (!GraphService.db) {
+            GraphService._initPromise = null;
+            await GraphService.initAsync();
+        }
     });
 
     test.beforeEach(async () => {
@@ -152,6 +157,32 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         const systemNode = await GraphService.getNodeRecord({id: '_SYSTEM_STATE'});
         expect(typeof systemNode.properties.lastDecayedAt).toBe('number');
         expect(systemNode.properties.lastDecayedAt).toBeGreaterThan(0);
+    });
+
+    test('decayGlobalTopology preserves factual RESOLVES edges while pruning weak ambient edges (#12644)', async () => {
+        await GraphService.upsertNode({id: 'pr-12644', type: 'PULL_REQUEST'});
+        await GraphService.upsertNode({id: 'issue-12644', type: 'ISSUE'});
+        await GraphService.upsertNode({id: 'AmbientSource', type: 'TEST_NODE'});
+        await GraphService.upsertNode({id: 'AmbientTarget', type: 'TEST_NODE'});
+
+        GraphService.linkNodes('pr-12644', 'issue-12644', 'RESOLVES', 0.05);
+        GraphService.linkNodes('AmbientSource', 'AmbientTarget', 'RELATES_TO', 0.05);
+
+        GraphService.decayGlobalTopology(0.5, 0.2, true);
+
+        const edgeRow = GraphService.db.storage.db.prepare(`
+            SELECT data
+            FROM Edges
+            WHERE source = ?
+              AND target = ?
+              AND type = ?
+        `);
+
+        const resolvesRow = edgeRow.get('pr-12644', 'issue-12644', 'RESOLVES');
+        expect(resolvesRow).toBeTruthy();
+        expect(JSON.parse(resolvesRow.data).properties.weight).toBe(0.05);
+
+        expect(edgeRow.get('AmbientSource', 'AmbientTarget', 'RELATES_TO')).toBeUndefined();
     });
 
     test('getNodeRecord returns the properties blob that getNode strips (#11637)', async () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex). Session dbb1a88c-987f-4519-9645-8f13e9d71000.

Resolves #12644

Protects PR->issue `RESOLVES` provenance edges from ambient topology decay/pruning and adds focused unit coverage for both sides of the ticket: PR markdown ingestion creates `PULL_REQUEST` nodes plus `RESOLVES` edges, and topology decay preserves those factual edges while pruning weak ambient relationships.

Evidence: L2 (focused unit coverage for graph decay + PR markdown ingestion with mocked content/SQLite graph service) -> L2 required (runtime path is covered by unit-testable graph and ingestion contracts). No residuals.

## Deltas from ticket
The implementation also centralizes the protected edge types in `GraphService` so decay and pruning share the same allow-list. This keeps the existing `IMPLEMENTS`, `EXTENDS`, and `SYSTEM_TENET` behavior while adding `RESOLVES`.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs --workers=1` -> 38 passed
- `git diff --check origin/dev...HEAD` -> passed
- Pre-commit hooks passed: whitespace, shorthand, ticket archaeology

## Post-Merge Validation
- [ ] Next Memory Core decay cycle can retain PR resolution provenance in the shared graph after synced PR markdown is ingested.

## Commit
- d4ab44adb — `fix(memory-core): protect PR RESOLVES edges (#12644)`

## Evolution
`#10058` was valid as a stale-intent signal but not valid as written: current source already creates `PULL_REQUEST` nodes and PR -> issue `RESOLVES` edges, so this PR implements the narrowed residual that remained after current-source V-B-A.
