### PR TITLE
feat(github-workflow): add lean issue list projection (#12706)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -878,6 +878,8 @@ paths:
 
         **When to Use:**
         - To find open work items or review recent closed issues.
+        - Use `projection: 'title'` for title-first backlog scans where issue bodies would waste context.
+        - Use the default `projection: 'full'` when you need issue bodies in the list response.
         - To look up issue numbers for use in other tools.
       tags: [Issues]
       parameters:
@@ -910,6 +912,14 @@ paths:
           description: Filter issues by a single assignee login.
           schema:
             type: string
+        - name: projection
+          in: query
+          required: false
+          description: Response projection. `full` preserves the existing body-bearing shape, `summary` omits body but keeps triage metadata, and `title` / `title_only` return a compact title-scan shape. Use `get_conversation` for full context after selecting a candidate issue.
+          schema:
+            type: string
+            enum: [full, summary, title, title_only]
+            default: full
       responses:
         '200':
           description: A list of issues.
@@ -2071,6 +2081,9 @@ components:
               login:
                 type: string
         createdAt:
+          type: string
+          format: date-time
+        updatedAt:
           type: string
           format: date-time
 

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -1255,11 +1255,21 @@ class IssueService extends Base {
      * @param {number}          [options.limit=30]     The maximum number of issues to return
      * @param {string}          [options.state='open'] Filter issues by state (open, closed)
      * @param {string[]|string} [options.labels]       Comma separated list of labels to filter by
-     * @param {string}          [options.assignee]     Filter issues by a single assignee login
-     * @param {string}          [options.cursor]       Cursor for pagination
+     * @param {string}          [options.assignee]          Filter issues by a single assignee login
+     * @param {'full'|'summary'|'title'|'title_only'} [options.projection='full'] Response shape projection
+     * @param {string}          [options.cursor]            Cursor for pagination
      * @returns {Promise<object>}
      */
-    async listIssues({limit=30, state='open', labels=null, assignee=null, cursor=null} = {}) {
+    async listIssues({limit=30, state='open', labels=null, assignee=null, projection='full', cursor=null} = {}) {
+        const normalizedProjection = this.normalizeIssueListProjection(projection);
+
+        if (!normalizedProjection) {
+            return {
+                error  : 'Bad Request',
+                message: `Invalid projection '${projection}'. Expected one of: full, summary, title, title_only.`,
+                code   : 'INVALID_PROJECTION'
+            };
+        }
 
         // normalize state to uppercase array (GraphQL expects IssueState enum values)
         const states = state ? (Array.isArray(state) ? state.map(s => s.toUpperCase()) : [state.toUpperCase()]) : undefined;
@@ -1300,6 +1310,7 @@ class IssueService extends Base {
                 issue.labels    = issue.labels?.nodes    || [];
                 issue.assignees = issue.assignees?.nodes || [];
             }
+            issues = issues.map(issue => this.projectListedIssue(issue, normalizedProjection));
 
             return {
                 count: issues.length,
@@ -1313,6 +1324,61 @@ class IssueService extends Base {
                 code   : 'GRAPHQL_API_ERROR'
             };
         }
+    }
+
+    /**
+     * @summary Normalizes the issue-list response projection.
+     *
+     * `title_only` is accepted as an alias for `title` because it is the phrase agents naturally
+     * use when asking for backlog scans, while the canonical enum value stays compact.
+     *
+     * @param {String} projection Requested projection.
+     * @returns {'full'|'summary'|'title'|null} Normalized projection or null when invalid.
+     */
+    normalizeIssueListProjection(projection = 'full') {
+        const normalized = String(projection || 'full').toLowerCase();
+
+        if (normalized === 'title_only') {
+            return 'title';
+        }
+
+        return ['full', 'summary', 'title'].includes(normalized) ? normalized : null;
+    }
+
+    /**
+     * @summary Applies the requested payload projection to a listed issue.
+     *
+     * Projection happens after GraphQL retrieval and client-side filters, preserving the existing
+     * query/filter path while letting queue scans omit heavy bodies.
+     *
+     * @param {Object} issue Flattened issue record.
+     * @param {'full'|'summary'|'title'} projection Normalized projection.
+     * @returns {Object} Projected issue record.
+     */
+    projectListedIssue(issue, projection) {
+        if (projection === 'full') {
+            return issue;
+        }
+
+        const base = {
+            number   : issue.number,
+            title    : issue.title,
+            state    : issue.state,
+            url      : issue.url,
+            labels   : issue.labels,
+            assignees: issue.assignees
+        };
+
+        if (projection === 'title') {
+            return base;
+        }
+
+        return {
+            ...base,
+            author   : issue.author,
+            createdAt: issue.createdAt,
+            updatedAt: issue.updatedAt
+        };
     }
 
     /**

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -336,6 +336,7 @@ export const FETCH_ISSUES_LIST = `
           body
           state
           createdAt
+          updatedAt
           url
 
           author {

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -18,20 +18,150 @@ import Neo             from '../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
 
+test.describe('Neo.ai.services.github-workflow.IssueService — listIssues projections (#12706)', () => {
+    let IssueService;
+    let GraphqlService;
+    let originalQuery;
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        IssueService   = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService);
+    });
+
+    test.afterEach(() => {
+        GraphqlService.query = originalQuery;
+    });
+
+    function installIssueListStub(capture = {}) {
+        GraphqlService.query = async (query, variables) => {
+            capture.query     = query;
+            capture.variables = variables;
+
+            return {
+                repository: {
+                    issues: {
+                        nodes: [{
+                            number   : 12706,
+                            title    : 'Add lean projection to GitHub Workflow issue lists',
+                            body     : 'Long ticket body that title scans should not return.',
+                            state    : 'OPEN',
+                            createdAt: '2026-06-08T00:00:00Z',
+                            updatedAt: '2026-06-08T01:00:00Z',
+                            url      : 'https://github.com/neomjs/neo/issues/12706',
+                            author   : {login: 'neo-gpt'},
+                            labels   : {nodes: [{name: 'ai'}, {name: 'model-experience'}]},
+                            assignees: {nodes: [{login: 'neo-gpt'}]}
+                        }, {
+                            number   : 12705,
+                            title    : 'Path-scope docs-only CI',
+                            body     : 'Filtered body',
+                            state    : 'OPEN',
+                            createdAt: '2026-06-08T00:10:00Z',
+                            updatedAt: '2026-06-08T01:10:00Z',
+                            url      : 'https://github.com/neomjs/neo/issues/12705',
+                            author   : {login: 'neo-opus-vega'},
+                            labels   : {nodes: [{name: 'ci'}]},
+                            assignees: {nodes: []}
+                        }]
+                    }
+                }
+            };
+        };
+    }
+
+    test('keeps full projection as the default body-bearing response', async () => {
+        const capture = {};
+        installIssueListStub(capture);
+
+        const result = await IssueService.listIssues({limit: 10, state: 'open'});
+
+        expect(capture.variables).toMatchObject({
+            limit : 10,
+            states: ['OPEN']
+        });
+        expect(result.count).toBe(2);
+        expect(result.issues[0]).toMatchObject({
+            body     : 'Long ticket body that title scans should not return.',
+            createdAt: '2026-06-08T00:00:00Z',
+            updatedAt: '2026-06-08T01:00:00Z',
+            labels   : [{name: 'ai'}, {name: 'model-experience'}],
+            assignees: [{login: 'neo-gpt'}]
+        });
+    });
+
+    test('summary projection omits body after label and assignee filters', async () => {
+        installIssueListStub();
+
+        const result = await IssueService.listIssues({
+            assignee  : 'neo-gpt',
+            labels    : 'ai, model-experience',
+            projection: 'summary'
+        });
+
+        expect(result.count).toBe(1);
+        expect(result.issues[0]).toEqual({
+            number   : 12706,
+            title    : 'Add lean projection to GitHub Workflow issue lists',
+            state    : 'OPEN',
+            url      : 'https://github.com/neomjs/neo/issues/12706',
+            labels   : [{name: 'ai'}, {name: 'model-experience'}],
+            assignees: [{login: 'neo-gpt'}],
+            author   : {login: 'neo-gpt'},
+            createdAt: '2026-06-08T00:00:00Z',
+            updatedAt: '2026-06-08T01:00:00Z'
+        });
+        expect(result.issues[0]).not.toHaveProperty('body');
+    });
+
+    test('title_only projection returns the compact title-scan shape', async () => {
+        installIssueListStub();
+
+        const result = await IssueService.listIssues({projection: 'title_only'});
+
+        expect(result.issues[0]).toEqual({
+            number   : 12706,
+            title    : 'Add lean projection to GitHub Workflow issue lists',
+            state    : 'OPEN',
+            url      : 'https://github.com/neomjs/neo/issues/12706',
+            labels   : [{name: 'ai'}, {name: 'model-experience'}],
+            assignees: [{login: 'neo-gpt'}]
+        });
+        expect(result.issues[0]).not.toHaveProperty('body');
+        expect(result.issues[0]).not.toHaveProperty('createdAt');
+    });
+
+    test('invalid projection is rejected before GraphQL is called', async () => {
+        let called = false;
+        GraphqlService.query = async () => {
+            called = true;
+        };
+
+        const result = await IssueService.listIssues({projection: 'fields'});
+
+        expect(called).toBe(false);
+        expect(result).toMatchObject({
+            code : 'INVALID_PROJECTION',
+            error: 'Bad Request'
+        });
+    });
+});
+
 /**
- * @summary Contract coverage for `IssueService.manageIssueComment` enriched return shape (#10272 Phase 1).
+ * @summary Contract coverage for `IssueService.manageIssueComment` enriched return shape.
  *
- * Prior to #10272, `createComment` returned only `{message}` — callers had no access to the
+ * Previously, `createComment` returned only `{message}` — callers had no access to the
  * canonical comment identifier (GitHub global node ID), URL, or creation timestamp. The missing
- * identifier blocked the A2A propagation pattern (§2.3 of #10272): review-posts couldn't be
+ * identifier blocked the A2A propagation pattern: review-posts couldn't be
  * referenced by the author for selective-fetch via `get_conversation({comment_id: ...})`.
  *
  * `updateComment` already returned `{message, commentId, url, updatedAt}` — this spec locks in the
  * symmetric create-path contract: `{message, commentId, url, createdAt}`. Backward-compatible
  * extension (existing consumers reading only `message` continue to work).
  *
- * Tests exercise the GraphQL response parsing path; the actual GitHub API call is mocked via
- * `GraphqlService.query` monkey-patch (pattern established by `LabelService.spec.mjs` #10112).
+ * Tests exercise the GraphQL response parsing path; the actual GitHub API call is mocked via the
+ * established `GraphqlService.query` monkey-patch pattern.
  *
  * @see Neo.ai.services.github-workflow.IssueService#createComment
  * @see Neo.ai.services.github-workflow.IssueService#updateComment
@@ -200,8 +330,8 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
     });
 
     test.describe('update action (existing contract — regression lock)', () => {
-        test('returns {message, commentId, url, updatedAt} — unchanged by #10272', async () => {
-            // Update path was already enriched pre-#10272; this test pins the existing contract
+        test('returns {message, commentId, url, updatedAt} — unchanged by create-path enrichment', async () => {
+            // Update path was already enriched before the create-path work; this test pins the existing contract
             // so the create-path enrichment doesn't accidentally drift it. Symmetry matters.
             const COMMENT_ID      = 'IC_kwDOABcD_existing_1234';
             const COMMENT_URL     = 'https://github.com/neomjs/neo/issues/10272#issuecomment-4309098042';
@@ -269,7 +399,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
 });
 
 /**
- * @summary Contract coverage for `IssueService.manageIssueLabels` issue-or-PR labelable lookup (#10077).
+ * @summary Contract coverage for `IssueService.manageIssueLabels` issue-or-PR labelable lookup.
  *
  * `manage_issue_labels` advertises an `issue_number` path parameter that can target either a
  * GitHub Issue or Pull Request. GitHub GraphQL models those as distinct fields, but both implement
@@ -460,7 +590,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
 });
 
 /**
- * @summary Contract coverage for `IssueService.manageIssueProjects` ProjectV2 membership surface (#11233 Phase 1).
+ * @summary Contract coverage for `IssueService.manageIssueProjects` ProjectV2 membership surface.
  *
  * `manage_issue_projects` is the substrate-correct replacement for the deprecated `release:v*`
  * label-as-project-proxy pattern. The three actions (`add`, `remove`, `update_field`) mirror the
@@ -729,13 +859,13 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueProje
 });
 
 /**
- * @summary Contract coverage for `IssueService.assignIssue` precondition + post-verify gate (#11537).
+ * @summary Contract coverage for `IssueService.assignIssue` precondition + post-verify gate.
  *
- * Pre-#11537, `assignIssue` performed blind-add: passing `['@me']` to an issue already assigned
+ * Previously, `assignIssue` performed blind-add: passing `['@me']` to an issue already assigned
  * to another peer would silently add @me as a second assignee, producing parallel-claim collisions
- * (empirical anchor: PR #11245 in `peer-role-mode.md` §7).
+ * between agents.
  *
- * Post-#11537, the method enforces a precondition + post-verify gate:
+ * The method now enforces a precondition + post-verify gate:
  * - Fetches current assignees via `GET_ISSUE_ASSIGNEES`.
  * - If non-empty and `requireUnassigned: true` (default), rejects with `ASSIGNEE_CONFLICT` (HTTP 409)
  *   unless `acknowledgedReassign: '<reason>'` is provided.
@@ -744,7 +874,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueProje
  *
  * This spec pins the **conflict-path** behavior — the substrate-discipline value-add of the gate.
  * Override/strict-replacement/audit-trail paths depend on `child_process.exec` (no ES-module-friendly
- * mock pattern in the current test harness); coverage gap documented in #11537 PR body for follow-up.
+ * mock pattern in the current test harness), so this file keeps coverage at the service boundary.
  *
  * @see Neo.ai.services.github-workflow.IssueService#assignIssue
  * @see https://github.com/orgs/neomjs/discussions/11536 — graduation origin (Pre-Write Coordination Substrate)
@@ -892,7 +1022,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — assignIssue prec
 });
 
 /**
- * @summary Contract coverage for `IssueService.getConversation` (#10702).
+ * @summary Contract coverage for `IssueService.getConversation`.
  *
  * Issue-side twin of `PullRequestService.getConversation` — `get_conversation` is now a
  * single dual-purpose tool routing by `pr_number` xor `issue_number`. This block pins the


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12706

Adds a lean projection contract to the GitHub Workflow `list_issues` tool so backlog surveys can request issue titles without loading every full issue body.

- Adds `projection` support to `IssueService.listIssues()` with `full`, `summary`, `title`, and `title_only`.
- Documents the `/issues` OpenAPI parameter and the title-first survey path for agents.
- Adds focused unit coverage for full, summary, title alias, and invalid projection behavior.

Evidence: L2 (targeted unit coverage for IssueService projection behavior plus OpenAPI/tool-registration compatibility) -> L2 required (service contract and MCP schema change). Residual: stale running MCP server processes need restart before already-running clients expose the new parameter.

## Deltas from ticket

- Added `updatedAt` to the issue-list query because the summary projection needs useful triage metadata without requiring the full body.
- Accepted `title_only` as an alias while also exposing canonical `title`.
- Removed stale durable-ticket references from touched IssueService spec comments because the commit archaeology hook rejected those comment anchors.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs`
- `git diff --check`

## Post-Merge Validation

- [ ] Restart stale GitHub Workflow MCP server/harness processes so the live tool schema includes `projection`.
- [ ] Re-probe `list_issues({state: 'open', limit: 40, projection: 'title'})` and confirm the response stays title-first and compact.

## Commits

- `ec7291c35` - `feat(github-workflow): add lean issue list projection (#12706)`
