### PR TITLE
docs(release): add v13 changelog digest (#12733)

### DIFF
--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -1336,11 +1336,12 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/releases/13.0.0</loc>
-    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
+    <lastmod>2026-06-08T08:23:24Z</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12692</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12686</loc>
@@ -1352,49 +1353,63 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12679</loc>
-  </url>
-  <url>
-    <loc>https://neomjs.com/news/tickets/12677</loc>
     <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
+    <loc>https://neomjs.com/news/tickets/12677</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
+  </url>
+  <url>
     <loc>https://neomjs.com/news/tickets/12674</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12673</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12671</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12666</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12662</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12655</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12650</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12648</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12646</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12644</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12639</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12635</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12633</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12632</loc>
@@ -1434,186 +1449,247 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12588</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12585</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12582</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12580</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12578</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12577</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12574</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12573</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12572</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12571</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12568</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12567</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12566</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12565</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12557</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12550</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12549</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12546</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12545</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12543</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12541</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12538</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12536</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12535</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12531</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12529</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12527</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12526</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12522</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12519</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12518</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12517</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12515</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12514</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12513</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12511</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12509</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12508</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12506</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12504</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12499</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12496</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12495</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12493</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12491</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12487</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12486</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12483</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12480</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12479</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12477</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12474</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12473</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12467</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12465</loc>
+    <lastmod>2026-06-04T10:43:07+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12464</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12462</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12461</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12459</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12457</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12456</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/news/tickets/12455</loc>
@@ -37300,139 +37376,172 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12689</loc>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://neomjs.com/news/pulls/12688</loc>
     <lastmod>2026-06-04T10:43:07+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://neomjs.com/news/pulls/12688</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://neomjs.com/news/pulls/12687</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12685</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12684</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12683</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12681</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12680</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12678</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12676</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12675</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12672</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12670</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12668</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12667</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12665</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12664</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12663</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12661</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12660</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12659</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12658</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12657</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12656</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12654</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12653</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12652</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12651</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12649</loc>
+    <lastmod>2026-06-07T21:02:51+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12647</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12645</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12643</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12642</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12641</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
@@ -37482,390 +37591,487 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12622</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12620</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12619</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12618</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12616</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12615</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12614</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12611</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12610</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12608</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12607</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12605</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12604</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12603</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12602</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12601</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12600</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12599</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12598</loc>
+    <lastmod>2026-06-07T19:26:08+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12596</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12595</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12594</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12593</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12592</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12591</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12590</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12589</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12587</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12586</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12584</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12583</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12581</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12579</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12576</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12575</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12570</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12569</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12564</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12563</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12562</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12561</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12560</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12559</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12558</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12556</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12555</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12554</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12553</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12552</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12551</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12548</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12547</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12544</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12542</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12540</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12539</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12537</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12534</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12533</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12532</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12530</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12528</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12525</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12524</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12523</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12521</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12520</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12516</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12512</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12510</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12507</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12505</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12503</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12502</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12500</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12498</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12497</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12494</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12492</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12490</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12489</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12488</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12485</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12484</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12482</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12481</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12478</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12476</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12475</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12472</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12471</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12470</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12469</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12468</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12466</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12463</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/pulls/12460</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
@@ -54475,6 +54681,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/discussions/12627</loc>
+    <lastmod>2026-06-06T18:58:41+02:00</lastmod>
     <priority>0.4</priority>
   </url>
   <url>
@@ -54484,6 +54691,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/discussions/12501</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.4</priority>
   </url>
   <url>
@@ -54533,23 +54741,27 @@
   </url>
   <url>
     <loc>https://neomjs.com/news/discussions/12100</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/discussions/12062</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/discussions/12049</loc>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/discussions/12034</loc>
+    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://neomjs.com/news/discussions/11992</loc>
-    <lastmod>2026-05-26T09:57:11+02:00</lastmod>
+    <lastmod>2026-06-07T08:38:57+02:00</lastmod>
     <priority>0.4</priority>
   </url>
   <url>

--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -331,6 +331,88 @@ The public framing stays crisp: Neo is a self-evolving digital organism with a B
 
 ---
 
+## Curated Changelog Digest
+
+The sections above tell the v13 story. This digest is the scan layer: representative shipped work grouped by the systems it changed. It is not the exhaustive v13 corpus. That belongs in generated appendices, because the release window contains more than a thousand merged PRs and well over a thousand closed tickets.
+
+```mermaid
+flowchart LR
+    Corpus["v13 release corpus<br/>1,200+ merged PRs<br/>1,600+ closed issues"]
+    Digest["Curated digest<br/>representative shipped anchors"]
+    Stories["Engineering war stories<br/>causal narrative"]
+    Appendix["Generated appendices<br/>exhaustive audit tables"]
+
+    Corpus --> Digest
+    Corpus --> Stories
+    Corpus --> Appendix
+    Digest --> Reader["Fast reader scan"]
+    Stories --> Reader
+    Appendix --> Auditor["Deep release audit"]
+```
+
+### Agent OS / Memory Core
+
+* **Chronological recall:** `query_recent_turns` gives agents a time-ordered recovery path after compaction, complementing semantic recall instead of replacing it ([#12672](https://github.com/neomjs/neo/pull/12672)).
+* **Memory condensation:** mini-summary backfill turns raw session history into graph-readable summary nodes while preserving the raw memory trail ([#12676](https://github.com/neomjs/neo/pull/12676)).
+* **Wake reliability:** heavy GraphLog deltas no longer force immediate digest flushes that can starve active cycles ([#12690](https://github.com/neomjs/neo/pull/12690)).
+* **Instruction-substrate safety:** system-anchor decay validation makes cleanup around loaded instruction substrate explicit instead of silent ([#12691](https://github.com/neomjs/neo/pull/12691)).
+
+### Native Edge Graph / Dream Pipeline
+
+* **Native graph substrate:** v13 adds the graph services family behind semantic extraction, topology inference, deterministic gap inference, graph maintenance, and Golden Path synthesis (`ai/services/graph/`).
+* **Graph schema protection:** SQLite graph schema reset is guarded so graph state cannot silently reset during ordinary operation ([#12618](https://github.com/neomjs/neo/pull/12618)).
+* **REM regression anchors:** Phase-A Dream/REM behavior has explicit regression coverage instead of living as untested orchestration code ([#12620](https://github.com/neomjs/neo/pull/12620)).
+* **Precision guards:** `VALIDATES` edge creation is bounded so graph evidence does not over-connect unrelated tests and classes ([#12643](https://github.com/neomjs/neo/pull/12643)).
+* **Real-service guards:** silent-failure modes in the Dream pipeline now have real-service integration coverage ([#12680](https://github.com/neomjs/neo/pull/12680)).
+
+### Swarm Governance / GitHub Workflow
+
+* **Stable identity routing:** active agent handle routing and static propagation were repaired so A2A, review, and skill surfaces point at current maintainers ([#12579](https://github.com/neomjs/neo/pull/12579), [#12581](https://github.com/neomjs/neo/pull/12581)).
+* **Reviewer-state truth:** reviewer-request reconciliation prevents stale review invitations and claims from drifting apart ([#12626](https://github.com/neomjs/neo/pull/12626)).
+* **Coordination semantics:** wake-suppressed FYI delivery separates awareness traffic from actionable peer wakeups ([#12641](https://github.com/neomjs/neo/pull/12641)).
+* **Planning surfaces:** PR and Discussion news routes make current planning context visible through generated public content ([#12647](https://github.com/neomjs/neo/pull/12647)).
+* **Release sync repair:** cached release tags are now hydrated, so warm sync no longer behaves as if every release note must be fetched again ([#12693](https://github.com/neomjs/neo/pull/12693)).
+
+### Multi-Tenant Deployment / External Providers
+
+* **Session-scoped MCP runtime:** the transport moved away from a one-client server shape toward session-keyed server instances with request context ([#10916](https://github.com/neomjs/neo/pull/10916)).
+* **Tenant isolation:** Knowledge Base tenant filtering is fail-closed and covered by both unit and integration tests ([#11674](https://github.com/neomjs/neo/pull/11674), [#11703](https://github.com/neomjs/neo/pull/11703)).
+* **Cloud proxy path:** public-host allowlisting supports reverse-proxy deployment without treating every host as trusted ([#12373](https://github.com/neomjs/neo/pull/12373)).
+* **External forge support:** real GitLab issue and merge-request services expand Agent OS workflow beyond GitHub-only operations ([#12625](https://github.com/neomjs/neo/pull/12625), [#12653](https://github.com/neomjs/neo/pull/12653)).
+
+### AiConfig / Config Substrate
+
+* **Reactive Provider SSOT:** ADR 0019 establishes AiConfig as the reactive Provider source of truth for `ai/` configuration ([#12458](https://github.com/neomjs/neo/pull/12458)).
+* **Defensive-read cleanup:** memory-core and MCP/runtime B3 defensive reads were removed instead of preserving local fallback copies ([#12553](https://github.com/neomjs/neo/pull/12553)).
+* **Provider naming:** `BaseConfig` became `ConfigProvider`, aligning the class name with its actual substrate role ([#12564](https://github.com/neomjs/neo/pull/12564)).
+* **Residual B3 cleanup:** later verification removed remaining raw defensive reads without replaying stale census assumptions ([#12592](https://github.com/neomjs/neo/pull/12592)).
+* **Lifecycle routing:** wake and lifecycle knobs now route through AiConfig rather than parallel ad hoc config paths ([#12622](https://github.com/neomjs/neo/pull/12622)).
+* **Test isolation:** the first memory-core specs moved to by-construction AiConfig isolation instead of mutating the shared singleton ([#12687](https://github.com/neomjs/neo/pull/12687)).
+
+### Body / Grid / UI
+
+* **Multi-body drag proof:** SortZone now resolves column drag operations against the correct multi-body region body ([#12708](https://github.com/neomjs/neo/pull/12708)).
+* **VDOM contract docs:** VDOM node config shape is documented for future component and agent work ([#12689](https://github.com/neomjs/neo/pull/12689)).
+* **Focus coverage:** atomic container moves now have explicit focus side-effect coverage ([#12667](https://github.com/neomjs/neo/pull/12667)).
+* **Drag/drop repair:** remote drag-leave restores the target dashboard state instead of leaving stale drag UI behind ([#12661](https://github.com/neomjs/neo/pull/12661)).
+* **Theme and form polish:** dialog/fieldset styling and form field sizing regressions were repaired ([#12610](https://github.com/neomjs/neo/pull/12610), [#12593](https://github.com/neomjs/neo/pull/12593)).
+
+Body/Grid guardrail: [#12708](https://github.com/neomjs/neo/pull/12708) is landed evidence. The release note must not claim the full View-owned multi-body grid architecture until [#9491](https://github.com/neomjs/neo/issues/9491), [#9872](https://github.com/neomjs/neo/issues/9872), and [#9492](https://github.com/neomjs/neo/issues/9492) are terminal.
+
+### Reliability / Tests / Build Hygiene
+
+* **Graph and REM guards:** graph schema, REM Phase A, and real-service REM paths now have targeted regression coverage ([#12618](https://github.com/neomjs/neo/pull/12618), [#12620](https://github.com/neomjs/neo/pull/12620), [#12680](https://github.com/neomjs/neo/pull/12680)).
+* **Neural Link baseline:** the Neural Link fixture gained an E2E baseline, making browser/runtime introspection safer to evolve ([#12665](https://github.com/neomjs/neo/pull/12665)).
+* **Container behavior:** atomic move focus behavior is covered at the unit level ([#12667](https://github.com/neomjs/neo/pull/12667)).
+* **Bundle hygiene:** Data worker lazy-import globs exclude tests, preventing webpack from sweeping non-runtime test files into worker bundles ([#12298](https://github.com/neomjs/neo/pull/12298)).
+
+### Docs / Identity / Public Surface
+
+* **Platform evidence:** Windows support has an explicit audit rather than relying on implicit claims ([#12684](https://github.com/neomjs/neo/pull/12684)).
+* **Guide ontology alignment:** guide-gap docs now match the concept ontology model used by graph inference ([#12681](https://github.com/neomjs/neo/pull/12681)).
+* **Runtime boundary docs:** the `me=this` runtime boundary is documented for component authors and agents ([#12688](https://github.com/neomjs/neo/pull/12688)).
+* **CTA governance:** identity calls-to-action are governed as action surfaces, not just copy ([#12587](https://github.com/neomjs/neo/pull/12587)).
+
 ## Full Changelog Appendix Snapshot
 
 Do not put the release-window PR and issue corpus into the narrative body.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12733
Related: #12696

Adds the missing reader-facing changelog digest to `resources/content/release-notes/v13.0.0.md`. The new section sits between the narrative chapters and the generated appendix strategy, matching the v12.1/v11.24 pattern of category headings plus representative shipped anchors without dumping the full v13 corpus into the narrative body.

The patch also renames `Full Changelog Strategy` to `Generated Appendix Strategy` so the split is explicit: curated digest in the release note, exhaustive PR/issue tables in generated appendices. The current SEO generator was run after the edit, updating checked-in `apps/portal/sitemap.xml` lastmod output.

Evidence: L1 (static release-note structure, generated release/SEO output, lint, and live issue/PR state checks) → L1 required (#12733 docs/content ACs). No residuals.

## Deltas from ticket

- Added `## Curated Changelog Digest` with a Mermaid digest/appendix boundary diagram and category bullets for Agent OS / Memory Core, Native Edge Graph / Dream Pipeline, Swarm Governance / GitHub Workflow, Multi-Tenant Deployment / External Providers, AiConfig / Config Substrate, Body / Grid / UI, Reliability / Tests / Build Hygiene, and Docs / Identity / Public Surface.
- Kept exhaustive history out of the narrative body and preserved the appendix generation command under `## Generated Appendix Strategy`.
- Kept Body/Grid wording guarded: live checks confirmed #9491, #9872, and #9492 are still open; #12708 is cited only as landed SortZone evidence.
- Omitted #12728 from the digest because live PR state shows it is still open, despite approval. The release note does not cite it as shipped evidence.
- Running the current sitemap generator updated checked-in `apps/portal/sitemap.xml` lastmod data. `releases.json` and `llms.txt` were regenerated/checked and produced no final diff.

## Test Evidence

- `node buildScripts/docs/index/release.mjs` — passed; scanned 167 releases and wrote `apps/portal/resources/data/releases.json` with no final diff.
- `node buildScripts/docs/seo/generate.mjs --format xml --base-url https://neomjs.com -o apps/portal/sitemap.xml` — passed; updated checked-in sitemap output.
- `node buildScripts/docs/seo/generate.mjs --format llms --base-url https://neomjs.com -o apps/portal/llms.txt` — passed; no final diff.
- `npm run ai:lint-tree-json` — passed; `learn/tree.json` mirrors `learn/` and checked-in SEO outputs (196 nodes).
- `git diff --check` and `git diff --cached --check` — passed.
- Live V-B-A: #12728 is OPEN; #9491, #9872, and #9492 are OPEN.

## Post-Merge Validation

- [ ] Final v13 release cut refreshes the merged-PR / closed-issue counts and appendix evidence after the last release-blocking PR lands.
- [ ] Final narrative-arc pass remains tracked by #12734 after content coverage is complete.

## Commit

- `80ca72afa` — `docs(release): add v13 changelog digest (#12733)`