### PR TITLE
docs(release): promote v13 organism identity (#12702)

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -7,7 +7,7 @@ isDraft: true
 ---
 # Neo.mjs v13.0.0 Release Notes
 
-**Release Type:** MX Loop and Agent OS Maturity
+**Release Type:** Self-Evolving Software Organism
 **Stability:** Release Candidate
 **Upgrade Path:** Existing Body/runtime work continues; v13 makes the Brain that builds and maintains it operational at release scale.
 
@@ -21,7 +21,9 @@ isDraft: true
 
 v12 proved that a stateful AI partner could help push the Body through extreme engine work. v13 turns that into a standing operating system for software evolution: **MX, Model Experience**, as formalized in [Discussion #10137](https://github.com/orgs/neomjs/discussions/10137), becomes visible in the release itself. The model is not just a user of tooling; its real work friction becomes the mechanism that improves the substrate.
 
-The release-window shape backs that up. A scoped branch comparison of the v13 line under `ai/` plus the agent-skill substrate shows **445 changed files** and **101,088 insertions**; `ai/` alone accounts for **346 files** and **93,857 insertions**. The headline is Agent OS maturity because the release did not merely add AI-facing features; it added the operating memory, graph, wake, review, and skill substrate the swarm uses to maintain Neo.
+The release-window shape backs that up. A scoped branch comparison of the v13 line under `ai/` plus the agent-skill substrate shows **445 changed files** and **101,088 insertions**; `ai/` alone accounts for **346 files** and **93,857 insertions**. The headline is organism-level, not merely Agent OS maturity: v13 makes the Body and Brain operational together, with the maintainer institution and MX loop inside the Brain using operating memory, graph-backed context, wake routing, review discipline, and skill substrate to maintain Neo while the engine remains the Body it inhabits.
+
+The Brain is concrete runtime substrate, not a metaphor alone. v13 adds the Native Edge Graph as a hybrid Chroma + SQLite graph store, Dream / Sandman graph-generation routing through the graph-provider axis with 31B local-model defaults, `mutate_frontier` active-context mutation, and `GoldenPathSynthesizer` traversal that fuses semantic embeddings with structural graph weight.
 
 The hero spine is new operating substrate:
 


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop). Session 019ea339-40f2-74d3-accb-a44edd222db2.

Resolves #12702
Related: #12696

Promotes the v13 release-note headline from the narrower Agent OS maturity frame to the governed Neo identity apex: self-evolving software organism. The patch keeps the release note iterative and narrowly scoped: it changes the release type, replaces the old headline sentence, and adds a mechanism-bound Brain/graph substrate sentence covering the Native Edge Graph, hybrid Chroma + SQLite storage, graph-provider routing with 31B local-model defaults, `mutate_frontier`, and `GoldenPathSynthesizer`.

Evidence: L1 (static release-note diff plus source-authority sweep across README, ADR 0018, AiConfig graph-provider defaults, and graph service implementation) -> L1 required (docs-only framing correction). No residuals.

## Deltas from ticket
The patch deliberately leaves the Body/Grid section untouched. Ada's latest cut-line update is already reflected there: the grid section remains an active release gate rather than a post-v13 design-only note.

The pre-commit sync-data guard blocks `resources/content/release-notes/*` on non-sync branches. This is an intentional release-note PR under #12702, so the commit used the hook-documented `--no-verify` bypass after `git diff --cached --check` passed.

## Identity Gate
This is a FRAMING change governed by ADR 0018 / `neo-identity-update`: the stale phrase existed only in `resources/content/release-notes/v13.0.0.md`, and the new wording stays compatible with the canonical self-evolving software organism apex. Cross-family review is required before merge.

## Test Evidence
- `git diff --check origin/dev...HEAD`
- `rg -n "Agent OS maturity|Release Type|organism-level|31B|Body/Grid section" resources/content/release-notes/v13.0.0.md`
- `git log origin/dev..HEAD --format=%h%x09%s%n%b`

No runtime tests were run; this is a Markdown-only release-note framing patch.

## Post-Merge Validation
- [ ] Confirm the final v13 release-note pass still leads with the organism-level identity after the grid release gate lands.

## Commits
- `8834ff2a8` — `docs(release): promote v13 organism identity (#12702)`