### PR TITLE
feat(grid): cross-toolbar column DnD across split headers (#9491)

### DIFF
--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -91,6 +91,25 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * @summary The owner toolbar's column-index offset into the global `gridContainer.columns` collection.
+     *
+     * The header splits into start / center / end toolbars, each indexing its own columns from 0,
+     * while `gridContainer.columns` is the single global collection that {@link #moveTo} reorders. A
+     * locked-region toolbar's local index must therefore be offset by the column counts of the regions
+     * that precede it (start → 0; center → start count; end → start + center counts). In the no-locked
+     * common case the offset is 0, so single-region grids are unaffected.
+     *
+     * @returns {Number}
+     */
+    columnIndexOffset() {
+        let {gridContainer, layoutLock} = this.owner;
+
+        if (layoutLock === 'start') return 0;
+        if (layoutLock === 'end')   return gridContainer.lockedStartColumns.length + gridContainer.centerColumns.length;
+        return gridContainer.lockedStartColumns.length // center
+    }
+
+    /**
      * @param {Neo.util.Rectangle} rect
      * @param {Neo.util.Rectangle} parentRect
      */
@@ -221,7 +240,11 @@ class SortZone extends BaseSortZone {
      */
     moveTo(fromIndex, toIndex) {
         super.moveTo(fromIndex, toIndex);
-        this.owner.gridContainer.columns.move(fromIndex, toIndex)
+
+        // super.moveTo reorders the owner toolbar's own items (local space); the global columns
+        // collection needs the locked-region offset so center / end toolbars move the right columns.
+        let offset = this.columnIndexOffset();
+        this.owner.gridContainer.columns.move(fromIndex + offset, toIndex + offset)
     }
 
     /**

--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -67,6 +67,30 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * @summary Resolves the target lock-region for a column drop by mapping the release x-coordinate
+     * against the locked-start / locked-end body x-ranges.
+     *
+     * The neighbor-based inference in {@link #onDragEnd} keys within-region resorting off the dragged
+     * column's siblings, but a cross-toolbar drag (e.g. center → locked-start) is keyed by *where* the
+     * pointer is released, not by neighbors. This maps the release x-coordinate to the region whose body
+     * it falls within; anything outside the locked bodies resolves to the center (unlocked) region.
+     *
+     * @param {Number}      dropX             Pointer x-coordinate at release (client space).
+     * @param {Object}      regionRects       Per-region client rects; either side may be null when absent.
+     * @param {Object|null} regionRects.start Locked-start body rect (`{left, right}`) or null.
+     * @param {Object|null} regionRects.end   Locked-end body rect (`{left, right}`) or null.
+     * @returns {'start'|'end'|null}          Target lock region, or null for the center (unlocked) region.
+     */
+    getDropRegion(dropX, regionRects) {
+        let {start, end} = regionRects;
+
+        if (start && dropX >= start.left && dropX <= start.right) return 'start';
+        if (end   && dropX >= end.left   && dropX <= end.right)   return 'end';
+
+        return null
+    }
+
+    /**
      * @param {Neo.util.Rectangle} rect
      * @param {Neo.util.Rectangle} parentRect
      */

--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -273,6 +273,21 @@ class SortZone extends BaseSortZone {
             newLocked = 'end'
         }
 
+        // Cross-toolbar: a release over a different region's body is the direct lock-region
+        // signal and supersedes the neighbor inference for cross-region moves. Within-region drops
+        // resolve to the column's existing region, so the neighbor-based path above is preserved.
+        if (Neo.isNumber(me.lastDragClientX) && (grid.bodyStart || grid.bodyEnd)) {
+            let bodyStartRect = grid.bodyStart ? await grid.bodyStart.getDomRect() : null,
+                bodyEndRect   = grid.bodyEnd   ? await grid.bodyEnd.getDomRect()   : null,
+                positionRegion = me.getDropRegion(me.lastDragClientX, {start: bodyStartRect, end: bodyEndRect});
+
+            if (positionRegion !== column.locked) {
+                newLocked = positionRegion
+            }
+        }
+
+        me.lastDragClientX = null;
+
         if (column.locked !== newLocked) {
             // This implicitly triggers grid.Container#onColumnLockChange,
             // which handles sorting, DOM syncing, and layout calculations.
@@ -301,6 +316,9 @@ class SortZone extends BaseSortZone {
 
         // Avoid conflicts with grid.header.plugin.Resizable
         if (!me.owner.dragResortable) return;
+
+        // Track the release x-coordinate so onDragEnd can resolve the cross-toolbar drop region.
+        me.lastDragClientX = data.clientX;
 
         await super.onDragMove(data)
     }

--- a/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
@@ -50,4 +50,18 @@ test.describe('Neo.draggable.grid.header.toolbar.SortZone', () => {
         expect(resolve(50,  centerOnly)).toBe(null);
         expect(resolve(350, centerOnly)).toBe(null)
     })
+
+    test('columnIndexOffset offsets the toolbar-local index into the global columns by preceding-region counts (#9491)', () => {
+        const columnIndexOffset = SortZone.prototype.columnIndexOffset,
+              gridContainer     = {lockedStartColumns: {length: 2}, centerColumns: {length: 5}, lockedEndColumns: {length: 1}},
+              resolve           = layoutLock => columnIndexOffset.call({owner: {gridContainer, layoutLock}});
+
+        expect(resolve('start')).toBe(0);   // start region → no preceding columns
+        expect(resolve(null)).toBe(2);      // center → after the 2 locked-start columns
+        expect(resolve('end')).toBe(7);     // end → after start(2) + center(5)
+
+        // no-locked common case: a single center toolbar → offset 0 (unchanged from pre-fix behavior)
+        const noLocked = {lockedStartColumns: {length: 0}, centerColumns: {length: 4}, lockedEndColumns: {length: 0}};
+        expect(columnIndexOffset.call({owner: {gridContainer: noLocked, layoutLock: null}})).toBe(0)
+    })
 });

--- a/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
@@ -32,4 +32,22 @@ test.describe('Neo.draggable.grid.header.toolbar.SortZone', () => {
         expect(resolve(null)).toBe('centerBody');       // center toolbar (no layoutLock) → body
         expect(resolve(undefined)).toBe('centerBody')   // center toolbar (unset) → body
     })
+
+    test('getDropRegion maps the release x-coordinate to the target lock region (#9491 cross-toolbar)', () => {
+        const getDropRegion = SortZone.prototype.getDropRegion,
+              resolve        = (dropX, regionRects) => getDropRegion.call({}, dropX, regionRects),
+              // locked-start body [0,100], center gap (100,300), locked-end body [300,400]
+              regions        = {start: {left: 0, right: 100}, end: {left: 300, right: 400}};
+
+        expect(resolve(50,  regions)).toBe('start');     // inside locked-start body → start region
+        expect(resolve(200, regions)).toBe(null);        // center gap → unlocked
+        expect(resolve(350, regions)).toBe('end');       // inside locked-end body → end region
+        expect(resolve(0,   regions)).toBe('start');     // left boundary inclusive
+        expect(resolve(400, regions)).toBe('end');       // right boundary inclusive
+
+        // center-only grid (no locked start/end bodies present) → always center/unlocked
+        const centerOnly = {start: null, end: null};
+        expect(resolve(50,  centerOnly)).toBe(null);
+        expect(resolve(350, centerOnly)).toBe(null)
+    })
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 31325e4f-0fdf-4627-96ed-7983dd1b1002.

Resolves #9491

> **DRAFT** — logic complete + unit-tested; the cross-toolbar **motion** is pending a visual-verify in a live locked-multi-region grid (operator env) before this goes ready/merge. Draft status keeps it mechanically un-mergeable until that gate passes.

Cross-toolbar column drag-and-drop across the split header (start / center / end toolbars). Builds on the merged within-region fix (#12708) and the merged multi-body SelectionModel (#12754). Three slices:

1. **`getDropRegion(dropX, regionRects)`** — maps the pointer release x-coordinate to the target lock region (start / center / end) via the locked-start / locked-end body x-ranges. The position-based signal a cross-toolbar drag needs (vs the within-region neighbor-inference).
2. **`onDragEnd` wiring** — `onDragMove` captures the release x; `onDragEnd` resolves the start/end body rects, calls `getDropRegion`, and overrides `column.locked` ONLY for cross-region moves (purely additive — within-region keeps the neighbor-inference path). The `column.locked` change triggers `Container#onColumnLockChange`, which already re-sorts (stably), resets indices, redistributes to the toolbars, and re-renders — so the cross-region re-homing rides the existing redistribution.
3. **`columnIndexOffset()` + `moveTo`** — offsets the owner-toolbar-local index into the global `columns` collection by preceding-region counts, fixing within-region positioning in locked-multi-region grids. Backward-compatible: offset is 0 in the no-locked case, so #12708's within-region resort is unchanged.

Evidence: L2 (targeted unit tests for the pure helpers `getDropRegion` + `columnIndexOffset`) → L4 required (the cross-toolbar MOTION end-to-end is visual; the `onDragEnd` integration is embedded in the async method, not unit-testable in isolation). Residual: the cross-toolbar drag motion + within-region positioning in a locked-multi-region grid need a live-env visual-verify (operator) — hence DRAFT.

## Deltas from ticket
- Scoped to the cross-toolbar **functional core** (region-detection + re-homing + locked-region positioning). The cross-boundary **visual indicators** (drag-feedback showing the target region) are deferred to a follow-up — the core re-homing works without them, and the indicators are polish best shaped against the verified motion.
- The "index-remap" originally scoped as a separate concern turned out largely unneeded: `onColumnLockChange` already re-indexes + redistributes on a `column.locked` change; only the within-region `moveTo` offset (slice 3) was the real gap.

## Test Evidence
- `test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs` — 3 passed: `gridBody` region-resolution (#12708 regression) + `getDropRegion` (start/center/end + boundary-inclusive + center-only) + `columnIndexOffset` (start/center/end offsets + no-locked).
- The pure helpers are unit-tested; the `onDragEnd` integration is logic-sound but its end-to-end motion is visual (the DRAFT gate).

## Post-Merge Validation
- [ ] **Pre-ready gate (operator env):** visual-verify the cross-toolbar drag in a locked-multi-region grid — drag a column from the center across to a locked start/end region; confirm it re-homes to that region and lands at the dropped position. Mark the PR ready only after this passes.
- [ ] Cross-family review (§6.1) of the logic before merge (this is a feature, not micro-exempt; Ada/Claude is the author + same-family, so a non-Claude family signs).
- [ ] Follow-up ticket: cross-boundary visual indicators (drag-feedback) — polish, shaped against the verified motion.

## Commits
- `6bf8fba96` — add cross-toolbar drop-region detection (`getDropRegion`)
- `872b9e06a` — wire it into `onDragEnd` (cross-region `column.locked` override)
- `8811188ca` — `moveTo` locked-region column-index offset
