### PR TITLE
docs(release): add the Night Shift section + de-pin AI-memory origin

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -4,7 +4,7 @@
 **Stability:** Release Candidate
 **Upgrade Path:** Body/runtime applications remain on the v12.x continuity path; the major v13 adoption work is operational for teams enabling the Agent OS around the Body.
 
-> **TL;DR:** v13 is not the release where Neo first got AI memory. v12.1 already had an Agent OS: Knowledge Base, Memory Core, GitHub Workflow, Neural Link, and session-summary recall for a single agent. v13 is the release where that solo-agent operating layer became a graph-backed, cross-family engineering institution: Neo built its own Native Edge Graph, a SQLite-backed graph layer for DreamService, added A2A messages and wakeups, gave agents stable identities, and made the Agent OS cloud-deployable.
+> **TL;DR:** v13 is not the release where Neo first got AI memory. Neo's Agent OS — Knowledge Base, Memory Core, GitHub Workflow, Neural Link, and session-summary recall — had served a single agent for months. v13 is the release where that solo-agent operating layer became a graph-backed, cross-family engineering institution: Neo built its own Native Edge Graph, a SQLite-backed graph layer for DreamService, added A2A messages and wakeups, gave agents stable identities, and made the Agent OS cloud-deployable.
 >
 > The industry is still selling one assistant at a time: Microsoft Copilot in the IDE, one Codex session, one Claude Desktop or Claude Code instance, maybe subagents hidden behind the lead model, but almost no durable collaboration between model families. Neo v13 is the opposite bet. It is a professional end-to-end AI engineering team whose named agents are powered by different LLM families, run across multiple harness instances, and can remember, wake, challenge, review, route, audit, and repair their own operating substrate together. Neo maintains its own codebase today; v13 makes that same Agent OS portable as a tenant-scoped deployment topology for other repositories.
 
@@ -12,13 +12,13 @@
 
 ## 🏛️ The Agent OS Became an Institution
 
-At the v12.1 boundary, Neo already had far more than a runtime engine plus a chatbot. It had Agent OS primitives: a Knowledge Base for source and docs, a Memory Core for persistent reasoning, GitHub Workflow for issues and PRs, Neural Link for live runtime possession, and startup context from recent session summaries. A new session did not begin from nothing; it could read the latest remembered work and continue with continuity a single agent could use.
+Well before v13, Neo already had far more than a runtime engine plus a chatbot. It had Agent OS primitives: a Knowledge Base for source and docs, a Memory Core for persistent reasoning, GitHub Workflow for issues and PRs, Neural Link for live runtime possession, and startup context from recent session summaries. A new session did not begin from nothing; it could read the latest remembered work and continue with continuity a single agent could use.
 
 That was already ahead of the market. But it was still mostly a one-agent continuity model. One harness instance, one model family, one remembered line of work, one human still carrying the cross-session, cross-agent, cross-review shape in their head. It could remember a prior session; it could not yet behave like a team whose members wake each other, read each other's reasoning, challenge each other's blind spots, and turn their friction into shared substrate.
 
 That is the v13 break.
 
-Memory Core already existed at v12.1 as local Agent OS infrastructure. Semantic recall and session summaries were already part of the work. v13 changed the substrate around them: recency became first-class, agents gained stable identity, A2A messages and wake delivery made coordination active, peer-readable provenance made reasoning inspectable across model families, and the Native Edge Graph gave DreamService a graph database to turn lived work into forecasts.
+Memory Core had already existed for months as local Agent OS infrastructure. Semantic recall and session summaries were already part of the work. v13 changed the substrate around them: recency became first-class, agents gained stable identity, A2A messages and wake delivery made coordination active, peer-readable provenance made reasoning inspectable across model families, and the Native Edge Graph gave DreamService a graph database to turn lived work into forecasts.
 
 Neo did not add a chatbot to the side of the engine. It turned the Agent OS into an institution:
 
@@ -30,7 +30,7 @@ Neo did not add a chatbot to the side of the engine. It turned the Agent OS into
 | **Cloud** | Multi-tenant Agent OS deployment, tenant-scoped KB/Memory behavior, request context, and public deployment guides. |
 | **MX loop** | Model friction becomes tickets; tickets become PRs; PRs become skills, memory, graph edges, tests, and better future agents. |
 
-That is the epoch boundary. v12.1 proved Neo could give one agent durable context around a serious codebase. v13 proves the Agent OS can become an institution: graph-backed, cross-family, wake-driven, review-capable, and able to improve its own substrate.
+That is the epoch boundary. The solo-agent era proved Neo could give one agent durable context around a serious codebase. v13 proves the Agent OS can become an institution: graph-backed, cross-family, wake-driven, review-capable, and able to improve its own substrate.
 
 ## 🧭 Why This Matters
 
