### PR TITLE
feat(ticket-create): A2A in-flight claim sweep + first-claim-wins in §1a dedup gate (#12856)

### DIFF
--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -15,7 +15,11 @@ Before the duplicate sweep or the Fat-Ticket body: is this the right work — do
 ### 1a. The Content Sweep (Duplicate Detection)
 Verify no equivalent ticket already exists. Redundant tickets pollute the Knowledge Base.
 
-**Live freshness sweep (mandatory):** before any `create_issue` call, read at least the latest 20 open GitHub issues from the live tracker, including issue number, title, author, labels, and URL.
+Duplicates hide in **two substrates**, and you MUST sweep **both as the LAST step immediately before `create_issue`** — not at turn-start, not when you begin drafting. A sweep run before authoring goes stale while you write the Fat Ticket: in a thundering herd (multiple agents booting on the same prompt), a peer's ticket can land in the minutes between your sweep and your create call. The turn-start mailbox check (`§mailbox_check_protocol`) is for general coordination — it is **not** the dup gate.
+
+> **Empirical anchor (`#12856`, 2026-06-10):** four agents raced an operator's "one (not all!)" prompt → three duplicate tickets, despite every agent running the GitHub sweep honestly. The one agent who used a two-phase *claim → re-check → execute* filed zero. Check-at-start freshness decays across a multi-minute protocol; check-at-last collapses the stale window to the create-call gap.
+
+**(i) GitHub live freshness sweep (mandatory) — catches already-FILED duplicates:** read at least the latest 20 open GitHub issues from the live tracker, including issue number, title, author, labels, and URL.
 
 ```bash
 gh issue list --state open --limit 20 --json number,title,author,labels,url
@@ -26,6 +30,14 @@ An equivalent GitHub Workflow MCP or GitHub API call is acceptable when it retur
 If the live latest-open sweep fails because of sandbox, network, or auth state, retry through the appropriate approved/escalated path. If live GitHub state still cannot be fetched, stop before `create_issue` and report the blocker; do not file from stale-only evidence.
 
 Record the live-open sweep result in the ticket body or creation notes, e.g. `Live latest-open sweep: checked latest 20 open issues at <timestamp>; no equivalent found` or link the existing ticket you found instead of filing a duplicate.
+
+**(ii) A2A in-flight claim sweep (mandatory) — catches IN-FLIGHT duplicates not yet on GitHub:** for the first minutes of a thundering herd a peer's intent exists only as an A2A `[lane-claim]`/`[lane-intent]`, not yet a GitHub ticket — the `(i)` sweep above cannot see it. Immediately before `create_issue`, scan the mailbox for recent claims on the same scope:
+
+```js
+list_messages({ status: 'unread' })  // scan recent [lane-claim] / [lane-intent] on the same subject / write-surface
+```
+
+**Tiebreak — first-claim-timestamp-wins:** if a competing claim or a just-filed ticket surfaces, the **earliest claim/file timestamp wins**; the later claimant stands down (or closes its duplicate, porting any unique substance as a comment onto the survivor). Deterministic and self-healing — resolves simultaneous filings without lead mediation. Never `wakeSuppress` a contested-lane resolution: the "do-not-re-file" signal must wake, or it reaches no one in time.
 
 ```
 grep on resources/content/issues/       # active + archived tickets

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -34,10 +34,12 @@ Record the live-open sweep result in the ticket body or creation notes, e.g. `Li
 **(ii) A2A in-flight claim sweep (mandatory) — catches IN-FLIGHT duplicates not yet on GitHub:** for the first minutes of a thundering herd a peer's intent exists only as an A2A `[lane-claim]`/`[lane-intent]`, not yet a GitHub ticket — the `(i)` sweep above cannot see it. Immediately before `create_issue`, scan the mailbox for recent claims on the same scope:
 
 ```js
-list_messages({ status: 'unread' })  // scan recent [lane-claim] / [lane-intent] on the same subject / write-surface
+list_messages({ status: 'all', limit: 30 })  // ALL read-states — recency is the bound, not read-status
 ```
 
-**Tiebreak — first-claim-timestamp-wins:** if a competing claim or a just-filed ticket surfaces, the **earliest claim/file timestamp wins**; the later claimant stands down (or closes its duplicate, porting any unique substance as a comment onto the survivor). Deterministic and self-healing — resolves simultaneous filings without lead mediation. Never `wakeSuppress` a contested-lane resolution: the "do-not-re-file" signal must wake, or it reaches no one in time.
+**Filter by recency + scope, NOT read-status.** A `[lane-claim]` you have already *read* (e.g. your turn-start mailbox triage marked it read) is still an active claim — `status: 'unread'` would make it invisible and you would refile the duplicate, the exact late-boot ordering this gate exists to stop (read-status is consumption tracking, not a relevance signal). From the returned slice, keep messages whose `sentAt` falls in the herd window (~last 30–60 min) **and** whose `[lane-claim]`/`[lane-intent]` subject overlaps your scope (`taggedConcepts: ['lane-claim']` is optional narrowing — tag discipline is conventional, not guaranteed, so subject-scan stays primary).
+
+**Tiebreak — first-claim-timestamp-wins:** if a competing claim or a just-filed ticket surfaces, the **earliest claim/file timestamp wins** — and an earlier *unfiled claim* outranks a later *filed ticket* (claims must bind against fast-filers, or the sweep is toothless). The later party stands down; if it already filed, it closes its duplicate and ports any unique substance onto the survivor — i.e. the earlier claimant absorbs the later filer's content, **not** the reverse. Deterministic and self-healing — resolves simultaneous filings without lead mediation. Never `wakeSuppress` a contested-lane resolution: the "do-not-re-file" signal must wake, or it reaches no one in time.
 
 ```
 grep on resources/content/issues/       # active + archived tickets


### PR DESCRIPTION
Resolves #12856

Closes the structural hole behind tonight's 4-way dup-ticket race: `ticket-create` §1a swept **GitHub state only**, but for the first ~3 min of a thundering herd the duplicates exist solely as A2A `[lane-claim]`s — not yet GitHub tickets — so an honest GitHub sweep finds nothing. This adds the missing **A2A in-flight claim sweep** as §1a's second substrate, mandates **both** sweeps run as the **last step immediately before `create_issue`** (not turn-start), and codifies a deterministic **first-claim-timestamp-wins** tiebreak so simultaneous filings self-heal without lead mediation.

This is the zero-infra **discipline** layer (`C′`). The durable tool-side backstop — a sink-side *semantic* dedup gate on the `create_issue` MCP tool, mirroring `manage_issue_assignees`'s `requireUnassigned`/`acknowledgedReassign` — is captured separately as a higher-blast Ideation lane (`#12856` Out-of-Scope).

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus). Session c9d6ec4c-ada2-45a1-9c65-355faf402ab8.

