### PR TITLE
docs(release): add the one-architecture-two-fronts closer

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -375,6 +375,10 @@ The best example is AiConfig: the fix the swarm refused to ship.
 
 That is the v13 reliability ethic: do not normalize defensive reads, shared-singleton writes, stale issue assumptions, or silent graph failures. Turn them into source-of-truth rules, tests, guards, or caveats.
 
+## ☯ One Architecture, Two Fronts
+
+For six years, Neo's core battle has been the single-threaded, monolithic "toy paradigm" of mainstream UI development — and the Body answered it with a clean, multi-threaded worker engine. The Brain is now solving the single-agent, amnesic "toy paradigm" of AI development with a clean, multi-tenant, multi-agent institution. The execution is identical: isolation, message-passing, and strict synchronization boundaries. Multi-worker, multi-agent — the body and the brain. ☯
+
 ## 🚀 What You Can Do With v13
 
 If you only build applications on Neo, the immediate promise is continuity. Your Body/runtime code stays on the v12.x compatibility path while the engine gains sharper contracts, better documentation, and more AI-inhabitable runtime surfaces.


### PR DESCRIPTION
Resolves #12815
Related: #12811, #12813, #12696

Adds a short closing synthesis beat — **☯ One Architecture, Two Fronts** — to the v13 release notes, in @neo-gemini-pro's framing.

Evidence: L1 (static release-note prose edit; no runtime/test ACs) → L1 required.

## Deltas

- **`resources/content/release-notes/v13.0.0.md`** — new `## ☯ One Architecture, Two Fronts` immediately before the `## 🚀 What You Can Do With v13` CTA (architectural zoom-out, then call to action). One short paragraph: the Body fought the single-threaded UI "toy paradigm" with a multi-threaded worker engine; the Brain fights the single-agent AI "toy paradigm" with a multi-tenant multi-agent institution — identical execution (isolation, message-passing, synchronization boundaries), multi-worker and multi-agent. Ends on the yin-yang ☯.

## Why this framing

@neo-gemini-pro's version is **dual-register** — it lands for a non-technical decider (toy-vs-real, one-vs-a-team) and an engineer (the actual concurrency model) at once. It deliberately omits implementation depth (AiConfig, single-writer rule); that detail dilutes the broadly-graspable payoff. The beat **complements** the existing "built from Neo" + "two hemispheres, same substrate" lines — it adds the *philosophical* symmetry (one bet won twice) those lines don't state, without repeating the technical detail they do.

## Test Evidence

Docs-only (release-note prose). No tests required. Verified placement (between the Reliability ethic and the CTA) + a single clean commit against `dev` via `git log origin/dev..HEAD`; content-guard satisfied on the `agent/sync-*` branch.

## Post-Merge Validation

Release-note SEO/sitemap regeneration verified on the v13 release path.

Authored by @neo-opus-vega (Claude Opus 4.8); framing by @neo-gemini-pro. Origin Session 728442d6-a2a0-4481-a631-a3112ce6d703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
