### PR TITLE
fix(memory-core): bound miniSummary backfill run under the supervisor watchdog (#12746)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -17,6 +17,16 @@ import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoo
 const MINI_SUMMARY_TIMEOUT_MS = 30000;
 
 /**
+ * Wall-clock budget for a single `backfillMiniSummaries` run. Bounds the run safely under the
+ * ProcessSupervisor watchdog (`taskDefinitions.mjs` `memory-summary-backfill` maxRuntimeMs=900000):
+ * the loop exits cleanly at this budget and defers the unprocessed remainder to the next scheduled
+ * sweep, rather than risking a watchdog SIGKILL that makes zero forward progress. A slow or contended
+ * local model can otherwise push a full batch past the 15-minute watchdog and loop without draining.
+ * @type {Number}
+ */
+const MINI_SUMMARY_BACKFILL_MAX_RUN_MS = 600000;
+
+/**
  * Maximum time to wait for the backfill's content-store (Chroma) metadata fetch before deferring
  * the whole batch. Usually milliseconds; the bound exists only to defeat a hung connection.
  * @type {Number}
@@ -793,21 +803,27 @@ class MemoryService extends Base {
      * can retry it. A failure for one row never aborts the batch.
      *
      * @param {Object} [options]
-     * @param {Number} [options.limit] Maximum rows to process. Defaults to
+     * @param {Number} [options.limit] Maximum rows to fetch. Defaults to
      *     `aiConfig.summarizationBatchLimit`.
      * @param {Function} [options.buildMiniSummary] Optional summarizer seam for deterministic tests.
-     * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number}>}
+     * @param {Number} [options.maxRunMs] Wall-clock budget for the run; defaults to
+     *     `MINI_SUMMARY_BACKFILL_MAX_RUN_MS`. The loop stops starting new rows once reached and defers
+     *     the remainder to the next sweep, keeping the supervised child under its watchdog.
+     * @param {Function} [options.now] Clock seam (defaults to `Date.now`) for deterministic budget tests.
+     * @returns {Promise<{processed: Number, updated: Number, deferred: Number, missingContent: Number, runBudgetHit: Boolean}>}
      */
-    async backfillMiniSummaries({limit, buildMiniSummary} = {}) {
+    async backfillMiniSummaries({limit, buildMiniSummary, maxRunMs, now = () => Date.now()} = {}) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, runBudgetHit: false};
         }
 
         const defaultLimit = Number(aiConfig.summarizationBatchLimit) || 50;
         const numericLimit = Number(limit) || defaultLimit;
         const boundedLimit = Math.max(1, Math.min(numericLimit, defaultLimit));
         const summarize    = buildMiniSummary || (options => this.buildMiniSummary(options));
+        const runBudgetMs  = Number(maxRunMs) > 0 ? Number(maxRunMs) : MINI_SUMMARY_BACKFILL_MAX_RUN_MS;
+        const startedAt    = now();
 
         const rows = sqlite.prepare(`
             SELECT memory.id                                          AS id,
@@ -820,7 +836,7 @@ class MemoryService extends Base {
         `).all(boundedLimit);
 
         if (rows.length === 0) {
-            return {processed: 0, updated: 0, deferred: 0, missingContent: 0};
+            return {processed: 0, updated: 0, deferred: 0, missingContent: 0, runBudgetHit: false};
         }
 
         let byId;
@@ -830,12 +846,22 @@ class MemoryService extends Base {
             byId             = new Map((fetched.ids || []).map((id, index) => [id, fetched.metadatas?.[index] || {}]));
         } catch (error) {
             logger.warn(`[MemoryService] miniSummary backfill deferred the whole batch (content store unreachable, fail-soft): ${error.message}`);
-            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0};
+            return {processed: rows.length, updated: 0, deferred: rows.length, missingContent: 0, runBudgetHit: false};
         }
 
-        let updated = 0, deferred = 0, missingContent = 0;
+        let updated = 0, deferred = 0, missingContent = 0, processed = 0, runBudgetHit = false;
 
         for (const row of rows) {
+            // Bound the run safely under the ProcessSupervisor watchdog: stop starting new rows once
+            // the wall-clock budget is reached and defer the unprocessed remainder to the next
+            // scheduled sweep, rather than risk a watchdog SIGKILL that makes zero forward progress.
+            if (now() - startedAt >= runBudgetMs) {
+                runBudgetHit = true;
+                break;
+            }
+
+            processed++;
+
             const metadata = byId.get(row.id);
             if (!metadata || (!metadata.prompt && !metadata.response)) {
                 missingContent++;
@@ -865,7 +891,11 @@ class MemoryService extends Base {
             }
         }
 
-        return {processed: rows.length, updated, deferred, missingContent};
+        if (runBudgetHit) {
+            logger.info(`[MemoryService] miniSummary backfill hit the ${runBudgetMs}ms run budget after ${processed}/${rows.length} row(s); deferring the remainder to the next sweep`);
+        }
+
+        return {processed, updated, deferred, missingContent, runBudgetHit};
     }
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -225,7 +225,7 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
             }
         });
         expect(calls).toEqual(['new prompt']);
-        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0});
+        expect(result).toEqual({processed: 1, updated: 1, deferred: 0, missingContent: 0, runBudgetHit: false});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-new');
         const data = JSON.parse(row.data);
@@ -254,10 +254,51 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
                 throw new Error('provider unavailable');
             }
         });
-        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0});
+        expect(result).toEqual({processed: 1, updated: 0, deferred: 1, missingContent: 0, runBudgetHit: false});
 
         const row  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get('backfill-failure');
         const data = JSON.parse(row.data);
         expect(data.properties.miniSummary).toBeUndefined();
