### PR TITLE
feat(ai): share MCP runtime freshness helper (#12776)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1658,39 +1658,19 @@ components:
           example: "1.0.0"
         runtimeFreshness:
           type: object
-          description: Boot-vs-current runtime source identity for detecting stale MCP client/server attachments.
+          description: Compact boot-vs-current runtime freshness diagnostic for detecting stale GitHub Workflow MCP process attachments.
           properties:
             status:
               type: string
               enum: [current, stale, unknown]
-              description: Whether the running MCP process matches the current checkout identity.
+              description: Whether service-owned OpenAPI identity marks the running process stale. Git HEAD drift is contextual only.
             startedAt:
               type: string
               format: date-time
               description: When the MCP runtime module was loaded.
-            boot:
-              type: object
-              description: Source identity captured when the MCP process started.
-              properties:
-                gitHead:
-                  type: string
-                  description: Git commit SHA at process boot, when available.
-                openApiDigest:
-                  type: string
-                  description: SHA-256 digest of the OpenAPI contract at process boot.
-            current:
-              type: object
-              description: Source identity read from the current checkout during healthcheck.
-              properties:
-                gitHead:
-                  type: string
-                  description: Current checkout Git commit SHA, when available.
-                openApiDigest:
-                  type: string
-                  description: Current SHA-256 digest of the OpenAPI contract.
             stale:
               type: object
-              description: Per-identity stale flags. Null means the field could not be compared.
+              description: Per-identity stale flags. Null means the field could not be compared; gitHead is informational and does not by itself mark status stale.
               properties:
                 gitHead:
                   type: boolean

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -595,18 +595,15 @@ components:
             status:
               type: string
               enum: [current, stale, unknown]
-              description: Whether service-owned config/OpenAPI identity marks the running process stale. Git HEAD drift is contextual only.
+              description: Whether service-owned config/OpenAPI identity marks the running process stale.
             startedAt:
               type: string
               format: date-time
               description: When the MCP runtime module was loaded.
             stale:
               type: object
-              description: Per-identity stale flags. Null means the field could not be compared; gitHead is informational and does not by itself mark status stale.
+              description: Per-identity stale flags. Null means the field could not be compared.
               properties:
-                gitHead:
-                  type: boolean
-                  nullable: true
                 configDigest:
                   type: boolean
                   nullable: true

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -595,14 +595,14 @@ components:
             status:
               type: string
               enum: [current, stale, unknown]
-              description: Whether the running MCP process matches comparable current checkout/config/OpenAPI identity.
+              description: Whether service-owned config/OpenAPI identity marks the running process stale. Git HEAD drift is contextual only.
             startedAt:
               type: string
               format: date-time
               description: When the MCP runtime module was loaded.
             stale:
               type: object
-              description: Per-identity stale flags. Null means the field could not be compared.
+              description: Per-identity stale flags. Null means the field could not be compared; gitHead is informational and does not by itself mark status stale.
               properties:
                 gitHead:
                   type: boolean

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1557,7 +1557,7 @@ components:
             status:
               type: string
               enum: [current, stale, unknown]
-              description: "Whether service-owned config/OpenAPI identity marks the running process stale. Git HEAD drift is contextual only."
+              description: "Whether service-owned config/OpenAPI identity marks the running process stale."
               example: "current"
             startedAt:
               type: string
@@ -1566,12 +1566,8 @@ components:
               example: "2026-06-08T15:00:00.000Z"
             stale:
               type: object
-              description: "Per-field stale comparison. Null means the field could not be compared; gitHead is informational and does not by itself mark status stale."
+              description: "Per-field stale comparison. Null means the field could not be compared."
               properties:
-                gitHead:
-                  type: boolean
-                  nullable: true
-                  example: false
                 configDigest:
                   type: boolean
                   nullable: true

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1552,52 +1552,21 @@ components:
           example: "2025-10-24T10:00:00.000Z"
         runtimeFreshness:
           type: object
-          description: "Boot-vs-current Memory Core MCP runtime identity. Stale is diagnostic metadata, not a service outage."
+          description: "Compact boot-vs-current Memory Core MCP runtime freshness diagnostic. Stale is diagnostic metadata, not a service outage."
           properties:
             status:
               type: string
               enum: [current, stale, unknown]
+              description: "Whether service-owned config/OpenAPI identity marks the running process stale. Git HEAD drift is contextual only."
               example: "current"
             startedAt:
               type: string
               format: date-time
               description: "ISO timestamp captured when the Memory Core service module loaded."
               example: "2026-06-08T15:00:00.000Z"
-            boot:
-              type: object
-              description: "Source/config/schema identity captured at MCP process boot."
-              properties:
-                gitHead:
-                  type: string
-                  nullable: true
-                  example: "5c5723cdd2e2f7d2a7c4e6e63f8c3ab4c5d6e7f8"
-                configDigest:
-                  type: string
-                  nullable: true
-                  example: "sha256:5e9a2d3f..."
-                openApiDigest:
-                  type: string
-                  nullable: true
-                  example: "sha256:1f2a3b4c..."
-            current:
-              type: object
-              description: "Source/config/schema identity read from the current checkout."
-              properties:
-                gitHead:
-                  type: string
-                  nullable: true
-                  example: "5c5723cdd2e2f7d2a7c4e6e63f8c3ab4c5d6e7f8"
-                configDigest:
-                  type: string
-                  nullable: true
-                  example: "sha256:5e9a2d3f..."
-                openApiDigest:
-                  type: string
-                  nullable: true
-                  example: "sha256:1f2a3b4c..."
             stale:
               type: object
-              description: "Per-field stale comparison. Null means the field could not be compared."
+              description: "Per-field stale comparison. Null means the field could not be compared; gitHead is informational and does not by itself mark status stale."
               properties:
                 gitHead:
                   type: boolean

--- a/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
+++ b/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
@@ -1,0 +1,440 @@
+import {execFile, execFileSync} from 'child_process';
+import {createHash}             from 'crypto';
+import {readFileSync}           from 'fs';
+import {promisify}              from 'util';
+import Base                     from '../../../../../src/core/Base.mjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary Normalizes comparable runtime identity values.
+ * @param {*} value Candidate identity value.
+ * @returns {String|null}
+ */
+function normalizeComparableValue(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed || null;
+}
+
+/**
+ * @summary Compares one boot/current runtime identity field.
+ * @param {String} field Field name to compare.
+ * @param {Object} boot Boot-time identity.
+ * @param {Object} current Current identity.
+ * @returns {Boolean|null}
+ */
+function compareIdentityField(field, boot, current) {
+    const
+        bootValue    = normalizeComparableValue(boot[field]),
+        currentValue = normalizeComparableValue(current[field]);
+
+    if (!bootValue || !currentValue) {
+        return null;
+    }
+
+    return bootValue !== currentValue;
+}
+
+/**
+ * @summary Normalizes runtime identity file descriptors.
+ *
+ * Each file descriptor contributes one SHA-256 digest field to the runtime identity block.
+ * The descriptor label is used only for compact diagnostic errors; the digest value itself
+ * stays private to the boot/current comparison and is not echoed in public healthcheck output.
+ *
+ * @param {Object[]} files File descriptors.
+ * @returns {Object[]}
+ */
+function normalizeIdentityFiles(files = []) {
+    return files
+        .filter(Boolean)
+        .map(file => ({
+            key       : file.key,
+            path      : file.path,
+            errorLabel: file.errorLabel || file.key
+        }));
+}
+
+/**
+ * @summary Per-consumer runtime freshness tracker created by RuntimeFreshnessService.
+ *
+ * The tracker owns boot identity capture, current identity reads, compact stale classification,
+ * and a short per-consumer cache. Consumers only provide the identity inputs and service-facing
+ * wording, so GitHub Workflow, Memory Core, and Knowledge Base cannot drift the semantics apart.
+ */
+export class RuntimeFreshnessTracker {
+    #cachedRuntimeFreshness = null;
+    #fieldKeys;
+    #files;
+    #lastRuntimeFreshnessCheckTime = null;
+    #runtimeService;
+    #statusFieldSet;
+
+    /**
+     * @param {Object} options
+     * @param {RuntimeFreshnessService} options.runtimeService Shared runtime freshness service.
+     * @param {String} options.rootDir Git project root used for contextual `gitHead` reads.
+     * @param {Object[]} options.files Runtime identity files to digest.
+     * @param {String} options.serviceName Service display name used in restart guidance.
+     * @param {String} options.identityLabel Human-readable identity label.
+     * @param {String} options.assertionFacts Facts callers should not assert while stale.
+     * @param {String} options.restartScope Cached state refreshed by restarting/reconnecting.
+     * @param {String[]} options.statusFields Fields that drive `status:'stale'`.
+     * @param {String} options.unavailableSummary Compact list of unavailable identity sources.
+     * @param {String} options.startedAt Runtime module load timestamp.
+     */
+    constructor(options = {}) {
+        this.#runtimeService = options.runtimeService;
+        this.rootDir         = options.rootDir;
+        this.files           = options.files || [];
+        this.serviceName     = options.serviceName || 'MCP server';
+        this.identityLabel   = options.identityLabel || 'source/config/schema identity';
+        this.assertionFacts  = options.assertionFacts || 'source, config, or tool-schema facts';
+        this.restartScope    = options.restartScope || 'cached source, config, and tool definitions';
+        this.unavailableSummary = options.unavailableSummary ||
+            'git metadata, config digest, and OpenAPI digest';
+        this.startedAt          = options.startedAt || new Date().toISOString();
+
+        this.#fieldKeys      = ['gitHead', ...this.#files.map(file => file.key)];
+        this.#statusFieldSet = new Set(options.statusFields || this.#fieldKeys.filter(key => key !== 'gitHead'));
+
+        const boot = this.#runtimeService.readRuntimeIdentitySync({
+            files  : this.#files,
+            phase  : 'boot',
+            rootDir: this.rootDir
+        });
+
+        this.bootRuntimeIdentity        = boot.identity;
+        this.bootRuntimeFreshnessErrors = boot.errors;
+    }
+
+    /**
+     * @member {Object[]} files
+     */
+    set files(files) {
+        this.#files = normalizeIdentityFiles(files);
+    }
+
+    get files() {
+        return this.#files;
+    }
+
+    /**
+     * Clears the short runtime freshness cache.
+     * @returns {void}
+     */
+    clearCache() {
+        this.#cachedRuntimeFreshness        = null;
+        this.#lastRuntimeFreshnessCheckTime = null;
+    }
+
+    /**
+     * Reads the current checkout/config/schema identity.
+     * @returns {Promise<{current: Object, errors: String[]}>}
+     */
+    async readCurrentIdentity() {
+        const {identity, errors} = await this.#runtimeService.readRuntimeIdentity({
+            files  : this.#files,
+            phase  : 'current',
+            rootDir: this.rootDir
+        });
+
+        return {current: identity, errors};
+    }
+
+    /**
+     * Resolves and caches the compact runtime freshness diagnostic.
+     *
+     * `gitHead` is intentionally contextual: it helps explain that a checkout advanced, but a
+     * repo-wide SHA change alone does not prove this MCP server's source/config/schema is stale.
+     * Service-owned digests such as `configDigest` and `openApiDigest` drive `status:'stale'`.
+     *
+     * @param {Object} options
+     * @param {Function|null} options.reader Optional test seam returning `{boot,current,errors}`.
+     * @param {Number} options.cacheDuration Cache duration in milliseconds.
+     * @param {Number} options.now Current timestamp in milliseconds.
+     * @returns {Promise<Object>}
+     */
+    async resolve({reader = null, cacheDuration = 30 * 1000, now = Date.now()} = {}) {
+        if (
+            this.#cachedRuntimeFreshness &&
+            this.#lastRuntimeFreshnessCheckTime !== null &&
+            (now - this.#lastRuntimeFreshnessCheckTime) < cacheDuration
+        ) {
+            return this.#cachedRuntimeFreshness;
+        }
+
+        let freshness;
+
+        try {
+            const identity = reader
+                ? await reader()
+                : await this.readCurrentIdentity();
+
+            const runtimeErrors = Array.isArray(identity.errors)
+                ? identity.errors
+                : [identity.errors].filter(Boolean);
+
+            freshness = this.#runtimeService.classifyRuntimeFreshness({
+                assertionFacts  : this.assertionFacts,
+                boot            : identity.boot || this.bootRuntimeIdentity,
+                current         : identity.current || {},
+                errors          : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    ...runtimeErrors
+                ],
+                fieldKeys       : this.#fieldKeys,
+                identityLabel   : this.identityLabel,
+                restartScope    : this.restartScope,
+                serviceName     : this.serviceName,
+                startedAt       : this.startedAt,
+                statusFields    : [...this.#statusFieldSet],
+                unavailableSummary: this.unavailableSummary
+            });
+        } catch (e) {
+            freshness = this.#runtimeService.classifyRuntimeFreshness({
+                assertionFacts  : this.assertionFacts,
+                boot            : this.bootRuntimeIdentity,
+                current         : {},
+                errors          : [
+                    ...this.bootRuntimeFreshnessErrors,
+                    `runtime freshness reader failed: ${e.message}`
+                ],
+                fieldKeys       : this.#fieldKeys,
+                identityLabel   : this.identityLabel,
+                restartScope    : this.restartScope,
+                serviceName     : this.serviceName,
+                startedAt       : this.startedAt,
+                statusFields    : [...this.#statusFieldSet],
+                unavailableSummary: this.unavailableSummary
+            });
+        }
+
+        this.#cachedRuntimeFreshness        = freshness;
+        this.#lastRuntimeFreshnessCheckTime = now;
+
+        return freshness;
+    }
+}
+
+/**
+ * @summary Shared runtime freshness infrastructure for Neo.mjs MCP healthchecks.
+ *
+ * Long-lived MCP processes can stay dependency-healthy while their checkout, config, or
+ * OpenAPI schema has moved underneath them. This service centralizes the boot-vs-current
+ * comparison used by MCP healthchecks and keeps the public payload compact: callers see stale
+ * booleans and restart guidance, never raw boot/current identity objects.
+ *
+ * `gitHead` is kept as contextual diagnostic metadata only. A repo-wide commit can be unrelated
+ * to a specific MCP server, so service-owned digests decide whether `status` becomes `stale`.
+ *
+ * @class Neo.ai.mcp.server.shared.services.RuntimeFreshnessService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class RuntimeFreshnessService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.mcp.server.shared.services.RuntimeFreshnessService'
+         * @protected
+         */
+        className: 'Neo.ai.mcp.server.shared.services.RuntimeFreshnessService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Classifies boot-vs-current runtime identity into compact healthcheck metadata.
+     *
+     * @param {Object} options
+     * @param {String} options.startedAt Runtime module load timestamp.
+     * @param {Object} options.boot Boot-time identity.
+     * @param {Object} options.current Current identity.
+     * @param {String[]} options.errors Identity-read errors.
+     * @param {String[]} options.fieldKeys Comparable identity fields.
+     * @param {String[]} options.statusFields Fields that drive `status:'stale'`.
+     * @param {String} options.serviceName Service display name.
+     * @param {String} options.identityLabel Identity label for details.
+     * @param {String} options.assertionFacts Facts guarded by stale status.
+     * @param {String} options.restartScope Cached state refreshed by restart/reconnect.
+     * @param {String} options.unavailableSummary Compact unavailable-source label.
+     * @returns {Object}
+     */
+    classifyRuntimeFreshness({
+        startedAt,
+        boot = {},
+        current = {},
+        errors = [],
+        fieldKeys = [],
+        statusFields = [],
+        serviceName = 'MCP server',
+        identityLabel = 'source/config/schema identity',
+        assertionFacts = 'source, config, or tool-schema facts',
+        restartScope = 'cached source, config, and tool definitions',
+        unavailableSummary = 'git metadata, config digest, and OpenAPI digest'
+    } = {}) {
+        const
+            stale          = {},
+            statusFieldSet = new Set(statusFields),
+            details        = [];
+
+        for (const field of fieldKeys) {
+            stale[field] = compareIdentityField(field, boot, current);
+        }
+
+        const
+            comparableFields = Object.entries(stale)
+                                      .filter(([, value]) => value !== null)
+                                      .map(([key]) => key),
+            staleFields      = Object.entries(stale)
+                                      .filter(([, value]) => value === true)
+                                      .map(([key]) => key),
+            statusComparableFields  = comparableFields.filter(field => statusFieldSet.has(field)),
+            statusStaleFields       = staleFields.filter(field => statusFieldSet.has(field)),
+            contextualStaleFields = staleFields.filter(field => !statusFieldSet.has(field));
+
+        let status;
+
+        if (statusStaleFields.length) {
+            status = 'stale';
+            details.push(
+                `Runtime ${identityLabel} differs from the current checkout (${statusStaleFields.join(', ')}). ` +
+                `Restart or reconnect the ${serviceName} before asserting ${assertionFacts}.`
+            );
+        } else if (statusComparableFields.length || (!statusFieldSet.size && comparableFields.length)) {
+            status = 'current';
+            details.push(`Runtime ${identityLabel} matches the current checkout.`);
+        } else {
+            status = 'unknown';
+            details.push(
+                `Runtime ${identityLabel} could not be compared; ` +
+                `${unavailableSummary} reads were unavailable or incomplete.`
+            );
+        }
+
+        if (contextualStaleFields.length) {
+            details.push(
+                `Contextual runtime identity differs (${contextualStaleFields.join(', ')}); these fields ` +
+                `are informational and do not by themselves mark the ${serviceName} stale.`
+            );
+        }
+
+        for (const error of errors.filter(Boolean)) {
+            details.push(error);
+        }
+
+        return {
+            status,
+            startedAt,
+            stale,
+            details,
+            hint: status === 'stale'
+                ? `Restart or reconnect the ${serviceName} to refresh ${restartScope}.`
+                : null
+        };
+    }
+
+    /**
+     * Computes a stable SHA-256 digest for runtime freshness file identity.
+     *
+     * @param {String} filePath Absolute file path.
+     * @returns {String}
+     */
+    createFileDigest(filePath) {
+        const contents = readFileSync(filePath);
+
+        return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
+    }
+
+    /**
+     * Creates a per-consumer runtime freshness tracker.
+     *
+     * @param {Object} options Tracker configuration.
+     * @returns {RuntimeFreshnessTracker}
+     */
+    createTracker(options = {}) {
+        return new RuntimeFreshnessTracker({
+            ...options,
+            runtimeService: this
+        });
+    }
+
+    /**
+     * Reads source/config/schema identity with async git access for request-time checks.
+     *
+     * @param {Object} options
+     * @param {String} options.rootDir Git project root.
+     * @param {Object[]} options.files File descriptors to digest.
+     * @param {String} options.phase Error-label prefix.
+     * @returns {Promise<{identity: Object, errors: String[]}>}
+     */
+    async readRuntimeIdentity({rootDir, files = [], phase = 'current'} = {}) {
+        const
+            identity = {},
+            errors   = [];
+
+        try {
+            const {stdout} = await execFileAsync('git', ['-C', rootDir, 'rev-parse', 'HEAD']);
+
+            identity.gitHead = stdout.trim();
+        } catch (e) {
+            errors.push(`${phase} gitHead unavailable: ${e.message}`);
+        }
+
+        for (const file of normalizeIdentityFiles(files)) {
+            try {
+                identity[file.key] = this.createFileDigest(file.path);
+            } catch (e) {
+                errors.push(`${phase} ${file.errorLabel} unavailable: ${e.message}`);
+            }
+        }
+
+        return {identity, errors};
+    }
+
+    /**
+     * Reads source/config/schema identity with sync git access for module boot capture.
+     *
+     * @param {Object} options
+     * @param {String} options.rootDir Git project root.
+     * @param {Object[]} options.files File descriptors to digest.
+     * @param {String} options.phase Error-label prefix.
+     * @returns {{identity: Object, errors: String[]}}
+     */
+    readRuntimeIdentitySync({rootDir, files = [], phase = 'boot'} = {}) {
+        const
+            identity = {},
+            errors   = [];
+
+        try {
+            const stdout = execFileSync('git', ['-C', rootDir, 'rev-parse', 'HEAD'], {
+                encoding: 'utf8',
+                stdio   : ['ignore', 'pipe', 'pipe']
+            });
+
+            identity.gitHead = stdout.trim();
+        } catch (e) {
+            errors.push(`${phase} gitHead unavailable: ${e.message}`);
+        }
+
+        for (const file of normalizeIdentityFiles(files)) {
+            try {
+                identity[file.key] = this.createFileDigest(file.path);
+            } catch (e) {
+                errors.push(`${phase} ${file.errorLabel} unavailable: ${e.message}`);
+            }
+        }
+
+        return {identity, errors};
+    }
+}
+
+export default Neo.setupClass(RuntimeFreshnessService);

