### PR TITLE
feat(memory-core): add runtime freshness healthcheck (#12772)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1550,6 +1550,76 @@ components:
           format: date-time
           description: The ISO 8601 timestamp of when the health check was performed.
           example: "2025-10-24T10:00:00.000Z"
+        runtimeFreshness:
+          type: object
+          description: "Boot-vs-current Memory Core MCP runtime identity. Stale is diagnostic metadata, not a service outage."
+          properties:
+            status:
+              type: string
+              enum: [current, stale, unknown]
+              example: "current"
+            startedAt:
+              type: string
+              format: date-time
+              description: "ISO timestamp captured when the Memory Core service module loaded."
+              example: "2026-06-08T15:00:00.000Z"
+            boot:
+              type: object
+              description: "Source/config/schema identity captured at MCP process boot."
+              properties:
+                gitHead:
+                  type: string
+                  nullable: true
+                  example: "5c5723cdd2e2f7d2a7c4e6e63f8c3ab4c5d6e7f8"
+                configDigest:
+                  type: string
+                  nullable: true
+                  example: "sha256:5e9a2d3f..."
+                openApiDigest:
+                  type: string
+                  nullable: true
+                  example: "sha256:1f2a3b4c..."
+            current:
+              type: object
+              description: "Source/config/schema identity read from the current checkout."
+              properties:
+                gitHead:
+                  type: string
+                  nullable: true
+                  example: "5c5723cdd2e2f7d2a7c4e6e63f8c3ab4c5d6e7f8"
+                configDigest:
+                  type: string
+                  nullable: true
+                  example: "sha256:5e9a2d3f..."
+                openApiDigest:
+                  type: string
+                  nullable: true
+                  example: "sha256:1f2a3b4c..."
+            stale:
+              type: object
+              description: "Per-field stale comparison. Null means the field could not be compared."
+              properties:
+                gitHead:
+                  type: boolean
+                  nullable: true
+                  example: false
+                configDigest:
+                  type: boolean
+                  nullable: true
+                  example: false
+                openApiDigest:
+                  type: boolean
+                  nullable: true
+                  example: false
+            details:
+              type: array
+              items:
+                type: string
+              example: ["Runtime source/config identity matches the current checkout."]
+            hint:
+              type: string
+              nullable: true
+              example: null
         session:
           type: object
           properties:

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1,3 +1,6 @@
+import {execFileSync}           from 'child_process';
+import {createHash}             from 'crypto';
+import {readFileSync}           from 'fs';
 import fs                       from 'fs/promises';
 import fsExtra                  from 'fs-extra';
 import path                     from 'path';
@@ -17,6 +20,156 @@ import {
 import {readRecentRemRunStates} from './helpers/remRunStateStore.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const
+    configPath  = path.resolve(__dirname, '../../config.mjs'),
+    openApiPath = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
+    startedAt   = new Date().toISOString();
+
+/**
+ * @summary Computes a stable SHA-256 digest for runtime freshness file identity.
+ * @param {String} filePath Absolute file path.
+ * @returns {String}
+ */
+function createFileDigest(filePath) {
+    const contents = readFileSync(filePath);
+
+    return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
+}
+
+/**
+ * @summary Reads the current checkout HEAD for the Memory Core runtime identity block.
+ * @returns {String}
+ */
+function readGitHead() {
+    const stdout = execFileSync('git', ['-C', aiConfig.neoRootDir, 'rev-parse', 'HEAD'], {
+        encoding: 'utf8',
+        stdio   : ['ignore', 'pipe', 'pipe']
+    });
+
+    return stdout.trim();
+}
+
+/**
+ * @summary Reads source, config, and schema identity for runtime freshness comparison.
+ * @returns {{identity: Object, errors: String[]}}
+ */
+function readRuntimeIdentity() {
+    const errors = [],
+          identity = {};
+
+    try {
+        identity.gitHead = readGitHead();
+    } catch (e) {
+        errors.push(`gitHead unavailable: ${e.message}`);
+    }
+
+    try {
+        identity.configDigest = createFileDigest(configPath);
+    } catch (e) {
+        errors.push(`config digest unavailable: ${e.message}`);
+    }
+
+    try {
+        identity.openApiDigest = createFileDigest(openApiPath);
+    } catch (e) {
+        errors.push(`OpenAPI digest unavailable: ${e.message}`);
+    }
+
+    return {identity, errors};
+}
+
+const initialRuntimeIdentity = readRuntimeIdentity();
+
+/**
+ * @summary Normalizes comparable runtime identity values.
+ * @param {*} value Candidate identity field value.
+ * @returns {String|null}
+ */
+function normalizeRuntimeIdentityValue(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed || null;
+}
+
+/**
+ * @summary Compares one boot/current runtime identity field.
+ * @param {String} field Field name to compare.
+ * @param {Object} boot Boot-time identity.
+ * @param {Object} current Current identity.
+ * @returns {Boolean|null}
+ */
+function compareRuntimeIdentityField(field, boot, current) {
+    const
+        bootValue    = normalizeRuntimeIdentityValue(boot[field]),
+        currentValue = normalizeRuntimeIdentityValue(current[field]);
+
+    if (!bootValue || !currentValue) {
+        return null;
+    }
+
+    return bootValue !== currentValue;
+}
+
+/**
+ * @summary Classifies boot-vs-current Memory Core MCP runtime identity.
+ *
+ * `status:'stale'` is a diagnostic warning, not a hard outage. The MCP process can
+ * still answer read-only calls while warning agents to restart before asserting provider,
+ * config, or schema facts.
+ *
+ * @param {Object} options
+ * @param {String} options.startedAt Runtime start timestamp.
+ * @param {Object} options.boot Boot-time source/config/schema identity.
+ * @param {Object} options.current Current checkout/config/schema identity.
+ * @param {String[]} options.errors Optional identity-read errors.
+ * @returns {Object}
+ */
+export function classifyRuntimeFreshness({startedAt, boot = {}, current = {}, errors = []} = {}) {
+    const stale = {
+        gitHead      : compareRuntimeIdentityField('gitHead', boot, current),
+        configDigest : compareRuntimeIdentityField('configDigest', boot, current),
+        openApiDigest: compareRuntimeIdentityField('openApiDigest', boot, current)
+    };
+    const comparableFields = Object.values(stale).filter(value => value !== null),
+          staleFields      = Object.entries(stale)
+                              .filter(([, value]) => value === true)
+                              .map(([key]) => key),
+          details          = [];
+
+    let status;
+
+    if (staleFields.length) {
+        status = 'stale';
+        details.push(`Runtime source/config identity differs from the current checkout (${staleFields.join(', ')}). Restart or reconnect the Memory Core MCP server before asserting provider, config, or tool-schema facts.`);
+    } else if (comparableFields.length) {
+        status = 'current';
+        details.push('Runtime source/config identity matches the current checkout.');
+    } else {
+        status = 'unknown';
+        details.push('Runtime source/config identity could not be compared; git metadata, config digest, and OpenAPI digest reads were unavailable or incomplete.');
+    }
+
+    for (const error of errors.filter(Boolean)) {
+        details.push(error);
+    }
+
+    return {
+        status,
+        startedAt,
+        boot,
+        current,
+        stale,
+        details,
+        hint: status === 'stale'
+            ? 'Restart or reconnect the Memory Core MCP server to refresh cached provider/config state.'
+            : null
+    };
+}
 
 /**
  * @summary Heartbeat-liveness file path resolution shared with `SwarmHeartbeatService`.
@@ -900,6 +1053,30 @@ class HealthService extends Base {
     #stdioIdentityState = null;
 
     /**
+     * Boot-time runtime identity captured before long-lived MCP clients can go stale.
+     * @member {Object} bootRuntimeIdentity
+     */
+    bootRuntimeIdentity = initialRuntimeIdentity.identity;
+
+    /**
+     * Boot-time runtime identity read errors.
+     * @member {String[]} bootRuntimeFreshnessErrors
+     */
+    bootRuntimeFreshnessErrors = initialRuntimeIdentity.errors;
+
+    /**
+     * Optional unit-test seam for injecting boot/current runtime identity reads.
+     * @member {Function|null} runtimeFreshnessReader
+     */
+    runtimeFreshnessReader = null;
+
+    /**
+     * ISO timestamp captured when this service module was loaded.
+     * @member {String} runtimeStartedAt
+     */
+    runtimeStartedAt = startedAt;
+
+    /**
      * Checks if the active vector and graph databases are running and accessible.
      * @returns {Promise<Object>} {running: boolean, error: string|undefined, engines: Object}
      * @private
@@ -1022,8 +1199,9 @@ class HealthService extends Base {
 
         const freshPayload = {
             ...cachedHealth,
-            timestamp: new Date(now).toISOString(),
-            database : {
+            timestamp       : new Date(now).toISOString(),
+            runtimeFreshness: await this.resolveRuntimeFreshness(),
+            database        : {
                 ...database,
                 connection: {
                     ...connection,
@@ -1192,6 +1370,66 @@ class HealthService extends Base {
         return buildChromaMigrationStats(metadatas, options);
     }
 
+    /**
+     * Reads current source/config/schema identity for the attached MCP process.
+     *
+     * Intent: the running Memory Core server can stay healthy while stale relative to the
+     * checkout/config the operator just migrated. This lightweight reader compares process
+     * boot identity to the current filesystem without re-importing or mutating AiConfig.
+     *
+     * @returns {{boot: Object, current: Object, errors: String[]}}
+     * @private
+     */
+    #readCurrentRuntimeIdentity() {
+        const {identity, errors} = readRuntimeIdentity();
+
+        return {
+            boot   : this.bootRuntimeIdentity,
+            current: identity,
+            errors
+        };
+    }
+
+    /**
+     * Resolves the live runtime freshness diagnostic for the attached Memory Core MCP process.
+     *
+     * A stale runtime is a warning, not a service outage: callers can still use healthy read
+     * paths while being told to restart before asserting provider/config/schema state.
+     *
+     * @returns {Promise<Object>} Runtime freshness diagnostic payload.
+     */
+    async resolveRuntimeFreshness() {
+        try {
+            const identity = this.runtimeFreshnessReader
+                ? await this.runtimeFreshnessReader()
+                : this.#readCurrentRuntimeIdentity();
+
+            const runtimeErrors = Array.isArray(identity.errors)
+                ? identity.errors
+                : [identity.errors].filter(Boolean);
+
+            return classifyRuntimeFreshness({
+                startedAt: this.runtimeStartedAt,
+                boot     : identity.boot || this.bootRuntimeIdentity,
+                current  : identity.current || {},
+                errors   : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    ...runtimeErrors
+                ]
+            });
+        } catch (e) {
+            return classifyRuntimeFreshness({
+                startedAt: this.runtimeStartedAt,
+                boot     : this.bootRuntimeIdentity,
+                current  : {},
+                errors   : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    `runtime freshness reader failed: ${e.message}`
+                ]
+            });
+        }
+    }
+
 
 
     #checkApiKeyConfigured() {
