### PR TITLE
feat(ai): real GitLab MergeRequestService — MR ops + tests (#12631)

### DIFF
--- a/ai/mcp/server/gitlab-workflow/openapi.yaml
+++ b/ai/mcp/server/gitlab-workflow/openapi.yaml
@@ -112,7 +112,7 @@ paths:
     get:
       operationId: list_merge_requests
       summary: List GitLab merge requests
-      description: Lists GitLab merge requests. Scaffolded until the GitLabClient subtask lands.
+      description: Lists GitLab merge requests for the configured project via the GitLab GraphQL API.
       tags: [Merge Requests]
       x-pass-as-object: true
       x-annotations:
@@ -138,16 +138,201 @@ paths:
         - name: author
           in: query
           required: false
-          description: Filter merge requests by GitLab username.
+          description: Filter merge requests by author GitLab username.
           schema:
             type: string
       responses:
         '200':
-          description: Scaffolded merge-request list response.
+          description: The matching merge requests, or a structured error.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListResponse'
+                $ref: '#/components/schemas/MergeRequestListResponse'
+
+  /merge-requests/{merge_request_iid}:
+    get:
+      operationId: get_merge_request
+      summary: Get a GitLab merge request
+      description: Reads a single GitLab merge request by iid via the GitLab GraphQL API.
+      tags: [Merge Requests]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      parameters:
+        - name: merge_request_iid
+          in: path
+          required: true
+          description: GitLab merge request iid.
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: The merge request, or a structured error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeRequestResponse'
+
+  /merge-requests/comments/manage:
+    post:
+      operationId: manage_mr_comment
+      summary: Manage GitLab merge request comments
+      description: Creates or updates a GitLab merge request comment (note) via the GitLab GraphQL API.
+      tags: [Merge Requests]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, merge_request_iid, body]
+              properties:
+                action:
+                  type: string
+                  enum: [create, update]
+                  description: Comment action.
+                merge_request_iid:
+                  type: integer
+                  description: GitLab merge request iid.
+                note_id:
+                  type: integer
+                  description: GitLab note id for updates.
+                body:
+                  type: string
+                  description: Comment body.
+      responses:
+        '200':
+          description: The comment result, or a structured error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeRequestCommentResponse'
+
+  /merge-requests/{merge_request_iid}/labels/manage:
+    post:
+      operationId: manage_mr_labels
+      summary: Manage GitLab merge request labels
+      description: Adds or removes GitLab merge request labels (by name) via the GitLab GraphQL API.
+      tags: [Merge Requests]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      parameters:
+        - name: merge_request_iid
+          in: path
+          required: true
+          description: GitLab merge request iid.
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, labels]
+              properties:
+                action:
+                  type: string
+                  enum: [add, remove]
+                  description: Label action.
+                labels:
+                  type: array
+                  items:
+                    type: string
+                  description: Labels to add or remove.
+      responses:
+        '200':
+          description: The label result, or a structured error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeRequestLabelResponse'
+
+  /merge-requests/{merge_request_iid}/assignees/manage:
+    post:
+      operationId: manage_mr_assignees
+      summary: Manage GitLab merge request assignees
+      description: Adds or removes GitLab merge request assignees (by username) via the GitLab GraphQL API.
+      tags: [Merge Requests]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      parameters:
+        - name: merge_request_iid
+          in: path
+          required: true
+          description: GitLab merge request iid.
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, assignees]
+              properties:
+                action:
+                  type: string
+                  enum: [add, remove]
+                  description: Assignee action.
+                assignees:
+                  type: array
+                  items:
+                    type: string
+                  description: GitLab usernames to add or remove.
+      responses:
+        '200':
+          description: The assignee result, or a structured error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeRequestAssigneeResponse'
+
+  /merge-requests/{merge_request_iid}/reviewers/manage:
+    post:
+      operationId: manage_mr_reviewers
+      summary: Manage GitLab merge request reviewers
+      description: Adds or removes GitLab merge request reviewers (by username) via the GitLab GraphQL API.
+      tags: [Merge Requests]
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: false
+      parameters:
+        - name: merge_request_iid
+          in: path
+          required: true
+          description: GitLab merge request iid.
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, reviewers]
+              properties:
+                action:
+                  type: string
+                  enum: [add, remove]
+                  description: Reviewer action.
+                reviewers:
+                  type: array
+                  items:
+                    type: string
+                  description: GitLab usernames to add or remove.
+      responses:
+        '200':
+          description: The reviewer result, or a structured error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeRequestReviewerResponse'
 
   /local/issues/{issue_number}:
     get:
@@ -388,6 +573,114 @@ components:
         message:
           type: string
         assignees:
+          type: array
+          items:
+            type: string
+        error:
+          type: string
+        code:
+          type: string
+    MergeRequestResponse:
+      type: object
+      description: A single GitLab merge request, or a structured error.
+      properties:
+        iid:
+          type: string
+        title:
+          type: string
+        state:
+          type: string
+        webUrl:
+          type: string
+        sourceBranch:
+          type: string
+        targetBranch:
+          type: string
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        assignees:
+          type: array
+          items:
+            type: string
+        reviewers:
+          type: array
+          items:
+            type: string
+        error:
+          type: string
+        message:
+          type: string
+        code:
+          type: string
+    MergeRequestListResponse:
+      type: object
+      description: A list of GitLab merge requests, or a structured error.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MergeRequestResponse'
+        count:
+          type: integer
+        error:
+          type: string
+        message:
+          type: string
+        code:
+          type: string
+    MergeRequestCommentResponse:
+      type: object
+      description: The result of a GitLab merge request comment (note) operation, or a structured error.
+      properties:
+        message:
+          type: string
+        noteId:
+          type: string
+        error:
+          type: string
+        code:
+          type: string
+    MergeRequestLabelResponse:
+      type: object
+      description: The resulting GitLab merge request labels, or a structured error.
+      properties:
+        message:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        error:
+          type: string
+        code:
+          type: string
+    MergeRequestAssigneeResponse:
+      type: object
+      description: The resulting GitLab merge request assignees, or a structured error.
+      properties:
+        message:
+          type: string
+        assignees:
+          type: array
+          items:
+            type: string
+        error:
+          type: string
+        code:
+          type: string
+    MergeRequestReviewerResponse:
+      type: object
+      description: The resulting GitLab merge request reviewers, or a structured error.
+      properties:
+        message:
+          type: string
+        reviewers:
           type: array
           items:
             type: string

