### PR TITLE
fix(knowledge-base): degrade ask synthesis failures (#12737)

### DIFF
--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -150,6 +150,42 @@ class SearchService extends Base {
     }
 
     /**
+     * @summary Creates the degraded response used when retrieval succeeds but synthesis is unavailable.
+     * @param {Object} params
+     * @param {Object[]} params.references Ranked references returned by QueryService.
+     * @param {Error|String} params.error The synthesis failure to expose in bounded form.
+     * @returns {{answer: String, references: Object[], degraded: Boolean, error: String, reason: String}}
+     * @private
+     */
+    #createDegradedSynthesisResponse({references, error}) {
+        const reason = this.#sanitizeSynthesisError(error);
+
+        return {
+            answer: `Knowledge-base retrieval succeeded, but answer synthesis is currently unavailable (${reason}). Use the references directly while the synthesis provider recovers.`,
+            references,
+            degraded: true,
+            error: 'synthesis_failed',
+            reason
+        };
+    }
+
+    /**
+     * @summary Bounds synthesis-provider errors before returning them through MCP callers.
+     * @param {Error|String} error The raw provider error.
+     * @returns {String} A credential-safe, bounded reason string.
+     * @private
+     */
+    #sanitizeSynthesisError(error) {
+        const raw = typeof error === 'string'
+            ? error
+            : (error?.message || 'Synthesis provider unavailable');
+
+        return raw
+            .replace(/AIza[0-9A-Za-z_-]{20,}/g, '[redacted-api-key]')
+            .slice(0, 500);
+    }
+
+    /**
      * Performs a semantic search via QueryService and synthesizes an answer using the LLM.
      *
      * @param {Object} params
@@ -171,15 +207,19 @@ class SearchService extends Base {
             };
         }
 
-        if (!this.model) {
-            throw new Error('GEMINI_API_KEY is required for RAG features.');
-        }
-
         const references = queryResult.results.map(r => ({
             name  : r.source.split('/').pop(),
             source: r.source,
             score : Number(r.score)
         }));
+
+        if (!this.model) {
+            return this.#createDegradedSynthesisResponse({
+                references,
+                error: 'GEMINI_API_KEY is required for RAG features.'
+            });
+        }
+
         const contextReferences = queryResult.results.map((r, index) => ({
             ...references[index],
             metadata: r.metadata || {}
@@ -190,7 +230,7 @@ class SearchService extends Base {
         // All source loaders store `metadata.source` as a path relative to `neoRootDir`
         // so the Chroma collection shipped with each neo release remains portable across
         // recipients' filesystems. We resolve against the consumer's own `neoRootDir`
-        // at read time. Before #10097 this branch did a bare `fs.pathExists(ref.source)`
+        // at read time. Before the relative-source fix, this branch did a bare `fs.pathExists(ref.source)`
         // which silently succeeded for legacy absolute-path chunks but failed for the
         // relative-path chunks emitted by ApiSource / TestSource — producing phantom
         // `No Content (File missing or empty)` context. The synthesis LLM then saw
@@ -199,8 +239,8 @@ class SearchService extends Base {
         // `path.isAbsolute` short-circuit keeps legacy absolute-path chunks working
         // during the grace period when a consumer has not yet re-synced.
         //
-        // #11636 chooses Q12 Option A (metadata-embedded hydration) for tenant content.
-        // The measured chunk distribution keeps the V1 storage cost acceptable, while
+        // Tenant content uses metadata-embedded hydration. The measured chunk distribution
+        // keeps the V1 storage cost acceptable, while
         // avoiding server-mirror infrastructure. Non-local tenants may use the same
         // relative `source` strings as Neo itself, so those references hydrate from
         // metadata.content and never fall through to the host checkout.
@@ -232,8 +272,18 @@ Instructions:
 `;
 
         // 3. Generate Answer
-        const result = await this.model.generateContent(prompt);
-        const answer = result.response.text();
+        let result, answer;
+
+        try {
+            result = await this.model.generateContent(prompt);
+            answer = result.response.text();
+        } catch (error) {
+            const degraded = this.#createDegradedSynthesisResponse({references, error});
+
+            logger.warn(`[SearchService] Synthesis failed after retrieval; returning degraded references: ${degraded.reason}`);
+
+            return degraded;
+        }
 
         return {
             answer,

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
@@ -43,13 +43,22 @@ test.describe('Neo.ai.services.knowledge-base.SearchService model guard', () => 
         });
     });
 
-    test('ask still requires a Gemini model when retrieval finds references', async () => {
+    test('ask returns degraded references when retrieval finds references without a Gemini model', async () => {
         SearchService.model         = null;
         QueryService.queryDocuments = async () => ({
             results: [{source: 'learn/agentos/KnowledgeBase.md', score: '100', metadata: {}}]
         });
 
-        await expect(SearchService.ask({query: 'How does KB work?'}))
-            .rejects.toThrow('GEMINI_API_KEY is required for RAG features.');
+        await expect(SearchService.ask({query: 'How does KB work?'})).resolves.toEqual({
+            answer    : 'Knowledge-base retrieval succeeded, but answer synthesis is currently unavailable (GEMINI_API_KEY is required for RAG features.). Use the references directly while the synthesis provider recovers.',
+            degraded  : true,
+            error     : 'synthesis_failed',
+            reason    : 'GEMINI_API_KEY is required for RAG features.',
+            references: [{
+                name  : 'KnowledgeBase.md',
+                score : 100,
+                source: 'learn/agentos/KnowledgeBase.md'
+            }]
+        });
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -21,7 +21,7 @@ import fs              from 'fs-extra';
 import path            from 'path';
 
 /**
- * @summary Regression coverage for the SearchService type-filter synthesis bug (#10097).
+ * @summary Regression coverage for the SearchService type-filter synthesis bug.
  *
  * Before the fix, `SearchService.ask` piped chunk source paths directly into `fs.pathExists` /
  * `fs.readFile` without resolving relatives against `neoRootDir`. LearningSource emits absolute
@@ -87,7 +87,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         expect(result.references[0].source).toBe(tmpFileRelativeToRoot);
 
         // The prompt must contain the ACTUAL file content, not the "No Content" placeholder.
-        // This is the regression guard for #10097.
+        // This is the regression guard for relative source hydration.
         expect(capturedPrompt).toContain(tmpFileContents);
         expect(capturedPrompt).not.toContain('No Content (File missing or empty)');
     });
@@ -225,5 +225,50 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         expect(result.answer).toBe('mocked-answer');
         // Fallback should kick in for genuinely-missing files.
         expect(capturedPrompt).toContain('No Content (File missing or empty)');
+    });
+
+    test('ask returns degraded references when synthesis rejects after retrieval', async () => {
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{source: tmpFileRelativeToRoot, score: '1234'}]
+        });
+
+        SearchService.model = {
+            generateContent: async () => {
+                throw new Error('quota 429 AIza123456789012345678901234567890');
+            }
+        };
+
+        const result = await SearchService.ask({query: 'provider quota fixture', type: 'src'});
+
+        expect(result.degraded).toBe(true);
+        expect(result.error).toBe('synthesis_failed');
+        expect(result.reason).toContain('quota 429');
+        expect(result.reason).toContain('[redacted-api-key]');
+        expect(result.answer).toContain('Knowledge-base retrieval succeeded');
+        expect(result.references).toEqual([{
+            name  : path.basename(tmpFileRelativeToRoot),
+            source: tmpFileRelativeToRoot,
+            score : 1234
+        }]);
+    });
+
+    test('ask returns degraded references when no synthesis model is configured', async () => {
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{source: tmpFileRelativeToRoot, score: '321'}]
+        });
+
+        SearchService.model = null;
+
+        const result = await SearchService.ask({query: 'missing model fixture', type: 'src'});
+
+        expect(result.degraded).toBe(true);
+        expect(result.error).toBe('synthesis_failed');
+        expect(result.reason).toBe('GEMINI_API_KEY is required for RAG features.');
+        expect(result.references[0]).toMatchObject({
+            source: tmpFileRelativeToRoot,
+            score : 321
+        });
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12737
Related: #12696

Keeps `ask_knowledge_base` useful when retrieval succeeds but the synthesis provider is unavailable. `SearchService.ask()` now returns the ranked references with `degraded: true`, `error: "synthesis_failed"`, and a bounded reason instead of throwing away the retrieval payload after a `generateContent()` failure.

Evidence: L1 (focused unit coverage + static service contract patch) -> L1 required (service return-shape ACs covered by unit tests). No residuals for #12737.

## Deltas from ticket

- Applies the same degraded response shape when no synthesis model is configured after retrieval succeeds.
- Updates the existing no-model guard spec to assert degraded references instead of the old hard-reject contract.
- Removes stale durable ticket-number comments from the two touched files so the archaeology hook passes without bypassing policy.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs` -> 10 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs` -> 8 passed before the no-model contract update.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.

## Post-Merge Validation

- [ ] After the knowledge-base MCP server restarts on merged code, re-run an `ask_knowledge_base` query during synthesis-provider failure or with a stubbed unavailable model and verify references still return with `degraded: true`.

## Commit

- `2246dc4d1` — `fix(knowledge-base): degrade ask synthesis failures (#12737)`