### PR TITLE
fix(memory-core): remove the obsolete 30-day window from session summarization (#12823)

### DIFF
--- a/ai/scripts/lifecycle/summarize-sessions.mjs
+++ b/ai/scripts/lifecycle/summarize-sessions.mjs
@@ -6,8 +6,8 @@
  * Chroma collection, bypassing the auto-summarization that was disabled on MC server
  * startup to avoid daemon collision. Operator-runnable via `npm run ai:summarize-sessions`.
  *
- * Defaults to last-30-days lookback (`includeAll: false`); for fresh-deployment
- * full-summarization, edit the call-site or extend with a `--include-all` CLI flag (future).
+ * Summarizes all unsummarized sessions (all-time). The earlier 30-day lookback window was
+ * removed as an obsolete boot/healthcheck-timeout safeguard.
  *
  * @see ai/services/memory-core/SessionService.summarizeSessions
  */
@@ -38,8 +38,8 @@ async function summarize() {
         console.log(`[summarize-sessions] Pending drain complete. Pending: ${pendingResult?.pending || 0}; processed: ${pendingResult?.processed || 0}`);
 
         console.log('[summarize-sessions] Starting drift-detection session summarization...');
-        // includeAll: false will only summarize sessions from the last 30 days
-        const result = await Memory_SessionService.summarizeSessions({ includeAll: false });
+        // All-time scope: summarizes every unsummarized session (the 30-day window was removed).
+        const result = await Memory_SessionService.summarizeSessions();
 
         if (result && result.error) {
             console.error(`[summarize-sessions] Summarization failed: ${result.message}`);

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -308,8 +308,8 @@ class SessionService extends Base {
      * and the summary metadata.
      *
      * **Logic:**
-     * 1.  **Scope:** Fetches memory and summary metadata for the last 30 days. This optimization
-     *     prevents full-table scans on large databases while covering the vast majority of active work.
+     * 1.  **Scope:** Fetches memory and summary metadata across all sessions (all-time). The prior
+     *     30-day window was an obsolete safeguard from boot-coupled summarization that stranded old sessions.
      * 2.  **Grouping:** Aggregates actual memory counts per session from the raw memory data.
      * 3.  **Comparison:**
      *     -   **Missing Summary:** If a session has memories but no summary, it is flagged.
@@ -322,15 +322,11 @@ class SessionService extends Base {
      * -   **Parallel / Crash Path:** Session A crashes after adding 5 memories. Summary has 10, DB has 15.
      *     Next startup sees Mismatch. Re-summarizes to capture the lost 5 memories.
      *
-     * @param {Boolean} [includeAll=false] If true, ignores the 30-day limit and scans all sessions.
      * @returns {Promise<String[]>} List of Session IDs requiring summarization.
      */
-    async findSessionsToSummarize(includeAll = false) {
-        // 1. Get metadata for memories
-        // Default: Last 30 Days only (limits scope to recent active work).
-        // Override: All time (if includeAll is true).
-        const ONE_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
-        const minTimestamp = Date.now() - ONE_MONTH_MS;
+    async findSessionsToSummarize() {
+        // 1. Get metadata for memories — all-time scope. (The prior 30-day window was an obsolete
+        // boot/healthcheck-timeout safeguard from when MC summarized on server boot.)
         const limit = aiConfig.summarizationBatchLimit;
         const maxIterations = 1000; // Safety break: max 2M records (2000 * 1000)
 
@@ -346,14 +342,6 @@ class SessionService extends Base {
         };
 
         const memoryQueryOptions = { ...baseQueryOptions };
-
-        if (!includeAll) {
-            memoryQueryOptions.where = {
-                timestamp: {
-                    '$gt': minTimestamp
-                }
-            };
-        }
 
         while (hasMore) {
             if (iterations++ > maxIterations) {
@@ -402,14 +390,6 @@ class SessionService extends Base {
         iterations = 0;
 
         const summaryQueryOptions = { ...baseQueryOptions };
-
-        if (!includeAll) {
-            summaryQueryOptions.where = {
-                timestamp: {
-                    '$gt': minTimestamp
-                }
-            };
-        }
 
         while (hasMore) {
             if (iterations++ > maxIterations) {
@@ -1250,11 +1230,10 @@ ${sessionContent}
      * Summarizes sessions based on the provided sessionId or all unsummarized sessions.
      * Note: If the current active sessionId is explicitly passed, it WILL be summarized.
      * @param {Object}  options
-     * @param {Boolean} [options.includeAll] If true, scans all sessions regardless of time window.
      * @param {String}  [options.sessionId]  A specific session ID to summarize.
      * @returns {Promise<{processed: number, sessions: object[]}|{error: string, message: string, code: string}>}
      */
-    async summarizeSessions({ includeAll, sessionId } = {}) {
+    async summarizeSessions({ sessionId } = {}) {
         try {
             let processed = [];
             const leaseToken = crypto.randomUUID();
@@ -1277,7 +1256,7 @@ ${sessionContent}
                     logger.info(`[SessionService] Skipping session ${sessionId} - active lease held by another instance or already completed.`);
                 }
             } else {
-                const sessionsToSummarize = await this.findSessionsToSummarize(includeAll);
+                const sessionsToSummarize = await this.findSessionsToSummarize();
 
                 // Hardware concurrency scaling
                 let batchSize;

--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -425,6 +425,23 @@ test.describe('SessionService Drift Detection — Timestamp Filtering', () => {
         }
     });
 
+    test('findSessionsToSummarize includes >30-day-old sessions (30-day window removed)', async () => {
+        // Regression guard for the deleted time window: an ancient unsummarized session must now
+        // be returned (it was previously excluded by the timestamp $gt filter).
+        const collection       = await SDK.Memory_ChromaManager.getMemoryCollection();
+        const ancientSessionId = `ancient-alltime-${crypto.randomUUID()}`;
+        const ancientTimestamp = Date.now() - (90 * 24 * 60 * 60 * 1000); // 90 days ago
+
+        await collection.add({
+            ids      : [`ancient-alltime-mem-${testTs}`],
+            documents: ['Ancient unsummarized session memory'],
+            metadatas: [{sessionId: ancientSessionId, timestamp: ancientTimestamp, type: 'agent-interaction'}]
+        });
+
+        const sessionsToSummarize = await SDK.Memory_SessionService.findSessionsToSummarize();
+        expect(sessionsToSummarize).toContain(ancientSessionId);
+    });
+
     test('ChromaDB $gt filter should correctly compare epoch timestamps', async () => {
         // Direct ChromaDB timestamp filtering test
         // This validates your hypothesis about potential date/type issues


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session 0f94aade-f9b1-4214-b17e-be0bdf33e2be.

Resolves #12823

Removes the obsolete 30-day lookback window (and the now-dead `includeAll` parameter) from `SessionService.findSessionsToSummarize` / `summarizeSessions` and the `summarize-sessions.mjs` call site. The periodic summarizer was hard-windowed to the last 30 days while the orchestrator backlog metric `getPendingSessionSummaryCount` is all-time — so ~299 of 478 sessions (older than 30 days) were counted pending while the sweep structurally never reached them. The window was a boot/healthcheck-timeout safeguard from when Memory Core summarized on server boot; that coupling is gone (summarization runs in the spawned orchestrator daemon child, and the MC healthcheck no longer calls it), so it was dead-weight stranding the historical tail. The sweep is now all-time and matches the metric; the backlog drains (degraded summaries via `#12820`'s fallback where oversized).

Evidence: L2 (unit specs — `findSessionsToSummarize` now returns an ancient >30-day unsummarized session; active/peer-exclusion behavior preserved) → L4 required (AC4 post-merge: the live orchestrator `pending-session-summary` count drains and no longer floors at ~299). Residual: AC4 [#12823].

## Deltas from ticket

None — scope matches the ticket. `includeAll` was removed entirely (not retained as a vestigial param) per the ticket's Avoided-Traps.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs` → **12 passed**, including the new `findSessionsToSummarize includes >30-day-old sessions (30-day window removed)` test (seeds a 90-day-old unsummarized session, asserts it is now returned).
- `npm run test-unit -- QueryReRanker.spec.mjs SessionSummarization.spec.mjs` → **17 passed** — no regression in drift-detection, active-session exclusion, or peer-exclusion behavior; gemma4 summarization ran healthy locally.
- `grep -n "includeAll|minTimestamp|ONE_MONTH"` over `SessionService.mjs` + `summarize-sessions.mjs` → 0 residual references.

## Post-Merge Validation

- [ ] Restart/reconnect the orchestrator and confirm the periodic `pending-session-summary` count drains toward 0 over successive sweeps (no longer floors at ~299).
- [ ] Confirm the first all-time sweeps emit degraded summaries (`sourceTier: truncatedRaw`/`miniSummary`) for oversized old sessions via the `#12820` fallback, rather than null.

## Commits

- `54d045841` — fix(memory-core): remove the obsolete 30-day window from session summarization (#12823)

## Note

Cross-family reviewers (GPT + Claude family) are at their weekly rate-limit caps until 2026-06-11, so this awaits cross-family review per §6.1 until then (or operator merge). Opened under operator lead-delegation for the v13 session-summary backlog cluster (sibling: #12824).