--- a/ai/mcp/server/gitlab-workflow/toolService.mjs
+++ b/ai/mcp/server/gitlab-workflow/toolService.mjs
@@ -11,21 +11,26 @@ const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 
 /**
- * @summary GitLab Workflow scaffold tool registry.
+ * @summary GitLab Workflow tool registry.
  *
- * The operation IDs intentionally match the initial GitHub Workflow-compatible
- * surface. Service implementations return scaffold responses until the GitLab
- * client and syncer replace them with real GitLab API behavior.
+ * The operation IDs intentionally match the GitHub Workflow-compatible surface. The issue and
+ * merge-request operations call the real GitLab GraphQL API via the shared `GitLabClient`; the
+ * local-file syncer surface remains scaffold-level pending its subtask.
  */
 const serviceMapping = {
-    create_issue             : IssueService       .createIssue          .bind(IssueService),
-    get_local_issue_by_id    : LocalFileService   .getIssueById         .bind(LocalFileService),
-    healthcheck              : HealthService      .healthcheck          .bind(HealthService),
-    list_issues              : IssueService       .listIssues           .bind(IssueService),
-    list_merge_requests      : MergeRequestService.listMergeRequests    .bind(MergeRequestService),
-    manage_issue_assignees   : IssueService       .manageIssueAssignees .bind(IssueService),
-    manage_issue_comment     : IssueService       .manageIssueComment   .bind(IssueService),
-    manage_issue_labels      : IssueService       .manageIssueLabels    .bind(IssueService)
+    create_issue           : IssueService       .createIssue                .bind(IssueService),
+    get_local_issue_by_id  : LocalFileService   .getIssueById               .bind(LocalFileService),
+    get_merge_request      : MergeRequestService.getMergeRequest            .bind(MergeRequestService),
+    healthcheck            : HealthService      .healthcheck                .bind(HealthService),
+    list_issues            : IssueService       .listIssues                 .bind(IssueService),
+    list_merge_requests    : MergeRequestService.listMergeRequests          .bind(MergeRequestService),
+    manage_issue_assignees : IssueService       .manageIssueAssignees       .bind(IssueService),
+    manage_issue_comment   : IssueService       .manageIssueComment         .bind(IssueService),
+    manage_issue_labels    : IssueService       .manageIssueLabels          .bind(IssueService),
+    manage_mr_assignees    : MergeRequestService.manageMergeRequestAssignees.bind(MergeRequestService),
+    manage_mr_comment      : MergeRequestService.manageMergeRequestComment  .bind(MergeRequestService),
+    manage_mr_labels       : MergeRequestService.manageMergeRequestLabels   .bind(MergeRequestService),
+    manage_mr_reviewers    : MergeRequestService.manageMergeRequestReviewers.bind(MergeRequestService)
 };
 
 const toolService = Neo.create(ToolService, {

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -26,6 +26,7 @@ GH_Config.data.syncOnStartup = false;
 
 // --- GitLab Workflow Services ---
 import _GL_IssueService from './services/gitlab-workflow/IssueService.mjs';
+import _GL_MergeRequestService from './services/gitlab-workflow/MergeRequestService.mjs';
 
 // --- Knowledge Base Services ---
 import _KB_DatabaseService from './services/knowledge-base/DatabaseService.mjs';
@@ -202,6 +203,7 @@ const GH_SyncService = makeSafe(_GH_SyncService, ghSpec);
 
 // GitLab
 const GL_IssueService = makeSafe(_GL_IssueService, gitlabSpec);
+const GL_MergeRequestService = makeSafe(_GL_MergeRequestService, gitlabSpec);
 
 // Knowledge Base
 const KB_DatabaseService = makeSafe(_KB_DatabaseService, kbSpec);
@@ -273,6 +275,7 @@ export {
 
     // GitLab Workflow
     GL_IssueService,
+    GL_MergeRequestService,
 
     // Knowledge Base
     KB_Config,

--- a/ai/services/gitlab-workflow/MergeRequestService.mjs
+++ b/ai/services/gitlab-workflow/MergeRequestService.mjs
@@ -1,10 +1,40 @@
-import Base from '../../../src/core/Base.mjs';
+import Base          from '../../../src/core/Base.mjs';
+import GitLabClient  from './GitLabClient.mjs';
+import aiConfig      from '../../mcp/server/gitlab-workflow/config.mjs';
+import logger        from '../../mcp/server/gitlab-workflow/logger.mjs';
+import {GET_PROJECT_LABEL_IDS}                                         from './queries/issueQueries.mjs';
+import {CREATE_NOTE, UPDATE_NOTE}                                      from './queries/mutations.mjs';
+import {LIST_MERGE_REQUESTS, GET_MERGE_REQUEST, GET_MERGE_REQUEST_GID} from './queries/mrQueries.mjs';
+import {MR_SET_LABELS, MR_SET_ASSIGNEES, MR_SET_REVIEWERS}             from './queries/mrMutations.mjs';
 
 /**
- * @summary Scaffold merge-request service for GitLab Workflow MCP.
+ * @summary Merge-request-tool service for the GitLab Workflow MCP server.
  *
- * Registers the #11768 merge-request list operation with a truthful scaffold
- * response. Real API calls are deferred to the GitLabClient subtask.
+ * The merge-request twin of `IssueService`: implements real GitLab GraphQL behavior for the MR
+ * surface — `listMergeRequests`, `getMergeRequest`, `manageMergeRequestComment`,
+ * `manageMergeRequestLabels`, `manageMergeRequestAssignees`, `manageMergeRequestReviewers` — via
+ * the shared `GitLabClient` (no new client — the GitLab MCP-parity epic mandates one
+ * provider-agnostic transport). GitLab addresses MRs by `iid` under
+ * `project(fullPath)`; comments are `notes`; labels/assignees/reviewers are set through the
+ * dedicated `mergeRequestSet*` mutations with a `MutationOperationMode` (`APPEND` / `REMOVE`).
+ *
+ * **Reuse, not rebuild:** comment writes share the noteable-generic `createNote` / `updateNote`
+ * mutations (`mutations.mjs`) and label resolution shares the project-scoped `GET_PROJECT_LABEL_IDS`
+ * query (`issueQueries.mjs`) — duplicating identical GraphQL would be migration debt.
+ *
+ * **Read error contract (deliberate divergence from the issue twin):** `listMergeRequests` /
+ * `getMergeRequest` wrap transport failures in `#apiErrorResponse` so the full MR surface returns
+ * a uniform structured `{error, code}` (no throw across the MCP boundary — this ticket's Contract
+ * Ledger). The issue read methods currently let transport errors propagate; aligning them is a
+ * trivial follow-up, intentionally out of scope here to avoid touching the freshly-merged
+ * issue-service code.
+ *
+ * Argument validation lives at the OpenAPI/Zod `makeSafe` boundary in `ai/services.mjs`, not inside
+ * these methods; the per-method `action` guards here are domain routing, not schema validation. The
+ * GraphQL strings are best-knowledge against GitLab's current schema and are **not yet
+ * integration-validated against a live instance** (a deferred follow-up); the unit suite mocks
+ * `GitLabClient.query` and exercises this service's logic (routing, id resolution, variable
+ * forwarding, error surfacing).
  *
  * @class Neo.ai.services.gitlab-workflow.MergeRequestService
  * @extends Neo.core.Base
@@ -25,19 +55,333 @@ class MergeRequestService extends Base {
     }
 
     /**
-     * @summary Lists GitLab merge requests once the GitLabClient subtask is implemented.
-     * @param {Object} [options={}]
-     * @returns {Promise<Object>}
+     * @summary Builds the structured error response for a GitLab API/transport failure.
+     * @param {Error}  error
+     * @param {String} context Human-readable description of the attempted operation.
+     * @returns {Object}
+     * @private
      */
-    async listMergeRequests(options = {}) {
+    #apiErrorResponse(error, context) {
+        logger.error(`Error ${context} via GitLab GraphQL:`, error);
+        return {error: 'GitLab API request failed', message: error.message, code: 'GITLAB_API_ERROR'};
+    }
+
+    /**
+     * @summary Builds the structured error response for a GitLab mutation that returned
+     * user-facing validation errors in its `errors` payload.
+     * @param {String[]} errors
+     * @param {String}   context Human-readable description of the attempted operation.
+     * @returns {Object}
+     * @private
+     */
+    #mutationErrorResponse(errors, context) {
+        const message = `GitLab rejected ${context}: ${errors.join('; ')}`;
+        logger.warn(message);
+        return {error: 'GitLab API error', message, code: 'GITLAB_MUTATION_ERROR'};
+    }
+
+    /**
+     * @summary Returns a GitLab mutation payload's user-facing `errors` array if non-empty.
+     * @param {Object} payload The named mutation payload (e.g. `data.mergeRequestSetLabels`).
+     * @returns {String[]|null}
+     * @private
+     */
+    #userErrors(payload) {
+        const errors = payload?.errors;
+        return Array.isArray(errors) && errors.length > 0 ? errors : null;
+    }
+
+    /**
+     * @summary Maps a GitLab `mergeRequest` GraphQL node to the flat MCP-contract item shape.
+     * Shared by `listMergeRequests` and `getMergeRequest` so the two reads cannot drift apart.
+     * @param {Object} node
+     * @returns {Object}
+     * @private
+     */
+    #mapMergeRequest(node) {
         return {
-            status : 'scaffolded',
-            tool   : 'list_merge_requests',
-            message: 'GitLab Workflow MCP tool is registered; real GitLab API behavior lands with the GitLabClient subtask.',
-            received: options,
-            items  : [],
-            count  : 0
+            iid         : node.iid,
+            title       : node.title,
+            state       : node.state,
+            webUrl      : node.webUrl,
+            sourceBranch: node.sourceBranch,
+            targetBranch: node.targetBranch,
+            createdAt   : node.createdAt,
+            updatedAt   : node.updatedAt,
+            labels      : (node.labels?.nodes    || []).map(label => label.title),
+            assignees   : (node.assignees?.nodes || []).map(user  => user.username),
+            reviewers   : (node.reviewers?.nodes || []).map(user  => user.username)
         };
+    }
+
+    /**
+     * @summary Resolves an MR `iid` to its opaque global id (the `noteableId` a comment needs).
+     * @param {Number|String} iid
+     * @returns {Promise<String|null>}
+     * @private
+     */
+    async #resolveMergeRequestGid(iid) {
+        const data = await GitLabClient.query(GET_MERGE_REQUEST_GID, {
+            fullPath: aiConfig.gitlab.projectPath,
+            iid     : String(iid)
+        });
+        return data?.project?.mergeRequest?.id || null;
+    }
+
+    /**
+     * @summary Resolves project label names to their opaque global ids (drops unknown names).
+     * Shares the project-scoped `GET_PROJECT_LABEL_IDS` query with the issue surface.
+     * @param {String[]} labelNames
+     * @returns {Promise<String[]>}
+     * @private
+     */
+    async #resolveLabelIds(labelNames) {
+        if (!labelNames?.length) return [];
+
+        const data          = await GitLabClient.query(GET_PROJECT_LABEL_IDS, {fullPath: aiConfig.gitlab.projectPath}),
+              projectLabels = data?.project?.labels?.nodes || [];
+
+        return labelNames.map(name => projectLabels.find(label => label.title === name)?.id).filter(Boolean);
+    }
+
+    /**
+     * @summary Shared `mergeRequestSetAssignees` mutation runner (username-native; no id pre-lookup).
+     * @param {Number|String} iid
+     * @param {String[]}      assignees     GitLab usernames.
+     * @param {String}        operationMode `APPEND` | `REMOVE` | `REPLACE`.
+     * @returns {Promise<Object>} `{message, assignees}` on success, or a structured error.
+     * @private
+     */
+    async #setAssignees(iid, assignees, operationMode) {
+        try {
+            const data    = await GitLabClient.query(MR_SET_ASSIGNEES, {
+                projectPath      : aiConfig.gitlab.projectPath,
+                iid              : String(iid),
+                assigneeUsernames: assignees,
+                operationMode
+            });
+            const payload = data?.mergeRequestSetAssignees,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `setting assignees on merge request !${iid}`);
+
+            return {
+                message  : `Successfully updated assignees on merge request !${iid}`,
+                assignees: (payload?.mergeRequest?.assignees?.nodes || []).map(user => user.username)
+            };
+        } catch (error) {
+            return this.#apiErrorResponse(error, `setting assignees on merge request !${iid}`);
+        }
+    }
+
+    /**
+     * @summary Shared `mergeRequestSetReviewers` mutation runner (username-native; no id pre-lookup).
+     * The reviewer surface is MR-only — the issue twin has no analog.
+     * @param {Number|String} iid
+     * @param {String[]}      reviewers     GitLab usernames.
+     * @param {String}        operationMode `APPEND` | `REMOVE` | `REPLACE`.
+     * @returns {Promise<Object>} `{message, reviewers}` on success, or a structured error.
+     * @private
+     */
+    async #setReviewers(iid, reviewers, operationMode) {
+        try {
+            const data    = await GitLabClient.query(MR_SET_REVIEWERS, {
+                projectPath      : aiConfig.gitlab.projectPath,
+                iid              : String(iid),
+                reviewerUsernames: reviewers,
+                operationMode
+            });
+            const payload = data?.mergeRequestSetReviewers,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `setting reviewers on merge request !${iid}`);
+
+            return {
+                message  : `Successfully updated reviewers on merge request !${iid}`,
+                reviewers: (payload?.mergeRequest?.reviewers?.nodes || []).map(user => user.username)
+            };
+        } catch (error) {
+            return this.#apiErrorResponse(error, `setting reviewers on merge request !${iid}`);
+        }
+    }
+
+    /**
+     * @summary Lists the configured GitLab project's merge requests via the GitLab GraphQL API.
+     * @param {Object} [options={}]
+     * @param {Number} [options.limit=30]
+     * @param {String} [options.state='opened'] One of `opened` / `closed` / `merged` / `all`.
+     * @param {String} [options.author] A single GitLab username to filter by (author).
+     * @returns {Promise<Object>} `{items, count}`, or a structured error.
+     */
+    async listMergeRequests({limit=30, state='opened', author=null} = {}) {
+        try {
+            const data = await GitLabClient.query(LIST_MERGE_REQUESTS, {
+                fullPath      : aiConfig.gitlab.projectPath,
+                state,
+                first         : limit,
+                authorUsername: author
+            });
+
+            const nodes = data?.project?.mergeRequests?.nodes || [];
+
+            return {items: nodes.map(node => this.#mapMergeRequest(node)), count: nodes.length};
+        } catch (error) {
+            return this.#apiErrorResponse(error, 'listing merge requests');
+        }
+    }
+
+    /**
+     * @summary Reads a single GitLab merge request by `iid`.
+     * @param {Object}        options
+     * @param {Number|String} options.merge_request_iid The MR `iid`.
+     * @returns {Promise<Object>} The merge-request item shape, or a structured error.
+     */
+    async getMergeRequest({merge_request_iid}) {
+        try {
+            const data = await GitLabClient.query(GET_MERGE_REQUEST, {
+                fullPath: aiConfig.gitlab.projectPath,
+                iid     : String(merge_request_iid)
+            });
+            const node = data?.project?.mergeRequest;
+
+            if (!node) {
+                return {error: 'Not Found', message: `Merge request !${merge_request_iid} not found in project '${aiConfig.gitlab.projectPath}'.`, code: 'MERGE_REQUEST_NOT_FOUND'};
+            }
+
+            return this.#mapMergeRequest(node);
+        } catch (error) {
+            return this.#apiErrorResponse(error, `reading merge request !${merge_request_iid}`);
+        }
+    }
+
+    /**
+     * @summary Creates or updates a comment (GitLab "note") on a merge request.
+     *
+     * `create` resolves the MR's global id (`noteableId`); `update` addresses the note by the
+     * global id reconstructed from the numeric `note_id` (`gid://gitlab/Note/<id>`). Shares the
+     * noteable-generic `createNote` / `updateNote` mutations with the issue surface.
+     *
+     * @param {Object} options
+     * @param {String} options.action             `create` | `update`.
+     * @param {Number} [options.merge_request_iid] MR `iid` (required for `create`).
+     * @param {Number} [options.note_id]           Note id (required for `update`).
+     * @param {String} options.body               Comment body.
+     * @returns {Promise<Object>} `{message, noteId}` or a structured error.
+     */
+    async manageMergeRequestComment({action, merge_request_iid, note_id, body}) {
+        if (!['create', 'update'].includes(action)) {
+            return {error: 'Bad Request', message: "Invalid action. Must be 'create' or 'update'.", code: 'INVALID_ARGUMENTS'};
+        }
+
+        try {
+            if (action === 'create') {
+                const noteableId = await this.#resolveMergeRequestGid(merge_request_iid);
+
+                if (!noteableId) {
+                    return {error: 'Not Found', message: `Merge request !${merge_request_iid} not found in project '${aiConfig.gitlab.projectPath}'.`, code: 'MERGE_REQUEST_NOT_FOUND'};
+                }
+
+                const data    = await GitLabClient.query(CREATE_NOTE, {noteableId, body}),
+                      payload = data?.createNote,
+                      errors  = this.#userErrors(payload);
+
+                if (errors) return this.#mutationErrorResponse(errors, `commenting on merge request !${merge_request_iid}`);
+
+                return {message: `Successfully created comment on merge request !${merge_request_iid}`, noteId: payload?.note?.id};
+            }
+
+            // action === 'update'
+            if (!note_id) {
+                return {error: 'Bad Request', message: "Missing required argument: 'note_id' is required for updating comments.", code: 'MISSING_ARGUMENTS'};
+            }
+
+            const data    = await GitLabClient.query(UPDATE_NOTE, {id: `gid://gitlab/Note/${note_id}`, body}),
+                  payload = data?.updateNote,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `updating comment ${note_id}`);
+
+            return {message: `Successfully updated comment ${note_id}`, noteId: payload?.note?.id};
+        } catch (error) {
+            return this.#apiErrorResponse(error, `managing comment on merge request !${merge_request_iid}`);
+        }
+    }
+
+    /**
+     * @summary Adds or removes labels on a merge request.
+     *
+     * Resolves label names to global ids (rejects unknown names with `LABEL_NOT_FOUND` rather than
+     * silently dropping), then routes them through `mergeRequestSetLabels` with `APPEND` (add) /
+     * `REMOVE` (remove).
+     *
+     * @param {Object}        options
+     * @param {Number|String} options.merge_request_iid MR `iid`.
+     * @param {String}        options.action            `add` | `remove`.
+     * @param {String[]}      options.labels            Label names to add or remove.
+     * @returns {Promise<Object>} `{message, labels}` or a structured error.
+     */
+    async manageMergeRequestLabels({merge_request_iid, action, labels}) {
+        if (!['add', 'remove'].includes(action)) {
+            return {error: 'Bad Request', message: "Invalid action. Must be 'add' or 'remove'.", code: 'INVALID_ARGUMENTS'};
+        }
+
+        try {
+            const labelIds = await this.#resolveLabelIds(labels);
+
+            if (labelIds.length !== (labels?.length || 0)) {
+                return {error: 'Not Found', message: `One or more labels not found in project '${aiConfig.gitlab.projectPath}': ${labels.join(', ')}`, code: 'LABEL_NOT_FOUND'};
+            }
+
+            const data    = await GitLabClient.query(MR_SET_LABELS, {
+                projectPath  : aiConfig.gitlab.projectPath,
+                iid          : String(merge_request_iid),
+                labelIds,
+                operationMode: action === 'add' ? 'APPEND' : 'REMOVE'
+            });
+            const payload = data?.mergeRequestSetLabels,
+                  errors  = this.#userErrors(payload);
+
+            if (errors) return this.#mutationErrorResponse(errors, `${action === 'add' ? 'adding labels to' : 'removing labels from'} merge request !${merge_request_iid}`);
+
+            return {
+                message: `Successfully ${action === 'add' ? 'added labels to' : 'removed labels from'} merge request !${merge_request_iid}`,
+                labels : (payload?.mergeRequest?.labels?.nodes || []).map(label => label.title)
+            };
+        } catch (error) {
+            return this.#apiErrorResponse(error, `managing labels on merge request !${merge_request_iid}`);
+        }
+    }
+
+    /**
+     * @summary Adds or removes assignees on a merge request (username-native via `mergeRequestSetAssignees`).
+     * @param {Object}        options
+     * @param {Number|String} options.merge_request_iid MR `iid`.
+     * @param {String}        options.action            `add` (APPEND) | `remove` (REMOVE).
+     * @param {String[]}      options.assignees         GitLab usernames.
+     * @returns {Promise<Object>} `{message, assignees}` or a structured error.
+     */
+    async manageMergeRequestAssignees({merge_request_iid, action, assignees}) {
+        if (!['add', 'remove'].includes(action)) {
+            return {error: 'Bad Request', message: "Invalid action. Must be 'add' or 'remove'.", code: 'INVALID_ARGUMENTS'};
+        }
+
+        return this.#setAssignees(merge_request_iid, assignees, action === 'add' ? 'APPEND' : 'REMOVE');
+    }
+
+    /**
+     * @summary Adds or removes reviewers on a merge request (username-native via `mergeRequestSetReviewers`).
+     * @param {Object}        options
+     * @param {Number|String} options.merge_request_iid MR `iid`.
+     * @param {String}        options.action            `add` (APPEND) | `remove` (REMOVE).
+     * @param {String[]}      options.reviewers         GitLab usernames.
+     * @returns {Promise<Object>} `{message, reviewers}` or a structured error.
+     */
+    async manageMergeRequestReviewers({merge_request_iid, action, reviewers}) {
+        if (!['add', 'remove'].includes(action)) {
+            return {error: 'Bad Request', message: "Invalid action. Must be 'add' or 'remove'.", code: 'INVALID_ARGUMENTS'};
+        }
+
+        return this.#setReviewers(merge_request_iid, reviewers, action === 'add' ? 'APPEND' : 'REMOVE');
     }
 }
 

