### PR TITLE
fix(ai): cap Sandman handoff sections (GP 10/others 5) + bare issue refs (#12655)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -224,7 +224,7 @@ class Config extends ConfigProvider {
              * Maximum stale-assignment candidates rendered into the Sandman handoff.
              * @type {number}
              */
-            goldenPathStaleAssignmentRenderLimit: leaf(20, 'NEO_GOLDEN_PATH_STALE_ASSIGNMENT_RENDER_LIMIT', 'number'),
+            goldenPathStaleAssignmentRenderLimit: leaf(5, 'NEO_GOLDEN_PATH_STALE_ASSIGNMENT_RENDER_LIMIT', 'number'),
             /**
              * Idle threshold used by `GoldenPathSynthesizer` when rendering unassigned
              * Silent Threads. Defaults to 14 days so the section surfaces longer-running
@@ -241,12 +241,19 @@ class Config extends ConfigProvider {
              * Maximum Silent Threads candidates rendered into the Sandman handoff.
              * @type {number}
              */
-            goldenPathSilentThreadRenderLimit: leaf(10, 'NEO_GOLDEN_PATH_SILENT_THREAD_RENDER_LIMIT', 'number'),
+            goldenPathSilentThreadRenderLimit: leaf(5, 'NEO_GOLDEN_PATH_SILENT_THREAD_RENDER_LIMIT', 'number'),
             /**
              * Maximum recent open PR rows rendered inside `Active PR Cycle State`.
              * @type {number}
              */
             goldenPathRecentOpenPrRenderLimit: leaf(5, 'NEO_GOLDEN_PATH_RECENT_OPEN_PR_RENDER_LIMIT', 'number'),
+            /**
+             * Maximum Golden Path priority nodes rendered into the Sandman handoff. The
+             * Golden Path is the one section that earns more depth than the 5-row
+             * convention applied to every other category; defaults to 10.
+             * @type {number}
+             */
+            goldenPathTopNodeRenderLimit: leaf(10, 'NEO_GOLDEN_PATH_TOP_NODE_RENDER_LIMIT', 'number'),
             /**
              * The Hebbian decay factor applied every 24 hours to the edge graph (e.g., 0.98 for ~79 day half-life).
              * @type {number}

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -396,7 +396,7 @@ class GoldenPathSynthesizer extends Base {
 
         for (const candidate of visibleCandidates) {
             const assignees = candidate.assignees.map(assignee => `@${assignee}`).join(', ');
-            const issueRef  = candidate.url ? `[#${candidate.number}](${candidate.url})` : `#${candidate.number}`;
+            const issueRef  = `#${candidate.number}`;
             section += `- **${issueRef}** — ${candidate.title} — assignee ${assignees} — last qualifying activity ${candidate.lastActivityAt} by @${candidate.lastActivityBy} (${candidate.daysIdle} days ago; ${candidate.reason})\n`;
         }
 
@@ -641,7 +641,7 @@ class GoldenPathSynthesizer extends Base {
         }
 
         for (const candidate of visibleCandidates) {
-            const issueRef = candidate.url ? `[#${candidate.number}](${candidate.url})` : `#${candidate.number}`;
+            const issueRef = `#${candidate.number}`;
             section += `- **${issueRef}** — ${candidate.title} — ${candidate.daysIdle} days idle; ` +
                 `last activity ${candidate.lastActivityAt} by @${candidate.lastActivityBy}; ` +
                 `structural weight ${candidate.structuralWeight.toFixed(2)}; ` +
@@ -694,7 +694,7 @@ class GoldenPathSynthesizer extends Base {
 
         for (const pr of recent) {
             const author = pr.author?.login || 'unknown';
-            section += `- **PR #${pr.number}**: [${pr.title}](${pr.url}) — author @${author} — opened ${pr.createdAt} — cross-family reviewed: ${this.hasCrossFamilyReview(pr) ? 'yes' : 'no'}\n`;
+            section += `- **PR #${pr.number}**: ${pr.title} — author @${author} — opened ${pr.createdAt} — cross-family reviewed: ${this.hasCrossFamilyReview(pr) ? 'yes' : 'no'}\n`;
         }
 
         section += `\n`;
@@ -876,7 +876,7 @@ class GoldenPathSynthesizer extends Base {
         scoredNodes.sort((a, b) => b.score - a.score);
 
         // Remove mathematically rejected targets (Negative ROI), then slice
-        const topNodes = scoredNodes.filter(n => n.score > -5000).slice(0, 5);
+        const topNodes = scoredNodes.filter(n => n.score > -5000).slice(0, aiConfig.goldenPathTopNodeRenderLimit);
         const goldenIds = new Set(topNodes.map(item => item.node.id));
 
         let markdownAppend = '';
@@ -1171,7 +1171,7 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
                                     }
                                 }
 
-                                prStateAppend += `- **PR #${pr.number}**: [${pr.title}](${pr.url})\n`;
+                                prStateAppend += `- **PR #${pr.number}**: ${pr.title}\n`;
                                 prStateAppend += `  - **Lane State**: \`${laneState}\`\n`;
                                 prStateAppend += `  - **Cycle**: \`${cycle}\`\n`;
                                 prStateAppend += `  - **Reviewers**: ${reviewers}\n`;

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -42,6 +42,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let originalEmbeddingModel;
     let originalEmbeddingProvider;
     let originalGoldenPathRecentOpenPrRenderLimit;
+    let originalGoldenPathTopNodeRenderLimit;
     let originalGoldenPathStaleAssignmentRenderLimit;
     let originalGoldenPathStaleAssignmentThresholdMs;
     let originalGoldenPathSilentThreadMinScore;
@@ -85,6 +86,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         originalEmbeddingProvider = aiConfig.embeddingProvider;
         originalExecSync          = child_process.execSync;
         originalGoldenPathRecentOpenPrRenderLimit       = aiConfig.goldenPathRecentOpenPrRenderLimit;
+        originalGoldenPathTopNodeRenderLimit            = aiConfig.goldenPathTopNodeRenderLimit;
         originalGoldenPathStaleAssignmentRenderLimit    = aiConfig.goldenPathStaleAssignmentRenderLimit;
         originalGoldenPathStaleAssignmentThresholdMs    = aiConfig.goldenPathStaleAssignmentThresholdMs;
         originalGoldenPathSilentThreadMinScore          = aiConfig.goldenPathSilentThreadMinScore;
@@ -94,6 +96,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         originalWarn              = logger.warn;
 
         aiConfig.goldenPathRecentOpenPrRenderLimit       = 5;
+        aiConfig.goldenPathTopNodeRenderLimit            = 10;
         aiConfig.goldenPathStaleAssignmentRenderLimit    = 20;
         aiConfig.goldenPathStaleAssignmentThresholdMs    = 7 * 24 * 60 * 60 * 1000;
         aiConfig.goldenPathSilentThreadMinScore          = 14;
@@ -105,6 +108,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         aiConfig.embeddingModel    = originalEmbeddingModel;
         aiConfig.embeddingProvider = originalEmbeddingProvider;
         aiConfig.goldenPathRecentOpenPrRenderLimit       = originalGoldenPathRecentOpenPrRenderLimit;
+        aiConfig.goldenPathTopNodeRenderLimit            = originalGoldenPathTopNodeRenderLimit;
         aiConfig.goldenPathStaleAssignmentRenderLimit    = originalGoldenPathStaleAssignmentRenderLimit;
         aiConfig.goldenPathStaleAssignmentThresholdMs    = originalGoldenPathStaleAssignmentThresholdMs;
         aiConfig.goldenPathSilentThreadMinScore          = originalGoldenPathSilentThreadMinScore;
@@ -236,7 +240,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain('### Recent Open PRs');
         expect(handoffContent).toContain('cross-family reviewed: yes');
         expect(handoffContent).toContain('### @neo-gemini-pro');
-        expect(handoffContent).toContain('- **PR #11178**: [feat(ai): Automate PR Cycle State Extraction](https://github.com/neomjs/neo/pull/11178)');
+        expect(handoffContent).toContain('- **PR #11178**: feat(ai): Automate PR Cycle State Extraction');
+        expect(handoffContent).not.toContain('](https://github.com/');
         expect(handoffContent).toContain('- **Lane State**: `AWAITING_REVIEW`');
         expect(handoffContent).toContain('- **Cycle**: `2`');
         expect(handoffContent).toContain('- **Reviewers**: neo-opus-ada');
@@ -368,7 +373,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
 
         expect(handoffContent).toContain('## Stale Assignment Candidates');
-        expect(handoffContent).toContain('[#9001](https://github.com/neomjs/neo/issues/9001)');
+        expect(handoffContent).toContain('**#9001**');
+        expect(handoffContent).not.toContain('](https://github.com/');
         expect(handoffContent).toContain('assignee @neo-opus-ada');
         expect(handoffContent).toContain('last qualifying activity 2026-05-10T00:00:00.000Z by @neo-opus-ada');
         expect(handoffContent).not.toContain('Fresh assigned issue');
@@ -449,7 +455,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
         expect(handoffContent).toContain('## Stale Assignment Candidates');
         expect(handoffContent).toContain('## Silent Threads');
-        expect(handoffContent).toContain('[#9401](https://github.com/neomjs/neo/issues/9401)');
+        expect(handoffContent).toContain('**#9401**');
+        expect(handoffContent).not.toContain('](https://github.com/');
         expect(handoffContent).toContain('visibility-only, no routing');
         expect(handoffContent).not.toContain('Fresh unassigned issue');
         expect(handoffContent.indexOf('## Stale Assignment Candidates')).toBeLessThan(handoffContent.indexOf('## Silent Threads'));


### PR DESCRIPTION
Resolves #12655

Trims the always-injected Sandman strategic-priming handoff (`GoldenPathSynthesizer` → `sandman_handoff.md`, parsed into every headless agent's context by `AgentOrchestrator`) from a token drain: oversized per-section render caps + full GitHub-URL hyperlinks on every issue/PR row.

- `goldenPathStaleAssignmentRenderLimit` 20 → 5, `goldenPathSilentThreadRenderLimit` 10 → 5 (the 5-row convention)
- new `goldenPathTopNodeRenderLimit` = 10 — the Golden Path is the one section that earns more depth
- bare `#N` / `PR #N` instead of `[#N](https://…)` / `[title](url)` — ~73 URL hyperlinks dropped, titles kept

No defensive `?? <n>` fallback on the leaf reads — the SSOT leaf is authoritative (aligned with ADR 0019 + #12461's B3-defense removal).

Evidence: L2 (unit render specs execute the capped + bare-ref output; synthesize-level assertions exercised via tests 4 + 6) → L2 required (token-budget AC is render-output + naming-convention, covered by render specs). No residuals.

## Deltas from ticket
- Kept issue/PR **titles** — only the URL hyperlink is dropped (the token waste is the URL, not the human-readable title).
- Made the Golden-Path main cap a config leaf rather than a hardcoded `10`, for consistency with its 3 sibling render-limit leaves + env-tunability (`NEO_GOLDEN_PATH_TOP_NODE_RENDER_LIMIT`).

## Test Evidence
- `npm run test-unit -- …/GoldenPathSynthesizer.spec.mjs -g "renders empty and capped|caps noisy local issue sync"` → **2 passed (693ms)** — directly exercise the cap + bare-ref render path (no Chroma).
- Full-spec run: test 4 (Active PR Cycle State → bare `PR #11178`) + test 6 (Stale Assignments → bare `#9001`) **passed** with the updated assertions.
- Test 7 (`synthesizeGoldenPath renders Silent Threads`, full-synthesize) times out **locally** on the live Chroma/graph query — confirmed env-contention: an active orchestrator *REM sleep graph extraction* was deferring golden-path synthesis + holding the local graph during the run (operator-surfaced). My diff (slice value + string format) cannot hang; CI (clean substrate) is the gate.
- Post-edit `git grep '](https://github.com/'` on `GoldenPathSynthesizer.mjs` → zero emissions.

## Post-Merge Validation
- [ ] Full CI unit + integration green on ubuntu (clean substrate, no competing REM extraction), including the `renders Silent Threads` full-synthesize test.
- [ ] After config regen (`config.mjs` advanced from the new template, or env override), a freshly generated `sandman_handoff.md` shows ≤5 Stale-Assignment + ≤5 Silent-Thread rows, ≤10 Golden-Path rows, and zero `https://github.com/` URLs.

## Commits
- `1e129675d` — config caps (20→5, 10→5, +topNode=10) + bare issue/PR refs + spec snapshot/restore + assertion updates.

Authored by Claude Opus 4.8 (Claude Code). Session 4c567b8a-c0ac-447a-901b-5369ed4449d5.
