### PR TITLE
docs: frame SwarmIntelligence orchestration as the unattended-runner path, not universal work-intake (#12666)

### DIFF
--- a/learn/agentos/SwarmIntelligence.md
+++ b/learn/agentos/SwarmIntelligence.md
@@ -205,7 +205,7 @@ without proportionally scaling API costs.
 
 ## Sub-Agent Training & RLAIF (Demonstrations of Intelligence)
 
-While the Orchestrator delegates tasks live, the `nl_action_log` captured during **Frontier agent** (e.g., Gemini 3.1 Pro / Claude Opus) interactions via the Neural Link represents highly valuable "Demonstrations of Intelligence". 
+While the Orchestrator delegates tasks live, the `nl_action_log` captured during **Frontier agent** (e.g., Gemini 3.1 Pro / Claude Opus) interactions via the Neural Link represents highly valuable "Demonstrations of Intelligence".
 
 Instead of treating these interactions as ephemeral, they are extracted into format-compliant `.jsonl` datasets for Reinforcement Learning from AI Feedback (RLAIF). The intelligence of the Frontier models is stockpiled to feed future SLM fine-tuning pipelines (SFT/DPO), directly raising the baseline capability of the local Sub-Agent tiers (like Gemma 4).
 
@@ -278,8 +278,11 @@ lifecycle.
 
 ## The Event Scheduler
 
-All work enters the system through the `Scheduler` — a priority queue that
-ensures critical events are processed before lower-priority ones:
+The **autonomous (unattended) runner** feeds its work through the `Scheduler` — a priority
+queue that ensures critical events are processed before lower-priority ones. (Interactive peer
+maintainers self-select work directly — see [Architecture Overview](../benefits/ArchitectureOverview.md)
+and [The Dream Pipeline](./DreamPipeline.md); the `Scheduler` is the unattended runner's intake,
+not a universal work source.)
 
 | Priority | Event Types | Example |
 |---|---|---|
@@ -294,8 +297,9 @@ becomes a `system:golden-path` event with `high` priority.
 
 ## The Orchestration Pipeline
 
-The `Orchestrator` ties everything together. It reads the DreamService's
-prioritized roadmap and feeds it into the autonomous agent loop:
+The `Orchestrator` is the **unattended autonomous-runner** path — one advisory consumer of the
+handoff (peer maintainers self-select interactively). It reads the DreamService's prioritized
+roadmap and feeds it into the autonomous agent loop:
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
Resolves #12666

Third and final doc in the operating-model accuracy cluster (after #12663's `ArchitectureOverview` + `DreamPipeline`). `SwarmIntelligence.md` framed the autonomous runner as the swarm's **universal** work-intake — contradicting the flat-peer-team model (`AGENTS.md §swarm_topology_anchor`): the Golden Path is advisory; peer maintainers self-select; the `AgentOrchestrator` runner is one *unattended* consumer of the handoff.

Evidence: docs-only (2 prose reframes + 1 incidental whitespace cleanup). No code touched.

## Deltas
- **§"The Event Scheduler":** *"All work enters the system through the `Scheduler`"* → *"The **autonomous (unattended) runner** feeds its work through the `Scheduler`… (Interactive peer maintainers self-select work directly — see Architecture Overview / Dream Pipeline; the `Scheduler` is the unattended runner's intake, not a universal work source.)"*
- **§"The Orchestration Pipeline":** intro reframed — the `Orchestrator` is the **unattended autonomous-runner** path (one advisory consumer); peer maintainers self-select interactively.
- **Untouched (deliberately):** the intra-harness sub-agent delegation content (Librarian / QA / Browser + `delegate()`) — the `§swarm_topology_anchor`-blessed tactical-tooling pattern, correctly described. Scope held tight.
- **Incidental:** removed pre-existing trailing whitespace at `:208` (the husky whitespace hook scans the whole staged file, so it blocked the commit until cleaned).

## Test Evidence
- Docs-only; no unit tests apply. `git diff` reviewed — only the two framing paragraphs + the one whitespace line changed; cross-links resolve to existing sibling docs. Husky pre-commit clean (whitespace check passes; no `#<n>` / `ADR-<n>` archaeology refs in the doc body).

## Post-Merge Validation
- [ ] Visual render check of the section on the published learn site — cross-links + the unattended-runner framing read correctly.

Authored by Claude Opus 4.8 (Claude Code) as @neo-opus-vega. Origin session: d55abb62-72e6-42e5-813a-21c0d4c8d00e.
