### PR TITLE
fix(seo): pin release-note github links (#12735)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -16,6 +16,7 @@ const RELEASES_PATH     = path.resolve(PORTAL_DIR, 'resources/data/releases.json
 const DEFAULT_BASE_PATH = '/learn';
 const GIT_LOG_CHUNK_SIZE = 200;
 const STATUS_RENAME_CODES = new Set(['R', 'C']);
+const MUTABLE_RELEASE_NOTE_GITHUB_LINK_PATTERN = /https:\/\/github\.com\/neomjs\/neo\/blob\/dev\/[^\s)]+/g;
 
 // Top-level routes that don't map to content files
 const TOP_LEVEL_ROUTES = [
@@ -164,6 +165,36 @@ function getPriority(id) {
  */
 function getGitPath(filePath) {
     return path.relative(ROOT_DIR, filePath).split(path.sep).join('/');
+}
+
+/**
+ * @summary Finds mutable GitHub branch links that should not ship in release-note SEO routes.
+ * @param {String} content Markdown content to inspect
+ * @returns {String[]} Matched `github.com/neomjs/neo/blob/dev/...` links
+ */
+export function getMutableReleaseNoteGithubLinks(content='') {
+    return Array.from(content.matchAll(MUTABLE_RELEASE_NOTE_GITHUB_LINK_PATTERN), match => match[0]);
+}
+
+/**
+ * @summary Fails release-note route generation before mutable `/blob/dev/` links become SEO-visible.
+ * @param {Object} options
+ * @param {String} options.filePath Absolute release-note markdown path
+ * @param {String} options.content Markdown content to inspect
+ */
+export function assertStableReleaseNoteGithubLinks({filePath, content}) {
+    const links = getMutableReleaseNoteGithubLinks(content);
+
+    if (links.length === 0) {
+        return;
+    }
+
+    const fileLabel = filePath ? getGitPath(filePath) : 'unknown release-note source';
+    throw new Error([
+        `Release-note SEO route source "${fileLabel}" contains mutable GitHub dev links.`,
+        'Use an immutable commit/tag URL or a canonical successor target before publishing:',
+        ...links.map(link => `- ${link}`)
+    ].join('\n'));
 }
 
 /**
@@ -527,10 +558,13 @@ async function collectReleaseRoutes() {
         ignore : ['**/node_modules/**']
     });
 
-    const releases = files.map(file => {
+    const releases = await Promise.all(files.map(async file => {
         const filePath = path.resolve(ROOT_DIR, file);
+        const content  = await fs.readFile(filePath, 'utf-8');
         const fileName = path.basename(file, '.md'); // e.g., 'v12.1.0'
         const version  = fileName.startsWith('v') ? fileName.substring(1) : fileName;
+
+        assertStableReleaseNoteGithubLinks({filePath, content});
 
         return {
             category: 'release-notes',
@@ -538,7 +572,7 @@ async function collectReleaseRoutes() {
             id      : `/news/releases/${version}`,
             version : version
         };
-    });
+    }));
 
     return releases.sort((a, b) => {
         const vA = semver.valid(a.version) || semver.coerce(a.version)?.version;
@@ -1174,6 +1208,8 @@ export default {
     getContentRoutes,
     getContentRouteObjects,
     getContentUrls,
+    getMutableReleaseNoteGithubLinks,
     getSitemapXml,
-    getLlmsTxt
+    getLlmsTxt,
+    assertStableReleaseNoteGithubLinks
 };

--- a/resources/content/release-notes/chunk-1/v8.23.0.md
+++ b/resources/content/release-notes/chunk-1/v8.23.0.md
@@ -17,5 +17,5 @@ Online Demo:
 https://neomjs.com/examples/component/magicmovetext/
 
 Source Code:
-https://github.com/neomjs/neo/blob/dev/src/component/MagicMoveText.mjs
-https://github.com/neomjs/neo/blob/dev/resources/scss/src/component/MagicMoveText.scss
+https://github.com/neomjs/neo/blob/07b6933fd0f1afa022146c5dee3d3becac582ff7/src/component/MagicMoveText.mjs
+https://github.com/neomjs/neo/blob/fe65bfadc7bc4aaaa93d7052b3376160cb6531e5/resources/scss/src/component/MagicMoveText.scss

--- a/resources/content/release-notes/chunk-1/v9.2.0.md
+++ b/resources/content/release-notes/chunk-1/v9.2.0.md
@@ -13,8 +13,8 @@ isDraft: false
 * It demonstrates that fetching neo component trees **significantly** reduces traffic compared to passing DOM trees
 
 Code:
-https://github.com/neomjs/neo/blob/dev/examples/serverside/toolbarItems/Viewport.mjs
-https://github.com/neomjs/neo/blob/dev/examples/serverside/toolbarItems/resources/data/toolbar-items.json
+https://github.com/neomjs/neo/blob/f56ea57be3eb68446236e1f79d7893a35fd103fd/examples/serverside/toolbarItems/Viewport.mjs
+https://github.com/neomjs/neo/blob/854bac57fcfb951771c45871b854ce14f01bdefc/examples/serverside/toolbarItems/resources/data/toolbar-items.json
 
 <img width="1699" alt="Screenshot 2025-05-23 at 14 54 53" src="https://github.com/user-attachments/assets/d7ccb8c3-9172-4054-938b-65247fc8293c" />
 

--- a/resources/content/release-notes/chunk-1/v9.5.0.md
+++ b/resources/content/release-notes/chunk-1/v9.5.0.md
@@ -19,8 +19,8 @@ https://neomjs.com/examples/serverside/gridContainer/
 <img width="1703" alt="Screenshot 2025-05-25 at 21 27 57" src="https://github.com/user-attachments/assets/eb18dd23-7c76-4d50-9a91-9c9858c2e3f3" />
 
 Most important files:
-https://github.com/neomjs/neo/blob/dev/examples/serverside/gridContainer/Viewport.mjs
-https://github.com/neomjs/neo/blob/dev/examples/serverside/gridContainer/resources/data/grid-container.json
+https://github.com/neomjs/neo/blob/f56ea57be3eb68446236e1f79d7893a35fd103fd/examples/serverside/gridContainer/Viewport.mjs
+https://github.com/neomjs/neo/blob/8ec49d11238545f132587bae40b36f2c1d008170/examples/serverside/gridContainer/resources/data/grid-container.json
 
 The JSON file contains:
 ```json
@@ -28,7 +28,7 @@ The JSON file contains:
     "modules": [
         "src/grid/Container.mjs"
     ],
-    
+
     "items": [/**/]
 }
 ```

--- a/resources/content/release-notes/chunk-2/v10.0.0-beta.5.md
+++ b/resources/content/release-notes/chunk-2/v10.0.0-beta.5.md
@@ -75,5 +75,5 @@ We are incredibly excited for you to explore these new capabilities.
 
 *   **Explore Effects**: Try creating your own effects to manage component logic and state.
 *   **Leverage State Providers**: Experiment with the new Proxy-based data objects and formulas in `state.Provider`.
-*   **Read the New Guide**: Check out the [Declarative VDOM with Effects guide](https://github.com/neomjs/neo/blob/dev/learn/guides/fundamentals/DeclarativeVDOMWithEffects.md) to get started with the new paradigm.
+*   **Read the New Guide**: Check out the [Declarative VDOM with Effects guide](https://github.com/neomjs/neo/blob/689761427e7e55b0165280fd09b7b11caa4ea4b1/learn/guides/fundamentals/DeclarativeVDOMWithEffects.md) to get started with the new paradigm.
 *   **Share Your Feedback**: Your insights are invaluable. Please share your experiences and report any issues via [GitHub Issues](https://github.com/neomjs/neo/issues) or our [Slack Channel](https://join.slack.com/t/neomjs/shared_invite/zt-6c50ueeu-3E1~M4T9xkNnb~M_prEEOA).

--- a/resources/content/release-notes/chunk-2/v10.3.0.md
+++ b/resources/content/release-notes/chunk-2/v10.3.0.md
@@ -57,8 +57,8 @@ The introduction of HTML templates was made possible by a series of significant 
 
 To support this major new feature, we have added two comprehensive guides:
 
--   [Using HTML Templates](https://github.com/neomjs/neo/blob/dev/learn/guides/uibuildingblocks/HtmlTemplates.md): A guide focused on the syntax, features, and best practices for using the new template system.
--   [Under the Hood: HTML Templates](https://github.com/neomjs/neo/blob/dev/learn/guides/uibuildingblocks/HtmlTemplatesUnderTheHood.md): A deep dive into the philosophy and the dual-mode architecture, explaining how templates work in both development and production environments.
+-   [Using HTML Templates](https://github.com/neomjs/neo/blob/d3ca8f558241395bbc5114f7d3553a95dc0753f9/learn/guides/uibuildingblocks/HtmlTemplates.md): A guide focused on the syntax, features, and best practices for using the new template system.
+-   [Under the Hood: HTML Templates](https://github.com/neomjs/neo/blob/cbabf7cb1863a387b8ab142a243e875738d6e7aa/learn/guides/uibuildingblocks/HtmlTemplatesUnderTheHood.md): A deep dive into the philosophy and the dual-mode architecture, explaining how templates work in both development and production environments.
 
 All changes combined into 1 commit: https://github.com/neomjs/neo/commit/0841e7e1a715c7afe67d07eebb8229e54828eedd
 

--- a/resources/content/release-notes/chunk-2/v10.7.0.md
+++ b/resources/content/release-notes/chunk-2/v10.7.0.md
@@ -18,10 +18,10 @@ Version 10.7.0 massively enhances the **AI-Native Developer Experience** introdu
 ## ✨ New Features
 
 -   **AI Agent Guidelines (`#7220`, `#7221`):** A new `AGENTS.md` file has been created to provide a comprehensive operational manual for AI agents working within the repository.
