### PR TITLE
feat(orchestrator): primary-dev-sync migrates config.mjs after dev pull (#12854)

### DIFF
--- a/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
@@ -50,6 +50,36 @@ export function isKbRelevantChangePath(filePath) {
         KB_RELEVANT_PATH_PREFIXES.some(prefix => normalized.startsWith(prefix));
 }
 
+const CONFIG_TEMPLATE_PATHS = Object.freeze(new Set([
+    'ai/config.template.mjs'
+]));
+
+const SERVER_CONFIG_TEMPLATE_PATTERN = /^ai\/mcp\/server\/[^/]+\/config\.template\.mjs$/;
+
+/**
+ * @summary Checks whether a changed repository path is a config TEMPLATE whose drift
+ * requires reconciling the gitignored operator-overlay (`config.mjs`) via
+ * `initServerConfigs.mjs --migrate-config`.
+ *
+ * A plain `git pull` updates the tracked `config.template.mjs` (Tier-1 or per-server) but
+ * never the gitignored `config.mjs` the daemons actually read — so a template change in the
+ * pulled range is the signal that the overlay needs a migrate. Mirrors
+ * {@link isKbRelevantChangePath}'s normalization so both predicates classify the same
+ * `git diff --name-only` output from one diff.
+ *
+ * @param {String} filePath Repository-relative path.
+ * @returns {Boolean}
+ */
+export function isConfigTemplateChangePath(filePath) {
+    const normalized = String(filePath || '').replace(/\\/g, '/').replace(/^\.\//, '');
+
+    if (!normalized) {
+        return false;
+    }
+
+    return CONFIG_TEMPLATE_PATHS.has(normalized) || SERVER_CONFIG_TEMPLATE_PATTERN.test(normalized);
+}
+
 /**
  * @summary Parses the optional multi-checkout dev-sync root list.
  *
@@ -256,7 +286,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Optional logger.
      * @returns {Object}
      */
-    syncConfiguredDevRoot({root, execFileSyncFn, writeLog}) {
+    syncConfiguredDevRoot({root, execFileSyncFn, writeLog, taskStateService, healthService}) {
         try {
             const topLevel = path.resolve(this.git(['rev-parse', '--show-toplevel'], root, execFileSyncFn).trim());
 
@@ -274,7 +304,9 @@ class PrimaryRepoSyncService extends Base {
                 execFileSyncFn,
                 writeLog,
                 fetchBeforeBranch: true,
-                runKbSync: false
+                runKbSync: false,
+                taskStateService,
+                healthService
             });
         } catch (e) {
             return this.fail('root-sync-failed', {root, error: e.message}, writeLog);
@@ -294,7 +326,7 @@ class PrimaryRepoSyncService extends Base {
      */
     syncConfiguredDevRoots({primaryRoot, roots, execFileSyncFn, writeLog, taskStateService, healthService}) {
         const rootResults = roots.map(root => {
-            const result = this.syncConfiguredDevRoot({root, execFileSyncFn, writeLog});
+            const result = this.syncConfiguredDevRoot({root, execFileSyncFn, writeLog, taskStateService, healthService});
             return {status: result.status, ...result.details};
         });
 
@@ -395,6 +427,9 @@ class PrimaryRepoSyncService extends Base {
             this.git(['pull', '--ff-only', REMOTE_NAME, DEV_BRANCH], root, execFileSyncFn);
             const newHead = this.resolveOptionalHead(root, execFileSyncFn);
             const kbSyncDecision = this.resolveKbSyncDecision({root, oldHead, newHead, execFileSyncFn});
+            if (kbSyncDecision.configMigrateRequired) {
+                this.runConfigMigrate(root, execFileSyncFn, {taskStateService, healthService});
+            }
             if (runKbSync && kbSyncDecision.kbSyncRequired) {
                 this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
             }
@@ -403,8 +438,9 @@ class PrimaryRepoSyncService extends Base {
                 details: {
                     ...rootDetails,
                     behind,
-                    layer : 'ff-pull',
-                    kbSync: runKbSync && kbSyncDecision.kbSyncRequired,
+                    layer        : 'ff-pull',
+                    kbSync       : runKbSync && kbSyncDecision.kbSyncRequired,
+                    configMigrate: kbSyncDecision.configMigrateRequired,
                     ...kbSyncDecision
                 }
             };
@@ -469,6 +505,9 @@ class PrimaryRepoSyncService extends Base {
         this.git(['pull', '--ff-only', REMOTE_NAME, DEV_BRANCH], root, execFileSyncFn);
         const newHead = this.resolveOptionalHead(root, execFileSyncFn);
         const kbSyncDecision = this.resolveKbSyncDecision({root, oldHead, newHead, execFileSyncFn});
+        if (kbSyncDecision.configMigrateRequired) {
+            this.runConfigMigrate(root, execFileSyncFn, {taskStateService, healthService});
+        }
         if (runKbSync && kbSyncDecision.kbSyncRequired) {
             this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
         }
@@ -478,9 +517,10 @@ class PrimaryRepoSyncService extends Base {
             details: {
                 ...rootDetails,
                 behind,
-                layer   : 'meta-sync-reset',
-                resolved: 'meta-sync',
-                kbSync  : runKbSync && kbSyncDecision.kbSyncRequired,
+                layer        : 'meta-sync-reset',
+                resolved     : 'meta-sync',
+                kbSync       : runKbSync && kbSyncDecision.kbSyncRequired,
+                configMigrate: kbSyncDecision.configMigrateRequired,
                 ...kbSyncDecision
             }
         };
@@ -562,6 +602,77 @@ class PrimaryRepoSyncService extends Base {
     }
 
     /**
+     * Runs `node <root>/ai/scripts/setup/initServerConfigs.mjs --migrate-config` from the
+     * pulled checkout to reconcile the gitignored `config.mjs` operator-overlay with the
+     * `config.template.mjs` leaves that just advanced on `dev`.
+     *
+     * A `git pull` updates the tracked template but never the gitignored overlay the daemons
+     * actually read — so a config-template change in the pulled range leaves every daemon
+     * (orchestrator, wake-daemon, DreamService, KB pipeline) running current code against
+     * stale config until this migrate runs. The bare script is warn-only; the
+     * `--migrate-config` flag is what actually rewrites the overlay (gitignored; safe — never
+     * touches tracked files). The script resolves its repo from its own `__dirname`, so the
+     * script PATH under `root` selects the checkout to reconcile.
+     *
+     * Annotated as a first-class `configMigrate` task lifecycle event (same pattern as
+     * {@link runKbSync}) so the cascade is observable in `TaskStateService` +
+     * `HealthService` rather than hidden inside `primary-dev-sync`. Both injections are
+     * optional-chained for backward compatibility.
+     *
+     * Unlike {@link runKbSync}, a migrate failure is **isolated, not rethrown**: a stale
+     * overlay must never abort the (already-successful) pull, the sibling KB cascade, or the
+     * parent task. The failure is recorded + surfaced; the daemon keeps running.
+     *
+     * Config migration is **per-clone** (each checkout owns its own gitignored `config.mjs`),
+     * so this runs once per synced root — unlike the KB cascade, which runs once from the
+     * owning checkout.
+     *
+     * @param {String} root Checkout path whose overlay is being reconciled.
+     * @param {Function} execFileSyncFn Command execution seam.
+     * @param {Object} [options]
+     * @param {Object} [options.taskStateService] Injected `TaskStateService` for state-lifecycle annotation; if absent the call is a pure shell-out with no state mutation.
+     * @param {Object} [options.healthService] Injected `HealthService` for outcome-telemetry annotation; if absent no outcomes are recorded.
+     * @param {String} [options.parentTaskName='primary-dev-sync'] Parent task name for cascade provenance.
+     * @returns {void}
+     */
+    runConfigMigrate(root, execFileSyncFn, {taskStateService, healthService, parentTaskName = 'primary-dev-sync'} = {}) {
+        const reason     = `cascaded-from-${parentTaskName}`;
+        const scriptPath = path.join(root, 'ai', 'scripts', 'setup', 'initServerConfigs.mjs');
+
+        taskStateService?.markStarted?.('configMigrate', reason);
+        healthService?.recordTaskOutcome?.('configMigrate', 'running', {
+            reason,
+            parent   : parentTaskName,
+            startedAt: new Date().toISOString()
+        });
+
+        try {
+            execFileSyncFn(process.execPath, [scriptPath, '--migrate-config'], {
+                cwd     : root,
+                encoding: 'utf8',
+                stdio   : ['ignore', 'pipe', 'pipe']
+            });
+
+            taskStateService?.markCompleted?.('configMigrate');
+            healthService?.recordTaskOutcome?.('configMigrate', 'completed', {
+                reason,
+                parent     : parentTaskName,
+                completedAt: new Date().toISOString()
+            });
+        } catch (e) {
+            // Isolation: a stale overlay must not abort the successful pull, the KB cascade,
+            // or the parent task. Record + surface; never rethrow (contrast runKbSync).
+            taskStateService?.markFailed?.('configMigrate', e.status || 1);
+            healthService?.recordTaskOutcome?.('configMigrate', 'failed', {
+                reason,
+                parent  : parentTaskName,
+                error   : e.message,
+                failedAt: new Date().toISOString()
+            });
+        }
+    }
+
+    /**
      * Runs a git command in a specific working directory.
      * @param {String[]} args Git arguments.
      * @param {String} cwd Working directory.
@@ -629,7 +740,13 @@ class PrimaryRepoSyncService extends Base {
     }
 
     /**
-     * Decides whether a successful dev pull needs the expensive KB cascade.
+     * Decides whether a successful dev pull needs the expensive KB cascade and/or a
+     * config-overlay migrate, from a single `git diff` of the pulled range. The KB decision
+     * gates {@link runKbSync}; the config-migrate decision (`configMigrateRequired`) gates
+     * {@link runConfigMigrate} when a `config.template.mjs` (Tier-1 or per-server) advanced in
+     * the pulled commits. Both classifiers share the one changed-path projection, so
+     * no second diff is spawned. Unknown-head / diff-failure short-circuits fail safe (both
+     * cascades required) because the cheaper outcome is a redundant reconcile, not stale state.
      * @param {Object} options
      * @param {String} options.root Repository root.
      * @param {String} options.oldHead Previous HEAD.
@@ -640,8 +757,10 @@ class PrimaryRepoSyncService extends Base {
     resolveKbSyncDecision({root, oldHead, newHead, execFileSyncFn}) {
         if (!oldHead || !newHead) {
             return {
-                kbSyncRequired  : true,
-                kbSyncReasonCode: 'kb-relevance-unknown-head',
+                kbSyncRequired         : true,
+                kbSyncReasonCode       : 'kb-relevance-unknown-head',
+                configMigrateRequired  : true,
+                configMigrateReasonCode: 'config-migrate-unknown-head',
                 oldHead,
                 newHead
             };
@@ -649,14 +768,18 @@ class PrimaryRepoSyncService extends Base {
 
         if (oldHead === newHead) {
             return {
-                kbSyncRequired     : false,
-                kbSyncReasonCode   : 'no-kb-relevant-changes',
-                reasonCode         : 'no-kb-relevant-changes',
+                kbSyncRequired         : false,
+                kbSyncReasonCode       : 'no-kb-relevant-changes',
+                configMigrateRequired  : false,
+                configMigrateReasonCode: 'no-config-template-changes',
+                reasonCode             : 'no-kb-relevant-changes',
                 oldHead,
                 newHead,
-                changedPathCount   : 0,
-                kbChangedPathCount : 0,
-                kbChangedPathSample: []
+                changedPathCount       : 0,
+                kbChangedPathCount     : 0,
+                kbChangedPathSample    : [],
+                configChangedPathCount : 0,
+                configChangedPathSample: []
             };
         }
 
@@ -665,25 +788,32 @@ class PrimaryRepoSyncService extends Base {
             changedPaths = this.resolveChangedPaths({root, oldHead, newHead, execFileSyncFn});
         } catch (e) {
             return {
-                kbSyncRequired  : true,
-                kbSyncReasonCode: 'kb-relevance-check-failed',
+                kbSyncRequired         : true,
+                kbSyncReasonCode       : 'kb-relevance-check-failed',
+                configMigrateRequired  : true,
+                configMigrateReasonCode: 'config-migrate-relevance-check-failed',
                 oldHead,
                 newHead,
-                error         : e.message
+                error                  : e.message
             };
         }
 
-        const kbChangedPaths = changedPaths.filter(isKbRelevantChangePath);
+        const kbChangedPaths     = changedPaths.filter(isKbRelevantChangePath);
+        const configChangedPaths = changedPaths.filter(isConfigTemplateChangePath);
 
         return {
-            kbSyncRequired     : kbChangedPaths.length > 0,
-            kbSyncReasonCode   : kbChangedPaths.length > 0 ? 'kb-relevant-changes' : 'no-kb-relevant-changes',
+            kbSyncRequired         : kbChangedPaths.length > 0,
+            kbSyncReasonCode       : kbChangedPaths.length > 0 ? 'kb-relevant-changes' : 'no-kb-relevant-changes',
+            configMigrateRequired  : configChangedPaths.length > 0,
+            configMigrateReasonCode: configChangedPaths.length > 0 ? 'config-template-changes' : 'no-config-template-changes',
             ...(kbChangedPaths.length > 0 ? {} : {reasonCode: 'no-kb-relevant-changes'}),
             oldHead,
             newHead,
-            changedPathCount   : changedPaths.length,
-            kbChangedPathCount : kbChangedPaths.length,
-            kbChangedPathSample: kbChangedPaths.slice(0, 10)
+            changedPathCount       : changedPaths.length,
+            kbChangedPathCount     : kbChangedPaths.length,
+            kbChangedPathSample    : kbChangedPaths.slice(0, 10),
+            configChangedPathCount : configChangedPaths.length,
+            configChangedPathSample: configChangedPaths.slice(0, 10)
         };
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
@@ -3,6 +3,7 @@ import Neo       from '../../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../../src/core/_export.mjs';
 import PrimaryRepoSyncService, {
     DEV_SYNC_ROOTS_ENV_VAR,
+    isConfigTemplateChangePath,
     isKbRelevantChangePath,
     parseDevSyncRoots
 } from '../../../../../../../ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs';
@@ -108,6 +109,22 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(isKbRelevantChangePath('package.json')).toBe(false);
     });
 
+    test('classifies config-template change paths for the migrate cascade (#12854)', () => {
+        // Tier-1 + per-server templates trigger the overlay reconcile; their gitignored
+        // overlays and non-template siblings do not.
+        expect(isConfigTemplateChangePath('ai/config.template.mjs')).toBe(true);
+        expect(isConfigTemplateChangePath('ai/mcp/server/memory-core/config.template.mjs')).toBe(true);
+        expect(isConfigTemplateChangePath('ai/mcp/server/github-workflow/config.template.mjs')).toBe(true);
+        // The gitignored overlay itself never appears in a dev diff, but assert it is NOT a trigger.
+        expect(isConfigTemplateChangePath('ai/config.mjs')).toBe(false);
+        expect(isConfigTemplateChangePath('ai/mcp/server/memory-core/config.mjs')).toBe(false);
+        // Deeper than one server segment, or a different template family, must not match.
+        expect(isConfigTemplateChangePath('ai/mcp/server/memory-core/sub/config.template.mjs')).toBe(false);
+        expect(isConfigTemplateChangePath('.codex/config.template.toml')).toBe(false);
+        expect(isConfigTemplateChangePath('ai/services/knowledge-base/source/ApiSource.mjs')).toBe(false);
+        expect(isConfigTemplateChangePath('')).toBe(false);
+    });
+
     test('falls back to KB cascade when changed-path detection fails', () => {
         const execStub = createExecStub([{
             cmd  : 'git',
@@ -121,11 +138,13 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             newHead       : 'new-head',
             execFileSyncFn: execStub
         })).toEqual({
-            kbSyncRequired  : true,
-            kbSyncReasonCode: 'kb-relevance-check-failed',
-            oldHead         : 'old-head',
-            newHead         : 'new-head',
-            error           : 'bad revision'
+            kbSyncRequired         : true,
+            kbSyncReasonCode       : 'kb-relevance-check-failed',
+            configMigrateRequired  : true,
+            configMigrateReasonCode: 'config-migrate-relevance-check-failed',
+            oldHead                : 'old-head',
+            newHead                : 'new-head',
+            error                  : 'bad revision'
         });
     });
 
@@ -243,6 +262,137 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             changedPathCount   : 1,
             kbChangedPathCount : 1,
             kbChangedPathSample: ['src/button/Base.mjs']
+        });
+    });
+
+    test('runs config-overlay migrate then KB cascade when a config template advanced (#12854)', () => {
+        const execStub = createExecStub([{
+            cmd   : 'git',
+            args  : ['worktree', 'list', '--porcelain'],
+            output: 'worktree /primary/neo\n'
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', '--abbrev-ref', 'HEAD'],
+            output: 'dev\n'
+        }, {
+            cmd : 'git',
+            args: ['fetch', 'origin', 'dev', '--quiet']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-list', '--count', 'dev..origin/dev'],
+            output: '1\n'
+        }, {
+            cmd   : 'git',
+            args  : ['status', '--porcelain'],
+            output: ''
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'old-head\n'
+        }, {
+            cmd : 'git',
+            args: ['pull', '--ff-only', 'origin', 'dev']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'new-head\n'
+        }, {
+            cmd   : 'git',
+            args  : ['diff', '--name-only', 'old-head..new-head'],
+            output: 'ai/config.template.mjs\n'
+        }, {
+            // config-migrate runs FIRST (per-clone overlay freshness), before the KB cascade.
+            cmd : process.execPath,
+            args: ['/primary/neo/ai/scripts/setup/initServerConfigs.mjs', '--migrate-config']
+        }, {
+            // `ai/` paths are also KB-relevant, so the KB cascade still fires from the same diff.
+            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args: ['run', 'ai:sync-kb']
+        }]);
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd           : '/primary/neo',
+            execFileSyncFn: execStub,
+            writeLog      : () => {}
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details).toMatchObject({
+            primaryRoot            : '/primary/neo',
+            behind                 : 1,
+            layer                  : 'ff-pull',
+            kbSync                 : true,
+            configMigrate          : true,
+            configMigrateRequired  : true,
+            configMigrateReasonCode: 'config-template-changes',
+            configChangedPathCount : 1,
+            configChangedPathSample: ['ai/config.template.mjs']
+        });
+
+        // Ordering contract: the node migrate precedes the npm KB cascade.
+        const migrateIdx = execStub.calls.findIndex(call => call.cmd === process.execPath);
+        const kbSyncIdx  = execStub.calls.findIndex(call => call.cmd === (process.platform === 'win32' ? 'npm.cmd' : 'npm'));
+        expect(migrateIdx).toBeGreaterThan(-1);
+        expect(kbSyncIdx).toBeGreaterThan(migrateIdx);
+    });
+
+    test('a per-server config template advance triggers the migrate cascade (#12854)', () => {
+        // A per-server template lives under ai/ too, so the KB cascade co-fires. The point of this
+        // case is to pin that a *server* template (not just Tier-1) triggers the migrate.
+        const execStub = createExecStub([{
+            cmd   : 'git',
+            args  : ['worktree', 'list', '--porcelain'],
+            output: 'worktree /primary/neo\n'
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', '--abbrev-ref', 'HEAD'],
+            output: 'dev\n'
+        }, {
+            cmd : 'git',
+            args: ['fetch', 'origin', 'dev', '--quiet']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-list', '--count', 'dev..origin/dev'],
+            output: '1\n'
+        }, {
+            cmd   : 'git',
+            args  : ['status', '--porcelain'],
+            output: ''
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'old-head\n'
+        }, {
+            cmd : 'git',
+            args: ['pull', '--ff-only', 'origin', 'dev']
+        }, {
+            cmd   : 'git',
+            args  : ['rev-parse', 'HEAD'],
+            output: 'new-head\n'
+        }, {
+            cmd   : 'git',
+            args  : ['diff', '--name-only', 'old-head..new-head'],
+            output: 'ai/mcp/server/memory-core/config.template.mjs\n'
+        }, {
+            cmd : process.execPath,
+            args: ['/primary/neo/ai/scripts/setup/initServerConfigs.mjs', '--migrate-config']
+        }, {
+            cmd : process.platform === 'win32' ? 'npm.cmd' : 'npm',
+            args: ['run', 'ai:sync-kb']
+        }]);
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd           : '/primary/neo',
+            execFileSyncFn: execStub,
+            writeLog      : () => {}
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details).toMatchObject({
+            configMigrate          : true,
+            configMigrateRequired  : true,
+            configChangedPathCount : 1,
+            configChangedPathSample: ['ai/mcp/server/memory-core/config.template.mjs']
         });
     });
 
@@ -389,18 +539,23 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
                 skipped    : 1,
                 failed     : 0,
                 roots      : [{
-                    status             : 'completed',
-                    root               : '/primary/neo',
-                    behind             : 2,
-                    layer              : 'ff-pull',
-                    kbSync             : false,
-                    kbSyncRequired     : true,
-                    kbSyncReasonCode   : 'kb-relevant-changes',
-                    oldHead            : 'old-head',
-                    newHead            : 'new-head',
-                    changedPathCount   : 1,
-                    kbChangedPathCount : 1,
-                    kbChangedPathSample: ['learn/guides/testing/UnitTesting.md']
+                    status                 : 'completed',
+                    root                   : '/primary/neo',
+                    behind                 : 2,
+                    layer                  : 'ff-pull',
+                    kbSync                 : false,
+                    configMigrate          : false,
+                    kbSyncRequired         : true,
+                    kbSyncReasonCode       : 'kb-relevant-changes',
+                    configMigrateRequired  : false,
+                    configMigrateReasonCode: 'no-config-template-changes',
+                    oldHead                : 'old-head',
+                    newHead                : 'new-head',
+                    changedPathCount       : 1,
+                    kbChangedPathCount     : 1,
+                    kbChangedPathSample    : ['learn/guides/testing/UnitTesting.md'],
+                    configChangedPathCount : 0,
+                    configChangedPathSample: []
                 }, {
                     status    : 'skipped',
                     reasonCode: 'up-to-date',
@@ -685,7 +840,7 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
     });
 
     // ─────────────────────────────────────────────────────────────────────────────
-    // Lane D narrow observability of #11503 (#11520):
+    // Cascade observability (Lane D):
     //   runKbSync cascade is annotated as a first-class `kbSync` task lifecycle
     //   event via TaskStateService + HealthService so monitoring agents +
     //   post-incident forensics can see cascade kbSync separately from the parent
@@ -697,7 +852,7 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
     // ─────────────────────────────────────────────────────────────────────────────
 
     test('runKbSync annotates cascade as kbSync lifecycle via TaskStateService + HealthService on success — STRICT TEMPORAL ORDERING (#11520 AC1+AC2+AC6+AC8)', () => {
-        // Per @neo-gpt PR #11521 cycle 1 review (PRR_kwDODSospM8AAAABAJRHVA): the end-state
+        // Per @neo-gpt's cross-family review: the end-state
         // assertions on `events` and `outcomes` arrays prove WHAT happened but NOT WHEN.
         // AC6 mandates temporal ordering: markStarted + running outcome MUST occur BEFORE
         // execFileSyncFn begins; markCompleted + completed outcome MUST occur AFTER it
@@ -846,7 +1001,7 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         // WITHOUT acquire/release (returns 'inherited').
         //
         // Without this forwarding the cascade would attempt to acquire its own lease,
-        // see the parent's, and self-defer with 'held' — the #11519 self-defer bug.
+        // see the parent's, and self-defer with 'held' — the self-defer bug this env-forwarding prevents.
         const taskStateService = createTaskStateService();
         const healthService    = {recordTaskOutcome() {}};
         const captured         = [];
@@ -934,5 +1089,107 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         expect(taskStateService.events[0]).toEqual(['started', 'kbSync', 'cascaded-from-custom-parent-task']);
         expect(outcomes[0].details.parent).toBe('custom-parent-task');
         expect(outcomes[0].details.reason).toBe('cascaded-from-custom-parent-task');
+    });
+
+    test('runConfigMigrate annotates a first-class configMigrate task with strict temporal ordering (#12854)', () => {
+        // Mirrors the runKbSync lifecycle contract: markStarted + running BEFORE exec,
+        // markCompleted + completed AFTER. exec is `node <root>/ai/scripts/setup/initServerConfigs.mjs --migrate-config`.
+        const sequence = [];
+
+        const taskStateService = {
+            events: [],
+            getTaskState() { return {running: false}; },
+            markStarted(taskName, reason) {
+                this.events.push(['started', taskName, reason]);
+                sequence.push(`state-started:${taskName}:${reason}`);
+            },
+            markCompleted(taskName) {
+                this.events.push(['completed', taskName]);
+                sequence.push(`state-completed:${taskName}`);
+            },
+            markFailed(taskName, code) {
+                this.events.push(['failed', taskName, code]);
+                sequence.push(`state-failed:${taskName}:${code}`);
+            }
+        };
+        const outcomes      = [];
+        const healthService = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+                sequence.push(`health-${status}:${taskName}`);
+            }
+        };
+        const execFileSyncFn = (cmd, args) => {
+            sequence.push(`exec:${cmd}:${args.join(' ')}`);
+            return '';
+        };
+
+        PrimaryRepoSyncService.runConfigMigrate('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+
+        expect(sequence).toEqual([
+            'state-started:configMigrate:cascaded-from-primary-dev-sync',
+            'health-running:configMigrate',
+            `exec:${process.execPath}:/primary/neo/ai/scripts/setup/initServerConfigs.mjs --migrate-config`,
+            'state-completed:configMigrate',
+            'health-completed:configMigrate'
+        ]);
+        expect(outcomes[0]).toMatchObject({
+            taskName: 'configMigrate',
+            status  : 'running',
+            details : expect.objectContaining({reason: 'cascaded-from-primary-dev-sync', parent: 'primary-dev-sync'})
+        });
+        expect(outcomes[1]).toMatchObject({
+            taskName: 'configMigrate',
+            status  : 'completed',
+            details : expect.objectContaining({reason: 'cascaded-from-primary-dev-sync', parent: 'primary-dev-sync'})
+        });
+    });
+
+    test('runConfigMigrate isolates failure — records failed but does NOT rethrow (#12854 AC6, contrast runKbSync)', () => {
+        // A stale-overlay migrate failure must never abort the already-successful pull, the sibling
+        // KB cascade, or the parent task. Unlike runKbSync, runConfigMigrate swallows + records.
+        const taskStateService = createTaskStateService();
+        const outcomes         = [];
+        const healthService    = {
+            recordTaskOutcome(taskName, status, details) {
+                outcomes.push({taskName, status, details});
+            }
+        };
+        const execFileSyncFn = () => {
+            const e  = new Error('initServerConfigs failed: drift overwrite error');
+            e.status = 1;
+            throw e;
+        };
+
+        expect(() => {
+            PrimaryRepoSyncService.runConfigMigrate('/primary/neo', execFileSyncFn, {taskStateService, healthService});
+        }).not.toThrow();
+
+        expect(taskStateService.events).toEqual([
+            ['started', 'configMigrate', 'cascaded-from-primary-dev-sync'],
+            ['failed', 'configMigrate', 1]
+        ]);
+        expect(outcomes[1]).toMatchObject({
+            taskName: 'configMigrate',
+            status  : 'failed',
+            details : expect.objectContaining({
+                parent: 'primary-dev-sync',
+                error : 'initServerConfigs failed: drift overwrite error'
+            })
+        });
+    });
+
+    test('runConfigMigrate is a pure shell-out when no services injected (#12854 backward-compat)', () => {
+        const execFileSyncFn = createExecStub([{
+            cmd : process.execPath,
+            args: ['/primary/neo/ai/scripts/setup/initServerConfigs.mjs', '--migrate-config']
+        }]);
+
+        expect(() => {
+            PrimaryRepoSyncService.runConfigMigrate('/primary/neo', execFileSyncFn);
+        }).not.toThrow();
+
+        expect(execFileSyncFn.calls.length).toBe(1);
+        expect(execFileSyncFn.calls[0].cmd).toBe(process.execPath);
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session fa0b47bc-e066-4e8b-8aec-a9de8fc69a09.

Resolves #12854
Refs #11017
Related: #11013

The shipped `primary-dev-sync` orchestrator daemon (`#11017`) FF-pulls primary's `dev` and cascades `npm run ai:sync-kb`, but never runs `initServerConfigs.mjs --migrate-config` — so an evolved `config.template.mjs` is pulled while the gitignored `config.mjs` operator-overlay the daemons actually read stays stale (the "a `git pull` alone is not enough" gap the `#11013` sunset probe already documents). This adds a config-template-change-gated `--migrate-config` step to the post-pull cascade, so the daemon that keeps the operator's primary fresh now reconciles config too — not just code + KB.

Evidence: L2 (unit: stubbed `execFileSync` verifies the migrate command/args, config-template gating, per-clone semantics, first-class lifecycle annotation, and failure-isolation) → L4 would confirm a live orchestrator-daemon reconciling a real overlay after a real `config.template.mjs` merge. Residual: live-daemon end-to-end [#12854 post-merge].

## Implementation

- `isConfigTemplateChangePath(path)` — classifies `ai/config.template.mjs` (Tier-1) and `ai/mcp/server/*/config.template.mjs` (per-server) change paths, mirroring `isKbRelevantChangePath` normalization.
- `resolveKbSyncDecision` now derives `configMigrateRequired` from the **same single `git diff`** it already runs for the KB decision (no second diff; unknown-head / diff-failure short-circuits fail safe — redundant reconcile beats stale state).
- `runConfigMigrate(root, ...)` execs `node <root>/ai/scripts/setup/initServerConfigs.mjs --migrate-config`, annotated as a first-class `configMigrate` task (mirrors `runKbSync`). **Unlike `runKbSync`, a migrate failure is isolated — recorded, not rethrown** — so a stale overlay never aborts the already-successful pull, the KB cascade, or the parent task.
- Hooked into both pull paths (`syncDevRoot` clean-pull + `resolveMetaAndPull` meta-sync), running **per-clone** (each checkout owns its own gitignored overlay) before the KB cascade — distinct from the once-from-owning-checkout KB sync. Services are threaded through the configured-multi-root path so the migrate is annotated there too.

Only fires when a config template actually advanced in the pulled range — non-config pulls are untouched. `--migrate-config` only rewrites the gitignored overlay (never tracked files).

## Deltas from ticket (if any)
- None in scope. AC1–AC7 are unit-covered. AC8 ("no tracked-file writes from the migrate") is satisfied **by construction** — the target (`config.mjs`) is gitignored and `--migrate-config` only rewrites that overlay — rather than by a dedicated test (a real-write assertion needs `initServerConfigs` to run against a real tree, an L3+ integration concern, not a unit).
- Minor hygiene: the `check-ticket-archaeology` pre-commit hook scans the whole staged file, so I de-referenced 3 **pre-existing** ticket anchors in the touched spec's `runKbSync` test comments (kept the descriptive intent + `@neo-gpt` attribution; git-blame preserves exact provenance). Non-behavioral.

## Test Evidence
- `PrimaryRepoSyncService.spec.mjs`: **26 passed** (18 prior + 6 new + 2 updated `.toEqual`). New coverage: config-template predicate classification (Tier-1, per-server, negatives); Tier-1 + per-server template advance → migrate-then-KB cascade with ordering assertion; `runConfigMigrate` strict-temporal-ordering lifecycle; failure isolation (asserts **no** rethrow); pure-shell-out backward-compat.
- Full orchestrator unit dir: **444 passed**, 1 unrelated failure — `DreamServiceGoldenPath › synthesizeGoldenPath executes without crashing` **times out at 60s in isolation too** (no live LLM provider in a fresh worktree; `dev` CI is green, so it passes there). Architecturally disjoint from this change (different service, no shared state with `PrimaryRepoSyncService`).
- Command: `UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/`

## Post-Merge Validation
- [ ] On a live orchestrator-daemon whose primary pulls a `config.template.mjs` change, confirm `initServerConfigs --migrate-config` runs and the gitignored `config.mjs` reconciles — the operator's original friction (manual config refresh of the primary) is gone.
- [ ] Confirm a `configMigrate` outcome surfaces in `HealthService` with `{parent: 'primary-dev-sync'}`.
- [ ] Confirm a simulated migrate failure records `failed` + warns without aborting the pull / KB cascade.

## Commits
- `3b37290ac` — feat(orchestrator): primary-dev-sync migrates config.mjs after dev pull (#12854)
