### PR TITLE
feat(orchestrator): log the session-summary backlog count on the periodic sweep (#12821)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -62,6 +62,42 @@ export function getPendingSummarizationCount(db) {
 }
 
 /**
+ * Counts sessions that have `AGENT_MEMORY` turns but no `SESSION_SUMMARY` — the real
+ * unsummarized-session backlog the periodic sweep drains (parallel to the mini-summary backlog
+ * count, not the capped SummarizationJobs marker fetch).
+ *
+ * @summary Feeds the periodic-sweep trigger reason so the orchestrator log reports the
+ * session-summary backlog depth. Fail-soft: returns `null` when the graph table is unavailable.
+ * @param {Object} db SQLite database handle.
+ * @returns {Number|null}
+ */
+export function getPendingSessionSummaryCount(db) {
+    if (!db?.prepare) {
+        return null;
+    }
+
+    try {
+        const row = db.prepare(`
+            SELECT COUNT(*) AS n FROM (
+                SELECT DISTINCT json_extract(memory.data, '$.properties.sessionId') AS sessionId
+                FROM Nodes memory
+                WHERE json_extract(memory.data, '$.label')                = 'AGENT_MEMORY'
+                  AND json_extract(memory.data, '$.properties.sessionId') IS NOT NULL
+                  AND json_extract(memory.data, '$.properties.sessionId') NOT IN (
+                      SELECT json_extract(summary.data, '$.properties.sessionId')
+                      FROM Nodes summary
+                      WHERE json_extract(summary.data, '$.label') = 'SESSION_SUMMARY'
+                  )
+            )
+        `).get();
+
+        return Number.isInteger(row?.n) ? row.n : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Builds the task trigger for the summarization sweep lane.
  *
  * Three wake-up sources, in priority order:
@@ -79,9 +115,11 @@ export function getPendingSummarizationCount(db) {
  * @param {String[]} [options.pendingJobs=[]] Pending SummarizationJobs session ids (capped at fetch limit).
  * @param {Number} [options.totalPending] Uncapped pending-summarization depth for the (logged) reason;
  *     falls back to `pendingJobs.length` when not an integer.
+ * @param {Number} [options.unsummarizedCount] Uncapped unsummarized-session backlog depth; appended to
+ *     the periodic-sweep reason when an integer so the log reports the session-summary backlog depth.
  * @returns {Object|null} A summary task trigger or null when no work is due.
  */
-export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [], pendingJobs = [], totalPending}) {
+export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [], pendingJobs = [], totalPending, unsummarizedCount}) {
     if (handovers.length > 0) {
         return {
             taskName     : 'summary',
@@ -106,7 +144,9 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [],
         return {
             taskName: 'summary',
             source  : 'periodic-sweep',
-            reason  : `periodic-sweep:${intervalMs}`
+            reason  : Number.isInteger(unsummarizedCount)
+                ? `periodic-sweep:${intervalMs} pending-session-summary:${unsummarizedCount}`
+                : `periodic-sweep:${intervalMs}`
         };
     }
 
@@ -136,18 +176,26 @@ export function getDueTask({
     getUnreadSunsetHandoversFn = getUnreadSunsetHandovers,
     getPendingSummarizationJobsFn = getPendingSummarizationJobs,
     getPendingSummarizationCountFn = getPendingSummarizationCount,
+    getPendingSessionSummaryCountFn = getPendingSessionSummaryCount,
     markNodesAsReadFn          = markNodesAsRead,
     log
 }) {
     const handovers = getUnreadSunsetHandoversFn(db);
     const pendingJobs = handovers.length > 0 ? [] : getPendingSummarizationJobsFn(db);
+    const lastRunAt   = state.summary?.lastRunAt || 0;
+    // Only count the unsummarized-session backlog when the periodic sweep is the path that will
+    // fire (no handover, no marked jobs, interval due) — so the COUNT query runs at most once per
+    // sweep, never on every poll.
+    const periodicSweepDue = handovers.length === 0 && pendingJobs.length === 0 &&
+        summarySweepIntervalMs > 0 && now - lastRunAt >= summarySweepIntervalMs;
     const trigger   = buildSummaryTrigger({
         now,
         handovers,
         pendingJobs,
-        totalPending: pendingJobs.length > 0 ? getPendingSummarizationCountFn(db) : null,
+        totalPending     : pendingJobs.length > 0 ? getPendingSummarizationCountFn(db) : null,
+        unsummarizedCount: periodicSweepDue ? getPendingSessionSummaryCountFn(db) : null,
         intervalMs: summarySweepIntervalMs,
-        lastRunAt : state.summary?.lastRunAt || 0
+        lastRunAt
     });
 
     if (!trigger) {

--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -77,16 +77,20 @@ export function getPendingSessionSummaryCount(db) {
     }
 
     try {
+        // Null-safe anti-join: a correlated NOT EXISTS rather than `NOT IN (subquery)`. A single
+        // SESSION_SUMMARY row with a NULL sessionId would make `NOT IN` evaluate to NULL for every
+        // row, silently collapsing the backlog count to 0; NOT EXISTS is immune to that.
         const row = db.prepare(`
             SELECT COUNT(*) AS n FROM (
                 SELECT DISTINCT json_extract(memory.data, '$.properties.sessionId') AS sessionId
                 FROM Nodes memory
                 WHERE json_extract(memory.data, '$.label')                = 'AGENT_MEMORY'
                   AND json_extract(memory.data, '$.properties.sessionId') IS NOT NULL
-                  AND json_extract(memory.data, '$.properties.sessionId') NOT IN (
-                      SELECT json_extract(summary.data, '$.properties.sessionId')
+                  AND NOT EXISTS (
+                      SELECT 1
                       FROM Nodes summary
-                      WHERE json_extract(summary.data, '$.label') = 'SESSION_SUMMARY'
+                      WHERE json_extract(summary.data, '$.label')                = 'SESSION_SUMMARY'
+                        AND json_extract(summary.data, '$.properties.sessionId') = json_extract(memory.data, '$.properties.sessionId')
                   )
             )
         `).get();

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs
@@ -1,0 +1,71 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'SessionSummaryBacklogCountTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}              from '@playwright/test';
+import Neo                         from '../../../../../../../src/Neo.mjs';
+import {getPendingSessionSummaryCount} from '../../../../../../../ai/daemons/orchestrator/scheduling/summary.mjs';
+
+/**
+ * getPendingSessionSummaryCount real-graph coverage.
+ *
+ * The count drives the orchestrator periodic-sweep log. Its anti-join (sessions with AGENT_MEMORY
+ * but no SESSION_SUMMARY) must be null-safe: a single SESSION_SUMMARY row with a NULL sessionId
+ * must not collapse the count to 0 (the `NOT IN (subquery)` trap). Real :memory: graph under
+ * UNIT_TEST_MODE — no Chroma / live model, CI-safe.
+ */
+test.describe('orchestrator/scheduling getPendingSessionSummaryCount (#12821)', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let GraphService, LifecycleService, sqlite;
+
+    test.beforeAll(async () => {
+        GraphService     = (await import('../../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        LifecycleService = (await import('../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+
+        sqlite = GraphService.db?.storage?.db;
+    });
+
+    test('counts unsummarized sessions and is null-safe against a SESSION_SUMMARY with a NULL sessionId', () => {
+        const before = getPendingSessionSummaryCount(sqlite);
+        expect(Number.isInteger(before)).toBe(true);
+
+        // sA: memory + a matching summary (summarized → not counted).
+        GraphService.upsertNode({id: 'bk-mem-A', type: 'AGENT_MEMORY', name: 'mem A', properties: {sessionId: 'bk-sess-A', timestamp: 1, miniSummary: 'a'}});
+        GraphService.upsertNode({id: 'summary_bk-sess-A', type: 'SESSION_SUMMARY', name: 'sum A', properties: {sessionId: 'bk-sess-A'}});
+        // sB: memory, no summary (unsummarized → the one new row the count must report).
+        GraphService.upsertNode({id: 'bk-mem-B', type: 'AGENT_MEMORY', name: 'mem B', properties: {sessionId: 'bk-sess-B', timestamp: 1, miniSummary: 'b'}});
+        // The trap: a SESSION_SUMMARY with a NULL sessionId. With `NOT IN` this would null out the
+        // whole anti-join and force the count to 0; NOT EXISTS must be immune.
+        GraphService.upsertNode({id: 'summary_bk-null', type: 'SESSION_SUMMARY', name: 'sum null', properties: {sessionId: null}});
+
+        const after = getPendingSessionSummaryCount(sqlite);
+
+        // Exactly one new unsummarized session (sB); sA is summarized; the null-sessionId summary
+        // must NOT collapse the count.
+        expect(after).toBe(before + 1);
+        expect(after).toBeGreaterThan(0);
+    });
+
+    test('is fail-soft when the db handle is unavailable', () => {
+        expect(getPendingSessionSummaryCount(null)).toBeNull();
+        expect(getPendingSessionSummaryCount({})).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
@@ -2,6 +2,7 @@ import {test, expect} from '@playwright/test';
 import {
     buildSummaryTrigger,
     getPendingSummarizationJobs,
+    getPendingSessionSummaryCount,
     getDueTask
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/summary.mjs';
 
@@ -175,5 +176,43 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
             reason      : 'pending-summarization:730',
             pendingCount: 2
         });
+    });
+
+    test('#12821: buildSummaryTrigger appends the unsummarized-session count to the periodic-sweep reason', () => {
+        expect(buildSummaryTrigger({now: 600000, lastRunAt: 0, intervalMs: 600000, handovers: [], unsummarizedCount: 42})).toEqual({
+            taskName: 'summary',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:600000 pending-session-summary:42'
+        });
+    });
+
+    test('#12821: periodic-sweep reason omits the count when not provided (backward-compatible)', () => {
+        expect(buildSummaryTrigger({now: 600000, lastRunAt: 0, intervalMs: 600000, handovers: []})).toEqual({
+            taskName: 'summary',
+            source  : 'periodic-sweep',
+            reason  : 'periodic-sweep:600000'
+        });
+    });
+
+    test('#12821: getDueTask threads the session-summary backlog count into the periodic-sweep reason', () => {
+        const result = getDueTask({
+            db                             : 'mock-db',
+            state                          : {summary: {lastRunAt: 0}},
+            now                            : 600000,
+            summarySweepIntervalMs         : 600000,
+            getUnreadSunsetHandoversFn     : () => [],
+            getPendingSummarizationJobsFn  : () => [],
+            getPendingSessionSummaryCountFn: () => 42
+        });
+        expect(result).toMatchObject({
+            source: 'periodic-sweep',
+            reason: 'periodic-sweep:600000 pending-session-summary:42'
+        });
+    });
+
+    test('#12821: getPendingSessionSummaryCount is fail-soft when the graph table is unavailable', () => {
+        const db = {prepare() { throw new Error('no graph table'); }};
+        expect(getPendingSessionSummaryCount(db)).toBeNull();
+        expect(getPendingSessionSummaryCount(null)).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

Resolves #12821. Refs #12810, #12819, #12820, #12817.

#12810 surfaced the **mini-summary** backlog in the orchestrator log (`pending-memory-minisummary:N`) — that task only fires when there's a backlog, so it always logs the count. The **summary** task also fires on the **periodic sweep** (the path that drains ordinary unsummarized sessions), whose reason was bare `periodic-sweep:600000` — so the session-summary backlog depth was invisible. @tobiu: "we need both."

## Deltas

- **`ai/daemons/orchestrator/scheduling/summary.mjs`**
  - new `getPendingSessionSummaryCount(db)` — fail-soft, graph-direct count of sessions with `AGENT_MEMORY` turns but **no** `SESSION_SUMMARY` (the real unsummarized-session backlog; parallel to the mini-summary count's "rows missing a miniSummary" semantics, not the capped `SummarizationJobs` marker fetch).
  - `buildSummaryTrigger` appends `pending-session-summary:N` to the periodic-sweep reason when the count is an integer; reason otherwise unchanged (backward-compatible).
  - `getDueTask` computes the count **only when the periodic sweep will fire** (no handover, no marked jobs, interval due) — so the COUNT query runs at most once per sweep, never on every poll.
- **`test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs`** — +4 deterministic tests.

## Test Evidence

Evidence: `npm run test-unit -- "scheduling/summary.spec"` → **16/16 passed** (12 existing + 4 new): periodic-sweep reason carries `pending-session-summary:N`; omits it when not provided (backward-compat — the existing `periodic-sweep:600000` assertion still holds); `getDueTask` threads the count; `getPendingSessionSummaryCount` fail-soft (bad/missing db → null). `node --check` clean on both files.

## Post-Merge Validation

- Watch `orchestrator.log`: periodic summary sweeps now read `periodic-sweep:600000 pending-session-summary:N`, giving the session-summary backlog depth alongside the mini-summary `pending-memory-minisummary:N`.

## Out of scope

- The session-summary fallback fix itself (#12819 / #12820).
- Draining the backlog faster (batch-limit tuning) — separate.

Authored by Claude Opus 4.8 (Claude Code)
