### PR TITLE
fix(codex): remove default Gemini key pass-through (#12744)

### DIFF
--- a/.codex/HARNESS_RESTART.md
+++ b/.codex/HARNESS_RESTART.md
@@ -39,6 +39,23 @@ the higher-signal proof for the active Codex session.
 End the turn with native `add_memory`. If a shell-based Memory Core client
 cannot reach localhost, that is not enough reason to skip the native MCP save.
 
+## Remote AI Key Clear
+
+When a remote provider key is deleted, rotated, or suspected unsafe, assume
+already-running MCP children still hold the old environment until the harness is
+restarted.
+
+1. Remove the key from shell profiles, launch settings, and the provider
+   console.
+2. Keep `GEMINI_API_KEY` out of ignored `.codex/config.toml` MCP `env_vars`
+   unless a specific local server is intentionally testing remote Gemini. The
+   tracked template does not forward it by default.
+3. Restart Codex Desktop or the active harness so Knowledge Base and Memory Core
+   MCP servers respawn without the old environment.
+4. Re-check native Memory Core `healthcheck.providers` before assuming the key
+   has disappeared from running services. Billing caps and key deletion remain
+   provider-console actions.
+
 ## GitHub Calls
 
 `gh auth status` can lie inside Codex sandboxing. Use:

--- a/.codex/config.template.toml
+++ b/.codex/config.template.toml
@@ -35,11 +35,14 @@ startup_timeout_sec = 30
 tool_timeout_sec = 120
 enabled = true
 
+# Remote Gemini credentials are intentionally opt-in for local Codex MCP
+# servers. Add GEMINI_API_KEY only to the specific ignored .codex/config.toml
+# server env_vars that is explicitly testing remote Gemini, then restart the
+# harness so already-running MCP children drop any old environment.
 [mcp_servers."neo-mjs-knowledge-base"]
 command = "npm"
 args = ["run", "--silent", "ai:mcp-server-knowledge-base"]
 env_vars = [
-    "GEMINI_API_KEY",
     "NEO_AGENT_IDENTITY",
     "NEO_CHROMA_EMBEDDING_PROVIDER",
     "NEO_CHROMA_UNIFIED",
@@ -58,7 +61,6 @@ enabled = true
 command = "npm"
 args = ["run", "--silent", "ai:mcp-server-memory-core"]
 env_vars = [
-    "GEMINI_API_KEY",
     "NEO_AGENT_IDENTITY",
     "NEO_CHROMA_EMBEDDING_PROVIDER",
     "NEO_CHROMA_UNIFIED",

--- a/test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs
@@ -23,7 +23,50 @@ function listProbeArtifacts(root) {
 }
 
 /**
- * @summary Coverage for the Codex Desktop SQLite sandbox diagnostic (#10714).
+ * @summary Reads the tracked Codex config template for static MCP policy guards.
+ * @returns {String}
+ */
+function readCodexConfigTemplate() {
+    return fs.readFileSync(
+        new URL('../../../../../../.codex/config.template.toml', import.meta.url),
+        'utf8'
+    );
+}
+
+/**
+ * @summary Extracts one MCP server TOML block from the Codex config template.
+ * @param {String} config
+ * @param {String} serverName
+ * @returns {String}
+ */
+function getMcpServerBlock(config, serverName) {
+    const header = `[mcp_servers."${serverName}"]`;
+    const start  = config.indexOf(header);
+
+    expect(start).toBeGreaterThan(-1);
+
+    const remaining = config.slice(start + header.length);
+    const nextBlock = remaining.search(/\n\[/);
+    const end       = nextBlock === -1 ? config.length : start + header.length + nextBlock;
+
+    return config.slice(start, end);
+}
+
+/**
+ * @summary Extracts the env_vars array body from a single MCP server block.
+ * @param {String} serverBlock
+ * @returns {String}
+ */
+function getEnvVarsBlock(serverBlock) {
+    const match = serverBlock.match(/env_vars\s*=\s*\[([\s\S]*?)\]/);
+
+    expect(match).not.toBeNull();
+
+    return match[1];
+}
+
+/**
+ * @summary Coverage for the Codex Desktop SQLite sandbox diagnostic.
  *
  * The tests keep all file writes in OS temp dirs and inject the failure-path
  * SQLite constructor so the diagnostic can prove cleanup and remediation output
@@ -128,5 +171,22 @@ test.describe('bootstrapCodexSandbox diagnostic (#10714)', () => {
         expect(paths.physicalDir).toBe(paths.logicalDir);
         expect(paths.symlinkTarget).toBeNull();
         expect(paths.fileName).toBe('codex-sandbox-probe-paths.sqlite');
+    });
+});
+
+test.describe('Codex MCP config template (#12744)', () => {
+    test('keeps remote Gemini credentials opt-in for local KB and Memory Core servers', () => {
+        const config = readCodexConfigTemplate();
+
+        expect(config).toContain('Remote Gemini credentials are intentionally opt-in');
+
+        for (const serverName of ['neo-mjs-knowledge-base', 'neo-mjs-memory-core']) {
+            const serverBlock = getMcpServerBlock(config, serverName);
+            const envVars     = getEnvVarsBlock(serverBlock);
+
+            expect(envVars).not.toContain('"GEMINI_API_KEY"');
+            expect(envVars).toContain('"NEO_OPENAI_COMPATIBLE_HOST"');
+            expect(envVars).toContain('"NEO_OPENAI_COMPATIBLE_MODEL"');
+        }
     });
 });


### PR DESCRIPTION
Resolves #12744
Related: #12740

Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Removes default `GEMINI_API_KEY` inheritance from the tracked Codex MCP config template for Knowledge Base and Memory Core, keeps local/openai-compatible provider controls intact, documents restart/key-clear semantics, and adds a static unit guard so the pass-through cannot quietly return.

Evidence: L1 (static config-template guard + restart doc audit) → L1 required (tracked default/config-doc ACs). No residuals.

## Deltas from ticket
- Scope stayed on Codex local MCP defaults and restart documentation; no provider-runtime support was removed.
- While committing the touched spec, the pre-commit hook also required removing an existing stale ticket token from a durable JSDoc summary. That is hook-required comment hygiene only.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/bootstrapCodexSandbox.spec.mjs` → 6 passed.
- `git diff --check` → passed.
- Commit hooks passed: whitespace, shorthand, ticket archaeology.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `1e3ccc30b fix(codex): remove default Gemini key pass-through (#12744)`.

## Post-Merge Validation
- [ ] Remove `GEMINI_API_KEY` from ignored local `.codex/config.toml` KB/MC `env_vars` copies unless explicitly testing remote Gemini.
- [ ] Restart the active Codex harness and verify native Memory Core `healthcheck.providers` no longer reports an unintended remote Gemini credential.