### PR TITLE
fix(bootstrap-worktree): auto-derive BOOTSTRAP_CONFIGS from server templates (#12808)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -108,6 +108,7 @@
  */
 import {execFile}       from 'child_process';
 import fs               from 'fs/promises';
+import {existsSync, readdirSync} from 'fs';
 import path             from 'path';
 import {fileURLToPath}  from 'url';
 import {promisify}      from 'util';
@@ -116,12 +117,28 @@ import {materializeServerConfigTemplate} from '../setup/initServerConfigs.mjs';
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * The set of gitignored config overlays a fresh worktree must hydrate from the main
+ * checkout: the Tier-1 `ai/config.mjs` plus each per-server `ai/mcp/server/<name>/config.mjs`.
+ *
+ * **Auto-derived, not hand-maintained.** The per-server list is globbed at load time from the
+ * `ai/mcp/server/*` dirs that ship a `config.template.mjs` — the same predicate
+ * `initServerConfigs` uses. The previous hand-maintained allow-list silently drifted whenever a
+ * new MCP server was added: the new server's gitignored `config.mjs` went un-hydrated, so a
+ * worktree importing that server's chain crashed with `ERR_MODULE_NOT_FOUND`. Deriving from the
+ * filesystem eliminates that drift class — any server shipping a template is hydrated
+ * automatically; dirs without one (e.g. `file-system`, `shared`) are excluded.
+ */
+const serverConfigsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../mcp/server');
+
 export const BOOTSTRAP_CONFIGS = [
     'ai/config.mjs',
-    'ai/mcp/server/github-workflow/config.mjs',
-    'ai/mcp/server/knowledge-base/config.mjs',
-    'ai/mcp/server/memory-core/config.mjs',
-    'ai/mcp/server/neural-link/config.mjs'
+    ...readdirSync(serverConfigsDir, {withFileTypes: true})
+        .filter(entry => entry.isDirectory())
+        .map(entry => entry.name)
+        .filter(name => existsSync(path.join(serverConfigsDir, name, 'config.template.mjs')))
+        .sort()
+        .map(name => `ai/mcp/server/${name}/config.mjs`)
 ];
 
 /**

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -87,8 +87,25 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
         }
     });
 
-    test('exports the canonical BOOTSTRAP_CONFIGS list', () => {
-        expect(BOOTSTRAP_CONFIGS).toEqual(fixtureConfigs);
+    test('auto-derives BOOTSTRAP_CONFIGS from server dirs that ship a config.template.mjs', () => {
+        // Tier-1 operator overlay is always first.
+        expect(BOOTSTRAP_CONFIGS[0]).toBe('ai/config.mjs');
+
+        // Every MCP server that ships a config.template.mjs is hydrated — including
+        // gitlab-workflow, whose omission from the old hand-maintained list broke fresh
+        // worktrees with ERR_MODULE_NOT_FOUND (the regression this guards against).
+        for (const name of ['github-workflow', 'gitlab-workflow', 'knowledge-base', 'memory-core', 'neural-link']) {
+            expect(BOOTSTRAP_CONFIGS).toContain(`ai/mcp/server/${name}/config.mjs`);
+        }
+
+        // Dirs without a config.template.mjs (file-system, shared) are excluded.
+        expect(BOOTSTRAP_CONFIGS).not.toContain('ai/mcp/server/file-system/config.mjs');
+        expect(BOOTSTRAP_CONFIGS).not.toContain('ai/mcp/server/shared/config.mjs');
+
+        // Every entry is the Tier-1 overlay or a well-formed per-server overlay path.
+        for (const rel of BOOTSTRAP_CONFIGS) {
+            expect(rel === 'ai/config.mjs' || /^ai\/mcp\/server\/[^/]+\/config\.mjs$/.test(rel)).toBe(true);
+        }
     });
 
     test('resolveCliProjectRoot climbs migrations/ → scripts/ → ai/ → root (#12147)', () => {


### PR DESCRIPTION
Resolves #12808

`BOOTSTRAP_CONFIGS` in `ai/scripts/migrations/bootstrapWorktree.mjs` is now auto-derived by globbing the `ai/mcp/server/*` dirs that ship a `config.template.mjs`, instead of a hand-maintained allow-list. That hand-list had never been updated for the later-added `gitlab-workflow` server, so a fresh worktree importing the gitlab service chain crashed with `ERR_MODULE_NOT_FOUND` on its un-hydrated gitignored `config.mjs`. Deriving from the filesystem fixes that instance **and eliminates the drift class** — any future MCP server shipping a template is hydrated automatically.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega. Session: 2026-06-10 nightshift.

Evidence: L2 (unit: derive includes gitlab-workflow + the 4 existing servers, excludes the templateless `file-system`/`shared`; 36/36 green; bootstrapWorktree copy mechanics pre-covered) → L3 for AC2 (real fresh-worktree bootstrap + gitlab service-chain import succeeds). Residual: AC2 end-to-end [#12808].

## The fix
- `BOOTSTRAP_CONFIGS` = `'ai/config.mjs'` + `readdirSync(ai/mcp/server)` filtered to dirs that contain a `config.template.mjs`, sorted, mapped to `ai/mcp/server/<name>/config.mjs` — the same template-presence predicate `initServerConfigs` uses.
- This is the ticket's **preferred** shape (AC3): the list derives from the server dirs, so a newly-added server cannot reintroduce the gap.

## Deltas from ticket
- Rewrote the `bootstrapWorktree.spec.mjs` "canonical list" test from a hardcoded `toEqual(fixtureConfigs)` to **behavior validation** of the derive: asserts gitlab-workflow (+ the 4 known servers) are present, the templateless `file-system`/`shared` are excluded, Tier-1 is first, and every entry is well-formed. A hardcoded fixture would have just relocated the same drift into the test.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` → **36/36 passed** (the rewritten derive-validation test + the existing copy/symlink/prune coverage; the module's load-time glob resolves against the real `ai/mcp/server`).

## Post-Merge Validation
- [ ] AC2 (integration/operator): a fresh `.claude/worktrees/<name>/` bootstrapped via `bootstrapWorktree` has `ai/mcp/server/gitlab-workflow/config.mjs` hydrated, and importing the gitlab service chain no longer throws `ERR_MODULE_NOT_FOUND`.

## Out of scope
- npm-install / `--build-all` path (`#10351`, done) and theme CSS build.

Retrieval Hint: structural — `ai/scripts/migrations/bootstrapWorktree.mjs` `BOOTSTRAP_CONFIGS` derive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
