### PR TITLE
fix(ai): defer wake digest flush during heavy GraphLog deltas (#12479)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -57,6 +57,11 @@ import {
     resolveGuiInstancePid
 } from './instanceResolver.mjs';
 import {HEARTBEAT_PULSE_ENTITY_TYPE, match} from '../../services/memory-core/heartbeatPulseEvaluator.mjs';
+import {
+    HEAVY_DELTA_SETTLE_MS,
+    isHeavyDeltaPoll,
+    shouldDeferFlush
+} from './flushDeferPolicy.mjs';
 
 const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
 const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
@@ -267,6 +272,11 @@ let lastSyncId;
 // Structure: { [subscriptionId]: { timer: Timeout, queue: [events], subscription: {...} } }
 const coalesceState = {};
 
+// Epoch ms of the most recent poll that observed a heavy GraphLog / data-sync delta. flushSubscription
+// defers while within the settle window of this, so digests are computed against committed read-state
+// (see ./flushDeferPolicy.mjs for the failure mode + policy).
+let lastHeavyPollAt = 0;
+
 /**
  * Main polling loop
  */
@@ -274,6 +284,17 @@ async function pollLoop() {
     try {
         // Fetch deltas
         const logs = getGraphLogEntries(db, lastSyncId);
+
+        // A heavy GraphLog / data-sync delta commits in batches; mid-sync the per-message read-state
+        // lookup transiently under-reports readAt, leaking already-read backlog into the digest. Flag it
+        // so flushSubscription defers until the delta settles + read-state is committed.
+        if (isHeavyDeltaPoll(logs.length)) {
+            const wasSettled = (Date.now() - lastHeavyPollAt) >= HEAVY_DELTA_SETTLE_MS;
+            lastHeavyPollAt  = Date.now();
+            if (wasSettled) {
+                writeLog('INFO', `[Wake Daemon] Heavy GraphLog delta in flight (${logs.length} entries); deferring digest flushes until read-state settles.`);
+            }
+        }
 
         if (logs.length > 0) {
             const invalidNodes = new Set();
@@ -504,6 +525,16 @@ function isMessageReadFor(db, messageId, recipient) {
 async function flushSubscription(subId) {
     const state = coalesceState[subId];
     if (!state) return;
+
+    // Defer while a heavy GraphLog / data-sync delta is still settling: mid-sync the per-message
+    // read-state lookup is transiently inconsistent, so already-read backlog would leak into the
+    // "N new messages" count and spoof a HIGH digest priority. Keep the coalesced queue intact + re-arm;
+    // the cap inside shouldDeferFlush guarantees a genuine wake is delayed, never dropped.
+    if (shouldDeferFlush({now: Date.now(), lastHeavyPollAt, deferCount: state.deferCount})) {
+        state.deferCount = (state.deferCount || 0) + 1;
+        state.timer      = setTimeout(() => flushSubscription(subId), HEAVY_DELTA_SETTLE_MS);
+        return;
+    }
 
     const { queue, subscription } = state;
     delete coalesceState[subId]; // reset

--- a/ai/daemons/wake/flushDeferPolicy.mjs
+++ b/ai/daemons/wake/flushDeferPolicy.mjs
@@ -1,0 +1,75 @@
+/**
+ * @summary Pure policy helpers governing when the wake daemon defers a coalesced digest flush
+ * because a heavy GraphLog / data-sync delta is still settling.
+ *
+ * **Failure mode this guards (the "phantom wake-flood"):** a large GraphLog / data-sync delta — e.g. a
+ * multi-thousand-row content sync — commits to SQLite in batches. While those batches are landing, the
+ * daemon's per-message read-state lookup (`isMessageReadFor`) transiently under-reports `readAt`, so
+ * already-read backlog rows slip past the digest's read filter. The digest then over-counts
+ * "N new messages" and can spoof a HIGH priority from that inflated set even though nothing
+ * genuinely-new arrived — which trains agents to distrust HIGH wakes.
+ *
+ * **Mechanism (in `daemon.mjs`):** `pollLoop` flags a heavy delta when a single poll returns an
+ * unusually large batch (`isHeavyDeltaPoll`); `flushSubscription` then defers (`shouldDeferFlush`) —
+ * keeping the coalesced queue intact and re-arming its timer — until the delta has settled, so the
+ * digest is computed against committed read-state. Deferral is capped so a genuine wake is delayed,
+ * never withheld.
+ *
+ * Kept pure (no timers, DB, or daemon state) so the policy is unit-testable in isolation, mirroring the
+ * daemon's other focused modules (`queries.mjs`, `instanceResolver.mjs`).
+ *
+ * @module ai/daemons/wake/flushDeferPolicy
+ */
+
+/**
+ * GraphLog entries observed in a single poll at or above which the delta is treated as a heavy / sync
+ * delta in flight. Normal agent activity yields a handful of entries per poll; a data-sync yields
+ * thousands — so this threshold sits well above ambient traffic and well below sync magnitude.
+ * @type {Number}
+ */
+export const HEAVY_DELTA_THRESHOLD = 500;
+
+/**
+ * Quiet period (ms) after the most recent heavy poll before per-message read-state is trusted again.
+ * Spans several poll cycles so the daemon observes the sync stop producing large batches before it
+ * resumes flushing digests.
+ * @type {Number}
+ */
+export const HEAVY_DELTA_SETTLE_MS = 15000;
+
+/**
+ * Maximum number of times a single coalesced flush may defer. Bounds total deferral
+ * (`MAX_FLUSH_DEFERS * HEAVY_DELTA_SETTLE_MS`) so a genuine wake is delayed, never dropped, even if a
+ * sync runs unusually long.
+ * @type {Number}
+ */
+export const MAX_FLUSH_DEFERS = 10;
+
+/**
+ * @summary Whether a single poll's GraphLog batch marks a heavy / sync delta in flight.
+ * @param {Number} deltaSize GraphLog entries returned by one poll.
+ * @returns {Boolean} `true` when the batch is at or above {@link HEAVY_DELTA_THRESHOLD}.
+ */
+export function isHeavyDeltaPoll(deltaSize) {
+    return deltaSize >= HEAVY_DELTA_THRESHOLD;
+}
+
+/**
+ * @summary Whether a coalesced wake flush must defer because a heavy delta is still settling.
+ *
+ * Returns `true` while within {@link HEAVY_DELTA_SETTLE_MS} of the last heavy poll AND the flush has
+ * not yet hit the {@link MAX_FLUSH_DEFERS} cap. Once the settle window elapses (read-state is
+ * committed) or the cap is reached (never withhold a genuine wake), returns `false`.
+ *
+ * @param {Object}  opts
+ * @param {Number}  opts.now             Current epoch ms.
+ * @param {Number}  opts.lastHeavyPollAt Epoch ms of the most recent heavy poll (`0` when none seen).
+ * @param {Number} [opts.deferCount=0]   Number of times this flush has already deferred.
+ * @returns {Boolean} `true` → defer the flush; `false` → read-state trusted, proceed.
+ */
+export function shouldDeferFlush({now, lastHeavyPollAt, deferCount = 0}) {
+    const withinSettleWindow = (now - lastHeavyPollAt) < HEAVY_DELTA_SETTLE_MS;
+    const underDeferCap      = deferCount < MAX_FLUSH_DEFERS;
+
+    return withinSettleWindow && underDeferCap;
+}

--- a/ai/daemons/wake/flushDeferPolicy.mjs
+++ b/ai/daemons/wake/flushDeferPolicy.mjs
@@ -30,20 +30,27 @@
 export const HEAVY_DELTA_THRESHOLD = 500;
 
 /**
- * Quiet period (ms) after the most recent heavy poll before per-message read-state is trusted again.
- * Spans several poll cycles so the daemon observes the sync stop producing large batches before it
- * resumes flushing digests.
+ * Quiet period (ms) of no heavy polls after the most recent heavy poll before per-message read-state is
+ * trusted again, and also the re-check interval while deferring. `lastHeavyPollAt` refreshes on every
+ * heavy poll, so this window only elapses once the sync genuinely stops producing large batches — it
+ * therefore rides out a *sustained* multi-minute heavy op (data-syncs can run many minutes) regardless
+ * of total duration. Sized to absorb brief inter-batch gaps within one sync; the cost is a one-time
+ * post-sync wake delay of roughly this window.
  * @type {Number}
  */
-export const HEAVY_DELTA_SETTLE_MS = 15000;
+export const HEAVY_DELTA_SETTLE_MS = 60000;
 
 /**
- * Maximum number of times a single coalesced flush may defer. Bounds total deferral
- * (`MAX_FLUSH_DEFERS * HEAVY_DELTA_SETTLE_MS`) so a genuine wake is delayed, never dropped, even if a
- * sync runs unusually long.
+ * Absolute backstop on consecutive deferrals for a single flush. `MAX_FLUSH_DEFERS *
+ * HEAVY_DELTA_SETTLE_MS` (~60 min) is a **stuck-signal safety net, NOT a normal-operation limit**: a
+ * real heavy op — even an "easily 15-minute" data-sync — settles and flushes well before this, because
+ * deferral ends as soon as heavy polls stop (the settle window), not at a fixed time budget. The cap
+ * only fires if the heavy-delta signal wedges on (e.g. a poll-batch bug), so a genuine wake is delayed,
+ * never dropped indefinitely. (Earlier `10` capped total deferral at ~2.5 min, which would force a flush
+ * mid-sync on a multi-minute heavy op and re-expose the very leak this guards — hence the larger net.)
  * @type {Number}
  */
-export const MAX_FLUSH_DEFERS = 10;
+export const MAX_FLUSH_DEFERS = 60;
 
 /**
  * @summary Whether a single poll's GraphLog batch marks a heavy / sync delta in flight.

--- a/test/playwright/unit/ai/daemons/wake/flushDeferPolicy.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/flushDeferPolicy.spec.mjs
@@ -47,5 +47,20 @@ test.describe('ai/daemons/wake/flushDeferPolicy (#12479 phantom wake-flood guard
             const lastHeavyPollAt = now - 1;
             expect(shouldDeferFlush({now, lastHeavyPollAt})).toBe(true);
         });
+
+        test('keeps deferring through a sustained heavy op while polls stay hot (capped only by the backstop)', () => {
+            // lastHeavyPollAt refreshes on every heavy poll, so a long-but-active sync stays within the
+            // settle window; deferral continues until the op stops (settle) or the stuck-signal cap.
+            const lastHeavyPollAt  = now - 1; // a heavy poll just landed
+            const midRunDeferCount = Math.floor(MAX_FLUSH_DEFERS / 2);
+            expect(shouldDeferFlush({now, lastHeavyPollAt, deferCount: midRunDeferCount})).toBe(true);
+        });
+
+        test('absolute backstop comfortably exceeds a multi-minute heavy op (operator: "a heavy OP can easily take 15m")', () => {
+            // The cap is a stuck-signal net, so it must dwarf a real heavy op — otherwise it would
+            // force-flush mid-sync and re-expose the leak this guards. Encode the floor: >= 2x a 15-min op.
+            const fifteenMinutes = 15 * 60 * 1000;
+            expect(MAX_FLUSH_DEFERS * HEAVY_DELTA_SETTLE_MS).toBeGreaterThanOrEqual(2 * fifteenMinutes);
+        });
     });
 });

--- a/test/playwright/unit/ai/daemons/wake/flushDeferPolicy.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/flushDeferPolicy.spec.mjs
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import {
+    HEAVY_DELTA_SETTLE_MS,
+    HEAVY_DELTA_THRESHOLD,
+    MAX_FLUSH_DEFERS,
+    isHeavyDeltaPoll,
+    shouldDeferFlush
+} from '../../../../../../ai/daemons/wake/flushDeferPolicy.mjs';
+
+test.describe('ai/daemons/wake/flushDeferPolicy (#12479 phantom wake-flood guard)', () => {
+    test.describe('isHeavyDeltaPoll', () => {
+        test('flags a batch at or above the heavy threshold', () => {
+            expect(isHeavyDeltaPoll(HEAVY_DELTA_THRESHOLD)).toBe(true);
+            expect(isHeavyDeltaPoll(HEAVY_DELTA_THRESHOLD + 5000)).toBe(true);
+        });
+
+        test('ignores ambient (below-threshold) poll batches', () => {
+            expect(isHeavyDeltaPoll(0)).toBe(false);
+            expect(isHeavyDeltaPoll(HEAVY_DELTA_THRESHOLD - 1)).toBe(false);
+        });
+    });
+
+    test.describe('shouldDeferFlush', () => {
+        const now = 1_000_000;
+
+        test('does not defer when no heavy delta has ever been seen (lastHeavyPollAt = 0)', () => {
+            expect(shouldDeferFlush({now, lastHeavyPollAt: 0, deferCount: 0})).toBe(false);
+        });
+
+        test('defers while within the settle window after a heavy poll', () => {
+            const lastHeavyPollAt = now - (HEAVY_DELTA_SETTLE_MS - 1); // 1ms inside the window
+            expect(shouldDeferFlush({now, lastHeavyPollAt, deferCount: 0})).toBe(true);
+        });
+
+        test('stops deferring once the settle window has elapsed (read-state committed)', () => {
+            const lastHeavyPollAt = now - HEAVY_DELTA_SETTLE_MS; // boundary = settled
+            expect(shouldDeferFlush({now, lastHeavyPollAt, deferCount: 0})).toBe(false);
+        });
+
+        test('never withholds a genuine wake past the deferral cap', () => {
+            const lastHeavyPollAt = now - 1; // still well inside the settle window
+            expect(shouldDeferFlush({now, lastHeavyPollAt, deferCount: MAX_FLUSH_DEFERS - 1})).toBe(true);
+            expect(shouldDeferFlush({now, lastHeavyPollAt, deferCount: MAX_FLUSH_DEFERS})).toBe(false);
+        });
+
+        test('defaults deferCount to 0 when omitted', () => {
+            const lastHeavyPollAt = now - 1;
+            expect(shouldDeferFlush({now, lastHeavyPollAt})).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Resolves #12479

A heavy GraphLog / data-sync delta (e.g. a multi-thousand-row content sync) commits to SQLite in batches. Mid-sync the wake daemon's per-message read-state lookup (`isMessageReadFor`) transiently under-reports `readAt`, so already-read backlog rows leak past the digest's read filter — inflating the "N new messages" count and spoofing a HIGH digest priority even when nothing genuinely-new arrived. This is the phantom wake-flood (the recurring `priority:HIGH` "5xx events" wakes that name an already-read message as "latest"), which trains agents to distrust genuine HIGH wakes.

Diagnosis/direction by @neo-claude-opus (root cause pinned to the mid-delta read-state timing); implementation + pure-policy extraction here. Converged 1:1 on defer-until-settled.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada.

## What shipped

`flushSubscription` now defers while a heavy GraphLog/data-sync delta is still settling, so the digest is computed against committed read-state:

- `pollLoop` flags a heavy delta when a single poll's GraphLog batch is unusually large (`isHeavyDeltaPoll`), recording `lastHeavyPollAt`.
- `flushSubscription` checks `shouldDeferFlush` first; while within the settle window it keeps the coalesced queue intact and re-arms its timer instead of emitting, then recomputes once read-state has settled.
- **Sized for real heavy ops:** `lastHeavyPollAt` refreshes on every heavy poll, so deferral lasts as long as the sync stays active and ends once heavy polls stop (60 s settle window). A data-sync can easily run 15 min+, so the absolute backstop is ~60 min (`MAX_FLUSH_DEFERS × HEAVY_DELTA_SETTLE_MS`) — a **stuck-signal safety net, not a duration budget**; a real op flushes as soon as it settles, regardless of length.
- Normal (non-sync) operation is unaffected: `lastHeavyPollAt` stays old, so `shouldDeferFlush` returns `false` and flushes proceed immediately.

The defer/threshold policy is extracted to a pure `ai/daemons/wake/flushDeferPolicy.mjs` (no timers/DB/daemon state), mirroring the daemon's other focused modules (`queries.mjs`, `instanceResolver.mjs`), so it is unit-testable in isolation.

**Why defer, not a "better read":** mid-sync you cannot read committed read-state that has not been committed yet, so robustifying the lookup does not help — only waiting for the delta to settle does.

Evidence: L1 (deterministic unit tests of the pure defer/threshold policy — 9 passing, including a floor test that the backstop ≥ 2× a 15-min op) → L3 required (live daemon observing a real heavy sync emit no phantom flood). Residual: the L3 flood-cessation is post-merge observable only — the sandbox cannot drive a multi-thousand-row sync against a live daemon. [`#12479`]

## Deltas from ticket

The ticket lists three candidate causes (emission re-fire / misleading preview / cursor non-advance); @neo-claude-opus's reopen pinned the read-state-timing mechanism, and this implements the converged **defer-until-settled** direction. The heavy-delta signal is **self-contained** (poll batch size) rather than reaching for the pre-existing `MaintenanceBackpressureService` (`ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs`, already in `dev`) — this lane can adopt that service later without changing the policy surface. Distinct region from `#12659`'s `evaluateSubscription` / `match()` consolidation (digest path vs trigger-match); confirmed clean — this branch rebases on current `dev` (with `#12683` / `#12687`) without conflict.

**Re-sized after operator review:** the initial cap (10 deferrals ≈ 2.5 min) would have force-flushed mid-sync on a multi-minute heavy op and re-exposed the leak; the settle window is now 60 s and the backstop ~60 min.

## Test Evidence

```
# pure-policy spec (new):
npm run test-unit -- test/playwright/unit/ai/daemons/wake/flushDeferPolicy.spec.mjs
→ 9 passed

# full wake-daemon suite (daemon + queries + instanceResolver + new policy):
npm run test-unit -- test/playwright/unit/ai/daemons/wake/
→ 51 passed  (remote CI + @neo-gpt's clean local run)
```

Note: my local sandbox EPERMs the spawn/osascript `daemon.spec` cases, so it runs 31/31 of the non-EPERM subset; the full 51/51 is confirmed by remote CI + @neo-gpt's review run. Branch rebased fresh onto current `origin/dev` at head `0851578b0`; `git diff --check` + `node --check` clean; pre-commit hooks (`check-shorthand`, `check-ticket-archaeology`) passed.

## Post-Merge Validation

- [ ] During the next large data-sync, the wake-daemon log shows `Heavy GraphLog delta in flight ... deferring digest flushes` and no `priority:HIGH` "5xx events" phantom flood follows (genuine wakes still deliver after the settle window).
- [ ] A multi-minute (15 min+) heavy op defers throughout and flushes correctly once it settles — no mid-sync flush.
- [ ] Steady-state (no sync): wake latency unchanged — no spurious deferral.

## Commits

- `dab31e488` — fix(ai): defer wake digest flush during heavy GraphLog deltas (#12479)
- `0851578b0` — fix(ai): size wake-flush defer backstop for multi-minute heavy ops (#12479)
