### PR TITLE
fix(ai): lazy-load configured chat provider (#12763)

### DIFF
--- a/ai/provider/buildChatModel.mjs
+++ b/ai/provider/buildChatModel.mjs
@@ -1,6 +1,51 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
-import OllamaProvider           from './Ollama.mjs';
-import OpenAiCompatibleProvider from './OpenAiCompatible.mjs';
+let GoogleGenerativeAIClass,
+    OllamaProviderClass,
+    OpenAiCompatibleProviderClass;
+
+/**
+ * @summary Loads the remote Gemini SDK only when the configured chat provider needs it.
+ * @returns {Promise<Function>}
+ */
+async function getGoogleGenerativeAIClass() {
+    if (!GoogleGenerativeAIClass) {
+        ({GoogleGenerativeAI: GoogleGenerativeAIClass} = await import('@google/generative-ai'));
+    }
+
+    return GoogleGenerativeAIClass;
+}
+
+/**
+ * @summary Loads the native Ollama provider only when the configured chat provider needs it.
+ * @returns {Promise<Function>}
+ */
+async function getOllamaProviderClass() {
+    if (!OllamaProviderClass) {
+        ({default: OllamaProviderClass} = await import('./Ollama.mjs'));
+    }
+
+    return OllamaProviderClass;
+}
+
+/**
+ * @summary Loads the OpenAI-compatible provider only when the configured chat provider needs it.
+ * @returns {Promise<Function>}
+ */
+async function getOpenAiCompatibleProviderClass() {
+    if (!OpenAiCompatibleProviderClass) {
+        ({default: OpenAiCompatibleProviderClass} = await import('./OpenAiCompatible.mjs'));
+    }
+
+    return OpenAiCompatibleProviderClass;
+}
+
+/**
+ * @param {Object} result
+ * @returns {Object}
+ */
+function toGeminiEnvelope(result) {
+    const content = result.content || result.raw?.message?.content || '';
+    return {response: {text: () => content}};
+}
 
 /**
  * @summary Builds a provider-agnostic chat-completion model for the configured `modelProvider`.
@@ -15,19 +60,20 @@ import OpenAiCompatibleProvider from './OpenAiCompatible.mjs';
  * service so any `ai/services/*` consumer can import it without dragging that service's
  * module-load side effects (graph/storage/request-context) across the service boundary.
  *
- * Side effects are limited to provider instantiation via the injected factories — tests can
- * pass mocked factories to verify selector boundaries + envelope shape without hitting real
- * Ollama / OpenAI-compatible endpoints. Production callers pass `Neo.create`-based factories.
+ * Side effects are limited to the configured provider branch: local-provider imports and
+ * instantiation are lazy inside the async `generateContent()` shim, while custom injected
+ * factories still let tests verify selector boundaries + envelope shape without hitting real
+ * Ollama / OpenAI-compatible endpoints.
  *
  * @param {Object} options
  * @param {String} options.modelProvider 'gemini' | 'openAiCompatible' | 'ollama'.
- * @param {Object} [options.openAiCompatibleConfig] Slice of `aiConfig.openAiCompatible` ({host, apiKey, model, keep_alive}).
- * @param {Object} [options.ollamaConfig] Slice of `aiConfig.ollama` ({host, model, embeddingModel, keep_alive}).
+ * @param {Object} [options.openAiCompatibleConfig] Resolved `aiConfig.openAiCompatible` leaves ({host, apiKey, model, keep_alive}).
+ * @param {Object} [options.ollamaConfig] Resolved `aiConfig.ollama` leaves ({host, model, embeddingModel, keep_alive}).
  * @param {String} [options.geminiApiKey] `GEMINI_API_KEY` env value (passed for testability).
  * @param {String} [options.geminiModelName] Gemini model name (e.g. `aiConfig.modelName`).
- * @param {Function} [options.ollamaProviderFactory] Test seam — defaults to `Neo.create(OllamaProvider, cfg)`.
- * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — defaults to `Neo.create(OpenAiCompatibleProvider, cfg)`.
- * @param {Function} [options.geminiClientFactory] Test seam — defaults to `new GoogleGenerativeAI(...).getGenerativeModel({model})`.
+ * @param {Function} [options.ollamaProviderFactory] Test seam — if omitted, lazily imports `./Ollama.mjs` and calls `Neo.create(...)`.
+ * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — if omitted, lazily imports `./OpenAiCompatible.mjs` and calls `Neo.create(...)`.
+ * @param {Function} [options.geminiClientFactory] Test seam — if omitted, lazily imports `@google/generative-ai` on first `generateContent()`.
  * @returns {Object|null} Gemini-shaped `{generateContent}` model, OR `null` for gemini without an API key.
  * @throws {Error} When `modelProvider` is not in the supported set.
  */
@@ -37,58 +83,112 @@ export function buildChatModel({
     ollamaConfig,
     geminiApiKey,
     geminiModelName,
-    ollamaProviderFactory          = (cfg) => Neo.create(OllamaProvider, cfg),
-    openAiCompatibleProviderFactory = (cfg) => Neo.create(OpenAiCompatibleProvider, cfg),
-    geminiClientFactory             = (apiKey, modelName) => new GoogleGenerativeAI(apiKey).getGenerativeModel({model: modelName})
+    ollamaProviderFactory,
+    openAiCompatibleProviderFactory,
+    geminiClientFactory
 } = {}) {
     if (modelProvider === 'openAiCompatible') {
         const cfg = openAiCompatibleConfig || {};
-        const provider = openAiCompatibleProviderFactory({
-            apiKey   : cfg.apiKey,
-            host     : cfg.host,
-            modelName: cfg.model,
-            ...(cfg.keep_alive !== undefined ? {keepAlive: cfg.keep_alive} : {})
-        });
+        let providerPromise;
+
+        const getProvider = () => {
+            providerPromise ||= Promise.resolve((async () => {
+                const providerConfig = {
+                    apiKey   : cfg.apiKey,
+                    host     : cfg.host,
+                    modelName: cfg.model,
+                    ...(cfg.keep_alive !== undefined ? {keepAlive: cfg.keep_alive} : {})
+                };
+
+                if (openAiCompatibleProviderFactory) {
+                    return openAiCompatibleProviderFactory(providerConfig);
+                }
+
+                const ProviderClass = await getOpenAiCompatibleProviderClass();
+                return Neo.create(ProviderClass, providerConfig);
+            })());
+
+            return providerPromise;
+        };
+
         return {
             generateContent: async (promptText, generationOptions = {}) => {
+                const provider = await getProvider();
+
                 provider.apiKey    = cfg.apiKey;
                 provider.host      = cfg.host;
                 provider.modelName = cfg.model;
                 if (cfg.keep_alive !== undefined) {
                     provider.keepAlive = cfg.keep_alive;
                 }
-                const result  = await provider.generate(promptText, generationOptions);
-                const content = result.content || result.raw?.message?.content || '';
-                return {response: {text: () => content}};
+
+                return toGeminiEnvelope(await provider.generate(promptText, generationOptions));
             }
         };
     }
 
     if (modelProvider === 'ollama') {
         const cfg = ollamaConfig || {};
-        const provider = ollamaProviderFactory({
-            host          : cfg.host           || 'http://127.0.0.1:11434',
-            modelName     : cfg.model          || 'gemma4',
-            embeddingModel: cfg.embeddingModel || null,
-            ...(cfg.keep_alive !== undefined ? {keepAlive: cfg.keep_alive} : {})
-        });
+        let providerPromise;
+
+        const getProvider = () => {
+            providerPromise ||= Promise.resolve((async () => {
+                const providerConfig = {
+                    host          : cfg.host,
+                    modelName     : cfg.model,
+                    embeddingModel: cfg.embeddingModel,
+                    ...(cfg.keep_alive !== undefined ? {keepAlive: cfg.keep_alive} : {})
+                };
+
+                if (ollamaProviderFactory) {
+                    return ollamaProviderFactory(providerConfig);
+                }
+
+                const ProviderClass = await getOllamaProviderClass();
+                return Neo.create(ProviderClass, providerConfig);
+            })());
+
+            return providerPromise;
+        };
+
         return {
             generateContent: async (promptText, generationOptions = {}) => {
-                provider.host      = cfg.host  || provider.host;
-                provider.modelName = cfg.model || provider.modelName;
+                const provider = await getProvider();
+
+                provider.host      = cfg.host;
+                provider.modelName = cfg.model;
                 if (cfg.keep_alive !== undefined) {
                     provider.keepAlive = cfg.keep_alive;
                 }
-                const result  = await provider.generate(promptText, generationOptions);
-                const content = result.content || result.raw?.message?.content || '';
-                return {response: {text: () => content}};
+
+                return toGeminiEnvelope(await provider.generate(promptText, generationOptions));
             }
         };
     }
 
     if (modelProvider === 'gemini') {
         if (!geminiApiKey) return null;
-        return geminiClientFactory(geminiApiKey, geminiModelName);
+
+        if (geminiClientFactory) {
+            return geminiClientFactory(geminiApiKey, geminiModelName);
+        }
+
+        let modelPromise;
+        const getModel = () => {
+            modelPromise ||= Promise.resolve((async () => {
+                const GoogleGenerativeAI = await getGoogleGenerativeAIClass();
+                return new GoogleGenerativeAI(geminiApiKey).getGenerativeModel({model: geminiModelName});
+            })());
+
+            return modelPromise;
+        };
+
+        return {
+            generateContent: async (...args) => {
+                const model = await getModel();
+                return model.generateContent(...args);
+            }
+        };
     }
 
     throw new Error(`buildChatModel: unsupported modelProvider '${modelProvider}'. Expected one of: 'gemini', 'openAiCompatible', 'ollama'.`);

--- a/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
@@ -14,6 +14,7 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
@@ -33,6 +34,16 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
         expect(() => buildChatModel({
             modelProvider: 'mystery'
         })).toThrow(/unsupported modelProvider 'mystery'/);
+    });
+
+    test('buildChatModel has no static provider imports (#12763)', async () => {
+        const source = await fs.readFile(new URL('../../../../../../ai/provider/buildChatModel.mjs', import.meta.url), 'utf8');
+
+        expect(source).not.toMatch(/^import\s+.*@google\/generative-ai/m);
+        expect(source).not.toMatch(/^import\s+.*\.\/Ollama\.mjs/m);
+        expect(source).not.toMatch(/^import\s+.*\.\/OpenAiCompatible\.mjs/m);
+        expect(source).not.toContain('http://127.0.0.1:11434');
+        expect(source).not.toContain("'gemma4'");
     });
 
     test('modelProvider=ollama returns generateContent wrapping native Ollama provider', async () => {
@@ -144,6 +155,36 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
                 timeoutMs     : 4000
             }
         });
