### PR TITLE
fix(ai): route resumeHarness to addressed Claude instance (#12536)

### DIFF
--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -472,7 +472,67 @@ class SwarmHeartbeatService extends Base {
      * @protected
      */
     async resumeHarness(identity, reason, originSessionId, abandonedCount) {
-        return resumeHarnessScript(identity, reason, originSessionId, abandonedCount)
+        const harnessTargetMetadata = await this.getResumeHarnessTargetMetadata(identity);
+        return resumeHarnessScript(identity, reason, originSessionId, abandonedCount, {
+            deploymentMode: AiConfig.orchestrator.deploymentMode,
+            env           : {},
+            harnessTargetMetadata
+        })
+    }
+
+    /**
+     * @summary Resolve the active bridge-daemon route metadata used by resumeHarness.
+     *
+     * Central swarm heartbeat runs in the Orchestrator process, not inside the target harness. It
+     * therefore cannot rely on the target harness's process environment for `userDataDir` routing.
+     * The bootstrapped wake subscription is the current route authority: prefer an active
+     * bridge-daemon `SENT_TO_ME` subscription with an instance-address tuple, falling back to the
+     * latest active bridge route so default-instance resumes keep their legacy behavior.
+     *
+     * @param {String} identity Agent identity node id.
+     * @returns {Promise<Object>} Harness target metadata or an empty object.
+     * @protected
+     */
+    async getResumeHarnessTargetMetadata(identity) {
+        try {
+            return await RequestContextService.run({agentIdentityNodeId: identity}, async () => {
+                const result = await WakeSubscriptionService.list({});
+                const candidates = (result?.subscriptions || [])
+                    .filter(subscription =>
+                        subscription.trigger === 'SENT_TO_ME' &&
+                        subscription.harnessTarget === 'bridge-daemon' &&
+                        (subscription.status || 'active') === 'active'
+                    )
+                    .sort((a, b) =>
+                        Date.parse(b.updatedAt || b.createdAt || '') -
+                        Date.parse(a.updatedAt || a.createdAt || '')
+                    );
+
+                const addressed = candidates.find(subscription =>
+                    this.hasInstanceAddressMetadata(subscription.harnessTargetMetadata || {})
+                );
+
+                return {
+                    ...((addressed || candidates[0])?.harnessTargetMetadata || {})
+                };
+            })
+        } catch (err) {
+            logger.error(`[SwarmHeartbeatService] getResumeHarnessTargetMetadata failed for ${identity}: ${err.message}`);
+            return {}
+        }
+    }
+
+    /**
+     * @summary Whether wake route metadata carries a complete generic instance address.
+     * @param {Object} metadata Harness target metadata.
+     * @returns {Boolean}
+     * @protected
+     */
+    hasInstanceAddressMetadata(metadata = {}) {
+        const addressType = metadata.addressType || (metadata.userDataDir ? 'userDataDir' : null),
+              address     = metadata.instanceAddress || (addressType === 'userDataDir' ? metadata.userDataDir : null);
+
+        return Boolean(addressType && address)
     }
 
     /**

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -472,7 +472,17 @@ class SwarmHeartbeatService extends Base {
      * @protected
      */
     async resumeHarness(identity, reason, originSessionId, abandonedCount) {
-        const harnessTargetMetadata = await this.getResumeHarnessTargetMetadata(identity);
+        let harnessTargetMetadata;
+        try {
+            harnessTargetMetadata = await this.getResumeHarnessTargetMetadata(identity);
+        } catch (err) {
+            logger.error(
+                `[SwarmHeartbeatService] Skipping resumeHarness for ${identity}: ` +
+                `failed to resolve wake route metadata (${err.message}).`
+            );
+            return
+        }
+
         return resumeHarnessScript(identity, reason, originSessionId, abandonedCount, {
             deploymentMode: AiConfig.orchestrator.deploymentMode,
             env           : {},
@@ -490,36 +500,33 @@ class SwarmHeartbeatService extends Base {
      * latest active bridge route so default-instance resumes keep their legacy behavior.
      *
      * @param {String} identity Agent identity node id.
-     * @returns {Promise<Object>} Harness target metadata or an empty object.
+     * @returns {Promise<Object>} Harness target metadata or an empty object when no active route exists.
+     * @throws {Error} When the route lookup itself fails; callers fail closed instead of resuming
+     *     through generic app activation.
      * @protected
      */
     async getResumeHarnessTargetMetadata(identity) {
-        try {
-            return await RequestContextService.run({agentIdentityNodeId: identity}, async () => {
-                const result = await WakeSubscriptionService.list({});
-                const candidates = (result?.subscriptions || [])
-                    .filter(subscription =>
-                        subscription.trigger === 'SENT_TO_ME' &&
-                        subscription.harnessTarget === 'bridge-daemon' &&
-                        (subscription.status || 'active') === 'active'
-                    )
-                    .sort((a, b) =>
-                        Date.parse(b.updatedAt || b.createdAt || '') -
-                        Date.parse(a.updatedAt || a.createdAt || '')
-                    );
-
-                const addressed = candidates.find(subscription =>
-                    this.hasInstanceAddressMetadata(subscription.harnessTargetMetadata || {})
+        return RequestContextService.run({agentIdentityNodeId: identity}, async () => {
+            const result = await WakeSubscriptionService.list({});
+            const candidates = (result?.subscriptions || [])
+                .filter(subscription =>
+                    subscription.trigger === 'SENT_TO_ME' &&
+                    subscription.harnessTarget === 'bridge-daemon' &&
+                    (subscription.status || 'active') === 'active'
+                )
+                .sort((a, b) =>
+                    Date.parse(b.updatedAt || b.createdAt || '') -
+                    Date.parse(a.updatedAt || a.createdAt || '')
                 );
 
-                return {
-                    ...((addressed || candidates[0])?.harnessTargetMetadata || {})
-                };
-            })
-        } catch (err) {
-            logger.error(`[SwarmHeartbeatService] getResumeHarnessTargetMetadata failed for ${identity}: ${err.message}`);
-            return {}
-        }
+            const addressed = candidates.find(subscription =>
+                this.hasInstanceAddressMetadata(subscription.harnessTargetMetadata || {})
+            );
+
+            return {
+                ...((addressed || candidates[0])?.harnessTargetMetadata || {})
+            };
+        })
     }
 
     /**

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -52,7 +52,10 @@ import {
     isHarnessPresenceFresh
 } from './queries.mjs';
 import {applyHarnessMetadataDefaults} from '../../scripts/lifecycle/harnessRouting.mjs';
-import {getDefaultInstancePid, getInstancePid} from './instanceResolver.mjs';
+import {
+    getDefaultInstancePid,
+    resolveGuiInstancePid
+} from './instanceResolver.mjs';
 
 const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
 const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
@@ -799,42 +802,22 @@ async function deliverDigest(subscription, digest) {
             // app-activate — a targeted wake must never silently degrade to an untargeted one. Uses
             // the canonical AiConfig.orchestrator.deploymentMode signal.
             let instancePid = null;
-            if (addressType === 'pid') {
-                if (AiConfig.orchestrator.deploymentMode === 'cloud') {
+            if (addressType === 'pid' || addressType === 'userDataDir') {
+                try {
+                    instancePid = await resolveGuiInstancePid({
+                        instanceAddress,
+                        addressType,
+                        deploymentMode: AiConfig.orchestrator.deploymentMode,
+                        target        : 'wake daemon',
+                        appName
+                    });
+                } catch (err) {
                     writeLog('ERROR',
-                        `[Wake Daemon] Instance wake refused for ${subscription.id}: ` +
-                        `pid targeting requires local deployment (deploymentMode='cloud'). ` +
-                        `Failing closed — instance-addressed GUI wakes are local-only (ADR 0014).`
+                        `[Wake Daemon] Instance wake refused for ${subscription.id}: ${err.message}`
                     );
                     return;
                 }
-                instancePid = normalizePid(instanceAddress);
-                if (!instancePid) {
-                    writeLog('ERROR',
-                        `[Wake Daemon] Instance wake refused for ${subscription.id}: ` +
-                        `invalid pid instanceAddress='${instanceAddress}'. Failing closed.`
-                    );
-                    return;
-                }
-            } else if (addressType === 'userDataDir' && instanceAddress) {
-                if (AiConfig.orchestrator.deploymentMode === 'cloud') {
-                    writeLog('ERROR',
-                        `[Wake Daemon] Instance wake refused for ${subscription.id}: ` +
-                        `userDataDir targeting requires local deployment (deploymentMode='cloud'). ` +
-                        `Failing closed — instance-addressed GUI wakes are local-only (ADR 0014).`
-                    );
-                    return;
-                }
-                instancePid = await getInstancePid({userDataDir: instanceAddress});
-                if (!instancePid) {
-                    writeLog('ERROR',
-                        `[Wake Daemon] Instance wake refused for ${subscription.id}: ` +
-                        `no running process found for userDataDir='${instanceAddress}'. ` +
-                        `Failing closed to avoid misrouting to another ${appName} instance.`
-                    );
-                    return;
-                }
-            } else if (AiConfig.orchestrator.deploymentMode !== 'cloud') {
+            } else if (AiConfig.orchestrator.deploymentMode === 'local') {
                 // No userDataDir = the DEFAULT instance, started as the normal macOS app (which can
                 // never carry --user-data-dir without breaking its system app / menu-bar integration).
                 // When a same-bundle sibling instance is running, "activate + frontmost" is ambiguous;
@@ -1065,17 +1048,6 @@ function assertFreshTargetPresence(subscription, {addressType}) {
         `Failing closed; recipient will pick up the unread event on next turn.`
     );
     return false;
-}
-
-/**
- * @summary Normalizes a pid string for direct-pid address dispatch.
- * @param {*} pid Process id candidate.
- * @returns {Number|null}
- */
-function normalizePid(pid) {
-    const numericPid = Number(pid);
-
-    return Number.isInteger(numericPid) && numericPid > 0 ? numericPid : null;
 }
 
 /**

--- a/ai/daemons/wake/instanceResolver.mjs
+++ b/ai/daemons/wake/instanceResolver.mjs
@@ -2,6 +2,7 @@ import {execFile} from 'child_process';
 import {promisify} from 'util';
 
 const execFileAsync = promisify(execFile);
+const GUI_INSTANCE_ADDRESS_TYPES = Object.freeze(['userDataDir', 'pid']);
 
 /**
  * @summary Resolves the OS process id of a specific GUI harness *instance* from its
@@ -109,6 +110,154 @@ export async function getInstancePid({userDataDir, exec = execFileAsync} = {}) {
     }
 
     return resolveInstancePid({userDataDir, psOutput});
+}
+
+/**
+ * @summary Normalize a pid-like value into a positive integer.
+ * @param {*} value Candidate process id.
+ * @returns {Number|null}
+ */
+export function normalizeInstancePid(value) {
+    const pid = Number(String(value ?? '').trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+/**
+ * @summary Normalize metadata/env GUI instance-address tuples shared by wake delivery and resume.
+ *
+ * A partial tuple is refused because falling through from a targeted route into default app
+ * activation can wake or resume the wrong same-bundle harness instance. This helper covers the
+ * GUI address types that are directly osascript-addressable (`pid`) or resolve to one
+ * (`userDataDir`); tmux/webhook addresses remain transport-specific in the wake daemon.
+ *
+ * @param {Object} options
+ * @param {String} [options.instanceAddress] Instance address value.
+ * @param {String} [options.addressType] Address type (`userDataDir` or `pid`).
+ * @param {String} [options.source='metadata'] Human-readable source for diagnostics.
+ * @param {String} [options.target='harness'] Human-readable target surface for diagnostics.
+ * @returns {{instanceAddress:String,addressType:String}|null}
+ */
+export function normalizeGuiInstanceAddressTuple({
+    instanceAddress,
+    addressType,
+    source = 'metadata',
+    target = 'harness'
+} = {}) {
+    const address = String(instanceAddress ?? '').trim(),
+          type    = String(addressType ?? '').trim();
+
+    if (!address && !type) return null;
+
+    if (!address || !type) {
+        throw new Error(
+            `Partial ${target} instance address from ${source}: ` +
+            'instanceAddress and addressType must be set together. ' +
+            'Failing closed to avoid routing a targeted GUI action into the default instance.'
+        );
+    }
+
+    if (!GUI_INSTANCE_ADDRESS_TYPES.includes(type)) {
+        throw new Error(
+            `Unsupported ${target} instance addressType '${type}' from ${source}. ` +
+            `Supported types: ${GUI_INSTANCE_ADDRESS_TYPES.join(', ')}.`
+        );
+    }
+
+    return {
+        instanceAddress: address,
+        addressType    : type
+    };
+}
+
+/**
+ * @summary Resolve GUI instance-address metadata, preferring wake route metadata over env probes.
+ *
+ * Caller-provided wake-subscription metadata wins over the CLI/manual environment envelope. This
+ * keeps orchestrator-driven recovery identity-specific while preserving direct-script probes where
+ * the caller supplies an explicit local deployment mode.
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.metadata={}] Wake route metadata (`instanceAddress` + `addressType`,
+ *     or legacy `userDataDir`).
+ * @param {Object} [options.env={}] Environment map for direct CLI invocations.
+ * @param {String} [options.target='harness'] Human-readable target surface for diagnostics.
+ * @returns {{instanceAddress:String,addressType:String}|null}
+ */
+export function resolveGuiInstanceAddress({metadata = {}, env = {}, target = 'harness'} = {}) {
+    const metadataType = metadata.addressType || (metadata.userDataDir ? 'userDataDir' : null),
+          metadataAddr = metadata.instanceAddress || (metadataType === 'userDataDir' ? metadata.userDataDir : null),
+          fromMetadata = normalizeGuiInstanceAddressTuple({
+              instanceAddress: metadataAddr,
+              addressType    : metadataType,
+              source         : 'harnessTargetMetadata',
+              target
+          });
+
+    if (fromMetadata) return fromMetadata;
+
+    return normalizeGuiInstanceAddressTuple({
+        instanceAddress: env.NEO_HARNESS_INSTANCE_ADDRESS,
+        addressType    : env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE,
+        source         : 'environment',
+        target
+    });
+}
+
+/**
+ * @summary Resolve an osascript-addressable pid for a GUI instance address.
+ *
+ * Deployment mode is intentionally caller-supplied instead of re-read from env: the Orchestrator
+ * and wake daemon read `AiConfig.orchestrator.deploymentMode` at their use site, preserving the
+ * reactive Provider SSOT. Missing/unknown/non-local modes fail closed before any GUI targeting.
+ *
+ * @param {Object} options
+ * @param {String} options.instanceAddress
+ * @param {String} options.addressType `userDataDir` or `pid`.
+ * @param {String} options.deploymentMode Resolved deployment mode from AiConfig.
+ * @param {String} [options.target='harness'] Human-readable target surface for diagnostics.
+ * @param {String} [options.appName='harness'] Human-readable app name for diagnostics.
+ * @param {Function} [options.getInstancePidFn=getInstancePid] Injectable resolver for tests.
+ * @returns {Promise<Number>}
+ */
+export async function resolveGuiInstancePid({
+    instanceAddress,
+    addressType,
+    deploymentMode,
+    target = 'harness',
+    appName = 'harness',
+    getInstancePidFn = getInstancePid
+} = {}) {
+    const mode = String(deploymentMode ?? '').trim();
+    if (mode !== 'local') {
+        throw new Error(
+            `${target} instance targeting requires local deployment (deploymentMode='${mode || 'unset'}'). ` +
+            'Failing closed — instance-addressed GUI actions are local-only (ADR 0014).'
+        );
+    }
+
+    if (addressType === 'pid') {
+        const pid = normalizeInstancePid(instanceAddress);
+        if (!pid) {
+            throw new Error(
+                `Invalid ${target} pid instanceAddress='${instanceAddress}'. ` +
+                'Failing closed to avoid generic app activation.'
+            );
+        }
+        return pid;
+    }
+
+    if (addressType === 'userDataDir') {
+        const pid = await getInstancePidFn({userDataDir: instanceAddress});
+        if (!pid) {
+            throw new Error(
+                `No running ${appName} instance found for userDataDir='${instanceAddress}'. ` +
+                `Failing closed to avoid routing into another ${appName} instance.`
+            );
+        }
+        return pid;
+    }
+
+    throw new Error(`Unsupported ${target} instance addressType '${addressType}'.`);
 }
 
 /**

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -21,7 +21,10 @@ import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
 import { createSpawnRequest } from './windowsBatchSpawn.mjs';
-import { getInstancePid } from '../../daemons/wake/instanceResolver.mjs';
+import {
+    resolveGuiInstanceAddress,
+    resolveGuiInstancePid
+} from '../../daemons/wake/instanceResolver.mjs';
 import {
     normalizeAgentIdentityNodeId,
     resolveHarnessTargetForIdentity
@@ -31,7 +34,6 @@ export {normalizeAgentIdentityNodeId};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
-const INSTANCE_ADDRESS_TYPES = Object.freeze(['userDataDir', 'pid']);
 
 /**
  * @summary Spawn a child process and (optionally) record its PID for later harness cleanup.
@@ -244,51 +246,6 @@ function assertCodexAppServerAllowed() {
 }
 
 /**
- * @summary Normalize a pid-like value into a positive integer.
- * @param {*} value Candidate process id.
- * @returns {Number|null}
- */
-function normalizeInstancePid(value) {
-    const pid = Number(String(value ?? '').trim());
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
-}
-
-/**
- * @summary Normalize and validate a generic instance-address tuple.
- * @param {Object} options
- * @param {String} [options.instanceAddress] Instance address value.
- * @param {String} [options.addressType] Address type.
- * @param {String} options.source Human-readable source for diagnostics.
- * @returns {{instanceAddress:String,addressType:String}|null}
- */
-function normalizeInstanceAddressTuple({instanceAddress, addressType, source}) {
-    const address = String(instanceAddress ?? '').trim(),
-          type    = String(addressType ?? '').trim();
-
-    if (!address && !type) return null;
-
-    if (!address || !type) {
-        throw new Error(
-            `Partial resumeHarness instance address from ${source}: ` +
-            'instanceAddress and addressType must be set together. ' +
-            'Failing closed to avoid routing a targeted resume into the default Claude instance.'
-        );
-    }
-
-    if (!INSTANCE_ADDRESS_TYPES.includes(type)) {
-        throw new Error(
-            `Unsupported resumeHarness instance addressType '${type}' from ${source}. ` +
-            `Supported types: ${INSTANCE_ADDRESS_TYPES.join(', ')}.`
-        );
-    }
-
-    return {
-        instanceAddress: address,
-        addressType    : type
-    };
-}
-
-/**
  * @summary Resolve the instance-address tuple for an osascript resume.
  *
  * Caller-provided wake-subscription metadata wins over the CLI/manual environment envelope. This
@@ -302,21 +259,7 @@ function normalizeInstanceAddressTuple({instanceAddress, addressType, source}) {
  * @returns {{instanceAddress:String,addressType:String}|null}
  */
 export function resolveResumeHarnessInstanceAddress({metadata = {}, env = process.env} = {}) {
-    const metadataType = metadata.addressType || (metadata.userDataDir ? 'userDataDir' : null),
-          metadataAddr = metadata.instanceAddress || (metadataType === 'userDataDir' ? metadata.userDataDir : null),
-          fromMetadata = normalizeInstanceAddressTuple({
-              instanceAddress: metadataAddr,
-              addressType    : metadataType,
-              source         : 'harnessTargetMetadata'
-          });
-
-    if (fromMetadata) return fromMetadata;
-
-    return normalizeInstanceAddressTuple({
-        instanceAddress: env.NEO_HARNESS_INSTANCE_ADDRESS,
-        addressType    : env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE,
-        source         : 'environment'
-    });
+    return resolveGuiInstanceAddress({metadata, env, target: 'resumeHarness'});
 }
 
 /**
@@ -335,39 +278,17 @@ export function resolveResumeHarnessInstanceAddress({metadata = {}, env = proces
 export async function resolveResumeHarnessInstancePid({
     instanceAddress,
     addressType,
-    deploymentMode = process.env.NEO_AI_DEPLOYMENT_MODE || 'local',
-    getInstancePidFn = getInstancePid
+    deploymentMode,
+    getInstancePidFn
 } = {}) {
-    if (deploymentMode === 'cloud') {
-        throw new Error(
-            `resumeHarness instance targeting requires local deployment (deploymentMode='cloud'). ` +
-            'Failing closed — instance-addressed GUI resumes are local-only (ADR 0014).'
-        );
-    }
-
-    if (addressType === 'pid') {
-        const pid = normalizeInstancePid(instanceAddress);
-        if (!pid) {
-            throw new Error(
-                `Invalid resumeHarness pid instanceAddress='${instanceAddress}'. ` +
-                'Failing closed to avoid generic app activation.'
-            );
-        }
-        return pid;
-    }
-
-    if (addressType === 'userDataDir') {
-        const pid = await getInstancePidFn({userDataDir: instanceAddress});
-        if (!pid) {
-            throw new Error(
-                `No running Claude instance found for userDataDir='${instanceAddress}'. ` +
-                'Failing closed to avoid routing resume into another Claude instance.'
-            );
-        }
-        return pid;
-    }
-
-    throw new Error(`Unsupported resumeHarness instance addressType '${addressType}'.`);
+    return resolveGuiInstancePid({
+        instanceAddress,
+        addressType,
+        deploymentMode,
+        getInstancePidFn,
+        target : 'resumeHarness',
+        appName: 'Claude'
+    });
 }
 
 /**
@@ -398,7 +319,7 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
  * @returns {Promise<void>}
  */
 export async function resumeHarness(identity, reason, originSessionId, abandonedCount = 0, {
-    deploymentMode        = process.env.NEO_AI_DEPLOYMENT_MODE || 'local',
+    deploymentMode,
     env                   = process.env,
     harnessTargetMetadata = {}
 } = {}) {

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -21,6 +21,7 @@ import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
 import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
 import { createSpawnRequest } from './windowsBatchSpawn.mjs';
+import { getInstancePid } from '../../daemons/wake/instanceResolver.mjs';
 import {
     normalizeAgentIdentityNodeId,
     resolveHarnessTargetForIdentity
@@ -30,6 +31,7 @@ export {normalizeAgentIdentityNodeId};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
+const INSTANCE_ADDRESS_TYPES = Object.freeze(['userDataDir', 'pid']);
 
 /**
  * @summary Spawn a child process and (optionally) record its PID for later harness cleanup.
@@ -242,6 +244,133 @@ function assertCodexAppServerAllowed() {
 }
 
 /**
+ * @summary Normalize a pid-like value into a positive integer.
+ * @param {*} value Candidate process id.
+ * @returns {Number|null}
+ */
+function normalizeInstancePid(value) {
+    const pid = Number(String(value ?? '').trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+/**
+ * @summary Normalize and validate a generic instance-address tuple.
+ * @param {Object} options
+ * @param {String} [options.instanceAddress] Instance address value.
+ * @param {String} [options.addressType] Address type.
+ * @param {String} options.source Human-readable source for diagnostics.
+ * @returns {{instanceAddress:String,addressType:String}|null}
+ */
+function normalizeInstanceAddressTuple({instanceAddress, addressType, source}) {
+    const address = String(instanceAddress ?? '').trim(),
+          type    = String(addressType ?? '').trim();
+
+    if (!address && !type) return null;
+
+    if (!address || !type) {
+        throw new Error(
+            `Partial resumeHarness instance address from ${source}: ` +
+            'instanceAddress and addressType must be set together. ' +
+            'Failing closed to avoid routing a targeted resume into the default Claude instance.'
+        );
+    }
+
+    if (!INSTANCE_ADDRESS_TYPES.includes(type)) {
+        throw new Error(
+            `Unsupported resumeHarness instance addressType '${type}' from ${source}. ` +
+            `Supported types: ${INSTANCE_ADDRESS_TYPES.join(', ')}.`
+        );
+    }
+
+    return {
+        instanceAddress: address,
+        addressType    : type
+    };
+}
+
+/**
+ * @summary Resolve the instance-address tuple for an osascript resume.
+ *
+ * Caller-provided wake-subscription metadata wins over the CLI/manual environment envelope. This
+ * keeps the central heartbeat path identity-specific while preserving the existing direct-script
+ * escape hatch for operator probes.
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.metadata={}] Wake route metadata (`instanceAddress` + `addressType`,
+ *     or legacy `userDataDir`).
+ * @param {Object} [options.env=process.env] Environment map for direct CLI invocations.
+ * @returns {{instanceAddress:String,addressType:String}|null}
+ */
+export function resolveResumeHarnessInstanceAddress({metadata = {}, env = process.env} = {}) {
+    const metadataType = metadata.addressType || (metadata.userDataDir ? 'userDataDir' : null),
+          metadataAddr = metadata.instanceAddress || (metadataType === 'userDataDir' ? metadata.userDataDir : null),
+          fromMetadata = normalizeInstanceAddressTuple({
+              instanceAddress: metadataAddr,
+              addressType    : metadataType,
+              source         : 'harnessTargetMetadata'
+          });
+
+    if (fromMetadata) return fromMetadata;
+
+    return normalizeInstanceAddressTuple({
+        instanceAddress: env.NEO_HARNESS_INSTANCE_ADDRESS,
+        addressType    : env.NEO_HARNESS_INSTANCE_ADDRESS_TYPE,
+        source         : 'environment'
+    });
+}
+
+/**
+ * @summary Resolve an osascript-addressable process id for a configured resume instance.
+ *
+ * An explicit instance address is a safety boundary: missing/stale processes throw instead of
+ * falling back to app activation, because app activation is ambiguous across same-bundle Claude
+ * instances.
+ *
+ * @param {Object} options
+ * @param {String} options.instanceAddress
+ * @param {String} options.addressType `userDataDir` or `pid`.
+ * @param {Function} [options.getInstancePidFn=getInstancePid] Injectable resolver for tests.
+ * @returns {Promise<Number>}
+ */
+export async function resolveResumeHarnessInstancePid({
+    instanceAddress,
+    addressType,
+    deploymentMode = process.env.NEO_AI_DEPLOYMENT_MODE || 'local',
+    getInstancePidFn = getInstancePid
+} = {}) {
+    if (deploymentMode === 'cloud') {
+        throw new Error(
+            `resumeHarness instance targeting requires local deployment (deploymentMode='cloud'). ` +
+            'Failing closed — instance-addressed GUI resumes are local-only (ADR 0014).'
+        );
+    }
+
+    if (addressType === 'pid') {
+        const pid = normalizeInstancePid(instanceAddress);
+        if (!pid) {
+            throw new Error(
+                `Invalid resumeHarness pid instanceAddress='${instanceAddress}'. ` +
+                'Failing closed to avoid generic app activation.'
+            );
+        }
+        return pid;
+    }
+
+    if (addressType === 'userDataDir') {
+        const pid = await getInstancePidFn({userDataDir: instanceAddress});
+        if (!pid) {
+            throw new Error(
+                `No running Claude instance found for userDataDir='${instanceAddress}'. ` +
+                'Failing closed to avoid routing resume into another Claude instance.'
+            );
+        }
+        return pid;
+    }
+
+    throw new Error(`Unsupported resumeHarness instance addressType '${addressType}'.`);
+}
+
+/**
  * Build a boot-grounding prompt that instructs the fresh agent to read
  * AGENTS_STARTUP.md and pick up prior context via Memory Core + sandman_handoff.
  * @param {string} identity        Agent identity (e.g. '@neo-opus-ada').
@@ -268,7 +397,11 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
  * @param {Number} [abandonedCount=0] Prior abandoned wake action count for lock bookkeeping.
  * @returns {Promise<void>}
  */
-export async function resumeHarness(identity, reason, originSessionId, abandonedCount = 0) {
+export async function resumeHarness(identity, reason, originSessionId, abandonedCount = 0, {
+    deploymentMode        = process.env.NEO_AI_DEPLOYMENT_MODE || 'local',
+    env                   = process.env,
+    harnessTargetMetadata = {}
+} = {}) {
     identity = normalizeAgentIdentityNodeId(identity);
 
     // Direct fresh-session-spawn invocations must fail closed when the wake
@@ -413,8 +546,16 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
             console.log(`Successfully resumed ${identity} via codex-app-server`);
         } else if (adapter === 'osascript') {
             const { appName, tabShortcut, freshSessionShortcut } = harnessTarget;
+            const instanceAddress = resolveResumeHarnessInstanceAddress({metadata: harnessTargetMetadata, env});
+            const instancePid     = instanceAddress
+                ? await resolveResumeHarnessInstancePid({
+                    ...instanceAddress,
+                    deploymentMode
+                })
+                : null;
             // Fresh-session spawn flow:
             //   1. Activate target app
+            //      - With an explicit instance address, raise the resolved PID before any keystrokes.
             //   2. (Optional) Cmd+`tabShortcut` — get to the right tab (Code tab = Cmd+3 for Claude Desktop)
             //   3. Cmd+`freshSessionShortcut` — spawn a NEW chat session (Cmd+N for Antigravity + Claude Desktop).
             //      This creates a new chat instead of writing into the sunsetted one.
@@ -431,6 +572,10 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
                 '-e', '    set savedClipboard to ""',
                 '-e', '  end try',
                 '-e', `  tell application "${appName}" to activate`,
+                ...(instancePid ? [
+                '-e', '  delay 0.2',
+                '-e', `  tell application "System Events" to set frontmost of (first process whose unix id is ${instancePid}) to true`
+                ] : []),
                 '-e', '  delay 0.5',
                 '-e', '  tell application "System Events"',
                 '-e', '    set frontmostProcess to first application process whose frontmost is true',
@@ -483,7 +628,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
             ];
 
             await spawnAsync('osascript', osascriptArgs);
-            console.log(`Successfully resumed ${identity} via osascript (${appName})`);
+            console.log(`Successfully resumed ${identity} via osascript (${appName}${instancePid ? ` pid=${instancePid}` : ''})`);
         } else if (adapter === 'tmux') {
             // Provide tmux fallback
             const tmuxSession = harnessTarget.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -279,6 +279,46 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(resumeCalls[0]).toEqual(['@test', 'Subscription missing', 'sid-456', 2]);
     });
 
+    test('getResumeHarnessTargetMetadata prefers addressed active bridge route (#12536)', async () => {
+        applyDefaultStubs();
+        const originalList = WakeSubscriptionService.list;
+        WakeSubscriptionService.list = async () => ({
+            subscriptions: [{
+                id                   : 'WAKE_SUB:generic',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                updatedAt            : '2026-06-06T22:00:00.000Z',
+                harnessTargetMetadata: {
+                    appName    : 'Claude',
+                    tabShortcut: '3'
+                }
+            }, {
+                id                   : 'WAKE_SUB:addressed',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                updatedAt            : '2026-06-06T21:00:00.000Z',
+                harnessTargetMetadata: {
+                    appName        : 'Claude',
+                    tabShortcut    : '3',
+                    instanceAddress: '/Users/example/.claude-instances/neo-opus-vega',
+                    addressType    : 'userDataDir'
+                }
+            }]
+        });
+
+        try {
+            await expect(SwarmHeartbeatService.getResumeHarnessTargetMetadata('@neo-opus-vega')).resolves.toMatchObject({
+                appName        : 'Claude',
+                instanceAddress: '/Users/example/.claude-instances/neo-opus-vega',
+                addressType    : 'userDataDir'
+            });
+        } finally {
+            WakeSubscriptionService.list = originalList;
+        }
+    });
+
     test('pulse() routes idle_out_nudge when gate is open and recommendation matches', async () => {
         applyDefaultStubs();
         const nudgeCalls = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -319,6 +319,25 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         }
     });
 
+    test('resumeHarness fails closed when route metadata lookup fails (#12536)', async () => {
+        applyDefaultStubs();
+        const originalGetMetadata = SwarmHeartbeatService.getResumeHarnessTargetMetadata;
+        SwarmHeartbeatService.getResumeHarnessTargetMetadata = async () => {
+            throw new Error('simulated route lookup failure')
+        };
+
+        try {
+            await expect(SwarmHeartbeatService.resumeHarness(
+                '@neo-opus-ada',
+                'sunset_restart',
+                'sid-route-failure',
+                0
+            )).resolves.toBeUndefined();
+        } finally {
+            SwarmHeartbeatService.getResumeHarnessTargetMetadata = originalGetMetadata;
+        }
+    });
+
     test('pulse() routes idle_out_nudge when gate is open and recommendation matches', async () => {
         applyDefaultStubs();
         const nudgeCalls = [];

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1198,7 +1198,7 @@ test.describe('Wake Daemon', () => {
                 }
             });
             daemonProcess.stderr.on('data', data => {
-                if (data.toString().includes('no running process found for userDataDir')) { clearTimeout(timeout); resolve(); }
+                if (data.toString().includes('No running Claude instance found for userDataDir')) { clearTimeout(timeout); resolve(); }
             });
             daemonProcess.on('error', reject);
         });

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -26,6 +26,10 @@ import {
     applyHarnessMetadataDefaults,
     resolveHarnessTargetForIdentity
 } from '../../../../../../ai/scripts/lifecycle/harnessRouting.mjs';
+import {
+    resolveResumeHarnessInstanceAddress,
+    resolveResumeHarnessInstancePid
+} from '../../../../../../ai/scripts/lifecycle/resumeHarness.mjs';
 
 test.describe('ai/scripts/resumeHarness', () => {
     test.describe.configure({mode: 'serial'});
@@ -125,6 +129,92 @@ test.describe('ai/scripts/resumeHarness', () => {
             tabShortcut         : '3',
             freshSessionShortcut: 'n'
         });
+    });
+
+    test('resumeHarness resolves addressed Claude instance metadata without hardcoded paths (#12536)', async () => {
+        expect(resolveResumeHarnessInstanceAddress({
+            metadata: {
+                appName        : 'Claude',
+                instanceAddress: '/Users/example/.claude-instances/neo-opus-vega',
+                addressType    : 'userDataDir'
+            },
+            env: {}
+        })).toEqual({
+            instanceAddress: '/Users/example/.claude-instances/neo-opus-vega',
+            addressType    : 'userDataDir'
+        });
+
+        expect(resolveResumeHarnessInstanceAddress({
+            metadata: {
+                appName    : 'Claude',
+                userDataDir: '/Users/example/.claude-instances/legacy'
+            },
+            env: {}
+        })).toEqual({
+            instanceAddress: '/Users/example/.claude-instances/legacy',
+            addressType    : 'userDataDir'
+        });
+
+        expect(resolveResumeHarnessInstanceAddress({
+            metadata: {},
+            env: {
+                NEO_HARNESS_INSTANCE_ADDRESS     : '  4242  ',
+                NEO_HARNESS_INSTANCE_ADDRESS_TYPE: '  pid  '
+            }
+        })).toEqual({
+            instanceAddress: '4242',
+            addressType    : 'pid'
+        });
+
+        expect(() => resolveResumeHarnessInstanceAddress({
+            metadata: {
+                appName    : 'Claude',
+                addressType: 'userDataDir'
+            },
+            env: {
+                NEO_HARNESS_INSTANCE_ADDRESS     : '/env/must-not-mask-partial-metadata',
+                NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'userDataDir'
+            }
+        })).toThrow(/Partial resumeHarness instance address/);
+
+        expect(() => resolveResumeHarnessInstanceAddress({
+            metadata: {},
+            env: {
+                NEO_HARNESS_INSTANCE_ADDRESS     : '/tmp/vega',
+                NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'tmuxSession'
+            }
+        })).toThrow(/Unsupported resumeHarness instance addressType/);
+    });
+
+    test('resumeHarness resolves instance PID and fails closed on stale addressed routes (#12536)', async () => {
+        expect(await resolveResumeHarnessInstancePid({
+            addressType    : 'pid',
+            instanceAddress: '12345'
+        })).toBe(12345);
+
+        expect(await resolveResumeHarnessInstancePid({
+            addressType      : 'userDataDir',
+            instanceAddress  : '/Users/example/.claude-instances/neo-opus-vega',
+            getInstancePidFn : async ({userDataDir}) =>
+                userDataDir === '/Users/example/.claude-instances/neo-opus-vega' ? 24680 : null
+        })).toBe(24680);
+
+        await expect(resolveResumeHarnessInstancePid({
+            addressType      : 'userDataDir',
+            instanceAddress  : '/Users/example/.claude-instances/missing',
+            getInstancePidFn : async () => null
+        })).rejects.toThrow(/No running Claude instance found/);
+
+        await expect(resolveResumeHarnessInstancePid({
+            addressType    : 'pid',
+            instanceAddress: 'not-a-pid'
+        })).rejects.toThrow(/Invalid resumeHarness pid/);
+
+        await expect(resolveResumeHarnessInstancePid({
+            addressType    : 'pid',
+            instanceAddress: '12345',
+            deploymentMode : 'cloud'
+        })).rejects.toThrow(/instance targeting requires local deployment/);
     });
 
     test('normalizes GitHub-login identity form before harness dispatch (#11797)', async () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -189,12 +189,14 @@ test.describe('ai/scripts/resumeHarness', () => {
     test('resumeHarness resolves instance PID and fails closed on stale addressed routes (#12536)', async () => {
         expect(await resolveResumeHarnessInstancePid({
             addressType    : 'pid',
-            instanceAddress: '12345'
+            instanceAddress: '12345',
+            deploymentMode : 'local'
         })).toBe(12345);
 
         expect(await resolveResumeHarnessInstancePid({
             addressType      : 'userDataDir',
             instanceAddress  : '/Users/example/.claude-instances/neo-opus-vega',
+            deploymentMode   : 'local',
             getInstancePidFn : async ({userDataDir}) =>
                 userDataDir === '/Users/example/.claude-instances/neo-opus-vega' ? 24680 : null
         })).toBe(24680);
@@ -202,13 +204,20 @@ test.describe('ai/scripts/resumeHarness', () => {
         await expect(resolveResumeHarnessInstancePid({
             addressType      : 'userDataDir',
             instanceAddress  : '/Users/example/.claude-instances/missing',
+            deploymentMode   : 'local',
             getInstancePidFn : async () => null
         })).rejects.toThrow(/No running Claude instance found/);
 
         await expect(resolveResumeHarnessInstancePid({
             addressType    : 'pid',
-            instanceAddress: 'not-a-pid'
+            instanceAddress: 'not-a-pid',
+            deploymentMode : 'local'
         })).rejects.toThrow(/Invalid resumeHarness pid/);
+
+        await expect(resolveResumeHarnessInstancePid({
+            addressType    : 'pid',
+            instanceAddress: '12345'
+        })).rejects.toThrow(/deploymentMode='unset'/);
 
         await expect(resolveResumeHarnessInstancePid({
             addressType    : 'pid',


### PR DESCRIPTION
Resolves #12536

Authored by GPT-5 (Codex Desktop). Session 0c4ef520-9f97-4899-8770-9cb423d6c936.

Routes Orchestrator-owned sunset restart into the target identity active bridge-daemon route metadata before invoking `resumeHarness`. `resumeHarness` understands generic `instanceAddress`/`addressType` tuples and legacy `userDataDir`; the shared GUI instance resolver now lives in `ai/daemons/wake/instanceResolver.mjs` and is consumed by both `resumeHarness` and the wake daemon.

Evidence: L2 (focused unit coverage across `resumeHarness`, `SwarmHeartbeatService`, `wake/daemon`, and `instanceResolver`) -> L2 required (runtime wake routing plus local-only cloud guard). Current GitHub CI is queued on head `59091d772`.

## Deltas from ticket
The issue body was broader and partially stale after #12554, #12570, #12576, and adjacent bridge fixes. Current-source V-B-A narrowed the remaining close target to central `SwarmHeartbeatService` still invoking `resumeHarness` with generic Claude Desktop routing for same-bundle Claude identities. This PR intentionally does not touch Dockerfile or cloud deployment surfaces.

## Cloud safety
- `resumeHarness` has no `AiConfig` import; Orchestrator-owned calls pass `deploymentMode: AiConfig.orchestrator.deploymentMode` at the use site.
- Direct CLI/env instance-address probes cannot silently authorize addressed GUI targeting: absent or non-local `deploymentMode` fails closed before pid/userDataDir targeting.
- Central heartbeat passes `env: {}` so the Orchestrator process cannot leak its own local instance-address env into a target identity.
- The shared `resolveGuiInstancePid()` fails closed for `deploymentMode !== "local"`, invalid pid, stale/missing `userDataDir`, and unsupported address types.
- If route metadata lookup itself fails, `SwarmHeartbeatService.resumeHarness()` logs and skips dispatch instead of falling back to generic app activation.

## Test Evidence
- `node --check ai/daemons/wake/instanceResolver.mjs` -> passed.
- `node --check ai/scripts/lifecycle/resumeHarness.mjs` -> passed.
- `node --check ai/daemons/wake/daemon.mjs` -> passed.
- `node --check ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs` -> passed.
- `git diff --check` / `git diff --cached --check` -> passed before commit.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs test/playwright/unit/ai/daemons/wake/instanceResolver.spec.mjs` -> sandbox EPERM at `.neo-ai-data/wake-daemon/inflight-sunset_restart-neo-gemini-pro.txt`; exact escalated rerun passed, 72 passed, 2 skipped.
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` -> sandbox EPERM on `127.0.0.1` listen for webhookUrl test; exact escalated rerun passed, 24 passed.

## Post-Merge Validation
- [ ] With vega bootstrapped using `NEO_HARNESS_INSTANCE_ADDRESS_TYPE=userDataDir` and `NEO_HARNESS_INSTANCE_ADDRESS=<vega user data dir>`, force a sunset-restart pulse and verify resume targets the vega running Claude instance, not the default Claude/Tab-3 instance.
- [ ] With `NEO_AI_DEPLOYMENT_MODE=cloud`, addressed GUI resume fails closed instead of invoking local GUI targeting.