### PR TITLE
feat(memory-core): backfill memory miniSummary nodes (#12673)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
+++ b/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
@@ -1,0 +1,67 @@
+/**
+ * Reads pending `AGENT_MEMORY` rows that still lack `miniSummary`.
+ *
+ * @summary Cheap scheduler-side existence check; the supervised lifecycle child owns the actual
+ * Chroma join, model call, and graph update.
+ * @param {Object} db SQLite database handle.
+ * @param {Object} [options]
+ * @param {Number} [options.limit=50] Maximum ids to return.
+ * @returns {String[]}
+ */
+export function getPendingMemorySummaryBackfillJobs(db, {limit = 50} = {}) {
+    if (!db?.prepare) {
+        return [];
+    }
+
+    const numericLimit = Number.isInteger(limit) && limit > 0 ? limit : 50;
+
+    try {
+        return db.prepare(`
+            SELECT memory.id AS id
+            FROM Nodes memory
+            WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
+              AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
+            ORDER BY json_extract(memory.data, '$.properties.timestamp') DESC, memory.id DESC
+            LIMIT ?
+        `).all(numericLimit).map(row => row.id).filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Builds the task trigger for memory miniSummary backfill.
+ *
+ * @param {Object} options
+ * @param {String[]} [options.pendingJobs=[]] Pending AGENT_MEMORY ids.
+ * @returns {Object|null}
+ */
+export function buildMemorySummaryBackfillTrigger({pendingJobs = []} = {}) {
+    if (pendingJobs.length > 0) {
+        return {
+            taskName    : 'memory-summary-backfill',
+            source      : 'pending-memory-minisummary',
+            reason      : `pending-memory-minisummary:${pendingJobs.length}`,
+            pendingCount: pendingJobs.length
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Resolves the next memory miniSummary backfill trigger.
+ *
+ * @param {Object} options
+ * @param {Object} options.db SQLite database handle.
+ * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn] Test seam.
+ * @returns {Object|null}
+ */
+export function getDueTask({
+    db,
+    getPendingMemorySummaryBackfillJobsFn = getPendingMemorySummaryBackfillJobs
+}) {
+    return buildMemorySummaryBackfillTrigger({
+        pendingJobs: getPendingMemorySummaryBackfillJobsFn(db)
+    });
+}

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -3,6 +3,7 @@ import {getDueTask as getBackupDueTask}              from './backup.mjs';
 import {getDueTask as getDreamDueTask}               from './dream.mjs';
 import {getDueTask as getGraphLogCompactionDueTask}  from './graphLogCompaction.mjs';
 import {getDueTask as getGoldenPathDueTask}          from './goldenPath.mjs';
+import {getDueTask as getMemorySummaryBackfillDueTask} from './memorySummaryBackfill.mjs';
 import {getDueTask as getPrimaryDevSyncDueTask}      from './primaryDevSync.mjs';
 import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs';
 import {getDueTask as getTenantRepoSyncDueTask}      from './tenantRepoSync.mjs';
@@ -47,6 +48,16 @@ export const TASK_REGISTRY = Object.freeze([
                 summarySweepIntervalMs: intervals.summarySweep,
                 log                   : hooks.log
             });
+        }
+    },
+    {
+        taskName        : 'memory-summary-backfill',
+        executionKind   : 'supervised-child-process',
+        maintenanceClass: 'heavy',
+        backpressure    : 'exclusive-heavy',
+        dependencies    : [],
+        getDueTask({db}) {
+            return getMemorySummaryBackfillDueTask({db});
         }
     },
     {

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -17,6 +17,7 @@ import {DEFAULT_DATA_DIR} from '../taskDefinitions.mjs';
  */
 export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
     'summary',
+    'memory-summary-backfill',
     'kbSync',
     'backup',
     'graphlog-compaction',

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -87,6 +87,13 @@ export function buildTaskDefinitions({
             pidFileName    : 'summarization.pid',
             expectedCommand: 'summarize-sessions.mjs'
         },
+        'memory-summary-backfill': {
+            label          : 'memory miniSummary backfill',
+            command        : nodeBin,
+            args           : [path.join(scriptDir, 'lifecycle', 'backfill-memory-summaries.mjs')],
+            pidFileName    : 'memory-summary-backfill.pid',
+            expectedCommand: 'backfill-memory-summaries.mjs'
+        },
         kbSync: {
             label          : 'knowledge base sync',
             command        : nodeBin,

--- a/ai/scripts/lifecycle/backfill-memory-summaries.mjs
+++ b/ai/scripts/lifecycle/backfill-memory-summaries.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * @summary Lifecycle child that backfills `AGENT_MEMORY.miniSummary` in bounded batches.
+ *
+ * The Orchestrator schedules this as a supervised child process, mirroring
+ * `summarize-sessions.mjs`. The business logic remains in `MemoryService` so this entry point is
+ * a thin bootstrap + observability wrapper and can also be run manually for recovery.
+ *
+ * Exit codes:
+ *  - 0: batch completed (including successful no-op or fail-soft deferred rows)
+ *  - 1: lifecycle or storage failure prevented the batch from running
+ *
+ * @see ai/services/memory-core/MemoryService.backfillMiniSummaries
+ * @see ai/scripts/lifecycle/summarize-sessions.mjs
+ */
+import Neo              from '../../../src/Neo.mjs';
+import * as core        from '../../../src/core/_export.mjs';
+import {withHeavyMaintenanceLease} from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import LifecycleService from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
+import MemoryService    from '../../services/memory-core/MemoryService.mjs';
+
+async function main() {
+    const outcome = await withHeavyMaintenanceLease(
+        async () => {
+            await LifecycleService.initAsync();
+            return MemoryService.backfillMiniSummaries();
+        },
+        {
+            owner   : 'memory-summary-backfill',
+            reason  : 'manual-cli',
+            metadata: {script: 'ai/scripts/lifecycle/backfill-memory-summaries.mjs'}
+        }
+    );
+
+    if (outcome.status === 'held') {
+        const held = outcome.lease;
+        console.log(JSON.stringify({
+            success : true,
+            deferred: true,
+            reason  : 'heavy-maintenance-lease-held',
+            holder  : held ? {
+                owner     : held.owner,
+                reason    : held.reason,
+                pid       : held.pid,
+                acquiredAt: held.acquiredAt
+            } : null
+        }));
+        process.exit(0)
+    }
+
+    console.log(JSON.stringify({success: true, ...(outcome.result || {})}));
+    process.exit(0)
+}
+
+main().catch(error => {
+    console.error('backfill-memory-summaries failed:', error.message);
+    process.exit(1)
+});

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -704,6 +704,130 @@ class MemoryService extends Base {
     }
 
     /**
+     * @summary Merges a generated `miniSummary` into an existing `AGENT_MEMORY` node without changing tenant ownership.
+     *
+     * Backfill runs as daemon/system work, usually without a request-bound tenant. Plain
+     * {@link GraphService#upsertNode} is intentionally RLS-aware and may not see private
+     * tenant rows from that context, so it can treat an existing tenant-owned memory as a
+     * new node. The backfill path must instead update the full persisted node JSON in
+     * place, preserving `userId`, `agentIdentity`, `sessionId`, timestamps, and every
+     * other property while adding only `miniSummary`.
+     *
+     * @param {Object} options
+     * @param {String} options.id          Existing `AGENT_MEMORY` node id.
+     * @param {String} options.miniSummary Generated compact summary to merge.
+     * @returns {Boolean} `true` when the node was updated, `false` when the row is missing.
+     * @private
+     */
+    updateMemoryMiniSummary({id, miniSummary}) {
+        const graph  = GraphService.db,
+              sqlite = graph?.storage?.db;
+
+        if (!sqlite) {
+            return false;
+        }
+
+        const row = sqlite.prepare('SELECT data FROM Nodes WHERE id = ? LIMIT 1').get(id);
+        if (!row?.data) {
+            return false;
+        }
+
+        const existing   = JSON.parse(row.data),
+              properties = {...(existing.properties || {}), miniSummary},
+              nodeData   = {
+                  id        : existing.id || id,
+                  label     : existing.label || 'AGENT_MEMORY',
+                  properties
+              };
+
+        graph.storage.addNodes([nodeData]);
+
+        return true;
+    }
+
+    /**
+     * @summary Backfills compact per-turn summaries for existing `AGENT_MEMORY` graph rows.
+     *
+     * Mirrors the inline {@link addMemory} enrichment path for pre-existing memories and for
+     * turns written while the summarizer was unavailable. The scan is graph-first and
+     * most-recent-first; Chroma is only joined by the selected node ids to fetch that memory's own
+     * prompt/response. Updates merge `miniSummary` into the same graph node through a
+     * tenant-preserving storage-layer merge, preserving tenant attribution (`userId`, `agentIdentity`)
+     * and every other property already present on the row.
+     *
+     * Fail-soft by construction: model/provider failures leave the row unmodified so a later batch
+     * can retry it. A failure for one row never aborts the batch.
+     *
+     * @param {Object} [options]
+     * @param {Number} [options.limit] Maximum rows to process. Defaults to
+     *     `aiConfig.summarizationBatchLimit`.
+     * @param {Function} [options.buildMiniSummary] Optional summarizer seam for deterministic tests.
+     * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number}>}
+     */
+    async backfillMiniSummaries({limit, buildMiniSummary} = {}) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) {
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0};
+        }
+
+        const defaultLimit = Number(aiConfig.summarizationBatchLimit) || 50;
+        const numericLimit = Number(limit) || defaultLimit;
+        const boundedLimit = Math.max(1, Math.min(numericLimit, defaultLimit));
+        const summarize    = buildMiniSummary || (options => this.buildMiniSummary(options));
+
+        const rows = sqlite.prepare(`
+            SELECT memory.id                                          AS id,
+                   json_extract(memory.data, '$.properties.timestamp') AS timestamp
+            FROM Nodes memory
+            WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
+              AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
+            ORDER BY json_extract(memory.data, '$.properties.timestamp') DESC, memory.id DESC
+            LIMIT ?
+        `).all(boundedLimit);
+
+        if (rows.length === 0) {
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0};
+        }
+
+        const collection = await StorageRouter.getMemoryCollection();
+        const fetched    = await collection.get({ids: rows.map(row => row.id), include: ['metadatas']});
+        const byId       = new Map((fetched.ids || []).map((id, index) => [id, fetched.metadatas?.[index] || {}]));
+
+        let updated = 0, deferred = 0, missingContent = 0;
+
+        for (const row of rows) {
+            const metadata = byId.get(row.id);
+            if (!metadata || (!metadata.prompt && !metadata.response)) {
+                missingContent++;
+                continue;
+            }
+
+            try {
+                const miniSummary = await summarize({
+                    prompt  : metadata.prompt,
+                    response: metadata.response
+                });
+
+                if (!miniSummary) {
+                    deferred++;
+                    continue;
+                }
+
+                if (this.updateMemoryMiniSummary({id: row.id, miniSummary})) {
+                    updated++;
+                } else {
+                    missingContent++;
+                }
+            } catch (error) {
+                logger.warn(`[MemoryService] miniSummary backfill deferred for ${row.id} (fail-soft): ${error.message}`);
+                deferred++;
+            }
+        }
+
+        return {processed: rows.length, updated, deferred, missingContent};
+    }
+
+    /**
      * Executes a semantic search against the memory collection.
      * @param {Object} options
      * @param {String} options.query         The search query string.

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -167,7 +167,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -729,9 +729,11 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         expect(orchestrator.stateFile).toBe(path.join(dataDir, 'orchestrator-state.json'));
 
         const expectedSummaryScript = path.resolve(repoRoot, 'ai/scripts/lifecycle/summarize-sessions.mjs');
-        const expectedKbSyncScript = path.resolve(repoRoot, 'ai/scripts/maintenance/syncKnowledgeBase.mjs');
+        const expectedBackfillScript = path.resolve(repoRoot, 'ai/scripts/lifecycle/backfill-memory-summaries.mjs');
+        const expectedKbSyncScript   = path.resolve(repoRoot, 'ai/scripts/maintenance/syncKnowledgeBase.mjs');
 
         expect(orchestrator.taskDefinitions.summary.args[0]).toBe(expectedSummaryScript);
+        expect(orchestrator.taskDefinitions['memory-summary-backfill'].args[0]).toBe(expectedBackfillScript);
         expect(orchestrator.taskDefinitions.kbSync.args[0]).toBe(expectedKbSyncScript);
         expect(orchestrator.taskDefinitions.mlx).toBeUndefined();
     });
@@ -906,6 +908,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             'backup',
             'graphlog-compaction',
             'kbSync',
+            'memory-summary-backfill',
             'primary-dev-sync',
             'dream',
             'summary'

--- a/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs
@@ -26,6 +26,10 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
         expect(tasks.summary.args).toEqual([path.join(scriptDir, 'lifecycle', 'summarize-sessions.mjs')]);
         expect(tasks.summary.expectedCommand).toBe('summarize-sessions.mjs');
 
+        expect(tasks['memory-summary-backfill'].command).toBe('/test/node');
+        expect(tasks['memory-summary-backfill'].args).toEqual([path.join(scriptDir, 'lifecycle', 'backfill-memory-summaries.mjs')]);
+        expect(tasks['memory-summary-backfill'].expectedCommand).toBe('backfill-memory-summaries.mjs');
+
         expect(tasks.kbSync.command).toBe('/test/node');
         expect(tasks.kbSync.args).toEqual([path.join(scriptDir, 'maintenance', 'syncKnowledgeBase.mjs')]);
         expect(tasks.kbSync.expectedCommand).toBe('syncKnowledgeBase.mjs');
@@ -41,6 +45,17 @@ test.describe('ai/daemons/orchestrator/daemon.mjs (#11006/#11009)', () => {
             '--apply'
         ]);
         expect(tasks['graphlog-compaction'].expectedCommand).toBe('compactGraphLog.mjs');
+    });
+
+    test('memory-summary backfill CLI is guarded by the shared heavy-maintenance lease', () => {
+        const source = fs.readFileSync(
+            path.resolve(process.cwd(), 'ai/scripts/lifecycle/backfill-memory-summaries.mjs'),
+            'utf8'
+        );
+
+        expect(source).toContain('withHeavyMaintenanceLease');
+        expect(source).toContain("owner   : 'memory-summary-backfill'");
+        expect(source).toContain("reason  : 'manual-cli'");
     });
 
     test('buildTaskDefinitions is pure: tasks.mlx is omitted when mlxEnabled is false', () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
@@ -1,0 +1,41 @@
+import {test, expect} from '@playwright/test';
+import {
+    buildMemorySummaryBackfillTrigger,
+    getDueTask,
+    getPendingMemorySummaryBackfillJobs
+} from '../../../../../../../ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs';
+
+test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
+    test('buildMemorySummaryBackfillTrigger schedules pending miniSummary rows', () => {
+        expect(buildMemorySummaryBackfillTrigger({pendingJobs: ['mem-1', 'mem-2']})).toEqual({
+            taskName    : 'memory-summary-backfill',
+            source      : 'pending-memory-minisummary',
+            reason      : 'pending-memory-minisummary:2',
+            pendingCount: 2
+        });
+    });
+
+    test('buildMemorySummaryBackfillTrigger returns null when no rows are pending', () => {
+        expect(buildMemorySummaryBackfillTrigger({pendingJobs: []})).toBeNull();
+    });
+
+    test('getDueTask uses the pending-row finder seam', () => {
+        expect(getDueTask({
+            db                                      : {},
+            getPendingMemorySummaryBackfillJobsFn: () => ['mem-1']
+        })).toMatchObject({
+            taskName: 'memory-summary-backfill',
+            reason  : 'pending-memory-minisummary:1'
+        });
+    });
+
+    test('getPendingMemorySummaryBackfillJobs is fail-soft when the graph table is unavailable', () => {
+        const db = {
+            prepare() {
+                throw new Error('no graph table');
+            }
+        };
+
+        expect(getPendingMemorySummaryBackfillJobs(db)).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -41,7 +41,7 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
     test('expected scheduling lanes are registered (#11862 Prescription parity)', () => {
         const names = TASK_REGISTRY.map(d => d.taskName);
         expect(names).toEqual(expect.arrayContaining([
-            'summary', 'kbSync', 'backup', 'graphlog-compaction',
+            'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction',
             'primary-dev-sync', 'tenant-repo-sync', 'dream',
             'golden-path', 'swarm-heartbeat'
         ]));

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -59,6 +59,7 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             'dream',
             'graphlog-compaction',
             'kbSync',
+            'memory-summary-backfill',
             'primary-dev-sync',
             'summary'
         ].sort());

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -30,7 +30,9 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
  *                     mechanically prevents the fail-open default — AC7a alone passes even if this path is broken).
  */
 test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
-    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection, originalEmbedText;
+    test.describe.configure({mode: 'serial'});
+
+    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection, originalEmbedText, memStore;
 
     test.beforeAll(async () => {
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
@@ -44,7 +46,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         // an in-memory fake so the spec exercises the real addMemory→queryRecentTurns flow without a
         // live Chroma. The recency query reads the GRAPH; the fake only stands in for the content
         // store (the write + the detail:'full' join).
-        const memStore = new Map();
+        memStore = new Map();
         originalGetMemoryCollection = StorageRouter.getMemoryCollection;
         StorageRouter.getMemoryCollection = async () => ({
             add: async ({ids = [], metadatas = []} = {}) => { ids.forEach((id, i) => memStore.set(id, metadatas[i] || {})); },
@@ -194,5 +196,68 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         const page2 = await RequestContextService.run(ctx, async () => MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 1, before: page1.nextCursor}));
         expect(page2.count).toBe(1);
         expect(page2.turns[0].id).toBe('mem-cursor-1');   // the OTHER equal-timestamp turn — no dup, no skip
+    });
+
+    test('backfillMiniSummaries summarizes pending rows most-recent-first and preserves tenant metadata', async () => {
+        const oldTs = '2099-01-01T00:00:00.000Z';
+        const newTs = '2099-01-02T00:00:00.000Z';
+
+        memStore.set('backfill-old', {prompt: 'old prompt', response: 'old response'});
+        memStore.set('backfill-new', {prompt: 'new prompt', response: 'new response'});
+
+        GraphService.upsertNode({
+            id: 'backfill-old', type: 'AGENT_MEMORY', name: 'Memory: old', description: 'old',
+            semanticVectorId: 'backfill-old',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'backfill', timestamp: oldTs}
+        });
+        GraphService.upsertNode({
+            id: 'backfill-new', type: 'AGENT_MEMORY', name: 'Memory: new', description: 'new',
+            semanticVectorId: 'backfill-new',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'backfill', timestamp: newTs}
+        });
+
+        const calls = [];
+        const result = await MemoryService.backfillMiniSummaries({
+            limit: 1,
+            buildMiniSummary: async ({prompt}) => {
+                calls.push(prompt);
+                return `summary:${prompt}`;
+            }
+        });
+        expect(calls).toEqual(['new prompt']);
+        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0});
+
+        const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-new');
+        const data = JSON.parse(row.data);
+        expect(data.properties.miniSummary).toBe('summary:new prompt');
+        expect(data.properties.userId).toBe('tenant-a');
+        expect(data.properties.agentIdentity).toBe('@agent-a');
+
+        const oldRow  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-old');
+        const oldData = JSON.parse(oldRow.data);
+        expect(oldData.properties.miniSummary).toBeUndefined();
+    });
+
+    test('backfillMiniSummaries leaves provider failures retryable without aborting the batch', async () => {
+        const ts = '2099-01-03T00:00:00.000Z';
+
+        memStore.set('backfill-failure', {prompt: 'failure prompt', response: 'failure response'});
+        GraphService.upsertNode({
+            id: 'backfill-failure', type: 'AGENT_MEMORY', name: 'Memory: failure', description: 'failure',
+            semanticVectorId: 'backfill-failure',
+            properties      : {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'backfill', timestamp: ts}
+        });
+
+        const result = await MemoryService.backfillMiniSummaries({
+            limit: 1,
+            buildMiniSummary: async () => {
+                throw new Error('provider unavailable');
+            }
+        });
+        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0});
+
+        const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-failure');
+        const data = JSON.parse(row.data);
+        expect(data.properties.miniSummary).toBeUndefined();
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 12f410ea-466b-4594-a13b-dae2684eb702.

