### PR TITLE
docs(ai): align Chroma backup prose with unified store (#12153)

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -79,17 +79,19 @@ const execFileAsync = promisify(execFile);
  *
  * - `.neo-ai-data/neo-sqlite/memory-core.sqlite` — retired combined vector+graph store.
  *   Current Memory Core persistence is split between
- *   `.neo-ai-data/sqlite/memory-core-graph.sqlite` for graph state and
- *   `.neo-ai-data/chroma/memory-core/` for vectors. `defragSQLiteDB.mjs` targets a
- *   different filename (`knowledge-graph.sqlite`) and never touches this file. No
- *   production backup or restore path reads it.
+ *   `.neo-ai-data/sqlite/memory-core-graph.sqlite` for graph state and the
+ *   `neo-agent-memory` / `neo-agent-sessions` collections inside the flat unified
+ *   Chroma store. `defragSQLiteDB.mjs` targets a different filename
+ *   (`knowledge-graph.sqlite`) and never touches this file. No production backup or
+ *   restore path reads it.
  * - `.neo-ai-data/wake-daemon/{bridge.log,inflight-*.txt,lastSyncId,heartbeat-*.log,sweep-errors.log}`
  *   — operational / process state owned by the bridge daemon and heartbeat substrate; classified
  *   as live-orchestration recovery, not substrate backup. Distinct backup track if needed.
- * - Physical Chroma data directories (`.neo-ai-data/chroma/{kb,mc}/`) — the bundle captures the
- *   logical state via JSONL exports, not the on-disk HNSW indexes. Restore re-ingests via the
- *   canonical `manageDatabaseImport` SDK path. Physical pre-nuke snapshots remain
- *   `defragChromaDB.mjs`-exclusive at `dist/chromadb-backups/`.
+ * - The physical Chroma persist directory (`.neo-ai-data/chroma/unified/`) — the
+ *   bundle captures logical collection state via JSONL exports, not the on-disk
+ *   HNSW indexes. Restore re-ingests via the canonical `manageDatabaseImport` SDK
+ *   path. Physical pre-nuke snapshots remain `defragChromaDB.mjs`-exclusive at
+ *   `dist/chromadb-backups/`.
  *
  * @see ai/scripts/maintenance/defragChromaDB.mjs
  */

--- a/learn/agentos/KnowledgeBase.md
+++ b/learn/agentos/KnowledgeBase.md
@@ -26,20 +26,20 @@ This server provides the first dimension of the Agent OS's context model:
 
 ### 1. The Discovery Pattern (Learning)
 
-**Goal:** An agent needs to understand how to use a specific component.  
-**Query:** `query_documents(query="How do I use the Grid component?", type="guide")`  
+**Goal:** An agent needs to understand how to use a specific component.
+**Query:** `query_documents(query="How do I use the Grid component?", type="guide")`
 **Result:** The server returns the "Grid" guide first, followed by relevant examples. The agent learns the *concept* before diving into the code.
 
 ### 2. Forensic Debugging (History)
 
-**Goal:** An agent encounters a regression in the VDOM engine.  
-**Query:** `query_documents(query="VDOM collision logic changes", type="ticket")`  
+**Goal:** An agent encounters a regression in the VDOM engine.
+**Query:** `query_documents(query="VDOM collision logic changes", type="ticket")`
 **Result:** The server returns closed tickets describing previous bugs and fixes. The agent learns *why* the current logic exists, preventing it from re-introducing an old bug.
 
 ### 3. Architectural Analysis (Intent)
 
-**Goal:** An agent needs to refactor a worker.  
-**Query:** `query_documents(query="worker thread communication patterns", type="src")`  
+**Goal:** An agent needs to refactor a worker.
+**Query:** `query_documents(query="worker thread communication patterns", type="src")`
 **Result:** Thanks to the **inheritance boosting** algorithm, the server returns not just the worker file, but its parent class `Neo.worker.Base` and `Neo.core.Base`, giving the agent the full architectural picture.
 
 ## Architecture
@@ -98,9 +98,13 @@ Inspection and debugging.
 
 ### 3. ChromaDB & Vector Search
 
-The server manages a local instance of **ChromaDB**, a high-performance vector database.
-- **Persistence:** Data is stored locally in `chroma-neo-knowledge-base/`.
-- **Collection:** Uses a single collection `neo-knowledge-base` for all content types.
+The Knowledge Base uses **ChromaDB**, a high-performance vector database. Per ADR 0017,
+the Knowledge Base and Memory Core share one flat Chroma store; separation happens at the
+collection and metadata layers, not by daemon or directory.
+
+- **Persistence:** local data lives in `.neo-ai-data/chroma/unified/`; cloud data lives in
+  `/chroma/unified` via `PERSIST_DIRECTORY=/chroma/unified`.
+- **Collection:** KB content lives in the `neo-knowledge-base` collection.
 
 ## Available Tools
 
@@ -160,11 +164,18 @@ This cycle turns technical debt into an asset, continuously improving the projec
 
 The server is designed to be self-contained. It manages its own database process and configuration to ensure it doesn't conflict with other services.
 
-### Architecture: Service Isolation
+### Architecture: Unified Chroma Boundary
 
-The Agent OS runs multiple cognitive services. The **Knowledge Base** (technical facts) and **Memory Core** (personal history) each require their own dedicated vector storage. To prevent cross-contamination and ensure reliability, they operate as **independent services**.
+The Agent OS runs multiple cognitive services. The **Knowledge Base** (technical facts)
+and **Memory Core** (institutional memory) now share a single Chroma daemon and persist
+directory by design. The shared storage coordinates live in `AiConfig.engines.chroma`;
+the local orchestrator and cloud compose file must point at the same flat `unified`
+store shape.
 
-**Do NOT use global environment variables** (like `CHROMA_PORT` or `CHROMA_DATA_PATH`) to configure these services, as this would force them to share the same database instance, leading to conflicts. Instead, use the dedicated configuration file.
+Use the canonical shared Chroma bindings (`NEO_CHROMA_HOST`, `NEO_CHROMA_PORT`, and
+`AiConfig.engines.chroma.dataDir`) when deployment overrides are needed. Do not recreate
+server-prefixed Chroma aliases or per-realm persist folders; that reintroduces the
+retired local/cloud topology drift from #12153.
 
 ### Key Configurable Items
 
@@ -182,10 +193,6 @@ npm run ai:mcp-server-knowledge-base -- -c ./my-custom-config.mjs
 **Example `my-custom-config.mjs`:**
 ```javascript readonly
 export default {
-    // Isolate this instance on a different port
-    port: 8100,
-    path: './my-custom-chroma-db',
-    
     // Tune the brain to be more sensitive to bug reports
     queryScoreWeights: {
         ticketPenalty: -20, // Reduce penalty from -70
@@ -196,11 +203,14 @@ export default {
 
 #### Configuration Options
 
-*   **Database Isolation:**
-    *   `port`: The port for the local ChromaDB instance (default: `8000`).
-    *   `path`: The filesystem path for vector storage (default: `chroma-neo-knowledge-base`).
+*   **Unified Chroma Coordinates:**
+    *   `host`: The shared ChromaDB host (default from `AiConfig.engines.chroma.host`; env var `NEO_CHROMA_HOST`).
+    *   `port`: The shared ChromaDB port (default from `AiConfig.engines.chroma.port`; env var `NEO_CHROMA_PORT`).
+    *   `path`: The unified Chroma persist directory, read from `AiConfig.engines.chroma.dataDir`.
+    *   `collectionName`: The KB collection name (default: `neo-knowledge-base`).
     *   `dataPath`: The location of the source-of-truth JSONL file.
-    *   *Note:* Ensure these do not overlap with the Memory Core's configuration.
+    *   *Note:* KB and Memory Core intentionally share the same Chroma daemon and persist
+        directory. Do not configure a separate KB Chroma folder.
 
 *   **Transport & Cloud Deployments:**
     *   `transport`: Defines the MCP transport protocol. Defaults to `'stdio'` for local CLI usage. Set to `'sse'` to run the server as a cloud-native HTTP microservice (e.g., in a Docker container).


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 0c4ef520-9f97-4899-8770-9cb423d6c936.

Resolves #12153

Completes the unified-Chroma parent closeout residual from the #12153 epic-resolution matrix by removing stale prose that still described retired `chroma/memory-core/`, `{kb,mc}`, and independent Knowledge Base storage layouts as current. The updated prose now points backup/restore and Knowledge Base readers at the flat `unified` Chroma store, with collection/metadata boundaries as the separation layer.

Evidence: L1 (source/doc prose sweep + syntax + focused unit tests) -> L1 required (the remaining blocker was stale current topology prose, not a runtime behavior change). Residual: none.

## Deltas from ticket

- **Parent closeout target:** #12153 is an epic. The normal PR shape resolves a leaf sub-ticket, but this branch intentionally resolves the parent closeout residual because all named subs are closed, the residual was discovered by the epic-resolution matrix itself, and the operator constrained v13 nightshift work against creating new tickets unless three existing tickets are resolved via PRs.
- **Adjacent stale doc included:** The proven blocker was `ai/scripts/maintenance/backup.mjs`; the same stale "independent KB storage" topology existed in `learn/agentos/KnowledgeBase.md`, so the PR updates both current-reader surfaces in one narrow cleanup.
- **Clean-as-you-touch whitespace:** The pre-commit hook surfaced pre-existing trailing spaces in `learn/agentos/KnowledgeBase.md`; those were removed with no content change.

## Test Evidence

- `node --check ai/scripts/maintenance/backup.mjs` -> passed.
- `git diff --check origin/dev...HEAD` -> passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs test/playwright/unit/ai/scripts/maintenance/peer-architecture.spec.mjs` -> 12 passed.
- `rg -n "chroma-neo-knowledge-base|Knowledge Base.*independent services|Memory Core.*independent services|CHROMA_DATA_PATH|\\.neo-ai-data/chroma/(memory-core|knowledge-base|\\{kb,mc\\}|kb|mc)/|Physical Chroma data directories" ai/scripts/maintenance/backup.mjs learn/agentos/KnowledgeBase.md` -> no matches.
- Pre-commit hooks passed on commit `5114ca1e5`.

## Post-Merge Validation

- [ ] Confirm #12153 is closed as completed and Project 12 moves it to Done after merge.
- [ ] Re-run the #12153 epic-resolution matrix if any peer objects to parent-close semantics.

## Commits

- `5114ca1e5` — `docs(ai): align Chroma backup prose with unified store (#12153)`

## Evolution

The original closeout audit recommended a missing sub-ticket. During nightshift pickup, the queue-expansion constraint made a new ticket negative ROI; the safer path was a direct parent closeout PR with the exception documented in the body instead of hiding the parent relationship behind a fabricated leaf.
