### PR TITLE
session-sunset: no agent sandman-trigger + config-migrate on dev-pull (#12650)

### DIFF
--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -79,7 +79,7 @@ BEHIND=$(git -C "$PRIMARY_ROOT" rev-list --count dev..origin/dev 2>/dev/null || 
 
 **Conditional handover-comment block (fire only when `BEHIND > 0`):**
 
-> ⚠️ **Primary-checkout reminder:** the operator's primary checkout (`<PRIMARY_ROOT>`) `dev` branch is **`<BEHIND>` commits behind `origin/dev`**. The `orchestrator-daemon` (Agent OS canonical scheduled-maintenance daemon) and its siblings (`bridge-daemon`, `DreamService`, KB sync pipeline) read pre-merge code until refresh. Run `git -C <PRIMARY_ROOT> pull origin dev` in your main checkout to refresh `orchestrator-daemon` and downstream-daemon state.
+> ⚠️ **Primary-checkout reminder:** the operator's primary checkout (`<PRIMARY_ROOT>`) `dev` branch is **`<BEHIND>` commits behind `origin/dev`**. The `orchestrator-daemon` (Agent OS canonical scheduled-maintenance daemon) and its siblings (`bridge-daemon`, `DreamService`, KB sync pipeline) read pre-merge code until refresh. Run `git -C <PRIMARY_ROOT> pull origin dev` **then `node <PRIMARY_ROOT>/ai/scripts/setup/initServerConfigs.mjs --migrate-config`** in your main checkout to refresh `orchestrator-daemon` and downstream-daemon state. **A `git pull` alone is not enough:** it updates the committed `config.template.mjs`, but the daemons read the gitignored `config.mjs` operator-overlay — which only reconciles to new template leaves via `--migrate-config`, so without it the daemons run fresh code against stale config.
 
 When `BEHIND == 0`, suppress the block — no handover-comment noise on a fresh primary.
 

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -85,15 +85,13 @@ When `BEHIND == 0`, suppress the block — no handover-comment noise on a fresh 
 
 **Why this lives at sunset rather than mid-session:** sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness is unaddressed by this probe; the daemon-driven Shape A solution under #11013's follow-up will register a `primary-dev-sync` periodic task in the `orchestrator-daemon` (post-#11009 `Orchestrator.mjs` class extraction) to close that gap with an automatic `git pull --ff-only`.
 
-### Step 2: Refresh Active PR Cycle State (The Pre-Sunset Capture)
+### Step 2: Active PR Cycle State is daemon-owned — agents must NOT trigger sandman
 
-**Scope-conditional execution:**
+`sandman_handoff.md` (incl. the `## Active PR Cycle State`) is written **exclusively by the orchestrator-daemon's periodic `dream` + `golden-path` service-tasks** (`ai/daemons/TaskDefinitions.mjs`) — the canonical SSOT writer (the REM / Golden-Path "sandman" pipeline is orchestrator-owned; Epic #12065). This step therefore requires **no agent action**.
 
-- **`scope: solo-refresh`** (single-agent sunset, daemon-driven path unavailable or stale): You MUST execute `npm run ai:run-sandman` via the `run_command` tool. This forces the `GoldenPathSynthesizer` (the canonical writer) to query GitHub and emit the `## Active PR Cycle State` into `sandman_handoff.md`.
+**Agents must NOT trigger sandman (`npm run ai:run-sandman` / `GoldenPathSynthesizer`) at sunset, under any scope (`solo-refresh` or `convergent`).** Running it ad-hoc duplicates the daemon, contends on the shared SQLite + Chroma substrate (parallel invocations serialize for ~45min, last-write-wins), and couples a deployment-specific local command into the sunset flow. If `sandman_handoff.md` is stale (mtime > 4h) or the daemon is verified dead, **surface it as a daemon-health issue** (A2A the swarm / file a ticket) — do NOT run the pipeline yourself. Session continuity is preserved without it by the Step 10 Sandman memory + the A2A continuity ping + Memory Core context-priming.
 
-- **`scope: convergent`** (multi-agent coordinated sunset event): **SKIP** this step. Three parallel `ai:run-sandman` invocations against the shared SQLite + Chroma substrate produce ≈45min of contention serialization (3× the solo cost) and overwrite each other's output — only the last write survives. The orchestrator-daemon's `dream` + `golden-path` periodic service-tasks (`ai/daemons/TaskDefinitions.mjs#L85-95`) cover the same artifact emission automatically on hourly cadence; the daemon-driven path is the canonical writer for convergent-scope events. The lead-role agent (per `lead-role-mode.md`) MAY exceptionally run `ai:run-sandman` once on behalf of the swarm if the daemon path is empirically stale (e.g., `sandman_handoff.md` mtime > 4h or the daemon process is verified dead) — declare the exception in the sunset payload Step 5 if exercised.
-
-Do NOT attempt to edit `sandman_handoff.md` manually under any scope — it is overwritten by the canonical writer (daemon OR `ai:run-sandman`).
+Do NOT edit `sandman_handoff.md` manually under any scope — it is overwritten by the canonical daemon writer.
 
 ### Step 3: Handovers Posted (Active Work)
 For any tickets or tasks that you actively worked on but did not fully complete, you MUST post a self-contained handover comment directly on the GitHub Issue (using `manage_issue_comment`).


### PR DESCRIPTION
Resolves #12650

Two operator-directed (@tobiu) corrections to the `session-sunset` skill, both about the **daemon environment** the skill sets up at sunset. Bundled per the operator's "one addition."

## 1. Step 2 — agents must NOT trigger sandman (net-reduction)
Step 2 mandated `scope: solo-refresh` agents run `npm run ai:run-sandman` (forcing `GoldenPathSynthesizer` to query GitHub + write `sandman_handoff.md`) and let the lead-role agent run it "exceptionally" on `scope: convergent`. The REM / Golden-Path (sandman) pipeline is **orchestrator-daemon-owned SSOT** — the daemon's `dream` + `golden-path` periodic tasks (`ai/daemons/TaskDefinitions.mjs`) were already named, in the same step, as the canonical writer. An agent triggering it ad-hoc duplicates the daemon, contends on the shared SQLite + Chroma substrate (~45min serialization, last-write-wins), and couples a deployment-specific local command into the sunset flow.

**Change:** the daemon is the sole writer; agents never trigger sandman (any scope); a stale handoff is surfaced as a daemon-health issue; continuity is preserved by the Step 10 Sandman memory + the A2A ping + context-priming. Drops the redundant "OR `ai:run-sandman`" clause. (Consumer-side complement to Epic #12065.)

## 2. Step 1 — migrate config from template after the dev pull
The primary-checkout refresh reminder told the operator to run only `git -C <PRIMARY_ROOT> pull origin dev`. That refreshes committed code incl. `config.template.mjs`, but the daemons read the **gitignored `config.mjs` operator-overlay**, which a pull does not update — so daemons run fresh code against stale config. **Change:** the reminder now also runs `node <PRIMARY_ROOT>/ai/scripts/setup/initServerConfigs.mjs --migrate-config` (the script's own documented refresh path).

Evidence: L1 (skill-documentation change; no code paths, no runtime behavior) → L1 required (the close-target ACs are "the skill text instructs/omits the right thing", fully satisfied by static doc inspection). No residuals.

## Test Evidence
Skill-documentation only — no automated tests apply (no `.mjs` / runtime changed). Static verification instead:
- `--migrate-config` confirmed as the documented refresh path in `ai/scripts/setup/initServerConfigs.mjs` JSDoc.
- `config.mjs` confirmed gitignored (operator overlay) vs committed `config.template.mjs` (`git check-ignore` / `git ls-files`).
- The daemon `dream`+`golden-path` tasks were already named the canonical sandman writer in the pre-change Step 2 — so removing the agent-trigger loses no continuity.
- `git diff --stat`: fix 1 = −2 lines (net-reduction); fix 2 = 1-line swap.
- Commit hooks (whitespace / shorthand / ticket-archaeology) passed on both commits.

## Deltas
- Fix 2 (config-migration on dev-pull) was an operator addition after the ticket was created; bundled into this PR (same skill, same daemon-environment concern), and #12650's title + an AC were updated to cover it.
- Used the targeted `node ... initServerConfigs.mjs --migrate-config` rather than the JSDoc-documented `npm run prepare -- --migrate-config`, so the refresh is config-only and does not also re-download the Knowledge Base.

## Post-Merge Validation
- [ ] Next `scope: solo-refresh` / `convergent` sunset does NOT run `ai:run-sandman`; `sandman_handoff.md` stays daemon-written.
- [ ] A primary-checkout-behind sunset reminder now includes the `initServerConfigs.mjs --migrate-config` step.
- [ ] Confirm with @neo-opus-ada whether to adopt #12650 as a sub of Epic #12065.

## Related
- Epic #12065 — Orchestrator-as-SSOT for the REM (Sandman) Pipeline (consumer-side complement).
- Discussion #12062 — origin of the REM/Sandman SSOT direction.

## Out of Scope
- The pipeline execution-path consolidation (Epic #12065's subs).
- The Step 10 `add_memory` "Sandman memory" (agent memory persistence — kept).
- The daemon's `dream` / `golden-path` tasks themselves.

Authored by Claude Opus 4.8 (Claude Code). Session db066a97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
