### PR TITLE
docs(agentos): align guide gap docs with concept ontology (#9994)

### DIFF
--- a/learn/agentos/DreamPipeline.md
+++ b/learn/agentos/DreamPipeline.md
@@ -120,23 +120,22 @@ reads these on startup and can reconcile them before beginning work.
 ### Phase 3: Capability Gap Inference
 
 This is the **deterministic** phase — no LLM is used for the core analysis. The
-DreamService scans the graph for nodes of type `CLASS`, `METHOD`, or `COMPONENT`
-and checks three coverage dimensions:
+DreamService delegates to `GapInferenceEngine`, which keeps structural test
+coverage and ontology-wide concept coverage separate:
 
 | Gap Type | Detection Method |
 |---|---|
 | `[TEST_GAP]` | No test file paths in `test/` provide precise evidence for the structural node name; matching test `FILE` nodes create `VALIDATES` edges only when all semantic name tokens are present |
-| `[GUIDE_GAP]` | No guide paths in `learn/guides/` match the node name (with LLM verification fallback) |
+| `[GUIDE_GAP]` | A high-weight `CONCEPT` node has no outbound `EXPLAINED_BY` edge in the Concept Ontology |
+| `[EXAMPLE_GAP]` | A high-weight `CONCEPT` node has `EXPLAINED_BY` coverage but no `EXEMPLIFIED_BY` edge |
+| `[ORPHAN_CONCEPT]` | A high-weight `CONCEPT` node has no `IMPLEMENTED_BY` edge |
 
-The `[GUIDE_GAP]` detection has a two-stage pipeline:
-
-1. **Filesystem match:** Tokenize the node name and scan `learn/guides/` paths
-2. **LLM verification:** If a path matches, truncate the guide to 3000 chars and
-   ask the LLM: "Does this guide ACTUALLY describe `{node.name}`?" with a strict
-   `{verified: true/false}` response
-
-This prevents false negatives where a file named `ConfigSystem.md` exists but
-doesn't actually cover the specific class being checked.
+The historical guide-path scan and LLM verification fallback were retired by the
+concept-graph refactor. Guide coverage is now an explicit ontology fact:
+`ConceptIngestor` materializes `EXPLAINED_BY` / `EXEMPLIFIED_BY` /
+`IMPLEMENTED_BY` edges, and `GapInferenceEngine.inferConceptGraphGaps()` traverses
+those edges once per REM cycle. The LLM no longer rubber-stamps whether a guide
+filename happens to match a structural class or component name.
 
 Capability gaps are stored as JSON arrays on the graph node's `properties.capabilityGap`
 field, with a `lastGapCheck` timestamp for TTL pruning.

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -298,9 +298,9 @@ flowchart TD
    to `sandman_handoff.md`.
 
 4. **Capability Gap Inference:** This phase is **deterministic** — it does not use an LLM.
-   It cross-references graph nodes directly against the filesystem:
+   It cross-references structural code nodes and concept-ontology nodes against explicit graph evidence:
    - Does `test/` contain files with precise evidence for this class's semantic name tokens? If not: **TEST_GAP**; if yes, add a `VALIDATES` edge from the test `FILE` node to the structural source node.
-   - Does `learn/guides/` have a matching guide? If not: **GUIDE_GAP**
+   - Does a high-weight `CONCEPT` node have an outbound `EXPLAINED_BY` edge to a guide/doc file? If not: **GUIDE_GAP**. Concepts with guide coverage but no `EXEMPLIFIED_BY` edge become **EXAMPLE_GAP**.
 
 5. **Hebbian Decay:** Universal edge weight fade and garbage collection of stale nodes,
    inspired by synaptic pruning in neuroscience.

--- a/learn/benefits/SelfEvolution.md
+++ b/learn/benefits/SelfEvolution.md
@@ -36,7 +36,7 @@ Nobody hand-maintains that priority order. It emerges from the system's own mode
 
 ## It finds its own gaps
 
-One pipeline phase is fully deterministic — no LLM guessing. The DreamService cross-references graph nodes directly against the filesystem and flags where the codebase is under-covered: a class with no matching tests becomes a **test gap**; a component with no matching guide becomes a **documentation gap**. The system surfaces its own blind spots and routes them into the next cycle's priorities, with stale gaps pruned automatically so the signal stays fresh.
+One pipeline phase is fully deterministic — no LLM guessing. The DreamService cross-references graph nodes against explicit evidence: a class with no precise `test/` coverage becomes a **test gap**; a high-weight concept with no `EXPLAINED_BY` edge to a guide becomes a **documentation gap**; a documented concept with no example becomes an **example gap**. The system surfaces its own blind spots and routes them into the next cycle's priorities, with stale gaps pruned automatically so the signal stays fresh.
 
 ## Friction becomes substrate
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 12f410ea-466b-4594-a13b-dae2684eb702.

Resolves #9994

Aligns the Dream Pipeline and benefits docs with the current Concept Ontology implementation for `GUIDE_GAP`. The original runtime intent is already delivered by `#10035` / PR `#10084`; this PR closes the remaining stale-open issue surface by removing the retired guide-path / LLM-verification description from docs that agents and humans still read.

Evidence: L1 (current-source/doc/test grep + focused unit contract) -> L1 required (docs authority alignment; no runtime AC residual).

## Deltas from ticket

- No `.mjs` runtime changes. `GapInferenceEngine.inferConceptGraphGaps()` and `DreamService.inferConceptGraphGaps()` already implement concept-edge traversal.
- Updated `learn/agentos/DreamPipeline.md` to describe `GUIDE_GAP`, `EXAMPLE_GAP`, and `ORPHAN_CONCEPT` as concept-ontology edge signals.
- Updated `learn/benefits/ArchitectureOverview.md` and `learn/benefits/SelfEvolution.md` so public benefits prose no longer implies a component/file-to-guide matcher.

## Test Evidence

- `rg -n "No guide paths|with LLM verification fallback|Filesystem match|matching guide\\?|component with no matching guide" learn -g "!node_modules"` -> no matches.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs --grep "GUIDE_GAP"` -> 2 passed.
- `git diff --check origin/dev..HEAD` -> passed.

## Post-Merge Validation

- [ ] Confirm #9994 auto-closes on merge.

## Commit

- `d88e1a6cc` - `docs(agentos): align guide gap docs with concept ontology (#9994)`
