### PR TITLE
refactor(agentos): drop hookless daemon config suffixes (#11836)

### DIFF
--- a/ai/daemons/kb-alerting/KbAlertingService.mjs
+++ b/ai/daemons/kb-alerting/KbAlertingService.mjs
@@ -65,26 +65,26 @@ class KbAlertingService extends Base {
         singleton: true,
         /**
          * Whether the poll loop is running.
-         * @member {Boolean} isPolling_=false
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Boolean} isPolling=false
          * @protected
-         * @reactive
          */
-        isPolling_: false,
+        isPolling: false,
         /**
          * Active `setTimeout` handle for the next pulse; `null` when not scheduled.
-         * @member {Object|null} pollHandle_=null
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Object|null} pollHandle=null
          * @protected
-         * @reactive
          */
-        pollHandle_: null,
+        pollHandle: null,
         /**
          * Interval between alerting pulses in milliseconds.
          * Populated from `aiConfig.knowledgeBase.alertingIntervalMs` when the daemon starts.
-         * @member {Number|null} pollIntervalMs_=null
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Number|null} pollIntervalMs=null
          * @protected
-         * @reactive
          */
-        pollIntervalMs_: null
+        pollIntervalMs: null
     }
 
     /**

--- a/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
+++ b/ai/daemons/kb-gc/KbGarbageCollectionService.mjs
@@ -69,26 +69,26 @@ class KbGarbageCollectionService extends Base {
         singleton: true,
         /**
          * Whether the poll loop is running.
-         * @member {Boolean} isPolling_=false
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Boolean} isPolling=false
          * @protected
-         * @reactive
          */
-        isPolling_: false,
+        isPolling: false,
         /**
          * Active `setTimeout` handle for the next pulse; `null` when not scheduled.
-         * @member {Object|null} pollHandle_=null
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Object|null} pollHandle=null
          * @protected
-         * @reactive
          */
-        pollHandle_: null,
+        pollHandle: null,
         /**
          * Interval between GC pulses in milliseconds.
          * Populated from `aiConfig.knowledgeBase.gcIntervalMs` when the daemon starts.
-         * @member {Number|null} pollIntervalMs_=null
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Number|null} pollIntervalMs=null
          * @protected
-         * @reactive
          */
-        pollIntervalMs_: null
+        pollIntervalMs: null
     }
 
     /**

--- a/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
+++ b/ai/daemons/kb-reconciliation/KbReconciliationService.mjs
@@ -73,26 +73,26 @@ class KbReconciliationService extends Base {
         singleton: true,
         /**
          * Whether the poll loop is running.
-         * @member {Boolean} isPolling_=false
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Boolean} isPolling=false
          * @protected
-         * @reactive
          */
-        isPolling_: false,
+        isPolling: false,
         /**
          * Active `setTimeout` handle for the next pulse; `null` when not scheduled.
-         * @member {Object|null} pollHandle_=null
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Object|null} pollHandle=null
          * @protected
-         * @reactive
          */
-        pollHandle_: null,
+        pollHandle: null,
         /**
          * Interval between reconciliation pulses in milliseconds.
          * Populated from `aiConfig.knowledgeBase.reconciliationIntervalMs` when the daemon starts.
-         * @member {Number|null} pollIntervalMs_=null
+         * Plain singleton state; no reactive hooks are attached.
+         * @member {Number|null} pollIntervalMs=null
          * @protected
-         * @reactive
          */
-        pollIntervalMs_: null
+        pollIntervalMs: null
     }
 
     /**

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -92,7 +92,7 @@ function heartbeatAlivePath() {
  *
  * Singleton scope is intentional: initialization only waits for peer services,
  * while `identity` and `pollIntervalMs` are pulse-time runtime config. The
- * Orchestrator sets those reactive configs before awaiting readiness. There is
+ * Orchestrator sets those config slots before awaiting readiness. There is
  * one Orchestrator daemon per host, so the service-to-parent relationship does
  * not share mutable pulse state across multiple scheduler owners.
  *
@@ -131,14 +131,13 @@ class SwarmHeartbeatService extends Base {
          */
         identity_: null,
         /**
-         * Interval between pulses in milliseconds. Parent (Orchestrator) sets this
-         * via reactive config assignment to the orchestrator's
-         * `swarmHeartbeatIntervalMs` value, which already honors the
-         * `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS` env override.
-         * @member {Number} pollIntervalMs_=300000
-         * @reactive
+         * Interval between pulses in milliseconds. Parent (Orchestrator) assigns
+         * this to the orchestrator's `swarmHeartbeatIntervalMs` value, which
+         * already honors the `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS` env
+         * override. Plain config: there are no get/set hooks for this slot.
+         * @member {Number} pollIntervalMs=300000
          */
