### PR TITLE
feat: never-fail add_memory — JSONL write-ahead + deferred embed (#12838)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -1,6 +1,7 @@
 // Loads the Tier-1 realm root (Neo.ai.Config) so getParent() inheritance resolves in this process;
 // MC reads no AiConfig values directly — they resolve via the chain, not a binding.
 import '../../../config.template.mjs';
+import os                                        from 'os';
 import path                                      from 'path';
 import ConfigProvider, {createConfigProxy, leaf} from '../../../ConfigProvider.mjs';
 import {fileURLToPath}                           from 'url';
@@ -28,6 +29,11 @@ const DAY_MS            = 24 * 60 * 60 * 1000;
 // the leaves stay declarative; selection is the `collections.useTestDatabase` toggle + formulas below.
 const testMemoryCollection  = `test-memory-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 const testSessionCollection = `test-session-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+
+// Per-worker-unique WAL test directory under the OS temp root (same isolation rationale as the
+// test collection names above): fullyParallel workers never share a write-ahead directory, and
+// unit tests never touch the repo-local `.neo-ai-data/memory-wal` production path.
+const testMemoryWalDir = path.join(os.tmpdir(), `neo-memory-wal-test-${Date.now()}-${Math.random().toString(36).substring(7)}`);
 
 /**
  * @summary Configuration manager for the Memory Core MCP server.
@@ -226,6 +232,50 @@ class Config extends ConfigProvider {
              */
             remRunRetentionLimit: leaf(200, 'NEO_REM_RUN_RETENTION_LIMIT', 'number'),
             /**
+             * Durable JSONL write-ahead store for `add_memory` payloads.
+             *
+             * The mandated per-turn save appends its full payload here BEFORE any model-dependent
+             * work, so an embed/Chroma failure or stall never fails or loses the save. `dir` (the
+             * active path consumers read) is a reactive formula (see `formulas` below) resolving
+             * `dirProd` / `dirTest` by construction from `useTestDatabase` — unit tests can never
+             * write into the production WAL.
+             */
+            memoryWal: {
+                /**
+                 * Production WAL segment directory. Declarative leaf; env override via `NEO_MEMORY_WAL_DIR`.
+                 * @type {string}
+                 */
+                dirProd        : leaf(path.resolve(cwd, '.neo-ai-data/memory-wal'), 'NEO_MEMORY_WAL_DIR', 'string'),
+                /**
+                 * Unit-test WAL directory: per-worker-unique under the OS temp root (module const above).
+                 * @type {string}
+                 */
+                dirTest        : leaf(testMemoryWalDir, 'NEO_MEMORY_WAL_DIR_TEST', 'string'),
+                /**
+                 * Test-mode toggle (env-driven via `UNIT_TEST_MODE`). The `memoryWal.dir` formula
+                 * reads this to select `dirTest` (true) or `dirProd` (false) — safe-by-construction.
+                 * @type {boolean}
+                 */
+                useTestDatabase: leaf(false, 'UNIT_TEST_MODE', 'boolean'),
+                /**
+                 * Maximum fully-reconciled (every record embed-marked) WAL day-segments retained on
+                 * disk. Pruned on append; segments holding ANY pending record are never pruned —
+                 * the WAL is a durability buffer first, a log second.
+                 * @type {number}
+                 */
+                retentionLimit : leaf(30, 'NEO_MEMORY_WAL_RETENTION_LIMIT', 'number'),
+                /**
+                 * Minimum per-field length (after trim) for `prompt`/`thought`/`response` accepted
+                 * by `add_memory`. Default 1 = reject only empty/whitespace-only fields — the
+                 * unambiguous corrupted-memory class. Deliberately conservative: boot
+                 * heartbeats (`resumeHarness.mjs` health-check) carry thin-but-real content and
+                 * must keep passing until the planned boot-heartbeat liveness-marker carve-out
+                 * routes them off this path. Raise only with a derived threshold.
+                 * @type {number}
+                 */
+                minFieldLength : leaf(1, 'NEO_MEMORY_MIN_FIELD_LENGTH', 'number')
+            },
+            /**
              * Target markdown file used for autonomous agent-to-user reporting (offline jobs).
              * @type {string}
              */
@@ -421,7 +471,8 @@ class Config extends ConfigProvider {
             // Replaces the prior inline-`process.env` leaf ternaries.
             'storagePaths.graph' : data => data.storagePaths.useTestDatabase ? data.storagePaths.graphTest  : data.storagePaths.graphProd,
             'collections.memory' : data => data.collections.useTestDatabase  ? data.collections.memoryTest  : data.collections.memoryProd,
-            'collections.session': data => data.collections.useTestDatabase  ? data.collections.sessionTest : data.collections.sessionProd
+            'collections.session': data => data.collections.useTestDatabase  ? data.collections.sessionTest : data.collections.sessionProd,
+            'memoryWal.dir'      : data => data.memoryWal.useTestDatabase    ? data.memoryWal.dirTest       : data.memoryWal.dirProd
         }
     }
 }

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -5,6 +5,7 @@ import GraphService          from './GraphService.mjs';
 import logger                from '../../mcp/server/memory-core/logger.mjs';
 import SessionService        from './SessionService.mjs';
 import {withTimeout}         from './helpers/withTimeout.mjs';
