### PR TITLE
fix(ai): detect config leaf default drift (#12767)

### DIFF
--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -42,6 +42,195 @@ const MATERIALIZED_SERVER_IMPORTS = new Set([
 ]);
 
 /**
+ * Finds the closing parenthesis for a source-text call while ignoring quoted content.
+ *
+ * @param {String} src       Source text.
+ * @param {Number} openIndex Index of the opening `(`.
+ * @returns {Number}
+ */
+function findClosingParen(src, openIndex) {
+    let quote = null;
+    let depth = 0;
+    let escape = false;
+
+    for (let i = openIndex; i < src.length; i++) {
+        const char = src[i];
+
+        if (quote) {
+            if (escape) {
+                escape = false;
+            } else if (char === '\\') {
+                escape = true;
+            } else if (char === quote) {
+                quote = null;
+            }
+            continue
+        }
+
+        if (char === '\'' || char === '"' || char === '`') {
+            quote = char;
+            continue
+        }
+
+        if (char === '(') {
+            depth++;
+        } else if (char === ')') {
+            depth--;
+            if (depth === 0) {
+                return i
+            }
+        }
+    }
+
+    return -1
+}
+
+/**
+ * Splits a function-call argument list on top-level commas only.
+ *
+ * @param {String} src Function-call argument text without the enclosing parentheses.
+ * @returns {String[]}
+ */
+function splitTopLevelArgs(src) {
+    const args = [];
+    let quote = null;
+    let depth = 0;
+    let start = 0;
+    let escape = false;
+
+    for (let i = 0; i < src.length; i++) {
+        const char = src[i];
+
+        if (quote) {
+            if (escape) {
+                escape = false;
+            } else if (char === '\\') {
+                escape = true;
+            } else if (char === quote) {
+                quote = null;
+            }
+            continue
+        }
+
+        if (char === '\'' || char === '"' || char === '`') {
+            quote = char;
+            continue
+        }
+
+        if (char === '(' || char === '[' || char === '{') {
+            depth++;
+            continue
+        }
+
+        if (char === ')' || char === ']' || char === '}') {
+            depth--;
+            continue
+        }
+
+        if (char === ',' && depth === 0) {
+            args.push(src.slice(start, i).trim());
+            start = i + 1;
+        }
+    }
+
+    args.push(src.slice(start).trim());
+
+    return args
+}
+
+/**
+ * Extracts a plain single- or double-quoted string literal value.
+ *
+ * @param {String} src Candidate source expression.
+ * @returns {String|null}
+ */
+function stringLiteralValue(src) {
+    const value = src.trim();
+    const quote = value[0];
+
+    if ((quote === '\'' || quote === '"') && value[value.length - 1] === quote) {
+        return value.slice(1, -1)
+    }
+
+    return null
+}
+
+/**
+ * Normalizes an AiConfig `leaf()` default expression for stable source-shape comparison.
+ *
+ * @param {String} src Default-expression source.
+ * @returns {String}
+ */
+function normalizeLeafDefault(src) {
+    return src.trim().replace(/\s+/g, ' ')
+}
+
+/**
+ * Builds the same-env/type/key identity used to compare leaf defaults across files.
+ *
+ * @param {{key: String, env: String, type: String}} leaf Leaf-default descriptor.
+ * @returns {String}
+ */
+function leafDefaultIdentity(leaf) {
+    return `${leaf.key}:${leaf.env}:${leaf.type}`
+}
+
+/**
+ * Builds a stable sort key for projected leaf-default descriptors.
+ *
+ * @param {{key: String, env: String, type: String, default: String}} leaf Leaf-default descriptor.
+ * @returns {String}
+ */
+function leafDefaultSortKey(leaf) {
+    return `${leafDefaultIdentity(leaf)}:${leaf.default}`
+}
+
+/**
+ * Projects env-bound `key: leaf(default, 'ENV', 'type')` calls from config source text.
+ *
+ * @param {String} src Source text.
+ * @returns {Array<{key: String, env: String, type: String, default: String}>}
+ */
+function projectLeafDefaults(src) {
+    const leafDefaults = [];
+    const leafPattern  = /([A-Za-z_$][\w$]*)\s*:\s*leaf\s*\(/g;
+
+    for (const match of src.matchAll(leafPattern)) {
+        const openIndex  = match.index + match[0].lastIndexOf('(');
+        const closeIndex = findClosingParen(src, openIndex);
+
+        if (closeIndex === -1) continue;
+
+        const args = splitTopLevelArgs(src.slice(openIndex + 1, closeIndex));
+        if (args.length < 3) continue;
+
+        const env  = stringLiteralValue(args[1]);
+        const type = stringLiteralValue(args[2]);
+
+        if (!env || !type || !/^[A-Z][A-Z0-9_]+$/.test(env)) continue;
+
+        leafDefaults.push({
+            key    : match[1],
+            env,
+            type,
+            default: normalizeLeafDefault(args[0])
+        });
+    }
+
+    return leafDefaults.sort((a, b) => leafDefaultSortKey(a).localeCompare(leafDefaultSortKey(b)))
+}
+
+/**
+ * Formats a changed leaf default for operator-facing drift warnings.
+ *
+ * @param {{key: String, env: String, type: String, configDefault: String, templateDefault: String}} leaf Drift item.
+ * @returns {String}
+ */
+function formatChangedLeafDefault(leaf) {
+    return `${leaf.key} (${leaf.env}, ${leaf.type}): ${leaf.configDefault} -> ${leaf.templateDefault}`
+}
+
+/**
  * Projects a `.mjs` file's structural shape — the surface that `initServerConfigs`
  * watches for drift between template and gitignored config.
  *
@@ -74,9 +263,13 @@ const MATERIALIZED_SERVER_IMPORTS = new Set([
  * - **Env-var literals**: UPPER_SNAKE string literals (the `env` arg of each `leaf(...)`). New
  *   entries flag a template that added a config leaf — `data`-tree drift the import/export
  *   projection cannot see. See the inline note in {@link projectSourceShape}.
+ * - **Env-bound leaf defaults**: stable descriptors for `key: leaf(default, 'NEO_FOO', 'type')`
+ *   calls. Same-env default flips are semantic AiConfig drift; env-var projection alone treats
+ *   `leaf('gemini', 'NEO_MODEL_PROVIDER', 'string')` and
+ *   `leaf('openAiCompatible', 'NEO_MODEL_PROVIDER', 'string')` as equal.
  *
- * @param {String} filePath  Absolute path to a readable `.mjs` file.
- * @returns {Promise<{imports: String[], exports: String[], envVars: String[]}>}
+ * @param {String} src Source text to project.
+ * @returns {{imports: String[], exports: String[], envVars: String[], leafDefaults: Object[]}}
  */
 export function projectSourceShape(src) {
     const imports = [];
@@ -127,7 +320,9 @@ export function projectSourceShape(src) {
         [...src.matchAll(/['"]([A-Z][A-Z0-9_]+)['"]/g)].map(m => m[1])
     )].sort();
 
-    return {imports, exports, envVars}
+    const leafDefaults = projectLeafDefaults(src);
+
+    return {imports, exports, envVars, leafDefaults}
 }
 
 export async function projectShape(filePath) {
@@ -160,7 +355,7 @@ export function materializeServerConfigTemplate(src) {
  * Detects the narrow drift shape where an existing per-server `config.mjs`
  * only needs its Tier-1 import materialized, not a full template overwrite.
  *
- * @param {{missingImports: String[], missingExports: String[], hasDrift: Boolean}} drift
+ * @param {{missingImports: String[], missingExports: String[], missingEnvVars?: String[], changedLeafDefaults?: Object[], hasDrift: Boolean}} drift
  * @returns {Boolean}
  */
 export function isOnlyServerMaterializationDrift(drift) {
@@ -170,6 +365,7 @@ export function isOnlyServerMaterializationDrift(drift) {
         // A new env-bound leaf (data-tree drift) needs the full template refresh, not an
         // import-only patch — so env-var drift disqualifies the materialize-only fast path.
         (drift.missingEnvVars?.length ?? 0) === 0 &&
+        (drift.changedLeafDefaults?.length ?? 0) === 0 &&
         drift.missingImports.length > 0 &&
         drift.missingImports.every(i => MATERIALIZED_SERVER_IMPORTS.has(i))
     )
@@ -181,21 +377,40 @@ export function isOnlyServerMaterializationDrift(drift) {
  * config but not in template — operator-removed paths) is intentionally NOT
  * reported, since this is a one-way "template advanced, config stale" detector.
  *
- * @param {{imports: String[], exports: String[], envVars?: String[]}} templateShape
- * @param {{imports: String[], exports: String[], envVars?: String[]}} configShape
- * @returns {{missingImports: String[], missingExports: String[], missingEnvVars: String[], hasDrift: Boolean}}
+ * @param {{imports: String[], exports: String[], envVars?: String[], leafDefaults?: Object[]}} templateShape
+ * @param {{imports: String[], exports: String[], envVars?: String[], leafDefaults?: Object[]}} configShape
+ * @returns {{missingImports: String[], missingExports: String[], missingEnvVars: String[], changedLeafDefaults: Object[], hasDrift: Boolean}}
  */
 export function detectDrift(templateShape, configShape) {
     const missingImports = templateShape.imports.filter(i => !configShape.imports.includes(i));
     const missingExports = templateShape.exports.filter(e => !configShape.exports.includes(e));
     // `envVars` is optional on hand-built shapes (e.g. unit fixtures) → default to empty.
     const missingEnvVars = (templateShape.envVars || []).filter(e => !(configShape.envVars || []).includes(e));
+    const configLeafDefaults = new Map((configShape.leafDefaults || []).map(leaf => [leafDefaultIdentity(leaf), leaf]));
+    const changedLeafDefaults = (templateShape.leafDefaults || [])
+        .map(templateLeaf => {
+            const configLeaf = configLeafDefaults.get(leafDefaultIdentity(templateLeaf));
+
+            if (!configLeaf || configLeaf.default === templateLeaf.default) {
+                return null
+            }
+
+            return {
+                key            : templateLeaf.key,
+                env            : templateLeaf.env,
+                type           : templateLeaf.type,
+                templateDefault: templateLeaf.default,
+                configDefault  : configLeaf.default
+            }
+        })
+        .filter(Boolean);
 
     return {
         missingImports,
         missingExports,
         missingEnvVars,
-        hasDrift: missingImports.length + missingExports.length + missingEnvVars.length > 0
+        changedLeafDefaults,
+        hasDrift: missingImports.length + missingExports.length + missingEnvVars.length + changedLeafDefaults.length > 0
     }
 }
 
@@ -281,6 +496,7 @@ export async function initConfigs({argv = process.argv, logger = console, server
             drift.missingImports.forEach(i => logger.warn(`  + import: ${i}`));
             drift.missingExports.forEach(e => logger.warn(`  + export: ${e}`));
             drift.missingEnvVars.forEach(e => logger.warn(`  + env: ${e}`));
+            drift.changedLeafDefaults.forEach(leaf => logger.warn(`  + leaf-default: ${formatChangedLeafDefault(leaf)}`));
             logger.warn(`  Run \`npm run prepare -- ${MIGRATE_FLAG}\` to refresh (gitignored; safe).`);
             processed.push({serverName, action: 'warn', drift});
         }
@@ -346,6 +562,7 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
     drift.missingImports.forEach(i => logger.warn(`  + import: ${i}`));
     drift.missingExports.forEach(e => logger.warn(`  + export: ${e}`));
     drift.missingEnvVars.forEach(e => logger.warn(`  + env: ${e}`));
+    drift.changedLeafDefaults.forEach(leaf => logger.warn(`  + leaf-default: ${formatChangedLeafDefault(leaf)}`));
     logger.warn(`  Run \`npm run prepare -- ${MIGRATE_FLAG}\` to refresh (gitignored; safe).`);
 
     return {action: 'warn', drift}

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -26,7 +26,7 @@ import path           from 'path';
 test.describe.configure({mode: 'serial'});
 
 test.describe('initServerConfigs — template drift detection (#10815)', () => {
-    let initConfigs, projectShape, detectDrift, materializeServerConfigTemplate;
+    let initConfigs, projectSourceShape, projectShape, detectDrift, materializeServerConfigTemplate;
     let workRoot;
 
     function recordingLogger() {
@@ -61,6 +61,7 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
     test.beforeAll(async () => {
         ({
             initConfigs,
+            projectSourceShape,
             projectShape,
             detectDrift,
             materializeServerConfigTemplate
@@ -531,6 +532,98 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         // Lowercase default values + type tokens must NOT be mistaken for env vars.
         expect(shape.envVars).not.toContain('oidc');
         expect(shape.envVars).not.toContain('string');
+    });
+
+    test('leaf-default projection captures env-bound AiConfig defaults (#12767)', () => {
+        const src = [
+            `export default {`,
+            `    modelProvider: leaf('openAiCompatible', 'NEO_MODEL_PROVIDER', 'string'),`,
+            `    host         : leaf(path.resolve(neoRootDir, '.neo-ai-data/backups'), 'NEO_BACKUP_PATH', 'string'),`,
+            `    modelName    : leaf('gemini-3.5-flash')`,
+            `};`,
+            ``
+        ].join('\n');
+
+        const shape = projectSourceShape(src);
+
+        expect(shape.leafDefaults).toEqual([
+            {
+                key    : 'host',
+                env    : 'NEO_BACKUP_PATH',
+                type   : 'string',
+                default: `path.resolve(neoRootDir, '.neo-ai-data/backups')`
+            },
+            {
+                key    : 'modelProvider',
+                env    : 'NEO_MODEL_PROVIDER',
+                type   : 'string',
+                default: `'openAiCompatible'`
+            }
+        ]);
+    });
+
+    test('detectDrift reports same-env leaf default changes (#12767)', () => {
+        const templateShape = projectSourceShape([
+            `export default {`,
+            `    modelProvider: leaf('openAiCompatible', 'NEO_MODEL_PROVIDER', 'string')`,
+            `};`,
+            ``
+        ].join('\n'));
+        const configShape = projectSourceShape([
+            `export default {`,
+            `    modelProvider: leaf('gemini', 'NEO_MODEL_PROVIDER', 'string')`,
+            `};`,
+            ``
+        ].join('\n'));
+
+        const drift = detectDrift(templateShape, configShape);
+
+        expect(drift.hasDrift).toBe(true);
+        expect(drift.missingImports).toEqual([]);
+        expect(drift.missingExports).toEqual([]);
+        expect(drift.missingEnvVars).toEqual([]);
+        expect(drift.changedLeafDefaults).toEqual([{
+            key            : 'modelProvider',
+            env            : 'NEO_MODEL_PROVIDER',
+            type           : 'string',
+            templateDefault: `'openAiCompatible'`,
+            configDefault  : `'gemini'`
+        }]);
+    });
+
+    test('same-env leaf default drift warns without overwriting (#12767)', async () => {
+        const templateSrc = [
+            `export default {`,
+            `    modelProvider: leaf('openAiCompatible', 'NEO_MODEL_PROVIDER', 'string')`,
+            `};`,
+            ``
+        ].join('\n');
+        const configSrc = [
+            `export default {`,
+            `    modelProvider: leaf('gemini', 'NEO_MODEL_PROVIDER', 'string')`,
+            `};`,
+            ``
+        ].join('\n');
+        const root = buildServerSandbox({
+            sandboxName     : 'leaf-default-drift-warn',
+            templateContents: templateSrc,
+            configContents  : configSrc
+        });
+
+        const logger = recordingLogger();
+        const result = await initConfigs({argv: ['node', 'initServerConfigs.mjs'], logger, serversRoot: root});
+
+        const action = result.processed.find(p => p.serverName === 'memory-core');
+        expect(action.action).toBe('warn');
+        expect(action.drift.changedLeafDefaults).toEqual([{
+            key            : 'modelProvider',
+            env            : 'NEO_MODEL_PROVIDER',
+            type           : 'string',
+            templateDefault: `'openAiCompatible'`,
+            configDefault  : `'gemini'`
+        }]);
+        expect(logger.entries.warn.some(l => l.includes("+ leaf-default: modelProvider (NEO_MODEL_PROVIDER, string): 'gemini' -> 'openAiCompatible'"))).toBe(true);
+        expect(fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8')).toBe(configSrc);
     });
 
     test('detectDrift reports a new env-bound leaf as missingEnvVars (data-tree drift the import projection misses)', () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12767
Related: #12740

Extends `initServerConfigs.mjs` drift detection so env-bound AiConfig leaf defaults participate in source-shape comparison. Existing gitignored overlays that still default `NEO_MODEL_PROVIDER` to Gemini now surface as drift instead of reporting `hasDrift: false`.

Evidence: L1 (static config-shape audit plus focused source-projection unit coverage) -> L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket
- Captures source-text descriptors for env-bound `key: leaf(default, ENV, type)` calls using a small balanced scanner, not the live AiConfig singleton.
- Adds `changedLeafDefaults` to `detectDrift()` and warning output.
- Keeps existing import/export/env-var drift behavior and current migrate semantics unchanged.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` — 23 passed.
- Real local overlay reproducer now reports `changedLeafDefaults` for stale `chatProvider` and `modelProvider` defaults, with `hasDrift: true`.
- `git diff --check` passed.

## Post-Merge Validation
- [ ] Operator can run `npm run prepare -- --migrate-config` when ready to refresh gitignored overlays; the detector will now warn before that refresh.

## Commit
- `d5314ed1c` — `fix(ai): detect config leaf default drift (#12767)`