### PR TITLE
test(memory-core): validate system anchor apoptosis guard (#9945)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -38,7 +38,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         }
         testDbPath = path.join(tmpDir, testDbName);
 
-        // ADR 0019 B4: storagePaths.graph (→ `:memory:`) + collections.{memory,session} (→ test-*)
+        // Reactive provider SSOT: storagePaths.graph (→ `:memory:`) + collections.{memory,session} (→ test-*)
         // resolve to test values BY CONSTRUCTION under UNIT_TEST_MODE (config.template's
         // `useTestDatabase` toggle). The test never mutates the shared AiConfig singleton.
 
@@ -136,6 +136,18 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
     test('removeNodes rejects invalid node ids before Database.removeNode null path (#11698)', async () => {
         expect(() => GraphService.removeNodes([null])).toThrow(/invalid node id/);
         expect(() => GraphService.removeNodes(['ValidNode', undefined])).toThrow(/invalid node id/);
+    });
+
+    test('getOrphanedNodes preserves SYSTEM_ANCHOR nodes while returning ordinary orphans (#9945)', async () => {
+        await GraphService.upsertNode({id: 'frontier', type: 'SYSTEM_ANCHOR'});
+        await GraphService.upsertNode({id: 'DisposableConcept', type: 'CONCEPT'});
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const orphaned = GraphService.getOrphanedNodes();
+
+        expect(orphaned).toContain('DisposableConcept');
+        expect(orphaned).not.toContain('frontier');
     });
 
     test('decayGlobalTopology updates cached _SYSTEM_STATE records without losing the node id (#12070)', async () => {


### PR DESCRIPTION
Resolves #9945

Authored by GPT-5 (Codex Desktop). Session 12f410ea-466b-4594-a13b-dae2684eb702.

Adds focused regression coverage for the remaining live #9945 contract: `SYSTEM_ANCHOR` nodes must not be returned by `GraphService.getOrphanedNodes()` / GraphMaintenance apoptosis even when edge-less, while an ordinary orphan remains eligible for cleanup. The current production code already contains the protection; this PR validates it directly without changing graph behavior.

Evidence: L1 (focused unit test of `GraphService.getOrphanedNodes()` plus full `GraphService.spec.mjs` run) -> L1 required (ticket asks for unit/offline validation of decay/GC protection). No residuals.

## Deltas from ticket

- Current-source V-B-A found that `GraphService.mjs` already protects `SYSTEM_ANCHOR` in `getOrphanedNodes()` and protects durable structural/provenance edges (`SYSTEM_TENET`, `RESOLVES`) in `decayGlobalTopology()`.
- Existing tests already covered `_SYSTEM_STATE` decay bookkeeping and `RESOLVES` edge protection; the missing residual was direct `SYSTEM_ANCHOR` orphan/apoptosis validation.
- Cleaned one pre-existing durable comment in the touched spec from an ADR-number citation to behavior-only wording so the current `check-ticket-archaeology` hook passes.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` -> 31 passed after rebase onto `origin/dev` (`cf4f70176`).
- `git diff --check HEAD~1..HEAD` -> passed.
- Commit hook passed: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.
- Pre-push freshness passed: `git merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `99bbd7408 test(memory-core): validate system anchor apoptosis guard (#9945)`.

## Post-Merge Validation

- [ ] GitHub `unit` / `integration-unified` remain green on the PR head.

## Commit

- `99bbd7408` - `test(memory-core): validate system anchor apoptosis guard (#9945)`