### PR TITLE
docs(component): document vdom node config shape (#6823)

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -16,6 +16,32 @@ const
     lengthRE          = /^\d+\w+$/;
 
 /**
+ * @typedef {Object} ComponentReferenceConfig
+ * @property {String} componentId The id of the child component instance represented by this placeholder.
+ * @property {String} [id] The root VNode id for the referenced component. Defaults to `componentId` when omitted.
+ * @property {Boolean} [removeDom=false] Removes the referenced component's DOM while preserving the VDom placeholder.
+ */
+
+/**
+ * @typedef {Object|ComponentReferenceConfig} VDomNodeConfig
+ * @property {String} [tag='div'] The HTML tag name used to create the node. `fragment` creates a transparent container.
+ * @property {String} [id] A stable VNode id. Component code usually lets the framework generate this value.
+ * @property {String|String[]} [cls] CSS classes to apply to the node.
+ * @property {Object|String} [style] Inline style declaration for the node.
+ * @property {String|Number} [html] Raw HTML content. Exclusive with `text` and `cn`.
+ * @property {String|Number|Boolean} [text] Text content. Exclusive with `html` and `cn`.
+ * @property {VDomNodeConfig[]} [cn] Child VDom node configs. Exclusive with `html` and `text`.
+ * @property {'vnode'|'text'|'root'} [vtype='vnode'] VNode type. Use `text` for pure text nodes.
+ * @property {Boolean} [static=false] Excludes this node and its children from delta updates.
+ * @property {Boolean} [removeDom=false] Removes the corresponding DOM node while keeping the logical VDom node.
+ * @property {Object.<String, String|Number|Boolean>} [data] Values rendered as `data-*` attributes.
+ * @property {String} [flag] Component-local lookup marker for direct access to this VDom node.
+ * @property {String|Number} [tabIndex] HTML tabindex attribute.
+ * @property {String} [role] ARIA role attribute.
+ * @property {Boolean} [disabled] HTML disabled attribute.
+ */
+
+/**
  * Base class for all Components which have a DOM representation
  * @class Neo.component.Base
  * @extends Neo.component.Abstract
@@ -286,7 +312,7 @@ class Component extends Abstract {
         },
         /**
          * The vdom markup for this component.
-         * @member {Object} _vdom={}
+         * @member {VDomNodeConfig} _vdom={}
          */
         _vdom: {}
     }
@@ -313,7 +339,7 @@ class Component extends Abstract {
 
     /**
      * The setter will handle vdom updates automatically
-     * @member {Object} vdom=this._vdom
+     * @member {VDomNodeConfig} vdom=this._vdom
      */
     get vdom() {
         return this._vdom


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019e9e86-0759-7243-a9f2-3af8f50b290d.

Resolves #6823

Adds source-adjacent JSDoc typedefs for the existing component VDom config shape, then points `Neo.component.Base` `_vdom` and `vdom` member docs at that typedef instead of generic `Object`. This is documentation-only: no runtime code, no Docker/cloud deployment surface, and no new `.mjs` file.

Evidence: L1 (source/diff hygiene + syntax check + pre-commit hooks) → L1 required (documentation/JSDoc-only close target). No residuals.

## Deltas from ticket

- Implements the requested JSDoc shape in `src/component/Base.mjs`, where class consumers and KB extraction see the component API surface.
- Keeps TypeScript interface generation out of scope; the repo does not currently carry the proposed `src/types/vdom.d.ts` surface.
- Aligns `vtype` with current VDom/VNode documentation (`vnode`, `text`, `root`) and includes the current `flag` lookup convention from `WorkingWithVDom.md`.

## Test Evidence

- `git diff --check`
- `node --check src/component/Base.mjs`
- Pre-commit hooks during `git commit`: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`

## Post-Merge Validation

- [ ] #6823 auto-closes after merge.

## Commit

- `ce0bd234a` — `docs(component): document vdom node config shape (#6823)`