### PR TITLE
fix(memory-core): bound session-summary synthesis with a timeout + degraded fallback (#12833)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -122,6 +122,22 @@ class Config extends ConfigProvider {
              */
             summarizationConcurrency: leaf(5),
             /**
+             * Wall-clock budget (ms) for a single session-summary synthesis call. Bounds
+             * `SessionService.summarizeSession`'s LLM invocation so a slow local synthesis aborts and
+             * degrades gracefully instead of grinding to the provider socket cap — the ~30-min stall that
+             * leaves `SummarizationJobs` leases stuck `in_progress` past expiry. Mirrors the
+             * `buildMiniSummary` timeout guard. Calibrated against the **300000ms `SummarizationJobs` lease
+             * TTL** (`claimSummarizationJob` default): the raw synthesis must abort well under the lease so
+             * it never expires the lease mid-run, AND the degraded (compact) fallback — a second, smaller
+             * synthesis — still completes within the lease. 180s leaves ~120s of that headroom. A synthesis
+             * approaching the lease TTL is already heading for the stuck-lease bug, so degrading it via the
+             * fast compact retry is the correct outcome. On overshoot the synthesis aborts and the
+             * provenance-labeled degraded fallback runs, so a too-slow session still gets a summary.
+             * Env-overridable; refine against a worst-case session-synthesis measurement (stay below the lease TTL).
+             * @type {number}
+             */
+            sessionSummaryTimeoutMs: leaf(180000, 'NEO_MEMORY_SESSION_SUMMARY_TIMEOUT_MS', 'number'),
+            /**
              * The target Storage Architecture to use.
              * Note: Chroma is the only supported Vector DB.
              * Options: 'hybrid' (Chroma vectors + SQLite graph), 'chroma' (Chroma vectors only).

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -4,6 +4,7 @@ import crypto                from 'crypto';
 import GraphService          from './GraphService.mjs';
 import logger                from '../../mcp/server/memory-core/logger.mjs';
 import SessionService        from './SessionService.mjs';
+import {withTimeout}         from './helpers/withTimeout.mjs';
 import {buildChatModel}      from '../../provider/buildChatModel.mjs';
 import aiConfig              from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -34,20 +35,11 @@ const MINI_SUMMARY_BACKFILL_MAX_RUN_MS = 600000;
 const CHROMA_FETCH_TIMEOUT_MS = 10000;
 
 /**
- * Races a promise against a timeout so a hung downstream call (model inference, content-store
- * fetch) rejects instead of blocking the maintenance loop forever.
- * @param {Promise} promise The work to bound.
- * @param {Number}  ms      Timeout in milliseconds.
- * @param {String}  label   Human-readable label surfaced in the timeout error.
- * @returns {Promise}
+ * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
+ * a `MemoryService` ⇄ `SessionService` import cycle). Kept exported here for back-compat with
+ * existing importers.
  */
-export function withTimeout(promise, ms, label) {
-    let timer;
-    const timeout = new Promise((resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    });
-    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
-}
+export {withTimeout};
 
 /**
  * Computes a lightweight inbox snapshot for the bound AgentIdentity to piggyback on every

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -2,6 +2,7 @@ import aiConfig from '../../mcp/server/memory-core/config.mjs';
 import Base from '../../../src/core/Base.mjs';
 import {buildChatModel} from '../../provider/buildChatModel.mjs';
 import {invokeWithGuardrail} from './helpers/consumerFrictionHelper.mjs';
+import {withTimeout} from './helpers/withTimeout.mjs';
 import crypto from 'crypto';
 import GraphService from './GraphService.mjs';
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
@@ -571,9 +572,20 @@ ${sessionContent}
             aiConfig.modelName;
         const consumerContextTokens = aiConfig.localModels.chat.contextLimitTokens;
         const consumerSafeTokens    = aiConfig.localModels.chat.safeProcessingLimitTokens;
+        const summaryTimeoutMs      = aiConfig.sessionSummaryTimeoutMs;
 
+        // Bound the synthesis call: pass the interactive budget to the provider (both honor
+        // `options.timeoutMs` and throw a uniform PROVIDER_TIMEOUT on overshoot) AND race a
+        // `withTimeout` as a provider-agnostic backstop, mirroring `buildMiniSummary`. Without this an
+        // in-size-band but slow local synthesis grinds to the provider socket cap — the ~30-min stall
+        // that strands SummarizationJobs leases past expiry. On timeout the guardrail emits a `timeout`
+        // friction symptom, which the degraded fallback below treats like an oversize skip.
         const runGuardrailed = (prompt, note) => invokeWithGuardrail({
-            invocationFn             : () => this.model.generateContent(prompt),
+            invocationFn             : () => withTimeout(
+                this.model.generateContent(prompt, {timeoutMs: summaryTimeoutMs, operationLabel: 'session summarization'}),
+                summaryTimeoutMs,
+                'session summarization'
+            ),
             inputPayload             : prompt,
             model                    : consumerModel,
             assetRef                 : sessionId,
@@ -592,14 +604,18 @@ ${sessionContent}
                 `summarizationBatchLimit=${aiConfig.summarizationBatchLimit}`
             );
 
-        // A too-large RAW prompt is pre-check-skipped by the guardrail. Rather than silently
-        // emitting NO summary for an oversized session, fall back to a compact per-turn input:
+        // The RAW synthesis can fail two recoverable ways: an oversized prompt is pre-check-skipped
+        // (`size-precheck-skip`), or a slow in-band synthesis exceeds `sessionSummaryTimeoutMs` and aborts
+        // (`timeout`). Rather than silently emitting NO summary, fall back to a compact per-turn input:
         // the stored miniSummary when present, else a truncated raw snippet (the
-        // _hydrateRecentTurnSummaries pattern). This is robust to the fail-soft / absent-miniSummary
-        // case (buildMiniSummary + the backfill can leave turns with no miniSummary), so the fallback
-        // never falls through to a null summary. The result is provenance-labeled degraded; raw turns
-        // remain the canonical drill-down substrate, and graph extraction still consumes raw.
-        if (!guardrailed.result && guardrailed.friction?.symptom === 'size-precheck-skip') {
+        // _hydrateRecentTurnSummaries pattern). The compact prompt is far smaller, so it also clears the
+        // timeout the raw prompt could not. Robust to the fail-soft / absent-miniSummary case
+        // (buildMiniSummary + the backfill can leave turns with no miniSummary), so the fallback never
+        // falls through to a null summary. The result is provenance-labeled degraded; raw turns remain
+        // the canonical drill-down substrate, and graph extraction still consumes raw.
+        const skipSymptom     = guardrailed.friction?.symptom,
+              recoverableSkip = skipSymptom === 'size-precheck-skip' || skipSymptom === 'timeout';
+        if (!guardrailed.result && recoverableSkip) {
             const FALLBACK_CHARS   = 280, // truncated-raw snippet cap (matches the per-turn miniSummary cap)
                   miniByMemoryId   = this.getSessionMiniSummaries(sessionId),
                   degradedEntries  = (memories.ids || [])
@@ -623,7 +639,7 @@ ${sessionContent}
                     guardrailed       = degradedResult;
                     summarySourceTier = usedTier;
                     summaryDegraded   = true;
-                    logger.info(`[SessionService] summarizeSession: raw prompt exceeded the safe band; built a provenance-labeled degraded (${usedTier}) summary from ${degradedEntries.length} turns for session ${sessionId}.`);
+                    logger.info(`[SessionService] summarizeSession: raw synthesis ${skipSymptom === 'timeout' ? 'timed out' : 'exceeded the safe band'}; built a provenance-labeled degraded (${usedTier}) summary from ${degradedEntries.length} turns for session ${sessionId}.`);
                 }
             }
         }

--- a/ai/services/memory-core/helpers/withTimeout.mjs
+++ b/ai/services/memory-core/helpers/withTimeout.mjs
@@ -1,0 +1,21 @@
+/**
+ * @summary Races a promise against a timeout so a hung downstream call (model inference,
+ * content-store fetch) rejects instead of blocking the maintenance loop forever.
+ *
+ * Lives in its own module so multiple memory-core services share one definition without an
+ * import cycle: `MemoryService` imports `SessionService`, so `SessionService` cannot import this
+ * from `MemoryService` (where it originally lived) without creating a `MemoryService` ⇄
+ * `SessionService` cycle. Generic promise utility — no Neo / AiConfig dependency.
+ *
+ * @param {Promise} promise The work to bound.
+ * @param {Number}  ms      Timeout in milliseconds.
+ * @param {String}  label   Human-readable label surfaced in the timeout error.
+ * @returns {Promise}
+ */
+export function withTimeout(promise, ms, label) {
+    let timer;
+    const timeout = new Promise((resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    });
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}

--- a/test/playwright/unit/ai/services/memory-core/SessionSummaryDegradedFallback.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummaryDegradedFallback.spec.mjs
@@ -16,6 +16,7 @@ setup({
 import {test, expect}        from '@playwright/test';
 import Neo                   from '../../../../../../src/Neo.mjs';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {PROVIDER_TIMEOUT_CODE} from '../../../../../../ai/provider/createTimeoutError.mjs';
 
 /**
  * SessionService degraded session-summary fallback (graduated from the session-summary fidelity
@@ -180,5 +181,44 @@ test.describe('Neo.ai.services.memory-core.SessionService — degraded session-s
         expect(res).not.toBeNull();
         expect(captured.metadatas[0].sourceTier).toBe('raw');
         expect(captured.metadatas[0].degraded).toBe(false);
+    });
+
+    test('in-band raw that TIMES OUT → degraded compact summary, not null (timeout symptom triggers the fallback)', async () => {
+        captured = null;
+        const sessionId = 'sess-timeout';
+        // Stored miniSummaries so the compact fallback has content to synthesize.
+        seedMiniSummaries(sessionId, [{ts: 1, text: 'turn one gist'}, {ts: 2, text: 'turn two gist'}]);
+
+        // In-band raw content (passes the size pre-check) — the synthesis itself is what times out.
+        SessionService.memoryCollection = {get: async () => ({
+            ids      : [`${sessionId}-mem-0`, `${sessionId}-mem-1`],
+            documents: ['a short in-band raw turn', 'another short in-band raw turn'],
+            metadatas: [
+                {timestamp: 1, agent: 'test-agent', model: 'gemma4'},
+                {timestamp: 2, agent: 'test-agent', model: 'gemma4'}
+            ]
+        })};
+
+        // First (RAW) synthesis throws the uniform PROVIDER_TIMEOUT; the smaller compact retry succeeds.
+        let call = 0;
+        SessionService.model = {generateContent: async () => {
+            if (call++ === 0) {
+                const err = new Error('session summarization timed out after 180000ms');
+                err.code = PROVIDER_TIMEOUT_CODE;
+                throw err;
+            }
+            return {response: {text: () => CANNED}};
+        }};
+
+        const res = await RequestContextService.run(
+            {userId: 'tenant-a', agentIdentityNodeId: '@test-agent'},
+            async () => SessionService.summarizeSession(sessionId)
+        );
+
+        expect(res).not.toBeNull();
+        expect(captured).toBeTruthy();
+        expect(captured.metadatas[0].sourceTier).toBe('miniSummary');
+        expect(captured.metadatas[0].degraded).toBe(true);
+        expect(captured.metadatas[0].rawCanonical).toBe(true);
     });
 });


### PR DESCRIPTION
Resolves #12833

`SessionService.summarizeSession`'s synthesis call had no timeout — a slow in-band local synthesis ground to the provider socket cap (the ~30-min stall @neo-opus-ada surfaced root-causing #12830), stranding `SummarizationJobs` leases past their 5-min TTL (the 6 stuck `in_progress`-past-expiry jobs) and starving the REM cycle that defers behind the session-summary `HeavyMaintenanceLease`. This bounds the synthesis and degrades gracefully instead.

Authored by Claude Opus 4.8 (@neo-opus-vega).

Evidence: L1 (unit: timeout→degraded-fallback + within/over-band paths, mocked provider; `withTimeout` re-export; config-leaf migration confirmed) → L3 required for the live "synthesis aborts at the budget + no lease stuck past expiry" behavior. Residual: live timeout/lease behavior [#12833 Post-Merge].

## What shipped
- **`SessionService.summarizeSession`** — the synthesis call is now bounded: `generateContent(prompt, {timeoutMs, operationLabel})` raced with a `withTimeout` backstop. The degraded-fallback trigger (previously `size-precheck-skip` only) now also fires on the **`timeout`** friction symptom, so a too-slow raw synthesis retries the compact (miniSummary/truncatedRaw) input instead of returning `null`.
- **`sessionSummaryTimeoutMs`** — new env-overridable leaf (`180000`) in the memory-core config. Calibrated **below the 300000ms `SummarizationJobs` lease TTL** (`claimSummarizationJob` default) so the raw synthesis aborts before its own lease expires, leaving ~120s headroom for the degraded retry to finish within the lease. A synthesis approaching the lease TTL is already heading for the stuck-lease bug, so degrading it via the fast compact retry is the correct outcome.
- **`withTimeout`** extracted from `MemoryService` to `ai/services/memory-core/helpers/withTimeout.mjs` (shared without a `MemoryService ⇄ SessionService` import cycle; re-exported from `MemoryService` so its existing spec is untouched).

## Deltas from ticket
- The ticket's `consumerFrictionHelper.categorizeInvocationError` → `PROVIDER_TIMEOUT_CODE` structural adoption is **deferred to a small follow-up**. The degrade-on-timeout path already works via the existing `/timed out/i` regex (the provider's `PROVIDER_TIMEOUT` message matches it), so the structural check is a non-blocking robustness upgrade. Deferred here to keep this PR scoped to the SessionService stall fix and avoid churning unrelated grandfathered ticket-refs in that file's comments (a `check-ticket-archaeology` pre-commit friction). I'll carry it as a follow-up — it's also the sibling of the ask-path adoption in PR #12832, per the split with @neo-claude-opus.
- Timeout default anchored to the lease TTL (180s < 300s) rather than a fresh model measurement (deferred — see Post-Merge Validation).

## Test Evidence
- `npm run test-unit -- SessionSummaryDegradedFallback consumerFrictionHelper WithTimeout` → **29 passed**, incl. the new `in-band raw that TIMES OUT → degraded compact summary` regression + the existing oversize/within-band paths + the `MemoryService.WithTimeout` re-export spec.
- The ESM import-race flake (#12693) surfaced transient failures in the **untouched** `SessionService.ResumeValidation` spec under concurrent workers; confirmed unrelated via an isolated **9/9** re-run.
- `SessionSummarization` live-gemma4 tests are CI-skipped (`NEO_TEST_SKIP_CI`, bucket A #10903) + gated on a reachable local model; the 300s timeouts in local runs are the busy local endpoint, not this change (the 300s per-test cap is hit regardless of the 180s synthesis budget).
- Config-leaf resolution verified: `initServerConfigs --migrate-config` propagates `sessionSummaryTimeoutMs: leaf(180000)` into the gitignored overlay; CI generates a fresh overlay from the template.

## Config-template change (per mcp-config-template-change-guide)
- **Added key:** `sessionSummaryTimeoutMs` (`180000`, env `NEO_MEMORY_SESSION_SUMMARY_TIMEOUT_MS`) in `ai/mcp/server/memory-core/config.template.mjs`.
- **Local `config.mjs` follow-up:** each clone's gitignored `config.mjs` lacks the new leaf until regenerated — run `npm run prepare -- --migrate-config` (or `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`). Until then `aiConfig.sessionSummaryTimeoutMs` resolves `undefined`; CI generates a fresh overlay so this is a clone-local step.
- **Harness restart:** recommended for the memory-core server to load the new budget.
- No gitignored `config.mjs` committed.

## Post-Merge Validation
- [ ] Regenerate `config.mjs` on active clones (`--migrate-config`) + restart the memory-core server so `sessionSummaryTimeoutMs` resolves.
- [ ] Confirm a live slow/timed-out session synthesis aborts at ~180s and yields a degraded summary (not a 30-min stall, not a null skip); no `SummarizationJobs` lease stuck `in_progress` past expiry.
- [ ] Refine `sessionSummaryTimeoutMs` against a worst-case session-synthesis measurement (must stay below the 300s lease TTL).

## Related
- #12065 — [Epic] Orchestrator-as-SSOT for the REM (Sandman) Pipeline (parent)
- #12830 — corrupted-memory root-cause (@neo-opus-ada; handed this lane the L576 finding)
- #12831 / PR #12832 — sibling KB-ask degraded-references (the `PROVIDER_TIMEOUT_CODE` split)
- #12805 / #12722 — miniSummary timeout right-size / abort-hung (the mirrored pattern)
- #12814 / #12818 — `PROVIDER_TIMEOUT_CODE` provider-timeout contract