+import {appendWalEmbedMarker, appendWalMemory, pruneReconciledWalSegments, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
 import {buildChatModel}      from '../../provider/buildChatModel.mjs';
 import aiConfig              from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -199,6 +200,34 @@ function buildMailboxDelta() {
  * @see Neo.ai.mcp.server.shared.services.RequestContextService
  */
 class MemoryService extends Base {
+    /**
+     * In-flight deferred embed promises. Tracked so shutdown paths and tests can flush
+     * the fire-and-forget tail deterministically via {@link drainPendingEmbeds} — a floating
+     * promise that nothing can await is not an acceptable lifecycle primitive.
+     * @member {Set<Promise>} inFlightEmbeds
+     * @protected
+     */
+    inFlightEmbeds = new Set();
+
+    /**
+     * Recently purged sessions: sessionId → `{userId, purgedAt}`. {@link embedPendingMemory}
+     * consults this BEFORE its `collection.add`, so an embed deferred past a `purgeSession` cannot
+     * resurrect deleted data — and purge never has to WAIT on embed latency to be safe (a purge
+     * blocked on a stalled embedder would be the exact failure mode this ticket removes). Entries
+     * are pruned on insert after {@link MemoryService#purgedSessionTtlMs}; in-flight embeds live
+     * for seconds, so the bound only guards pathological cases.
+     * @member {Map<String, {userId: String|null, purgedAt: Number}>} purgedSessions
+     * @protected
+     */
+    purgedSessions = new Map();
+
+    /**
+     * Retention window for {@link MemoryService#purgedSessions} entries.
+     * @member {Number} purgedSessionTtlMs=600000
+     * @protected
+     */
+    purgedSessionTtlMs = 600000;
+
     static config = {
         /**
          * @member {String} className='Neo.ai.services.memory-core.MemoryService'
@@ -281,7 +310,20 @@ class MemoryService extends Base {
     }
 
     /**
-     * Adds a new memory to the collection.
+     * Adds a new memory to the collection — the protocol-mandated per-turn save, engineered to
+     * **never fail or stall on the embed**.
+     *
+     * Write order is the contract:
+     * 1. **Validation gate** — rejects the unambiguous corruption class (empty / whitespace-only /
+     *    below-`memoryWal.minFieldLength` fields — the corrupted-memory class) before any write.
+     * 2. **Durable JSONL write-ahead append** — the full payload lands on local disk first, so a
+     *    crash or embed failure never loses the turn.
+     * 3. **Synchronous graph writes** — the `AGENT_MEMORY` node + edges keep the read-after-write
+     *    recency contract (`queryRecentTurns` reads these rows "fresh the instant the write returns").
+     * 4. **Deferred embed** — the model-dependent Chroma `collection.add` runs fire-and-forget via
+     *    {@link embedPendingMemory}; on success the WAL record is marked, on failure it stays
+     *    pending for a later drain (Phase 2: the `ai/daemons/embed/` daemon). Embed/Chroma
+     *    contention therefore can no longer fail or block this tool.
      *
      * When the MCP transport has resolved a real `AgentIdentity`, the write stamps both the
      * Chroma metadata (`agentIdentity`) and a graph `AUTHORED_BY` edge. Fallback-only identities
@@ -305,8 +347,18 @@ class MemoryService extends Base {
      *     see {@link buildMailboxDelta}.
      */
     async addMemory({prompt, response, thought, sessionId, agent, model, amountToolCalls, toolsUsed}) {
+        // The validation gate is a deliberate rejection — the ONE path that
+        // intentionally returns an MCP error envelope. Everything after it is never-fail.
+        const invalidFields = this.getInvalidMemoryFields({prompt, thought, response});
+        if (invalidFields.length > 0) {
+            return {
+                error  : 'Invalid memory payload',
+                message: `Rejected empty/below-minimum field(s): ${invalidFields.join(', ')}. The per-turn save must carry the turn's real content — empty fields are the corrupted-memory class.`,
+                code   : 'MEMORY_VALIDATION_ERROR'
+            };
+        }
+
         try {
-            const collection   = await StorageRouter.getMemoryCollection();
             const combinedText = `User Prompt: ${prompt}\nAgent Thought: ${thought}\nAgent Response: ${response}`;
             const now          = Date.now();
             const timestamp    = new Date(now).toISOString();
@@ -342,13 +394,17 @@ class MemoryService extends Base {
                 metadata.toolsUsed = typeof toolsUsed === 'string' ? toolsUsed : JSON.stringify(toolsUsed);
             }
 
-            await collection.add({
-                ids: [memoryId],
-                metadatas: [metadata],
-                documents: [combinedText]
-            });
+            // 1. Durable write-ahead append: full payload to local disk BEFORE any
+            //    model-dependent work. This is the never-fail anchor — once this returns, the turn
+            //    survives a crash, an embed failure, or a Chroma outage. The embed used to be
+            //    awaited here, which also lost the graph node below whenever it threw.
+            const walDir       = aiConfig.memoryWal.dir;
+            const {segmentKey} = await appendWalMemory(
+                {id: memoryId, timestamp: now, metadata, document: combinedText},
+                {dir: walDir}
+            );
 
-            // 1. Topologically inject the new memory into the Native Edge Graph
+            // 2. Topologically inject the new memory into the Native Edge Graph
             const memoryProperties = {
                 ...(canonicalIdentity ? { agentIdentity: canonicalIdentity } : {}),
                 ...(userId ? { userId } : {}),
@@ -365,7 +421,7 @@ class MemoryService extends Base {
                 properties: memoryProperties
             });
 
-            // 2. Stamp write-time provenance when the transport resolved a real AgentIdentity.
+            // 3. Stamp write-time provenance when the transport resolved a real AgentIdentity.
             // Fallback-only identities remain scalar metadata so single-tenant/unseeded callers
             // keep working without hallucinated graph edges to nodes that do not exist.
             if (requestIdentity) {
@@ -376,10 +432,25 @@ class MemoryService extends Base {
                 });
             }
 
-            // 3. Link this memory dynamically to the active context frontier
+            // 4. Link this memory dynamically to the active context frontier
             GraphService.linkNodes('frontier', memoryId, 'SPAWNED_MEMORY', 0.8);
 
-            // 4. Best-effort inline tweet-summary via the configured chat model (the modelProvider
+            // 5. Deferred embed: the model-dependent Chroma write runs OFF the
+            //    critical path, fire-and-forget. Success marks the WAL record; failure leaves it
+            //    pending — recency recall overlays the WAL meanwhile, so nothing is hidden.
+            //    Transitional Phase-1 shape: the Phase-2 `ai/daemons/embed/` daemon replaces this
+            //    in-process drain with a durable, retrying one.
+            this.embedPendingMemory({id: memoryId, metadata, document: combinedText, segmentKey, dir: walDir});
+
+            // 6. WAL retention (write-side, best-effort): bound the reconciled-segment count on
+            //    each append. Never prunes a segment holding a pending record, never fails the save.
+            pruneReconciledWalSegments({
+                dir             : walDir,
+                retentionLimit  : aiConfig.memoryWal.retentionLimit,
+                activeSegmentKey: segmentKey
+            }).catch(() => {});
+
+            // 7. Best-effort inline tweet-summary via the configured chat model (the modelProvider
             //    SSOT — reads the resolved leaf at the use site, never aliases it). Fire-and-forget
             //    so the per-turn write stays fast: the memory node above is already written (fresh
             //    for recency recall); this only enriches it asynchronously. Fully self-contained —
@@ -399,13 +470,15 @@ class MemoryService extends Base {
                 }
             }).catch(() => {});
 
-            // 5. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
+            // 8. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
             //    Non-fatal — buildMailboxDelta swallows its own errors and returns null on failure,
             //    so a degraded mailbox query never blocks a successful memory write.
             const mailbox = buildMailboxDelta();
 
             return {id: memoryId, sessionId, timestamp, message: "Memory successfully added", mailbox};
         } catch (error) {
+            // Reaches here only for LOCAL write failures (WAL filesystem / SQLite graph) — the
+            // embed and every other model-dependent step are off this path by construction.
             logger.error('[MemoryService] Error adding memory:', error);
             return {
                 error  : 'Failed to add memory',
@@ -413,6 +486,153 @@ class MemoryService extends Base {
                 code   : 'MEMORY_ADD_ERROR'
             };
         }
+    }
+
+    /**
+     * @summary Returns the names of memory payload fields failing the validation gate.
+     *
+     * The gate targets the unambiguous corrupted-memory class: empty / whitespace-only
+     * content (every corrupted row had empty `prompt`/`thought`/`response` *metadata* — the Chroma
+     * document always embeds non-empty labels, which is why the predicate reads the fields, not the
+     * document). The floor is the `memoryWal.minFieldLength` config leaf, defaulting to 1
+     * (= non-empty after trim): deliberately conservative so thin-but-real boot heartbeats
+     * (`resumeHarness.mjs` resume health-check) keep passing until the planned boot-heartbeat
+     * liveness-marker carve-out routes them off this path entirely.
+     *
+     * @param {Object} fields
+     * @param {String} fields.prompt
+     * @param {String} fields.thought
+     * @param {String} fields.response
+     * @returns {String[]} Invalid field names; empty array when the payload passes.
+     */
+    getInvalidMemoryFields(fields) {
+        const minLength = aiConfig.memoryWal.minFieldLength;
+
+        return Object.entries(fields)
+            .filter(([, value]) => typeof value !== 'string' || value.trim().length < minLength)
+            .map(([name]) => name);
+    }
+
+    /**
+     * @summary Embeds one WAL-pending memory into Chroma, fire-and-forget.
+     *
+     * The transitional in-process drain: resolves the collection, runs the embed, and appends the
+     * WAL embed-marker on success. Every failure path is swallowed into a warn-log — the record
+     * simply stays pending in the WAL for a later pass (Phase 2: the orchestrator-managed
+     * `ai/daemons/embed/` daemon, which replaces this method's call site and adds retry/backoff).
+     * Never throws into the write path; sibling discipline to {@link buildMiniSummary}.
+     *
+     * @param {Object} options
+     * @param {String} options.id         Memory UUID (= Chroma document id = graph node id).
+     * @param {Object} options.metadata   Full Chroma metadata payload.
+     * @param {String} options.document   Combined text to index.
+     * @param {String} options.segmentKey WAL segment the record was appended to.
+     * @param {String} options.dir        WAL directory (resolved `memoryWal.dir` leaf).
+     * @returns {Promise<Boolean>} `true` when embedded + marked; `false` when left pending.
+     */
+    embedPendingMemory({id, metadata, document, segmentKey, dir}) {
+        const embedPromise = Promise.resolve()
+            .then(() => {
+                // Purge guard: a session purged AFTER this memory's write but BEFORE this
+                // deferred embed must not be resurrected into Chroma. Tenant-aware — a tenant-scoped
+                // purge only suppresses records inside that tenant boundary. The WAL record is
+                // marked reconciled either way (purgeSession tombstones it too; double markers are
+                // harmless appends).
+                const purge = metadata?.sessionId && this.purgedSessions.get(metadata.sessionId);
+                if (purge && purge.purgedAt >= (metadata.timestamp ?? 0) && (!purge.userId || purge.userId === metadata.userId)) {
+                    return appendWalEmbedMarker({id, segmentKey}, {dir}).then(() => false);
+                }
+
+                return StorageRouter.getMemoryCollection()
+                    .then(collection => collection.add({ids: [id], metadatas: [metadata], documents: [document]}))
+                    .then(() => appendWalEmbedMarker({id, segmentKey}, {dir}))
+                    .then(() => true);
+            })
+            .catch(error => {
+                logger.warn(`[MemoryService] Deferred embed for ${id} failed — record stays pending in the WAL: ${error.message}`);
+                return false;
+            });
+
+        // Track for drainPendingEmbeds(); embedPromise never rejects (catch above), so the
+        // cleanup chain cannot leak an unhandled rejection.
+        const tracked = embedPromise.finally(() => this.inFlightEmbeds.delete(tracked));
+        this.inFlightEmbeds.add(tracked);
+
+        return tracked;
+    }
+
+    /**
+     * @summary Awaits every deferred embed currently in flight.
+     *
+     * The deterministic flush point for the fire-and-forget embed tail: graceful shutdown calls
+     * it so a process exit cannot strand an embed mid-write (the WAL would recover it, but a
+     * clean drain avoids the redundant re-embed), and specs call it instead of polling. Snapshot
+     * semantics — embeds started while draining are not awaited.
+     *
+     * @returns {Promise<void>}
+     */
+    async drainPendingEmbeds() {
+        await Promise.allSettled([...this.inFlightEmbeds]);
+    }
+
+    /**
+     * @summary Records a session purge so deferred embeds cannot resurrect purged data.
+     *
+     * Called by `SessionService.purgeSession` BEFORE it reads the collection: any embed still in
+     * flight for that session (within the caller's tenant boundary, for records written before the
+     * purge) sees the entry and skips its `collection.add`. Synchronous on purpose — purge must
+     * never wait on embed latency; waiting on a stalled embedder is the exact failure mode the
+     * write-ahead decouple removes. Insertion prunes entries older than {@link MemoryService#purgedSessionTtlMs}.
+     *
+     * @param {Object} options
+     * @param {String} options.sessionId Purged session id.
+     * @param {String|null} [options.userId=null] Tenant scope of the purge; `null` = all tenants.
+     */
+    markSessionPurged({sessionId, userId = null}) {
+        if (!sessionId) return;
+
+        const now = Date.now();
+
+        for (const [key, entry] of this.purgedSessions) {
+            if (now - entry.purgedAt > this.purgedSessionTtlMs) {
+                this.purgedSessions.delete(key);
+            }
+        }
+
+        this.purgedSessions.set(sessionId, {userId: userId || null, purgedAt: now});
+    }
+
+    /**
+     * @summary Reads WAL-pending payload metadata for specific memory ids (the pending-overlay).
+     *
+     * Backs the recency-hydration fallback: a just-written turn whose embed is still deferred (or
+     * failing) has no Chroma document yet, but its full payload sits in the WAL. Best-effort —
+     * any store error degrades to an empty map, never into the read path.
+     *
+     * @param {String[]} ids Memory UUIDs to look up.
+     * @returns {Promise<Map<String, Object>>} id → WAL `metadata` payload for pending records.
+     */
+    async _readWalMetadataByIds(ids) {
+        try {
+            const records = await readPendingWalRecords({dir: aiConfig.memoryWal.dir, ids});
+            return new Map(records.map(record => [record.id, record.metadata || {}]));
+        } catch {
+            return new Map();
+        }
+    }
+
+    /**
+     * @summary Builds the truncated raw-content summary used when no `miniSummary` exists yet.
+     * Shared by the Chroma and WAL fallback paths of {@link _hydrateRecentTurnSummaries}.
+     * @param {Object} meta Payload metadata (`prompt` / `response`).
+     * @returns {String|null} ≤200-char one-liner, or `null` when the metadata carries no content.
+     */
+    _rawSummaryFromMeta(meta) {
+        const raw = [meta?.prompt, meta?.response].filter(Boolean).join(' — ').replace(/\s+/g, ' ').trim();
+
+        if (!raw) return null;
+
+        return raw.length > 200 ? `${raw.slice(0, 200)}…` : raw;
     }
 
     /**
@@ -620,6 +840,12 @@ class MemoryService extends Base {
      * @summary Joins `AGENT_MEMORY` rows to their Chroma content for the `detail:'full'` projection.
      * The graph node id equals the Chroma document id (both are the memory's UUID), so the join key
      * is `row.id`. The private `thought` field is included only for the explicit `'private'` projection.
+     *
+     * **Pending-overlay:** turns whose embed is still deferred (or failing) have no Chroma
+     * document yet — their payload is filled from the WAL instead, and a Chroma outage degrades to
+     * the overlay rather than failing the whole recency read. Read-after-write stays content-complete
+     * even under the exact contention the decoupled write path exists for.
+     *
      * @param {Object[]} rows       Graph rows from {@link queryRecentTurns}.
      * @param {String}   projection `'public'` (default, strips `thought`) | `'private'`.
      * @returns {Promise<Object[]>}
@@ -627,9 +853,29 @@ class MemoryService extends Base {
     async _hydrateRecentTurnContent(rows, projection) {
         if (rows.length === 0) return [];
 
-        const collection = await StorageRouter.getMemoryCollection();
-        const fetched    = await collection.get({ids: rows.map(r => r.id), include: ['metadatas']});
-        const byId       = new Map(fetched.ids.map((id, i) => [id, fetched.metadatas[i] || {}]));
+        let byId = new Map();
+
+        try {
+            const collection = await StorageRouter.getMemoryCollection();
+            const fetched    = await collection.get({ids: rows.map(r => r.id), include: ['metadatas']});
+
+            byId = new Map(fetched.ids.map((id, i) => [id, fetched.metadatas[i] || {}]));
+        } catch {
+            // Content store unreachable: fall through to the WAL overlay below instead of failing
+            // the read — before the write-ahead decouple, a Chroma outage made every detail:'full' recency read error out.
+        }
+
+        const missingIds = rows
+            .map(row => row.id)
+            .filter(id => {
+                const meta = byId.get(id);
+                return !meta || (meta.prompt == null && meta.response == null);
+            });
+
+        if (missingIds.length > 0) {
+            const walById = await this._readWalMetadataByIds(missingIds);
+            walById.forEach((meta, id) => byId.set(id, meta));
+        }
 
         return rows.map(row => {
             const meta = byId.get(row.id) || {};
@@ -680,15 +926,30 @@ class MemoryService extends Base {
 
                 for (const turn of turns) {
                     if (turn.summary) continue;
-                    const meta = byId.get(turn.id) || {};
-                    const raw  = [meta.prompt, meta.response].filter(Boolean).join(' — ').replace(/\s+/g, ' ').trim();
-                    if (raw) {
-                        turn.summary         = raw.length > 200 ? `${raw.slice(0, 200)}…` : raw;
+                    const summary = this._rawSummaryFromMeta(byId.get(turn.id));
+                    if (summary) {
+                        turn.summary         = summary;
                         turn.summaryFallback = true;
                     }
                 }
             } catch {
-                // Best-effort: if the content store is unreachable, un-summarized turns keep summary:null.
+                // Best-effort: if the content store is unreachable, the WAL overlay below still runs.
+            }
+
+            // Pending-overlay: turns whose embed is still deferred/failing are not in
+            // Chroma yet — derive their fallback summary from the WAL payload so the recency feed
+            // is never content-empty for just-written turns.
+            const stillEmpty = turns.filter(turn => !turn.summary);
+            if (stillEmpty.length > 0) {
+                const walById = await this._readWalMetadataByIds(stillEmpty.map(turn => turn.id));
+
+                for (const turn of stillEmpty) {
+                    const summary = this._rawSummaryFromMeta(walById.get(turn.id));
+                    if (summary) {
+                        turn.summary         = summary;
+                        turn.summaryFallback = true;
+                    }
+                }
             }
         }
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -3,6 +3,7 @@ import Base from '../../../src/core/Base.mjs';
 import {buildChatModel} from '../../provider/buildChatModel.mjs';
 import {invokeWithGuardrail} from './helpers/consumerFrictionHelper.mjs';
 import {withTimeout} from './helpers/withTimeout.mjs';
+import {appendWalEmbedMarker, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
 import crypto from 'crypto';
 import GraphService from './GraphService.mjs';
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
@@ -1023,6 +1024,36 @@ ${sessionContent}
             // Fall through — treat as no memories.
         }
 
+        // The embed is deferred, so a just-written memory (e.g. the resume boot-heartbeat
+        // this validator exists to health-check) may not be in Chroma yet — and a Chroma outage
+        // lands here too. The AGENT_MEMORY graph rows are written synchronously; consult them
+        // (same tenant predicate as the Chroma where above) before declaring SESSION_NOT_FOUND.
+        if (memoryCount === 0 && sqlite) {
+            try {
+                const userId = normalizeUserId(RequestContextService.getUserId());
+                const tenantClause = userId
+                    ? `AND (json_extract(data, '$.properties.userId') = ? OR json_extract(data, '$.properties.userId') = ?)`
+                    : '';
+                const params = userId ? [sessionId, userId, SHARED_USER_ID] : [sessionId];
+
+                const row = sqlite.prepare(`
+                    SELECT COUNT(*)                                          AS count,
+                           MAX(json_extract(data, '$.properties.timestamp')) AS lastTimestamp
+                    FROM Nodes
+                    WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
+                      AND json_extract(data, '$.properties.sessionId') = ?
+                      ${tenantClause}
+                `).get(...params);
+
+                if (row?.count > 0) {
+                    memoryCount    = row.count;
+                    lastActivityAt = row.lastTimestamp || lastActivityAt;
+                }
+            } catch (e) {
+                logger.warn(`[SessionService] validateSessionForResume: graph fallback failed for ${sessionId}: ${e.message}`);
+            }
+        }
+
         if (memoryCount === 0 && summarizationStatus === 'none') {
             return {
                 error: 'No session found with the supplied ID. Either the session never existed or its data has been purged.',
@@ -1351,6 +1382,30 @@ ${sessionContent}
 
             // Construct filter: ensure tenant isolation.
             const where = userId ? { '$and': [{ sessionId }, { userId }] } : { sessionId };
+
+            // The embed runs deferred. Mark the purge FIRST (synchronous — purge must never
+            // wait on embed latency) so any in-flight embed for this session skips its Chroma add
+            // instead of resurrecting purged data, and tombstone the WAL-pending records below so
+            // a later drain (the Phase-2 embed daemon) cannot re-embed them either.
+            // Dynamic import: MemoryService statically imports SessionService — see the
+            // withTimeout.mjs extraction note on avoiding that import cycle.
+            const {default: MemoryService} = await import('./MemoryService.mjs');
+            MemoryService.markSessionPurged({sessionId, userId: userId || null});
+
+            try {
+                const walDir = aiConfig.memoryWal.dir;
+
+                for (const record of await readPendingWalRecords({dir: walDir})) {
+                    const meta = record.metadata || {};
+                    // Mirror the tenant-scoped `where` predicate: never tombstone across the
+                    // caller's tenant boundary.
+                    if (meta.sessionId !== sessionId) continue;
+                    if (userId && meta.userId !== userId) continue;
+                    await appendWalEmbedMarker({id: record.id, segmentKey: record.segmentKey}, {dir: walDir});
+                }
+            } catch (walError) {
+                logger.warn(`[SessionService] WAL tombstone pass for ${sessionId} failed: ${walError.message}`);
+            }
 
             let deletedMemories = 0;
             if (this.memoryCollection) {

--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -1,0 +1,265 @@
+import fs   from 'fs/promises';
+import path from 'path';
+
+/**
+ * @summary Durable JSONL write-ahead store for `add_memory` payloads.
+ *
+ * The per-turn save (AGENTS.md §critical_gates #5) must never fail or stall on the model-dependent
+ * Chroma embed. `MemoryService.addMemory` therefore appends the FULL turn payload here — a local,
+ * append-only filesystem write, the most reliable write available — BEFORE returning, and the embed
+ * happens asynchronously afterwards (Phase 1: a transitional fire-and-forget in-process; Phase 2:
+ * the orchestrator-managed `ai/daemons/embed/` drain daemon). A crash, embed failure, or stalled
+ * embedding model never loses the payload: it stays pending in the WAL until an embed pass succeeds.
+ *
+ * ## File layout (two files per UTC-day segment, each with exactly ONE writer)
+ *
+ * - `wal-YYYY-MM-DD.jsonl`          — memory records; written only by the MCP-server process.
+ * - `wal-YYYY-MM-DD.embedded.jsonl` — embed markers; written only by the embedder of the era
+ *                                     (Phase 1: the server's deferred embed; Phase 2: the daemon).
+ *
+ * Records and markers are deliberately split into separate single-writer files instead of one
+ * shared append stream: POSIX `O_APPEND` atomicity is only dependable for small writes, and memory
+ * records (multi-KB `thought` payloads) appended concurrently with tiny markers from a second
+ * process could interleave. One writer per file removes the interleave class by construction.
+ * A record is "pending" when its id has no marker; a segment is "reconciled" when no record in it
+ * is pending. Reads tolerate corrupt lines (skip, never throw) — sibling discipline to
+ * {@link module:ai/services/memory-core/helpers/remRunStateStore}.
+ *
+ * @module ai/services/memory-core/helpers/memoryWalStore
+ */
+
+const SEGMENT_RE = /^wal-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+/**
+ * @summary Derives the UTC-day segment key for a write timestamp.
+ *
+ * Date-keyed segments rotate naturally without any cross-process coordination, and their names
+ * sort lexicographically === chronologically, which `readPendingWalRecords` relies on.
+ *
+ * @param {Date|Number} [now=new Date()] Clock source (epoch ms or Date).
+ * @returns {String} `YYYY-MM-DD` UTC day key.
+ */
+export function getWalSegmentKey(now = new Date()) {
+    return new Date(now).toISOString().slice(0, 10);
+}
+
+/**
+ * @summary Builds the records file name for a segment key.
+ * @param {String} segmentKey `YYYY-MM-DD` day key.
+ * @returns {String} JSONL records file name.
+ */
+export function getWalRecordsFileName(segmentKey) {
+    return `wal-${segmentKey}.jsonl`;
+}
+
+/**
+ * @summary Builds the embed-markers file name for a segment key.
+ * @param {String} segmentKey `YYYY-MM-DD` day key.
+ * @returns {String} JSONL markers file name.
+ */
+export function getWalMarkersFileName(segmentKey) {
+    return `wal-${segmentKey}.embedded.jsonl`;
+}
+
+/**
+ * @summary Appends one memory record to its UTC-day WAL segment. The durable write `addMemory`
+ * awaits BEFORE any model-dependent work — this returning is what makes the turn save crash-safe.
+ *
+ * @param {Object} record
+ * @param {String} record.id        Memory UUID (= Chroma document id = graph node id).
+ * @param {Number} record.timestamp Epoch-ms write time.
+ * @param {Object} record.metadata  The FULL Chroma metadata payload (prompt/thought/response/...).
+ * @param {String} record.document  The combined text the embedder will index.
+ * @param {Object} options
+ * @param {String} options.dir Directory for WAL segment files.
+ * @param {Date|Number} [options.now] Clock source for the segment key (defaults to record.timestamp).
+ * @returns {Promise<{filePath: String, segmentKey: String}>}
+ */
+export async function appendWalMemory(record, {dir, now} = {}) {
+    if (!dir) {
+        throw new TypeError('appendWalMemory: dir is required');
+    }
+    if (typeof record?.id !== 'string' || record.id.length === 0) {
+        throw new TypeError('appendWalMemory: record.id is required');
+    }
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const segmentKey = getWalSegmentKey(now ?? record.timestamp ?? new Date());
+    const filePath   = path.join(dir, getWalRecordsFileName(segmentKey));
+
+    await fs.appendFile(filePath, `${JSON.stringify({...record, segmentKey})}\n`, 'utf8');
+
+    return {filePath, segmentKey};
+}
+
+/**
+ * @summary Appends an embed-success marker for one record. A marked record is no longer pending;
+ * its WAL copy only awaits segment pruning.
+ *
+ * @param {Object} marker
+ * @param {String} marker.id         Memory UUID the embed succeeded for.
+ * @param {String} marker.segmentKey Segment key the record was written under.
+ * @param {Number} [marker.embeddedAt] Epoch-ms embed completion time.
+ * @param {Object} options
+ * @param {String} options.dir Directory for WAL segment files.
+ * @returns {Promise<String>} Written markers file path.
+ */
+export async function appendWalEmbedMarker({id, segmentKey, embeddedAt}, {dir} = {}) {
+    if (!dir) {
+        throw new TypeError('appendWalEmbedMarker: dir is required');
+    }
+    if (typeof id !== 'string' || id.length === 0 || typeof segmentKey !== 'string' || segmentKey.length === 0) {
+        throw new TypeError('appendWalEmbedMarker: id and segmentKey are required');
+    }
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const filePath = path.join(dir, getWalMarkersFileName(segmentKey));
+
+    await fs.appendFile(filePath, `${JSON.stringify({id, embeddedAt: embeddedAt ?? Date.now()})}\n`, 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Parses one JSONL file into entries, skipping corrupt lines.
+ *
+ * Corruption tolerance is load-bearing: a torn final line (crash mid-append) must cost exactly
+ * that line, never the read path — the WAL backs both the embed drain and the recency-recall
+ * content fallback.
+ *
+ * @param {String} filePath JSONL file path.
+ * @returns {Promise<Object[]>} Parsed entries; `[]` when the file does not exist.
+ */
+async function readJsonlEntries(filePath) {
+    let text;
+    try {
+        text = await fs.readFile(filePath, 'utf8');
+    } catch (e) {
+        if (e?.code === 'ENOENT') return [];
+        throw e;
+    }
+
+    const entries = [];
+
+    for (const line of text.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+            entries.push(JSON.parse(line));
+        } catch (e) {
+            // Torn/corrupt line: skip — the WAL read path must never throw on partial appends.
+        }
+    }
+
+    return entries;
+}
+
+/**
+ * @summary Lists segment keys present in the WAL directory, newest first.
+ * @param {String} dir Directory for WAL segment files.
+ * @returns {Promise<String[]>} Sorted segment keys (lexicographic desc === chronological desc).
+ */
+async function listWalSegmentKeys(dir) {
+    let names;
+    try {
+        names = await fs.readdir(dir);
+    } catch (e) {
+        if (e?.code === 'ENOENT') return [];
+        throw e;
+    }
+
+    return names
+        .map(name => name.match(SEGMENT_RE)?.[1])
+        .filter(Boolean)
+        .sort((a, b) => b.localeCompare(a));
+}
+
+/**
+ * @summary Reads pending (appended but not yet embed-marked) WAL records, newest segment first.
+ *
+ * Serves two consumers: the embed drain (Phase 1 deferred embed / Phase 2 daemon) reading the
+ * backlog, and `MemoryService`'s recency-hydration fallback reading specific ids whose content is
+ * not yet in Chroma — the pending-overlay that keeps `query_recent_turns` content-complete while
+ * the embed is deferred or failing.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Directory for WAL segment files.
+ * @param {String[]} [options.ids] When given, only records with these ids are returned.
+ * @param {Number} [options.limit] Maximum records to return (applied after the ids filter).
+ * @returns {Promise<Object[]>} Pending records (each carries its `segmentKey`), newest segment first.
+ */
+export async function readPendingWalRecords({dir, ids, limit} = {}) {
+    if (!dir) return [];
+
+    const idFilter = Array.isArray(ids) ? new Set(ids) : null;
+    const bounded  = Number.isFinite(limit) && limit > 0 ? limit : Infinity;
+    const pending  = [];
+
+    for (const segmentKey of await listWalSegmentKeys(dir)) {
+        if (pending.length >= bounded) break;
+
+        const records = await readJsonlEntries(path.join(dir, getWalRecordsFileName(segmentKey)));
+        if (records.length === 0) continue;
+
+        const markedIds = new Set(
+            (await readJsonlEntries(path.join(dir, getWalMarkersFileName(segmentKey)))).map(entry => entry.id)
+        );
+
+        for (const record of records) {
+            if (pending.length >= bounded) break;
+            if (!record?.id || markedIds.has(record.id)) continue;
+            if (idFilter && !idFilter.has(record.id)) continue;
+            pending.push(record);
+        }
+    }
+
+    return pending;
+}
+
+/**
+ * @summary Removes fully-reconciled, non-active WAL segments beyond a retention bound.
+ *
+ * Write-side retention (sibling discipline to `pruneRemRunStates`): bounding on append keeps both
+ * the directory file count and the read-path fan-out from growing with deployment age. Segments
+ * with ANY pending record are never removed — the WAL is a durability buffer first, a log second;
+ * pruning must never lose an un-embedded payload. The active segment is excluded so the file the
+ * server is currently appending to is never deleted underneath it.
+ *
+ * @param {Object} options
+ * @param {String} options.dir Directory for WAL segment files.
+ * @param {Number} options.retentionLimit Maximum reconciled segments to retain; older ones are removed.
+ *   Non-positive / non-finite values disable pruning (no-op).
+ * @param {String} [options.activeSegmentKey] Segment key currently being written; always retained.
+ * @returns {Promise<Number>} Count of removed segments.
+ */
+export async function pruneReconciledWalSegments({dir, retentionLimit, activeSegmentKey} = {}) {
+    if (!dir || !Number.isFinite(retentionLimit) || retentionLimit <= 0) {
+        return 0;
+    }
+
+    const reconciled = [];
+
+    for (const segmentKey of await listWalSegmentKeys(dir)) {
+        if (segmentKey === activeSegmentKey) continue;
+
+        const records = await readJsonlEntries(path.join(dir, getWalRecordsFileName(segmentKey)));
+        const marked  = new Set(
+            (await readJsonlEntries(path.join(dir, getWalMarkersFileName(segmentKey)))).map(entry => entry.id)
+        );
+
+        if (records.every(record => record?.id && marked.has(record.id))) {
+            reconciled.push(segmentKey);
+        }
+    }
+
+    // listWalSegmentKeys returns newest-first; everything beyond the bound is oldest.
+    const toRemove = reconciled.slice(retentionLimit);
+
+    await Promise.all(toRemove.flatMap(segmentKey => [
+        fs.rm(path.join(dir, getWalRecordsFileName(segmentKey)), {force: true}),
+        fs.rm(path.join(dir, getWalMarkersFileName(segmentKey)), {force: true})
+    ]));
+
+    return toRemove.length;
+}

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
@@ -144,6 +144,9 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
             response : 'hi'
         }));
 
