### PR TITLE
test(ai): opt-in gate for live agent-loop specs, not key-presence (#12747)

### DIFF
--- a/test/playwright/unit/ai/agent/Librarian.spec.mjs
+++ b/test/playwright/unit/ai/agent/Librarian.spec.mjs
@@ -41,7 +41,7 @@ test.describe('Librarian Sub-Agent Orchestration', () => {
         test.setTimeout(180_000);
 
         // Skip test in CI environments without API keys
-        test.skip(!process.env.GEMINI_API_KEY, 'Skipping: GEMINI_API_KEY not found');
+        test.skip(!process.env.NEO_RUN_LIVE_AI_TESTS, 'Skipping live agent-loop test (real inference); set NEO_RUN_LIVE_AI_TESTS=1 to run');
 
         // Note: The primary agent itself does not need any MCP servers connected.
         // It relies purely on the delegation architecture to communicate with the sub-agent.
@@ -54,12 +54,12 @@ test.describe('Librarian Sub-Agent Orchestration', () => {
         // We wrap the delegate method to verify it was executed correctly natively
         let delegateCalled      = false;
         let delegatedAgentAlias = null;
-        
+
         const originalDelegate = primaryAgent.delegate;
         primaryAgent.delegate = async function(profileName, request) {
             delegateCalled      = true;
             delegatedAgentAlias = profileName;
-            
+
             // Execute the true delegation and sub-agent boot
             return await originalDelegate.call(this, profileName, request);
         };

--- a/test/playwright/unit/ai/agent/QA.spec.mjs
+++ b/test/playwright/unit/ai/agent/QA.spec.mjs
@@ -53,9 +53,9 @@ test.describe('QA Sub-Agent Swarm Node', () => {
 
     test('Primary Agent delegates unit testing task to QA via Gemma4/Ollama', async () => {
         // Skip test in CI environments or if we explicitly don't have a local daemon
-        // Since this relies on a local Ollama daemon hosting gemma-4, we just let it run locally 
+        // Since this relies on a local Ollama daemon hosting gemma-4, we just let it run locally
         // to evaluate the Swarm's intelligence.
-        test.skip(!!process.env.NEO_TEST_SKIP_CI || !process.env.GEMINI_API_KEY, 'CI-skip: missing GEMINI_API_KEY - bucket G1 (#10924)');
+        test.skip(!process.env.NEO_RUN_LIVE_AI_TESTS, 'Skipping live agent-loop test (real inference); set NEO_RUN_LIVE_AI_TESTS=1 to run');
         test.setTimeout(120000); // Give Gemma4 up to 2 minutes to generate the test code
 
         // The primary orchestrator boots up
@@ -73,7 +73,7 @@ test.describe('QA Sub-Agent Swarm Node', () => {
         Return ONLY the code block and nothing else.
         `;
 
-        // We DO NOT mock the delegate method here. We want to actually hit the local Gemma-4 node 
+        // We DO NOT mock the delegate method here. We want to actually hit the local Gemma-4 node
         // through the Ollama provider to evaluate its ability to follow the System Prompt rules.
         console.log('Sending request to local Gemma4 Swarm node...');
         const generatedCode = await primaryAgent.delegate('qa', request);


### PR DESCRIPTION
Resolves #12747

Authored by Claude Opus 4.8 (Claude Code). Session 64fd183e-d252-4520-af42-3e2063a954d8.

`QA.spec.mjs` + `Librarian.spec.mjs` run the real agent loop gated on `test.skip(!process.env.GEMINI_API_KEY)` — so a *present* key (a dev `.env`) made them run **live/billed on every test pass**. This is a **latent test-isolation hazard surfaced by** the 2026-06-08 cost incident — **not its root**: per #12743 the incident's attribution lead is the miniSummary backfill, the single-checkout volume doesn't reconcile to the peak alone, and final attribution is blocked on a Cloud Billing export. This PR closes the test-surface hazard (a sibling cost-safety gap), not the incident's causation. The gate inverts to an explicit opt-in: `test.skip(!process.env.NEO_RUN_LIVE_AI_TESTS)` — both specs **skip by default** (dev + CI), run only when `NEO_RUN_LIVE_AI_TESTS=1`. QA's gate was doubly wrong: a local-Gemma4 test gated on the *remote* key.

Evidence: L1 (unit: both specs skip by default — verified `2 skipped` with `NEO_RUN_LIVE_AI_TESTS` unset → zero live/billed calls). The opted-in path resolving local is covered by the merged provider-default flip (#12760).

## Deltas from ticket
- AC1 (opt-in gate) is the change. **AC2** (default runs resolve local by construction) is satisfied two ways: by default the specs **skip** (no provider resolution at all), and when opted-in the loop resolves `openAiCompatible` local via the merged #12760 default — no AiConfig forcing needed. **AC3** (no AiConfig singleton mutation) holds — gate-only change.
- Stripped 4 pre-existing trailing-whitespace lines the whole-file `check-whitespace` hook flagged in the touched files.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  ai/agent/QA.spec ai/agent/Librarian.spec
→ 2 skipped   (NEO_RUN_LIVE_AI_TESTS unset — the safety property)
```

## Post-Merge Validation
- [ ] None — the safety property is *skip-by-default* (verified in-test). Opted-in live runs are an explicit operator action (`NEO_RUN_LIVE_AI_TESTS=1`).

## Coordination
Sibling cost-safety hazard to @neo-gpt's #12740 lanes; the incident's **root attribution stays with #12743** (backfill / billing reconciliation). Gate-only test change on a distinct surface — no collision.

Refs #12740
Refs #12743
Refs #12435