+    });
+
+    test('modelProvider=openAiCompatible delays provider construction until generateContent (#12763)', async () => {
+        const factoryCalls = [];
+        const fakeProvider = {
+            async generate(promptText) {
+                return {content: 'lazy:' + promptText};
+            }
+        };
+
+        const model = buildChatModel({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'lazy-model'},
+            openAiCompatibleProviderFactory: (cfg) => {
+                factoryCalls.push(cfg);
+                return fakeProvider;
+            },
+            geminiClientFactory            : () => { throw new Error('Gemini must not be constructed for local providers'); }
+        });
+
+        expect(factoryCalls).toEqual([]);
+
+        const response = await model.generateContent('hello');
+
+        expect(response.response.text()).toBe('lazy:hello');
+        expect(factoryCalls).toEqual([{
+            host     : 'http://oai.test',
+            modelName: 'lazy-model',
+            apiKey   : undefined
+        }]);
     });
 
     test('local provider is used even when a Gemini key is present — key does not override the configured provider (#12741)', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12763
Related: #12740

Lazy-loads only the configured chat provider inside `buildChatModel` while preserving the synchronous selector contract used by Knowledge Base and Memory Core. Local provider branches now return async `generateContent()` shims that import their provider module only on first use, and the Gemini branch imports `@google/generative-ai` only when a Gemini-backed model is actually invoked.

Evidence: L2 (provider-selector static + unit coverage, plus KB/HealthService provider-routing regression set) -> L2 required (`#12763` module-load + sync-call-site ACs). No residuals.

## Deltas from ticket

The implementation also incorporates the operator's scope correction: `buildChatModel` no longer carries hidden fallback values for local provider host/model/embedding fields. It treats `openAiCompatibleConfig` and `ollamaConfig` as resolved `AiConfig` leaves per ADR 0019, so invalid local defaults such as bare `gemma4` cannot be reintroduced in this helper.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs` -> 11 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs` -> 24 passed.
- `git diff --check origin/dev...HEAD` -> passed.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`; branch history contains only `47cec0787ebe14d364087ce84e61c8ea0faa6791`.

## Post-Merge Validation

- [ ] Restart stale MCP harnesses and verify local/default KB and Memory Core synthesis no longer route through Gemini when `modelProvider` is local.

## Commits

- 47cec0787 — fix(ai): lazy-load configured chat provider (#12763)