--- a/ai/services/gitlab-workflow/queries/mrMutations.mjs
+++ b/ai/services/gitlab-workflow/queries/mrMutations.mjs
@@ -1,0 +1,72 @@
+/**
+ * @summary GitLab GraphQL mutation constants for merge-request write operations.
+ *
+ * Unlike the issue label flow (which routes through `updateIssue` with split
+ * `addLabelIds` / `removeLabelIds`), GitLab exposes dedicated `mergeRequestSetLabels` /
+ * `mergeRequestSetAssignees` / `mergeRequestSetReviewers` mutations that all take a single
+ * collection plus a `MutationOperationMode` (`APPEND` | `REMOVE` | `REPLACE`) — the same shape
+ * as the issue `issueSetAssignees` mutation. `MergeRequestService` maps the MCP `add` / `remove`
+ * action to `APPEND` / `REMOVE`.
+ *
+ * Comment (note) writes are **not** declared here: `createNote` / `updateNote` are noteable-generic
+ * (an MR global id is a valid `NoteableID`), so the service re-uses them from `mutations.mjs`
+ * rather than duplicating identical GraphQL.
+ *
+ * Each mutation payload carries a top-level `errors: [String!]` array of user-facing validation
+ * errors (distinct from transport / GraphQL-level errors, which `GitLabClient.query` raises in
+ * strict mode). These strings are best-knowledge against GitLab's GraphQL schema and are **not
+ * yet integration-validated against a live instance**; the unit tests exercise the service logic
+ * (action routing, id resolution, variable forwarding, error surfacing) against a mocked
+ * `GitLabClient`.
+ */
+
+/**
+ * Sets a merge request's labels by global id (resolved via `GET_PROJECT_LABEL_IDS`).
+ * `operationMode` controls the semantics: `APPEND` (add), `REMOVE` (remove), or `REPLACE`.
+ * @type {String}
+ */
+export const MR_SET_LABELS = `
+    mutation MergeRequestSetLabels($projectPath: ID!, $iid: String!, $labelIds: [LabelID!]!, $operationMode: MutationOperationMode) {
+        mergeRequestSetLabels(input: {projectPath: $projectPath, iid: $iid, labelIds: $labelIds, operationMode: $operationMode}) {
+            mergeRequest {
+                iid
+                labels { nodes { title } }
+            }
+            errors
+        }
+    }
+`;
+
+/**
+ * Sets a merge request's assignees by username. GitLab resolves usernames natively here, so no
+ * user-id pre-lookup is needed. `operationMode`: `APPEND` (add), `REMOVE` (remove), or `REPLACE`.
+ * @type {String}
+ */
+export const MR_SET_ASSIGNEES = `
+    mutation MergeRequestSetAssignees($projectPath: ID!, $iid: String!, $assigneeUsernames: [String!]!, $operationMode: MutationOperationMode) {
+        mergeRequestSetAssignees(input: {projectPath: $projectPath, iid: $iid, assigneeUsernames: $assigneeUsernames, operationMode: $operationMode}) {
+            mergeRequest {
+                iid
+                assignees { nodes { username } }
+            }
+            errors
+        }
+    }
+`;
+
+/**
+ * Sets a merge request's reviewers by username (the MR-only surface the issue twin has no analog
+ * for). `operationMode`: `APPEND` (add), `REMOVE` (remove), or `REPLACE`.
+ * @type {String}
+ */
+export const MR_SET_REVIEWERS = `
+    mutation MergeRequestSetReviewers($projectPath: ID!, $iid: String!, $reviewerUsernames: [String!]!, $operationMode: MutationOperationMode) {
+        mergeRequestSetReviewers(input: {projectPath: $projectPath, iid: $iid, reviewerUsernames: $reviewerUsernames, operationMode: $operationMode}) {
+            mergeRequest {
+                iid
+                reviewers { nodes { username } }
+            }
+            errors
+        }
+    }
+`;

