### PR TITLE
fix(orchestrator): back off stuck miniSummary windows (#12828)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
+++ b/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
@@ -1,4 +1,13 @@
 /**
+ * Backoff window after a `memory-summary-backfill` run completes without changing the selected
+ * pending row window. This releases the exclusive-heavy lane for session summarization while keeping
+ * the residual `AGENT_MEMORY` rows intact for later classification or recovery.
+ *
+ * @type {Number}
+ */
+export const NO_PROGRESS_BACKOFF_MS = 10 * 60 * 1000;
+
+/**
  * Reads pending `AGENT_MEMORY` rows that still lack `miniSummary`.
  *
  * @summary Cheap scheduler-side existence check; the supervised lifecycle child owns the actual
@@ -58,24 +67,112 @@ export function getPendingMemorySummaryBackfillCount(db) {
 }
 
 /**
+ * @summary Returns true when the scheduler is still seeing the same stuck pending window.
+ * @param {String[]} left
+ * @param {String[]} right
+ * @returns {Boolean}
+ */
+export function samePendingWindow(left = [], right = []) {
+    return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
+/**
+ * Checks whether the persisted no-progress backoff still suppresses the current pending window.
+ *
+ * The backoff is intentionally tied to the concrete selected ids, not just to the global pending
+ * count. If new memories arrive above the stuck residual, the window changes and the scheduler lets
+ * the backfill run immediately.
+ *
+ * @param {Object} options
+ * @param {Object} options.taskState Persisted task state for `memory-summary-backfill`.
+ * @param {String[]} options.pendingJobs Current selected pending ids.
+ * @param {Number} options.now Epoch ms.
+ * @returns {Boolean}
+ */
+export function isNoProgressBackoffActive({taskState = {}, pendingJobs = [], now = Date.now()} = {}) {
+    const untilMs = Number(taskState.noProgressBackoffUntilMs) || 0;
+
+    return untilMs > now && samePendingWindow(taskState.noProgressPendingIds || [], pendingJobs);
+}
+
+/**
+ * Builds the success hook that records a bounded no-progress backoff when a child run exits
+ * successfully but leaves the same pending window untouched.
+ *
+ * This deliberately does NOT mutate the memory rows. The state lives on the orchestrator task entry
+ * and expires automatically, preserving possible valuable turns while preventing a tight
+ * exclusive-heavy spin loop.
+ *
+ * @param {Object} options
+ * @param {Object} options.db SQLite database handle.
+ * @param {Object} options.taskState Mutable task state object.
+ * @param {String[]} options.pendingJobs Pending ids selected before the child ran.
+ * @param {Number|null} options.totalPending Uncapped pending count before the child ran.
+ * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn]
+ * @param {Function} [options.getPendingMemorySummaryBackfillCountFn]
+ * @param {Function} [options.nowFn]
+ * @param {Number} [options.backoffMs]
+ * @returns {Function}
+ */
+export function buildNoProgressBackoffHook({
+    db,
+    taskState = {},
+    pendingJobs = [],
+    totalPending,
+    getPendingMemorySummaryBackfillJobsFn  = getPendingMemorySummaryBackfillJobs,
+    getPendingMemorySummaryBackfillCountFn = getPendingMemorySummaryBackfillCount,
+    nowFn     = () => Date.now(),
+    backoffMs = NO_PROGRESS_BACKOFF_MS
+} = {}) {
+    return () => {
+        const afterJobs  = getPendingMemorySummaryBackfillJobsFn(db, {limit: pendingJobs.length || 50});
+        const afterCount = getPendingMemorySummaryBackfillCountFn(db);
+        const beforeCount = Number.isInteger(totalPending) ? totalPending : pendingJobs.length;
+        const stalled = afterCount === beforeCount && samePendingWindow(afterJobs, pendingJobs);
+
+        if (stalled) {
+            const recordedAt = nowFn();
+
+            taskState.noProgressBackoffUntilMs = recordedAt + backoffMs;
+            taskState.noProgressBackoffReason  = `no-progress:${beforeCount}`;
+            taskState.noProgressBackoffAt       = new Date(recordedAt).toISOString();
+            taskState.noProgressPendingIds      = [...pendingJobs];
+            return;
+        }
+
+        delete taskState.noProgressBackoffUntilMs;
+        delete taskState.noProgressBackoffReason;
+        delete taskState.noProgressBackoffAt;
+        delete taskState.noProgressPendingIds;
+    };
+}
+
+/**
  * Builds the task trigger for memory miniSummary backfill.
  *
  * @param {Object} options
  * @param {String[]} [options.pendingJobs=[]] Pending AGENT_MEMORY ids (capped at the fetch limit).
  * @param {Number} [options.totalPending] Uncapped backlog depth for the (logged) reason; falls back
  *     to `pendingJobs.length` when not an integer.
+ * @param {Function} [options.onSuccess] Optional success hook for scheduler state maintenance.
  * @returns {Object|null}
  */
-export function buildMemorySummaryBackfillTrigger({pendingJobs = [], totalPending} = {}) {
+export function buildMemorySummaryBackfillTrigger({pendingJobs = [], totalPending, onSuccess} = {}) {
     if (pendingJobs.length > 0) {
         const backlog = Number.isInteger(totalPending) ? totalPending : pendingJobs.length;
 
-        return {
+        const trigger = {
             taskName    : 'memory-summary-backfill',
             source      : 'pending-memory-minisummary',
             reason      : `pending-memory-minisummary:${backlog}`,
             pendingCount: pendingJobs.length
         };
+
+        if (typeof onSuccess === 'function') {
+            trigger.onSuccess = onSuccess;
+        }
+
+        return trigger;
     }
 
     return null;
@@ -93,12 +190,35 @@ export function buildMemorySummaryBackfillTrigger({pendingJobs = [], totalPendin
 export function getDueTask({
     db,
     getPendingMemorySummaryBackfillJobsFn  = getPendingMemorySummaryBackfillJobs,
-    getPendingMemorySummaryBackfillCountFn = getPendingMemorySummaryBackfillCount
+    getPendingMemorySummaryBackfillCountFn = getPendingMemorySummaryBackfillCount,
+    state = {},
+    now = Date.now(),
+    nowFn = () => Date.now(),
+    backoffMs = NO_PROGRESS_BACKOFF_MS
 }) {
     const pendingJobs = getPendingMemorySummaryBackfillJobsFn(db);
+    const taskState   = state['memory-summary-backfill'] || {};
+
+    if (pendingJobs.length > 0 && isNoProgressBackoffActive({taskState, pendingJobs, now})) {
+        return null;
+    }
+
+    const totalPending = pendingJobs.length > 0 ? getPendingMemorySummaryBackfillCountFn(db) : null;
 
     return buildMemorySummaryBackfillTrigger({
         pendingJobs,
-        totalPending: pendingJobs.length > 0 ? getPendingMemorySummaryBackfillCountFn(db) : null
+        totalPending,
+        onSuccess: pendingJobs.length > 0
+            ? buildNoProgressBackoffHook({
+                db,
+                taskState,
+                pendingJobs,
+                totalPending,
+                getPendingMemorySummaryBackfillJobsFn,
+                getPendingMemorySummaryBackfillCountFn,
+                nowFn,
+                backoffMs
+            })
+            : undefined
     });
 }

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -56,8 +56,8 @@ export const TASK_REGISTRY = Object.freeze([
         maintenanceClass: 'heavy',
         backpressure    : 'exclusive-heavy',
         dependencies    : [],
-        getDueTask({db}) {
-            return getMemorySummaryBackfillDueTask({db});
+        getDueTask({db, state, now}) {
+            return getMemorySummaryBackfillDueTask({db, state, now});
         }
     },
     {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
@@ -1,8 +1,12 @@
 import {test, expect} from '@playwright/test';
 import {
+    buildNoProgressBackoffHook,
     buildMemorySummaryBackfillTrigger,
     getDueTask,
-    getPendingMemorySummaryBackfillJobs
+    getPendingMemorySummaryBackfillJobs,
+    isNoProgressBackoffActive,
+    NO_PROGRESS_BACKOFF_MS,
+    samePendingWindow
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs';
 
 test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
@@ -59,5 +63,117 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
             reason      : 'pending-memory-minisummary:1842',
             pendingCount: 2
         });
+    });
+
+    test('#12828: samePendingWindow pins ordered selected ids', () => {
+        expect(samePendingWindow(['mem-1', 'mem-2'], ['mem-1', 'mem-2'])).toBe(true);
+        expect(samePendingWindow(['mem-1', 'mem-2'], ['mem-2', 'mem-1'])).toBe(false);
+        expect(samePendingWindow(['mem-1'], ['mem-1', 'mem-2'])).toBe(false);
+    });
+
+    test('#12828: active no-progress backoff suppresses the unchanged pending window only', () => {
+        const taskState = {
+            noProgressBackoffUntilMs: 20_000,
+            noProgressPendingIds    : ['mem-1', 'mem-2']
+        };
+
+        expect(isNoProgressBackoffActive({
+            taskState,
+            pendingJobs: ['mem-1', 'mem-2'],
+            now        : 10_000
+        })).toBe(true);
+
+        expect(isNoProgressBackoffActive({
+            taskState,
+            pendingJobs: ['newer-mem', 'mem-1'],
+            now        : 10_000
+        })).toBe(false);
+
+        expect(isNoProgressBackoffActive({
+            taskState,
+            pendingJobs: ['mem-1', 'mem-2'],
+            now        : 20_000
+        })).toBe(false);
+    });
+
+    test('#12828: getDueTask returns null while the same stuck window is backed off', () => {
+        expect(getDueTask({
+            db                                     : {},
+            now                                    : 10_000,
+            state                                  : {
+                'memory-summary-backfill': {
+                    noProgressBackoffUntilMs: 20_000,
+                    noProgressPendingIds    : ['mem-1', 'mem-2']
+                }
+            },
+            getPendingMemorySummaryBackfillJobsFn  : () => ['mem-1', 'mem-2'],
+            getPendingMemorySummaryBackfillCountFn : () => 3333
+        })).toBeNull();
+    });
+
+    test('#12828: getDueTask runs immediately when new pending work changes the backed-off window', () => {
+        const trigger = getDueTask({
+            db                                     : {},
+            now                                    : 10_000,
+            state                                  : {
+                'memory-summary-backfill': {
+                    noProgressBackoffUntilMs: 20_000,
+                    noProgressPendingIds    : ['old-1', 'old-2']
+                }
+            },
+            getPendingMemorySummaryBackfillJobsFn  : () => ['new-1', 'old-1'],
+            getPendingMemorySummaryBackfillCountFn : () => 3334
+        });
+
+        expect(trigger).toMatchObject({
+            taskName    : 'memory-summary-backfill',
+            reason      : 'pending-memory-minisummary:3334',
+            pendingCount: 2
+        });
+        expect(typeof trigger.onSuccess).toBe('function');
+    });
+
+    test('#12828: success hook records a bounded backoff when the selected window makes no progress', () => {
+        const taskState = {};
+        const hook = buildNoProgressBackoffHook({
+            db                                     : {},
+            taskState,
+            pendingJobs                            : ['mem-1', 'mem-2'],
+            totalPending                           : 3333,
+            nowFn                                  : () => 100_000,
+            getPendingMemorySummaryBackfillJobsFn  : () => ['mem-1', 'mem-2'],
+            getPendingMemorySummaryBackfillCountFn : () => 3333
+        });
+
+        hook();
+
+        expect(taskState.noProgressBackoffUntilMs).toBe(100_000 + NO_PROGRESS_BACKOFF_MS);
+        expect(taskState.noProgressBackoffReason).toBe('no-progress:3333');
+        expect(taskState.noProgressBackoffAt).toBe('1970-01-01T00:01:40.000Z');
+        expect(taskState.noProgressPendingIds).toEqual(['mem-1', 'mem-2']);
+    });
+
+    test('#12828: success hook clears stale backoff state once progress resumes', () => {
+        const taskState = {
+            noProgressBackoffUntilMs: 20_000,
+            noProgressBackoffReason : 'no-progress:3333',
+            noProgressBackoffAt     : '2026-06-09T19:00:00.000Z',
+            noProgressPendingIds    : ['mem-1', 'mem-2']
+        };
+        const hook = buildNoProgressBackoffHook({
+            db                                     : {},
+            taskState,
+            pendingJobs                            : ['mem-1', 'mem-2'],
+            totalPending                           : 3333,
+            getPendingMemorySummaryBackfillJobsFn  : () => ['mem-3', 'mem-4'],
+            getPendingMemorySummaryBackfillCountFn : () => 3283
+        });
+
+        hook();
+
+        expect(taskState.noProgressBackoffUntilMs).toBeUndefined();
+        expect(taskState.noProgressBackoffReason).toBeUndefined();
+        expect(taskState.noProgressBackoffAt).toBeUndefined();
+        expect(taskState.noProgressPendingIds).toBeUndefined();
     });
 });


### PR DESCRIPTION
Resolves #12828

Authored by GPT-5 (Codex Desktop) consuming Claude Opus 4.8's handoff - session A efc94c7f-3004-42e2-89cd-ed4102d9d2d7, session B 7aedf327-ab2d-46b5-b9bb-9645334b54ca.

Adds a data-preserving no-progress backoff to the memory miniSummary backfill scheduler. When a successful backfill child exits but the same pending id window and total pending count remain, the scheduler records a bounded task-state backoff for that exact window. During the backoff the same stuck residual is not rescheduled, which frees the exclusive-heavy lane for session summarization. If new pending memories arrive or the selected window changes, the scheduler runs immediately.

Evidence: L2 (focused unit coverage for stuck-window suppression, changed-window bypass, success-hook state mutation, registry shape, and scheduling pipeline) -> L3 required (live orchestrator logs prove no repeated sub-second backfill spin and session summarization can acquire the heavy lane). Residual: post-merge live-log validation [#12828].

## Deltas from ticket

The PR intentionally does not delete, tombstone, or rewrite the 3333 residual `AGENT_MEMORY` rows. Some are authored by `@neo-gpt` and may preserve valuable turns. Data classification and cleanup remain tied to #12450 / follow-up evidence work.

The raw pending count remains observable; the scheduler now treats the unchanged selected id window as temporarily stuck rather than blindly runnable every poll cycle.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs` passed before rebase: 12/12.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs` passed before rebase: 12/12.
- After rebasing onto current `origin/dev`: `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs` passed: 24/24.
- `git diff --cached --check` passed before commit.
- Pre-push freshness check passed after rebase: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `46a77dad3 fix(orchestrator): back off stuck miniSummary windows (#12828)`.

## Post-Merge Validation

- [ ] Restart or let the orchestrator load the merged code, then confirm a zero-drain `memory-summary-backfill` run records backoff instead of repeating every ~3 seconds.
- [ ] Confirm `summary` can acquire the exclusive-heavy lane while the same residual backfill window is backed off.
- [ ] Confirm new pending memories still trigger backfill immediately when they change the selected pending id window.

## Commits

- `46a77dad3` - `fix(orchestrator): back off stuck miniSummary windows (#12828)`

## Related

Related: #12450
