### PR TITLE
fix(wake-daemon): fail corrupt resume-cursor to log tip + atomic cursor write (#12849)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -43,6 +43,7 @@ const __dirname = path.dirname(__filename);
 import {
     initializeDatabase,
     getLastSyncId,
+    writeLastSyncId,
     getActiveShapeCSubscriptions,
     getGraphLogEntries,
     getNodesData,
@@ -334,7 +335,7 @@ async function pollLoop() {
             }
 
             lastSyncId = maxId;
-            fs.writeFileSync(STATE_FILE, lastSyncId.toString(), 'utf8');
+            writeLastSyncId(STATE_FILE, lastSyncId);
         }
 
     } catch (err) {

--- a/ai/daemons/wake/queries.mjs
+++ b/ai/daemons/wake/queries.mjs
@@ -14,17 +14,70 @@ export function initializeDatabase(dbPath) {
     }
 }
 
+/**
+ * @summary Resolves the wake-daemon resume cursor — the GraphLog id to tail-sync from.
+ *
+ * **Fail-to-the-tip semantics.** A missing OR corrupt/empty cursor file resolves to
+ * `MAX(log_id)` (resume at the log tip, skip the backlog), never `0`. The previous
+ * `parseInt(...) || 0` collapsed a corrupt/empty cursor (`parseInt` → `NaN`) to `0`, which
+ * makes the daemon tail-sync the ENTIRE GraphLog from id 0 and re-fire the whole unread
+ * backlog as one volume-escalated HIGH wake (the full-backlog wake-flood this guards against).
+ * Only a genuinely-parseable non-negative integer is trusted as a cursor: a legitimately
+ * persisted `0` is preserved, while `NaN` (truncated/empty file) or a negative value falls
+ * through to the safe tip.
+ *
+ * @param {Database} db        SQLite database handle.
+ * @param {String}   stateFile Path to the persisted cursor file.
+ * @returns {Number} The log id to resume tail-sync from.
+ */
 export function getLastSyncId(db, stateFile) {
     if (fs.existsSync(stateFile)) {
-        return parseInt(fs.readFileSync(stateFile, 'utf8'), 10) || 0;
-    } else {
-        try {
-            const row = db.prepare('SELECT MAX(log_id) as max_id FROM GraphLog').get();
-            return row?.max_id || 0;
-        } catch (e) {
-            return 0;
-        }
+        const parsed = parseInt(fs.readFileSync(stateFile, 'utf8'), 10);
+        // A valid cursor is a non-negative integer; anything else (NaN from a truncated/empty
+        // file, or a negative value) is corruption → fail to the tip, never replay from 0.
+        return Number.isInteger(parsed) && parsed >= 0 ? parsed : getMaxLogId(db);
     }
+
+    // Missing cursor (first boot / fresh data dir) → resume at the tip, skip the backlog.
+    return getMaxLogId(db);
+}
+
+/**
+ * @summary Returns the highest GraphLog id, or `0` when the log is empty / unreadable.
+ *
+ * Shared by {@link getLastSyncId} across both the missing-cursor and corrupt-cursor branches
+ * so the two cannot drift apart. An empty log legitimately yields `0` (nothing to replay).
+ *
+ * @param {Database} db SQLite database handle.
+ * @returns {Number}
+ */
+function getMaxLogId(db) {
+    try {
+        const row = db.prepare('SELECT MAX(log_id) as max_id FROM GraphLog').get();
+        return row?.max_id || 0;
+    } catch (e) {
+        return 0;
+    }
+}
+
+/**
+ * @summary Atomically persists the wake-daemon resume cursor.
+ *
+ * Writes to a sibling temp file then `renameSync`s it over the live cursor. `rename(2)` is
+ * atomic within a filesystem, so a process kill mid-write can only ever truncate the
+ * disposable temp file — the live cursor is always either the old value or the new one, never
+ * an empty string. That empty-string truncation is precisely the corruption that drove a
+ * subsequent boot into the replay-from-0 backlog flood; pairing this atomic write with the
+ * fail-to-the-tip read in {@link getLastSyncId} is the write-side half of that defense.
+ *
+ * @param {String} stateFile  Path to the persisted cursor file.
+ * @param {Number} lastSyncId The cursor value to persist.
+ * @returns {void}
+ */
+export function writeLastSyncId(stateFile, lastSyncId) {
+    const tmpFile = `${stateFile}.tmp`;
+    fs.writeFileSync(tmpFile, lastSyncId.toString(), 'utf8');
+    fs.renameSync(tmpFile, stateFile);
 }
 
 export function getActiveShapeCSubscriptions(db) {

--- a/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 import Database from 'better-sqlite3';
-import { getUnreadSunsetHandovers, markNodesAsRead } from '../../../../../../ai/daemons/wake/queries.mjs';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { getLastSyncId, getUnreadSunsetHandovers, markNodesAsRead, writeLastSyncId } from '../../../../../../ai/daemons/wake/queries.mjs';
 
 test.describe('ai/daemons/wake/queries', () => {
     let db;
@@ -100,6 +103,97 @@ test.describe('ai/daemons/wake/queries', () => {
 
         test('handles empty array gracefully', () => {
             expect(() => markNodesAsRead(db, [])).not.toThrow();
+        });
+    });
+
+    test.describe('getLastSyncId / writeLastSyncId (resume cursor)', () => {
+        let tmpDir, stateFile;
+
+        test.beforeEach(() => {
+            // GraphLog is the MAX(log_id) source for the fail-to-the-tip fallback.
+            // The outer beforeEach already created `db`; add the cursor source here.
+            db.exec(`
+                CREATE TABLE GraphLog (
+                    log_id      INTEGER PRIMARY KEY,
+                    entity_id   TEXT,
+                    entity_type TEXT
+                )
+            `);
+            tmpDir    = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-cursor-'));
+            stateFile = path.join(tmpDir, 'lastSyncId');
+        });
+
+        test.afterEach(() => {
+            try { fs.removeSync(tmpDir); } catch (e) {}
+        });
+
+        const seedLog = maxId => {
+            const stmt = db.prepare('INSERT INTO GraphLog (log_id, entity_id, entity_type) VALUES (?, ?, ?)');
+            for (let id = 1; id <= maxId; id++) {
+                stmt.run(id, `n-${id}`, 'nodes');
+            }
+        };
+
+        test.describe('getLastSyncId', () => {
+            test('missing cursor file → MAX(log_id) (resume at tip, skip backlog)', () => {
+                seedLog(42);
+                expect(getLastSyncId(db, stateFile)).toBe(42);
+            });
+
+            test('empty cursor file → MAX(log_id), NOT 0 (prevents full-backlog flood)', () => {
+                seedLog(42);
+                fs.writeFileSync(stateFile, '', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(42);
+            });
+
+            test('corrupt (non-numeric) cursor file → MAX(log_id), NOT 0', () => {
+                seedLog(99);
+                fs.writeFileSync(stateFile, 'not-a-number', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(99);
+            });
+
+            test('negative cursor value → MAX(log_id) (negative is corruption, not a replay)', () => {
+                seedLog(99);
+                fs.writeFileSync(stateFile, '-5', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(99);
+            });
+
+            test('valid positive cursor is preserved', () => {
+                seedLog(99);
+                fs.writeFileSync(stateFile, '42', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(42);
+            });
+
+            test('valid 0 cursor is preserved (not treated as corruption)', () => {
+                seedLog(99);
+                fs.writeFileSync(stateFile, '0', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(0);
+            });
+
+            test('empty cursor + empty log → 0 (nothing to replay)', () => {
+                fs.writeFileSync(stateFile, '', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(0);
+            });
+        });
+
+        test.describe('writeLastSyncId', () => {
+            test('persists the cursor value (readable back)', () => {
+                writeLastSyncId(stateFile, 137);
+                expect(fs.readFileSync(stateFile, 'utf8')).toBe('137');
+            });
+
+            test('round-trips through getLastSyncId', () => {
+                seedLog(500);
+                writeLastSyncId(stateFile, 137);
+                expect(getLastSyncId(db, stateFile)).toBe(137);
+            });
+
+            test('overwrites an existing cursor and leaves no .tmp residue', () => {
+                writeLastSyncId(stateFile, 1);
+                writeLastSyncId(stateFile, 2);
+                expect(fs.readFileSync(stateFile, 'utf8')).toBe('2');
+                expect(fs.existsSync(`${stateFile}.tmp`)).toBe(false);
+            });
         });
     });
 });


### PR DESCRIPTION
Resolves #12849

A corrupt/empty wake-daemon resume-cursor no longer collapses to `0`. The read-side (`getLastSyncId`) now trusts only a non-negative integer and otherwise fails to `MAX(log_id)` (the log tip); the write-side is a new atomic `writeLastSyncId` (temp + `renameSync`) replacing the kill-truncatable inline write at `daemon.mjs:337`. Together this closes the read- and write-halves of the full-backlog wake-flood (the live 557-event repro).

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega. Session: 2026-06-10 nightshift (Memory Core origin — see Retrieval Hint).

Evidence: L2 (unit: corrupt/empty/non-numeric/negative/valid-incl-0 cursor branches + atomic-write / no-`.tmp`-residue / round-trip — 16/16 green; full wake dir 64/64 green) → L4 required (AC4 operator-observable: a daemon restart no longer replays the whole GraphLog). Residual: AC4 [#12849] (flagged post-merge in the ticket).

## Root cause
`getLastSyncId` resolved the cursor asymmetrically:
- **Missing** file → `MAX(log_id)` (resume at tip — correct).
- **Existing but corrupt/empty** → `parseInt(readFileSync(...), 10) || 0` → `NaN || 0` → **0** → daemon tail-syncs the ENTIRE GraphLog from id 0 and re-fires the whole unread backlog as one volume-escalated HIGH wake.

Corruption source: the cursor was persisted via a non-atomic `fs.writeFileSync(STATE_FILE, …)` (`daemon.mjs:337`); a restart-kill mid-write truncates it to empty → next boot hits the corrupt branch → 0 → flood. The all-clones memory-core restart wave was the operational trigger; the bug predates it.

## The fix
1. **Read-side** (`queries.mjs` `getLastSyncId`): trust only `Number.isInteger(parsed) && parsed >= 0`; otherwise fall through to a shared `getMaxLogId(db)` helper (used by both the missing-file and corrupt-cursor branches so they cannot drift). A legitimately-persisted `0` is preserved; `NaN` / negative garbage fails to the tip.
2. **Write-side** (`queries.mjs` new `writeLastSyncId`): write `${stateFile}.tmp` then `fs.renameSync` over the live cursor. `rename(2)` is atomic within a filesystem, so a kill mid-write can only truncate the disposable temp file — the live cursor is always the old or new value, never empty. `daemon.mjs:337` now calls this instead of the inline write.

Defense-in-depth: the read-side validation stops the flood even on a legacy-corrupt cursor; the atomic write prevents the corruption from occurring at all.

## Deltas from ticket
- Added a `parsed >= 0` guard (negative cursor → tip) beyond the ticket's NaN-only framing: a negative value is equally corruption and would make `WHERE log_id > -5` ≈ replay everything. Covered by a dedicated test. Within the "distinguish a legit cursor from garbage" AC intent.
- Co-located the write-side as `writeLastSyncId` in `queries.mjs` (rather than an inline atomic block in `daemon.mjs`) so both halves of the cursor contract live in the unit-tested module.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/queries.spec.mjs` → **16/16 passed** (10 new: missing / empty / non-numeric / negative / valid+ / valid-0 / empty-log read branches + persist / round-trip / no-`.tmp`-residue write).
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/` → **64/64 passed** (full wake dir incl. the 85KB `daemon.spec.mjs` — no regression from the `daemon.mjs:337` write-path change).

## Post-Merge Validation
- [ ] AC4 (operator-observable): after a daemon restart on a freshly-merged primary, confirm the daemon resumes at the log tip and does NOT replay the full GraphLog as a backlog wake-flood.

## Out of scope (tracked elsewhere)
- Bulk mailbox drain → @neo-fable's memory-core MailboxService sibling.
- Restart-burst bounding / digest → `#12612`.
- The memory-core restart wave itself (`#12844` — operational trigger, not the bug).

Retrieval Hint: semantic — "wake daemon corrupt cursor 557 flood getLastSyncId MAX log_id atomic write"; structural — `ai/daemons/wake/queries.mjs` `getLastSyncId` / `writeLastSyncId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
