### PR TITLE
fix(memory-core): structural provider-timeout discrimination in categorizeInvocationError (#12845)

### DIFF
--- a/ai/services/memory-core/helpers/consumerFrictionHelper.mjs
+++ b/ai/services/memory-core/helpers/consumerFrictionHelper.mjs
@@ -32,13 +32,15 @@
  * Token estimation: V1 uses a 4-chars/token heuristic (`Math.ceil(Buffer.byteLength(payload) / 4)`)
  * because the codebase has no canonical provider-specific tokenizer. Bytes are retained on
  * the record as evidence; tokens are the durable LLM-relevant contract.
- * Future V2 may integrate with Model-Stats registry (ADR 0012) for per-provider tokenization.
+ * Future V2 may integrate with Model-Stats registry (ADR 0012) for per-provider tokenization. ticket-ref-ok: load-bearing ADR design-pointer (mirrors the @see below).
  *
  * @see learn/agentos/decisions/0012-model-stats-framework.md
  * @see ai/services/graph/GoldenPathSynthesizer.mjs (handoff section consumer)
  * @see ai/services/graph/SemanticGraphExtractor.mjs (canonical emitter — Dream Pipeline)
  * @see ai/services/memory-core/SessionService.mjs#summarizeSession (canonical emitter — Memory Core)
  */
+
+import {PROVIDER_TIMEOUT_CODE} from '../../../provider/createTimeoutError.mjs';
 
 /**
  * @typedef {Object} ConsumerFriction
@@ -141,7 +143,10 @@ export function bytesToTokens(bytes) {
 
 /**
  * @summary Categorizes a thrown invocation error into a ConsumerFriction symptom.
- * Pure helper, exported for testability.
+ * Pure helper, exported for testability. A provider timeout is detected structurally first
+ * (`error.code === PROVIDER_TIMEOUT_CODE`, the uniform cross-provider contract) so the
+ * classification does not depend on the provider's message wording; the message regex remains a
+ * fallback for non-coded error paths.
  *
  * @param {*} err The caught error (or thrown value).
  * @returns {'context-overflow' | 'parse-failure' | 'timeout'} The categorized symptom.
@@ -149,6 +154,7 @@ export function bytesToTokens(bytes) {
 export function categorizeInvocationError(err) {
     const msg = String(err?.message || err || '');
 
+    if (err?.code === PROVIDER_TIMEOUT_CODE)                    return 'timeout';
     if (/context|overflow|too large|maximum|exceed/i.test(msg)) return 'context-overflow';
     if (/timeout|aborted|timed[ -]out/i.test(msg))              return 'timeout';
     return 'parse-failure';

--- a/test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.providerTimeout.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/consumerFrictionHelper.providerTimeout.spec.mjs
@@ -1,0 +1,50 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'ConsumerFrictionProviderTimeoutTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../../src/core/_export.mjs';
+import {PROVIDER_TIMEOUT_CODE} from '../../../../../../../ai/provider/createTimeoutError.mjs';
+
+/**
+ * @summary Regression coverage for structural provider-timeout discrimination in
+ * `categorizeInvocationError`. A provider timeout carries the uniform `error.code`
+ * (the cross-provider `PROVIDER_TIMEOUT` contract), so the symptom is detected without
+ * depending on the message-wording regex. Kept in a dedicated spec so this coverage does not
+ * entangle with the broader consumerFrictionHelper spec.
+ */
+test.describe.serial('Neo.ai.services.memory-core.helpers.ConsumerFrictionHelper — provider-timeout discrimination', () => {
+    let categorizeInvocationError;
+
+    test.beforeAll(async () => {
+        ({categorizeInvocationError} = await import('../../../../../../../ai/services/memory-core/helpers/consumerFrictionHelper.mjs'));
+    });
+
+    test('detects a provider timeout structurally via error.code, regex-independent', () => {
+        // The message matches NEITHER the context-overflow nor the timeout regex — a 'timeout' result
+        // can only come from the structural PROVIDER_TIMEOUT_CODE check, not the message wording.
+        const err = new Error('the upstream request was cancelled by the interactive budget');
+        err.code  = PROVIDER_TIMEOUT_CODE;
+        expect(categorizeInvocationError(err)).toBe('timeout');
+
+        // The same message WITHOUT the code falls through to parse-failure (proves the code did the work).
+        expect(categorizeInvocationError(new Error('the upstream request was cancelled by the interactive budget'))).toBe('parse-failure');
+    });
+
+    test('falls back to the message regex when no structural code is present', () => {
+        expect(categorizeInvocationError(new Error('Request timed out after 30000ms'))).toBe('timeout');
+        expect(categorizeInvocationError(new Error('context window exceeded'))).toBe('context-overflow');
+    });
+});


### PR DESCRIPTION
Resolves #12845

`categorizeInvocationError` detected a provider timeout only by message-regex (`/timeout|aborted|timed[ -]out/i`). It now checks `error.code === PROVIDER_TIMEOUT_CODE` first — the uniform cross-provider contract — with the regex as a fallback for non-coded error paths. This is the deferred sibling-half of the #12833 / #12837 split (with @neo-claude-opus); he adopted the same shape on the ask-path in #12832 / #12844.

Authored by Claude Opus 4.8 (@neo-opus-vega).

Evidence: L1 (unit: regex-independent structural discrimination + the regex fallback, pure functions) → L1 required (the AC is a pure-function contract). No residuals.

## What shipped
- `consumerFrictionHelper.categorizeInvocationError` — a structural `error.code === PROVIDER_TIMEOUT_CODE` check **before** the message-regex (the regex remains the fallback for non-coded errors). Pure addition: non-coded paths are unchanged.
- A regex-independent regression test in a new focused spec (`consumerFrictionHelper.providerTimeout.spec.mjs`) — the error carries the code, the message deliberately does NOT say "timed out" → still `'timeout'`; the same message without the code → `'parse-failure'` (proving the code did the work).

## Deltas from ticket
- The test lives in a **new dedicated spec** rather than the existing `consumerFrictionHelper.spec.mjs`. Rationale: staging the existing spec would inherit ~5 grandfathered `#N`-in-comment refs (another author's) that `check-ticket-archaeology` flags whole-file — the new focused spec keeps the coverage without churning those (authorship-respect). The `ticket-ref-ok` marker was used only for the one genuinely-load-bearing ADR pointer in the helper's own module JSDoc.
- The hook's whole-file scan (flagging grandfathered refs on any touched file) is noted in #12845 as a separate MX-friction observation.

## Test Evidence
- `npm run test-unit -- consumerFrictionHelper` → **22 passed** (the new providerTimeout spec's 2 tests + the existing 20). Pure-addition guard → existing consumers (`SessionService`, `SemanticGraphExtractor`) are unaffected: a `PROVIDER_TIMEOUT` error already resolved to `'timeout'` via the message-regex; this just makes it structural.

## Post-Merge Validation
- [ ] None required — pure-function contract, fully unit-covered.

## Related
- #12833 / #12837 — SessionService stall fix (this is its deferred sibling-half)
- #12832 / #12844 — ask-path `PROVIDER_TIMEOUT_CODE` adoption (@neo-claude-opus; the mirror)
- #12818 / #12814 — the `PROVIDER_TIMEOUT_CODE` provider contract
