### PR TITLE
fix(ai): align Ollama + OpenAiCompatible interactive-timeout contracts (#12814)

### DIFF
--- a/ai/provider/Ollama.mjs
+++ b/ai/provider/Ollama.mjs
@@ -1,4 +1,5 @@
-import Base from './Base.mjs';
+import Base                 from './Base.mjs';
+import {createTimeoutError} from './createTimeoutError.mjs';
 
 /**
  * Concrete AI provider for a local Ollama daemon.
@@ -120,6 +121,7 @@ class OllamaProvider extends Base {
      *     1 hour when unset/invalid, preserving prior behavior. Lets interactive callers (e.g. KB
      *     `ask` synthesis) fail fast and degrade rather than wait behind a long batch inference.
      * @param {String} [options.operationLabel] Safe diagnostic label surfaced in the timeout error.
+     * @param {AbortSignal} [options.signal] Upstream cancellation signal; when it aborts, the in-flight request is destroyed (parity with OpenAiCompatible).
      * @returns {Promise<{content: String, raw: Object}>}
      */
     async generate(input, options = {}) {
@@ -143,6 +145,7 @@ class OllamaProvider extends Base {
                 headers: {
                     'Content-Type': 'application/json'
                 },
+                signal : options.signal,  // honor upstream cancellation (parity with OpenAiCompatible)
                 timeout: requestTimeoutMs // configurable; defaults to 1h (see options.timeoutMs)
             }, (res) => {
                 let body = '';
@@ -167,7 +170,13 @@ class OllamaProvider extends Base {
 
             req.on('timeout', () => {
                 req.destroy();
-                rejectFunc(new Error(`[Ollama] ${operationLabel} timed out after ${requestTimeoutMs}ms (host=${this.host}, model=${this.modelName})`));
+                rejectFunc(createTimeoutError({
+                    provider      : 'Ollama',
+                    operationLabel,
+                    timeoutMs     : requestTimeoutMs,
+                    host          : this.host,
+                    modelName     : this.modelName
+                }));
             });
 
             req.write(JSON.stringify(payload));

--- a/ai/provider/OpenAiCompatible.mjs
+++ b/ai/provider/OpenAiCompatible.mjs
@@ -1,23 +1,5 @@
-import Base from './Base.mjs';
-
-/**
- * @summary Creates a provider-timeout error that identifies the safe transport context.
- *
- * The message names the operation, timeout budget, host, and model while deliberately
- * omitting prompt content and credentials.
- *
- * @param {Object} options
- * @param {String} options.operationLabel Safe diagnostic label for the caller operation.
- * @param {Number} options.timeoutMs Timeout budget in milliseconds.
- * @param {String} options.host Provider host.
- * @param {String} options.modelName Chat model id.
- * @returns {Error}
- */
-function createTimeoutError({operationLabel, timeoutMs, host, modelName}) {
-    const error = new Error(`[OpenAiCompatible] ${operationLabel} timed out after ${timeoutMs}ms (host=${host}, model=${modelName})`);
-    error.code  = 'OPENAI_COMPATIBLE_TIMEOUT';
-    return error;
-}
+import Base                 from './Base.mjs';
+import {createTimeoutError} from './createTimeoutError.mjs';
 
 /**
  * Concrete AI provider for a local MLX-native or any OpenAI-compatible API server.
@@ -278,6 +260,7 @@ class OpenAiCompatibleProvider extends Base {
             timeoutId = setTimeout(() => {
                 timedOut = true;
                 controller.abort(createTimeoutError({
+                    provider : 'OpenAiCompatible',
                     operationLabel,
                     timeoutMs,
                     host     : this.host,
@@ -350,6 +333,7 @@ class OpenAiCompatibleProvider extends Base {
         } catch (error) {
             if (timedOut) {
                 const timeoutError = createTimeoutError({
+                    provider : 'OpenAiCompatible',
                     operationLabel,
                     timeoutMs,
                     host     : this.host,

--- a/ai/provider/createTimeoutError.mjs
+++ b/ai/provider/createTimeoutError.mjs
@@ -1,0 +1,61 @@
+/**
+ * @summary Shared interactive-timeout contract for the local chat providers.
+ *
+ * Both {@link Neo.ai.provider.OpenAiCompatible} and {@link Neo.ai.provider.Ollama}
+ * throw the exact error shape produced here, so a caller can detect a provider
+ * timeout via a single uniform `error.code` regardless of which provider served the
+ * request. Housing the helper plus the documented `generate(options)` contract in one
+ * module keeps the two parallel provider implementations from silently drifting apart
+ * (their transport differs — `fetch` + `AbortController` vs node `http.request` — but
+ * the observable contract here must stay uniform).
+ *
+ * @module Neo.ai.provider.createTimeoutError
+ */
+
+/**
+ * Uniform, caller-detectable code set on every provider-timeout error, so consumers
+ * (e.g. KB `ask` synthesis degradation, a future daemon-yield) branch on one value
+ * instead of per-provider knowledge.
+ * @type {String}
+ */
+const PROVIDER_TIMEOUT_CODE = 'PROVIDER_TIMEOUT';
+
+/**
+ * @summary The shared interactive options contract honored by every local chat
+ * provider's `generate(input, options)` / `stream(input, options)`.
+ *
+ * @typedef {Object} ProviderGenerateOptions
+ * @property {Number} [timeoutMs] Abort the provider request after this many milliseconds.
+ *     Unset/invalid falls back to the provider's default deadline.
+ * @property {AbortSignal} [signal] Upstream cancellation signal. When it aborts, the
+ *     in-flight request is destroyed — both providers honor it identically.
+ * @property {String} [operationLabel] Safe diagnostic label surfaced in the timeout
+ *     error message; must never carry prompt content or credentials.
+ */
+
+/**
+ * @summary Creates the shared provider-timeout error.
+ *
+ * The message names the provider, operation, timeout budget, host, and model while
+ * deliberately omitting prompt content and credentials. `code` is uniform across
+ * providers (detection); `provider` preserves the per-provider origin (diagnosis).
+ *
+ * @param {Object} options
+ * @param {String} options.provider Provider id used both in the message prefix and the `provider` field (e.g. 'Ollama').
+ * @param {String} options.operationLabel Safe diagnostic label for the caller operation.
+ * @param {Number} options.timeoutMs Timeout budget in milliseconds.
+ * @param {String} options.host Provider host.
+ * @param {String} options.modelName Chat model id.
+ * @returns {Error} Error with `code='PROVIDER_TIMEOUT'`, plus `provider` and `timeoutMs` fields.
+ */
+function createTimeoutError({provider, operationLabel, timeoutMs, host, modelName}) {
+    const error = new Error(`[${provider}] ${operationLabel} timed out after ${timeoutMs}ms (host=${host}, model=${modelName})`);
+
+    error.code      = PROVIDER_TIMEOUT_CODE;
+    error.provider  = provider;
+    error.timeoutMs = timeoutMs;
+
+    return error;
+}
+
+export {PROVIDER_TIMEOUT_CODE, createTimeoutError};

--- a/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
+++ b/test/playwright/unit/ai/provider/KeepAlive.spec.mjs
@@ -135,12 +135,48 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         try {
             const provider = Neo.create(OllamaProvider, {host, modelName: 'gemma4-test'});
 
-            await expect(provider.generate('hello', {
+            const error = await provider.generate('hello', {
                 timeoutMs     : 50,
                 operationLabel: 'ask_knowledge_base synthesis'
-            })).rejects.toThrow(
+            }).then(() => null, e => e);
+
+            expect(error?.message).toMatch(
                 /\[Ollama\] ask_knowledge_base synthesis timed out after 50ms \(host=http:\/\/127\.0\.0\.1:\d+, model=gemma4-test\)/
             );
+            expect(error?.code).toBe('PROVIDER_TIMEOUT');
+            expect(error?.provider).toBe('Ollama');
+        } finally {
+            await new Promise(resolve => server.close(resolve));
+        }
+    });
+
+    test('Ollama.generate() honors options.signal and aborts the in-flight request (#12814)', async () => {
+        // A hung server (accepts but never responds) — so only an honored abort signal can end
+        // the request quickly; the prior signal-stripping behavior would hang past the test.
+        const server = http.createServer((req) => {
+            req.on('data', () => {});
+            req.on('end', () => {/* intentionally never respond */});
+        });
+        await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+        const host = `http://127.0.0.1:${server.address().port}`;
+
+        try {
+            const provider   = Neo.create(OllamaProvider, {host, modelName: 'gemma4-test'});
+            const controller = new AbortController();
+
+            const promise = provider.generate('hello', {
+                signal        : controller.signal,
+                operationLabel: 'daemon-yield cancel'
+            });
+
+            controller.abort();
+
+            const error = await promise.then(() => null, e => e);
+
+            expect(error).toBeTruthy();
+            // Honored upstream signal → an AbortError, NOT a hang and NOT the provider-timeout shape.
+            expect(error.code === 'ABORT_ERR' || error.name === 'AbortError').toBe(true);
+            expect(error.code).not.toBe('PROVIDER_TIMEOUT');
         } finally {
             await new Promise(resolve => server.close(resolve));
         }
@@ -386,7 +422,8 @@ test.describe('AI provider keep_alive payload shape (#12080, #12089)', () => {
         );
 
         expect(aborted).toBe(true);
-        expect(abortReason?.code).toBe('OPENAI_COMPATIBLE_TIMEOUT');
+        expect(abortReason?.code).toBe('PROVIDER_TIMEOUT');
+        expect(abortReason?.provider).toBe('OpenAiCompatible');
         expect(capturedPayload).toMatchObject({
             model      : 'gemma4-test',
             stream     : true,


### PR DESCRIPTION
## Summary

Resolves #12814. Refs #12806, #12799 (LEAF 2), #12748.

Post-#12806 the two local chat providers' interactive-timeout **contracts** diverged. A caller (`SearchService.ask` today; the #12799 LEAF-2 daemon-yield next) got different behavior depending on which provider was active:

- **Error shape:** `OpenAiCompatible` threw a structured error with `error.code = 'OPENAI_COMPATIBLE_TIMEOUT'`; `Ollama` threw a **plain `Error`** with **no `.code`** → a caller checking `err.code` detected one provider's timeout and not the other's.
- **`options.signal`:** `OpenAiCompatible` honored upstream cancellation (full AbortSignal adoption); `Ollama` **stripped** it → an in-flight Ollama request could not be cancelled.

This unifies the observable contract (detectable error + signal honoring) and houses it in one module so the two parallel providers can't silently re-drift — without forcing identical transport (`fetch`+`AbortController` vs node `http.request`).

## Deltas

- **`ai/provider/createTimeoutError.mjs`** (new) — the shared timeout-error helper + the documented `generate(options)` contract (`@typedef ProviderGenerateOptions`). Exports `createTimeoutError({provider, operationLabel, timeoutMs, host, modelName})` → a uniform `error.code = 'PROVIDER_TIMEOUT'` plus `provider` (diagnosis) and `timeoutMs` fields. Generalized from `OpenAiCompatible`'s former module-private function.
- **`ai/provider/Ollama.mjs`** — `generate()` now passes `options.signal` natively to `http.request` (honors upstream abort → request destroyed) and throws the shared timeout-error shape on its own socket-timeout deadline (replacing the plain `Error`). JSDoc documents `options.signal`.
- **`ai/provider/OpenAiCompatible.mjs`** — adopts the shared helper at both timeout sites; message text + behavior unchanged, `.code` unified `OPENAI_COMPATIBLE_TIMEOUT` → `PROVIDER_TIMEOUT`.
- **`test/playwright/unit/ai/provider/KeepAlive.spec.mjs`** — both providers' timeout tests now assert the uniform `code`/`provider`; new regression: `Ollama.generate() honors options.signal and aborts the in-flight request`.

## Test Evidence

Evidence: `npm run test-unit -- KeepAlive` → **12/12 passed (851ms)**. Covers:
- the new Ollama signal-abort regression — hung loopback server + an `AbortController` → rejects with an `AbortError`, **not** a hang and **not** the timeout shape (proving the signal is honored vs the prior strip);
- the Ollama own-timeout test now asserting `code='PROVIDER_TIMEOUT'` + `provider='Ollama'` (message unchanged);
- the OpenAiCompatible timeout test asserting the unified `code` + `provider='OpenAiCompatible'`.

`node --check` clean on all four changed files. Repo-wide V-B-A: **zero** surviving `OPENAI_COMPATIBLE_TIMEOUT` references, and **no consumer** branches on the timeout `.code` (`SearchService.ask`'s catch is generic → degraded envelope), so the code-unification is non-breaking.

## Post-Merge Validation

- Confirm CI `unit` + `integration-unified` stay green.
- The #12799 LEAF-2 daemon-yield can now cancel an in-flight Ollama inference via `options.signal` and detect any provider timeout via the single `PROVIDER_TIMEOUT` code; #12748 (chat queue) inherits the same uniform shape.

## Contract interpretation note (reviewer confirm)

AC1 reads "upstream abort → … → timeout-shaped error". I implemented this to **match the `OpenAiCompatible` reference impl's actual behavior**: an *upstream-signal* abort surfaces the raw `AbortError` (carrying the upstream reason), while the *timeout-shaped* error (`PROVIDER_TIMEOUT`) is thrown only on the provider's **own** deadline. "Raw abort on upstream cancel, timeout-shape on own-deadline" is the faithful parity reading — flag if you intended Ollama to coerce upstream aborts into the timeout shape (which would *diverge* from OpenAiCompatible).

## Out of Scope

- The chat interactive/batch **queue** (#12748, mine — a *consumer* of this contract).
- The LEAF-2 daemon-yield itself (#12799 — the first `signal` consumer).
- Signal/contract parity for `Ollama.stream()` / `embed()` (the ticket scopes to `generate()` — the path `SearchService.ask` + the daemon-yield use).

Authored by Claude Opus 4.8 (Claude Code)
