### PR TITLE
docs: reframe closed-loop diagrams to advisory Golden Path + peer self-selection (#12662)

### DIFF
--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -8,7 +8,7 @@ The name is intentional: like biological REM sleep, the system processes the day
 experiences overnight and wakes up with a clearer model of the world.
 
 For the overall platform topology, see [Architecture Overview](../benefits/ArchitectureOverview.md).
-For the agent delegation model, see [Swarm Intelligence](./SwarmIntelligence.md).
+For the intra-harness sub-agent delegation model (tactical tooling within a single agent's cognitive loop), see [Swarm Intelligence](./SwarmIntelligence.md).
 
 ## The Philosophy
 
@@ -346,28 +346,36 @@ flowchart LR
     classDef session fill:#0f3460,stroke:#16c79a,stroke-width:2px,color:#fff
     classDef dream fill:#3d1f00,stroke:#f39c12,stroke-width:2px,color:#eee
     classDef db fill:#1a1a2e,stroke:#e94560,stroke-width:1px,color:#eee
-    classDef orch fill:#1a3c34,stroke:#2ecc71,stroke-width:1px,color:#eee
+    classDef peer fill:#1a3c34,stroke:#2ecc71,stroke-width:1px,color:#eee
+    classDef human fill:#4a1942,stroke:#e94560,stroke-width:2px,color:#eee
 
     Sessions["Agent Sessions"]:::session
     Dream["DreamService"]:::dream
     Graph["Native Edge Graph"]:::db
     Handoff["sandman_handoff.md"]:::dream
-    Orch["Orchestrator"]:::orch
-    Agent["Autonomous Agent"]:::session
+    Peers["Peer Maintainers"]:::peer
+    Operator["Human Operator"]:::human
 
     Sessions -->|"raw memories"| Dream
     Dream -->|"tri-vectors"| Graph
     Dream -->|"gap inference"| Graph
     Dream -->|"golden path"| Handoff
     Graph -->|"topology + vectors"| Dream
-    Handoff -->|"directives"| Orch
-    Orch -->|"scheduled events"| Agent
-    Agent -->|"new sessions"| Sessions
+    Handoff -.->|"advisory forecast"| Peers
+    Operator -.->|"direction, not assignment"| Peers
+    Peers -->|"self-selected work"| Sessions
 ```
 
 The closed loop: agents create sessions → DreamService digests sessions into graph
-intelligence → graph intelligence informs the Golden Path → Golden Path directs the
-Orchestrator → Orchestrator schedules agent work → agents create new sessions.
+intelligence → graph intelligence informs the Golden Path → the Golden Path is an
+**advisory forecast** (not a work queue): peer maintainers read it and **self-select**
+what to pick up, while the human operator steers direction rather than assigning tickets
+→ the work they choose produces new sessions.
+
+The autonomous runner (`AgentOrchestrator.parseGoldenPath()`) is one *optional* consumer
+of the same advisory handoff — during unattended cycles it auto-processes the top
+`## Computed Golden Path` recommendations. Even then it surfaces the math's forecast; it
+is not an externally assigned queue.
 
 The system evolves by predicting its own evolution.
 
@@ -408,7 +416,7 @@ This is by design — Project metadata is a presentation/coordination convenienc
 ## Related Guides
 
 - [Architecture Overview](../benefits/ArchitectureOverview.md) — Platform-level topology
-- [Swarm Intelligence](./SwarmIntelligence.md) — Delegation model and Orchestrator
+- [Swarm Intelligence](./SwarmIntelligence.md) — Sub-agent delegation model and Orchestrator
 - [The Memory Core Server](./MemoryCore.md) — Episodic memory and graph storage
 - [The Knowledge Base Server](./KnowledgeBase.md) — Semantic RAG architecture
 - [The GitHub Workflow Server](./GitHubWorkflow.md) — issue substrate + ProjectV2 derived-view rules

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -323,24 +323,28 @@ flowchart TD
     classDef kb fill:#1a1a2e,stroke:#e94560,stroke-width:1px,color:#eee
     classDef code fill:#222,stroke:#f5a623,stroke-width:2px,color:#fff
 
-    Human["Human"]:::human
-    Agent["Agent works on ticket"]:::agent
+    Human["Human Operator"]:::human
+    Agent["Peer maintainer (self-selects)"]:::agent
     Memory["Memory Core records"]:::memory
     Dream["Sandman digests"]:::dream
     GraphNode["Graph re-prioritizes"]:::dream
     KB["Knowledge Base updated"]:::kb
     Code["Codebase improved"]:::code
 
-    Human -->|"Assigns ticket"| Agent
+    GraphNode -->|"sandman_handoff.md (advisory forecast)"| Agent
+    Human -.->|"Gives direction (optional)"| Agent
     Agent -->|"add_memory"| Memory
     Memory -->|"Undigested sessions"| Dream
     Dream --> GraphNode
-    GraphNode -->|"sandman_handoff.md"| Agent
-    Agent -->|"PR merged"| Code
+    Agent -->|"Opens PR"| Code
+    Human -->|"Reviews + merges PR"| Code
     Code -->|"KB sync"| KB
     KB -->|"ask_knowledge_base"| Agent
-    Human -->|"Reviews PR"| Code
 ```
+
+The Golden Path (`sandman_handoff.md`) is an **advisory forecast**, not a work queue: peer
+maintainers self-select what to work on, while the human operator steers direction and holds
+the merge gate rather than assigning tickets.
 
 The agent's improvements to the framework also improve the agent's knowledge base,
 which improves the agent's future decisions. This is what distinguishes Neo.mjs from tools


### PR DESCRIPTION
Resolves #12662

Two operating-model guides framed agent work as **top-down assignment**, contradicting the flat-peer-team model (`AGENTS.md §swarm_topology_anchor`). Operator flagged it directly: *"i can give you a direction, but our working model is that peers chose on their own."* This reframes both closed-loop diagrams so the Golden Path reads as an **advisory forecast** that peer maintainers **self-select** from, with the human operator steering **direction + the merge-gate**, not assigning tickets.

Evidence: docs-only (mermaid + prose). The offending edge was literal — `learn/benefits/ArchitectureOverview.md` had `Human -->|"Assigns ticket"| Agent` while the *same* diagram already fed the agent from `sandman_handoff.md` (redundant **and** contradictory). No runtime/code change; `AgentOrchestrator.parseGoldenPath()` behavior is untouched and is now described honestly as a secondary advisory consumer.

## Deltas
- **`ArchitectureOverview.md` "The Closed Loop":** removed `Human -->|"Assigns ticket"| Agent`; added `Human -.->|"Gives direction (optional)"| Agent` (dotted = advisory). Agent node → "Peer maintainer (self-selects)"; the `sandman_handoff.md` edge is relabeled "advisory forecast" and is now the agent's primary work-source. Merge semantics tightened to the human merge-gate: agent "Opens PR", human "Reviews + merges PR" (was the imprecise `Agent -->|"PR merged"|`). One prose line added stating the advisory/self-selection model.
- **`DreamPipeline.md` "How It All Connects":** `Handoff -->|"directives"| Orch -->|"scheduled events"| Agent` → `Handoff -.->|"advisory forecast"| Peers`, `Operator -.->|"direction, not assignment"| Peers`, `Peers -->|"self-selected work"| Sessions`. Closed-loop prose reframed; the autonomous runner kept **honestly** as an *optional* secondary consumer (auto-processes the top `## Computed Golden Path` — still surfacing the forecast, not an assigned queue).
- **Cross-ref precision (DreamPipeline):** the two "agent delegation model" links now say "intra-harness **sub-agent** delegation" — disambiguating the `§swarm_topology_anchor`-blessed tactical-tooling pattern from maintainer task-assignment (the exact conflation that made this drift easy to miss).

## Out of scope (surfaced, not fixed here)
- `SwarmIntelligence.md` §"The Event Scheduler" + §"The Orchestration Pipeline" carry the same autonomous-runner *"all work enters through the Scheduler"* framing — sibling drift, flagged on the ticket for an operator/peer call.
- `ArchitectureOverview.md:125` `Orchestrator -->|"schedule"| Agent` is the runtime cognitive-loop boot (genuinely what `AgentOrchestrator` does) — kept as-is.
- `MX.md:29` is correct (it *contrasts* Neo against the "agent delegated by user; acts as proxy" anti-pattern).

## Test Evidence
- Docs-only; no unit tests apply. Mermaid syntax validated by inspection — standard `-.->|"label"|` dotted edges + `classDef`/node definitions; quoted labels protect the parentheses. `git diff` reviewed: both diagrams still close their loops; no unrelated lines touched.
- Husky pre-commit clean (whitespace check passed; no `#<n>` / `ADR-<n>` archaeology refs added to doc bodies).

## Post-Merge Validation
- [ ] Visual render check of both mermaid diagrams on the published learn site (the sandbox cannot render mermaid) — confirm the dotted "direction/advisory" edges + the self-selection loop read correctly.

Authored by Claude Opus 4.8 (Claude Code) as @neo-opus-vega. Origin session: d55abb62-72e6-42e5-813a-21c0d4c8d00e.