--- a/ai/services/gitlab-workflow/queries/mrQueries.mjs
+++ b/ai/services/gitlab-workflow/queries/mrQueries.mjs
@@ -1,0 +1,77 @@
+/**
+ * @summary GitLab GraphQL query constants for merge-request read + lookup operations.
+ *
+ * The merge-request twin of `issueQueries.mjs`: merge requests live under `project(fullPath)`,
+ * the user-facing id is `iid`, and labels/assignees/reviewers are connection nodes
+ * (`labels.nodes`, `assignees.nodes`, `reviewers.nodes`). MRs additionally expose
+ * `sourceBranch` / `targetBranch`, which the issue surface has no analog for. These query
+ * strings are best-knowledge against GitLab's GraphQL schema and are **not yet
+ * integration-validated against a live instance**; the unit tests validate the
+ * `MergeRequestService` response-parsing against mocked `GitLabClient` responses (the query
+ * strings themselves are not exercised by unit mocks).
+ *
+ * The merge-request global-id lookup (`GET_MERGE_REQUEST_GID`) resolves the opaque
+ * `gid://gitlab/MergeRequest/...` id that the shared `createNote` comment mutation requires as
+ * its `noteableId` — the MR analog of `GET_ISSUE_GID`. Project-label resolution is shared with
+ * the issue surface via `GET_PROJECT_LABEL_IDS` (project-scoped, re-used from `issueQueries.mjs`).
+ */
+
+/**
+ * The merge-request fields shared by the list and single-MR reads. Factored out so the two
+ * queries cannot drift apart.
+ * @type {String}
+ */
+const MERGE_REQUEST_FIELDS = `
+    iid
+    title
+    state
+    webUrl
+    sourceBranch
+    targetBranch
+    createdAt
+    updatedAt
+    labels    { nodes { title } }
+    assignees { nodes { username } }
+    reviewers { nodes { username } }
+`;
+
+/**
+ * Lists a project's merge requests with optional state / author filters.
+ * @type {String}
+ */
+export const LIST_MERGE_REQUESTS = `
+    query ListMergeRequests($fullPath: ID!, $state: MergeRequestState, $first: Int, $authorUsername: String) {
+        project(fullPath: $fullPath) {
+            mergeRequests(state: $state, first: $first, authorUsername: $authorUsername) {
+                nodes {${MERGE_REQUEST_FIELDS}}
+            }
+        }
+    }
+`;
+
+/**
+ * Reads a single merge request by `iid`.
+ * @type {String}
+ */
+export const GET_MERGE_REQUEST = `
+    query GetMergeRequest($fullPath: ID!, $iid: String!) {
+        project(fullPath: $fullPath) {
+            mergeRequest(iid: $iid) {${MERGE_REQUEST_FIELDS}}
+        }
+    }
+`;
+
+/**
+ * Resolves a merge-request `iid` to its opaque global id (`gid://gitlab/MergeRequest/...`) —
+ * required as the `noteableId` for the shared `createNote` comment mutation.
+ * @type {String}
+ */
+export const GET_MERGE_REQUEST_GID = `
+    query GetMergeRequestGid($fullPath: ID!, $iid: String!) {
+        project(fullPath: $fullPath) {
+            mergeRequest(iid: $iid) {
+                id
+            }
+        }
+    }
+`;