--- a/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
+++ b/ai/mcp/server/shared/services/RuntimeFreshnessService.mjs
@@ -78,7 +78,10 @@ export class RuntimeFreshnessTracker {
     /**
      * @param {Object} options
      * @param {RuntimeFreshnessService} options.runtimeService Shared runtime freshness service.
-     * @param {String} options.rootDir Git project root used for contextual `gitHead` reads.
+     * @param {String} [options.rootDir] Git project root for contextual `gitHead` reads. Omit to
+     * disable gitHead tracking entirely (e.g. cloud-deployed services with no git checkout); the
+     * tracker then never spawns `git` and never surfaces a `gitHead` field. Only services whose
+     * domain is git itself (GitHub Workflow) should supply it.
      * @param {Object[]} options.files Runtime identity files to digest.
      * @param {String} options.serviceName Service display name used in restart guidance.
      * @param {String} options.identityLabel Human-readable identity label.
@@ -100,7 +103,7 @@ export class RuntimeFreshnessTracker {
             'git metadata, config digest, and OpenAPI digest';
         this.startedAt          = options.startedAt || new Date().toISOString();
 
-        this.#fieldKeys      = ['gitHead', ...this.#files.map(file => file.key)];
+        this.#fieldKeys      = [...(this.rootDir ? ['gitHead'] : []), ...this.#files.map(file => file.key)];
         this.#statusFieldSet = new Set(options.statusFields || this.#fieldKeys.filter(key => key !== 'gitHead'));
 
         const boot = this.#runtimeService.readRuntimeIdentitySync({
@@ -230,8 +233,11 @@ export class RuntimeFreshnessTracker {
  * comparison used by MCP healthchecks and keeps the public payload compact: callers see stale
  * booleans and restart guidance, never raw boot/current identity objects.
  *
- * `gitHead` is kept as contextual diagnostic metadata only. A repo-wide commit can be unrelated
- * to a specific MCP server, so service-owned digests decide whether `status` becomes `stale`.
+ * `gitHead` is kept as contextual diagnostic metadata only, and ONLY for consumers that supply a
+ * `rootDir`. A repo-wide commit can be unrelated to a specific MCP server, so service-owned digests
+ * decide whether `status` becomes `stale`. Services with no git checkout (e.g. cloud-deployed
+ * Memory Core / Knowledge Base) omit `rootDir`, never spawn `git`, and drop `gitHead` from the
+ * payload — keeping the freshness signal digest-only and fully portable off a GitHub workflow.
  *
  * @class Neo.ai.mcp.server.shared.services.RuntimeFreshnessService
  * @extends Neo.core.Base
@@ -371,7 +377,7 @@ class RuntimeFreshnessService extends Base {
      * Reads source/config/schema identity with async git access for request-time checks.
      *
      * @param {Object} options
-     * @param {String} options.rootDir Git project root.
+     * @param {String} [options.rootDir] Git project root. When omitted, `git` is never spawned and `gitHead` is not read.
      * @param {Object[]} options.files File descriptors to digest.
      * @param {String} options.phase Error-label prefix.
      * @returns {Promise<{identity: Object, errors: String[]}>}
@@ -381,12 +387,14 @@ class RuntimeFreshnessService extends Base {
             identity = {},
             errors   = [];
 
-        try {
-            const {stdout} = await execFileAsync('git', ['-C', rootDir, 'rev-parse', 'HEAD']);
+        if (rootDir) {
+            try {
+                const {stdout} = await execFileAsync('git', ['-C', rootDir, 'rev-parse', 'HEAD']);
 
-            identity.gitHead = stdout.trim();
-        } catch (e) {
-            errors.push(`${phase} gitHead unavailable: ${e.message}`);
+                identity.gitHead = stdout.trim();
+            } catch (e) {
+                errors.push(`${phase} gitHead unavailable: ${e.message}`);
+            }
         }
 
         for (const file of normalizeIdentityFiles(files)) {
@@ -404,7 +412,7 @@ class RuntimeFreshnessService extends Base {
      * Reads source/config/schema identity with sync git access for module boot capture.
      *
      * @param {Object} options
-     * @param {String} options.rootDir Git project root.
+     * @param {String} [options.rootDir] Git project root. When omitted, `git` is never spawned and `gitHead` is not read.
      * @param {Object[]} options.files File descriptors to digest.
      * @param {String} options.phase Error-label prefix.
      * @returns {{identity: Object, errors: String[]}}
@@ -414,15 +422,17 @@ class RuntimeFreshnessService extends Base {
             identity = {},
             errors   = [];
 
-        try {
-            const stdout = execFileSync('git', ['-C', rootDir, 'rev-parse', 'HEAD'], {
-                encoding: 'utf8',
-                stdio   : ['ignore', 'pipe', 'pipe']
-            });
+        if (rootDir) {
+            try {
+                const stdout = execFileSync('git', ['-C', rootDir, 'rev-parse', 'HEAD'], {
+                    encoding: 'utf8',
+                    stdio   : ['ignore', 'pipe', 'pipe']
+                });
 
-            identity.gitHead = stdout.trim();
-        } catch (e) {
-            errors.push(`${phase} gitHead unavailable: ${e.message}`);
+                identity.gitHead = stdout.trim();
+            } catch (e) {
+                errors.push(`${phase} gitHead unavailable: ${e.message}`);
+            }
         }
 
         for (const file of normalizeIdentityFiles(files)) {

--- a/ai/services/github-workflow/HealthService.mjs
+++ b/ai/services/github-workflow/HealthService.mjs
@@ -1,133 +1,27 @@
-import {exec, execFile, execFileSync} from 'child_process';
-import {createHash}                   from 'crypto';
-import {readFileSync}                 from 'fs';
-import path                           from 'path';
-import {fileURLToPath}                from 'url';
-import {promisify}                    from 'util';
-import aiConfig                       from '../../mcp/server/github-workflow/config.mjs';
-import Base                           from '../../../src/core/Base.mjs';
-import logger                         from '../../mcp/server/github-workflow/logger.mjs';
-import semver                         from 'semver';
+import {exec}                  from 'child_process';
+import {promisify}             from 'util';
+import aiConfig                from '../../mcp/server/github-workflow/config.mjs';
+import RuntimeFreshnessService from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
+import Base                    from '../../../src/core/Base.mjs';
+import logger                  from '../../mcp/server/github-workflow/logger.mjs';
+import semver                  from 'semver';
 
 const
-    execAsync     = promisify(exec),
-    execFileAsync = promisify(execFile),
-    serviceDir    = path.dirname(fileURLToPath(import.meta.url)),
-    openApiPath   = path.resolve(serviceDir, '../../mcp/server/github-workflow/openapi.yaml'),
-    startedAt     = new Date().toISOString();
-
-function createOpenApiDigest(filePath = openApiPath) {
-    const contents = readFileSync(filePath);
-
-    return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
-}
-
-function readBootGitHead() {
-    const stdout = execFileSync('git', ['-C', aiConfig.projectRoot, 'rev-parse', 'HEAD'], {
-        encoding: 'utf8',
-        stdio   : ['ignore', 'pipe', 'pipe']
+    execAsync               = promisify(exec),
+    runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
+        rootDir: aiConfig.projectRoot,
+        files  : [{
+            key       : 'openApiDigest',
+            path      : new URL('../../mcp/server/github-workflow/openapi.yaml', import.meta.url),
+            errorLabel: 'OpenAPI digest'
+        }],
+        serviceName       : 'GitHub Workflow MCP server',
+        identityLabel     : 'source/schema identity',
+        assertionFacts    : 'tool-schema/source facts',
+        restartScope      : 'cached tool definitions',
+        statusFields      : ['openApiDigest'],
+        unavailableSummary: 'git metadata and OpenAPI digest'
     });
-
-    return stdout.trim();
-}
-
-function readBootRuntimeIdentity() {
-    const errors = [],
-          boot   = {};
-
-    try {
-        boot.gitHead = readBootGitHead();
-    } catch (e) {
-        errors.push(`boot gitHead unavailable: ${e.message}`);
-    }
-
-    try {
-        boot.openApiDigest = createOpenApiDigest();
-    } catch (e) {
-        errors.push(`boot OpenAPI digest unavailable: ${e.message}`);
-    }
-
-    return {boot, errors};
-}
-
-const initialRuntimeIdentity = readBootRuntimeIdentity();
-
-function normalizeString(value) {
-    if (typeof value !== 'string') {
-        return null;
-    }
-
-    const trimmed = value.trim();
-
-    return trimmed || null;
-}
-
-function compareIdentityField(field, boot, current) {
-    const
-        bootValue    = normalizeString(boot[field]),
-        currentValue = normalizeString(current[field]);
-
-    if (!bootValue || !currentValue) {
-        return null;
-    }
-
-    return bootValue !== currentValue;
-}
-
-/**
- * @summary Classifies boot-vs-current MCP runtime source identity.
- *
- * `status:'stale'` is a diagnostic warning, not a hard outage. The attached MCP
- * process can remain usable for read-only work while still telling agents to restart
- * before asserting source/tool-schema facts.
- *
- * @param {Object} options
- * @param {String} options.startedAt Runtime start timestamp.
- * @param {Object} options.boot Boot-time source identity.
- * @param {Object} options.current Current checkout identity.
- * @param {String[]} options.errors Optional identity-read errors.
- * @returns {Object}
- */
-function classifyRuntimeFreshness({startedAt, boot = {}, current = {}, errors = []} = {}) {
-    const stale = {
-        gitHead      : compareIdentityField('gitHead', boot, current),
-        openApiDigest: compareIdentityField('openApiDigest', boot, current)
-    };
-    const comparableFields = Object.values(stale).filter(value => value !== null),
-          staleFields      = Object.entries(stale)
-                                .filter(([, value]) => value === true)
-                                .map(([key]) => key),
-          details          = [];
-
-    let status;
-
-    if (staleFields.length) {
-        status = 'stale';
-        details.push(`Runtime source identity differs from the current checkout (${staleFields.join(', ')}). Restart or reconnect the MCP client/server before asserting tool-schema/source facts.`);
-    } else if (comparableFields.length) {
-        status = 'current';
-        details.push('Runtime source identity matches the current checkout.');
-    } else {
-        status = 'unknown';
-        details.push('Runtime source identity could not be compared; git metadata and OpenAPI digest reads were unavailable or incomplete.');
-    }
-
-    for (const error of errors.filter(Boolean)) {
-        details.push(error);
-    }
-
-    return {
-        status,
-        startedAt,
-        boot,
-        current,
-        stale,
-        details,
-        hint: status === 'stale'
-            ? 'Restart or reconnect the MCP client/server to refresh cached tool definitions.'
-            : null
-    };
-}
 
 /**
  * @summary Monitors and validates the GitHub CLI dependency for the MCP server.
@@ -205,16 +99,35 @@ class HealthService extends Base {
     #previousStatus = null;
 
     /**
+     * Shared runtime freshness tracker.
+     * @member {RuntimeFreshnessTracker} #runtimeFreshnessTracker
+     * @private
+     */
+    #runtimeFreshnessTracker = runtimeFreshnessTracker;
+
+    /**
      * Boot-time runtime identity captured before long-lived MCP clients can go stale.
      * @member {Object} bootRuntimeIdentity
      */
-    bootRuntimeIdentity = initialRuntimeIdentity.boot;
+    get bootRuntimeIdentity() {
+        return this.#runtimeFreshnessTracker.bootRuntimeIdentity;
+    }
+
+    set bootRuntimeIdentity(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeIdentity = value || {};
+    }
 
     /**
      * Boot-time runtime identity read errors.
      * @member {String[]} bootRuntimeFreshnessErrors
      */
-    bootRuntimeFreshnessErrors = initialRuntimeIdentity.errors;
+    get bootRuntimeFreshnessErrors() {
+        return this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors;
+    }
+
+    set bootRuntimeFreshnessErrors(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors = Array.isArray(value) ? value : [];
+    }
 
     /**
      * Optional unit-test seam for injecting boot/current runtime identity reads.
@@ -226,7 +139,19 @@ class HealthService extends Base {
      * ISO timestamp captured when this server module was loaded.
      * @member {String} runtimeStartedAt
      */
-    runtimeStartedAt = startedAt;
+    get runtimeStartedAt() {
+        return this.#runtimeFreshnessTracker.startedAt;
+    }
+
+    set runtimeStartedAt(value) {
+        this.#runtimeFreshnessTracker.startedAt = value;
+    }
+
+    /**
+     * Duration (in milliseconds) for which runtime freshness remains cached.
+     * @member {Number} runtimeFreshnessCacheDuration
+     */
+    runtimeFreshnessCacheDuration = 30 * 1000;
 
     /**
      * Verifies that the user is authenticated with GitHub via the `gh` CLI.
@@ -306,6 +231,7 @@ class HealthService extends Base {
     clearCache() {
         this.#cachedHealth  = null;
         this.#lastCheckTime = null;
+        this.#runtimeFreshnessTracker.clearCache();
         logger.debug('[HealthService] Cache cleared, next health check will be fresh');
     }
 
@@ -375,8 +301,6 @@ class HealthService extends Base {
      *     },
      *     runtimeFreshness: {
      *       status: 'current' | 'stale' | 'unknown',
-     *       boot: object,
-     *       current: object,
      *       stale: object,
      *       details: string[],
      *       hint: string | null
@@ -449,35 +373,10 @@ class HealthService extends Base {
      * @returns {Promise<Object>} Runtime freshness diagnostic payload.
      */
     async resolveRuntimeFreshness() {
-        try {
-            const identity = this.runtimeFreshnessReader
-                ? await this.runtimeFreshnessReader()
-                : await this.#readCurrentRuntimeIdentity();
-
-            const runtimeErrors = Array.isArray(identity.errors)
-                ? identity.errors
-                : [identity.errors].filter(Boolean);
-
-            return classifyRuntimeFreshness({
-                startedAt: this.runtimeStartedAt,
-                boot     : identity.boot || this.bootRuntimeIdentity,
-                current  : identity.current || {},
-                errors   : [
-                    ...this.bootRuntimeFreshnessErrors,
-                    ...runtimeErrors
-                ]
-            });
-        } catch (e) {
-            return classifyRuntimeFreshness({
-                startedAt: this.runtimeStartedAt,
-                boot     : this.bootRuntimeIdentity,
-                current  : {},
-                errors   : [
-                    ...this.bootRuntimeFreshnessErrors,
-                    `runtime freshness reader failed: ${e.message}`
-                ]
-            });
-        }
+        return this.#runtimeFreshnessTracker.resolve({
+            reader       : this.runtimeFreshnessReader,
+            cacheDuration: this.runtimeFreshnessCacheDuration
+        });
     }
 
     /**
@@ -591,33 +490,6 @@ class HealthService extends Base {
         }
 
         return payload;
-    }
-
-    /**
-     * Reads the current checkout identity without touching GitHub credentials.
-     *
-     * @returns {Promise<Object>} `{current, errors}` source identity tuple.
-     * @private
-     */
-    async #readCurrentRuntimeIdentity() {
-        const current = {},
-              errors  = [];
-
-        try {
-            const {stdout} = await execFileAsync('git', ['-C', aiConfig.projectRoot, 'rev-parse', 'HEAD']);
-
-            current.gitHead = stdout.trim();
-        } catch (e) {
-            errors.push(`current gitHead unavailable: ${e.message}`);
-        }
-
-        try {
-            current.openApiDigest = createOpenApiDigest();
-        } catch (e) {
-            errors.push(`current OpenAPI digest unavailable: ${e.message}`);
-        }
-
-        return {current, errors};
     }
 
     #parseAuthOutput(out) {

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -12,7 +12,6 @@ const
     configPath              = path.resolve(serviceDir, '../../config.mjs'),
     openApiPath             = path.resolve(serviceDir, '../../mcp/server/knowledge-base/openapi.yaml'),
     runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
