### PR TITLE
feat(orchestrator): report true summary backlog depth, not the fetch limit (#12809)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
+++ b/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
@@ -30,18 +30,50 @@ export function getPendingMemorySummaryBackfillJobs(db, {limit = 50} = {}) {
 }
 
 /**
+ * Counts ALL pending `AGENT_MEMORY` rows lacking `miniSummary` — the true backlog depth.
+ *
+ * @summary Distinct from {@link getPendingMemorySummaryBackfillJobs} (capped at the fetch limit).
+ * This uncapped COUNT feeds the trigger reason so the orchestrator log reports the real backlog
+ * rather than the fetch limit. Fail-soft: returns `null` when the graph table is unavailable.
+ * @param {Object} db SQLite database handle.
+ * @returns {Number|null}
+ */
+export function getPendingMemorySummaryBackfillCount(db) {
+    if (!db?.prepare) {
+        return null;
+    }
+
+    try {
+        const row = db.prepare(`
+            SELECT COUNT(*) AS n
+            FROM Nodes memory
+            WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
+              AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
+        `).get();
+
+        return Number.isInteger(row?.n) ? row.n : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Builds the task trigger for memory miniSummary backfill.
  *
  * @param {Object} options
- * @param {String[]} [options.pendingJobs=[]] Pending AGENT_MEMORY ids.
+ * @param {String[]} [options.pendingJobs=[]] Pending AGENT_MEMORY ids (capped at the fetch limit).
+ * @param {Number} [options.totalPending] Uncapped backlog depth for the (logged) reason; falls back
+ *     to `pendingJobs.length` when not an integer.
  * @returns {Object|null}
  */
-export function buildMemorySummaryBackfillTrigger({pendingJobs = []} = {}) {
+export function buildMemorySummaryBackfillTrigger({pendingJobs = [], totalPending} = {}) {
     if (pendingJobs.length > 0) {
+        const backlog = Number.isInteger(totalPending) ? totalPending : pendingJobs.length;
+
         return {
             taskName    : 'memory-summary-backfill',
             source      : 'pending-memory-minisummary',
-            reason      : `pending-memory-minisummary:${pendingJobs.length}`,
+            reason      : `pending-memory-minisummary:${backlog}`,
             pendingCount: pendingJobs.length
         };
     }
@@ -54,14 +86,19 @@ export function buildMemorySummaryBackfillTrigger({pendingJobs = []} = {}) {
  *
  * @param {Object} options
  * @param {Object} options.db SQLite database handle.
- * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn] Test seam.
+ * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn] Test seam for the limited fetch.
+ * @param {Function} [options.getPendingMemorySummaryBackfillCountFn] Test seam for the uncapped count.
  * @returns {Object|null}
  */
 export function getDueTask({
     db,
-    getPendingMemorySummaryBackfillJobsFn = getPendingMemorySummaryBackfillJobs
+    getPendingMemorySummaryBackfillJobsFn  = getPendingMemorySummaryBackfillJobs,
+    getPendingMemorySummaryBackfillCountFn = getPendingMemorySummaryBackfillCount
 }) {
+    const pendingJobs = getPendingMemorySummaryBackfillJobsFn(db);
+
     return buildMemorySummaryBackfillTrigger({
-        pendingJobs: getPendingMemorySummaryBackfillJobsFn(db)
+        pendingJobs,
+        totalPending: pendingJobs.length > 0 ? getPendingMemorySummaryBackfillCountFn(db) : null
     });
 }

--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -35,6 +35,33 @@ export function getPendingSummarizationJobs(db, {limit = 50} = {}) {
 }
 
 /**
+ * Counts ALL pending `SummarizationJobs` rows — the true session-summary backlog depth.
+ *
+ * @summary Distinct from {@link getPendingSummarizationJobs} (capped at the fetch limit). This
+ * uncapped COUNT feeds the trigger reason so the orchestrator log reports the real backlog rather
+ * than the fetch limit. Fail-soft: returns `null` when the table is unavailable.
+ * @param {Object} db SQLite database handle.
+ * @returns {Number|null}
+ */
+export function getPendingSummarizationCount(db) {
+    if (!db?.prepare) {
+        return null;
+    }
+
+    try {
+        const row = db.prepare(`
+            SELECT COUNT(*) AS n
+            FROM SummarizationJobs
+            WHERE status = 'pending'
+        `).get();
+
+        return Number.isInteger(row?.n) ? row.n : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Builds the task trigger for the summarization sweep lane.
  *
  * Three wake-up sources, in priority order:
@@ -49,10 +76,12 @@ export function getPendingSummarizationJobs(db, {limit = 50} = {}) {
  * @param {Number} options.lastRunAt Last summary task start timestamp.
  * @param {Number} options.intervalMs Periodic sweep interval; `0` disables the interval source.
  * @param {Object[]} [options.handovers=[]] Unread sunset-handover message nodes.
- * @param {String[]} [options.pendingJobs=[]] Pending SummarizationJobs session ids.
+ * @param {String[]} [options.pendingJobs=[]] Pending SummarizationJobs session ids (capped at fetch limit).
+ * @param {Number} [options.totalPending] Uncapped pending-summarization depth for the (logged) reason;
+ *     falls back to `pendingJobs.length` when not an integer.
  * @returns {Object|null} A summary task trigger or null when no work is due.
  */
-export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [], pendingJobs = []}) {
+export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [], pendingJobs = [], totalPending}) {
     if (handovers.length > 0) {
         return {
             taskName     : 'summary',
@@ -63,10 +92,12 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [],
     }
 
     if (pendingJobs.length > 0) {
+        const backlog = Number.isInteger(totalPending) ? totalPending : pendingJobs.length;
+
         return {
             taskName    : 'summary',
             source      : 'pending-summarization',
-            reason      : `pending-summarization:${pendingJobs.length}`,
+            reason      : `pending-summarization:${backlog}`,
             pendingCount: pendingJobs.length
         };
     }
@@ -104,6 +135,7 @@ export function getDueTask({
     summarySweepIntervalMs,
     getUnreadSunsetHandoversFn = getUnreadSunsetHandovers,
     getPendingSummarizationJobsFn = getPendingSummarizationJobs,
+    getPendingSummarizationCountFn = getPendingSummarizationCount,
     markNodesAsReadFn          = markNodesAsRead,
     log
 }) {
@@ -113,6 +145,7 @@ export function getDueTask({
         now,
         handovers,
         pendingJobs,
+        totalPending: pendingJobs.length > 0 ? getPendingSummarizationCountFn(db) : null,
         intervalMs: summarySweepIntervalMs,
         lastRunAt : state.summary?.lastRunAt || 0
     });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
@@ -38,4 +38,26 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
 
         expect(getPendingMemorySummaryBackfillJobs(db)).toEqual([]);
     });
+
+    test('#12809: buildMemorySummaryBackfillTrigger reports the TRUE backlog depth, not the fetch limit', () => {
+        // 50 fetched (the LIMIT), but 1842 actually pending — the logged reason must show the true depth.
+        const fetched = Array.from({length: 50}, (_, i) => `mem-${i}`);
+        expect(buildMemorySummaryBackfillTrigger({pendingJobs: fetched, totalPending: 1842})).toEqual({
+            taskName    : 'memory-summary-backfill',
+            source      : 'pending-memory-minisummary',
+            reason      : 'pending-memory-minisummary:1842',
+            pendingCount: 50
+        });
+    });
+
+    test('#12809: getDueTask threads the uncapped count into the reason', () => {
+        expect(getDueTask({
+            db                                     : {},
+            getPendingMemorySummaryBackfillJobsFn  : () => ['mem-1', 'mem-2'],
+            getPendingMemorySummaryBackfillCountFn : () => 1842
+        })).toMatchObject({
+            reason      : 'pending-memory-minisummary:1842',
+            pendingCount: 2
+        });
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
@@ -147,4 +147,33 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
         expect(calls[0]).toContain("WHERE status = 'pending'");
         expect(calls[1]).toBe(2);
     });
+
+    test('#12809: buildSummaryTrigger reports the TRUE backlog depth, not the fetch limit', () => {
+        const fetched = Array.from({length: 50}, (_, i) => `session-${i}`);
+        expect(buildSummaryTrigger({
+            now: 600000, lastRunAt: 0, intervalMs: 600000, handovers: [],
+            pendingJobs: fetched, totalPending: 730
+        })).toEqual({
+            taskName    : 'summary',
+            source      : 'pending-summarization',
+            reason      : 'pending-summarization:730',
+            pendingCount: 50
+        });
+    });
+
+    test('#12809: getDueTask threads the uncapped pending count into the reason', () => {
+        const result = getDueTask({
+            db                            : 'mock-db',
+            state                         : {summary: {lastRunAt: 0}},
+            now                           : 100,
+            summarySweepIntervalMs        : 600000,
+            getUnreadSunsetHandoversFn    : () => [],
+            getPendingSummarizationJobsFn : () => ['session-1', 'session-2'],
+            getPendingSummarizationCountFn: () => 730
+        });
+        expect(result).toMatchObject({
+            reason      : 'pending-summarization:730',
+            pendingCount: 2
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Resolves #12809. Refs #12740, #12746, #12804.

**Biggest-friction prio-0 (operator): backlog blindness.** Both summary schedulers capped their pending count at the fetch `LIMIT (50)`, so the logged trigger reason (`pending-memory-minisummary:50`, `pending-summarization:50`) was the *fetch limit*, not the true depth — no way to tell whether the queue is draining or growing.

## Deltas

- **`ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs`** — new fail-soft `getPendingMemorySummaryBackfillCount(db)` (uncapped `COUNT(*)` of `AGENT_MEMORY` rows lacking `miniSummary`); `getDueTask` threads it into `buildMemorySummaryBackfillTrigger` as `totalPending`; the reason now shows the true depth.
- **`ai/daemons/orchestrator/scheduling/summary.mjs`** — same pattern: `getPendingSummarizationCount(db)` (uncapped `COUNT(*)` of pending `SummarizationJobs`), threaded into `buildSummaryTrigger`'s `pending-summarization` reason.
- Backward-compatible: the fetched-IDs existence check + the trigger output shape are unchanged; only the reason's *number* changes (falls back to the fetched length when no count is provided).
- Specs: 4 new true-depth tests (`build*Trigger` with `totalPending`; `getDueTask` with the count seam) across both scheduler specs.

## Test Evidence

Evidence: `npm run test-unit -- "orchestrator/scheduling"` → **116/116 passed**, including the 4 new tests asserting the reason shows the true depth (e.g. 50 fetched / 1842 pending → `pending-memory-minisummary:1842`) and the existing trigger-shape `toEqual` assertions still passing (backward-compat confirmed).

## Post-Merge Validation

- Confirm `orchestrator.log` now shows the real backlog: `Starting memory miniSummary backfill (pending-memory-minisummary:<true-depth>)` (and the session-summary equivalent), so the drain trend is visible across cycles — now that #12802 + #12805 make it actually drain.

## Scope notes

- Completes the prio-0 summary-subsystem trio: **#12802** (bound the run under the watchdog) + **#12805** (4s→20s so items complete) + **#12809** (see the true backlog drain).
- Out of scope: lease-starvation (heavy tasks always running, mutually deferring); per-item progress beyond the backlog count; the `:11434`→live `:1234` endpoint-config.
- ⚠️ Off `dev` (currently red on `unit` / `lint-tree-json` from the unrelated `v13.0.0.md` `/blob/dev/` link, gpt's #12798); this orchestrator-scheduling change is independent and its scheduling specs are green. The inherited red clears once #12798 merges and this rebases.

Authored by Claude Opus 4.8 (Claude Code)
