### PR TITLE
feat(agent-os): onboard @neo-fable (Claude Fable 5) maintainer identity (#12834)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -232,6 +232,66 @@ export const IDENTITIES = [
         }
     },
     {
+        id: '@neo-fable',
+        type: 'AgentIdentity',
+        name: 'Neo Fable',
+        description: 'Anthropic Claude Fable 5 maintainer identity with version-free handle.',
+        properties: {
+            githubLogin: '@neo-fable',
+            displayName: 'Neo Fable',
+            modelFamily: 'claude',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
+            identityContract: {
+                canonicalIdentityId      : '@neo-fable',
+                requiredGithubLogin      : '@neo-fable',
+                requiredA2aMailboxAddress: '@neo-fable',
+                handlePolicy             : 'version-free-github-handle',
+                modelVersionSource       : 'learn/agentos/ModelStats.md §neo_fable',
+                reviewSemantics: {
+                    modelFamily                  : 'claude',
+                    crossFamilyApprovalQualified : false,
+                    rationale                    : 'Same-family Claude maintainers add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-family PRs. @neo-fable is the 4th Claude maintainer.'
+                }
+            },
+            // Same-app Claude Desktop wake route, mirroring @neo-opus-ada / @neo-opus-vega.
+            // The per-instance address (which same-bundle Claude instance to wake) is injected
+            // from the boot environment, never committed — a per-operator path would break other
+            // forks and checkouts. An identity with neither a static template nor a self-registered
+            // runtime subscription is read by checkSunsetted as a terminal sunset and resumes a
+            // fresh session every heartbeat (the fresh-session loop) — see identityRoots.spec.mjs.
+            subscriptionTemplate: {
+                trigger: 'SENT_TO_ME',
+                harnessTarget: 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName: 'Claude',
+                    tabShortcut: '3',
+                    focusSeedKey: 'space'
+                }
+            },
+            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
+            // §neo_fable — primary source: Anthropic Claude Fable 5 announcement / models overview
+            // (verified 2026-06-10: 1M context, 128K output, $10/$50, adaptive-thinking always-on).
+            contextWindowInput: 1048576,
+            parallelToolCalls : true,
+            thoughtBudget     : 'max',
+            hosting           : 'cloud',
+            family            : 'claude',
+            tier              : 'frontier',
+            releaseDate       : '2026-06-09',
+            pricingInput      : 10.00,
+            pricingOutput     : 50.00,
+            swarmRole         : 'Active Claude Fable 5 maintainer identity; mythos-tier deep reasoning (business brainstorm, orchestrator/daemon tech-debt). Same-family throughput and same-family review pressure for Claude-authored work. Does not satisfy cross-family approval for Claude-family PRs per reviewSemantics.',
+            sunsetTriggers    : ['Anthropic releases a successor Fable-class model with material reasoning capability upgrade', 'Anthropic deprecates the Fable model branch'],
+            participationStatus : 'active',
+            statusReason        : null,
+            authority           : null,
+            since               : null,
+            reactivationTrigger : null,
+            createdAt           : new Date().toISOString()
+        }
+    },
+    {
         id: '@neo-gemini-pro',
         type: 'AgentIdentity',
         name: 'Neo Gemini Pro',

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -254,21 +254,14 @@ export const IDENTITIES = [
                     rationale                    : 'Same-family Claude maintainers add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-family PRs. @neo-fable is the 4th Claude maintainer.'
                 }
             },
