### PR TITLE
docs(release): refresh v13 evidence snapshot at cut prep (#12876)

### DIFF
--- a/resources/content/release-notes/v13.0.0.md
+++ b/resources/content/release-notes/v13.0.0.md
@@ -112,14 +112,14 @@ Neo's AI maintainers are not anonymous background agents. They have stable ident
 
 | Maintainer | Joined | Contributions |
 |---|---:|---:|
-| [@neo-opus-ada](https://github.com/neo-opus-ada) | 2026-04-21 23:12Z | 2,003 |
+| [@neo-opus-ada](https://github.com/neo-opus-ada) | 2026-04-21 23:12Z | 2,017 |
 | [@neo-gpt](https://github.com/neo-gpt) | 2026-04-28 17:58Z | 1,510 |
 | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | 2026-04-21 22:57Z | 1,039 |
-| [@neo-claude-opus](https://github.com/neo-claude-opus) | 2026-06-02 20:59Z | 201 |
-| [@neo-opus-vega](https://github.com/neo-opus-vega) | 2026-06-04 15:27Z | 137 |
-| [@neo-fable](https://github.com/neo-fable) | 2026-06-10 09:56Z | newly onboarded |
+| [@neo-claude-opus](https://github.com/neo-claude-opus) | 2026-06-02 20:59Z | 223 |
+| [@neo-opus-vega](https://github.com/neo-opus-vega) | 2026-06-04 15:27Z | 159 |
+| [@neo-fable](https://github.com/neo-fable) | 2026-06-10 09:56Z | 25 |
 
-@neo-fable (Claude Fable 5) joined as v13 ships — the institution's first Fable-family maintainer, onboarding now; its contribution history starts post-v13.
+@neo-fable (Claude Fable 5) joined as v13 ships — the institution's first Fable-family maintainer; its first contributions landed in the release's final nights.
 
 The roster is not the point. The point is topology.
 
@@ -430,7 +430,7 @@ The sections above tell the v13 story. This digest is the scan layer: representa
 
 ```mermaid
 flowchart LR
-    Corpus["v13 release corpus<br/>1,200+ merged PRs<br/>1,600+ closed issues"]
+    Corpus["v13 release corpus<br/>1,300+ merged PRs<br/>1,700+ closed issues"]
     Digest["Curated digest<br/>representative shipped anchors"]
     Stories["Engineering war stories<br/>causal narrative"]
     Appendix["Generated appendices<br/>exhaustive audit tables"]
@@ -519,13 +519,13 @@ For the final release artifact, generate appendices from the recursive local con
 node buildScripts/release/analyzeClosedSinceRelease.mjs 2026-03-27 --format markdown --include-items --output /tmp/v13-release-appendix.md
 ```
 
-Current evidence snapshot from the previous release-note pass, to be refreshed once at final cut:
+Current evidence snapshot from the v13 cut-prep pass (live counts verified 2026-06-11; the publish step re-checks them once more):
 
-- Live GitHub GraphQL merged PRs since `v12.1.0`: **1,260**.
-- Live GitHub GraphQL closed issues since `v12.1.0`: **1,664**.
-- Local appendix mirror merged PRs since `v12.1.0`: **1,228**.
-- Local appendix mirror closed issues since `v12.1.0`: **1,587**.
-- Generated local appendix snapshot: **2,933 lines**.
+- Live GitHub GraphQL merged PRs since `v12.1.0`: **1,307**.
+- Live GitHub GraphQL closed issues since `v12.1.0`: **1,717**.
+- Local appendix mirror merged PRs since `v12.1.0`: **1,228** (mirror as of the last `sync_all`; reconciles at release cut).
+- Local appendix mirror closed issues since `v12.1.0`: **1,587** (same mirror boundary).
+- Generated local appendix snapshot: **2,933 lines** (regenerated 2026-06-11 from the current mirror).
 - Top PR authors: `neo-opus-ada`, `neo-gpt`, `neo-gemini-pro`, `tobiu`, `neo-claude-opus`.
 - Top PR scopes: `feat(ai)`, `fix(ai)`, `docs(ai)`, `docs(agentos)`, `feat(memory-core)`.
 - Top issue labels: `ai`, `enhancement`, `architecture`, `model-experience`, `bug`.


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session 567191c3-16f6-4235-914c-b51fc94d1514.

Resolves #12876
Related: #12696

Refreshes the v13 release note's at-cut evidence surfaces, per the Post-Merge Validation checklist of merged PR #12697: live release-window counts (1,260→**1,307** merged PRs, 1,664→**1,717** closed issues since `v12.1.0`, verified 2026-06-11), the curated-digest mermaid corpus figures (1,200+/1,600+ → 1,300+/1,700+), and the maintainer contribution table (ada 2,003→2,017, claude-opus 201→223, vega 137→159, fable "newly onboarded"→25; gpt/gemini unchanged — method-reproduction confirmed the original derivation). The appendix snapshot bullets now carry explicit freshness boundaries (live vs lagging mirror) instead of "to be refreshed once at final cut".

Evidence: L1 (static content verification: live GraphQL count probes, per-user contributionsCollection GraphQL, appendix generator re-run → 2,933 lines, post-edit grep sweep for stale values) → L1 required (documentation evidence refresh; no runtime ACs). No residuals — the AC3 operator runbook is posted: https://github.com/neomjs/neo/issues/12696#issuecomment-4675564872

## Deltas from ticket

- **README / `learn/benefits/AIEngineeringTeam.md` deliberately NOT touched.** Mid-implementation V-B-A surfaced that #12725 (the prior identity-count refresh attempt) was operator-rejected on 2026-06-08: public identity surfaces show *fixed-month* velocity proof ("In May 2026 … 706/800"), not drifting release-window stats. The release note's appendix snapshot is the opposite class — release-window evidence inside the release artifact itself, with an explicit refresh-at-cut instruction — so only the note changes here.
- Maintainer-table derivation verified before writing: GraphQL `contributionsCollection.contributionCalendar.totalContributions` reproduces the documented values exactly for the two inactive accounts (gpt 1,510, gemini 1,039), confirming the method; active accounts refreshed with the same query.
- One prose line adjusted for factual accuracy: @neo-fable's "contribution history starts post-v13" → "first contributions landed in the release's final nights" (25 contributions exist pre-cut; the old claim aged out mid-release).

## Test Evidence

- `gh api '/search/issues?q=repo:neomjs/neo+is:pr+is:merged+merged:%3E=2026-03-27'` → **1307**
- `gh api '/search/issues?q=repo:neomjs/neo+is:issue+is:closed+closed:%3E=2026-03-27'` → **1717**
- Per-user `contributionsCollection` GraphQL → ada 2017, gpt 1510, gemini 1039, claude-opus 223, vega 159, fable 25
- `node buildScripts/release/analyzeClosedSinceRelease.mjs 2026-03-27 --format markdown --include-items --output /tmp/v13-release-appendix.md` → 2,933 lines; mirror totals 1,228 PRs / 1,587 issues (unchanged mirror boundary, documented as such)
- Post-edit sweep: `grep -n "1,260\|1,664\|2,003\|newly onboarded\|1,200+\|1,600+"` on the note → zero matches
- Pre-commit `check-chore-sync` + whitespace lint passed on the `agent/sync-*` branch; branch freshness: merge-base == origin/dev tip; single commit, no stray close-keywords in branch history

## Post-Merge Validation

- [ ] At publish: `publish.mjs` Step 6 `runFullSync` reconciles the lagging mirror counts (documented in the runbook comment; no action before cut)

## Review note

§6.1 micro-change exemption claimed: pure documentation, no runtime impact (12 lines changed in `resources/content/release-notes/v13.0.0.md`). Cross-family review welcome but non-blocking for the cut; operator reviews the note at publish regardless.