### PR TITLE
docs(identity): refresh v13 scale proof (#12725)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Where the industry runs one AI agent and gets slop, Neo.mjs runs a swarm of mind
 
 Through the **Neural Link** possession interface, the swarm does not just read code; it inhabits live applications — inspecting semantic runtime state, mutating UI and data in real time, turning conversational UIs from chat panels into agents collaborating inside the application. It autonomously runs the full engineering lifecycle: ideating, building, and cross-reviewing a production multi-threaded engine, running DreamService cycles to re-steer priorities, and closing self-healing loops where runtime failures, code defects, agent mistakes, and architectural friction become fixes, tickets, skills, memory, and new graph topology for the next cycle.
 
-In May 2026, the canonical repo recorded **706 merged PRs and 800 closed issues**. It maintains its own codebase today; it is being built to inhabit yours — regardless of the models' training data.
+As of 2026-06-08, the v13 release window alone records **1,237 merged PRs and 1,639 closed issues** since `v12.1.0`. It maintains its own codebase today; it is being built to inhabit yours — regardless of the models' training data.
 
 The organism has two hemispheres, joined by the Neural Link:
 
@@ -37,7 +37,7 @@ Every other 2026 platform asks: *how can AI help humans use this software?* Neo.
 </br></br>
 ## Deploy a Cross-Model AI Engineering Team on Your Own Codebase
 
-Neo.mjs runs this organism on its own repository, in public — 706 merged PRs of proof. **v13 turns it outward: the Agent OS becomes a multi-tenant cloud deployment you point at your own codebases.**
+Neo.mjs runs this organism on its own repository, in public — **1,237 merged PRs and 1,639 closed issues** in the v13 release window. **v13 turns it outward: the Agent OS becomes a multi-tenant cloud deployment you point at your own codebases.**
 
 Point it at your repositories and the same swarm that maintains Neo — Claude, Gemini, and GPT, with a persistent Memory Core, cross-family review, and DreamService self-improvement — builds durable, queryable understanding of *your* code and keeps it across every session. Not a stateless copilot that forgets each conversation and reviews nothing: a standing engineering institution with memory and peer review, running on your repo. Per-tenant identity and visibility isolation; one Brain, many tenants; onboarding a codebase is a config entry, not a fork.
 

--- a/learn/benefits/AIEngineeringTeam.md
+++ b/learn/benefits/AIEngineeringTeam.md
@@ -48,7 +48,7 @@ flowchart LR
     Review -.->|"changes requested"| Build
 ```
 
-> **Dated proof point:** in May 2026, the canonical Neo.mjs repository recorded **706 merged PRs and 800 closed issues** (GitHub search, verified 2026-05-31; merged-PR and closed-issue totals only).
+> **Dated proof point:** as of 2026-06-08, the v13 release window records **1,237 merged PRs and 1,639 closed issues** since `v12.1.0` (GitHub GraphQL Search; merged-PR and closed-issue totals only).
 
 ## Gated by design, not by limitation
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12725
Related: #12696

Refreshes the hand-edited public identity proof counts so README and the AI Engineering Team benefits page no longer present the May 2026 706 / 800 snapshot as current scale proof while v13 release notes use the refreshed release-window evidence.

Evidence: L1 (live GitHub GraphQL count checks + exact stale-surface sweep + static doc patch) -> L1 required (identity FACT synchronization for #12725). No residuals for #12725.

## Deltas from ticket

- Kept ADR 0018 unchanged because its 706 / 800 text is a fixed 2026-05-31 historical decision anchor, not a mirror surface.
- Did not touch generated SEO output; no generated/generator-owned stale count occurrence was found in the scoped sweep.

## Test Evidence

- `gh api graphql -f query=... -f q="repo:neomjs/neo is:pr is:merged merged:>=2026-03-27"` -> `issueCount: 1237`.
- `gh api graphql -f query=... -f q="repo:neomjs/neo is:issue is:closed closed:>=2026-03-27"` -> `issueCount: 1639`.
- `rg -n "706 merged PRs|800 closed issues|706 merged|800 closed|1,237 merged PRs|1,639 closed issues" README.md learn .github package.json buildScripts apps/portal/index.html apps/portal/view apps/portal/canvas apps/portal/model apps/portal/store -g "*.md" -g "*.json" -g "*.mjs" -g "*.html"` -> stale 706 / 800 remains only in ADR 0018 historical text; updated surfaces show 1,237 / 1,639.
- `git diff --name-only learn/agentos/decisions/0018-neo-identity-source-of-truth-model.md` -> no output; ADR untouched.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-commit hook ran `node ./buildScripts/util/check-whitespace.mjs` -> passed.

## Identity-Surface Review Note

Per `neo-identity-update` / ADR 0018, this PR mutates identity surfaces and therefore needs cross-family review before merge. No out-of-tree Class 4 changes were made.

## Post-Merge Validation

- [ ] Final release cut reruns count evidence immediately before publishing if the README proof point is meant to remain exact at cut time.

## Commits

- `687c6c163` — refresh README and AI Engineering Team proof counts.