-        rootDir: aiConfig.neoRootDir,
         files  : [{
             key       : 'configDigest',
             path      : configPath,
@@ -27,7 +26,7 @@ const
         assertionFacts    : 'tool-schema/source facts',
         restartScope      : 'cached source, config, and tool definitions',
         statusFields      : ['configDigest', 'openApiDigest'],
-        unavailableSummary: 'git metadata, config digest, and OpenAPI digest'
+        unavailableSummary: 'config digest and OpenAPI digest'
     });
 
 /**

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -1,138 +1,34 @@
-import {execFile, execFileSync} from 'child_process';
-import {createHash}             from 'crypto';
-import {readFileSync}           from 'fs';
 import path                     from 'path';
 import {fileURLToPath}          from 'url';
-import {promisify}              from 'util';
 import aiConfig                 from '../../mcp/server/knowledge-base/config.mjs';
 import Base                     from '../../../src/core/Base.mjs';
 import ChromaManager            from './ChromaManager.mjs';
 import DatabaseLifecycleService from './DatabaseLifecycleService.mjs';
 import logger                   from '../../mcp/server/knowledge-base/logger.mjs';
+import RuntimeFreshnessService  from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
 
 const
-    execFileAsync = promisify(execFile),
-    serviceDir    = path.dirname(fileURLToPath(import.meta.url)),
-    configPath    = path.resolve(serviceDir, '../../config.mjs'),
-    openApiPath   = path.resolve(serviceDir, '../../mcp/server/knowledge-base/openapi.yaml'),
-    startedAt     = new Date().toISOString();
-
-function createFileDigest(filePath) {
-    const contents = readFileSync(filePath);
-
-    return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
-}
-
-function readBootGitHead() {
-    const stdout = execFileSync('git', ['-C', aiConfig.neoRootDir, 'rev-parse', 'HEAD'], {
-        encoding: 'utf8',
-        stdio   : ['ignore', 'pipe', 'pipe']
+    serviceDir              = path.dirname(fileURLToPath(import.meta.url)),
+    configPath              = path.resolve(serviceDir, '../../config.mjs'),
+    openApiPath             = path.resolve(serviceDir, '../../mcp/server/knowledge-base/openapi.yaml'),
+    runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
+        rootDir: aiConfig.neoRootDir,
+        files  : [{
+            key       : 'configDigest',
+            path      : configPath,
+            errorLabel: 'config digest'
+        }, {
+            key       : 'openApiDigest',
+            path      : openApiPath,
+            errorLabel: 'OpenAPI digest'
+        }],
+        serviceName       : 'Knowledge Base MCP server',
+        identityLabel     : 'source/config identity',
+        assertionFacts    : 'tool-schema/source facts',
+        restartScope      : 'cached source, config, and tool definitions',
+        statusFields      : ['configDigest', 'openApiDigest'],
+        unavailableSummary: 'git metadata, config digest, and OpenAPI digest'
     });
-
-    return stdout.trim();
-}
-
-function readBootRuntimeIdentity() {
-    const errors = [],
-          boot   = {};
-
-    try {
-        boot.gitHead = readBootGitHead();
-    } catch (e) {
-        errors.push(`boot gitHead unavailable: ${e.message}`);
-    }
-
-    try {
-        boot.configDigest = createFileDigest(configPath);
-    } catch (e) {
-        errors.push(`boot config digest unavailable: ${e.message}`);
-    }
-
-    try {
-        boot.openApiDigest = createFileDigest(openApiPath);
-    } catch (e) {
-        errors.push(`boot OpenAPI digest unavailable: ${e.message}`);
-    }
-
-    return {boot, errors};
-}
-
-const initialRuntimeIdentity = readBootRuntimeIdentity();
-
-function normalizeString(value) {
-    if (typeof value !== 'string') {
-        return null;
-    }
-
-    const trimmed = value.trim();
-
-    return trimmed || null;
-}
-
-function compareRuntimeIdentityField(field, boot, current) {
-    const
-        bootValue    = normalizeString(boot[field]),
-        currentValue = normalizeString(current[field]);
-
-    if (!bootValue || !currentValue) {
-        return null;
-    }
-
-    return bootValue !== currentValue;
-}
-
-/**
- * @summary Classifies boot-vs-current Knowledge Base MCP runtime identity.
- *
- * A stale runtime is an observability warning, not a hard outage. The process can stay usable
- * while still telling agents to restart before asserting source, config, or tool-schema facts.
- *
- * @param {Object} options
- * @param {String} options.startedAt Runtime start timestamp.
- * @param {Object} options.boot Boot-time source identity.
- * @param {Object} options.current Current checkout/config identity.
- * @param {String[]} options.errors Optional identity-read errors.
- * @returns {Object}
- */
-function classifyRuntimeFreshness({startedAt, boot = {}, current = {}, errors = []} = {}) {
-    const stale = {
-        gitHead      : compareRuntimeIdentityField('gitHead', boot, current),
-        configDigest : compareRuntimeIdentityField('configDigest', boot, current),
-        openApiDigest: compareRuntimeIdentityField('openApiDigest', boot, current)
-    };
-    const comparableFields = Object.values(stale).filter(value => value !== null),
-          staleFields      = Object.entries(stale)
-                                .filter(([, value]) => value === true)
-                                .map(([key]) => key),
-          details          = [];
-
-    let status;
-
-    if (staleFields.length) {
-        status = 'stale';
-        details.push(`Runtime source identity differs from the current checkout (${staleFields.join(', ')}). Restart or reconnect the Knowledge Base MCP server before asserting tool-schema/source facts.`);
-    } else if (comparableFields.length) {
-        status = 'current';
-        details.push('Runtime source identity matches the current checkout.');
-    } else {
-        status = 'unknown';
-        details.push('Runtime source identity could not be compared; git metadata, config digest, and OpenAPI digest reads were unavailable or incomplete.');
-    }
-
-    for (const error of errors.filter(Boolean)) {
-        details.push(error);
-    }
-
-    return {
-        status,
-        startedAt,
-        stale,
-        details,
-        hint: status === 'stale'
-            ? 'Restart or reconnect the Knowledge Base MCP server to refresh cached source, config, and tool definitions.'
-            : null
-    };
-}
 
 /**
  * @summary Monitors and validates the ChromaDB dependency for the Knowledge Base MCP server.
@@ -212,31 +108,35 @@ class HealthService extends Base {
     #previousStatus = null;
 
     /**
-     * Cached runtime freshness diagnostic. Separate from dependency health so the freshness
-     * warning can update quickly without spawning git/hash work on every healthcheck call.
-     * @member {Object|null} #cachedRuntimeFreshness
+     * Shared runtime freshness tracker.
+     * @member {RuntimeFreshnessTracker} #runtimeFreshnessTracker
      * @private
      */