-        pollIntervalMs_: DEFAULT_POLL_INTERVAL_MS,
+        pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
         /**
          * Target-resolver source enum consumed by `getPulseIdentities()` per pulse.
          * Controls which identity set the lane pulses for. `'self'` (default) is

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs
@@ -21,6 +21,12 @@ const REPO_ROOT  = path.resolve(__dirname, '../../../../../..');
 const ORCHESTRATOR_MJS_PATH    = path.join(REPO_ROOT, 'ai/daemons/orchestrator/Orchestrator.mjs');
 const ORCHESTRATOR_DAEMON_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/daemon.mjs');
 const TASK_DEFINITIONS_MJS_PATH = path.join(REPO_ROOT, 'ai/daemons/orchestrator/taskDefinitions.mjs');
+const SIBLING_DAEMON_CONFIG_PATHS = {
+    'SwarmHeartbeatService.mjs'     : path.join(REPO_ROOT, 'ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs'),
+    'KbAlertingService.mjs'         : path.join(REPO_ROOT, 'ai/daemons/kb-alerting/KbAlertingService.mjs'),
+    'KbReconciliationService.mjs'   : path.join(REPO_ROOT, 'ai/daemons/kb-reconciliation/KbReconciliationService.mjs'),
+    'KbGarbageCollectionService.mjs': path.join(REPO_ROOT, 'ai/daemons/kb-gc/KbGarbageCollectionService.mjs')
+};
 
 let invariantSeq         = 0;
 let savedIntervals       = null;
@@ -423,6 +429,17 @@ test.describe('Orchestrator source-level invariants (#11834 AC4)', () => {
         });
 
         expect(missingHook, `Reactive config slots with \`_\`-suffix MUST have a corresponding \`beforeSetX\` or \`afterSetX\` hook (Sub-1 anti-pattern: cargo-cult underscores without hooks). Offending slots: ${missingHook.join(', ')}.`).toEqual([]);
+    });
+});
+
+test.describe('Sibling daemon source-level invariants (#11836)', () => {
+    test('poll-loop singleton state does not use hookless reactive config suffixes', async () => {
+        for (const [name, filePath] of Object.entries(SIBLING_DAEMON_CONFIG_PATHS)) {
+            const source  = stripCommentsAndStrings(await fs.readFile(filePath, 'utf8'));
+            const matches = source.match(/\b(?:isPolling|pollHandle|pollIntervalMs)_\s*:/g) || [];
+
+            expect(matches, `${name} must keep poll-loop state as plain config unless a real before/after hook is added.`).toHaveLength(0);
+        }
     });
 });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -39,8 +39,8 @@ import {test, expect} from '@playwright/test';
  * band-aid, no manual idempotency guard). The framework triggers it ONCE during
  * singleton creation; external callers MUST use `await service.ready()` to wait for
  * completion. Identity / pollIntervalMs are pulse-time runtime config set by the
- * parent (Orchestrator) via reactive config assignment BEFORE `await
- * service.ready()` in `start()` (the framework already fired identity-agnostic
+ * parent (Orchestrator) before `await service.ready()` in `start()` (the
+ * framework already fired identity-agnostic
  * `initAsync()` at module-load, so the BEFORE-`.ready()` ordering matches the
  * `Orchestrator.start()` code); tests assign them directly via property write
  * post-fixture-setup to exercise `beforeSetIdentity` normalization without


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 0c4ef520-9f97-4899-8770-9cb423d6c936.

Resolves #11836
Related: #11831

This removes the remaining hookless reactive-config suffixes from the current sibling daemon surfaces that still matched the masterclass-reference cleanup intent. The change keeps the public property names unchanged (`isPolling`, `pollHandle`, `pollIntervalMs`) while removing `_` backing-slot metadata where no `beforeGet*`, `beforeSet*`, or `afterSet*` hook exists. It also adds a source invariant covering the current sibling-daemon residue so the pattern does not quietly return.

Evidence: L2 (focused unit tests plus static source invariants) -> L2 required (daemon config-shape and behavior ACs). No residuals.

## Deltas from ticket

The original target paths were stale. Current-source V-B-A narrowed the implementation to:

- `ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs`
- `ai/daemons/kb-alerting/KbAlertingService.mjs`
- `ai/daemons/kb-reconciliation/KbReconciliationService.mjs`
- `ai/daemons/kb-gc/KbGarbageCollectionService.mjs`

`ai/services/graph/GapInferenceEngine.mjs` has no corresponding sibling-daemon config residue on current `dev`, so it is intentionally unchanged. Dockerfiles, cloud deployment files, `WakeDecisionService.mjs`, and unrelated DEFAULT/configure residue remain out of scope.

## Test Evidence

- `node --check ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs`
- `node --check ai/daemons/kb-alerting/KbAlertingService.mjs`
- `node --check ai/daemons/kb-reconciliation/KbReconciliationService.mjs`
- `node --check ai/daemons/kb-gc/KbGarbageCollectionService.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs`
- `node --check test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.invariants.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs test/playwright/unit/ai/daemons/kb-alerting/KbAlertingService.spec.mjs test/playwright/unit/ai/daemons/kb-reconciliation/KbReconciliationService.spec.mjs test/playwright/unit/ai/daemons/kb-gc/KbGarbageCollectionService.spec.mjs` -> 107 passed
- `git diff --check`
- pre-commit hooks: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`

## Post-Merge Validation

- [ ] Confirm #11836 auto-closes and #11831 remains open until its epic-resolution closeout.
- [ ] Confirm Project 12 moves #11836 to Done after merge.

## Commit

- `fc6450fd4` — `refactor(agentos): drop hookless daemon config suffixes (#11836)`

## Consensus Source

Parent epic #11831 was graduated from Discussion #11828. @neo-gpt posted the first-pickup epic review on #11831 before claiming this sub; verdict: greenlight for narrowed #11836 intake only after current-path V-B-A.