### PR TITLE
fix(build): recency-tier release-note SEO priority (#12753)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -132,13 +132,49 @@ const PRIORITIES = new Map([
 const DEFAULT_PRIORITY = 0.5;
 
 /**
+ * Recency-tiered priority for `/news/releases/` routes, indexed by delta from the newest
+ * release-note major. The current and most-recent major stay high; older patch notes decay
+ * below the curated evergreen tier so the sitemap `<priority>` stays a useful crawl-budget
+ * hint instead of a flat wall of release notes.
+ * @type {Number[]}
+ */
+const RELEASE_PRIORITY_BY_DELTA = [0.9, 0.9, 0.7, 0.6, 0.5]; // index = newestMajor - releaseMajor; delta >= 5 -> 0.4
+
+/**
+ * Newest release-note major, set by `collectReleaseRoutes`; anchors the recency delta.
+ * Deliberately NOT the `package.json` major, which lags the in-progress release.
+ * @type {Number|null}
+ */
+let maxReleaseMajor = null;
+
+/**
+ * Resolves the recency-tiered priority for a release-note version.
+ *
+ * Anchored on the newest release-note major so the tiers self-maintain as new majors ship.
+ * Returns `DEFAULT_PRIORITY` when the version is unparseable or the anchor is unknown.
+ *
+ * @param {String} version Release-note version (e.g. `12.1.0`).
+ * @param {Number|null} [maxMajor=maxReleaseMajor] Newest release-note major.
+ * @returns {Number}
+ */
+export function getReleaseNotePriority(version, maxMajor=maxReleaseMajor) {
+    const major = semver.coerce(version)?.major;
+
+    if (major == null || maxMajor == null) {
+        return DEFAULT_PRIORITY;
+    }
+
+    return RELEASE_PRIORITY_BY_DELTA[maxMajor - major] ?? 0.4;
+}
+
+/**
  * Gets the priority for a given route ID.
  * @param {String} id The route ID
  * @returns {Number} The priority value
  */
 function getPriority(id) {
     if (id.startsWith('/news/releases/')) {
-        return 0.9;
+        return getReleaseNotePriority(id.slice('/news/releases/'.length));
     }
 
     if (id.startsWith('/news/tickets/')) {
@@ -574,7 +610,7 @@ async function collectReleaseRoutes() {
         };
     }));
 
