### PR TITLE
feat(ticket-create): scope-gate release-board attachment; follow-ups default boardless (#12865)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -393,7 +393,7 @@ strategic landscape, what's the right merge decision?" Four first-class options:
    - Cycle N+1 churn risks high-cost-low-marginal-value iteration
    - The PR ships measurable substrate value even with documented gaps
    - Required Actions surface concerns that are better-tracked-separately
-   **The follow-up defaults OFF the release board** (`ticket-create` §4 — state `Release classification: post-release` in its body): an `Approve+Follow-Up` follow-up that *must* land before release contradicts the Approve verdict that spawned it (the verdict certifies "shippable without it"), so it is post-release by construction; if the gap is genuinely release-blocking, the correct verdict was **Request Changes**.
+   **The follow-up defaults OFF the release board** — `ticket-create` §4 (`Release classification: post-release`) carries the invariant; a release-blocking gap means the verdict was wrong → **Request Changes**.
    Tell the author to run `pull-request-workflow.md §6.3.1` before merge.
 3. **Request Changes** — must-fix before merge; defects block substrate correctness.
 4. **Drop+Supersede** — the entire PR premise is stale/wrong with current

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -393,6 +393,7 @@ strategic landscape, what's the right merge decision?" Four first-class options:
    - Cycle N+1 churn risks high-cost-low-marginal-value iteration
    - The PR ships measurable substrate value even with documented gaps
    - Required Actions surface concerns that are better-tracked-separately
+   **The follow-up defaults OFF the release board** (`ticket-create` §4 — state `Release classification: post-release` in its body): an `Approve+Follow-Up` follow-up that *must* land before release contradicts the Approve verdict that spawned it (the verdict certifies "shippable without it"), so it is post-release by construction; if the gap is genuinely release-blocking, the correct verdict was **Request Changes**.
    Tell the author to run `pull-request-workflow.md §6.3.1` before merge.
 3. **Request Changes** — must-fix before merge; defects block substrate correctness.
 4. **Drop+Supersede** — the entire PR premise is stale/wrong with current

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -71,7 +71,7 @@ For source anchors (`#11078` / `#11082` / `#11083` / `#11084`), Discussion `#110
 
 ### 1d. Project Attachment Pre-Flight (during release cycle)
 
-Before draft, confirm the target project number is current (cite the project number in your Pre-Flight reasoning statement, e.g., *"Will attach to Project 12 per §4."*). Prevents stale-project-number drift across release cycles. Pairs mechanically with the §4 mandate below.
+Before draft, make the §4 scope judgment — does this ticket **block or belong to** the release? If yes, confirm the target project number is current and cite it in your Pre-Flight statement (e.g., *"Release-blocking → Project 12 per §4."*); if no, it is **boardless** — state the `Release classification:` in the body instead. Prevents both stale-project-number drift and board over-attachment.
 
 ## 2. Six-Stage Challenge Chain
 
@@ -109,10 +109,12 @@ Keep titles under ~70 characters. PR titles derive from ticket titles; length di
 - **Primary — exactly one:** `epic`, `enhancement`, or `bug`.
 - **Secondary — as applicable:** `architecture`, `performance`, `regression`, `refactoring`, `documentation`, `testing`, plus domain labels (`core`, `grid`, `build`, etc.).
 - Before filing: call `list_labels` to confirm the labels exist. Do not invent label names.
-- **Project attachment is MANDATORY on every ticket during the v13 release cycle.** Visibility primitive: every new ticket goes onto Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) so the swarm + operator have a single overview. ProjectV2 memberships supersede the deprecated `release:v*` label family per [ProjectV2 migration ticket](https://github.com/neomjs/neo/issues/11233).
-  - **`create_issue` MCP tool path:** pass `projects: [{projectNumber: 12}]` atomically with the create.
-  - **`gh issue create` CLI bypass path:** ALWAYS follow with `gh project item-add 12 --owner neomjs --url <new-issue-url>` immediately. Treat the two-step as inseparable.
-  - **Project anchor** is currently `12` (v13). When v14 release work begins, update the project number in this section AND any hard-coded `create_issue` examples or call-sites that name the release project (the MCP tool's `projects` parameter is caller-supplied with `[]` default — not a configurable tool-side default to update). Sunset condition: once v13 release ships, this rule needs disposition review (`keep` with updated project number, OR `compress-to-trigger` if mid-release ambiguity arises).
+- **Project attachment is a SCOPE JUDGMENT, not an unconditional mandate.** Attach a new ticket to Project 12 ([Neo v13 Release board](https://github.com/orgs/neomjs/projects/12)) **IFF it blocks or belongs to the release** — bugs in release-scoped subsystems, ship-hardening, release-process work. Everything else defaults **boardless**. ProjectV2 memberships supersede the deprecated `release:v*` label family per [ProjectV2 migration ticket](https://github.com/neomjs/neo/issues/11233).
+  - **Why a judgment, not attach-everything:** "created during the v13 cycle" ≠ "required for v13". Unconditional attachment composes with `pr-review` §9 `Approve+Follow-Up` into a **release asymptote** — every merge that spawns a board-attached follow-up grows the release, so the faster the swarm merges the further the release recedes. Resolving invariant: **a follow-up that must land before release contradicts the `Approve+Follow-Up` verdict that spawned it** (the verdict certifies "shippable without it"), so its follow-ups are post-release by construction; a release-blocking gap means the verdict should have been `Request Changes`.
+  - **Default boardless + classify:** `Approve+Follow-Up`-born tickets, hypothesis validations, and post-release hardening skip the board and state a one-line **`Release classification:`** in the body (greppable, reviewable, operator-reversible) — e.g. `Release classification: post-release (Approve+Follow-Up follow-up — non-blocking)` or `Release classification: ON the board — <why it blocks the release>`.
+  - **`create_issue` MCP tool path:** release-blocking → pass `projects: [{projectNumber: 12}]` atomically with the create; boardless → `projects: []` (the default).
+  - **`gh issue create` CLI bypass path:** release-blocking only → follow with `gh project item-add 12 --owner neomjs --url <new-issue-url>` (inseparable two-step); skip it for boardless tickets.
+  - **Project anchor** is currently `12` (v13). When v14 release work begins, update the project number here AND any hard-coded `create_issue` call-sites naming the release project. Sunset condition: once v13 ships, this rule needs disposition review (`keep` with updated project number, OR `compress-to-trigger`).
 
 ## 5. Fat Ticket Body Structure
 
@@ -157,7 +159,7 @@ When drafting ticket bodies, read [`learn/agentos/process/reference-hygiene.md`]
 | Inventing label names | Breaks label taxonomy; causes silent GitHub API rejections |
 | Precedent-following without skill check | Propagates anti-patterns from prior sessions (e.g., `[enhancement]` prefix spread this way) |
 | Cross-scope bundling | `epic` label on a single-commit ticket; hurts granularity |
-| Using `gh issue create` without follow-up `gh project item-add` (during release cycle) | Bypasses §4 v13 release-board attachment; ticket invisible in swarm/operator overview; two-step CLI path MUST be treated as inseparable per §4 |
+| Boarding a non-release-blocking ticket, OR the `gh issue create` → `gh project item-add` bypass on a release-blocking one | §4 is a scope judgment (board IFF release-blocking, else boardless + `Release classification:`); over-attaching inflates the release surface (the asymptote `#12865` fixes), and the CLI two-step stays inseparable for release-blocking tickets |
 
 ## 9. When to Escalate to Discussion Instead
 


### PR DESCRIPTION
Resolves #12865

Release classification: ON the board — this PR changes how the release board converges, so it blocks the release process by definition (the classification test applied to itself).

Closes the v13 release-asymptote @tobiu surfaced: `ticket-create` §4's unconditional board-attach composed with `pr-review` §9 `Approve+Follow-Up` so every merge that spawned a follow-up GREW the release — inflow ≈ drain rate. §4 becomes a **scope judgment** (board IFF release-blocking, else boardless + a greppable `Release classification:` body line), and §9 verdict-2 gains the resolving invariant: an `Approve+Follow-Up` follow-up that *must* land before release contradicts the Approve verdict → if release-blocking, the verdict was `Request Changes`.

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus). Session c9d6ec4c-ada2-45a1-9c65-355faf402ab8.

