### PR TITLE
feat(orchestrator): consume registry dispatch pipeline (#11900)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -1,8 +1,4 @@
-// Neo + core/_export + InstanceManager bootstrap belongs to the daemon entry point
-// (`ai/daemons/orchestrator/daemon.mjs`), NOT to this consumed-class file. Class files
-// rely on `globalThis.Neo` populated by the entry-point bootstrap; importing Neo here
-// would violate the entry-point-only invariant + risk partial-namespace damage if the
-// class were ever loaded outside its entry-point's chain.
+// Class bootstrap belongs to `daemon.mjs`; this consumed class relies on global Neo.
 import fs                          from 'fs-extra';
 import {spawn}                     from 'child_process';
 import net                         from 'net';
@@ -32,8 +28,10 @@ import SwarmHeartbeatService             from './services/SwarmHeartbeatService.
 import GoldenPathSynthesizer             from '../../services/graph/GoldenPathSynthesizer.mjs';
 import {getDueTask as tenantRepoSyncGetDueTaskImport} from './scheduling/tenantRepoSync.mjs';
 import {TASK_REGISTRY}                   from './scheduling/registry.mjs';
-import {collectDueCandidates}            from './scheduling/collector.mjs';
-import {pickNextCandidate}               from './scheduling/picker.mjs';
+import {
+    buildOrchestratorSchedulingOptions,
+    runSchedulingPipeline
+} from './scheduling/pipeline.mjs';
 import {
     DEFAULT_DB_PATH,
     DEFAULT_DATA_DIR,
@@ -41,65 +39,12 @@ import {
     buildTaskDefinitions
 } from './taskDefinitions.mjs';
 
-/**
- * Resolves the dev-sync roots config while preserving env-var precedence.
- * @param {Object} options
- * @param {String|undefined|null} options.envValue Environment value.
- * @param {String[]|String|undefined|null} options.configValue Local config value.
- * @returns {String[]|String|undefined|null}
- */
-/**
- * @summary Self-bootstrapping orchestrator database open — replaces the previous
- * `wake/queries.mjs::initializeDatabase` consumption in this daemon's `start()`
- * path for fresh `npx-neo-app` workspaces with missing sqlite files.
- *
- * **Behavior contract**:
- * - Fresh workspace with absent sqlite path → creates the directory + opens the
- *   sqlite file + initializes the Memory Core graph schema (Nodes / Edges /
- *   GraphLog / triggers / SummarizationJobs), then returns the underlying
- *   better-sqlite3 handle for downstream orchestrator + wake daemon consumption.
- * - Pre-existing sqlite path with valid schema → opens cleanly (no destructive
- *   re-create; `initSchema()` self-skips when schema is already valid).
- * - Invalid/malformed dbPath → throws (orchestrator-scoped; lane-isolated
- *   failure-recovery in `start()`'s outer try handles it). **No `process.exit(1)`**
- *   from this path — that hard-exit semantic was the original failure symptom.
- *
- * **Schema parity with Memory Core MCP first-boot**: delegates to
- * `ai/graph/storage/SQLite.mjs`'s self-bootstrap chain
- * (`ensureDir` → open without `fileMustExist` → `initSchema()`), so the
- * orchestrator-bootstrapped schema is byte-equivalent to the MC-bootstrapped
- * schema. Day-2 workspaces where the user boots orchestrator before MC produce
- * the same on-disk shape as the inverse boot order.
- *
- * **Why this lives here (not in `wake/queries.mjs`):** the wake daemon's
- * `initializeDatabase` (still in `wake/queries.mjs`) intentionally keeps the
- * `fileMustExist: true` + `process.exit(1)` strict contract — the wake daemon is a child
- * task that assumes a pre-initialized DB inherited from its parent orchestrator.
- * Separating the two open-paths preserves the bridge contract (Contract Ledger
- * Row 2) while giving the orchestrator the safer self-bootstrap discipline.
- *
- * Exported for test seam — tests can inject a sync mock via the orchestrator's
- * `initializeDatabaseFn` config slot.
- *
- * @param {String} dbPath Absolute path to the sqlite file
- * @returns {Promise<Object>} better-sqlite3 database handle, schema-initialized
- * @see ai/graph/storage/SQLite.mjs — shared schema-creation primitive
- * @see ai/daemons/wake/queries.mjs — sibling strict-open primitive (preserved)
- */
+/** @summary Opens/creates the orchestrator sqlite DB via the shared Memory Core schema bootstrap. */
 export async function initializeDatabaseSelfBootstrap(dbPath) {
     const storage = Neo.create(SQLite, {dbPath});
     await storage.ready();
     return storage.db;
 }
-
-// dev-sync roots precedence used to live in two resolver helpers
-// (`resolvePrimaryDevSyncRootsConfig` + `resolvePrimaryDevSyncRootsSource`) plus a
-// caller-side `process.env[DEV_SYNC_ROOTS_ENV_VAR]` read. Both layers are removed
-// in favour of the SSOT chain: `ai/config.template.mjs::orchestrator.devSyncRoots`
-// (with `envBindings.orchestrator.devSyncRoots → NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`)
-// owns env-vs-config precedence at config-load time. Operator-instance overrides
-// flow through the `primaryDevSyncRootsConfig` Class A/B reactive config slot,
-// defaulting to the env-applied tier-1 value when the operator does not pass one.
 
 /**
  * Resolves a deployment-aware boolean toggle from `AiConfig.orchestrator.localOnly[key]`.
@@ -134,42 +79,9 @@ function resolveCloudOnlyEnabled(key) {
 /**
  * @summary Neo daemon class for Agent OS maintenance scheduling.
  *
- * `ai/daemons/orchestrator/daemon.mjs` owns the Node-process boot wrapper:
- * PID file, lifecycle traps, and fatal-start isolation. This class owns the
- * actual maintenance loop, task-state persistence, subprocess execution,
- * recovery of already-running child tasks, and task outcome reporting through
- * `HealthService.recordTaskOutcome(...)`.
- *
- * Failure isolation is per task: summary scheduling and KB-sync scheduling are
- * wrapped independently so a thrown sunset-handover read or summary success hook
- * cannot stop the KB-sync lane, and a KB-sync failure cannot stop the next summary
- * sweep.
- *
- * **Service-DI 4-way classification:**
- * - **(A) Parent-configured child collaborator** — `processSupervisorService_`
- *   reactive config with `beforeSet` creation from parent-sourced config + parent
- *   `afterSet*` propagation hooks for `dataDir`/`taskDefinitions`/`taskStateService`/
- *   `healthService`/`spawnFn` so subsequent parent mutations flow to the child.
- * - **(B) Simple imported collaborator** — direct-import instance fields
- *   (`primaryRepoSyncService`, `tenantRepoSyncService`, `dreamService`, etc.) for class-shaped execution
- *   collaborators, and function-typed instance fields
- *   (`summaryGetDueTask`, `backupGetDueTask`, `graphLogCompactionGetDueTask`,
- *   `primaryDevSyncGetDueTask`, `tenantRepoSyncGetDueTask`, `dreamGetDueTask`,
- *   `goldenPathGetDueTask`) for
- *   pure-function scheduling triggers from `./scheduling/<task>.mjs` — no
- *   class-system conversion, no parent-child propagation, no lifecycle side effect.
- *   The function-typed fields default to the imported pure functions so tests can
- *   override the seam without touching module-level mocks.
- * - **(C) Operator policy value** — pure config values (intervals, ports, model/host,
- *   cadence/jitter) are read inline as `AiConfig.<path>` at their call sites; the env
- *   override is layered into the aiConfig substrate at config-load time, so there is no
- *   per-access env probe and no delegation getter re-exposing them. A few getters remain
- *   for values carrying real logic (deployment-mode resolution, list-parsing, or a direct
- *   runtime-identity read — `swarmHeartbeatIdentity` reads `NEO_AGENT_IDENTITY`).
- *
- * No `configure()` shadow-resolver. No `DEFAULT_X_*_MS` constants. No
- * `parseInterval`/`parseEnabledFlag` helpers. No `processSupervisorService.set({...this...})`
- * context-replay block in `start()`.
+ * The process wrapper lives in `daemon.mjs`; cadence decisions and descriptor
+ * dispatch live in `scheduling/*`. This class keeps boot, continuous-daemon
+ * supervision, and the timer loop thin.
  *
  * @class Neo.ai.daemons.Orchestrator
  * @extends Neo.core.Base
@@ -181,65 +93,18 @@ function resolveCloudOnlyEnabled(key) {
  */
 export class Orchestrator extends Base {
     static config = {
-        /**
-         * @member {String} className='Neo.ai.daemons.Orchestrator'
-         * @protected
-         */
         className: 'Neo.ai.daemons.Orchestrator',
-        /**
-         * @member {Boolean} singleton=true
-         * @protected
-         */
         singleton: true,
-
-        // === Service-DI Class A: parent-configured child collaborator + propagated parent props ===
-        /**
-         * @member {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} processSupervisorService_=null
-         * @reactive
-         */
         processSupervisorService_: null,
-        /**
-         * @member {Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService|Object|null} maintenanceBackpressureService_=MaintenanceBackpressureService
-         * @reactive
-         */
         maintenanceBackpressureService_: MaintenanceBackpressureService,
-        /**
-         * @member {String} dataDir_=DEFAULT_DATA_DIR
-         * @reactive
-         */
         dataDir_: DEFAULT_DATA_DIR,
-        /**
-         * @member {Object|null} taskDefinitions_=null
-         * @reactive
-         */
         taskDefinitions_: null,
-        /**
-         * @member {Object} taskStateService_=TaskStateService
-         * @reactive
-         */
         taskStateService_: TaskStateService,
-        /**
-         * @member {Object} healthService_=HealthService
-         * @reactive
-         */
         healthService_: HealthService,
-        /**
-         * @member {Function} spawnFn_=spawn
-         * @reactive
-         */
         spawnFn_: spawn,
-        /**
-         * Shared heavy-maintenance lease file path. Reactive so `start()` overrides
-         * propagate to the MaintenanceBackpressureService instance via
-         * `afterSetHeavyMaintenanceLeasePath`; otherwise the public `start()` option
-         * would be silently disconnected from the service that uses it.
-         * @member {String|null} heavyMaintenanceLeasePath_=null
-         * @reactive
-         */
         heavyMaintenanceLeasePath_: null
     }
 
-    // === Service-DI Class B: simple imported collaborators (instance fields) ===
     primaryRepoSyncService   = PrimaryRepoSyncService
     tenantRepoSyncService    = TenantRepoSyncService
     dreamService             = DreamService
@@ -254,7 +119,6 @@ export class Orchestrator extends Base {
     dreamGetDueTask          = dreamGetDueTaskImport
     goldenPathGetDueTask     = goldenPathGetDueTaskImport
 
-    // === Instance state (mutated at runtime; non-reactive) ===
     isPolling                     = false
     pollHandle                    = null
     db                            = null
@@ -266,21 +130,9 @@ export class Orchestrator extends Base {
     heavyMaintenanceTaskNames     = DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
     goldenPathDependencyTaskNames = DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 
-    /**
-     * Stable logger seam for the processSupervisorService writeLog config slot.
-     * Avoids per-call `.bind(this)` allocation drift.
-     * @member {Function} processSupervisorWriteLog
-     */
     processSupervisorWriteLog = (level, msg) => this.writeLog(level, msg)
-
-    /**
-     * Stable logger seam for the maintenanceBackpressureService writeLog binding.
-     * Mirrors `processSupervisorWriteLog` — same rationale, same shape.
-     * @member {Function} maintenanceBackpressureWriteLog
-     */
     maintenanceBackpressureWriteLog = (level, msg) => this.writeLog(level, msg)
 
-    // === Service-DI Class A: processSupervisorService + maintenanceBackpressureService beforeSet + parent afterSet propagation ===
     /**
      * @param {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} value
      * @returns {Neo.ai.daemons.services.ProcessSupervisorService}
@@ -296,22 +148,6 @@ export class Orchestrator extends Base {
         });
     }
 
-    /**
-     * Wires a per-Orchestrator MaintenanceBackpressureService instance with
-     * parent context at creation time. Subsequent parent-prop changes flow via
-     * direct reactive-config assignment on the MBS instance (e.g.
-     * `this.maintenanceBackpressureService.taskStateService = value`) from the
-     * matching `afterSetX` hooks below. The cloud multi-repo Orchestrator
-     * variant (one Orchestrator polling N tenant repos) likewise re-assigns
-     * MBS reactive configs per poll cycle to switch context.
-     *
-     * MBS is per-instance (not singleton) because it requires external
-     * configuration — singleton classes self-contain their config; classes
-     * that need parent-injected configuration are per-instance.
-     *
-     * @param {Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService|Object|null} value
-     * @returns {Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService}
-     */
     beforeSetMaintenanceBackpressureService(value) {
         return ClassSystemUtil.beforeSetInstance(value, MaintenanceBackpressureService, {
             heavyMaintenanceTaskNames    : this.heavyMaintenanceTaskNames,
@@ -354,21 +190,7 @@ export class Orchestrator extends Base {
         this.maintenanceBackpressureService.heavyMaintenanceLeasePath = value;
     }
 
-    // === Operator policy values — config-template + envBindings is the SSOT ===
-    // Pure config values (intervals, ports, model/host, cadence/jitter) are read inline as
-    // `AiConfig.<path>` at their call sites — no delegation getters re-expose them. Env vars are
-    // declared on `ai/config.template.mjs::envBindings.orchestrator.*` and applied at config-load
-    // time; there is no per-access env probe. The getters below carry real logic
-    // (deployment-mode resolution, coercion, env reads, list-parsing), so they remain.
     get swarmHeartbeatIdentity()      { return process.env.NEO_AGENT_IDENTITY?.trim() || undefined; }
-    /**
-     * Explicit env-driven target list for the swarm-heartbeat resolver. Comma-separated
-     * `@handle` form via `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGETS`. Empty or absent →
-     * `null` so the resolver falls through to `targetSource` semantics. The raw string
-     * arrives via `AiConfig.orchestrator.swarmHeartbeat.targets`; this getter splits +
-     * trims because the array-shape parsing is consumer-side concern, not config-shape.
-     * @returns {String[]|null}
-     */
     get swarmHeartbeatExplicitTargets() {
         const raw = AiConfig.orchestrator.swarmHeartbeat.targets;
         if (!raw) return null;
@@ -385,33 +207,12 @@ export class Orchestrator extends Base {
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
     get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction.enabled;      }
 
-    // MLX + LM Studio CLI inference-server lane config. Canonical defaults + env overrides
-    // live in `ai/config.template.mjs::orchestrator.{mlx,lms}` + `envBindings.orchestrator.{mlx,lms}`.
     get mlxEnabled() { return !!AiConfig.orchestrator.mlx.enabled; }
     get lmsEnabled() { return !!AiConfig.orchestrator.lms.enabled; }
     get lmsPreloadConfig() { return buildLmsPreloadConfig(AiConfig); }
     get lmsModels()        { return this.lmsPreloadConfig.models;      }
 
-    /**
-     * Starts the orchestrator process loop after the wrapper has selected this process.
-     *
-     * Lane-internal config (intervals, enable flags, mlx/lms server tuning) is NOT read
-     * from `options`. The Orchestrator owns those via getters that consult env vars +
-     * `AiConfig.orchestrator.X` directly. Test fixtures override individual lane configs
-     * via env vars or by stubbing the getter on a test instance.
-     *
-     * @param {Object} [options] Boot-wrapper paths + harness/process seams.
-     * @param {String} [options.scriptDir]
-     * @param {String} [options.dataDir]
-     * @param {String} [options.dbPath]
-     * @param {String} [options.logFile]
-     * @param {String} [options.stateFile]
-     * @param {String} [options.heavyMaintenanceLeasePath]
-     * @param {Object} [options.taskDefinitions] Pre-built task definitions (test-injection).
-     * @param {String} [options.nodeBin]
-     * @param {String[]|String|null} [options.primaryDevSyncRootsConfig]
-     * @returns {Promise<void>}
-     */
+    /** @summary Starts the orchestrator timer loop after the wrapper selects this process. */
     async start(options = {}) {
         if (this.isPolling) {
             this.writeLog('INFO', '[Orchestrator] Already polling; start() is a no-op.');
@@ -421,8 +222,6 @@ export class Orchestrator extends Base {
         const scriptDir = options.scriptDir || DEFAULT_SCRIPT_DIR;
         const dataDir   = options.dataDir   || DEFAULT_DATA_DIR;
 
-        // Set reactive parent props FIRST so afterSet* propagation lands when
-        // processSupervisorService gets re-created below.
         this.dataDir           = dataDir;
         const lmsPreloadConfig = this.lmsPreloadConfig;
         this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
@@ -442,7 +241,6 @@ export class Orchestrator extends Base {
             graphLogCompactionVacuum: AiConfig.orchestrator.graphLogCompaction.vacuum
         });
 
-        // Non-reactive boot-wrapper-provided instance state
         this.dbPath                    = options.dbPath   || DEFAULT_DB_PATH;
         this.logFile                   = options.logFile  || path.join(dataDir, 'orchestrator.log');
         this.stateFile                 = options.stateFile || path.join(dataDir, 'orchestrator-state.json');
@@ -451,14 +249,6 @@ export class Orchestrator extends Base {
             ? options.primaryDevSyncRootsConfig
             : AiConfig.orchestrator.devSyncRoots;
         this.maintenanceDeferralLogKeys = new Set();
-        // Chroma max-runtime recycle: process-local (non-persisted) flags.
-        // `_chromaDefragPending` gates the post-restart defrag; `_chromaDefragInFlight` prevents
-        // poll re-entry during the readiness probe. The defrag is BEST-EFFORT: if the orchestrator
-        // restarts after killTask but before the defrag fires, the flag is lost and the defrag is
-        // skipped for that cycle — the next max-runtime recycle compacts the store. This is sound
-        // for an idempotent compaction step (persisting the intent would instead introduce a
-        // pending-forever / endless-retry failure mode); the kill→restart, the primary recycle
-        // value, is unaffected by an orchestrator restart.
         this._chromaDefragPending  = false;
         this._chromaDefragInFlight = false;
 
@@ -470,26 +260,13 @@ export class Orchestrator extends Base {
             writeLogFn     : this.writeLog.bind(this)
         });
 
-        // Trigger processSupervisorService creation via reactive setter (beforeSet reads
-        // current parent state). The static-config-block `processSupervisorService_: null`
-        // does pre-create at construct time with default parent state; this re-creates
-        // with the now-correct options-derived state. After this point, parent mutations
-        // flow through afterSet* propagation hooks.
         this.processSupervisorService = {};
         this.processSupervisorService.recoverTasks();
 
         this.db = await this.initializeDatabaseFn(this.dbPath);
 
-        // One-time swarm-heartbeat lane init. An init failure must log but
-        // NOT crash the Orchestrator — the lane disables itself for this run via the
-        // daemon-local `initFailed` instance field (preserves fail-safe invariant
-        // without env-registry mutation; `poll()` swarm-heartbeat lane checks it).
         if (this.swarmHeartbeatEnabled) {
             try {
-                // Set pulse-time runtime config on the singleton BEFORE awaiting ready().
-                // initAsync() is identity-agnostic (peer-service .ready() only); identity
-                // and pollIntervalMs are read by pulse() per tick, so post-init assignment
-                // is sufficient. Order matches the JSDoc contract on the service class.
                 this.swarmHeartbeatService.identity        = this.swarmHeartbeatIdentity;
                 this.swarmHeartbeatService.pollIntervalMs  = AiConfig.orchestrator.intervals.swarmHeartbeatMs;
                 this.swarmHeartbeatService.targetSource    = AiConfig.orchestrator.swarmHeartbeat.targetSource;
@@ -542,63 +319,14 @@ export class Orchestrator extends Base {
         }
     }
 
-    /**
-     * Wraps a task executor with cross-task heavy-maintenance backpressure by delegating
-     * to {@link MaintenanceBackpressureService#acquireLeaseAndExecute}. MBS owns the
-     * two-tier backpressure (intra-process `activeHeavyTask` tracker + inter-process
-     * file lease at `heavyMaintenanceLeasePath`) + deferral logging + lease lifecycle.
-     * Class A propagation keeps MBS bindings synced with parent Orchestrator state.
-     *
-     * @param {Function} executeFn Task executor; receives `(taskName, reason, onSuccess, options)`.
-     * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
-     * @returns {Function}
-     */
-    createMaintenanceExecutor(executeFn, activeHeavyTask) {
-        return (taskName, reason, onSuccess) =>
-            this.maintenanceBackpressureService.acquireLeaseAndExecute({
-                taskName, executeFn, reason, onSuccess, activeHeavyTask
-            });
-    }
-
-    /**
-     * Wraps Golden Path execution with dependency ordering via
-     * {@link MaintenanceBackpressureService#executeWithGoldenPathDependencyGate}.
-     * @param {Function} executeFn Task executor.
-     * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
-     * @returns {Function}
-     */
-    createGoldenPathExecutor(executeFn, activeHeavyTask) {
-        return (taskName, reason) =>
-            this.maintenanceBackpressureService.executeWithGoldenPathDependencyGate({
-                taskName, executeFn, reason, activeHeavyTask
-            });
-    }
-
-    /**
-     * Whether the supervised Chroma daemon's uptime has exceeded the configured recycle
-     * ceiling. Pure predicate over task state + `chromaMaxRuntimeMs`; a `0`/absent ceiling
-     * disables recycling.
-     * @param {Object} state Chroma task state ({running, lastRunAt}).
-     * @param {Number} now Epoch ms.
-     * @returns {Boolean}
-     */
+    /** @summary Returns true when the Chroma supervised process exceeds max runtime. */
     isChromaRecycleDue(state, now) {
         const maxRuntimeMs = AiConfig.orchestrator.chroma.maxRuntimeMs;
         const lastRunAt    = state?.lastRunAt || 0;
-        // lastRunAt === 0 means no recorded spawn (uninitialized / never started): uptime is
-        // undefined, so never recycle. A genuinely running daemon always carries a real start
-        // stamp (markStarted), so this only excludes inconsistent/uninitialized state.
         return Boolean(state?.running) && maxRuntimeMs > 0 && lastRunAt > 0 && (now - lastRunAt) > maxRuntimeMs;
     }
 
-    /**
-     * Resolves true once a TCP connection to the local Chroma port succeeds — a
-     * connection-ready proxy mirroring the integration stack's `/dev/tcp` healthcheck.
-     * Overridable in tests; never rejects.
-     * @param {Object} [options]
-     * @param {Number} [options.timeoutMs=2000] Probe timeout.
-     * @returns {Promise<Boolean>}
-     */
+    /** @summary Resolves true when Chroma's TCP port accepts a connection. */
     probeChromaReady({timeoutMs = 2000} = {}) {
         return new Promise(resolve => {
             const socket = net.connect({host: 'localhost', port: AiConfig.engines.chroma.port});
@@ -607,355 +335,6 @@ export class Orchestrator extends Base {
             socket.once('connect', () => finish(true));
             socket.once('timeout', () => finish(false));
             socket.once('error',   () => finish(false));
-        });
-    }
-
-    /**
-     * @summary Builds the read-only scheduling context consumed by the registry descriptors.
-     *
-     * The `enables` map reads Orchestrator getter SSOTs at the use site, so cloud/local
-     * policy stays aligned with `AiConfig` without duplicating deployment rules inside
-     * static descriptors or the picker.
-     *
-     * @param {Number} now Epoch milliseconds for this poll cycle.
-     * @returns {Object} Uniform collector context for `TASK_REGISTRY`.
-     */
-    buildSchedulingContext(now) {
-        return {
-            db       : this.db,
-            state    : this.taskStateService.getState(),
-            now,
-            intervals: {
-                summarySweep          : AiConfig.orchestrator.intervals.summarySweepMs,
-                kbSync                : AiConfig.orchestrator.intervals.kbSyncMs,
-                backup                : AiConfig.orchestrator.intervals.backupMs,
-                graphLogCompaction    : AiConfig.orchestrator.intervals.graphLogCompactionMs,
-                primaryDevSync        : AiConfig.orchestrator.intervals.primaryDevSyncMs,
-                tenantRepoSync        : AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs,
-                dream                 : AiConfig.orchestrator.intervals.dreamMs,
-                dreamOverflowThreshold: AiConfig.orchestrator.intervals.dreamOverflowThreshold,
-                goldenPath            : AiConfig.orchestrator.intervals.goldenPathMs,
-                swarmHeartbeat        : AiConfig.orchestrator.intervals.swarmHeartbeatMs
-            },
-            enables: {
-                kbSync             : this.kbSyncEnabled,
-                graphLogCompaction : this.graphLogCompactionEnabled,
-                primaryDevSync     : this.primaryDevSyncEnabled,
-                tenantRepoSync     : this.tenantRepoSyncEnabled,
-                swarmHeartbeat     : this.swarmHeartbeatEnabled
-            },
-            hooks: {
-                log                       : this.writeLog.bind(this),
-                summaryGetDueTask         : this.summaryGetDueTask,
-                backupGetDueTask          : this.backupGetDueTask,
-                graphLogCompactionGetDueTask: this.graphLogCompactionGetDueTask,
-                primaryDevSyncGetDueTask  : this.primaryDevSyncGetDueTask,
-                tenantRepoSyncGetDueTask  : this.tenantRepoSyncGetDueTask,
-                dreamGetDueTask           : this.dreamGetDueTask,
-                goldenPathGetDueTask      : this.goldenPathGetDueTask,
-                swarmHeartbeatGetDueTask  : this.swarmHeartbeatGetDueTask,
-                swarmHeartbeatInitFailed  : !!this.swarmHeartbeatService.initFailed
-            }
-        };
-    }
-
-    /**
-     * @summary Reports scheduling projection failures with the same isolation semantics
-     * formerly provided by `CadenceEngine.runIfDue`.
-     * @param {Object[]} errors Collector error envelopes.
-     * @returns {void}
-     */
-    recordSchedulingErrors(errors) {
-        for (const {taskName, error} of errors) {
-            this.writeLog?.('ERROR', `[Orchestrator] ${taskName} scheduling failed: ${error.message}`);
-            this.healthService?.recordTaskOutcome?.(taskName, 'failed', {
-                phase: 'schedule',
-                error: error.message
-            });
-        }
-    }
-
-    /**
-     * @summary Resolves running task names from the persisted task-state envelope.
-     * @param {Object} state Current task-state map.
-     * @returns {String[]} Running task names.
-     */
-    getRunningTaskNames(state) {
-        return Object.keys(state).filter(taskName => state[taskName]?.running);
-    }
-
-    /**
-     * @summary Resolves running heavy tasks for picker policy without extending
-     * `TaskStateService`'s public API.
-     * @param {String[]} runningTaskNames Running task names.
-     * @returns {Set<String>} Running heavy task names.
-     */
-    getRunningHeavyTaskNames(runningTaskNames) {
-        return new Set(
-            runningTaskNames.filter(taskName => this.maintenanceBackpressureService.isHeavyMaintenanceTask(taskName))
-        );
-    }
-
-    /**
-     * @summary Records observable deferrals for candidates the pure picker will filter.
-     *
-     * `pickNextCandidate` must stay a side-effect-free selector. The Orchestrator still
-     * owns operator-visible deferral telemetry, so it mirrors the picker filters that
-     * correspond to existing backpressure outcomes before selecting the winner.
-     *
-     * @param {Object[]} candidates Due candidates before picker filtering.
-     * @param {String[]} runningTaskNames Running task names.
-     * @param {Set<String>} runningHeavyTasks Running heavy task names.
-     * @returns {void}
-     */
-    recordPickerDeferrals(candidates, runningTaskNames, runningHeavyTasks) {
-        const runningSet        = new Set(runningTaskNames);
-        const blockingHeavyTask = runningHeavyTasks.values().next().value;
-
-        for (const candidate of candidates) {
-            if (runningSet.has(candidate.taskName)) continue;
-
-            if (blockingHeavyTask && candidate.descriptor.maintenanceClass === 'heavy') {
-                this.maintenanceBackpressureService.recordDeferral({
-                    taskName        : candidate.taskName,
-                    reasonCode      : 'heavy-maintenance-backpressure',
-                    reasonText      : candidate.trigger.reason,
-                    blockingTaskName: blockingHeavyTask
-                });
-                continue;
-            }
-
-            const blockingDependency = (candidate.descriptor.dependencies || [])
-                .find(taskName => runningSet.has(taskName));
-
-            if (blockingDependency) {
-                this.maintenanceBackpressureService.recordDeferral({
-                    taskName        : candidate.taskName,
-                    reasonCode      : 'golden-path-dependency-backpressure',
-                    reasonText      : candidate.trigger.reason,
-                    blockingTaskName: blockingDependency
-                });
-            }
-        }
-    }
-
-    /**
-     * @summary Executes the selected registry candidate via the dispatch surface declared
-     * by its descriptor.
-     * @param {Object} candidate Winner from `pickNextCandidate`.
-     * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
-     * @returns {*}
-     */
-    executeCandidate(candidate, activeHeavyTask) {
-        const dispatch = {
-            'supervised-child-process': () => this.executeSupervisedCandidate(candidate, activeHeavyTask),
-            'service-runner'          : () => this.executeServiceRunnerCandidate(candidate, activeHeavyTask),
-            'in-process-async'        : () => this.executeInProcessCandidate(candidate, activeHeavyTask)
-        };
-
-        const execute = dispatch[candidate.descriptor.executionKind];
-
-        if (!execute) {
-            this.recordUnsupportedCandidate(candidate, `Unsupported executionKind: ${candidate.descriptor.executionKind}`);
-            return false;
-        }
-
-        return execute();
-    }
-
-    /**
-     * @param {Object} candidate Supervised child-process candidate.
-     * @param {Object} activeHeavyTask Mutable active-heavy tracker.
-     * @returns {*}
-     */
-    executeSupervisedCandidate(candidate, activeHeavyTask) {
-        const {taskName, trigger} = candidate;
-        return this.createMaintenanceExecutor(
-            this.processSupervisorService.runTask.bind(this.processSupervisorService),
-            activeHeavyTask
-        )(taskName, trigger.reason, trigger.onSuccess);
-    }
-
-    /**
-     * @param {Object} candidate Service-backed candidate.
-     * @param {Object} activeHeavyTask Mutable active-heavy tracker.
-     * @returns {*}
-     */
-    executeServiceRunnerCandidate(candidate, activeHeavyTask) {
-        const runners = {
-            'primary-dev-sync': (taskName, reason) => this.primaryRepoSyncService.runTask({
-                taskName,
-                reason,
-                taskStateService  : this.taskStateService,
-                healthService     : this.healthService,
-                writeLog          : this.writeLog.bind(this),
-                devSyncRootsConfig: this.primaryDevSyncRootsConfig
-            }),
-            'tenant-repo-sync': (taskName, reason) => this.tenantRepoSyncService.runTask({
-                taskName,
-                reason,
-                taskStateService: this.taskStateService,
-                healthService   : this.healthService,
-                writeLog        : this.writeLog.bind(this),
-                globalCadenceMs : AiConfig.orchestrator.intervals.tenantRepoSyncMs,
-                jitterRatio     : AiConfig.orchestrator.tenantRepoSync.jitterRatio
-            })
-        };
-
-        const executeFn = runners[candidate.taskName];
-        if (!executeFn) {
-            this.recordUnsupportedCandidate(candidate, `Unsupported service-runner task: ${candidate.taskName}`);
-            return false;
-        }
-
-        return this.createMaintenanceExecutor(executeFn, activeHeavyTask)(
-            candidate.taskName,
-            candidate.trigger.reason,
-            candidate.trigger.onSuccess
-        );
-    }
-
-    /**
-     * @param {Object} candidate In-process async candidate.
-     * @param {Object} activeHeavyTask Mutable active-heavy tracker.
-     * @returns {*}
-     */
-    executeInProcessCandidate(candidate, activeHeavyTask) {
-        const runners = {
-            dream          : (taskName, reason) => this.runDreamTask(taskName, reason),
-            'golden-path'  : (taskName, reason) => this.runGoldenPathTask(taskName, reason),
-            'swarm-heartbeat': (taskName, reason) => this.runSwarmHeartbeatTask(taskName, reason)
-        };
-
-        const executeFn = runners[candidate.taskName];
-        if (!executeFn) {
-            this.recordUnsupportedCandidate(candidate, `Unsupported in-process task: ${candidate.taskName}`);
-            return false;
-        }
-
-        if (candidate.taskName === 'golden-path') {
-            return this.createGoldenPathExecutor(executeFn, activeHeavyTask)(
-                candidate.taskName,
-                candidate.trigger.reason
-            );
-        }
-
-        if (candidate.taskName === 'swarm-heartbeat') {
-            return executeFn(candidate.taskName, candidate.trigger.reason);
-        }
-
-        return this.createMaintenanceExecutor(executeFn, activeHeavyTask)(
-            candidate.taskName,
-            candidate.trigger.reason,
-            candidate.trigger.onSuccess
-        );
-    }
-
-    /**
-     * @param {String} taskName Task name.
-     * @param {String} reason Scheduling reason.
-     * @returns {Promise<void>}
-     */
-    async runDreamTask(taskName, reason) {
-        this.taskStateService.markStarted(taskName, reason);
-        this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
-
-        const outcome = await this.dreamService.executeRemCycle({
-            reason,
-            mode        : 'periodic',
-            includeDecay: true
-        });
-
-        const recordPayload = {
-            reason,
-            completedAt      : outcome.completedAt,
-            durationMs       : outcome.durationMs,
-            sessionsProcessed: outcome.sessionsProcessed,
-            runId            : outcome.runId
-        };
-
-        switch (outcome.status) {
-            case 'completed':
-                this.taskStateService.markCompleted(taskName);
-                this.healthService?.recordTaskOutcome?.(taskName, 'completed', recordPayload);
-                break;
-            case 'skipped':
-                this.taskStateService.markCompleted(taskName);
-                this.healthService?.recordTaskOutcome?.(taskName, 'skipped', {
-                    ...recordPayload,
-                    skipReason: outcome.skipReason
-                });
-                break;
-            case 'failed': {
-                const state = this.taskStateService.getTaskState(taskName);
-                if (state) {
-                    state.lastReason = outcome.diagnostic?.reason || outcome.error?.message;
-                }
-                this.taskStateService.markFailed(taskName, 1);
-                this.healthService?.recordTaskOutcome?.(taskName, 'failed', {
-                    ...recordPayload,
-                    failedAt    : outcome.completedAt,
-                    failurePhase: outcome.diagnostic ? 'provider-readiness' : 'in-pipeline',
-                    diagnostic  : outcome.diagnostic,
-                    error       : outcome.error?.message
-                });
-                break;
-            }
-        }
-    }
-
-    /**
-     * @param {String} taskName Task name.
-     * @param {String} reason Scheduling reason.
-     * @returns {Promise<void>}
-     */
-    async runGoldenPathTask(taskName, reason) {
-        this.taskStateService.markStarted(taskName, reason);
-        this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
-        try {
-            await this.goldenPathSynthesizer.synthesizeGoldenPath({
-                repoEnrichmentEnabled: this.goldenPathRepoEnrichmentEnabled
-            });
-            this.taskStateService.markCompleted(taskName);
-            this.healthService?.recordTaskOutcome?.(taskName, 'completed', { reason, completedAt: new Date().toISOString() });
-        } catch (e) {
-            const state = this.taskStateService.getTaskState(taskName);
-            if (state) state.lastReason = e.message;
-            this.taskStateService.markFailed(taskName, 1);
-            this.healthService?.recordTaskOutcome?.(taskName, 'failed', { reason, error: e.message, failedAt: new Date().toISOString() });
-        }
-    }
-
-    /**
-     * @param {String} taskName Task name.
-     * @param {String} reason Scheduling reason.
-     * @returns {Promise<void>}
-     */
-    async runSwarmHeartbeatTask(taskName, reason) {
-        this.taskStateService.markStarted(taskName, reason);
-        this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
-        try {
-            await this.swarmHeartbeatService.pulse();
-            this.taskStateService.markCompleted(taskName);
-            this.healthService?.recordTaskOutcome?.(taskName, 'completed', { reason, completedAt: new Date().toISOString() });
-        } catch (e) {
-            const state = this.taskStateService.getTaskState(taskName);
-            if (state) state.lastReason = e.message;
-            this.taskStateService.markFailed(taskName, 1);
-            this.healthService?.recordTaskOutcome?.(taskName, 'failed', { reason, error: e.message, failedAt: new Date().toISOString() });
-        }
-    }
-
-    /**
-     * @param {Object} candidate Unsupported candidate.
-     * @param {String} error Error text.
-     * @returns {void}
-     */
-    recordUnsupportedCandidate(candidate, error) {
-        this.writeLog?.('ERROR', `[Orchestrator] ${error}`);
-        this.healthService?.recordTaskOutcome?.(candidate.taskName, 'failed', {
-            phase: 'dispatch',
-            error
         });
     }
 
@@ -975,31 +354,18 @@ export class Orchestrator extends Base {
         ];
         const RESTART_COOLDOWN_MS = 15000;
         for (const taskName of continuousTasks) {
-            // Singularity guard: reap any duplicate listeners on a singleton-port task's
-            // port (chroma) before the spawn check, so exactly one daemon stays alive.
             this.processSupervisorService.reapDuplicateListeners(taskName);
 
             const state = this.taskStateService.getTaskState(taskName);
 
-            // Max-runtime recycle: kill an over-age chroma daemon (SIGKILL — chroma
-            // ignores SIGTERM) so the restart branch below respawns it; the KB defrag fires
-            // once the fresh daemon is connection-ready. Implicitly gated by chromaDaemonEnabled
-            // (chroma is only a continuousTask when that lane is enabled).
             if (taskName === 'chroma' && this.isChromaRecycleDue(state, now)) {
                 this.processSupervisorService.killTask('chroma', `max-runtime:${now - (state.lastRunAt || 0)}ms>${AiConfig.orchestrator.chroma.maxRuntimeMs}ms`);
                 this._chromaDefragPending = true;
                 continue;
             }
 
-            // Liveness-gated (re)start is owned by the supervisor: process-match by default, or a
-            // task-owned liveness probe for a fire-and-exit lane whose served process persists
-            // out-of-band (so the running flag never recovers and a process match would loop).
             this.processSupervisorService.superviseTask(taskName, now, RESTART_COOLDOWN_MS);
 
-            // Post-recycle defrag: once the restarted chroma is connection-ready, run
-            // the unified-store-safe KB defrag against the fresh daemon. MC defrag is deferred
-            // because it has no rebuild-from-source fallback. The in-flight guard prevents
-            // poll re-entry while the async readiness probe is pending.
             if (taskName === 'chroma' && state?.running && this._chromaDefragPending && !this._chromaDefragInFlight) {
                 this._chromaDefragInFlight = true;
                 this.probeChromaReady()
@@ -1014,32 +380,9 @@ export class Orchestrator extends Base {
             }
         }
 
-        const schedulingContext = this.buildSchedulingContext(now);
-        const {candidates, errors} = collectDueCandidates({
-            registry: TASK_REGISTRY,
-            context : schedulingContext
+        runSchedulingPipeline({
+            ...buildOrchestratorSchedulingOptions({orchestrator: this, config: AiConfig, now, registry: TASK_REGISTRY})
         });
-
-        this.recordSchedulingErrors(errors);
-
-        const runningTaskNames  = this.getRunningTaskNames(schedulingContext.state);
-        const runningHeavyTasks = this.getRunningHeavyTaskNames(runningTaskNames);
-
-        this.recordPickerDeferrals(candidates, runningTaskNames, runningHeavyTasks);
-
-        const winner = pickNextCandidate({
-            candidates,
-            runningTasks  : runningTaskNames,
-            policyContext : {
-                runningHeavyTasks
-            }
-        });
-
-        if (winner) {
-            this.executeCandidate(winner, {
-                name: this.maintenanceBackpressureService.getActiveHeavyMaintenanceTask()
-            });
-        }
 
         if (this.isPolling) {
             this.pollHandle = setTimeout(() => this.poll(), AiConfig.orchestrator.intervals.pollMs);

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -23,14 +23,17 @@ import {getDueTask as summaryGetDueTaskImport}        from './scheduling/summary
 import {getDueTask as backupGetDueTaskImport}         from './scheduling/backup.mjs';
 import {getDueTask as graphLogCompactionGetDueTaskImport} from './scheduling/graphLogCompaction.mjs';
 import {getDueTask as primaryDevSyncGetDueTaskImport} from './scheduling/primaryDevSync.mjs';
+import {getDueTask as goldenPathGetDueTaskImport} from './scheduling/goldenPath.mjs';
 import {getDueTask as dreamGetDueTaskImport}          from './scheduling/dream.mjs';
 import TaskStateService                  from './services/TaskStateService.mjs';
 import ProcessSupervisorService          from './services/ProcessSupervisorService.mjs';
-import CadenceEngine                     from './services/CadenceEngine.mjs';
 import DreamService                      from './services/DreamService.mjs';
 import SwarmHeartbeatService             from './services/SwarmHeartbeatService.mjs';
 import GoldenPathSynthesizer             from '../../services/graph/GoldenPathSynthesizer.mjs';
 import {getDueTask as tenantRepoSyncGetDueTaskImport} from './scheduling/tenantRepoSync.mjs';
+import {TASK_REGISTRY}                   from './scheduling/registry.mjs';
+import {collectDueCandidates}            from './scheduling/collector.mjs';
+import {pickNextCandidate}               from './scheduling/picker.mjs';
 import {
     DEFAULT_DB_PATH,
     DEFAULT_DATA_DIR,
@@ -143,23 +146,21 @@ function resolveCloudOnlyEnabled(key) {
  * sweep.
  *
  * **Service-DI 4-way classification:**
- * - **(A) Class-system-managed utility collaborator** — `cadenceEngine_` reactive
- *   config with `beforeSet` + `ClassSystemUtil.beforeSetInstance` for polymorphic
- *   class/instance/config-object input and proper lifecycle on swap.
- * - **(B) Parent-configured child collaborator** — `processSupervisorService_`
+ * - **(A) Parent-configured child collaborator** — `processSupervisorService_`
  *   reactive config with `beforeSet` creation from parent-sourced config + parent
  *   `afterSet*` propagation hooks for `dataDir`/`taskDefinitions`/`taskStateService`/
  *   `healthService`/`spawnFn` so subsequent parent mutations flow to the child.
- * - **(C) Simple imported collaborator** — direct-import instance fields
- *   (`primaryRepoSyncService`, `dreamService`, etc.) for class-shaped execution
+ * - **(B) Simple imported collaborator** — direct-import instance fields
+ *   (`primaryRepoSyncService`, `tenantRepoSyncService`, `dreamService`, etc.) for class-shaped execution
  *   collaborators, and function-typed instance fields
  *   (`summaryGetDueTask`, `backupGetDueTask`, `graphLogCompactionGetDueTask`,
- *   `primaryDevSyncGetDueTask`, `dreamGetDueTask`) for
+ *   `primaryDevSyncGetDueTask`, `tenantRepoSyncGetDueTask`, `dreamGetDueTask`,
+ *   `goldenPathGetDueTask`) for
  *   pure-function scheduling triggers from `./scheduling/<task>.mjs` — no
  *   class-system conversion, no parent-child propagation, no lifecycle side effect.
  *   The function-typed fields default to the imported pure functions so tests can
  *   override the seam without touching module-level mocks.
- * - **(D) Operator policy value** — pure config values (intervals, ports, model/host,
+ * - **(C) Operator policy value** — pure config values (intervals, ports, model/host,
  *   cadence/jitter) are read inline as `AiConfig.<path>` at their call sites; the env
  *   override is layered into the aiConfig substrate at config-load time, so there is no
  *   per-access env probe and no delegation getter re-exposing them. A few getters remain
@@ -191,14 +192,7 @@ export class Orchestrator extends Base {
          */
         singleton: true,
 
-        // === Service-DI Class A: class-system-managed utility collaborator ===
-        /**
-         * @member {Neo.ai.daemons.services.CadenceEngine|Object|null} cadenceEngine_=null
-         * @reactive
-         */
-        cadenceEngine_: null,
-
-        // === Service-DI Class B: parent-configured child collaborator + propagated parent props ===
+        // === Service-DI Class A: parent-configured child collaborator + propagated parent props ===
         /**
          * @member {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} processSupervisorService_=null
          * @reactive
@@ -245,7 +239,7 @@ export class Orchestrator extends Base {
         heavyMaintenanceLeasePath_: null
     }
 
-    // === Service-DI Class C: simple imported collaborators (instance fields) ===
+    // === Service-DI Class B: simple imported collaborators (instance fields) ===
     primaryRepoSyncService   = PrimaryRepoSyncService
     tenantRepoSyncService    = TenantRepoSyncService
     dreamService             = DreamService
@@ -258,6 +252,7 @@ export class Orchestrator extends Base {
     primaryDevSyncGetDueTask = primaryDevSyncGetDueTaskImport
     tenantRepoSyncGetDueTask = tenantRepoSyncGetDueTaskImport
     dreamGetDueTask          = dreamGetDueTaskImport
+    goldenPathGetDueTask     = goldenPathGetDueTaskImport
 
     // === Instance state (mutated at runtime; non-reactive) ===
     isPolling                     = false
@@ -285,18 +280,7 @@ export class Orchestrator extends Base {
      */
     maintenanceBackpressureWriteLog = (level, msg) => this.writeLog(level, msg)
 
-    // === Service-DI Class A: cadenceEngine beforeSet (polymorphic class/instance/config input) ===
-    /**
-     * @param {Neo.ai.daemons.services.CadenceEngine|Object|null} value
-     * @param {Neo.ai.daemons.services.CadenceEngine|null} oldValue
-     * @returns {Neo.ai.daemons.services.CadenceEngine}
-     */
-    beforeSetCadenceEngine(value, oldValue) {
-        oldValue?.destroy?.();
-        return ClassSystemUtil.beforeSetInstance(value, CadenceEngine, {});
-    }
-
-    // === Service-DI Class B: processSupervisorService + maintenanceBackpressureService beforeSet + parent afterSet propagation ===
+    // === Service-DI Class A: processSupervisorService + maintenanceBackpressureService beforeSet + parent afterSet propagation ===
     /**
      * @param {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} value
      * @returns {Neo.ai.daemons.services.ProcessSupervisorService}
@@ -563,7 +547,7 @@ export class Orchestrator extends Base {
      * to {@link MaintenanceBackpressureService#acquireLeaseAndExecute}. MBS owns the
      * two-tier backpressure (intra-process `activeHeavyTask` tracker + inter-process
      * file lease at `heavyMaintenanceLeasePath`) + deferral logging + lease lifecycle.
-     * Class B propagation keeps MBS bindings synced with parent Orchestrator state.
+     * Class A propagation keeps MBS bindings synced with parent Orchestrator state.
      *
      * @param {Function} executeFn Task executor; receives `(taskName, reason, onSuccess, options)`.
      * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
@@ -627,16 +611,361 @@ export class Orchestrator extends Base {
     }
 
     /**
+     * @summary Builds the read-only scheduling context consumed by the registry descriptors.
+     *
+     * The `enables` map reads Orchestrator getter SSOTs at the use site, so cloud/local
+     * policy stays aligned with `AiConfig` without duplicating deployment rules inside
+     * static descriptors or the picker.
+     *
+     * @param {Number} now Epoch milliseconds for this poll cycle.
+     * @returns {Object} Uniform collector context for `TASK_REGISTRY`.
+     */
+    buildSchedulingContext(now) {
+        return {
+            db       : this.db,
+            state    : this.taskStateService.getState(),
+            now,
+            intervals: {
+                summarySweep          : AiConfig.orchestrator.intervals.summarySweepMs,
+                kbSync                : AiConfig.orchestrator.intervals.kbSyncMs,
+                backup                : AiConfig.orchestrator.intervals.backupMs,
+                graphLogCompaction    : AiConfig.orchestrator.intervals.graphLogCompactionMs,
+                primaryDevSync        : AiConfig.orchestrator.intervals.primaryDevSyncMs,
+                tenantRepoSync        : AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs,
+                dream                 : AiConfig.orchestrator.intervals.dreamMs,
+                dreamOverflowThreshold: AiConfig.orchestrator.intervals.dreamOverflowThreshold,
+                goldenPath            : AiConfig.orchestrator.intervals.goldenPathMs,
+                swarmHeartbeat        : AiConfig.orchestrator.intervals.swarmHeartbeatMs
+            },
+            enables: {
+                kbSync             : this.kbSyncEnabled,
+                graphLogCompaction : this.graphLogCompactionEnabled,
+                primaryDevSync     : this.primaryDevSyncEnabled,
+                tenantRepoSync     : this.tenantRepoSyncEnabled,
+                swarmHeartbeat     : this.swarmHeartbeatEnabled
+            },
+            hooks: {
+                log                       : this.writeLog.bind(this),
+                summaryGetDueTask         : this.summaryGetDueTask,
+                backupGetDueTask          : this.backupGetDueTask,
+                graphLogCompactionGetDueTask: this.graphLogCompactionGetDueTask,
+                primaryDevSyncGetDueTask  : this.primaryDevSyncGetDueTask,
+                tenantRepoSyncGetDueTask  : this.tenantRepoSyncGetDueTask,
+                dreamGetDueTask           : this.dreamGetDueTask,
+                goldenPathGetDueTask      : this.goldenPathGetDueTask,
+                swarmHeartbeatGetDueTask  : this.swarmHeartbeatGetDueTask,
+                swarmHeartbeatInitFailed  : !!this.swarmHeartbeatService.initFailed
+            }
+        };
+    }
+
+    /**
+     * @summary Reports scheduling projection failures with the same isolation semantics
+     * formerly provided by `CadenceEngine.runIfDue`.
+     * @param {Object[]} errors Collector error envelopes.
+     * @returns {void}
+     */
+    recordSchedulingErrors(errors) {
+        for (const {taskName, error} of errors) {
+            this.writeLog?.('ERROR', `[Orchestrator] ${taskName} scheduling failed: ${error.message}`);
+            this.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                phase: 'schedule',
+                error: error.message
+            });
+        }
+    }
+
+    /**
+     * @summary Resolves running task names from the persisted task-state envelope.
+     * @param {Object} state Current task-state map.
+     * @returns {String[]} Running task names.
+     */
+    getRunningTaskNames(state) {
+        return Object.keys(state).filter(taskName => state[taskName]?.running);
+    }
+
+    /**
+     * @summary Resolves running heavy tasks for picker policy without extending
+     * `TaskStateService`'s public API.
+     * @param {String[]} runningTaskNames Running task names.
+     * @returns {Set<String>} Running heavy task names.
+     */
+    getRunningHeavyTaskNames(runningTaskNames) {
+        return new Set(
+            runningTaskNames.filter(taskName => this.maintenanceBackpressureService.isHeavyMaintenanceTask(taskName))
+        );
+    }
+
+    /**
+     * @summary Records observable deferrals for candidates the pure picker will filter.
+     *
+     * `pickNextCandidate` must stay a side-effect-free selector. The Orchestrator still
+     * owns operator-visible deferral telemetry, so it mirrors the picker filters that
+     * correspond to existing backpressure outcomes before selecting the winner.
+     *
+     * @param {Object[]} candidates Due candidates before picker filtering.
+     * @param {String[]} runningTaskNames Running task names.
+     * @param {Set<String>} runningHeavyTasks Running heavy task names.
+     * @returns {void}
+     */
+    recordPickerDeferrals(candidates, runningTaskNames, runningHeavyTasks) {
+        const runningSet        = new Set(runningTaskNames);
+        const blockingHeavyTask = runningHeavyTasks.values().next().value;
+
+        for (const candidate of candidates) {
+            if (runningSet.has(candidate.taskName)) continue;
+
+            if (blockingHeavyTask && candidate.descriptor.maintenanceClass === 'heavy') {
+                this.maintenanceBackpressureService.recordDeferral({
+                    taskName        : candidate.taskName,
+                    reasonCode      : 'heavy-maintenance-backpressure',
+                    reasonText      : candidate.trigger.reason,
+                    blockingTaskName: blockingHeavyTask
+                });
+                continue;
+            }
+
+            const blockingDependency = (candidate.descriptor.dependencies || [])
+                .find(taskName => runningSet.has(taskName));
+
+            if (blockingDependency) {
+                this.maintenanceBackpressureService.recordDeferral({
+                    taskName        : candidate.taskName,
+                    reasonCode      : 'golden-path-dependency-backpressure',
+                    reasonText      : candidate.trigger.reason,
+                    blockingTaskName: blockingDependency
+                });
+            }
+        }
+    }
+
+    /**
+     * @summary Executes the selected registry candidate via the dispatch surface declared
+     * by its descriptor.
+     * @param {Object} candidate Winner from `pickNextCandidate`.
+     * @param {Object} activeHeavyTask Mutable active-heavy tracker for the current poll.
+     * @returns {*}
+     */
+    executeCandidate(candidate, activeHeavyTask) {
+        const dispatch = {
+            'supervised-child-process': () => this.executeSupervisedCandidate(candidate, activeHeavyTask),
+            'service-runner'          : () => this.executeServiceRunnerCandidate(candidate, activeHeavyTask),
+            'in-process-async'        : () => this.executeInProcessCandidate(candidate, activeHeavyTask)
+        };
+
+        const execute = dispatch[candidate.descriptor.executionKind];
+
+        if (!execute) {
+            this.recordUnsupportedCandidate(candidate, `Unsupported executionKind: ${candidate.descriptor.executionKind}`);
+            return false;
+        }
+
+        return execute();
+    }
+
+    /**
+     * @param {Object} candidate Supervised child-process candidate.
+     * @param {Object} activeHeavyTask Mutable active-heavy tracker.
+     * @returns {*}
+     */
+    executeSupervisedCandidate(candidate, activeHeavyTask) {
+        const {taskName, trigger} = candidate;
+        return this.createMaintenanceExecutor(
+            this.processSupervisorService.runTask.bind(this.processSupervisorService),
+            activeHeavyTask
+        )(taskName, trigger.reason, trigger.onSuccess);
+    }
+
+    /**
+     * @param {Object} candidate Service-backed candidate.
+     * @param {Object} activeHeavyTask Mutable active-heavy tracker.
+     * @returns {*}
+     */
+    executeServiceRunnerCandidate(candidate, activeHeavyTask) {
+        const runners = {
+            'primary-dev-sync': (taskName, reason) => this.primaryRepoSyncService.runTask({
+                taskName,
+                reason,
+                taskStateService  : this.taskStateService,
+                healthService     : this.healthService,
+                writeLog          : this.writeLog.bind(this),
+                devSyncRootsConfig: this.primaryDevSyncRootsConfig
+            }),
+            'tenant-repo-sync': (taskName, reason) => this.tenantRepoSyncService.runTask({
+                taskName,
+                reason,
+                taskStateService: this.taskStateService,
+                healthService   : this.healthService,
+                writeLog        : this.writeLog.bind(this),
+                globalCadenceMs : AiConfig.orchestrator.intervals.tenantRepoSyncMs,
+                jitterRatio     : AiConfig.orchestrator.tenantRepoSync.jitterRatio
+            })
+        };
+
+        const executeFn = runners[candidate.taskName];
+        if (!executeFn) {
+            this.recordUnsupportedCandidate(candidate, `Unsupported service-runner task: ${candidate.taskName}`);
+            return false;
+        }
+
+        return this.createMaintenanceExecutor(executeFn, activeHeavyTask)(
+            candidate.taskName,
+            candidate.trigger.reason,
+            candidate.trigger.onSuccess
+        );
+    }
+
+    /**
+     * @param {Object} candidate In-process async candidate.
+     * @param {Object} activeHeavyTask Mutable active-heavy tracker.
+     * @returns {*}
+     */
+    executeInProcessCandidate(candidate, activeHeavyTask) {
+        const runners = {
+            dream          : (taskName, reason) => this.runDreamTask(taskName, reason),
+            'golden-path'  : (taskName, reason) => this.runGoldenPathTask(taskName, reason),
+            'swarm-heartbeat': (taskName, reason) => this.runSwarmHeartbeatTask(taskName, reason)
+        };
+
+        const executeFn = runners[candidate.taskName];
+        if (!executeFn) {
+            this.recordUnsupportedCandidate(candidate, `Unsupported in-process task: ${candidate.taskName}`);
+            return false;
+        }
+
+        if (candidate.taskName === 'golden-path') {
+            return this.createGoldenPathExecutor(executeFn, activeHeavyTask)(
+                candidate.taskName,
+                candidate.trigger.reason
+            );
+        }
+
+        if (candidate.taskName === 'swarm-heartbeat') {
+            return executeFn(candidate.taskName, candidate.trigger.reason);
+        }
+
+        return this.createMaintenanceExecutor(executeFn, activeHeavyTask)(
+            candidate.taskName,
+            candidate.trigger.reason,
+            candidate.trigger.onSuccess
+        );
+    }
+
+    /**
+     * @param {String} taskName Task name.
+     * @param {String} reason Scheduling reason.
+     * @returns {Promise<void>}
+     */
+    async runDreamTask(taskName, reason) {
+        this.taskStateService.markStarted(taskName, reason);
+        this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
+
+        const outcome = await this.dreamService.executeRemCycle({
+            reason,
+            mode        : 'periodic',
+            includeDecay: true
+        });
+
+        const recordPayload = {
+            reason,
+            completedAt      : outcome.completedAt,
+            durationMs       : outcome.durationMs,
+            sessionsProcessed: outcome.sessionsProcessed,
+            runId            : outcome.runId
+        };
+
+        switch (outcome.status) {
+            case 'completed':
+                this.taskStateService.markCompleted(taskName);
+                this.healthService?.recordTaskOutcome?.(taskName, 'completed', recordPayload);
+                break;
+            case 'skipped':
+                this.taskStateService.markCompleted(taskName);
+                this.healthService?.recordTaskOutcome?.(taskName, 'skipped', {
+                    ...recordPayload,
+                    skipReason: outcome.skipReason
+                });
+                break;
+            case 'failed': {
+                const state = this.taskStateService.getTaskState(taskName);
+                if (state) {
+                    state.lastReason = outcome.diagnostic?.reason || outcome.error?.message;
+                }
+                this.taskStateService.markFailed(taskName, 1);
+                this.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                    ...recordPayload,
+                    failedAt    : outcome.completedAt,
+                    failurePhase: outcome.diagnostic ? 'provider-readiness' : 'in-pipeline',
+                    diagnostic  : outcome.diagnostic,
+                    error       : outcome.error?.message
+                });
+                break;
+            }
+        }
+    }
+
+    /**
+     * @param {String} taskName Task name.
+     * @param {String} reason Scheduling reason.
+     * @returns {Promise<void>}
+     */
+    async runGoldenPathTask(taskName, reason) {
+        this.taskStateService.markStarted(taskName, reason);
+        this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
+        try {
+            await this.goldenPathSynthesizer.synthesizeGoldenPath({
+                repoEnrichmentEnabled: this.goldenPathRepoEnrichmentEnabled
+            });
+            this.taskStateService.markCompleted(taskName);
+            this.healthService?.recordTaskOutcome?.(taskName, 'completed', { reason, completedAt: new Date().toISOString() });
+        } catch (e) {
+            const state = this.taskStateService.getTaskState(taskName);
+            if (state) state.lastReason = e.message;
+            this.taskStateService.markFailed(taskName, 1);
+            this.healthService?.recordTaskOutcome?.(taskName, 'failed', { reason, error: e.message, failedAt: new Date().toISOString() });
+        }
+    }
+
+    /**
+     * @param {String} taskName Task name.
+     * @param {String} reason Scheduling reason.
+     * @returns {Promise<void>}
+     */
+    async runSwarmHeartbeatTask(taskName, reason) {
+        this.taskStateService.markStarted(taskName, reason);
+        this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
+        try {
+            await this.swarmHeartbeatService.pulse();
+            this.taskStateService.markCompleted(taskName);
+            this.healthService?.recordTaskOutcome?.(taskName, 'completed', { reason, completedAt: new Date().toISOString() });
+        } catch (e) {
+            const state = this.taskStateService.getTaskState(taskName);
+            if (state) state.lastReason = e.message;
+            this.taskStateService.markFailed(taskName, 1);
+            this.healthService?.recordTaskOutcome?.(taskName, 'failed', { reason, error: e.message, failedAt: new Date().toISOString() });
+        }
+    }
+
+    /**
+     * @param {Object} candidate Unsupported candidate.
+     * @param {String} error Error text.
+     * @returns {void}
+     */
+    recordUnsupportedCandidate(candidate, error) {
+        this.writeLog?.('ERROR', `[Orchestrator] ${error}`);
+        this.healthService?.recordTaskOutcome?.(candidate.taskName, 'failed', {
+            phase: 'dispatch',
+            error
+        });
+    }
+
+    /**
      * Executes a sweep and schedules the next poll when the daemon remains active.
      * @returns {void}
      */
     poll() {
         const now = Date.now();
         const executeTask = this.processSupervisorService.runTask.bind(this.processSupervisorService);
-        const context = {
-            writeLog     : this.writeLog.bind(this),
-            healthService: this.healthService
-        };
 
         const continuousTasks = [
             ...(this.chromaDaemonEnabled ? ['chroma'] : []),
@@ -685,208 +1014,32 @@ export class Orchestrator extends Base {
             }
         }
 
-        const activeHeavyTask = {name: this.maintenanceBackpressureService.getActiveHeavyMaintenanceTask()};
-        const executeMaintenanceTask = executeFn => this.createMaintenanceExecutor(executeFn, activeHeavyTask);
+        const schedulingContext = this.buildSchedulingContext(now);
+        const {candidates, errors} = collectDueCandidates({
+            registry: TASK_REGISTRY,
+            context : schedulingContext
+        });
 
-        this.cadenceEngine.runIfDue('summary', () => {
-            return this.summaryGetDueTask({
-                db                    : this.db,
-                state                 : this.taskStateService.getState(),
-                now,
-                summarySweepIntervalMs: AiConfig.orchestrator.intervals.summarySweepMs,
-                log                   : this.writeLog.bind(this)
-            });
-        }, executeMaintenanceTask(executeTask), context);
+        this.recordSchedulingErrors(errors);
 
-        this.cadenceEngine.runIfDue('kbSync', () => {
-            if (!this.kbSyncEnabled) {
-                return null;
+        const runningTaskNames  = this.getRunningTaskNames(schedulingContext.state);
+        const runningHeavyTasks = this.getRunningHeavyTaskNames(runningTaskNames);
+
+        this.recordPickerDeferrals(candidates, runningTaskNames, runningHeavyTasks);
+
+        const winner = pickNextCandidate({
+            candidates,
+            runningTasks  : runningTaskNames,
+            policyContext : {
+                runningHeavyTasks
             }
+        });
 
-            if (this.cadenceEngine.shouldRunIntervalTask({
-                now,
-                lastRunAt : this.taskStateService.getTaskState('kbSync').lastRunAt,
-                intervalMs: AiConfig.orchestrator.intervals.kbSyncMs
-            })) {
-                return { reason: `periodic-sync:${AiConfig.orchestrator.intervals.kbSyncMs}` };
-            }
-            return null;
-        }, executeMaintenanceTask(executeTask), context);
-
-        this.cadenceEngine.runIfDue('backup', () => {
-            return this.backupGetDueTask({
-                state           : this.taskStateService.getState(),
-                now,
-                backupIntervalMs: AiConfig.orchestrator.intervals.backupMs
+        if (winner) {
+            this.executeCandidate(winner, {
+                name: this.maintenanceBackpressureService.getActiveHeavyMaintenanceTask()
             });
-        }, executeMaintenanceTask(executeTask), context);
-
-        this.cadenceEngine.runIfDue('graphlog-compaction', () => {
-            return this.graphLogCompactionGetDueTask({
-                state                        : this.taskStateService.getState(),
-                now,
-                graphLogCompactionIntervalMs: AiConfig.orchestrator.intervals.graphLogCompactionMs,
-                enabled                      : this.graphLogCompactionEnabled
-            });
-        }, executeMaintenanceTask(executeTask), context);
-
-        this.cadenceEngine.runIfDue('primary-dev-sync', () => {
-            return this.primaryDevSyncGetDueTask({
-                state     : this.taskStateService.getState(),
-                now,
-                intervalMs: AiConfig.orchestrator.intervals.primaryDevSyncMs,
-                enabled   : this.primaryDevSyncEnabled
-            });
-        }, executeMaintenanceTask((taskName, reason) => {
-            return this.primaryRepoSyncService.runTask({
-                taskName,
-                reason,
-                taskStateService  : this.taskStateService,
-                healthService     : this.healthService,
-                writeLog          : this.writeLog.bind(this),
-                devSyncRootsConfig: this.primaryDevSyncRootsConfig
-            });
-        }), context);
-
-        // Two distinct cadences: the SWEEP cadence (`tenantRepoSync.sweepCadenceMs`, short by
-        // design) is how often the sweep is invoked; the per-repo `intervals.tenantRepoSyncMs` is
-        // the actual interval between a single repo's sync attempts, with `jitterRatio` spreading
-        // per-repo work across the window instead of synchronizing it onto the sweep boundary.
-        this.cadenceEngine.runIfDue('tenant-repo-sync', () => {
-            return this.tenantRepoSyncGetDueTask({
-                state     : this.taskStateService.getState(),
-                now,
-                intervalMs: AiConfig.orchestrator.tenantRepoSync.sweepCadenceMs,
-                enabled   : this.tenantRepoSyncEnabled
-            });
-        }, executeMaintenanceTask((taskName, reason) => {
-            return this.tenantRepoSyncService.runTask({
-                taskName,
-                reason,
-                taskStateService: this.taskStateService,
-                healthService   : this.healthService,
-                writeLog        : this.writeLog.bind(this),
-                globalCadenceMs : AiConfig.orchestrator.intervals.tenantRepoSyncMs,
-                jitterRatio     : AiConfig.orchestrator.tenantRepoSync.jitterRatio
-            });
-        }), context);
-
-        this.cadenceEngine.runIfDue('dream', () => {
-            return this.dreamGetDueTask({
-                state                 : this.taskStateService.getTaskState('dream') ?? {},
-                now,
-                dreamIntervalMs       : AiConfig.orchestrator.intervals.dreamMs,
-                dreamOverflowThreshold: AiConfig.orchestrator.intervals.dreamOverflowThreshold
-            });
-        }, executeMaintenanceTask(async (taskName, reason) => {
-            this.taskStateService.markStarted(taskName, reason);
-            this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
-
-            const outcome = await this.dreamService.executeRemCycle({
-                reason,
-                mode        : 'periodic',
-                includeDecay: true
-            });
-
-            const recordPayload = {
-                reason,
-                completedAt      : outcome.completedAt,
-                durationMs       : outcome.durationMs,
-                sessionsProcessed: outcome.sessionsProcessed,
-                runId            : outcome.runId
-            };
-
-            switch (outcome.status) {
-                case 'completed':
-                    this.taskStateService.markCompleted(taskName);
-                    this.healthService?.recordTaskOutcome?.(taskName, 'completed', recordPayload);
-                    break;
-                case 'skipped':
-                    this.taskStateService.markCompleted(taskName);
-                    this.healthService?.recordTaskOutcome?.(taskName, 'skipped', {
-                        ...recordPayload,
-                        skipReason: outcome.skipReason
-                    });
-                    break;
-                case 'failed': {
-                    const state = this.taskStateService.getTaskState(taskName);
-                    if (state) {
-                        state.lastReason = outcome.diagnostic?.reason || outcome.error?.message;
-                    }
-                    this.taskStateService.markFailed(taskName, 1);
-                    this.healthService?.recordTaskOutcome?.(taskName, 'failed', {
-                        ...recordPayload,
-                        failedAt    : outcome.completedAt,
-                        failurePhase: outcome.diagnostic ? 'provider-readiness' : 'in-pipeline',
-                        diagnostic  : outcome.diagnostic,
-                        error       : outcome.error?.message
-                    });
-                    break;
-                }
-            }
-        }), context);
-
-        this.cadenceEngine.runIfDue('golden-path', () => {
-            if (this.cadenceEngine.shouldRunIntervalTask({
-                now,
-                lastRunAt : this.taskStateService.getTaskState('golden-path')?.lastRunAt,
-                intervalMs: AiConfig.orchestrator.intervals.goldenPathMs
-            })) {
-                return { reason: `periodic-golden-path:${AiConfig.orchestrator.intervals.goldenPathMs}` };
-            }
-            return null;
-        }, this.createGoldenPathExecutor(async (taskName, reason) => {
-            this.taskStateService.markStarted(taskName, reason.reason);
-            this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
-            try {
-                await this.goldenPathSynthesizer.synthesizeGoldenPath({
-                    repoEnrichmentEnabled: this.goldenPathRepoEnrichmentEnabled
-                });
-                this.taskStateService.markCompleted(taskName);
-                this.healthService?.recordTaskOutcome?.(taskName, 'completed', { reason, completedAt: new Date().toISOString() });
-            } catch (e) {
-                const state = this.taskStateService.getTaskState(taskName);
-                if (state) state.lastReason = e.message;
-                this.taskStateService.markFailed(taskName, 1);
-                this.healthService?.recordTaskOutcome?.(taskName, 'failed', { reason, error: e.message, failedAt: new Date().toISOString() });
-            }
-        }, activeHeavyTask), context);
-
-        // Swarm-heartbeat lane. NOT heavy maintenance — the pulse is a light
-        // wake-substrate check, so the executor runs directly (no `executeMaintenanceTask`
-        // wrap). `reason` is passed as a string straight from `CadenceEngine.runIfDue`.
-        this.cadenceEngine.runIfDue('swarm-heartbeat', () => {
-            if (!this.swarmHeartbeatEnabled) {
-                return null;
-            }
-            // Daemon-local runtime guard: swarm-heartbeat init failure sets
-            // `initFailed = true` on the service in start(); skip pulse() for the rest
-            // of this run regardless of static enable-config (the fail-safe invariant).
-            if (this.swarmHeartbeatService.initFailed) {
-                return null;
-            }
-            if (this.cadenceEngine.shouldRunIntervalTask({
-                now,
-                lastRunAt : this.taskStateService.getTaskState('swarm-heartbeat')?.lastRunAt,
-                intervalMs: AiConfig.orchestrator.intervals.swarmHeartbeatMs
-            })) {
-                return { reason: `periodic-heartbeat:${AiConfig.orchestrator.intervals.swarmHeartbeatMs}` };
-            }
-            return null;
-        }, async (taskName, reason) => {
-            this.taskStateService.markStarted(taskName, reason);
-            this.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
-            try {
-                await this.swarmHeartbeatService.pulse();
-                this.taskStateService.markCompleted(taskName);
-                this.healthService?.recordTaskOutcome?.(taskName, 'completed', { reason, completedAt: new Date().toISOString() });
-            } catch (e) {
-                const state = this.taskStateService.getTaskState(taskName);
-                if (state) state.lastReason = e.message;
-                this.taskStateService.markFailed(taskName, 1);
-                this.healthService?.recordTaskOutcome?.(taskName, 'failed', { reason, error: e.message, failedAt: new Date().toISOString() });
-            }
-        }, context);
+        }
 
         if (this.isPolling) {
             this.pollHandle = setTimeout(() => this.poll(), AiConfig.orchestrator.intervals.pollMs);

--- a/ai/daemons/orchestrator/scheduling/collector.mjs
+++ b/ai/daemons/orchestrator/scheduling/collector.mjs
@@ -6,9 +6,10 @@
  * the descriptor as metadata so downstream `pickNextCandidate` can apply policy rules.
  *
  * The collector is intentionally policy-blind: it contains no task-kind,
- * maintenance-class, or deployment-profile branching. Policy decisions live in
- * `pickNextCandidate`; per-task destructuring lives in registry descriptor adapters.
- * The collector itself is pure iteration + normalization + metadata attachment.
+ * maintenance-class, or deployment-profile branching. Eligibility decisions live in
+ * registry descriptor adapters via caller-provided getter values; cross-candidate
+ * policy decisions live in `pickNextCandidate`. The collector itself is pure
+ * iteration + normalization + metadata attachment.
  *
  * Descriptor failures are reported as data, not written directly to Orchestrator
  * state. The caller owns state-mutating health reporting, keeping this module
@@ -47,9 +48,8 @@ export function collectDueCandidates({registry, context}) {
 /**
  * Normalizes a getDueTask return value to a uniform `{reason, onSuccess}` shape.
  *
- * `CadenceEngine.runIfDue` accepts both boolean-true and object triggers. The
- * registry uses object triggers, but this normalizer keeps the collector tolerant
- * of any future bare-boolean trigger.
+ * Registry descriptors use object triggers, but this normalizer keeps the collector
+ * tolerant of any future bare-boolean trigger.
  *
  * @param {Object|Boolean} trigger Raw trigger from `getDueTask`.
  * @returns {Object} Normalized `{reason, onSuccess?, ...originalFields}`.

--- a/ai/daemons/orchestrator/scheduling/picker.mjs
+++ b/ai/daemons/orchestrator/scheduling/picker.mjs
@@ -22,7 +22,7 @@
  * @param {Object} options
  * @param {Array<Object>} options.candidates Due candidates from `collectDueCandidates`.
  * @param {Set<String>|Array<String>} options.runningTasks Task names currently running
- *   (per `TaskStateService.getRunning()` or equivalent).
+ *   (derived from the current task-state snapshot).
  * @param {Object} options.policyContext Additional policy state (currently unused;
  *   reserved for future deployment-profile + cross-daemon-lease integration).
  * @returns {Object|null} The winning candidate, or null if no candidate survives the pipeline.

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -1,0 +1,450 @@
+import {collectDueCandidates} from './collector.mjs';
+import {pickNextCandidate}    from './picker.mjs';
+
+/**
+ * @summary Builds the read-only context consumed by scheduling descriptors.
+ * @param {Object} options Scheduling context fields.
+ * @returns {Object} Uniform collector context.
+ */
+export function buildSchedulingContext({db, state, now, intervals, enables, hooks}) {
+    return {db, state, now, intervals, enables, hooks};
+}
+
+/**
+ * @summary Adapts an Orchestrator instance to the scheduling-pipeline input shape.
+ * @param {Object} options
+ * @param {Object} options.orchestrator Runtime Orchestrator instance.
+ * @param {Object} options.config Resolved AiConfig object.
+ * @param {Number} options.now Epoch milliseconds.
+ * @param {Array<Object>} options.registry Scheduling descriptor registry.
+ * @returns {Object} `runSchedulingPipeline()` options.
+ */
+export function buildOrchestratorSchedulingOptions({orchestrator, config, now, registry}) {
+    return {
+        registry,
+        context: buildSchedulingContext({
+            db       : orchestrator.db,
+            state    : orchestrator.taskStateService.getState(),
+            now,
+            intervals: {
+                summarySweep          : config.orchestrator.intervals.summarySweepMs,
+                kbSync                : config.orchestrator.intervals.kbSyncMs,
+                backup                : config.orchestrator.intervals.backupMs,
+                graphLogCompaction    : config.orchestrator.intervals.graphLogCompactionMs,
+                primaryDevSync        : config.orchestrator.intervals.primaryDevSyncMs,
+                tenantRepoSync        : config.orchestrator.tenantRepoSync.sweepCadenceMs,
+                dream                 : config.orchestrator.intervals.dreamMs,
+                dreamOverflowThreshold: config.orchestrator.intervals.dreamOverflowThreshold,
+                goldenPath            : config.orchestrator.intervals.goldenPathMs,
+                swarmHeartbeat        : config.orchestrator.intervals.swarmHeartbeatMs
+            },
+            enables: {
+                kbSync            : orchestrator.kbSyncEnabled,
+                graphLogCompaction: orchestrator.graphLogCompactionEnabled,
+                primaryDevSync    : orchestrator.primaryDevSyncEnabled,
+                tenantRepoSync    : orchestrator.tenantRepoSyncEnabled,
+                swarmHeartbeat    : orchestrator.swarmHeartbeatEnabled
+            },
+            hooks: {
+                log                       : orchestrator.writeLog.bind(orchestrator),
+                summaryGetDueTask         : orchestrator.summaryGetDueTask,
+                backupGetDueTask          : orchestrator.backupGetDueTask,
+                graphLogCompactionGetDueTask: orchestrator.graphLogCompactionGetDueTask,
+                primaryDevSyncGetDueTask  : orchestrator.primaryDevSyncGetDueTask,
+                tenantRepoSyncGetDueTask  : orchestrator.tenantRepoSyncGetDueTask,
+                dreamGetDueTask           : orchestrator.dreamGetDueTask,
+                goldenPathGetDueTask      : orchestrator.goldenPathGetDueTask,
+                swarmHeartbeatGetDueTask  : orchestrator.swarmHeartbeatGetDueTask,
+                swarmHeartbeatInitFailed  : !!orchestrator.swarmHeartbeatService.initFailed
+            }
+        }),
+        services: {
+            dreamService                 : orchestrator.dreamService,
+            goldenPathSynthesizer        : orchestrator.goldenPathSynthesizer,
+            healthService                : orchestrator.healthService,
+            maintenanceBackpressureService: orchestrator.maintenanceBackpressureService,
+            primaryRepoSyncService       : orchestrator.primaryRepoSyncService,
+            processSupervisorService     : orchestrator.processSupervisorService,
+            swarmHeartbeatService        : orchestrator.swarmHeartbeatService,
+            taskStateService             : orchestrator.taskStateService,
+            tenantRepoSyncService        : orchestrator.tenantRepoSyncService
+        },
+        runtime: {
+            goldenPathRepoEnrichmentEnabled: orchestrator.goldenPathRepoEnrichmentEnabled,
+            primaryDevSyncRootsConfig      : orchestrator.primaryDevSyncRootsConfig,
+            tenantRepoSyncGlobalCadenceMs  : config.orchestrator.intervals.tenantRepoSyncMs,
+            tenantRepoSyncJitterRatio      : config.orchestrator.tenantRepoSync.jitterRatio,
+            writeLog                       : orchestrator.writeLog.bind(orchestrator)
+        }
+    };
+}
+
+/**
+ * @summary Runs one registry scheduling pass and dispatches the selected candidate.
+ *
+ * This module owns cadence-pipeline side effects: scheduling-error reporting,
+ * picker-visible deferral telemetry, and descriptor execution dispatch. The
+ * Orchestrator supplies current runtime facts and remains the thin process-loop
+ * coordinator.
+ *
+ * @param {Object} options
+ * @param {Array<Object>} options.registry Scheduling descriptor registry.
+ * @param {Object} options.context Context from `buildSchedulingContext()`.
+ * @param {Object} options.services Runtime collaborators.
+ * @param {Object} options.runtime Runtime policy values and stable functions.
+ * @returns {{candidates: Object[], errors: Object[], winner: Object|null}}
+ */
+export function runSchedulingPipeline({registry, context, services, runtime}) {
+    const {candidates, errors} = collectDueCandidates({registry, context});
+
+    recordSchedulingErrors({errors, healthService: services.healthService, writeLog: runtime.writeLog});
+
+    const runningTaskNames  = getRunningTaskNames(context.state);
+    const runningHeavyTasks = getRunningHeavyTaskNames({
+        runningTaskNames,
+        maintenanceBackpressureService: services.maintenanceBackpressureService
+    });
+
+    recordPickerDeferrals({
+        candidates,
+        runningTaskNames,
+        runningHeavyTasks,
+        maintenanceBackpressureService: services.maintenanceBackpressureService
+    });
+
+    const winner = pickNextCandidate({
+        candidates,
+        runningTasks  : runningTaskNames,
+        policyContext : {runningHeavyTasks}
+    });
+
+    if (winner) {
+        executeCandidate({
+            candidate: winner,
+            activeHeavyTask: {
+                name: services.maintenanceBackpressureService.getActiveHeavyMaintenanceTask()
+            },
+            services,
+            runtime
+        });
+    }
+
+    return {candidates, errors, winner};
+}
+
+/**
+ * @param {Object} options
+ * @param {Object[]} options.errors Collector error envelopes.
+ * @param {Object} options.healthService Health reporter.
+ * @param {Function} options.writeLog Log function.
+ * @returns {void}
+ */
+export function recordSchedulingErrors({errors, healthService, writeLog}) {
+    for (const {taskName, error} of errors) {
+        writeLog?.('ERROR', `[Orchestrator] ${taskName} scheduling failed: ${error.message}`);
+        healthService?.recordTaskOutcome?.(taskName, 'failed', {
+            phase: 'schedule',
+            error: error.message
+        });
+    }
+}
+
+/**
+ * @param {Object} state Current task-state map.
+ * @returns {String[]} Running task names.
+ */
+export function getRunningTaskNames(state) {
+    return Object.keys(state).filter(taskName => state[taskName]?.running);
+}
+
+/**
+ * @param {Object} options
+ * @param {String[]} options.runningTaskNames Running task names.
+ * @param {Object} options.maintenanceBackpressureService Backpressure service.
+ * @returns {Set<String>} Running heavy task names.
+ */
+export function getRunningHeavyTaskNames({runningTaskNames, maintenanceBackpressureService}) {
+    return new Set(
+        runningTaskNames.filter(taskName => maintenanceBackpressureService.isHeavyMaintenanceTask(taskName))
+    );
+}
+
+/**
+ * Records observable deferrals for candidates the pure picker will filter.
+ * @param {Object} options
+ * @returns {void}
+ */
+export function recordPickerDeferrals({
+    candidates,
+    runningTaskNames,
+    runningHeavyTasks,
+    maintenanceBackpressureService
+}) {
+    const runningSet        = new Set(runningTaskNames);
+    const blockingHeavyTask = runningHeavyTasks.values().next().value;
+
+    for (const candidate of candidates) {
+        if (runningSet.has(candidate.taskName)) continue;
+
+        if (blockingHeavyTask && candidate.descriptor.maintenanceClass === 'heavy') {
+            maintenanceBackpressureService.recordDeferral({
+                taskName        : candidate.taskName,
+                reasonCode      : 'heavy-maintenance-backpressure',
+                reasonText      : candidate.trigger.reason,
+                blockingTaskName: blockingHeavyTask
+            });
+            continue;
+        }
+
+        const blockingDependency = (candidate.descriptor.dependencies || [])
+            .find(taskName => runningSet.has(taskName));
+
+        if (blockingDependency) {
+            maintenanceBackpressureService.recordDeferral({
+                taskName        : candidate.taskName,
+                reasonCode      : 'golden-path-dependency-backpressure',
+                reasonText      : candidate.trigger.reason,
+                blockingTaskName: blockingDependency
+            });
+        }
+    }
+}
+
+/**
+ * @param {Object} options
+ * @returns {*}
+ */
+export function executeCandidate({candidate, activeHeavyTask, services, runtime}) {
+    const dispatch = {
+        'supervised-child-process': executeSupervisedCandidate,
+        'service-runner'          : executeServiceRunnerCandidate,
+        'in-process-async'        : executeInProcessCandidate
+    };
+
+    const execute = dispatch[candidate.descriptor.executionKind];
+
+    if (!execute) {
+        recordUnsupportedCandidate({
+            candidate,
+            error        : `Unsupported executionKind: ${candidate.descriptor.executionKind}`,
+            healthService: services.healthService,
+            writeLog     : runtime.writeLog
+        });
+        return false;
+    }
+
+    return execute({candidate, activeHeavyTask, services, runtime});
+}
+
+function executeSupervisedCandidate({candidate, activeHeavyTask, services}) {
+    const {taskName, trigger} = candidate;
+    return executeWithMaintenance({
+        taskName,
+        reason      : trigger.reason,
+        onSuccess   : trigger.onSuccess,
+        executeFn   : services.processSupervisorService.runTask.bind(services.processSupervisorService),
+        activeHeavyTask,
+        maintenanceBackpressureService: services.maintenanceBackpressureService
+    });
+}
+
+function executeServiceRunnerCandidate({candidate, activeHeavyTask, services, runtime}) {
+    const runners = {
+        'primary-dev-sync': (taskName, reason) => services.primaryRepoSyncService.runTask({
+            taskName,
+            reason,
+            taskStateService  : services.taskStateService,
+            healthService     : services.healthService,
+            writeLog          : runtime.writeLog,
+            devSyncRootsConfig: runtime.primaryDevSyncRootsConfig
+        }),
+        'tenant-repo-sync': (taskName, reason) => services.tenantRepoSyncService.runTask({
+            taskName,
+            reason,
+            taskStateService: services.taskStateService,
+            healthService   : services.healthService,
+            writeLog        : runtime.writeLog,
+            globalCadenceMs : runtime.tenantRepoSyncGlobalCadenceMs,
+            jitterRatio     : runtime.tenantRepoSyncJitterRatio
+        })
+    };
+
+    const executeFn = runners[candidate.taskName];
+    if (!executeFn) {
+        recordUnsupportedCandidate({
+            candidate,
+            error        : `Unsupported service-runner task: ${candidate.taskName}`,
+            healthService: services.healthService,
+            writeLog     : runtime.writeLog
+        });
+        return false;
+    }
+
+    return executeWithMaintenance({
+        taskName    : candidate.taskName,
+        reason      : candidate.trigger.reason,
+        onSuccess   : candidate.trigger.onSuccess,
+        executeFn,
+        activeHeavyTask,
+        maintenanceBackpressureService: services.maintenanceBackpressureService
+    });
+}
+
+function executeInProcessCandidate({candidate, activeHeavyTask, services, runtime}) {
+    const runners = {
+        dream: (taskName, reason) => runDreamTask({taskName, reason, services}),
+        'golden-path': (taskName, reason) => runGoldenPathTask({
+            taskName,
+            reason,
+            services,
+            repoEnrichmentEnabled: runtime.goldenPathRepoEnrichmentEnabled
+        }),
+        'swarm-heartbeat': (taskName, reason) => runSwarmHeartbeatTask({taskName, reason, services})
+    };
+
+    const executeFn = runners[candidate.taskName];
+    if (!executeFn) {
+        recordUnsupportedCandidate({
+            candidate,
+            error        : `Unsupported in-process task: ${candidate.taskName}`,
+            healthService: services.healthService,
+            writeLog     : runtime.writeLog
+        });
+        return false;
+    }
+
+    if (candidate.taskName === 'golden-path') {
+        return services.maintenanceBackpressureService.executeWithGoldenPathDependencyGate({
+            taskName: candidate.taskName,
+            executeFn,
+            reason: candidate.trigger.reason,
+            activeHeavyTask
+        });
+    }
+
+    if (candidate.taskName === 'swarm-heartbeat') {
+        return executeFn(candidate.taskName, candidate.trigger.reason);
+    }
+
+    return executeWithMaintenance({
+        taskName    : candidate.taskName,
+        reason      : candidate.trigger.reason,
+        onSuccess   : candidate.trigger.onSuccess,
+        executeFn,
+        activeHeavyTask,
+        maintenanceBackpressureService: services.maintenanceBackpressureService
+    });
+}
+
+function executeWithMaintenance({
+    taskName,
+    reason,
+    onSuccess,
+    executeFn,
+    activeHeavyTask,
+    maintenanceBackpressureService
+}) {
+    return maintenanceBackpressureService.acquireLeaseAndExecute({
+        taskName, executeFn, reason, onSuccess, activeHeavyTask
+    });
+}
+
+async function runDreamTask({taskName, reason, services}) {
+    services.taskStateService.markStarted(taskName, reason);
+    services.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
+
+    const outcome = await services.dreamService.executeRemCycle({
+        reason,
+        mode        : 'periodic',
+        includeDecay: true
+    });
+
+    const recordPayload = {
+        reason,
+        completedAt      : outcome.completedAt,
+        durationMs       : outcome.durationMs,
+        sessionsProcessed: outcome.sessionsProcessed,
+        runId            : outcome.runId
+    };
+
+    switch (outcome.status) {
+        case 'completed':
+            services.taskStateService.markCompleted(taskName);
+            services.healthService?.recordTaskOutcome?.(taskName, 'completed', recordPayload);
+            break;
+        case 'skipped':
+            services.taskStateService.markCompleted(taskName);
+            services.healthService?.recordTaskOutcome?.(taskName, 'skipped', {
+                ...recordPayload,
+                skipReason: outcome.skipReason
+            });
+            break;
+        case 'failed': {
+            const state = services.taskStateService.getTaskState(taskName);
+            if (state) {
+                state.lastReason = outcome.diagnostic?.reason || outcome.error?.message;
+            }
+            services.taskStateService.markFailed(taskName, 1);
+            services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                ...recordPayload,
+                failedAt    : outcome.completedAt,
+                failurePhase: outcome.diagnostic ? 'provider-readiness' : 'in-pipeline',
+                diagnostic  : outcome.diagnostic,
+                error       : outcome.error?.message
+            });
+            break;
+        }
+    }
+}
+
+async function runGoldenPathTask({taskName, reason, services, repoEnrichmentEnabled}) {
+    services.taskStateService.markStarted(taskName, reason);
+    services.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
+    try {
+        await services.goldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled});
+        services.taskStateService.markCompleted(taskName);
+        services.healthService?.recordTaskOutcome?.(taskName, 'completed', {
+            reason,
+            completedAt: new Date().toISOString()
+        });
+    } catch (e) {
+        const state = services.taskStateService.getTaskState(taskName);
+        if (state) state.lastReason = e.message;
+        services.taskStateService.markFailed(taskName, 1);
+        services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+            reason,
+            error   : e.message,
+            failedAt: new Date().toISOString()
+        });
+    }
+}
+
+async function runSwarmHeartbeatTask({taskName, reason, services}) {
+    services.taskStateService.markStarted(taskName, reason);
+    services.healthService?.recordTaskOutcome?.(taskName, 'running', { reason, startedAt: new Date().toISOString() });
+    try {
+        await services.swarmHeartbeatService.pulse();
+        services.taskStateService.markCompleted(taskName);
+        services.healthService?.recordTaskOutcome?.(taskName, 'completed', {
+            reason,
+            completedAt: new Date().toISOString()
+        });
+    } catch (e) {
+        const state = services.taskStateService.getTaskState(taskName);
+        if (state) state.lastReason = e.message;
+        services.taskStateService.markFailed(taskName, 1);
+        services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+            reason,
+            error   : e.message,
+            failedAt: new Date().toISOString()
+        });
+    }
+}
+
+function recordUnsupportedCandidate({candidate, error, healthService, writeLog}) {
+    writeLog?.('ERROR', `[Orchestrator] ${error}`);
+    healthService?.recordTaskOutcome?.(candidate.taskName, 'failed', {
+        phase: 'dispatch',
+        error
+    });
+}

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -1,9 +1,11 @@
 import {getDueTask as getSummaryDueTask}             from './summary.mjs';
 import {getDueTask as getBackupDueTask}              from './backup.mjs';
 import {getDueTask as getDreamDueTask}               from './dream.mjs';
+import {getDueTask as getGraphLogCompactionDueTask}  from './graphLogCompaction.mjs';
 import {getDueTask as getGoldenPathDueTask}          from './goldenPath.mjs';
 import {getDueTask as getPrimaryDevSyncDueTask}      from './primaryDevSync.mjs';
 import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs';
+import {getDueTask as getTenantRepoSyncDueTask}      from './tenantRepoSync.mjs';
 
 /**
  * Coordinator-descriptor registry for the Orchestrator scheduling pipeline.
@@ -23,8 +25,8 @@ import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs'
  * Continuous tasks (`chroma`, `bridgeDaemon`, `mlx`) are intentionally NOT in this registry
  * — they are supervisor-restart-cooldown tasks handled directly in `Orchestrator#poll()`
  * before the cadence-driven pipeline runs. They have no cadence trigger, no due-check, and
- * no backpressure interaction. Forcing them into the descriptor model would require a
- * `maintenanceClass: 'continuous'` discriminator the picker would just bypass — pure ceremony.
+ * no backpressure interaction. Forcing them into the descriptor model would add
+ * trigger-less descriptors the picker would just bypass — pure ceremony.
  *
  * @see Orchestrator#poll
  * @see collectDueCandidates
@@ -34,11 +36,11 @@ export const TASK_REGISTRY = Object.freeze([
     {
         taskName        : 'summary',
         executionKind   : 'supervised-child-process',
-        maintenanceClass: 'continuous',
-        backpressure    : 'none',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
         dependencies    : [],
         getDueTask({db, state, now, intervals, hooks}) {
-            return getSummaryDueTask({
+            return (hooks.summaryGetDueTask || getSummaryDueTask)({
                 db,
                 state,
                 now,
@@ -73,8 +75,8 @@ export const TASK_REGISTRY = Object.freeze([
         maintenanceClass: 'heavy',
         backpressure    : 'exclusive-heavy',
         dependencies    : [],
-        getDueTask({state, now, intervals}) {
-            return getBackupDueTask({
+        getDueTask({state, now, intervals, hooks}) {
+            return (hooks.backupGetDueTask || getBackupDueTask)({
                 state,
                 now,
                 backupIntervalMs: intervals.backup
@@ -82,13 +84,28 @@ export const TASK_REGISTRY = Object.freeze([
         }
     },
     {
+        taskName        : 'graphlog-compaction',
+        executionKind   : 'supervised-child-process',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
+        dependencies    : [],
+        getDueTask({state, now, intervals, enables, hooks}) {
+            return (hooks.graphLogCompactionGetDueTask || getGraphLogCompactionDueTask)({
+                state,
+                now,
+                graphLogCompactionIntervalMs: intervals.graphLogCompaction,
+                enabled                      : enables.graphLogCompaction
+            });
+        }
+    },
+    {
         taskName        : 'primary-dev-sync',
         executionKind   : 'service-runner',
-        maintenanceClass: 'continuous',
-        backpressure    : 'none',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
         dependencies    : [],
-        getDueTask({state, now, intervals, enables}) {
-            return getPrimaryDevSyncDueTask({
+        getDueTask({state, now, intervals, enables, hooks}) {
+            return (hooks.primaryDevSyncGetDueTask || getPrimaryDevSyncDueTask)({
                 state,
                 now,
                 intervalMs: intervals.primaryDevSync,
@@ -97,13 +114,28 @@ export const TASK_REGISTRY = Object.freeze([
         }
     },
     {
+        taskName        : 'tenant-repo-sync',
+        executionKind   : 'service-runner',
+        maintenanceClass: 'continuous',
+        backpressure    : 'none',
+        dependencies    : [],
+        getDueTask({state, now, intervals, enables, hooks}) {
+            return (hooks.tenantRepoSyncGetDueTask || getTenantRepoSyncDueTask)({
+                state,
+                now,
+                intervalMs: intervals.tenantRepoSync,
+                enabled   : enables.tenantRepoSync
+            });
+        }
+    },
+    {
         taskName        : 'dream',
         executionKind   : 'in-process-async',
-        maintenanceClass: 'graph-dependent',
-        backpressure    : 'after-heavy',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
         dependencies    : [],
-        getDueTask({state, now, intervals}) {
-            return getDreamDueTask({
+        getDueTask({state, now, intervals, hooks}) {
+            return (hooks.dreamGetDueTask || getDreamDueTask)({
                 state                 : state.dream ?? {},
                 now,
                 dreamIntervalMs       : intervals.dream,
@@ -117,8 +149,8 @@ export const TASK_REGISTRY = Object.freeze([
         maintenanceClass: 'graph-dependent',
         backpressure    : 'after-heavy',
         dependencies    : ['dream'],
-        getDueTask({state, now, intervals}) {
-            return getGoldenPathDueTask({
+        getDueTask({state, now, intervals, hooks}) {
+            return (hooks.goldenPathGetDueTask || getGoldenPathDueTask)({
                 state               : state['golden-path'] ?? {},
                 now,
                 goldenPathIntervalMs: intervals.goldenPath
@@ -134,7 +166,7 @@ export const TASK_REGISTRY = Object.freeze([
         getDueTask({state, now, intervals, enables, hooks}) {
             if (!enables.swarmHeartbeat) return null;
             if (hooks.swarmHeartbeatInitFailed) return null;
-            return getSwarmHeartbeatDueTask({
+            return (hooks.swarmHeartbeatGetDueTask || getSwarmHeartbeatDueTask)({
                 state                   : state['swarm-heartbeat'] ?? {},
                 now,
                 swarmHeartbeatIntervalMs: intervals.swarmHeartbeat

--- a/ai/daemons/orchestrator/services/CadenceEngine.mjs
+++ b/ai/daemons/orchestrator/services/CadenceEngine.mjs
@@ -5,9 +5,9 @@ import Base from '../../../../src/core/Base.mjs';
  * @extends Neo.core.Base
  * @summary A pure functional service that manages polling intervals and timing triggers for maintenance tasks.
  *
- * The engine is intentionally non-singleton because it receives parent-provided
- * runtime configuration. The orchestrator owns the instance through a reactive
- * config slot and `ClassSystemUtil.beforeSetInstance`.
+ * The engine is intentionally non-singleton. Orchestrator scheduling now routes
+ * through registry descriptors; this helper remains the narrow interval predicate
+ * used by direct consumers and unit tests.
  */
 export class CadenceEngine extends Base {
     static config = {
@@ -31,27 +31,6 @@ export class CadenceEngine extends Base {
         return intervalMs > 0 && now - lastRunAt >= intervalMs;
     }
 
-    /**
-     * @summary Evaluates a due-check and executes the task if due, with failure isolation.
-     * @param {String} taskName Task key.
-     * @param {Function} dueCheckFn Function returning a trigger object or boolean.
-     * @param {Function} executeFn Function to run the task if triggered.
-     * @param {Object} context Context for logging and health reporting.
-     * @returns {void}
-     */
-    runIfDue(taskName, dueCheckFn, executeFn, context) {
-        try {
-            const trigger = dueCheckFn();
-            if (trigger) {
-                const reason    = typeof trigger === 'object' ? trigger.reason : `periodic-sync`;
-                const onSuccess = typeof trigger === 'object' ? trigger.onSuccess : undefined;
-                executeFn(taskName, reason, onSuccess);
-            }
-        } catch (e) {
-            context.writeLog?.('ERROR', `[Orchestrator] ${taskName} scheduling failed: ${e.message}`);
-            context.healthService?.recordTaskOutcome(taskName, 'failed', {phase: 'schedule', error: e.message});
-        }
-    }
 }
 
 export default Neo.setupClass(CadenceEngine);

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -220,7 +220,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         }]);
     });
 
-    test('backpressures overdue heavy maintenance tasks within the same poll', () => {
+    test('selects only the first due maintenance candidate per poll (#11900)', () => {
         const logs     = [];
         const outcomes = [];
         const started  = [];
@@ -251,19 +251,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             taskName: 'summary',
             reason  : 'periodic-sweep:600000'
         }]);
-        expect(outcomes).toContainEqual({
-            taskName: 'kbSync',
-            status  : 'skipped',
-            details : expect.objectContaining({
-                blockingTaskName: 'summary',
-                reason          : 'periodic-sync:600000',
-                reasonCode      : 'heavy-maintenance-backpressure'
-            })
-        });
-        expect(logs).toContainEqual({
-            level  : 'INFO',
-            message: expect.stringContaining('Deferring knowledge base sync')
-        });
+        expect(outcomes).toEqual([]);
+        expect(logs).toEqual([]);
     });
 
     test('defers due heavy maintenance when another heavy task is already running', () => {
@@ -1341,6 +1330,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         };
 
         const orchestrator = createTestOrchestrator({
+            kbSyncEnabled : false,
             dreamIntervalMs: 1,
             healthService  : {
                 recordTaskOutcome(taskName, status, details) {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -1,0 +1,250 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildSchedulingContext,
+    runSchedulingPipeline
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/pipeline.mjs';
+
+function makeContext(overrides = {}) {
+    return buildSchedulingContext({
+        db       : {},
+        state    : {},
+        now      : 1_000,
+        intervals: {},
+        enables  : {},
+        hooks    : {},
+        ...overrides
+    });
+}
+
+function makeCandidateDescriptor({
+    taskName = 'summary',
+    executionKind = 'supervised-child-process',
+    maintenanceClass = 'heavy',
+    trigger = {reason: `${taskName}-reason`}
+} = {}) {
+    return {
+        taskName,
+        executionKind,
+        maintenanceClass,
+        backpressure : maintenanceClass === 'heavy' ? 'exclusive-heavy' : 'none',
+        dependencies : [],
+        getDueTask   : () => trigger
+    };
+}
+
+function makeServices(overrides = {}) {
+    return {
+        dreamService: {
+            executeRemCycle: () => Promise.resolve({status: 'completed'})
+        },
+        goldenPathSynthesizer: {
+            synthesizeGoldenPath: () => Promise.resolve()
+        },
+        healthService: {
+            recordTaskOutcome() {}
+        },
+        maintenanceBackpressureService: {
+            acquireLeaseAndExecute({executeFn, taskName, reason, onSuccess, activeHeavyTask}) {
+                return executeFn(taskName, reason, onSuccess, {activeHeavyTask});
+            },
+            executeWithGoldenPathDependencyGate({executeFn, taskName, reason}) {
+                return executeFn(taskName, reason);
+            },
+            getActiveHeavyMaintenanceTask() { return null; },
+            isHeavyMaintenanceTask() { return false; },
+            recordDeferral() {}
+        },
+        primaryRepoSyncService: {
+            runTask: () => true
+        },
+        processSupervisorService: {
+            runTask: () => true
+        },
+        swarmHeartbeatService: {
+            pulse: () => Promise.resolve()
+        },
+        taskStateService: {
+            getTaskState: () => null,
+            markCompleted() {},
+            markFailed() {},
+            markStarted() {}
+        },
+        tenantRepoSyncService: {
+            runTask: () => true
+        },
+        ...overrides
+    };
+}
+
+function makeRuntime(overrides = {}) {
+    return {
+        goldenPathRepoEnrichmentEnabled: true,
+        primaryDevSyncRootsConfig      : null,
+        tenantRepoSyncGlobalCadenceMs  : 10_000,
+        tenantRepoSyncJitterRatio      : 0.1,
+        writeLog                       : () => {},
+        ...overrides
+    };
+}
+
+test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
+    test('reports descriptor errors and still dispatches the selected candidate', () => {
+        const outcomes = [];
+        const started  = [];
+        const logs     = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                {
+                    taskName: 'broken',
+                    getDueTask() { throw new Error('boom'); }
+                },
+                makeCandidateDescriptor({taskName: 'summary'})
+            ],
+            context : makeContext(),
+            services: makeServices({
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                },
+                processSupervisorService: {
+                    runTask(taskName, reason) {
+                        started.push({taskName, reason});
+                        return true;
+                    }
+                }
+            }),
+            runtime: makeRuntime({
+                writeLog(level, message) {
+                    logs.push({level, message});
+                }
+            })
+        });
+
+        expect(result.errors).toHaveLength(1);
+        expect(result.winner.taskName).toBe('summary');
+        expect(outcomes).toContainEqual({
+            taskName: 'broken',
+            status  : 'failed',
+            details : {phase: 'schedule', error: 'boom'}
+        });
+        expect(logs).toContainEqual({
+            level  : 'ERROR',
+            message: '[Orchestrator] broken scheduling failed: boom'
+        });
+        expect(started).toEqual([{taskName: 'summary', reason: 'summary-reason'}]);
+    });
+
+    test('records heavy-maintenance picker deferrals before selecting a winner', () => {
+        const deferrals = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({taskName: 'kbSync', maintenanceClass: 'heavy'})
+            ],
+            context : makeContext({
+                state: {
+                    summary: {running: true},
+                    kbSync : {running: false}
+                }
+            }),
+            services: makeServices({
+                maintenanceBackpressureService: {
+                    acquireLeaseAndExecute() { throw new Error('should not execute'); },
+                    getActiveHeavyMaintenanceTask() { return 'summary'; },
+                    isHeavyMaintenanceTask(taskName) { return taskName === 'summary'; },
+                    recordDeferral(deferral) {
+                        deferrals.push(deferral);
+                    }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        expect(result.winner).toBeNull();
+        expect(deferrals).toEqual([{
+            taskName        : 'kbSync',
+            reasonCode      : 'heavy-maintenance-backpressure',
+            reasonText      : 'kbSync-reason',
+            blockingTaskName: 'summary'
+        }]);
+    });
+
+    test('dispatches service-runner candidates through runtime-provided collaborators', () => {
+        const calls = [];
+
+        runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName        : 'tenant-repo-sync',
+                    executionKind   : 'service-runner',
+                    maintenanceClass: 'continuous'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                tenantRepoSyncService: {
+                    runTask(config) {
+                        calls.push(config);
+                        return true;
+                    }
+                }
+            }),
+            runtime: makeRuntime({
+                tenantRepoSyncGlobalCadenceMs: 25_000,
+                tenantRepoSyncJitterRatio    : 0.25
+            })
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({
+            taskName       : 'tenant-repo-sync',
+            reason         : 'tenant-repo-sync-reason',
+            globalCadenceMs: 25_000,
+            jitterRatio    : 0.25
+        });
+    });
+
+    test('reports unsupported executionKind as dispatch failure', () => {
+        const outcomes = [];
+        const logs     = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({
+                    taskName     : 'future-task',
+                    executionKind: 'future-kind',
+                    maintenanceClass: 'continuous'
+                })
+            ],
+            context : makeContext(),
+            services: makeServices({
+                healthService: {
+                    recordTaskOutcome(taskName, status, details) {
+                        outcomes.push({taskName, status, details});
+                    }
+                }
+            }),
+            runtime: makeRuntime({
+                writeLog(level, message) {
+                    logs.push({level, message});
+                }
+            })
+        });
+
+        expect(result.winner.taskName).toBe('future-task');
+        expect(outcomes).toEqual([{
+            taskName: 'future-task',
+            status  : 'failed',
+            details : {
+                phase: 'dispatch',
+                error: 'Unsupported executionKind: future-kind'
+            }
+        }]);
+        expect(logs).toEqual([{
+            level  : 'ERROR',
+            message: '[Orchestrator] Unsupported executionKind: future-kind'
+        }]);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 import {TASK_REGISTRY} from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+import {DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES} from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 
 const VALID_EXECUTION_KINDS = ['supervised-child-process', 'service-runner', 'in-process-async', 'local-only-service'];
 const VALID_MAINTENANCE_CLASSES = ['continuous', 'heavy', 'graph-dependent', 'lightweight-signal', 'local-only'];
@@ -40,14 +41,26 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
     test('expected scheduling lanes are registered (#11862 Prescription parity)', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
         expect(names).toEqual(expect.arrayContaining([
-            'summary', 'kbSync', 'backup', 'primary-dev-sync',
-            'dream', 'golden-path', 'swarm-heartbeat'
+            'summary', 'kbSync', 'backup', 'graphlog-compaction',
+            'primary-dev-sync', 'tenant-repo-sync', 'dream',
+            'golden-path', 'swarm-heartbeat'
         ]));
     });
 
-    test('graphlog-compaction stays out until collectDueCandidates is wired into Orchestrator.poll()', () => {
+    test('cloud-deployable graph lanes are registered once Orchestrator.poll() consumes the registry', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
-        expect(names).not.toContain('graphlog-compaction');
+        expect(names).toContain('graphlog-compaction');
+        expect(names).toContain('tenant-repo-sync');
+    });
+
+    test('heavy task descriptors match MaintenanceBackpressureService SSOT (#11900)', () => {
+        const descriptorByName = new Map(TASK_REGISTRY.map(descriptor => [descriptor.taskName, descriptor]));
+        for (const taskName of DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES) {
+            const descriptor = descriptorByName.get(taskName);
+            expect(descriptor, `${taskName} is registered`).toBeTruthy();
+            expect(descriptor.maintenanceClass, `${taskName} metadata`).toBe('heavy');
+            expect(descriptor.backpressure, `${taskName} metadata`).toBe('exclusive-heavy');
+        }
     });
 
     test('continuous tasks (chroma/bridgeDaemon/mlx) are intentionally NOT in registry', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/CadenceEngine.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/CadenceEngine.spec.mjs
@@ -22,39 +22,7 @@ test.describe('Neo.ai.daemons.services.CadenceEngine (#11051)', () => {
         expect(ce.shouldRunIntervalTask({now: 2000, lastRunAt: 500, intervalMs: 1000})).toBe(true);
     });
 
-    test('runIfDue() executes task when trigger is truthy and handles fallback shapes', () => {
-        let executed = false;
-        let lastTask, lastReason, lastSuccess;
-        const executeFn = (t, r, s) => { executed = true; lastTask = t; lastReason = r; lastSuccess = s; };
-        const ctx = { writeLog: () => {} };
-
-        // Test 1: Full object shape
-        const successCb = () => {};
-        ce.runIfDue('testTask1', () => ({reason: 'object-reason', onSuccess: successCb}), executeFn, ctx);
-        expect(executed).toBe(true);
-        expect(lastTask).toBe('testTask1');
-        expect(lastReason).toBe('object-reason');
-        expect(lastSuccess).toBe(successCb);
-
-        executed = false;
-
-        // Test 2: Truthy fallback shape (e.g. true boolean returning 'periodic-sync')
-        ce.runIfDue('testTask2', () => true, executeFn, ctx);
-        expect(executed).toBe(true);
-        expect(lastTask).toBe('testTask2');
-        expect(lastReason).toBe('periodic-sync');
-
-        executed = false;
-
-        // Test 3: Falsy trigger
-        ce.runIfDue('testTask3', () => false, executeFn, ctx);
-        expect(executed).toBe(false);
-
-        // Test 4: Exception in due-check isolated
-        let logError = '';
-        const badCtx = { writeLog: (lvl, msg) => { logError = msg; }, healthService: { recordTaskOutcome: () => {} } };
-        ce.runIfDue('testTask4', () => { throw new Error('bang'); }, executeFn, badCtx);
-        expect(executed).toBe(false);
-        expect(logError).toContain('testTask4 scheduling failed');
+    test('does not own task execution dispatch', () => {
+        expect(ce.runIfDue).toBeUndefined();
     });
 });


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9e86-0759-7243-a9f2-3af8f50b290d.

Resolves #11900
Resolves #11862

This switches Orchestrator polling from `CadenceEngine.runIfDue` execution ownership to the shared scheduling pipeline. `collector.mjs` projects due candidates, `picker.mjs` remains the pure selector, and the new `scheduling/pipeline.mjs` owns scheduling-error reporting, picker-deferral telemetry, and descriptor-kind dispatch. `Orchestrator.mjs` is back to a thin boot / continuous-supervision / timer-loop coordinator instead of absorbing the cadence engine.

Evidence: L2 (focused unit scheduling/orchestrator suite plus static hygiene and stale-descriptor sweep) -> L2 required (runtime scheduling dispatch behavior, heavy-backpressure policy, cloud-gated enablement, and tiny-orchestrator LOC gate are covered in unit scope).

## Deltas from ticket

The first PR head violated the #11862 tiny-orchestrator intent: it removed `CadenceEngine.runIfDue()` execution drift but inlined the replacement dispatch/context/error/runners into `Orchestrator.mjs` and grew the file to 1050 LOC. After operator challenge and author hold, the repair moves dispatch into `ai/daemons/orchestrator/scheduling/pipeline.mjs` and reduces `Orchestrator.mjs` to 393 LOC, satisfying the <= 400 LOC gate.

The static `deploymentScope` / `filterDeploymentEligibility` idea remains intentionally absent. Current locked design uses getter-SSOT enablement at descriptor projection time, so cloud/local behavior reads the same resolved Orchestrator getters and does not introduce a second deployment-scope truth source. No Dockerfile changes.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/collector.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/CadenceEngine.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` -> 76 passed on head `01674cda5`.
- `git diff --check origin/dev...HEAD` -> passed.
- `rg -n "deploymentScope|filterDeploymentEligibility|TaskStateService.getRunning" ai/daemons/orchestrator test/playwright/unit/ai/daemons/orchestrator` -> no matches.
- `wc -l ai/daemons/orchestrator/Orchestrator.mjs ai/daemons/orchestrator/scheduling/pipeline.mjs` -> Orchestrator 393 LOC; pipeline 450 LOC.
- Broader exploratory run before the corrective commit: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator` -> 396 passed, 11 failed in unrelated service specs. Narrow reruns showed existing out-of-scope failures: `HeavyMaintenanceLeaseService.spec.mjs -g "default singleton delegates"` returns `acquired-after-stale` where the test expects `acquired`; `DreamServiceGoldenPath.spec.mjs -g "synthesizeGoldenPath executes without crashing"` times out alone. Neither failed spec is touched by this PR.

## Post-Merge Validation

- [ ] Observe one cloud-profile Orchestrator poll after merge: graphlog-compaction and tenant-repo-sync candidates are collected through `TASK_REGISTRY` and respect getter-derived enablement.
- [ ] Confirm `Orchestrator.mjs` remains below the #11862 500-LOC revalidation trigger after merge.

## Commits

- `fd1a334f7` - `feat(orchestrator): consume registry dispatch pipeline (#11900)`
- `01674cda5` - `refactor(orchestrator): move dispatch pipeline out of orchestrator (#11862)`