Evidence: L1 (static skill-doc audit — §1a renders coherently, maps 1:1 to `#12856` ACs) → L1 required (no runtime-verify ACs; this substrate is read-and-followed by agents, not executed). No residuals.

## Deltas from ticket
None — implements `#12856` ACs 1–5 exactly. AC6 (substrate-accretion) is discharged in the slot-rationale below.

## Substrate Slot-Rationale (§1.1 — touches `.agents/skills/**`)
- **Added** — §1a `(ii)` A2A in-flight claim sweep, the two-substrate / just-in-time framing, the first-claim-wins tiebreak, and the no-`wakeSuppress`-on-contested-resolution companion:
  - **Disposition: `keep`**, but in the conditionally-loaded `references/ticket-create-workflow.md` (World Atlas) — the always-loaded `SKILL.md` router is **untouched**. Loads only when the `ticket-create` skill fires → ~zero always-loaded accretion.
  - **3-axis:** trigger-frequency = every ticket creation (high, but on-demand load) × failure-severity = dup tickets pollute the KB + split swarm attention + waste cycles (medium-high, demonstrated ×3 tonight) × enforceability = discipline-only until the tool-side gate ships (medium).
  - **Retirement trigger:** `compress-to-trigger` when the durable sink-side `create_issue` semantic dedup gate ships — at which point this discipline collapses to a one-line trigger note.
- Net: +13 / −1 lines, entirely in the `references/` payload. Progressive Disclosure (ADR 0008) preserved.

## Test Evidence
N/A — skill-doc (markdown) change, no executable surface. Verified by inspection: §1a renders coherently (fenced blocks balanced), the `(i)` GitHub / `(ii)` A2A substrate split is unambiguous, and each `#12856` AC maps to specific added prose. No `npx playwright` run (no test surface; per the pull-request skill's custom-config guidance).

## Post-Merge Validation
- [ ] Next thundering-herd (multi-agent same-prompt boot) yields ≤1 ticket per intent, or a clean first-claim-wins stand-down — the real-world falsifier.
- [ ] Agents begin citing the A2A claim sweep in their creation notes.

## Commits
- `4b296308e` — feat(ticket-create): A2A in-flight claim sweep + first-claim-wins in §1a dedup gate

---
Empirical anchor: the 2026-06-10 4-way sunset-ticket race (`#12851` canonical; `#12852`/`#12853` closed as dups). Related: `#11536`/`#11537` (the lane-claim / pre-write coordination substrate this extends).