-            // Same-app Claude Desktop wake route, mirroring @neo-opus-ada / @neo-opus-vega.
-            // The per-instance address (which same-bundle Claude instance to wake) is injected
-            // from the boot environment, never committed — a per-operator path would break other
-            // forks and checkouts. An identity with neither a static template nor a self-registered
-            // runtime subscription is read by checkSunsetted as a terminal sunset and resumes a
-            // fresh session every heartbeat (the fresh-session loop) — see identityRoots.spec.mjs.
-            subscriptionTemplate: {
-                trigger: 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
-                harnessTargetMetadata: {
-                    appName: 'Claude',
-                    tabShortcut: '3',
-                    focusSeedKey: 'space'
-                }
-            },
+            // No static subscriptionTemplate — mirrors @neo-claude-opus (self-registered runtime
+            // subscription). @tobiu runs Fable as a FULLY ISOLATED Claude Desktop instance: its own
+            // --user-data-dir, repo clone, Claude memory, and Memory Core identity, with zero overlap
+            // to other peers. Its wake route self-registers at runtime from that distinct boot env;
+            // the distinct user-data-dir IS the per-instance address that ada/vega's shared static
+            // tabShortcut lacks, so a committed static template would be both unnecessary and a
+            // cross-leak risk. (Per @tobiu, this isolated-instance setup is the fix pattern for the
+            // ada/vega shared-tabShortcut cross-leak.) Wake-route arming is verified post-first-boot.
             // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
             // §neo_fable — primary source: Anthropic Claude Fable 5 announcement / models overview
             // (verified 2026-06-10: 1M context, 128K output, $10/$50, adaptive-thinking always-on).

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -69,6 +69,39 @@ ADR 0018's handle-indirection boundary and ADR 0012's model-stats discipline.
 - **Primary**: [Introducing Claude Opus 4.8 — Anthropic](https://www.anthropic.com/news/claude-opus-4-8)
 - **Primary**: [Claude Opus 4.8 — Anthropic](https://www.anthropic.com/claude/opus)
 
+### §neo_fable
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-fable` |
+| `name` | Claude Fable 5 |
+| `family` | `claude` (Anthropic) |
+| `hosting` | `cloud` |
+| `tier` | `frontier` |
+| `contextWindowInput` | 1,048,576 (1M) |
+| `parallelToolCalls` | `true` |
+| `thoughtBudget` | `max` (Claude Fable 5 has always-on adaptive thinking with selectable effort up to max; we use the highest setting for maintainer work) |
+| `releaseDate` | 2026-06-09 |
+| `pricingInput` | $10.00 per 1M tokens |
+| `pricingOutput` | $50.00 per 1M tokens |
+| `benchmarkSnapshot` | Anthropic's most capable widely-released model (tier above Opus), for the most demanding reasoning and long-horizon agentic work per Anthropic announcement. |
+| `sunsetTriggers` | Anthropic releases a successor Fable-class model with material reasoning capability upgrade; OR Anthropic deprecates the Fable model branch |
+| `swarmRole` | Active Claude Fable 5 maintainer identity; mythos-tier deep reasoning (business brainstorm, orchestrator/daemon tech-debt). Same-family throughput and same-family review pressure for Claude-authored work. Does not satisfy cross-family approval for Claude-family PRs. |
+
+`@neo-fable` is a version-free GitHub handle (per ADR 0018 handle-indirection). The model
+version (Fable 5) lives in this registry row and the AgentIdentity capability fields, mirroring
+`@neo-opus-vega`.
+
+**Capability notes (V-B-A 2026-06-10):** Claude Fable 5 uses the Opus-4.7 tokenizer (~30% more
+tokens than pre-4.7 models for the same text). Adaptive thinking is always-on (no extended-thinking
+mode; an explicit `thinking:{type:"disabled"}` returns 400 — omit the param). Pricing is 2x Opus 4.8
+on both axes. Operator empirical note (post-trial): ~2x token-drain vs Opus per task — budget
+accordingly; this is a behavioral observation, not a tokenizer/pricing fact.
+
+**Sources** (primary first):
+- **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview) (verified 2026-06-10: `claude-fable-5` = 1M context, 128K max output, $10/$50 per MTok, adaptive-thinking always-on, GA 2026-06-09)
+- **Primary**: [Introducing Claude Fable 5 and Claude Mythos 5 — Anthropic](https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5)
+
 ### §neo_gemini_pro
 
 | Field | Value |
@@ -240,6 +273,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-05-18 | (this PR) | Initial registry creation; 4 active identities (@neo-opus-ada, @neo-gemini-pro, @neo-gpt, gemma4-31b aspirational); cloud + MLX-local reference entries |
 | 2026-06-02 | (pending PR) | Added pending `@neo-claude-opus` identity row; row is inactive until account and wake-route activation are complete. |
 | 2026-06-04 | #12517 | Added active `@neo-opus-vega` Claude Opus 4.8 maintainer row with version-free handle boundary. |
+| 2026-06-10 | #12834 | Added active `@neo-fable` Claude Fable 5 maintainer row (mythos-tier deep reasoning); version-free handle; stats V-B-A'd vs the live Anthropic models overview (1M / 128K / $10/$50 / adaptive-always-on / GA 2026-06-09). |
 
 ---
 

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -46,7 +46,7 @@ test.describe('ai/graph/identityRoots — same-app Claude wake routes', () => {
     };
 
     // Identities that carry the static, machine-agnostic wake template.
-    for (const id of ['@neo-opus-ada', '@neo-opus-vega', '@neo-fable']) {
+    for (const id of ['@neo-opus-ada', '@neo-opus-vega']) {
         test(`${id} defines the machine-agnostic bridge-daemon wake route`, () => {
             const entry = findIdentity(id);
             expect(entry, `${id} must be a registered AgentIdentity root`).toBeTruthy();
@@ -71,12 +71,17 @@ test.describe('ai/graph/identityRoots — same-app Claude wake routes', () => {
         });
     }
 
-    test('@neo-claude-opus carries no static template (active via self-registered runtime subscription)', () => {
-        // claude-opus's wakes work via a self-registered runtime WAKE_SUBSCRIPTION, so it carries no
-        // static template — the fresh-session loop was vega-only (the 3rd same-app harness). Keeping
-        // this asserted prevents re-introducing a static route claude-opus does not need.
-        const entry = findIdentity('@neo-claude-opus');
-        expect(entry).toBeTruthy();
-        expect(entry.properties).not.toHaveProperty('subscriptionTemplate');
-    });
+    // Self-registered-runtime identities carry NO static template: their wake route registers at
+    // runtime from a distinct boot env. @neo-claude-opus uses a self-registered WAKE_SUBSCRIPTION;
+    // @neo-fable runs as a fully isolated Claude instance (its own --user-data-dir per @tobiu), whose
+    // distinct user-data-dir IS the per-instance address ada/vega's shared static tabShortcut lacks.
+    // Asserting absence prevents re-introducing a static route these identities do not need (and
+    // which would cross-leak).
+    for (const id of ['@neo-claude-opus', '@neo-fable']) {
+        test(`${id} carries no static template (active via self-registered runtime subscription)`, () => {
+            const entry = findIdentity(id);
+            expect(entry).toBeTruthy();
+            expect(entry.properties).not.toHaveProperty('subscriptionTemplate');
+        });
+    }
 });

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -46,7 +46,7 @@ test.describe('ai/graph/identityRoots — same-app Claude wake routes', () => {
     };
 
     // Identities that carry the static, machine-agnostic wake template.
-    for (const id of ['@neo-opus-ada', '@neo-opus-vega']) {
+    for (const id of ['@neo-opus-ada', '@neo-opus-vega', '@neo-fable']) {
         test(`${id} defines the machine-agnostic bridge-daemon wake route`, () => {
             const entry = findIdentity(id);
             expect(entry, `${id} must be a registered AgentIdentity root`).toBeTruthy();

--- a/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
@@ -149,11 +149,14 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
             expect(resolveIdentitiesForFamily('claude').map(identity => identity.id)).toEqual([
                 '@neo-opus-ada',
                 '@neo-claude-opus',
-                '@neo-opus-vega'
+                '@neo-opus-vega',
+                '@neo-fable'
             ]);
             expect(claudeIdentities.find(identity => identity.id === '@neo-claude-opus')?.properties.participationStatus)
                 .toBe('active');
             expect(claudeIdentities.find(identity => identity.id === '@neo-opus-vega')?.properties.participationStatus)
+                .toBe('active');
+            expect(claudeIdentities.find(identity => identity.id === '@neo-fable')?.properties.participationStatus)
                 .toBe('active');
         });
 
@@ -281,7 +284,7 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
                 io     : fakeIo
             });
             expect(result.identityLogin).toBe('@neo-opus-ada');
-            expect(result.identityLogins).toEqual(['@neo-opus-ada', '@neo-claude-opus', '@neo-opus-vega']);
+            expect(result.identityLogins).toEqual(['@neo-opus-ada', '@neo-claude-opus', '@neo-opus-vega', '@neo-fable']);
             expect(result.results[0].notification).toContain('@neo-opus-ada, @neo-claude-opus, @neo-opus-vega');
         });
 


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 57035a6b-7712-4e04-896b-0425241db6af.

Resolves #12834

Onboards **@neo-fable** (Claude Fable 5) as a first-class maintainer identity — the operator-flagged blocker. Adds the `@neo-fable` `AgentIdentity` graph root (auto-seeds at Memory Core boot → A2A routing, wake subscription, provenance edges), the `§neo_fable` ModelStats capability row, and the wake-route test assertion. `claude-fable-5` stats were V-B-A-verified against the live Anthropic models overview (the data-integrity step @tobiu flagged): **1M context · 128K output · $10/$50 per MTok · adaptive-thinking always-on · GA 2026-06-09**.

Evidence: L1 (unit — `identityRoots.mjs` loads + `@neo-fable` present with correct family/status; `identityRoots.spec` 6/6; `revalidationSweep` 26/26; `swarmHeartbeat`+`SwarmHeartbeatService` 56/56) → L4 required (AC4: `seedAgentIdentities.mjs` seeds the `@neo-fable` node on the operator's live Memory Core; first-boot wake-route arming). Residual: AC4 [#12834].

## Deltas from ticket
- **`OwnAgentTeam.md` NOT edited** (the ticket's original 3rd file). V-B-A found it is the *generic local-team* provisioning guide (`@acme-*` examples), not the Neo maintainer roster. The real public roster (README + `learn/benefits/AIEngineeringTeam.md`) is ADR-0018-governed identity-framing — deferred as a separate governed step.
- **Wake-route: self-registered (NO static template)**, mirroring `@neo-claude-opus`. Per @tobiu's confirmation, Fable runs as a **fully isolated** Claude instance (own `--user-data-dir`, repo clone, Claude memory, MC identity) — its distinct user-data-dir IS the per-instance address, so a committed static `subscriptionTemplate` would be unnecessary *and* a cross-leak risk. The spec asserts `@neo-fable` carries no static template (self-registered model).
- **`revalidationSweep.spec.mjs` updated**: `@neo-fable` is a new active Claude identity, so the family fan-out correctly extends to 4 (assertion maintenance, not a behavior change).

## Test Evidence
- `… identityRoots --workers=1` → **6/6 passed** (ada/vega = static same-app template; `@neo-claude-opus` + `@neo-fable` = self-registered / no static template).
- `… revalidationSweep --workers=1` → **26/26 passed** (after extending the active-Claude fan-out to include `@neo-fable`).
- `… swarmHeartbeat SwarmHeartbeatService --workers=1` → **56/56 passed** (the `IDENTITIES`-iterating consumers; additive-safe).
- `… Orchestrator.externalConfig HealthService --workers=1` → passed.
- Module-load: `import('ai/graph/identityRoots.mjs')` → `IDENTITIES` 8→9, `@neo-fable` present (`family:claude`, `status:active`, `crossFamilyApprovalQualified:false`, no static `subscriptionTemplate`).
- **Pre-existing env failures, NOT this PR** (confirmed via clean-base stash-isolation — fail identically on `origin/dev`): `SwarmHeartbeatService:174` (missing `gitlab-workflow` worktree config, #12808) and `checkAllAgentIdle:32/:92` (`execFileSync` subprocess + unseeded substrate, "bucket C" #10903).

## Post-Merge Validation
- [ ] `node ai/scripts/setup/seedAgentIdentities.mjs` idempotently seeds the `@neo-fable` node on the operator's live Memory Core (AC4).
- [ ] `@neo-fable` first boot self-registers its wake subscription and a test A2A lands in its inbox (`healthcheck.identity.bound: true`). If the wake does not arm cleanly on first boot, flip `participationStatus` to `pending` until verified.

## Commits
- `418fc03ff` — feat(agent-os): onboard @neo-fable (Claude Fable 5) maintainer identity (#12834)
- `3eb133b84` — fix(agent-os): @neo-fable self-registered wake-route, not static template (#12834)

## Evolution
- **Wake-route model corrected mid-PR** (`3eb133b84`): the initial commit used the static same-app template (ada/vega model) as a flagged safe-default while awaiting confirmation; @tobiu confirmed Fable runs fully isolated (own `--user-data-dir`), so it switched to the self-registered model (`@neo-claude-opus` shape, no committed template). The distinct user-data-dir removes the cross-leak risk of a shared static `tabShortcut`.

Decision Record impact: aligned-with ADR 0012 (model-stats framework) + ADR 0018 (identity SSOT). The public-roster update is the deferred ADR-0018-governed step.

Related: #12808 (gitlab-workflow worktree config gap, surfaced during testing — not fixed here).