-    #cachedRuntimeFreshness = null;
-
-    /**
-     * Timestamp (in milliseconds) of when runtime freshness was last resolved.
-     * @member {Number|null} #lastRuntimeFreshnessCheckTime
-     * @private
-     */
-    #lastRuntimeFreshnessCheckTime = null;
+    #runtimeFreshnessTracker = runtimeFreshnessTracker;
 
     /**
      * Boot-time runtime identity captured before long-lived MCP clients can go stale.
      * @member {Object} bootRuntimeIdentity
      */
-    bootRuntimeIdentity = initialRuntimeIdentity.boot;
+    get bootRuntimeIdentity() {
+        return this.#runtimeFreshnessTracker.bootRuntimeIdentity;
+    }
+
+    set bootRuntimeIdentity(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeIdentity = value || {};
+    }
 
     /**
      * Boot-time runtime identity read errors.
      * @member {String[]} bootRuntimeFreshnessErrors
      */
-    bootRuntimeFreshnessErrors = initialRuntimeIdentity.errors;
+    get bootRuntimeFreshnessErrors() {
+        return this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors;
+    }
+
+    set bootRuntimeFreshnessErrors(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors = Array.isArray(value) ? value : [];
+    }
 
     /**
      * Optional unit-test seam for injecting boot/current runtime identity reads.
@@ -248,7 +148,13 @@ class HealthService extends Base {
      * ISO timestamp captured when this server module was loaded.
      * @member {String} runtimeStartedAt
      */
