### PR TITLE
docs(release): update v13 Body/Grid cut-line (#12698)

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -244,16 +244,29 @@ The common pattern is explicit: known failure modes become tests, guards, skills
 
 v13 is Agent-OS-centered, but the Body did not stop moving.
 
-Recent Body/UI anchors include VDOM node config documentation, drag/drop repair, dialog and fieldset styling, form sizing repairs, container focus side-effect coverage, and the multi-body grid gate below.
+Recent Body/UI anchors include VDOM node config documentation, drag/drop repair, dialog and fieldset styling, form sizing repairs, container focus side-effect coverage, and the multi-body grid cut-line below.
 
-The Body/Grid section is now an active release gate, not a settled design-only note. The peer-selection-model-per-body approach was tried, shipped, and reopened as structurally fragile: three physical bodies could drift into different model instances while still appearing visually selected through shared update paths. The converged direction remains one body-orchestrator selection model, owned by `grid.View`, with selection state keyed by logical `recordId` across up to three rendered body segments.
+The Body/Grid section is now an active release boundary, not a settled design-only note. The peer-selection-model-per-body approach was tried, shipped, and reopened as structurally fragile: three physical bodies could drift into different model instances while still appearing visually selected through shared update paths. The converged direction remains one body-orchestrator selection model, owned by `grid.View`, with selection state keyed by logical `recordId` across up to three rendered body segments.
 
-[#9492's design-lock comment](https://github.com/neomjs/neo/issues/9492#issuecomment-4644149298) carries the design source: `Container` normalizes the event seam, `View` becomes the state master, the bodies become render/event delegates, and cross-body keyboard/range behavior uses a flattened visible-column coordinate space. That design is no longer the release ceiling. v13 now waits for the grid work to land before this section is finalized: [#9872](https://github.com/neomjs/neo/issues/9872) must move split body creation and `syncBodies()` under `View`, #9492 must deliver the centralized selection model, and the multi-body column drag/drop resorting path must be verified against `src/draggable/grid/header/toolbar/SortZone.mjs`.
+[#9492's design-lock comment](https://github.com/neomjs/neo/issues/9492#issuecomment-4644149298) carries the design source: `Container` normalizes the event seam, `View` becomes the state master, the bodies become render/event delegates, and cross-body keyboard/range behavior uses a flattened visible-column coordinate space. That design is no longer the release ceiling. The release boundary now has one shipped slice and three still-open slices: #12708 proves the `SortZone` body-resolution path, while #9491, #9872, and #9492 remain open for index remapping, View-owned body orchestration, and centralized selection.
 
-Until those grid changes land, this draft intentionally does not claim the shipped Body/Grid state. The final v13 prose must replace this gate with the actual implementation and verification evidence from the grid PRs.
+One part of that gate has now moved from theory into shipped evidence. [#12708](https://github.com/neomjs/neo/pull/12708) resolves the [#12707](https://github.com/neomjs/neo/issues/12707) SortZone regression by resolving the grid through `owner.gridContainer` and the active body through the toolbar `layoutLock` region: `bodyStart`, `body`, or `bodyEnd`. That mirrors `grid.header.Toolbar`, gives locked-start and locked-end column drags the correct region body, and adds focused unit coverage for the body-resolution contract.
+
+```mermaid
+flowchart LR
+    A["Header toolbar drag"] --> B["SortZone resolves grid"]
+    B --> C["layoutLock selects region body"]
+    C --> D["#12708 landed: region body resolution"]
+    C -. "next" .-> E["#9491 global / region-local indexes"]
+    E -. "next" .-> F["#9872 body orchestration"]
+    F -. "next" .-> G["#9492 View-owned selection model"]
+```
+
+The remaining release boundary is the larger Body/Grid claim. [#9491](https://github.com/neomjs/neo/issues/9491) must still settle global-to-region-local column indexes and cross-toolbar resorting semantics, [#9872](https://github.com/neomjs/neo/issues/9872) must move split body creation and `syncBodies()` under `View`, and #9492 must deliver the centralized selection model. The final v13 prose should describe #12708 as landed Body evidence without implying that the View-owned multi-body grid architecture has fully shipped.
 
 Representative anchors:
 
+- [#12708](https://github.com/neomjs/neo/pull/12708) - SortZone resolves column drag against the multi-body region body.
 - [#12689](https://github.com/neomjs/neo/pull/12689) - VDOM node config shape documentation.
 - [#12667](https://github.com/neomjs/neo/pull/12667) - atomic move focus side-effect coverage.
 - [#12661](https://github.com/neomjs/neo/pull/12661) - drag/drop target dashboard restoration after remote drag leave.
@@ -323,7 +336,7 @@ The narrative body stays curated. The exhaustive history belongs in generated ap
 ## Release-Cut Checklist
 
 - [ ] Refresh the boundary, merged PR count, and closed issue count immediately before the release PR or release cut.
-- [ ] Replace the Body/Grid gate with shipped evidence after the View-owned SelectionModel, `#9872` body orchestration, and multi-body DnD resorting work land.
+- [ ] Replace the remaining Body/Grid gate with shipped evidence after the View-owned SelectionModel, `#9872` body orchestration, and `#9491` global-to-region-local column-index work land; #12708 SortZone body-resolution evidence is already reflected above.
 - [ ] Replace `publishedAt` with the actual release timestamp.
 - [ ] Switch `isDraft` to `false` when the release artifact is final.
 - [ ] Decide whether the v13 workflow should update `#10321` with lessons for the future release-workflow skill.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12698
Related: #12696
Refs #12708
Refs #12707
Refs #9491
Refs #9492
Refs #9872

Updates the v13 release-note Body/Grid section after #12708 merged. The section now treats SortZone region-body resolution as shipped evidence, keeps the larger View-owned multi-body grid architecture open, and adds a compact Mermaid cut-line diagram for the current landed/remaining split.

Evidence: L1 (live PR/issue/source verification plus Markdown renderer source verification) -> L1 required (docs-only release-note source-feed PR). No residuals for #12698; parent epic #12696 retains release-cut residuals.

## Deltas from ticket

#12698 began as the v13 war-story mining and weighting feed. Its comments already delivered the mined stories, source-boundary checks, and weighted content register; this PR consumes the remaining Body/Grid cut-line item from that register into the release-note artifact.

Mermaid inclusion was verified against the release-note rendering path: `Portal.view.news.release.Component` extends `Neo.app.content.Component`, which extends `Neo.component.Markdown`; `Markdown` extracts ` ```mermaid ` fences and instantiates `src/component/wrapper/Mermaid.mjs`.

## Test Evidence

- `gh pr view 12708 --json state,mergedAt,headRefOid,reviewDecision,statusCheckRollup,url,title` verified #12708 is merged, approved, and green.
- `gh pr view 12708 --json files,url,title` verified the runtime/test files changed by #12708.
- Read `src/draggable/grid/header/toolbar/SortZone.mjs` and `test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs` to verify the `owner.gridContainer` / `layoutLock` body-resolution claim.
- `ask_knowledge_base` plus source reads verified Mermaid support in `Neo.component.Markdown` and the portal release-note component inheritance path.
- `git diff --check origin/dev...HEAD` passed after rebase onto current `origin/dev`.

## Post-Merge Validation

- [ ] During final release QA, open the portal release-note page and visually confirm the Mermaid cut-line diagram renders.

## Commit

- `9747879cb` — `docs(release): update v13 Body/Grid cut-line (#12698)`