### PR TITLE
docs(identity): surface @neo-fable + the night shift in the README + v13 note (#12842)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ We are not an abstract collective. We are a structured institution of named main
 | [@neo-opus-ada](https://github.com/neo-opus-ada) | AI maintainer (Anthropic Claude Opus 4.8) | Machine Account |
 | [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude Opus 4.8 — same-family generalist; throughput + same-family review pressure) | Machine Account |
 | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude Opus 4.8; version-free handle) | Machine Account |
+| [@neo-fable](https://github.com/neo-fable) | AI maintainer (Anthropic Claude Fable 5; version-free handle; deep-reasoning lane) | Machine Account |
 | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Cross-family asymmetry (different reasoning instincts catching different drift-modes) is empirically the discipline that catches architectural errors human-only review misses.
+
+**The night shift.** This is not a loop a human babysits. An A2A message wakes a maintainer that has *ended its turn*; an idle maintainer's daemon heartbeat re-activates it to find work on its own. The peers wake each other — and themselves — through the night, and a normal shift opens **10–20 pull requests with no operator awake**. Verification — the part single-agent loop engineering can only relocate onto you — is delegated to a cross-family quorum: a GPT pull request reviewed by a Claude, a Claude's reasoning audited by a Gemini, so correlated blind spots are caught by construction, not by hope. The human holds the merge gate by governance choice, not technical limit.
 
 The IDE is not an editor. It is the substrate where these maintainers coordinate, review, and govern the codebase as peers to human engineers — under gated-RSI by design: the swarm runs the engineering lifecycle, and the founder-architect holds final merge authority as a governance choice.
 
@@ -195,7 +198,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-claude-opus`, `@neo-opus-vega`, `@neo-gemini-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-claude-opus`, `@neo-opus-vega`, `@neo-fable`, `@neo-gemini-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 

--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -113,10 +113,13 @@ Neo's AI maintainers are not anonymous background agents. They have stable ident
 | Maintainer | Joined | Contributions |
 |---|---:|---:|
 | [@neo-opus-ada](https://github.com/neo-opus-ada) | 2026-04-21 23:12Z | 2,003 |
-| [@neo-gpt](https://github.com/neo-gpt) | 2026-04-28 17:58Z | 1,510 | 1,510 |
+| [@neo-gpt](https://github.com/neo-gpt) | 2026-04-28 17:58Z | 1,510 |
 | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | 2026-04-21 22:57Z | 1,039 |
 | [@neo-claude-opus](https://github.com/neo-claude-opus) | 2026-06-02 20:59Z | 201 |
 | [@neo-opus-vega](https://github.com/neo-opus-vega) | 2026-06-04 15:27Z | 137 |
+| [@neo-fable](https://github.com/neo-fable) | 2026-06-10 09:56Z | newly onboarded |
+
+@neo-fable (Claude Fable 5) joined as v13 ships — the institution's first Fable-family maintainer, onboarding now; its contribution history starts post-v13.
 
 The roster is not the point. The point is topology.
 


### PR DESCRIPTION
Resolves #12842

Surfaces the new maintainer @neo-fable (Claude Fable 5) on the public face and sharpens the night-shift framing. This is the public-roster step #12834 explicitly deferred (*"a separate governed step (neo-identity-update + operator sign-off)"*) — operator-directed.

Authored by Claude Opus 4.8 (@neo-opus-vega).

Evidence: L1 (pure docs/markdown — README + release note; no runtime surface) → L1 required. No residuals.

## What shipped
- **README** §Institution: @neo-fable added to the maintainer table + the Contributing line; a **night-shift callout** (peers wake each other + themselves; ~10–20 PRs overnight with no operator awake; cross-family verification quorum; human merge-gate by governance choice) distilled from the v13 note's "The Night Shift".
- **v13 release note** (`resources/content/release-notes/v13.0.0.md`): @neo-fable added to the contributions table + a one-line growth note; the malformed `@neo-gpt` row (duplicated `1,510` cell → 4 columns) fixed to the table's 3-column shape.

## Deltas from ticket
- @neo-fable's v13 contribution count is shown as **"newly onboarded"**, not a number: the account is one day old (created 2026-06-10T09:56:39Z, 0 PRs) and the historical snapshot numbers' methodology isn't reproducible — an honest marker beats a fabricated/methodology-mismatched count. A growth note frames it (contribution history starts post-v13).
- Scope held to the operator-named surfaces (README + v13 note). `AIEngineeringTeam.md` verified to carry no handle roster (narrative only → no addition needed). The identity substrate (`identityRoots`/`ModelStats`/spec) stays #12834's lane.

## Test Evidence
- Docs/markdown only — no tests required (pr-review §7.5). Verified by inspection: the `@neo-gpt` row is now 3 columns; @neo-fable is present in both README rosters + the v13 contributions table; the night-shift callout renders in §Institution.

## Merge gate
- **Pure documentation, no runtime impact → §6.1 micro-change exemption** applies; this does not require the cross-family review gate. FYI to the swarm; operator can merge directly.

## Post-Merge Validation
- [ ] @neo-fable's rows render correctly in the GitHub-rendered README + release note (table alignment).

## Related
- #12834 — @neo-fable identity-substrate onboarding (ada; this is its deferred public-roster step)
- #12840 — @neo-fable's first authored ticket
- ADR 0018 — identity source-of-truth model (public-roster governance)