+        // The embed is deferred — flush it before asserting on the spy.
+        await MemoryService.drainPendingEmbeds();
+
         expect(collectionAddCalls).toHaveLength(1);
         expect(collectionAddCalls[0].metadatas[0].userId).toBe('neo-gpt');
         expect(collectionAddCalls[0].metadatas[0].agentIdentity).toBe('@neo-gpt');
@@ -177,6 +180,9 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
             thought  : 'thinking',
             response : 'hi'
         }));
+
+        // The embed is deferred — flush it before asserting on the spy.
+        await MemoryService.drainPendingEmbeds();
 
         expect(collectionAddCalls).toHaveLength(1);
         expect(collectionAddCalls[0].metadatas[0].userId).toBe('external-contributor');

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
@@ -143,6 +143,9 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
             })
         );
 
+        // The embed is deferred — flush it before asserting on the spy.
+        await MemoryService.drainPendingEmbeds();
+
         expect(spyCollection.addCalls).toHaveLength(1);
         const metadata = spyCollection.addCalls[0].metadatas[0];
         expect(metadata.userId).toBe('u-alice');
@@ -157,6 +160,9 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
             sessionId: 'session-solo'
         });
 
+        // The embed is deferred — flush it before asserting on the spy.
+        await MemoryService.drainPendingEmbeds();
+
         expect(spyCollection.addCalls).toHaveLength(1);
         const metadata = spyCollection.addCalls[0].metadatas[0];
         expect(metadata.userId).toBeUndefined();