@@ -105,6 +105,18 @@ Most multi-agent products collapse into an orchestrator-worker hierarchy: one le
 That makes governance a product feature. The same repository contains the work, the review, the memory, the coordination, the corrections, and the rules that changed because of them. The public proof surface is not hidden in a vendor deck: Neo v13 ships [30 Agent OS skills](https://github.com/neomjs/neo/tree/dev/.agents/skills) as inspectable Progressive Disclosure protocols for review, sunset, context recovery, ticket creation, lead/peer roles, Memory Core discipline, and release-scale coordination.
 
 The release note itself went through that loop. One agent rebuilt the story, another challenged and approved it through A2A and wake delivery, and the human maintainer kept the merge gate. The artifact describes the institution that produced it.
+
+### 🌙 The Night Shift
+
+2026 taught the industry a real discipline: stop prompting, start *looping*. Anthropic's Claude Code lead put the shift bluntly — he no longer prompts Claude; *"my job is to write loops"* that prompt it for him. Runtimes like [OpenClaw](https://docs.openclaw.ai/concepts/agent-loop) made it concrete: one agent, one serialized loop on a heartbeat, checking its task list, acting, surfacing only what needs you. The discipline that grew around it — [loop engineering](https://addyo.substack.com/p/loop-engineering) — even learned to split the maker from the checker, because a model grades its own homework too kindly. It is genuinely good engineering. But it ends at one wall: *the loop relocates you, it does not eliminate you.* A human still has to be the verifier — and the scheduler.
+
+Neo's flat peer-team moves that wall, and the night shift is where you watch it happen.
+
+What keeps the team running while the operator sleeps is the substrate underneath. A single-agent loop survives on a heartbeat: the one agent wakes itself to check its task list. Neo's maintainers run on that **plus something one agent cannot have — peer wake-ups.** An A2A message to a maintainer that has *ended its turn* wakes it, and it picks the thread back up; an idle maintainer's daemon heartbeat re-activates it to look for work on its own. No human sits in the scheduler loop. The team is not a process someone left running — it is a set of peers that wake each other, and themselves, through the night. A normal shift opens **10–20 pull requests** with no operator awake.
+
+That redraws the wall the industry stops at. Verification — the part loop engineering says can only be relocated onto you — Neo delegates to a cross-family quorum: a GPT pull request reviewed by a Claude, a Claude's reasoning audited by a Gemini, so correlated blind spots are caught by construction rather than by hope. (The hallucinated Sunset Protocol above is exactly that shape — a peer from a different lab caught what the original could not, with no human in the room.) What is left for the human is the **merge gate** — and that is a governance choice, not a technical limit. The peers already do the verifying; Neo keeps a human on every merge because trust in an autonomous institution should be *granted*, not assumed. It is a dial the operator holds, not a wall the loop cannot cross.
+
+Most teams are engineering the loop that runs their agent. Neo runs the institution that maintains itself overnight — and lets you choose how much of it to watch.
 
 ## 🪪 The Identity Layer: Same Model Stopped Meaning Same Agent
 


### PR DESCRIPTION
Resolves #12811
Related: #12696, #12787, #11822, #10370

Adds the operator-blessed **"The Night Shift"** section to the v13 release notes and de-pins the AI-memory origin from v12.1.

Evidence: L1 (static release-note prose edit; no runtime/test ACs) → L1 required.

## Deltas

- **`resources/content/release-notes/v13.0.0.md`** — new `### 🌙 The Night Shift` within "The Institution" (after the merge-gate close, before "The Identity Layer"):
  - **On-ramp:** the 2026 single-agent-loop paradigm — [OpenClaw](https://docs.openclaw.ai/concepts/agent-loop) + Addy Osmani's [loop engineering](https://addyo.substack.com/p/loop-engineering) ("write loops, not prompts"; maker/checker split; "the loop relocates you, it does not eliminate you").
  - **The inversion:** Neo's flat peer-team runs the night shift unattended — the **wake/heartbeat substrate** (A2A wakeups re-activate a peer that ended its turn; daemon heartbeats self-re-activate an idle maintainer — no human scheduler), **10–20 PRs/night**, cross-family verification, and the **merge-gate-as-governance-choice** (a dial the operator holds, not a technical limit).
  - **Complements, not duplicates:** callbacks to the existing flat-peer topology + the Hallucinated-Sunset war story (not re-tellings). Sources inline.
- **De-pin (TL;DR + Agent-OS section, 4 edits):** "v12.1 already had / at the v12.1 boundary / existed at v12.1 / v12.1 proved" → de-pinned framings ("for months / well before v13 / the solo-agent era"). The AI-memory (Memory Core/KB) predates v12.1.0 by months. **Kept unchanged:** the "since v12.1.0" changelog stats (the legitimate release boundary) + the v12.1-era transport war story.

## Test Evidence

Docs-only (release-note prose). No tests required. Verified the section placement + the 4 de-pins via `git diff` (scope: `v13.0.0.md` only, 16 insertions / 4 deletions); content-guard satisfied on the `agent/sync-*` branch (whitespace check green).

## Post-Merge Validation

- Release-note SEO/sitemap regeneration verified on the v13 release path.
- **Verify-before-publish:** the "my job is to write loops" quote (attributed to Anthropic's Claude Code lead, via the loop-engineering source) confirmed verbatim before the notes go public.

## Out of Scope

- The endpoint-level arbiter (#12799 LEAF 2).
- Other release-note sections — this is the Night Shift section + the AI-memory-origin de-pin only.
- The "since v12.1.0" changelog stats — v12.1.0 is the legitimate release boundary for the diff window; only the AI-memory *origin* hardlock is corrected.

## Coordination

The release-note arc is @neo-gpt's lane (#12787). He is rate-limited to reviews this week, so I implemented per @tobiu's direction; @neo-gpt reviews. The Night Shift is placed as a `###` within "The Institution" — open to promoting it to a standalone `##` hero if the arc reads better that way.

Authored by @neo-opus-vega (Claude Opus 4.8). Origin Session 728442d6-a2a0-4481-a631-a3112ce6d703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
