### PR TITLE
feat(knowledge-base): add runtime freshness healthcheck (#12774)

### DIFF
--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -588,6 +588,39 @@ components:
           format: date-time
           description: Timestamp of when the health check was performed.
           example: "2025-10-25T12:00:00Z"
+        runtimeFreshness:
+          type: object
+          description: Compact boot-vs-current runtime freshness diagnostic for detecting stale Knowledge Base MCP process attachments.
+          properties:
+            status:
+              type: string
+              enum: [current, stale, unknown]
+              description: Whether the running MCP process matches comparable current checkout/config/OpenAPI identity.
+            startedAt:
+              type: string
+              format: date-time
+              description: When the MCP runtime module was loaded.
+            stale:
+              type: object
+              description: Per-identity stale flags. Null means the field could not be compared.
+              properties:
+                gitHead:
+                  type: boolean
+                  nullable: true
+                configDigest:
+                  type: boolean
+                  nullable: true
+                openApiDigest:
+                  type: boolean
+                  nullable: true
+            details:
+              type: array
+              items:
+                type: string
+            hint:
+              type: string
+              nullable: true
+              description: Restart or re-handshake guidance when the runtime is stale.
         database:
           type: object
           properties:

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -1,8 +1,138 @@
+import {execFile, execFileSync} from 'child_process';
+import {createHash}             from 'crypto';
+import {readFileSync}           from 'fs';
+import path                     from 'path';
+import {fileURLToPath}          from 'url';
+import {promisify}              from 'util';
 import aiConfig                 from '../../mcp/server/knowledge-base/config.mjs';
 import Base                     from '../../../src/core/Base.mjs';
 import ChromaManager            from './ChromaManager.mjs';
 import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
 import logger                   from '../../mcp/server/knowledge-base/logger.mjs';
+
+const
+    execFileAsync = promisify(execFile),
+    serviceDir    = path.dirname(fileURLToPath(import.meta.url)),
+    configPath    = path.resolve(serviceDir, '../../config.mjs'),
+    openApiPath   = path.resolve(serviceDir, '../../mcp/server/knowledge-base/openapi.yaml'),
+    startedAt     = new Date().toISOString();
+
+function createFileDigest(filePath) {
+    const contents = readFileSync(filePath);
+
+    return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
+}
+
+function readBootGitHead() {
+    const stdout = execFileSync('git', ['-C', aiConfig.neoRootDir, 'rev-parse', 'HEAD'], {
+        encoding: 'utf8',
+        stdio   : ['ignore', 'pipe', 'pipe']
+    });
+
+    return stdout.trim();
+}
+
+function readBootRuntimeIdentity() {
+    const errors = [],
+          boot   = {};
+
+    try {
+        boot.gitHead = readBootGitHead();
+    } catch (e) {
+        errors.push(`boot gitHead unavailable: ${e.message}`);
+    }
+
+    try {
+        boot.configDigest = createFileDigest(configPath);
+    } catch (e) {
+        errors.push(`boot config digest unavailable: ${e.message}`);
+    }
+
+    try {
+        boot.openApiDigest = createFileDigest(openApiPath);
+    } catch (e) {
+        errors.push(`boot OpenAPI digest unavailable: ${e.message}`);
+    }
+
+    return {boot, errors};
+}
+
+const initialRuntimeIdentity = readBootRuntimeIdentity();
+
+function normalizeString(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed || null;
+}
+
+function compareRuntimeIdentityField(field, boot, current) {
+    const
+        bootValue    = normalizeString(boot[field]),
+        currentValue = normalizeString(current[field]);
+
+    if (!bootValue || !currentValue) {
+        return null;
+    }
+
+    return bootValue !== currentValue;
+}
+
+/**
+ * @summary Classifies boot-vs-current Knowledge Base MCP runtime identity.
+ *
+ * A stale runtime is an observability warning, not a hard outage. The process can stay usable
+ * while still telling agents to restart before asserting source, config, or tool-schema facts.
+ *
+ * @param {Object} options
+ * @param {String} options.startedAt Runtime start timestamp.
+ * @param {Object} options.boot Boot-time source identity.
+ * @param {Object} options.current Current checkout/config identity.
+ * @param {String[]} options.errors Optional identity-read errors.
+ * @returns {Object}
+ */
+function classifyRuntimeFreshness({startedAt, boot = {}, current = {}, errors = []} = {}) {
+    const stale = {
+        gitHead      : compareRuntimeIdentityField('gitHead', boot, current),
+        configDigest : compareRuntimeIdentityField('configDigest', boot, current),
+        openApiDigest: compareRuntimeIdentityField('openApiDigest', boot, current)
+    };
+    const comparableFields = Object.values(stale).filter(value => value !== null),
+          staleFields      = Object.entries(stale)
+                                .filter(([, value]) => value === true)
+                                .map(([key]) => key),
+          details          = [];
+
+    let status;
+
+    if (staleFields.length) {
+        status = 'stale';
+        details.push(`Runtime source identity differs from the current checkout (${staleFields.join(', ')}). Restart or reconnect the Knowledge Base MCP server before asserting tool-schema/source facts.`);
+    } else if (comparableFields.length) {
+        status = 'current';
+        details.push('Runtime source identity matches the current checkout.');
+    } else {
+        status = 'unknown';
+        details.push('Runtime source identity could not be compared; git metadata, config digest, and OpenAPI digest reads were unavailable or incomplete.');
+    }
+
+    for (const error of errors.filter(Boolean)) {
+        details.push(error);
+    }
+
+    return {
+        status,
+        startedAt,
+        stale,
+        details,
+        hint: status === 'stale'
+            ? 'Restart or reconnect the Knowledge Base MCP server to refresh cached source, config, and tool definitions.'
+            : null
+    };
+}
 
 /**
  * @summary Monitors and validates the ChromaDB dependency for the Knowledge Base MCP server.
@@ -80,6 +210,51 @@ class HealthService extends Base {
      * @private
      */
     #previousStatus = null;
+
+    /**
+     * Cached runtime freshness diagnostic. Separate from dependency health so the freshness
+     * warning can update quickly without spawning git/hash work on every healthcheck call.
+     * @member {Object|null} #cachedRuntimeFreshness
+     * @private
+     */
+    #cachedRuntimeFreshness = null;
+
+    /**
+     * Timestamp (in milliseconds) of when runtime freshness was last resolved.
+     * @member {Number|null} #lastRuntimeFreshnessCheckTime
+     * @private
+     */
+    #lastRuntimeFreshnessCheckTime = null;
+
+    /**
+     * Boot-time runtime identity captured before long-lived MCP clients can go stale.
+     * @member {Object} bootRuntimeIdentity
+     */
+    bootRuntimeIdentity = initialRuntimeIdentity.boot;
+
+    /**
+     * Boot-time runtime identity read errors.
+     * @member {String[]} bootRuntimeFreshnessErrors
+     */
+    bootRuntimeFreshnessErrors = initialRuntimeIdentity.errors;
+
+    /**
+     * Optional unit-test seam for injecting boot/current runtime identity reads.
+     * @member {Function|null} runtimeFreshnessReader
+     */
+    runtimeFreshnessReader = null;
+
+    /**
+     * ISO timestamp captured when this server module was loaded.
+     * @member {String} runtimeStartedAt
+     */
+    runtimeStartedAt = startedAt;
+
+    /**
+     * Duration (in milliseconds) for which runtime freshness remains cached.
+     * @member {Number} runtimeFreshnessCacheDuration
+     */
+    runtimeFreshnessCacheDuration = 30 * 1000;
 
     /**
      * Checks if ChromaDB is running and accessible.
@@ -212,7 +387,8 @@ class HealthService extends Base {
             },
             details: [],
             version: process.env.npm_package_version || '1.0.0',
-            uptime : process.uptime()
+            uptime : process.uptime(),
+            runtimeFreshness: await this.resolveRuntimeFreshness()
         };
 
         // Step 1: Check ChromaDB connectivity
@@ -294,7 +470,10 @@ class HealthService extends Base {
             // If the cache is still fresh (< 5 minutes old), return it immediately
             if (age < this.#cacheDuration) {
                 logger.debug(`[HealthService] Using cached health status (age: ${Math.round(age / 1000)}s)`);
-                return this.#cachedHealth;
+                return {
+                    ...this.#cachedHealth,
+                    runtimeFreshness: await this.resolveRuntimeFreshness()
+                };
             }
         }
 
@@ -380,9 +559,102 @@ class HealthService extends Base {
      * without waiting for the 5-minute cache to expire.
      */
     clearCache() {
-        this.#cachedHealth  = null;
-        this.#lastCheckTime = null;
+        this.#cachedHealth                    = null;
+        this.#lastCheckTime                   = null;
+        this.#cachedRuntimeFreshness          = null;
+        this.#lastRuntimeFreshnessCheckTime   = null;
         logger.debug('[HealthService] Cache cleared, next health check will be fresh');
+    }
+
+    /**
+     * Resolves the live runtime freshness diagnostic for the attached KB MCP process.
+     *
+     * Intent: a process can be dependency-healthy while stale relative to the checkout/config an
+     * agent is inspecting. Keeping this lightweight warning in healthcheck avoids duplicate source
+     * tickets when the right action is restart/reconnect.
+     *
+     * @returns {Promise<Object>} Runtime freshness diagnostic payload.
+     */
+    async resolveRuntimeFreshness() {
+        const now = Date.now();
+
+        if (
+            this.#cachedRuntimeFreshness &&
+            this.#lastRuntimeFreshnessCheckTime &&
+            (now - this.#lastRuntimeFreshnessCheckTime) < this.runtimeFreshnessCacheDuration
+        ) {
+            return this.#cachedRuntimeFreshness;
+        }
+
+        let freshness;
+
+        try {
+            const identity = this.runtimeFreshnessReader
+                ? await this.runtimeFreshnessReader()
+                : await this.#readCurrentRuntimeIdentity();
+
+            const runtimeErrors = Array.isArray(identity.errors)
+                ? identity.errors
+                : [identity.errors].filter(Boolean);
+
+            freshness = classifyRuntimeFreshness({
+                startedAt: this.runtimeStartedAt,
+                boot     : identity.boot || this.bootRuntimeIdentity,
+                current  : identity.current || {},
+                errors   : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    ...runtimeErrors
+                ]
+            });
+        } catch (e) {
+            freshness = classifyRuntimeFreshness({
+                startedAt: this.runtimeStartedAt,
+                boot     : this.bootRuntimeIdentity,
+                current  : {},
+                errors   : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    `runtime freshness reader failed: ${e.message}`
+                ]
+            });
+        }
+
+        this.#cachedRuntimeFreshness        = freshness;
+        this.#lastRuntimeFreshnessCheckTime = now;
+
+        return freshness;
+    }
+
+    /**
+     * Reads current checkout/config identity without touching ChromaDB or remote providers.
+     *
+     * @returns {Promise<Object>} `{current, errors}` source identity tuple.
+     * @private
+     */
+    async #readCurrentRuntimeIdentity() {
+        const current = {},
+              errors  = [];
+
+        try {
+            const {stdout} = await execFileAsync('git', ['-C', aiConfig.neoRootDir, 'rev-parse', 'HEAD']);
+
+            current.gitHead = stdout.trim();
+        } catch (e) {
+            errors.push(`current gitHead unavailable: ${e.message}`);
+        }
+
+        try {
+            current.configDigest = createFileDigest(configPath);
+        } catch (e) {
+            errors.push(`current config digest unavailable: ${e.message}`);
+        }
+
+        try {
+            current.openApiDigest = createFileDigest(openApiPath);
+        } catch (e) {
+            errors.push(`current OpenAPI digest unavailable: ${e.message}`);
+        }
+
+        return {current, errors};
     }
 }
 

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -14,8 +14,24 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {createHash}       from 'crypto';
+import {readFileSync}     from 'fs';
+import path               from 'path';
+import {fileURLToPath}    from 'url';
+import Neo                from '../../../../../../src/Neo.mjs';
+import * as core          from '../../../../../../src/core/_export.mjs';
+
+const
+    testDir            = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot           = path.resolve(testDir, '../../../../../../'),
+    sharedConfigPath   = path.resolve(repoRoot, 'ai/config.mjs'),
+    kbServerConfigPath = path.resolve(repoRoot, 'ai/mcp/server/knowledge-base/config.mjs');
+
+function createFileDigest(filePath) {
+    const contents = readFileSync(filePath);
+
+    return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
+}
 
 test.describe('Neo.ai.services.knowledge-base.HealthService provider-aware readiness (#12741)', () => {
     let HealthService, ChromaManager, DatabaseLifecycleService, aiConfig;
@@ -91,5 +107,195 @@ test.describe('Neo.ai.services.knowledge-base.HealthService provider-aware readi
             // The gate must not throw — local-provider ask is allowed with no GEMINI_API_KEY.
             await expect(HealthService.ensureHealthy()).resolves.toBeUndefined();
         });
+    });
+});
+
+test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshness (#12774)', () => {
+    let HealthService, ChromaManager, DatabaseLifecycleService,
+        bootRuntimeIdentity, bootRuntimeFreshnessErrors;
+
+    test.beforeAll(async () => {
+        HealthService            = (await import('../../../../../../ai/services/knowledge-base/HealthService.mjs')).default;
+        ChromaManager            = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        DatabaseLifecycleService = (await import('../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs')).default;
+        bootRuntimeIdentity        = HealthService.bootRuntimeIdentity;
+        bootRuntimeFreshnessErrors = HealthService.bootRuntimeFreshnessErrors;
+    });
+
+    test.afterEach(() => {
+        HealthService.runtimeFreshnessReader = null;
+        HealthService.runtimeFreshnessCacheDuration = 30 * 1000;
+        HealthService.bootRuntimeIdentity        = bootRuntimeIdentity;
+        HealthService.bootRuntimeFreshnessErrors = bootRuntimeFreshnessErrors;
+        HealthService.clearCache();
+    });
+
+    test('classifies matching boot/current identity as current', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'abc123',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current: {
+                gitHead      : 'abc123',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'current',
+            stale : {
+                gitHead      : false,
+                configDigest : false,
+                openApiDigest: false
+            },
+            hint: null
+        });
+        expect(result.details).toContain('Runtime source identity matches the current checkout.');
+        expect(result.boot).toBeUndefined();
+        expect(result.current).toBeUndefined();
+    });
+
+    test('classifies stale config and OpenAPI identity with KB restart guidance', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'same-head',
+                configDigest : 'sha256:old-config',
+                openApiDigest: 'sha256:old-openapi'
+            },
+            current: {
+                gitHead      : 'same-head',
+                configDigest : 'sha256:new-config',
+                openApiDigest: 'sha256:new-openapi'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'stale',
+            stale : {
+                gitHead      : false,
+                configDigest : true,
+                openApiDigest: true
+            },
+            hint: 'Restart or reconnect the Knowledge Base MCP server to refresh cached source, config, and tool definitions.'
+        });
+        expect(result.details[0]).toContain('Knowledge Base MCP server');
+        expect(result.details[0]).toContain('configDigest');
+    });
+
+    test('classifies missing identity as unknown without throwing', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot   : {},
+            current: {},
+            errors : ['current config digest unavailable: fixture']
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'unknown',
+            stale : {
+                gitHead      : null,
+                configDigest : null,
+                openApiDigest: null
+            },
+            hint: null
+        });
+        expect(result.details).toContain('current config digest unavailable: fixture');
+    });
+
+    test('default reader digests shared Tier-1 config, not the KB per-server config', async () => {
+        const kbServerConfigDigest = createFileDigest(kbServerConfigPath);
+
+        expect(kbServerConfigDigest).not.toBe(createFileDigest(sharedConfigPath));
+
+        HealthService.runtimeFreshnessCacheDuration = 0;
+        HealthService.runtimeFreshnessReader = null;
+        HealthService.bootRuntimeFreshnessErrors = [];
+        HealthService.bootRuntimeIdentity = {
+            configDigest: kbServerConfigDigest
+        };
+        HealthService.clearCache();
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'stale',
+            stale : {
+                configDigest: true
+            }
+        });
+        expect(result.details[0]).toContain('configDigest');
+    });
+
+    test('cached healthy healthcheck reuses runtime freshness inside the short TTL', async () => {
+        const originalClient        = ChromaManager.client,
+              originalGetCollection = ChromaManager.getKnowledgeBaseCollection,
+              originalGetDbStatus   = DatabaseLifecycleService.getDatabaseStatus;
+
+        let currentConfigDigest = 'sha256:boot-config';
+        let readCount           = 0;
+
+        try {
+            ChromaManager.client                       = {heartbeat: async () => ({})};
+            ChromaManager.getKnowledgeBaseCollection   = async () => ({count: async () => 1});
+            DatabaseLifecycleService.getDatabaseStatus = () => ({status: 'mocked'});
+
+            HealthService.runtimeFreshnessReader = async () => {
+                readCount++;
+
+                return {
+                    boot: {
+                        gitHead      : 'abc123',
+                        configDigest : 'sha256:boot-config',
+                        openApiDigest: 'sha256:same-openapi'
+                    },
+                    current: {
+                        gitHead      : 'abc123',
+                        configDigest : currentConfigDigest,
+                        openApiDigest: 'sha256:same-openapi'
+                    }
+                };
+            };
+
+            const cached = await HealthService.healthcheck();
+
+            expect(cached.status).toBe('healthy');
+            expect(cached.runtimeFreshness.status).toBe('current');
+            expect(readCount).toBe(1);
+
+            currentConfigDigest = 'sha256:changed-config';
+
+            const reused = await HealthService.healthcheck();
+
+            expect(reused.status).toBe('healthy');
+            expect(reused.runtimeFreshness.status).toBe('current');
+            expect(readCount).toBe(1);
+
+            HealthService.runtimeFreshnessCacheDuration = 0;
+
+            const refreshed = await HealthService.healthcheck();
+
+            expect(refreshed.status).toBe('healthy');
+            expect(refreshed.runtimeFreshness).toMatchObject({
+                status: 'stale',
+                stale : {
+                    gitHead      : false,
+                    configDigest : true,
+                    openApiDigest: false
+                }
+            });
+            expect(readCount).toBe(2);
+        } finally {
+            ChromaManager.client                       = originalClient;
+            ChromaManager.getKnowledgeBaseCollection   = originalGetCollection;
+            DatabaseLifecycleService.getDatabaseStatus = originalGetDbStatus;
+        }
     });
 });


