### PR TITLE
fix(ai): timeout-guard miniSummary backfill + orchestrator task watchdog

### DIFF
--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -379,12 +379,14 @@ export class ProcessSupervisorService extends Base {
         let deferredClear    = null;
         let readinessPending = typeof task.postSpawn === 'function';
         let readinessOutcome = null;
+        let watchdog         = null;
 
         const executeClear = (code, error, phase = 'start') => {
             if (cleared) {
                 return;
             }
             cleared = true;
+            clearTimeout(watchdog);
 
             try {
                 if (fs.existsSync(pidFile)) {
@@ -453,6 +455,24 @@ export class ProcessSupervisorService extends Base {
 
         child.on('close', code => clear(code));
         child.on('error', err => clear(null, err, 'child-process'));
+
+        // Max-runtime watchdog (opt-in via task.maxRuntimeMs): a child that hangs — e.g. a
+        // downstream model/store call with no timeout — must never keep its `running` flag set
+        // indefinitely and starve every other maintenance task. On breach, kill it and finalize
+        // as failed so the scheduler can move on.
+        if (task.maxRuntimeMs > 0) {
+            watchdog = setTimeout(() => {
+                if (cleared) {
+                    return;
+                }
+                this.writeLog?.('ERROR', `[ProcessSupervisor] ${task.label} exceeded max runtime (${task.maxRuntimeMs}ms) — killing child (watchdog).`);
+                try {
+                    child.kill?.('SIGTERM');
+                } catch (e) {}
+                clear(null, new Error(`max runtime ${task.maxRuntimeMs}ms exceeded`), 'watchdog-timeout');
+            }, task.maxRuntimeMs);
+            watchdog.unref?.();
+        }
 
         return true;
     }

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -92,7 +92,10 @@ export function buildTaskDefinitions({
             command        : nodeBin,
             args           : [path.join(scriptDir, 'lifecycle', 'backfill-memory-summaries.mjs')],
             pidFileName    : 'memory-summary-backfill.pid',
-            expectedCommand: 'backfill-memory-summaries.mjs'
+            expectedCommand: 'backfill-memory-summaries.mjs',
+            // Watchdog backstop: a healthy 50-item backfill finishes in minutes. 15min bounds a
+            // hang the per-call timeouts miss so one wedged child can't starve the maintenance loop.
+            maxRuntimeMs   : 900000
         },
         kbSync: {
             label          : 'knowledge base sync',

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -9,6 +9,36 @@ import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
 
 /**
+ * Maximum time to wait for a single mini-summary model call during backfill before failing soft.
+ * A hung inference endpoint must never block the supervised maintenance child indefinitely.
+ * @type {Number}
+ */
+const MINI_SUMMARY_TIMEOUT_MS = 30000;
+
+/**
+ * Maximum time to wait for the backfill's content-store (Chroma) metadata fetch before deferring
+ * the whole batch. Usually milliseconds; the bound exists only to defeat a hung connection.
+ * @type {Number}
+ */
+const CHROMA_FETCH_TIMEOUT_MS = 10000;
+
+/**
+ * Races a promise against a timeout so a hung downstream call (model inference, content-store
+ * fetch) rejects instead of blocking the maintenance loop forever.
+ * @param {Promise} promise The work to bound.
+ * @param {Number}  ms      Timeout in milliseconds.
+ * @param {String}  label   Human-readable label surfaced in the timeout error.
+ * @returns {Promise}
+ */
+export function withTimeout(promise, ms, label) {
+    let timer;
+    const timeout = new Promise((resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    });
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
  * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every
  * `add_memory` response — the per-turn **mailbox delta signal**.
  *
@@ -789,9 +819,15 @@ class MemoryService extends Base {
             return {processed: 0, updated: 0, deferred: 0, missingContent: 0};
         }
 
-        const collection = await StorageRouter.getMemoryCollection();
-        const fetched    = await collection.get({ids: rows.map(row => row.id), include: ['metadatas']});
-        const byId       = new Map((fetched.ids || []).map((id, index) => [id, fetched.metadatas?.[index] || {}]));
+        let byId;
+        try {
+            const collection = await withTimeout(StorageRouter.getMemoryCollection(), CHROMA_FETCH_TIMEOUT_MS, 'miniSummary backfill getMemoryCollection');
+            const fetched    = await withTimeout(collection.get({ids: rows.map(row => row.id), include: ['metadatas']}), CHROMA_FETCH_TIMEOUT_MS, 'miniSummary backfill collection.get');
+            byId             = new Map((fetched.ids || []).map((id, index) => [id, fetched.metadatas?.[index] || {}]));
+        } catch (error) {
+            logger.warn(`[MemoryService] miniSummary backfill deferred the whole batch (content store unreachable, fail-soft): ${error.message}`);
+            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0};
+        }
 
         let updated = 0, deferred = 0, missingContent = 0;
 
@@ -803,10 +839,11 @@ class MemoryService extends Base {
             }
 
             try {
-                const miniSummary = await summarize({
-                    prompt  : metadata.prompt,
-                    response: metadata.response
-                });
+                const miniSummary = await withTimeout(
+                    summarize({prompt: metadata.prompt, response: metadata.response}),
+                    MINI_SUMMARY_TIMEOUT_MS,
+                    'miniSummary backfill summarize'
+                );
 
                 if (!miniSummary) {
                     deferred++;

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -82,6 +82,49 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(markSpawnedCalled).toBe(true);
     });
 
+    test('runTask watchdog kills a child that exceeds maxRuntimeMs and finalizes it as failed', async () => {
+        const { service, taskOutcomes } = createTestService();
+        let killed = false;
+
+        service.taskDefinitions = {
+            ...service.taskDefinitions,
+            watchdogTask: {
+                label          : 'Watchdog Task',
+                command        : 'sleep',
+                args           : ['999'],
+                pidFileName    : 'watchdog.pid',
+                expectedCommand: 'sleep',
+                maxRuntimeMs   : 40
+            }
+        };
+
+        // Fake child that never fires 'close' — simulates a hung child (e.g. a downstream call
+        // with no timeout). The watchdog must kill it rather than let its running flag stick.
+        service.spawnFn = () => ({pid: 4242, on: () => {}, kill: () => { killed = true; }, stderr: {on: () => {}}});
+
+        const result = service.runTask('watchdogTask', 'watchdog-test');
+        expect(result).toBe(true);
+
+        await new Promise(resolve => setTimeout(resolve, 150));
+
+        expect(killed).toBe(true);
+        const failed = taskOutcomes.find(o => o.status === 'failed' && o.details?.phase === 'watchdog-timeout');
+        expect(failed).toBeTruthy();
+    });
+
+    test('runTask does NOT arm a watchdog when maxRuntimeMs is unset (opt-in)', async () => {
+        const { service } = createTestService();
+        let killed = false;
+
+        // mockTask has no maxRuntimeMs → no watchdog → a long-lived child is left alone.
+        service.spawnFn = () => ({pid: 4243, on: () => {}, kill: () => { killed = true; }, stderr: {on: () => {}}});
+
+        service.runTask('mockTask', 'no-watchdog-test');
+        await new Promise(resolve => setTimeout(resolve, 80));
+
+        expect(killed).toBe(false);
+    });
+
     test('runTask skips if already running', () => {
         const { service, mockTaskStateService } = createTestService();
 

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs
@@ -1,0 +1,23 @@
+import {test, expect}  from '@playwright/test';
+import {withTimeout}   from '../../../../../../ai/services/memory-core/MemoryService.mjs';
+
+/**
+ * Unit coverage for the backfill timeout guard. The miniSummary backfill wraps its model call
+ * and content-store fetch with `withTimeout` so a hung downstream endpoint rejects (then fails
+ * soft via the per-memory catch) instead of wedging the supervised maintenance child forever.
+ */
+test.describe('Neo.ai.memory-core MemoryService.withTimeout', () => {
+    test('rejects with a labeled error when the promise exceeds the timeout', async () => {
+        const hung = new Promise(() => {}); // never settles
+        await expect(withTimeout(hung, 25, 'unit op')).rejects.toThrow('unit op timed out after 25ms');
+    });
+
+    test('resolves with the value when the promise completes in time', async () => {
+        await expect(withTimeout(Promise.resolve('done'), 1000, 'unit op')).resolves.toBe('done');
+    });
+
+    test('propagates the original rejection when the promise fails before the timeout', async () => {
+        await expect(withTimeout(Promise.reject(new Error('upstream boom')), 1000, 'unit op'))
+            .rejects.toThrow('upstream boom');
+    });
+});


### PR DESCRIPTION
## Summary

Hardens the memory miniSummary backfill against hung downstream calls and adds an orchestrator per-task watchdog, so a single hung maintenance child can no longer wedge the entire orchestrator maintenance loop. Diagnosed live: the backfill hung ~4h on an un-timeout-guarded model call, keeping its `active` flag set and deferring all other maintenance (session-summarization, GraphLog-compaction).

Resolves #12711. Refs #12065.

## Deltas

- `MemoryService`: `withTimeout` helper; timeout-guard the per-memory `summarize()` model call (fails soft via the existing per-memory catch); wrap the content-store (Chroma) metadata fetch — previously **outside** the per-memory try/catch — so a stall defers the batch instead of hanging.
- `ProcessSupervisorService.runTask`: opt-in per-task **max-runtime watchdog** — a child exceeding `task.maxRuntimeMs` is killed and finalized failed.
- `taskDefinitions`: 15min `maxRuntimeMs` backstop on the backfill task.

## Test Evidence

`npm run test-unit -- MemoryService.WithTimeout.spec.mjs ProcessSupervisorService.spec.mjs` → **25 passed** (3 new `withTimeout` cases: timeout→reject, resolve, error-propagate; 2 new watchdog cases: kill-on-breach + opt-in-off).

Evidence: L2 (unit — timeout + watchdog logic, no real model/Chroma/process dependency) → L3 desired (live backfill bounded + maintenance resumes after restart). Residual: post-merge restart validation [#12711].

## Post-Merge Validation

After merge + orchestrator restart: confirm the backfill completes/defers within its bounds and the previously-deferred maintenance (session-summarization, GraphLog-compaction) resumes. Host/operator observation (not reachable in the agent sandbox).

Authored by neo-claude-opus.