### PR TITLE
fix(ai): expose mcp runtime freshness (#12765)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1656,6 +1656,56 @@ components:
           type: string
           description: The version of the MCP server.
           example: "1.0.0"
+        runtimeFreshness:
+          type: object
+          description: Boot-vs-current runtime source identity for detecting stale MCP client/server attachments.
+          properties:
+            status:
+              type: string
+              enum: [current, stale, unknown]
+              description: Whether the running MCP process matches the current checkout identity.
+            startedAt:
+              type: string
+              format: date-time
+              description: When the MCP runtime module was loaded.
+            boot:
+              type: object
+              description: Source identity captured when the MCP process started.
+              properties:
+                gitHead:
+                  type: string
+                  description: Git commit SHA at process boot, when available.
+                openApiDigest:
+                  type: string
+                  description: SHA-256 digest of the OpenAPI contract at process boot.
+            current:
+              type: object
+              description: Source identity read from the current checkout during healthcheck.
+              properties:
+                gitHead:
+                  type: string
+                  description: Current checkout Git commit SHA, when available.
+                openApiDigest:
+                  type: string
+                  description: Current SHA-256 digest of the OpenAPI contract.
+            stale:
+              type: object
+              description: Per-identity stale flags. Null means the field could not be compared.
+              properties:
+                gitHead:
+                  type: boolean
+                  nullable: true
+                openApiDigest:
+                  type: boolean
+                  nullable: true
+            details:
+              type: array
+              items:
+                type: string
+            hint:
+              type: string
+              nullable: true
+              description: Restart or re-handshake guidance when the runtime is stale.
         githubCli:
           type: object
           properties:

--- a/ai/services/github-workflow/HealthService.mjs
+++ b/ai/services/github-workflow/HealthService.mjs
@@ -1,11 +1,133 @@
-import {exec}      from 'child_process';
-import {promisify} from 'util';
-import aiConfig    from '../../mcp/server/github-workflow/config.mjs';
-import Base        from '../../../src/core/Base.mjs';
-import logger      from '../../mcp/server/github-workflow/logger.mjs';
-import semver      from 'semver';
+import {exec, execFile, execFileSync} from 'child_process';
+import {createHash}                   from 'crypto';
+import {readFileSync}                 from 'fs';
+import path                           from 'path';
+import {fileURLToPath}                from 'url';
+import {promisify}                    from 'util';
+import aiConfig                       from '../../mcp/server/github-workflow/config.mjs';
+import Base                           from '../../../src/core/Base.mjs';
+import logger                         from '../../mcp/server/github-workflow/logger.mjs';
+import semver                         from 'semver';
 
-const execAsync = promisify(exec);
+const
+    execAsync     = promisify(exec),
+    execFileAsync = promisify(execFile),
+    serviceDir    = path.dirname(fileURLToPath(import.meta.url)),
+    openApiPath   = path.resolve(serviceDir, '../../mcp/server/github-workflow/openapi.yaml'),
+    startedAt     = new Date().toISOString();
+
+function createOpenApiDigest(filePath = openApiPath) {
+    const contents = readFileSync(filePath);
+
+    return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
+}
+
+function readBootGitHead() {
+    const stdout = execFileSync('git', ['-C', aiConfig.projectRoot, 'rev-parse', 'HEAD'], {
+        encoding: 'utf8',
+        stdio   : ['ignore', 'pipe', 'pipe']
+    });
+
+    return stdout.trim();
+}
+
+function readBootRuntimeIdentity() {
+    const errors = [],
+          boot   = {};
+
+    try {
+        boot.gitHead = readBootGitHead();
+    } catch (e) {
+        errors.push(`boot gitHead unavailable: ${e.message}`);
+    }
+
+    try {
+        boot.openApiDigest = createOpenApiDigest();
+    } catch (e) {
+        errors.push(`boot OpenAPI digest unavailable: ${e.message}`);
+    }
+
+    return {boot, errors};
+}
+
+const initialRuntimeIdentity = readBootRuntimeIdentity();
+
+function normalizeString(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed || null;
+}
+
+function compareIdentityField(field, boot, current) {
+    const
+        bootValue    = normalizeString(boot[field]),
+        currentValue = normalizeString(current[field]);
+
+    if (!bootValue || !currentValue) {
+        return null;
+    }
+
+    return bootValue !== currentValue;
+}
+
+/**
+ * @summary Classifies boot-vs-current MCP runtime source identity.
+ *
+ * `status:'stale'` is a diagnostic warning, not a hard outage. The attached MCP
+ * process can remain usable for read-only work while still telling agents to restart
+ * before asserting source/tool-schema facts.
+ *
+ * @param {Object} options
+ * @param {String} options.startedAt Runtime start timestamp.
+ * @param {Object} options.boot Boot-time source identity.
+ * @param {Object} options.current Current checkout identity.
+ * @param {String[]} options.errors Optional identity-read errors.
+ * @returns {Object}
+ */
+function classifyRuntimeFreshness({startedAt, boot = {}, current = {}, errors = []} = {}) {
+    const stale = {
+        gitHead      : compareIdentityField('gitHead', boot, current),
+        openApiDigest: compareIdentityField('openApiDigest', boot, current)
+    };
+    const comparableFields = Object.values(stale).filter(value => value !== null),
+          staleFields      = Object.entries(stale)
+                                .filter(([, value]) => value === true)
+                                .map(([key]) => key),
+          details          = [];
+
+    let status;
+
+    if (staleFields.length) {
+        status = 'stale';
+        details.push(`Runtime source identity differs from the current checkout (${staleFields.join(', ')}). Restart or reconnect the MCP client/server before asserting tool-schema/source facts.`);
+    } else if (comparableFields.length) {
+        status = 'current';
+        details.push('Runtime source identity matches the current checkout.');
+    } else {
+        status = 'unknown';
+        details.push('Runtime source identity could not be compared; git metadata and OpenAPI digest reads were unavailable or incomplete.');
+    }
+
+    for (const error of errors.filter(Boolean)) {
+        details.push(error);
+    }
+
+    return {
+        status,
+        startedAt,
+        boot,
+        current,
+        stale,
+        details,
+        hint: status === 'stale'
+            ? 'Restart or reconnect the MCP client/server to refresh cached tool definitions.'
+            : null
+    };
+}
 
 /**
  * @summary Monitors and validates the GitHub CLI dependency for the MCP server.
@@ -81,6 +203,30 @@ class HealthService extends Base {
      * @private
      */
     #previousStatus = null;
+
+    /**
+     * Boot-time runtime identity captured before long-lived MCP clients can go stale.
+     * @member {Object} bootRuntimeIdentity
+     */
+    bootRuntimeIdentity = initialRuntimeIdentity.boot;
+
+    /**
+     * Boot-time runtime identity read errors.
+     * @member {String[]} bootRuntimeFreshnessErrors
+     */
+    bootRuntimeFreshnessErrors = initialRuntimeIdentity.errors;
+
+    /**
+     * Optional unit-test seam for injecting boot/current runtime identity reads.
+     * @member {Function|null} runtimeFreshnessReader
+     */
+    runtimeFreshnessReader = null;
+
+    /**
+     * ISO timestamp captured when this server module was loaded.
+     * @member {String} runtimeStartedAt
+     */
+    runtimeStartedAt = startedAt;
 
     /**
      * Verifies that the user is authenticated with GitHub via the `gh` CLI.
@@ -226,6 +372,14 @@ class HealthService extends Base {
      *       versionOk: boolean,
      *       version: string | null,
      *       details: string[]
+     *     },
+     *     runtimeFreshness: {
+     *       status: 'current' | 'stale' | 'unknown',
+     *       boot: object,
+     *       current: object,
+     *       stale: object,
+     *       details: string[],
+     *       hint: string | null
      *     }
      *   }
      */
@@ -242,7 +396,10 @@ class HealthService extends Base {
             // If the cache is still fresh (< 5 minutes old), return it immediately
             if (age < this.#cacheDuration) {
                 logger.debug(`[HealthService] Using cached health status (age: ${Math.round(age / 1000)}s)`);
-                return this.#cachedHealth;
+                return {
+                    ...this.#cachedHealth,
+                    runtimeFreshness: await this.resolveRuntimeFreshness()
+                };
             }
         }
 
@@ -280,6 +437,47 @@ class HealthService extends Base {
         this.#previousStatus = health.status;
 
         return health;
+    }
+
+    /**
+     * Resolves the live runtime freshness diagnostic for the attached MCP process.
+     *
+     * Intent: A process can be infrastructure-healthy while stale relative to the checkout an
+     * agent is inspecting. Keeping this as a lightweight, structured warning lets agents
+     * choose restart/re-handshake instead of filing duplicate source tickets.
+     *
+     * @returns {Promise<Object>} Runtime freshness diagnostic payload.
+     */
+    async resolveRuntimeFreshness() {
+        try {
+            const identity = this.runtimeFreshnessReader
+                ? await this.runtimeFreshnessReader()
+                : await this.#readCurrentRuntimeIdentity();
+
+            const runtimeErrors = Array.isArray(identity.errors)
+                ? identity.errors
+                : [identity.errors].filter(Boolean);
+
+            return classifyRuntimeFreshness({
+                startedAt: this.runtimeStartedAt,
+                boot     : identity.boot || this.bootRuntimeIdentity,
+                current  : identity.current || {},
+                errors   : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    ...runtimeErrors
+                ]
+            });
+        } catch (e) {
+            return classifyRuntimeFreshness({
+                startedAt: this.runtimeStartedAt,
+                boot     : this.bootRuntimeIdentity,
+                current  : {},
+                errors   : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    `runtime freshness reader failed: ${e.message}`
+                ]
+            });
+        }
     }
 
     /**
@@ -321,6 +519,8 @@ class HealthService extends Base {
                 details      : []
             }
         };
+
+        payload.runtimeFreshness = await this.resolveRuntimeFreshness();
 
         // Step 1: Check version and installation
         // This single check answers both "is gh installed?" and "is the version OK?"
@@ -391,6 +591,33 @@ class HealthService extends Base {
         }
 
         return payload;
+    }
+
+    /**
+     * Reads the current checkout identity without touching GitHub credentials.
+     *
+     * @returns {Promise<Object>} `{current, errors}` source identity tuple.
+     * @private
+     */
+    async #readCurrentRuntimeIdentity() {
+        const current = {},
+              errors  = [];
+
+        try {
+            const {stdout} = await execFileAsync('git', ['-C', aiConfig.projectRoot, 'rev-parse', 'HEAD']);
+
+            current.gitHead = stdout.trim();
+        } catch (e) {
+            errors.push(`current gitHead unavailable: ${e.message}`);
+        }
+
+        try {
+            current.openApiDigest = createOpenApiDigest();
+        } catch (e) {
+            errors.push(`current OpenAPI digest unavailable: ${e.message}`);
+        }
+
+        return {current, errors};
     }
 
     #parseAuthOutput(out) {