### PR DESCRIPTION
Resolves #12774

Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Adds a compact `runtimeFreshness` diagnostic to Knowledge Base healthcheck so agents can distinguish healthy-but-stale KB MCP processes from real source regressions. The field compares boot-time and current `gitHead`, the shared Tier-1 `ai/config.mjs` `configDigest`, and the KB `openApiDigest`; stale runtime is warning metadata, not an outage. Cached healthy healthchecks refresh the runtime-freshness block on a short TTL, avoiding per-call git/hash work on the cached path.

Evidence: L2 (focused HealthService unit coverage + OpenAPI schema update) -> L4 required (post-merge KB MCP restart/reconnect validation). Residual: post-merge validation [#12774].

## Deltas from Ticket

- Kept the helper local to `KnowledgeBase.HealthService` instead of adding a shared runtime-freshness module, matching the existing GitHub Workflow / Memory Core precedent and keeping the release leaf narrow. Follow-up extraction is tracked in #12776.
- `configDigest` intentionally tracks the shared Tier-1 `ai/config.mjs`, not the KB per-server `config.mjs`, because provider defaults and the `summary=gemini`-class drift live in the shared config.
- Kept the public `runtimeFreshness` payload compact: no `boot` / `current` identity echo.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs` -> 8 passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing branch contained only `e3aeaa5bd`.

## Post-Merge Validation

- [ ] Restart or reconnect the Knowledge Base MCP server and verify `healthcheck.runtimeFreshness.status` is `current` on the refreshed runtime.
- [ ] Optional live proof: change the ignored shared `ai/config.mjs` overlay without restarting and verify the old process reports `runtimeFreshness.status: stale` with a restart hint.

Related: #12740
Refs #12765
Refs #12772
Refs #12776

## Commit

- `e3aeaa5bd` — `feat(knowledge-base): add runtime freshness healthcheck (#12774)`