@@ -1295,9 +1533,10 @@ class HealthService extends Base {
         const { default: MailboxService } = await import('./MailboxService.mjs');
 
         const payload = {
-            status   : 'healthy',
-            timestamp: new Date().toISOString(),
-            session  : {
+            status          : 'healthy',
+            timestamp       : new Date().toISOString(),
+            runtimeFreshness: await this.resolveRuntimeFreshness(),
+            session         : {
                 currentId: Neo.ns('Neo.ai.services.memory-core.SessionService', false)?.currentSessionId
             },
             database : {

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -201,6 +201,106 @@ test.describe('HealthService #11009 — buildTaskOutcomesBlock', () => {
 });
 
 /**
+ * @summary Coverage for the Memory Core runtime freshness diagnostic.
+ *
+ * The incident was a healthy long-lived MCP process reporting stale provider/config state after
+ * `ai/config.mjs` had been migrated on disk. These tests pin the pure classification contract and
+ * the injected reader seam without restarting a live MCP server.
+ *
+ * @see Neo.ai.services.memory-core.HealthService#resolveRuntimeFreshness
+ */
+test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
+    let HealthService;
+
+    test.beforeAll(async () => {
+        HealthService = (await import('../../../../../../ai/services/memory-core/HealthService.mjs')).default;
+    });
+
+    test.afterEach(() => {
+        HealthService.runtimeFreshnessReader = null;
+        HealthService.clearCache();
+    });
+
+    test('classifies matching boot/current identity as current', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'abc123',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current: {
+                gitHead      : 'abc123',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'current',
+            stale : {
+                gitHead      : false,
+                configDigest : false,
+                openApiDigest: false
+            },
+            hint: null
+        });
+        expect(result.details).toContain('Runtime source/config identity matches the current checkout.');
+    });
+
+    test('classifies stale config identity with restart guidance', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'abc123',
+                configDigest : 'sha256:old-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current: {
+                gitHead      : 'abc123',
+                configDigest : 'sha256:new-config',
+                openApiDigest: 'sha256:same-openapi'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'stale',
+            stale : {
+                gitHead      : false,
+                configDigest : true,
+                openApiDigest: false
+            },
+            hint: 'Restart or reconnect the Memory Core MCP server to refresh cached provider/config state.'
+        });
+        expect(result.details[0]).toContain('Memory Core MCP server');
+        expect(result.details[0]).toContain('configDigest');
+    });
+
+    test('classifies missing identity as unknown without throwing', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot   : {},
+            current: {},
+            errors : ['current config digest unavailable: fixture']
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'unknown',
+            stale : {
+                gitHead      : null,
+                configDigest : null,
+                openApiDigest: null
+            },
+            hint: null
+        });
+        expect(result.details).toContain('current config digest unavailable: fixture');
+    });
+});
+
+/**
  * @summary Coverage for the request-fresh cached healthcheck path.
  *
  * The live bug was in the healthy-cache fast path: direct healthcheck callers observed the cached
@@ -275,6 +375,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         process.env.GEMINI_API_KEY               = 'unit-test-key';
 
         HealthService.setStdioIdentityState(null);
+        HealthService.runtimeFreshnessReader = null;
         HealthService.clearCache();
     });
 
@@ -297,6 +398,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         TextEmbeddingService.embedText            = originalEmbedText;
 
         HealthService.setStdioIdentityState(null);
+        HealthService.runtimeFreshnessReader = null;
         HealthService.clearCache();
     });
 
@@ -328,6 +430,44 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         const ensureHealthyFastPath = await HealthService.healthcheck({freshObservability: false});
         expect(ensureHealthyFastPath).toBe(cached);
         expect(ensureHealthyFastPath.database.connection.collections.memories.count).toBe(10);
+    });
+
+    test('direct healthcheck refreshes runtime freshness while reusing cached dependency status', async () => {
+        let currentConfigDigest = 'sha256:boot-config';
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'abc123',
+                configDigest : 'sha256:boot-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current: {
+                gitHead      : 'abc123',
+                configDigest : currentConfigDigest,
+                openApiDigest: 'sha256:same-openapi'
+            }
+        });
+
+        const cached = await HealthService.healthcheck();
+
+        expect(cached.status).toBe('healthy');
+        expect(cached.runtimeFreshness.status).toBe('current');
+
+        currentConfigDigest = 'sha256:migrated-config';
+        Date.now = () => originalDateNow() + 60_000;
+
+        const fresh = await HealthService.healthcheck();
+
+        expect(fresh.status).toBe('healthy');
+        expect(fresh.runtimeFreshness).toMatchObject({
+            status: 'stale',
+            stale : {
+                gitHead      : false,
+                configDigest : true,
+                openApiDigest: false
+            }
+        });
+        expect(fresh.runtimeFreshness.hint).toContain('Memory Core MCP server');
+        expect(fresh.database.connection.collections.memories.count).toBe(10);
     });
 
     test('direct healthcheck reuses a recent healthy embedding write canary', async () => {


### PR DESCRIPTION
Resolves #12772

Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Adds a compact top-level `runtimeFreshness` diagnostic to Memory Core healthcheck so agents can distinguish current source/config from a stale long-lived MCP process. The field compares boot-time and current git/config/OpenAPI identity, treats stale runtime as warning metadata instead of an outage, and refreshes the diagnostic even when the broader healthy healthcheck payload is served through the cached fast path.

Evidence: L2 (focused HealthService unit coverage + OpenAPI schema update) -> L2 required (schema + injected-reader runtime-freshness ACs). Residual: live MCP restart confirmation after merge.

## Deltas from Ticket

- Added `configDigest` alongside `gitHead` and `openApiDigest` because the incident class was specifically a migrated `ai/config.mjs` overlay with an unrestarted MCP process.
- Kept `status` unchanged when runtime freshness is `stale`; this is observability, not a dependency failure.
- Coordinated with `#12768` by keeping the payload compact and avoiding Chroma scans, mailbox previews, or migration census expansion.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 60 passed.
- `git diff --check` passed.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing branch contained only `fc423ef34`.

## Post-Merge Validation

- [ ] Restart or reconnect the Memory Core MCP server and verify `healthcheck.runtimeFreshness.status` is `current` on the refreshed runtime.
- [ ] Optional live proof: change the ignored config overlay without restarting and verify the old process reports `runtimeFreshness.status: stale` with a restart hint.

Related: #12740
Refs #12768

## Commit

- `fc423ef34` — `feat(memory-core): add runtime freshness healthcheck (#12772)`