### PR TITLE
fix(draggable): revert #12882 to restore drag-motion baseline (#12887)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -77,13 +77,6 @@ class SortZone extends DragZone {
          */
         ignoreDragSelector: null,
         /**
-         * Immutable drag-start geometry used to resolve in-bound landing indices without
-         * depending on native mousemove cadence.
-         * @member {Array|null} dragStartItemRects=null
-         * @protected
-         */
-        dragStartItemRects: null,
-        /**
          * @member {Object} indexMap=null
          * @protected
          */
@@ -374,64 +367,21 @@ class SortZone extends DragZone {
             }
 
             Object.assign(me, {
-                currentIndex      : -1,
-                dragStartItemRects: null,
-                indexMap          : null,
-                isRemoteDragging  : false,
-                isWindowDragging  : false,
-                itemRects         : null,
-                itemStyles        : null,
-                ownerRect         : null,
-                startIndex        : -1,
-                sortableItems     : null
+                currentIndex    : -1,
+                indexMap        : null,
+                isRemoteDragging: false,
+                isWindowDragging: false,
+                itemRects       : null,
+                itemStyles      : null,
+                ownerRect       : null,
+                startIndex      : -1,
+                sortableItems   : null
             });
 
             await me.timeout(30);
 
             me.dragEnd(data) // we do not want to trigger the super class call here
         }
-    }
-
-    /**
-     * @summary Resolves the target sort index from the cursor position and drag-start geometry.
-     *
-     * Native mousemove cadence can deliver several far-pointer events after each adjacent swap. If
-     * landing is calculated against mutated live rects, repeated events keep advancing the item and
-     * the final index scales with path length. The drag-start snapshot makes the landing index a pure
-     * function of the current cursor position, so repeated events at the same coordinate stay idempotent.
-     *
-     * @param {Object} data The drag move event data.
-     * @returns {Number|null} The target sort index, or null when no start geometry is available.
-     */
-    getDragMoveTargetIndex(data) {
-        let me    = this,
-            rects = me.dragStartItemRects;
-
-        if (!rects?.length) return null;
-
-        let horizontal  = me.sortDirection === 'horizontal',
-            ownerX      = me.adjustItemRectsToParent ? me.ownerRect.x : 0,
-            ownerY      = me.adjustItemRectsToParent ? me.ownerRect.y : 0,
-            coordinate  = horizontal ? data.clientX - ownerX + me.scrollLeft : data.clientY - ownerY + me.scrollTop,
-            position    = horizontal ? 'left' : 'top',
-            size        = horizontal ? 'width' : 'height',
-            visualRects = rects.map((rect, index) => ({index, rect})).sort((a, b) => a.rect[position] - b.rect[position]),
-            lastIndex   = visualRects.length - 1;
-
-        if (coordinate <= visualRects[0].rect[position]) {
-            return visualRects[0].index
-        }
-
-        for (let i = 0; i < visualRects.length; i++) {
-            let {index, rect} = visualRects[i],
-                end  = rect[position] + rect[size];
-
-            if (coordinate <= end) {
-                return index
-            }
-        }
-
-        return visualRects[lastIndex].index
     }
 
     /**
@@ -472,7 +422,7 @@ class SortZone extends DragZone {
             ownerX             = me.adjustItemRectsToParent ? me.ownerRect.x : 0,
             ownerY             = me.adjustItemRectsToParent ? me.ownerRect.y : 0,
             reversed           = me.reversedLayoutDirection,
-            delta, direction, isOverDragging, isOverDraggingEnd, isOverDraggingStart, itemHeightOrWidth, moveFactor, targetIndex;
+            delta, isOverDragging, isOverDraggingEnd, isOverDraggingStart, itemHeightOrWidth, moveFactor;
 
         if (me.sortDirection === 'horizontal') {
             delta               = clientX - ownerX + me.scrollLeft - me.offsetX - itemRects[index].left;
@@ -488,23 +438,6 @@ class SortZone extends DragZone {
 
         isOverDragging = isOverDraggingEnd || isOverDraggingStart;
         moveFactor     = isOverDragging ? 0.02 : 0.55; // We can not use 0.5, since items would jump back & forth
-
-        if (!isOverDragging) {
-            targetIndex = me.getDragMoveTargetIndex(data);
-
-            if (Neo.isNumber(targetIndex)) {
-                while (me.currentIndex !== targetIndex) {
-                    index     = me.currentIndex;
-                    direction = targetIndex > index ? 1 : -1;
-
-                    me.currentIndex += direction;
-                    me.switchItems(index, me.currentIndex)
-                }
-
-                me.isOverDragging = false;
-                return
-            }
-        }
 
         if (isOverDraggingStart) {
             if (index > 0) {
@@ -686,7 +619,6 @@ class SortZone extends DragZone {
             });
 
             me.itemRects = itemRects;
-            me.dragStartItemRects = itemRects.map(rect => rect.clone());
 
             await me.dragStart(data);
 

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -16,72 +16,6 @@ import VdomHelper      from '../../../../../src/vdom/Helper.mjs';
 import Container       from '../../../../../src/container/Base.mjs';
 import SortZone        from '../../../../../src/draggable/container/SortZone.mjs';
 
-const createRect = (left, width) => ({
-    x: left, y: 0, left, top: 0, width, height: 40,
-    clone() {
-        return createRect(this.left, this.width)
-    }
-});
-
-const createDragMoveHarness = () => {
-    const
-        dragStartItemRects = [
-            createRect(387, 100), // Total
-            createRect(488, 52),  // Commits %
-            createRect(541, 70),  // Private %
-            createRect(612, 40),
-            createRect(653, 40),
-            createRect(694, 40)
-        ],
-        itemRects = dragStartItemRects.map(rect => rect.clone()),
-        trace     = [],
-        zone      = Object.create(SortZone.prototype);
-
-    Object.assign(zone, {
-        adjustItemRectsToParent: false,
-        boundaryContainerRect  : {left: 0, right: 1000, top: 0, bottom: 100},
-        currentIndex           : 0,
-        dragProxy              : null,
-        dragStartItemRects,
-        indexMap               : {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5},
-        isRemoteDragging       : false,
-        isScrolling            : false,
-        itemRects,
-        offsetX                : 50,
-        offsetY                : 0,
-        ownerRect              : {x: 0, y: 0},
-        reversedLayoutDirection: false,
-        scrollLeft             : 0,
-        scrollTop              : 0,
-        sortDirection          : 'horizontal',
-        timeout                : () => Promise.resolve(),
-        trace,
-        switchItems(index1, index2) {
-            trace.push([index1, index2]);
-            SortZone.prototype.switchItems.call(this, index1, index2)
-        },
-        updateItem() {}
-    });
-
-    return zone
-};
-
-const createReverseDragMoveHarness = () => {
-    const zone = createDragMoveHarness();
-
-    zone.currentIndex           = 0;
-    zone.dragStartItemRects     = [
-        createRect(541, 70),
-        createRect(488, 52),
-        createRect(387, 100)
-    ];
-    zone.itemRects              = zone.dragStartItemRects.map(rect => rect.clone());
-    zone.indexMap               = {0: 0, 1: 1, 2: 2};
-    zone.reversedLayoutDirection = true;
-
-    return zone
-};
-
 /**
  * @summary Tests for Neo.draggable.container.SortZone
  */