--- a/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
@@ -1,0 +1,101 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GithubWorkflowHealthServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+test.describe.serial('Neo.ai.services.github-workflow.HealthService - runtimeFreshness (#12765)', () => {
+    let HealthService;
+
+    test.beforeAll(async () => {
+        HealthService = (await import('../../../../../../ai/services/github-workflow/HealthService.mjs')).default;
+    });
+
+    test.afterEach(() => {
+        HealthService.runtimeFreshnessReader = null;
+        HealthService.clearCache();
+    });
+
+    test('classifies matching boot/current identity as current', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'abc123',
+                openApiDigest: 'sha256:same'
+            },
+            current: {
+                gitHead      : 'abc123',
+                openApiDigest: 'sha256:same'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'current',
+            stale : {
+                gitHead      : false,
+                openApiDigest: false
+            },
+            hint: null
+        });
+        expect(result.details).toContain('Runtime source identity matches the current checkout.');
+    });
+
+    test('classifies stale git and OpenAPI identity with restart guidance', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'old-head',
+                openApiDigest: 'sha256:old'
+            },
+            current: {
+                gitHead      : 'new-head',
+                openApiDigest: 'sha256:new'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'stale',
+            stale : {
+                gitHead      : true,
+                openApiDigest: true
+            },
+            hint: 'Restart or reconnect the MCP client/server to refresh cached tool definitions.'
+        });
+        expect(result.details[0]).toContain('Restart or reconnect the MCP client/server');
+    });
+
+    test('classifies missing identity as unknown without throwing', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot   : {},
+            current: {},
+            errors : ['current gitHead unavailable: fixture']
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'unknown',
+            stale : {
+                gitHead      : null,
+                openApiDigest: null
+            },
+            hint: null
+        });
+        expect(result.details).toContain('current gitHead unavailable: fixture');
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12765
Related: #12740

