### PR TITLE
docs(release): elevate v13 Dream Pipeline chapter (#12716)

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -66,6 +66,34 @@ Representative anchors:
 
 The practical result is not just faster code generation. It is durable engineering memory with visible failure modes: agents can resume, challenge, review, and repair from shared evidence, while degraded retrieval becomes a routed problem instead of an invisible loss of context.
 
+## The Brain Learned to Dream
+
+Dream Pipeline is the release mechanism that turns the memory substrate above into direction. v13 does not just preserve what agents did; it digests those sessions into graph intelligence, audits the current codebase, infers capability gaps, and synthesizes a Golden Path: an advisory forecast of the highest-ROI work for the swarm.
+
+This is completely new v13 substrate. The v12.1 baseline has no `learn/agentos/DreamPipeline.md`, no `ai/graph`, and no `ai/services/graph`; the v13 line adds the Native Edge Graph, graph extraction services, topology inference, deterministic gap inference, graph maintenance, and Golden Path synthesis. That is a Brain-level capability, not a row in a changelog.
+
+```mermaid
+flowchart LR
+    A["Agent sessions"] --> B["DreamService REM cycle"]
+    B --> C["Native Edge Graph"]
+    C --> D["Golden Path math"]
+    D --> E["sandman_handoff.md"]
+    E -. "advisory forecast" .-> F["Peer maintainers self-select work"]
+    F --> A
+```
+
+The loop matters because it changes the system's next move. `DreamService` starts by syncing the live workspace into the graph, then extracts tri-vectors from episodic memory: semantic graph entities, a feature namespace, and a human-readable summary. A separate topology pass can surface stale or superseded issue relationships. A deterministic gap pass keeps test, guide, example, and orphan-concept coverage distinct. Garbage collection removes broken edges and orphaned graph/vector nodes. Golden Path synthesis then combines semantic distance from the current frontier with structural edge weight, producing a ranked forecast plus an optional strategic brief.
+
+The boundary is just as important as the mechanism. Golden Path is not a central scheduler assigning workers. It is an advisory forecast generated from Memory Core, Chroma vectors, and SQLite graph topology. The named peer maintainers still choose, challenge, and review the work. That is why the v13 Brain stays compatible with Neo's flat swarm topology: the graph can make friction visible without turning maintainers into a hierarchy.
+
+Representative anchors:
+
+- [`learn/agentos/DreamPipeline.md`](https://github.com/neomjs/neo/blob/dev/learn/agentos/DreamPipeline.md) - six-phase REM pipeline, Golden Path math, and advisory loop.
+- [`ai/services/graph/GoldenPathSynthesizer.mjs`](https://github.com/neomjs/neo/blob/dev/ai/services/graph/GoldenPathSynthesizer.mjs) - Hybrid GraphRAG traversal over semantic embeddings plus structural graph weight.
+- [`resources/content/sandman_handoff.md`](https://github.com/neomjs/neo/blob/dev/resources/content/sandman_handoff.md) - generated Native Edge Graph audit and Golden Path handoff surface.
+- [#12663](https://github.com/neomjs/neo/pull/12663) - closed-loop diagrams reframed around advisory Golden Path and peer self-selection.
+- [#12680](https://github.com/neomjs/neo/pull/12680) - real-service REM guards for silent failure modes.
+
 ## Swarm Governance Becomes a Product Feature
 
 v13 makes the maintainer institution explicit. Neo is maintained by a named human + AI peer team, not by a hidden assistant workflow. The swarm now has persistent identities, A2A coordination, cross-family review, lead/peer role discipline, public review templates, and lifecycle rules that make collaboration auditable.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12716
Related: #12696
Refs #12698
Refs #12065

Adds a dedicated v13 release-note chapter for Dream Pipeline / Golden Path as a major Brain capability. The section explains the REM loop from sessions to Native Edge Graph intelligence, Golden Path math, `sandman_handoff.md`, and peer-selected follow-up work, while preserving the advisory forecast boundary so it does not read as hierarchical auto-assignment.

Evidence: L1 (source and branch-diff verification) -> L1 required (docs-only release-note chapter). No residuals for #12716; final release counts and full-arc polish remain parent-epic work.

## Deltas from ticket

The ticket allowed either a dedicated chapter or elevated subsection. I chose a dedicated chapter because the operator explicitly called out v13 scale and `learn/agentos/DreamPipeline.md` as big-win ammunition, and because the current note only had Dream / Golden Path as opening-table evidence.

## Test Evidence

- `git ls-tree -r --name-only origin/main -- learn/agentos/DreamPipeline.md ai/graph ai/services/graph` returned no files, while `origin/dev` contains the Dream Pipeline doc and graph service/source tree.
- `git diff --shortstat origin/main...origin/dev -- ai learn/agentos/DreamPipeline.md resources/content/sandman_handoff.md` reported `347 files changed, 94278 insertions(+)`.
- Read `learn/agentos/DreamPipeline.md` and verified the six REM phases, Golden Path scoring, advisory loop, and `sandman_handoff.md` output surface before drafting.
- `git diff --check origin/dev...HEAD` passed.

## Post-Merge Validation

- [ ] During final release QA, visually confirm the Mermaid loop diagram renders on the portal release-note page.
- [ ] Refresh live merged-PR / closed-issue counts before release cut; this PR intentionally does not freeze the moving release-window count.

## Commit

- `53f3b4d06` — `docs(release): elevate v13 Dream Pipeline chapter (#12716)`