### PR TITLE
fix(ai): keep mailbox available during summary degradation (#12752)

### DIFF
--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -69,11 +69,11 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary Tools allowed without the healthcheck gate (database lifecycle + agent FAQs).
+     * @summary Tools allowed without the healthcheck gate.
      * @returns {Array<String>}
      */
     getHealthExemptTools() {
-        return ['healthcheck', 'start_database', 'stop_database', 'list_agent_faqs'];
+        return ['healthcheck', 'list_agent_faqs'];
     }
 
     /**
@@ -129,7 +129,7 @@ class Server extends BaseServer {
             health.details.forEach(detail => logger.warn(`    ${detail}`));
 
             if (!health.database.process.running) {
-                logger.warn('    💡 Tip: Use the start_database tool after server starts, or run:');
+                logger.warn('    💡 Tip: Start ChromaDB externally, or run:');
                 logger.warn(`       chroma run --path ${process.env.CHROMA_DATA_PATH || './data/chroma'} --port ${process.env.CHROMA_PORT || '8000'}`);
             }
             logger.warn('    The server will periodically retry and recover automatically once dependencies are met.');

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -94,11 +94,28 @@ class Server extends BaseServer {
 
     /**
      * @summary Tools allowed without the healthcheck gate. Database lifecycle tools must
-     * remain reachable while ChromaDB is unavailable so operators can recover.
+     * remain reachable while ChromaDB is unavailable so operators can recover. The A2A
+     * mailbox/permission surface is graph/SQLite-scoped and must remain reachable during
+     * summarization/vector-provider incidents so agents can coordinate the recovery.
      * @returns {Array<String>}
      */
     getHealthExemptTools() {
-        return ['healthcheck', 'start_database', 'stop_database'];
+        return [
+            'healthcheck',
+            'start_database',
+            'stop_database',
+            'add_message',
+            'list_messages',
+            'get_message',
+            'mark_read',
+            'archive_message',
+            'delete_message',
+            'transition_task',
+            'grant_permission',
+            'revoke_permission',
+            'list_permissions',
+            'manage_wake_subscription'
+        ];
     }
 
     /**

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -93,8 +93,7 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary Tools allowed without the healthcheck gate. Database lifecycle tools must
-     * remain reachable while ChromaDB is unavailable so operators can recover. The A2A
+     * @summary Tools allowed without the healthcheck gate. The A2A
      * mailbox/permission surface is graph/SQLite-scoped and must remain reachable during
      * summarization/vector-provider incidents so agents can coordinate the recovery.
      * @returns {Array<String>}
@@ -102,8 +101,6 @@ class Server extends BaseServer {
     getHealthExemptTools() {
         return [
             'healthcheck',
-            'start_database',
-            'stop_database',
             'add_message',
             'list_messages',
             'get_message',
@@ -380,7 +377,7 @@ class Server extends BaseServer {
             health.details.forEach(detail => logger.warn(`    ${detail}`));
 
             if (!health.database?.process?.running) {
-                logger.warn('    💡 Tip: Use the start_database tool after server starts, or run:');
+                logger.warn('    💡 Tip: Start ChromaDB manually, for example:');
                 logger.warn(`       chroma run --path ${process.env.CHROMA_DATA_PATH || './data/chroma'} --port ${process.env.CHROMA_PORT || '8000'}`);
             }
             logger.warn('    The server will periodically retry and recover automatically once dependencies are met.');

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -97,7 +97,7 @@ class HealthService extends Base {
         } catch (e) {
             return {
                 running: false,
-                error  : `ChromaDB is not accessible at ${aiConfig.host}:${aiConfig.port}. Please start ChromaDB or use the start_database tool.`
+                error  : `ChromaDB is not accessible at ${aiConfig.host}:${aiConfig.port}. Please start ChromaDB externally or update the configured host/port.`
             };
         }
     }

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -339,9 +339,9 @@ class HealthService extends Base {
      * This method leverages the cached health check, so calling it frequently
      * (e.g., before each tool invocation) has minimal performance impact.
      *
-     * Note: Both ChromaDB and GEMINI_API_KEY are required for all knowledge base operations,
-     * since adding/querying knowledge requires text embeddings via the Gemini API.
-     * Only database lifecycle operations (start/stop) can work in degraded state.
+     * Note: ChromaDB and the configured embedding provider are required for retrieval.
+     * Database lifecycle is managed outside the MCP tool surface; degraded state only
+     * permits health/introspection helpers that do not touch the vector store.
      *
      * @throws {Error} If the Knowledge Base is not fully healthy, with a detailed message
      * @returns {Promise<void>}

--- a/learn/agentos/KnowledgeBase.md
+++ b/learn/agentos/KnowledgeBase.md
@@ -69,7 +69,7 @@ The brain of the operation. It handles the search logic and implements the **Wei
 #### SearchService (`services/SearchService.mjs`)
 
 The RAG (Retrieval-Augmented Generation) engine.
-- **Synthesizes Answers:** Unlike `QueryService` which returns raw files, `SearchService` takes a question, retrieves relevant documents, reads their full content from disk, and uses an LLM (Gemini) to generate a concise, synthesized answer with citations.
+- **Synthesizes Answers:** Unlike `QueryService` which returns raw files, `SearchService` takes a question, retrieves relevant documents, reads their full content from disk, and uses the configured synthesis provider to generate a concise, synthesized answer with citations.
 - **Contextual Reading:** It reads the actual files from the filesystem before feeding them to the LLM, ensuring the context is complete and up-to-date.
 
 #### DatabaseService (`services/DatabaseService.mjs`)
@@ -83,13 +83,13 @@ The ETL (Extract, Transform, Load) engine.
 
 The gatekeeper.
 - **Intelligent Caching:** Caches "healthy" status for 5 minutes to reduce overhead. Unhealthy states are never cached, allowing immediate recovery detection.
-- **Gatekeeping:** Every tool call passes through `ensureHealthy()`. If dependencies (ChromaDB, API Key) are missing, it fails fast with actionable error messages.
+- **Gatekeeping:** Every non-exempt tool call passes through `ensureHealthy()`. If dependencies (ChromaDB, embedding provider) are missing, it fails fast with actionable error messages.
 
 #### DatabaseLifecycleService (`services/DatabaseLifecycleService.mjs`)
 
 Process manager.
-- Automatically manages the local `chroma` server process.
-- Can start/stop the database on demand via tools.
+- Reports local `chroma` process state for health diagnostics.
+- Database lifecycle is managed outside the MCP tool surface.
 
 #### DocumentService (`services/DocumentService.mjs`)
 

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -11,15 +11,15 @@ Without memory, every session is a blank slate. An agent fixing a bug today has 
 
 ## Architecture
 
-The server is built on a modular service architecture, extending `Neo.core.Base`. It uses **ChromaDB** as the vector database for semantic search and **Google Gemini** for text embeddings and summarization. The Native Edge Graph persists in SQLite via `ai/graph/storage/SQLite.mjs`, which sets `PRAGMA foreign_keys=ON` at connection time so the schema-declared `Edges` `ON DELETE CASCADE` fires on Node deletion (#10856).
+The server is built on a modular service architecture, extending `Neo.core.Base`. It uses **ChromaDB** as the vector database for semantic search and the configured AI providers for text embeddings and summarization. The Native Edge Graph persists in SQLite via `ai/graph/storage/SQLite.mjs`, which sets `PRAGMA foreign_keys=ON` at connection time so the schema-declared `Edges` `ON DELETE CASCADE` fires on Node deletion (#10856).
 
 ### Key Services
 
 *   **`MemoryService`**: Manages raw, granular memories. It handles the ingestion of new agent interactions and performs semantic searches across the raw interaction history.
 *   **`SessionService`**: Responsible for the "Auto-Discovery" process. It uses an LLM to analyze completed sessions and generate structured summaries (Title, Category, Quality Scores) to make them easily searchable.
 *   **`SummaryService`**: Manages the high-level session summaries. It provides tools to query past work based on topics or categories (e.g., "refactoring", "bugfix").
-*   **`DatabaseLifecycleService`**: Manages the underlying ChromaDB process. It can start, stop, and monitor the database status, ensuring the persistence layer is available when needed.
-*   **`HealthService`**: A gatekeeper that ensures all dependencies (ChromaDB connectivity, Collections, API Keys) are healthy before allowing operations.
+*   **`DatabaseLifecycleService`**: Reports the underlying ChromaDB process state so health diagnostics can explain whether the persistence layer is available.
+*   **`HealthService`**: A gatekeeper that ensures dependencies (ChromaDB connectivity, collections, and provider readiness) are healthy before allowing operations.
 
 ## The "Save-Then-Respond" Protocol
 

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -78,11 +78,9 @@ The server exposes a suite of tools via the Model Context Protocol (MCP).
 *   **`resume_session`**: Pure validation/query — returns structural metadata about whether a candidate session ID is safe for the agent to keep using on reconnect (set the `Mcp-Session-Id` header to that ID for subsequent calls). Does NOT mutate `RequestContextService` or any server-side session state. Returns either a success payload (`status: 'resumable'` plus `memoryCount`, `lastActivityAt`, `summarizationStatus`) or one of four structured errors: `INVALID_SESSION_ID`, `SESSION_NOT_FOUND`, `SESSION_FINALIZED` (already summarized — start fresh), `SESSION_BUSY` (concurrent summarization mid-flight — retry shortly). Use after recovering a candidate session ID from a prior `query_summaries` result or local context.
 *   **`set_session_id`**: Legacy / single-tenant fallback only. Overrides the process-global `_legacySessionId`. Rejected with `REQUEST_SCOPED_SESSION_ACTIVE` when invoked under a request-bound `Mcp-Session-Id` context to prevent multi-tenant state corruption. Prefer transport-layer session binding via the `Mcp-Session-Id` header in shared deployments.
 
-### Database Management
+### Health & Data Management
 
 *   **`healthcheck`**: Diagnostics tool. Checks ChromaDB status, collection health, API key configuration, identity binding, and effective ChromaDB topology. See **Healthcheck Response Shape** below for the full payload contract.
-*   **`start_database`**: Starts the local ChromaDB process.
-*   **`stop_database`**: Stops the local ChromaDB process.
 *   **`export_database`**: Exports memories and summaries to JSONL files for backup.
 *   **`import_database`**: Imports data from JSONL backups.
 

--- a/learn/agentos/tooling/MemoryCoreMcpApi.md
+++ b/learn/agentos/tooling/MemoryCoreMcpApi.md
@@ -76,7 +76,7 @@ The server exposes the following tools, which are derived from its OpenAPI speci
 
 Database lifecycle is managed outside the MCP tool surface. Agents should use `healthcheck`
 to inspect ChromaDB connectivity and the configured topology rather than invoking database
-start/stop tools.
+lifecycle commands.
 
 ## Tool Specifications
 

--- a/learn/agentos/tooling/MemoryCoreMcpApi.md
+++ b/learn/agentos/tooling/MemoryCoreMcpApi.md
@@ -60,9 +60,6 @@ The server exposes the following tools, which are derived from its OpenAPI speci
 | :--- | :--- |
 | **Health** | |
 | `healthcheck` | Confirms the server is running and can connect to the ChromaDB instance. |
-| **Database Lifecycle** | |
-| `start_database` | Starts the ChromaDB database instance as a background process. |
-| `stop_database` | Stops the running ChromaDB database instance. |
 | **Memories** | |
 | `add_memory` | Stores a new agent interaction (prompt, thought, response) as a memory. |
 | `get_session_memories` | Retrieves all memories for a specific session, in chronological order. |
@@ -77,6 +74,10 @@ The server exposes the following tools, which are derived from its OpenAPI speci
 | `export_database` | Exports the entire memory database to a JSONL file. |
 | `import_database` | Imports a previously exported JSONL file back into the database. |
 
+Database lifecycle is managed outside the MCP tool surface. Agents should use `healthcheck`
+to inspect ChromaDB connectivity and the configured topology rather than invoking database
+start/stop tools.
+
 ## Tool Specifications
 
 This section details the parameters and behavior of each tool exposed by the Memory Core server.
@@ -85,14 +86,6 @@ This section details the parameters and behavior of each tool exposed by the Mem
 
 #### `healthcheck`
 Confirms server health and database connectivity. This tool takes no parameters.
-
-### Database Lifecycle Tools
-
-#### `start_database`
-Starts the ChromaDB database instance as a background process. This tool takes no parameters.
-
-#### `stop_database`
-Stops the running ChromaDB database instance. This tool takes no parameters.
 
 ### Memory Tools
 

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -1,0 +1,41 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'KnowledgeBaseServerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs';
+
+test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
+    let Server;
+
+    test.beforeAll(async () => {
+        Server = (await import('../../../../../../../ai/mcp/server/knowledge-base/Server.mjs')).default;
+    });
+
+    test('#12752: health exemptions do not expose retired database lifecycle tools', () => {
+        const serverInstance = Neo.create(Server);
+
+        try {
+            const exemptTools = serverInstance.getHealthExemptTools();
+
+            expect(exemptTools).toEqual(['healthcheck', 'list_agent_faqs']);
+            expect(exemptTools).not.toContain('start_database');
+            expect(exemptTools).not.toContain('stop_database');
+        } finally {
+            serverInstance.destroy();
+        }
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -14,6 +14,7 @@ setup({
 });
 
 import {test, expect}  from '@playwright/test';
+import {CallToolRequestSchema} from '@modelcontextprotocol/sdk/types.js';
 import path            from 'path';
 import fs              from 'fs-extra';
 import Neo             from '../../../../../../../src/Neo.mjs';
@@ -80,8 +81,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
         // Regression guard: in production, `GraphService.getNode` returns a Promise (Neo
         // singleton method wrapping). If `bindAgentIdentity` drops the `await`, `node.id`
-        // on the Promise object is `undefined` — the actual root cause of #10241's merged-
-        // but-incomplete fix that #10249 corrects. `unitTestMode` may resolve the method
+        // on the Promise object is `undefined`. `unitTestMode` may resolve the method
         // synchronously, so the other test in this suite does not reproduce the failure
         // mode; this test forces the Promise path explicitly by stubbing `getNode` to
         // return a Promise regardless of the framework's runtime decision.
@@ -168,6 +168,78 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         } finally {
             SDK.Memory_SessionService.queueSummarizationJob = originalQueue;
             SDK.Memory_CoalescingEngineService.removeMcpServer = originalRemove;
+            serverInstance.destroy();
+        }
+    });
+
+    test('#12752: mailbox tools bypass summary-degraded health gate, memory writes do not', async () => {
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const handlers = new Map();
+        const healthCalls = [];
+        const toolCalls = [];
+        const degradedError = new Error([
+            'Memory Core is not fully operational:',
+            '  - GEMINI_API_KEY not set - summarization features unavailable'
+        ].join('\n'));
+
+        const mcpServer = {
+            server: {
+                setRequestHandler(schema, handler) {
+                    handlers.set(schema, handler);
+                }
+            }
+        };
+
+        serverInstance.getToolService = () => ({
+            listTools: () => ({tools: [], nextCursor: undefined}),
+            callTool : (name, args) => {
+                toolCalls.push({name, args});
+                return {ok: true, name};
+            }
+        });
+        serverInstance.getHealthService = () => ({
+            ensureHealthy: async () => {
+                healthCalls.push('ensureHealthy');
+                throw degradedError;
+            }
+        });
+
+        serverInstance.setupRequestHandlers(mcpServer);
+
+        try {
+            const callTool = handlers.get(CallToolRequestSchema);
+
+            const mailboxResult = await callTool({
+                params: {
+                    name     : 'list_messages',
+                    arguments: {status: 'unread'}
+                }
+            });
+
+            expect(mailboxResult.isError).toBe(false);
+            expect(mailboxResult.structuredContent).toEqual({
+                ok  : true,
+                name: 'list_messages'
+            });
+            expect(healthCalls).toEqual([]);
+            expect(toolCalls).toEqual([{
+                name: 'list_messages',
+                args: {status: 'unread'}
+            }]);
+
+            const memoryResult = await callTool({
+                params: {
+                    name     : 'add_memory',
+                    arguments: {prompt: 'p', thought: 't', response: 'r'}
+                }
+            });
+
+            expect(memoryResult.isError).toBe(true);
+            expect(memoryResult.content[0].text).toContain('Cannot execute add_memory: Memory Core is not fully operational');
+            expect(memoryResult.content[0].text).toContain('GEMINI_API_KEY not set - summarization features unavailable');
+            expect(healthCalls).toEqual(['ensureHealthy']);
+            expect(toolCalls).toHaveLength(1);
+        } finally {
             serverInstance.destroy();
         }
     });

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -243,4 +243,17 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             serverInstance.destroy();
         }
     });
+
+    test('#12752: health exemptions do not expose retired database lifecycle tools', () => {
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+
+        try {
+            const exemptTools = serverInstance.getHealthExemptTools();
+
+            expect(exemptTools).not.toContain('start_database');
+            expect(exemptTools).not.toContain('stop_database');
+        } finally {
+            serverInstance.destroy();
+        }
+    });
 });


### PR DESCRIPTION
Resolves #12752

Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Keeps Memory Core graph/mailbox coordination tools reachable when the broad health gate is degraded by summarization/vector-provider incidents. Memory writes still use the existing health gate, so degraded summarization blocks `add_memory` while `list_messages` can still support recovery coordination.

Evidence: L2 (MCP dispatch-unit test with summary-degraded health stub + retired-tool runtime/docs sweep) -> L2 required (`#12752` dispatch-policy ACs). No residuals.

## Deltas from ticket

Implementation uses the existing `getHealthExemptTools()` hook instead of adding a new `ensureHealthyForTool` path. Service-level graph, identity, permission, and database errors remain inside the mailbox services.

Follow-up cleanup after operator V-B-A:
- Removed stale Memory Core `start_database` / `stop_database` health exemptions.
- Removed stale Knowledge Base `start_database` / `stop_database` health exemptions and startup/health hints.
- Removed current Memory Core and Knowledge Base docs that still advertised retired database lifecycle tools or Gemini-only provider assumptions.
- Added regression specs for both Memory Core and Knowledge Base server exemption lists.

Related: #12740
Related: #12742
Related: #12741
Related: #12746
Related: #12748

## Test Evidence

- `rg -n "start_database|stop_database|start/stop|Can start|start, stop|can start|API Key|API Keys|Google Gemini for text embeddings|Gemini\)" ai/services/knowledge-base ai/mcp/server/knowledge-base learn/agentos test/playwright/unit/ai/mcp/server` -> only negative assertions and unrelated agent-family references remain.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs` -> 7 passed.
- `npm run ai:check-retired-primitives` -> PASS.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed before commit.
- Normal commit hooks passed, including scoped `check-ticket-archaeology.mjs`.

## Post-Merge Validation

- [ ] Restart MCP servers and verify `list_messages({status: "unread"})` remains callable in an environment with summary provider credentials absent or invalid, while `add_memory` remains gated.

## Commits

- `6f632b8b7` - `fix(ai): keep mailbox available during summary degradation (#12752)`
- `1c0cad0f3` - `fix(ai): drop stale memory-core database tools (#12752)`
- `981980dfa` - `fix(ai): retire database tool remnants (#12752)`
- `7706c1353` - `docs(ai): remove retired database lifecycle wording (#12752)`