@@ -166,13 +172,18 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
     test('listMemories under team policy returns ALL maintainers\' session records — cross-author (#12527)', async () => {
         // Seed: alice writes 2 memories to session-shared, bob writes 1 memory to session-shared.
         // All three share the same sessionId but carry distinct userId metadata.
+        // Non-empty response/thought: the validation gate rejects empty fields (the
+        // corrupted-memory class), so seed fixtures must carry real content.
         await RequestContextService.run({userId: 'u-alice'}, async () => {
-            await MemoryService.addMemory({prompt: 'a1', response: '', thought: '', sessionId: 'session-shared'});
-            await MemoryService.addMemory({prompt: 'a2', response: '', thought: '', sessionId: 'session-shared'});
+            await MemoryService.addMemory({prompt: 'a1', response: 'r-a1', thought: 't-a1', sessionId: 'session-shared'});
+            await MemoryService.addMemory({prompt: 'a2', response: 'r-a2', thought: 't-a2', sessionId: 'session-shared'});
         });
         await RequestContextService.run({userId: 'u-bob'}, () =>
-            MemoryService.addMemory({prompt: 'b1', response: '', thought: '', sessionId: 'session-shared'})
+            MemoryService.addMemory({prompt: 'b1', response: 'r-b1', thought: 't-b1', sessionId: 'session-shared'})
         );
+
+        // The embed is deferred — flush before reading the spy store back.
+        await MemoryService.drainPendingEmbeds();
 
         // Under team policy (deployment-wide read), Alice reads the shared session and sees ALL
         // three records — her own two AND Bob's (transparent swarm introspection). The team DEFAULT
@@ -192,8 +203,11 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
     });
 
     test('listMemories without a request context returns all session memories (stdio fallback)', async () => {
-        await MemoryService.addMemory({prompt: 'solo1', response: '', thought: '', sessionId: 'session-local'});
-        await MemoryService.addMemory({prompt: 'solo2', response: '', thought: '', sessionId: 'session-local'});
+        await MemoryService.addMemory({prompt: 'solo1', response: 'r-solo1', thought: 't-solo1', sessionId: 'session-local'});
+        await MemoryService.addMemory({prompt: 'solo2', response: 'r-solo2', thought: 't-solo2', sessionId: 'session-local'});
+
+        // The embed is deferred — flush before reading the spy store back.
+        await MemoryService.drainPendingEmbeds();
 
         const view = await MemoryService.listMemories({sessionId: 'session-local', limit: 10});
 
@@ -310,6 +324,9 @@ test.describe('MemoryService — additive shared-commons access (#10556)', () =>
                 response : 'test'
             })
         );
