### PR TITLE
fix(memory-core): un-expose the destructive delete_all_summaries MCP tool (#12824)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -482,41 +482,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-    delete:
-      summary: Delete All Summaries
-      operationId: delete_all_summaries
-      x-pass-as-object: true
-      x-annotations:
-        destructiveHint: true
-      description: |
-        Deletes all session summaries from the database.
-
-        **Warning:** This is a destructive operation. It is useful for resetting the summary index while keeping raw memories intact.
-      tags: [Summaries]
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                confirmation:
-                  type: string
-                  description: Explicit production confirmation token required with the destructive bypass env for the legacy single-tenant drop path.
-      responses:
-        '200':
-          description: All summaries deleted successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteResponse'
-        '503':
-          description: Cannot connect to database
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
   /summaries/query:
     post:
       summary: Search Summaries

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -16,7 +16,11 @@ const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 
 const serviceMapping = {
     add_memory              : MemoryService          .addMemory               .bind(MemoryService),
-    delete_all_summaries    : SummaryService         .deleteAllSummaries      .bind(SummaryService),
+    // `SummaryService.deleteAllSummaries` stays as the tenant-safe internal primitive (the
+    // multi-tenant scoped-delete guard + future gated cleanups reuse it) but is deliberately
+    // NOT agent-callable: a mass-destructive op does not belong on the MCP surface, and any
+    // confirmation an agent can supply is not a guard. An operator path, if ever needed,
+    // routes through DestructiveOperationGuard — never through tool re-exposure.
     get_all_summaries       : SummaryService         .listSummaries           .bind(SummaryService),
     get_context_frontier    : MemoryService          .getContextFrontier      .bind(MemoryService),
     get_neighbors           : GraphService           .getNeighbors            .bind(GraphService),

--- a/learn/agentos/MemoryCore.md
+++ b/learn/agentos/MemoryCore.md
@@ -70,7 +70,6 @@ The server exposes a suite of tools via the Model Context Protocol (MCP).
 
 *   **`query_summaries`**: Performs a semantic vector search across session summaries. Use this to find relevant *past sessions* (e.g., "Have I worked on the Grid component before?").
 *   **`get_all_summaries`**: Lists all session summaries, sorted by date.
-*   **`delete_all_summaries`**: A destructive tool to clear the summary index (useful if you want to re-summarize everything with a new model).
 *   **`summarize_sessions`**: Manually triggers the summarization process for specific or all pending sessions.
 
 ### Session Operations

--- a/learn/agentos/tooling/MemoryCoreMcpApi.md
+++ b/learn/agentos/tooling/MemoryCoreMcpApi.md
@@ -66,7 +66,6 @@ The server exposes the following tools, which are derived from its OpenAPI speci
 | `query_raw_memories` | Performs semantic search across all raw memories using vector similarity. |
 | **Summaries** | |
 | `get_all_summaries` | Retrieves all session summaries, sorted by timestamp. |
-| `delete_all_summaries` | Deletes all session summaries from the database. |
 | `query_summaries` | Performs semantic search across session summaries. |
 | **Sessions** | |
 | `summarize_sessions` | Triggers the session summarization process. |
@@ -139,9 +138,6 @@ Searches session summaries semantically.
 - `query` (string, required): The natural language search query.
 - `nResults` (integer, optional): Number of results to return (default: 10).
 - `category` (string, optional): Filter by category.
-
-#### `delete_all_summaries`
-Deletes all session summaries (raw memories are preserved). This tool takes no parameters.
 
 ### Session Tools
 


### PR DESCRIPTION
Resolves #12824

Release classification: ON the board — multi-tenant safety for the 15-dev cloud deployment class (a mass-destructive op leaves the agent-callable surface before strangers hold tokens).

The `delete_all_summaries` MCP tool is removed from the agent-callable surface — Shape A exactly as converged on the ticket (author @neo-claude-opus, peer-role falsification @neo-opus-ada, operator confirmation @tobiu: *"remove the MCP tool (binding). keeping the logic itself is fine, just exposing it is definitely not"*). The tenant-safe `SummaryService.deleteAllSummaries` method and its #10000/#10128 multi-tenant security regression spec are **kept untouched** — it remains the scoped-delete primitive the gated #12830 cleanup will reuse, just no longer reachable by any agent.

Authored by Claude Fable 5 (Claude Code), @neo-fable — implementing the converged shape. Session 00ab373d-0219-4093-948b-f9d30ecd4c7b.

Evidence: L2 (boundary + security specs green; repo-wide reference grep) → L2 required (the tool-absence AC is verified by the OpenAPI validator spec + post-restart tool enumeration). Residual: none beyond the routine server-restart pickup.

## Deltas from ticket

None — Shape A verbatim. One addition in spirit: the `toolService.mjs` removal site carries a behavior-describing comment (why the method stays internal-only, where an operator path would route — `DestructiveOperationGuard`, never re-exposure) so the next reader doesn't "helpfully" re-bind it.

## Changed surfaces

- `ai/mcp/server/memory-core/toolService.mjs` — binding removed (+ the guard comment).
- `ai/mcp/server/memory-core/openapi.yaml` — the `delete:` operation removed from `/summaries` (−36 lines; also trims the per-agent tool-enumeration context-tax the ticket flags). Per the §5.3 budget audit: a pure removal, net-negative.
- `learn/agentos/MemoryCore.md` + `learn/agentos/tooling/MemoryCoreMcpApi.md` — the three advertising entries removed (bullet, table row, section). `ROADMAP.md:24`'s tenant-safe-method mention retained per AC4.

## Test Evidence

- `npm run test-unit -- <McpServerToolLimits + McpServerListToolsSmoke + OpenApiValidatorCompliance + SummaryService.TenantIsolation specs>` → **16/16 passed** — the OpenAPI validator confirms the yaml post-removal, and the #10000/#10128 tenant-safety guard (cloud-mode scoped delete, NO `collection.drop()`, stdio legacy path) stays green and untouched.
- AC3 repo-wide grep (NOT `ai/`-scoped, per the reshaped AC): zero `delete_all_summaries` references remain outside the synced `resources/content` archive; the `deleteAllSummaries` method + spec + ROADMAP mention all present.

## Post-Merge Validation

- [ ] After per-clone memory-core restart: the MC tool list no longer advertises `delete_all_summaries` (each agent's next tool-enumeration confirms; my own live connection still shows it from the pre-merge server build — the absence lands with the restart).

## Commits

- `f385f85f3` — the un-expose + docs

Related: #10000/#10128 (the preserved tenant-safety lineage), #12830 (the future reuser of the kept primitive), #12778 (runtime-safety theme).