### PR TITLE
refactor(grid): replace GridDragScroll bbox hit-detection with proxy-node path check (#9636)

### DIFF
--- a/src/main/addon/GridDragScroll.mjs
+++ b/src/main/addon/GridDragScroll.mjs
@@ -242,18 +242,12 @@ class GridDragScroll extends Base {
             return
         }
 
-        // Ignore clicks on the native scrollbar (including Mac OS overlay scrollbars)
-        if (event.target === registration.bodyElement) {
-            let style = window.getComputedStyle(registration.bodyElement);
-            let hasVisibleScrollbar = style.scrollbarWidth !== 'none' && style.display !== 'none';
-            let rect = registration.bodyElement.getBoundingClientRect();
-
-            let isRightEdge = hasVisibleScrollbar && (event.offsetX >= registration.bodyElement.clientWidth  || event.clientX >= (rect.right - 18));
-            let isBottomEdge = hasVisibleScrollbar && (event.offsetY >= registration.bodyElement.clientHeight || event.clientY >= (rect.bottom - 18));
-            
-            if (isRightEdge || isBottomEdge) {
-                return
-            }
+        // Ignore mousedown / touchstart on the proxy scrollbar overlays. The dedicated
+        // grid.VerticalScrollbar / grid.HorizontalScrollbar components are discrete overlay
+        // nodes, so a thumb-drag is detected directly via the event path instead of
+        // bounding-box math against the body element.
+        if (path.some(el => el.classList?.contains('neo-grid-vertical-scrollbar') || el.classList?.contains('neo-grid-horizontal-scrollbar'))) {
+            return
         }
 
         if (event.type === 'mousedown') {


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 31325e4f-0fdf-4627-96ed-7983dd1b1002.

Resolves #9636
Refs #9486

Replaces the `GridDragScroll` scrollbar hit-detection in `onDragStart()` — previously bounding-box math (`getComputedStyle` + `getBoundingClientRect` + `event.offsetX` / `clientWidth` against the body element, with a magic `18px` gutter) — with a direct `event.composedPath()` check for the proxy overlay nodes (`neo-grid-vertical-scrollbar` / `neo-grid-horizontal-scrollbar`), mirroring the existing `neo-draggable` path guard a few lines above in the same method.

The removed branch was **dead code**: it only ran when `event.target === bodyElement` AND `hasVisibleScrollbar`, but `resources/scss/src/grid/View.scss` sets `scrollbar-width: none`, so `getComputedStyle(...).scrollbarWidth` is always `'none'` → `hasVisibleScrollbar` is always `false` → it never returned.

**Net value:** removes dead + fragile geometry math (a `getComputedStyle` forced layout on every mousedown + the magic `18px`). The proxy-node guard is the mechanism #9636 prescribes and is forward-correct, though **currently inert** — see Deltas.

Lane: clean-split from @neo-claude-opus's active grid render/SM spine (#9872 / #9492). Touches only `src/main/addon/GridDragScroll.mjs` — zero overlap with `Container.mjs`.

Evidence: L1 (static structural-orthogonality + dead-code proof — see Test Evidence). The repo CI surface is `integration-unified` + `unit` only (`.github/workflows/test.yml`); the `GridThumbDrag*` e2e specs are **not** CI-gated. Both CI suites pass on this head. No runtime-AC residual — the change is proven orthogonal to scrollbar-thumb behavior.

## Deltas from ticket (if any)
- The ticket cites a reference impl "in the `neo-testing` branch" — that branch no longer exists on origin or locally (stale). Implemented from the current proxy-scrollbar architecture instead.
- **The proxy-node guard is currently inert** (honest finding): `Container.mjs` creates `view` and `verticalScrollbar` as **siblings** (both `parentId: me.id`), so the scrollbar is not inside the view's DOM subtree. `GridDragScroll`'s `mousedown` listener is on the view, so `onDragStart` never fires on scrollbar mousedowns, and the new `composedPath` guard never triggers in the current layout. The scenario #9636 describes (pan-while-grabbing-thumb) is therefore already structurally prevented; the scrollbar-thumb path is owned solely by `GridRowScrollPinning`. The guard remains as a forward-correct defensive replacement matching the ticket's prescription. If the team prefers pure deletion of the dead block over a defensive guard, happy to adjust.

## Test Evidence
- **CI (green on `b5ce9d7b7`):** `integration-unified` + `unit` both pass. *(Correction per review: an earlier revision of this body claimed `GridThumbDrag*` e2e runs in CI — it does NOT. `test.yml`'s matrix is `[integration-unified, unit]` only.)*
- **Structural orthogonality (load-bearing):** `Container.mjs` (~lines 288 / 306 / 322) creates `view` and `verticalScrollbar` as siblings under the Container. `GridDragScroll`'s listener is on the view (`bodyElement = viewId`); a mousedown on the sibling scrollbar never reaches it ⇒ `onDragStart` does not execute for scrollbar mousedowns ⇒ this edit cannot change scrollbar-thumb behavior.
- **`GridThumbDragPause` classification = pre-existing / environmental:** ran the spec on clean `origin/dev` (`9520a96f6`, without this change) → it fails **identically** to this head — `beforeEach` timeout (`.neo-grid-row` never attaches within 30s; an app-bootstrap failure, not the pinning assertion). Same failure with and without the change ⇒ not introduced by this PR.
- Removed code confirmed dead: `View.scss` `scrollbar-width: none` ⇒ old `hasVisibleScrollbar` always false.
- Pre-commit hooks passed: check-whitespace, check-shorthand, check-ticket-archaeology.

## Post-Merge Validation
- [ ] Visual (manual; e2e is not CI-gated): grabbing the vertical / horizontal proxy scrollbar thumb scrolls without panning the grid body (expected unchanged — guard is orthogonal/inert per Deltas).

## Commits
- `refactor(grid): replace GridDragScroll bbox hit-detection with proxy-node path check (#9636)`
