### PR TITLE
fix(ai): reject GitHub sync CLI off dev (#12780)

### DIFF
--- a/ai/scripts/maintenance/syncGithubWorkflow.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflow.mjs
@@ -1,5 +1,10 @@
 import {GH_Config, GH_SyncService}     from '../../services.mjs';
 import {withHeavyMaintenanceLease}     from '../../daemons/orchestrator/services/HeavyMaintenanceLeaseService.mjs';
+import {pathToFileURL}                 from 'url';
+import {
+    buildSyncGithubWorkflowDevBranchGuard,
+    defaultSyncGithubWorkflowBranchDetector
+} from './syncGithubWorkflowBranchGuard.mjs';
 
 /**
  * @module ai/scripts/maintenance/syncGithubWorkflow
@@ -43,9 +48,35 @@ import {withHeavyMaintenanceLease}     from '../../daemons/orchestrator/services
  *   # Exit code 0 on success / 1 on failure.
  */
 
+/**
+ * @summary Asserts that the GitHub Workflow sync CLI is running from dev.
+ * @returns {Promise<void>}
+ */
+async function assertSyncGithubWorkflowDevBranch() {
+    const
+        projectRoot = GH_Config.projectRoot || GH_Config.data?.projectRoot || process.cwd(),
+        guard       = buildSyncGithubWorkflowDevBranchGuard(
+            async () => true,
+            () => defaultSyncGithubWorkflowBranchDetector({projectRoot})
+        );
+
+    await guard();
+}
+
+/**
+ * @summary CLI entry point for the full GitHub Workflow mirror sync.
+ * @returns {Promise<void>}
+ */
 async function syncGithubWorkflow() {
     const verbose = process.argv.includes('--verbose');
     GH_Config.data.logLevel = verbose ? 'debug' : 'info';
+
+    try {
+        await assertSyncGithubWorkflowDevBranch();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
 
     console.log('🔄 Starting full GitHub Workflow sync via GH_SyncService.runFullSync()...');
 
@@ -75,4 +106,8 @@ async function syncGithubWorkflow() {
     process.exit(0);
 }
 
-syncGithubWorkflow();
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    syncGithubWorkflow();
+}
+
+export {assertSyncGithubWorkflowDevBranch, syncGithubWorkflow};

--- a/ai/scripts/maintenance/syncGithubWorkflowBranchGuard.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflowBranchGuard.mjs
@@ -1,0 +1,72 @@
+import {execFile}  from 'child_process';
+import path        from 'path';
+import {promisify} from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary Detects the current Git branch for the GitHub Workflow sync CLI.
+ * @param {Object} [options]
+ * @param {String} [options.projectRoot=process.cwd()] Repository root expected by the CLI.
+ * @param {Function} [options.execFileAsyncImpl=execFileAsync] Test seam for Git commands.
+ * @returns {Promise<String>} Active branch name, or an empty string for detached HEAD.
+ */
+async function defaultSyncGithubWorkflowBranchDetector({projectRoot = process.cwd(), execFileAsyncImpl = execFileAsync} = {}) {
+    let toplevel;
+    try {
+        const {stdout} = await execFileAsyncImpl('git', ['rev-parse', '--show-toplevel'], {cwd: projectRoot});
+        toplevel = stdout.trim();
+    } catch (error) {
+        throw new Error(`syncGithubWorkflow REJECTED: could not resolve git top-level (git error: ${error.message}).`);
+    }
+
+    const
+        normalizedProjectRoot = path.resolve(projectRoot),
+        normalizedToplevel    = path.resolve(toplevel);
+
+    if (normalizedProjectRoot !== normalizedToplevel) {
+        throw new Error(
+            `syncGithubWorkflow REJECTED: Root mismatch. CLI projectRoot '${normalizedProjectRoot}' ` +
+            `does not match git repository top-level '${normalizedToplevel}'. ` +
+            `This prevents cross-checkout branch diagnostics and context leakage.`
+        );
+    }
+
+    const {stdout} = await execFileAsyncImpl('git', ['branch', '--show-current'], {cwd: projectRoot});
+    return stdout.trim();
+}
+
+/**
+ * @summary Wraps the GitHub Workflow sync CLI delegate with a dev-branch-only guard.
+ * @param {Function} delegate Delegate to invoke when the active branch is dev.
+ * @param {Function} [getBranch=defaultSyncGithubWorkflowBranchDetector] Branch detector.
+ * @returns {Function} Guarded delegate.
+ */
+function buildSyncGithubWorkflowDevBranchGuard(delegate, getBranch = defaultSyncGithubWorkflowBranchDetector) {
+    return async function syncGithubWorkflowOnDevOnly(...args) {
+        let branch;
+        try {
+            branch = await getBranch();
+        } catch (error) {
+            if (error.message?.startsWith('syncGithubWorkflow REJECTED:')) {
+                throw error;
+            }
+            throw new Error(`syncGithubWorkflow REJECTED: could not determine current branch (git error: ${error.message}). Refusing to sync without branch confirmation.`);
+        }
+
+        if (branch !== 'dev') {
+            throw new Error(
+                `syncGithubWorkflow REJECTED: working-tree is on branch '${branch || '(detached)'}', not 'dev'. ` +
+                `syncGithubWorkflow writes to resources/content/{issues,pulls,discussions,release-notes}/ and metadata, which would pollute a non-dev branch. ` +
+                `Switch to 'dev' and rerun npm run ai:sync-github-workflow, or let the daemon run the canonical sync from its dev context.`
+            );
+        }
+
+        return delegate(...args);
+    };
+}
+
+export {
+    buildSyncGithubWorkflowDevBranchGuard,
+    defaultSyncGithubWorkflowBranchDetector
+};

--- a/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs
@@ -1,0 +1,100 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs/promises';
+import path           from 'path';
+
+import {
+    buildSyncGithubWorkflowDevBranchGuard
+} from '../../../../../../ai/scripts/maintenance/syncGithubWorkflowBranchGuard.mjs';
+
+const cliScriptPath = path.resolve(process.cwd(), 'ai/scripts/maintenance/syncGithubWorkflow.mjs');
+
+/**
+ * @summary Regression coverage for the manual GitHub Workflow sync CLI branch guard.
+ *
+ * The behavior tests exercise the pure guard helper with injected branch detectors so the
+ * suite never runs the full GitHub sync. The wiring test source-checks the heavy CLI script
+ * because importing it boots the canonical AI services SDK and is intentionally expensive.
+ */
+test.describe('syncGithubWorkflow CLI dev-branch guard (#12780)', () => {
+    test('delegates when the active branch is dev', async () => {
+        let delegateCalls = 0;
+        const guarded = buildSyncGithubWorkflowDevBranchGuard(async (...args) => {
+            delegateCalls++;
+            return {args};
+        }, async () => 'dev');
+
+        const result = await guarded('full-sync');
+
+        expect(delegateCalls).toBe(1);
+        expect(result).toEqual({args: ['full-sync']});
+    });
+
+    test('rejects feature branches before delegate work begins', async () => {
+        let delegateCalls = 0;
+        const guarded = buildSyncGithubWorkflowDevBranchGuard(async () => {
+            delegateCalls++;
+        }, async () => 'codex/feature');
+
+        await expect(guarded()).rejects.toThrow(/syncGithubWorkflow REJECTED.*codex\/feature.*not 'dev'/);
+        expect(delegateCalls).toBe(0);
+    });
+
+    test('rejects main before delegate work begins', async () => {
+        let delegateCalls = 0;
+        const guarded = buildSyncGithubWorkflowDevBranchGuard(async () => {
+            delegateCalls++;
+        }, async () => 'main');
+
+        await expect(guarded()).rejects.toThrow(/syncGithubWorkflow REJECTED.*main.*not 'dev'/);
+        expect(delegateCalls).toBe(0);
+    });
+
+    test('rejects detached HEAD before delegate work begins', async () => {
+        const guarded = buildSyncGithubWorkflowDevBranchGuard(async () => {
+            throw new Error('delegate must not run');
+        }, async () => '');
+
+        await expect(guarded()).rejects.toThrow(/syncGithubWorkflow REJECTED.*\(detached\)/);
+    });
+
+    test('preserves root-mismatch rejections from the branch detector', async () => {
+        const guarded = buildSyncGithubWorkflowDevBranchGuard(async () => {
+            throw new Error('delegate must not run');
+        }, async () => {
+            throw new Error('syncGithubWorkflow REJECTED: Root mismatch. CLI projectRoot ...');
+        });
+
+        await expect(guarded()).rejects.toThrow(/syncGithubWorkflow REJECTED: Root mismatch/);
+    });
+
+    test('wraps generic detector errors with a syncGithubWorkflow rejection', async () => {
+        const guarded = buildSyncGithubWorkflowDevBranchGuard(async () => {
+            throw new Error('delegate must not run');
+        }, async () => {
+            throw new Error('git: not a git repository');
+        });
+
+        await expect(guarded()).rejects.toThrow(/could not determine current branch.*not a git repository/);
+    });
+
+    test('wires the CLI guard before lease acquisition and real sync delegation', async () => {
+        const source = await fs.readFile(cliScriptPath, 'utf8');
+
+        const
+            guardIndex  = source.indexOf('await assertSyncGithubWorkflowDevBranch();'),
+            startIndex  = source.indexOf('Starting full GitHub Workflow sync'),
+            leaseIndex  = source.indexOf('outcome = await withHeavyMaintenanceLease('),
+            syncIndex   = source.indexOf('async () => GH_SyncService.runFullSync()'),
+            autorunGate = source.indexOf("if (import.meta.url === pathToFileURL(process.argv[1] || '').href)");
+
+        expect(guardIndex, 'branch guard call must exist').toBeGreaterThan(-1);
+        expect(startIndex, 'start log must exist').toBeGreaterThan(-1);
+        expect(leaseIndex, 'heavy-maintenance lease call must exist').toBeGreaterThan(-1);
+        expect(syncIndex, 'real sync delegate must exist').toBeGreaterThan(-1);
+        expect(autorunGate, 'import-safe CLI autorun gate must exist').toBeGreaterThan(-1);
+
+        expect(guardIndex).toBeLessThan(startIndex);
+        expect(guardIndex).toBeLessThan(leaseIndex);
+        expect(guardIndex).toBeLessThan(syncIndex);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session e8f07ef9-ef7e-4815-8ff4-7abe13720621.

Resolves #12780
Related: #12696
Related: #12779

Adds a dev-branch preflight guard to the manual GitHub Workflow sync CLI so `npm run ai:sync-github-workflow` now fails before remote calls, local writes, or heavy-maintenance lease acquisition when invoked outside `dev`.

Evidence: L2 (pure branch-guard unit tests + source-order wiring check + existing script/config contract tests) -> L2 required (reject/delegate behavior without running a real full sync). No residuals.

## Deltas from ticket

- Added a pure `syncGithubWorkflowBranchGuard.mjs` helper so reject/delegate behavior is unit-testable without importing the heavy AI services SDK.
- Kept `GH_SyncService.runFullSync()` unchanged; the guard remains at the operator CLI invocation surface, matching the existing MCP tool-boundary precedent from `#11145`.
- Added an import-safe autorun gate to `syncGithubWorkflow.mjs`, preserving CLI execution while making the entry point source-checkable.
- Verified the guard call appears before the start log, heavy-maintenance lease, and real `GH_SyncService.runFullSync()` delegate.

Decision Record impact: none. This is a branch-safety parity fix for an existing manual CLI surface.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflow.spec.mjs test/playwright/unit/ai/scripts/maintenance/manualHeavyMaintenanceScriptLeaseAdoption.spec.mjs test/playwright/unit/ai/mcp/server/github-workflow/ConfigCompleteness.spec.mjs` -> 28 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Branch-history close-keyword check: `git log origin/dev..HEAD --format='%h%x09%s%n%b'` contains only commit `d954b2832 fix(ai): reject GitHub sync CLI off dev (#12780)`.
- Pre-push freshness: `git merge-base HEAD origin/dev` matched `git rev-parse origin/dev`; branch was 1 ahead / 0 behind before push.

## Post-Merge Validation

- [ ] From `dev`, run `npm run ai:sync-github-workflow -- --verbose` only when an operator intentionally wants a full GitHub Workflow sync; confirm the CLI enters the lease and sync path.
- [ ] From a feature branch, optionally run `node ai/scripts/maintenance/syncGithubWorkflow.mjs` and confirm it exits with `syncGithubWorkflow REJECTED` before sync startup logs.

## Commit

- `d954b2832` — `fix(ai): reject GitHub sync CLI off dev (#12780)`
