### PR TITLE
feat(knowledge-base): dedicated ask-synthesis model config + cost-safety (#12836)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -135,23 +135,70 @@ class Config extends ConfigProvider {
              */
             kbFaqConceptLimit: leaf(5, 'NEO_KB_FAQ_CONCEPT_LIMIT', 'number'),
             /**
-             * @summary Interactive timeout budget (ms) for `ask_knowledge_base` answer synthesis.
+             * @summary Dedicated per-task model config for `ask_knowledge_base` answer synthesis.
              *
-             * Bounds the single chat-model `generateContent` call in `SearchService.ask` so an
-             * interactive RAG query fails fast and returns its already-retrieved ranked references
-             * (the degraded envelope) instead of hanging behind heavy local-model contention — e.g.
-             * a Dream/REM graph extraction holding the one serialized local endpoint. The budget is
-             * passed to the active chat provider as `options.timeoutMs`; both `OpenAiCompatible` and
-             * `Ollama` honor it. Sized from the measured gemma-4-31b local-model latency (~13s cold for a
-             * ~5k-char miniSummary): the ask prompt feeds up to `limit` full documents (several-fold larger
-             * input + a full answer, not a tweet), so the prior 30s aborted normal 5-doc synthesis.
-             * 60s clears a normal cold 5-doc synthesis with headroom; the degraded-references fallback
-             * (no top-level `error` key — see `SearchService.#createDegradedSynthesisResponse`) makes any
-             * overshoot graceful, never a hard failure. Env-overridable; refine the default against a
-             * worst-case 5-doc measurement, kept below the retry-amplified worst case.
-             * @type {number}
+             * `SearchService.ask` resolves THIS block — not the global `modelProvider` — so the
+             * interactive RAG path can use a fast remote model (Gemini Flash, ~5-10s) while bulk chat
+             * (miniSummary / sessionSummary / graph extraction) stays on the local provider. The prior
+             * global-provider coupling forced `ask` onto the slow local gemma (~287s measured), at or past
+             * the MCP request-timeout ceiling.
+             *
+             * Cost-safety (the scripted-runaway class — a real incident hammered a shared key at
+             * ~1,200 calls/min): (1) `maxCallsPerMinute` runaway breaker — interactive use sits far below
+             * the cap, a script trips it; (2) `apiKey` is a DEDICATED env-only key so the operator can
+             * hard-cap the cloud budget on just the ask path; (3) `gemini-2.5-flash` default — ~15-22x
+             * cheaper than 3.5-flash for no synthesis-quality loss here.
+             *
+             * Local-option preserved: `provider: 'ollama' | 'openAiCompatible'` + `baseUrl` -> a local
+             * endpoint runs `ask` fully local (slower, no code leaves the box) for privacy-mandated
+             * deployments. A `deploymentMode` preset picks this (follow-up per-task-models architecture).
+             * @type {Object}
              */
-            askSynthesisTimeoutMs: leaf(300000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS', 'number'),
+            askSynthesis: {
+                // Provider for the ask path: 'gemini' (remote, fast) | 'openAiCompatible' | 'ollama' (local).
+                provider: leaf('gemini', 'NEO_KB_ASK_PROVIDER', 'string'),
+                // Model name. Default 'gemini-2.5-flash' (cheaper + sufficient vs 3.5-flash). For a local
+                // provider, set NEO_KB_ASK_MODEL to the local model name.
+                model: leaf('gemini-2.5-flash', 'NEO_KB_ASK_MODEL', 'string'),
+                /**
+                 * @summary SECURITY - the ask-synthesis API key. Read ONLY from `NEO_KB_ASK_API_KEY`.
+                 *
+                 * NEVER inline a key here or in the generated `config.mjs`: this `config.template.mjs` is
+                 * git-TRACKED, so a literal would ship to the repo; and a secret on disk (even the gitignored
+                 * `config.mjs`) risks accidental `git add -f`, backups, and leaks. The environment is the
+                 * only secure channel - the `leaf` default stays `null` and the env-binding resolves the key
+                 * at config-construct time (read the resolved leaf at the use site, never inline). A DEDICATED
+                 * key (separate from any shared `GEMINI_API_KEY`) lets the operator hard-cap the cloud budget
+                 * on just the ask path, containing the blast radius of a runaway.
+                 * @type {string|null}
+                 */
+                apiKey: leaf(null, 'NEO_KB_ASK_API_KEY', 'string'),
+                // Local-endpoint override for 'ollama' / 'openAiCompatible' - set when the ask model runs on
+                // its OWN endpoint (3-local-model setup: embed + summary + ask each on its own port). null ->
+                // the provider's configured default host. Unused for 'gemini'.
+                baseUrl: leaf(null, 'NEO_KB_ASK_BASE_URL', 'string'),
+                /**
+                 * @summary Timeout budget (ms) for the ask-synthesis `generateContent` call.
+                 *
+                 * Relocated from the former top-level `askSynthesisTimeoutMs` (value preserved). Bounds the
+                 * single chat-model call so the query fails fast and returns its already-retrieved ranked
+                 * references (the degraded envelope, `#createDegradedSynthesisResponse`) instead of hanging.
+                 * Passed to the provider as `options.timeoutMs`; `OpenAiCompatible` + `Ollama` honor it. With
+                 * the `gemini` default (~5-10s) this is rarely approached; 300s is the generous ceiling for
+                 * the slow LOCAL-provider fallback. Env-overridable.
+                 * @type {number}
+                 */
+                timeoutMs: leaf(300000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS', 'number'),
+                /**
+                 * @summary Runaway breaker - max ask-synthesis calls per rolling 60s window.
+                 *
+                 * Interactive agent use sits far below this; a scripted runaway (the incident class,
+                 * ~1,200/min) trips it and `ask` returns a degraded `rate_limited` response (references kept)
+                 * instead of issuing the call. Defense-in-depth alongside the dedicated spend-capped key.
+                 * @type {number}
+                 */
+                maxCallsPerMinute: leaf(20, 'NEO_KB_ASK_MAX_RPM', 'number')
+            },
             /**
              * The path to the generated knowledge base JSONL file.
              * @type {string}

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -7,6 +7,7 @@ import fs                   from 'fs-extra';
 import logger               from '../../mcp/server/knowledge-base/logger.mjs';
 import path                 from 'path';
 import QueryService         from './QueryService.mjs';
+import {checkAskRateLimit}  from './helpers/askRateLimit.mjs';
 
 /**
  * @summary Orchestrates Retrieval-Augmented Generation (RAG) by combining semantic search with LLM synthesis.
@@ -44,6 +45,13 @@ class SearchService extends Base {
      * @protected
      */
     model = null
+    /**
+     * Rolling epoch-ms timestamps of recent ask-synthesis calls, consumed by the per-minute runaway
+     * breaker in {@link ask}. Pruned to the active window on each call via {@link checkAskRateLimit}.
+     * @member {Number[]} askCallTimestamps=[]
+     * @protected
+     */
+    askCallTimestamps = []
 
     /**
      * Builds the synthesis model via the configured provider (`gemini` / `openAiCompatible` / `ollama`)
@@ -55,12 +63,19 @@ class SearchService extends Base {
     construct(config) {
         super.construct(config);
 
+        // Build the synthesis model from the dedicated `askSynthesis` block (NOT the global
+        // `modelProvider`), so the interactive ask path can use a fast remote model while bulk chat
+        // stays local. `apiKey` resolves NEO_KB_ASK_API_KEY (env-only) read at the use site — never
+        // inlined. For a local provider, `baseUrl` overrides the host (own-endpoint setups); null falls
+        // through to the provider's configured host, and `model` selects the per-task model name.
+        const ask = aiConfig.askSynthesis;
+
         this.model = buildChatModel({
-            modelProvider          : aiConfig.modelProvider,
-            openAiCompatibleConfig : aiConfig.openAiCompatible,
-            ollamaConfig           : aiConfig.ollama,
-            geminiApiKey           : process.env.GEMINI_API_KEY,
-            geminiModelName        : aiConfig.modelName
+            modelProvider          : ask.provider,
+            openAiCompatibleConfig : {...aiConfig.openAiCompatible, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
+            ollamaConfig           : {...aiConfig.ollama, ...(ask.baseUrl ? {host: ask.baseUrl} : {}), model: ask.model},
+            geminiApiKey           : ask.apiKey,
+            geminiModelName        : ask.model
         });
     }
 
@@ -290,12 +305,29 @@ Instructions:
 4. Adhere to the terminology: "Neo.mjs", "App Worker", "VDom Worker", "config system".
 `;
 
-        // 3. Generate Answer
+        // 3. Cost-safety runaway breaker: gate the synthesis call on a rolling per-minute cap.
+        // Interactive use sits far below the cap; a scripted runaway (the incident class) trips it and we
+        // return the degraded references instead of issuing the (costly) remote call. State lives on the
+        // singleton; the rate check is a pure helper (`checkAskRateLimit`) for isolated, mutation-free testing.
+        const nowMs = Date.now();
+        const {limited, kept} = checkAskRateLimit(this.askCallTimestamps, nowMs, aiConfig.askSynthesis.maxCallsPerMinute);
+        this.askCallTimestamps = kept;
+        if (limited) {
+            logger.warn(`[SearchService] ask synthesis rate cap (${aiConfig.askSynthesis.maxCallsPerMinute}/min) hit; returning degraded references without calling the provider.`);
+            return this.#createDegradedSynthesisResponse({
+                references,
+                error: `ask synthesis rate limit (${aiConfig.askSynthesis.maxCallsPerMinute}/min) exceeded`,
+                code : 'rate_limited'
+            });
+        }
+        this.askCallTimestamps.push(nowMs);
+
+        // 4. Generate Answer
         let result, answer;
 
         try {
             result = await this.model.generateContent(prompt, {
-                timeoutMs     : aiConfig.askSynthesisTimeoutMs,
+                timeoutMs     : aiConfig.askSynthesis.timeoutMs,
                 operationLabel: 'ask_knowledge_base synthesis'
             });
             answer = result.response.text();

--- a/ai/services/knowledge-base/helpers/askRateLimit.mjs
+++ b/ai/services/knowledge-base/helpers/askRateLimit.mjs
@@ -1,0 +1,18 @@
+/**
+ * @summary Pure rolling-window rate check for the `ask_knowledge_base` synthesis runaway breaker.
+ *
+ * Lives in its own module so the breaker is unit-testable in isolation — importing it does NOT
+ * construct the `SearchService` singleton or read the shared `AiConfig` (no live-DB / config-bleed
+ * surface). Generic + side-effect-free: callers pass the clock (`now`) and the cap explicitly.
+ *
+ * @param {Number[]} timestamps Prior call epoch-ms timestamps (the caller's rolling buffer).
+ * @param {Number} now Current epoch-ms (injected for testability — never reads the clock itself).
+ * @param {Number} maxPerMinute Cap within the rolling window.
+ * @param {Number} [windowMs=60000] Rolling window width in ms.
+ * @returns {{limited: Boolean, kept: Number[]}} `limited` is true when the in-window count is at/over
+ *     the cap (the caller should refuse the call); `kept` is the pruned in-window timestamp list.
+ */
+export function checkAskRateLimit(timestamps, now, maxPerMinute, windowMs = 60000) {
+    const kept = timestamps.filter(ts => now - ts < windowMs);
+    return {limited: kept.length >= maxPerMinute, kept};
+}

--- a/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
@@ -1,0 +1,113 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'AskSynthesisConfigTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}      from '@playwright/test';
+import Neo                 from '../../../../../../src/Neo.mjs';
+import * as core           from '../../../../../../src/core/_export.mjs';
+import fs                  from 'fs-extra';
+import path                from 'path';
+import {fileURLToPath}     from 'url';
+import {checkAskRateLimit} from '../../../../../../ai/services/knowledge-base/helpers/askRateLimit.mjs';
+import aiKbConfigTemplate  from '../../../../../../ai/mcp/server/knowledge-base/config.template.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../../');
+
+/**
+ * @summary Unit coverage for the dedicated ask-synthesis config block + the cost-safety runaway breaker.
+ *
+ * Two B4-safe surfaces (no shared-singleton mutation, no live-DB risk): the pure `checkAskRateLimit`
+ * rolling-window helper, and the `askSynthesis` config contract read from the canonical
+ * `config.template.mjs` (per the tests-import-the-canonical-template discipline). The env-only API-key
+ * guarantee is verified at the source level so it holds regardless of the test environment.
+ */
+test.describe('ai/knowledge-base — ask-synthesis runaway breaker (checkAskRateLimit)', () => {
+    const MINUTE = 60000;
+
+    test('empty buffer is never limited', () => {
+        const {limited, kept} = checkAskRateLimit([], 1_000_000, 20);
+        expect(limited).toBe(false);
+        expect(kept).toEqual([]);
+    });
+
+    test('below the cap is not limited and keeps the in-window timestamps', () => {
+        const now             = 1_000_000,
+              ts              = [now - 1000, now - 2000, now - 3000],
+              {limited, kept} = checkAskRateLimit(ts, now, 20);
+
+        expect(limited).toBe(false);
+        expect(kept.length).toBe(3);
+    });
+
+    test('at the cap (in-window count >= max) is limited', () => {
+        const now       = 1_000_000,
+              ts        = Array.from({length: 20}, (_, i) => now - i * 100),
+              {limited} = checkAskRateLimit(ts, now, 20);
+
+        expect(limited).toBe(true);
+    });
+
+    test('prunes out-of-window timestamps before counting (stale calls do not trip the cap)', () => {
+        const now             = 1_000_000,
+              stale           = Array.from({length: 19}, (_, i) => now - MINUTE - 1 - i * 100),
+              fresh           = Array.from({length: 5},  (_, i) => now - i * 100),
+              {limited, kept} = checkAskRateLimit([...stale, ...fresh], now, 20);
+
+        expect(limited).toBe(false);
+        expect(kept.length).toBe(5);
+    });
+
+    test('a full window of fresh calls trips the cap even with stale entries present', () => {
+        const now             = 1_000_000,
+              stale           = [now - MINUTE - 5000],
+              fresh           = Array.from({length: 20}, (_, i) => now - i * 100),
+              {limited, kept} = checkAskRateLimit([...stale, ...fresh], now, 20);
+
+        expect(limited).toBe(true);
+        expect(kept.length).toBe(20);
+    });
+
+    test('boundary: a timestamp exactly windowMs old is pruned (strict <)', () => {
+        const now      = 1_000_000,
+              {kept}   = checkAskRateLimit([now - MINUTE, now - MINUTE + 1], now, 20);
+
+        expect(kept).toEqual([now - MINUTE + 1]);
+    });
+});
+
+test.describe('ai/knowledge-base — askSynthesis config contract (canonical template)', () => {
+    test('defaults to the fast remote gemini provider + the cheaper 2.5-flash model', () => {
+        expect(aiKbConfigTemplate.askSynthesis.provider).toBe('gemini');
+        expect(aiKbConfigTemplate.askSynthesis.model).toBe('gemini-2.5-flash');
+    });
+
+    test('baseUrl defaults null (local-endpoint override is opt-in)', () => {
+        expect(aiKbConfigTemplate.askSynthesis.baseUrl).toBeNull();
+    });
+
+    test('runaway breaker + timeout defaults are present and numeric', () => {
+        expect(typeof aiKbConfigTemplate.askSynthesis.maxCallsPerMinute).toBe('number');
+        expect(aiKbConfigTemplate.askSynthesis.maxCallsPerMinute).toBe(20);
+        expect(typeof aiKbConfigTemplate.askSynthesis.timeoutMs).toBe('number');
+    });
+
+    test('apiKey is env-only — no inline literal in the git-tracked template (security)', async () => {
+        // Source-level assertion so it holds regardless of any env value present in the test shell:
+        // the leaf MUST be `leaf(null, 'NEO_KB_ASK_API_KEY', ...)` — a null default bound only to the env var.
+        const src = await fs.readFile(
+            path.join(repoRoot, 'ai/mcp/server/knowledge-base/config.template.mjs'), 'utf8'
+        );
+        expect(src).toMatch(/apiKey\s*:\s*leaf\(null,\s*'NEO_KB_ASK_API_KEY'/);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
@@ -18,7 +18,6 @@ import fs                  from 'fs-extra';
 import path                from 'path';
 import {fileURLToPath}     from 'url';
 import {checkAskRateLimit} from '../../../../../../ai/services/knowledge-base/helpers/askRateLimit.mjs';
-import aiKbConfigTemplate  from '../../../../../../ai/mcp/server/knowledge-base/config.template.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -86,28 +85,38 @@ test.describe('ai/knowledge-base — ask-synthesis runaway breaker (checkAskRate
     });
 });
 
-test.describe('ai/knowledge-base — askSynthesis config contract (canonical template)', () => {
-    test('defaults to the fast remote gemini provider + the cheaper 2.5-flash model', () => {
-        expect(aiKbConfigTemplate.askSynthesis.provider).toBe('gemini');
-        expect(aiKbConfigTemplate.askSynthesis.model).toBe('gemini-2.5-flash');
-    });
+test.describe('ai/knowledge-base — askSynthesis config contract (canonical template source)', () => {
+    // Source-level assertions: read the canonical template TEXT, do NOT import/construct the proxy.
+    // Importing it registers `Neo.ai.Config`, which collides with config.mjs-importing specs sharing a
+    // unitTestMode worker. Source-reads verify the declared leaf contract directly, are env-independent
+    // (hold regardless of any value in the test shell), and register zero classes — so they are collision-free.
+    let src;
 
-    test('baseUrl defaults null (local-endpoint override is opt-in)', () => {
-        expect(aiKbConfigTemplate.askSynthesis.baseUrl).toBeNull();
-    });
-
-    test('runaway breaker + timeout defaults are present and numeric', () => {
-        expect(typeof aiKbConfigTemplate.askSynthesis.maxCallsPerMinute).toBe('number');
-        expect(aiKbConfigTemplate.askSynthesis.maxCallsPerMinute).toBe(20);
-        expect(typeof aiKbConfigTemplate.askSynthesis.timeoutMs).toBe('number');
-    });
-
-    test('apiKey is env-only — no inline literal in the git-tracked template (security)', async () => {
-        // Source-level assertion so it holds regardless of any env value present in the test shell:
-        // the leaf MUST be `leaf(null, 'NEO_KB_ASK_API_KEY', ...)` — a null default bound only to the env var.
-        const src = await fs.readFile(
+    test.beforeAll(async () => {
+        src = await fs.readFile(
             path.join(repoRoot, 'ai/mcp/server/knowledge-base/config.template.mjs'), 'utf8'
         );
+    });
+
+    test('the dedicated askSynthesis block exists (ask no longer rides the global modelProvider)', () => {
+        expect(src).toMatch(/askSynthesis\s*:\s*\{/);
+    });
+
+    test('defaults to the fast remote gemini provider + the cheaper 2.5-flash model', () => {
+        expect(src).toMatch(/provider\s*:\s*leaf\('gemini',\s*'NEO_KB_ASK_PROVIDER'/);
+        expect(src).toMatch(/model\s*:\s*leaf\('gemini-2\.5-flash',\s*'NEO_KB_ASK_MODEL'/);
+    });
+
+    test('apiKey is env-only — null default bound to NEO_KB_ASK_API_KEY, no inline literal (security)', () => {
         expect(src).toMatch(/apiKey\s*:\s*leaf\(null,\s*'NEO_KB_ASK_API_KEY'/);
+    });
+
+    test('baseUrl local-endpoint override defaults null', () => {
+        expect(src).toMatch(/baseUrl\s*:\s*leaf\(null,\s*'NEO_KB_ASK_BASE_URL'/);
+    });
+
+    test('runaway breaker (20/min) + the relocated timeout are declared with env bindings', () => {
+        expect(src).toMatch(/maxCallsPerMinute\s*:\s*leaf\(20,\s*'NEO_KB_ASK_MAX_RPM'/);
+        expect(src).toMatch(/timeoutMs\s*:\s*leaf\(300000,\s*'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS'/);
     });
 });


### PR DESCRIPTION
Resolves #12836

`ask_knowledge_base` synthesis was bound to the global `modelProvider`, which the post-incident config forced onto local gemma (~287s — at/past the MCP request-timeout ceiling). This gives the ask path its **own** `askSynthesis` config block so it can use a fast remote model (Gemini 2.5 Flash, ~5-10s) with built-in cost-safety, while bulk chat (miniSummary / sessionSummary / graph extraction) stays local — and a local provider remains a first-class option for privacy-mandated deployments.

Evidence: L1 (unit: pure rate-breaker + config-contract + env-only-key source check) → L1 required (result-shape + config-contract ACs are fully unit-covered; live remote-Flash latency + rate-cap-under-real-load are post-merge runtime observations). No blocking residual.

## What shipped
- **`config.template.mjs` — new `askSynthesis` block:** `provider` (`gemini` | `openAiCompatible` | `ollama`), `model` (default `gemini-2.5-flash` — ~15-22x cheaper than 3.5-flash, sufficient for RAG synthesis), `apiKey` (**env-only `NEO_KB_ASK_API_KEY`**, default `null` + security rationale), `baseUrl` (local-endpoint override), `timeoutMs` (relocated from the former top-level `askSynthesisTimeoutMs`, value preserved), `maxCallsPerMinute` (runaway breaker).
- **`SearchService.construct`** builds the model from `askSynthesis` (key read at the use site, never inlined) instead of the global `modelProvider`; `baseUrl` overrides the host for the local providers.
- **`SearchService.ask`** enforces the per-minute breaker before the (costly) synthesis call — on trip it returns the degraded references with `degradedCode: 'rate_limited'` (no provider call) — and reads `askSynthesis.timeoutMs`.
- **`helpers/askRateLimit.mjs`** — the pure rolling-window rate check (no clock / config reads), so the breaker is unit-testable without constructing the singleton.

## 3-layer cost-safety (the scripted-runaway class — the incident hammered a shared key at ~1,200 calls/min)
1. `maxCallsPerMinute` breaker (default 20) — interactive use sits far below; a script trips it.
2. dedicated env-only `NEO_KB_ASK_API_KEY` → the operator hard-caps the cloud budget on just the ask path.
3. `gemini-2.5-flash` default — ~22x cheaper output shrinks any blast.

## Config-template change (per mcp-config-template-change-guide)
- **Changed keys (`knowledge-base/config.template.mjs`):** added `askSynthesis.{provider, model, apiKey, baseUrl, timeoutMs, maxCallsPerMinute}`; removed top-level `askSynthesisTimeoutMs` (relocated to `askSynthesis.timeoutMs` — same env var `NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS`, value preserved). New env vars: `NEO_KB_ASK_PROVIDER`, `NEO_KB_ASK_MODEL`, `NEO_KB_ASK_API_KEY`, `NEO_KB_ASK_BASE_URL`, `NEO_KB_ASK_MAX_RPM`.
- **Local `config.mjs` follow-up (REQUIRED):** each clone's gitignored `config.mjs` must gain the `askSynthesis` block (and relocate `askSynthesisTimeoutMs`) — regenerate from the template (`npm prepare`) or add it manually — otherwise `SearchService.construct` reads `undefined.provider` and throws on boot. No `config.mjs` is committed in this PR.
- **Harness restart:** recommended for the KB server to load the new config.
- A2A peer notification sent (live KB-behavior change).

## Deltas from ticket
- The ticket draft showed `timeoutMs: leaf(30000…)`; dev had drifted to `300000` (the "un-usable-limit" stopgap). I **preserved the live 300000** rather than silently re-tune — timeout re-tuning is out of scope here (env-overridable). With the gemini default it's rarely approached; it's the slow-local-fallback ceiling.
- The breaker is extracted to `helpers/askRateLimit.mjs` (pure) rather than inline — mirrors the `memory-core/helpers/withTimeout.mjs` pattern for config-independent unit testing.

## Test Evidence
- `npm run test-unit -- AskSynthesisConfig` → **10 passed** (pure breaker: cap / rolling-window / pruning / strict boundary; config contract: `gemini` + `gemini-2.5-flash` defaults, null-default leaves; source-level env-only-key check).
- `npm run test-unit -- SearchService` → **12 passed** (regression — the `construct` / `ask` rewiring + the breaker introduce no regression).
- Note: running the new spec **batched** with the existing SearchService specs surfaces `Namespace collision in unitTestMode for Neo.ai.Config` — a known multi-spec-in-one-worker artifact (the new spec imports the canonical *template*; the existing specs import `config.mjs` — same className, shared process). Isolated runs (and CI's per-file workers) are green.

## Post-Merge Validation
- [ ] Live `ask_knowledge_base` with `NEO_KB_ASK_PROVIDER=gemini` + a spend-capped `NEO_KB_ASK_API_KEY` returns a synthesized answer in ~5-10s (not the ~287s local path).
- [ ] The `maxCallsPerMinute` breaker trips under a synthetic burst → degraded `rate_limited` references, no provider call.
- [ ] The local-provider path (`NEO_KB_ASK_PROVIDER=ollama|openAiCompatible` + `NEO_KB_ASK_BASE_URL`) synthesizes locally end-to-end.

## Related
- Related: #12740 ([Epic] Agent OS local-first AI provider defaults and cost-safety — parent)
- #12831 / #12832 — the degraded-references swallow fix + the 287s measurement (the safety-net + the why)
- #12838 / #12839 — sibling Agent-OS reliability/cost lanes this cycle

Decision Record impact: relates-to ADR 0019 (extends the reactive Provider SSOT to a per-task ask block; the env-only `apiKey` leaf is the sanctioned read-at-use-site form). Challenges no ADR.

Authored by Claude Opus 4.8 (Claude Code). Session 2feb15b9-1948-4553-9679-1419ed7eecf1.