Adds a lightweight `runtimeFreshness` diagnostic to GitHub Workflow `healthcheck()` so agents can distinguish an infrastructure-healthy but stale MCP process from missing source functionality. The service captures boot-time git/OpenAPI identity, compares it with the current checkout on healthcheck, and returns `current`, `stale`, or `unknown` with restart guidance. The OpenAPI response schema now publishes the field, and unit coverage exercises the three classifications through an injected reader without GitHub credentials.

Evidence: L2 (unit-level injected boot/current identity + MCP tool-registration contract test) -> L2 required (runtime healthcheck classification and schema contract within local unit sandbox). No residuals.

## Deltas from ticket
- Kept scope to `github-workflow` as the ticket minimum required server.
- Runtime drift is warning metadata only; it does not mark `gh` unhealthy or block normal tool calls.
- Recomputes `runtimeFreshness` when returning cached healthy `gh` status so stale-source signal is not hidden by the GitHub CLI cache.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs` passed 3/3.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs` passed 4/4.
- `git diff --check` passed.
- Pre-commit hooks passed: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`.

## Post-Merge Validation
- [ ] Restart/reconnect GitHub Workflow MCP server and confirm `healthcheck.runtimeFreshness.status` reports `current` on fresh `dev`.

## Commits
- `3c79b3911` - `fix(ai): expose mcp runtime freshness (#12765)`

## Evolution
V-B-A showed the noisy issue-list symptom was not a missing projection feature: current source and tests already had title-only projections. The implementation therefore targets the higher-value runtime freshness gap that made a stale MCP attachment look like missing source.