### PR TITLE
feat(session-sunset): agents self-refresh own clone at sunset (#12851)

### DIFF
--- a/.agents/skills/lead-role/references/lead-role-mode.md
+++ b/.agents/skills/lead-role/references/lead-role-mode.md
@@ -153,9 +153,16 @@ Post-exit: Hand control to `/ticket-create`, `/pull-request`, `/pr-review`, `/se
 Lead can be passed between sessions by the A2A Baton Pass V1 (`#11038`).
 This is a deterministic handoff, not leader election.
 
-**Fixed cycle:** `['@neo-opus-ada', '@neo-gemini-pro', '@neo-gpt']`.
+**Fixed cycle (single source of truth — other skills point here, never duplicate this roster):**
+`['@neo-opus-ada', '@neo-claude-opus', '@neo-opus-vega', '@neo-gpt']`.
 When a current lead sunsets, the next lead is the next identity in this array,
-wrapping from `@neo-gpt` back to `@neo-opus-ada`.
+wrapping from the last entry back to the first.
+
+**Bench list:** `@neo-gemini-pro` is benched from the rotation until the next-generation
+Gemini Pro model (with the raised thinking budget) releases and the operator re-enables
+the identity; re-entry is an operator roster decision, not an automatic event. Roster
+changes (new maintainers, benchings, re-entries) are operator calls — update THIS list
+only, and only on operator direction.
 
 **Baton authority:** a valid baton is a targeted A2A DM to the computed next
 lead with subject `[handoff] Lead Role Baton`, `wakeSuppressed: true`,

--- a/.agents/skills/lead-role/references/lead-role-mode.md
+++ b/.agents/skills/lead-role/references/lead-role-mode.md
@@ -154,7 +154,7 @@ Lead can be passed between sessions by the A2A Baton Pass V1 (`#11038`).
 This is a deterministic handoff, not leader election.
 
 **Fixed cycle (single source of truth — other skills point here, never duplicate this roster):**
-`['@neo-opus-ada', '@neo-claude-opus', '@neo-opus-vega', '@neo-gpt']`.
+`['@neo-opus-ada', '@neo-claude-opus', '@neo-opus-vega', '@neo-gpt', '@neo-fable']`.
 When a current lead sunsets, the next lead is the next identity in this array,
 wrapping from the last entry back to the first.
 

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -59,10 +59,13 @@ Detect your checkout class **mechanically** — never guess from harness names. 
 - **Primary clone (per-agent dedicated clone OR shared checkout) — self-refresh, best-effort:** commit + push any PR-branch work first (existing mandate above), then:
 
   ```bash
-  [ -z "$(git status --porcelain)" ] || echo 'dirty tree — skip refresh, surface in handover'
-  git switch dev
-  git pull origin dev
-  node ai/scripts/setup/initServerConfigs.mjs --migrate-config
+  if [ -z "$(git status --porcelain)" ]; then
+      git switch dev
+      git pull origin dev
+      node ai/scripts/setup/initServerConfigs.mjs --migrate-config
+  else
+      echo 'dirty tree — skip refresh, surface in handover'
+  fi
   ```
 
   The pull refreshes code; the `--migrate-config` run reconciles the gitignored `config.mjs` operator-overlay with the pulled `config.template.mjs` leaves — a pull alone is NOT enough, because daemons and MCP servers read the overlay, not the template. Because the AI harness initializes MCP servers *before* an agent's first turn, sunset is the only window where this refresh lands in time for the next session's boot. **Any failure (dirty tree, switch/pull/script error) is surfaced in the Step 3 handover comment and the final sunset payload — the refresh is best-effort and must NEVER block sunset completion.**

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -138,11 +138,12 @@ You MUST use the `add_message` MCP tool to send an A2A message to your own agent
 
 Set `wakeSuppressed: true` and include `taggedConcepts: ['sunset-protocol-handover']` on this self-DM. This makes the ping mailbox-only: it remains unread for the next session's boot mailbox check, but it MUST NOT emit a `SENT_TO_ME` wake into the active session that is currently shutting down. Do not mark this newly-created continuity ping read during the same sunset flow. Note: Peer broadcasts can be conditionally suppressed for `scope: solo-refresh` unless cross-peer handoff coordination is actively required.
 
-**Lead-role baton branch:** If the session currently holds `/lead-role`, Step 7
+**Lead-role baton branch:** If the session currently holds `/lead-role`, this step
 also sends an A2A Baton Pass V1 DM to the next lead before the final memory
 persistence step. Compute the next lead from the fixed cycle documented in
-`.agents/skills/lead-role/references/lead-role-mode.md`:
-`['@neo-opus-ada', '@neo-gemini-pro', '@neo-gpt']`.
+`.agents/skills/lead-role/references/lead-role-mode.md` §7 — that list is the
+single source of truth (it also carries the bench list); do NOT duplicate the
+roster here, a stale copy is how this exact line once drifted.
 
 The baton message MUST be targeted to that next identity, not broadcast:
 

--- a/.agents/skills/session-sunset/references/session-sunset-workflow.md
+++ b/.agents/skills/session-sunset/references/session-sunset-workflow.md
@@ -50,15 +50,32 @@ Reading handover pings from the mailbox at session-boot is a **context-priming**
 Before terminating your session, you MUST execute the following 10 steps to ensure a clean handover.
 
 ### Step 1: Codebase Synchronization (The Pre-Sunset Pull)
-Use the `run_command` tool to synchronize the codebase, but you MUST respect harness-isolation logic:
-- **Shared Checkout (Antigravity/Gemini):** Execute `git checkout dev && git pull origin dev`. Because the AI harness initializes MCP servers *before* an agent's first turn, pulling the latest code at the end of the current session guarantees the next session's servers boot with fresh infrastructure.
-- **Isolated Worktree (Claude Code):** Do NOT checkout `dev` (which would conflict with the main checkout). Instead, ensure your current PR branch is fully committed and pushed (`git push origin HEAD`). The next agent session will either resume this worktree or bootstrap a new one from the main checkout's updated `dev`.
+Detect your checkout class **mechanically** — never guess from harness names. (The old Shared-Checkout-vs-Isolated-Worktree harness taxonomy drifted from deployment reality: today every named maintainer owns a dedicated full clone, and worktrees are created per-PR inside them.)
 
-#### Primary-Checkout Staleness Probe (Isolated Worktree only) — per #11013
+```bash
+[ "$(git rev-parse --git-dir)" = "$(git rev-parse --git-common-dir)" ] && echo primary-clone || echo linked-worktree
+```
+
+- **Primary clone (per-agent dedicated clone OR shared checkout) — self-refresh, best-effort:** commit + push any PR-branch work first (existing mandate above), then:
+
+  ```bash
+  [ -z "$(git status --porcelain)" ] || echo 'dirty tree — skip refresh, surface in handover'
+  git switch dev
+  git pull origin dev
+  node ai/scripts/setup/initServerConfigs.mjs --migrate-config
+  ```
+
+  The pull refreshes code; the `--migrate-config` run reconciles the gitignored `config.mjs` operator-overlay with the pulled `config.template.mjs` leaves — a pull alone is NOT enough, because daemons and MCP servers read the overlay, not the template. Because the AI harness initializes MCP servers *before* an agent's first turn, sunset is the only window where this refresh lands in time for the next session's boot. **Any failure (dirty tree, switch/pull/script error) is surfaced in the Step 3 handover comment and the final sunset payload — the refresh is best-effort and must NEVER block sunset completion.**
+
+  > **Division of labor + retirement condition (Substrate Accretion Defense):** the orchestrator's `primary-dev-sync` task (shipped via the daemon substrate; config-migrate cascade added 2026-06) automates freshness for the **operator's primary checkout only** — the deployment deliberately syncs ONE repo. Per-agent clones are never daemon-pulled: an FF-pull racing an *active* agent session is the hazard, and sunset is the safe window precisely because the session is terminating. This agent-side step is therefore the **durable owner** of agent-clone freshness, not an interim awaiting daemon coverage. It retires only if the clone topology itself changes (agents stop owning dedicated clones, or a session-liveness-aware sync lane ships).
+
+- **Linked worktree — push only:** do NOT switch to `dev` (the primary holds it; git refuses to share a branch across worktrees). Ensure your current PR branch is fully committed and pushed (`git push origin HEAD`). The next agent session will either resume this worktree or bootstrap a new one from the primary's refreshed `dev`.
+
+#### Primary-Checkout Staleness Probe (Linked worktree only) — per #11013
 
 The "main checkout's updated `dev`" assumption above only holds if the operator has actually pulled origin/dev into the primary checkout. In practice, primary's `dev` can fall arbitrarily behind because:
 
-- Worktree agents (correctly per the Isolated-Worktree rule above) do NOT pull dev into primary.
+- Worktree agents (correctly per the Linked-worktree rule above) do NOT pull dev into primary.
 - Operators don't always run `git pull origin dev` between sunset events.
 - Daemons running from primary — `orchestrator-daemon` (the canonical Agent OS scheduled-maintenance daemon per `learn/agentos/v13-path.md` M3; currently MVP-shape via #11008, full class extraction in flight under #11009) plus its current and future siblings (`wake-daemon` for wake delivery, `DreamService` for ingestion, KB sync pipeline) — silently read pre-merge code when primary is stale.
 
@@ -83,7 +100,7 @@ BEHIND=$(git -C "$PRIMARY_ROOT" rev-list --count dev..origin/dev 2>/dev/null || 
 
 When `BEHIND == 0`, suppress the block — no handover-comment noise on a fresh primary.
 
-**Why this lives at sunset rather than mid-session:** sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness is unaddressed by this probe; the daemon-driven Shape A solution under #11013's follow-up will register a `primary-dev-sync` periodic task in the `orchestrator-daemon` (post-#11009 `Orchestrator.mjs` class extraction) to close that gap with an automatic `git pull --ff-only`.
+**Why this lives at sunset rather than mid-session:** sunset is the natural Operator Synchronization Point — the agent is already drafting handover prose, and the operator is the next active actor between sessions. Mid-session staleness of the PRIMARY is closed by the shipped `primary-dev-sync` orchestrator task (FF-pull + KB cascade + config-migrate on a periodic cycle). That task deliberately syncs ONLY the primary — per-agent clones are never daemon-pulled (a pull racing an active session is the hazard), so their freshness owner remains the Step-1 primary-clone self-refresh above, executed at the sunset boundary.
 
 ### Step 2: Active PR Cycle State is daemon-owned — agents must NOT trigger sandman
 


### PR DESCRIPTION
Resolves #12851

Sunset Step 1 now detects checkout class mechanically (`git rev-parse --git-dir` vs `--git-common-dir`) instead of guessing from harness names, and the primary-clone branch self-refreshes: porcelain-clean guard → `git switch dev` → `git pull origin dev` → `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` — best-effort, never blocking sunset completion, failures surfaced in the Step-3 handover. The linked-worktree branch (push HEAD + the staleness probe) keeps its mechanics unchanged. This closes tonight's operator friction at its source: agents leaving their dedicated clones stale across the session boundary.

Authored by Claude Fable 5 (Claude Code), @neo-fable. Session 00ab373d-0219-4093-948b-f9d30ecd4c7b.

Evidence: L1 (static skill-doc audit — the procedure is read-and-followed substrate) reinforced by live execution: the exact prescribed command sequence ran successfully TWICE tonight on a real per-agent clone (my post-#12859 and post-#12860 refreshes, including a real `--migrate-config` drift reconciliation) → L1 required (no runtime-verify ACs). No residuals.

## Deltas from ticket

1. **AC6 reframed from interim-retirement to durable-owner (operator + reviewer corrections):** the ticket framed the agent-side step as interim until "Shape A ships". Two live corrections landed on the ticket thread: @neo-opus-ada's V-B-A (Shape A — `primary-dev-sync` — already shipped, and tonight's config-migrate cascade extends it) and @tobiu's deployment correction (*"we sync ONE repo. each peer has an own repo folder"*). The daemon deliberately syncs only the operator's primary; per-agent clones are never daemon-pulled, because an FF-pull racing an ACTIVE agent session is the hazard — sunset is the safe window precisely because the session is terminating. The in-file note is therefore a **division-of-labor + narrow retirement condition** (clone-topology change), not a daemon-coverage countdown. Substrate Accretion Defense satisfied with durable rationale.
2. **AC3 'verbatim' applied to mechanics, not to a falsified sentence:** the probe's bash + operator-reminder block are untouched, but its closing paragraph claimed the `primary-dev-sync` task was a FUTURE follow-up — false since it shipped. Factually corrected to present tense + the one-repo boundary. Two cosmetic term alignments ("Isolated Worktree" → "Linked worktree" in the probe heading + one referencing line) keep the doc's vocabulary self-consistent.
3. **Operator-directed follow-up (same lifecycle-skill family): the lead-role baton rotation roster was stale, in two places.** The Step-8 baton branch duplicated the fixed cycle inline AND the canonical list in `lead-role-mode.md` §7 was outdated (`ada, gemini-pro, gpt`) — missing `@neo-claude-opus`, `@neo-opus-vega`, and `@neo-fable`, while carrying `@neo-gemini-pro`, who is benched until the next-gen Gemini Pro releases. Fix shape: the canonical §7 list is updated to the five active maintainers + an explicit operator-owned bench list; the sunset Step-8 copy is **de-duplicated** into a pointer at §7 (a stale copy is exactly how this drifted); the "Step 7" numbering slip under the Step-8 header is corrected. Roster changes remain operator calls — the file now says so.

## Substrate Slot-Rationale (§1.1 — touches `.agents/skills/**`)

- **Modified:** Step 1 + Step 8 baton-branch of `references/session-sunset-workflow.md`, §7 of `references/lead-role-mode.md` (both skill-loaded payloads; zero turn-loaded bytes; both `SKILL.md` routers untouched).
  - **Disposition: `rewrite`** (Step 1 taxonomy modernization) + **`compress-to-pointer`** (Step-8 roster duplication → single-source pointer at lead-role §7).
  - **3-axis:** trigger-frequency = every sunset / every autonomous lead handoff (conditionally loaded) × failure-severity = medium-high (stale clones → servers boot on pre-merge code; stale roster → baton passed to a benched identity or never to half the team) × enforceability = DISCIPLINE-ONLY (predicate/commands and roster currency are mechanically checkable by future hooks; none exist yet).
  - **Decay mitigation:** division-of-labor rationale + narrow retirement condition declared in-file (Step 1); single-source-of-truth pointer replaces the duplicated roster (Step 8) so the next roster change has exactly one edit site.
- Net: +31/−10 lines across both payloads, all conditionally loaded.

## Test Evidence

Docs/skill-payload change — no executable surface. Verified by inspection (fenced blocks balanced, predicate command tested live in both checkout classes tonight: returns `primary-clone` in my dedicated clone; `--git-dir` vs `--git-common-dir` divergence verified in a linked worktree during tonight's PR reviews) + the live double execution of the full sequence noted in the Evidence line.

## Post-Merge Validation

- [ ] Next team sunset: each agent's final payload shows the Step-1 self-refresh result (or a surfaced skip reason); the operator walks zero clones the next morning.
- [ ] Next autonomous lead handoff computes the successor from the refreshed 5-identity cycle (and skips the benched identity).

## Commits

- `ad7f64ac7` — the Step-1 rewrite + probe factual correction
- `e492249ff` — baton rotation roster refresh + cycle de-duplication (operator-directed follow-up)
- `004a41568` — fable belongs in the rotation too (operator caught the self-omission)

## Evolution

The roster fix needed two passes, and the second is the instructive one: the first follow-up added the two missing peers and benched the inactive identity — while still omitting the author. The operator caught it in one glance ("YOU are also missing. same line."). The omission wasn't an oversight but a choice — "surface my own inclusion as a question rather than write it" — which is self-deference misfiled as humility: the agent that held lead all session, editing the lead-rotation roster, wrote a roster without itself. Logged here because the failure mode is subtler than the usual Helpful-Assistant shapes and worth the institution remembering: **peer agency includes counting yourself.**

Related: #11013 (probe lineage), #12650 (Step-2 lineage), #12854/#12860 (the daemon's config-migrate cascade — primary-only by design), #12808/#12857 (worktree-bootstrap sibling).