--- a/test/playwright/unit/ai/services/gitlab-workflow/MergeRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/gitlab-workflow/MergeRequestService.spec.mjs
@@ -1,0 +1,251 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GitLabMergeRequestServiceTest';
+setup({neoConfig: {unitTestMode: true}, appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Unit coverage for the GitLab MergeRequestService real behavior. Mocks `GitLabClient.query` (the
+ * transport boundary) and asserts the GitLab GraphQL response -> MCP-contract parsing, the GitLab
+ * id-resolution steps (MR iid -> gid, label name -> id), action routing, the username-native
+ * assignee/reviewer set-mutations, and mutation error surfacing. Mirrors the IssueService test
+ * pattern (the MR twin). Multi-call methods branch on the operation name embedded in the query
+ * string; the `GetMergeRequestGid` check is ordered before `GetMergeRequest` because the former
+ * is a substring of nothing else but the latter is a prefix of the former.
+ */
+let MergeRequestService, GitLabClient, originalQuery;
+
+test.beforeAll(async () => {
+    GitLabClient         = (await import('../../../../../../ai/services/gitlab-workflow/GitLabClient.mjs')).default;
+    MergeRequestService  = (await import('../../../../../../ai/services/gitlab-workflow/MergeRequestService.mjs')).default;
+    originalQuery        = GitLabClient.query.bind(GitLabClient);
+});
+
+test.afterEach(() => {
+    GitLabClient.query = originalQuery;
+});
+
+test.describe('Neo.ai.services.gitlab-workflow.MergeRequestService', () => {
+    // --- listMergeRequests -------------------------------------------------------------------
+
+    test('listMergeRequests maps GitLab project.mergeRequests nodes to the MCP item shape (#12631)', async () => {
+        GitLabClient.query = async () => ({
+            project: {mergeRequests: {nodes: [
+                {iid: '1', title: 'First', state: 'opened', webUrl: 'https://gitlab/1', sourceBranch: 'feat/a', targetBranch: 'main', createdAt: 't1', updatedAt: 't2', labels: {nodes: [{title: 'bug'}, {title: 'p1'}]}, assignees: {nodes: [{username: 'alice'}]}, reviewers: {nodes: [{username: 'bob'}]}},
+                {iid: '2', title: 'Second', state: 'merged', webUrl: 'https://gitlab/2', sourceBranch: 'feat/b', targetBranch: 'main', createdAt: 't3', updatedAt: 't4', labels: {nodes: []}, assignees: {nodes: []}, reviewers: {nodes: []}}
+            ]}}
+        });
+
+        const result = await MergeRequestService.listMergeRequests({limit: 10, state: 'all'});
+
+        expect(result.count).toBe(2);
+        expect(result.items[0]).toEqual({
+            iid      : '1', title: 'First', state: 'opened', webUrl: 'https://gitlab/1',
+            sourceBranch: 'feat/a', targetBranch: 'main', createdAt: 't1', updatedAt: 't2',
+            labels: ['bug', 'p1'], assignees: ['alice'], reviewers: ['bob']
+        });
+        expect(result.items[1].labels).toEqual([]);
+        expect(result.items[1].assignees).toEqual([]);
+        expect(result.items[1].reviewers).toEqual([]);
+    });
+
+    test('listMergeRequests forwards filters as GitLab GraphQL variables (#12631)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {project: {mergeRequests: {nodes: []}}};
+        };
+
+        await MergeRequestService.listMergeRequests({limit: 5, state: 'merged', author: 'bob'});
+
+        expect(captured.first).toBe(5);
+        expect(captured.state).toBe('merged');
+        expect(captured.authorUsername).toBe('bob');
+    });
+
+    test('listMergeRequests returns empty and is resilient to a null project (#12631)', async () => {
+        GitLabClient.query = async () => ({project: null});
+
+        const result = await MergeRequestService.listMergeRequests();
+
+        expect(result).toEqual({items: [], count: 0});
+    });
+
+    test('listMergeRequests wraps a transport failure in a structured error (#12631)', async () => {
+        GitLabClient.query = async () => { throw new Error('network down'); };
+
+        const result = await MergeRequestService.listMergeRequests();
+
+        expect(result.code).toBe('GITLAB_API_ERROR');
+    });
+
+    // --- getMergeRequest ---------------------------------------------------------------------
+
+    test('getMergeRequest maps a single MR node (#12631)', async () => {
+        GitLabClient.query = async () => ({
+            project: {mergeRequest: {iid: '7', title: 'MR', state: 'opened', webUrl: 'https://gitlab/7', sourceBranch: 'feat/x', targetBranch: 'main', createdAt: 't1', updatedAt: 't2', labels: {nodes: [{title: 'bug'}]}, assignees: {nodes: []}, reviewers: {nodes: [{username: 'carol'}]}}}
+        });
+
+        const result = await MergeRequestService.getMergeRequest({merge_request_iid: 7});
+
+        expect(result.iid).toBe('7');
+        expect(result.sourceBranch).toBe('feat/x');
+        expect(result.reviewers).toEqual(['carol']);
+        expect(result.labels).toEqual(['bug']);
+    });
+
+    test('getMergeRequest returns MERGE_REQUEST_NOT_FOUND for a missing MR (#12631)', async () => {
+        GitLabClient.query = async () => ({project: {mergeRequest: null}});
+
+        const result = await MergeRequestService.getMergeRequest({merge_request_iid: 999});
+
+        expect(result.code).toBe('MERGE_REQUEST_NOT_FOUND');
+    });
+
+    // --- manageMergeRequestComment -----------------------------------------------------------
+
+    test('manageMergeRequestComment create resolves the MR gid then creates a note (#12631)', async () => {
+        let noteVars;
+        GitLabClient.query = async (query, variables) => {
+            if (query.includes('GetMergeRequestGid')) return {project: {mergeRequest: {id: 'gid://gitlab/MergeRequest/99'}}};
+            noteVars = variables;
+            return {createNote: {note: {id: 'gid://gitlab/Note/500', body: 'hi'}, errors: []}};
+        };
+
+        const result = await MergeRequestService.manageMergeRequestComment({action: 'create', merge_request_iid: 3, body: 'hi'});
+
+        expect(noteVars.noteableId).toBe('gid://gitlab/MergeRequest/99');
+        expect(result.noteId).toBe('gid://gitlab/Note/500');
+    });
+
+    test('manageMergeRequestComment create returns MERGE_REQUEST_NOT_FOUND when the gid is null (#12631)', async () => {
+        GitLabClient.query = async () => ({project: {mergeRequest: null}});
+
+        const result = await MergeRequestService.manageMergeRequestComment({action: 'create', merge_request_iid: 404, body: 'hi'});
+
+        expect(result.code).toBe('MERGE_REQUEST_NOT_FOUND');
+    });
+
+    test('manageMergeRequestComment update addresses the note by reconstructed global id (#12631)', async () => {
+        let updateVars;
+        GitLabClient.query = async (query, variables) => {
+            updateVars = variables;
+            return {updateNote: {note: {id: 'gid://gitlab/Note/500', body: 'edited'}, errors: []}};
+        };
+
+        const result = await MergeRequestService.manageMergeRequestComment({action: 'update', note_id: 500, body: 'edited'});
+
+        expect(updateVars.id).toBe('gid://gitlab/Note/500');
+        expect(result.noteId).toBe('gid://gitlab/Note/500');
+    });
+
+    test('manageMergeRequestComment rejects an invalid action (#12631)', async () => {
+        const result = await MergeRequestService.manageMergeRequestComment({action: 'destroy', merge_request_iid: 1, body: 'x'});
+        expect(result.code).toBe('INVALID_ARGUMENTS');
+    });
+
+    // --- manageMergeRequestLabels ------------------------------------------------------------
+
+    test('manageMergeRequestLabels add resolves label names to ids and forwards labelIds + APPEND (#12631)', async () => {
+        let setVars;
+        GitLabClient.query = async (query, variables) => {
+            if (query.includes('GetProjectLabelIds')) {
+                return {project: {labels: {nodes: [
+                    {id: 'gid://gitlab/ProjectLabel/1', title: 'bug'},
+                    {id: 'gid://gitlab/ProjectLabel/2', title: 'p1'}
+                ]}}};
+            }
+            setVars = variables;
+            return {mergeRequestSetLabels: {mergeRequest: {iid: '4', labels: {nodes: [{title: 'bug'}, {title: 'p1'}]}}, errors: []}};
+        };
+
+        const result = await MergeRequestService.manageMergeRequestLabels({merge_request_iid: 4, action: 'add', labels: ['bug', 'p1']});
+
+        expect(setVars.labelIds).toEqual(['gid://gitlab/ProjectLabel/1', 'gid://gitlab/ProjectLabel/2']);
+        expect(setVars.operationMode).toBe('APPEND');
+        expect(setVars.iid).toBe('4');
+        expect(result.labels).toEqual(['bug', 'p1']);
+    });
+
+    test('manageMergeRequestLabels remove forwards REMOVE (#12631)', async () => {
+        let setVars;
+        GitLabClient.query = async (query, variables) => {
+            if (query.includes('GetProjectLabelIds')) return {project: {labels: {nodes: [{id: 'gid://gitlab/ProjectLabel/1', title: 'bug'}]}}};
+            setVars = variables;
+            return {mergeRequestSetLabels: {mergeRequest: {iid: '4', labels: {nodes: []}}, errors: []}};
+        };
+
+        await MergeRequestService.manageMergeRequestLabels({merge_request_iid: 4, action: 'remove', labels: ['bug']});
+
+        expect(setVars.operationMode).toBe('REMOVE');
+    });
+
+    test('manageMergeRequestLabels rejects unknown label names with LABEL_NOT_FOUND (#12631)', async () => {
+        GitLabClient.query = async () => ({project: {labels: {nodes: [{id: 'gid://gitlab/ProjectLabel/1', title: 'bug'}]}}});
+
+        const result = await MergeRequestService.manageMergeRequestLabels({merge_request_iid: 4, action: 'add', labels: ['bug', 'ghost']});
+
+        expect(result.code).toBe('LABEL_NOT_FOUND');
+    });
+
+    // --- manageMergeRequestAssignees ---------------------------------------------------------
+
+    test('manageMergeRequestAssignees add forwards APPEND + usernames (#12631)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {mergeRequestSetAssignees: {mergeRequest: {assignees: {nodes: [{username: 'alice'}]}}, errors: []}};
+        };
+
+        const result = await MergeRequestService.manageMergeRequestAssignees({merge_request_iid: 6, action: 'add', assignees: ['alice']});
+
+        expect(captured.operationMode).toBe('APPEND');
+        expect(captured.assigneeUsernames).toEqual(['alice']);
+        expect(result.assignees).toEqual(['alice']);
+    });
+
+    test('manageMergeRequestAssignees surfaces a GitLab mutation error payload (#12631)', async () => {
+        GitLabClient.query = async () => ({mergeRequestSetAssignees: {mergeRequest: null, errors: ['Cannot assign']}});
+
+        const result = await MergeRequestService.manageMergeRequestAssignees({merge_request_iid: 6, action: 'add', assignees: ['ghost']});
+
+        expect(result.code).toBe('GITLAB_MUTATION_ERROR');
+        expect(result.message).toContain('Cannot assign');
+    });
+
+    // --- manageMergeRequestReviewers ---------------------------------------------------------
+
+    test('manageMergeRequestReviewers add forwards APPEND + reviewerUsernames (#12631)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {mergeRequestSetReviewers: {mergeRequest: {reviewers: {nodes: [{username: 'carol'}]}}, errors: []}};
+        };
+
+        const result = await MergeRequestService.manageMergeRequestReviewers({merge_request_iid: 6, action: 'add', reviewers: ['carol']});
+
+        expect(captured.operationMode).toBe('APPEND');
+        expect(captured.reviewerUsernames).toEqual(['carol']);
+        expect(result.reviewers).toEqual(['carol']);
+    });
+
+    test('manageMergeRequestReviewers remove forwards REMOVE (#12631)', async () => {
+        let captured;
+        GitLabClient.query = async (query, variables) => {
+            captured = variables;
+            return {mergeRequestSetReviewers: {mergeRequest: {reviewers: {nodes: []}}, errors: []}};
+        };
+
+        await MergeRequestService.manageMergeRequestReviewers({merge_request_iid: 6, action: 'remove', reviewers: ['carol']});
+
+        expect(captured.operationMode).toBe('REMOVE');
+    });
+
+    test('manageMergeRequestReviewers rejects an invalid action (#12631)', async () => {
+        const result = await MergeRequestService.manageMergeRequestReviewers({merge_request_iid: 6, action: 'toggle', reviewers: ['carol']});
+        expect(result.code).toBe('INVALID_ARGUMENTS');
+    });
+});


