### PR TITLE
refactor(grid): grid.View owns body-scroll orchestration (#12757)

### DIFF
--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -287,12 +287,13 @@ class GridContainer extends BaseContainer {
 
         me.view = Neo.create(View, {
             appName,
-            flex     : 1,
-            isLoading: me.isLoading,
-            parentId : me.id,
-            theme    : me.theme,
+            flex         : 1,
+            gridContainer: me,
+            isLoading    : me.isLoading,
+            parentId     : me.id,
+            theme        : me.theme,
             windowId,
-            items    : [me.body]
+            items        : [me.body]
         });
 
         me.horizontalScrollbar = Neo.create(HorizontalScrollbar, {
@@ -1003,6 +1004,17 @@ class GridContainer extends BaseContainer {
 
         me.createOrUpdateSubGrids();
 
+        // Split bodies created here (bodyStart/bodyEnd) aren't covered by the resize-driven
+        // measurement, so without this their containerWidth/columnPositions stay unset and
+        // Body.createViewData short-circuits to an empty body. Mirror the onResize sequence:
+        // measure the container, then (once the width is known) re-derive each body's mounted
+        // and visible columns so createViewData can render their rows.
+        me.passSizeToBody().then(() => {
+            me.bodyStart?.updateMountedAndVisibleColumns();
+            me.body.updateMountedAndVisibleColumns();
+            me.bodyEnd?.updateMountedAndVisibleColumns()
+        });
+
         me.lockedStartColumns.forEach((col, targetIndex) => {
             let btn = me.getButton(col.dataField);
 
@@ -1239,44 +1251,11 @@ class GridContainer extends BaseContainer {
     }
 
     /**
-     * Pushes synchronized scrolling coordinates (like startIndex) into all active bodies
+     * Delegates body scroll-synchronization to grid.View, which owns body orchestration.
      * @param {Number} scrollTop
      */
     syncBodies(scrollTop) {
-        let me               = this,
-            {body, bodyEnd, bodyStart, scrollManager} = me,
-            {bufferRowRange, rowHeight} = body,
-            newStartIndex    = Math.floor(scrollTop / rowHeight);
-
-        let updateBody = _body => {
-            let isCenter = _body === body;
-            _body.skipCreateViewData = true;
-
-            _body.set({
-                scrollLeft: isCenter ? scrollManager.scrollLeft : 0, // Horizontal sync applies from scrollManager state ONLY for center
-                scrollTop : scrollTop
-            });
-
-            if (Math.abs(_body.startIndex - newStartIndex) >= bufferRowRange) {
-                _body.startIndex = newStartIndex
-            } else {
-                _body.visibleRows[0] = newStartIndex;
-                _body.visibleRows[1] = newStartIndex + _body.availableRows
-            }
-
-            _body.skipCreateViewData = false;
-            _body.createViewData(true); // silent = true
-        };
-
-        updateBody(body);
-        bodyStart && updateBody(bodyStart);
-        bodyEnd   && updateBody(bodyEnd);
-
-        if (me.view) {
-            me.view.scrollTop   = scrollTop;
-            me.view.updateDepth = 3;
-            me.view.update()
-        }
+        this.view.syncBodies(scrollTop)
     }
 
     /**

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -22,6 +22,14 @@ class View extends Base {
          */
         baseCls: ['neo-grid-view', 'neo-hide-scrollbar'],
         /**
+         * Back-reference to the owning grid.Container (the macro layer). grid.View orchestrates the
+         * 1-3 bodies (`bodyStart`, `body`, `bodyEnd`) but reaches up to the container for macro state
+         * it does not own — column distribution and the ScrollManager (horizontal scroll position plus
+         * main-thread scroll/hover/pinning addon coordination).
+         * @member {Neo.grid.Container|null} gridContainer=null
+         */
+        gridContainer: null,
+        /**
          * @member {Object} layout={ntype: 'hbox', align: 'stretch'}
          * @protected
          */
@@ -40,6 +48,53 @@ class View extends Base {
         return {
             scrollTop: this.scrollTop
         }
+    }
+
+    /**
+     * Pushes synchronized scrolling coordinates (startIndex / scrollTop) into all active bodies
+     * (`bodyStart`, `body`, `bodyEnd`). Owned here because grid.View is the body orchestrator; the
+     * horizontal scroll position is read from the gridContainer macro layer, which retains the
+     * ScrollManager.
+     *
+     * Preserves the row/cell pooling invariant: each body recomputes view data for a fixed node pool
+     * via the silent `createViewData(true)` path — never inserting, removing, or moving DOM nodes
+     * while scrolling.
+     * @param {Number} scrollTop
+     */
+    syncBodies(scrollTop) {
+        let me        = this,
+            container = me.gridContainer,
+            {body, bodyEnd, bodyStart, scrollManager} = container,
+            {bufferRowRange, rowHeight} = body,
+            newStartIndex = Math.floor(scrollTop / rowHeight);
+
+        let updateBody = _body => {
+            let isCenter = _body === body;
+            _body.skipCreateViewData = true;
+
+            _body.set({
+                scrollLeft: isCenter ? scrollManager.scrollLeft : 0, // Horizontal sync applies from scrollManager state ONLY for center
+                scrollTop : scrollTop
+            });
+
+            if (Math.abs(_body.startIndex - newStartIndex) >= bufferRowRange) {
+                _body.startIndex = newStartIndex
+            } else {
+                _body.visibleRows[0] = newStartIndex;
+                _body.visibleRows[1] = newStartIndex + _body.availableRows
+            }
+
+            _body.skipCreateViewData = false;
+            _body.createViewData(true) // silent = true
+        };
+
+        updateBody(body);
+        bodyStart && updateBody(bodyStart);
+        bodyEnd   && updateBody(bodyEnd);
+
+        me.scrollTop   = scrollTop;
+        me.updateDepth = 3;
+        me.update()
     }
 }
 


### PR DESCRIPTION
Resolves #12757

Authored by Claude Opus 4.8 (Claude Code). Implementation session 1cf2ad9f-28af-4242-9069-fd14c04e1b62; reduction/review session 3f9ffeb7-a284-4783-912b-f39912115d2e.

`grid.View` now owns body-scroll synchronization. `syncBodies` (push synchronized `startIndex`/`scrollLeft`/`scrollTop` into `bodyStart`/`body`/`bodyEnd`) moves from `Container` to `View`; `Container.syncBodies` delegates. Adds the `View.gridContainer` back-reference (so View can reach the macro layer for column distribution + the ScrollManager) and a split-body initial-render fix in `Container.onColumnsMutate` (`passSizeToBody` → `updateMountedAndVisibleColumns` per body). Behavior-preserving; preserves the row/cell pooling invariant.

## Scope (reduced after review)
This PR originally also attempted the multi-body SelectionModel rework. The cross-family review (@neo-gpt, above) + V-B-A established two things: (a) the SM change removed the peer-*sync* (`getActivePeers` fan-out + `register()` Peer State Adoption) **without** removing the per-body model *construction* — `Container.createOrUpdateSubGrids()` still spreads `...me.body.initialConfig` (incl. `selectionModel`) into the locked bodies (`Container.mjs:43-44`/`:78-79`) — leaving a stale-model / desync risk; and (b) user-facing multi-body selection **already works on dev** (`GridSelectionMultiBody.spec.mjs` cross-body selection is green on dev; probe-confirmed, not a stale-server false-green). So the SM work was reverted and re-homed as the holistic **`grid.View`-owned single SelectionModel** migration in #12758 (which carries @neo-gpt's two empirical probes as its acceptance gates). What remains here is the safe, behavior-preserving View body-orchestration foundation.

Evidence: L3 (browser E2E, local Chrome) — the relocated `syncBodies` preserves scroll-sync and multi-body render. No runtime-verify residual for #12757's ACs.

## Test Evidence
```
npx playwright test test/playwright/e2e/GridThumbDrag.spec.mjs test/playwright/e2e/GridSelectionMultiBody.spec.mjs \
  -c test/playwright/playwright.config.e2e.mjs
```
- `GridThumbDrag` › High-Velocity Vertical Thumb Drag Stale Render Detection — ✓ passed
- `GridThumbDrag` › Horizontal Drag Scroll Moves Cells + Data Virtualization — ✓ passed
- `GridSelectionMultiBody` › Cross-Body Row Selection (Neural Link) — ✓ passed
- `GridSelectionMultiBody` › Live Property Updation (Column Width) — ✗ fails **identically on `dev`** (pre-existing #9868 `2050px` column-width issue; not in this PR's surface)

## Post-Merge Validation
- [ ] None — #12757's ACs are covered by the E2E above (scroll-sync + render are observable in-test).

## Deltas from ticket
None — #12757 was authored to match this reduced PR exactly.

Refs #9872
Refs #12758
Refs #9486