-    runtimeStartedAt = startedAt;
+    get runtimeStartedAt() {
+        return this.#runtimeFreshnessTracker.startedAt;
+    }
+
+    set runtimeStartedAt(value) {
+        this.#runtimeFreshnessTracker.startedAt = value;
+    }
 
     /**
      * Duration (in milliseconds) for which runtime freshness remains cached.
@@ -559,10 +465,9 @@ class HealthService extends Base {
      * without waiting for the 5-minute cache to expire.
      */
     clearCache() {
-        this.#cachedHealth                    = null;
-        this.#lastCheckTime                   = null;
-        this.#cachedRuntimeFreshness          = null;
-        this.#lastRuntimeFreshnessCheckTime   = null;
+        this.#cachedHealth    = null;
+        this.#lastCheckTime   = null;
+        this.#runtimeFreshnessTracker.clearCache();
         logger.debug('[HealthService] Cache cleared, next health check will be fresh');
     }
 
@@ -576,85 +481,10 @@ class HealthService extends Base {
      * @returns {Promise<Object>} Runtime freshness diagnostic payload.
      */
     async resolveRuntimeFreshness() {
-        const now = Date.now();
-
-        if (
-            this.#cachedRuntimeFreshness &&
-            this.#lastRuntimeFreshnessCheckTime &&
-            (now - this.#lastRuntimeFreshnessCheckTime) < this.runtimeFreshnessCacheDuration
-        ) {
-            return this.#cachedRuntimeFreshness;
-        }
-
-        let freshness;
-
-        try {
-            const identity = this.runtimeFreshnessReader
-                ? await this.runtimeFreshnessReader()
-                : await this.#readCurrentRuntimeIdentity();
-
-            const runtimeErrors = Array.isArray(identity.errors)
-                ? identity.errors
-                : [identity.errors].filter(Boolean);
-
-            freshness = classifyRuntimeFreshness({
-                startedAt: this.runtimeStartedAt,
-                boot     : identity.boot || this.bootRuntimeIdentity,
-                current  : identity.current || {},
-                errors   : [
-                    ...this.bootRuntimeFreshnessErrors,
-                    ...runtimeErrors
-                ]
-            });
-        } catch (e) {
-            freshness = classifyRuntimeFreshness({
-                startedAt: this.runtimeStartedAt,
-                boot     : this.bootRuntimeIdentity,
-                current  : {},
-                errors   : [
-                    ...this.bootRuntimeFreshnessErrors,
-                    `runtime freshness reader failed: ${e.message}`
-                ]
-            });
-        }
-
-        this.#cachedRuntimeFreshness        = freshness;
-        this.#lastRuntimeFreshnessCheckTime = now;
-
-        return freshness;
-    }
-
-    /**
-     * Reads current checkout/config identity without touching ChromaDB or remote providers.
-     *
-     * @returns {Promise<Object>} `{current, errors}` source identity tuple.
-     * @private
-     */
-    async #readCurrentRuntimeIdentity() {
-        const current = {},
-              errors  = [];
-
-        try {
-            const {stdout} = await execFileAsync('git', ['-C', aiConfig.neoRootDir, 'rev-parse', 'HEAD']);
-
-            current.gitHead = stdout.trim();
-        } catch (e) {
-            errors.push(`current gitHead unavailable: ${e.message}`);
-        }
-
-        try {
-            current.configDigest = createFileDigest(configPath);
-        } catch (e) {
-            errors.push(`current config digest unavailable: ${e.message}`);
-        }
-
-        try {
-            current.openApiDigest = createFileDigest(openApiPath);
-        } catch (e) {
-            errors.push(`current OpenAPI digest unavailable: ${e.message}`);
-        }
-
-        return {current, errors};
+        return this.#runtimeFreshnessTracker.resolve({
+            reader       : this.runtimeFreshnessReader,
+            cacheDuration: this.runtimeFreshnessCacheDuration
+        });
     }
 }
 

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -23,7 +23,6 @@ const
     configPath  = path.resolve(__dirname, '../../config.mjs'),
     openApiPath = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
     runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