--   **New Guide: [Styling and Theming](https://github.com/neomjs/neo/blob/dev/learn/guides/uibuildingblocks/StylingAndTheming.md) (`#6778`):** A new, in-depth guide covering all aspects of styling and theming in Neo.mjs.
--   **New Guide: [Unit Testing with Siesta](https://github.com/neomjs/neo/blob/dev/learn/guides/testing/UnitTestingWithSiesta.md) (`#7222`):** A new guide providing a step-by-step introduction to the unit testing workflow.
--   **New Tutorial: [Multi-Page App Routing](https://github.com/neomjs/neo/blob/dev/learn/tutorials/Routing.md) (`#7223`):** A new tutorial that walks developers through building a simple single-page application with client-side routing.
--   **New Blog Post (`#7226`, `d7492da61`):** Added the blog post "[The UI Revolution: How JSON Blueprints & Shared Workers Power Next-Gen AI Interfaces](https://github.com/neomjs/neo/blob/dev/learn/blog/json-blueprints-and-shared-workers.md)" to the repository.
+-   **New Guide: [Styling and Theming](https://github.com/neomjs/neo/blob/aa8c3824edadc4e4bc4a22995dd2e90064cbe011/learn/guides/uibuildingblocks/StylingAndTheming.md) (`#6778`):** A new, in-depth guide covering all aspects of styling and theming in Neo.mjs.
+-   **New Guide: [Unit Testing](https://github.com/neomjs/neo/blob/bcd86117defbe3ca3fb0d6e84c51ad7f6a5eb911/learn/guides/testing/UnitTesting.md) (`#7222`):** A new guide providing a step-by-step introduction to the unit testing workflow.
+-   **New Tutorial: [Multi-Page App Routing](https://github.com/neomjs/neo/blob/0fc27e0f23360351ce6779781ee4d1244da39554/learn/tutorials/Routing.md) (`#7223`):** A new tutorial that walks developers through building a simple single-page application with client-side routing.
+-   **New Blog Post (`#7226`, `d7492da61`):** Added the blog post "[The UI Revolution: How JSON Blueprints & Shared Workers Power Next-Gen AI Interfaces](https://github.com/neomjs/neo/blob/178464b1078c3ba11010b650c50a90b5ff3581b7/learn/blog/json-blueprints-and-shared-workers.md)" to the repository.
 
 ## 💡 Enhancements
 
@@ -41,7 +41,7 @@ Version 10.7.0 massively enhances the **AI-Native Developer Experience** introdu
 
 With the significant enhancements to the AI Knowledge Base and the new `AGENTS.md` guidelines, the Neo.mjs repository is now fully equipped for AI-driven development. We encourage you to try it out using tools like Gemini CLI or your own custom agents.
 
-Get started in minutes by following our **[AI Quick Start Guide](https://github.com/neomjs/neo/blob/dev/.github/AI_QUICK_START.md)**.
+Get started in minutes by following our **[AI Quick Start Guide](https://github.com/neomjs/neo/blob/0d5c3b31224dd21fb971df0afdc2a8fba6b62ce2/.github/AI_QUICK_START.md)**.
 
 All changes in 1 commit: https://github.com/neomjs/neo/commit/49eeda7dcad8e607b964fea936760722c9cdad35
 

--- a/resources/content/release-notes/chunk-2/v11.0.0.md
+++ b/resources/content/release-notes/chunk-2/v11.0.0.md
@@ -51,7 +51,7 @@ We have officially moved beyond brittle, shell-based scripts to a robust, agent-
 -   **Memory Core Server (#7316):** Gives our AI agent a persistent, long-term memory. The agent can now recall past conversations, decisions, and outcomes, allowing it to learn from experience and improve over time.
 -   **GitHub Workflow Server (#7364):** The crown jewel of our new tooling. This server provides robust, bi-directional synchronization for GitHub issues and release notes, storing them as local markdown files. This enables agents (and humans) to interact with them as part of the local knowledge base while ensuring everything stays in sync with GitHub. It automates the entire issue and pull request lifecycle, empowering the agent to participate directly in the development workflow.
 
-To get started with this new AI-native workflow, please see our guides on [Working with Agents](https://github.com/neomjs/neo/blob/dev/.github/WORKING_WITH_AGENTS.md) and the [AI Quick Start](https://github.com/neomjs/neo/blob/dev/.github/AI_QUICK_START.md).
+To get started with this new AI-native workflow, please see our guides on [Working with Agents](https://github.com/neomjs/neo/blob/816ae4c81fe04410c4851b17b3f92f350b4443d3/learn/agentos/StrategicWorkflows.md) and the [AI Quick Start](https://github.com/neomjs/neo/blob/0d5c3b31224dd21fb971df0afdc2a8fba6b62ce2/.github/AI_QUICK_START.md).
 
 ### 🧪 Enabling Agent-Driven Quality with Playwright (#7262)
 

--- a/resources/content/release-notes/chunk-2/v11.22.0.md
+++ b/resources/content/release-notes/chunk-2/v11.22.0.md
@@ -7,9 +7,9 @@ isDraft: false
 ---
 # Neo.mjs v11.22.0 Release Notes
 
-**Release Type:** Visual Identity & Simulation Engine  
-**Stability:** Production-Ready  
-**Upgrade Path:** Drop-in replacement for v11.21.0  
+**Release Type:** Visual Identity & Simulation Engine
+**Stability:** Production-Ready
+**Upgrade Path:** Drop-in replacement for v11.21.0
 
 > **TL;DR:** **v11.22.0 establishes a new paradigm: "UI as a Continuous Simulation".** We moved beyond static layouts to treat the interface as a persistent, physics-driven world. This release deploys two massive SharedWorker simulations—**The Neural Swarm** and **Sonic Waves**—running autonomous agents and fluid dynamics at 60fps. It proves that with a **Zero-Allocation** architecture, the browser can deliver desktop-class, living experiences without blocking the main thread. **62 tickets** resolved in **2 days**.
 
@@ -23,7 +23,7 @@ To prove this, we built two high-fidelity simulations that run entirely in **Sha
 
 ### Proof 1: The Neural Swarm (Home Hero)
 
-> **[Experience the Interactive Simulation](https://neomjs.com)** | **[Read the Architecture Guide](https://github.com/neomjs/neo/blob/dev/learn/guides/advanced/NeuralSwarm.md)**
+> **[Experience the Interactive Simulation](https://neomjs.com)** | **[Read the Architecture Guide](https://github.com/neomjs/neo/blob/e68d7f3daaede6b55dab52860bae61a6431f5eb6/learn/guides/advanced/NeuralSwarm.md)**
 
 A complex topological simulation representing the "Agent-Native" runtime.
 
@@ -33,7 +33,7 @@ A complex topological simulation representing the "Agent-Native" runtime.
 
 ### Proof 2: Sonic Waves (Header Toolbar)
 
-> **"The UI that breathes."** | **[Read the Architecture Guide](https://github.com/neomjs/neo/blob/dev/learn/guides/advanced/CanvasArchitecture.md)**
+> **"The UI that breathes."** | **[Read the Architecture Guide](https://github.com/neomjs/neo/blob/e68d7f3daaede6b55dab52860bae61a6431f5eb6/learn/guides/advanced/CanvasArchitecture.md)**
 
 ### 🧬 The "Split Stream" Engine
 Instead of discrete hover animations, the header is governed by a **continuous fluid simulation**: a persistent Double Helix energy stream that flows across the navigation bar and responds to obstacles and input in real time.

--- a/resources/content/release-notes/chunk-2/v11.23.1.md
+++ b/resources/content/release-notes/chunk-2/v11.23.1.md
@@ -7,9 +7,9 @@ isDraft: false
 ---
 # Neo.mjs v11.23.1 Release Notes
 
-**Release Type:** Critical Fix & Methodology Proof  
-**Stability:** Production-Critical  
-**Upgrade Path:** Drop-in replacement for v11.23.0  
+**Release Type:** Critical Fix & Methodology Proof
+**Stability:** Production-Critical
+**Upgrade Path:** Drop-in replacement for v11.23.0
 
 > **TL;DR:** **v11.23.0 broke production.** The ambitious shift to Native ESM output resulted in a "Blank Page" on neomjs.com. But the fix wasn't just a code patch; it was a vindication of **Context Engineering**. After multiple AI agents failed to solve the build complexity, we paused, wrote a 2,000-word architectural guide, and fed it to the Knowledge Base. The result? The next agent read the guide and fixed the bug in minutes.
 
@@ -37,7 +37,7 @@ A human developer could have fixed this manually in an hour. **But that wasn't t
 
 We stopped coding. We spent the next session solely on writing:
 
-> **📖 [Build Architecture & Service Workers](https://github.com/neomjs/neo/blob/dev/learn/guides/advanced/BuildArchitecture.md)**
+> **📖 [Build Architecture & Service Workers](https://github.com/neomjs/neo/blob/bcda1f14de5caa731c39fa544393d236ae42e39a/learn/guides/advanced/BuildArchitecture.md)**
 > *2,000 words documenting Universal Entry Points, Webpack Path Rewriting, Service Worker Scope Conflicts, and Realm-Scoped Chunking.*
 
 ### 4. The Vindication

--- a/resources/content/release-notes/chunk-2/v11.24.0.md
+++ b/resources/content/release-notes/chunk-2/v11.24.0.md
@@ -7,9 +7,9 @@ isDraft: false
 ---
 # Neo.mjs v11.24.0 Release Notes
 
-**Release Type:** Core Architecture & UX Physics  
-**Stability:** Production-Ready  
-**Upgrade Path:** Drop-in replacement for v11.23.0  
+**Release Type:** Core Architecture & UX Physics
+**Stability:** Production-Ready
+**Upgrade Path:** Drop-in replacement for v11.23.0
 
 > **TL;DR:** **v11.24.0 is the "Grid Supremacy" update.** We successfully engineered the convergence of our two most complex systems: **Buffered Row Recycling** (Grid) and **VDOM Teleportation** (Disjoint Updates). This required a foundational shift to **App-Worker Authority** for VDOM identity to eliminate race conditions in high-frequency mutable views. Additionally, we brought **Desktop Drag-Scrolling** and **Kinetic Physics** to the Grid, delivering a native-app feel across all devices. **46 tickets** resolved in **10 days**.
 
@@ -184,12 +184,12 @@ We have addressed a major documentation gap by publishing a complete suite of **
 These guides serve as the perfect baseline for both **Developers** and **AI Agents** to master the framework's unique testing pillars.
 
 ### Overview: The Three Pillars
-> **[Read the Guide](https://github.com/neomjs/neo/blob/dev/learn/guides/testing/Overview.md)**
+> **[Read the Guide](https://github.com/neomjs/neo/blob/ad7a13afb0ed0f36dbddc1104ec1fbae17ef68fc/learn/guides/testing/Overview.md)**
 
 Explains *why* we need three different environments (Node.js, Real Browser, specialized Harness) to test a multi-threaded App Engine.
 
 ### 1. Unit Testing (Logic & State)
-> **[Read the Guide](https://github.com/neomjs/neo/blob/dev/learn/guides/testing/UnitTesting.md)**
+> **[Read the Guide](https://github.com/neomjs/neo/blob/bcd86117defbe3ca3fb0d6e84c51ad7f6a5eb911/learn/guides/testing/UnitTesting.md)**
 
 **Focus:** Core Logic, VDOM Diffing, State Management.
 **Environment:** Simulated Single-Thread Node.js.
@@ -198,7 +198,7 @@ Explains *why* we need three different environments (Node.js, Real Browser, spec
 *   Master the **Developer Workflow**: Running single files, debugging with `--debug`, and using the "Safety Net".
 
 ### 2. Component Testing (Visuals & Events)
-> **[Read the Guide](https://github.com/neomjs/neo/blob/dev/learn/guides/testing/ComponentTesting.md)**
+> **[Read the Guide](https://github.com/neomjs/neo/blob/b0b47a3af47053c4c75b7629d3f7fa2760e0a625/learn/guides/testing/ComponentTesting.md)**
 
 **Focus:** DOM Events, Layout, CSS, Browser APIs.
 **Environment:** Real Browser (Chrome/Firefox/Webkit).
@@ -207,7 +207,7 @@ Explains *why* we need three different environments (Node.js, Real Browser, spec
 *   Explore advanced patterns like **E2E Testing** and **Custom Test Harnesses**.
 
 ### 3. Benchmarking (Performance)
-> **[Read the Guide](https://github.com/neomjs/neo/blob/dev/learn/guides/testing/Benchmarking.md)**
+> **[Read the Guide](https://github.com/neomjs/neo/blob/92f84273c7778ed46cbf731e565455761475c468/learn/guides/testing/Benchmarking.md)**
 
 **Focus:** Resilience, Concurrency, FPS.
 **Environment:** Specialized Harness (Separate Repo).

--- a/resources/content/release-notes/chunk-2/v11.9.0.md
+++ b/resources/content/release-notes/chunk-2/v11.9.0.md
@@ -20,10 +20,10 @@ This release moves beyond the "Tool Use" era into a future where agents are firs
 ### 📘 Agent OS: The Comprehensive Manual
 
 We have cemented the "Agent OS" vision with a complete suite of documentation. New guides cover everything from the high-level "Agent OS" concept to deep dives into each MCP server.
--   **[Agent OS Introduction](https://github.com/neomjs/neo/blob/dev/learn/guides/mcp/Introduction.md):** The high-level vision and architecture.
--   **[Code Execution Guide](https://github.com/neomjs/neo/blob/dev/learn/guides/mcp/CodeExecution.md):** A definitive guide to the "Thick Client" pattern (`ai/services.mjs`), including a real-world case study on self-healing database schemas.
+-   **[Agent OS Introduction](https://github.com/neomjs/neo/blob/0d0994376062688ecee15c6b0a7a364aabfceb04/learn/agentos/tooling/Introduction.md):** The high-level vision and architecture.
+-   **[Code Execution Guide](https://github.com/neomjs/neo/blob/35d1b68418f84e945b58575045c340dd867b7787/learn/agentos/CodeExecution.md):** A definitive guide to the "Thick Client" pattern (`ai/services.mjs`), including a real-world case study on self-healing database schemas.
 -   **Real-World Showcase:** While v11.8 introduced the concept, v11.9 delivers the proof. We've added concrete examples like `ai/examples/debug_session_state.mjs` (a "Thick Client" diagnostic tool) and `ai/examples/migrate_timestamps.mjs` (an autonomous migration utility), proving how agents can maintain their own infrastructure.
--   **Server Guides:** Detailed architecture breakdowns for the **[Knowledge Base](https://github.com/neomjs/neo/blob/dev/learn/guides/mcp/KnowledgeBase.md)**, **[Memory Core](https://github.com/neomjs/neo/blob/dev/learn/guides/mcp/MemoryCore.md)**, and **[GitHub Workflow](https://github.com/neomjs/neo/blob/dev/learn/guides/mcp/GitHubWorkflow.md)** servers.
+-   **Server Guides:** Detailed architecture breakdowns for the **[Knowledge Base](https://github.com/neomjs/neo/blob/d047efdbf7beeadba89e08eade84294b64b3a1fc/learn/agentos/KnowledgeBase.md)**, **[Memory Core](https://github.com/neomjs/neo/blob/d8c22cea1ca502aa7948bce22d33fb62f16f4960/learn/agentos/MemoryCore.md)**, and **[GitHub Workflow](https://github.com/neomjs/neo/blob/0d5c3b31224dd21fb971df0afdc2a8fba6b62ce2/learn/agentos/GitHubWorkflow.md)** servers.
 -   **Philosophy:** We've documented the "Why" behind our Context Engineering and "Save-Then-Respond" protocols.
 
 ### 🏗 Unified MCP Architecture & The Runner Pattern

--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -88,9 +88,9 @@ The boundary is just as important as the mechanism. Golden Path is not a central
 
 Representative anchors:
 
-- [`learn/agentos/DreamPipeline.md`](https://github.com/neomjs/neo/blob/dev/learn/agentos/DreamPipeline.md) - six-phase REM pipeline, Golden Path math, and advisory loop.
-- [`ai/services/graph/GoldenPathSynthesizer.mjs`](https://github.com/neomjs/neo/blob/dev/ai/services/graph/GoldenPathSynthesizer.mjs) - Hybrid GraphRAG traversal over semantic embeddings plus structural graph weight.
-- [`resources/content/sandman_handoff.md`](https://github.com/neomjs/neo/blob/dev/resources/content/sandman_handoff.md) - generated Native Edge Graph audit and Golden Path handoff surface.
+- [`learn/agentos/DreamPipeline.md`](https://github.com/neomjs/neo/blob/60150a87f4ea389944b186c7797f1b0bb9356457/learn/agentos/DreamPipeline.md) - six-phase REM pipeline, Golden Path math, and advisory loop.
+- [`ai/services/graph/GoldenPathSynthesizer.mjs`](https://github.com/neomjs/neo/blob/952770392f09356021a7777aa2ff46a29e859fe5/ai/services/graph/GoldenPathSynthesizer.mjs) - Hybrid GraphRAG traversal over semantic embeddings plus structural graph weight.
+- [`learn/agentos/wake-substrate/sandman-handoff-format.md`](https://github.com/neomjs/neo/blob/f17fc9941dbd2f57326edb269a186a84ab7e2e7e/learn/agentos/wake-substrate/sandman-handoff-format.md) - generated Native Edge Graph audit and Golden Path handoff surface.
 - [#12663](https://github.com/neomjs/neo/pull/12663) - closed-loop diagrams reframed around advisory Golden Path and peer self-selection.
 - [#12680](https://github.com/neomjs/neo/pull/12680) - real-service REM guards for silent failure modes.
 

--- a/test/playwright/unit/ai/buildScripts/docs/seo/Generate.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/seo/Generate.spec.mjs
@@ -1,0 +1,51 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import path           from 'path';
+import fg             from 'fast-glob';
+
+import {
+    assertStableReleaseNoteGithubLinks,
+    getMutableReleaseNoteGithubLinks
+} from '../../../../../../../buildScripts/docs/seo/generate.mjs';
+
+test.describe('docs SEO generator release-note link guard', () => {
+    test('getMutableReleaseNoteGithubLinks returns only mutable /blob/dev/ links', () => {
+        const links = getMutableReleaseNoteGithubLinks([
+            'https://github.com/neomjs/neo/blob/dev/learn/agentos/DreamPipeline.md',
+            'https://github.com/neomjs/neo/blob/abc123/learn/agentos/DreamPipeline.md',
+            'https://github.com/neomjs/neo/blob/dev/src/Neo.mjs)'
+        ].join('\n'));
+
+        expect(links).toEqual([
+            'https://github.com/neomjs/neo/blob/dev/learn/agentos/DreamPipeline.md',
+            'https://github.com/neomjs/neo/blob/dev/src/Neo.mjs'
+        ]);
+    });
+
+    test('assertStableReleaseNoteGithubLinks fails with the release-note path and mutable link', () => {
+        expect(() => assertStableReleaseNoteGithubLinks({
+            filePath: path.join(process.cwd(), 'resources/content/release-notes/v0.0.0.md'),
+            content : 'See https://github.com/neomjs/neo/blob/dev/.github/WORKING_WITH_AGENTS.md'
+        })).toThrow(/resources\/content\/release-notes\/v0\.0\.0\.md[\s\S]*blob\/dev\/\.github\/WORKING_WITH_AGENTS\.md/);
+    });
+
+    test('active release notes do not publish mutable GitHub dev links', async () => {
+        const files = await fg('resources/content/release-notes/**/*.md', {
+            cwd   : process.cwd(),
+            ignore: ['resources/content/archive/**']
+        });
+
+        const violations = [];
+
+        for (const file of files) {
+            const content = await fs.readFile(path.resolve(process.cwd(), file), 'utf-8');
+            const links   = getMutableReleaseNoteGithubLinks(content);
+
+            if (links.length > 0) {
+                violations.push({file, links});
+            }
+        }
+
+        expect(violations).toEqual([]);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12735
Related: #12696, #12728, #12732

Pins active release-note GitHub links away from mutable `/blob/dev/` URLs and adds a generator guard so future active release-note SEO sources fail before publishing branch-relative GitHub links. Retired or moved documentation links now point at canonical successor paths on immutable commit URLs instead of relying on live `dev` file layout.

Evidence: L1 (focused unit guard + static active release-note scan + pinned-link object verifier) -> L1 required (release-note SEO source contract with no mutable `/blob/dev/` links). No residuals.

## Deltas from ticket
`#12732` now retires `.github/WORKING_WITH_AGENTS.md` into a redirect stub, not deletion; this PR remaps that release-note link to `learn/agentos/StrategicWorkflows.md`.

The generator does not hide the issue through publication-time URL rewriting. It rejects mutable active release-note links at source, keeping the content contract visible to authors.

Current `dev` still exposes only the top-level release route until `#12728` lands; the new unit coverage scans every active release-note markdown file so the cleanup is ready for the recursive route change.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/docs/seo/Generate.spec.mjs` -> 3 passed.
- `node --input-type=module -e "const seo = await import('./buildScripts/docs/seo/generate.mjs'); const routes = await seo.getContentRoutes(); console.log(JSON.stringify({releaseRoutes: routes.filter(route => route.includes('/news/releases/')).length, total: routes.length}));"` -> `{"releaseRoutes":1,"total":12926}`.
- `rg -n "https://github\.com/neomjs/neo/blob/dev/" resources/content/release-notes` -> no matches.
- Pinned-link verifier checked 31 pinned release-note GitHub links with `git cat-file -e`.
- `git diff --cached --check` -> passed before commit.
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, and scoped `check-ticket-archaeology`.

## Post-Merge Validation
- [ ] After `#12728` lands or this branch rebases over it, run `getContentRoutes()` and confirm recursive release routes still pass the mutable-link guard.
- [ ] Regenerate or inspect `apps/portal/sitemap.xml` and `apps/portal/llms.txt` after the release-route stack lands to verify no release-note route emits `/blob/dev/` GitHub links.

## Commit
- `10d34493f` — `fix(seo): pin release-note github links (#12735)`