### PR TITLE
test(neural-link): add fixture e2e baseline (#9835)

### DIFF
--- a/test/playwright/e2e/NeuralLinkFixture.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkFixture.spec.mjs
@@ -1,0 +1,61 @@
+import { test, expect } from '../fixtures.mjs';
+
+test.describe('Neural Link Playwright Fixture Baseline', () => {
+    test.setTimeout(90000);
+
+    test('verifies layout, VDOM, computed style, and event simulation bridge APIs', async ({ page, neuralLink }) => {
+        await page.goto('/examples/button/base/index.html');
+
+        const exampleButton = page.locator('.neo-example-container .neo-button').first();
+        await expect(exampleButton).toBeVisible({ timeout: 30000 });
+
+        const app      = await neuralLink.connectToApp('Neo.examples.button.base');
+        const buttonId = await exampleButton.getAttribute('id');
+
+        expect(buttonId).toBeTruthy();
+
+        const buttonProps = await app.getComponent(buttonId, ['windowId']);
+        expect(buttonProps.windowId).toBeDefined();
+
+        const [workerRect] = await app.getDomRect(buttonId);
+        const domBox       = await exampleButton.boundingBox();
+
+        expect(workerRect.width).toBeGreaterThan(0);
+        expect(workerRect.height).toBeGreaterThan(0);
+        expect(Math.abs(workerRect.width - domBox.width)).toBeLessThan(2);
+        expect(Math.abs(workerRect.height - domBox.height)).toBeLessThan(2);
+
+        const workerStyles = await app.getComputedStyles(buttonId, ['display', 'cursor']);
+        const domStyles    = await exampleButton.evaluate(node => {
+            const computed = window.getComputedStyle(node);
+
+            return {
+                cursor : computed.cursor,
+                display: computed.display
+            };
+        });
+
+        expect(workerStyles.display).toBe(domStyles.display);
+        expect(workerStyles.cursor).toBe(domStyles.cursor);
+
+        const vdomResult = await app.queryVdom({ tag: 'button' }, buttonId);
+        expect(vdomResult.vdom.tag).toBe('button');
+
+        await page.evaluate(id => {
+            window.__nlFixtureClickCount = 0;
+            document.getElementById(id).addEventListener('click', () => {
+                window.__nlFixtureClickCount += 1;
+            }, { once: true });
+        }, buttonId);
+
+        const dispatched = await app.simulateEvent({
+            options : { bubbles: true, cancelable: true },
+            targetId: buttonId,
+            type    : 'click',
+            windowId: String(buttonProps.windowId)
+        });
+
+        expect(dispatched).toBe(true);
+        await expect.poll(() => page.evaluate(() => window.__nlFixtureClickCount)).toBe(1);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9e86-0759-7243-a9f2-3af8f50b290d.

Resolves #9835

Adds a focused Neural Link Playwright fixture e2e baseline that drives the Button Base example through the real bridge and verifies the four fixture APIs named by the ticket: `getDomRect()`, `getComputedStyles()`, `queryVdom()`, and `simulateEvent()`.

Evidence: L3 (browser-rendered e2e on local Chrome with the Neural Link bridge) -> L3 required (ticket asks for live-app bridge verification). No residuals.

## Deltas from ticket
Existing `ButtonBaseNL.spec.mjs` already covered `getDomRect()`, `getComputedStyles()`, and `queryVdom()`. This PR adds `NeuralLinkFixture.spec.mjs` as the dedicated fixture-baseline suite and includes the previously missing `simulateEvent()` proof without changing Neural Link runtime code.

## Test Evidence
- `git diff --cached --check` passed before commit.
- `env NEO_MEMORY_DB_PATH=/private/tmp/neo-9835-memory-core-graph.sqlite NEO_AI_DAEMON_DIR=/private/tmp/neo-9835-wake-daemon npx playwright test test/playwright/e2e/NeuralLinkFixture.spec.mjs -c test/playwright/playwright.config.e2e.mjs` passed: 1 test, 1 passed.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `dd1236836 test(neural-link): add fixture e2e baseline (#9835)`.

## Post-Merge Validation
- [ ] CI confirms PR body lint and no broader test regression.

## Commit
- `dd1236836` — `test(neural-link): add fixture e2e baseline (#9835)`