### PR TITLE
test(container): cover atomic move focus side effects (#8621)

### DIFF
--- a/test/playwright/component/container/AtomicMoves.spec.mjs
+++ b/test/playwright/component/container/AtomicMoves.spec.mjs
@@ -186,7 +186,7 @@ test.describe('Neo.container.Base Atomic Moves', () => {
     });
 
     test('Atomic Move: Preserve focus when moving', async ({neo, page}) => {
-         const config = {
+        const config = {
             importPath: '../container/Base.mjs',
             ntype     : 'container',
             parentId  : 'component-test-viewport',
@@ -223,5 +223,60 @@ test.describe('Neo.container.Base Atomic Moves', () => {
 
         // Verify focus is preserved
         await expect(page.locator('#focus-field__input')).toBeFocused();
+    });
+
+    test('Atomic Move: Suppress focusLeave side effects while restoring focus', async ({neo, page}) => {
+        const config = {
+            importPath: '../container/Base.mjs',
+            ntype     : 'container',
+            parentId  : 'component-test-viewport',
+            layout    : 'vbox',
+            items: [
+                {ntype: 'container', id: 'container-focus-a', items: [
+                    {ntype: 'textfield', id: 'focus-flicker-field', labelText: 'Focus Field', required: true}
+                ]},
+                {ntype: 'container', id: 'container-focus-b', items: []}
+            ]
+        };
+
+        const result = await neo.createComponent(config);
+        rootId = result.id;
+
+        const field = page.locator('#focus-flicker-field');
+        const input = page.locator('#focus-flicker-field__input');
+
+        await expect(input).toBeVisible();
+
+        await page.evaluate(() => {
+            Neo.main.DeltaUpdates.nativeMoveBefore = false;
+        });
+
+        await input.focus();
+
+        await expect(input).toBeFocused();
+        await expect(field).not.toHaveClass(/neo-is-touched/);
+        await expect(field).not.toHaveClass(/neo-invalid/);
+
+        await neo.moveComponent({
+            id      : 'focus-flicker-field',
+            parentId: 'container-focus-b'
+        });
+
+        await page.waitForFunction(() => {
+            const el         = document.getElementById('focus-flicker-field');
+            const containerB = document.getElementById('container-focus-b');
+            return containerB && el && containerB.contains(el);
+        });
+
+        await page.waitForTimeout(75);
+
+        await expect(input).toBeFocused();
+        await expect(field).not.toHaveClass(/neo-is-touched/);
+        await expect(field).not.toHaveClass(/neo-invalid/);
+
+        await input.blur();
+
+        await expect(field).toHaveClass(/neo-is-touched/);
+        await expect(field).toHaveClass(/neo-invalid/);
     });
 });


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9e86-0759-7243-a9f2-3af8f50b290d.

Resolves #8621

Adds Atomic Move component regression coverage for the FocusManager side-effect contract. The new test forces the `DeltaUpdates.moveNode()` fallback path, focuses a required text field, moves it between sibling containers, waits past the FocusManager debounce window, and verifies that focus is preserved without `focusLeave` side effects (`neo-is-touched` / `neo-invalid`). It then performs a real blur to prove those side effects still fire when focus truly leaves.

Evidence: L3 (component Playwright in Chromium with forced DeltaUpdates fallback) -> L3 required (component-level Atomic Move focus/focusLeave behavior). No residuals.

## Deltas from ticket
The ticket proposed adding runtime debounce/flicker detection if side effects were found. Current source already contains that FocusManager behavior (`maxFocusInOutGap`, delayed `focusLeave`, and `focusMove` routing), so this PR keeps runtime unchanged and closes the gap with regression coverage.

## Test Evidence
- `npm run test-components -- test/playwright/component/container/AtomicMoves.spec.mjs` failed inside the sandbox before spec execution: local SQLite initialization hit `SQLITE_READONLY`.
- `npm run test-components -- test/playwright/component/container/AtomicMoves.spec.mjs` passed outside the sandbox: 5 passed.
- `git diff --check` passed.
- Commit hook evidence: `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology` passed.

## Post-Merge Validation
- [ ] GitHub CI remains green on the pushed head.

## Commit
- `0d27a6597` - `test(container): cover atomic move focus side effects (#8621)`

## Evolution
Ticket intake found valid intent but stale implementation prescription: the runtime debounce exists now, while AtomicMoves coverage only proved DOM/value/focus preservation. The implementation therefore narrowed to behavior coverage rather than production code changes.