### PR TITLE
fix(knowledge-base): weight broad query candidates (#12719)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -337,6 +337,35 @@ class Config extends ConfigProvider {
              */
             nResults: leaf(100),
             /**
+             * Candidate budgets for broad `type='all'` queries.
+             *
+             * These pools run before hybrid scoring so current source/documentation chunks
+             * cannot be starved out by high-volume historical corpora such as pull-request
+             * conversations. Shares are applied to `nResults` in declaration order.
+             * @type {Array}
+             */
+            queryCandidatePools: leaf([
+                {
+                    name : 'primary',
+                    share: 0.65,
+                    types: ['src', 'ai-infrastructure', 'guide', 'concept', 'skill', 'adr']
+                },
+                {
+                    name : 'secondary',
+                    share: 0.2,
+                    types: ['app', 'example', 'test', 'raw']
+                },
+                {
+                    name : 'historical',
+                    share: 0.1,
+                    types: ['ticket', 'pull', 'discussion', 'release', 'blog']
+                },
+                {
+                    name : 'custom',
+                    share: 0.05
+                }
+            ]),
+            /**
              * Weights used in the query scoring algorithm.
              * @type {Object}
              */
@@ -351,6 +380,7 @@ class Config extends ConfigProvider {
                 namePartMatch    : 30,
                 lexicalRescueMatch: 3200,
                 ticketPenalty    : -70,
+                pullPenalty      : -250,
                 releasePenalty   : -50,
                 baseFileBonus    : 20,
                 releaseExactMatch: 1000,

--- a/ai/services/knowledge-base/QueryService.mjs
+++ b/ai/services/knowledge-base/QueryService.mjs
@@ -25,6 +25,9 @@ const lexicalRescueSkipDirs   = new Set([
 ]);
 const codeTermRescueRoots     = ['ai/services', 'ai/mcp/server', 'ai/graph'];
 const codeTermRescueFileLimit = 500;
+const sourceLikeTypeAliases = {
+    src: ['src', 'ai-infrastructure']
+};
 
 dotenv.config({
     path : insideNeo ? path.resolve(cwd, '.env') : path.resolve(cwd, '../../.env'),
@@ -128,38 +131,23 @@ class QueryService extends Base {
         const queryEmbeddingValues = await TextEmbeddingService.embedText(query, mcConfig.embeddingProvider);
         const queryLower           = query.toLowerCase();
 
-        const whereClause = (type && type !== 'all') ? { type } : {};
-
         // Read-side tenant filter: a requester retrieves its own tenant's chunks plus
         // Neo's curated `neo-shared` corpus. The requester is derived server-side from the
         // authenticated request context — never from a client-supplied parameter (a forged
         // `tenantId` query arg is therefore ignored). No request context (stdio single-tenant
         // / offline daemon) → no tenant filter, byte-equivalent with the legacy behavior.
         const requesterTenantId = normalizeUserId(RequestContextService.getUserId());
-        if (requesterTenantId) {
-            whereClause.tenantId = {$in: [requesterTenantId, aiConfig.defaultTenantId]};
-        }
-
-        const queryOptions = {
-            queryEmbeddings: [queryEmbeddingValues],
-            nResults       : aiConfig.nResults,
-            where          : whereClause
-        };
-
-        if (Object.keys(whereClause).length === 0) {
-            delete queryOptions.where;
-        }
-
-        const results        = await collection.query(queryOptions);
+        const queryOptions    = this.createQueryOptions({queryEmbeddingValues, requesterTenantId, type});
+        const queryResults    = await Promise.all(queryOptions.map(options => collection.query(options)));
         const sourceScores   = {};
         const sourceMetadata = {};
-        const metadatas      = results.metadatas?.[0] || [];
+        const metadatas      = this.dedupeCandidateMetadatas(queryResults.flatMap(result => result.metadatas?.[0] || []));
         const queryWords     = this.getQueryWords(queryLower);
 
         metadatas.forEach((metadata, index) => {
             if (!metadata.source || metadata.source === 'unknown') return;
 
-            let score             = (results.metadatas[0].length - index) * queryScoreWeights.baseIncrement;
+            let score             = (metadatas.length - index) * queryScoreWeights.baseIncrement;
             const sourcePath      = metadata.source;
             const sourcePathLower = sourcePath.toLowerCase();
             const fileName        = sourcePath.split('/').pop().toLowerCase();
@@ -199,6 +187,7 @@ class QueryService extends Base {
             });
 
             if (metadata.type === 'ticket' && type === 'all') score += queryScoreWeights.ticketPenalty;
+            if (metadata.type === 'pull' && type === 'all') score += queryScoreWeights.pullPenalty;
             if (metadata.type === 'release') score += queryScoreWeights.releasePenalty;
             if (fileName.endsWith('base.mjs')) score += queryScoreWeights.baseFileBonus;
             if (metadata.type === 'release' && queryLower.startsWith('v') && nameLower === queryLower) score += queryScoreWeights.releaseExactMatch;
@@ -265,6 +254,200 @@ class QueryService extends Base {
     }
 
     /**
+     * @summary Builds Chroma query option objects for a request.
+     *
+     * Broad `type='all'` searches are stratified before Chroma retrieval so historical
+     * conversations cannot monopolize the candidate set before current source/docs reach
+     * the hybrid scorer.
+     *
+     * @param {Object} options
+     * @param {Number[][]} options.queryEmbeddingValues Query embedding payload.
+     * @param {String|null} options.requesterTenantId Authenticated requester tenant.
+     * @param {String} options.type Requested KB content type.
+     * @returns {Object[]} Chroma query option objects.
+     */
+    createQueryOptions({queryEmbeddingValues, requesterTenantId, type}) {
+        if (type === 'all') {
+            return this.createBroadQueryOptions({queryEmbeddingValues, requesterTenantId});
+        }
+
+        return [
+            this.createQueryOption({
+                queryEmbeddingValues,
+                requesterTenantId,
+                typeFilter: this.resolveTypeFilter(type),
+                nResults  : aiConfig.nResults
+            })
+        ];
+    }
+
+    /**
+     * @summary Builds source-tiered Chroma queries for broad KB searches.
+     * @param {Object} options
+     * @returns {Object[]} Chroma query option objects.
+     */
+    createBroadQueryOptions({queryEmbeddingValues, requesterTenantId}) {
+        const pools = Array.isArray(aiConfig.queryCandidatePools) ? aiConfig.queryCandidatePools : [];
+
+        const activePools = pools.filter(pool => this.isCandidatePoolActive(pool));
+
+        if (activePools.length === 0) {
+            return [
+                this.createQueryOption({
+                    queryEmbeddingValues,
+                    requesterTenantId,
+                    nResults: aiConfig.nResults
+                })
+            ];
+        }
+
+        const total = Math.max(1, Number(aiConfig.nResults) || 1);
+        let allocated = 0;
+
+        return activePools
+            .map((pool, index) => {
+                const isLast = index === activePools.length - 1;
+                const rawResults = pool.nResults ?? (
+                    isLast ? total - allocated : Math.floor(total * (pool.share ?? 0))
+                );
+                const nResults = Math.max(1, Math.min(total, rawResults));
+                allocated += nResults;
+
+                return this.createQueryOption({
+                    queryEmbeddingValues,
+                    requesterTenantId,
+                    typeFilter: pool.types,
+                    nResults
+                });
+            });
+    }
+
+    /**
+     * @summary Checks whether a configured broad-query candidate pool can run.
+     *
+     * A pool with omitted `types` is intentionally valid: it is the bounded fallback lane for
+     * tenant-ingested custom parser kinds (`module-context`, `cpp-function`, `proto-message`,
+     * etc.) that are not part of Neo's curated source taxonomy.
+     *
+     * @param {Object} pool Candidate pool config entry.
+     * @returns {Boolean} True when the pool should be queried.
+     */
+    isCandidatePoolActive(pool) {
+        if (!pool || typeof pool !== 'object') {
+            return false;
+        }
+
+        if (!Object.hasOwn(pool, 'types') || pool.types == null) {
+            return true;
+        }
+
+        return Array.isArray(pool.types) && pool.types.length > 0;
+    }
+
+    /**
+     * @summary Removes exact duplicate Chroma candidates returned by overlapping pools.
+     *
+     * The broad fallback lane intentionally queries without a type predicate, so it can return
+     * the same high-similarity chunk already seen in a typed pool. Keep distinct chunks from the
+     * same source, but avoid double-counting the same metadata row.
+     *
+     * @param {Object[]} metadatas Flattened Chroma metadata candidates.
+     * @returns {Object[]} Deduplicated metadata candidates.
+     */
+    dedupeCandidateMetadatas(metadatas) {
+        const seen = new Set();
+
+        return metadatas.filter(metadata => {
+            const key = [
+                metadata?.tenantId || '',
+                metadata?.repoSlug || '',
+                metadata?.source || '',
+                metadata?.type || '',
+                metadata?.name || '',
+                metadata?.content || metadata?.description || '',
+                metadata?.line_start || '',
+                metadata?.line_end || ''
+            ].join('\u001f');
+
+            if (seen.has(key)) {
+                return false;
+            }
+
+            seen.add(key);
+            return true;
+        });
+    }
+
+    /**
+     * @summary Builds one Chroma query option with a valid optional where clause.
+     * @param {Object} options
+     * @returns {Object} Chroma query options.
+     */
+    createQueryOption({queryEmbeddingValues, requesterTenantId, typeFilter, nResults}) {
+        const where = this.createWhereClause({requesterTenantId, typeFilter});
+        const option = {
+            queryEmbeddings: [queryEmbeddingValues],
+            nResults
+        };
+
+        if (where) {
+            option.where = where;
+        }
+
+        return option;
+    }
+
+    /**
+     * @summary Creates a Chroma metadata filter without emitting invalid empty objects.
+     * @param {Object} options
+     * @returns {Object|undefined} Chroma where clause.
+     */
+    createWhereClause({requesterTenantId, typeFilter}) {
+        const clauses = [];
+
+        if (typeFilter) {
+            clauses.push(Array.isArray(typeFilter) ? {type: {$in: typeFilter}} : {type: typeFilter});
+        }
+
+        if (requesterTenantId) {
+            clauses.push({tenantId: {$in: [requesterTenantId, aiConfig.defaultTenantId]}});
+        }
+
+        if (clauses.length === 0) {
+            return undefined;
+        }
+
+        return clauses.length === 1 ? clauses[0] : {$and: clauses};
+    }
+
+    /**
+     * @summary Resolves public query type aliases into indexed KB type filters.
+     * @param {String} type Requested content type.
+     * @returns {String|String[]|null} Chroma type filter.
+     */
+    resolveTypeFilter(type) {
+        if (!type || type === 'all') {
+            return null;
+        }
+
+        return sourceLikeTypeAliases[type] || type;
+    }
+
+    /**
+     * @summary Checks whether an indexed type belongs to a requested filter.
+     * @param {String} candidateType Indexed content type.
+     * @param {String|String[]|null} typeFilter Requested type filter.
+     * @returns {Boolean} True when the candidate type is allowed.
+     */
+    matchesTypeFilter(candidateType, typeFilter) {
+        if (!typeFilter) {
+            return true;
+        }
+
+        return Array.isArray(typeFilter) ? typeFilter.includes(candidateType) : candidateType === typeFilter;
+    }
+
+    /**
      * @summary Normalizes query text into scoring words while preserving numerical anchors.
      * @param {String} queryLower Lower-cased query string.
      * @returns {String[]} Query words longer than two characters.
@@ -294,9 +477,10 @@ class QueryService extends Base {
     async addLexicalRescueScores({query, queryLower, queryWords, sourceMetadata, sourceScores, type}) {
         const candidates = await this.getLexicalRescueCandidates({query, queryLower, queryWords, type});
         const rescueBase = queryScoreWeights.lexicalRescueMatch || queryScoreWeights.sourcePathMatch * 80;
+        const typeFilter = this.resolveTypeFilter(type);
 
         candidates.forEach(candidate => {
-            if (type && type !== 'all' && candidate.type && candidate.type !== type) {
+            if (!this.matchesTypeFilter(candidate.type, typeFilter)) {
                 return;
             }
 
@@ -327,6 +511,7 @@ class QueryService extends Base {
      */
     async getLexicalRescueCandidates({query, queryLower, queryWords, type}) {
         const candidateMap = new Map();
+        const typeFilter   = this.resolveTypeFilter(type);
         const addCandidate = async (source, reason, score = 0) => {
             const normalizedSource = this.normalizeSourcePath(source);
 
@@ -334,7 +519,7 @@ class QueryService extends Base {
                 return;
             }
 
-            if (type && type !== 'all' && this.inferSourceType(normalizedSource) !== type) {
+            if (!this.matchesTypeFilter(this.inferSourceType(normalizedSource), typeFilter)) {
                 return;
             }
 
@@ -580,7 +765,7 @@ class QueryService extends Base {
         if (source.startsWith('test/')) return 'test';
         if (source.startsWith('resources/content/issues/') || source.startsWith('resources/content/archive/issues/')) return 'ticket';
         if (source.startsWith('resources/content/discussions/') || source.startsWith('resources/content/archive/discussions/')) return 'discussion';
-        if (source.startsWith('resources/content/pulls/') || source.startsWith('resources/content/archive/pulls/')) return 'pull-request';
+        if (source.startsWith('resources/content/pulls/') || source.startsWith('resources/content/archive/pulls/')) return 'pull';
         if (source.startsWith('resources/content/release-notes/') || source.startsWith('.github/RELEASE_NOTES/')) return 'release';
 
         const apiSourceMap = aiConfig.sourcePaths.ApiSource || {};

--- a/learn/agentos/KnowledgeBase.md
+++ b/learn/agentos/KnowledgeBase.md
@@ -196,6 +196,7 @@ export default {
     // Tune the brain to be more sensitive to bug reports
     queryScoreWeights: {
         ticketPenalty: -20, // Reduce penalty from -70
+        pullPenalty  : -150, // Reduce penalty from -250
         guideMatch: 60      // Increase boost from 50
     }
 };
@@ -220,7 +221,14 @@ export default {
 *   **Scoring Weights (`queryScoreWeights`):**
     *   You can fine-tune the brain's retrieval logic here.
     *   *Example:* Decrease `ticketPenalty` if you want the agent to focus more on historical bug reports.
+    *   *Example:* Decrease `pullPenalty` only when PR conversation history should compete more directly with current source/docs in broad searches.
     *   *Example:* Increase `sourcePathMatch` to prioritize exact file location matches.
+
+*   **Candidate Pools (`queryCandidatePools`):**
+    *   Broad `type='all'` searches run source-tiered Chroma queries before hybrid scoring.
+    *   The default pool shape gives current source/docs most of the candidate budget, keeps apps/examples/tests visible, and bounds historical sources (`ticket`, `pull`, `discussion`, `release`, `blog`) to a smaller budget.
+    *   A low-budget pool with omitted `types` keeps tenant-ingested custom parser kinds visible without letting the fallback dominate current source/docs.
+    *   This prevents large synced conversation corpora from starving source-of-authority files before the reranker can score them.
 
 *   **Performance:**
     *   `nResults`: Retrieval depth (default: 100).

--- a/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs
@@ -22,15 +22,15 @@ import path                  from 'path';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 /**
- * @summary Fail-closed tenant-isolation suite for the Knowledge Base read side (#11632).
+ * @summary Fail-closed tenant-isolation suite for the Knowledge Base read side.
  *
- * Covers the 8 fail-closed cases graduated from Discussion #11623 §8, parameterized over the
+ * Covers the 8 fail-closed cases graduated from the tenant-isolation design discussion, parameterized over the
  * 5 public KB MCP facades. ChromaDB is replaced with an in-memory spy collection that locally
  * simulates the `where: {tenantId: {$in: [...]}}` filter, and `RequestContextService.run`
  * controls the server-side requester identity — no real SQLite / Chroma is touched.
  *
  * Cases 3 and 4 are write-side concerns (tenant-aware chunk-id derivation and write-side spoof
- * rejection). They are exhaustively covered by `VectorService.tenantStamping.spec.mjs` (#11631);
+ * rejection). They are exhaustively covered by `VectorService.tenantStamping.spec.mjs`;
  * this suite re-anchors their security property against the `VectorService` primitives so all
  * 8 cases stay visible in one load-bearing place, without re-driving the `embed` pipeline.
  *
@@ -52,6 +52,9 @@ function createSpyCollection() {
 
     const matchesWhere = (metadata, where) => {
         if (!where) return true;
+        if (Array.isArray(where.$and)) {
+            return where.$and.every(clause => matchesWhere(metadata, clause));
+        }
         return Object.entries(where).every(([key, cond]) => {
             if (cond && typeof cond === 'object' && Array.isArray(cond.$in)) {
                 return cond.$in.includes(metadata?.[key]);
@@ -106,6 +109,20 @@ function createSpyCollection() {
             };
         }
     };
+}
+
+function hasTenantFilter(where, expected) {
+    if (!where) {
+        return false;
+    }
+
+    if (Array.isArray(where.$and)) {
+        return where.$and.some(clause => hasTenantFilter(clause, expected));
+    }
+
+    return expected
+        ? JSON.stringify(where.tenantId) === JSON.stringify({$in: expected})
+        : Object.hasOwn(where, 'tenantId');
 }
 
 /**
@@ -206,7 +223,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
         expect(sources).toEqual(expect.arrayContaining([
             OWN.metadata.source, FOREIGN.metadata.source, SHARED.metadata.source
         ]));
-        expect(spy.calls.query.at(-1).where).toBeUndefined();
+        expect(spy.calls.query.every(call => !hasTenantFilter(call.where))).toBe(true);
     });
 
     test('case 1 — tenant isolation: query_documents hides another tenant\'s private chunks', async () => {
@@ -219,7 +236,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
         expect(sources).not.toContain(FOREIGN.metadata.source);
 
         // The filter is server-derived and carries exactly the requester plus the team namespace.
-        expect(spy.calls.query.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+        expect(spy.calls.query.every(call => hasTenantFilter(call.where, ['tenant-a', 'neo-shared']))).toBe(true);
     });
 
     test('case 2 — team visibility: neo-shared chunks stay visible across every tenant', async () => {
@@ -235,7 +252,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
     });
 
     test('case 3 — chunk-shadow: identical content under two tenants yields distinct chunk ids', () => {
-        // Write-side anchor — full coverage in VectorService.tenantStamping.spec.mjs (#11631).
+        // Write-side anchor — full coverage in VectorService.tenantStamping.spec.mjs.
         const content = {hash: 'identical-content-hash', type: 'guide', name: 'Doc', source: 'shared/Doc.md'};
 
         const idA = VectorService.createTenantAwareChunkId(content, {tenantId: 'tenant-a', repoSlug: 'repo'});
@@ -246,7 +263,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
     });
 
     test('case 4 — write-side spoof: a forged client tenantId is rejected in reject mode', () => {
-        // Write-side anchor — full coverage in VectorService.tenantStamping.spec.mjs (#11631).
+        // Write-side anchor — full coverage in VectorService.tenantStamping.spec.mjs.
         const originalMode = aiConfig.spoofRejectionMode;
         aiConfig.spoofRejectionMode = 'reject';
 
@@ -269,7 +286,7 @@ test.describe('KnowledgeBase — fail-closed tenant isolation (#11632)', () => {
             QueryService.queryDocuments({query: 'anything', type: 'all', tenantId: 'tenant-b'})
         );
 
-        expect(spy.calls.query.at(-1).where).toEqual({tenantId: {$in: ['tenant-a', 'neo-shared']}});
+        expect(spy.calls.query.every(call => hasTenantFilter(call.where, ['tenant-a', 'neo-shared']))).toBe(true);
         expect(result.results.map(r => r.source)).not.toContain(FOREIGN.metadata.source);
     });
 

--- a/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
@@ -46,15 +46,19 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
         ChromaManager.getKnowledgeBaseCollection = originalGetKnowledgeBaseCollection;
     });
 
-    function installQueryStub(metadatas, capture) {
+    function installQueryStub(metadatasOrFactory, capture) {
+        capture.options = [];
         TextEmbeddingService.embedText = async () => [0.1, 0.2, 0.3];
 
         ChromaManager.getKnowledgeBaseCollection = async () => ({
             query: async options => {
-                capture.options = options;
+                capture.options.push(options);
+                const metadatas = typeof metadatasOrFactory === 'function'
+                    ? metadatasOrFactory(options)
+                    : metadatasOrFactory;
 
                 return {
-                    metadatas: [metadatas]
+                    metadatas: [metadatas || []]
                 };
             }
         });
@@ -80,29 +84,131 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
             limit: 5
         });
 
-        expect(capture.options.queryEmbeddings).toEqual([[0.1, 0.2, 0.3]]);
-        expect(capture.options.where).toEqual({type: 'guide'});
+        expect(capture.options[0].queryEmbeddings).toEqual([[0.1, 0.2, 0.3]]);
+        expect(capture.options[0].where).toEqual({type: 'guide'});
         expect(result.topResult).toBe('learn/guides/testing/UnitTesting.md');
         expect(result.results).toHaveLength(1);
     });
 
-    test('omits where when type is all', async () => {
+    test('stratifies broad searches into source-first candidate pools (#12719)', async () => {
         const capture = {};
-        installQueryStub([{
-            source          : 'src/component/Base.mjs',
-            type            : 'src',
-            name            : 'Neo.component.Base',
-            className       : 'Neo.component.Base',
-            inheritanceChain: '[]'
-        }], capture);
+        installQueryStub(options => {
+            const types = options.where?.type?.$in || [];
 
-        await QueryService.queryDocuments({
-            query: 'component base',
+            if (types.includes('ai-infrastructure')) {
+                return [{
+                    source          : 'ai/services/knowledge-base/QueryService.mjs',
+                    type            : 'ai-infrastructure',
+                    name            : 'Neo.ai.services.knowledge-base.QueryService',
+                    className       : 'Neo.ai.services.knowledge-base.QueryService',
+                    inheritanceChain: '[]'
+                }];
+            }
+
+            if (types.includes('pull')) {
+                return [{
+                    source          : 'resources/content/pulls/chunk-1/pr-12703.md',
+                    type            : 'pull',
+                    name            : 'pr-12703',
+                    inheritanceChain: '[]'
+                }];
+            }
+
+            return [];
+        }, capture);
+
+        const result = await QueryService.queryDocuments({
+            query: 'query service scorer',
             type : 'all',
             limit: 5
         });
 
-        expect(Object.hasOwn(capture.options, 'where')).toBe(false);
+        expect(capture.options).toHaveLength(4);
+        expect(capture.options[0].nResults).toBeGreaterThan(capture.options[2].nResults);
+        expect(capture.options[0].where).toEqual({type: {$in: ['src', 'ai-infrastructure', 'guide', 'concept', 'skill', 'adr']}});
+        expect(capture.options[2].where).toEqual({type: {$in: ['ticket', 'pull', 'discussion', 'release', 'blog']}});
+        expect(capture.options[3].where).toBeUndefined();
+        expect(result.topResult).toBe('ai/services/knowledge-base/QueryService.mjs');
+        expect(result.results.map(item => item.source)).toContain('resources/content/pulls/chunk-1/pr-12703.md');
+    });
+
+    test('keeps a bounded broad-search fallback for custom parser chunk kinds (#12719)', async () => {
+        const capture = {};
+        installQueryStub(options => {
+            if (!options.where) {
+                return [{
+                    source          : 'src/MainView.mjs',
+                    type            : 'module-context',
+                    name            : 'MiniNeo.MainView',
+                    className       : 'MiniNeo.MainView',
+                    tenantId        : 'tenant-alpha',
+                    repoSlug        : 'mini-neo-workspace',
+                    content         : 'alpha-exclusive-query neo workspace panel',
+                    inheritanceChain: '[]'
+                }];
+            }
+
+            return [];
+        }, capture);
+
+        const result = await QueryService.queryDocuments({
+            query: 'alpha-exclusive-query',
+            type : 'all',
+            limit: 5
+        });
+
+        expect(capture.options).toHaveLength(4);
+        expect(capture.options[3]).toMatchObject({
+            nResults: 5
+        });
+        expect(result.topResult).toBe('src/MainView.mjs');
+        expect(result.results[0].metadata).toBeUndefined();
+    });
+
+    test('deduplicates candidates returned by overlapping broad-search pools (#12719)', async () => {
+        const capture = {};
+        const duplicate = {
+            source          : 'learn/agentos/KnowledgeBase.md',
+            type            : 'guide',
+            name            : 'The Knowledge Base Server',
+            content         : 'duplicate candidate',
+            inheritanceChain: '[]'
+        };
+
+        installQueryStub(options => {
+            const types = options.where?.type?.$in || [];
+
+            return types.includes('guide') || !options.where ? [duplicate] : [];
+        }, capture);
+
+        const result = await QueryService.queryDocuments({
+            query          : 'knowledge base',
+            type           : 'all',
+            includeMetadata: true
+        });
+
+        expect(capture.options).toHaveLength(4);
+        expect(result.results.filter(item => item.source === duplicate.source)).toHaveLength(1);
+    });
+
+    test('expands source searches to include Agent OS implementation chunks (#12719)', async () => {
+        const capture = {};
+        installQueryStub([{
+            source          : 'ai/services/knowledge-base/QueryService.mjs',
+            type            : 'ai-infrastructure',
+            name            : 'Neo.ai.services.knowledge-base.QueryService',
+            className       : 'Neo.ai.services.knowledge-base.QueryService',
+            inheritanceChain: '[]'
+        }], capture);
+
+        await QueryService.queryDocuments({
+            query: 'query service',
+            type : 'src',
+            limit: 5
+        });
+
+        expect(capture.options).toHaveLength(1);
+        expect(capture.options[0].where).toEqual({type: {$in: ['src', 'ai-infrastructure']}});
     });
 
     test('returns the no-results message when Chroma returns an empty metadata payload', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12719
Related: #12715

This fixes the KB broad-search candidate path so synced PR conversations no longer compete as neutral first-class evidence against current source files and documentation. `type='all'` now queries Chroma through source-tiered candidate pools before hybrid scoring, `pull` chunks get an explicit broad-search penalty, and `type='src'` also reaches Agent OS implementation chunks indexed as `ai-infrastructure`.

The broad query path also keeps a small custom fallback lane for tenant-ingested parser kinds such as `module-context`, `method`, `cpp-function`, and `proto-message`. That preserves cloud/external workspace retrieval without letting the fallback dominate source/docs or historical weighting.

Evidence: L2 (focused Playwright unit coverage with Chroma query stubs + tenant-filter regression coverage) -> L2 required (QueryService query construction and rerank contracts). No residuals.

## Deltas from ticket

- Added a composed Chroma `where` builder so type filters and server-derived tenant filters combine via `$and` instead of producing invalid multi-key or empty filters.
- Added source-tiered broad-query candidate pools, with a bounded custom fallback pool for valid tenant parser kinds outside Neo's curated source taxonomy.
- Added exact-candidate de-duplication so overlapping typed/fallback pool queries do not double-count the same Chroma metadata row.
- Added a defensive fallback to the legacy unfiltered query when an operator overlay configures no valid candidate pools.
- Removed stale durable ticket-number references from comments in the touched tenant-isolation spec because the current pre-commit archaeology lint rejects them.

## Config Template Sync

Changed config keys:

- `queryCandidatePools`
- `queryScoreWeights.pullPenalty`

`ai/mcp/server/knowledge-base/config.mjs` is gitignored and was not committed. Active local clones with an older KB `config.mjs` need a config-template migration or local shape refresh after merge to inherit the new keys. A running Knowledge Base MCP server should be restarted after that refresh so live query behavior uses the new pool and penalty settings.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs` -> 10 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs` -> 14 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs test/playwright/unit/ai/services/knowledge-base/KnowledgeBase.TenantIsolation.spec.mjs` -> 24 passed.
- `npm run test-integration-unified -- test/playwright/integration/ai/kb-ingestion/multi-tenant.spec.mjs` -> local sandbox run failed before test start on `listen EPERM 127.0.0.1:13090`; escalated local run started but skipped the Dockerized matrix scenario because the fixture stack was unavailable. CI integration re-run is the decisive L3 signal.
- `git diff --check` -> passed.
- Pre-commit hooks passed on the final staged diff.

Known non-blocking baseline: `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base` previously reached 292 passed, 2 unrelated pre-existing failures in `DatabaseLifecycleService.spec.mjs` before test collection: `Neo.gatekeep is not a function`.

## Post-Merge Validation

- [ ] Refresh gitignored KB `config.mjs` overlays in active clones or rerun config migration.
- [ ] Restart stale Knowledge Base MCP servers.
- [ ] Re-probe representative `ask_knowledge_base` queries against the restarted server to verify source/docs stay ahead of pull conversations.

## Commits

- 2a6a3a6ca — `fix(knowledge-base): weight broad query candidates (#12719)`