-        rootDir: aiConfig.neoRootDir,
         files  : [{
             key       : 'configDigest',
             path      : configPath,
@@ -38,7 +37,7 @@ const
         assertionFacts    : 'provider, config, or tool-schema facts',
         restartScope      : 'cached provider/config state',
         statusFields      : ['configDigest', 'openApiDigest'],
-        unavailableSummary: 'git metadata, config digest, and OpenAPI digest'
+        unavailableSummary: 'config digest and OpenAPI digest'
     });
 
 /**

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1,12 +1,10 @@
-import {execFileSync}           from 'child_process';
-import {createHash}             from 'crypto';
-import {readFileSync}           from 'fs';
 import fs                       from 'fs/promises';
 import fsExtra                  from 'fs-extra';
 import path                     from 'path';
 import {fileURLToPath}          from 'url';
 import aiConfig                 from '../../mcp/server/memory-core/config.mjs';
 import Base                     from '../../../src/core/Base.mjs';
+import RuntimeFreshnessService  from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
 import ChromaManager            from './managers/ChromaManager.mjs';
 import StorageRouter            from './managers/StorageRouter.mjs';
 import ChromaLifecycleService   from './lifecycle/ChromaLifecycleService.mjs';
@@ -24,152 +22,24 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const
     configPath  = path.resolve(__dirname, '../../config.mjs'),
     openApiPath = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
-    startedAt   = new Date().toISOString();
-
-/**
- * @summary Computes a stable SHA-256 digest for runtime freshness file identity.
- * @param {String} filePath Absolute file path.
- * @returns {String}
- */
-function createFileDigest(filePath) {
-    const contents = readFileSync(filePath);
-
-    return `sha256:${createHash('sha256').update(contents).digest('hex')}`;
-}
-
-/**
- * @summary Reads the current checkout HEAD for the Memory Core runtime identity block.
- * @returns {String}
- */
-function readGitHead() {
-    const stdout = execFileSync('git', ['-C', aiConfig.neoRootDir, 'rev-parse', 'HEAD'], {
-        encoding: 'utf8',
-        stdio   : ['ignore', 'pipe', 'pipe']
+    runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
+        rootDir: aiConfig.neoRootDir,
+        files  : [{
+            key       : 'configDigest',
+            path      : configPath,
+            errorLabel: 'config digest'
+        }, {
+            key       : 'openApiDigest',
+            path      : openApiPath,
+            errorLabel: 'OpenAPI digest'
+        }],
+        serviceName       : 'Memory Core MCP server',
+        identityLabel     : 'source/config identity',
+        assertionFacts    : 'provider, config, or tool-schema facts',
+        restartScope      : 'cached provider/config state',
+        statusFields      : ['configDigest', 'openApiDigest'],
+        unavailableSummary: 'git metadata, config digest, and OpenAPI digest'
     });
-
-    return stdout.trim();
-}
-
-/**
- * @summary Reads source, config, and schema identity for runtime freshness comparison.
- * @returns {{identity: Object, errors: String[]}}
- */
-function readRuntimeIdentity() {
-    const errors = [],
-          identity = {};
-
-    try {
-        identity.gitHead = readGitHead();
-    } catch (e) {
-        errors.push(`gitHead unavailable: ${e.message}`);
-    }
-
-    try {
-        identity.configDigest = createFileDigest(configPath);
-    } catch (e) {
-        errors.push(`config digest unavailable: ${e.message}`);
-    }
-
-    try {
-        identity.openApiDigest = createFileDigest(openApiPath);
-    } catch (e) {
-        errors.push(`OpenAPI digest unavailable: ${e.message}`);
-    }
-
-    return {identity, errors};
-}
-
-const initialRuntimeIdentity = readRuntimeIdentity();
-
-/**
- * @summary Normalizes comparable runtime identity values.
- * @param {*} value Candidate identity field value.
- * @returns {String|null}
- */
-function normalizeRuntimeIdentityValue(value) {
-    if (typeof value !== 'string') {
-        return null;
-    }
-
-    const trimmed = value.trim();
-
-    return trimmed || null;
-}
-
-/**
- * @summary Compares one boot/current runtime identity field.
- * @param {String} field Field name to compare.
- * @param {Object} boot Boot-time identity.
- * @param {Object} current Current identity.
- * @returns {Boolean|null}
- */
-function compareRuntimeIdentityField(field, boot, current) {
-    const
-        bootValue    = normalizeRuntimeIdentityValue(boot[field]),
-        currentValue = normalizeRuntimeIdentityValue(current[field]);
-
-    if (!bootValue || !currentValue) {
-        return null;
-    }
-
-    return bootValue !== currentValue;
-}
-
-/**
- * @summary Classifies boot-vs-current Memory Core MCP runtime identity.
- *
- * `status:'stale'` is a diagnostic warning, not a hard outage. The MCP process can
- * still answer read-only calls while warning agents to restart before asserting provider,
- * config, or schema facts.
- *
- * @param {Object} options
- * @param {String} options.startedAt Runtime start timestamp.
- * @param {Object} options.boot Boot-time source/config/schema identity.
- * @param {Object} options.current Current checkout/config/schema identity.
- * @param {String[]} options.errors Optional identity-read errors.
- * @returns {Object}
- */
-export function classifyRuntimeFreshness({startedAt, boot = {}, current = {}, errors = []} = {}) {
-    const stale = {
-        gitHead      : compareRuntimeIdentityField('gitHead', boot, current),
-        configDigest : compareRuntimeIdentityField('configDigest', boot, current),
-        openApiDigest: compareRuntimeIdentityField('openApiDigest', boot, current)
-    };
-    const comparableFields = Object.values(stale).filter(value => value !== null),
-          staleFields      = Object.entries(stale)
-                              .filter(([, value]) => value === true)
-                              .map(([key]) => key),
-          details          = [];
-
-    let status;
-
-    if (staleFields.length) {
-        status = 'stale';
-        details.push(`Runtime source/config identity differs from the current checkout (${staleFields.join(', ')}). Restart or reconnect the Memory Core MCP server before asserting provider, config, or tool-schema facts.`);
-    } else if (comparableFields.length) {
-        status = 'current';
-        details.push('Runtime source/config identity matches the current checkout.');
-    } else {
-        status = 'unknown';
-        details.push('Runtime source/config identity could not be compared; git metadata, config digest, and OpenAPI digest reads were unavailable or incomplete.');
-    }
-
-    for (const error of errors.filter(Boolean)) {
-        details.push(error);
-    }
-
-    return {
-        status,
-        startedAt,
-        boot,
-        current,
-        stale,
-        details,
-        hint: status === 'stale'
-            ? 'Restart or reconnect the Memory Core MCP server to refresh cached provider/config state.'
-            : null
-    };
-}
 
 /**
  * @summary Heartbeat-liveness file path resolution shared with `SwarmHeartbeatService`.
@@ -1053,16 +923,35 @@ class HealthService extends Base {
     #stdioIdentityState = null;
 
     /**
+     * Shared runtime freshness tracker.
+     * @member {RuntimeFreshnessTracker} #runtimeFreshnessTracker
+     * @private
+     */
+    #runtimeFreshnessTracker = runtimeFreshnessTracker;
+
+    /**
      * Boot-time runtime identity captured before long-lived MCP clients can go stale.
      * @member {Object} bootRuntimeIdentity
      */
-    bootRuntimeIdentity = initialRuntimeIdentity.identity;
+    get bootRuntimeIdentity() {
+        return this.#runtimeFreshnessTracker.bootRuntimeIdentity;
+    }
+
+    set bootRuntimeIdentity(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeIdentity = value || {};
+    }
 
     /**
      * Boot-time runtime identity read errors.
      * @member {String[]} bootRuntimeFreshnessErrors
      */
-    bootRuntimeFreshnessErrors = initialRuntimeIdentity.errors;
+    get bootRuntimeFreshnessErrors() {
+        return this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors;
+    }
+
+    set bootRuntimeFreshnessErrors(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors = Array.isArray(value) ? value : [];
+    }
 
     /**
      * Optional unit-test seam for injecting boot/current runtime identity reads.
@@ -1074,7 +963,19 @@ class HealthService extends Base {
      * ISO timestamp captured when this service module was loaded.
      * @member {String} runtimeStartedAt
      */
-    runtimeStartedAt = startedAt;
+    get runtimeStartedAt() {
+        return this.#runtimeFreshnessTracker.startedAt;
+    }
+
+    set runtimeStartedAt(value) {
+        this.#runtimeFreshnessTracker.startedAt = value;
+    }
+
+    /**
+     * Duration (in milliseconds) for which runtime freshness remains cached.
+     * @member {Number} runtimeFreshnessCacheDuration
+     */
+    runtimeFreshnessCacheDuration = 30 * 1000;
 
     /**
      * Checks if the active vector and graph databases are running and accessible.
@@ -1371,26 +1272,6 @@ class HealthService extends Base {
     }
 
     /**
-     * Reads current source/config/schema identity for the attached MCP process.
-     *
-     * Intent: the running Memory Core server can stay healthy while stale relative to the
-     * checkout/config the operator just migrated. This lightweight reader compares process
-     * boot identity to the current filesystem without re-importing or mutating AiConfig.
-     *
-     * @returns {{boot: Object, current: Object, errors: String[]}}
-     * @private
-     */
-    #readCurrentRuntimeIdentity() {
-        const {identity, errors} = readRuntimeIdentity();
-
-        return {
-            boot   : this.bootRuntimeIdentity,
-            current: identity,
-            errors
-        };
-    }
-
-    /**
      * Resolves the live runtime freshness diagnostic for the attached Memory Core MCP process.
      *
      * A stale runtime is a warning, not a service outage: callers can still use healthy read
@@ -1399,35 +1280,10 @@ class HealthService extends Base {
      * @returns {Promise<Object>} Runtime freshness diagnostic payload.
      */
     async resolveRuntimeFreshness() {
-        try {
-            const identity = this.runtimeFreshnessReader
-                ? await this.runtimeFreshnessReader()
-                : this.#readCurrentRuntimeIdentity();
-
-            const runtimeErrors = Array.isArray(identity.errors)
-                ? identity.errors
-                : [identity.errors].filter(Boolean);
-
-            return classifyRuntimeFreshness({
-                startedAt: this.runtimeStartedAt,
-                boot     : identity.boot || this.bootRuntimeIdentity,
-                current  : identity.current || {},
-                errors   : [
-                    ...this.bootRuntimeFreshnessErrors,
-                    ...runtimeErrors
-                ]
-            });
-        } catch (e) {
-            return classifyRuntimeFreshness({
-                startedAt: this.runtimeStartedAt,
-                boot     : this.bootRuntimeIdentity,
-                current  : {},
-                errors   : [
-                    ...this.bootRuntimeFreshnessErrors,
-                    `runtime freshness reader failed: ${e.message}`
-                ]
-            });
-        }
+        return this.#runtimeFreshnessTracker.resolve({
+            reader       : this.runtimeFreshnessReader,
+            cacheDuration: this.runtimeFreshnessCacheDuration
+        });
     }
 
 
