### PR TITLE
fix(drag-drop): restore target dashboard after remote drag leave (#8162)

### DIFF
--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -306,7 +306,9 @@ class DashboardSortZone extends SortZone {
         let me = this;
 
         if (me.isRemoteDragging) {
-            me.isRemoteDragging = false;
+            // A target-zone visitor leaving is cleanup, not a local drop. Keep remote state active and
+            // suppress the shared onDragEnd() moveNode path so the remote component is not inserted here.
+            me.isWindowDragging = true;
             await me.onDragEnd({})
         }
     }

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -117,4 +117,73 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         expect(sortZone.lastIntersectionRatio).toBeCloseTo(0.70);
         expect(sortZone.isWindowDragging).toBe(true);
     });
+
+    test('does not move a remote drag visitor into the target when it leaves (#8162)', async () => {
+        const appliedDeltas = [];
+
+        Neo.applyDeltas = (windowId, deltas) => {
+            appliedDeltas.push(...deltas);
+            return Promise.resolve()
+        };
+
+        const existingItem = {
+            id          : 'target-item',
+            vdom        : {cls: ['neo-draggable']},
+            wrapperStyle: {}
+        };
+        const placeholder = {
+            id          : 'placeholder',
+            vdom        : {cls: []},
+            wrapperStyle: {},
+            destroy     : () => {}
+        };
+        const remoteItem = {
+            id          : 'remote-item',
+            wrapperStyle: {}
+        };
+
+        const mockOwner = {
+            id              : 'mockOwner',
+            cls             : [],
+            dragResortable  : true,
+            items           : [existingItem, placeholder],
+            style           : {},
+            vdom            : {},
+            addDomListeners : () => {},
+            getDomRect      : () => Promise.resolve([{x:0, y:0, width:200, height:100}]),
+            getVdomItemsRoot: () => ({id: 'mockOwner-items'}),
+            on              : () => {}
+        };
+
+        sortZone = Neo.create(DashboardSortZone, {
+            owner  : mockOwner,
+            timeout: () => Promise.resolve()
+        });
+
+        Object.assign(sortZone, {
+            currentIndex    : 1,
+            dragComponent   : remoteItem,
+            dragPlaceholder : placeholder,
+            dragProxy       : {id: 'proxy', cls: [], destroy: () => {}},
+            isRemoteDragging: true,
+            itemRects       : [
+                {height: 100, left: 0, top: 0, width: 100},
+                {height: 100, left: 100, top: 0, width: 100}
+            ],
+            itemStyles: [
+                {height: '100px', width: '100px'},
+                {height: '100px', width: '100px'}
+            ],
+            ownerStyle   : {},
+            sortableItems: [existingItem, placeholder],
+            startIndex   : 1,
+            windowId     : 1
+        });
+
+        await sortZone.onRemoteDragLeave({});
+
+        expect(appliedDeltas.some(delta => delta.action === 'moveNode' && delta.id === remoteItem.id)).toBe(false);
+        expect(sortZone.isRemoteDragging).toBe(false);
+        expect(sortZone.isWindowDragging).toBe(false)
+    });
 });


### PR DESCRIPTION
Resolves #8162

Authored by GPT-5 (Codex Desktop). Session 0c4ef520-9f97-4899-8770-9cb423d6c936.

Keeps remote drag leave cleanup classified as a remote/window-drag cleanup until the shared `onDragEnd()` path finishes. This prevents the target dashboard from queuing a `moveNode` for the visiting component when the drag leaves the target window, while still removing the placeholder/proxy and resetting state.

Evidence: L2 (focused unit regression + neighboring SortZone unit coverage) -> L2 required (the close target is shared drag-state cleanup covered by unit-level deltas). No residuals.

## Deltas from ticket
The ticket suspected stale style restoration. Current-source V-B-A found the concrete failure boundary one layer earlier: `onRemoteDragLeave()` flipped `isRemoteDragging` false before cleanup, so the shared drag-end path could treat a visitor leave as a local finalized drop.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/draggable/dashboard/SortZone.spec.mjs` -> 2/2 passed.
- `npm run test-unit -- test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/draggable/dashboard/SortZone.spec.mjs` -> 8/8 passed.
- `git diff --check` -> passed.

## Post-Merge Validation
- [ ] In a live multi-window dashboard, drag a widget from Window A into Window B, then out of Window B into void/popup; Window B layout returns to its pre-visitor state and Window A resumes popup.