### PR TITLE
fix(memory-core): raise miniSummary timeout above measured local-model latency (#12804)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -708,7 +708,12 @@ class MemoryService extends Base {
      * @returns {Promise<String|null>} A ≤280-char one-line summary, or `null`.
      */
     async buildMiniSummary({prompt, response}) {
-        const TIMEOUT_MS = 4000;
+        // Calibrated above the measured local-model summary latency so a real summary is not aborted
+        // before it completes. Benchmark (2026-06-09, MacBook M5 Max 128GB, gemma-4-31b-it via LM
+        // Studio): a ~5k-char -> tweet-size summary takes ~5.3s warm / ~13s cold. The prior 4s cap
+        // aborted most local summaries -> null -> zero backfill drain. Stays under the 30s outer
+        // backfill per-item timeout (MINI_SUMMARY_TIMEOUT_MS).
+        const TIMEOUT_MS = 20000;
         try {
             const model = buildChatModel({
                 modelProvider         : aiConfig.modelProvider,


### PR DESCRIPTION
## Summary

Resolves #12804. Refs #12740, #12746, #12799.

**Prio-0 drain-root, benchmark-proven.** `buildMiniSummary` capped each local model call at **4s**, but a benchmark on this hardware (MacBook M5 Max 128GB, `gemma-4-31b-it` via LM Studio :1234) measured a ~5k-char → tweet-size summary at **~5.3s warm / ~13s cold**. The 4s cap aborted most summaries before completion → `null` → the row stays pending → **zero backfill drain** (and null inline `add_memory` summaries). This is *why the queue never empties* — independent of PR #12802's run-budget (a bounded run still drains 0 if every item aborts at 4s).

## Deltas

- **`ai/services/memory-core/MemoryService.mjs`** — `buildMiniSummary`'s inner `TIMEOUT_MS` raised `4000 → 20000` (above the ~13s cold reading + headroom, under the 30s outer backfill timeout `MINI_SUMMARY_TIMEOUT_MS`). The benchmark rationale (figures + date + hardware/model) is documented at the constant so the value is not silently re-tightened.

## Test Evidence

Evidence: the benchmark — a `node` client against the live LM Studio endpoint (127.0.0.1:1234, `gemma-4-31b-it`), 5086-char input → tweet-size output: **warm-up 13.3s; runs 6.8s / 4.5s / 4.4s; avg ~5.3s**. The measured latency exceeds the prior 4s cap on every run, confirming the abort. `node --check` parses clean.

Not unit-tested in isolation: `TIMEOUT_MS` is a module-internal calibration constant, and the existing `QueryRecentTurns` backfill specs use the `buildMiniSummary` seam (which bypasses the real timeout). The empirical benchmark is the verification; the documented rationale guards against regression.

## Post-Merge Validation

- Confirm `orchestrator.log` shows the miniSummary backfill producing `updated` rows (drain > 0) and `pending-memory-minisummary` trending down — vs the prior 0-drain loop.
- Confirm inline `add_memory` summaries populate (rows no longer land with null `miniSummary` under the local provider).

## Scope notes

- Pairs with PR #12802 (run-budget): #12802 stops the watchdog-kill; this lets items complete so the bounded run actually drains. Together the backfill works.
- Out of scope: the `:11434` (config default) vs live `:1234` endpoint-host discrepancy; deeper model-speed / ask-vs-Dream contention (#12799 / #12803); backlog-depth observability (separate leaf).
- Rebased onto `dev` after #12784 + the `v13.0.0.md` SEO-link fix (#12798) landed; the `unit` CI is now green and the PR is mergeable.

Authored by Claude Opus 4.8 (Claude Code)

