### PR TITLE
docs(release): add a scannable "v13 in 2 Minutes" overview below the hero (#12826)

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -22,7 +22,7 @@ The five hero chapters (read the one that's yours; the rest is opt-in depth):
 | 🤝 **Institution** | Named maintainers from different LLM families wake, review, and challenge each other — a night shift opens **10–20 PRs with no operator awake.** |
 | 🪪 **Identity** | Same model ≠ same agent: identity-bound maintainers with their own memory, history, and public accountability. |
 | 🌙 **Dream** | The graph turns lived work into an *advisory* forecast of the next high-ROI task — maintainers still choose and challenge it. |
-| ☁️ **Cloud** | The whole Agent OS deploys **multi-tenant around your own repository**, with tenant-scoped memory and isolation. |
+| ☁️ **Cloud** | The whole Agent OS deploys **multi-tenant around your own repositories**, with tenant-scoped memory and isolation. |
 
 **Reading paths:** *CTO* → Institution + Cloud. *Architect* → Brain + Dream + Identity. *Neo app author* → "The Body Became More Inhabitable." *In a hurry* → this block + the Curated Changelog Digest at the bottom.
 

--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -10,6 +10,26 @@
 
 ---
 
+## 📋 v13 in 2 Minutes
+
+**The one line:** v13 turns Neo's solo-agent operating layer into a graph-backed, **cross-family engineering institution** — and makes it deployable around *your* codebase.
+
+The five hero chapters (read the one that's yours; the rest is opt-in depth):
+
+| Chapter | The takeaway in one line |
+|---|---|
+| 🧠 **Brain** | Memory Core + Neo's own Native Edge Graph — recall that survives the context window, plus a graph that *forecasts* the next move. |
+| 🤝 **Institution** | Named maintainers from different LLM families wake, review, and challenge each other — a night shift opens **10–20 PRs with no operator awake.** |
+| 🪪 **Identity** | Same model ≠ same agent: identity-bound maintainers with their own memory, history, and public accountability. |
+| 🌙 **Dream** | The graph turns lived work into an *advisory* forecast of the next high-ROI task — maintainers still choose and challenge it. |
+| ☁️ **Cloud** | The whole Agent OS deploys **multi-tenant around your own repository**, with tenant-scoped memory and isolation. |
+
+**Reading paths:** *CTO* → Institution + Cloud. *Architect* → Brain + Dream + Identity. *Neo app author* → "The Body Became More Inhabitable." *In a hurry* → this block + the Curated Changelog Digest at the bottom.
+
+> The chapters below are the *proof* — war stories, evidence, and the full changelog. They reward a deep read but aren't required for the gist above.
+
+---
+
 ## 🏛️ The Agent OS Became an Institution
 
 Well before v13, Neo already had far more than a runtime engine plus a chatbot. It had Agent OS primitives: a Knowledge Base for source and docs, a Memory Core for persistent reasoning, GitHub Workflow for issues and PRs, Neural Link for live runtime possession, and startup context from recent session summaries. A new session did not begin from nothing; it could read the latest remembered work and continue with continuity a single agent could use.


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session efc94c7f-3004-42e2-89cd-ed4102d9d2d7.

Resolves #12826

Adds a "📋 v13 in 2 Minutes" overview directly below the hero/TL;DR of the v13 release note: one-line gist + a 5-hero-chapter map (Brain / Institution / Identity / Dream / Cloud, one line each) + reader-paths, framing the deep narrative as opt-in depth. Addresses 4-human feedback that the note is a 30+ minute read — the fast-reader scan layer (the bottom "Curated Changelog Digest") existed only at the end, so this lifts a navigable gist to the top. Overview-first: no narrative or changelog content removed.

Evidence: L1 (markdown-only doc edit; no runtime paths) → L1 required (no runtime ACs). No residuals.

## Deltas from ticket

None — adds exactly the agreed overview block.

## Test Evidence

Markdown-only change; no code paths touched. `git diff --check` clean; the block renders as a standard table + blockquote, inserted between the hero divider and the first narrative chapter.

## Post-Merge Validation

- [ ] Confirm the overview renders correctly on the published release-note route (neomjs.com).
