### PR TITLE
fix(draggable): stabilize SortZone landing index (#12880)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -77,6 +77,13 @@ class SortZone extends DragZone {
          */
         ignoreDragSelector: null,
         /**
+         * Immutable drag-start geometry used to resolve in-bound landing indices without
+         * depending on native mousemove cadence.
+         * @member {Array|null} dragStartItemRects=null
+         * @protected
+         */
+        dragStartItemRects: null,
+        /**
          * @member {Object} indexMap=null
          * @protected
          */
@@ -367,21 +374,64 @@ class SortZone extends DragZone {
             }
 
             Object.assign(me, {
-                currentIndex    : -1,
-                indexMap        : null,
-                isRemoteDragging: false,
-                isWindowDragging: false,
-                itemRects       : null,
-                itemStyles      : null,
-                ownerRect       : null,
-                startIndex      : -1,
-                sortableItems   : null
+                currentIndex      : -1,
+                dragStartItemRects: null,
+                indexMap          : null,
+                isRemoteDragging  : false,
+                isWindowDragging  : false,
+                itemRects         : null,
+                itemStyles        : null,
+                ownerRect         : null,
+                startIndex        : -1,
+                sortableItems     : null
             });
 
             await me.timeout(30);
 
             me.dragEnd(data) // we do not want to trigger the super class call here
         }
+    }
+
+    /**
+     * @summary Resolves the target sort index from the cursor position and drag-start geometry.
+     *
+     * Native mousemove cadence can deliver several far-pointer events after each adjacent swap. If
+     * landing is calculated against mutated live rects, repeated events keep advancing the item and
+     * the final index scales with path length. The drag-start snapshot makes the landing index a pure
+     * function of the current cursor position, so repeated events at the same coordinate stay idempotent.
+     *
+     * @param {Object} data The drag move event data.
+     * @returns {Number|null} The target sort index, or null when no start geometry is available.
+     */
+    getDragMoveTargetIndex(data) {
+        let me    = this,
+            rects = me.dragStartItemRects;
+
+        if (!rects?.length) return null;
+
+        let horizontal  = me.sortDirection === 'horizontal',
+            ownerX      = me.adjustItemRectsToParent ? me.ownerRect.x : 0,
+            ownerY      = me.adjustItemRectsToParent ? me.ownerRect.y : 0,
+            coordinate  = horizontal ? data.clientX - ownerX + me.scrollLeft : data.clientY - ownerY + me.scrollTop,
+            position    = horizontal ? 'left' : 'top',
+            size        = horizontal ? 'width' : 'height',
+            visualRects = rects.map((rect, index) => ({index, rect})).sort((a, b) => a.rect[position] - b.rect[position]),
+            lastIndex   = visualRects.length - 1;
+
+        if (coordinate <= visualRects[0].rect[position]) {
+            return visualRects[0].index
+        }
+
+        for (let i = 0; i < visualRects.length; i++) {
+            let {index, rect} = visualRects[i],
+                end  = rect[position] + rect[size];
+
+            if (coordinate <= end) {
+                return index
+            }
+        }
+
+        return visualRects[lastIndex].index
     }
 
     /**
@@ -422,7 +472,7 @@ class SortZone extends DragZone {
             ownerX             = me.adjustItemRectsToParent ? me.ownerRect.x : 0,
             ownerY             = me.adjustItemRectsToParent ? me.ownerRect.y : 0,
             reversed           = me.reversedLayoutDirection,
-            delta, isOverDragging, isOverDraggingEnd, isOverDraggingStart, itemHeightOrWidth, moveFactor;
+            delta, direction, isOverDragging, isOverDraggingEnd, isOverDraggingStart, itemHeightOrWidth, moveFactor, targetIndex;
 
         if (me.sortDirection === 'horizontal') {
             delta               = clientX - ownerX + me.scrollLeft - me.offsetX - itemRects[index].left;
@@ -438,6 +488,23 @@ class SortZone extends DragZone {
 
         isOverDragging = isOverDraggingEnd || isOverDraggingStart;
         moveFactor     = isOverDragging ? 0.02 : 0.55; // We can not use 0.5, since items would jump back & forth
+
+        if (!isOverDragging) {
+            targetIndex = me.getDragMoveTargetIndex(data);
+
+            if (Neo.isNumber(targetIndex)) {
+                while (me.currentIndex !== targetIndex) {
+                    index     = me.currentIndex;
+                    direction = targetIndex > index ? 1 : -1;
+
+                    me.currentIndex += direction;
+                    me.switchItems(index, me.currentIndex)
+                }
+
+                me.isOverDragging = false;
+                return
+            }
+        }
 
         if (isOverDraggingStart) {
             if (index > 0) {
@@ -619,6 +686,7 @@ class SortZone extends DragZone {
             });
 
             me.itemRects = itemRects;
+            me.dragStartItemRects = itemRects.map(rect => rect.clone());
 
             await me.dragStart(data);
 

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -16,6 +16,72 @@ import VdomHelper      from '../../../../../src/vdom/Helper.mjs';
 import Container       from '../../../../../src/container/Base.mjs';
 import SortZone        from '../../../../../src/draggable/container/SortZone.mjs';
 
+const createRect = (left, width) => ({
+    x: left, y: 0, left, top: 0, width, height: 40,
+    clone() {
+        return createRect(this.left, this.width)
+    }
+});
+
+const createDragMoveHarness = () => {
+    const
+        dragStartItemRects = [
+            createRect(387, 100), // Total
+            createRect(488, 52),  // Commits %
+            createRect(541, 70),  // Private %
+            createRect(612, 40),
+            createRect(653, 40),
+            createRect(694, 40)
+        ],
+        itemRects = dragStartItemRects.map(rect => rect.clone()),
+        trace     = [],
+        zone      = Object.create(SortZone.prototype);
+
+    Object.assign(zone, {
+        adjustItemRectsToParent: false,
+        boundaryContainerRect  : {left: 0, right: 1000, top: 0, bottom: 100},
+        currentIndex           : 0,
+        dragProxy              : null,
+        dragStartItemRects,
+        indexMap               : {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
+        isRemoteDragging       : false,
+        isScrolling            : false,
+        itemRects,
+        offsetX                : 50,
+        offsetY                : 0,
+        ownerRect              : {x: 0, y: 0},
+        reversedLayoutDirection: false,
+        scrollLeft             : 0,
+        scrollTop              : 0,
+        sortDirection          : 'horizontal',
+        timeout                : () => Promise.resolve(),
+        trace,
+        switchItems(index1, index2) {
+            trace.push([index1, index2]);
+            SortZone.prototype.switchItems.call(this, index1, index2)
+        },
+        updateItem() {}
+    });
+
+    return zone
+};
+
+const createReverseDragMoveHarness = () => {
+    const zone = createDragMoveHarness();
+
+    zone.currentIndex           = 0;
+    zone.dragStartItemRects     = [
+        createRect(541, 70),
+        createRect(488, 52),
+        createRect(387, 100)
+    ];
+    zone.itemRects              = zone.dragStartItemRects.map(rect => rect.clone());
+    zone.indexMap               = {0: 0, 1: 1, 2: 2};
+    zone.reversedLayoutDirection = true;
+
+    return zone
+};
+
 /**
  * @summary Tests for Neo.draggable.container.SortZone
  */
