### PR TITLE
docs(agentos): add Windows support audit (#10135)

### DIFF
--- a/apps/portal/llms.txt
+++ b/apps/portal/llms.txt
@@ -266,6 +266,7 @@ The sections below (Release Notes, Guides/Blogs, GitHub Tickets, Pull Requests, 
 - [GitHub Workflow Server: gh-absent](https://neomjs.com/raw/learn/agentos/tooling/GitHubWorkflowServerGhAbsent.md)
 - [Troubleshooting Tool Calls](https://neomjs.com/raw/learn/agentos/tooling/TroubleshootingToolCalls.md)
 - [AI Tooling WSL Setup](https://neomjs.com/raw/learn/agentos/tooling/AiToolingWslSetup.md)
+- [Agent OS Windows Support Audit](https://neomjs.com/raw/learn/agentos/tooling/WindowsSupport.md)
 - [Introduction to MCP](https://neomjs.com/raw/learn/agentos/tooling/Introduction.md)
 - [Restoration Runbook](https://neomjs.com/raw/learn/agentos/tooling/RestorationRunbook.md)
 - [Wake Substrate Incident Protocol](https://neomjs.com/raw/learn/agentos/tooling/WakeSubstrateIncidentProtocol.md)

--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -366,6 +366,10 @@
     <lastmod>2026-03-31T02:29:29+02:00</lastmod>
   </url>
   <url>
+    <loc>https://neomjs.com/learn/agentos/tooling/WindowsSupport</loc>
+    <lastmod>2026-06-07T11:13:34Z</lastmod>
+  </url>
+  <url>
     <loc>https://neomjs.com/learn/agentos/tooling/Introduction</loc>
     <lastmod>2026-05-08T19:39:35+02:00</lastmod>
   </url>

--- a/learn/agentos/tooling/AiToolingWslSetup.md
+++ b/learn/agentos/tooling/AiToolingWslSetup.md
@@ -1,7 +1,7 @@
 # Setting up the AI Development Environment on Windows with WSL
 
 > **IMPORTANT NOTE:** The Neo.mjs framework runs perfectly on native Windows. This guide is **only** for setting up the AI development environment, which includes tools like the local Knowledge Base and Memory Core. These tools rely on the ChromaDB vector database, which has a known installation issue on native Windows (see [chroma-core/chroma#5188](https://github.com/chroma-core/chroma/issues/5188)).
-> 
+>
 > The following instructions use the Windows Subsystem for Linux (WSL) as a robust workaround for this third-party dependency issue.
 
 This guide provides a step-by-step walkthrough for setting up your AI development environment on Windows using WSL. This is the recommended approach to avoid a known installation issue with the ChromaDB vector database on native x64 Windows.
@@ -106,10 +106,10 @@ sudo apt update && sudo apt upgrade -y
 sudo apt install -y git curl build-essential
 ```
 
-### Install Node.js (version 20)
+### Install Node.js (version 24+)
 
 ```bash
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
 sudo apt install -y nodejs
 ```
 

--- a/learn/agentos/tooling/WindowsSupport.md
+++ b/learn/agentos/tooling/WindowsSupport.md
@@ -1,0 +1,100 @@
+# Agent OS Windows Support Audit
+
+Issue #10135 asked for an Agent OS Windows support audit after the prerequisite
+work in #9999. The live state on June 7, 2026 is that #9999 is closed and the
+audit is no longer blocked.
+
+## Decision
+
+Agent OS remains **WSL-first** for v13. Native Windows is not a supported Agent
+OS target yet, and the repository should not add a Windows CI lane for Agent OS
+until the native dependency and shell-script boundaries below are intentionally
+resolved.
+
+This decision is scoped to Agent OS tooling. The Neo runtime / Body layer is
+still expected to run on native Windows; the WSL boundary only applies to the AI
+development environment that uses Memory Core, the Knowledge Base, local Chroma,
+and the daemon/tooling scripts.
+
+## Evidence Summary
+
+- `learn/agentos/tooling/AiToolingWslSetup.md` already documents the support
+  boundary: native Windows is fine for Neo itself, while the AI development
+  environment uses WSL because ChromaDB has a native x64 Windows installation
+  issue.
+- `package.json` requires Node `>=24.0.0`, starts the local vector store through
+  `chroma run --path ./.neo-ai-data/chroma/unified`, and depends on
+  `chromadb` plus `better-sqlite3`.
+- Most repo automation is Node-based `.mjs`, but core package scripts still
+  contain POSIX shell assumptions such as `UNIT_TEST_MODE=true playwright ...`
+  in `test-unit`.
+- Existing CI runs on `ubuntu-latest` only. There is no current Windows matrix
+  providing native Agent OS proof.
+- The codebase has targeted Windows handling where it has been required:
+  `ai/scripts/lifecycle/windowsBatchSpawn.mjs` dispatches `.cmd` / `.bat`
+  wrappers through `cmd.exe` with repo-owned quoting, and
+  `test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs` covers that
+  behavior.
+- Some diagnostics intentionally stay POSIX-only. For example,
+  `ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs` reports that `lsof` is
+  required on macOS / Linux when it is unavailable.
+- Shell files exist in example/deployment and MLX setup paths, not as the main
+  Agent OS boot path: `ai/examples/cloud-deployment/pre-push-hook.sh`,
+  `ai/examples/cloud-deployment/deploy-pipeline.sh`, and
+  `ai/mcp/server/memory-core/scripts/setup_mlx.sh`.
+
+## Findings
+
+| Scope Area | Severity | Current State | Decision |
+| --- | --- | --- | --- |
+| Path handling | Minor | Many source paths use `path` APIs or normalize separators; selected build/doc scripts explicitly handle `path.sep === '\\'`. Native Windows is not broadly proven. | Keep WSL-first. Fix path issues only when a native-Windows support lane is opened. |
+| Process invocation | Minor | Build scripts use Windows binary names such as `node.exe` / `npm.cmd` in places, and lifecycle resume has explicit `.cmd` support. Package scripts still use POSIX env-prefix syntax. | Do not claim native support. Keep new process code Node-owned and platform-explicit. |
+| SQLite / native modules | WSL-only | Memory Core, wake, graph, and tests use `better-sqlite3`. There is no Windows CI proving install/runtime behavior. | WSL remains the supported Windows path for Agent OS persistence. |
+| Chroma server | Native blocker | The documented Windows setup routes through WSL because the AI environment depends on ChromaDB, and `package.json` exposes `ai:server` through `chroma run`. | No native Agent OS support until Chroma install/runtime is empirically proven or replaced. |
+| Shell scripts | Minor | The few `.sh` files are example/deployment or MLX helper paths, while primary orchestration is `.mjs`. Some npm scripts still depend on POSIX shell semantics. | Accept under WSL-first. Make future boot-critical scripts portable by construction. |
+| Line endings | No current blocker | No audit evidence showed JSONL, markdown, or script failure from CRLF handling. | No follow-up ticket from this audit. Re-test if native Windows support becomes a target. |
+| `.env`, home, and config conventions | Minor | Config is environment-driven and generally Node-owned. Native Windows home/config proof is not present. | WSL-first avoids promising behavior not covered by CI. |
+| Tool limits | No current blocker | No Windows-specific path-length or watcher limit was found in the audited surfaces. | No follow-up ticket from this audit. |
+| WSL escape hatch | Intended support path | The WSL setup guide is the current documented route for Windows users who need Agent OS tooling. | Keep WSL as the supported v13 answer. |
+
+## CI Decision
+
+Do **not** add Windows CI for Agent OS in v13. A Windows matrix would imply a
+support contract the repo does not yet satisfy and would likely fail for reasons
+outside the audited code paths, especially Chroma/native persistence and
+POSIX-oriented npm scripts.
+
+A future native-Windows support effort should add CI only after these acceptance
+conditions are met:
+
+1. `npm install` succeeds on native Windows with the repo's Node engine and
+   native dependencies.
+2. Chroma can be installed, started, and reached through the same contract used
+   by Memory Core and Knowledge Base.
+3. Boot-critical npm scripts are portable without POSIX env-prefix assumptions.
+4. At least one targeted Agent OS unit/integration slice runs green under
+   Windows CI.
+
+## Follow-Up Tickets
+
+No follow-up tickets were created by this audit. The current finding is a
+support-boundary decision, not a set of v13 blockers. Creating native-Windows
+fix tickets now would expand the release scope and violate the stale-ticket
+check: #10135 asked for the audit report, and current reality supports a
+WSL-first decision.
+
+File follow-ups only if the operator decides native Windows Agent OS support is
+a release target. In that case, start with the Chroma/native dependency proof and
+portable npm-script contract before lower-priority path or line-ending cleanup.
+
+## Acceptance Criteria Mapping
+
+- Structured report location: this document is the audit report.
+- Every scope area covered: findings include path handling, process invocation,
+  SQLite/native modules, Chroma server, shell scripts, line endings, environment
+  conventions, tool limits, and WSL fallback.
+- Severity ranking: each row is classified as no current blocker, minor,
+  WSL-only, or native blocker.
+- Decision recorded: v13 Agent OS is WSL-first; no Windows CI lane is added now.
+- Follow-up handling: no new tickets are required unless the support target
+  changes from WSL-first to native Windows.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -75,6 +75,7 @@
             {"name": "GitHub Workflow Server: gh-absent",              "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GitHubWorkflowServerGhAbsent"},
             {"name": "Troubleshooting Tool Calls",                     "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/TroubleshootingToolCalls"},
             {"name": "AI Tooling WSL Setup",                           "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/AiToolingWslSetup"},
+            {"name": "Agent OS Windows Support Audit",                 "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/WindowsSupport"},
             {"name": "Introduction to MCP",                            "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/Introduction"},
             {"name": "Restoration Runbook",                            "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/RestorationRunbook"},
             {"name": "Wake Substrate Incident Protocol",               "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/WakeSubstrateIncidentProtocol"},


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9e86-0759-7243-a9f2-3af8f50b290d.

Resolves #10135

Adds the Agent OS Windows support audit report under `learn/agentos/tooling` and publishes it through `learn/tree.json`, `apps/portal/llms.txt`, and `apps/portal/sitemap.xml`. The audit validates current reality after `#9999`: v13 Agent OS should remain WSL-first; native Windows support and Windows CI are not claimed until Chroma/native persistence and POSIX script boundaries are resolved. It also updates the WSL setup guide from Node 20 to Node 24+ to match `package.json`.

Evidence: L1 (static repo audit + docs/tree/SEO lint) -> L1 required (audit/report ACs). No residuals.

## Deltas from ticket
The ticket requested an audit report plus per-fix follow-up tickets if blockers or minors warranted them. No follow-up tickets were created because the audit result is a support-boundary decision, not a discovered v13 blocker.

## Test Evidence
- `npm run ai:lint-tree-json` -> passed (`learn/tree.json` mirrors the learn folder and checked-in SEO outputs; 196 nodes)
- `git diff --check` -> passed
- `git diff --cached --check` -> passed
- Commit hook `node ./buildScripts/util/check-whitespace.mjs` -> passed

## Post-Merge Validation
- [ ] `https://neomjs.com/raw/learn/agentos/tooling/WindowsSupport.md` is available after the portal/docs deployment.

## Commits
- `09b17a18e` - `docs(agentos): add Windows support audit (#10135)`
