### PR TITLE
fix(grid): resolve SortZone column DnD against multi-body region bodies (#12707)

### DIFF
--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -51,6 +51,22 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * Resolves the `grid.Body` paired with this SortZone's owner header toolbar, keyed by the
+     * toolbar's `layoutLock` region. The prior single `grid.body` lookup only saw the center body,
+     * so locked-column cells — which live in the start / end bodies — were missed once the grid
+     * split into separate locked-start / center / locked-end bodies. Mirrors the body resolution
+     * in `grid.header.Toolbar`.
+     * @returns {Neo.grid.Body}
+     */
+    get gridBody() {
+        let {gridContainer, layoutLock} = this.owner;
+
+        if (layoutLock === 'start') return gridContainer.bodyStart;
+        if (layoutLock === 'end')   return gridContainer.bodyEnd;
+        return gridContainer.body
+    }
+
+    /**
      * @param {Neo.util.Rectangle} rect
      * @param {Neo.util.Rectangle} parentRect
      */
@@ -77,8 +93,8 @@ class SortZone extends BaseSortZone {
         }
 
         let me = this,
-            grid = me.owner.parent,
-            { body } = grid,
+            grid = me.owner.gridContainer,
+            body = me.gridBody,
             viewId = Neo.getId('grid-view'),
             columnIndex = me.dragElement['aria-colindex'] - 1,
             { dataField } = body.columnPositions.getAt(columnIndex),
@@ -181,7 +197,7 @@ class SortZone extends BaseSortZone {
      */
     moveTo(fromIndex, toIndex) {
         super.moveTo(fromIndex, toIndex);
-        this.owner.parent.columns.move(fromIndex, toIndex)
+        this.owner.gridContainer.columns.move(fromIndex, toIndex)
     }
 
     /**
@@ -213,7 +229,7 @@ class SortZone extends BaseSortZone {
         }
 
         let { owner } = me,
-            grid = owner.parent,
+            grid = owner.gridContainer,
             { columns } = grid,
             toIndex = me.dragElement['aria-colindex'] - 1,
             column = columns.getAt(toIndex),
@@ -249,7 +265,7 @@ class SortZone extends BaseSortZone {
 
             await this.timeout(20);
 
-            grid.body.createViewData(false, true)
+            me.gridBody.createViewData(false, true)
         }
     }
 
@@ -277,7 +293,7 @@ class SortZone extends BaseSortZone {
         await super.onDragStart(data);
 
         if (me.dragComponent && me.moveColumnContent) {
-            let { body } = me.owner.parent,
+            let body = me.gridBody,
                 columnIndex = me.dragElement['aria-colindex'] - 1,
                 columnPosition = body.columnPositions.getAt(columnIndex),
                 { dataField } = columnPosition,
@@ -305,7 +321,7 @@ class SortZone extends BaseSortZone {
         if (this.moveColumnContent) {
             let me = this,
                 { itemRects } = me,
-                { body } = me.owner.parent,
+                body = me.gridBody,
                 { columnPositions } = body,
                 column1Position = columnPositions.getAt(index1),
                 column2Position = columnPositions.getAt(index2),

--- a/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
@@ -1,0 +1,35 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'GridHeaderSortZoneTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import SortZone       from '../../../../../../../src/draggable/grid/header/toolbar/SortZone.mjs';
+
+/**
+ * @summary Regression coverage for Neo.draggable.grid.header.toolbar.SortZone multi-body resolution.
+ *
+ * Once the grid split into separate locked-start / center / locked-end bodies, the SortZone could
+ * no longer assume a single `grid.body`: locked-column cells live in the start / end body. The
+ * `gridBody` getter resolves the body paired with the dragged toolbar via its `layoutLock` region,
+ * read off the durable `gridContainer` back-reference.
+ */
+test.describe('Neo.draggable.grid.header.toolbar.SortZone', () => {
+    test('gridBody resolves the region body via owner.layoutLock off owner.gridContainer', () => {
+        const getGridBody   = Object.getOwnPropertyDescriptor(SortZone.prototype, 'gridBody').get,
+              gridContainer = {bodyStart: 'startBody', body: 'centerBody', bodyEnd: 'endBody'},
+              resolve       = layoutLock => getGridBody.call({owner: {gridContainer, layoutLock}});
+
+        expect(resolve('start')).toBe('startBody');     // locked-start toolbar → bodyStart
+        expect(resolve('end')).toBe('endBody');         // locked-end toolbar   → bodyEnd
+        expect(resolve(null)).toBe('centerBody');       // center toolbar (no layoutLock) → body
+        expect(resolve(undefined)).toBe('centerBody')   // center toolbar (unset) → body
+    })
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 31325e4f-0fdf-4627-96ed-7983dd1b1002.

Resolves #12707
Refs #9491
Refs #9486

Fixes the multi-body grid column-drag regression. `Neo.draggable.grid.header.toolbar.SortZone` assumed a single contiguous header toolbar + `grid.body`, which the flattened multi-body DOM (#9633 / #9634) invalidated: after the split, `me.owner.parent` is the `headerWrapper` (not the grid Container) and `grid.body` is only the center body — so grid access broke even in the no-locked-columns case, and locked-column cells (which live in `bodyStart` / `bodyEnd`) were missed.

Adds a `gridBody` getter resolving the region body via `me.owner.gridContainer` + `me.owner.layoutLock` (`start`→`bodyStart`, `end`→`bodyEnd`, else→`body`), mirroring `grid.header.Toolbar`; replaces `me.owner.parent` → `me.owner.gridContainer` and center-only `grid.body` → `me.gridBody` across `createDragProxy` / `onDragStart` / `switchItems` / `onDragEnd` / `moveTo`. The body handles stay on `grid.Container` (durable contract — survives the #9872 Container→View ownership move, confirmed with @neo-claude-opus).

Evidence: L1 (static root-cause — `aria-colindex` is per-toolbar [`src/grid/header/Toolbar.mjs:194`] + `columnPositions` is per-Body ⇒ the region index lines up; resolution mirrors `Toolbar.mjs:254-256`) + L2 (CI-gated unit test for `gridBody` resolution). → L3/L4 (live within-region drag in DevIndex) routed to @tobiu — grid e2e is not CI-gated and headless DevIndex bootstrap is flaky for the agents. Residual: AC3 live-verify [#12707].

## Deltas from ticket (if any)
- None beyond the ticket; scope is the within-region regression only.

## Test Evidence
- New unit test `test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs` — `gridBody` resolves `start`→`bodyStart` / `end`→`bodyEnd` / center→`body`. Runs in the CI `unit` suite. **Ran locally: 1 passed (753ms).**
- Static V-B-A: post-edit grep confirms no residual `me.owner.parent` / center `grid.body` (only the explanatory JSDoc mentions the old path). `aria-colindex` per-toolbar + `columnPositions` per-Body confirmed.
- Pre-commit hooks passed: check-whitespace, check-shorthand, check-ticket-archaeology.

## Post-Merge Validation
- [ ] @tobiu live-verify in DevIndex: within-region column drag-reorder works (no-locked common case + within a locked region) — the L3/L4 evidence the agents cannot get headless.

## Out of Scope (follow-ups)
- Cross-toolbar drag (center→start re-lock) + redistribution / newly-locked-body render on drop-to-lock — @neo-claude-opus's View-owned SM + #9872 (the #9491 enhancement).
- Locked-region column-index remap in `moveTo` / `onDragEnd` — folds into @neo-claude-opus's shared global↔region-local column-index map (SM keynav); the no-locked common case is already correct.

## Commits
- `fix(grid): resolve SortZone column DnD against multi-body region bodies (#12707)`
