### PR TITLE
feat(memory-core): embed daemon durably drains the add_memory WAL (#12840)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -476,6 +476,11 @@ class Config extends ConfigProvider {
                     // reaches the compose-owned `chroma` peer container instead.
                     chromaDaemonEnabled            : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),
                     bridgeDaemonEnabled            : leaf(null, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
+                    // The embed daemon durably drains the add_memory WAL into the content store
+                    // (ai/daemons/embed/daemon.mjs). Local profile supervises it as a child
+                    // process; cloud deployments own their drain story per-container (mirror of
+                    // the chromaDaemonEnabled split).
+                    embedDaemonEnabled             : leaf(null, 'NEO_ORCHESTRATOR_EMBED_DAEMON_ENABLED', 'boolean'),
                     goldenPathRepoEnrichmentEnabled: leaf(null, 'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED', 'boolean'),
                     // `null` = use the deployment-profile default (local enables, cloud disables);
                     // the swarm-heartbeat lane emits wake-substrate pulses through bridge delivery.

--- a/ai/daemons/embed/daemon.mjs
+++ b/ai/daemons/embed/daemon.mjs
@@ -1,0 +1,300 @@
+/**
+ * @summary Embed daemon for the `add_memory` write-ahead log.
+ *
+ * Durably drains the JSONL WAL that `MemoryService.addMemory` appends every agent turn —
+ * the daemon half of the never-fail `add_memory` design: polls the pending
+ * backlog on a config-driven interval, embeds batches into the memory content store with
+ * retry/backoff, reconciles embed markers, compensates purge races, and prunes reconciled
+ * segments. Crash/restart-safe by construction — the WAL is the durable source of truth;
+ * an interrupted cycle simply leaves records pending for the next pass (`collection.add`
+ * is idempotent per id at worst-duplicate level).
+ *
+ * Sibling of `ai/daemons/wake/daemon.mjs`: same orchestrator supervision
+ * (`taskDefinitions.mjs` → `embedDaemon`, continuous task), same singleton PID lock, same
+ * dual-sink logging contract. Drain logic lives in `./drainCycle.mjs` so specs exercise the
+ * exact production path without spawning this process.
+ *
+ * **Diagnostic log persistence:**
+ * All lines are written to both stdout (live observability) and
+ * `.neo-ai-data/embed-daemon/embed-daemon.log` (post-hoc audit), format
+ * `[ISO-timestamp] [PID:NNN] [LEVEL] message`, with daily rotation and retention pruning.
+ */
+// Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate
+// `globalThis.Neo` so any consumed class file relying on `Neo.setupClass()` works
+// at module-load. `InstanceManager` binds `Neo.find` / `Neo.findFirst` / `Neo.get`
+// aliases + sets `Base.instanceManagerAvailable=true` + consumes pre-singleton
+// `Neo.idMap`. All 3 MUST run before consumed class imports.
+import Neo              from '../../../src/Neo.mjs';
+import * as core        from '../../../src/core/_export.mjs';
+import InstanceManager  from '../../../src/manager/Instance.mjs';
+import memoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
+
+import fs   from 'fs-extra';
+import path from 'path';
+import {execSync} from 'child_process';
+
+import StorageRouter  from '../../services/memory-core/managers/StorageRouter.mjs';
+import {drainWalOnce} from './drainCycle.mjs';
+import {getMissingMemoryWalLeaves} from '../../services/memory-core/helpers/memoryWalStore.mjs';
+
+// Stale-config boot guard: the gitignored config.mjs is a MATERIALIZED template copy — on a
+// deployment whose overlay predates the memoryWal daemon leaves they resolve undefined, and
+// everything below (data dir, log paths, poll loop) would crash with an unactionable TypeError.
+// Fail loud + name the fix instead; the orchestrator's restart cooldown surfaces the line.
+const missingLeaves = getMissingMemoryWalLeaves(memoryCoreConfig.memoryWal,
+    ['dir', 'daemonDataDir', 'pollIntervalMs', 'batchSize', 'maxRetries', 'backoffBaseMs', 'retentionLimit']);
+
+if (missingLeaves.length > 0) {
+    console.error(`[Embed Daemon] memoryWal config leaves missing: ${missingLeaves.join(', ')} — ` +
+        'sync the memoryWal block from config.template.mjs into the local config.mjs ' +
+        '(node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart. Exiting.');
+    process.exit(1);
+}
+
+const DAEMON_DATA_DIR    = memoryCoreConfig.memoryWal.daemonDataDir;
+const LOG_FILE           = path.join(DAEMON_DATA_DIR, 'embed-daemon.log');
+const PID_FILE           = path.join(DAEMON_DATA_DIR, 'embed-daemon.pid');
+const LOG_RETENTION_DAYS = 30;
+
+// Ensure daemon data dir exists
+fs.ensureDirSync(DAEMON_DATA_DIR);
+
+/**
+ * Rotates `embed-daemon.log` if its mtime falls on a calendar day different from today's.
+ * Renames the previous-day file to `embed-daemon.log.YYYY-MM-DD` so the active file always
+ * holds the current day's lines. Best-effort: failures surface to stderr and the daemon
+ * continues (log integrity is not allowed to gate daemon liveness).
+ * @protected
+ */
+function rotateLogIfNewDay() {
+    if (!fs.existsSync(LOG_FILE)) return;
+    try {
+        const stats    = fs.statSync(LOG_FILE);
+        const fileDay  = stats.mtime.toISOString().split('T')[0];
+        const todayDay = new Date().toISOString().split('T')[0];
+        if (fileDay !== todayDay) {
+            fs.renameSync(LOG_FILE, `${LOG_FILE}.${fileDay}`);
+        }
+    } catch (e) {
+        process.stderr.write(`[Embed Daemon] Log rotation failed: ${e.message}\n`);
+    }
+}
+
+/**
+ * Prunes archived log files (`embed-daemon.log.*`) older than `LOG_RETENTION_DAYS` from
+ * `DAEMON_DATA_DIR`. Runs once at daemon startup. Best-effort: per-file unlink failures
+ * are silently swallowed (better to keep a stale archive than gate startup).
+ * @protected
+ */
+function pruneOldLogs() {
+    const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    try {
+        for (const entry of fs.readdirSync(DAEMON_DATA_DIR)) {
+            if (!entry.startsWith('embed-daemon.log.') || entry === 'embed-daemon.log') continue;
+            const fullPath = path.join(DAEMON_DATA_DIR, entry);
+            try {
+                if (fs.statSync(fullPath).mtime.getTime() < cutoff) {
+                    fs.unlinkSync(fullPath);
+                }
+            } catch (e) {
+                // Per-entry failure is non-fatal
+            }
+        }
+    } catch (e) {
+        // Directory listing failure is non-fatal
+    }
+}
+
+/**
+ * Persistent + console log writer. Writes a single line to BOTH stdout (live terminal
+ * observability) AND the persistent `embed-daemon.log` file (post-hoc audit trail).
+ * Format: `[ISO-timestamp] [PID:NNN] [LEVEL] message`. Daily rotation is checked on every call.
+ *
+ * Failures on file-write are silently swallowed — daemon liveness MUST NOT depend on log
+ * integrity. Failures on console-write propagate naturally.
+ *
+ * @param {String} level   One of 'INFO' | 'ERROR'.
+ * @param {String} message Message body without trailing newline — `writeLog` appends one.
+ * @protected
+ */
+function writeLog(level, message) {
+    rotateLogIfNewDay();
+    const line = `[${new Date().toISOString()}] [PID:${process.pid}] [${level}] ${message}`;
+
+    try {
+        fs.appendFileSync(LOG_FILE, line + '\n', 'utf8');
+    } catch (e) {
+        // Best-effort; daemon must stay alive even if file-write fails
+    }
+
+    if (level === 'ERROR') {
+        console.error(line);
+    } else {
+        console.log(line);
+    }
+}
+
+// One-shot prune at startup; reaper for archived logs older than retention window
+pruneOldLogs();
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Enforces the one-instance-per-data-dir singleton contract: takes over from a live prior
+ * instance (SIGTERM → 3s grace → SIGKILL), ignores recycled PIDs owned by foreign processes,
+ * claims the PID file atomically (`wx`), and installs exit/signal cleanup. Mirrors the wake
+ * daemon's lock verbatim — an interrupted drain cycle is safe by WAL construction, so cleanup
+ * exits immediately rather than awaiting the in-flight cycle.
+ * @protected
+ */
+async function enforceSingleton() {
+    if (fs.existsSync(PID_FILE)) {
+        try {
+            const oldPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+            if (!isNaN(oldPid) && oldPid > 0 && oldPid !== process.pid) {
+                let isAlive = false;
+                try {
+                    process.kill(oldPid, 0);
+                    isAlive = true;
+                } catch (e) {
+                    // Process is not alive
+                }
+
+                if (isAlive) {
+                    try {
+                        // Use ps -p to verify the PID hasn't been recycled by a non-daemon process
+                        const cmd = execSync(`ps -p ${oldPid} -o command=`).toString().trim();
+                        if (cmd.includes('daemons/embed/daemon.mjs')) {
+                            writeLog('INFO', `[Embed Daemon] Found existing instance (PID: ${oldPid}). Sending SIGTERM...`);
+                            process.kill(oldPid, 'SIGTERM');
+                        } else {
+                            writeLog('INFO', `[Embed Daemon] Stale PID file found. PID ${oldPid} used by a different process. Proceeding.`);
+                            isAlive = false; // We won't wait for it to exit
+                        }
+                    } catch (psErr) {
+                        writeLog('INFO', `[Embed Daemon] Could not verify process name. Sending SIGTERM to PID ${oldPid} to be safe...`);
+                        process.kill(oldPid, 'SIGTERM');
+                    }
+                }
+
+                if (isAlive) {
+                    // Wait up to 3s for graceful exit
+                    let alive = true;
+                    for (let i = 0; i < 30; i++) {
+                        await wait(100);
+                        try {
+                            process.kill(oldPid, 0);
+                        } catch (e) {
+                            alive = false;
+                            break;
+                        }
+                    }
+                    if (alive) {
+                        writeLog('INFO', `[Embed Daemon] PID ${oldPid} did not exit after 3s. Escalating to SIGKILL...`);
+                        try {
+                            process.kill(oldPid, 'SIGKILL');
+                        } catch (e) {}
+                    }
+                }
+
+                try {
+                    fs.unlinkSync(PID_FILE);
+                } catch (e) {}
+            }
+        } catch (e) {
+            writeLog('ERROR', `[Embed Daemon] Failed to check existing PID file: ${e.message || e}`);
+        }
+    }
+
+    // Write new PID using atomic wx claim
+    try {
+        fs.writeFileSync(PID_FILE, process.pid.toString(), {encoding: 'utf8', flag: 'wx'});
+    } catch (e) {
+        if (e.code === 'EEXIST') {
+            writeLog('ERROR', '[Embed Daemon] Failed to claim PID file (EEXIST). Another instance started simultaneously. Exiting.');
+            process.exit(1);
+        } else {
+            throw e;
+        }
+    }
+
+    // Cleanup on exit
+    let cleanedUp = false;
+    const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        try {
+            if (fs.existsSync(PID_FILE)) {
+                const currentPid = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
+                if (currentPid === process.pid) {
+                    fs.unlinkSync(PID_FILE);
+                }
+            }
+        } catch (e) {}
+        process.exit();
+    };
+
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+    process.on('exit', cleanup);
+    process.on('uncaughtException', err => {
+        writeLog('ERROR', `[Embed Daemon] Uncaught exception: ${err && err.stack ? err.stack : err}`);
+        cleanup(); // Calls process.exit() automatically
+    });
+}
+
+/**
+ * Cross-cycle per-record retry/cooldown state (`id → {failures, nextAttemptAt}`).
+ * In-memory by design: the WAL is the durable source of truth; a restart merely retries sooner.
+ * @type {Map<String, {failures: Number, nextAttemptAt: Number}>}
+ */
+const retryState = new Map();
+
+/**
+ * Runs one drain cycle and schedules the next via `setTimeout` chaining (no overlap by
+ * construction — the next cycle is armed only after the current one settles). Config leaves
+ * are read at the use site each cycle (the provider is the SSOT). The collection handle is resolved per cycle
+ * so an orchestrator-recycled Chroma daemon never strands this loop on a stale connection.
+ * Cycle failures are logged and absorbed: the WAL retains the backlog, the loop must outlive
+ * any single bad pass.
+ * @protected
+ */
+async function pollLoop() {
+    const {memoryWal} = memoryCoreConfig;
+
+    try {
+        const collection = await StorageRouter.getMemoryCollection();
+        const summary    = await drainWalOnce({
+            dir           : memoryWal.dir,
+            collection,
+            batchSize     : memoryWal.batchSize,
+            maxRetries    : memoryWal.maxRetries,
+            backoffBaseMs : memoryWal.backoffBaseMs,
+            retentionLimit: memoryWal.retentionLimit,
+            retryState,
+            log           : writeLog
+        });
+
+        // Idle cycles stay silent — at a multi-second poll interval, per-cycle no-op lines
+        // would dominate the log without adding signal.
+        if (summary.pending > 0 || summary.prunedSegments > 0) {
+            writeLog('INFO', `[Embed Daemon] Cycle: ${JSON.stringify(summary)}`);
+        }
+    } catch (error) {
+        writeLog('ERROR', `[Embed Daemon] Drain cycle failed: ${error.message || error}`);
+    }
+
+    setTimeout(pollLoop, memoryCoreConfig.memoryWal.pollIntervalMs);
+}
+
+// Start loop
+async function main() {
+    await enforceSingleton();
+    await StorageRouter.ready();
+
+    writeLog('INFO', `[Embed Daemon] Started. Draining WAL dir: ${memoryCoreConfig.memoryWal.dir} (poll: ${memoryCoreConfig.memoryWal.pollIntervalMs}ms, batch: ${memoryCoreConfig.memoryWal.batchSize})`);
+
+    pollLoop();
+}
+
+main();

--- a/ai/daemons/embed/daemon.mjs
+++ b/ai/daemons/embed/daemon.mjs
@@ -33,8 +33,8 @@ import fs   from 'fs-extra';
 import path from 'path';
 import {execSync} from 'child_process';
 
-import StorageRouter  from '../../services/memory-core/managers/StorageRouter.mjs';
-import {drainWalOnce} from './drainCycle.mjs';
+import StorageRouter   from '../../services/memory-core/managers/StorageRouter.mjs';
+import {startDrainLoop} from './drainCycle.mjs';
 import {getMissingMemoryWalLeaves} from '../../services/memory-core/helpers/memoryWalStore.mjs';
 
 // Stale-config boot guard: the gitignored config.mjs is a MATERIALIZED template copy — on a
