### PR TITLE
feat(ai): add MCP policy refusal guard (#10294)

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -343,7 +343,11 @@ class BaseServer extends Base {
 
                 return this.formatToolResult(result);
             } catch (error) {
-                this.logger?.error?.(`[MCP] Error executing tool ${name}:`, error);
+                if (error?.code === 'POLICY_REFUSED') {
+                    this.logger?.warn?.(`[MCP] Policy refused tool ${name}:`, error.reason || error.message);
+                } else {
+                    this.logger?.error?.(`[MCP] Error executing tool ${name}:`, error);
+                }
                 return this.formatToolError(name, error);
             }
         });
@@ -417,6 +421,28 @@ class BaseServer extends Base {
      * @protected
      */
     formatToolError(toolName, error) {
+        if (error?.code === 'POLICY_REFUSED') {
+            const structuredContent = {
+                error : 'Policy Refused',
+                code  : 'POLICY_REFUSED',
+                reason: error.reason || error.message
+            };
+
+            if (error.policyId) structuredContent.policyId = error.policyId;
+            if (error.action)   structuredContent.action   = error.action;
+            if (error.tenet)    structuredContent.tenet    = error.tenet;
+            if (error.details)  structuredContent.details  = error.details;
+
+            return {
+                content: [{
+                    type: 'text',
+                    text: `Policy Refused executing ${toolName}: ${structuredContent.reason}`
+                }],
+                isError: true,
+                structuredContent
+            };
+        }
+
         return {
             content: [{type: 'text', text: `Error executing ${toolName}: ${error.message}`}],
             isError: true

--- a/ai/mcp/server/file-system/Server.mjs
+++ b/ai/mcp/server/file-system/Server.mjs
@@ -1,4 +1,5 @@
 import BaseServer            from '../BaseServer.mjs';
+import PolicyService         from '../shared/services/PolicyService.mjs';
 import {listTools, callTool} from './services/toolService.mjs';
 
 /**
@@ -55,6 +56,27 @@ class Server extends BaseServer {
      */
     getToolService() {
         return {listTools, callTool};
+    }
+
+    /**
+     * @summary Refuses MCP file writes to the operator-ratified tenets document placeholder.
+     *
+     * This v0 guard hardcodes the exact repo-root path. Future
+     * runtime-configurable policy must flow through AiConfig leaves; do not add
+     * a parallel policy config file under `ai/`.
+     * @param {Object} context
+     * @param {String} context.toolName
+     * @param {Object} context.args
+     */
+    async beforeToolDispatch({toolName, args}) {
+        PolicyService.assertProtectedRepoRootWrite({
+            toolName,
+            args,
+            protectedRelativePath: 'AGENTS_TENETS.md',
+            policyId             : 'file-system.agents-tenets.write-protect',
+            tenet                : '#10293',
+            reason               : 'AGENTS_TENETS.md is operator-ratified tenets substrate; MCP file-system writes are refused until the multi-party update path exists.'
+        });
     }
 }
 

--- a/ai/mcp/server/shared/services/PolicyService.mjs
+++ b/ai/mcp/server/shared/services/PolicyService.mjs
@@ -1,3 +1,4 @@
+import fs   from 'fs';
 import path from 'path';
 import Base from '../../../../../src/core/Base.mjs';
 
@@ -71,12 +72,12 @@ class PolicyService extends Base {
     /**
      * @summary Refuses an exact repo-root file write through the MCP file-system server.
      *
-     * The guard compares resolved absolute paths through a case-normalized
-     * policy key. This keeps macOS/Windows case-insensitive filesystems from
-     * allowing case-variant writes to the same protected file while preserving
-     * the original resolved paths in refusal diagnostics. Missing path
-     * arguments fall through to the normal OpenAPI/Zod validation layer instead
-     * of being misclassified as policy.
+     * The guard compares canonical parent directories plus a case-normalized
+     * basename. Realpathing the parent catches symlink aliases without requiring
+     * the target file to exist, so create-write calls for the future
+     * `AGENTS_TENETS.md` still refuse. Missing path arguments fall through to
+     * the normal OpenAPI/Zod validation layer instead of being misclassified as
+     * policy.
      *
      * @param {Object} options
      * @param {String} options.toolName The incoming MCP tool name.
@@ -105,12 +106,14 @@ class PolicyService extends Base {
             return;
         }
 
-        const protectedPath    = path.resolve(repoRoot, protectedRelativePath);
-        const targetPath       = path.resolve(args[pathArg]);
-        const protectedPathKey = protectedPath.toLowerCase();
-        const targetPathKey    = targetPath.toLowerCase();
+        const protectedPath      = path.resolve(repoRoot, protectedRelativePath);
+        const targetPath         = path.resolve(args[pathArg]);
+        const protectedParentKey = this.getCanonicalParentKey(protectedPath);
+        const targetParentKey    = this.getCanonicalParentKey(targetPath);
+        const protectedNameKey   = path.basename(protectedPath).toLowerCase();
+        const targetNameKey      = path.basename(targetPath).toLowerCase();
 
-        if (targetPathKey !== protectedPathKey) {
+        if (targetParentKey !== protectedParentKey || targetNameKey !== protectedNameKey) {
             return;
         }
 
@@ -122,9 +125,35 @@ class PolicyService extends Base {
             details: {
                 pathArg,
                 protectedPath,
+                protectedParentKey,
                 targetPath
             }
         });
+    }
+
+    /**
+     * @summary Returns a stable comparison key for an existing or future file's parent directory.
+     *
+     * `fs.realpathSync` requires the target path to exist, but protected writes
+     * are often file-creation calls. Canonicalizing the parent directory closes
+     * symlink aliases while preserving a deterministic fallback for missing
+     * parents that should still flow through ordinary validation.
+     *
+     * @param {String} filePath Resolved file path.
+     * @returns {String}
+     */
+    getCanonicalParentKey(filePath) {
+        const parentPath = path.dirname(filePath);
+
+        try {
+            return fs.realpathSync.native(parentPath).toLowerCase();
+        } catch (error) {
+            if (error?.code !== 'ENOENT') {
+                throw error;
+            }
+
+            return path.resolve(parentPath).toLowerCase();
+        }
     }
 }
 

--- a/ai/mcp/server/shared/services/PolicyService.mjs
+++ b/ai/mcp/server/shared/services/PolicyService.mjs
@@ -71,10 +71,12 @@ class PolicyService extends Base {
     /**
      * @summary Refuses an exact repo-root file write through the MCP file-system server.
      *
-     * The guard compares resolved absolute paths, so both an absolute
-     * `/repo/AGENTS_TENETS.md` and a relative `AGENTS_TENETS.md` resolve to the
-     * same protected target. Missing path arguments fall through to the normal
-     * OpenAPI/Zod validation layer instead of being misclassified as policy.
+     * The guard compares resolved absolute paths through a case-normalized
+     * policy key. This keeps macOS/Windows case-insensitive filesystems from
+     * allowing case-variant writes to the same protected file while preserving
+     * the original resolved paths in refusal diagnostics. Missing path
+     * arguments fall through to the normal OpenAPI/Zod validation layer instead
+     * of being misclassified as policy.
      *
      * @param {Object} options
      * @param {String} options.toolName The incoming MCP tool name.
@@ -103,10 +105,12 @@ class PolicyService extends Base {
             return;
         }
 
-        const protectedPath = path.resolve(repoRoot, protectedRelativePath);
-        const targetPath    = path.resolve(args[pathArg]);
+        const protectedPath    = path.resolve(repoRoot, protectedRelativePath);
+        const targetPath       = path.resolve(args[pathArg]);
+        const protectedPathKey = protectedPath.toLowerCase();
+        const targetPathKey    = targetPath.toLowerCase();
 
-        if (targetPath !== protectedPath) {
+        if (targetPathKey !== protectedPathKey) {
             return;
         }
 

--- a/ai/mcp/server/shared/services/PolicyService.mjs
+++ b/ai/mcp/server/shared/services/PolicyService.mjs
@@ -1,0 +1,127 @@
+import path from 'path';
+import Base from '../../../../../src/core/Base.mjs';
+
+/**
+ * @summary Error thrown when an MCP policy guard refuses a tool call.
+ *
+ * Carries a stable `POLICY_REFUSED` code plus a machine-readable `reason` so
+ * `BaseServer.formatToolError()` can emit a structured refusal envelope while
+ * preserving the normal MCP `isError: true` response contract.
+ *
+ * @class PolicyRefusedError
+ * @extends Error
+ */
+export class PolicyRefusedError extends Error {
+    /**
+     * @param {Object} options
+     * @param {String} options.reason Human-readable refusal reason.
+     * @param {String} [options.policyId] Stable policy identifier.
+     * @param {String} [options.action] Tool action being refused.
+     * @param {String} [options.tenet] Optional tenet/source identifier.
+     * @param {Object} [options.details] Optional diagnostic details for tests/operators.
+     */
+    constructor({reason, policyId, action, tenet, details} = {}) {
+        super(`POLICY_REFUSED: ${reason || 'Tool call refused by policy'}`);
+
+        this.name     = 'PolicyRefusedError';
+        this.code     = 'POLICY_REFUSED';
+        this.reason   = reason || 'Tool call refused by policy';
+        this.policyId = policyId;
+        this.action   = action;
+        this.tenet    = tenet;
+        this.details  = details;
+    }
+}
+
+/**
+ * @summary Shared MCP tool-boundary policy helpers.
+ *
+ * This is intentionally a tiny hardcoded v0 policy helper, not a runtime policy
+ * config substrate. If future policy needs operator-configurable leaves, add
+ * them to AiConfig and read resolved leaves at the use site.
+ *
+ * @class Neo.ai.mcp.server.shared.services.PolicyService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class PolicyService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.shared.services.PolicyService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.shared.services.PolicyService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Throws a structured policy-refusal error.
+     *
+     * @param {Object} options
+     * @throws {PolicyRefusedError}
+     */
+    refuse(options = {}) {
+        throw new PolicyRefusedError(options);
+    }
+
+    /**
+     * @summary Refuses an exact repo-root file write through the MCP file-system server.
+     *
+     * The guard compares resolved absolute paths, so both an absolute
+     * `/repo/AGENTS_TENETS.md` and a relative `AGENTS_TENETS.md` resolve to the
+     * same protected target. Missing path arguments fall through to the normal
+     * OpenAPI/Zod validation layer instead of being misclassified as policy.
+     *
+     * @param {Object} options
+     * @param {String} options.toolName The incoming MCP tool name.
+     * @param {Object} options.args Incoming tool arguments.
+     * @param {String} [options.expectedToolName='write_file'] Tool name to guard.
+     * @param {String} [options.pathArg='absolutePath'] Argument containing the target path.
+     * @param {String} options.protectedRelativePath Repo-root relative protected path.
+     * @param {String} [options.repoRoot=process.cwd()] Repository root.
+     * @param {String} options.policyId Stable policy identifier.
+     * @param {String} options.reason Human-readable refusal reason.
+     * @param {String} [options.tenet] Optional tenet/source identifier.
+     * @throws {PolicyRefusedError} When the call targets the protected path.
+     */
+    assertProtectedRepoRootWrite({
+        toolName,
+        args,
+        expectedToolName = 'write_file',
+        pathArg = 'absolutePath',
+        protectedRelativePath,
+        repoRoot = process.cwd(),
+        policyId,
+        reason,
+        tenet
+    } = {}) {
+        if (toolName !== expectedToolName || !args?.[pathArg] || !protectedRelativePath) {
+            return;
+        }
+
+        const protectedPath = path.resolve(repoRoot, protectedRelativePath);
+        const targetPath    = path.resolve(args[pathArg]);
+
+        if (targetPath !== protectedPath) {
+            return;
+        }
+
+        this.refuse({
+            policyId,
+            reason,
+            tenet,
+            action : toolName,
+            details: {
+                pathArg,
+                protectedPath,
+                targetPath
+            }
+        });
+    }
+}
+
+export default Neo.setupClass(PolicyService);

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -214,6 +214,33 @@ test.describe('Neo.ai.mcp.server.BaseServer — formatToolResult shapes', () => 
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toBe('Error executing toolY: Boom');
     });
+
+    test('formatToolError maps policy refusals to structuredContent', () => {
+        const Cls    = makeTestServerClass();
+        const server = Neo.create(Cls);
+        const error  = new Error('POLICY_REFUSED: blocked');
+
+        error.code     = 'POLICY_REFUSED';
+        error.reason   = 'blocked by policy';
+        error.policyId = 'test.policy';
+        error.action   = 'write_file';
+        error.tenet    = '#10293';
+        error.details  = {targetPath: '/repo/AGENTS_TENETS.md'};
+
+        const result = server.formatToolError('write_file', error);
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toBe('Policy Refused executing write_file: blocked by policy');
+        expect(result.structuredContent).toEqual({
+            error    : 'Policy Refused',
+            code     : 'POLICY_REFUSED',
+            reason   : 'blocked by policy',
+            policyId : 'test.policy',
+            action   : 'write_file',
+            tenet    : '#10293',
+            details  : {targetPath: '/repo/AGENTS_TENETS.md'}
+        });
+    });
 });
 
 test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', () => {