### PR DESCRIPTION
Resolves #12631

Related: #11404

Brings GitLab's merge-request surface to parity with the issue surface: the list-only `MergeRequestService` scaffold is replaced with real GitLab GraphQL behavior — list / get / comment / labels / assignees / reviewers — driven through the shared `GitLabClient` (no second client). Mirrors the proven `IssueService` shape (private `#apiErrorResponse` / `#mutationErrorResponse` / `#userErrors` / id-resolvers), so a client-project GitLab deployment can now coordinate the full MR lifecycle through Neo's Agent-OS substrate.

Evidence: L2 (mocked-`GitLabClient` unit suite — 18 MR specs covering node→item mapping, filter forwarding, MR-gid + label-id resolution, `userErrors` surfacing, assignee/reviewer set-mutations, structured read errors) → L2 required (every AC is unit/contract-scoped; AC7 explicitly defers live-GitLab integration to a follow-up). No residuals.

## Deltas from ticket
- **Reuse over rebuild (AC6 spirit):** comment writes reuse the noteable-generic `CREATE_NOTE` / `UPDATE_NOTE` (`mutations.mjs`) and label resolution reuses `GET_PROJECT_LABEL_IDS` (`issueQueries.mjs`, project-scoped) rather than duplicating identical GraphQL. New files are MR-specific only: `mrQueries.mjs` (list / get / gid) + `mrMutations.mjs` (`mergeRequestSetLabels` / `…SetAssignees` / `…SetReviewers`).
- **Scaffold count:** the ticket anticipated "2 scaffold MR entries"; the live scaffold had only `list_merge_requests`, so `get_merge_request` is added fresh.
- **Read error contract:** MR reads (`list` / `get`) wrap transport failures in a structured `{error, code}` (this ticket's Contract Ledger) — a deliberate, JSDoc-documented divergence from the issue twin whose reads currently propagate. Aligning the issue reads is a noted trivial follow-up (out of scope to avoid touching freshly-merged code).
- **MR label mutation:** GitLab exposes `mergeRequestSetLabels` (`labelIds` + `operationMode`), cleaner than the issue `updateIssue` add/remove split — used accordingly; all three MR set-mutations share the `APPEND` / `REMOVE` operationMode shape.

## Test Evidence
- `UNIT_TEST_MODE=true playwright -c …unit.mjs test/playwright/unit/ai/services/gitlab-workflow/` → **37 passed** (18 new MR specs + 19 `IssueService` specs, confirming the shared-query reuse did not regress issues).
- `npm run ai:lint-mcp-test-locations` → OK.
- `OpenApiValidatorCompliance.spec.mjs` → 26 passed. Note: `gitlab-workflow` is **not** in that spec's `servers` list, so I ran its 4 strict-client guards (#10064 array-items, #9837 lenient-output, #10070 open-bag, #9837-overreach root-strict) directly against the gitlab spec — **13/13 ops build, 0 violations**.
- `openapi.yaml`: valid YAML, all `$ref`s resolve, no orphaned schemas; 13 `operationId`s ↔ 13 `serviceMapping` keys exact match.

## Post-Merge Validation
- [ ] Live GitLab instance integration validation of the MR GraphQL strings (AC7 — best-knowledge, not yet live-validated; the deferred live-integration follow-up).
- [ ] **Follow-up gap surfaced:** add `gitlab-workflow` to `OpenApiValidatorCompliance.spec.mjs` `servers` list so the issue/MR specs are CI-guarded like the other servers. Deferred here to avoid colliding with #12649, which is actively editing that spec file; best done as a rider after #12649 merges.

## Out of scope (per ticket)
- `create_merge_request` (source/target branch + diff semantics) and the `MergeRequestSyncer` / `LocalFileService` file-IO subtask remain deferred.

## Coordination note
- `ai/services.mjs` is also touched by #12649 (a single validation-import-path rename on a different line); this PR's change there is an additive import/`makeSafe`/export. Whichever lands first, the other rebases trivially.

Authored by Claude Opus 4.8 (Claude Code). Session d55abb62-72e6-42e5-813a-21c0d4c8d00e.