@@ -243,50 +243,6 @@ async function enforceSingleton() {
     });
 }
 
-/**
- * Cross-cycle per-record retry/cooldown state (`id → {failures, nextAttemptAt}`).
- * In-memory by design: the WAL is the durable source of truth; a restart merely retries sooner.
- * @type {Map<String, {failures: Number, nextAttemptAt: Number}>}
- */
-const retryState = new Map();
-
-/**
- * Runs one drain cycle and schedules the next via `setTimeout` chaining (no overlap by
- * construction — the next cycle is armed only after the current one settles). Config leaves
- * are read at the use site each cycle (the provider is the SSOT). The collection handle is resolved per cycle
- * so an orchestrator-recycled Chroma daemon never strands this loop on a stale connection.
- * Cycle failures are logged and absorbed: the WAL retains the backlog, the loop must outlive
- * any single bad pass.
- * @protected
- */
-async function pollLoop() {
-    const {memoryWal} = memoryCoreConfig;
-
-    try {
-        const collection = await StorageRouter.getMemoryCollection();
-        const summary    = await drainWalOnce({
-            dir           : memoryWal.dir,
-            collection,
-            batchSize     : memoryWal.batchSize,
-            maxRetries    : memoryWal.maxRetries,
-            backoffBaseMs : memoryWal.backoffBaseMs,
-            retentionLimit: memoryWal.retentionLimit,
-            retryState,
-            log           : writeLog
-        });
-
-        // Idle cycles stay silent — at a multi-second poll interval, per-cycle no-op lines
-        // would dominate the log without adding signal.
-        if (summary.pending > 0 || summary.prunedSegments > 0) {
-            writeLog('INFO', `[Embed Daemon] Cycle: ${JSON.stringify(summary)}`);
-        }
-    } catch (error) {
-        writeLog('ERROR', `[Embed Daemon] Drain cycle failed: ${error.message || error}`);
-    }
-
-    setTimeout(pollLoop, memoryCoreConfig.memoryWal.pollIntervalMs);
-}
-
 // Start loop
 async function main() {
     await enforceSingleton();
@@ -294,7 +250,13 @@ async function main() {
 
     writeLog('INFO', `[Embed Daemon] Started. Draining WAL dir: ${memoryCoreConfig.memoryWal.dir} (poll: ${memoryCoreConfig.memoryWal.pollIntervalMs}ms, batch: ${memoryCoreConfig.memoryWal.batchSize})`);
 
-    pollLoop();
+    // The shared loop host (`drainCycle.mjs`) owns cycle scheduling, per-cycle config/collection
+    // resolution, and failure absorption; this process wrapper owns PID/lifecycle/logging only.
+    startDrainLoop({
+        getCollection: () => StorageRouter.getMemoryCollection(),
+        getConfig    : () => memoryCoreConfig.memoryWal,
+        log          : writeLog
+    });
 }
 
 main();

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -1,0 +1,240 @@
+import {
+    appendWalEmbedMarker,
+    getWalSegmentKey,
+    pruneReconciledWalSegments,
+    readPendingWalRecords
+} from '../../services/memory-core/helpers/memoryWalStore.mjs';
+
+/**
+ * @summary One durable drain pass over the `add_memory` write-ahead log.
+ *
+ * The pure logic core of the embed daemon (`ai/daemons/embed/daemon.mjs`): reads the pending
+ * WAL backlog, embeds it into the memory content store with retry/backoff, reconciles markers,
+ * compensates purge races, and prunes fully-reconciled segments. Every collaborator is injected
+ * (collection, clock, sleep, logger, retry state), so specs exercise the exact production drain
+ * against a fake collection without spawning a process — the same seam
+ * `MemoryService.WriteAhead.spec.mjs` established for the Phase-1 write path.
+ *
+ * ## Sole-drainer invariant (load-bearing)
+ *
+ * This module is the ONLY writer of embed markers in the daemon era — `MemoryService.addMemory`
+ * appends records but never markers, and `SessionService.purgeSession` appends markers only as
+ * purge TOMBSTONES (and always BEFORE its content-store delete). That ordering is what makes the
+ * mid-drain purge race decidable: after a successful `collection.add`, any batch id that is no
+ * longer pending must have been tombstoned by a purge mid-embed — so the drain compensates with
+ * a `collection.delete` for exactly those ids instead of marking them (see {@link drainWalOnce}).
+ *
+ * ## Scan-cost bound (AC10)
+ *
+ * `readPendingWalRecords` scans every WAL segment file per call. The fan-out is bounded by
+ * `memoryWal.retentionLimit` reconciled day-segments on disk (write-side pruning) plus however
+ * many segments hold pending records — and THIS daemon's drain cadence (`memoryWal.pollIntervalMs`)
+ * is what keeps the pending set small: even under a sustained embedder outage the backlog grows by
+ * one record per agent turn (minutes apart), not per second, and drains in `batchSize` chunks per
+ * cycle once the embedder recovers.
+ *
+ * @module ai/daemons/embed/drainCycle
+ * @see module:ai/services/memory-core/helpers/memoryWalStore
+ */
+
+/**
+ * Hard ceiling for the per-record cross-cycle retry cooldown. A persistently failing
+ * ("poison") record is retried with exponential spacing up to this bound — never abandoned
+ * (a process restart or an embedder recovery may heal it), never allowed to hot-loop the
+ * embedder every poll either.
+ * @type {Number}
+ */
+export const MAX_RECORD_COOLDOWN_MS = 3600000;
+
+/**
+ * @summary Computes the exponential backoff delay for a retry attempt.
+ *
+ * `base * 2^attempt`, capped at {@link MAX_RECORD_COOLDOWN_MS}. Pure; shared by the in-cycle
+ * batch retry loop and the cross-cycle per-record cooldown so both schedules stay coherent.
+ *
+ * @param {Number} backoffBaseMs Base delay (the `memoryWal.backoffBaseMs` leaf).
+ * @param {Number} attempt       Zero-based attempt index.
+ * @returns {Number} Delay in ms.
+ */
+export function getBackoffDelayMs(backoffBaseMs, attempt) {
+    return Math.min(backoffBaseMs * 2 ** attempt, MAX_RECORD_COOLDOWN_MS);
+}
+
+/**
+ * @summary Embeds one batch of WAL records via `collection.add`, retrying transient failures.
+ *
+ * Whole-batch first (one round-trip for the common case), with `maxRetries` exponential-backoff
+ * attempts for transient outages. If the batch still fails, falls back to per-record adds so a
+ * single poison record cannot hold the rest of the backlog hostage — per-record failures are
+ * reported back for cross-cycle cooldown bookkeeping rather than retried inline.
+ *
+ * @param {Object}   options
+ * @param {Object}   options.collection    Content-store collection (`add({ids, metadatas, documents})`).
+ * @param {Object[]} options.records       Pending WAL records (`{id, metadata, document, segmentKey}`).
+ * @param {Number}   options.maxRetries    In-cycle whole-batch retry bound.
+ * @param {Number}   options.backoffBaseMs Exponential backoff base for in-cycle retries.
+ * @param {Function} options.sleep         `ms => Promise` delay primitive (injected for specs).
+ * @param {Function} options.log           `(level, message)` sink.
+ * @returns {Promise<{succeeded: Object[], failed: Array<{record: Object, error: Error}>}>}
+ */
+export async function embedBatch({collection, records, maxRetries, backoffBaseMs, sleep, log}) {
+    const payload = {
+        ids      : records.map(record => record.id),
+        metadatas: records.map(record => record.metadata),
+        documents: records.map(record => record.document)
+    };
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            await collection.add(payload);
+            return {succeeded: [...records], failed: []};
+        } catch (error) {
+            if (attempt < maxRetries) {
+                const delay = getBackoffDelayMs(backoffBaseMs, attempt);
+                log('INFO', `Batch embed attempt ${attempt + 1}/${maxRetries + 1} failed (${error.message}) — backing off ${delay}ms`);
+                await sleep(delay);
+            } else {
+                log('ERROR', `Batch embed exhausted ${maxRetries + 1} attempts (${error.message}) — isolating per record`);
+            }
+        }
+    }
+
+    // Per-record isolation pass: exactly one attempt each — a poison record surfaces here as the
+    // only failure while its healthy batch-mates proceed; cross-cycle cooldown spaces its retries.
+    const succeeded = [];
+    const failed    = [];
+
+    for (const record of records) {
+        try {
+            await collection.add({ids: [record.id], metadatas: [record.metadata], documents: [record.document]});
+            succeeded.push(record);
+        } catch (error) {
+            failed.push({record, error});
+        }
+    }
+
+    return {succeeded, failed};
+}
+
+/**
+ * @summary Executes one full drain cycle: read pending → embed → reconcile/compensate → prune.
+ *
+ * **Reconcile vs compensate:** after a successful embed, the cycle re-reads the pending state for
+ * exactly the embedded ids. Ids still pending get their embed marker (the normal path). Ids that
+ * VANISHED from the pending set mid-embed were tombstoned by `SessionService.purgeSession`
+ * (sole-drainer invariant — nothing else writes markers), meaning the purge's content-store
+ * delete may have run before our `add` resurrected the document: the cycle compensates with
+ * `collection.delete` for those ids and writes no marker (the purge already did).
+ *
+ * **Failure isolation:** records failing the per-record pass enter `retryState`
+ * (`id → {failures, nextAttemptAt}`) and are skipped while cooling down — exponentially spaced
+ * via {@link getBackoffDelayMs}, never abandoned. The state is in-memory by design: a daemon
+ * restart simply retries sooner, and the WAL remains the durable source of truth throughout.
+ *
+ * @param {Object}   options
+ * @param {String}   options.dir              WAL segment directory (resolved `memoryWal.dir` leaf).
+ * @param {Object}   options.collection       Content-store collection (`add` + `delete`).
+ * @param {String[]} [options.ids]            Targeted drain: only these record ids are considered.
+ *     The daemon loop never passes this (it drains the whole backlog); explicit flush callers
+ *     (specs, future on-demand drains) use it to reconcile specific records without touching
+ *     unrelated pending state.
+ * @param {Number}   options.batchSize        Maximum records embedded per cycle.
+ * @param {Number}   options.maxRetries       In-cycle whole-batch retry bound.
+ * @param {Number}   options.backoffBaseMs    Exponential backoff base.
+ * @param {Number}   options.retentionLimit   Reconciled-segment retention bound for pruning.
+ * @param {Map}      [options.retryState]     Cross-cycle per-record cooldown state (caller-owned).
+ * @param {Function} [options.log]            `(level, message)` sink. Defaults to a no-op.
+ * @param {Function} [options.sleep]          Delay primitive. Defaults to a real timer.
+ * @param {Function} [options.now]            Clock source (epoch ms). Defaults to `Date.now`.
+ * @returns {Promise<{pending: Number, embedded: Number, compensated: Number, failed: Number, cooling: Number, prunedSegments: Number}>}
+ *     Cycle summary for the daemon's log line.
+ */
+export async function drainWalOnce({
+    dir,
+    collection,
+    ids,
+    batchSize,
+    maxRetries,
+    backoffBaseMs,
+    retentionLimit,
+    retryState = new Map(),
+    log        = () => {},
+    sleep      = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    now        = Date.now
+} = {}) {
+    const summary = {pending: 0, embedded: 0, compensated: 0, failed: 0, cooling: 0, prunedSegments: 0};
+
+    // Full pending read (not limit-bounded): a newest-first limited read would let records
+    // cooling down at the head permanently shadow older drainable ones. Scan cost is bounded —
+    // see the module-level "Scan-cost bound (AC10)" note.
+    const allPending = await readPendingWalRecords({dir, ids});
+    summary.pending  = allPending.length;
+
+    const cycleStart = now();
+    const drainable  = [];
+
+    for (const record of allPending) {
+        if (drainable.length >= batchSize) break;
+
+        const cooldown = retryState.get(record.id);
+        if (cooldown && cooldown.nextAttemptAt > cycleStart) {
+            summary.cooling++;
+            continue;
+        }
+
+        drainable.push(record);
+    }
+
+    if (drainable.length > 0) {
+        const {succeeded, failed} = await embedBatch({collection, records: drainable, maxRetries, backoffBaseMs, sleep, log});
+
+        summary.failed = failed.length;
+
+        for (const {record, error} of failed) {
+            const failures = (retryState.get(record.id)?.failures ?? 0) + 1;
+
+            retryState.set(record.id, {failures, nextAttemptAt: now() + getBackoffDelayMs(backoffBaseMs, failures)});
+            log('ERROR', `Record ${record.id} failed embed #${failures} (${error.message}) — cooling down`);
+        }
+
+        if (succeeded.length > 0) {
+            // Purge-race compensation window: re-read pending state for exactly the embedded ids.
+            const succeededIds = succeeded.map(record => record.id);
+            const stillPending = new Set((await readPendingWalRecords({dir, ids: succeededIds})).map(record => record.id));
+            const tombstoned   = succeeded.filter(record => !stillPending.has(record.id));
+
+            if (tombstoned.length > 0) {
+                // Tombstoned mid-embed: purgeSession marked these records (always BEFORE its own
+                // content-store delete), so our add may have resurrected purged documents — undo it.
+                // A failed compensation delete cannot be retried from the WAL (the records are
+                // already reconciled by the purge's tombstone), so it is logged loudly with the
+                // exact ids instead of rethrowing the whole cycle.
+                const tombstonedIds = tombstoned.map(record => record.id);
+                try {
+                    await collection.delete({ids: tombstonedIds});
+                    summary.compensated = tombstoned.length;
+                    log('INFO', `Compensated ${tombstoned.length} record(s) purged mid-embed`);
+                } catch (error) {
+                    log('ERROR', `Compensation delete failed (${error.message}) — purged doc(s) may persist in the content store: ${tombstonedIds.join(', ')}`);
+                }
+            }
+
+            for (const record of succeeded) {
+                retryState.delete(record.id);
+
+                if (!stillPending.has(record.id)) continue;
+
+                await appendWalEmbedMarker({id: record.id, segmentKey: record.segmentKey, embeddedAt: now()}, {dir});
+                summary.embedded++;
+            }
+        }
+    }
+
+    summary.prunedSegments = await pruneReconciledWalSegments({
+        dir,
+        retentionLimit,
+        activeSegmentKey: getWalSegmentKey(now())
+    });
+
+    return summary;
+}

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -238,3 +238,68 @@ export async function drainWalOnce({
 
     return summary;
 }
+
+/**
+ * @summary Hosts the drain loop: `setTimeout`-chained {@link drainWalOnce} cycles until stopped.
+ *
+ * The loop is host-agnostic on purpose — the same single implementation runs in BOTH drain
+ * deployment modes:
+ *
+ * - **Supervised daemon process** (`ai/daemons/embed/daemon.mjs`): the local-profile shape,
+ *   orchestrator-managed with PID lock + rotating log.
+ * - **In-process inside the memory-core server** (`memoryWal.inProcessDrain` leaf): the
+ *   containerized / single-process deployment shape, where no orchestrator or daemon process
+ *   exists (e.g. the dockerized MC containers, `npx neo-app`-class workspaces).
+ *
+ * **Sole-drainer invariant (config-declared mutual exclusion):** exactly ONE drain loop may run
+ * per WAL directory. Never enable `inProcessDrain` on a deployment where the embed daemon also
+ * runs — two loops would race the marker files and break the purge-compensation logic, which
+ * relies on "a marker I didn't write = purge tombstone".
+ *
+ * Cycle failures are logged and absorbed (the WAL retains the backlog; the loop must outlive any
+ * single bad pass). Config is re-read via `getConfig()` every cycle and the collection handle is
+ * re-resolved via `getCollection()` every cycle, so a recycled content-store daemon never strands
+ * the loop on a stale connection.
+ *
+ * @param {Object}   options
+ * @param {Function} options.getCollection Async resolver for the content-store collection.
+ * @param {Function} options.getConfig     Returns the `memoryWal` config slice (read per cycle).
+ * @param {Function} [options.log]         `(level, message)` sink. Defaults to a no-op.
+ * @param {Map}      [options.retryState]  Cross-cycle per-record cooldown state.
+ * @returns {{stop: Function}} Handle whose `stop()` ends the loop (idempotent).
+ */
+export function startDrainLoop({getCollection, getConfig, log = () => {}, retryState = new Map()}) {
+    let stopped = false;
+    let timer   = null;
+
+    const tick = async () => {
+        const {dir, batchSize, maxRetries, backoffBaseMs, retentionLimit, pollIntervalMs} = getConfig();
+
+        try {
+            const collection = await getCollection();
+            const summary    = await drainWalOnce({dir, collection, batchSize, maxRetries, backoffBaseMs, retentionLimit, retryState, log});
+
+            // Idle cycles stay silent — at a multi-second poll interval, per-cycle no-op lines
+            // would dominate the log without adding signal.
+            if (summary.pending > 0 || summary.prunedSegments > 0) {
+                log('INFO', `WAL drain cycle: ${JSON.stringify(summary)}`);
+            }
+        } catch (error) {
+            log('ERROR', `WAL drain cycle failed: ${error.message || error}`);
+        }
+
+        if (!stopped) {
+            timer = setTimeout(tick, pollIntervalMs);
+        }
+    };
+
+    // First cycle on the next macrotask: starting the loop must never block the host's boot.
+    timer = setTimeout(tick, 0);
+
+    return {
+        stop() {
+            stopped = true;
+            clearTimeout(timer);
+        }
+    };
+}

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -203,6 +203,7 @@ export class Orchestrator extends Base {
     get tenantRepoSyncEnabled()          { return resolveCloudOnlyEnabled('tenantRepoSyncEnabled');           }
     get chromaDaemonEnabled()            { return resolveDeploymentEnabled('chromaDaemonEnabled');            }
     get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
+    get embedDaemonEnabled()             { return resolveDeploymentEnabled('embedDaemonEnabled');             }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
     get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction.enabled;      }
@@ -349,6 +350,7 @@ export class Orchestrator extends Base {
         const continuousTasks = [
             ...(this.chromaDaemonEnabled ? ['chroma'] : []),
             ...(this.bridgeDaemonEnabled ? ['bridgeDaemon'] : []),
+            ...(this.embedDaemonEnabled  ? ['embedDaemon'] : []),
             'mlx',
             'lms'
         ];

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -80,6 +80,13 @@ export function buildTaskDefinitions({
             pidFileName    : 'wake-daemon.pid',
             expectedCommand: 'daemons/wake/daemon.mjs'
         },
+        embedDaemon: {
+            label          : 'embed daemon (add_memory WAL drain)',
+            command        : nodeBin,
+            args           : [path.resolve(scriptDir, '../daemons/embed/daemon.mjs')],
+            pidFileName    : 'embed-daemon.pid',
+            expectedCommand: 'daemons/embed/daemon.mjs'
+        },
         summary: {
             label          : 'session summarization',
             command        : nodeBin,

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -151,6 +151,13 @@ services:
       - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
       - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+      # Single-process container = no orchestrator-supervised embed daemon: the server hosts
+      # the WAL drain loop itself (sole-drainer invariant holds — exactly one loop per WAL dir).
+      # Fast cadence keeps semantic read-back near-synchronous for the integration matrix; the
+      # WAL shares the graph DB's tmpfs so both stay ephemeral per compose run.
+      - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
+      - NEO_MEMORY_WAL_DIR=/tmp/neo-integration/memory-wal
     tmpfs:
       - /tmp/neo-integration
     depends_on:
@@ -207,6 +214,10 @@ services:
       - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
       - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
       - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+      # Single-process container: server-hosted WAL drain (see the mc-server comment block).
+      - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
+      - NEO_MEMORY_WAL_DIR=/tmp/neo-integration/memory-wal-oidc
     tmpfs:
       - /tmp/neo-integration
     depends_on:

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -17,9 +17,11 @@ import {
     Memory_HealthService           as HealthService,
     Memory_SessionService          as SessionService,
     Memory_InferenceLifecycleService as InferenceLifecycleService,
+    Memory_StorageRouter           as StorageRouter,
     Memory_WakeSubscriptionService as WakeSubscriptionService,
     Memory_CoalescingEngineService as CoalescingEngineService
 } from '../../../services.mjs';
+import {startDrainLoop} from '../../../daemons/embed/drainCycle.mjs';
 
 /**
  * @summary The Memory Core MCP Server application.
@@ -178,6 +180,21 @@ class Server extends BaseServer {
         // Wait for dependent services.
         await InferenceLifecycleService.ready();
         await SessionService.ready();
+
+        // In-process WAL drain (containerized / single-process deployments): hosts the embed
+        // daemon's exact drain loop inside this server when no orchestrator-supervised daemon
+        // exists. Config-declared mutual exclusion — never enabled where the embed daemon runs
+        // (sole-drainer invariant; see the `memoryWal.inProcessDrain` leaf + `drainCycle.mjs`).
+        // Absent-block tolerance is deliberate: a stale overlay simply leaves the loop off;
+        // `addMemory`'s own guard speaks for the missing config.
+        if (aiConfig.memoryWal && aiConfig.memoryWal.inProcessDrain) {
+            this.walDrainLoop = startDrainLoop({
+                getCollection: () => StorageRouter.getMemoryCollection(),
+                getConfig    : () => aiConfig.memoryWal,
+                log          : (level, message) => logger[level === 'ERROR' ? 'error' : 'info'](`[neo-memory-core MCP] ${message}`)
+            });
+            logger.info('[neo-memory-core MCP] In-process WAL drain loop active (memoryWal.inProcessDrain)');
+        }
 
         // Stdio identity resolution BEFORE healthcheck snapshot.
         if (aiConfig.transport !== 'sse') {

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -304,7 +304,18 @@ class Config extends ConfigProvider {
                  * drain module's `MAX_RECORD_COOLDOWN_MS`).
                  * @type {number}
                  */
-                backoffBaseMs  : leaf(1000, 'NEO_MEMORY_WAL_BACKOFF_BASE_MS', 'number')
+                backoffBaseMs  : leaf(1000, 'NEO_MEMORY_WAL_BACKOFF_BASE_MS', 'number'),
+                /**
+                 * Hosts the WAL drain loop INSIDE the memory-core server process — the
+                 * containerized / single-process deployment shape (dockerized MC, npx-neo-app
+                 * workspaces) where no orchestrator-supervised embed daemon exists.
+                 *
+                 * **Mutual exclusion (sole-drainer invariant):** never enable on a deployment
+                 * where the embed daemon also runs — exactly ONE drain loop per WAL directory.
+                 * The local maintainer profile keeps this `false` and runs the daemon.
+                 * @type {boolean}
+                 */
+                inProcessDrain : leaf(false, 'NEO_MEMORY_WAL_IN_PROCESS_DRAIN', 'boolean')
             },
             /**
              * Target markdown file used for autonomous agent-to-user reporting (offline jobs).

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -273,7 +273,38 @@ class Config extends ConfigProvider {
                  * routes them off this path. Raise only with a derived threshold.
                  * @type {number}
                  */
-                minFieldLength : leaf(1, 'NEO_MEMORY_MIN_FIELD_LENGTH', 'number')
+                minFieldLength : leaf(1, 'NEO_MEMORY_MIN_FIELD_LENGTH', 'number'),
+                /**
+                 * Data directory (PID file, rotating log) for the embed daemon —
+                 * `ai/daemons/embed/daemon.mjs`, the durable WAL drainer. Declarative leaf;
+                 * env override via `NEO_MEMORY_EMBED_DAEMON_DIR`.
+                 * @type {string}
+                 */
+                daemonDataDir  : leaf(path.resolve(cwd, '.neo-ai-data/embed-daemon'), 'NEO_MEMORY_EMBED_DAEMON_DIR', 'string'),
+                /**
+                 * Embed-daemon drain cadence. Per-turn saves arrive minutes apart; 5s keeps
+                 * semantic recall near-realtime without hot-looping the store. This cadence is
+                 * also what bounds the pending-backlog scan cost (see `drainCycle.mjs` AC10 note).
+                 * @type {number}
+                 */
+                pollIntervalMs : leaf(5000, 'NEO_MEMORY_WAL_POLL_INTERVAL_MS', 'number'),
+                /**
+                 * Maximum WAL records embedded per drain cycle.
+                 * @type {number}
+                 */
+                batchSize      : leaf(20, 'NEO_MEMORY_WAL_BATCH_SIZE', 'number'),
+                /**
+                 * In-cycle whole-batch retry bound for transient embed failures; beyond it the
+                 * cycle isolates failures per record (cross-cycle exponential cooldown).
+                 * @type {number}
+                 */
+                maxRetries     : leaf(5, 'NEO_MEMORY_WAL_MAX_RETRIES', 'number'),
+                /**
+                 * Exponential-backoff base for embed retries (`base * 2^attempt`, capped at the
+                 * drain module's `MAX_RECORD_COOLDOWN_MS`).
+                 * @type {number}
+                 */
+                backoffBaseMs  : leaf(1000, 'NEO_MEMORY_WAL_BACKOFF_BASE_MS', 'number')
             },
             /**
              * Target markdown file used for autonomous agent-to-user reporting (offline jobs).

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -5,7 +5,7 @@ import GraphService          from './GraphService.mjs';
 import logger                from '../../mcp/server/memory-core/logger.mjs';
 import SessionService        from './SessionService.mjs';
 import {withTimeout}         from './helpers/withTimeout.mjs';
-import {appendWalEmbedMarker, appendWalMemory, pruneReconciledWalSegments, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
+import {appendWalMemory, getMissingMemoryWalLeaves, pruneReconciledWalSegments, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
 import {buildChatModel}      from '../../provider/buildChatModel.mjs';
 import aiConfig              from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -200,34 +200,6 @@ function buildMailboxDelta() {
  * @see Neo.ai.mcp.server.shared.services.RequestContextService
  */
 class MemoryService extends Base {
-    /**
-     * In-flight deferred embed promises. Tracked so shutdown paths and tests can flush
-     * the fire-and-forget tail deterministically via {@link drainPendingEmbeds} — a floating
-     * promise that nothing can await is not an acceptable lifecycle primitive.
-     * @member {Set<Promise>} inFlightEmbeds
-     * @protected
-     */
-    inFlightEmbeds = new Set();
-
-    /**
-     * Recently purged sessions: sessionId → `{userId, purgedAt}`. {@link embedPendingMemory}
-     * consults this BEFORE its `collection.add`, so an embed deferred past a `purgeSession` cannot
-     * resurrect deleted data — and purge never has to WAIT on embed latency to be safe (a purge
-     * blocked on a stalled embedder would be the exact failure mode this ticket removes). Entries
-     * are pruned on insert after {@link MemoryService#purgedSessionTtlMs}; in-flight embeds live
-     * for seconds, so the bound only guards pathological cases.
-     * @member {Map<String, {userId: String|null, purgedAt: Number}>} purgedSessions
-     * @protected
-     */
-    purgedSessions = new Map();
-
-    /**
-     * Retention window for {@link MemoryService#purgedSessions} entries.
-     * @member {Number} purgedSessionTtlMs=600000
-     * @protected
-     */
-    purgedSessionTtlMs = 600000;
-
     static config = {
         /**
          * @member {String} className='Neo.ai.services.memory-core.MemoryService'
@@ -311,19 +283,22 @@ class MemoryService extends Base {
 
     /**
      * Adds a new memory to the collection — the protocol-mandated per-turn save, engineered to
-     * **never fail or stall on the embed**.
+     * never fail or stall **on the embed**, once the `memoryWal` config block is present
+     * (an absent block — a stale materialized overlay — returns a caught, actionable envelope).
      *
      * Write order is the contract:
-     * 1. **Validation gate** — rejects the unambiguous corruption class (empty / whitespace-only /
-     *    below-`memoryWal.minFieldLength` fields — the corrupted-memory class) before any write.
+     * 1. **Config + validation gates** — the stale-overlay guard and the corruption-class
+     *    rejection (empty / whitespace-only / below-`memoryWal.minFieldLength` fields) are the
+     *    only deliberate error envelopes; everything after them is never-fail.
      * 2. **Durable JSONL write-ahead append** — the full payload lands on local disk first, so a
      *    crash or embed failure never loses the turn.
      * 3. **Synchronous graph writes** — the `AGENT_MEMORY` node + edges keep the read-after-write
      *    recency contract (`queryRecentTurns` reads these rows "fresh the instant the write returns").
-     * 4. **Deferred embed** — the model-dependent Chroma `collection.add` runs fire-and-forget via
-     *    {@link embedPendingMemory}; on success the WAL record is marked, on failure it stays
-     *    pending for a later drain (Phase 2: the `ai/daemons/embed/` daemon). Embed/Chroma
-     *    contention therefore can no longer fail or block this tool.
+     * 4. **No embed on this path.** The model-dependent Chroma `collection.add` is owned entirely
+     *    by the orchestrator-managed embed daemon (`ai/daemons/embed/daemon.mjs`), which drains the
+     *    WAL with retry/backoff and marks records reconciled. Until a record is drained, the WAL
+     *    pending-overlay keeps recency recall content-complete. Embed/Chroma contention therefore
+     *    cannot fail, block, or even touch this tool.
      *
      * When the MCP transport has resolved a real `AgentIdentity`, the write stamps both the
      * Chroma metadata (`agentIdentity`) and a graph `AUTHORED_BY` edge. Fallback-only identities
@@ -347,18 +322,34 @@ class MemoryService extends Base {
      *     see {@link buildMailboxDelta}.
      */
     async addMemory({prompt, response, thought, sessionId, agent, model, amountToolCalls, toolsUsed}) {
-        // The validation gate is a deliberate rejection — the ONE path that
-        // intentionally returns an MCP error envelope. Everything after it is never-fail.
-        const invalidFields = this.getInvalidMemoryFields({prompt, thought, response});
-        if (invalidFields.length > 0) {
+        // Stale-overlay guard (caught + actionable): the gitignored config.mjs is a MATERIALIZED
+        // template copy, so on a clone predating the memoryWal block these leaves resolve
+        // undefined — and the validation gate's minFieldLength read below was an UNCAUGHT
+        // TypeError on every save. Fail loud and name the fix; never fabricate a default
+        // dir/minFieldLength here (the config template owns defaults; a hidden fallback
+        // would silently split the WAL across directories).
+        const missingLeaves = getMissingMemoryWalLeaves(aiConfig.memoryWal, ['dir', 'minFieldLength', 'retentionLimit']);
+        if (missingLeaves.length > 0) {
             return {
-                error  : 'Invalid memory payload',
-                message: `Rejected empty/below-minimum field(s): ${invalidFields.join(', ')}. The per-turn save must carry the turn's real content — empty fields are the corrupted-memory class.`,
-                code   : 'MEMORY_VALIDATION_ERROR'
+                error  : 'Failed to add memory',
+                message: `memoryWal config leaves missing: ${missingLeaves.join(', ')} — sync the memoryWal block from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart memory-core.`,
+                code   : 'MEMORY_ADD_ERROR'
             };
         }
 
         try {
+            // The validation gate is a deliberate rejection — the ONE path that intentionally
+            // returns a validation envelope. Living inside the try keeps enveloping uniform:
+            // anything unexpected it throws still surfaces as MEMORY_ADD_ERROR, never uncaught.
+            const invalidFields = this.getInvalidMemoryFields({prompt, thought, response});
+            if (invalidFields.length > 0) {
+                return {
+                    error  : 'Invalid memory payload',
+                    message: `Rejected empty/below-minimum field(s): ${invalidFields.join(', ')}. The per-turn save must carry the turn's real content — empty fields are the corrupted-memory class.`,
+                    code   : 'MEMORY_VALIDATION_ERROR'
+                };
+            }
+
             const combinedText = `User Prompt: ${prompt}\nAgent Thought: ${thought}\nAgent Response: ${response}`;
             const now          = Date.now();
             const timestamp    = new Date(now).toISOString();
@@ -373,6 +364,9 @@ class MemoryService extends Base {
                 response,
                 thought,
                 sessionId,
+                // Deliberate dual timestamp representation: Chroma metadata.timestamp = epoch-ms
+                // (numeric where-range filtering); the graph row's properties.timestamp below =
+                // ISO string (drives validateSessionForResume.lastActivityAt).
                 timestamp: now,
                 type: 'agent-interaction'
             };
@@ -435,22 +429,18 @@ class MemoryService extends Base {
             // 4. Link this memory dynamically to the active context frontier
             GraphService.linkNodes('frontier', memoryId, 'SPAWNED_MEMORY', 0.8);
 
-            // 5. Deferred embed: the model-dependent Chroma write runs OFF the
-            //    critical path, fire-and-forget. Success marks the WAL record; failure leaves it
-            //    pending — recency recall overlays the WAL meanwhile, so nothing is hidden.
-            //    Transitional Phase-1 shape: the Phase-2 `ai/daemons/embed/` daemon replaces this
-            //    in-process drain with a durable, retrying one.
-            this.embedPendingMemory({id: memoryId, metadata, document: combinedText, segmentKey, dir: walDir});
-
-            // 6. WAL retention (write-side, best-effort): bound the reconciled-segment count on
+            // 5. WAL retention (write-side, best-effort): bound the reconciled-segment count on
             //    each append. Never prunes a segment holding a pending record, never fails the save.
+            //    The embed itself no longer runs here — the orchestrator-managed embed daemon
+            //    (`ai/daemons/embed/daemon.mjs`) drains pending records with retry/backoff; the
+            //    WAL pending-overlay keeps recency recall content-complete in the meantime.
             pruneReconciledWalSegments({
                 dir             : walDir,
                 retentionLimit  : aiConfig.memoryWal.retentionLimit,
                 activeSegmentKey: segmentKey
             }).catch(() => {});
 
-            // 7. Best-effort inline tweet-summary via the configured chat model (the modelProvider
+            // 6. Best-effort inline tweet-summary via the configured chat model (the modelProvider
             //    SSOT — reads the resolved leaf at the use site, never aliases it). Fire-and-forget
             //    so the per-turn write stays fast: the memory node above is already written (fresh
             //    for recency recall); this only enriches it asynchronously. Fully self-contained —
@@ -470,7 +460,7 @@ class MemoryService extends Base {
                 }
             }).catch(() => {});
 
-            // 8. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
+            // 7. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
             //    Non-fatal — buildMailboxDelta swallows its own errors and returns null on failure,
             //    so a degraded mailbox query never blocks a successful memory write.
             const mailbox = buildMailboxDelta();
@@ -511,95 +501,6 @@ class MemoryService extends Base {
         return Object.entries(fields)
             .filter(([, value]) => typeof value !== 'string' || value.trim().length < minLength)
             .map(([name]) => name);
-    }
-
-    /**
-     * @summary Embeds one WAL-pending memory into Chroma, fire-and-forget.
-     *
-     * The transitional in-process drain: resolves the collection, runs the embed, and appends the
-     * WAL embed-marker on success. Every failure path is swallowed into a warn-log — the record
-     * simply stays pending in the WAL for a later pass (Phase 2: the orchestrator-managed
-     * `ai/daemons/embed/` daemon, which replaces this method's call site and adds retry/backoff).
-     * Never throws into the write path; sibling discipline to {@link buildMiniSummary}.
-     *
-     * @param {Object} options
-     * @param {String} options.id         Memory UUID (= Chroma document id = graph node id).
-     * @param {Object} options.metadata   Full Chroma metadata payload.
-     * @param {String} options.document   Combined text to index.
-     * @param {String} options.segmentKey WAL segment the record was appended to.
-     * @param {String} options.dir        WAL directory (resolved `memoryWal.dir` leaf).
-     * @returns {Promise<Boolean>} `true` when embedded + marked; `false` when left pending.
-     */
-    embedPendingMemory({id, metadata, document, segmentKey, dir}) {
-        const embedPromise = Promise.resolve()
-            .then(() => {
-                // Purge guard: a session purged AFTER this memory's write but BEFORE this
-                // deferred embed must not be resurrected into Chroma. Tenant-aware — a tenant-scoped
-                // purge only suppresses records inside that tenant boundary. The WAL record is
-                // marked reconciled either way (purgeSession tombstones it too; double markers are
-                // harmless appends).
-                const purge = metadata?.sessionId && this.purgedSessions.get(metadata.sessionId);
-                if (purge && purge.purgedAt >= (metadata.timestamp ?? 0) && (!purge.userId || purge.userId === metadata.userId)) {
-                    return appendWalEmbedMarker({id, segmentKey}, {dir}).then(() => false);
-                }
-
-                return StorageRouter.getMemoryCollection()
-                    .then(collection => collection.add({ids: [id], metadatas: [metadata], documents: [document]}))
-                    .then(() => appendWalEmbedMarker({id, segmentKey}, {dir}))
-                    .then(() => true);
-            })
-            .catch(error => {
-                logger.warn(`[MemoryService] Deferred embed for ${id} failed — record stays pending in the WAL: ${error.message}`);
-                return false;
-            });
-
-        // Track for drainPendingEmbeds(); embedPromise never rejects (catch above), so the
-        // cleanup chain cannot leak an unhandled rejection.
-        const tracked = embedPromise.finally(() => this.inFlightEmbeds.delete(tracked));
-        this.inFlightEmbeds.add(tracked);
-
-        return tracked;
-    }
-
-    /**
-     * @summary Awaits every deferred embed currently in flight.
-     *
-     * The deterministic flush point for the fire-and-forget embed tail: graceful shutdown calls
-     * it so a process exit cannot strand an embed mid-write (the WAL would recover it, but a
-     * clean drain avoids the redundant re-embed), and specs call it instead of polling. Snapshot
-     * semantics — embeds started while draining are not awaited.
-     *
-     * @returns {Promise<void>}
-     */
-    async drainPendingEmbeds() {
-        await Promise.allSettled([...this.inFlightEmbeds]);
-    }
-
-    /**
-     * @summary Records a session purge so deferred embeds cannot resurrect purged data.
-     *
-     * Called by `SessionService.purgeSession` BEFORE it reads the collection: any embed still in
-     * flight for that session (within the caller's tenant boundary, for records written before the
-     * purge) sees the entry and skips its `collection.add`. Synchronous on purpose — purge must
-     * never wait on embed latency; waiting on a stalled embedder is the exact failure mode the
-     * write-ahead decouple removes. Insertion prunes entries older than {@link MemoryService#purgedSessionTtlMs}.
-     *
-     * @param {Object} options
-     * @param {String} options.sessionId Purged session id.
-     * @param {String|null} [options.userId=null] Tenant scope of the purge; `null` = all tenants.
-     */
-    markSessionPurged({sessionId, userId = null}) {
-        if (!sessionId) return;
-
-        const now = Date.now();
-
-        for (const [key, entry] of this.purgedSessions) {
-            if (now - entry.purgedAt > this.purgedSessionTtlMs) {
-                this.purgedSessions.delete(key);
-            }
-        }
-
-        this.purgedSessions.set(sessionId, {userId: userId || null, purgedAt: now});
     }
 
     /**

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -1383,15 +1383,12 @@ ${sessionContent}
             // Construct filter: ensure tenant isolation.
             const where = userId ? { '$and': [{ sessionId }, { userId }] } : { sessionId };
 
-            // The embed runs deferred. Mark the purge FIRST (synchronous — purge must never
-            // wait on embed latency) so any in-flight embed for this session skips its Chroma add
-            // instead of resurrecting purged data, and tombstone the WAL-pending records below so
-            // a later drain (the Phase-2 embed daemon) cannot re-embed them either.
-            // Dynamic import: MemoryService statically imports SessionService — see the
-            // withTimeout.mjs extraction note on avoiding that import cycle.
-            const {default: MemoryService} = await import('./MemoryService.mjs');
-            MemoryService.markSessionPurged({sessionId, userId: userId || null});
-
+            // Tombstone the WAL-pending records BEFORE the content-store delete below — this
+            // ordering is the load-bearing purge contract with the embed daemon: the daemon
+            // re-reads pending state after every successful embed, so a record tombstoned here
+            // mid-embed surfaces in that re-read and is compensated with a `collection.delete`.
+            // If the delete ran first, a daemon add landing in between would resurrect purged
+            // data with no tombstone left to detect it (see `ai/daemons/embed/drainCycle.mjs`).
             try {
                 const walDir = aiConfig.memoryWal.dir;
 

--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -31,6 +31,31 @@ import path from 'path';
 const SEGMENT_RE = /^wal-(\d{4}-\d{2}-\d{2})\.jsonl$/;
 
 /**
+ * @summary Names the `memoryWal` config leaves missing from a config slice.
+ *
+ * The stale-overlay guard: gitignored `config.mjs` files are MATERIALIZED copies of
+ * `config.template.mjs` (reconciled via `ai/scripts/setup/initServerConfigs.mjs
+ * --migrate-config`), so a deployment whose overlay predates the `memoryWal` block — or this
+ * block's daemon leaves — resolves them as `undefined` at runtime. Consumers
+ * (`MemoryService.addMemory`, `ai/daemons/embed/daemon.mjs`) call this BEFORE touching the
+ * leaves and fail loud with the remediation, naming exactly what is missing. Deliberately no
+ * hidden fallbacks: fabricating a default `dir` here would silently split the WAL across two
+ * directories — the config provider owns defaults, via the template.
+ *
+ * Pure function over a plain slice — unit-testable without reading or mutating the shared
+ * AiConfig singleton (the B4 shared-singleton write ban).
+ *
+ * @param {Object|undefined} memoryWal The resolved `memoryWal` config slice (may be absent entirely).
+ * @param {String[]} requiredLeaves Leaf names the calling consumer is about to read.
+ * @returns {String[]} Missing leaf names; empty array when the slice satisfies the consumer.
+ */
+export function getMissingMemoryWalLeaves(memoryWal, requiredLeaves) {
+    if (!memoryWal) return [...requiredLeaves];
+
+    return requiredLeaves.filter(leaf => memoryWal[leaf] === undefined || memoryWal[leaf] === null);
+}
+
+/**
  * @summary Derives the UTC-day segment key for a write timestamp.
  *
  * Date-keyed segments rotate naturally without any cross-process coordination, and their names

--- a/test/playwright/integration/BackupRestoreWipe.integration.spec.mjs
+++ b/test/playwright/integration/BackupRestoreWipe.integration.spec.mjs
@@ -265,12 +265,13 @@ test.describe('Dockerized MC backup -> wipe detection -> restore integration (#1
             memoryId = addResult.id;
             expect(memoryId).toBeTruthy();
 
-            const seededResults = await callJsonTool(client, 'query_raw_memories', {
+            // Semantic recall is eventually consistent (server-hosted WAL drain) — poll the
+            // seeded read-back to convergence before snapshotting backup evidence.
+            await expect.poll(async () => memoryTexts(await callJsonTool(client, 'query_raw_memories', {
                 nResults: 5,
                 query   : sentinel,
                 sessionId
-            });
-            expect(memoryTexts(seededResults)).toContain(sentinel);
+            })), {timeout: 20000, message: 'WAL drain convergence (seeded memory)'}).toContain(sentinel);
 
             const seededGraph = readGraphEvidence(memoryId);
             expect(seededGraph.exists).toBe(true);

--- a/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
+++ b/test/playwright/integration/CrossTenantIsolation.integration.spec.mjs
@@ -61,6 +61,16 @@ test.describe('Dockerized MC cross-tenant isolation integration (#10895)', () =>
                 toolsUsed      : []
             });
 
+            // Semantic recall is eventually consistent (server-hosted WAL drain) — await
+            // convergence of BOTH writes before asserting the isolation contract below.
+            await expect.poll(async () => {
+                const [a, b] = await Promise.all([
+                    callJsonTool(alice, 'query_raw_memories', {nResults: 10, query: aliceSentinel, sessionId, memorySharing: 'private'}),
+                    callJsonTool(bob,   'query_raw_memories', {nResults: 10, query: bobSentinel,   sessionId, memorySharing: 'private'})
+                ]);
+                return memoryTexts(a).includes(aliceSentinel) && memoryTexts(b).includes(bobSentinel);
+            }, {timeout: 20000, message: 'WAL drain convergence (alice + bob writes)'}).toBe(true);
+
             // Under explicit `private` policy the cross-tenant leak guard holds: each identity
             // retrieves only its own tenant-tagged memories — the isolation contract multi-tenant
             // SaaS forks rely on (see PR security posture).

--- a/test/playwright/integration/OidcAuth.integration.spec.mjs
+++ b/test/playwright/integration/OidcAuth.integration.spec.mjs
@@ -100,6 +100,17 @@ test.describe('OIDC Authentication Fixture', () => {
                 agent: 'neo-agent'
             });
 
+            // Semantic recall is eventually consistent (server-hosted WAL drain) — await
+            // alice's write converging before asserting either side of the isolation contract.
+            await expect.poll(async () => {
+                const r = await callJsonTool(aliceClient, 'query_raw_memories', {
+                    query: 'secret code',
+                    nResults: 5,
+                    memorySharing: 'private'
+                });
+                return r.results?.some(mem => mem.response.includes('OMEGA-99')) ?? false;
+            }, {timeout: 20000, message: 'WAL drain convergence (alice secret write)'}).toBe(true);
+
             // Bob searches under explicit `private` policy — the multi-tenant isolation contract.
             // The team default is deployment-wide by design, so OIDC-tenant isolation is asserted
             // under the policy that enforces it (multi-tenant forks set defaultPolicy='private').

--- a/test/playwright/integration/RemoteMcpTransport.integration.spec.mjs
+++ b/test/playwright/integration/RemoteMcpTransport.integration.spec.mjs
@@ -69,15 +69,15 @@ test.describe('Remote MCP Transport (v13 Release Gate)', () => {
             });
             expect(addResult).toBeDefined();
 
-            // Call 2 (same session)
-            const queryResult = await callJsonTool(client1, 'query_raw_memories', {
-                query: 'Remote transport test',
-                nResults: 5
-            });
-            expect(queryResult.results).toBeDefined();
-            expect(Array.isArray(queryResult.results)).toBe(true);
-            const found = queryResult.results.some(mem => mem.prompt === testPrompt);
-            expect(found).toBe(true);
+            // Call 2 (same session). Semantic recall is eventually consistent (server-hosted
+            // WAL drain) — poll the read-back to convergence over the same live transport.
+            await expect.poll(async () => {
+                const queryResult = await callJsonTool(client1, 'query_raw_memories', {
+                    query: 'Remote transport test',
+                    nResults: 5
+                });
+                return Array.isArray(queryResult.results) && queryResult.results.some(mem => mem.prompt === testPrompt);
+            }, {timeout: 20000, message: 'WAL drain convergence (remote-transport write)'}).toBe(true);
         } finally {
             await client1.close();
         }

--- a/test/playwright/integration/TeamPrivateRetrieval.integration.spec.mjs
+++ b/test/playwright/integration/TeamPrivateRetrieval.integration.spec.mjs
@@ -423,6 +423,17 @@ test.describe('Dockerized MC team/private retrieval integration (#10951)', () =>
 
             seedChromaRecords(directSeedPayload);
 
+            // Semantic recall is eventually consistent (server-hosted WAL drain) — await both
+            // add_memory writes converging before the boundary assertions below. The direct
+            // Chroma seeds above are synchronous and need no convergence.
+            await expect.poll(async () => {
+                const [o, p] = await Promise.all([
+                    callJsonTool(owner, 'query_raw_memories', {nResults: 10, query: ownerMemorySentinel, sessionId, memorySharing: 'private'}),
+                    callJsonTool(peer,  'query_raw_memories', {nResults: 10, query: peerMemorySentinel,  sessionId, memorySharing: 'private'})
+                ]);
+                return memoryTexts(o).includes(ownerMemorySentinel) && memoryTexts(p).includes(peerMemorySentinel);
+            }, {timeout: 20000, message: 'WAL drain convergence (owner + peer writes)'}).toBe(true);
+
             // Private-boundary queries pin `memorySharing: 'private'`: the team default is
             // deployment-wide, so per-tenant raw-memory boundaries are asserted under the policy
             // that enforces them. The shared-commons queries below intentionally use the default

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -144,6 +144,7 @@ test.describe('Tier 1 Config Immutability', () => {
             kbSyncEnabled        : null,
             chromaDaemonEnabled  : null,
             bridgeDaemonEnabled  : null,
+            embedDaemonEnabled   : null,
             goldenPathRepoEnrichmentEnabled: null,
             swarmHeartbeatEnabled: null,
             wakeDispatchEnabled  : null

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -1,0 +1,281 @@
+import {test, expect} from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm}   from 'fs/promises';
+import os              from 'os';
+import path            from 'path';
+
+import {
+    appendWalEmbedMarker,
+    appendWalMemory,
+    readPendingWalRecords
+} from '../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+import {
+    drainWalOnce,
+    embedBatch,
+    getBackoffDelayMs,
+    MAX_RECORD_COOLDOWN_MS
+} from '../../../../../../ai/daemons/embed/drainCycle.mjs';
+
+/**
+ * Embed-daemon drain cycle (`ai/daemons/embed/drainCycle.mjs`) — falsifier coverage for the
+ * durable WAL drain:
+ *
+ *   AC1 drain/mark/prune — pending records are embedded, marker-reconciled, and reconciled
+ *                          segments beyond the retention bound are pruned (seeded JSONL).
+ *   Retry/backoff        — transient whole-batch failures retry with exponential backoff up to
+ *                          maxRetries before falling back to per-record isolation.
+ *   Poison isolation     — one persistently failing record cannot hold the backlog hostage: its
+ *                          batch-mates drain, it enters cross-cycle exponential cooldown, and it
+ *                          is retried (never abandoned) once the cooldown expires.
+ *   AC5 purge safety     — a record tombstoned BEFORE the drain is never re-embedded, and a
+ *                          record tombstoned MID-embed (the purge race) is compensated with a
+ *                          `collection.delete` instead of a daemon marker (sole-drainer invariant).
+ *
+ * Pure-node module: every collaborator (collection, clock, sleep, retry state) is injected, so
+ * the spec drives the EXACT production drain logic with a fake collection and a virtual clock.
+ */
+test.describe('Neo.ai.daemons.embed.drainCycle', () => {
+    let tmpDir;
+
+    test.beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'neo-embed-drain-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(tmpDir, {recursive: true, force: true});
+    });
+
+    const record = (id, timestampMs) => ({
+        id,
+        timestamp: timestampMs,
+        metadata : {prompt: `p-${id}`, sessionId: `session-${id}`, timestamp: timestampMs},
+        document : `doc-${id}`
+    });
+
+    const seed = async (id, timestampMs = Date.now()) =>
+        (await appendWalMemory(record(id, timestampMs), {dir: tmpDir})).segmentKey;
+
+    /**
+     * Controllable content-store fake: records every add/delete, stores by id, and exposes
+     * `failNextAdds` (transient whole-batch failures) + `onAdd` (per-payload hook, e.g. poison
+     * records or mid-embed tombstones).
+     */
+    const createFakeCollection = () => {
+        const fake = {
+            store      : new Map(),
+            addCalls   : [],
+            deleteCalls: [],
+            failNextAdds: 0,
+            onAdd      : null,
+            add: async payload => {
+                fake.addCalls.push(payload);
+                if (fake.onAdd) await fake.onAdd(payload);
+                if (fake.failNextAdds > 0) {
+                    fake.failNextAdds--;
+                    throw new Error('store down (spec)');
+                }
+                payload.ids.forEach((id, i) => fake.store.set(id, payload.metadatas[i]));
+            },
+            delete: async ({ids}) => {
+                fake.deleteCalls.push(ids);
+                ids.forEach(id => fake.store.delete(id));
+            }
+        };
+        return fake;
+    };
+
+    const drain = (collection, options = {}) => drainWalOnce({
+        dir           : tmpDir,
+        collection,
+        batchSize     : 50,
+        maxRetries    : 2,
+        backoffBaseMs : 1000,
+        retentionLimit: 0,
+        sleep         : async () => {},
+        ...options
+    });
+
+    test('AC1: pending records are embedded, marked reconciled, and counted', async () => {
+        await seed('a');
+        await seed('b');
+        await seed('c');
+
+        const collection = createFakeCollection();
+        const summary    = await drain(collection);
+
+        expect(summary).toMatchObject({pending: 3, embedded: 3, compensated: 0, failed: 0, cooling: 0});
+        expect(collection.addCalls).toHaveLength(1); // whole-batch fast path
+        expect([...collection.store.keys()].sort()).toEqual(['a', 'b', 'c']);
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
+
+        // Reconciled means durable: a second cycle finds no work and re-embeds nothing.
+        const second = await drain(collection);
+        expect(second).toMatchObject({pending: 0, embedded: 0});
+        expect(collection.addCalls).toHaveLength(1);
+    });
+
+    test('retry/backoff: transient whole-batch failures retry with exponential delays, then succeed', async () => {
+        await seed('t1');
+        await seed('t2');
+
+        const collection = createFakeCollection();
+        collection.failNextAdds = 2;
+
+        const sleeps  = [];
+        const summary = await drain(collection, {sleep: async ms => sleeps.push(ms)});
+
+        expect(summary.embedded).toBe(2);
+        expect(summary.failed).toBe(0);
+        expect(collection.addCalls).toHaveLength(3);   // fail, fail, success — within maxRetries=2
+        expect(sleeps).toEqual([
+            getBackoffDelayMs(1000, 0),
+            getBackoffDelayMs(1000, 1)
+        ]);
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
+    });
+
+    test('poison isolation + cooldown: a failing record cannot block its batch-mates and retries after backoff', async () => {
+        await seed('healthy');
+        await seed('poison');
+
+        const collection = createFakeCollection();
+        collection.onAdd = ({ids}) => {
+            if (ids.includes('poison')) throw new Error('poison record (spec)');
+        };
+
+        const retryState = new Map();
+        let   virtualNow = 1_000_000;
+        const now        = () => virtualNow;
+
+        // Cycle 1: whole-batch attempts fail (poison in batch) → per-record pass isolates it.
+        const first = await drain(collection, {retryState, now});
+        expect(first.embedded).toBe(1);
+        expect(first.failed).toBe(1);
+        expect(collection.store.has('healthy')).toBe(true);
+        expect(collection.store.has('poison')).toBe(false);
+        expect(retryState.get('poison')).toMatchObject({failures: 1});
+
+        // Cycle 2, same instant: the poison record is cooling down — skipped, not retried.
+        const second = await drain(collection, {retryState, now});
+        expect(second).toMatchObject({pending: 1, embedded: 0, failed: 0, cooling: 1});
+
+        // Cycle 3, past the cooldown, embedder healed: the record drains — never abandoned.
+        collection.onAdd = null;
+        virtualNow += getBackoffDelayMs(1000, 1) + 1;
+        const third = await drain(collection, {retryState, now});
+        expect(third.embedded).toBe(1);
+        expect(collection.store.has('poison')).toBe(true);
+        expect(retryState.has('poison')).toBe(false); // state cleared on success
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
+    });
+
+    test('AC5: a record tombstoned BEFORE the drain is never re-embedded', async () => {
+        const tombstonedSegment = await seed('purged');
+        await seed('kept');
+
+        // SessionService.purgeSession's tombstone: an embed marker reconciles the record.
+        await appendWalEmbedMarker({id: 'purged', segmentKey: tombstonedSegment}, {dir: tmpDir});
+
+        const collection = createFakeCollection();
+        const summary    = await drain(collection);
+
+        expect(summary.pending).toBe(1);               // only 'kept' is pending work
+        expect(summary.embedded).toBe(1);
+        expect(collection.store.has('purged')).toBe(false);
+        expect(collection.store.has('kept')).toBe(true);
+    });
+
+    test('AC5: a record tombstoned MID-embed is compensated (deleted, not marker-claimed)', async () => {
+        const racedSegment = await seed('raced');
+        await seed('normal');
+
+        const collection = createFakeCollection();
+        // Simulate purgeSession racing the in-flight embed: the tombstone lands while
+        // collection.add is executing (after the drain's pending read, before its re-read).
+        collection.onAdd = async ({ids}) => {
+            if (ids.includes('raced')) {
+                await appendWalEmbedMarker({id: 'raced', segmentKey: racedSegment}, {dir: tmpDir});
+            }
+        };
+
+        const summary = await drain(collection);
+
+        expect(summary.compensated).toBe(1);
+        expect(summary.embedded).toBe(1);                    // 'normal' drains normally
+        expect(collection.deleteCalls).toEqual([['raced']]); // the resurrected doc is removed
+        expect(collection.store.has('raced')).toBe(false);
+        expect(collection.store.has('normal')).toBe(true);
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
+    });
+
+    test('targeted drain: `ids` reconciles only the requested records', async () => {
+        await seed('mine');
+        await seed('foreign');
+
+        const collection = createFakeCollection();
+        const summary    = await drain(collection, {ids: ['mine']});
+
+        expect(summary).toMatchObject({pending: 1, embedded: 1});
+        expect(collection.store.has('mine')).toBe(true);
+        expect(collection.store.has('foreign')).toBe(false);
+        expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(1); // 'foreign' untouched
+    });
+
+    test('batchSize bounds one cycle; the next cycle picks up the remainder', async () => {
+        await seed('b1');
+        await seed('b2');
+        await seed('b3');
+
+        const collection = createFakeCollection();
+
+        const first = await drain(collection, {batchSize: 2});
+        expect(first).toMatchObject({pending: 3, embedded: 2});
+
+        const second = await drain(collection, {batchSize: 2});
+        expect(second).toMatchObject({pending: 1, embedded: 1});
+        expect(collection.store.size).toBe(3);
+    });
+
+    test('prune wiring: fully-reconciled old segments beyond the retention bound are removed', async () => {
+        const day = 24 * 60 * 60 * 1000;
+        await seed('old1', Date.now() - 40 * day);
+        await seed('old2', Date.now() - 39 * day);
+
+        const collection = createFakeCollection();
+
+        // Drain reconciles both old segments; retentionLimit 1 keeps the newer, prunes the older.
+        const summary = await drain(collection, {retentionLimit: 1});
+
+        expect(summary.embedded).toBe(2);
+        expect(summary.prunedSegments).toBe(1);
+    });
+
+    test('embedBatch: per-record fallback reports exactly the failing records', async () => {
+        const records    = ['x', 'y'].map(id => ({...record(id, Date.now()), segmentKey: 'unused'}));
+        const collection = createFakeCollection();
+        collection.onAdd = ({ids}) => {
+            if (ids.includes('y')) throw new Error('y is poison (spec)');
+        };
+
+        const {succeeded, failed} = await embedBatch({
+            collection,
+            records,
+            maxRetries   : 0,
+            backoffBaseMs: 1,
+            sleep        : async () => {},
+            log          : () => {}
+        });
+
+        expect(succeeded.map(r => r.id)).toEqual(['x']);
+        expect(failed).toHaveLength(1);
+        expect(failed[0].record.id).toBe('y');
+        expect(failed[0].error.message).toContain('poison');
+    });
+
+    test('getBackoffDelayMs caps at MAX_RECORD_COOLDOWN_MS', () => {
+        expect(getBackoffDelayMs(1000, 0)).toBe(1000);
+        expect(getBackoffDelayMs(1000, 3)).toBe(8000);
+        expect(getBackoffDelayMs(1000, 60)).toBe(MAX_RECORD_COOLDOWN_MS);
+    });
+});

--- a/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs
@@ -14,6 +14,7 @@ import {
     drainWalOnce,
     embedBatch,
     getBackoffDelayMs,
+    startDrainLoop,
     MAX_RECORD_COOLDOWN_MS
 } from '../../../../../../ai/daemons/embed/drainCycle.mjs';
 
@@ -277,5 +278,47 @@ test.describe('Neo.ai.daemons.embed.drainCycle', () => {
         expect(getBackoffDelayMs(1000, 0)).toBe(1000);
         expect(getBackoffDelayMs(1000, 3)).toBe(8000);
         expect(getBackoffDelayMs(1000, 60)).toBe(MAX_RECORD_COOLDOWN_MS);
+    });
+
+    test.describe('startDrainLoop (shared loop host — daemon AND in-process server modes)', () => {
+        const loopConfig = (dir) => () => ({dir, batchSize: 10, maxRetries: 0, backoffBaseMs: 1, retentionLimit: 0, pollIntervalMs: 10});
+
+        test('drains seeded records on its cadence; stop() ends the loop', async () => {
+            await seed('loop-1');
+            const collection = createFakeCollection();
+
+            const loop = startDrainLoop({
+                getCollection: async () => collection,
+                getConfig    : loopConfig(tmpDir)
+            });
+
+            await expect.poll(() => collection.store.has('loop-1'), {timeout: 5000}).toBe(true);
+            expect(await readPendingWalRecords({dir: tmpDir})).toHaveLength(0);
+
+            loop.stop();
+
+            // A record seeded after stop() is never drained — the loop is genuinely ended.
+            await seed('after-stop');
+            await new Promise(resolve => setTimeout(resolve, 60));
+            expect(collection.store.has('after-stop')).toBe(false);
+        });
+
+        test('absorbs a failing cycle and keeps looping (collection resolution failure)', async () => {
+            await seed('resilient');
+            const collection = createFakeCollection();
+            let resolutions  = 0;
+
+            const loop = startDrainLoop({
+                getCollection: async () => {
+                    if (++resolutions === 1) throw new Error('store down (spec)');
+                    return collection;
+                },
+                getConfig: loopConfig(tmpDir)
+            });
+
+            // First cycle fails on collection resolution; a later cycle drains the record anyway.
+            await expect.poll(() => collection.store.has('resilient'), {timeout: 5000}).toBe(true);
+            loop.stop();
+        });
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -80,6 +80,9 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.localOnly.kbSyncEnabled                  = config.kbSyncEnabled                  ?? true;
     AiConfig.orchestrator.localOnly.primaryDevSyncEnabled          = config.primaryDevSyncEnabled          ?? false;
     AiConfig.orchestrator.localOnly.bridgeDaemonEnabled            = config.bridgeDaemonEnabled            ?? true;
+    // Default-disabled like primaryDevSyncEnabled: the embed-daemon lane has its own dedicated
+    // test; every other test's supervision expectations stay scoped to the lanes under test.
+    AiConfig.orchestrator.localOnly.embedDaemonEnabled             = config.embedDaemonEnabled             ?? false;
     AiConfig.orchestrator.localOnly.swarmHeartbeatEnabled          = config.swarmHeartbeatEnabled          ?? true;
     AiConfig.orchestrator.localOnly.goldenPathRepoEnrichmentEnabled = config.goldenPathRepoEnrichmentEnabled ?? true;
 
@@ -167,7 +170,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             nodeBin  : '/node'
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -459,6 +462,28 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             taskName: 'chroma',
             reason  : 'supervisor-restart'
         }]);
+    });
+
+    test('supervises the embed daemon as a continuous task when the lane is enabled', () => {
+        const started = [];
+
+        const orchestrator = createTestOrchestrator({embedDaemonEnabled: true});
+
+        TaskStateService.taskState.embedDaemon.running   = false;
+        TaskStateService.taskState.embedDaemon.lastRunAt = 0;
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started).toContainEqual({
+            taskName: 'embedDaemon',
+            reason  : 'supervisor-restart'
+        });
     });
 
     test('supervises lms via the supervisor HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
@@ -20,6 +20,7 @@ import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../../../../../ai/gr
 import MemoryService         from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {drainMemoryWal}      from './util.mjs';
 
 /**
  * Validates the AGENT_MEMORY graph node payload structure to prevent hollow-success regressions
@@ -144,8 +145,8 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
             response : 'hi'
         }));
 
-        // The embed is deferred — flush it before asserting on the spy.
-        await MemoryService.drainPendingEmbeds();
+        // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
+        await drainMemoryWal({ids: [result.id]});
 
         expect(collectionAddCalls).toHaveLength(1);
         expect(collectionAddCalls[0].metadatas[0].userId).toBe('neo-gpt');
@@ -169,7 +170,7 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
     });
 
     test('addMemory preserves unresolved-identity fallthrough without hallucinating AUTHORED_BY edges', async () => {
-        await RequestContextService.run({
+        const result = await RequestContextService.run({
             userId             : 'external-contributor',
             username           : 'External Contributor',
             agentIdentityNodeId: null,
@@ -181,8 +182,8 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
             response : 'hi'
         }));
 
-        // The embed is deferred — flush it before asserting on the spy.
-        await MemoryService.drainPendingEmbeds();
+        // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
+        await drainMemoryWal({ids: [result.id]});
 
         expect(collectionAddCalls).toHaveLength(1);
         expect(collectionAddCalls[0].metadatas[0].userId).toBe('external-contributor');

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
@@ -19,6 +19,7 @@ import * as core             from '../../../../../../src/core/_export.mjs';
 import MemoryService         from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {drainMemoryWal}      from './util.mjs';
 
 /**
  * Tenant isolation across `MemoryService.addMemory` / `listMemories` / `queryMemories`.
@@ -134,7 +135,7 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
     });
 
     test('addMemory attaches userId metadata when a request context is active', async () => {
-        await RequestContextService.run({userId: 'u-alice'}, () =>
+        const result = await RequestContextService.run({userId: 'u-alice'}, () =>
             MemoryService.addMemory({
                 prompt   : 'hello',
                 response : 'hi',
@@ -143,8 +144,8 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
             })
         );
 
-        // The embed is deferred — flush it before asserting on the spy.
-        await MemoryService.drainPendingEmbeds();
+        // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
+        await drainMemoryWal({ids: [result.id]});
 
         expect(spyCollection.addCalls).toHaveLength(1);
         const metadata = spyCollection.addCalls[0].metadatas[0];
@@ -153,15 +154,15 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
     });
 
     test('addMemory omits userId when no request context is active (stdio fallback)', async () => {
-        await MemoryService.addMemory({
+        const result = await MemoryService.addMemory({
             prompt   : 'hello',
             response : 'hi',
             thought  : 'greeting',
             sessionId: 'session-solo'
         });
 
-        // The embed is deferred — flush it before asserting on the spy.
-        await MemoryService.drainPendingEmbeds();
+        // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
+        await drainMemoryWal({ids: [result.id]});
 
         expect(spyCollection.addCalls).toHaveLength(1);
         const metadata = spyCollection.addCalls[0].metadatas[0];
@@ -174,16 +175,17 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
         // All three share the same sessionId but carry distinct userId metadata.
         // Non-empty response/thought: the validation gate rejects empty fields (the
         // corrupted-memory class), so seed fixtures must carry real content.
+        const seeded = [];
         await RequestContextService.run({userId: 'u-alice'}, async () => {
-            await MemoryService.addMemory({prompt: 'a1', response: 'r-a1', thought: 't-a1', sessionId: 'session-shared'});
-            await MemoryService.addMemory({prompt: 'a2', response: 'r-a2', thought: 't-a2', sessionId: 'session-shared'});
+            seeded.push(await MemoryService.addMemory({prompt: 'a1', response: 'r-a1', thought: 't-a1', sessionId: 'session-shared'}));
+            seeded.push(await MemoryService.addMemory({prompt: 'a2', response: 'r-a2', thought: 't-a2', sessionId: 'session-shared'}));
         });
-        await RequestContextService.run({userId: 'u-bob'}, () =>
+        seeded.push(await RequestContextService.run({userId: 'u-bob'}, () =>
             MemoryService.addMemory({prompt: 'b1', response: 'r-b1', thought: 't-b1', sessionId: 'session-shared'})
-        );
+        ));
 
-        // The embed is deferred — flush before reading the spy store back.
-        await MemoryService.drainPendingEmbeds();
+        // addMemory leaves the records WAL-pending — flush them through the daemon drain path.
+        await drainMemoryWal({ids: seeded.map(r => r.id)});
 
         // Under team policy (deployment-wide read), Alice reads the shared session and sees ALL
         // three records — her own two AND Bob's (transparent swarm introspection). The team DEFAULT
@@ -203,11 +205,11 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
     });
 
     test('listMemories without a request context returns all session memories (stdio fallback)', async () => {
-        await MemoryService.addMemory({prompt: 'solo1', response: 'r-solo1', thought: 't-solo1', sessionId: 'session-local'});
-        await MemoryService.addMemory({prompt: 'solo2', response: 'r-solo2', thought: 't-solo2', sessionId: 'session-local'});
+        const solo1 = await MemoryService.addMemory({prompt: 'solo1', response: 'r-solo1', thought: 't-solo1', sessionId: 'session-local'});
+        const solo2 = await MemoryService.addMemory({prompt: 'solo2', response: 'r-solo2', thought: 't-solo2', sessionId: 'session-local'});
 
-        // The embed is deferred — flush before reading the spy store back.
-        await MemoryService.drainPendingEmbeds();
+        // addMemory leaves the records WAL-pending — flush them through the daemon drain path.
+        await drainMemoryWal({ids: [solo1.id, solo2.id]});
 
         const view = await MemoryService.listMemories({sessionId: 'session-local', limit: 10});
 
@@ -316,7 +318,7 @@ test.describe('MemoryService — additive shared-commons access (#10556)', () =>
         // Canonical-form invariant on the write side: AgentIdentity nodeId form is `@x`,
         // ChromaDB userId form is `x`. The boundary helper strips the prefix at write time
         // so a future read filter using either form will always match.
-        await RequestContextService.run({userId: '@neo-test-agent'}, () =>
+        const result = await RequestContextService.run({userId: '@neo-test-agent'}, () =>
             MemoryService.addMemory({
                 sessionId: 'session-canonical',
                 prompt   : 'test',
@@ -325,8 +327,8 @@ test.describe('MemoryService — additive shared-commons access (#10556)', () =>
             })
         );
 
-        // The embed is deferred — flush it before asserting on the spy.
-        await MemoryService.drainPendingEmbeds();
+        // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
+        await drainMemoryWal({ids: [result.id]});
 
         const addCall = spyCollection.addCalls.at(-1);
         const tagged  = addCall.metadatas[0]?.userId;

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -16,18 +16,22 @@ setup({
 import {test, expect}        from '@playwright/test';
 import Neo                   from '../../../../../../src/Neo.mjs';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
-import {readPendingWalRecords} from '../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+import {appendWalEmbedMarker, readPendingWalRecords} from '../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+import {drainMemoryWal}      from './util.mjs';
 
 /**
- * add_memory never-fail write path (write-ahead decouple, Phase 1) — falsifier coverage:
+ * add_memory never-fail write path (write-ahead decouple) — falsifier coverage:
  *
  *   AC1 validation gate — empty/whitespace fields are rejected BEFORE any write.
- *   AC2 never-fail      — a throwing or HANGING embed no longer fails or stalls the tool;
- *                         the payload is durable in the WAL (pending) either way.
+ *   AC2 never-fail      — the write path never touches the content store at all (the embed
+ *                         daemon owns the drain), so a down OR hung store can neither fail nor
+ *                         stall the tool; the payload is durable in the WAL (pending) either way.
  *   AC3 recency         — the AGENT_MEMORY graph row stays synchronous: a just-written turn is
  *                         immediately visible to query_recent_turns even with the embed down,
  *                         and the WAL pending-overlay serves its content for BOTH detail levels.
- *   Marker reconcile    — a successful deferred embed marks the WAL record (no longer pending).
+ *   Drain reconcile     — the daemon drain path (`drainWalOnce` via the `drainMemoryWal` spec
+ *                         helper) embeds pending records and marks them reconciled, and never
+ *                         re-embeds a purge-tombstoned record.
  *
  * Test isolation by construction: UNIT_TEST_MODE resolves memoryWal.dir → a per-worker-unique
  * temp directory and the graph → ':memory:'; the shared AiConfig singleton is never mutated
@@ -39,7 +43,7 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
     test.describe.configure({mode: 'serial'});
 
     let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter,
-        originalGetMemoryCollection, originalEmbedText, memStore, collectionMode, testWalDir;
+        originalGetMemoryCollection, originalEmbedText, memStore, collectionMode, collectionTouches, testWalDir;
 
     test.beforeAll(async () => {
         const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
@@ -53,10 +57,14 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
 
         // Controllable content-store fake: 'ok' embeds into an in-memory map, 'throw' fails the
         // embed, 'hang' never resolves — the two failure shapes AC2 pins (error AND stall).
+        // `collectionTouches` counts resolution attempts: AC2's strongest form is that the write
+        // path performs ZERO of them (the embed daemon is the only collection consumer).
         memStore                    = new Map();
         collectionMode              = 'ok';
+        collectionTouches           = 0;
         originalGetMemoryCollection = StorageRouter.getMemoryCollection;
         StorageRouter.getMemoryCollection = async () => {
+            collectionTouches++;
             if (collectionMode === 'throw') throw new Error('chroma down (spec)');
             if (collectionMode === 'hang')  return new Promise(() => {}); // never settles
             return {
@@ -107,8 +115,9 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         expect((await readPendingWalRecords({dir: testWalDir})).length).toBe(before);
     });
 
-    test('AC2: a THROWING embed no longer fails the save; the payload is durable + pending', async () => {
+    test('AC2: a DOWN content store cannot fail the save — the write path never touches it', async () => {
         collectionMode = 'throw';
+        const touchesBefore = collectionTouches;
 
         const result = await asTenant(() => MemoryService.addMemory({
             prompt: 'embed-down prompt', thought: 'embed-down thought', response: 'embed-down response'
@@ -119,6 +128,10 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         expect(result.id).toBeTruthy();
         expect(result.message).toBe('Memory successfully added');
 
+        // Strongest form of never-fail: addMemory performed ZERO collection resolutions —
+        // the embed daemon is the only consumer of the content store on the memory write side.
+        expect(collectionTouches).toBe(touchesBefore);
+
         const pending = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
         expect(pending).toHaveLength(1);
         expect(pending[0].metadata.prompt).toBe('embed-down prompt');
@@ -126,16 +139,18 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         collectionMode = 'ok';
     });
 
-    test('AC2: a HANGING embed no longer stalls the save', async () => {
+    test('AC2: a HUNG content store cannot stall the save — nothing on the write path awaits it', async () => {
         collectionMode = 'hang';
+        const touchesBefore = collectionTouches;
 
         const result = await asTenant(() => MemoryService.addMemory({
             prompt: 'hang prompt', thought: 'hang thought', response: 'hang response'
         }));
-        // Reaching these assertions at all proves the embed is off the await path — previously
-        // this call suspended on the hung collection promise until an outer timeout killed it.
+        // Reaching these assertions at all proves nothing on the write path awaited the hung
+        // collection promise — and the touch counter proves it was never even resolved.
         expect(result.id).toBeTruthy();
         expect(result.error).toBeUndefined();
+        expect(collectionTouches).toBe(touchesBefore);
 
         collectionMode = 'ok';
     });
@@ -168,51 +183,42 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         collectionMode = 'ok';
     });
 
-    test('purge guard: an embed deferred past a session purge is suppressed, never resurrected', async () => {
-        collectionMode = 'throw'; // hold the embed back so the purge wins the race deterministically
-
+    test('purge tombstone: a record tombstoned before the drain is never re-embedded', async () => {
         const result = await asTenant(() => MemoryService.addMemory({
             prompt: 'purge-race prompt', thought: 'purge-race thought', response: 'purge-race response'
         }));
         expect(result.id).toBeTruthy();
 
-        // Purge marker lands BEFORE the embed can run (mirrors SessionService.purgeSession).
-        MemoryService.markSessionPurged({sessionId: result.sessionId, userId: 'tenant-wal'});
-
-        collectionMode = 'ok';
-
-        // Retry the pending record through the deferred-embed path (what the Phase-2 daemon —
-        // or any later inline attempt — would do): the purge guard must skip the Chroma add and
-        // reconcile the WAL record instead.
         const pending = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
         expect(pending).toHaveLength(1);
 
-        const embedded = await MemoryService.embedPendingMemory({
-            id        : pending[0].id,
-            metadata  : pending[0].metadata,
-            document  : pending[0].document,
-            segmentKey: pending[0].segmentKey,
-            dir       : testWalDir
-        });
+        // Purge tombstone lands BEFORE any drain runs (mirrors SessionService.purgeSession's
+        // tombstone-before-delete ordering): the marker reconciles the record, so the daemon's
+        // pending read never surfaces it again.
+        await appendWalEmbedMarker({id: result.id, segmentKey: pending[0].segmentKey}, {dir: testWalDir});
 
-        expect(embedded).toBe(false);                 // suppressed, not embedded
+        const summary = await drainMemoryWal({ids: [result.id]});
+
+        expect(summary.pending).toBe(0);              // the tombstoned record is not pending work
         expect(memStore.has(result.id)).toBe(false);  // nothing resurrected into the content store
         expect((await readPendingWalRecords({dir: testWalDir, ids: [result.id]})).length).toBe(0); // reconciled
     });
 
-    test('a successful deferred embed reconciles the WAL record (marker written, no longer pending)', async () => {
+    test('the daemon drain reconciles a pending record (embedded + marker written)', async () => {
         const result = await asTenant(() => MemoryService.addMemory({
             prompt: 'happy prompt', thought: 'happy thought', response: 'happy response'
         }));
 
         expect(result.id).toBeTruthy();
 
-        // The embed is fire-and-forget — poll until it lands in the fake store + the marker
-        // reconciles the WAL record.
-        await expect.poll(async () => memStore.has(result.id), {timeout: 5000}).toBe(true);
-        await expect.poll(
-            async () => (await readPendingWalRecords({dir: testWalDir, ids: [result.id]})).length,
-            {timeout: 5000}
-        ).toBe(0);
+        // New write-path contract: addMemory leaves the record PENDING — only the daemon drains.
+        expect((await readPendingWalRecords({dir: testWalDir, ids: [result.id]})).length).toBe(1);
+
+        // One targeted production drain cycle (the exact daemon logic) — deterministic, no polling.
+        const summary = await drainMemoryWal({ids: [result.id]});
+
+        expect(summary.embedded).toBe(1);
+        expect(memStore.has(result.id)).toBe(true);
+        expect((await readPendingWalRecords({dir: testWalDir, ids: [result.id]})).length).toBe(0);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.spec.mjs
@@ -19,12 +19,13 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import Neo             from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
-import path            from 'path';
-import {fileURLToPath} from 'url';
-import dotenv          from 'dotenv';
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../../../src/Neo.mjs';
+import * as core        from '../../../../../../src/core/_export.mjs';
+import path             from 'path';
+import {fileURLToPath}  from 'url';
+import dotenv           from 'dotenv';
+import {drainMemoryWal} from './util.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -127,8 +128,8 @@ test.describe('SessionService setSessionId', () => {
                 });
                 expect(memoryResult1.sessionId).toBe(sessionId1);
 
-                // The embed is deferred — flush before reading the store back.
-                await SDK.Memory_Service.drainPendingEmbeds();
+                // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
+                await drainMemoryWal({SDK, ids: [memoryResult1.id]});
 
                 const listResult = await SDK.Memory_Service.listMemories({ sessionId: sessionId1 });
                 expect(listResult.memories.length).toBe(1);
@@ -143,8 +144,8 @@ test.describe('SessionService setSessionId', () => {
                 });
                 expect(memoryResult2.sessionId).toBe(sessionId2);
 
-                // The embed is deferred — flush before reading the store back.
-                await SDK.Memory_Service.drainPendingEmbeds();
+                // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
+                await drainMemoryWal({SDK, ids: [memoryResult2.id]});
 
                 const listResult = await SDK.Memory_Service.listMemories({ sessionId: sessionId2 });
                 expect(listResult.memories.length).toBe(1);
@@ -165,7 +166,7 @@ test.describe('SessionService setSessionId', () => {
         const otherSessionId = crypto.randomUUID();
 
         // Add memory to target session
-        await SDK.Memory_Service.addMemory({
+        const targetAdd = await SDK.Memory_Service.addMemory({
             prompt: 'target prompt',
             response: 'target response',
             thought: 'target thought',
@@ -173,16 +174,16 @@ test.describe('SessionService setSessionId', () => {
         });
 
         // Add memory to other session
-        await SDK.Memory_Service.addMemory({
+        const otherAdd = await SDK.Memory_Service.addMemory({
             prompt: 'other prompt',
             response: 'other response',
             thought: 'other thought',
             sessionId: otherSessionId
         });
 
-        // The embed is deferred — flush so BOTH memories are in Chroma before the
-        // purge: this test verifies purge deletes embedded data (deletedMemories > 0).
-        await SDK.Memory_Service.drainPendingEmbeds();
+        // Flush the WAL-pending records through the daemon drain path so BOTH memories are in
+        // Chroma before the purge: this test verifies purge deletes embedded data (deletedMemories > 0).
+        await drainMemoryWal({SDK, ids: [targetAdd.id, otherAdd.id]});
 
         // Manually add summaries just to be sure we test both collections
         await SDK.Memory_SessionService.sessionsCollection.upsert({
@@ -259,16 +260,17 @@ test.describe('SessionService setSessionId', () => {
         // Verify tenant isolation: try to purge a session that belongs to a different user, or without the proper tenant.
         // We'll create another memory under SHARED_USER_ID, then try to delete it from testUserId context.
         const sharedSessionId = crypto.randomUUID();
-        await SDK.Memory_Service.addMemory({
+        const sharedAdd = await SDK.Memory_Service.addMemory({
             prompt: 'shared prompt',
             response: 'shared response',
             thought: 'shared thought',
             sessionId: sharedSessionId
         });
 
-        // The embed is deferred — flush so the shared memory is IN Chroma when the
-        // tenant-scoped purge runs: the isolation claim below is only meaningful against real data.
-        await SDK.Memory_Service.drainPendingEmbeds();
+        // Flush the WAL-pending record through the daemon drain path so the shared memory is IN
+        // Chroma when the tenant-scoped purge runs: the isolation claim below is only meaningful
+        // against real data.
+        await drainMemoryWal({SDK, ids: [sharedAdd.id]});
 
         await RequestContextService.run({ sessionId: sharedSessionId, userId: testUserId }, async () => {
             const result = await SDK.Memory_SessionService.purgeSession({ sessionId: sharedSessionId });

--- a/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs
@@ -18,13 +18,14 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import Neo             from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import path            from 'path';
-import {fileURLToPath} from 'url';
-import dotenv          from 'dotenv';
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../../../src/Neo.mjs';
+import * as core        from '../../../../../../src/core/_export.mjs';
+import InstanceManager  from '../../../../../../src/manager/Instance.mjs';
+import path             from 'path';
+import {fileURLToPath}  from 'url';
+import dotenv           from 'dotenv';
+import {drainMemoryWal} from './util.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -175,6 +176,7 @@ test.describe('Memory Core Offline Summarization', () => {
         // Ensure database is ready before adding memories
         await SDK.Memory_ChromaManager.ready();
 
+        const seededIds = [];
         for (const turn of turns) {
             const addResult = await SDK.Memory_Service.addMemory({
                 prompt   : turn.prompt,
@@ -186,11 +188,14 @@ test.describe('Memory Core Offline Summarization', () => {
             });
             if (addResult.error) {
                 console.error('ADD_MEMORY ERROR:', addResult);
+            } else {
+                seededIds.push(addResult.id);
             }
         }
 
-        // The embed is deferred — flush so the summarization read sees every turn.
-        await SDK.Memory_Service.drainPendingEmbeds();
+        // Flush the WAL-pending records through the daemon drain path so the summarization
+        // read sees every turn.
+        await drainMemoryWal({SDK, ids: seededIds});
 
         console.log(`[Playwright] Injected 5 dummy turns via SDK. Triggering Memory_SessionService.summarizeSession...`);
         const startTime = Date.now();
@@ -243,7 +248,7 @@ test.describe('Memory Core Offline Summarization', () => {
         // Create a massive string > 10000 chars (approx 20,000 chars)
         const hugeString = new Array(20000).fill('A').join('');
 
-        await SDK.Memory_Service.addMemory({
+        const bigAdd = await SDK.Memory_Service.addMemory({
             prompt   : "Massive text request",
             thought  : "Thinking deeply...",
             response : hugeString,
@@ -252,8 +257,9 @@ test.describe('Memory Core Offline Summarization', () => {
             sessionId: bigDummySessionId
         });
 
-        // The embed is deferred — flush so the summarization read sees the turn.
-        await SDK.Memory_Service.drainPendingEmbeds();
+        // Flush the WAL-pending record through the daemon drain path so the summarization
+        // read sees the turn.
+        await drainMemoryWal({SDK, ids: [bigAdd.id]});
 
         // Mock the model.generateContent to avoid actual LLM calls and verify the exact prompt content
         const originalGenerateContent = SDK.Memory_SessionService.model ? SDK.Memory_SessionService.model.generateContent : null;
@@ -348,7 +354,7 @@ test.describe('Memory Core Offline Summarization', () => {
                 };
             };
 
-            await SDK.Memory_Service.addMemory({
+            const qwenAdd = await SDK.Memory_Service.addMemory({
                 prompt   : "Validate Qwen3 chat summarization",
                 thought  : "Exercise the local OpenAI-compatible chat summary path.",
                 response : "The summary should preserve structured metadata.",
@@ -357,8 +363,9 @@ test.describe('Memory Core Offline Summarization', () => {
                 sessionId: qwenSessionId
             });
 
-            // The embed is deferred — flush so the summarization read sees the turn.
-            await SDK.Memory_Service.drainPendingEmbeds();
+            // Flush the WAL-pending record through the daemon drain path so the summarization
+            // read sees the turn.
+            await drainMemoryWal({SDK, ids: [qwenAdd.id]});
 
             const result = await SDK.Memory_SessionService.summarizeSession(qwenSessionId);
 
@@ -409,7 +416,7 @@ test.describe('Memory Core Offline Summarization', () => {
             content: massiveToolConfig
         })];
 
-        await SDK.Memory_Service.addMemory({
+        const toolsAdd = await SDK.Memory_Service.addMemory({
             prompt   : "Massive tools",
             thought  : "Thinking...",
             response : "Done",
@@ -419,9 +426,9 @@ test.describe('Memory Core Offline Summarization', () => {
             sessionId: dummySessionId
         });
 
-        // The embed is deferred — flush it so summarizeSession's Chroma read below
-        // sees the just-written memory.
-        await SDK.Memory_Service.drainPendingEmbeds();
+        // Flush the WAL-pending record through the daemon drain path so summarizeSession's
+        // Chroma read below sees the just-written memory.
+        await drainMemoryWal({SDK, ids: [toolsAdd.id]});
 
         const originalGenerateContent = SDK.Memory_SessionService.model ? SDK.Memory_SessionService.model.generateContent : null;
         let capturedPrompts = [];
@@ -464,27 +471,28 @@ test.describe('Memory Core Offline Summarization', () => {
         const s3 = crypto.randomUUID();
 
         // Memory 1 is oldest
-        await SDK.Memory_Service.addMemory({
+        const add1 = await SDK.Memory_Service.addMemory({
             prompt: "Test s1", thought: "T1", response: "R1", agent: "dev", model: "gemini-3.1-pro", sessionId: s1
         });
 
         await new Promise(r => setTimeout(r, 100)); // Sleep to ensure timestamp difference
 
         // Memory 2 is middle
-        await SDK.Memory_Service.addMemory({
+        const add2 = await SDK.Memory_Service.addMemory({
             prompt: "Test s2", thought: "T2", response: "R2", agent: "dev", model: "gemini-3.1-pro", sessionId: s2
         });
 
         await new Promise(r => setTimeout(r, 100)); // Sleep
 
         // Memory 3 is newest
-        await SDK.Memory_Service.addMemory({
+        const add3 = await SDK.Memory_Service.addMemory({
             prompt: "Test s3", thought: "T3", response: "R3", agent: "dev", model: "gemini-3.1-pro", sessionId: s3
         });
 
-        // The embed is deferred — flush so all three sessions are visible below.
-        // (Ordering is unaffected: lastActivity derives from the write-time metadata timestamp.)
-        await SDK.Memory_Service.drainPendingEmbeds();
+        // Flush the WAL-pending records through the daemon drain path so all three sessions are
+        // visible below. (Ordering is unaffected: lastActivity derives from the write-time
+        // metadata timestamp.)
+        await drainMemoryWal({SDK, ids: [add1.id, add2.id, add3.id]});
 
         // Use findSessionsToSummarize explicitly
         const candidates = await SDK.Memory_SessionService.findSessionsToSummarize(true);
@@ -519,7 +527,7 @@ test.describe('Memory Core Offline Summarization', () => {
         await SDK.Memory_ChromaManager.ready();
 
         // Inject 1 typical turn
-        await SDK.Memory_Service.addMemory({
+        const perfAdd = await SDK.Memory_Service.addMemory({
             prompt   : "Quick performance test for remote API generation",
             thought  : "Measuring true API latency, avoiding map-reduce overhead.",
             response : "This is a brief response to establish baseline latency for 1 session generation.",
@@ -528,9 +536,9 @@ test.describe('Memory Core Offline Summarization', () => {
             sessionId: perfSessionId
         });
 
-        // The embed is deferred — flush BEFORE the measurement window so the
-        // summarization latency below stays a pure API measurement.
-        await SDK.Memory_Service.drainPendingEmbeds();
+        // Flush the WAL-pending record through the daemon drain path BEFORE the measurement
+        // window so the summarization latency below stays a pure API measurement.
+        await drainMemoryWal({SDK, ids: [perfAdd.id]});
 
         const start = Date.now();
         const result = await SDK.Memory_SessionService.summarizeSession(perfSessionId);

--- a/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
@@ -9,6 +9,7 @@ import path            from 'path';
 import {
     appendWalEmbedMarker,
     appendWalMemory,
+    getMissingMemoryWalLeaves,
     getWalMarkersFileName,
     getWalRecordsFileName,
     getWalSegmentKey,
@@ -131,5 +132,20 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     test('pruning is a no-op without a positive retention bound or with a missing directory', async () => {
         expect(await pruneReconciledWalSegments({dir: tmpDir, retentionLimit: 0})).toBe(0);
         expect(await pruneReconciledWalSegments({dir: path.join(tmpDir, 'missing'), retentionLimit: 5})).toBe(0);
+    });
+
+    test('getMissingMemoryWalLeaves names exactly the absent leaves (stale-overlay guard, pure predicate)', () => {
+        // Block absent entirely (overlay predates the memoryWal block): every consumer leaf missing.
+        expect(getMissingMemoryWalLeaves(undefined, ['dir', 'minFieldLength'])).toEqual(['dir', 'minFieldLength']);
+
+        // Partially stale overlay (block exists, daemon leaves predate it): only those surface.
+        const phase1Slice = {dir: '/tmp/wal', retentionLimit: 30, minFieldLength: 1};
+        expect(getMissingMemoryWalLeaves(phase1Slice, ['dir', 'pollIntervalMs', 'batchSize'])).toEqual(['pollIntervalMs', 'batchSize']);
+
+        // Current slice: nothing missing — the consumer proceeds.
+        expect(getMissingMemoryWalLeaves({...phase1Slice, pollIntervalMs: 5000, batchSize: 20}, ['dir', 'pollIntervalMs', 'batchSize'])).toEqual([]);
+
+        // `null` is treated as absent (no hidden fallback may paper over it).
+        expect(getMissingMemoryWalLeaves({dir: null}, ['dir'])).toEqual(['dir']);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -80,6 +80,42 @@ export async function cleanupChromaManager(SDK) {
     await resetMemoryCoreLifecycle(SDK);
 }
 
+/**
+ * @summary Flushes pending WAL records through the production embed-drain path.
+ *
+ * The spec-side replacement for the removed `MemoryService.drainPendingEmbeds()`: `addMemory`
+ * no longer embeds in-process (the orchestrator-managed embed daemon owns the drain), so specs
+ * flush deterministically by running one targeted `drainWalOnce` cycle — the EXACT production
+ * logic the daemon executes — against the worker's resolved WAL dir and the currently-installed
+ * memory collection (real or spy).
+ *
+ * Pass `ids` (recommended) to reconcile only the records the calling spec just wrote: sibling
+ * specs sharing the worker's WAL dir may deliberately leave foreign records pending
+ * (`MemoryService.WriteAhead.spec.mjs` does), and an unscoped drain would pull those into the
+ * caller's collection.
+ *
+ * @param {Object} [options]
+ * @param {String[]} [options.ids]      Record ids to drain; omit to drain the whole dir.
+ * @param {Object} [options.collection] Explicit collection; defaults to `StorageRouter.getMemoryCollection()`.
+ * @param {Object} [options.SDK]        Optional `ai/services.mjs` aggregate for callers that already hold it.
+ * @returns {Promise<Object>} The `drainWalOnce` cycle summary.
+ */
+export async function drainMemoryWal({ids, collection, SDK} = {}) {
+    const aiConfig       = SDK?.Memory_Config ?? (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+    const StorageRouter  = SDK?.Memory_StorageRouter ?? (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+    const {drainWalOnce} = await import('../../../../../../ai/daemons/embed/drainCycle.mjs');
+
+    return drainWalOnce({
+        dir           : aiConfig.memoryWal.dir,
+        collection    : collection ?? await StorageRouter.getMemoryCollection(),
+        ids,
+        batchSize     : 1000,
+        maxRetries    : 0,  // single attempt — a failing spy must leave records pending, not retry-loop
+        backoffBaseMs : 1,
+        retentionLimit: 0   // non-positive disables pruning: no side-effects on the shared worker dir
+    });
+}
+
 export class TestLifecycleHelper {
     static async cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, strategy = 'destroy') {
         if (strategy === 'clear') {


### PR DESCRIPTION
Resolves #12840

The orchestrator-managed embed daemon now owns the model-dependent half of the never-fail `add_memory` design: `ai/daemons/embed/daemon.mjs` polls the JSONL WAL on a config-driven interval and drains pending records into the memory content store with whole-batch retry/backoff, per-record poison isolation (cross-cycle exponential cooldown, never abandoned), purge-race compensation, and reconciled-segment pruning. The transitional in-process embed is removed from `MemoryService.addMemory` atomically in the same PR — the drain loop is the sole marker-writer (the WAL store's single-writer-per-file invariant), and `addMemory` now performs **zero** content-store touches (proven by spec counter).

Authored by Claude Fable 5 (Claude Code), @neo-fable. Session 00ab373d-0219-4093-948b-f9d30ecd4c7b (ticket authored in predecessor session 5000ac5e-dabb-4f39-8a5c-e8ba55133f3d).

Evidence: L3 (real-process daemon smoke on live config/storage — boot guard, leaf resolution, PID lifecycle, idle cycles, clean shutdown — + 115 targeted unit specs incl. real-Chroma drain paths + the dockerized integration matrix exercising the in-process drain mode over live SSE transport in CI) → L4 required (AC6 live heavy-backfill drain under contention). Residual: AC6 [#12840] (flagged post-merge in the ticket).

## Deltas from ticket (key design decisions)

1. **Daemon-side purge safety without the in-memory map.** The ticket's either/or ("reuses `embedPendingMemory` or replicates its guard semantics") resolves to replication: the daemon is a separate process and cannot see `MemoryService.purgedSessions`. Purge safety = WAL tombstones (`SessionService.purgeSession` marks pending records BEFORE its content-store delete — that ordering is now documented as load-bearing) + post-add compensation: after a successful `collection.add`, the cycle re-reads pending state for exactly the embedded ids; ids that vanished were tombstoned mid-embed (unambiguous under the sole-drainer invariant) → compensating `collection.delete`, no daemon marker.
2. **The whole in-process embed cluster is removed**, not just the call site: `embedPendingMemory`, `drainPendingEmbeds`, `inFlightEmbeds`, `purgedSessions`, `markSessionPurged`, `purgedSessionTtlMs` + the `SessionService` dynamic-import call. With no in-process embeds, the in-memory purge guard protects nothing — dead code in a hot service.
3. **Spec migration to the production drain path.** ~20 `drainPendingEmbeds()` call sites across 5 spec files now flush via `drainMemoryWal({ids})` (new shared helper in `test/.../util.mjs`) — one targeted `drainWalOnce` cycle, the EXACT daemon logic. ids-scoped on purpose: sibling specs sharing the per-worker WAL dir deliberately leave foreign pending records. Net effect: the whole memory-core suite now exercises the daemon drain dozens of times.
4. **`drainWalOnce({ids})` passthrough** (delta): targeted-drain primitive for explicit flush callers; the daemon loop never passes it.
5. **AC7 guard generalized**: `getMissingMemoryWalLeaves(slice, requiredLeaves)` pure predicate in `memoryWalStore.mjs` (B4-safe unit tests, no singleton mutation) serves BOTH consumers — `addMemory` (caught + actionable `MEMORY_ADD_ERROR` envelope naming the migrate-config fix) and the daemon boot guard (fail-loud exit). AC8 (validation gate inside `try`, JSDoc headline tightened), AC9 (dual-timestamp comment), AC10 (scan-cost bound documented at the drain module + cadence note on the config leaf) all land.
6. **In-process drain mode (delta, surfaced by the integration matrix).** The drain loop is hosted by a shared `startDrainLoop` in `drainCycle.mjs`, consumed by BOTH deployment shapes: the supervised daemon process (local maintainer profile) AND the memory-core server itself via the new `memoryWal.inProcessDrain` leaf (containerized / single-process deployments — the dockerized MC containers, npx-neo-app-class workspaces). The sole-drainer invariant is config-declared mutual exclusion: exactly ONE loop per WAL dir, never both modes on one deployment (documented loudly at the leaf + the loop host). This closes the "cloud deployments own their drain story per-container" gap with zero extra containers.
7. **Integration contract made honest: semantic recall is eventually consistent.** The 5 dockerized integration tests that queried `query_raw_memories` immediately after `add_memory` now `expect.poll` to convergence — which is the real consumer contract under the WAL design. The compose MC services run the in-process drain at a 250ms cadence with the WAL on the same tmpfs as the graph DB.

## Changed config keys (per `mcp-config-template-change-guide.md`)

- `ai/mcp/server/memory-core/config.template.mjs` → `memoryWal.{daemonDataDir, pollIntervalMs, batchSize, maxRetries, backoffBaseMs, inProcessDrain}` (all declarative `leaf()`, env-overridable: `NEO_MEMORY_EMBED_DAEMON_DIR`, `NEO_MEMORY_WAL_POLL_INTERVAL_MS`, `NEO_MEMORY_WAL_BATCH_SIZE`, `NEO_MEMORY_WAL_MAX_RETRIES`, `NEO_MEMORY_WAL_BACKOFF_BASE_MS`, `NEO_MEMORY_WAL_IN_PROCESS_DRAIN`).
- `ai/config.template.mjs` → `orchestrator.localOnly.embedDaemonEnabled` (`NEO_ORCHESTRATOR_EMBED_DAEMON_ENABLED`, deployment-profile default: local enables, cloud disables).
- **Local follow-up per clone (REQUIRED):** `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` (materializes the new leaves into the gitignored `config.mjs`), then restart the **orchestrator daemon** (picks up the `embedDaemon` continuous task) — memory-core MCP restart recommended (activates the new `addMemory` path). Both guards fail loud + name exactly this fix if skipped. Local clones keep `inProcessDrain` at its `false` default — the daemon is the local drain owner.

## Test Evidence

- `npm run test-unit -- <drainCycle + memoryWalStore + WriteAhead + TenantIsolation + Schema specs>` → **46/46 passed (1.2s)**. `drainCycle.spec.mjs`: 12 falsifiers (drain/mark/prune, retry/backoff with recorded delays, poison isolation + cooldown expiry, tombstone pre-filter, mid-embed tombstone compensation incl. `collection.delete` assertion, ids targeting, batchSize bounding, prune wiring, per-record failure reporting, backoff cap, loop host drains + stops, loop survives failing cycles).
- `npm run test-unit -- <Orchestrator + config.template specs>` → **65/65 passed** after extending the topology contracts (state-envelope keys, fixture flag default-disabled like `primaryDevSyncEnabled`, new enabled-path supervision test).
- `SessionService.spec.mjs` → all 4 migrated flush sites green against the **real** test collection + embedder.
- `SessionSummarization.spec.mjs` → 11/13 on this branch; the 2 failures are 300s timeouts in gemma4-31B summarization calls. **Falsified as diff-caused:** identical-class failures (3/13, a superset) reproduced on a clean `origin/dev` worktree on the same machine under the same load — LM Studio saturation during tonight's multi-agent shift (the branch run passed one MORE test than the dev baseline).
- Real-process smoke (×2, incl. post-refactor onto `startDrainLoop`): daemon booted against live config/storage — stale-config boot guard, leaf resolution, atomic PID claim, silent idle cycles, SIGTERM cleanup (PID file removed).
- Integration matrix: verified via CI (docker unavailable on the authoring machine) — the compose MC containers now host the in-process drain.

## Post-Merge Validation

- [ ] AC6: under a live heavy embed backfill, `add_memory` latency stays bounded, never returns `MEMORY_ADD_ERROR`, and the pending backlog drains once contention clears.
- [ ] Per-clone: `--migrate-config` + orchestrator restart → `embed-daemon.pid` appears under `.neo-ai-data/embed-daemon/` and the orchestrator supervises the new continuous task.

## Commits

- `774467556` — daemon + drainCycle + config leaves + orchestrator wire-up + MemoryService/SessionService surgery + spec migration
- `407ec90bd` — shared `startDrainLoop` host + in-process drain mode + compose wiring + eventually-consistent integration contract + topology-contract spec updates

## Evolution

The first CI round failed 12 unit + 5 integration tests. Unit: two topology-contract specs (`config.template.spec`, `Orchestrator.spec`) legitimately pinned the pre-daemon task/key shapes — updated, plus a new enabled-path supervision test. Integration: the dockerized MC containers had **no drain owner** (single-process containers, no orchestrator), so removing the inline embed correctly broke semantic read-back there — surfacing that the ticket's daemon-only shape left every daemon-less deployment without a drain story. Rather than sidecar containers (×2 services, ×2 shared volumes), the drain loop became a shared host (`startDrainLoop`) the server itself can run under `memoryWal.inProcessDrain` — same module, same sole-drainer invariant, config-declared exclusivity. The integration specs' immediate-read assertions were then made honest against the eventually-consistent contract via `expect.poll`.

Related: #12838 (Phase 1), #12065 (orchestrator SSOT pattern), #12830 (corrupted-memory carve-out, untouched), #12851 (the migrate-config sunset step this PR's stale-config guards point at).