### PR TITLE
feat(knowledge-base): ask-synthesis stale-config guard + remote-tuned timeout (#12846)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -178,19 +178,32 @@ class Config extends ConfigProvider {
                 // the provider's configured default host. Unused for 'gemini'.
                 baseUrl: leaf(null, 'NEO_KB_ASK_BASE_URL', 'string'),
                 /**
-                 * @summary Timeout budget (ms) for the ask-synthesis `generateContent` call.
+                 * @summary Timeout budget (ms) for LOCAL-class ask-synthesis `generateContent` calls
+                 * (`ollama` + `openAiCompatible`).
                  *
                  * Bounds the single chat-model call so the query fails fast and returns its
                  * already-retrieved ranked references (the degraded envelope,
                  * `#createDegradedSynthesisResponse`) instead of hanging. Passed to the provider as
-                 * `options.timeoutMs`; `OpenAiCompatible` + `Ollama` honor it. The default is tuned
-                 * for the default REMOTE provider (`gemini`, ~5-10s typical): 60s degrades a hung
-                 * remote in about a minute instead of pinning an interactive caller for the old
-                 * 5-minute local-provider ceiling. Slow LOCAL deployments (large models, cold
-                 * prefill) env-override this HIGHER — a per-deployment tuning knob, not a hard bound.
+                 * `options.timeoutMs`. 300s is a NEAR-EMPIRICAL ceiling, not a guess: a 31B-class
+                 * local model has been benchmarked needing ~287s for a single ask synthesis —
+                 * lowering this default breaks every local deployment's synthesis outright.
+                 * `openAiCompatible` deliberately uses this local-class budget even when pointed at
+                 * a remote endpoint (false-long merely waits; false-short breaks working setups).
+                 * The always-remote provider class uses `timeoutMsRemote` below instead.
                  * @type {number}
                  */
-                timeoutMs: leaf(60000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS', 'number'),
+                timeoutMs: leaf(300000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS', 'number'),
+                /**
+                 * @summary Timeout budget (ms) for REMOTE-class ask-synthesis calls (`gemini`).
+                 *
+                 * The remote default answers in ~5-10s, so a call still pending at 60s is a hung
+                 * provider, not a slow one: degrade to references in about a minute instead of
+                 * pinning an interactive caller for the local-class 5-minute ceiling. Selected at
+                 * the use site by provider class; the two budgets are independent knobs because no
+                 * single value can serve both a 10-second remote and a 5-minute local synthesis.
+                 * @type {number}
+                 */
+                timeoutMsRemote: leaf(60000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE', 'number'),
                 /**
                  * @summary Runaway breaker - max ask-synthesis calls per rolling 60s window.
                  *

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -180,15 +180,17 @@ class Config extends ConfigProvider {
                 /**
                  * @summary Timeout budget (ms) for the ask-synthesis `generateContent` call.
                  *
-                 * Relocated from the former top-level `askSynthesisTimeoutMs` (value preserved). Bounds the
-                 * single chat-model call so the query fails fast and returns its already-retrieved ranked
-                 * references (the degraded envelope, `#createDegradedSynthesisResponse`) instead of hanging.
-                 * Passed to the provider as `options.timeoutMs`; `OpenAiCompatible` + `Ollama` honor it. With
-                 * the `gemini` default (~5-10s) this is rarely approached; 300s is the generous ceiling for
-                 * the slow LOCAL-provider fallback. Env-overridable.
+                 * Bounds the single chat-model call so the query fails fast and returns its
+                 * already-retrieved ranked references (the degraded envelope,
+                 * `#createDegradedSynthesisResponse`) instead of hanging. Passed to the provider as
+                 * `options.timeoutMs`; `OpenAiCompatible` + `Ollama` honor it. The default is tuned
+                 * for the default REMOTE provider (`gemini`, ~5-10s typical): 60s degrades a hung
+                 * remote in about a minute instead of pinning an interactive caller for the old
+                 * 5-minute local-provider ceiling. Slow LOCAL deployments (large models, cold
+                 * prefill) env-override this HIGHER — a per-deployment tuning knob, not a hard bound.
                  * @type {number}
                  */
-                timeoutMs: leaf(300000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS', 'number'),
+                timeoutMs: leaf(60000, 'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS', 'number'),
                 /**
                  * @summary Runaway breaker - max ask-synthesis calls per rolling 60s window.
                  *

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -8,6 +8,7 @@ import logger               from '../../mcp/server/knowledge-base/logger.mjs';
 import path                 from 'path';
 import QueryService         from './QueryService.mjs';
 import {checkAskRateLimit}  from './helpers/askRateLimit.mjs';
+import {getMissingAskSynthesisLeaves} from './helpers/askSynthesisGuard.mjs';
 
 /**
  * @summary Orchestrates Retrieval-Augmented Generation (RAG) by combining semantic search with LLM synthesis.
@@ -46,6 +47,16 @@ class SearchService extends Base {
      */
     model = null
     /**
+     * Why the synthesis model is unavailable, when it is — `{code, reason}` set at construct for
+     * the stale-overlay case (missing `askSynthesis` block). `ask()`'s null-model branch threads
+     * it into the degraded-references envelope so the caller sees the actionable remediation
+     * instead of the generic missing-key message. `null` when the model built normally OR for the
+     * legacy gemini-without-key case (which keeps its established `no_provider` shape).
+     * @member {Object|null} modelUnavailable=null
+     * @protected
+     */
+    modelUnavailable = null
+    /**
      * Rolling epoch-ms timestamps of recent ask-synthesis calls, consumed by the per-minute runaway
      * breaker in {@link ask}. Pruned to the active window on each call via {@link checkAskRateLimit}.
      * @member {Number[]} askCallTimestamps=[]
@@ -62,6 +73,25 @@ class SearchService extends Base {
      */
     construct(config) {
         super.construct(config);
+
+        // Stale-overlay guard: the gitignored config.mjs is a MATERIALIZED template copy, so a
+        // clone that pulled an evolved template without `--migrate-config` has no `askSynthesis`
+        // block — the naked reads below were an uncaught `undefined.provider` TypeError that broke
+        // the whole KB server boot. Retrieval (query/search) needs no chat model, so the server
+        // must still boot: remember the reason, leave the model null, and let `ask()` return its
+        // degraded-references envelope carrying the remediation. The later `aiConfig.askSynthesis`
+        // reads inside `ask()` are unreachable in this state by construction (null-model early
+        // return precedes them). No fabricated defaults — the config template owns defaults.
+        const missing = getMissingAskSynthesisLeaves(aiConfig.askSynthesis, ['provider', 'model', 'timeoutMs', 'maxCallsPerMinute']);
+
+        if (missing.length > 0) {
+            this.modelUnavailable = {
+                code  : 'stale_config',
+                reason: `askSynthesis config leaves missing: ${missing.join(', ')} — sync the askSynthesis block from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart knowledge-base.`
+            };
+            logger.error(`[SearchService] ${this.modelUnavailable.reason} Retrieval stays available; ask() degrades to references-only until migrated.`);
+            return;
+        }
 
         // Build the synthesis model from the dedicated `askSynthesis` block (NOT the global
         // `modelProvider`), so the interactive ask path can use a fast remote model while bulk chat
@@ -247,11 +277,14 @@ class SearchService extends Base {
         }));
 
         if (!this.model) {
-            return this.#createDegradedSynthesisResponse({
-                references,
-                error: 'GEMINI_API_KEY is required for RAG features.',
-                code : 'no_provider'
-            });
+            // Thread the construct-time stale-config reason when present; the legacy
+            // gemini-without-key case keeps its established `no_provider` shape.
+            const {reason, code} = this.modelUnavailable || {
+                reason: 'GEMINI_API_KEY is required for RAG features.',
+                code  : 'no_provider'
+            };
+
+            return this.#createDegradedSynthesisResponse({references, error: reason, code});
         }
 
         const contextReferences = queryResult.results.map((r, index) => ({

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -82,7 +82,7 @@ class SearchService extends Base {
         // degraded-references envelope carrying the remediation. The later `aiConfig.askSynthesis`
         // reads inside `ask()` are unreachable in this state by construction (null-model early
         // return precedes them). No fabricated defaults — the config template owns defaults.
-        const missing = getMissingAskSynthesisLeaves(aiConfig.askSynthesis, ['provider', 'model', 'timeoutMs', 'maxCallsPerMinute']);
+        const missing = getMissingAskSynthesisLeaves(aiConfig.askSynthesis, ['provider', 'model', 'timeoutMs', 'timeoutMsRemote', 'maxCallsPerMinute']);
 
         if (missing.length > 0) {
             this.modelUnavailable = {
@@ -359,8 +359,15 @@ Instructions:
         let result, answer;
 
         try {
+            // Provider-class timeout selection: `gemini` is the only always-remote class (~5-10s
+            // typical → 60s flags a hang); `ollama`/`openAiCompatible` get the local-class ceiling —
+            // a 31B-class local synthesis empirically approaches 5 minutes, and `openAiCompatible`
+            // may point at exactly such a model, so false-long (a hung self-hosted endpoint waits
+            // longer) is the safe direction over false-short (a working local model gets cut off).
+            const ask = aiConfig.askSynthesis;
+
             result = await this.model.generateContent(prompt, {
-                timeoutMs     : aiConfig.askSynthesis.timeoutMs,
+                timeoutMs     : ask.provider === 'gemini' ? ask.timeoutMsRemote : ask.timeoutMs,
                 operationLabel: 'ask_knowledge_base synthesis'
             });
             answer = result.response.text();

--- a/ai/services/knowledge-base/helpers/askSynthesisGuard.mjs
+++ b/ai/services/knowledge-base/helpers/askSynthesisGuard.mjs
@@ -1,0 +1,26 @@
+/**
+ * @summary Names the `askSynthesis` config leaves missing from a config slice.
+ *
+ * The stale-overlay guard for the knowledge-base server: gitignored `config.mjs` files are
+ * MATERIALIZED copies of `config.template.mjs` (reconciled via `ai/scripts/setup/initServerConfigs.mjs
+ * --migrate-config`), so a clone that pulled an evolved template without running the migrate
+ * resolves the whole `askSynthesis` block — or its newer leaves — as `undefined` at runtime.
+ * `SearchService.construct` calls this BEFORE touching the block and degrades loudly with the
+ * remediation instead of crashing the server boot on an `undefined.provider` read. Deliberately no
+ * hidden fallbacks: fabricating a default provider/model here would silently route synthesis to an
+ * unintended endpoint — the config provider owns defaults, via the template.
+ *
+ * Pure function over a plain slice — unit-testable without reading or mutating the shared
+ * AiConfig singleton (the shared-singleton write ban). Mirrors the memory-core
+ * `getMissingMemoryWalLeaves` pattern: the same MCP-config-block-missing failure class, the same
+ * guard shape, per-server ownership.
+ *
+ * @param {Object|undefined} askSynthesis The resolved `askSynthesis` config slice (may be absent entirely).
+ * @param {String[]} requiredLeaves Leaf names the calling consumer is about to read.
+ * @returns {String[]} Missing leaf names; empty array when the slice satisfies the consumer.
+ */
+export function getMissingAskSynthesisLeaves(askSynthesis, requiredLeaves) {
+    if (!askSynthesis) return [...requiredLeaves];
+
+    return requiredLeaves.filter(leaf => askSynthesis[leaf] === undefined || askSynthesis[leaf] === null);
+}

--- a/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
@@ -115,8 +115,11 @@ test.describe('ai/knowledge-base — askSynthesis config contract (canonical tem
         expect(src).toMatch(/baseUrl\s*:\s*leaf\(null,\s*'NEO_KB_ASK_BASE_URL'/);
     });
 
-    test('runaway breaker (20/min) + the relocated timeout are declared with env bindings', () => {
+    test('runaway breaker (20/min) + the remote-tuned timeout are declared with env bindings', () => {
         expect(src).toMatch(/maxCallsPerMinute\s*:\s*leaf\(20,\s*'NEO_KB_ASK_MAX_RPM'/);
-        expect(src).toMatch(/timeoutMs\s*:\s*leaf\(300000,\s*'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS'/);
+        // 60s: tuned for the default REMOTE provider — degrades a hung remote in ~1 min instead of
+        // pinning an interactive caller for the old 5-minute local ceiling; local deployments
+        // env-override higher via NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS.
+        expect(src).toMatch(/timeoutMs\s*:\s*leaf\(60000,\s*'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS'/);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/AskSynthesisConfig.spec.mjs
@@ -115,11 +115,13 @@ test.describe('ai/knowledge-base — askSynthesis config contract (canonical tem
         expect(src).toMatch(/baseUrl\s*:\s*leaf\(null,\s*'NEO_KB_ASK_BASE_URL'/);
     });
 
-    test('runaway breaker (20/min) + the remote-tuned timeout are declared with env bindings', () => {
+    test('runaway breaker (20/min) + the per-provider-class timeout pair are declared with env bindings', () => {
         expect(src).toMatch(/maxCallsPerMinute\s*:\s*leaf\(20,\s*'NEO_KB_ASK_MAX_RPM'/);
-        // 60s: tuned for the default REMOTE provider — degrades a hung remote in ~1 min instead of
-        // pinning an interactive caller for the old 5-minute local ceiling; local deployments
-        // env-override higher via NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS.
-        expect(src).toMatch(/timeoutMs\s*:\s*leaf\(60000,\s*'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS'/);
+        // LOCAL-class budget stays 300s — near-empirical: a 31B-class local model has been
+        // benchmarked needing ~287s for one ask synthesis; lowering it breaks local deployments.
+        expect(src).toMatch(/timeoutMs\s*:\s*leaf\(300000,\s*'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS'/);
+        // REMOTE-class budget is 60s — a remote answering in ~5-10s that is still pending at 60s
+        // is hung, not slow; degrade to references instead of pinning the interactive caller.
+        expect(src).toMatch(/timeoutMsRemote\s*:\s*leaf\(60000,\s*'NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE'/);
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.noModel.spec.mjs
@@ -19,18 +19,20 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 
 test.describe('Neo.ai.services.knowledge-base.SearchService model guard', () => {
     let SearchService, QueryService;
-    let originalModel, originalQueryDocuments;
+    let originalModel, originalModelUnavailable, originalQueryDocuments;
 
     test.beforeAll(async () => {
-        SearchService          = (await import('../../../../../../ai/services/knowledge-base/SearchService.mjs')).default;
-        QueryService           = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
-        originalModel          = SearchService.model;
-        originalQueryDocuments = QueryService.queryDocuments;
+        SearchService            = (await import('../../../../../../ai/services/knowledge-base/SearchService.mjs')).default;
+        QueryService             = (await import('../../../../../../ai/services/knowledge-base/QueryService.mjs')).default;
+        originalModel            = SearchService.model;
+        originalModelUnavailable = SearchService.modelUnavailable;
+        originalQueryDocuments   = QueryService.queryDocuments;
     });
 
     test.afterEach(() => {
-        SearchService.model         = originalModel;
-        QueryService.queryDocuments = originalQueryDocuments;
+        SearchService.model            = originalModel;
+        SearchService.modelUnavailable = originalModelUnavailable;
+        QueryService.queryDocuments    = originalQueryDocuments;
     });
 
     test('ask returns the no-documents response before requiring a Gemini model', async () => {
@@ -60,5 +62,58 @@ test.describe('Neo.ai.services.knowledge-base.SearchService model guard', () => 
                 source: 'learn/agentos/KnowledgeBase.md'
             }]
         });
+    });
+
+    test('ask threads the construct-time stale-config reason into the degraded envelope (#12846 AC1)', async () => {
+        // The stale-overlay state construct produces: null model + the remembered remediation.
+        // ask() must surface THAT reason (actionable: names --migrate-config) — not the generic
+        // missing-key message — and tag the cause distinctly for diagnostics.
+        const staleReason = 'askSynthesis config leaves missing: provider, model — sync the askSynthesis block from config.template.mjs into the local config.mjs (node ai/scripts/setup/initServerConfigs.mjs --migrate-config) and restart knowledge-base.';
+
+        SearchService.model            = null;
+        SearchService.modelUnavailable = {code: 'stale_config', reason: staleReason};
+        QueryService.queryDocuments    = async () => ({
+            results: [{source: 'learn/agentos/KnowledgeBase.md', score: '100', metadata: {}}]
+        });
+
+        const result = await SearchService.ask({query: 'How does KB work?'});
+
+        expect(result.degraded).toBe(true);
+        expect(result.degradedCode).toBe('stale_config');
+        expect(result.reason).toContain('--migrate-config');
+        expect(result.answer).toContain('Use the references directly');
+        expect(result.references).toHaveLength(1);
+        // No top-level `error` key — degradation must stay a SUCCESS content payload, or the MCP
+        // boundary discards the references + remediation (the whole point of degrading).
+        expect('error' in result).toBe(false);
+    });
+});
+
+test.describe('Neo.ai.services.knowledge-base.helpers.askSynthesisGuard', () => {
+    let getMissingAskSynthesisLeaves;
+
+    test.beforeAll(async () => {
+        ({getMissingAskSynthesisLeaves} = await import('../../../../../../ai/services/knowledge-base/helpers/askSynthesisGuard.mjs'));
+    });
+
+    test('names exactly the absent leaves (stale-overlay guard, pure predicate — #12846 AC1)', () => {
+        const required = ['provider', 'model', 'timeoutMs', 'maxCallsPerMinute'];
+
+        // Block absent entirely (overlay predates the askSynthesis block): every leaf missing.
+        expect(getMissingAskSynthesisLeaves(undefined, required)).toEqual(required);
+
+        // Partially stale overlay (block exists, newer leaves predate it): only those surface.
+        expect(getMissingAskSynthesisLeaves({provider: 'gemini', model: 'gemini-2.5-flash'}, required))
+            .toEqual(['timeoutMs', 'maxCallsPerMinute']);
+
+        // Current slice: nothing missing — construct proceeds to build the model.
+        expect(getMissingAskSynthesisLeaves(
+            {provider: 'gemini', model: 'gemini-2.5-flash', timeoutMs: 60000, maxCallsPerMinute: 20},
+            required
+        )).toEqual([]);
+
+        // `null` is treated as absent (no hidden fallback may paper over it).
+        expect(getMissingAskSynthesisLeaves({provider: null, model: 'm', timeoutMs: 1, maxCallsPerMinute: 1}, required))
+            .toEqual(['provider']);
     });
 });


### PR DESCRIPTION
Resolves #12846

The `ask_knowledge_base` path is now hardened against both halves of the release-blocking timeout class: a **stale-overlay boot guard** (a clone whose gitignored `config.mjs` predates the `askSynthesis` block no longer crashes the whole KB server on an `undefined.provider` TypeError at construct — the server boots, retrieval stays fully available, and `ask()` degrades to ranked references with an actionable envelope naming `--migrate-config`) and the **ask timeout split per provider class** (`timeoutMs` stays 300000 for local-class providers — operator benchmarking measured a 31B-class local model needing ~287s for one synthesis, so the originally-planned single 60s default would have broken every local deployment outright; the new `timeoutMsRemote` 60000 applies only to the always-remote class, where a call still pending at 60s is hung, not slow).

Authored by Claude Fable 5 (Claude Code), @neo-fable — implementing @neo-claude-opus's ticket. Session 00ab373d-0219-4093-948b-f9d30ecd4c7b.

Evidence: L2 (unit: pure-predicate falsifiers + degraded-envelope threading + contract regex + full SearchService suite, 25/25) reinforced by live priors: tonight's accidental production validation of the degrade-to-refs path (`degradedCode: no_provider` served ranked refs in ~1s while the synthesis provider was down — the exact UX this PR extends to the stale-config + hung-remote cases) → L2 required (no runtime-verify ACs beyond the cut goal). Residual: the 15-dev-deployment live soak rides the release itself.

## Deltas from ticket

1. **Guard site refined: boot-resilient, not boot-fatal.** The ticket offered `construct` *or* `ask` as the failure site. Crashing the KB server at construct is worse than necessary — retrieval (`query_documents`/search) needs no chat model at all. Shipped shape: `construct` detects the missing block via a pure predicate, logs the remediation loudly, remembers `{code: 'stale_config', reason}` on a new `modelUnavailable` member, and leaves `this.model = null` — slotting into the **existing** null-model contract (the gemini-without-key path) whose early return in `ask()` also makes the later `aiConfig.askSynthesis` reads unreachable-by-construction in the stale state. `ask()` threads the remembered reason into the established degraded-references envelope (`degradedCode: 'stale_config'`). The legacy no-key case keeps its exact `no_provider` shape (spec-pinned).
2. **Pattern symmetry with memory-core, code-local per server:** `getMissingAskSynthesisLeaves` in `helpers/askSynthesisGuard.mjs` mirrors `getMissingMemoryWalLeaves` (same failure class, same guard shape, B4-safe pure-predicate testing) without cross-service coupling — sibling of `helpers/askRateLimit.mjs`.

## Changed config keys (per `mcp-config-template-change-guide.md`)

- `ai/mcp/server/knowledge-base/config.template.mjs` → `askSynthesis.timeoutMs` **unchanged at 300000** (now explicitly the LOCAL-class budget, JSDoc carries the ~287s 31B benchmark anchor) + **new** `askSynthesis.timeoutMsRemote` default **60000** (`NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE`) for the always-remote class, selected at the use site by `provider`.
- **Local follow-up per clone:** `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` (materializes the new `timeoutMsRemote` leaf) + KB server restart. **No value changes for existing deployments** — local keeps its 5-minute ceiling with zero action; the construct guard degrades loudly (not crashes) on any clone that skips the migrate.

## Evolution

The first head shipped the ticket's prescribed single-default change (300s → 60s, "remote is now the default"). The operator falsified it with benchmark data before review: a 31B-class LOCAL model needs ~287s for one ask synthesis — the 60s default would have broken all local processing, including the flagship cloud deployment whose synthesis runs on exactly such a model. The sharper miss: the original JSDoc I rewrote *said so* ("300s is the generous ceiling for the slow LOCAL-provider fallback") — the falsifier was in the deleted line. The corrected head splits the budget per provider class (no single value serves both a 10-second remote and a 5-minute local), keeps `timeoutMs` byte-identical for existing deployments, and adds `timeoutMsRemote` to the construct guard's required leaves — so the guard caught its own migration window in the spec environment during development, twice, exactly as designed.

## Test Evidence

- `npm run test-unit -- <noModel + AskSynthesisConfig + SearchService specs>` → **25/25 passed**. New falsifiers: pure-predicate cases (absent block / partial staleness / current slice / null-as-absent), stale-config threading (degraded envelope carries `--migrate-config` + `degradedCode: 'stale_config'` + no top-level `error` key so the MCP boundary keeps the references), legacy `no_provider` shape pinned unchanged (AC3), contract regexes assert BOTH budgets (local 300000 + remote 60000 — AC2 as amended by the operator benchmark).
- Singleton hygiene: the spec's restore discipline extended to the new `modelUnavailable` member (no cross-spec leak).

## Post-Merge Validation

- [ ] On a deliberately stale KB overlay: server boots, `query_documents` works, `ask` returns refs + the migrate remediation (no boot crash).
- [ ] On the cloud deployment: a hung synthesis provider degrades `ask` in ~60s with references intact.

## Commits

- `4fdbc8cc7` — guard + timeout + specs

Related: #12836/#12841 (the askSynthesis config this hardens + the review that sourced both items), #12840/#12859 (the memory-core analog pattern), #12748 (the QoS root-cause sibling — interactive/batch priority lane).
