### PR TITLE
fix(ai): restore embedText mock in QueryRecentTurns.spec afterAll (#12682)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -30,7 +30,7 @@ import RequestContextService from '../../../../../../ai/mcp/server/shared/servic
  *                     mechanically prevents the fail-open default — AC7a alone passes even if this path is broken).
  */
 test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
-    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection;
+    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, originalGetMemoryCollection, originalEmbedText;
 
     test.beforeAll(async () => {
         GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
@@ -60,7 +60,10 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             await LifecycleService.ready();
         }
 
-        // Offline tests cannot hit a real embedder.
+        // Offline tests cannot hit a real embedder. Save the original first so afterAll can restore
+        // it: an unrestored embedText mock leaks a 4096-length vector into sibling specs sharing the
+        // worker (e.g. the retry spec asserting a [0.1, 0.2, 0.3] return), reddening their unit run.
+        originalEmbedText              = TextEmbeddingService.embedText;
         TextEmbeddingService.embedText = async () => new Array(4096).fill(0.1);
 
         // Seed the AgentIdentity nodes the AUTHORED_BY edge + '@me' resolution depend on.
@@ -70,6 +73,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
 
     test.afterAll(async () => {
         if (originalGetMemoryCollection) StorageRouter.getMemoryCollection = originalGetMemoryCollection;
+        if (originalEmbedText)           TextEmbeddingService.embedText     = originalEmbedText;
         const {cleanupChromaManager} = await import('./util.mjs');
         await cleanupChromaManager();
     });


### PR DESCRIPTION
Resolves #12682

Restores `TextEmbeddingService.embedText` in `QueryRecentTurns.spec.mjs`'s `afterAll` so the offline-embedder mock no longer leaks into sibling specs sharing the Playwright worker — closing the cross-spec flake that reddened the `unit` CI lane on the docs-only PR #12681 (#9994).

Authored by Claude Opus 4.8 (Claude Code). Session 2d558ccb-e067-4777-bb80-e52f86d5ca43.
Diagnosed by @neo-gpt (read-only V-B-A: ordered repro + root-cause + HealthService precedent).

## What shipped

The spec already saves/restores `originalGetMemoryCollection`; this mirrors that pattern for `embedText` — declare `originalEmbedText`, capture the original before the override, restore it in `afterAll`. 6 lines, test-only, no production change.

Evidence: L1 (deterministic in-process repro — the ordered two-spec run is green) → L1 required (test-isolation hygiene; the AC is the unit-lane behavior, fully reproduced locally). No residuals.

## Deltas from ticket

None — implements the ticket's prescribed fix verbatim.

## Test Evidence

```
# the leak case (gpt's ordered repro) — was 1 failed + 8 passed, now fully green:
npm run test-unit -- test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs \
                     test/playwright/unit/ai/services/memory-core/TextEmbeddingService.retry.spec.mjs --workers=1
→ 22 passed (1.1s)

# no regressions, standalone:
QueryRecentTurns.spec.mjs            → 8 passed
TextEmbeddingService.retry.spec.mjs  → 14 passed
```

Verified on a branch freshly off `origin/dev`.

## Post-Merge Validation

- [ ] #12681 (#9994) unit CI goes green after it rebases onto dev (the leak source removed).

## Commits

- 28491dc52 — fix(ai): restore embedText mock in QueryRecentTurns.spec afterAll (#12682)