@@ -281,40 +215,5 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
         expect(sortZone.sortDirection).toBe('vertical');
         expect(sortZone.reversedLayoutDirection).toBe(true);
         expect(sortZone.currentIndex).toBe(0)
-    });
-
-    test('Maps in-bound drag moves to drag-start geometry, independent of native event cadence (#12880)', async () => {
-        const shortMove = createDragMoveHarness();
-
-        expect(shortMove.getDragMoveTargetIndex({clientX: 500, clientY: 0})).toBe(1);
-
-        await shortMove.onDragMove({clientX: 500, clientY: 0});
-
-        expect(shortMove.currentIndex).toBe(1);
-        expect(shortMove.trace).toEqual([[0, 1]]);
-
-        const longMove = createDragMoveHarness();
-
-        expect(longMove.getDragMoveTargetIndex({clientX: 585, clientY: 0})).toBe(2);
-
-        await longMove.onDragMove({clientX: 585, clientY: 0});
-        await longMove.onDragMove({clientX: 585, clientY: 0});
-        await longMove.onDragMove({clientX: 585, clientY: 0});
-
-        expect(longMove.currentIndex).toBe(2);
-        expect(longMove.trace).toEqual([[0, 1], [1, 2]])
-    });
-
-    test('Keeps in-bound drag target resolution compatible with reverse layouts (#12880)', async () => {
-        const reversedMove = createReverseDragMoveHarness();
-
-        expect(reversedMove.getDragMoveTargetIndex({clientX: 500, clientY: 0})).toBe(1);
-        expect(reversedMove.getDragMoveTargetIndex({clientX: 400, clientY: 0})).toBe(2);
-
-        await reversedMove.onDragMove({clientX: 400, clientY: 0});
-        await reversedMove.onDragMove({clientX: 400, clientY: 0});
-
-        expect(reversedMove.currentIndex).toBe(2);
-        expect(reversedMove.trace).toEqual([[0, 1], [1, 2]])
     });
 });


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session 567191c3-16f6-4235-914c-b51fc94d1514.

Resolves #12887
Refs #12883
Refs #12880

Clean `git revert` of the #12882 squash (`b190f60b9`): restores `src/draggable/container/SortZone.mjs` to the state that is **byte-identical to v12.1 `main`** — the motion engine both known-good baselines shared (forensic evidence on #12883). Operator release call: working locked-column DnD is a hard v13 gate; the fix chain (#12886 eyes → #12883 fix) starts from this baseline.

Consequences: the #12880 landing-index overshoot returns temporarily (#12880 reopens for the eyes-verified re-land per the doctrine comment on #12883 — the landing-resolver concept survives as the targeting layer). PR #12881 (grid-subclass lock fixes) is independent and untouched.

Evidence: L2 (clean revert; 9/9 remaining related unit specs green — the pre-#12882 set; the −179 delta removes the resolver + its harness tests) → L3 post-merge (operator visual confirm: week-ago motion + overdrag scroll restored). Residual: post-merge operator confirm [#12887].

## Test Evidence
- `npx playwright test test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs -c test/playwright/playwright.config.unit.mjs` → 9 passed
- `git revert` applied without conflicts; 2 files, +10/−179

## Post-Merge Validation
- [ ] Operator: devindex drag (fresh browser context — module-cache pitfall) shows week-ago motion + working overdrag sideways scroll
- [ ] Reopen #12880 with the re-land note

## Deltas from ticket
None — clean revert exactly as #12887 prescribed.