+    });
+
+    test('backfillMiniSummaries bounds a run by maxRunMs and defers the remainder to the next sweep', async () => {
+        // Seed 3 pending rows with the highest timestamps so they sort first under the
+        // (timestamp DESC, id DESC) scan and are exactly the rows this limited fetch returns.
+        const ids = ['budget-row-a', 'budget-row-b', 'budget-row-c'];
+        ids.forEach((id, i) => {
+            memStore.set(id, {prompt: `p-${id}`, response: `r-${id}`});
+            GraphService.upsertNode({
+                id, type: 'AGENT_MEMORY', name: `Memory: ${id}`, description: id, semanticVectorId: id,
+                properties: {agentIdentity: '@agent-a', userId: 'tenant-a', sessionId: 'budget', timestamp: `2099-12-31T23:59:5${2 - i}.000Z`}
+            });
+        });
+
+        // Clock seam advanced by each summarize call: the first row runs while elapsed (0) is under the
+        // 100ms budget; that one call pushes elapsed to 1000ms, so the next iteration exits the loop.
+        let fakeNow   = 0;
+        const calls   = [];
+        const result  = await MemoryService.backfillMiniSummaries({
+            limit   : 3,
+            maxRunMs: 100,
+            now     : () => fakeNow,
+            buildMiniSummary: async ({prompt}) => {
+                calls.push(prompt);
+                fakeNow += 1000;
+                return `summary:${prompt}`;
+            }
+        });
+
+        // Exactly one row processed before the budget bounded the run; the rest deferred to a later sweep.
+        expect(result.runBudgetHit).toBe(true);
+        expect(result.processed).toBe(1);
+        expect(result.updated).toBe(1);
+        expect(calls.length).toBe(1);
+
+        // The two unprocessed rows retain no miniSummary, so a subsequent sweep drains them.
+        const summarized = ids.filter(id => {
+            const seeded = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(id);
+            return JSON.parse(seeded.data).properties.miniSummary !== undefined;
+        });
+        expect(summarized.length).toBe(1);
     });
 });


### PR DESCRIPTION
## Summary

Resolves #12746. Refs #12740, #12799.

**Prio-0 v13 blocker.** `memory miniSummary backfill` exceeds the 900000ms ProcessSupervisor watchdog on every cycle under the local gemma4 model → SIGKILL mid-batch → restart → never drains (`pending-memory-minisummary` stays full for hours; ~60-min CPU churn that starves other heavy-maintenance via the lease). Root: `MemoryService.backfillMiniSummaries` had **no total-run budget** — a full batch × slow/contended per-item inference can run past the 15-min watchdog.

## Deltas

- **`ai/services/memory-core/MemoryService.mjs`**
  - New `MINI_SUMMARY_BACKFILL_MAX_RUN_MS = 600000` (10 min) — a wall-clock run budget, safely under the supervisor watchdog (`taskDefinitions.mjs` `memory-summary-backfill` `maxRuntimeMs=900000`).
  - `backfillMiniSummaries` checks the budget at the top of each loop iteration: once reached it stops starting new rows, logs, sets `runBudgetHit`, and **defers the unprocessed remainder to the next scheduled sweep** rather than risk a watchdog SIGKILL. Per-item updates persist, so each bounded run makes forward progress.
  - Added `maxRunMs` + `now` option seams (defaults: the constant / `Date.now`) for deterministic budget testing; added `runBudgetHit` to the result for observability (the supervised child logs the outcome).
- **`test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs`** — new deterministic test: 3 high-timestamp pending rows, `maxRunMs: 100` + a `now` seam advanced by the summarizer → exactly 1 row processed before the budget bounds the run, the remainder deferred. Updated the 2 existing backfill assertions for the additive `runBudgetHit` field.

## Test Evidence

Evidence: `npm run test-unit -- QueryRecentTurns` → **11/11 passed**, including the new `backfillMiniSummaries bounds a run by maxRunMs and defers the remainder to the next sweep` test plus the 2 updated backfill specs. The fix bounds the run **by construction** (budget 600000ms + a final in-flight item ≤30s + init overhead < the 900000ms watchdog), so the child cannot be SIGKILLed mid-run regardless of per-item gemma4 latency. Robust both ways: slow items → budget caps the run + defers; fast items → no budget hit, normal completion (no-op).

## Post-Merge Validation

- Watch `orchestrator.log`: `memory miniSummary backfill` runs should now complete (or log `hit the … run budget … deferring the remainder`) and exit cleanly — **no more `exceeded max runtime … killing child (watchdog)`** entries.
- Confirm `pending-memory-minisummary` drains across successive sweeps (bounded forward progress) and the heavy-maintenance lease frees sooner for session-summarization / Dream / sync.

## Scope notes

- #12746 AC1 (per-sweep cap) + the pacing test (AC3) delivered. AC2 (429-backoff): verified **no tight retry loop exists** — `buildMiniSummary` is a single timed model call + fail-soft defer; moot under the local-provider default (`#12742`). The runaway shape AC2 targeted was the back-to-back loop, bounded here.
- This bounds the backfill **loop** (stops the watchdog churn + frees the lease). The deeper "local gemma4 is slow for heavy tasks" root — whether items summarize within their timeout at all, and ask-vs-Dream endpoint contention — is the broader `#12799` arbitration, out of scope here.
- Rebased onto `dev` after #12784 + the `v13.0.0.md` SEO-link fix (#12798) landed; the `unit` CI is now green and the PR is mergeable.

Authored by Claude Opus 4.8 (Claude Code)

