### PR TITLE
test(ai): by-construction aiConfig isolation for 5 memory-core specs (#12686)

### DIFF
--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -16,23 +16,13 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
-import path           from 'path';
-import fs             from 'fs-extra';
 
 test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
     let toolService;
 
     test.beforeAll(async () => {
-        // Import the config and apply any required setup
-        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-
-        // Setup temporary directory for db paths to avoid crashing
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, { recursive: true });
-        }
-
-        aiConfig.storagePaths.graph = path.join(tmpDir, `tool-limits-test-${Date.now()}.sqlite`);
+        // ADR 0019 B4: storagePaths.graph resolves to ':memory:' by construction under
+        // UNIT_TEST_MODE — no singleton mutation, no temp DB path needed.
 
         const ToolServiceModule = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs');
         toolService = {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -38,13 +38,9 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         }
         testDbPath = path.join(tmpDir, testDbName);
 
-        // Mock the SQLite target path to a safe pure temporary location
-        if (!aiConfig.storagePaths) aiConfig.storagePaths = {};
-        aiConfig.storagePaths.graph = testDbPath;
-        if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory = `test-memory-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${Date.now()}`;
-        console.log('--- TEST DB PATH MOCKED TO:', aiConfig.storagePaths.graph);
+        // ADR 0019 B4: storagePaths.graph (→ `:memory:`) + collections.{memory,session} (→ test-*)
+        // resolve to test values BY CONSTRUCTION under UNIT_TEST_MODE (config.template's
+        // `useTestDatabase` toggle). The test never mutates the shared AiConfig singleton.
 
         GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;

--- a/test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs
@@ -36,35 +36,13 @@ test.describe('SessionService setSessionId', () => {
     let SDK, TextEmbeddingService, dummySessionId;
 
     test.beforeAll(async () => {
-        const os = await import('os');
-        const fs = await import('fs');
-
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        const path = await import("path");
-        const tmpDir = path.resolve(process.cwd(), "tmp");
-        aiConfig.storagePaths.graph = path.join(tmpDir, "test-graph-" + Date.now() + "-" + Math.random().toString(36).substring(7) + ".db");
-
-        
-        if (!fs.existsSync(tmpDir)) {
-            fs.mkdirSync(tmpDir, { recursive: true });
-        }
-
-        const testDbName              = `memory-core-session-service-test-${process.pid}-${Date.now()}.sqlite`;
-        const testDbPath              = path.join(tmpDir, testDbName);
-
-        if (fs.existsSync(testDbPath)) {
-            fs.unlinkSync(testDbPath);
-        }
-
-        aiConfig.collections.memory = `test-memory-${process.pid}-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${process.pid}-${Date.now()}`;
-
+        // Test isolation by construction: under UNIT_TEST_MODE the config resolves storagePaths.graph
+        // (→ ':memory:') + collections.{memory,session} (→ test-*) to test values — never mutate the
+        // shared singleton (a write routes through the proxy set-trap → live-DB bleed). modelProvider
+        // resolves from NEO_MODEL_PROVIDER (set above); embeddingProvider defaults to 'openAiCompatible';
+        // autoSummarize is a retired primitive (no reader).
         SDK                  = await import('../../../../../../ai/services.mjs');
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
-
-        SDK.Memory_Config.data.modelProvider         = 'openAiCompatible';
-        SDK.Memory_Config.data.embeddingProvider     = 'openAiCompatible';
-        SDK.Memory_Config.data.autoSummarize         = false;
 
         TextEmbeddingService.embedText = async () => new Array(4096).fill(Math.random());
     });

--- a/test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs
@@ -59,11 +59,8 @@ test.describe('Neo.ai.services.memory-core.WriteSideInvariant (#10017)', () => {
         }
         dbPath = path.join(tmpDir, `neo-writeside-invariant-test-${Date.now()}-${Math.random().toString(36).substring(7)}.db`);
 
-        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
-        aiConfig.storagePaths.graph = dbPath;
-        if (!aiConfig.collections) aiConfig.collections = {};
-        aiConfig.collections.memory = `test-memory-${Date.now()}`;
-        aiConfig.collections.session = `test-session-${Date.now()}`;
+        // ADR 0019 B4: storagePaths.graph (→ ':memory:') + collections.{memory,session} (→ test-*)
+        // resolve to test values BY CONSTRUCTION under UNIT_TEST_MODE — no singleton mutation.
 
         GraphService     = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MailboxService   = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -23,11 +23,9 @@ import {CHROMA_PRODUCTION_DATABASE, CHROMA_TEST_DATABASE} from '../../../../../.
 import logger         from '../../../../../../../ai/mcp/server/memory-core/logger.mjs';
 import StorageRouter  from '../../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import SystemLifecycleService from '../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
-import path           from 'path';
 import {resetMemoryCoreLifecycle} from '../util.mjs';
 
-const tmpDir = path.resolve(process.cwd(), 'tmp');
-aiConfig.storagePaths.graph = path.join(tmpDir, 'test-graph-' + Date.now() + '-' + Math.random().toString(36).substring(7) + '.db');
+// ADR 0019 B4: storagePaths.graph resolves to ':memory:' by construction under UNIT_TEST_MODE.
 
 test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
     test('logs an operator-actionable config error before throwing on missing Chroma coordinates', () => {


### PR DESCRIPTION
Resolves #12686
Refs #12435

Migrates the 5 locally-verifiable memory-core specs to **by-construction** `aiConfig` isolation per ADR 0019 — dropping the singleton `aiConfig.<path> = …` mutations and letting the config resolve test values declaratively under `UNIT_TEST_MODE`. This is the do-able half of #12435 (its sole-open-blocker-of-#12456 status was flagged by @neo-gpt); the 6 gemma4-gated specs stay Phase-2 under #12435.

Authored by Claude Opus 4.8 (Claude Code). Session 2d558ccb-e067-4777-bb80-e52f86d5ca43.

## What shipped

Three commits removing the B4 antipattern from 5 specs (the proxy set-trap that routes `aiConfig.x = v` to `setData` on the shared singleton — live-DB-bleed risk per ADR 0019). The `config.template` already resolves `storagePaths.graph` + the provider leaves by construction under `UNIT_TEST_MODE`, so the fix is removal, not restore logic:

- `c36f67277` — GraphService.spec
- `eab3e0be7` — WriteSideInvariant / McpServerToolLimits / ChromaManager
- `4c0b1593d` — SessionService.spec (+ removed dead tmpDir/fs/os/path imports)

Evidence: L2 (in-process unit tests, 51 green) → L2 required (test-isolation hardening, fully unit-coverable). No residuals.

## Deltas from ticket

None — implements #12686 verbatim. (The snapshot/restore approach from the original #12435 framing was superseded by ADR 0019's by-construction model; PRs #12598/#12660 closed accordingly.)

## Test Evidence

```
GraphService.spec        30 passed
ChromaManager.spec        7 passed
SessionService.spec       7 passed
McpServerToolLimits.spec  4 passed
WriteSideInvariant.spec   3 passed
                         ── 51 passed
```

Verified on a branch freshly rebased onto `origin/dev` (clean rebase, no conflict).

## Post-Merge Validation

- [ ] CI unit lane green on the PR head.
- [ ] #12435 Phase-2 (SessionSummarization/ResumeValidation SLM specs + ingestion/Dream `handoffFilePath`) remains — gemma4-gated; needs a non-gemma4 verification path before #12435 closes and #12456 unblocks.

## Commits

- c36f67277 — test(ai): isolate GraphService.spec by construction
- eab3e0be7 — test(ai): isolate WriteSideInvariant/McpServerToolLimits/ChromaManager by construction
- 4c0b1593d — test(ai): isolate SessionService.spec by construction; drop aiConfig + provider mutations
