### PR TITLE
feat(embed-daemon): drain-lock enforces sole-drainer invariant (#12864)

### DIFF
--- a/ai/daemons/embed/daemon.mjs
+++ b/ai/daemons/embed/daemon.mjs
@@ -35,6 +35,7 @@ import {execSync} from 'child_process';
 
 import StorageRouter   from '../../services/memory-core/managers/StorageRouter.mjs';
 import {startDrainLoop} from './drainCycle.mjs';
+import {acquireDrainLock} from './drainLock.mjs';
 import {getMissingMemoryWalLeaves} from '../../services/memory-core/helpers/memoryWalStore.mjs';
 
 // Stale-config boot guard: the gitignored config.mjs is a MATERIALIZED template copy — on a
@@ -247,6 +248,26 @@ async function enforceSingleton() {
 async function main() {
     await enforceSingleton();
     await StorageRouter.ready();
+
+    // Sole-drainer guard: claim the per-WAL-directory drain lock BEFORE the loop. enforceSingleton
+    // (above) already resolved daemon-vs-daemon succession, so any prior daemon's lock is now a dead
+    // pid the claim reclaims as stale; a LIVE holder here means a SECOND host (an in-process server
+    // loop) drains the same dir — a misconfiguration that silently corrupts markers. Fail loud.
+    let drainLock;
+    try {
+        drainLock = acquireDrainLock({dir: memoryCoreConfig.memoryWal.dir, owner: 'daemon', log: writeLog});
+    } catch (err) {
+        if (err.code === 'DRAIN_LOCK_HELD') {
+            writeLog('ERROR', `[Embed Daemon] ${err.message} Exiting.`);
+            process.exit(1);
+        }
+        throw err;
+    }
+
+    // Release on every clean exit path: enforceSingleton's cleanup() calls process.exit(), so the
+    // 'exit' listener fires for SIGINT/SIGTERM/uncaughtException too. A SIGKILL leaves the lock for
+    // the next daemon to reclaim as stale.
+    process.on('exit', () => drainLock.release());
 
     writeLog('INFO', `[Embed Daemon] Started. Draining WAL dir: ${memoryCoreConfig.memoryWal.dir} (poll: ${memoryCoreConfig.memoryWal.pollIntervalMs}ms, batch: ${memoryCoreConfig.memoryWal.batchSize})`);
 

--- a/ai/daemons/embed/drainCycle.mjs
+++ b/ai/daemons/embed/drainCycle.mjs
@@ -251,10 +251,12 @@ export async function drainWalOnce({
  *   containerized / single-process deployment shape, where no orchestrator or daemon process
  *   exists (e.g. the dockerized MC containers, `npx neo-app`-class workspaces).
  *
- * **Sole-drainer invariant (config-declared mutual exclusion):** exactly ONE drain loop may run
- * per WAL directory. Never enable `inProcessDrain` on a deployment where the embed daemon also
- * runs — two loops would race the marker files and break the purge-compensation logic, which
- * relies on "a marker I didn't write = purge tombstone".
+ * **Sole-drainer invariant (drain-lock enforced):** exactly ONE drain loop may run per WAL
+ * directory — two loops would race the marker files and break the purge-compensation logic, which
+ * relies on "a marker I didn't write = purge tombstone". Both hosts claim a per-directory
+ * `.drain-lock` before starting (see `./drainLock.mjs`); a second live host refuses and fails loud,
+ * so enabling `inProcessDrain` where the embed daemon also runs is now caught at startup instead of
+ * silently corrupting markers.
  *
  * Cycle failures are logged and absorbed (the WAL retains the backlog; the loop must outlive any
  * single bad pass). Config is re-read via `getConfig()` every cycle and the collection handle is

--- a/ai/daemons/embed/drainLock.mjs
+++ b/ai/daemons/embed/drainLock.mjs
@@ -1,0 +1,190 @@
+/**
+ * @module ai/daemons/embed/drainLock
+ * @summary Per-WAL-directory drain lock that mechanically enforces the sole-drainer invariant.
+ *
+ * The WAL drain has two mutually-exclusive host modes — the orchestrator-supervised embed daemon
+ * (`ai/daemons/embed/daemon.mjs`, local profile) and the in-process loop inside the memory-core
+ * server (`memoryWal.inProcessDrain`, containerized / single-process deployments). The purge-race
+ * compensation in `./drainCycle.mjs` is only correct while exactly ONE loop drains a given WAL
+ * directory: each loop reads "a marker I didn't write" as a purge tombstone, so two concurrent
+ * loops would interpret each other's embed markers as tombstones and issue spurious
+ * `collection.delete`s against legitimately-embedded memories — a silent integrity failure.
+ *
+ * That invariant was previously only config-DECLARED (mutually-exclusive default profiles + JSDoc).
+ * This module makes it mechanically ENFORCED: whichever host starts first claims an atomic
+ * `<dir>/.drain-lock`; a second LIVE host refuses and fails loud — it does NOT take over (the
+ * daemon's PID-takeover stays scoped to daemon-vs-daemon succession; pointing it at the memory-core
+ * server process would kill the server). A dead holder's lock is reclaimed as stale via a
+ * `process.kill(pid, 0)` liveness probe, so a crashed host never wedges the drain.
+ *
+ * Pure + fully injectable (fs, clock, liveness probe, log) — the daemon and the server own the
+ * process-lifecycle wiring (acquire-at-boot, release-on-shutdown); this module owns only the atomic
+ * claim / refuse / reclaim / release decision, unit-tested against a real temp directory.
+ *
+ * The lock file does not match the `wal-<day>.jsonl` pattern `listWalSegmentKeys` filters on, so it
+ * never pollutes WAL segment enumeration despite living inside the WAL directory.
+ */
+
+import fs   from 'fs-extra';
+import path from 'path';
+
+/**
+ * Lock file name placed inside the WAL directory.
+ * @type {String}
+ */
+export const DRAIN_LOCK_FILENAME = '.drain-lock';
+
+/**
+ * @summary Error thrown when the drain lock is already held by a DIFFERENT live host. Carries the
+ * holder descriptor so the caller can fail loud with an actionable, holder-naming message.
+ */
+export class DrainLockHeldError extends Error {
+    constructor({lockPath, holder, requester}) {
+        const who = holder
+            ? `${holder.owner} pid ${holder.pid} (since ${holder.startedAt})`
+            : 'an unknown live process';
+
+        super(`WAL drain lock ${lockPath} is held by ${who}; ${requester.owner} pid ${requester.pid} ` +
+            'refuses to start a second drain loop on the same WAL directory (sole-drainer invariant). ' +
+            'Disable one drain host for this deployment — the embed daemon OR memoryWal.inProcessDrain.');
+
+        this.name      = 'DrainLockHeldError';
+        this.code      = 'DRAIN_LOCK_HELD';
+        this.lockPath  = lockPath;
+        this.holder    = holder;
+        this.requester = requester;
+    }
+}
+
+/**
+ * @summary Default process-liveness probe.
+ *
+ * `process.kill(pid, 0)` sends no signal but performs the permission/existence check: it throws
+ * `ESRCH` when the pid is dead (→ reclaimable) and `EPERM` when the pid is alive but unsignalable
+ * (still alive — a holder we must NOT displace).
+ *
+ * @param {Number} pid
+ * @returns {Boolean}
+ */
+function defaultIsAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (err) {
+        return err.code === 'EPERM';
+    }
+}
+
+/**
+ * Reads + parses the lock holder descriptor, or `null` when the file is absent (raced away) or
+ * corrupt (unparseable / missing a numeric pid). A `null` holder is reclaimable: a corrupt lock must
+ * never permanently wedge the drain.
+ * @param {String} lockPath
+ * @param {Object} fsImpl
+ * @returns {{pid: Number, owner: String, startedAt: String}|null}
+ */
+function readHolder(lockPath, fsImpl) {
+    try {
+        const parsed = JSON.parse(fsImpl.readFileSync(lockPath, 'utf8'));
+        return (parsed && Number.isInteger(parsed.pid)) ? parsed : null;
+    } catch (err) {
+        return null;
+    }
+}
+
+/**
+ * Builds the idempotent release handle: unlinks the lock iff it still records OUR pid (so a late
+ * release from a displaced host can never delete a successor's lock).
+ * @protected
+ */
+function makeHandle({lockPath, pid, owner, fsImpl, log}) {
+    let released = false;
+
+    return {
+        lockPath,
+        pid,
+        owner,
+        release() {
+            if (released) return;
+            released = true;
+            try {
+                const holder = readHolder(lockPath, fsImpl);
+                if (holder && holder.pid === pid) {
+                    fsImpl.unlinkSync(lockPath);
+                    log('INFO', `[drain-lock] released by ${owner} pid ${pid} (${lockPath})`);
+                }
+            } catch (err) {
+                // Best-effort: a failed release leaves a stale lock the next host reclaims via the
+                // liveness probe — never a correctness hazard, only a one-cycle reclaim cost.
+            }
+        }
+    };
+}
+
+/**
+ * @summary Atomically claims the drain lock for a WAL directory, enforcing single-host drain.
+ *
+ * Writes `<dir>/.drain-lock` with an exclusive (`wx`) flag. If the file already exists:
+ *  - held by a DIFFERENT live pid → throws {@link DrainLockHeldError} (refuse, no takeover);
+ *  - held by a dead pid, our own pid, or corrupt/unparseable → reclaimed (unlinked) and retried once.
+ *
+ * The WAL directory is created (`recursive`) before the claim — on a fresh deployment the daemon may
+ * boot before the first `add_memory` materializes the dir.
+ *
+ * @param {Object}   options
+ * @param {String}   options.dir       WAL directory (the resolved `memoryWal.dir` leaf).
+ * @param {String}   options.owner     Host kind for diagnostics: `'daemon'` | `'in-process'`.
+ * @param {Number}   [options.pid]     Owning pid (defaults to `process.pid`).
+ * @param {Function} [options.now]     Clock (epoch ms) for `startedAt`. Defaults to `Date.now`.
+ * @param {Object}   [options.fs]      Filesystem impl (injected for specs). Defaults to `fs-extra`.
+ * @param {Function} [options.isAlive] Liveness probe `(pid) => boolean`. Defaults to a `process.kill` probe.
+ * @param {Function} [options.log]     `(level, message)` sink. Defaults to a no-op.
+ * @returns {{lockPath: String, pid: Number, owner: String, release: Function}} Lock handle; `release()`
+ *     removes the lock iff it is still ours (idempotent, never displaces a successor).
+ * @throws {DrainLockHeldError} When a different live host already holds the lock.
+ */
+export function acquireDrainLock({
+    dir,
+    owner,
+    pid        = process.pid,
+    now        = Date.now,
+    fs: fsImpl = fs,
+    isAlive    = defaultIsAlive,
+    log        = () => {}
+} = {}) {
+    const lockPath = path.join(dir, DRAIN_LOCK_FILENAME);
+
+    fsImpl.mkdirSync(dir, {recursive: true});
+
+    // At most two passes: claim; on EEXIST inspect + (if reclaimable) unlink and re-claim once.
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            fsImpl.writeFileSync(
+                lockPath,
+                JSON.stringify({pid, owner, startedAt: new Date(now()).toISOString()}),
+                {encoding: 'utf8', flag: 'wx'}
+            );
+            log('INFO', `[drain-lock] acquired by ${owner} pid ${pid} (${lockPath})`);
+            return makeHandle({lockPath, pid, owner, fsImpl, log});
+        } catch (err) {
+            if (err.code !== 'EEXIST') throw err;
+
+            const holder = readHolder(lockPath, fsImpl);
+
+            if (holder && holder.pid !== pid && isAlive(holder.pid)) {
+                throw new DrainLockHeldError({lockPath, holder, requester: {owner, pid}});
+            }
+
+            // Stale (dead holder), our own leftover, or corrupt → reclaim and retry the wx claim.
+            log('INFO', `[drain-lock] reclaiming ${holder ? `stale lock (dead ${holder.owner} pid ${holder.pid})` : 'corrupt lock'} at ${lockPath}`);
+            try {
+                fsImpl.unlinkSync(lockPath);
+            } catch (unlinkErr) {
+                if (unlinkErr.code !== 'ENOENT') throw unlinkErr; // ENOENT = raced away; the retry wx settles it.
+            }
+        }
+    }
+
+    // Both passes lost the wx race: another host re-claimed between our unlink and re-claim.
+    throw new DrainLockHeldError({lockPath, holder: readHolder(lockPath, fsImpl), requester: {owner, pid}});
+}

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -21,7 +21,8 @@ import {
     Memory_WakeSubscriptionService as WakeSubscriptionService,
     Memory_CoalescingEngineService as CoalescingEngineService
 } from '../../../services.mjs';
-import {startDrainLoop} from '../../../daemons/embed/drainCycle.mjs';
+import {startDrainLoop}   from '../../../daemons/embed/drainCycle.mjs';
+import {acquireDrainLock} from '../../../daemons/embed/drainLock.mjs';
 
 /**
  * @summary The Memory Core MCP Server application.
@@ -183,17 +184,35 @@ class Server extends BaseServer {
 
         // In-process WAL drain (containerized / single-process deployments): hosts the embed
         // daemon's exact drain loop inside this server when no orchestrator-supervised daemon
-        // exists. Config-declared mutual exclusion — never enabled where the embed daemon runs
-        // (sole-drainer invariant; see the `memoryWal.inProcessDrain` leaf + `drainCycle.mjs`).
-        // Absent-block tolerance is deliberate: a stale overlay simply leaves the loop off;
-        // `addMemory`'s own guard speaks for the missing config.
+        // exists. Mutual exclusion is now drain-lock enforced — a live embed daemon (or another
+        // server) holding the per-directory lock makes this server REFUSE its loop and keep
+        // serving, instead of silently double-draining and corrupting markers (sole-drainer
+        // invariant; see the `memoryWal.inProcessDrain` leaf + `drainLock.mjs`). Absent-block
+        // tolerance is deliberate: a stale overlay simply leaves the loop off; `addMemory`'s own
+        // guard speaks for the missing config.
         if (aiConfig.memoryWal && aiConfig.memoryWal.inProcessDrain) {
-            this.walDrainLoop = startDrainLoop({
-                getCollection: () => StorageRouter.getMemoryCollection(),
-                getConfig    : () => aiConfig.memoryWal,
-                log          : (level, message) => logger[level === 'ERROR' ? 'error' : 'info'](`[neo-memory-core MCP] ${message}`)
-            });
-            logger.info('[neo-memory-core MCP] In-process WAL drain loop active (memoryWal.inProcessDrain)');
+            const drainLog = (level, message) => logger[level === 'ERROR' ? 'error' : 'info'](`[neo-memory-core MCP] ${message}`);
+
+            try {
+                this.walDrainLock = acquireDrainLock({dir: aiConfig.memoryWal.dir, owner: 'in-process', log: drainLog});
+            } catch (err) {
+                if (err.code !== 'DRAIN_LOCK_HELD') throw err;
+                // Another host already drains this dir. The drain is secondary to this server's MCP
+                // duties — log loud and continue serving rather than crash the whole server.
+                logger.error(`[neo-memory-core MCP] In-process WAL drain NOT started: ${err.message}`);
+            }
+
+            if (this.walDrainLock) {
+                this.walDrainLoop = startDrainLoop({
+                    getCollection: () => StorageRouter.getMemoryCollection(),
+                    getConfig    : () => aiConfig.memoryWal,
+                    log          : drainLog
+                });
+                // Release on process exit (the realistic single-process clean-shutdown path); a
+                // signal-kill leaves the lock for the next host to reclaim as stale.
+                process.on('exit', () => this.walDrainLock?.release());
+                logger.info('[neo-memory-core MCP] In-process WAL drain loop active (memoryWal.inProcessDrain)');
+            }
         }
 
         // Stdio identity resolution BEFORE healthcheck snapshot.

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -310,9 +310,11 @@ class Config extends ConfigProvider {
                  * containerized / single-process deployment shape (dockerized MC, npx-neo-app
                  * workspaces) where no orchestrator-supervised embed daemon exists.
                  *
-                 * **Mutual exclusion (sole-drainer invariant):** never enable on a deployment
-                 * where the embed daemon also runs — exactly ONE drain loop per WAL directory.
-                 * The local maintainer profile keeps this `false` and runs the daemon.
+                 * **Mutual exclusion (sole-drainer invariant):** exactly ONE drain loop per WAL
+                 * directory. Enabling this where the embed daemon also runs is refused at startup
+                 * by the per-directory `.drain-lock` guard (whichever host starts second fails
+                 * loud), not merely discouraged. The local maintainer profile keeps this `false`
+                 * and runs the daemon.
                  * @type {boolean}
                  */
                 inProcessDrain : leaf(false, 'NEO_MEMORY_WAL_IN_PROCESS_DRAIN', 'boolean')

--- a/test/playwright/unit/ai/daemons/embed/drainLock.spec.mjs
+++ b/test/playwright/unit/ai/daemons/embed/drainLock.spec.mjs
@@ -1,0 +1,127 @@
+import {test, expect}                  from '@playwright/test';
+import Neo                             from '../../../../../../src/Neo.mjs';
+import * as core                       from '../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm, readFile, writeFile, access} from 'fs/promises';
+import os                              from 'os';
+import path                            from 'path';
+
+import {
+    acquireDrainLock,
+    DrainLockHeldError,
+    DRAIN_LOCK_FILENAME
+} from '../../../../../../ai/daemons/embed/drainLock.mjs';
+
+/**
+ * Drain-lock primitive (`ai/daemons/embed/drainLock.mjs`) — falsifier coverage for the mechanically
+ * enforced sole-drainer invariant:
+ *
+ *   AC1 refuse      — a second LIVE host claiming the same WAL dir throws a holder-naming
+ *                     DrainLockHeldError and does NOT take over (holder descriptor unchanged).
+ *   AC2 stale       — a dead holder's lock is reclaimed by the next host (daemon succession path).
+ *   AC2 corrupt     — an unparseable lock never wedges the drain: it is reclaimed.
+ *   AC2 same-pid    — our own leftover lock is reclaimed (no self-deadlock on pid reuse / restart).
+ *   AC3 release     — release removes the lock iff it is still ours, is idempotent, and a displaced
+ *                     host's late release never clobbers a successor's lock.
+ *
+ * Real temp directory + real fs (the lock IS atomic-write behavior); only the process-liveness probe
+ * is injected so live/dead holders are simulated deterministically without spawning real PIDs.
+ */
+test.describe('Neo.ai.daemons.embed.drainLock', () => {
+    let dir;
+
+    test.beforeEach(async () => {
+        dir = await mkdtemp(path.join(os.tmpdir(), 'neo-drain-lock-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(dir, {recursive: true, force: true});
+    });
+
+    const lockPath  = () => path.join(dir, DRAIN_LOCK_FILENAME);
+    const alive     = () => true;
+    const dead      = () => false;
+    const holderNow = async () => JSON.parse(await readFile(lockPath(), 'utf8'));
+
+    test('acquire writes a holder descriptor and returns a release handle', async () => {
+        const handle = acquireDrainLock({dir, owner: 'daemon', pid: 4242, isAlive: dead, now: () => 1000});
+
+        expect(handle.owner).toBe('daemon');
+        expect(handle.pid).toBe(4242);
+
+        const holder = await holderNow();
+        expect(holder).toMatchObject({pid: 4242, owner: 'daemon'});
+        expect(holder.startedAt).toBe('1970-01-01T00:00:01.000Z');
+    });
+
+    test('AC1: a second LIVE host refuses and names the holder (no takeover)', async () => {
+        acquireDrainLock({dir, owner: 'daemon', pid: 4242, isAlive: alive});
+
+        let thrown;
+        try {
+            acquireDrainLock({dir, owner: 'in-process', pid: 7777, isAlive: alive});
+        } catch (err) {
+            thrown = err;
+        }
+
+        expect(thrown).toBeInstanceOf(DrainLockHeldError);
+        expect(thrown.code).toBe('DRAIN_LOCK_HELD');
+        expect(thrown.message).toContain('daemon pid 4242');     // the holder named
+        expect(thrown.message).toContain('in-process pid 7777'); // the refusing requester named
+
+        // Holder unchanged — the refusing host did NOT take over.
+        expect((await holderNow()).pid).toBe(4242);
+    });
+
+    test('AC2: a stale lock (dead holder) is reclaimed by the next host (daemon succession)', async () => {
+        acquireDrainLock({dir, owner: 'daemon', pid: 4242, isAlive: dead}); // prior daemon
+        const handle = acquireDrainLock({dir, owner: 'daemon', pid: 9001, isAlive: dead}); // successor, prior pid dead
+
+        expect(handle.pid).toBe(9001);
+
+        const holder = await holderNow();
+        expect(holder.pid).toBe(9001);
+        expect(holder.owner).toBe('daemon');
+    });
+
+    test('AC2: a corrupt lock is reclaimed — a garbage file never wedges the drain', async () => {
+        await writeFile(lockPath(), 'not-json{{{', 'utf8');
+
+        // Even with isAlive=true, an unparseable holder has no probeable pid → reclaim is the only
+        // non-wedging choice.
+        const handle = acquireDrainLock({dir, owner: 'in-process', pid: 5555, isAlive: alive});
+
+        expect(handle.pid).toBe(5555);
+        expect((await holderNow()).pid).toBe(5555);
+    });
+
+    test('AC2: our own leftover lock is reclaimed (no self-deadlock on restart / pid reuse)', async () => {
+        acquireDrainLock({dir, owner: 'in-process', pid: 4242, isAlive: alive});
+
+        // Same pid acquiring again must reclaim its own leftover rather than refuse itself.
+        const handle = acquireDrainLock({dir, owner: 'in-process', pid: 4242, isAlive: alive});
+
+        expect(handle.pid).toBe(4242);
+    });
+
+    test('AC3: release removes the lock only when still ours, and is idempotent', async () => {
+        const handle = acquireDrainLock({dir, owner: 'daemon', pid: 4242, isAlive: dead});
+
+        handle.release();
+        await expect(access(lockPath())).rejects.toThrow(); // file gone
+
+        handle.release(); // idempotent — no throw, no resurrection
+        await expect(access(lockPath())).rejects.toThrow();
+    });
+
+    test('AC3: a displaced host’s late release never clobbers a successor’s lock', async () => {
+        const first  = acquireDrainLock({dir, owner: 'daemon', pid: 4242, isAlive: dead});
+        const second = acquireDrainLock({dir, owner: 'daemon', pid: 9001, isAlive: dead}); // reclaims the stale lock
+
+        // The displaced first host releasing late must NOT delete the successor's lock.
+        first.release();
+
+        expect((await holderNow()).pid).toBe(9001);
+        second.release();
+        await expect(access(lockPath())).rejects.toThrow();
+    });
+});


### PR DESCRIPTION
Authored by @neo-opus-ada (Claude Opus 4.8, Claude Code). Origin session: fa0b47bc-e066-4e8b-8aec-a9de8fc69a09.

Resolves #12864
Related: #12859
Related: #12840

The WAL drain has two mutually-exclusive host modes — the orchestrator-supervised embed daemon (local profile) and the in-process loop inside the memory-core server (`memoryWal.inProcessDrain`, containerized / single-process). The purge-race compensation in `drainCycle.drainWalOnce` is only correct while exactly ONE loop drains a WAL directory: each loop reads "a marker I didn't write" as a purge tombstone, so two concurrent loops interpret each other's embed markers as tombstones and issue spurious `collection.delete`s against healthy memories — a silent, config-distance integrity failure. This was previously only config-DECLARED (mutually-exclusive default profiles + JSDoc); this PR makes it mechanically ENFORCED.

Evidence: L2 (unit) — the pure lock primitive drives the real atomic-write behaviour against a real temp directory with only the process-liveness probe injected, covering refuse-and-name / stale-reclaim / corrupt-reclaim / same-pid-reclaim / release-idempotent / no-successor-clobber; 19 passed (7 new + 12 `drainCycle` regression). L3 (a live two-host conflict on one WAL dir + restart durability) is the Post-Merge Validation below.

## Implementation

- **New pure primitive `ai/daemons/embed/drainLock.mjs`.** `acquireDrainLock({dir, owner, ...})` atomically claims `<dir>/.drain-lock` (`wx`); a second LIVE holder (different pid) throws a holder-naming `DrainLockHeldError` and does NOT take over; a dead holder, our own leftover, or a corrupt/unparseable file is reclaimed (the lock can never wedge the drain). Liveness via `process.kill(pid, 0)`. The handle's `release()` is idempotent and removes the file iff it still records our pid (never displaces a successor). Fully injectable (fs / clock / liveness probe / log).
- **Embed daemon** claims after `enforceSingleton` (so any prior daemon's lock is a dead pid reclaimed as stale — daemon-vs-daemon succession unaffected); a live foreign holder -> loud `exit(1)`, surfaced by the orchestrator restart cooldown. Releases on every clean exit path.
- **In-process server** refuses its loop but KEEPS SERVING on conflict (the drain is secondary to its MCP duties), logging the holder loudly; releases on process exit, with stale-reclaim covering signal-kill.
- The lock file never pollutes WAL segment enumeration — it does not match the `wal-<day>.jsonl` pattern `listWalSegmentKeys` filters on.

## Deltas from ticket

- **Liveness-only stale detection** (the ticket's recommended shape), not the daemon's heavier `ps -p` recycle-guard: the holder can be EITHER host, so a single command-name match does not generalise. A pid-recycle to the exact stale pid by a foreign long-lived process fails SAFE (refuse + loud error -> operator), never toward the corruption being prevented. Noted as a possible future hardening.
- **Server "refuse" = log-loud + skip-loop + keep-serving**, not crash — only the daemon's "refuse" is `exit(1)` (the daemon IS the drain; the server is not).
- Lock primitive lives in `ai/daemons/embed/drainLock.mjs` (sibling of `drainCycle.mjs`, which both hosts already import) rather than bloating `memoryWalStore.mjs` — process mutual-exclusion is a distinct concern from WAL record I/O.

## Test Evidence

- `UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/embed/` -> **19 passed** (7 new `drainLock.spec.mjs` falsifiers + 12 existing `drainCycle.spec.mjs`, no regression from the doc-only edit).
- New `drainLock.spec.mjs` (7): acquire descriptor; **AC1** second-live-host refuses + names holder + no takeover; **AC2** stale-reclaim (daemon succession), corrupt-reclaim, same-pid self-reclaim; **AC3** release iff-ours + idempotent, displaced-host late-release never clobbers a successor.
- `node --check` on all four edited/created source files — OK.

## Post-Merge Validation

- [ ] On a deployment with the embed daemon running, booting a memory-core server with `inProcessDrain=true` on the SAME WAL dir logs the loud "drain NOT started" refusal (naming the daemon holder) and the server keeps serving.
- [ ] Reverse order (server-first) -> the daemon `exit(1)`s naming the in-process holder; the orchestrator surfaces the line.
- [ ] A SIGKILL'd holder's `.drain-lock` is reclaimed as stale by the next host on its boot.
- [ ] Daemon-vs-daemon succession (the existing PID-takeover) still works end-to-end.

## Commits
- `52af7a5ee` — feat(embed-daemon): drain-lock enforces sole-drainer invariant (#12864)
