### PR TITLE
fix(sync): hydrate cached release tags (#12692)

### DIFF
--- a/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
+++ b/ai/services/github-workflow/sync/ReleaseNotesSyncer.mjs
@@ -77,7 +77,12 @@ class ReleaseNotesSyncer extends Base {
         logger.info('Checking for new releases...');
 
         const cachedReleases     = metadata.releases || {};
-        const cachedReleaseArray = Object.values(cachedReleases);
+        // Persisted metadata keeps release tags as object keys and prunes body fields.
+        const cachedReleaseArray = Object.entries(cachedReleases).map(([tagName, release]) => ({
+            ...release,
+            tagName,
+            metadataOnly: !Object.hasOwn(release, 'name') && !Object.hasOwn(release, 'description')
+        }));
 
         // Fast-path check against the cached latest release.
         if (cachedReleaseArray.length > 0) {
@@ -96,7 +101,7 @@ class ReleaseNotesSyncer extends Base {
                     latestRelease.tagName === cachedLatest.tagName &&
                     latestRelease.publishedAt === cachedLatest.publishedAt) {
                     logger.info(`✅ Releases are up-to-date (latest: ${latestRelease.tagName})`);
-                    this.releases = cachedReleases;
+                    this.releases = Object.fromEntries(cachedReleaseArray.map(release => [release.tagName, release]));
                     this.sortedReleases = cachedReleaseArray.map(r => ({
                         tagName    : r.tagName,
                         publishedAt: r.publishedAt
@@ -235,6 +240,18 @@ class ReleaseNotesSyncer extends Base {
                     chunkDir: `chunk-${chunkNumber}`
                 };
 
+                const cachedRelease = cachedReleases[release.tagName];
+
+                if (release.metadataOnly) {
+                    if (cachedRelease?.contentHash) {
+                        logger.debug(`Skipping release notes for ${release.tagName}, cached metadata has no body fields.`);
+                        release.contentHash = cachedRelease.contentHash;
+                    } else {
+                        logger.warn(`⚠️ Cannot sync release notes for ${release.tagName}: cached metadata has no body fields or contentHash.`);
+                    }
+                    continue;
+                }
+
                 const frontmatter = {
                     tagName     : release.tagName,
                     name        : release.name,
@@ -250,8 +267,6 @@ class ReleaseNotesSyncer extends Base {
 
                 // Store the hash on the release object for the main loop to cache later
                 release.contentHash = currentHash;
-
-                const cachedRelease = cachedReleases[release.tagName];
 
                 if (cachedRelease && cachedRelease.contentHash === currentHash) {
                     logger.debug(`Skipping release notes for ${release.tagName}, content unchanged.`);

--- a/test/playwright/unit/ai/services/github-workflow/ReleaseNotesSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ReleaseNotesSyncer.spec.mjs
@@ -62,8 +62,8 @@ test.describe('Neo.ai.services.github-workflow.sync.ReleaseNotesSyncer', () => {
     test('warm-cache path properly hydrates sortedReleases and skips full fetch', async () => {
         const metadata = {
             releases: {
-                'v1.0.0': { tagName: 'v1.0.0', publishedAt: '2024-01-01T00:00:00Z', contentHash: 'hash1' },
-                'v1.1.0': { tagName: 'v1.1.0', publishedAt: '2024-02-01T00:00:00Z', contentHash: 'hash2' }
+                'v1.0.0': {publishedAt: '2024-01-01T00:00:00Z', contentHash: 'hash1'},
+                'v1.1.0': {publishedAt: '2024-02-01T00:00:00Z', contentHash: 'hash2'}
             }
         };
 
@@ -88,7 +88,52 @@ test.describe('Neo.ai.services.github-workflow.sync.ReleaseNotesSyncer', () => {
             { tagName: 'v1.0.0', publishedAt: '2024-01-01T00:00:00Z' },
             { tagName: 'v1.1.0', publishedAt: '2024-02-01T00:00:00Z' }
         ]);
-        expect(ReleaseNotesSyncer.releases).toEqual(metadata.releases);
+        expect(ReleaseNotesSyncer.releases['v1.0.0']).toEqual(expect.objectContaining({
+            tagName     : 'v1.0.0',
+            publishedAt : '2024-01-01T00:00:00Z',
+            contentHash : 'hash1',
+            metadataOnly: true
+        }));
+        expect(ReleaseNotesSyncer.releases['v1.1.0']).toEqual(expect.objectContaining({
+            tagName     : 'v1.1.0',
+            publishedAt : '2024-02-01T00:00:00Z',
+            contentHash : 'hash2',
+            metadataOnly: true
+        }));
+    });
+
+    test('syncNotes skips pruned warm-cache releases instead of writing undefined markdown', async () => {
+        const start    = new Date(issueSyncConfig.syncStartDate).getTime();
+        const inWindow = new Date(start + 86400000).toISOString();
+        const metadata = {
+            releases: {
+                vCached: {publishedAt: inWindow, contentHash: 'cached-hash'}
+            }
+        };
+
+        GraphqlService.query = async () => ({
+            repository: {
+                latestRelease: {tagName: 'vCached', publishedAt: inWindow}
+            }
+        });
+
+        await ReleaseNotesSyncer.fetchAndCacheReleases(metadata);
+
+        const releaseDir = path.join(tmpRoot, 'release-notes');
+        await fs.emptyDir(releaseDir);
+
+        const stats = await ReleaseNotesSyncer.syncNotes(metadata);
+
+        expect(stats.count).toBe(0);
+        expect(stats.synced).toEqual([]);
+        expect(ReleaseNotesSyncer.releases.vCached.contentHash).toBe('cached-hash');
+        const filename = 'vCached'.startsWith(issueSyncConfig.releaseFilenamePrefix)
+            ? 'vCached'
+            : issueSyncConfig.releaseFilenamePrefix + 'vCached';
+        expect(await fs.pathExists(path.join(releaseDir, 'chunk-1', `${filename}.md`))).toBe(false);
+
+        const indexData = await fs.readJson(path.join(releaseDir, '_index.json'));
+        expect(indexData.items.vCached).toEqual({itemIndex: 0, chunk: 1, chunkDir: 'chunk-1'});
     });
 
     test('syncNotes generates ordinal pathing and updates _index.json correctly', async () => {


### PR DESCRIPTION
Resolves #12692

Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Hydrates cached GitHub releases from the persisted metadata map key so the `sync_all` warm-cache fast path can recognize an unchanged latest release without fetching the full release history. The warm path now preserves valid `sortedReleases` bucketing entries and marks pruned cached records as metadata-only so `syncNotes()` skips markdown generation instead of producing incomplete release notes from missing body fields.

Evidence: L2 (targeted unit regression with pruned persisted metadata + static diff checks) -> L3 required (post-merge `sync_all` no-op against live metadata on `dev`). Residual: post-merge validation [#12692].

## Deltas from ticket

- Kept `MetadataManager` pruning intact; the fix is read-side hydration from release map keys.
- Added a fail-closed guard for metadata-only cached releases without `contentHash`, so pruned records never enter markdown body generation.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/ReleaseNotesSyncer.spec.mjs` -> 5 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.

## Post-Merge Validation

- [ ] On fresh `dev`, run the GitHub Workflow sync path and confirm release handling logs the warm-cache/up-to-date path without full release pagination.

## Commits

- `533feef7a` - hydrate cached release tags and guard pruned release-note sync.
