### PR TITLE
refactor(grid): extract dedicated header.Wrapper orchestrator (#12800)

### DIFF
--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -141,17 +141,7 @@ class GridContainer extends BaseContainer {
             value         : null
         },
         /**
-         * @member {Neo.grid.header.Toolbar|null} headerEnd=null
-         * @protected
-         */
-        headerEnd: null,
-        /**
-         * @member {Neo.grid.header.Toolbar|null} headerStart=null
-         * @protected
-         */
-        headerStart: null,
-        /**
-         * @member {Neo.container.Base|null} headerWrapper=null
+         * @member {Neo.grid.header.Wrapper|null} headerWrapper=null
          * @protected
          */
         headerWrapper: null,
@@ -274,15 +264,13 @@ class GridContainer extends BaseContainer {
 
         me.items = me.items || [];
 
-        me.headerWrapper = Neo.create(BaseContainer, {
+        me.headerWrapper = Neo.create(header.Wrapper, {
             appName,
-            cls     : ['neo-header-wrapper'],
-            flex    : 'none',
-            layout  : {ntype: 'hbox', align: 'stretch'},
-            parentId: me.id,
-            theme   : me.theme,
+            gridContainer: me,
+            parentId     : me.id,
+            theme        : me.theme,
             windowId,
-            items   : [me.headerToolbar]
+            items        : [me.headerToolbar]
         });
 
         me.view = Neo.create(View, {
@@ -813,28 +801,12 @@ class GridContainer extends BaseContainer {
     createOrUpdateSubGrids(lockedStartButtons, centerButtons, lockedEndButtons) {
         let me = this;
 
-        // --- Center (Default) ---
-        if (me.centerColumns.length > 0) {
-            if (centerButtons) {
-                me.headerToolbar.items = centerButtons;
-                me.headerToolbar.createItems();
-            }
-        }
+        // The header region (locked + centre toolbars) is owned by the dedicated header.Wrapper orchestrator.
+        me.headerWrapper.updateHeaders(lockedStartButtons, centerButtons, lockedEndButtons);
 
-        // --- Start (Left) ---
+        // --- Start body (Left) ---
         if (me.lockedStartColumns.length > 0) {
-            if (!me.headerStart) {
-                me.headerStart = Neo.create(header.Toolbar, {
-                    ...me.headerToolbar.initialConfig,
-                    flex         : 'none',
-                    gridContainer: me,
-                    items        : lockedStartButtons || [],
-                    layoutLock   : 'start',
-                    parentId     : me.headerWrapper.id,
-                    theme        : me.theme,
-                    windowId     : me.windowId
-                });
-
+            if (!me.bodyStart) {
                 me.bodyStart = Neo.create(GridBody, {
                     ...me.body.initialConfig,
                     selectionModel: null, // grid.View owns the single model; locked bodies must not clone it
@@ -846,31 +818,16 @@ class GridContainer extends BaseContainer {
                     theme        : me.theme,
                     useInternalId: me.useInternalId,
                     windowId     : me.windowId
-                });
-            } else if (lockedStartButtons) {
-                me.headerStart.items = lockedStartButtons;
-                me.headerStart.createItems();
+                })
             }
-        } else if (me.headerStart) {
-            me.headerStart.destroy();
+        } else if (me.bodyStart) {
             me.bodyStart.destroy();
-            me.headerStart = me.bodyStart = null;
+            me.bodyStart = null
         }
 
-        // --- End (Right) ---
+        // --- End body (Right) ---
         if (me.lockedEndColumns.length > 0) {
-            if (!me.headerEnd) {
-                me.headerEnd = Neo.create(header.Toolbar, {
-                    ...me.headerToolbar.initialConfig,
-                    flex         : 'none',
-                    gridContainer: me,
-                    items        : lockedEndButtons || [],
-                    layoutLock   : 'end',
-                    parentId     : me.headerWrapper.id,
-                    theme        : me.theme,
-                    windowId     : me.windowId
-                });
-
+            if (!me.bodyEnd) {
                 me.bodyEnd = Neo.create(GridBody, {
                     ...me.body.initialConfig,
                     selectionModel: null, // grid.View owns the single model; locked bodies must not clone it
@@ -882,37 +839,27 @@ class GridContainer extends BaseContainer {
                     theme        : me.theme,
                     useInternalId: me.useInternalId,
                     windowId     : me.windowId
-                });
-            } else if (lockedEndButtons) {
-                me.headerEnd.items = lockedEndButtons;
-                me.headerEnd.createItems();
+                })
             }
-        } else if (me.headerEnd) {
-            me.headerEnd.destroy();
+        } else if (me.bodyEnd) {
             me.bodyEnd.destroy();
-            me.headerEnd = me.bodyEnd = null;
+            me.bodyEnd = null
         }
 
-        // Synchronize SubGrids into DOM via Symmetrical Wrappers
-        let bodyItems   = [],
-            headerItems = [];
+        // Synchronize the body sub-grids into the grid.View.
+        let bodyItems = [];
 
-        if (me.headerStart) headerItems.push(me.headerStart);
-        if (me.headerToolbar) headerItems.push(me.headerToolbar);
-        if (me.headerEnd) headerItems.push(me.headerEnd);
+        me.bodyStart && bodyItems.push(me.bodyStart);
+        me.body      && bodyItems.push(me.body);
+        me.bodyEnd   && bodyItems.push(me.bodyEnd);
 
-        if (me.bodyStart) bodyItems.push(me.bodyStart);
-        if (me.body) bodyItems.push(me.body);
-        if (me.bodyEnd) bodyItems.push(me.bodyEnd);
-
-        me.headerWrapper.items = headerItems;
         me.view.items = bodyItems;
 
         // Single View-owned SelectionModel: hoist the center body's model up to grid.View and share
         // the one instance to all bodies BEFORE they render (no per-body clones, no transient models).
         me.applyViewSelectionModel(me.view.selectionModel || me.body?.selectionModel);
 
-        me.headerWrapper.createItems();
+        // Header assembly is owned by header.Wrapper.updateHeaders(); only the bodies render here.
         me.view.createItems()
     }
 
@@ -1017,11 +964,7 @@ class GridContainer extends BaseContainer {
      * @protected
      */
     getButton(dataField) {
-        let me = this;
-        return me.headerStart?.getColumn(dataField) ||
-               me.headerToolbar?.getColumn(dataField) ||
-               me.headerEnd?.getColumn(dataField) ||
-               null
+        return this.headerWrapper.getButton(dataField)
     }
 
     /**
@@ -1047,56 +990,7 @@ class GridContainer extends BaseContainer {
             me.bodyEnd?.updateMountedAndVisibleColumns()
         });
 
-        me.lockedStartColumns.forEach((col, targetIndex) => {
-            let btn = me.getButton(col.dataField);
-
-            if (btn) {
-                if (btn.parentId !== me.headerStart.id) {
-                    Neo.getComponent(btn.parentId).remove(btn, false);
-                    me.headerStart.add(btn);
-                }
-
-                let currentIndex = me.headerStart.indexOf(btn);
-
-                if (currentIndex !== targetIndex) {
-                    me.headerStart.moveTo(currentIndex, targetIndex)
-                }
-            }
-        });
-
-        me.centerColumns.forEach((col, targetIndex) => {
-            let btn = me.getButton(col.dataField);
-
-            if (btn) {
-                if (btn.parentId !== me.headerToolbar.id) {
-                    Neo.getComponent(btn.parentId).remove(btn, false);
-                    me.headerToolbar.add(btn);
-                }
-
-                let currentIndex = me.headerToolbar.indexOf(btn);
-
-                if (currentIndex !== targetIndex) {
-                    me.headerToolbar.moveTo(currentIndex, targetIndex)
-                }
-            }
-        });
-
-        me.lockedEndColumns.forEach((col, targetIndex) => {
-            let btn = me.getButton(col.dataField);
-
-            if (btn) {
-                if (btn.parentId !== me.headerEnd.id) {
-                    Neo.getComponent(btn.parentId).remove(btn, false);
-                    me.headerEnd.add(btn);
-                }
-
-                let currentIndex = me.headerEnd.indexOf(btn);
-
-                if (currentIndex !== targetIndex) {
-                    me.headerEnd.moveTo(currentIndex, targetIndex)
-                }
-            }
-        });
+        me.headerWrapper.applyColumnButtonOrder(me.lockedStartColumns, me.centerColumns, me.lockedEndColumns);
 
         me.updateColCount()
     }

--- a/src/grid/header/Wrapper.mjs
+++ b/src/grid/header/Wrapper.mjs
@@ -1,0 +1,224 @@
+import BaseContainer from '../../container/Base.mjs';
+import Toolbar       from './Toolbar.mjs';
+
+/**
+ * @summary The dedicated orchestrator for a grid's header region within the multi-body architecture.
+ *
+ * `Neo.grid.header.Wrapper` is the header-side counterpart to {@link Neo.grid.View} (which owns the bodies).
+ * It is strictly responsible for the lifecycle of the up-to-three header toolbars of a multi-body grid:
+ *
+ * 1. `headerStart` — the locked-start toolbar (created on demand, owned here).
+ * 2. `headerToolbar` — the scrollable centre toolbar (owned as a reactive config by {@link Neo.grid.Container},
+ *    placed into this Wrapper for layout).
+ * 3. `headerEnd` — the locked-end toolbar (created on demand, owned here).
+ *
+ * Extracting this responsibility out of `grid.Container` removes header instantiation and column-button
+ * orchestration from the macro layout layer, so header concerns no longer thrash unrelated domains (body
+ * rendering, selection models) during column mutations. This mirrors `grid.View` owning the body lifecycle.
+ *
+ * @class Neo.grid.header.Wrapper
+ * @extends Neo.container.Base
+ */
+class Wrapper extends BaseContainer {
+    static config = {
+        /**
+         * @member {String} className='Neo.grid.header.Wrapper'
+         * @protected
+         */
+        className: 'Neo.grid.header.Wrapper',
+        /**
+         * @member {String} ntype='grid-header-wrapper'
+         * @protected
+         */
+        ntype: 'grid-header-wrapper',
+        /**
+         * @member {String[]} baseCls=['neo-grid-header-wrapper','neo-header-wrapper']
+         * @protected
+         */
+        baseCls: ['neo-grid-header-wrapper', 'neo-header-wrapper'],
+        /**
+         * @member {String} flex='none'
+         */
+        flex: 'none',
+        /**
+         * Back-reference to the owning grid.Container (the macro layer). The Wrapper reaches up to the
+         * container for the column distribution and the centre `headerToolbar` it does not own.
+         * @member {Neo.grid.Container|null} gridContainer=null
+         */
+        gridContainer: null,
+        /**
+         * The locked-end header toolbar. Created on demand when end-locked columns exist; destroyed once
+         * they no longer do. Owned by this Wrapper.
+         * @member {Neo.grid.header.Toolbar|null} headerEnd=null
+         * @protected
+         */
+        headerEnd: null,
+        /**
+         * The locked-start header toolbar. Created on demand when start-locked columns exist; destroyed
+         * once they no longer do. Owned by this Wrapper.
+         * @member {Neo.grid.header.Toolbar|null} headerStart=null
+         * @protected
+         */
+        headerStart: null,
+        /**
+         * @member {Object} layout={ntype:'hbox',align:'stretch'}
+         * @protected
+         */
+        layout: {ntype: 'hbox', align: 'stretch'}
+    }
+
+    /**
+     * Re-homes and re-orders the column header buttons across the locked-start, centre and locked-end
+     * toolbars to match the current column-collection order. Invoked by
+     * {@link Neo.grid.Container#onColumnsMutate} after a column mutation.
+     * @param {Object[]} lockedStartColumns
+     * @param {Object[]} centerColumns
+     * @param {Object[]} lockedEndColumns
+     */
+    applyColumnButtonOrder(lockedStartColumns, centerColumns, lockedEndColumns) {
+        let me              = this,
+            {headerToolbar} = me.gridContainer;
+
+        lockedStartColumns.forEach((col, targetIndex) => {
+            let btn = me.getButton(col.dataField);
+
+            if (btn) {
+                if (btn.parentId !== me.headerStart.id) {
+                    Neo.getComponent(btn.parentId).remove(btn, false);
+                    me.headerStart.add(btn)
+                }
+
+                let currentIndex = me.headerStart.indexOf(btn);
+
+                if (currentIndex !== targetIndex) {
+                    me.headerStart.moveTo(currentIndex, targetIndex)
+                }
+            }
+        });
+
+        centerColumns.forEach((col, targetIndex) => {
+            let btn = me.getButton(col.dataField);
+
+            if (btn) {
+                if (btn.parentId !== headerToolbar.id) {
+                    Neo.getComponent(btn.parentId).remove(btn, false);
+                    headerToolbar.add(btn)
+                }
+
+                let currentIndex = headerToolbar.indexOf(btn);
+
+                if (currentIndex !== targetIndex) {
+                    headerToolbar.moveTo(currentIndex, targetIndex)
+                }
+            }
+        });
+
+        lockedEndColumns.forEach((col, targetIndex) => {
+            let btn = me.getButton(col.dataField);
+
+            if (btn) {
+                if (btn.parentId !== me.headerEnd.id) {
+                    Neo.getComponent(btn.parentId).remove(btn, false);
+                    me.headerEnd.add(btn)
+                }
+
+                let currentIndex = me.headerEnd.indexOf(btn);
+
+                if (currentIndex !== targetIndex) {
+                    me.headerEnd.moveTo(currentIndex, targetIndex)
+                }
+            }
+        })
+    }
+
+    /**
+     * Returns the header.Button matching a given dataField, searching the locked-start, centre and
+     * locked-end toolbars in order.
+     * @param {String} dataField
+     * @returns {Neo.grid.header.Button|null}
+     */
+    getButton(dataField) {
+        let me = this;
+
+        return me.headerStart?.getColumn(dataField) ||
+               me.gridContainer.headerToolbar?.getColumn(dataField) ||
+               me.headerEnd?.getColumn(dataField) ||
+               null
+    }
+
+    /**
+     * Creates, updates or destroys the locked-start and locked-end header toolbars to match the current
+     * locked-column state, refreshes the centre toolbar buttons, and (re)assembles all toolbars into this
+     * Wrapper in left-to-right order. Invoked by {@link Neo.grid.Container#createOrUpdateSubGrids}.
+     * @param {Object[]} [lockedStartButtons]
+     * @param {Object[]} [centerButtons]
+     * @param {Object[]} [lockedEndButtons]
+     */
+    updateHeaders(lockedStartButtons, centerButtons, lockedEndButtons) {
+        let me              = this,
+            {gridContainer} = me,
+            {centerColumns, headerToolbar, lockedEndColumns, lockedStartColumns, theme, windowId} = gridContainer;
+
+        // --- Center (Default) ---
+        if (centerColumns.length > 0 && centerButtons) {
+            headerToolbar.items = centerButtons;
+            headerToolbar.createItems()
+        }
+
+        // --- Start (Left) ---
+        if (lockedStartColumns.length > 0) {
+            if (!me.headerStart) {
+                me.headerStart = Neo.create(Toolbar, {
+                    ...headerToolbar.initialConfig,
+                    flex      : 'none',
+                    gridContainer,
+                    items     : lockedStartButtons || [],
+                    layoutLock: 'start',
+                    parentId  : me.id,
+                    theme,
+                    windowId
+                })
+            } else if (lockedStartButtons) {
+                me.headerStart.items = lockedStartButtons;
+                me.headerStart.createItems()
+            }
+        } else if (me.headerStart) {
+            me.headerStart.destroy();
+            me.headerStart = null
+        }
+
+        // --- End (Right) ---
+        if (lockedEndColumns.length > 0) {
+            if (!me.headerEnd) {
+                me.headerEnd = Neo.create(Toolbar, {
+                    ...headerToolbar.initialConfig,
+                    flex      : 'none',
+                    gridContainer,
+                    items     : lockedEndButtons || [],
+                    layoutLock: 'end',
+                    parentId  : me.id,
+                    theme,
+                    windowId
+                })
+            } else if (lockedEndButtons) {
+                me.headerEnd.items = lockedEndButtons;
+                me.headerEnd.createItems()
+            }
+        } else if (me.headerEnd) {
+            me.headerEnd.destroy();
+            me.headerEnd = null
+        }
+
+        // Assemble the header toolbars into the wrapper in left-to-right order.
+        let headerItems = [];
+
+        me.headerStart && headerItems.push(me.headerStart);
+        headerToolbar  && headerItems.push(headerToolbar);
+        me.headerEnd   && headerItems.push(me.headerEnd);
+
+        me.items = headerItems;
+        me.createItems()
+    }
+}
+
+export default Neo.setupClass(Wrapper);

--- a/src/grid/header/_export.mjs
+++ b/src/grid/header/_export.mjs
@@ -1,4 +1,5 @@
 import Button  from './Button.mjs';
 import Toolbar from './Toolbar.mjs';
+import Wrapper from './Wrapper.mjs';
 
-export {Button, Toolbar};
+export {Button, Toolbar, Wrapper};


### PR DESCRIPTION
## Summary

Resolves #12800. Refs #9872, #9486.

Extracts the grid header region into a dedicated `Neo.grid.header.Wrapper` orchestrator — the header-side counterpart to `grid.View` (which already owns the bodies). This is **Tier 2** of `#9872`'s 3-tier orchestration refactor: it removes header-toolbar instantiation + column-button orchestration from `grid.Container`'s "God Object", so header concerns no longer bleed into the macro layout layer or thrash unrelated domains (body rendering, selection models) on column mutations.

## Deltas

- **`src/grid/header/Wrapper.mjs`** (new) — `Neo.grid.header.Wrapper extends Neo.container.Base` (`ntype: 'grid-header-wrapper'`). Owns `headerStart`/`headerEnd` configs + their create/destroy lifecycle, plus three methods relocated from `Container`:
  - `updateHeaders(lockedStartButtons, centerButtons, lockedEndButtons)` — centre-toolbar refresh + locked-toolbar lifecycle + left-to-right assembly.
  - `applyColumnButtonOrder(lockedStartColumns, centerColumns, lockedEndColumns)` — column-button re-homing/re-ordering across the three toolbars.
  - `getButton(dataField)` — header-button lookup.
- **`src/grid/Container.mjs`** — header concerns delegated: `createOrUpdateSubGrids` calls `headerWrapper.updateHeaders(...)` and retains only body creation/destroy/assembly; `onColumnsMutate` calls `headerWrapper.applyColumnButtonOrder(...)`; `getButton` delegates. The `headerStart`/`headerEnd` configs and the generic `BaseContainer` header-wrapper instantiation are removed (now `header.Wrapper`).
- **`src/grid/header/_export.mjs`** — register `Wrapper`.

## Test Evidence

Evidence: `npm run test-unit -- grid` post-refactor is **identical to the pre-change baseline** captured on the same `origin/dev` checkout (c1b921058) — the 7 pre-existing local-env bucket-B failures (LockedColumns 176/192, Pooling 171/299/331, Teleportation 138/267) are unchanged, **18 passed, zero new failures**. `LockedColumns:176` ("Header Toolbar items are synchronized with column collection order") exercises the exact button-ordering logic moved into `applyColumnButtonOrder` and fails *identically* (pre-existing local-env, not introduced by this change). `npm run test-unit -- GridScrollProfile` → **1 passed** (exercises the locked-`bodyStart` creation that was split out of `createOrUpdateSubGrids`).

Static verification: zero `headerStart`/`headerEnd` references remain in `Container.mjs` (all delegate via `headerWrapper`); `headerStart`/`headerEnd` had zero references anywhere outside `Container.mjs` across `src/` + `test/`; `getButton` had zero callers outside the relocated logic; `neo-header-wrapper` has no CSS-selector dependency, preserved as a `baseCls`.

## Post-Merge Validation

- Confirm the CI `unit` + `integration-unified` jobs stay green.
- Local/visual-verify a locked-column grid: header buttons render in the correct start/centre/end toolbars; column lock/unlock re-homes buttons; column reordering re-orders the header buttons (the `applyColumnButtonOrder` path — the dimension `LockedColumns:176` pins, currently local-env-skipped on CI).

## Sequencing note

Rebased onto `dev` after #12784 (the View-owned SelectionModel) merged. The anticipated `createOrUpdateSubGrids` conflict (this PR's header extraction vs #12784's body-SM edits) is **resolved + verified**: kept #12784's SM hoist + `applyViewSelectionModel`, applied the header→Wrapper delegation, dropped the now-redundant `headerWrapper.createItems()`. `unit` CI green; #12784's `ViewOwnedSelectionModel` AC1/AC2 + GridScrollProfile pass on the merged branch.

## Out of Scope (tracked follow-ups under #9872)

- **Tier-1**: `grid.Container` → pure macro layout coordinator (drop body instantiation).
- **Tier-3**: body creation/lifecycle → `grid.View` (overlaps the now-merged #12784 SM work; a clean follow-up on current dev).
- Full migration of the centre `headerToolbar` reactive config off `Container` (it remains a `Container` config; the Wrapper places it).

Authored by Claude Opus 4.8 (Claude Code)