@@ -215,5 +281,40 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
         expect(sortZone.sortDirection).toBe('vertical');
         expect(sortZone.reversedLayoutDirection).toBe(true);
         expect(sortZone.currentIndex).toBe(0)
+    });
+
+    test('Maps in-bound drag moves to drag-start geometry, independent of native event cadence (#12880)', async () => {
+        const shortMove = createDragMoveHarness();
+
+        expect(shortMove.getDragMoveTargetIndex({clientX: 500, clientY: 0})).toBe(1);
+
+        await shortMove.onDragMove({clientX: 500, clientY: 0});
+
+        expect(shortMove.currentIndex).toBe(1);
+        expect(shortMove.trace).toEqual([[0, 1]]);
+
+        const longMove = createDragMoveHarness();
+
+        expect(longMove.getDragMoveTargetIndex({clientX: 585, clientY: 0})).toBe(2);
+
+        await longMove.onDragMove({clientX: 585, clientY: 0});
+        await longMove.onDragMove({clientX: 585, clientY: 0});
+        await longMove.onDragMove({clientX: 585, clientY: 0});
+
+        expect(longMove.currentIndex).toBe(2);
+        expect(longMove.trace).toEqual([[0, 1], [1, 2]])
+    });
+
+    test('Keeps in-bound drag target resolution compatible with reverse layouts (#12880)', async () => {
+        const reversedMove = createReverseDragMoveHarness();
+
+        expect(reversedMove.getDragMoveTargetIndex({clientX: 500, clientY: 0})).toBe(1);
+        expect(reversedMove.getDragMoveTargetIndex({clientX: 400, clientY: 0})).toBe(2);
+
+        await reversedMove.onDragMove({clientX: 400, clientY: 0});
+        await reversedMove.onDragMove({clientX: 400, clientY: 0});
+
+        expect(reversedMove.currentIndex).toBe(2);
+        expect(reversedMove.trace).toEqual([[0, 1], [1, 2]])
     });
 });


### PR DESCRIPTION
Resolves #12880

Authored by GPT-5 (Codex Desktop). Session 019eb419-df87-7ce2-a4c8-d6f9ba799ca5.

SortZone now resolves in-bound drag landing from an immutable drag-start geometry snapshot instead of repeatedly comparing far-pointer events against mutated live rects. The result is idempotent for repeated mousemove events at the same coordinate while preserving the existing overdrag/auto-scroll path and reverse-layout behavior.

Evidence: L3 (branch-local Chromium devindex drag probe against the rendered grid header at `127.0.0.1:8090`) -> L3 required (observable grid-header drag landing behavior). No residuals.

## Deltas from ticket
The implementation fixes the landing calculation at the shared `Neo.draggable.container.SortZone` layer rather than adding grid-header-specific clamps. The new helper sorts the drag-start snapshot by visual coordinate before returning the source index, so reverse layouts keep their existing contract.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs` -> 11 passed.
- `node /private/tmp/neo-sortzone-12880-probe.mjs` against `http://127.0.0.1:8090/apps/devindex/index.html` -> Total drag to x=500 lands at index 1; drag to x=585 lands at index 2.
- `git diff --cached --check` -> passed before commit.
- Commit hook ran `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology` successfully.

## Post-Merge Validation
- [ ] On `dev`, verify the devindex grid header still lands Total at index 1 for x=500 and index 2 for x=585 after the merge.

## Evolution
An initial live probe against `localhost:8080` failed because that server was serving the old SortZone source. I started an isolated branch-local server on `127.0.0.1:8090`, verified it served the patched module, and used that surface for the final live evidence.

## Commit
- `8eba49843` - `fix(draggable): stabilize SortZone landing index (#12880)`
