### PR TITLE
fix(memory-core): abort hung miniSummary provider calls (#12713)

### DIFF
--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -76,6 +76,9 @@ class OllamaProvider extends Base {
         };
 
         const clonedOptions = { ...options };
+        delete clonedOptions.operationLabel;
+        delete clonedOptions.signal;
+        delete clonedOptions.timeoutMs;
 
         // Handle JSON extraction mirroring Gemini provider
         if (clonedOptions.responseMimeType === 'application/json' || clonedOptions.response_mime_type === 'application/json') {

--- a/ai/provider/OpenAiCompatible.mjs
+++ b/ai/provider/OpenAiCompatible.mjs
@@ -1,6 +1,25 @@
 import Base from './Base.mjs';
 
 /**
+ * @summary Creates a provider-timeout error that identifies the safe transport context.
+ *
+ * The message names the operation, timeout budget, host, and model while deliberately
+ * omitting prompt content and credentials.
+ *
+ * @param {Object} options
+ * @param {String} options.operationLabel Safe diagnostic label for the caller operation.
+ * @param {Number} options.timeoutMs Timeout budget in milliseconds.
+ * @param {String} options.host Provider host.
+ * @param {String} options.modelName Chat model id.
+ * @returns {Error}
+ */
+function createTimeoutError({operationLabel, timeoutMs, host, modelName}) {
+    const error = new Error(`[OpenAiCompatible] ${operationLabel} timed out after ${timeoutMs}ms (host=${host}, model=${modelName})`);
+    error.code  = 'OPENAI_COMPATIBLE_TIMEOUT';
+    return error;
+}
+
+/**
  * Concrete AI provider for a local MLX-native or any OpenAI-compatible API server.
  * Uses the native JS Fetch API. Defaults to http://127.0.0.1:8000.
  *
@@ -88,6 +107,9 @@ class OpenAiCompatibleProvider extends Base {
         };
 
         const clonedOptions = { ...options };
+        delete clonedOptions.operationLabel;
+        delete clonedOptions.signal;
+        delete clonedOptions.timeoutMs;
 
         // Handle JSON extraction
         if (clonedOptions.responseMimeType === 'application/json' || clonedOptions.response_mime_type === 'application/json' || clonedOptions.response_format?.type === 'json_object') {
@@ -222,13 +244,47 @@ class OpenAiCompatibleProvider extends Base {
      *
      * @param {String|Array} input
      * @param {Object} [options]
+     * @param {Number} [options.timeoutMs] Abort the provider request after this many milliseconds.
+     * @param {String} [options.operationLabel] Safe diagnostic label for timeout errors.
+     * @param {AbortSignal} [options.signal] Optional upstream cancellation signal.
      * @returns {AsyncGenerator<String>} Yields text chunks.
      */
     async *stream(input, options = {}) {
         const cleanOptions = { ...options };
+        const rawTimeoutMs  = Number(cleanOptions.timeoutMs),
+              timeoutMs     = Number.isFinite(rawTimeoutMs) && rawTimeoutMs > 0 ? rawTimeoutMs : null,
+              operationLabel = cleanOptions.operationLabel || 'OpenAI-compatible chat completion',
+              upstreamSignal = cleanOptions.signal;
+
         delete cleanOptions.num_ctx;
+        delete cleanOptions.operationLabel;
+        delete cleanOptions.signal;
+        delete cleanOptions.timeoutMs;
 
         const payload = this.preparePayload(input, cleanOptions, true);
+        const controller = timeoutMs || upstreamSignal ? new AbortController() : null;
+        let timeoutId, upstreamAbortListener, timedOut = false;
+
+        if (controller && upstreamSignal) {
+            if (upstreamSignal.aborted) {
+                controller.abort(upstreamSignal.reason);
+            } else {
+                upstreamAbortListener = () => controller.abort(upstreamSignal.reason);
+                upstreamSignal.addEventListener('abort', upstreamAbortListener, {once: true});
+            }
+        }
+
+        if (controller && timeoutMs && !controller.signal.aborted) {
+            timeoutId = setTimeout(() => {
+                timedOut = true;
+                controller.abort(createTimeoutError({
+                    operationLabel,
+                    timeoutMs,
+                    host     : this.host,
+                    modelName: this.modelName
+                }));
+            }, timeoutMs);
+        }
 
         try {
             const response = await fetch(`${this.host}/v1/chat/completions`, {
@@ -237,7 +293,8 @@ class OpenAiCompatibleProvider extends Base {
                     'Content-Type': 'application/json',
                     ...(this.apiKey ? {Authorization: `Bearer ${this.apiKey}`} : {})
                 },
-                body: JSON.stringify(payload)
+                body: JSON.stringify(payload),
+                ...(controller ? {signal: controller.signal} : {})
             });
 
             if (!response.ok) {
@@ -291,7 +348,24 @@ class OpenAiCompatibleProvider extends Base {
                 }
             }
         } catch (error) {
+            if (timedOut) {
+                const timeoutError = createTimeoutError({
+                    operationLabel,
+                    timeoutMs,
+                    host     : this.host,
+                    modelName: this.modelName
+                });
+                timeoutError.cause = error;
+                throw timeoutError;
+            }
             throw error;
+        } finally {
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
+            if (upstreamSignal && upstreamAbortListener) {
+                upstreamSignal.removeEventListener('abort', upstreamAbortListener);
+            }
         }
     }
 }

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -708,7 +708,6 @@ class MemoryService extends Base {
      */
     async buildMiniSummary({prompt, response}) {
         const TIMEOUT_MS = 4000;
-        let timer;
         try {
             const model = buildChatModel({
                 modelProvider         : aiConfig.modelProvider,
@@ -720,16 +719,20 @@ class MemoryService extends Base {
             if (!model) return null;
 
             const promptText = `Summarize this agent turn in one line, max 280 characters, no preamble:\nUser: ${prompt ?? ''}\nAgent: ${response ?? ''}`;
-            const timeout    = new Promise(resolve => { timer = setTimeout(() => resolve(null), TIMEOUT_MS); });
-            const result     = await Promise.race([model.generateContent(promptText).catch(() => null), timeout]);
+            const result     = await withTimeout(
+                model.generateContent(promptText, {
+                    timeoutMs      : TIMEOUT_MS,
+                    operationLabel : 'miniSummary generation'
+                }),
+                TIMEOUT_MS,
+                'miniSummary generation'
+            );
 
             const text = result?.response?.text?.() ?? null;
             return text ? String(text).replace(/\s+/g, ' ').trim().slice(0, 280) : null;
         } catch (error) {
             logger.warn(`[MemoryService] miniSummary generation failed (fail-soft): ${error.message}`);
             return null;
-        } finally {
-            clearTimeout(timer);
         }
     }
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -15,7 +15,8 @@ import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoo
  * injected factories. Returns a `{generateContent}` shim that wraps the provider's
  * `generate()` in a Gemini-shaped response envelope (`{response: {text()}}`) so
  * downstream consumers (`summarizeSession`, `invokeWithGuardrail`) stay
- * provider-agnostic.
+ * provider-agnostic. Wrapper `generateContent(promptText, options)` calls pass safe provider
+ * options such as `timeoutMs` through to local providers without leaking them into prompts.
  *
  * Extracted from `construct()` for testability: tests can pass mocked provider
  * factories to verify selector boundaries + envelope shape without hitting real
@@ -53,14 +54,14 @@ export function buildChatModel({
             ...(cfg.keep_alive !== undefined ? {keepAlive: cfg.keep_alive} : {})
         });
         return {
-            generateContent: async (promptText) => {
+            generateContent: async (promptText, generationOptions = {}) => {
                 provider.apiKey    = cfg.apiKey;
                 provider.host      = cfg.host;
                 provider.modelName = cfg.model;
                 if (cfg.keep_alive !== undefined) {
                     provider.keepAlive = cfg.keep_alive;
                 }
-                const result  = await provider.generate(promptText);
+                const result  = await provider.generate(promptText, generationOptions);
                 const content = result.content || result.raw?.message?.content || '';
                 return {response: {text: () => content}};
             }
@@ -76,13 +77,13 @@ export function buildChatModel({
             ...(cfg.keep_alive !== undefined ? {keepAlive: cfg.keep_alive} : {})
         });
         return {
-            generateContent: async (promptText) => {
+            generateContent: async (promptText, generationOptions = {}) => {
                 provider.host      = cfg.host  || provider.host;
                 provider.modelName = cfg.model || provider.modelName;
                 if (cfg.keep_alive !== undefined) {
                     provider.keepAlive = cfg.keep_alive;
                 }
-                const result  = await provider.generate(promptText);
+                const result  = await provider.generate(promptText, generationOptions);
                 const content = result.content || result.raw?.message?.content || '';
                 return {response: {text: () => content}};
             }

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -324,6 +324,55 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         });
     });
 
+    test('OpenAiCompatible.stream() aborts a hung request on timeout without leaking transport options', async () => {
+        let capturedPayload, aborted = false, abortReason;
+
+        globalThis.fetch = async (url, init) => {
+            expect(url).toBe('http://openai-compatible.test/v1/chat/completions');
+            capturedPayload = JSON.parse(init.body);
+
+            return new Promise((resolve, reject) => {
+                init.signal.addEventListener('abort', () => {
+                    aborted    = init.signal.aborted;
+                    abortReason = init.signal.reason;
+                    reject(abortReason);
+                }, {once: true});
+            });
+        };
+
+        const provider = Neo.create(OpenAiCompatibleProvider, {
+            host     : 'http://openai-compatible.test',
+            modelName: 'gemma4-test'
+        });
+
+        const collect = async () => {
+            const chunks = [];
+            for await (const chunk of provider.stream('hello', {
+                operationLabel: 'miniSummary backfill',
+                temperature   : 0.2,
+                timeoutMs     : 25
+            })) {
+                chunks.push(chunk);
+            }
+            return chunks;
+        };
+
+        await expect(collect()).rejects.toThrow(
+            /\[OpenAiCompatible\] miniSummary backfill timed out after 25ms \(host=http:\/\/openai-compatible\.test, model=gemma4-test\)/
+        );
+
+        expect(aborted).toBe(true);
+        expect(abortReason?.code).toBe('OPENAI_COMPATIBLE_TIMEOUT');
+        expect(capturedPayload).toMatchObject({
+            model      : 'gemma4-test',
+            stream     : true,
+            keep_alive : -1,
+            temperature: 0.2
+        });
+        expect(capturedPayload.operationLabel).toBeUndefined();
+        expect(capturedPayload.timeoutMs).toBeUndefined();
+    });
+
     test('OpenAiCompatible.generate() defaults keep_alive through the streaming payload', async () => {
         let capturedPayload;
 

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs
@@ -1,5 +1,22 @@
-import {test, expect}  from '@playwright/test';
-import {withTimeout}   from '../../../../../../ai/services/memory-core/MemoryService.mjs';
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MemoryServiceWithTimeoutTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {withTimeout}  from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 
 /**
  * Unit coverage for the backfill timeout guard. The miniSummary backfill wraps its model call

--- a/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
@@ -116,8 +116,8 @@ test.describe('SessionService.buildChatModel (#11965 Sub-2)', () => {
             modelName: null,
             apiKey   : null,
             keepAlive: null,
-            async generate(promptText) {
-                captured.push({promptText, host: this.host, modelName: this.modelName, apiKey: this.apiKey, keepAlive: this.keepAlive});
+            async generate(promptText, generationOptions) {
+                captured.push({promptText, generationOptions, host: this.host, modelName: this.modelName, apiKey: this.apiKey, keepAlive: this.keepAlive});
                 return {content: 'oai:' + promptText};
             }
         };
@@ -129,9 +129,21 @@ test.describe('SessionService.buildChatModel (#11965 Sub-2)', () => {
         });
 
         expect(model).toBeTruthy();
-        const response = await model.generateContent('hello');
+        const response = await model.generateContent('hello', {
+            operationLabel: 'miniSummary generation',
+            timeoutMs     : 4000
+        });
         expect(response.response.text()).toBe('oai:hello');
-        expect(captured[0]).toMatchObject({host: 'http://oai.test', modelName: 'oai-model', apiKey: 'sk-test', keepAlive: -1});
+        expect(captured[0]).toMatchObject({
+            host             : 'http://oai.test',
+            modelName        : 'oai-model',
+            apiKey           : 'sk-test',
+            keepAlive        : -1,
+            generationOptions: {
+                operationLabel: 'miniSummary generation',
+                timeoutMs     : 4000
+            }
+        });
     });
 
     test('modelProvider=gemini returns null when geminiApiKey is missing', () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12713

Identified the concrete hang class behind the miniSummary backfill incident: the OpenAI-compatible chat provider used native `fetch()` without an abort signal, so an endpoint that accepted the request but never returned a response/body chunk could leave the provider await alive indefinitely. The fix makes miniSummary generation pass a 4s provider timeout into the local provider path, aborts the OpenAI-compatible fetch with safe host/model diagnostics, and keeps transport-only timeout metadata out of model payloads.

Evidence: L2 (unit-level hung-fetch reproduction, abort assertion, timeout diagnostic assertion, and miniSummary/backfill regression coverage) -> L2 required (root cause identified/instrumented and bounded below the 30s backfill timeout in CI). Residual: post-merge live local-provider p99 spot-check for the deployed model/host.

## Deltas from ticket

- Fixed the provider-boundary root cause instead of adding another outer MemoryService guard: `OpenAiCompatibleProvider.stream()` now aborts hung requests via `AbortController`.
- Threaded `timeoutMs` / `operationLabel` through the Memory Core chat-model wrapper so miniSummary generation can request a provider-level timeout.
- Replaced `buildMiniSummary()`'s non-aborting `Promise.race` with the existing labeled `withTimeout()` plus abort-capable provider options.
- Stripped transport-only options from OpenAI-compatible and Ollama payload preparation so timeout metadata never reaches model prompts/options.
- Added the standard unit-test bootstrap imports to `MemoryService.WithTimeout.spec.mjs`, which was exposed by the focused verification path.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs` initially hit sandbox `listen EPERM` on the existing loopback provider test.
- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs` passed with escalation: 18/18.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs` passed: 13/13.
- `npm run test-unit -- test/playwright/unit/ai/provider/KeepAlive.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.WithTimeout.spec.mjs` passed with escalation: 31/31.
- `git diff --check`

## Post-Merge Validation

- [ ] Restart stale Memory Core/orchestrator harness processes so already-running providers pick up the abortable timeout path.
- [ ] Run one live miniSummary/backfill probe against the configured OpenAI-compatible provider and confirm completion or timeout diagnostic well below the 30s backfill ceiling.

## Commits

- `b8ac2e6dc` - `fix(memory-core): abort hung miniSummary provider calls (#12713)`