@@ -1850,6 +1706,7 @@ class HealthService extends Base {
         this.#cachedHealth                = null;
         this.#lastCheckTime               = null;
         this.#embeddingWriteCanaryCache   = null;
+        this.#runtimeFreshnessTracker.clearCache();
         logger.debug('[HealthService] Cache cleared, next health check will be fresh');
     }
 }

--- a/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
@@ -188,4 +188,34 @@ test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776
         });
         expect(readCount).toBe(2);
     });
+
+    test('a tracker created without rootDir never reads git and omits gitHead entirely', async () => {
+        const tracker = RuntimeFreshnessService.createTracker({
+            files: [{
+                key       : 'openApiDigest',
+                path      : path.resolve(repoRoot, 'ai/mcp/server/github-workflow/openapi.yaml'),
+                errorLabel: 'OpenAPI digest'
+            }],
+            serviceName       : 'Cloud MCP server',
+            identityLabel     : 'source/schema identity',
+            assertionFacts    : 'tool-schema/source facts',
+            restartScope      : 'cached tool definitions',
+            statusFields      : ['openApiDigest'],
+            unavailableSummary: 'config digest and OpenAPI digest'
+        });
+
+        // Real read (no reader seam): a rootDir-less consumer must never spawn `git`, so no
+        // `gitHead` field and no `gitHead unavailable` error can appear. This is the portability
+        // guarantee for cloud-deployed Memory Core / Knowledge Base on a non-git checkout.
+        const {current, errors} = await tracker.readCurrentIdentity();
+
+        expect(current).not.toHaveProperty('gitHead');
+        expect(current).toHaveProperty('openApiDigest');
+        expect(errors.some(error => error.includes('gitHead'))).toBe(false);
+
+        const result = await tracker.resolve({now: 1000});
+
+        expect(result.status).toBe('current');
+        expect(result.stale).not.toHaveProperty('gitHead');
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs
@@ -1,0 +1,191 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'RuntimeFreshnessServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}          from '@playwright/test';
+import path                    from 'path';
+import {fileURLToPath}         from 'url';
+import Neo                     from '../../../../../../../../src/Neo.mjs';
+import * as core               from '../../../../../../../../src/core/_export.mjs';
+import RuntimeFreshnessService from '../../../../../../../../ai/mcp/server/shared/services/RuntimeFreshnessService.mjs';
+
+const
+    testDir  = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot = path.resolve(testDir, '../../../../../../../../');
+
+/**
+ * @summary Unit coverage for the shared MCP runtime freshness substrate.
+ *
+ * The shared service owns the policy that service-owned digests drive stale status while
+ * repo-wide `gitHead` drift stays contextual. This prevents three MCP health services from
+ * re-deriving divergent restart warnings.
+ */
+test.describe('Neo.ai.mcp.server.shared.services.RuntimeFreshnessService (#12776)', () => {
+    test('keeps gitHead drift contextual when status-driving fields match', () => {
+        const result = RuntimeFreshnessService.classifyRuntimeFreshness({
+            startedAt       : '2026-06-08T00:00:00.000Z',
+            boot            : {
+                gitHead      : 'old-head',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current         : {
+                gitHead      : 'new-head',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            fieldKeys       : ['gitHead', 'openApiDigest'],
+            statusFields    : ['openApiDigest'],
+            serviceName     : 'Test MCP server',
+            identityLabel   : 'source/schema identity',
+            assertionFacts  : 'tool-schema/source facts',
+            restartScope    : 'cached tool definitions',
+            unavailableSummary: 'git metadata and OpenAPI digest'
+        });
+
+        expect(result).toMatchObject({
+            status   : 'current',
+            startedAt: '2026-06-08T00:00:00.000Z',
+            stale    : {
+                gitHead      : true,
+                openApiDigest: false
+            },
+            hint: null
+        });
+        expect(result.details[0]).toBe('Runtime source/schema identity matches the current checkout.');
+        expect(result.details[1]).toContain('Contextual runtime identity differs (gitHead)');
+        expect(result.boot).toBeUndefined();
+        expect(result.current).toBeUndefined();
+    });
+
+    test('marks stale when a status-driving digest differs', () => {
+        const result = RuntimeFreshnessService.classifyRuntimeFreshness({
+            startedAt       : '2026-06-08T00:00:00.000Z',
+            boot            : {
+                gitHead      : 'same-head',
+                configDigest : 'sha256:old-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current         : {
+                gitHead      : 'same-head',
+                configDigest : 'sha256:new-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            fieldKeys       : ['gitHead', 'configDigest', 'openApiDigest'],
+            statusFields    : ['configDigest', 'openApiDigest'],
+            serviceName     : 'Test MCP server',
+            identityLabel   : 'source/config identity',
+            assertionFacts  : 'provider/config facts',
+            restartScope    : 'cached provider/config state',
+            unavailableSummary: 'git metadata, config digest, and OpenAPI digest'
+        });
+
+        expect(result).toMatchObject({
+            status: 'stale',
+            stale : {
+                gitHead      : false,
+                configDigest : true,
+                openApiDigest: false
+            },
+            hint: 'Restart or reconnect the Test MCP server to refresh cached provider/config state.'
+        });
+        expect(result.details[0]).toContain('configDigest');
+    });
+
+    test('reports unknown when only contextual gitHead can be compared', () => {
+        const result = RuntimeFreshnessService.classifyRuntimeFreshness({
+            startedAt       : '2026-06-08T00:00:00.000Z',
+            boot            : {
+                gitHead: 'same-head'
+            },
+            current         : {
+                gitHead: 'same-head'
+            },
+            errors          : ['current OpenAPI digest unavailable: fixture'],
+            fieldKeys       : ['gitHead', 'openApiDigest'],
+            statusFields    : ['openApiDigest'],
+            serviceName     : 'Test MCP server',
+            identityLabel   : 'source/schema identity',
+            assertionFacts  : 'tool-schema/source facts',
+            restartScope    : 'cached tool definitions',
+            unavailableSummary: 'git metadata and OpenAPI digest'
+        });
+
+        expect(result).toMatchObject({
+            status: 'unknown',
+            stale : {
+                gitHead      : false,
+                openApiDigest: null
+            },
+            hint: null
+        });
+        expect(result.details[0]).toContain('could not be compared');
+        expect(result.details).toContain('current OpenAPI digest unavailable: fixture');
+    });
+
+    test('caches current identity reads per tracker until the short TTL expires', async () => {
+        const tracker = RuntimeFreshnessService.createTracker({
+            rootDir: repoRoot,
+            files  : [{
+                key       : 'openApiDigest',
+                path      : path.resolve(repoRoot, 'ai/mcp/server/github-workflow/openapi.yaml'),
+                errorLabel: 'OpenAPI digest'
+            }],
+            serviceName       : 'Test MCP server',
+            identityLabel     : 'source/schema identity',
+            assertionFacts    : 'tool-schema/source facts',
+            restartScope      : 'cached tool definitions',
+            statusFields      : ['openApiDigest'],
+            unavailableSummary: 'git metadata and OpenAPI digest'
+        });
+
+        let readCount = 0,
+            openApiDigest = 'sha256:same-openapi';
+
+        const reader = async () => {
+            readCount++;
+
+            return {
+                boot: {
+                    gitHead      : 'same-head',
+                    openApiDigest: 'sha256:same-openapi'
+                },
+                current: {
+                    gitHead      : 'same-head',
+                    openApiDigest
+                }
+            };
+        };
+
+        const first = await tracker.resolve({reader, cacheDuration: 1000, now: 1000});
+
+        expect(first.status).toBe('current');
+        expect(readCount).toBe(1);
+
+        openApiDigest = 'sha256:new-openapi';
+
+        const cached = await tracker.resolve({reader, cacheDuration: 1000, now: 1500});
+
+        expect(cached.status).toBe('current');
+        expect(readCount).toBe(1);
+
+        const refreshed = await tracker.resolve({reader, cacheDuration: 1000, now: 2501});
+
+        expect(refreshed).toMatchObject({
+            status: 'stale',
+            stale : {
+                openApiDigest: true
+            }
+        });
+        expect(readCount).toBe(2);
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
@@ -51,10 +51,12 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - runtimeFre
             },
             hint: null
         });
-        expect(result.details).toContain('Runtime source identity matches the current checkout.');
+        expect(result.details).toContain('Runtime source/schema identity matches the current checkout.');
+        expect(result.boot).toBeUndefined();
+        expect(result.current).toBeUndefined();
     });
 
-    test('classifies stale git and OpenAPI identity with restart guidance', async () => {
+    test('classifies stale OpenAPI identity with restart guidance', async () => {
         HealthService.runtimeFreshnessReader = async () => ({
             boot: {
                 gitHead      : 'old-head',
@@ -74,9 +76,36 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - runtimeFre
                 gitHead      : true,
                 openApiDigest: true
             },
-            hint: 'Restart or reconnect the MCP client/server to refresh cached tool definitions.'
+            hint: 'Restart or reconnect the GitHub Workflow MCP server to refresh cached tool definitions.'
         });
-        expect(result.details[0]).toContain('Restart or reconnect the MCP client/server');
+        expect(result.details[0]).toContain('Restart or reconnect the GitHub Workflow MCP server');
+        expect(result.details[0]).toContain('openApiDigest');
+        expect(result.details[1]).toContain('Contextual runtime identity differs (gitHead)');
+    });
+
+    test('keeps gitHead drift contextual when OpenAPI identity matches', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'old-head',
+                openApiDigest: 'sha256:same'
+            },
+            current: {
+                gitHead      : 'new-head',
+                openApiDigest: 'sha256:same'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'current',
+            stale : {
+                gitHead      : true,
+                openApiDigest: false
+            },
+            hint: null
+        });
+        expect(result.details[1]).toContain('informational');
     });
 
     test('classifies missing identity as unknown without throwing', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -155,7 +155,7 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
             },
             hint: null
         });
-        expect(result.details).toContain('Runtime source identity matches the current checkout.');
+        expect(result.details).toContain('Runtime source/config identity matches the current checkout.');
         expect(result.boot).toBeUndefined();
         expect(result.current).toBeUndefined();
     });
