### PR TITLE
fix(grid): resolve dragged column identity in SortZone onDragEnd (#12878)

### DIFF
--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -278,40 +278,60 @@ class SortZone extends BaseSortZone {
         let { owner } = me,
             grid = owner.gridContainer,
             { columns } = grid,
-            toIndex = me.dragElement['aria-colindex'] - 1,
-            column = columns.getAt(toIndex),
-            prevCol = toIndex > 0 ? columns.getAt(toIndex - 1) : null,
-            nextCol = toIndex < columns.count - 1 ? columns.getAt(toIndex + 1) : null,
-            newLocked = null;
+            column = null,
+            toIndex = -1,
+            newLocked = null,
+            i = 0,
+            prevCol, nextCol;
 
-        // Inference logic: Default to unlocked unless completely surrounded by a locked zone
-        // or placed at the absolute outer edge of a locked zone.
-        if (prevCol?.locked === 'start' && nextCol?.locked === 'start') {
-            newLocked = 'start'
-        } else if (prevCol?.locked === 'end' && nextCol?.locked === 'end') {
-            newLocked = 'end'
-        } else if (toIndex === 0 && nextCol?.locked === 'start') {
-            newLocked = 'start'
-        } else if (toIndex === columns.count - 1 && prevCol?.locked === 'end') {
-            newLocked = 'end'
+        // Re-resolve the dragged column inside the global collection AFTER super.onDragEnd applied
+        // the move. The prior `aria-colindex` read was toolbar-local and pre-drag-stale, so in a
+        // locked multi-region grid it indexed an unrelated (often locked) column, whose `locked`
+        // config the inference below then mutated — silently corrupting region membership.
+        if (me.dragColumnField) {
+            for (; i < columns.count; i++) {
+                if (columns.getAt(i).dataField === me.dragColumnField) {
+                    column  = columns.getAt(i);
+                    toIndex = i;
+                    break
+                }
+            }
+
+            me.dragColumnField = null
         }
 
-        // Cross-toolbar: a release over a different region's body is the direct lock-region
-        // signal and supersedes the neighbor inference for cross-region moves. Within-region drops
-        // resolve to the column's existing region, so the neighbor-based path above is preserved.
-        if (Neo.isNumber(me.lastDragClientX) && (grid.bodyStart || grid.bodyEnd)) {
-            let bodyStartRect = grid.bodyStart ? await grid.bodyStart.getDomRect() : null,
-                bodyEndRect   = grid.bodyEnd   ? await grid.bodyEnd.getDomRect()   : null,
-                positionRegion = me.getDropRegion(me.lastDragClientX, {start: bodyStartRect, end: bodyEndRect});
+        if (column) {
+            prevCol = toIndex > 0 ? columns.getAt(toIndex - 1) : null;
+            nextCol = toIndex < columns.count - 1 ? columns.getAt(toIndex + 1) : null;
 
-            if (positionRegion !== column.locked) {
-                newLocked = positionRegion
+            // Inference logic: Default to unlocked unless completely surrounded by a locked zone
+            // or placed at the absolute outer edge of a locked zone.
+            if (prevCol?.locked === 'start' && nextCol?.locked === 'start') {
+                newLocked = 'start'
+            } else if (prevCol?.locked === 'end' && nextCol?.locked === 'end') {
+                newLocked = 'end'
+            } else if (toIndex === 0 && nextCol?.locked === 'start') {
+                newLocked = 'start'
+            } else if (toIndex === columns.count - 1 && prevCol?.locked === 'end') {
+                newLocked = 'end'
+            }
+
+            // Positional truth: the release x-coordinate names the target lock-region for EVERY drop —
+            // within-region drops included. The earlier only-override-on-difference shape let the
+            // neighbor inference unlock a column dropped at the inner edge of its own locked region
+            // (prev locked, next unlocked -> null), silently ejecting it. The neighbor-based
+            // inference above remains as the fallback when no release coordinate is available.
+            // The rects come from the drag-start snapshot: live drag-end rects reflect the mid-drag
+            // re-flow (hidden dragged column), not the geometry the user dropped against.
+            if (Neo.isNumber(me.lastDragClientX) && me.regionRects) {
+                newLocked = me.getDropRegion(me.lastDragClientX, me.regionRects)
             }
         }
 
         me.lastDragClientX = null;
+        me.regionRects     = null;
 
-        if (column.locked !== newLocked) {
+        if (column && column.locked !== newLocked) {
             // This implicitly triggers grid.Container#onColumnLockChange,
             // which handles sorting, DOM syncing, and layout calculations.
             column.locked = newLocked
@@ -356,6 +376,23 @@ class SortZone extends BaseSortZone {
         if (!me.owner.dragResortable) return;
 
         await super.onDragStart(data);
+
+        // Capture the dragged column's identity at drag-start. `aria-colindex` is toolbar-local
+        // AND stale after the drop, so the global columns collection can only be safely indexed
+        // by re-resolving the dragged column itself at drag-end.
+        me.dragColumnField = me.dragComponent?.dataField || null;
+
+        // Snapshot the locked-body rects BEFORE any mid-drag re-flow: hiding the dragged column's
+        // cells re-flows the locked bodies, so a drag-end read can place an in-region release
+        // outside its own (shrunken) region body and silently eject the column.
+        let grid = me.owner.gridContainer;
+
+        if (grid.bodyStart || grid.bodyEnd) {
+            me.regionRects = {
+                start: grid.bodyStart ? await grid.bodyStart.getDomRect() : null,
+                end  : grid.bodyEnd   ? await grid.bodyEnd.getDomRect()   : null
+            }
+        }
 
         if (me.dragComponent && me.moveColumnContent) {
             let body = me.gridBody,


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session 567191c3-16f6-4235-914c-b51fc94d1514.

Resolves #12878
Related: #12880
Refs #12807
Refs #9486

Fixes the silent locked-region corruption in multi-region column drag-and-drop, operator-flagged as release-blocking ("polish the grid before v13 ships"). Three root causes in `src/draggable/grid/header/toolbar/SortZone.mjs`, all live-verified on the devindex 50k-row grid through an agent-driven whitebox rig:

1. **Wrong-column lock mutation:** `onDragEnd` indexed the global `columns` collection with the dragged element's `aria-colindex` — toolbar-local AND pre-drag-stale — so the lock-inference inspected and mutated an unrelated column (live case: a center-region drag unlocked the locked `#` index column). Now the dragged column's `dataField` is captured at drag-start and re-resolved against the global collection after the move applies; lock-logic never runs on an unresolved column.
2. **Inner-edge ejection:** the positional region check only overrode the neighbor inference when the regions differed, so a within-region drop at a locked region's inner edge fell through to the inference's `null` and silently unlocked the column. The release-coordinate region is now the verdict for every drop; neighbor inference remains the no-coordinate fallback.
3. **Re-flow race:** drag-end body rects reflect the mid-drag re-flow (the dragged column's cells are hidden, shrinking its region), mis-classifying in-region releases as outside. Region rects are now snapshotted at drag-START — the geometry the user actually drops against.

Evidence: L3 (live whitebox verification — agent-dispatched MouseEvent sequences on devindex, engine-truth assertions via Neural Link vdom/rect/lock-state queries, fresh session per case, three post-fix runs) → L3 required (#12878 AC3 documented-manual-protocol branch; declared in the ticket). Residual: durable CI regression spec lands via the #12807 simulatability substrate [active lane, @neo-opus-ada].

## Deltas from ticket

- **AC2 scope split (documented on the ticket pre-PR):** correct-REGION + stable-membership delivered here; landing-INDEX accuracy is the mechanically independent `container.SortZone` cadence defect, split to #12880 with full discriminator evidence (+1 short-drag / +3 long-drag deterministic overshoot, masked in small regions by clamping, likely affects single-region toolbars too). Separate code home, separate failure class, instrumentation-first next step.
- The fix deliberately stays in the grid subclass; the parent class is untouched (that is #12880's surface).

## Test Evidence

- `npx playwright test test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs -c test/playwright/playwright.config.unit.mjs` → **3 passed** (pure helpers `getDropRegion` / `columnIndexOffset` / `gridBody` unchanged).
- Live rig, pre-fix (defect reproduction): center drag → start region reordered `[#,Rank,User]`→`[Rank,User,#]`; within-start drag → `#` EJECTED into center idx 0 (start 3→2 items). Numeric fits to the pixel on the ticket.
- Live rig, post-fix (3 fresh sessions): within-start ejection-trigger drag → `[#, User, Rank]`, no ejection, locks stable; center drags → start region untouched, zero lock mutations; DragCoordinator clean after every drop; zero worker console errors.
- Full matrix + protocol: https://github.com/neomjs/neo/issues/12878#issuecomment-4675823020 (characterization) and https://github.com/neomjs/neo/issues/12878#issuecomment-4675945880 (post-fix verification).

## Post-Merge Validation

- [ ] Durable regression spec via #12807's dispatch substrate once it lands (the raw-MouseEvent recipe in the ticket is the reference behavior)
- [ ] #12880 instrumentation pass reuses this rig (recipe documented on both tickets)

## Commits

- `386c589db` — fix(grid): resolve dragged column identity in SortZone onDragEnd (#12878)