+
+        // The embed is deferred — flush it before asserting on the spy.
+        await MemoryService.drainPendingEmbeds();
 
         const addCall = spyCollection.addCalls.at(-1);
         const tagged  = addCall.metadatas[0]?.userId;

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -1,0 +1,218 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MemoryWriteAheadTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {readPendingWalRecords} from '../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+
+/**
+ * add_memory never-fail write path (write-ahead decouple, Phase 1) — falsifier coverage:
+ *
+ *   AC1 validation gate — empty/whitespace fields are rejected BEFORE any write.
+ *   AC2 never-fail      — a throwing or HANGING embed no longer fails or stalls the tool;
+ *                         the payload is durable in the WAL (pending) either way.
+ *   AC3 recency         — the AGENT_MEMORY graph row stays synchronous: a just-written turn is
+ *                         immediately visible to query_recent_turns even with the embed down,
+ *                         and the WAL pending-overlay serves its content for BOTH detail levels.
+ *   Marker reconcile    — a successful deferred embed marks the WAL record (no longer pending).
+ *
+ * Test isolation by construction: UNIT_TEST_MODE resolves memoryWal.dir → a per-worker-unique
+ * temp directory and the graph → ':memory:'; the shared AiConfig singleton is never mutated
+ * (the shared-singleton write ban). The spec reads the RESOLVED `memoryWal.dir` leaf from the same config instance
+ * the service reads (assertion-targeting only) — pinning a different dir via env is worker-order
+ * dependent, because another spec in the worker may construct the singleton first.
+ */
+test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter,
+        originalGetMemoryCollection, originalEmbedText, memStore, collectionMode, testWalDir;
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        testWalDir     = aiConfig.memoryWal.dir;
+
+        GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        MemoryService        = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+        LifecycleService     = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+        TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
+        StorageRouter        = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+
+        // Controllable content-store fake: 'ok' embeds into an in-memory map, 'throw' fails the
+        // embed, 'hang' never resolves — the two failure shapes AC2 pins (error AND stall).
+        memStore                    = new Map();
+        collectionMode              = 'ok';
+        originalGetMemoryCollection = StorageRouter.getMemoryCollection;
+        StorageRouter.getMemoryCollection = async () => {
+            if (collectionMode === 'throw') throw new Error('chroma down (spec)');
+            if (collectionMode === 'hang')  return new Promise(() => {}); // never settles
+            return {
+                add: async ({ids = [], metadatas = []} = {}) => { ids.forEach((id, i) => memStore.set(id, metadatas[i] || {})); },
+                get: async ({ids = []} = {}) => {
+                    const found = ids.filter(id => memStore.has(id));
+                    return {ids: found, metadatas: found.map(id => memStore.get(id))};
+                }
+            };
+        };
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+
+        // Offline tests cannot hit a real embedder; restored in afterAll so the stub never leaks
+        // into sibling specs sharing the worker.
+        originalEmbedText              = TextEmbeddingService.embedText;
+        TextEmbeddingService.embedText = async () => new Array(4096).fill(0.1);
+
+        GraphService.upsertNode({id: '@agent-wal', type: 'AgentIdentity', name: 'AgentWal', properties: {}});
+    });
+
+    test.afterAll(async () => {
+        if (originalGetMemoryCollection) StorageRouter.getMemoryCollection = originalGetMemoryCollection;
+        if (originalEmbedText)           TextEmbeddingService.embedText     = originalEmbedText;
+        const {cleanupChromaManager} = await import('./util.mjs');
+        await cleanupChromaManager();
+        // No rm of testWalDir: it is the per-worker config-resolved temp dir, shared with sibling
+        // specs in the same worker process; the OS temp root reclaims it.
+    });
+
+    const asTenant = fn => RequestContextService.run({userId: 'tenant-wal', agentIdentityNodeId: '@agent-wal'}, fn);
+
+    test('AC1: empty/whitespace fields are rejected before any write', async () => {
+        const before = (await readPendingWalRecords({dir: testWalDir})).length;
+
+        const result = await asTenant(() => MemoryService.addMemory({prompt: '', thought: '   ', response: 'real'}));
+
+        expect(result.code).toBe('MEMORY_VALIDATION_ERROR');
+        expect(result.message).toContain('prompt');
+        expect(result.message).toContain('thought');
+        expect(result.message).not.toContain('response');
+
+        // Rejected payloads must not reach the WAL (nor, transitively, the embed path).
+        expect((await readPendingWalRecords({dir: testWalDir})).length).toBe(before);
+    });
+
+    test('AC2: a THROWING embed no longer fails the save; the payload is durable + pending', async () => {
+        collectionMode = 'throw';
+
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'embed-down prompt', thought: 'embed-down thought', response: 'embed-down response'
+        }));
+
+        expect(result.code).toBeUndefined();
+        expect(result.error).toBeUndefined();
+        expect(result.id).toBeTruthy();
+        expect(result.message).toBe('Memory successfully added');
+
+        const pending = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
+        expect(pending).toHaveLength(1);
+        expect(pending[0].metadata.prompt).toBe('embed-down prompt');
+
+        collectionMode = 'ok';
+    });
+
+    test('AC2: a HANGING embed no longer stalls the save', async () => {
+        collectionMode = 'hang';
+
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'hang prompt', thought: 'hang thought', response: 'hang response'
+        }));
+        // Reaching these assertions at all proves the embed is off the await path — previously
+        // this call suspended on the hung collection promise until an outer timeout killed it.
+        expect(result.id).toBeTruthy();
+        expect(result.error).toBeUndefined();
+
+        collectionMode = 'ok';
+    });
+
+    test('AC3: with the embed down, a just-written turn is immediately recency-visible and the WAL overlay serves BOTH detail levels', async () => {
+        collectionMode = 'throw';
+
+        const {summaryResult, fullResult} = await asTenant(async () => {
+            await MemoryService.addMemory({
+                prompt: 'overlay prompt', thought: 'overlay thought', response: 'overlay response'
+            });
+            return {
+                summaryResult: await MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 1}),
+                fullResult   : await MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 1, detail: 'full', projection: 'private'})
+            };
+        });
+
+        // Graph row synchronous → immediately visible (read-after-write recency preserved).
+        expect(summaryResult.count).toBe(1);
+        // No Chroma content exists yet — the summary fallback comes from the WAL pending-overlay.
+        expect(summaryResult.turns[0].summary).toContain('overlay prompt');
+        expect(summaryResult.turns[0].summaryFallback).toBe(true);
+
+        // detail:'full' hydration equally falls back to the WAL payload.
+        expect(fullResult.count).toBe(1);
+        expect(fullResult.turns[0].prompt).toBe('overlay prompt');
+        expect(fullResult.turns[0].response).toBe('overlay response');
+        expect(fullResult.turns[0].thought).toBe('overlay thought');
+
+        collectionMode = 'ok';
+    });
+
+    test('purge guard: an embed deferred past a session purge is suppressed, never resurrected', async () => {
+        collectionMode = 'throw'; // hold the embed back so the purge wins the race deterministically
+
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'purge-race prompt', thought: 'purge-race thought', response: 'purge-race response'
+        }));
+        expect(result.id).toBeTruthy();
+
+        // Purge marker lands BEFORE the embed can run (mirrors SessionService.purgeSession).
+        MemoryService.markSessionPurged({sessionId: result.sessionId, userId: 'tenant-wal'});
+
+        collectionMode = 'ok';
+
+        // Retry the pending record through the deferred-embed path (what the Phase-2 daemon —
+        // or any later inline attempt — would do): the purge guard must skip the Chroma add and
+        // reconcile the WAL record instead.
+        const pending = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
+        expect(pending).toHaveLength(1);
+
+        const embedded = await MemoryService.embedPendingMemory({
+            id        : pending[0].id,
+            metadata  : pending[0].metadata,
+            document  : pending[0].document,
+            segmentKey: pending[0].segmentKey,
+            dir       : testWalDir
+        });
+
+        expect(embedded).toBe(false);                 // suppressed, not embedded
+        expect(memStore.has(result.id)).toBe(false);  // nothing resurrected into the content store
+        expect((await readPendingWalRecords({dir: testWalDir, ids: [result.id]})).length).toBe(0); // reconciled
+    });
+
+    test('a successful deferred embed reconciles the WAL record (marker written, no longer pending)', async () => {
+        const result = await asTenant(() => MemoryService.addMemory({
+            prompt: 'happy prompt', thought: 'happy thought', response: 'happy response'
+        }));
+
+        expect(result.id).toBeTruthy();
+
+        // The embed is fire-and-forget — poll until it lands in the fake store + the marker
+        // reconciles the WAL record.
+        await expect.poll(async () => memStore.has(result.id), {timeout: 5000}).toBe(true);
+        await expect.poll(
+            async () => (await readPendingWalRecords({dir: testWalDir, ids: [result.id]})).length,
+            {timeout: 5000}
+        ).toBe(0);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -41,11 +41,12 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
         StorageRouter        = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
 
-        // CI unit has no ChromaDB server, so addMemory's Chroma write (its first step, before the
-        // AGENT_MEMORY graph node the recency query reads) would throw. Back the content store with
-        // an in-memory fake so the spec exercises the real addMemory→queryRecentTurns flow without a
-        // live Chroma. The recency query reads the GRAPH; the fake only stands in for the content
-        // store (the write + the detail:'full' join).
+        // CI unit has no ChromaDB server. The Chroma embed is DEFERRED (fire-and-
+        // forget after the durable WAL append + synchronous graph writes), so a missing Chroma no
+        // longer fails addMemory — but the deferred embed and the detail:'full' join still hit the
+        // content store. Back it with an in-memory fake so the spec exercises the real
+        // addMemory→queryRecentTurns flow without a live Chroma. The recency query reads the GRAPH;
+        // content comes from the fake store or, for not-yet-embedded turns, the WAL pending-overlay.
         memStore = new Map();
         originalGetMemoryCollection = StorageRouter.getMemoryCollection;
         StorageRouter.getMemoryCollection = async () => ({

--- a/test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs
@@ -65,9 +65,9 @@ test.describe('SessionService setSessionId', () => {
     test('setSessionId happy path: mutates currentSessionId', async () => {
         const oldId = SDK.Memory_SessionService.currentSessionId;
         const newId = crypto.randomUUID();
-        
+
         const result = await SDK.Memory_SessionService.setSessionId({ sessionId: newId });
-        
+
         expect(result.success).toBe(true);
         expect(result.sessionId).toBe(newId);
         expect(result.replacedSessionId).toBe(oldId);
@@ -76,9 +76,9 @@ test.describe('SessionService setSessionId', () => {
 
     test('setSessionId idempotency: no mutation if same ID', async () => {
         const currentId = SDK.Memory_SessionService.currentSessionId;
-        
+
         const result = await SDK.Memory_SessionService.setSessionId({ sessionId: currentId });
-        
+
         expect(result.success).toBe(true);
         expect(result.message).toBe("Session ID unchanged.");
         expect(SDK.Memory_SessionService.currentSessionId).toBe(currentId);
@@ -86,27 +86,27 @@ test.describe('SessionService setSessionId', () => {
 
     test('setSessionId invalid input: throws ZodError via SDK validation', async () => {
         const currentId = SDK.Memory_SessionService.currentSessionId;
-        
+
         await expect(SDK.Memory_SessionService.setSessionId({})).rejects.toThrow();
         await expect(SDK.Memory_SessionService.setSessionId({ sessionId: null })).rejects.toThrow();
-        
+
         // Ensure state wasn't mutated
         expect(SDK.Memory_SessionService.currentSessionId).toBe(currentId);
     });
 
     test('setSessionId AC verification: empty session is abandoned', async () => {
         const emptySessionId = crypto.randomUUID();
-        
+
         // Force the empty session as current
         SDK.Memory_SessionService.currentSessionId = emptySessionId;
-        
+
         const newId = crypto.randomUUID();
         const result = await SDK.Memory_SessionService.setSessionId({ sessionId: newId });
-        
+
         expect(result.success).toBe(true);
         expect(result.replacedSessionId).toBe(emptySessionId);
         expect(SDK.Memory_SessionService.currentSessionId).toBe(newId);
-        
+
         // Note: The AC states we abandon it, meaning we do nothing to Chroma for a zero-memory session,
         // it simply leaves no footprint because it wasn't tracked anyway.
     });
@@ -127,6 +127,9 @@ test.describe('SessionService setSessionId', () => {
                 });
                 expect(memoryResult1.sessionId).toBe(sessionId1);
 
+                // The embed is deferred — flush before reading the store back.
+                await SDK.Memory_Service.drainPendingEmbeds();
+
                 const listResult = await SDK.Memory_Service.listMemories({ sessionId: sessionId1 });
                 expect(listResult.memories.length).toBe(1);
                 expect(listResult.memories[0].sessionId).toBe(sessionId1);
@@ -139,6 +142,9 @@ test.describe('SessionService setSessionId', () => {
                     thought: 'test thought 2'
                 });
                 expect(memoryResult2.sessionId).toBe(sessionId2);
+
+                // The embed is deferred — flush before reading the store back.
+                await SDK.Memory_Service.drainPendingEmbeds();
 
                 const listResult = await SDK.Memory_Service.listMemories({ sessionId: sessionId2 });
                 expect(listResult.memories.length).toBe(1);
@@ -173,6 +179,10 @@ test.describe('SessionService setSessionId', () => {
             thought: 'other thought',
             sessionId: otherSessionId
         });
+
+        // The embed is deferred — flush so BOTH memories are in Chroma before the
+        // purge: this test verifies purge deletes embedded data (deletedMemories > 0).
+        await SDK.Memory_Service.drainPendingEmbeds();
 
         // Manually add summaries just to be sure we test both collections
         await SDK.Memory_SessionService.sessionsCollection.upsert({
@@ -255,6 +265,10 @@ test.describe('SessionService setSessionId', () => {
             thought: 'shared thought',
             sessionId: sharedSessionId
         });
+
+        // The embed is deferred — flush so the shared memory is IN Chroma when the
+        // tenant-scoped purge runs: the isolation claim below is only meaningful against real data.
+        await SDK.Memory_Service.drainPendingEmbeds();
 
         await RequestContextService.run({ sessionId: sharedSessionId, userId: testUserId }, async () => {
             const result = await SDK.Memory_SessionService.purgeSession({ sessionId: sharedSessionId });

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -31,7 +31,7 @@ const __dirname  = path.dirname(__filename);
 dotenv.config({path: path.resolve(__dirname, '../../../../../../.env'), quiet: true});
 
 test.describe('Memory Core Offline Summarization', () => {
-    // Bucket A (#10903): heavy SLM (gemma4) dependency — no local LM Studio / Ollama in CI.
+    // Bucket A (#10903): heavy SLM (gemma4) dependency — no local LM Studio / Ollama in CI. ticket-ref-ok: bucket taxonomy is defined in that ticket
     // The per-test `localModelActive` guard below stays as a defensive fallback for local-dev
     // without gemma4 running, but the CI-side skip is the early exit that prevents `beforeAll`
     // from probing a nonexistent endpoint.
@@ -189,6 +189,9 @@ test.describe('Memory Core Offline Summarization', () => {
             }
         }
 
+        // The embed is deferred — flush so the summarization read sees every turn.
+        await SDK.Memory_Service.drainPendingEmbeds();
+
         console.log(`[Playwright] Injected 5 dummy turns via SDK. Triggering Memory_SessionService.summarizeSession...`);
         const startTime = Date.now();
 
@@ -248,6 +251,9 @@ test.describe('Memory Core Offline Summarization', () => {
             model    : "gemini-3.1-pro",
             sessionId: bigDummySessionId
         });
+
+        // The embed is deferred — flush so the summarization read sees the turn.
+        await SDK.Memory_Service.drainPendingEmbeds();
 
         // Mock the model.generateContent to avoid actual LLM calls and verify the exact prompt content
         const originalGenerateContent = SDK.Memory_SessionService.model ? SDK.Memory_SessionService.model.generateContent : null;
@@ -351,6 +357,9 @@ test.describe('Memory Core Offline Summarization', () => {
                 sessionId: qwenSessionId
             });
 
+            // The embed is deferred — flush so the summarization read sees the turn.
+            await SDK.Memory_Service.drainPendingEmbeds();
+
             const result = await SDK.Memory_SessionService.summarizeSession(qwenSessionId);
 
             expect(capturedProviderConfig).toEqual({
@@ -409,6 +418,10 @@ test.describe('Memory Core Offline Summarization', () => {
             toolsUsed,
             sessionId: dummySessionId
         });
+
+        // The embed is deferred — flush it so summarizeSession's Chroma read below
+        // sees the just-written memory.
+        await SDK.Memory_Service.drainPendingEmbeds();
 
         const originalGenerateContent = SDK.Memory_SessionService.model ? SDK.Memory_SessionService.model.generateContent : null;
         let capturedPrompts = [];
@@ -469,6 +482,10 @@ test.describe('Memory Core Offline Summarization', () => {
             prompt: "Test s3", thought: "T3", response: "R3", agent: "dev", model: "gemini-3.1-pro", sessionId: s3
         });
 
+        // The embed is deferred — flush so all three sessions are visible below.
+        // (Ordering is unaffected: lastActivity derives from the write-time metadata timestamp.)
+        await SDK.Memory_Service.drainPendingEmbeds();
+
         // Use findSessionsToSummarize explicitly
         const candidates = await SDK.Memory_SessionService.findSessionsToSummarize(true);
 
@@ -510,6 +527,10 @@ test.describe('Memory Core Offline Summarization', () => {
             model    : "gemini-3.1-pro",
             sessionId: perfSessionId
         });
+
+        // The embed is deferred — flush BEFORE the measurement window so the
+        // summarization latency below stays a pure API measurement.
+        await SDK.Memory_Service.drainPendingEmbeds();
 
         const start = Date.now();
         const result = await SDK.Memory_SessionService.summarizeSession(perfSessionId);

--- a/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
@@ -1,0 +1,135 @@
+import {test, expect} from '@playwright/test';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import fs              from 'fs/promises';
+import {mkdtemp, rm}   from 'fs/promises';
+import os              from 'os';
+import path            from 'path';
+
+import {
+    appendWalEmbedMarker,
+    appendWalMemory,
+    getWalMarkersFileName,
+    getWalRecordsFileName,
+    getWalSegmentKey,
+    pruneReconciledWalSegments,
+    readPendingWalRecords
+} from '../../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+
+/**
+ * memoryWalStore — the durable JSONL write-ahead substrate behind the never-fail
+ * `add_memory` write path. Falsifier coverage for the store contract:
+ *
+ *   - append → pending; embed-marker → reconciled (no longer pending)
+ *   - reads tolerate corrupt/torn lines and a missing directory
+ *   - pruning removes ONLY fully-reconciled, non-active segments beyond the retention bound —
+ *     a pending payload is never lost to retention
+ */
+test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-memory-wal-store-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    const record = (id, segmentMs) => ({
+        id,
+        timestamp: segmentMs,
+        metadata : {prompt: `p-${id}`, response: `r-${id}`, thought: `t-${id}`},
+        document : `doc-${id}`
+    });
+
+    const DAY1 = Date.UTC(2026, 5, 1, 12);
+    const DAY2 = Date.UTC(2026, 5, 2, 12);
+    const DAY3 = Date.UTC(2026, 5, 3, 12);
+
+    test('derives UTC day segment keys and portable file names', () => {
+        expect(getWalSegmentKey(DAY1)).toBe('2026-06-01');
+        expect(getWalRecordsFileName('2026-06-01')).toBe('wal-2026-06-01.jsonl');
+        expect(getWalMarkersFileName('2026-06-01')).toBe('wal-2026-06-01.embedded.jsonl');
+    });
+
+    test('appendWalMemory writes the full payload into its day segment and reports the key', async () => {
+        const {filePath, segmentKey} = await appendWalMemory(record('m1', DAY1), {dir: tmpDir});
+
+        expect(segmentKey).toBe('2026-06-01');
+        expect(filePath).toBe(path.join(tmpDir, 'wal-2026-06-01.jsonl'));
+
+        const lines = (await fs.readFile(filePath, 'utf8')).trim().split('\n');
+        expect(lines).toHaveLength(1);
+
+        const entry = JSON.parse(lines[0]);
+        expect(entry.id).toBe('m1');
+        expect(entry.segmentKey).toBe('2026-06-01');
+        expect(entry.metadata.prompt).toBe('p-m1');
+        expect(entry.document).toBe('doc-m1');
+    });
+
+    test('appendWalMemory and appendWalEmbedMarker reject missing required inputs', async () => {
+        await expect(appendWalMemory(record('m1', DAY1), {})).rejects.toThrow('dir is required');
+        await expect(appendWalMemory({timestamp: DAY1}, {dir: tmpDir})).rejects.toThrow('record.id is required');
+        await expect(appendWalEmbedMarker({id: 'm1'}, {dir: tmpDir})).rejects.toThrow('id and segmentKey are required');
+    });
+
+    test('readPendingWalRecords returns appended records until their embed marker lands', async () => {
+        await appendWalMemory(record('m1', DAY1), {dir: tmpDir});
+        await appendWalMemory(record('m2', DAY1), {dir: tmpDir});
+
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['m1', 'm2']);
+
+        await appendWalEmbedMarker({id: 'm1', segmentKey: '2026-06-01'}, {dir: tmpDir});
+
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['m2']);
+    });
+
+    test('readPendingWalRecords filters by ids, bounds by limit, and reads newest segments first', async () => {
+        await appendWalMemory(record('old', DAY1), {dir: tmpDir});
+        await appendWalMemory(record('new-a', DAY2), {dir: tmpDir});
+        await appendWalMemory(record('new-b', DAY2), {dir: tmpDir});
+
+        expect((await readPendingWalRecords({dir: tmpDir, ids: ['new-b']})).map(r => r.id)).toEqual(['new-b']);
+
+        // Newest segment first; limit applies across segments.
+        expect((await readPendingWalRecords({dir: tmpDir, limit: 2})).map(r => r.id)).toEqual(['new-a', 'new-b']);
+    });
+
+    test('reads tolerate a torn line and a missing directory', async () => {
+        const {filePath} = await appendWalMemory(record('m1', DAY1), {dir: tmpDir});
+        await fs.appendFile(filePath, '{"id":"torn-mid-append', 'utf8');
+
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['m1']);
+        expect(await readPendingWalRecords({dir: path.join(tmpDir, 'missing')})).toEqual([]);
+    });
+
+    test('pruning removes only fully-reconciled, non-active segments beyond the retention bound', async () => {
+        // Three reconciled segments + one with a pending record.
+        for (const [id, ms, key] of [['a', DAY1, '2026-06-01'], ['b', DAY2, '2026-06-02'], ['c', DAY3, '2026-06-03']]) {
+            await appendWalMemory(record(id, ms), {dir: tmpDir});
+            await appendWalEmbedMarker({id, segmentKey: key}, {dir: tmpDir});
+        }
+        await appendWalMemory(record('pending', Date.UTC(2026, 4, 30, 12)), {dir: tmpDir}); // 2026-05-30
+
+        const removed = await pruneReconciledWalSegments({dir: tmpDir, retentionLimit: 1, activeSegmentKey: '2026-06-03'});
+
+        // Reconciled candidates (newest-first, active excluded): 06-02, 06-01 → keep 1, remove 1.
+        expect(removed).toBe(1);
+
+        const names = await fs.readdir(tmpDir);
+        expect(names).toContain('wal-2026-06-03.jsonl');      // active — never pruned
+        expect(names).toContain('wal-2026-06-02.jsonl');      // newest reconciled within bound
+        expect(names).not.toContain('wal-2026-06-01.jsonl');  // beyond bound — removed
+        expect(names).toContain('wal-2026-05-30.jsonl');      // pending payload — NEVER pruned
+
+        // A pending record survives any retention pressure.
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['pending']);
+    });
+
+    test('pruning is a no-op without a positive retention bound or with a missing directory', async () => {
+        expect(await pruneReconciledWalSegments({dir: tmpDir, retentionLimit: 0})).toBe(0);
+        expect(await pruneReconciledWalSegments({dir: path.join(tmpDir, 'missing'), retentionLimit: 5})).toBe(0);
+    });
+});


### PR DESCRIPTION
Resolves #12838

Authored by Claude Fable 5 (Claude Code), @neo-fable. Session 5000ac5e-dabb-4f39-8a5c-e8ba55133f3d.

## Follow-ups
- #12840 — absent-config guard (caught, actionable envelope; no hidden fallback) + validation-read-inside-`try` + JSDoc headline tighten + timestamp-duality comment + WAL-scan bound note. Folded from @neo-opus-ada's `Approve+Follow-Up` review (`PRR_kwDODSospM8AAAABCmOs6A`) as ACs 7–10 on the ticket; #12840 is natively linked `blocked_by` #12838.
- **Active merge-coordination step** (upgraded from passive post-merge checkbox per review): `memoryWal` config-sync + memory-core restart broadcast to ALL clones. Pre-sync A2A already sent — the block is inert before merge, so clones syncing today close the uncaught-throw window before it opens.

**Phase 1 of the operator-settled two-phase design** — the per-turn save can no longer fail or stall on the model-dependent embed. Phase 2 (the orchestrator-managed `ai/daemons/embed/` drain daemon) continues in #12840, which carries AC4/AC5/AC7 + the daemon config leaves verbatim; the phase-split rationale is documented on the ticket (1-PR-per-ticket, one `Resolves` per PR).

**The new write order in `MemoryService.addMemory` is the contract:**
1. **Validation gate** (AC1) — rejects empty/whitespace/below-floor `prompt`/`thought`/`response` before any write (`MEMORY_VALIDATION_ERROR`, the one deliberate error path). Floor = new `memoryWal.minFieldLength` leaf, default 1 (non-empty-after-trim) — deliberately conservative so `resumeHarness.mjs` boot-heartbeats (fail-closed dispatch health-check) keep passing until #12830's liveness-marker carve-out lands. No derived stricter threshold exists, so none was invented.
2. **Durable JSONL write-ahead append** (AC2) — full payload to `memoryWal.dir` BEFORE any model-dependent work. New pure store helper `ai/services/memory-core/helpers/memoryWalStore.mjs` (sibling-lift of `remRunStateStore.mjs`): UTC-day segments, **one writer per file** (records vs embed-markers split so multi-KB record appends can never interleave with marker appends from a second process), corrupt-line-tolerant reads, retention that never prunes a pending record.
3. **Synchronous graph writes** (AC3) — unchanged content, moved BEFORE the embed. Previously an embed throw also lost the `AGENT_MEMORY` node (`upsertNode` sat after the awaited `collection.add`); read-after-write recency is now preserved by construction.
4. **Deferred embed** — `embedPendingMemory` runs fire-and-forget (transitional Phase-1 drain; #12840's daemon replaces it), marks the WAL record on success, leaves it pending on failure. In-flight embeds are tracked: `drainPendingEmbeds()` gives shutdown paths and specs a deterministic flush.

## Deltas from ticket (Tier-2 decide-and-document)

- **The "optional pending-overlay" design note is load-bearing for the recency axis, not optional**: `queryRecentTurns` hydrates `detail:'full'` content and the summary raw-fallback from Chroma metadata, so a deferred embed would leave just-written turns content-degraded under exactly the contention this ticket targets. Both hydrators now fall back to the WAL tail for missing ids — and a Chroma outage now degrades `detail:'full'` reads instead of erroring the whole query (strict improvement, previously `RECENT_TURNS_ERROR`).
- **Purge-vs-deferred-embed resurrection window closed without waiting**: `SessionService.purgeSession` marks the purge in a tenant-aware in-process registry (consulted by the embed BEFORE `collection.add`; write-time-stamped so legitimate session-id reuse after purge is unaffected) and tombstones the session's WAL-pending records. Deliberately NOT solved by draining embeds inside purge — a purge blocked on a stalled embedder is the exact failure mode this ticket removes (the first implementation did exactly that and timed out under load; the registry replaced it).
- **`validateSessionForResume` graph fallback**: the resume validator counted "memories exist" from Chroma only — under deferred embeds (or a Chroma outage) a just-heartbeated session could false-negative to `SESSION_NOT_FOUND`. When the Chroma probe returns 0 it now consults the synchronously-written `AGENT_MEMORY` graph rows with the same tenant predicate. Conservative: behavior unchanged whenever Chroma has the data.

## Config template changes (`ai/mcp/server/memory-core/config.template.mjs`)

New keys (per the mcp-config-template-change-guide): `memoryWal.dirProd` (`NEO_MEMORY_WAL_DIR`), `memoryWal.dirTest` (`NEO_MEMORY_WAL_DIR_TEST`, per-worker-unique tmp default), `memoryWal.useTestDatabase` (`UNIT_TEST_MODE`), `memoryWal.retentionLimit` (`NEO_MEMORY_WAL_RETENTION_LIMIT`, default 30), `memoryWal.minFieldLength` (`NEO_MEMORY_MIN_FIELD_LENGTH`, default 1) + the `memoryWal.dir` formula (test-isolation by construction, mirrors `storagePaths.graph`). **Local `config.mjs` files in other clones need the same block added after merge** (shape-sync, not byte-sync), and a memory-core server restart picks it up. ADR 0019 throughout: declarative `leaf()`s, use-site reads, no singleton mutation anywhere (the WAL helper is a pure no-Neo-import module taking values as arguments).

## Test Evidence

Evidence: L2 (unit specs — fake content-store, real fs WAL, real in-memory SQLite graph) → L2 sufficient for AC1–AC3. Residual: AC4/AC5/AC7 + daemon leaves [#12840].

- New `MemoryService.WriteAhead.spec.mjs` (7): AC1 rejection (no WAL/graph side-effects), AC2 embed-**throws** → success+pending, AC2 embed-**hangs** → prompt return, AC3 recency-visible + WAL overlay serves BOTH detail levels with embed down, purge-guard suppression falsifier, marker reconciliation via `expect.poll`.
- New `helpers/memoryWalStore.spec.mjs` (7): segment keys/names, append/read/reconcile, ids/limit filters, torn-line + missing-dir tolerance, retention never prunes pending, prune no-ops.
- Updated 6 sibling spec files: deterministic `drainPendingEmbeds()` flushes where assertions read the content store right after `addMemory` (the embed used to be awaited inline), non-empty seed fixtures (empty `response`/`thought` seeds are now the rejected corruption class — pre-gate fixtures, not behavior changes).
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/`: **484 passed**; the residual failures are the pre-existing live-endpoint families (SessionSummarization gemma4, TextEmbedding Ollama/LM, WriteSideInvariant mailbox-embed) — verified present on clean `dev` (23–26 failures on the full `ai/` tree both with and without this change, fluctuating with local LM Studio saturation; CI runs `workers: 1` with the heavy-SLM bucket skipped).

## Post-Merge Validation

- [ ] AC7 (#12840): under a live heavy embed backfill, `add_memory` latency stays bounded and never returns `MEMORY_ADD_ERROR`; WAL backlog drains once contention clears.
- [ ] Peer clones sync the `memoryWal` block into local `config.mjs` + restart memory-core (pre-sync A2A sent; merge-time broadcast committed).

## Surfaced adjacent debt (observations, deliberately not scope-crept)

- `SessionService.memoryCollection_` is captured once at init (`SessionService.mjs:205`) — in multi-file unit workers, whichever `StorageRouter` stub is active at first init gets baked in for the worker lifetime (observed as cross-file flake under `fullyParallel`). A live read-through would remove the class; candidate follow-up ticket if a peer concurs.
- The live-model spec families (gemma4/Ollama-dependent) fail nondeterministically on saturated local endpoints in full-tree runs — pre-existing, dev-baseline-verified, worth a bucket-gating sweep eventually.
