### PR TITLE
feat(ai): simplify worktree pruning (#12677)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -72,11 +72,16 @@
  *                                                    # independent-clone topology: explicit
  *                                                    # canonical-root override
  * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale
- *                                                    # dry-run stale .claude/worktrees cleanup
- * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --apply
- *                                                    # remove prunable worktrees via git
- * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --apply --force-dirty
- *                                                    # also force-remove dirty-but-stale worktrees
+ *                                                    # remove every non-current .claude/worktrees
+ *                                                    # checkout via git, then hydrate current
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run
+ *                                                    # report the same keep/remove plan
+ *                                                    # without mutating disk
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --interval-ms 21600000
+ *                                                    # local operator scheduler (6h example);
+ *                                                    # force-removes all non-current worktrees
+ *                                                    # on every tick; intentionally not an
+ *                                                    # orchestrator/cloud lane
  * ```
  *
  * Also supports the `NEO_AI_CANONICAL_ROOT` env var as a fallback for the `--canonical-root`
@@ -168,11 +173,6 @@ export const GITIGNORED_FILES_TO_LINK = [
 ];
 
 export const DEFAULT_CLAUDE_WORKTREES_ROOT = path.join('.claude', 'worktrees');
-
-export const PRUNABLE_WORKTREE_STATUSES = new Set([
-    'prunable-merged',
-    'prunable-deleted'
-]);
 
 /**
  * @summary Resolves the canonical "main checkout" path for a given project root.
@@ -648,162 +648,109 @@ export async function listClaudeWorktrees({
 }
 
 /**
- * @summary Classifies one Claude Code worktree for dry-run or removal.
+ * @summary Classifies one Claude Code worktree for keep-current/delete-rest pruning.
  *
- * Safety is biased toward preservation: dirty worktrees, branches with open PRs,
- * branches with unmerged commits, and branches whose PR status cannot be verified
- * are classified as non-prunable.
+ * Worktrees are disposable checkouts; committed work lives in branches/remotes. The only
+ * local filesystem state protected by this cleaner is the current active checkout. Every
+ * other Claude worktree is removable via `git worktree remove --force`, which keeps git's
+ * worktree admin records coherent while deleting any dirty or unmerged non-current checkout.
  *
  * @param {object}   options
  * @param {object}   options.worktree Parsed worktree record.
- * @param {string}   options.projectRoot Primary checkout path used for repo-wide git queries.
- * @param {string}   [options.baseRef='dev'] Base branch to compare against.
- * @param {Function} [options.exec] Dependency-injected execFile wrapper.
+ * @param {string}   options.currentPath Absolute current checkout path that must be preserved.
+ * @param {string}   options.mainCheckout Absolute primary checkout path that must be preserved.
  * @param {Function} [options.getSize] Optional size resolver.
  * @returns {Promise<object>}
  */
 export async function classifyWorktree({
     worktree,
-    projectRoot,
-    baseRef = 'dev',
+    currentPath,
+    mainCheckout,
     exec    = execFileAsync,
     getSize = getPathSizeBytes
 }) {
-    const sizeBytes = await getSize(worktree.path, {exec});
-    const dirty     = await isWorktreeDirty(worktree.path, exec);
-    const base      = {
-        ...worktree,
-        sizeBytes,
-        dirty,
-        prunable       : false,
-        forcePrunable  : false,
-        removeArgs     : ['worktree', 'remove', worktree.path],
-        status         : 'active',
-        reason         : ''
-    };
-
-    const branchExists = worktree.branch
-        ? await refExists(projectRoot, `refs/heads/${worktree.branch}`, exec)
-        : false;
-
-    const prState = worktree.branch ? await getPullRequestState(projectRoot, worktree.branch, exec) : null;
-    const merged = await isMergedToBase({projectRoot, worktree, baseRef, branchExists, exec});
-    const prStateBlocksRemoval = prState === 'OPEN' || prState === 'unknown';
-
-    if (dirty) {
-        return {
-            ...base,
-            status       : 'dirty',
-            reason       : merged || !branchExists ? 'dirty-but-otherwise-prunable' : 'dirty-active-or-unmerged',
-            forcePrunable: !prStateBlocksRemoval && (merged || !branchExists),
-            removeArgs   : ['worktree', 'remove', '--force', worktree.path]
-        };
-    }
-
-    if (prState === 'OPEN') {
-        return {
-            ...base,
-            status: 'active',
-            reason: `branch ${worktree.branch} has an open PR`
-        };
-    }
-
-    if (prState === 'unknown') {
-        return {
-            ...base,
-            status: 'active',
-            reason: `branch ${worktree.branch} PR status could not be verified`
-        };
-    }
-
-    if (worktree.branch && !branchExists) {
-        return {
-            ...base,
-            prunable: true,
-            status  : 'prunable-deleted',
-            reason  : `branch ${worktree.branch} no longer exists`
-        };
-    }
-
-    if (merged) {
-        return {
-            ...base,
-            prunable: true,
-            status  : 'prunable-merged',
-            reason  : worktree.branch
-                ? `branch ${worktree.branch} is merged or patch-equivalent to ${baseRef}`
-                : `detached HEAD ${worktree.head} is an ancestor of ${baseRef}`
-        };
-    }
+    const sizeBytes             = await getSize(worktree.path, {exec});
+    const current               = isSamePath(worktree.path, currentPath);
+    const primaryMainCheckout   = isSamePath(worktree.path, mainCheckout);
+    const protectedCheckoutPath = current || primaryMainCheckout;
 
     return {
-        ...base,
-        status: 'active',
-        reason: worktree.branch
-            ? `branch ${worktree.branch} has commits not merged into ${baseRef}`
-            : `detached HEAD ${worktree.head || 'unknown'} is not known merged into ${baseRef}`
+        ...worktree,
+        sizeBytes,
+        current,
+        mainCheckout: primaryMainCheckout,
+        remove      : !protectedCheckoutPath,
+        removeArgs: ['worktree', 'remove', '--force', worktree.path],
+        status    : current ? 'current' : (primaryMainCheckout ? 'main-checkout' : 'remove'),
+        reason    : current
+            ? 'current active worktree'
+            : (primaryMainCheckout ? 'primary checkout' : 'non-current Claude worktree')
     };
 }
 
 /**
- * @summary Dry-runs or applies stale Claude Code worktree pruning.
+ * @summary Deletes non-current Claude Code worktrees and hydrates the current checkout.
  *
- * Default mode never mutates. `apply=true` removes only clean worktrees classified
- * as prunable. Dirty worktrees remain preserved unless `forceDirty=true` is also
- * provided and the dirty worktree is otherwise prunable.
+ * Default mode mutates. Pass `dryRun=true` for the non-mutating plan. This cleaner is
+ * deliberately local-operator scoped; do not wire it into cloud-deployable orchestrator
+ * lanes where tenant deployments have no business running git worktree deletion.
  *
  * @param {object}   options
  * @param {string}   options.projectRoot Primary checkout path.
- * @param {boolean}  [options.apply=false] Whether to remove prunable worktrees.
- * @param {boolean}  [options.forceDirty=false] Whether dirty-but-prunable worktrees may be force-removed.
- * @param {string}   [options.baseRef='dev'] Base branch to compare against.
+ * @param {string}   [options.currentPath=projectRoot] Active checkout path that must not be removed.
+ * @param {boolean}  [options.dryRun=false] Whether to only report the keep/remove plan.
  * @param {string}   [options.worktreesRoot] Worktree parent path.
  * @param {Function} [options.exec] Dependency-injected execFile wrapper.
  * @param {Function} [options.getSize] Optional size resolver.
  * @param {Function} [options.log] Logger fn for action diagnostics.
- * @returns {Promise<{worktrees: object[], removed: object[], skipped: object[], totalBytes: number, reclaimableBytes: number, reclaimedBytes: number}>}
+ * @param {Function} [options.hydrate] Current-worktree hydration hook.
+ * @returns {Promise<{worktrees: object[], removed: object[], skipped: object[], totalBytes: number, reclaimableBytes: number, reclaimedBytes: number, hydrated: object|null}>}
  */
 export async function pruneStaleWorktrees({
     projectRoot,
-    apply         = false,
-    forceDirty    = false,
-    baseRef       = 'dev',
+    currentPath   = projectRoot,
+    dryRun        = false,
     worktreesRoot = DEFAULT_CLAUDE_WORKTREES_ROOT,
     exec          = execFileAsync,
     getSize       = getPathSizeBytes,
-    log           = console.log
+    log           = console.log,
+    hydrate       = hydrateCurrentWorktree
 }) {
     const worktrees = await listClaudeWorktrees({projectRoot, worktreesRoot, exec});
     const classified = [];
 
     for (const worktree of worktrees) {
-        classified.push(await classifyWorktree({worktree, projectRoot, baseRef, exec, getSize}));
+        classified.push(await classifyWorktree({worktree, currentPath, mainCheckout: projectRoot, exec, getSize}));
     }
 
-    const removable = classified.filter(item => item.prunable || (forceDirty && item.forcePrunable));
-    const skipped   = classified.filter(item => !removable.includes(item));
+    const removable = classified.filter(item => item.remove);
+    const skipped   = classified.filter(item => !item.remove);
     const removed   = [];
 
     const totalBytes       = classified.reduce((sum, item) => sum + item.sizeBytes, 0);
     const reclaimableBytes = removable.reduce((sum, item) => sum + item.sizeBytes, 0);
 
-    log(`Claude worktree prune ${apply ? 'apply' : 'dry-run'} against ${baseRef}`);
+    log(`Claude worktree prune ${dryRun ? 'dry-run' : 'apply'} (keep current: ${path.resolve(currentPath)})`);
     log(`Found ${classified.length} worktree(s), ${formatBytes(totalBytes)} total, ${formatBytes(reclaimableBytes)} reclaimable.`);
 
     for (const item of classified) {
-        const marker = removable.includes(item) ? (apply ? 'remove' : 'would-remove') : 'keep';
+        const marker = item.remove ? (dryRun ? 'would-remove' : 'remove') : 'keep';
         log(`${marker}: ${item.status} ${formatBytes(item.sizeBytes)} ${item.path}`);
         log(`  ${item.reason}`);
     }
 
-    if (apply) {
+    let hydrated = null;
+
+    if (!dryRun) {
         for (const item of removable) {
             await exec('git', item.removeArgs, {cwd: projectRoot});
             removed.push(item);
         }
         log(`Removed ${removed.length} worktree(s), reclaimed up to ${formatBytes(reclaimableBytes)}.`);
+        hydrated = await hydrate({mainCheckout: projectRoot, projectRoot: currentPath, log});
+        log(`Hydrated current worktree: ${path.resolve(currentPath)}`);
     } else {
-        log(`Dry-run only. Re-run with --apply to remove prunable worktrees.`);
+        log(`Dry-run only. Re-run without --dry-run to remove non-current worktrees.`);
     }
 
     return {
@@ -812,7 +759,73 @@ export async function pruneStaleWorktrees({
         skipped,
         totalBytes,
         reclaimableBytes,
-        reclaimedBytes: apply ? reclaimableBytes : 0
+        reclaimedBytes: dryRun ? 0 : reclaimableBytes,
+        hydrated
+    };
+}
+
+/**
+ * @summary Reuses the existing bootstrap + `--link-data` hydration path for one checkout.
+ *
+ * @param {object}   options
+ * @param {string}   options.mainCheckout Canonical checkout path.
+ * @param {string}   options.projectRoot Current checkout path to hydrate.
+ * @param {Function} [options.log] Logger fn.
+ * @returns {Promise<object>} Hydration sub-results.
+ */
+export async function hydrateCurrentWorktree({mainCheckout, projectRoot, log = console.log}) {
+    const bootstrap = await bootstrapWorktree({mainCheckout, projectRoot, log});
+    const data      = await symlinkDataDir({mainCheckout, projectRoot, log});
+    const files     = await symlinkGitignoredFiles({mainCheckout, projectRoot, log});
+
+    return {bootstrap, data, files};
+}
+
+/**
+ * @summary Runs the local-only prune loop on an interval for operator-managed hosts.
+ *
+ * This is intentionally a CLI/local scheduler, not an Orchestrator task. The Orchestrator
+ * has cloud-deployable lanes; worktree deletion is a desktop-harness hygiene action.
+ * Warning: each tick force-removes all non-current worktrees, including concurrently-active
+ * sibling sessions. Use only on operator-managed hosts where that disposable-worktree policy
+ * is acceptable.
+ *
+ * @param {object}   options
+ * @param {number}   options.intervalMs Interval between runs.
+ * @returns {Promise<{intervalMs: number, stop: Function}>}
+ */
+export async function runLocalPruneWorktreeSchedule({intervalMs, log = console.log, ...pruneOptions}) {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+        throw new Error(`--interval-ms must be a positive number`);
+    }
+
+    log(`WARNING: --schedule-local force-removes all non-current worktrees on every tick, including concurrently-active sibling sessions.`);
+
+    let running = false;
+    const runOnce = async () => {
+        if (running) {
+            log(`Skipping prune tick: prior run still active.`);
+            return null;
+        }
+
+        running = true;
+        try {
+            return await pruneStaleWorktrees({...pruneOptions, log});
+        } catch (e) {
+            log(`Prune tick failed: ${e.message}`);
+            return null;
+        } finally {
+            running = false;
+        }
+    };
+
+    await runOnce();
+    const timer = setInterval(runOnce, intervalMs);
+    log(`Local worktree prune scheduler active: interval ${intervalMs}ms.`);
+
+    return {
+        intervalMs,
+        stop: () => clearInterval(timer)
     };
 }
 
@@ -826,58 +839,19 @@ async function getPathSizeBytes(targetPath, {exec = execFileAsync} = {}) {
     }
 }
 
-async function isWorktreeDirty(worktreePath, exec) {
-    const {stdout} = await exec('git', ['status', '--porcelain'], {cwd: worktreePath});
-    return stdout.trim().length > 0;
+function isSamePath(a, b) {
+    return path.resolve(a) === path.resolve(b);
 }
 
-async function refExists(projectRoot, ref, exec) {
-    try {
-        await exec('git', ['show-ref', '--verify', '--quiet', ref], {cwd: projectRoot});
-        return true;
-    } catch {
-        return false;
-    }
-}
+function getNumberFlag(argv, flagName, defaultValue) {
+    const index = argv.indexOf(flagName);
+    if (index === -1) return defaultValue;
 
-async function isMergedToBase({projectRoot, worktree, baseRef, branchExists, exec}) {
-    if (worktree.head) {
-        try {
-            await exec('git', ['merge-base', '--is-ancestor', worktree.head, baseRef], {cwd: projectRoot});
-            return true;
-        } catch {}
+    const value = Number(argv[index + 1]);
+    if (!Number.isFinite(value)) {
+        throw new Error(`${flagName} requires a numeric value`);
     }
-
-    if (!worktree.branch || !branchExists) {
-        return false;
-    }
-
-    const {stdout: mergedBranches} = await exec('git', ['branch', '--merged', baseRef, '--format=%(refname:short)'], {cwd: projectRoot});
-    if (mergedBranches.split(/\r?\n/).map(line => line.trim()).includes(worktree.branch)) {
-        return true;
-    }
-
-    try {
-        const {stdout: cherry} = await exec('git', ['cherry', baseRef, worktree.branch], {cwd: projectRoot});
-        const lines = cherry.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
-        return lines.length > 0 && lines.every(line => line.startsWith('-'));
-    } catch {
-        return false;
-    }
-}
-
-async function getPullRequestState(projectRoot, branch, exec) {
-    try {
-        const {stdout} = await exec('gh', ['pr', 'view', branch, '--json', 'state', '--jq', '.state'], {cwd: projectRoot});
-        const state    = stdout.trim();
-        return state || null;
-    } catch (e) {
-        const stderr = String(e.stderr || e.message || '');
-        if (/no pull requests found|not found|could not resolve to a PullRequest/i.test(stderr)) {
-            return null;
-        }
-        return 'unknown';
-    }
+    return value;
 }
 
 function isPathInside(rootPath, candidatePath) {
@@ -916,8 +890,9 @@ if (isMain) {
     const force    = args.has('--force');
     const pruneStale = args.has('--prune-stale') || argv.includes('--mode=prune-stale') ||
         (argv.includes('--mode') && argv[argv.indexOf('--mode') + 1] === 'prune-stale');
-    const apply      = args.has('--apply');
-    const forceDirty = args.has('--force-dirty');
+    const dryRun        = args.has('--dry-run');
+    const scheduleLocal = args.has('--schedule-local');
+    const intervalMs    = getNumberFlag(argv, '--interval-ms', 6 * 60 * 60 * 1000);
 
     // `--canonical-root <path>` flag wins; `NEO_AI_CANONICAL_ROOT` env var is the fallback.
     // Both are no-ops when running in an actual git worktree (the existing
@@ -938,8 +913,18 @@ if (isMain) {
         if (explicitRoot) console.log(`✓ Canonical checkout (explicit): ${mainCheckout}`);
 
         if (pruneStale) {
-            await pruneStaleWorktrees({projectRoot: mainCheckout, apply, forceDirty});
-            process.exit(0);
+            if (scheduleLocal) {
+                await runLocalPruneWorktreeSchedule({
+                    projectRoot: mainCheckout,
+                    currentPath: projectRoot,
+                    dryRun,
+                    intervalMs
+                });
+                await new Promise(() => {});
+            } else {
+                await pruneStaleWorktrees({projectRoot: mainCheckout, currentPath: projectRoot, dryRun});
+                process.exit(0);
+            }
         }
 
         const result = await bootstrapWorktree({mainCheckout, projectRoot});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
         "ai:probe-keep-alive"          : "node ./ai/scripts/benchmark/keep-alive-probe.mjs",
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
+        "ai:prune-worktrees:dry-run"   : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run",
+        "ai:prune-worktrees:schedule-dangerous": "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --interval-ms 21600000",
         "ai:purge-test-collections"    : "node ./ai/scripts/maintenance/purgeTestCollections.mjs",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-config-template-ssot" : "node ./ai/scripts/lint/lint-config-template-ssot.mjs",

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -21,7 +21,7 @@ import fs              from 'fs-extra';
 import path            from 'path';
 
 /**
- * @summary Coverage for the worktree bootstrap script (#10095).
+ * @summary Coverage for the worktree bootstrap script.
  *
  * Uses tmp dirs as fake main-checkout and fake worktree to exercise the copy logic
  * without touching the real repo state. The CLI-mode `execFile` resolution of
@@ -241,7 +241,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     // --------------------------------------------------------------------------------
-    // #10435 resolveMainCheckout — explicit canonical-root override for independent
+    // resolveMainCheckout — explicit canonical-root override for independent
     // clone topologies (where `git worktree list` returns the clone itself rather than
     // the canonical sibling). The git-worktree-list fall-through path is intentionally
     // not exercised here (depends on a real git checkout); the explicit-root happy
@@ -283,11 +283,10 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     // --------------------------------------------------------------------------------
-    // #10432 symlinkDataDir — granular per-subdir symlinking of gitignored substrate-data
+    // symlinkDataDir — granular per-subdir symlinking of gitignored substrate-data
     // subdirs of `.neo-ai-data/`, while leaving the git-tracked `concepts/` subdir
-    // untouched. Refines the closed predecessor #10224 (coarse-grained parent-level
-    // symlink) and unblocks the cross-process coherence gap empirically anchored in
-    // #10424.
+    // untouched. Refines the closed coarse-grained parent-level symlink predecessor and
+    // unblocks the cross-process coherence gap.
     //
     // These tests use canary files PER SUBDIR in the main-checkout data dir to prove that
     // each symlinked worktree subdir sees its corresponding main-checkout subdir's data.
@@ -316,7 +315,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
 
             // CRITICAL invariant: concepts/ is git-tracked and MUST NEVER be in the
             // default allowlist. This is the load-bearing safety check that prevents
-            // the pre-#10432 clobber-bug from regressing.
+            // the parent-level symlink clobber bug from regressing.
             expect(DATA_SUBDIRS_TO_LINK).not.toContain('concepts');
         });
 
@@ -515,7 +514,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     // --------------------------------------------------------------------------------
-    // #10591 symlinkGitignoredFiles — granular per-file symlinking of gitignored single
+    // symlinkGitignoredFiles — granular per-file symlinking of gitignored single
     // files (initially: resources/content/sandman_handoff.md) outside .neo-ai-data/.
     //
     // Distinct from symlinkDataDir's directory-shaped substrate: each entry is a single
@@ -670,7 +669,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     // --------------------------------------------------------------------------------
-    // #10351 installDependencies + runBuildAll — opt-in flags that close the
+    // installDependencies + runBuildAll — opt-in flags that close the
     // multi-step manual bootstrap gap (npm install + bundle-parse5 + optional build-all).
     //
     // These tests inject a mock `exec` to capture invoked commands without spawning real
@@ -725,9 +724,9 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             });
 
             // Return value MUST reflect the action actually taken (skip), not just the
-            // post-condition that node_modules exists. Per @neo-gemini-3-1-pro's PR #10352
-            // cycle 1 review: a returned-action contract that always reports `'installed'`
-            // because node_modules ends up present either way is semantically broken.
+            // post-condition that node_modules exists. Prior review feedback caught the
+            // semantic break where the contract always reported `'installed'` because
+            // node_modules ends up present either way.
             expect(result).toBe('already-installed');
             expect(calls).toHaveLength(1);
             expect(calls[0].args).toEqual(['run', 'bundle-parse5']);
@@ -791,15 +790,14 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
         });
     });
 
-    test.describe('#11654 pruneStaleWorktrees', () => {
-        function makePruneExec({removed, unknownBranches = []}) {
+    test.describe('#12677 pruneStaleWorktrees', () => {
+        function makePruneExec({removed}) {
             const worktreesRoot = path.join(fakeMainCheckout, '.claude', 'worktrees');
             const paths = {
-                merged     : path.join(worktreesRoot, 'merged'),
-                deleted    : path.join(worktreesRoot, 'deleted'),
-                deletedOpen: path.join(worktreesRoot, 'deleted-open-pr'),
-                active     : path.join(worktreesRoot, 'active'),
-                dirty      : path.join(worktreesRoot, 'dirty')
+                current : path.join(worktreesRoot, 'current'),
+                stale   : path.join(worktreesRoot, 'stale'),
+                unmerged: path.join(worktreesRoot, 'unmerged'),
+                dirty   : path.join(worktreesRoot, 'dirty')
             };
 
             const porcelain = [
@@ -807,21 +805,17 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 'HEAD main-head',
                 'branch refs/heads/dev',
                 '',
-                `worktree ${paths.merged}`,
-                'HEAD merged-head',
-                'branch refs/heads/agent/merged',
+                `worktree ${paths.current}`,
+                'HEAD current-head',
+                'branch refs/heads/agent/current',
                 '',
-                `worktree ${paths.deleted}`,
-                'HEAD deleted-head',
-                'branch refs/heads/agent/deleted',
+                `worktree ${paths.stale}`,
+                'HEAD stale-head',
+                'branch refs/heads/agent/stale',
                 '',
-                `worktree ${paths.deletedOpen}`,
-                'HEAD deleted-open-head',
-                'branch refs/heads/agent/deleted-open',
-                '',
-                `worktree ${paths.active}`,
-                'HEAD active-head',
-                'branch refs/heads/agent/active',
+                `worktree ${paths.unmerged}`,
+                'HEAD unmerged-head',
+                'branch refs/heads/agent/unmerged',
                 '',
                 `worktree ${paths.dirty}`,
                 'HEAD dirty-head',
@@ -834,49 +828,9 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                     return {stdout: porcelain, stderr: ''};
                 }
 
-                if (cmd === 'git' && args.join(' ') === 'status --porcelain') {
-                    return {stdout: opts.cwd === paths.dirty ? ' M local.txt\n' : '', stderr: ''};
-                }
-
-                if (cmd === 'git' && args[0] === 'show-ref') {
-                    const ref = args[3];
-                    if (
-                        ref === 'refs/heads/agent/deleted' ||
-                        ref === 'refs/heads/agent/deleted-open' ||
-                        ref === 'refs/heads/agent/dirty'
-                    ) {
-                        throw Object.assign(new Error('missing ref'), {stderr: ''});
-                    }
-                    return {stdout: '', stderr: ''};
-                }
-
-                if (cmd === 'git' && args[0] === 'merge-base') {
-                    throw Object.assign(new Error('not ancestor'), {stderr: ''});
-                }
-
-                if (cmd === 'git' && args[0] === 'branch') {
-                    return {stdout: 'dev\n', stderr: ''};
-                }
-
-                if (cmd === 'git' && args[0] === 'cherry') {
-                    const branch = args[2];
-                    if (branch === 'agent/merged') {
-                        return {stdout: '- merged-head\n', stderr: ''};
-                    }
-                    return {stdout: '+ unmerged-head\n', stderr: ''};
-                }
-
                 if (cmd === 'git' && args[0] === 'worktree' && args[1] === 'remove') {
                     removed.push(args);
                     return {stdout: '', stderr: ''};
-                }
-
-                if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
-                    const branch = args[2];
-                    if (unknownBranches.includes(branch)) {
-                        throw Object.assign(new Error('api unavailable'), {stderr: 'api unavailable'});
-                    }
-                    return {stdout: ['agent/active', 'agent/deleted-open'].includes(branch) ? 'OPEN\n' : 'MERGED\n', stderr: ''};
                 }
 
                 throw new Error(`Unexpected command: ${cmd} ${args.join(' ')}`);
@@ -915,105 +869,128 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             ]);
         });
 
-        test('classifies stale Claude worktrees and dry-runs by default', async () => {
+        test('dry-runs the keep-current/delete-rest plan only when requested', async () => {
             const removed = [];
             const {exec, paths} = makePruneExec({removed});
 
             const result = await pruneStaleWorktrees({
                 projectRoot: fakeMainCheckout,
+                currentPath: paths.current,
+                dryRun    : true,
                 exec,
                 getSize: async p => ({
-                    [paths.merged]     : 1024,
-                    [paths.deleted]    : 2048,
-                    [paths.deletedOpen]: 3072,
-                    [paths.active]     : 4096,
-                    [paths.dirty]      : 8192
+                    [paths.current] : 1024,
+                    [paths.stale]   : 2048,
+                    [paths.unmerged]: 3072,
+                    [paths.dirty]   : 4096
                 })[p] || 0,
                 log: () => {}
             });
 
             const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
 
-            expect(byPath[paths.merged].status).toBe('prunable-merged');
-            expect(byPath[paths.merged].prunable).toBe(true);
-            expect(byPath[paths.deleted].status).toBe('prunable-deleted');
-            expect(byPath[paths.deleted].prunable).toBe(true);
-            expect(byPath[paths.deletedOpen].status).toBe('active');
-            expect(byPath[paths.deletedOpen].prunable).toBe(false);
-            expect(byPath[paths.deletedOpen].reason).toContain('open PR');
-            expect(byPath[paths.active].status).toBe('active');
-            expect(byPath[paths.active].prunable).toBe(false);
-            expect(byPath[paths.dirty].status).toBe('dirty');
-            expect(byPath[paths.dirty].prunable).toBe(false);
+            expect(byPath[paths.current].status).toBe('current');
+            expect(byPath[paths.current].remove).toBe(false);
+            expect(byPath[paths.stale].status).toBe('remove');
+            expect(byPath[paths.stale].remove).toBe(true);
+            expect(byPath[paths.unmerged].remove).toBe(true);
+            expect(byPath[paths.dirty].remove).toBe(true);
 
-            expect(result.reclaimableBytes).toBe(3072);
+            expect(result.reclaimableBytes).toBe(9216);
             expect(result.reclaimedBytes).toBe(0);
+            expect(result.hydrated).toBe(null);
             expect(removed).toHaveLength(0);
         });
 
-        test('preserves worktrees when PR state cannot be verified', async () => {
+        test('deletes all non-current worktrees by default and hydrates the current checkout', async () => {
             const removed = [];
-            const {exec, paths} = makePruneExec({removed, unknownBranches: ['agent/deleted']});
+            const hydrated = [];
+            const {exec, paths} = makePruneExec({removed});
 
             const result = await pruneStaleWorktrees({
                 projectRoot: fakeMainCheckout,
+                currentPath: paths.current,
                 exec,
                 getSize: async p => ({
-                    [paths.merged] : 1024,
-                    [paths.deleted]: 2048
+                    [paths.current] : 1024,
+                    [paths.stale]   : 2048,
+                    [paths.unmerged]: 3072,
+                    [paths.dirty]   : 4096
                 })[p] || 0,
+                hydrate: async args => {
+                    hydrated.push(args);
+                    return {ok: true};
+                },
                 log: () => {}
             });
 
             const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
 
-            expect(byPath[paths.deleted].status).toBe('active');
-            expect(byPath[paths.deleted].prunable).toBe(false);
-            expect(byPath[paths.deleted].reason).toContain('PR status could not be verified');
-            expect(result.reclaimableBytes).toBe(1024);
-            expect(removed).toHaveLength(0);
-        });
-
-        test('apply removes only clean prunable worktrees unless forceDirty is set', async () => {
-            const removed = [];
-            const {exec, paths} = makePruneExec({removed});
-            const getSize = async p => ({
-                [paths.merged]     : 1024,
-                [paths.deleted]    : 2048,
-                [paths.deletedOpen]: 3072,
-                [paths.active]     : 4096,
-                [paths.dirty]      : 8192
-            })[p] || 0;
-
-            await pruneStaleWorktrees({
-                projectRoot: fakeMainCheckout,
-                apply      : true,
-                exec,
-                getSize,
-                log: () => {}
-            });
-
+            expect(byPath[paths.current].remove).toBe(false);
+            expect(result.skipped.map(item => item.path)).toEqual([paths.current]);
             expect(removed).toEqual([
-                ['worktree', 'remove', paths.merged],
-                ['worktree', 'remove', paths.deleted]
-            ]);
-
-            removed.length = 0;
-
-            await pruneStaleWorktrees({
-                projectRoot: fakeMainCheckout,
-                apply      : true,
-                forceDirty : true,
-                exec,
-                getSize,
-                log: () => {}
-            });
-
-            expect(removed).toEqual([
-                ['worktree', 'remove', paths.merged],
-                ['worktree', 'remove', paths.deleted],
+                ['worktree', 'remove', '--force', paths.stale],
+                ['worktree', 'remove', '--force', paths.unmerged],
                 ['worktree', 'remove', '--force', paths.dirty]
             ]);
+            expect(result.removed.map(item => item.path)).toEqual([paths.stale, paths.unmerged, paths.dirty]);
+            expect(result.reclaimedBytes).toBe(9216);
+            expect(result.hydrated).toEqual({ok: true});
+            expect(hydrated).toHaveLength(1);
+            expect(hydrated[0].mainCheckout).toBe(fakeMainCheckout);
+            expect(hydrated[0].projectRoot).toBe(paths.current);
+        });
+
+        test('never removes the primary checkout even when the worktree root includes it', async () => {
+            const removed = [];
+            const {exec, paths} = makePruneExec({removed});
+
+            const result = await pruneStaleWorktrees({
+                projectRoot  : fakeMainCheckout,
+                currentPath  : paths.current,
+                worktreesRoot: fakeMainCheckout,
+                exec,
+                getSize: async () => 1,
+                hydrate: async () => ({ok: true}),
+                log: () => {}
+            });
+
+            const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
+
+            expect(byPath[fakeMainCheckout].status).toBe('main-checkout');
+            expect(byPath[fakeMainCheckout].remove).toBe(false);
+            expect(byPath[paths.current].status).toBe('current');
+            expect(byPath[paths.current].remove).toBe(false);
+            expect(removed).toEqual([
+                ['worktree', 'remove', '--force', paths.stale],
+                ['worktree', 'remove', '--force', paths.unmerged],
+                ['worktree', 'remove', '--force', paths.dirty]
+            ]);
+        });
+
+        test('main-checkout invocation removes every Claude worktree and hydrates main checkout', async () => {
+            const removed = [];
+            const {exec, paths} = makePruneExec({removed});
+            const hydrated = [];
+
+            await pruneStaleWorktrees({
+                projectRoot: fakeMainCheckout,
+                exec,
+                getSize: async () => 1,
+                hydrate: async args => {
+                    hydrated.push(args);
+                    return {ok: true};
+                },
+                log: () => {}
+            });
+
+            expect(removed).toEqual([
+                ['worktree', 'remove', '--force', paths.current],
+                ['worktree', 'remove', '--force', paths.stale],
+                ['worktree', 'remove', '--force', paths.unmerged],
+                ['worktree', 'remove', '--force', paths.dirty]
+            ]);
+            expect(hydrated[0].projectRoot).toBe(fakeMainCheckout);
         });
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 12f410ea-466b-4594-a13b-dae2684eb702.

Resolves #12677
Related: #11654

Replaces the stale merge/PR/dirty worktree taxonomy with the intended local cleanup model: keep the current checkout, protect the primary checkout, remove every other `.claude/worktrees/*` checkout via `git worktree remove --force`, then hydrate the kept checkout through the existing bootstrap + `--link-data` path. The default prune path now mutates; `--dry-run` is the explicit non-mutating mode.

Evidence: L2 (mocked `git worktree remove --force` unit coverage plus focused Playwright unit spec) + L3 non-destructive CLI dry-run (`npm run ai:prune-worktrees:dry-run`) -> L2 required (tracked script behavior and unit coverage; live destructive deletion intentionally not run from the shared checkout). No residuals.

## Deltas from ticket
- Implemented the interval trigger as a local operator scheduler: `--schedule-local --interval-ms <ms>` and `npm run ai:prune-worktrees:schedule-dangerous`. This is intentionally not an Orchestrator/cloud scheduler lane.
- Preserved the existing `--prune-stale` entrypoint for compatibility while changing semantics to delete by default.
- Added `npm run ai:prune-worktrees:dry-run` for explicit preview.
- Added an explicit primary-checkout guard, so even a mis-scoped custom `worktreesRoot` cannot remove the main checkout.
- Added a scheduler foot-gun warning in JSDoc and runtime logs: each scheduled tick force-removes all non-current worktrees, including concurrently-active sibling sessions.
- Removed stale ticket-number archaeology from durable comments in the touched spec so the pre-commit hook passes behavior-first comment hygiene.

## Test Evidence
- `node --check ai/scripts/migrations/bootstrapWorktree.mjs` passed.
- `package.json` parse check passed.
- `git diff --check` passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` passed: 36/36.
- `npm run ai:prune-worktrees:dry-run` passed on this checkout before the safety-polish amend: found 0 Claude worktrees and made no mutations.
- Pre-commit hook passed `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology`.

## Post-Merge Validation
- [ ] On a Claude primary checkout with disposable `.claude/worktrees/*` entries, run `npm run ai:prune-worktrees:dry-run`, then run `npm run ai:prune-worktrees` during a safe local cleanup window.
- [ ] If an interval process is desired, run `npm run ai:prune-worktrees:schedule-dangerous` only on a local operator host where force-removing all non-current sibling worktrees is acceptable; do not run it in a cloud deployment container.

## Commit
- `63f4a1525` — `feat(ai): simplify worktree pruning (#12677)`