@@ -187,6 +187,34 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
         });
         expect(result.details[0]).toContain('Knowledge Base MCP server');
         expect(result.details[0]).toContain('configDigest');
+    });
+
+    test('keeps gitHead drift contextual when service-owned identity matches', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'old-head',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current: {
+                gitHead      : 'new-head',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'current',
+            stale : {
+                gitHead      : true,
+                configDigest : false,
+                openApiDigest: false
+            },
+            hint: null
+        });
+        expect(result.details[1]).toContain('informational');
     });
 
     test('classifies missing identity as unknown without throwing', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -149,7 +149,6 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
         expect(result).toMatchObject({
             status: 'current',
             stale : {
-                gitHead      : false,
                 configDigest : false,
                 openApiDigest: false
             },
@@ -179,7 +178,6 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
         expect(result).toMatchObject({
             status: 'stale',
             stale : {
-                gitHead      : false,
                 configDigest : true,
                 openApiDigest: true
             },
@@ -189,7 +187,10 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
         expect(result.details[0]).toContain('configDigest');
     });
 
-    test('keeps gitHead drift contextual when service-owned identity matches', async () => {
+    test('does not track gitHead — injected gitHead drift is ignored entirely', async () => {
+        // Knowledge Base supplies no rootDir to the shared tracker, so gitHead is never read or
+        // surfaced. Even a reader returning differing gitHead values must not appear in `stale`
+        // nor flip status: the freshness signal is digest-only and portable off a git checkout.
         HealthService.runtimeFreshnessReader = async () => ({
             boot: {
                 gitHead      : 'old-head',
@@ -205,16 +206,10 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
 
         const result = await HealthService.resolveRuntimeFreshness();
 
-        expect(result).toMatchObject({
-            status: 'current',
-            stale : {
-                gitHead      : true,
-                configDigest : false,
-                openApiDigest: false
-            },
-            hint: null
-        });
-        expect(result.details[1]).toContain('informational');
+        expect(result.status).toBe('current');
+        expect(result.stale).not.toHaveProperty('gitHead');
+        expect(result.stale).toEqual({configDigest: false, openApiDigest: false});
+        expect(result.details.join(' ')).not.toContain('informational');
     });
 
     test('classifies missing identity as unknown without throwing', async () => {
@@ -229,7 +224,6 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
         expect(result).toMatchObject({
             status: 'unknown',
             stale : {
-                gitHead      : null,
                 configDigest : null,
                 openApiDigest: null
             },
@@ -314,7 +308,6 @@ test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshn
             expect(refreshed.runtimeFreshness).toMatchObject({
                 status: 'stale',
                 stale : {
-                    gitHead      : false,
                     configDigest : true,
                     openApiDigest: false
                 }

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -240,7 +240,6 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
         expect(result).toMatchObject({
             status: 'current',
             stale : {
-                gitHead      : false,
                 configDigest : false,
                 openApiDigest: false
             },
@@ -270,7 +269,6 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
         expect(result).toMatchObject({
             status: 'stale',
             stale : {
-                gitHead      : false,
                 configDigest : true,
                 openApiDigest: false
             },
@@ -280,7 +278,10 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
         expect(result.details[0]).toContain('configDigest');
     });
 
-    test('keeps gitHead drift contextual when service-owned identity matches', async () => {
+    test('does not track gitHead — injected gitHead drift is ignored entirely', async () => {
+        // Memory Core supplies no rootDir to the shared tracker, so gitHead is never read or
+        // surfaced. Even a reader returning differing gitHead values must not appear in `stale`
+        // nor flip status: the freshness signal is digest-only and portable off a git checkout.
         HealthService.runtimeFreshnessReader = async () => ({
             boot: {
                 gitHead      : 'old-head',
@@ -296,16 +297,10 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
 
         const result = await HealthService.resolveRuntimeFreshness();
 
-        expect(result).toMatchObject({
-            status: 'current',
-            stale : {
-                gitHead      : true,
-                configDigest : false,
-                openApiDigest: false
-            },
-            hint: null
-        });
-        expect(result.details[1]).toContain('informational');
+        expect(result.status).toBe('current');
+        expect(result.stale).not.toHaveProperty('gitHead');
+        expect(result.stale).toEqual({configDigest: false, openApiDigest: false});
+        expect(result.details.join(' ')).not.toContain('informational');
     });
 
     test('classifies missing identity as unknown without throwing', async () => {
@@ -320,7 +315,6 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
         expect(result).toMatchObject({
             status: 'unknown',
             stale : {
-                gitHead      : null,
                 configDigest : null,
                 openApiDigest: null
             },
@@ -491,7 +485,6 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(fresh.runtimeFreshness).toMatchObject({
             status: 'stale',
             stale : {
-                gitHead      : false,
                 configDigest : true,
                 openApiDigest: false
             }

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -247,6 +247,8 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
             hint: null
         });
         expect(result.details).toContain('Runtime source/config identity matches the current checkout.');
+        expect(result.boot).toBeUndefined();
+        expect(result.current).toBeUndefined();
     });
 
     test('classifies stale config identity with restart guidance', async () => {
@@ -276,6 +278,34 @@ test.describe.serial('HealthService #12772 — runtimeFreshness', () => {
         });
         expect(result.details[0]).toContain('Memory Core MCP server');
         expect(result.details[0]).toContain('configDigest');
+    });
+
+    test('keeps gitHead drift contextual when service-owned identity matches', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot: {
+                gitHead      : 'old-head',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            },
+            current: {
+                gitHead      : 'new-head',
+                configDigest : 'sha256:same-config',
+                openApiDigest: 'sha256:same-openapi'
+            }
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'current',
+            stale : {
+                gitHead      : true,
+                configDigest : false,
+                openApiDigest: false
+            },
+            hint: null
+        });
+        expect(result.details[1]).toContain('informational');
     });
 
     test('classifies missing identity as unknown without throwing', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12776
Related: #12740

Extracts the duplicated MCP runtime freshness logic into a shared `RuntimeFreshnessService` and migrates GitHub Workflow, Memory Core, and Knowledge Base healthchecks to consume it. The public payload is now compact across all three servers, current identity reads are cached per tracker, and `gitHead` drift is intentionally contextual rather than status-driving.

Evidence: L2 (targeted Playwright unit coverage + OpenAPI/static contract checks) -> L2 required (shared helper, consumer wiring, compact payload, cache behavior, and gitHead policy covered). No residuals.

## Deltas from ticket

- `gitHead` remains visible in `stale.gitHead`, but only service-owned digests (`configDigest`, `openApiDigest`) can make `status` become `stale`.
- GitHub Workflow and Memory Core no longer expose raw `boot` / `current` identity objects in the healthcheck schema, matching the compact Knowledge Base shape.
- The shared helper lives at `ai/mcp/server/shared/services/RuntimeFreshnessService.mjs`; structural fast-path applied against the existing shared MCP service siblings. Map maintenance is not needed because the existing `ai/mcp/server/shared/` inventory row already covers cross-cutting MCP infrastructure.
- While validating this lane, the currently running KB `ask_knowledge_base` tool still attempted `gemini-3.5-flash` and failed with `API_KEY_INVALID`. That appears consistent with stale running MCP servers rather than this branch's source, but it is useful post-merge validation evidence for the cost-safety cluster.

Decision Record impact: none. The implementation stays aligned with ADR 0019 by letting each consumer pass resolved service-local inputs; it does not re-export, alias, or mutate `aiConfig`.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/services/RuntimeFreshnessService.spec.mjs test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` -> 78 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-push freshness: `git merge-base HEAD origin/dev` matched `git rev-parse origin/dev`; branch contains only `26ce78bbf` over `origin/dev`.

## Post-Merge Validation

- [ ] Restart/reconnect GitHub Workflow, Memory Core, and Knowledge Base MCP servers and confirm `runtimeFreshness` appears with compact `{status, startedAt, stale, details, hint}` payloads.
- [ ] Re-run `ask_knowledge_base` after KB MCP restart/config refresh and confirm synthesis no longer routes to remote Gemini unexpectedly.

## Commit

- `26ce78bbf` — `feat(ai): share MCP runtime freshness helper (#12776)`
