### PR TITLE
fix(knowledge-base): cache code-term lexical rescue index (#12715)

### DIFF
--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -23,6 +23,8 @@ const lexicalRescueSkipDirs   = new Set([
     'playwright-report',
     'test-results'
 ]);
+const codeTermRescueRoots     = ['ai/services', 'ai/mcp/server', 'ai/graph'];
+const codeTermRescueFileLimit = 500;
 
 dotenv.config({
     path : insideNeo ? path.resolve(cwd, '.env') : path.resolve(cwd, '../../.env'),
@@ -360,7 +362,7 @@ class QueryService extends Base {
         await this.addGuideTitleRescues({addCandidate, queryLower, queryWords});
         await this.addPathHintRescues({addCandidate, query});
         await this.addFilenameHintRescues({addCandidate, query});
-        await this.addCodeTermRescues({addCandidate, query});
+        await this.addCodeTermRescues({addCandidate, query, type});
 
         return Array.from(candidateMap.values());
     }
@@ -447,31 +449,88 @@ class QueryService extends Base {
      * @param {Object} options
      * @returns {Promise<void>}
      */
-    async addCodeTermRescues({addCandidate, query}) {
+    async addCodeTermRescues({addCandidate, query, type}) {
         const terms = this.extractCodeTerms(query);
 
-        if (terms.length === 0) {
+        if (terms.length === 0 || (type && !['all', 'src', 'raw'].includes(type))) {
             return;
         }
 
-        const roots = ['ai/services', 'ai/mcp/server', 'ai/graph']
-            .map(root => path.resolve(aiConfig.neoRootDir, root));
+        const index = await this.getCodeTermRescueIndex();
+
+        for (const entry of index) {
+            if (terms.some(term => entry.compact.includes(term))) {
+                await addCandidate(entry.source, 'code-term', queryScoreWeights.classNameMatch);
+            }
+        }
+    }
+
+    /**
+     * @summary Returns the cached local source index for code-term lexical rescues.
+     *
+     * Code-term queries are common for Agent OS concepts (`mutate_frontier`,
+     * `query_recent_turns`, `golden_path`). Building the compact source index once per
+     * service lifetime keeps exact-anchor rescue behavior while avoiding a full
+     * filesystem walk + file-content read on every query.
+     *
+     * @returns {Promise<Array<{source: String, compact: String}>>} Cached source index.
+     */
+    async getCodeTermRescueIndex() {
+        if (this.codeTermRescueIndex) {
+            return this.codeTermRescueIndex;
+        }
+
+        if (!this.codeTermRescueIndexPromise) {
+            this.codeTermRescueIndexPromise = this.buildCodeTermRescueIndex()
+                .then(index => {
+                    this.codeTermRescueIndex = index;
+                    return index;
+                })
+                .finally(() => {
+                    this.codeTermRescueIndexPromise = null;
+                });
+        }
+
+        return this.codeTermRescueIndexPromise;
+    }
+
+    /**
+     * @summary Builds the compact local source index consumed by code-term lexical rescue.
+     * @returns {Promise<Array<{source: String, compact: String}>>} Source index entries.
+     */
+    async buildCodeTermRescueIndex() {
+        const entries = [];
+        const roots   = codeTermRescueRoots.map(root => path.resolve(aiConfig.neoRootDir, root));
 
         for (const root of roots) {
             if (!await fs.pathExists(root)) {
                 continue;
             }
 
-            const files = await this.collectFiles(root, {limit: 500});
+            const files = await this.collectFiles(root, {limit: codeTermRescueFileLimit});
             for (const file of files) {
                 const content = await fs.readFile(file, 'utf-8').catch(() => '');
                 const compact = this.normalizeLexicalValue(content);
 
-                if (terms.some(term => compact.includes(term))) {
-                    await addCandidate(path.relative(aiConfig.neoRootDir, file), 'code-term', queryScoreWeights.classNameMatch);
+                if (compact) {
+                    entries.push({
+                        source: this.normalizeSourcePath(path.relative(aiConfig.neoRootDir, file)),
+                        compact
+                    });
                 }
             }
         }
+
+        return entries;
+    }
+
+    /**
+     * @summary Clears the code-term rescue index so tests or future content-refresh hooks can rebuild it.
+     * @returns {void}
+     */
+    clearCodeTermRescueIndex() {
+        this.codeTermRescueIndex        = null;
+        this.codeTermRescueIndexPromise = null;
     }
 
     /**

--- a/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
@@ -25,6 +25,7 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
     let ChromaManager;
     let QueryService;
     let TextEmbeddingService;
+    let originalBuildCodeTermRescueIndex;
     let originalEmbedText;
     let originalGetKnowledgeBaseCollection;
 
@@ -33,12 +34,15 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
         QueryService         = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
 
+        originalBuildCodeTermRescueIndex  = QueryService.buildCodeTermRescueIndex;
         originalEmbedText                  = TextEmbeddingService.embedText;
         originalGetKnowledgeBaseCollection = ChromaManager.getKnowledgeBaseCollection;
     });
 
     test.afterEach(() => {
-        TextEmbeddingService.embedText        = originalEmbedText;
+        QueryService.buildCodeTermRescueIndex = originalBuildCodeTermRescueIndex;
+        QueryService.clearCodeTermRescueIndex();
+        TextEmbeddingService.embedText           = originalEmbedText;
         ChromaManager.getKnowledgeBaseCollection = originalGetKnowledgeBaseCollection;
     });
 
@@ -162,6 +166,81 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
             repoSlug: 'tenant-app',
             tenantId: 'tenant-a'
         });
+    });
+
+    test('does not build the code-term rescue index for no-anchor semantic queries (#12715)', async () => {
+        const capture = {};
+        let indexBuilt = false;
+        installQueryStub([{
+            source          : 'learn/agentos/MemoryCore.md',
+            type            : 'guide',
+            name            : 'Memory Core',
+            inheritanceChain: '[]'
+        }], capture);
+
+        QueryService.buildCodeTermRescueIndex = async () => {
+            indexBuilt = true;
+            return [];
+        };
+
+        const result = await QueryService.queryDocuments({
+            query: 'memory core context recovery overview',
+            type : 'all',
+            limit: 5
+        });
+
+        expect(result.topResult).toBe('learn/agentos/MemoryCore.md');
+        expect(indexBuilt).toBe(false);
+    });
+
+    test('does not build the code-term rescue index for non-code typed searches (#12715)', async () => {
+        const capture = {};
+        let indexBuilt = false;
+        installQueryStub([{
+            source          : 'learn/agentos/DreamPipeline.md',
+            type            : 'guide',
+            name            : 'The Dream Pipeline & Golden Path',
+            inheritanceChain: '[]'
+        }], capture);
+
+        QueryService.buildCodeTermRescueIndex = async () => {
+            indexBuilt = true;
+            return [];
+        };
+
+        const result = await QueryService.queryDocuments({
+            query: 'mutate_frontier guidance',
+            type : 'guide',
+            limit: 5
+        });
+
+        expect(result.topResult).toBe('learn/agentos/DreamPipeline.md');
+        expect(indexBuilt).toBe(false);
+    });
+
+    test('reuses the code-term rescue index across code-term queries (#12715)', async () => {
+        let indexBuilds = 0;
+        const rescuedSources = [];
+
+        QueryService.buildCodeTermRescueIndex = async () => {
+            indexBuilds++;
+
+            return [{
+                source : 'ai/services/memory-core/GraphService.mjs',
+                compact: 'exportfunctionmutatefrontierqueryrecentturns'
+            }];
+        };
+
+        const addCandidate = async source => rescuedSources.push(source);
+
+        await QueryService.addCodeTermRescues({addCandidate, query: 'mutate_frontier'});
+        await QueryService.addCodeTermRescues({addCandidate, query: 'query_recent_turns'});
+
+        expect(indexBuilds).toBe(1);
+        expect(rescuedSources).toEqual([
+            'ai/services/memory-core/GraphService.mjs',
+            'ai/services/memory-core/GraphService.mjs'
+        ]);
     });
 
     test('rescues exact local Brain graph anchors when semantic top-k misses them (#12703)', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12715

Caches the code-term lexical rescue scan behind a lazy compact source index so code-term queries stop reading the same bounded source tree on every `ask_knowledge_base` request. The exact-anchor rescue behavior remains covered, no-anchor semantic queries skip the rescue index, non-code typed searches skip it, and rescued metadata keeps the existing `neo` / `neo-shared` tenant posture.

Evidence: L2 (unit-level service contract tests with stubbed Chroma/model plus filesystem-cache probes) -> L2 required (service retrieval/perf ACs fully unit-observable). Residual: none.

## Deltas from ticket
- Replaced per-query full-content scans with a service-lifetime lazy cached compact index for the existing code-term rescue roots.
- Added explicit negative coverage that no-anchor semantic queries do not build the code-term index.
- Added explicit negative coverage that non-code typed searches do not build the code-term index.
- Added cache reuse coverage across repeated code-term queries.
- Preserved the existing exact Brain graph rescue and tenant metadata expectations.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs` -> 10 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs` -> 20 passed.
- `git diff --check` -> passed.
- Pre-commit hook passed: whitespace, shorthand, and ticket-archaeology checks.
- Pre-push freshness passed: `origin/dev` is an ancestor of `HEAD`, and outgoing history contains only `e7f710600`.

## Post-Merge Validation
- [ ] Restart any still-running Knowledge Base MCP server before comparing live `ask_knowledge_base` latency against the merged code.

## Commits
- `e7f710600` - `fix(knowledge-base): cache code-term lexical rescue index (#12715)`