### PR TITLE
docs(guidelines): document me=this runtime boundary (#10108)

### DIFF
--- a/.github/CODING_GUIDELINES.md
+++ b/.github/CODING_GUIDELINES.md
@@ -318,7 +318,7 @@ items: [HeaderContainer, {
     reference  : 'tab-container',
     sortable   : true,
     style      : {margin: '10px', marginTop: 0},
-  
+
     items: [{
         module   : () => import('./TableContainer.mjs'),
         reference: 'table-container',
@@ -429,7 +429,11 @@ adjustTotalHeight(data, silent=false) {
 * (32) Variables do use block formatting
 * (33) Variables are separated by commas (file size)
 * (34) Create variables for every item which you use more than 2 times. (maintainability, readability & file size)
-  + This rule also counts for `this`.
+  + This rule also counts for `this` in bundled runtime-engine code (`src/`, apps, examples and docs-app source)
+    where the `me = this` pattern supports readability and minified file size.
+  + In unbundled Node.js / Agent OS code (`ai/`, `buildScripts/`) prefer direct `this` for new code unless a local
+    callback-binding or readability case makes `me` useful. Existing call sites are grandfathered; clean them up only
+    when editing the surrounding code or via a dedicated follow-up ticket.
 * (35) The framework source code is using `const` very(!) rarely. The only reason is the minified bundle size.
 
 Example:


### PR DESCRIPTION
Resolves #10108

Authored by GPT-5 (Codex Desktop). Session 12f410ea-466b-4594-a13b-dae2684eb702.

Documents the Option B close target for the `me = this` policy: the repeated-`this` alias rule remains the bundled runtime-engine default, while unbundled Node.js / Agent OS code should prefer direct `this` for new code unless a local callback-binding or readability case justifies `me`.

Evidence: L1 (static guideline diff + source occurrence sweep) -> L1 required (documentation-only policy boundary). No residuals.

## Deltas from ticket

The ticket premise said Node.js code did not use the pattern. Intake V-B-A found existing `ai/`, `buildScripts/`, and `test/` callsites, so this PR explicitly grandfathers existing exceptions instead of implying a repository-wide cleanup or sweeping code.

## Test Evidence

- `git diff --check` passed.
- `node ./buildScripts/util/check-whitespace.mjs .github/CODING_GUIDELINES.md` passed.
- The pre-commit hook passed `node ./buildScripts/util/check-whitespace.mjs`.
- Pre-push freshness passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `3c0fac240 docs(guidelines): document me-this runtime boundary (#10108)`.

## Post-Merge Validation

- [ ] #10108 closes via `Resolves #10108`.

## Commits

- `3c0fac240` - `docs(guidelines): document me-this runtime boundary (#10108)`