Evidence: L1 (static skill-doc audit — §4/§8/§1d/§9 render coherently, map 1:1 to `#12865` AC1–AC2) → L1 required (no runtime-verify ACs; read-and-followed substrate). No residuals.

## Deltas from ticket
None — implements `#12865` AC1 (§4 scope-gate + §8 anti-pattern row) + AC2 (`pr-review` §9 verdict-2). Bonus: §1d "Project Attachment Pre-Flight" updated for consistency (it still referenced the now-removed "§4 mandate"). AC3 slot-rationale below; AC4 (one-time board triage, e.g. `#10321`) is operator-owned, post-merge.

## Substrate Slot-Rationale (§1.1 — touches `.agents/skills/**`)
- **Modified** — `ticket-create` §4 (mandate → judgment), §8 anti-pattern row, §1d pre-flight; `pr-review` §9 verdict-2:
  - **Disposition: `keep`** in the conditionally-loaded `references/` payloads (World Atlas); both `SKILL.md` routers untouched → loads only when ticket-create / pr-review fire → ~zero always-loaded accretion.
  - **3-axis:** trigger-frequency = every ticket creation + every `Approve+Follow-Up` review (high, on-demand) × failure-severity = the release never converges (operator-surfaced asymptote) × enforceability = judgment + greppable `Release classification:` line (discipline; medium — a create-side lint is deferred per `#12865` Out-of-Scope).
  - **Net:** +9 / −6 lines (the §4 rewrite is net-positive because the scope-gate needs its rationale; the rest replaces prose). Both payloads on-demand; no router bloat → Progressive Disclosure (ADR 0008) preserved.
- **Decision Record impact:** `none` — no ADR governs release-board mechanics; §4's own sunset note anticipated this revision.

## Test Evidence
N/A — skill-doc (markdown) change, no executable surface. Verified by inspection: §4 reads as a coherent judgment + two-defaults + classification-line; §8 row + §1d no longer contradict §4; §9 verdict-2 carries the invariant; each `#12865` AC maps to specific prose.

## Post-Merge Validation
- [ ] AC4 (operator-owned): one-time triage pass over the ~21 open board items; move deferred / post-release entries (e.g. `#10321` "deferred until v13 ships") off the board.
- [ ] The next `Approve+Follow-Up` follow-up is filed boardless with a `Release classification:` line.

## Commits
- `6e0ec1028` — feat(ticket-create): scope-gate release-board attachment; follow-ups default boardless

---
Sibling: `#12856` / PR `#12858` (the §1a dedup gate shipped tonight — same file, different section). Standing exhibit: `#10321`.