Resolves #12673

Adds a bounded Memory Core backfill path for pre-existing `AGENT_MEMORY` rows that lack `miniSummary`. The implementation scans graph rows most-recent-first, joins Chroma only by the selected memory ids, reuses `MemoryService.buildMiniSummary()`, and merges the resulting `miniSummary` into the same graph node so existing `userId` / `agentIdentity` attribution is preserved. Orchestrator integration stays in the scheduling registry + task definition; `Orchestrator.mjs` remains unchanged. The scheduled lane and the manual CLI both use the shared heavy-maintenance lease so the batch defers behind active embedder-heavy work such as `kbSync`.

Rebase delta at `531928424`: after `#12683` / `#12687`, the `QueryRecentTurns.spec.mjs` conflict exposed that daemon/system backfill runs outside a request-bound tenant and therefore cannot use the RLS-aware public `GraphService.upsertNode()` path for tenant-private memory rows. The fix adds a tenant-preserving storage-layer merge for `miniSummary`, plus an explicit summarizer seam for deterministic unit coverage. This keeps `userId`, `agentIdentity`, `sessionId`, timestamps, and other row properties intact.

Evidence: L2 (real MemoryService/GraphService unit path with fake Chroma/model + Orchestrator registry/task-definition tests) -> L3 required for live Chroma/provider backfill on deployed memory data. Residual: post-merge operator smoke [`#12673`].

