### PR TITLE
fix(wake-daemon): dedup already-woken events from the digest count + priority (#12850)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -63,11 +63,13 @@ import {
     isHeavyDeltaPoll,
     shouldDeferFlush
 } from './flushDeferPolicy.mjs';
+import {filterEventsByWatermark, maxLogId} from './wokenWatermark.mjs';
 
 const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
 const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
 const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');
 const LOG_FILE                 = path.join(DAEMON_DATA_DIR, 'wake-daemon.log');
+const WOKEN_WATERMARK_FILE     = path.join(DAEMON_DATA_DIR, 'woken-watermark.json');
 const LOG_RETENTION_DAYS       = 30;
 const POLL_INTERVAL_MS         = 3000;
 const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
@@ -79,6 +81,46 @@ const WAKE_PRIORITY_RANKS      = {
 
 // Ensure daemon data dir exists
 fs.ensureDirSync(DAEMON_DATA_DIR);
+
+/**
+ * @summary Loads the persisted per-subscription woken-watermark map, tolerant of a missing or
+ * corrupt file (a fresh daemon starts with an empty map → first wakes fire normally).
+ * @returns {Object<String, Number>}
+ */
+function loadWokenWatermark() {
+    try {
+        if (fs.existsSync(WOKEN_WATERMARK_FILE)) {
+            const parsed = JSON.parse(fs.readFileSync(WOKEN_WATERMARK_FILE, 'utf8'));
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+        }
+    } catch (e) {
+        // Corrupt watermark is non-fatal: worst case is one cycle of already-woken backlog being
+        // re-counted, self-healing as the map re-persists. Daemon liveness never gates on it.
+    }
+    return {};
+}
+
+/**
+ * @summary Best-effort persist of the woken-watermark map (mirrors the daemon's other internal
+ * state writes); a write failure never gates daemon liveness.
+ */
+function persistWokenWatermark() {
+    try {
+        fs.writeFileSync(WOKEN_WATERMARK_FILE, JSON.stringify(wokenWatermark), 'utf8');
+    } catch (e) {
+        // best-effort; the in-memory map still dedups for the running process
+    }
+}
+
+/**
+ * Per-subscription already-woken high-water-mark: `subId → highest GraphLog logId the recipient
+ * has already been woken for`. A digest counts/prioritizes only events ABOVE this mark, so a
+ * re-queued already-woken backlog (heavy-delta re-include / cursor reset) contributes zero to the
+ * count and cannot spoof a HIGH digest from a stale message. Durable across restart; composes
+ * with — does not replace — the `readAt` reconcile + the heavy-delta defer.
+ * @type {Object<String, Number>}
+ */
+let wokenWatermark = loadWokenWatermark();
 
 /**
  * Rotates `wake-daemon.log` if its mtime falls on a calendar day different from today's.
@@ -558,7 +600,17 @@ async function flushSubscription(subId) {
     // dropping real wakes (unread messages, tasks, permissions, and heartbeats all still fire).
     messages = messages.filter(ev => !isMessageReadFor(db, ev.messageId, identity));
 
-    // Nothing genuinely-new survived (the delta was entirely already-read messages) → suppress the stale wake.
+    // Already-woken dedup: drop events the recipient was already woken for
+    // (logId <= the per-subscription watermark) so a re-queued backlog can't inflate the "N new" count
+    // or spoof a HIGH digest from a stale message. Composes with the readAt reconcile above + the
+    // heavy-delta defer at the top — reconciling on the right axis (already-woken, not merely unread).
+    const watermark = wokenWatermark[subId] ?? 0;
+    messages    = filterEventsByWatermark(messages,    watermark);
+    tasks       = filterEventsByWatermark(tasks,       watermark);
+    permissions = filterEventsByWatermark(permissions, watermark);
+    heartbeats  = filterEventsByWatermark(heartbeats,  watermark);
+
+    // Nothing genuinely-new survived (the delta was entirely already-read or already-woken) → suppress.
     if (messages.length === 0 && tasks.length === 0 && permissions.length === 0 && heartbeats.length === 0) {
         return;
     }
@@ -591,6 +643,15 @@ async function flushSubscription(subId) {
 
     // Delivery to per-harness adapter
     await deliverDigest(subscription, digest);
+
+    // Advance the per-subscription watermark to the highest delivered logId so these events are not
+    // re-counted if the backlog is re-queued; persist for restart durability. logId is monotonic
+    // (append-only GraphLog), so genuinely-new events always land strictly above this mark.
+    const deliveredMax = maxLogId([...messages, ...tasks, ...permissions, ...heartbeats]);
+    if (deliveredMax !== null && deliveredMax > (wokenWatermark[subId] ?? 0)) {
+        wokenWatermark[subId] = deliveredMax;
+        persistWokenWatermark();
+    }
 }
 
 /**

--- a/ai/daemons/wake/wokenWatermark.mjs
+++ b/ai/daemons/wake/wokenWatermark.mjs
@@ -1,0 +1,64 @@
+/**
+ * @module ai/daemons/wake/wokenWatermark
+ * @summary Pure already-woken dedup for the wake digest.
+ *
+ * The wake daemon's digest historically reconciled only on `readAt`, so a genuinely-unread
+ * message the recipient had already been *woken for* (re-queued by a heavy-delta GraphLog
+ * re-include or a cursor reset) survived into the "N new" count and could spoof a HIGH digest
+ * from a stale backlog message. These pure helpers reconcile on the
+ * right axis — the GraphLog `logId` high-water-mark of what the recipient has already been woken
+ * for — and compose with (do NOT replace) the `readAt` reconcile + `flushDeferPolicy` defer.
+ *
+ * `logId` is the append-only GraphLog position, so it is monotonic: an event at or below the
+ * per-subscription watermark has already been included in a prior digest; only events strictly
+ * above it are genuinely-new-since-last-wake. The daemon owns the durable, per-subscription
+ * watermark map + its persistence; this module is the pure, unit-testable decision core.
+ */
+
+/**
+ * @summary Keeps only the coalesced events that are genuinely new since the last wake — those
+ * whose GraphLog `logId` is strictly above the per-subscription watermark.
+ *
+ * Events without a finite numeric `logId` are conservatively KEPT (treated as new) so a malformed
+ * event can never silently suppress a real wake — preserving the `flushDeferPolicy` "never withhold
+ * a genuine wake" invariant.
+ *
+ * @param {Array<{logId?: Number}>} events Coalesced wake events (daemon `{type, ..., logId}` shape).
+ * @param {Number} watermark Highest `logId` the recipient has already been woken for (0 = none).
+ * @returns {Array} The genuinely-new subset, original order preserved.
+ */
+export function filterEventsByWatermark(events, watermark) {
+    const mark = Number.isFinite(Number(watermark)) ? Number(watermark) : 0;
+
+    return events.filter(event => {
+        const raw = event?.logId;
+        // Missing logId (null / undefined) → conservatively new (never withhold a genuine wake).
+        // Note `Number(null) === 0`, so the explicit null check must precede the numeric coercion.
+        if (raw == null) return true;
+        const logId = Number(raw);
+        return !Number.isFinite(logId) || logId > mark;
+    });
+}
+
+/**
+ * @summary Highest finite `logId` across the events, or `null` when none carry one.
+ *
+ * Used to advance the per-subscription watermark after a digest is delivered: the next
+ * genuinely-new event must have a strictly greater `logId`. Returns `null` (not `0`) for an empty
+ * or logId-less set so the caller leaves the watermark unchanged rather than resetting it to `0`.
+ *
+ * @param {Array<{logId?: Number}>} events
+ * @returns {Number|null}
+ */
+export function maxLogId(events) {
+    let max = null;
+
+    for (const event of events) {
+        const raw = event?.logId;
+        if (raw == null) continue; // `Number(null) === 0` — skip missing rather than count it as 0.
+        const logId = Number(raw);
+        if (Number.isFinite(logId) && (max === null || logId > max)) max = logId;
+    }
+
+    return max;
+}

--- a/test/playwright/unit/ai/daemons/wake/wokenWatermark.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wokenWatermark.spec.mjs
@@ -1,0 +1,78 @@
+import {test, expect}                      from '@playwright/test';
+import {filterEventsByWatermark, maxLogId} from '../../../../../../ai/daemons/wake/wokenWatermark.mjs';
+
+test.describe('wake wokenWatermark (#12850)', () => {
+    test('filterEventsByWatermark keeps only events strictly above the watermark', () => {
+        const events = [
+            {messageId: 'a', logId: 10},
+            {messageId: 'b', logId: 50},
+            {messageId: 'c', logId: 51}
+        ];
+
+        expect(filterEventsByWatermark(events, 50).map(e => e.messageId)).toEqual(['c']);
+        expect(filterEventsByWatermark(events, 0).map(e => e.messageId)).toEqual(['a', 'b', 'c']);
+        expect(filterEventsByWatermark(events, 100)).toEqual([]);
+    });
+
+    test('filterEventsByWatermark conservatively KEEPS events without a finite logId (never withhold a genuine wake)', () => {
+        const events = [
+            {messageId: 'no-logid'},
+            {messageId: 'null-logid', logId: null},
+            {messageId: 'nan-logid', logId: 'x'},
+            {messageId: 'old', logId: 5},
+            {messageId: 'new', logId: 99}
+        ];
+
+        // Below-watermark numeric ids drop; logId-less ids survive as new.
+        expect(filterEventsByWatermark(events, 50).map(e => e.messageId))
+            .toEqual(['no-logid', 'null-logid', 'nan-logid', 'new']);
+    });
+
+    test('filterEventsByWatermark treats a non-finite watermark as 0 (keeps everything)', () => {
+        const events = [{messageId: 'a', logId: 1}, {messageId: 'b', logId: 2}];
+
+        expect(filterEventsByWatermark(events, undefined).map(e => e.messageId)).toEqual(['a', 'b']);
+        expect(filterEventsByWatermark(events, NaN).map(e => e.messageId)).toEqual(['a', 'b']);
+    });
+
+    test('maxLogId returns the highest finite logId, or null when none', () => {
+        expect(maxLogId([{logId: 3}, {logId: 99}, {logId: 12}])).toBe(99);
+        expect(maxLogId([{logId: 7}])).toBe(7);
+        expect(maxLogId([])).toBeNull();
+        expect(maxLogId([{messageId: 'x'}, {logId: null}, {logId: 'nope'}])).toBeNull();
+        // A 0 logId is finite and must win over null.
+        expect(maxLogId([{logId: 0}])).toBe(0);
+    });
+
+    test('AC2 repro — a stale already-woken HIGH message is filtered out before it can spoof the digest priority', () => {
+        // Recipient has already been woken through logId 100. A heavy-delta re-include re-queues an
+        // OLD high-priority message (logId 42, still readAt=null so the readAt filter alone misses it)
+        // alongside one genuinely-new normal message.
+        const watermark = 100;
+        const reincludedBacklog = [
+            {type: 'message', messageId: 'm-stale-high', priority: 'high',   logId: 42},
+            {type: 'message', messageId: 'm-new',        priority: 'normal', logId: 150}
+        ];
+
+        const survivors = filterEventsByWatermark(reincludedBacklog, watermark);
+
+        // The stale HIGH message never reaches getHighestWakePriority → no spoofed-HIGH digest,
+        // and the count reflects only the one genuinely-new message.
+        expect(survivors.map(e => e.messageId)).toEqual(['m-new']);
+        expect(survivors.some(e => e.priority === 'high')).toBe(false);
+        expect(survivors.length).toBe(1);
+    });
+
+    test('AC4 regression — genuinely-new events (all types) above the watermark are never dropped', () => {
+        const watermark = 200;
+        const fresh = [
+            {type: 'message',    messageId: 'm', logId: 201},
+            {type: 'task',       taskId: 't',    logId: 202},
+            {type: 'permission', scope: 'p',     logId: 203},
+            {type: 'heartbeat',  pulseId: 'h',   logId: 204}
+        ];
+
+        expect(filterEventsByWatermark(fresh, watermark)).toHaveLength(4);
+        expect(maxLogId(fresh)).toBe(204);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session fa0b47bc-e066-4e8b-8aec-a9de8fc69a09.

Resolves #12850
Related: #12479
Related: #12855

The wake digest reconciled only on `readAt`, so a genuinely-unread message the recipient had already been *woken for* (re-queued by a heavy-delta GraphLog re-include or a cursor reset) survived into the "N new" count, and a stale `priority:high` message in that backlog spoofed the whole digest as HIGH. That's the deferred hypothesis-1 of `#12479` — `readAt` is the wrong axis (a genuinely-unread message can still be already-woken-for). This reconciles on the right axis: the GraphLog `logId` high-water-mark of what the recipient has already been woken for.

Evidence: L2 (unit — the pure dedup logic: watermark filter incl. the stale-already-woken-HIGH-excluded repro + the all-event-types-survive regression + logId-less conservative-keep; 70/70 wake unit dir green) → L3 would confirm a live daemon's digest over a re-queued backlog + restart durability. Residual: live-daemon repro + restart durability [#12850 post-merge].

## Implementation

- New pure helpers `filterEventsByWatermark` / `maxLogId` in `ai/daemons/wake/wokenWatermark.mjs` (sibling of `flushDeferPolicy.mjs`): keep only events whose `logId` is strictly above the per-subscription watermark; `logId`-less events are conservatively **kept** (never withhold a genuine wake — `Number(null) === 0`, so the null check precedes coercion).
- `flushSubscription` filters **all** event types (message / task / permission / heartbeat) by the watermark *after* the existing `readAt` reconcile, then advances + persists the watermark to the highest delivered `logId`. `logId` is the append-only GraphLog position (monotonic), so genuinely-new events always land strictly above the mark.
- The per-subscription watermark map is **durable across restart** — a daemon-internal `woken-watermark.json` beside the other daemon state files (`STATE_FILE`/`LOG_FILE` pattern), tolerant of a missing / corrupt file.

Composes with — does not replace — the `readAt` reconcile + the `flushDeferPolicy` heavy-delta defer (which targets the *transient-readAt* facet; this is the complementary *genuinely-unread-but-already-woken* facet).

## Deltas from ticket

- **No config leaf / no `--migrate-config` friction.** The watermark is *daemon-internal* state, so it's derived in code from `DAEMON_DATA_DIR` exactly like `STATE_FILE` / `LOG_FILE` (only the cross-process `liveCursor` is a config leaf). Keeps the change off the config-template surface.
- **Pure-module split for testability.** The dedup decision core lives in a pure sibling module (unit-tested); the daemon owns the stateful load/persist + flush wiring. `daemon.mjs` has heavy module-level side effects (PID lock, dir ensure) so it isn't import-testable directly — verified instead via `node --check` + the pure-function tests, matching the established `flushDeferPolicy` (pure module tested, daemon integration trusted) pattern.

## Test Evidence

- `UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/wake/` → **70 passed** (6 new + 64 existing wake-unit, no regression).
- New `wokenWatermark.spec.mjs` (6): filter keeps-strictly-above-watermark; `logId`-less conservative keep + non-finite watermark→0; `maxLogId`; **AC2 repro** — a stale already-woken `priority:high` message (readAt=null) is filtered out *before* it can reach the priority compute → no spoofed-HIGH digest, count reflects only the genuinely-new message; **AC4 regression** — genuinely-new events of all four types above the watermark are never dropped.
- `node --check ai/daemons/wake/daemon.mjs` (syntax of the integration edits) — OK.

## Post-Merge Validation

- [ ] On a live wake daemon with a non-empty already-woken backlog including an old HIGH message, a heavy-delta re-include / cursor event yields a digest that does NOT report the full backlog count and is NOT tagged HIGH.
- [ ] The watermark survives a daemon restart (`woken-watermark.json` persisted + reloaded).
- [ ] Genuinely-new messages / tasks / permissions / heartbeats still wake correctly (no dropped wakes).

## Commits
- `38c7f1c6c` — fix(wake-daemon): dedup already-woken events from the digest count + priority (#12850)
