### PR TITLE
refactor(config-bootstrap): share server-template enumeration predicate (#12861)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -108,12 +108,11 @@
  */
 import {execFile}       from 'child_process';
 import fs               from 'fs/promises';
-import {existsSync, readdirSync} from 'fs';
 import path             from 'path';
 import {fileURLToPath}  from 'url';
 import {promisify}      from 'util';
 
-import {materializeServerConfigTemplate} from '../setup/initServerConfigs.mjs';
+import {listServersWithTemplates, materializeServerConfigTemplate} from '../setup/initServerConfigs.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -121,24 +120,17 @@ const execFileAsync = promisify(execFile);
  * The set of gitignored config overlays a fresh worktree must hydrate from the main
  * checkout: the Tier-1 `ai/config.mjs` plus each per-server `ai/mcp/server/<name>/config.mjs`.
  *
- * **Auto-derived, not hand-maintained.** The per-server list is globbed at load time from the
- * `ai/mcp/server/*` dirs that ship a `config.template.mjs` — the same predicate
- * `initServerConfigs` uses. The previous hand-maintained allow-list silently drifted whenever a
- * new MCP server was added: the new server's gitignored `config.mjs` went un-hydrated, so a
- * worktree importing that server's chain crashed with `ERR_MODULE_NOT_FOUND`. Deriving from the
- * filesystem eliminates that drift class — any server shipping a template is hydrated
- * automatically; dirs without one (e.g. `file-system`, `shared`) are excluded.
+ * **Auto-derived from one shared predicate.** The per-server list comes from
+ * {@link listServersWithTemplates} — the single enumeration owned by `initServerConfigs`, the
+ * same predicate `initConfigs` applies. A hand-maintained allow-list silently drifted whenever a
+ * new MCP server was added (its gitignored `config.mjs` went un-hydrated → a worktree importing
+ * that server's chain crashed with `ERR_MODULE_NOT_FOUND`). Deriving from one shared predicate
+ * means a new template-shipping server is hydrated automatically AND the two call-sites cannot
+ * disagree; dirs without a template (e.g. `file-system`, `shared`) are excluded.
  */
-const serverConfigsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../mcp/server');
-
 export const BOOTSTRAP_CONFIGS = [
     'ai/config.mjs',
-    ...readdirSync(serverConfigsDir, {withFileTypes: true})
-        .filter(entry => entry.isDirectory())
-        .map(entry => entry.name)
-        .filter(name => existsSync(path.join(serverConfigsDir, name, 'config.template.mjs')))
-        .sort()
-        .map(name => `ai/mcp/server/${name}/config.mjs`)
+    ...listServersWithTemplates().map(name => `ai/mcp/server/${name}/config.mjs`)
 ];
 
 /**

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -42,6 +42,41 @@ const MATERIALIZED_SERVER_IMPORTS = new Set([
 ]);
 
 /**
+ * @summary True when an `ai/mcp/server/<name>/` directory ships a `config.template.mjs`.
+ *
+ * The single definition of "this server has a bootstrappable config" — shared by
+ * {@link initConfigs} (which reports templateless dirs as `skip-no-template`) and
+ * {@link listServersWithTemplates}, so the predicate cannot drift across the config-bootstrap
+ * call-sites that consume it.
+ *
+ * @param {String} serverPath Absolute path to a single `ai/mcp/server/<name>/` directory.
+ * @returns {Boolean}
+ */
+export function hasConfigTemplate(serverPath) {
+    return fs.existsSync(path.join(serverPath, 'config.template.mjs'));
+}
+
+/**
+ * @summary Lists the `ai/mcp/server/*` directory names that ship a `config.template.mjs`, sorted.
+ *
+ * Synchronous so it can seed a module-load-time const — `bootstrapWorktree`'s `BOOTSTRAP_CONFIGS`
+ * consumes it to hydrate fresh-worktree overlays. Built on the same {@link hasConfigTemplate}
+ * predicate `initConfigs` applies, so "which servers are bootstrappable" has one answer across
+ * both paths.
+ *
+ * @param {String} [serversRoot=serversDir] Override for tests.
+ * @returns {String[]} Sorted server directory names containing a `config.template.mjs`.
+ */
+export function listServersWithTemplates(serversRoot = serversDir) {
+    if (!fs.existsSync(serversRoot)) return [];
+
+    return fs.readdirSync(serversRoot)
+        .filter(name => fs.statSync(path.join(serversRoot, name)).isDirectory())
+        .filter(name => hasConfigTemplate(path.join(serversRoot, name)))
+        .sort();
+}
+
+/**
  * Finds the closing parenthesis for a source-text call while ignoring quoted content.
  *
  * @param {String} src       Source text.
@@ -453,7 +488,7 @@ export async function initConfigs({argv = process.argv, logger = console, server
         const templatePath = path.join(serverPath, 'config.template.mjs');
         const activePath   = path.join(serverPath, 'config.mjs');
 
-        if (!fs.existsSync(templatePath)) {
+        if (!hasConfigTemplate(serverPath)) {
             processed.push({serverName, action: 'skip-no-template'});
             continue;
         }

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -26,7 +26,7 @@ import path           from 'path';
 test.describe.configure({mode: 'serial'});
 
 test.describe('initServerConfigs — template drift detection (#10815)', () => {
-    let initConfigs, projectSourceShape, projectShape, detectDrift, materializeServerConfigTemplate;
+    let initConfigs, projectSourceShape, projectShape, detectDrift, materializeServerConfigTemplate, listServersWithTemplates, hasConfigTemplate;
     let workRoot;
 
     function recordingLogger() {
@@ -64,7 +64,9 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
             projectSourceShape,
             projectShape,
             detectDrift,
-            materializeServerConfigTemplate
+            materializeServerConfigTemplate,
+            listServersWithTemplates,
+            hasConfigTemplate
         } = await import('../../../../../../ai/scripts/setup/initServerConfigs.mjs'));
 
         workRoot = path.resolve(process.cwd(), 'tmp', `init-server-configs-${process.pid}-${Date.now()}`);
@@ -697,5 +699,45 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         const onDisk = fs.readFileSync(path.join(root, 'memory-core', 'config.mjs'), 'utf-8');
         expect(onDisk).toBe(materializeServerConfigTemplate(templateSrc));
         expect(onDisk).toContain('NEO_AUTH_MODE');
+    });
+
+    test.describe('listServersWithTemplates / hasConfigTemplate (shared enumeration)', () => {
+        function buildMultiServerRoot(sandboxName, serverSpec) {
+            const root = path.join(workRoot, sandboxName);
+            fs.mkdirSync(root, {recursive: true});
+            for (const [name, kind] of Object.entries(serverSpec)) {
+                fs.mkdirSync(path.join(root, name), {recursive: true});
+                if (kind === 'template') {
+                    fs.writeFileSync(path.join(root, name, 'config.template.mjs'), 'export default {};\n');
+                }
+            }
+            return root;
+        }
+
+        test('lists only directories shipping a config.template.mjs, sorted', () => {
+            const root = buildMultiServerRoot('lswt-basic', {
+                'memory-core'    : 'template',
+                'github-workflow': 'template',
+                'file-system'    : 'no-template'
+            });
+            // A stray non-directory file in the servers root must be ignored.
+            fs.writeFileSync(path.join(root, 'README.md'), '# not a server\n');
+
+            expect(listServersWithTemplates(root)).toEqual(['github-workflow', 'memory-core']);
+        });
+
+        test('returns [] for a non-existent serversRoot (no throw)', () => {
+            expect(listServersWithTemplates(path.join(workRoot, 'lswt-missing'))).toEqual([]);
+        });
+
+        test('hasConfigTemplate is true only when config.template.mjs is present', () => {
+            const root = buildMultiServerRoot('hct', {
+                'with-template': 'template',
+                'no-template'  : 'no-template'
+            });
+
+            expect(hasConfigTemplate(path.join(root, 'with-template'))).toBe(true);
+            expect(hasConfigTemplate(path.join(root, 'no-template'))).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
Resolves #12861

Eliminates the duplicated "which `ai/mcp/server/*` dirs ship a `config.template.mjs`" predicate that PR `#12857` left split across `bootstrapWorktree.mjs` and `initServerConfigs.mjs` (flagged in @neo-claude-opus's `#12857` review). The predicate now has one home: `initServerConfigs` exports `hasConfigTemplate()` + `listServersWithTemplates()`, and both call-sites consume it — so "what's a bootstrappable server" can't drift between them.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega. Session: 2026-06-10 nightshift.

Evidence: L2 (unit: both specs 62/62 green — behavior preserved on both sides + the new helpers directly tested incl. the empty-dir guard) → L2 required (pure DRY refactor, no runtime-observable AC). No residual.

## The change
- `initServerConfigs.mjs`: new exported `hasConfigTemplate(serverPath)` (the predicate) + `listServersWithTemplates(serversRoot = serversDir)` (sync, sorted enumeration built on it). `initConfigs`'s loop now uses `hasConfigTemplate` for its template check — preserving its `skip-no-template` reporting, async model, and non-dir handling.
- `bootstrapWorktree.mjs`: `BOOTSTRAP_CONFIGS` now consumes `listServersWithTemplates()` instead of its own inline `readdirSync` glob; dropped the now-redundant `serverConfigsDir` const + the `{existsSync, readdirSync}` import.

## Deltas from ticket
- The ticket framed it as "~3 lines" (from the `#12857` review). V-B-A on `initConfigs` showed it's a **behavior-preserving refactor**, not a wholesale swap: `initConfigs` iterates **all** server dirs and reports templateless ones as `skip-no-template` (pinned by `initServerConfigs.spec.mjs:342`), with an async model + a non-dir branch. So the shared unit is the **predicate** (`hasConfigTemplate`) — consumed by both `initConfigs`'s loop (preserving its reporting) and `listServersWithTemplates` (for bootstrapWorktree) — rather than a single enumeration that would have dropped `skip-no-template`.
- Added the empty-`serversRoot` guard (`return []`) the old inline glob lacked (it would have thrown on a missing dir) — covered by a new test.
- Lineage: follows `#12808` (resolved by PR `#12857`), which introduced the now-shared predicate.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` → **62/62 passed**.
  - `initServerConfigs.spec`: existing `skip-no-template` / clone / migrate / warn / drift coverage stays green (the predicate refactor preserved behavior) + 3 new direct tests — `listServersWithTemplates` (filter + sort, empty-dir guard) and `hasConfigTemplate` (true/false).
  - `bootstrapWorktree.spec`: the derive-validation (gitlab-workflow present, `file-system`/`shared` excluded) stays green (same servers via the helper).

## Post-Merge Validation
- None — pure refactor, fully unit-covered; no runtime-observable AC beyond the green specs.

Authored by @neo-opus-vega.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
