### PR TITLE
fix(ai): bound ask_knowledge_base synthesis with an interactive timeout

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -135,6 +135,20 @@ class Config extends ConfigProvider {
              */
             kbFaqConceptLimit: leaf(5, 'NEO_KB_FAQ_CONCEPT_LIMIT', 'number'),
             /**
+             * @summary Interactive timeout budget (ms) for `ask_knowledge_base` answer synthesis.
+             *
+             * Bounds the single chat-model `generateContent` call in `SearchService.ask` so an
+             * interactive RAG query fails fast and returns its already-retrieved ranked references
+             * (the degraded envelope) instead of hanging behind heavy local-model contention — e.g.
+             * a Dream/REM graph extraction holding the one serialized local endpoint. The budget is
+             * passed to the active chat provider as `options.timeoutMs`; both `OpenAiCompatible` and
+             * `Ollama` honor it. Sized as a starting value above a normal local synthesis but well
+             * below the retry-amplified worst case (a token-exhausting extraction times the provider
+             * retry loop); re-tune once that retry loop is bounded.
+             * @type {number}
+             */
+            askSynthesisTimeoutMs: leaf(30000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS', 'number'),
+            /**
              * The path to the generated knowledge base JSONL file.
              * @type {string}
              */

--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -114,10 +114,19 @@ class OllamaProvider extends Base {
      *
      * @param {String|Array} input Prompt string or message history array.
      * @param {Object} [options]
+     * @param {Number} [options.timeoutMs] Abort the request after this many ms of socket inactivity.
+     *     For non-streaming Ollama chat (`stream:false`) the server emits no bytes until the full
+     *     completion is ready, so the idle timeout acts as an effective total deadline. Defaults to
+     *     1 hour when unset/invalid, preserving prior behavior. Lets interactive callers (e.g. KB
+     *     `ask` synthesis) fail fast and degrade rather than wait behind a long batch inference.
+     * @param {String} [options.operationLabel] Safe diagnostic label surfaced in the timeout error.
      * @returns {Promise<{content: String, raw: Object}>}
      */
     async generate(input, options = {}) {
-        const payload = this.preparePayload(input, options, false);
+        const payload          = this.preparePayload(input, options, false);
+        const rawTimeoutMs     = Number(options.timeoutMs);
+        const requestTimeoutMs = Number.isFinite(rawTimeoutMs) && rawTimeoutMs > 0 ? rawTimeoutMs : 60 * 60 * 1000;
+        const operationLabel   = options.operationLabel || 'Ollama chat completion';
 
         try {
             const parsedUrl = new URL(`${this.host}/api/chat`);
@@ -134,7 +143,7 @@ class OllamaProvider extends Base {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                timeout: 60 * 60 * 1000 // 1 hour timeout natively
+                timeout: requestTimeoutMs // configurable; defaults to 1h (see options.timeoutMs)
             }, (res) => {
                 let body = '';
                 res.on('data', chunk => body += chunk);
@@ -158,7 +167,7 @@ class OllamaProvider extends Base {
 
             req.on('timeout', () => {
                 req.destroy();
-                rejectFunc(new Error('Ollama request timed out after 1 hour'));
+                rejectFunc(new Error(`[Ollama] ${operationLabel} timed out after ${requestTimeoutMs}ms (host=${this.host}, model=${this.modelName})`));
             });
 
             req.write(JSON.stringify(payload));

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -280,7 +280,10 @@ Instructions:
         let result, answer;
 
         try {
-            result = await this.model.generateContent(prompt);
+            result = await this.model.generateContent(prompt, {
+                timeoutMs     : aiConfig.askSynthesisTimeoutMs,
+                operationLabel: 'ask_knowledge_base synthesis'
+            });
             answer = result.response.text();
         } catch (error) {
             const degraded = this.#createDegradedSynthesisResponse({references, error});

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -122,6 +122,30 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         expect(payloads[1].options.keep_alive).toBeUndefined();
     });
 
+    test('Ollama.generate() aborts a hung request at options.timeoutMs with a labeled timeout error (#12803)', async () => {
+        // A server that accepts the request but never responds — simulates a long inference
+        // holding the one serialized local endpoint, so the configurable socket timeout fires.
+        const server = http.createServer((req) => {
+            req.on('data', () => {});
+            req.on('end', () => {/* intentionally never respond */});
+        });
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+        const host = `http://127.0.0.1:${server.address().port}`;
+
+        try {
+            const provider = Neo.create(OllamaProvider, {host, modelName: 'gemma4-test'});
+
+            await expect(provider.generate('hello', {
+                timeoutMs     : 50,
+                operationLabel: 'ask_knowledge_base synthesis'
+            })).rejects.toThrow(
+                /\[Ollama\] ask_knowledge_base synthesis timed out after 50ms \(host=http:\/\/127\.0\.0\.1:\d+, model=gemma4-test\)/
+            );
+        } finally {
+            await new Promise(resolve => server.close(resolve));
+        }
+    });
+
     test('Ollama.preparePayload() defaults keep_alive for direct payload consumers', () => {
         const provider = Neo.create(OllamaProvider, {
             host     : 'http://ollama.test',

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -271,4 +271,41 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
             score : 321
         });
     });
+
+    test('ask passes the interactive budget and returns degraded references when synthesis times out', async () => {
+        let capturedOptions = null;
+
+        QueryService.queryDocuments = async () => ({
+            topResult: tmpFileRelativeToRoot,
+            results  : [{source: tmpFileRelativeToRoot, score: '1234'}]
+        });
+
+        // Simulate the active chat provider aborting on the interactive contention budget — the shape
+        // OpenAiCompatible.generate / Ollama.generate throw once options.timeoutMs is exceeded.
+        SearchService.model = {
+            generateContent: async (prompt, options) => {
+                capturedOptions = options;
+                throw new Error('[Ollama] ask_knowledge_base synthesis timed out after 30000ms (host=http://127.0.0.1:11434, model=gemma4:31b)');
+            }
+        };
+
+        const result = await SearchService.ask({query: 'contention timeout fixture', type: 'src'});
+
+        // Wiring: ask must pass the interactive budget + a safe operation label to the provider.
+        expect(capturedOptions).toBeTruthy();
+        expect(capturedOptions.operationLabel).toBe('ask_knowledge_base synthesis');
+        expect(Object.prototype.hasOwnProperty.call(capturedOptions, 'timeoutMs')).toBe(true);
+
+        // Degraded envelope: references preserved, bounded timeout reason, never collapses to "no documents".
+        expect(result.degraded).toBe(true);
+        expect(result.error).toBe('synthesis_failed');
+        expect(result.reason).toContain('timed out');
+        expect(result.answer).toContain('Knowledge-base retrieval succeeded');
+        expect(result.answer).not.toContain('No relevant documents found');
+        expect(result.references).toEqual([{
+            name  : path.basename(tmpFileRelativeToRoot),
+            source: tmpFileRelativeToRoot,
+            score : 1234
+        }]);
+    });
 });


### PR DESCRIPTION
Resolves #12803
Related: #12799, #12740, #12737, #12748, #10494, #12696

Bounds `ask_knowledge_base` answer synthesis with a config-backed **interactive timeout** so an interactive RAG query fails fast and returns its already-retrieved ranked references (the existing degraded envelope) under heavy local-model contention, instead of hanging toward the provider socket ceiling (1h on Ollama). The v13 release-bar fix (Discussion #12799 LEAF 1; OQ4 — graceful degradation acceptable iff fast + explicit + reference-bearing).

Evidence: L2 (multi-file behavioral change with regression specs) → L2 required.

## The root cause (V-B-A)

`SearchService.ask` → `buildChatModel` → `provider.generate(prompt, opts)`. The SearchService side was a no-op pass-through (no opts). The real gap was at the **provider**:

- `OpenAiCompatible.generate` already honored `options.timeoutMs` (`AbortController` → `createTimeoutError`).
- `Ollama.generate` hardcoded a **1h** socket timeout and consumed no caller-supplied budget — so the live local chat provider (`gemma4:31b`) had no interactive timeout. Wiring a budget into the ask alone would have been **silently discarded** on the runtime path (this refines the "wiring is small" premise — small for `openAiCompatible`, but the Ollama path needed the provider capability first).

## Deltas

- **`ai/provider/Ollama.mjs`** — `generate` honors `options.timeoutMs` (configurable socket timeout via the existing `req.on('timeout')` → `req.destroy()` mechanism; defaults to 1h when unset/invalid) + `options.operationLabel` in the timeout error. JSDoc added.
- **`ai/mcp/server/knowledge-base/config.template.mjs`** — new `askSynthesisTimeoutMs` leaf (30000ms default, `NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS`), sized above a normal local synthesis but below the retry-amplified worst case (a token-exhausting extraction × the provider retry loop, #10494); re-tune once that loop is bounded.
- **`ai/services/knowledge-base/SearchService.mjs`** — `ask` passes `{timeoutMs: aiConfig.askSynthesisTimeoutMs, operationLabel}` to the active provider (read at use site per ADR 0019 §5.1 — no alias / `?.` / re-derive). The existing catch routes the timeout error to `#createDegradedSynthesisResponse`.
- **`test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs`** — service-level regression: retrieval-success + a synthesis stub that rejects with a timeout error → degraded envelope (`degraded:true`, refs preserved, `reason` contains "timed out") + asserts the wiring (`operationLabel` + `timeoutMs` passed).
- **`test/playwright/unit/ai/provider/KeepAlive.spec.mjs`** — provider-level regression: a hung loopback server + `Ollama.generate({timeoutMs:50})` asserts the socket timeout fires and surfaces the labeled `[Ollama] … timed out after 50ms` error.

## Test Evidence

- `SearchService.spec.mjs` → **9 passed** (the service-level degraded-envelope + wiring test).
- `KeepAlive.spec.mjs` → **11 passed** (incl. the new provider-level `Ollama.generate({timeoutMs})` abort test — proves the provider *enforces* the budget, not just that the service passes it; closes @neo-gpt's provider-enforcement coverage gap).
- Blast-radius run (`ai/provider/` + `ai/services/knowledge-base/`) → **309 passed**. The one failure (`QueryService.queryDocuments` #12719 stratification) is **local-env, not a dev regression** — confirmed: dev `Tests` run green + this PR's full 3132-test `unit` job green (incl. `QueryService`); the local fail is operator-overlay `config.mjs` drift. **B4-safe** (ADR 0019 §5.4): the specs stub the instance model / `QueryService` / loopback transport, never the shared `aiConfig` singleton.

## Post-Merge Validation

Once the config-template change reaches the runtime overlay (the gitignored `config.mjs` is generated from the canonical template), confirm `ask_knowledge_base` under live daemon contention returns the degraded envelope within ~30s instead of hanging. Operators tune via `NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS`.

## Avoided traps

- **Not** a hardcoded socket timeout — config-backed, env-overridable, sized against the retry-amplified worst case.
- **Not** a new degraded path — reuses the existing `#createDegradedSynthesisResponse` (#12737); adds only the timeout trigger.
- **Not** just the SearchService wiring — the Ollama provider needed the interactive-timeout capability first (the live local chat path), which the `openAiCompatible`-only premise didn't cover.

## Out of scope

- The endpoint-level interactive/batch arbiter / daemon-yield / chunked-Dream extraction (Discussion #12799 LEAF 2 — high-blast, continues in the Discussion for OQ2 telemetry + §6 convergence). The chat interactive/batch queue (#12748) is complementary — it arbitrates ask-vs-chat-summary; this bounds the ask under *any* contention incl. Dream.
- **`options.signal` (upstream cancellation) is intentionally not added.** The ask sets its own `timeoutMs` budget and passes no signal, so per-request cancellation is YAGNI for this fix; signal-parity with `OpenAiCompatible`'s `AbortController` is a future provider capability (e.g. for LEAF-2 daemon-yield), added when a caller needs it. The #12803 provider AC is narrowed to `timeoutMs` accordingly (per @neo-gpt's #12806 review — see the AC-correction comment).

Authored by @neo-opus-vega (Claude Opus 4.8). Origin Session 728442d6-a2a0-4481-a631-a3112ce6d703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