Decision Record impact: aligned-with ADR 0019; uses the existing `summarizationBatchLimit` leaf at the use site and adds no config alias or singleton mutation.

Related: #12671

## Deltas from ticket
- Added a dedicated `memory-summary-backfill` supervised child task instead of overloading `summary`, preserving separate PID/state/health accounting.
- Scheduler triggers on pending `AGENT_MEMORY` rows with missing `miniSummary`; once drained, it returns no candidate instead of running periodic no-op batches.
- The manual lifecycle CLI is also lease-guarded, so operator/manual invocation will defer when another heavy maintenance owner is active.
- Reused `summarizationBatchLimit`; no new config leaf or public MCP surface.
- Kept the backfill out of the Orchestrator body; dispatch remains in the existing scheduling pipeline.
- Resolved the `QueryRecentTurns.spec.mjs` merge conflict by keeping both serial/shared fake Chroma state and the post-`#12683` embedText restore guard.
- Backfill updates tenant-private memory rows through a tenant-preserving storage merge, not through the RLS-aware public graph upsert that can hide private rows from daemon context.

## Test Evidence
- `git diff --check origin/dev...HEAD` -> OK.
- `node --check ai/scripts/lifecycle/backfill-memory-summaries.mjs` -> OK.
- `node --check ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs` -> OK.
- `node --check ai/services/memory-core/MemoryService.mjs` -> OK.
- `node --check ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs` -> OK.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs --grep "backfillMiniSummaries summarizes"` -> 1 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs` -> 44 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs test/playwright/unit/ai/daemons/orchestrator/daemon.spec.mjs` -> 57 passed.
- Commit hook passed during amend: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.
- Pre-push freshness: `git merge-base HEAD origin/dev` == `git rev-parse origin/dev` (`bf9cfa48a`).

## Post-Merge Validation
- [ ] Run or observe one `memory-summary-backfill` batch against a real Memory Core deployment with Chroma + configured model provider and verify JSON output reports bounded processing without cross-tenant read exposure.

## Commits
- `531928424` — `feat(memory-core): backfill memory miniSummary nodes (#12673)`
