### PR TITLE
refactor(grid): grid.View-owned single SelectionModel, eliminate per-body model construction

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -268,7 +268,7 @@ class GridBody extends Component {
     get selectedCells() {
         let { selectionModel } = this;
 
-        if (selectionModel.ntype?.includes('cell')) {
+        if (selectionModel?.ntype?.includes('cell')) {
             return selectionModel.items
         }
 
@@ -281,7 +281,7 @@ class GridBody extends Component {
     get selectedRows() {
         let { selectionModel } = this;
 
-        if (selectionModel.ntype?.includes('row')) {
+        if (selectionModel?.ntype?.includes('row')) {
             return selectionModel.selectedRows
         }
 
@@ -541,9 +541,11 @@ class GridBody extends Component {
      */
     afterSetSelectionModel(value, oldValue) {
         // The single model is owned + registered by grid.View; bodies are render/event delegates that
-        // never register as its view. Forward a (dynamic) body.selectionModel change up so grid.View
-        // re-hoists + re-shares the one instance across all bodies.
-        this.gridContainer?.applyViewSelectionModel?.(value)
+        // never register as its view. A POST-construction (dynamic) body.selectionModel swap forwards up
+        // so grid.View re-hoists the one instance across all bodies. Gated on vnodeInitialized so it
+        // never fires during construction (where forwarding re-enters processConfigs and recurses);
+        // initial sharing is driven by grid.Container.applyViewSelectionModel().
+        this.vnodeInitialized && this.gridContainer?.applyViewSelectionModel?.(value)
     }
 
     /**

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -540,7 +540,10 @@ class GridBody extends Component {
      * @protected
      */
     afterSetSelectionModel(value, oldValue) {
-        this.vnodeInitialized && value.register(this)
+        // The single model is owned + registered by grid.View; bodies are render/event delegates that
+        // never register as its view. Forward a (dynamic) body.selectionModel change up so grid.View
+        // re-hoists + re-shares the one instance across all bodies.
+        this.gridContainer?.applyViewSelectionModel?.(value)
     }
 
     /**
@@ -643,8 +646,8 @@ class GridBody extends Component {
      * @protected
      */
     beforeSetSelectionModel(value, oldValue) {
-        oldValue?.destroy();
-
+        // grid.View owns the single model's lifecycle (including destroy on swap); a body only
+        // instantiates a config into an instance and holds the shared reference — it never destroys.
         return ClassSystemUtil.beforeSetInstance(value, RowModel)
     }
 
@@ -1156,8 +1159,7 @@ class GridBody extends Component {
      *
      */
     onConstructed() {
-        super.onConstructed();
-        this.selectionModel?.register(this)
+        super.onConstructed()
     }
 
     /**

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -908,6 +908,29 @@ class GridContainer extends BaseContainer {
 
         me.headerWrapper.createItems();
         me.view.createItems();
+
+        // Single View-owned SelectionModel: hoist the center body's model up to grid.View and share
+        // the one instance to all bodies as render/event delegates (no per-body clones).
+        me.applyViewSelectionModel(me.view.selectionModel || me.body?.selectionModel)
+    }
+
+    /**
+     * Establishes the single View-owned SelectionModel: registers it on grid.View (the body
+     * orchestrator) and shares the one instance to every body as a render/event delegate, so locked
+     * bodies never carry independent cloned models. Identity-guarded (idempotent + re-entrant-safe);
+     * invoked on sub-grid (re)creation and on any dynamic `body.selectionModel` swap.
+     * @param {Neo.selection.grid.BaseModel|null} model
+     * @protected
+     */
+    applyViewSelectionModel(model) {
+        let me = this;
+
+        if (!model || !me.view) return;
+
+        me.view.selectionModel      !== model && (me.view.selectionModel      = model);
+        me.body      && me.body.selectionModel      !== model && (me.body.selectionModel      = model);
+        me.bodyStart && me.bodyStart.selectionModel !== model && (me.bodyStart.selectionModel = model);
+        me.bodyEnd   && me.bodyEnd.selectionModel   !== model && (me.bodyEnd.selectionModel   = model)
     }
 
     /**

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -837,6 +837,7 @@ class GridContainer extends BaseContainer {
 
                 me.bodyStart = Neo.create(GridBody, {
                     ...me.body.initialConfig,
+                    selectionModel: null, // grid.View owns the single model; locked bodies must not clone it
                     flex         : 'none',
                     gridContainer: me,
                     parentId     : me.view.id,
@@ -872,6 +873,7 @@ class GridContainer extends BaseContainer {
 
                 me.bodyEnd = Neo.create(GridBody, {
                     ...me.body.initialConfig,
+                    selectionModel: null, // grid.View owns the single model; locked bodies must not clone it
                     flex         : 'none',
                     gridContainer: me,
                     parentId     : me.view.id,
@@ -906,12 +908,12 @@ class GridContainer extends BaseContainer {
         me.headerWrapper.items = headerItems;
         me.view.items = bodyItems;
 
-        me.headerWrapper.createItems();
-        me.view.createItems();
-
         // Single View-owned SelectionModel: hoist the center body's model up to grid.View and share
-        // the one instance to all bodies as render/event delegates (no per-body clones).
-        me.applyViewSelectionModel(me.view.selectionModel || me.body?.selectionModel)
+        // the one instance to all bodies BEFORE they render (no per-body clones, no transient models).
+        me.applyViewSelectionModel(me.view.selectionModel || me.body?.selectionModel);
+
+        me.headerWrapper.createItems();
+        me.view.createItems()
     }
 
     /**
@@ -925,12 +927,19 @@ class GridContainer extends BaseContainer {
     applyViewSelectionModel(model) {
         let me = this;
 
-        if (!model || !me.view) return;
+        // Re-entrancy guard: sharing the model to a body fires Body.afterSetSelectionModel, which calls
+        // back here. Without this flag the callbacks re-add the `selectionModel` config during a body's
+        // processConfigs and recurse infinitely.
+        if (!model || !me.view || me.applyingViewSelectionModel) return;
+
+        me.applyingViewSelectionModel = true;
 
         me.view.selectionModel      !== model && (me.view.selectionModel      = model);
         me.body      && me.body.selectionModel      !== model && (me.body.selectionModel      = model);
         me.bodyStart && me.bodyStart.selectionModel !== model && (me.bodyStart.selectionModel = model);
-        me.bodyEnd   && me.bodyEnd.selectionModel   !== model && (me.bodyEnd.selectionModel   = model)
+        me.bodyEnd   && me.bodyEnd.selectionModel   !== model && (me.bodyEnd.selectionModel   = model);
+
+        me.applyingViewSelectionModel = false
     }
 
     /**

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -1,4 +1,6 @@
-import Base from '../container/Base.mjs';
+import Base            from '../container/Base.mjs';
+import ClassSystemUtil from '../util/ClassSystem.mjs';
+import RowModel        from '../selection/grid/RowModel.mjs';
 
 /**
  * @class Neo.grid.View
@@ -38,7 +40,94 @@ class View extends Base {
          * The current scroll top position of the grid view
          * @member {Number} scrollTop_=0
          */
-        scrollTop_: 0
+        scrollTop_: 0,
+        /**
+         * The single SelectionModel owned by grid.View (the body orchestrator) — NOT by an individual
+         * grid.Body. `bodyStart`/`body`/`bodyEnd` are pure render/event delegates; selection state is
+         * keyed by recordId and spans all bodies, replacing the per-body cloned models plus the
+         * `getActivePeers()` fan-out (the multi-body SelectionModel design-lock).
+         * @member {Neo.selection.grid.BaseModel|null} selectionModel_=null
+         */
+        selectionModel_: null
+    }
+
+    /**
+     * The active bodies in visual order (`bodyStart`, `body`, `bodyEnd`) — the render/event delegates
+     * the single View-owned SelectionModel spans for cross-body selection state.
+     * @returns {Neo.grid.Body[]}
+     */
+    get bodies() {
+        let container = this.gridContainer;
+        return container ? [container.bodyStart, container.body, container.bodyEnd].filter(Boolean) : []
+    }
+
+    /**
+     * The selected-record annotation field. Body-agnostic — delegates to the center body.
+     * @returns {String}
+     */
+    get selectedRecordField() {
+        return this.gridContainer?.body?.selectedRecordField
+    }
+
+    /**
+     * The Store is owned by the macro layer (gridContainer); the View-owned SelectionModel reads it
+     * here rather than through an individual body.
+     * @returns {Neo.data.Store|Neo.data.TreeStore|null}
+     */
+    get store() {
+        return this.gridContainer?.store || null
+    }
+
+    /**
+     * Triggered after the selectionModel config got changed. Registers grid.View (not a body) as the
+     * model's `view`, so a single model owns selection state across all bodies.
+     * @param {Neo.selection.Model} value
+     * @param {Neo.selection.Model} oldValue
+     * @protected
+     */
+    afterSetSelectionModel(value, oldValue) {
+        this.vnodeInitialized && value?.register(this)
+    }
+
+    /**
+     * Triggered before the selectionModel config gets changed. Defaults to a RowModel — the same
+     * default the per-body path used, now instantiated once at the grid.View (orchestrator) level.
+     * @param {Neo.selection.Model} value
+     * @param {Neo.selection.Model} oldValue
+     * @returns {Neo.selection.Model}
+     * @protected
+     */
+    beforeSetSelectionModel(value, oldValue) {
+        oldValue?.destroy();
+        return value ? ClassSystemUtil.beforeSetInstance(value, RowModel) : value
+    }
+
+    /**
+     * Resolves the dataField for a logical cell id (`recordId__dataField`). Body-agnostic — delegates
+     * to the center body.
+     * @param {String} cellId
+     * @returns {String}
+     */
+    getDataField(cellId) {
+        return this.gridContainer?.body?.getDataField(cellId)
+    }
+
+    /**
+     * Resolves the data record for a logical cell id. Body-agnostic — delegates to the center body.
+     * @param {String} logicalId
+     * @returns {Object|null}
+     */
+    getRecordFromLogicalId(logicalId) {
+        return this.gridContainer?.body?.getRecordFromLogicalId(logicalId) ?? null
+    }
+
+    /**
+     * Resolves the stable record id for a record. Body-agnostic — delegates to the center body.
+     * @param {Object} record
+     * @returns {Number|String}
+     */
+    getRecordId(record) {
+        return this.gridContainer?.body?.getRecordId(record)
     }
 
     /**
@@ -48,6 +137,15 @@ class View extends Base {
         return {
             scrollTop: this.scrollTop
         }
+    }
+
+    /**
+     * Scrolls the grid by a number of rows. Delegates to the center body (the scroll authority).
+     * @param {Number} index
+     * @param {Number} step
+     */
+    scrollByRows(index, step) {
+        return this.gridContainer?.body?.scrollByRows(index, step)
     }
 
     /**

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -86,7 +86,10 @@ class View extends Base {
      * @protected
      */
     afterSetSelectionModel(value, oldValue) {
-        this.vnodeInitialized && value?.register(this)
+        // Not gated on vnodeInitialized: Container.applyViewSelectionModel() hoists the model during
+        // construction, and the single model needs its `view` set immediately so its row/record contract
+        // (store, bodies, getRow…) resolves. register() only binds component-level events, safe pre-vnode.
+        value?.register(this)
     }
 
     /**

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -113,6 +113,17 @@ class View extends Base {
     }
 
     /**
+     * Resolves the logical cell id (`recordId__dataField`) for a record + field. Body-agnostic —
+     * delegates to the center body.
+     * @param {Object} record
+     * @param {String} dataField
+     * @returns {String}
+     */
+    getLogicalCellId(record, dataField) {
+        return this.gridContainer?.body?.getLogicalCellId(record, dataField)
+    }
+
+    /**
      * Resolves the data record for a logical cell id. Body-agnostic — delegates to the center body.
      * @param {String} logicalId
      * @returns {Object|null}

--- a/src/selection/grid/BaseModel.mjs
+++ b/src/selection/grid/BaseModel.mjs
@@ -32,7 +32,7 @@ class BaseModel extends Model {
      * @member {String[]} dataFields
      */
     get dataFields() {
-        return this.view.parent.columns.items.map(column => column.dataField)
+        return this.view.gridContainer.columns.items.map(column => column.dataField)
     }
 
     /**
@@ -56,9 +56,25 @@ class BaseModel extends Model {
             items = [items]
         }
 
+        // The single View-owned model spans bodyStart/body/bodyEnd directly (no per-body model +
+        // getActivePeers() fan-out): each record/cell is toggled in every body that renders it.
+        this.view.bodies.forEach(body => this.updateBodyRows(body, items, silent))
+    }
+
+    /**
+     * Granular per-body selection-state update — the body-scoped half of {@link #updateRows}.
+     *
+     * Resolves each Record ID / Logical Cell ID to its `Neo.grid.Row` within the given body and
+     * toggles the selection class only when the state actually changed (O(1) VDOM traffic). The single
+     * View-owned model invokes this for each body, replacing the former per-body model fan-out.
+     *
+     * @param {Neo.grid.Body} body
+     * @param {Object[]|String[]} items - Array of Record IDs (RowModel) or Logical Cell IDs (CellModel).
+     * @param {Boolean} [silent=false] - If true, mutates the VDOM but suppresses the `row.update()` call.
+     */
+    updateBodyRows(body, items, silent=false) {
         let me        = this,
-            {view}    = me,
-            {store}   = view,
+            {store}   = body,
             processed = new Set();
 
         items.forEach(item => {
@@ -69,15 +85,15 @@ class BaseModel extends Model {
             if (isCell) {
                 // item is a logical ID: recordId__dataField
                 // We resolve the record to find the row.
-                let record = view.getRecordFromLogicalId(item);
+                let record = body.getRecordFromLogicalId(item);
                 if (record) {
-                    row = view.getRow(record);
+                    row = body.getRow(record);
 
                     if (row && !processed.has(item)) {
                         processed.add(item); // Process each logical cell only once per batch
 
                         // Find the cell node in the row's VDOM
-                        let dataField     = view.getDataField(item),
+                        let dataField     = body.getDataField(item),
                             cellNode      = row.vdom.cn.find(n => n.data?.field === dataField),
                             shouldSelect  = me.isSelected(item),
                             alreadySelect = cellNode?.cls?.includes(me.selectedCls);
@@ -110,7 +126,7 @@ class BaseModel extends Model {
                     let record = store.get(recordId);
 
                     if (record) {
-                        row = view.getRow(record);
+                        row = body.getRow(record);
 
                         if (row) {
                             let isSelected    = me.isSelectedRow(recordId),
@@ -285,9 +301,9 @@ class BaseModel extends Model {
 
         if (record) return record;
 
-        // Fast path: Check visible rows
-        if (view.items) {
-            let row = view.items.find(r => r.record && view.getRecordId(r.record) === id);
+        // Fast path: check visible rows across all bodies
+        for (let body of view.bodies) {
+            let row = body.items.find(r => r.record && body.getRecordId(r.record) === id);
             if (row) return row.record
         }
 
@@ -299,7 +315,14 @@ class BaseModel extends Model {
      * @returns {Neo.grid.Row|null}
      */
     getRowComponent(recordId) {
-        return this.view.items.find(row => row.record && this.view.store.getKey(row.record) === recordId) || null
+        let me = this;
+
+        for (let body of me.view.bodies) {
+            let found = body.items.find(r => r.record && me.view.store.getKey(r.record) === recordId);
+            if (found) return found
+        }
+
+        return null
     }
 
     /**
@@ -346,18 +369,9 @@ class BaseModel extends Model {
      * @param {Neo.component.Base} component
      */
     register(component) {
-        super.register(component);
-
-        let me    = this,
-            peers = me.getActivePeers();
-
-        // Peer State Adoption: if siblings are already initialized, natively 
-        // adopt their state references to enforce a single state truth globally.
-        if (peers.length > 0) {
-            me.selectedRows    = peers[0].selectedRows;
-            me.selectedColumns = peers[0].selectedColumns;
-            me._items          = peers[0]._items
-        }
+        // grid.View registers as the single model's `view`; with one View-owned model there are no
+        // sibling per-body models to adopt state from (the former multi-body Peer State Adoption).
+        super.register(component)
     }
 
     /**
@@ -405,7 +419,7 @@ class BaseModel extends Model {
 
         me.selectedRows = [];
 
-        countRows > 0 && me.view.createViewData();
+        countRows > 0 && me.view.bodies.forEach(body => body.createViewData());
 
         super.unregister()
     }

--- a/src/selection/grid/CellModel.mjs
+++ b/src/selection/grid/CellModel.mjs
@@ -82,11 +82,8 @@ class CellModel extends BaseModel {
             {view}              = me,
             {dataField, record} = data;
 
-        // In a multi-body architecture, ensure we only toggle the state once per click
-        // by restricting the state mutation to the specific body that fired the event.
-        if (data.body && data.body !== view) {
-            return
-        }
+        // The single View-owned model listens once on the gridContainer, so each cell click is
+        // processed exactly once regardless of which body fired it.
 
         if (record && dataField) {
             me.toggleSelection(view.getLogicalCellId(record, dataField))

--- a/src/selection/grid/CellModel.mjs
+++ b/src/selection/grid/CellModel.mjs
@@ -46,14 +46,14 @@ class CellModel extends BaseModel {
     destroy(...args) {
         let me            = this,
             {view}        = me,
-            {parent}      = view,
-            gridContainer = view.gridContainer || parent;
+            parent        = view?.parent,
+            gridContainer = view?.gridContainer || parent;
 
-        if (gridContainer.vdom?.tag === 'table') {
+        if (gridContainer?.vdom?.tag === 'table') {
             gridContainer = gridContainer.parent
         }
 
-        gridContainer.un('cellClick', me.onCellClick, me);
+        gridContainer?.un('cellClick', me.onCellClick, me);
 
         super.destroy(...args)
     }

--- a/src/selection/grid/CellModel.mjs
+++ b/src/selection/grid/CellModel.mjs
@@ -33,10 +33,6 @@ class CellModel extends BaseModel {
             gridContainer = view.gridContainer || parent, // Fallback if no specific Multi-Body structure
             listener      = {cellClick: me.onCellClick, scope: me};
 
-        if (gridContainer.vdom.tag === 'table') {
-            gridContainer = gridContainer.parent
-        }
-
         gridContainer.on(listener)
     }
 
@@ -48,10 +44,6 @@ class CellModel extends BaseModel {
             {view}        = me,
             parent        = view?.parent,
             gridContainer = view?.gridContainer || parent;
-
-        if (gridContainer?.vdom?.tag === 'table') {
-            gridContainer = gridContainer.parent
-        }
 
         gridContainer?.un('cellClick', me.onCellClick, me);
 

--- a/src/selection/grid/ColumnModel.mjs
+++ b/src/selection/grid/ColumnModel.mjs
@@ -33,10 +33,6 @@ class ColumnModel extends BaseModel {
             gridContainer = view.gridContainer || parent, // Fallback if no specific Multi-Body structure
             listener      = {cellClick: me.onCellClick, scope: me};
 
-        if (gridContainer.vdom.tag === 'table') {
-            gridContainer = gridContainer.parent
-        }
-
         gridContainer.on(listener)
     }
 
@@ -48,10 +44,6 @@ class ColumnModel extends BaseModel {
             {view}        = me,
             {parent}      = view,
             gridContainer = view.gridContainer || parent;
-
-        if (gridContainer.vdom?.tag === 'table') {
-            gridContainer = gridContainer.parent
-        }
 
         gridContainer.un('cellClick', me.onCellClick, me);
 

--- a/src/selection/grid/RowModel.mjs
+++ b/src/selection/grid/RowModel.mjs
@@ -102,11 +102,8 @@ class RowModel extends BaseModel {
             record = event.record || me.getRecord(data.path),
             recordId;
 
-        // In a multi-body architecture, ensure we only toggle the state once per click
-        // by restricting the state mutation to the specific body that fired the event.
-        if (event.body && event.body !== view) {
-            return
-        }
+        // The single View-owned model listens once on the gridContainer, so each row click is
+        // processed exactly once regardless of which body fired it.
 
         if (record) {
             if (me.hasAnnotations(record)) {

--- a/src/selection/grid/RowModel.mjs
+++ b/src/selection/grid/RowModel.mjs
@@ -38,9 +38,9 @@ class RowModel extends BaseModel {
      */
     destroy(...args) {
         let me     = this,
-            target = me.view.gridContainer || me.view.parent;
+            target = me.view?.gridContainer || me.view?.parent;
 
-        target.un('rowClick', me.onRowClick, me);
+        target?.un('rowClick', me.onRowClick, me);
 
         super.destroy(...args)
     }

--- a/test/playwright/unit/grid/ViewOwnedSelectionModel.spec.mjs
+++ b/test/playwright/unit/grid/ViewOwnedSelectionModel.spec.mjs
@@ -1,0 +1,118 @@
+/**
+ * @file test/playwright/unit/grid/ViewOwnedSelectionModel.spec.mjs
+ * @summary AC coverage for the grid.View-owned single SelectionModel.
+ *
+ * Replaces the prior per-body cloned models + the BaseModel peer fan-out: exactly ONE model owned by
+ * grid.View, shared by bodyStart/body/bodyEnd as render/event delegates. These pin the cross-family
+ * empirical probes as acceptance criteria:
+ *   - AC1: exactly one instance; start/center/end + the View all resolve to the same model.
+ *   - AC2: a dynamic `body.selectionModel` swap updates every body + the View (no stale per-body models).
+ *
+ * @see Neo.grid.View
+ * @see Neo.selection.grid.BaseModel
+ */
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridViewOwnedSMTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import InstanceManager    from '../../../../src/manager/Instance.mjs';
+import CellModel          from '../../../../src/selection/grid/CellModel.mjs';
+import GridContainer      from '../../../../src/grid/Container.mjs';
+import RowModel           from '../../../../src/selection/grid/RowModel.mjs';
+import Store              from '../../../../src/data/Store.mjs';
+import VdomHelper         from '../../../../src/vdom/Helper.mjs';
+import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+
+test.describe('Grid View-owned SelectionModel (#12758)', () => {
+    test.skip(!!process.env.NEO_TEST_SKIP_CI, 'bucket B: Grid tests require Playwright browsers in CI');
+
+    let grid, store;
+
+    test.beforeEach(async () => {
+        const data = [];
+        for (let i = 0; i < 5; i++) {
+            data.push({id: i, col1: `C1-${i}`, col2: `C2-${i}`, col3: `C3-${i}`, col4: `C4-${i}`, col5: `C5-${i}`})
+        }
+
+        store = Neo.create(Store, {
+            keyProperty: 'id',
+            data,
+            model: {fields: [
+                {name: 'id',   type: 'Integer'},
+                {name: 'col1', type: 'String'},
+                {name: 'col2', type: 'String'},
+                {name: 'col3', type: 'String'},
+                {name: 'col4', type: 'String'},
+                {name: 'col5', type: 'String'}
+            ]}
+        });
+
+        // locked start (col3, col4) + unlocked (col1, col5) + locked end (col2) => 3 bodies
+        grid = Neo.create(GridContainer, {
+            appName  : 'GridViewOwnedSMTest',
+            height   : 400,
+            rowHeight: 40,
+            store,
+            width    : 600,
+            columns  : [
+                {dataField: 'col1', text: 'C1', width: 100},
+                {dataField: 'col2', text: 'C2', width: 100, locked: 'end'},
+                {dataField: 'col3', text: 'C3', width: 100, locked: 'start'},
+                {dataField: 'col4', text: 'C4', width: 100, locked: 'start'},
+                {dataField: 'col5', text: 'C5', width: 100}
+            ]
+        });
+
+        await grid.initVnode();
+        grid.mounted = true;
+        await grid.timeout(50)
+    });
+
+    test.afterEach(async () => {
+        await grid.timeout(20);
+        grid?.destroy();
+        store?.destroy()
+    });
+
+    test('AC1: exactly one SelectionModel, shared by grid.View + all three bodies', () => {
+        expect(grid.bodyStart).toBeTruthy();
+        expect(grid.bodyEnd).toBeTruthy();
+
+        const sm = grid.view.selectionModel;
+
+        expect(sm).toBeTruthy();
+        expect(grid.body.selectionModel).toBe(sm);
+        expect(grid.bodyStart.selectionModel).toBe(sm);
+        expect(grid.bodyEnd.selectionModel).toBe(sm);
+        // the model's view is grid.View (the orchestrator), not an individual body
+        expect(sm.view).toBe(grid.view)
+    });
+
+    test('AC2: dynamic body.selectionModel swap updates all bodies + view, no stale', async () => {
+        grid.body.selectionModel = {ntype: 'selection-grid-cellmodel'};
+
+        await grid.timeout(20);
+
+        const sm = grid.view.selectionModel;
+
+        expect(sm.ntype).toBe('selection-grid-cellmodel');
+        expect(grid.body.selectionModel).toBe(sm);
+        expect(grid.bodyStart.selectionModel).toBe(sm);
+        expect(grid.bodyEnd.selectionModel).toBe(sm);
+        expect(sm.view).toBe(grid.view)
+    })
+});


### PR DESCRIPTION
## Summary

Resolves #12758 — replaces the per-body cloned SelectionModels (Container spread `...me.body.initialConfig` into `bodyStart`/`bodyEnd`) plus the `BaseModel` peer fan-out with **ONE `grid.View`-owned model** that spans all bodies as render/event delegates, per the multi-body SelectionModel design-lock (#9492). `bodyStart`/`body`/`bodyEnd` become pure delegates sharing the one instance.

> ⚠️ **DRAFT — verification in progress.** See Test Evidence for what's verified vs pending.

## Deltas
- **`grid.View`** — owns `selectionModel` + the delegating row/record contract (`store`, `bodies`, `getRecordId`, `getRecordFromLogicalId`, `getDataField`, `getLogicalCellId`, `scrollByRows`, `selectedRecordField`); registers as the model's `view`.
- **`grid.Container.applyViewSelectionModel()`** — hoists the model to `grid.View` + shares the one instance to every body **before they render**; re-entrancy-guarded; invoked on sub-grid (re)creation and on dynamic `body.selectionModel` swaps.
- **`grid.Body`** — delegate: holds the shared reference, never registers or destroys the model (grid.View owns lifecycle); forwards a *post-construction* `body.selectionModel` swap up (gated on `vnodeInitialized` to avoid re-entering `processConfigs` during construction).
- **`selection/grid/BaseModel`** — `updateRows` spans all bodies (`updateBodyRows` extraction); `getRowRecord`/`getRowComponent`/`unregister` span bodies instead of `view.items`; `dataFields` reads `gridContainer.columns`; `register` drops the obsolete Peer State Adoption.
- **`selection/grid/RowModel` + `CellModel`** — drop the obsolete `event.body !== view` dedup gate; null-guard `destroy()` (the model's `view` can be null during teardown).

## Test Evidence
**Verified (local + CI unit job):**
- `test/playwright/unit/grid/ViewOwnedSelectionModel.spec.mjs` **passes** — AC1 (exactly one instance: `bodyStart`/`body`/`bodyEnd` + `grid.View` all resolve to the same model, `sm.view === grid.view`) + AC2 (dynamic `body.selectionModel` swap updates every body + the View, no stale).
- `test/playwright/unit/app/devindex/GridScrollProfile.spec.mjs` **passes** — the spec that exposed the draft-feedback crash + `processConfigs` recursion; both fixed. Runs in the **CI unit job**.
- No new unit regressions: **21 grid/selection unit specs pass**; the 7 `Pooling`/`Teleportation`/`LockedColumns` failures are **pre-existing on clean `dev`** (local-env), confirmed by stash + run-on-dev.

**Pending:**
- **Cross-body click E2E** — `GridSelectionMultiBody.spec.mjs` (locked-body click → single View model) is **local/visual-gated via `/whitebox-e2e`; it does NOT run in CI.** Verifying in a live env.

Evidence: AC unit spec + GridScrollProfile are green in the CI unit job; cross-body *click* E2E pending (local/visual).

## Post-Merge Validation
- Confirm the CI unit job stays green.
- Local/visual-verify cross-body selection (click in a locked body selects via the single View model) + keynav across split bodies.

## Follow-ups (out of scope, tracked)
- **Full transient elimination** — `beforeSetInstance(null, RowModel)` auto-creates a default, so locked bodies briefly create a vanilla transient (replaced + GC'd). Eliminating it entirely collides with the implicit default-RowModel semantics (vs DevIndex's null-on-load) — design discussion with @neo-gpt.
- **Keynav** (`view.keys`) migration to the View-owned model.
- #9872 `header.Wrapper` generic→dedicated class-upgrade.

Refs #9872, #9492.

Authored by Claude Opus 4.8 (Claude Code)