--- a/test/playwright/unit/ai/mcp/server/FileSystemPolicy.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/FileSystemPolicy.spec.mjs
@@ -86,6 +86,38 @@ test.describe('Neo.ai.mcp.server.file-system.Server policy guard (#10294)', () =
         });
     });
 
+    test('refuses write_file for case-variant repo-root AGENTS_TENETS.md before tool dispatch', async () => {
+        const calls = [];
+        const Cls   = makeTestFileSystemServerClass(async (name, args) => {
+            calls.push({name, args});
+            return 'should-not-run';
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+
+        server.setupRequestHandlers(mockMcp);
+
+        const result = await mockMcp.getCallToolHandler()({
+            params: {
+                name     : 'write_file',
+                arguments: {
+                    absolutePath: path.join(process.cwd(), 'agents_tenets.md'),
+                    content     : 'blocked'
+                }
+            }
+        });
+
+        expect(calls).toEqual([]);
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toMatchObject({
+            error   : 'Policy Refused',
+            code    : 'POLICY_REFUSED',
+            policyId: 'file-system.agents-tenets.write-protect',
+            action  : 'write_file',
+            tenet   : '#10293'
+        });
+    });
+
     test('allows write_file for non-protected paths', async () => {
         const calls = [];
         const Cls   = makeTestFileSystemServerClass(async (name, args) => {

--- a/test/playwright/unit/ai/mcp/server/FileSystemPolicy.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/FileSystemPolicy.spec.mjs
@@ -1,0 +1,140 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FileSystemPolicyTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                                  from '@playwright/test';
+import {CallToolRequestSchema}                         from '@modelcontextprotocol/sdk/types.js';
+import Neo                                             from '../../../../../../src/Neo.mjs';
+import * as core                                       from '../../../../../../src/core/_export.mjs';
+import path                                            from 'path';
+import FileSystemServer                                from '../../../../../../ai/mcp/server/file-system/Server.mjs';
+
+function makeMockMcpServer() {
+    const handlers = new Map();
+    return {
+        server: {
+            setRequestHandler(schema, handler) {
+                handlers.set(schema, handler);
+            }
+        },
+        getCallToolHandler() { return handlers.get(CallToolRequestSchema); },
+        handlerCount()       { return handlers.size; }
+    };
+}
+
+let _testClassCounter = 0;
+function makeTestFileSystemServerClass(callTool) {
+    const id = ++_testClassCounter;
+    class TestFileSystemServer extends FileSystemServer {
+        static config = {
+            className: `Neo.test.mcp.server.FileSystemPolicyServer${id}`
+        }
+
+        async initAsync() { /* isolated unit test: skip transport boot */ }
+
+        getToolService() {
+            return {
+                listTools: () => ({tools: [], nextCursor: undefined}),
+                callTool
+            };
+        }
+    }
+    return Neo.setupClass(TestFileSystemServer);
+}
+
+test.describe('Neo.ai.mcp.server.file-system.Server policy guard (#10294)', () => {
+    test('refuses write_file for repo-root AGENTS_TENETS.md before tool dispatch', async () => {
+        const calls = [];
+        const Cls   = makeTestFileSystemServerClass(async (name, args) => {
+            calls.push({name, args});
+            return 'should-not-run';
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+
+        server.setupRequestHandlers(mockMcp);
+
+        const result = await mockMcp.getCallToolHandler()({
+            params: {
+                name     : 'write_file',
+                arguments: {
+                    absolutePath: path.join(process.cwd(), 'AGENTS_TENETS.md'),
+                    content     : 'blocked'
+                }
+            }
+        });
+
+        expect(calls).toEqual([]);
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toMatchObject({
+            error   : 'Policy Refused',
+            code    : 'POLICY_REFUSED',
+            policyId: 'file-system.agents-tenets.write-protect',
+            action  : 'write_file',
+            tenet   : '#10293'
+        });
+    });
+
+    test('allows write_file for non-protected paths', async () => {
+        const calls = [];
+        const Cls   = makeTestFileSystemServerClass(async (name, args) => {
+            calls.push({name, args});
+            return {status: 'called'};
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+
+        server.setupRequestHandlers(mockMcp);
+
+        const result = await mockMcp.getCallToolHandler()({
+            params: {
+                name     : 'write_file',
+                arguments: {
+                    absolutePath: path.join(process.cwd(), 'tmp', 'AGENTS_TENETS.copy.md'),
+                    content     : 'allowed'
+                }
+            }
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].name).toBe('write_file');
+        expect(result.isError).toBe(false);
+        expect(result.structuredContent).toEqual({status: 'called'});
+    });
+
+    test('allows other file-system tools to reach dispatch', async () => {
+        const calls = [];
+        const Cls   = makeTestFileSystemServerClass(async (name, args) => {
+            calls.push({name, args});
+            return {status: 'read'};
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+
+        server.setupRequestHandlers(mockMcp);
+
+        const result = await mockMcp.getCallToolHandler()({
+            params: {
+                name     : 'read_file',
+                arguments: {
+                    absolutePath: path.join(process.cwd(), 'AGENTS_TENETS.md')
+                }
+            }
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].name).toBe('read_file');
+        expect(result.isError).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs
@@ -1,0 +1,83 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'PolicyServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+import path           from 'path';
+import PolicyService, {
+    PolicyRefusedError
+} from '../../../../../../../../ai/mcp/server/shared/services/PolicyService.mjs';
+
+test.describe('Neo.ai.mcp.server.shared.services.PolicyService (#10294)', () => {
+    test('refuses exact repo-root protected writes with stable metadata', () => {
+        const protectedPath = path.join(process.cwd(), 'AGENTS_TENETS.md');
+
+        expect(() => PolicyService.assertProtectedRepoRootWrite({
+            toolName              : 'write_file',
+            args                  : {absolutePath: protectedPath},
+            protectedRelativePath : 'AGENTS_TENETS.md',
+            policyId              : 'test.policy',
+            reason                : 'tenets protected',
+            tenet                 : '#10293'
+        })).toThrow(PolicyRefusedError);
+
+        try {
+            PolicyService.assertProtectedRepoRootWrite({
+                toolName             : 'write_file',
+                args                 : {absolutePath: protectedPath},
+                protectedRelativePath: 'AGENTS_TENETS.md',
+                policyId             : 'test.policy',
+                reason               : 'tenets protected',
+                tenet                : '#10293'
+            });
+        } catch (error) {
+            expect(error).toMatchObject({
+                code    : 'POLICY_REFUSED',
+                reason  : 'tenets protected',
+                policyId: 'test.policy',
+                action  : 'write_file',
+                tenet   : '#10293'
+            });
+            expect(error.details.targetPath).toBe(protectedPath);
+        }
+    });
+
+    test('allows non-write tools, missing path args, and neighboring paths', () => {
+        const common = {
+            protectedRelativePath: 'AGENTS_TENETS.md',
+            policyId             : 'test.policy',
+            reason               : 'tenets protected'
+        };
+
+        expect(() => PolicyService.assertProtectedRepoRootWrite({
+            ...common,
+            toolName: 'read_file',
+            args    : {absolutePath: path.join(process.cwd(), 'AGENTS_TENETS.md')}
+        })).not.toThrow();
+
+        expect(() => PolicyService.assertProtectedRepoRootWrite({
+            ...common,
+            toolName: 'write_file',
+            args    : {}
+        })).not.toThrow();
+
+        expect(() => PolicyService.assertProtectedRepoRootWrite({
+            ...common,
+            toolName: 'write_file',
+            args    : {absolutePath: path.join(process.cwd(), 'tmp', 'AGENTS_TENETS.md')}
+        })).not.toThrow();
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs
@@ -16,6 +16,8 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import os             from 'os';
 import path           from 'path';
 import PolicyService, {
     PolicyRefusedError
@@ -82,6 +84,46 @@ test.describe('Neo.ai.mcp.server.shared.services.PolicyService (#10294)', () => 
         }
 
         throw new Error('Expected case-variant protected path to be refused');
+    });
+
+    test('refuses symlink-parent aliases for not-yet-existing protected writes', () => {
+        const repoRoot    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-policy-root-'));
+        const symlinkRoot = `${repoRoot}-link`;
+
+        try {
+            fs.symlinkSync(repoRoot, symlinkRoot, 'dir');
+
+            const targetPath = path.join(symlinkRoot, 'AGENTS_TENETS.md');
+
+            expect(fs.existsSync(targetPath)).toBe(false);
+
+            try {
+                PolicyService.assertProtectedRepoRootWrite({
+                    toolName             : 'write_file',
+                    args                 : {absolutePath: targetPath},
+                    protectedRelativePath: 'AGENTS_TENETS.md',
+                    repoRoot,
+                    policyId             : 'test.policy',
+                    reason               : 'tenets protected',
+                    tenet                : '#10293'
+                });
+            } catch (error) {
+                expect(error).toMatchObject({
+                    code    : 'POLICY_REFUSED',
+                    reason  : 'tenets protected',
+                    policyId: 'test.policy',
+                    action  : 'write_file',
+                    tenet   : '#10293'
+                });
+                expect(error.details.targetPath).toBe(targetPath);
+                return;
+            }
+
+            throw new Error('Expected symlink-parent protected path to be refused');
+        } finally {
+            fs.rmSync(symlinkRoot, {force: true, recursive: true});
+            fs.rmSync(repoRoot, {force: true, recursive: true});
+        }
     });
 
     test('allows non-write tools, missing path args, and neighboring paths', () => {

--- a/test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs
@@ -55,6 +55,35 @@ test.describe('Neo.ai.mcp.server.shared.services.PolicyService (#10294)', () => 
         }
     });
 
+    test('refuses case-variant protected writes with stable diagnostics', () => {
+        const protectedPath = path.join(process.cwd(), 'AGENTS_TENETS.md');
+        const targetPath    = path.join(process.cwd(), 'agents_tenets.md');
+
+        try {
+            PolicyService.assertProtectedRepoRootWrite({
+                toolName             : 'write_file',
+                args                 : {absolutePath: targetPath},
+                protectedRelativePath: 'AGENTS_TENETS.md',
+                policyId             : 'test.policy',
+                reason               : 'tenets protected',
+                tenet                : '#10293'
+            });
+        } catch (error) {
+            expect(error).toMatchObject({
+                code    : 'POLICY_REFUSED',
+                reason  : 'tenets protected',
+                policyId: 'test.policy',
+                action  : 'write_file',
+                tenet   : '#10293'
+            });
+            expect(error.details.protectedPath).toBe(protectedPath);
+            expect(error.details.targetPath).toBe(targetPath);
+            return;
+        }
+
+        throw new Error('Expected case-variant protected path to be refused');
+    });
+
     test('allows non-write tools, missing path args, and neighboring paths', () => {
         const common = {
             protectedRelativePath: 'AGENTS_TENETS.md',


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9e86-0759-7243-a9f2-3af8f50b290d.

Resolves #10294
Related: #10291
Related: #10293
Related: #10284
Related: #12086

Adds the narrowed MCP-boundary policy-refusal path for #10294: `BaseServer` now preserves structured `POLICY_REFUSED` envelopes, the file-system MCP server refuses repo-root `AGENTS_TENETS.md` writes before dispatch, and the shared `PolicyService` carries the hardcoded v0 exact-surface guard without adding a runtime policy config substrate.

Review update: the policy path comparison now canonicalizes the parent directory on both sides with `fs.realpathSync.native()` and compares the basename case-insensitively. That folds the case-variant bypass and symlink-parent alias into one protected-path key while still refusing create-write calls where the protected target file does not exist yet.

Evidence: L2 (mock MCP dispatch + focused unit regressions) -> L2 required (MCP tool-boundary refusal/pass-through ACs). No residuals.

## Deltas From Ticket

- The issue body was updated before branch work to match current reality: the GitHub merge guard is out of scope / operator-deferred because the GitHub Workflow MCP server has no merge operation; merge protection belongs at the Bash/command layer.
- No standalone `ai/mcp/policy/*.mjs` runtime policy config was added. Future configurable policy must use AiConfig leaves at the consuming use site.
- The Mailbox FK guard was verified against the existing #10284 required-edge regressions instead of being reimplemented.
- No Dockerfile or cloud deployment config surface changed.

## Contract Ledger Closeout

- `BaseServer.beforeToolDispatch()`: existing dispatch hook remains the policy choke point; non-policy subclasses keep the no-op default.
- Policy source: hardcoded v0 helper only; no parallel config file under `ai/`.
- `POLICY_REFUSED` envelope: `formatToolError()` emits `error`, `code`, `reason`, optional `policyId`, `action`, `tenet`, and `details`, while preserving `isError: true`.
- `file-system.write_file`: exact, case-variant, and symlink-parent repo-root `AGENTS_TENETS.md` writes refuse before tool dispatch; neighboring paths and other file-system tools pass through.
- Mailbox FK guard: targeted #10284 tests verify required `SENT_TO` and broadcast `DELIVERED_TO` edge failures.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs test/playwright/unit/ai/mcp/server/FileSystemPolicy.spec.mjs` -> 8 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs test/playwright/unit/ai/mcp/server/FileSystemPolicy.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/PolicyService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Auth.spec.mjs` -> 59 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs --grep "required (SENT_TO routing|broadcast DELIVERED_TO) edge"` -> 2 passed. The Chroma cleanup warning is non-fatal in this focused CI-less run.
- `git diff --check` -> passed.
- Pre-commit hooks passed: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.

## Post-Merge Validation

- [ ] After #10293 lands, verify real file-system MCP `write_file` calls to repo-root `AGENTS_TENETS.md`, a case-variant path, and a symlink-parent alias all return `POLICY_REFUSED` on the merged branch.

## Commits

- `d76caa691` - `feat(ai): add MCP policy refusal guard (#10294)`
- `e4bd63529` - `fix(ai): harden policy path matching (#10294)`
- `17b46aa81` - `fix(ai): canonicalize policy write parents (#10294)`
