### PR TITLE
docs(release): clarify v13 upgrade path (#12729)

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -9,11 +9,21 @@ isDraft: true
 
 **Release Type:** Self-Evolving Software Organism
 **Stability:** Release Candidate
-**Upgrade Path:** Existing Body/runtime work continues; v13 makes the Brain that builds and maintains it operational at release scale.
+**Upgrade Path:** Body/runtime applications remain on the v12.x continuity path; the major v13 adoption work is operational for teams enabling the Agent OS around the Body.
 
 > **TL;DR:** v13 is the release where Neo learned to maintain itself. The MX (Model Experience) loop moved from design principle to operational substrate: model friction becomes tickets, tickets become PRs, PRs become skills, memory, and graph topology, and the next agent starts with sharper primitives. This is not a pivot away from the application engine. It is the Body becoming AI-inhabitable: the same Neo primitives that power multi-threaded apps now also support the Brain and Institution that build, review, remember, coordinate, and repair Neo in public.
 >
 > The scale is the proof. Since `v12.1.0`, live GitHub Search shows **1,228 merged PRs** and **1,629 closed issues**. A release this large cannot be explained as a list of changes. It has to be understood as a system crossing an operational threshold: Memory Core, Native Edge Graph, wake routing, GitHub Workflow, cross-family review, ProjectV2 planning, and the public skill/rule substrate became a working MX loop around the engine.
+
+---
+
+## Upgrade / Migration Notes
+
+The v11.x and v12.x release notes could accurately say "drop-in replacement" because each release mostly advanced the Body: grids, stores, VDOM identity, drag physics, cloud-oriented MCP hardening, and related runtime surfaces. v13 is broader. Existing Neo applications should continue treating the Body/runtime layer as the compatibility anchor; this release does not ask app authors to rewrite grids, data stores, workers, or VDOM surfaces into the Agent OS.
+
+The new migration surface is for maintainers and operators adopting Neo's Brain layer. Running the v13 Agent OS means provisioning and maintaining Memory Core, the Native Edge Graph, Dream / Sandman graph processing, wake and A2A routing, GitHub Workflow automation, ProjectV2 planning, and the public skill/rule substrate that turns MX friction into future work. That is an operational upgrade around the engine, not an abandonment of the engine.
+
+Body/Grid readers should also keep the release boundary precise. v13 records the multi-body grid direction and includes shipped SortZone body-resolution evidence, but the full View-owned multi-body orchestration and centralized SelectionModel work remains tracked through #9491, #9872, and #9492. Do not read this release as a completed migration to the final multi-body grid architecture until those follow-up tickets land.
 
 ---
 


### PR DESCRIPTION
Resolves #12729
Related: #12696

Authored by GPT-5 Codex (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Adds an explicit v13 Upgrade / Migration Notes section to the release notes and strengthens the headline Upgrade Path line. The new wording matches the v12.1/v11.24 precedent by answering compatibility directly while preserving the v13 Brain-on-Body thesis.

Evidence: L1 (static release-note diff plus release-index parser validation) -> L1 required (docs-only release-note ACs). No residuals.

## Deltas from ticket

- Kept the patch at the top of `resources/content/release-notes/v13.0.0.md` so it does not duplicate #12723 appendix-count work or #12727 SEO work.
- Left `isDraft`, `publishedAt`, release publishing, and generated appendix data untouched.
- Added a precise Body/Grid boundary: v13 records shipped SortZone body-resolution evidence, while #9491, #9872, and #9492 remain the follow-up path for full multi-body orchestration and centralized selection.

## Test Evidence

- `git diff --check`
- `node buildScripts/docs/index/release.mjs --output /tmp/neo-releases-12729.json`
- `node -e "const data=require(/tmp/neo-releases-12729.json); console.log(JSON.stringify(data.find(x=>x.id==='13.0.0'), null, 2));"`

The release indexer found 167 release notes and produced a valid `13.0.0` entry pointing at `resources/content/release-notes/v13.0.0.md`.

## Post-Merge Validation

- [ ] If #12724 lands first, verify the v13 top Upgrade / Migration Notes section and the appendix-count refresh both remain present after merge.