-    return releases.sort((a, b) => {
+    const sorted = releases.sort((a, b) => {
         const vA = semver.valid(a.version) || semver.coerce(a.version)?.version;
         const vB = semver.valid(b.version) || semver.coerce(b.version)?.version;
         if (vA && vB) {
@@ -582,6 +618,13 @@ async function collectReleaseRoutes() {
         }
         return 0;
     });
+
+    // Anchor the recency tiers on the newest release-note major (see getReleaseNotePriority).
+    const majors = releases.map(release => semver.coerce(release.version)?.major).filter(major => major != null);
+
+    maxReleaseMajor = majors.length ? Math.max(...majors) : null;
+
+    return sorted;
 }
 
 /**

--- a/test/playwright/unit/ai/buildScripts/docs/seo/Generate.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/seo/Generate.spec.mjs
@@ -5,7 +5,8 @@ import fg             from 'fast-glob';
 
 import {
     assertStableReleaseNoteGithubLinks,
-    getMutableReleaseNoteGithubLinks
+    getMutableReleaseNoteGithubLinks,
+    getReleaseNotePriority
 } from '../../../../../../../buildScripts/docs/seo/generate.mjs';
 
 test.describe('docs SEO generator release-note link guard', () => {
@@ -50,5 +51,33 @@ test.describe('docs SEO generator release-note link guard', () => {
         }
 
         expect(violations).toEqual([]);
+    });
+});
+
+test.describe('docs SEO generator release-note recency priority (#12753)', () => {
+    // Anchored on the newest release-note major = 13 (matches @tobiu's confirmed mapping).
+    test('current + most-recent major stay at 0.9', () => {
+        expect(getReleaseNotePriority('13.0.0', 13)).toBe(0.9);
+        expect(getReleaseNotePriority('12.1.0', 13)).toBe(0.9);
+    });
+
+    test('older majors decay below the evergreen 0.7+ tier', () => {
+        expect(getReleaseNotePriority('11.0.0', 13)).toBe(0.7);
+        expect(getReleaseNotePriority('10.5.0', 13)).toBe(0.6);
+        expect(getReleaseNotePriority('9.0.0',  13)).toBe(0.5);
+        expect(getReleaseNotePriority('8.1.2',  13)).toBe(0.4);
+        expect(getReleaseNotePriority('7.0.0',  13)).toBe(0.4); // delta 6 -> ancient floor
+    });
+
+    test('unparseable version or unknown anchor falls back to DEFAULT_PRIORITY (0.5)', () => {
+        expect(getReleaseNotePriority('not-a-version', 13)).toBe(0.5);
+        expect(getReleaseNotePriority('12.1.0', null)).toBe(0.5);
+    });
+
+    test('self-maintaining: re-anchoring on a newer major shifts the tiers down', () => {
+        // Once v14 ships, v14/v13 stay 0.9 and v12 decays to 0.7 — no code change needed.
+        expect(getReleaseNotePriority('14.0.0', 14)).toBe(0.9);
+        expect(getReleaseNotePriority('13.0.0', 14)).toBe(0.9);
+        expect(getReleaseNotePriority('12.0.0', 14)).toBe(0.7);
     });
 });


### PR DESCRIPTION
Resolves #12753

Authored by Claude Opus 4.8 (@neo-opus-vega, Claude Code). Session 728442d6-a2a0-4481-a631-a3112ce6d703.

`buildScripts/docs/seo/generate.mjs` `getPriority()` gave **every** `/news/releases/` route a flat `0.9`. Once #12728's recursive glob made the generator collect all 167 release notes, a sitemap regen emitted the whole catalog at `0.9` — value-inverting 5-year-old `v8` patch notes *above* the curated evergreen guides/blog (`0.7–0.8`) and diluting `<priority>` as a crawl-budget hint.

`getPriority()` now resolves `/news/releases/` via a new pure `getReleaseNotePriority(version)` — a recency tier **anchored on the newest release-note major** (deliberately NOT `package.json`, which lags the in-progress v13), so the tiers self-maintain as new majors ship. The curated evergreen `PRIORITIES` map is **unchanged** — it now genuinely outranks decayed old release notes.

| Releases (anchor = newest major, currently 13) | Priority |
|---|---|
| v13 / v12 (δ0–1, current + recent) | 0.9 |
| v11 (δ2) | 0.7 |
| v10 (δ3) | 0.6 |
| v9 (δ4) | 0.5 (= `DEFAULT_PRIORITY` → omitted from sitemap) |
| v8 and older (δ5+) | 0.4 |

@tobiu confirmed v13/v12 = `0.9` and v11 = `0.7`; the v10–v8 decay is my extension for a smooth fall below the evergreen `0.7+` tier — **please adjust the older-tier values in review if you'd prefer different.**

**Shape chosen:** delta-from-newest-major (self-maintaining) over a static per-major map — when v14 ships, v14/v13 stay `0.9` and v12 decays to `0.7` with no code change. Trivially switchable to an explicit static map if you'd rather tune per-release.

Evidence: unit — the #12753 ACs are a pure-function priority resolver, fully covered by unit tests (tier per major + fallback + self-maintaining re-anchor); evidence-ladder N/A (no runtime-effect AC a sandbox can't reach). The one runtime effect — the sitemap regen — is the Post-Merge Validation below. No residuals.

## Deltas from ticket
- Implemented shape **(a)** (delta-from-newest-major), not (b) (static map) — settled per the ticket's "settle in PR"; rationale: self-maintaining + reproduces the operator-confirmed values exactly. Trivially switchable.
- `getReleaseNotePriority` is `export`ed (matching the existing `getMutableReleaseNoteGithubLinks` / `assertStableReleaseNoteGithubLinks` test-export pattern) so the tiers are unit-testable as a pure function.
- `maxReleaseMajor` is a module-level anchor set by `collectReleaseRoutes` (which already parses + semver-sorts the versions); `getReleaseNotePriority` takes it as an overridable param (default = the module anchor) for pure testability.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/docs/seo/Generate.spec.mjs` → **7/7 passed** (700ms): 4 new recency-tier cases (current/recent `0.9`; older decay; unparseable/null-anchor fallback to `0.5`; self-maintaining re-anchor) + the 3 existing link-guard regression tests.
- `node --check buildScripts/docs/seo/generate.mjs` → parse OK.
- husky pre-commit (`check-whitespace` / `check-shorthand` / `check-ticket-archaeology`) passed.

## Post-Merge Validation
- [ ] Regenerate the sitemap on merged code; confirm `/news/releases/` priorities match the tiers (v13/v12 → `0.9`, v11 → `0.7`, v9 omitted as `DEFAULT`, v8 → `0.4`) and that old release notes sit below the evergreen guides/blog.

## Commits
- `241c96990` — fix(build): recency-tier release-note SEO priority (#12753)

Decision Record impact: none (heuristic tuning of an existing build-script resolver; no ADR).

Related: #12728
Related: #12749
Related: #12696
