### PR TITLE
feat(ai): add NL drag-motion observability tools (#12886)

### DIFF
--- a/.agents/skills/neural-link/references/operational-handbook.md
+++ b/.agents/skills/neural-link/references/operational-handbook.md
@@ -1,6 +1,6 @@
 # Neural Link Operational Handbook for Agents
 
-Your task is to effectively query and mutate a running Neo.mjs application using the Neural Link MCP toolset. Neo.mjs runs applications in a separate worker thread, utilizing a custom Virtual DOM that maps to the physical DOM. 
+Your task is to effectively query and mutate a running Neo.mjs application using the Neural Link MCP toolset. Neo.mjs runs applications in a separate worker thread, utilizing a custom Virtual DOM that maps to the physical DOM.
 
 **DO NOT GUESS.** Without specific chains of verification, you will inject corrupted instructions or patch incorrect classes. You MUST follow these sequences.
 
@@ -32,8 +32,24 @@ When verifying a fix or reproducing a bug interactively:
 1. **Fire the Event:** Use `simulate_event` on the validated Component ID.
 2. **Close the Loop:** Immediately trigger `get_console_logs` to capture downstream exceptions, warnings, or debug printouts triggered by your simulation.
 
+## 4.1 Drag-Motion Perception (Interaction Forensics)
+
+When debugging drag-and-drop, animations, or any "elements move wrong" symptom, final-state
+assertions are blind to the motion layer. Three tools cover it:
+
+1. **`observe_motion`** — start it (componentIds + window ≤8s) BEFORE driving the interaction;
+   it samples client rects per tick and returns the rendered-geometry trace. Pair with any
+   dispatch path (simulate_event, in-page MouseEvent, playwright `page.mouse`).
+2. **`get_drag_trace`** — AFTER a drag, returns the SortZone lifecycle ring (start geometry,
+   per-move target decisions, item switches, scroll activations, end resolution, grid lock
+   verdicts). The logic side; diff it against the `observe_motion` trace to localize whether
+   a defect is decision-layer or render-layer.
+3. **`verify_component_consistency`** — after any drop/update, diffs a container's logical
+   `items`, `vdom` children and the real DOM children (count/order/membership/duplicates).
+   Run it whenever duplication or ghost children are suspected.
+
 ## 5. Recovering from Page Reloads (Session Invalidation)
-Every time the connected Neo.mjs application page reloads, the main App Worker thread is destroyed and completely recreated. 
+Every time the connected Neo.mjs application page reloads, the main App Worker thread is destroyed and completely recreated.
 
 **This completely invalidates your current `sessionId`.**
 

--- a/.agents/skills/whitebox-e2e/references/whitebox-e2e-protocol.md
+++ b/.agents/skills/whitebox-e2e/references/whitebox-e2e-protocol.md
@@ -13,7 +13,7 @@ When tasked with creating new end-to-end tests for the Neo.mjs framework, you mu
 
 ## 2. Test Suite Scaffolding
 
-Whitebox E2E tests belong in `test/playwright/e2e/`. 
+Whitebox E2E tests belong in `test/playwright/e2e/`.
 Always use the custom `neuralLink` Playwright fixture provided by the Neo.mjs team.
 
 ```javascript
@@ -24,7 +24,7 @@ test.describe('Button Base Feature (Neural Link)', () => {
         await page.goto('/examples/button/base/index.html');
         // Explicitly bind the bridge to the application namespace
         const nlApp = await neuralLink.connectToApp('Neo.examples.button.base');
-        
+
         // ... assertions
     });
 });
@@ -64,8 +64,21 @@ Before authoring a new test, closely examine the following reference implementat
 
 ## 5. Telemetry & RLAIF Integration
 
-Tests utilizing the `neuralLink` fixture inherently generate rich user interaction trajectories. These paths are extracted as structured datasets to continuously train the Swarm's autonomous agents. 
+Tests utilizing the `neuralLink` fixture inherently generate rich user interaction trajectories. These paths are extracted as structured datasets to continuously train the Swarm's autonomous agents.
 The backend daemon `ai/scripts/analyzeNlTelemetry.mjs` curates these logs from the local `memory-core.sqlite` to generate the "Golden Path" SFT/DPO datasets used in Local SLM fine-tuning pipelines.
+
+## 5.1 Mid-Interaction Assertions (Motion & Consistency)
+
+Final-order assertions are insufficient for drag-and-drop and animation surfaces — a drag can
+land correctly while the motion layer misbehaves, or duplicate DOM nodes silently. For these
+surfaces, pair the Playwright interaction with the Neural Link perception tools:
+
+- **`observe_motion`** (start before `page.mouse.down()`): rect time-series of the affected
+  components during the drag window — assert the mid-drag slot geometry, not just the end state.
+- **`get_drag_trace`** (read after `mouse.up()`): the SortZone decision trace (targets, switches,
+  scroll activations) — assert the logic layer matches the intended cadence.
+- **`verify_component_consistency`** (after the drop): items/vdom/DOM three-surface diff —
+  assert zero duplicates and aligned order across all three.
 
 ## 6. Deep Dive Documentation
 For the complete API of the `neuralLink` test SDK (`nlApp`) including simulating native VNode events, VDOM querying, and complex store inspection, you MUST reference the foundational guide:

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -622,6 +622,111 @@ paths:
               schema:
                 type: object
 
+  /drag/trace:
+    post:
+      summary: Get Drag Trace
+      operationId: get_drag_trace
+      x-pass-as-object: true
+      description: |
+        Retrieves the recent drag-lifecycle traces recorded by SortZone (start geometry, per-move decisions, item switches, scroll activations, end resolution, grid lock verdicts).
+
+        **When to Use:**
+        To verify or debug drag-and-drop LOGIC decisions after driving a drag. Pair with observe_motion for the rendered-geometry side.
+      tags: [Inspection]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sessionId:
+                  type: string
+                  description: Target App Worker Session ID
+                clear:
+                  type: boolean
+                  description: Empty the trace ring buffer after reading
+      responses:
+        '200':
+          description: Recent drag traces
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /component/observeMotion:
+    post:
+      summary: Observe Motion
+      operationId: observe_motion
+      x-pass-as-object: true
+      description: |
+        Samples the client rects of the given components over a time window and returns the motion trace.
+
+        **When to Use:**
+        To SEE live motion (drag choreography, animations) while you or a user drive an interaction. Duration is clamped to 8000ms per call; chain calls for longer windows.
+      tags: [Component]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [componentIds]
+              properties:
+                sessionId:
+                  type: string
+                  description: Target App Worker Session ID
+                componentIds:
+                  type: array
+                  items:
+                    type: string
+                  description: Component ids to sample
+                durationMs:
+                  type: number
+                  description: Sampling window, clamped to [100, 8000] (default 2000)
+                intervalMs:
+                  type: number
+                  description: Sampling interval, clamped to [16, 1000] (default 100)
+      responses:
+        '200':
+          description: Motion trace samples
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /component/verifyConsistency:
+    post:
+      summary: Verify Component Consistency
+      operationId: verify_component_consistency
+      x-pass-as-object: true
+      description: |
+        Diffs a container's three child-order surfaces — logical items, vdom child nodes, and the rendered DOM — reporting count, order, membership and duplicate mismatches.
+
+        **When to Use:**
+        To detect engine-vs-DOM divergence, e.g. duplicated or ghost children after drag-and-drop or vdom updates.
+      tags: [Component]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [componentId]
+              properties:
+                sessionId:
+                  type: string
+                  description: Target App Worker Session ID
+                componentId:
+                  type: string
+                  description: The container component id
+      responses:
+        '200':
+          description: Consistency report
+          content:
+            application/json:
+              schema:
+                type: object
+
   /component/query:
     post:
       summary: Query Components

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -27,6 +27,7 @@ const serviceMapping = {
     get_dom_event_summary        : RuntimeService    .getDomEventSummary        .bind(RuntimeService),
     get_dom_rect                 : ComponentService  .getDomRect                .bind(ComponentService),
     get_drag_state               : InteractionService.getDragState              .bind(InteractionService),
+    get_drag_trace               : InteractionService.getDragTrace              .bind(InteractionService),
     get_instance_properties      : InstanceService   .getInstanceProperties     .bind(InstanceService),
     get_method_source            : RuntimeService    .getMethodSource           .bind(RuntimeService),
     get_namespace_tree           : RuntimeService    .getNamespaceTree          .bind(RuntimeService),
@@ -44,13 +45,15 @@ const serviceMapping = {
     manage_connection            : ConnectionService .manageConnection          .bind(ConnectionService),
     manage_neo_config            : RuntimeService    .manageNeoConfig           .bind(RuntimeService),
     modify_state_provider        : DataService       .modifyStateProvider       .bind(DataService),
+    observe_motion               : InteractionService.observeMotion             .bind(InteractionService),
     patch_code                   : RuntimeService    .patchCode                 .bind(RuntimeService),
     query_component              : ComponentService  .queryComponent            .bind(ComponentService),
     query_vdom                   : ComponentService  .queryVdom                 .bind(ComponentService),
     reload_page                  : RuntimeService    .reloadPage                .bind(RuntimeService),
     set_instance_properties      : InstanceService   .setInstanceProperties     .bind(InstanceService),
     set_route                    : RuntimeService    .setRoute                  .bind(RuntimeService),
-    simulate_event               : InteractionService.simulateEvent             .bind(InteractionService)
+    simulate_event               : InteractionService.simulateEvent             .bind(InteractionService),
+    verify_component_consistency : InteractionService.verifyComponentConsistency.bind(InteractionService)
 };
 
 const toolService = Neo.create(ToolService, {

--- a/ai/services/neural-link/InteractionService.mjs
+++ b/ai/services/neural-link/InteractionService.mjs
@@ -44,6 +44,41 @@ class InteractionService extends Base {
     }
 
     /**
+     * Retrieves the recent drag-lifecycle traces (SortZone ring buffer).
+     * @param {Object}  opts
+     * @param {Boolean} [opts.clear]
+     * @param {String}  [opts.sessionId]
+     * @returns {Promise<Object>}
+     */
+    async getDragTrace({clear, sessionId}) {
+        return await ConnectionService.call(sessionId, 'get_drag_trace', {clear})
+    }
+
+    /**
+     * Samples component client rects over a time window (motion trace).
+     * @param {Object}   opts
+     * @param {String[]} opts.componentIds
+     * @param {Number}   [opts.durationMs]
+     * @param {Number}   [opts.intervalMs]
+     * @param {String}   [opts.sessionId]
+     * @returns {Promise<Object>}
+     */
+    async observeMotion({componentIds, durationMs, intervalMs, sessionId}) {
+        return await ConnectionService.call(sessionId, 'observe_motion', {componentIds, durationMs, intervalMs})
+    }
+
+    /**
+     * Diffs a container's items / vdom / DOM child surfaces (duplication detector).
+     * @param {Object} opts
+     * @param {String} opts.componentId
+     * @param {String} [opts.sessionId]
+     * @returns {Promise<Object>}
+     */
+    async verifyComponentConsistency({componentId, sessionId}) {
+        return await ConnectionService.call(sessionId, 'verify_component_consistency', {componentId})
+    }
+
+    /**
      * Highlights a component visually for debugging purposes.
      * @param {Object} opts
      * @param {String} opts.sessionId

--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -94,8 +94,10 @@ class Client extends Base {
             get_vdom_vnode        : component,
             get_vnode             : component,
             highlight_component   : component,
+            observe_motion        : component,
             query_component       : component,
             query_vdom            : component,
+            verify_component      : component,
 
             call_method            : instance,
             find_instances         : instance,

--- a/src/ai/client/ComponentService.mjs
+++ b/src/ai/client/ComponentService.mjs
@@ -62,6 +62,123 @@ class ComponentService extends Service {
     }
 
     /**
+     * Samples the client rects of the given components over a time window, returning a motion
+     * trace. The perception side of drag verification: an agent drives the interaction through
+     * any dispatch path while this recorder observes where elements ACTUALLY render per tick.
+     * Duration is clamped below the bridge rpc timeout; chain calls for longer windows.
+     * @param {Object}   params
+     * @param {String[]} params.componentIds
+     * @param {Number}   [params.durationMs=2000] clamped to [100, 8000]
+     * @param {Number}   [params.intervalMs=100]  clamped to [16, 1000]
+     * @returns {Object} {componentIds, samples: [{t, rects}]}
+     */
+    async observeMotion({componentIds, durationMs = 2000, intervalMs = 100}) {
+        if (!Array.isArray(componentIds) || componentIds.length === 0) {
+            throw new Error('componentIds must be a non-empty array')
+        }
+
+        const component = Neo.getComponent(componentIds[0]);
+
+        if (!component) {
+            throw new Error(`Component not found: ${componentIds[0]}`)
+        }
+
+        durationMs = Math.max(100, Math.min(durationMs, 8000));
+        intervalMs = Math.max(16,  Math.min(intervalMs, 1000));
+
+        const
+            samples = [],
+            start   = Date.now();
+
+        while (Date.now() - start < durationMs) {
+            const
+                t     = Date.now() - start,
+                rects = await component.getDomRect(componentIds);
+
+            samples.push({
+                t,
+                rects: (Array.isArray(rects) ? rects : [rects]).map(rect =>
+                    rect ? {left: rect.left, top: rect.top, width: rect.width, height: rect.height} : null)
+            });
+
+            await this.timeout(intervalMs)
+        }
+
+        return {componentIds, samples}
+    }
+
+    /**
+     * Compares a container's three child-order surfaces — logical items, vdom child nodes,
+     * and the rendered DOM — and reports mismatches (count, order, membership, duplicates).
+     * The duplication detector: a column/item existing twice is a surface disagreement.
+     * @param {Object} params
+     * @param {String} params.componentId
+     * @returns {Object}
+     */
+    async verifyComponentConsistency({componentId}) {
+        const component = Neo.getComponent(componentId);
+
+        if (!component) {
+            throw new Error(`Component not found: ${componentId}`)
+        }
+
+        const
+            itemIds = (component.items || []).map(item => item?.id).filter(Boolean),
+            vdomIds = (component.getVdomItemsRoot?.()?.cn || component.vdom?.cn || [])
+                .map(node => node?.componentId || node?.id).filter(Boolean),
+            rootId  = component.getVdomItemsRoot?.()?.id || componentId;
+
+        const domIds = await Neo.main.DomAccess.getChildNodeIds({id: rootId, windowId: component.windowId});
+
+        return ComponentService.diffChildSurfaces({componentId, domIds, itemIds, vdomIds})
+    }
+
+    /**
+     * Pure differ for the three child-order surfaces. Static for direct unit coverage.
+     * @param {Object}        data
+     * @param {String}        data.componentId
+     * @param {String[]|null} data.domIds null when the root node was not found in the DOM
+     * @param {String[]}      data.itemIds
+     * @param {String[]}      data.vdomIds
+     * @returns {Object}
+     */
+    static diffChildSurfaces({componentId, domIds, itemIds, vdomIds}) {
+        const
+            mismatches = [],
+            dupes      = ids => ids.filter((id, index) => id && ids.indexOf(id) !== index);
+
+        if (domIds === null) {
+            mismatches.push({type: 'dom-root-missing'})
+        }
+
+        [['items', itemIds], ['vdom', vdomIds], ['dom', domIds || []]].forEach(([surface, ids]) => {
+            const duplicates = dupes(ids);
+
+            if (duplicates.length > 0) {
+                mismatches.push({type: 'duplicates', surface, ids: duplicates})
+            }
+        });
+
+        if (itemIds.join() !== vdomIds.join()) {
+            mismatches.push({type: 'order-or-membership', surfaces: ['items', 'vdom'], a: itemIds, b: vdomIds})
+        }
+
+        if (domIds !== null && vdomIds.join() !== domIds.join()) {
+            mismatches.push({type: 'order-or-membership', surfaces: ['vdom', 'dom'], a: vdomIds, b: domIds})
+        }
+
+        return {
+            componentId,
+            consistent: mismatches.length === 0,
+            counts    : {dom: domIds === null ? null : domIds.length, items: itemIds.length, vdom: vdomIds.length},
+            domIds,
+            itemIds,
+            mismatches,
+            vdomIds
+        }
+    }
+
+    /**
      * @param {Object} params
      * @param {String} params.componentId
      * @param {Object} [params.options]

--- a/src/ai/client/RuntimeService.mjs
+++ b/src/ai/client/RuntimeService.mjs
@@ -100,6 +100,28 @@ class RuntimeService extends Service {
     }
 
     /**
+     * Returns the recent drag-lifecycle traces recorded by Neo.draggable.container.SortZone
+     * (start geometry, per-move decisions, switches, scroll activations, end resolution).
+     * Resolved via the class namespace so apps without loaded SortZones pay nothing.
+     * @param {Object}  params
+     * @param {Boolean} [params.clear=false] Empty the ring buffer after reading
+     * @returns {Object}
+     */
+    getDragTrace({clear = false} = {}) {
+        const
+            SortZone = Neo.draggable?.container?.SortZone,
+            traces   = SortZone?.traces || [];
+
+        const result = {count: traces.length, traces: [...traces]};
+
+        if (clear && SortZone) {
+            SortZone.traces.length = 0
+        }
+
+        return result
+    }
+
+    /**
      * Retrieves the source code of a method on a class prototype.
      * @param {Object} params
      * @param {String} params.className  The fully qualified class name.

--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -139,6 +139,28 @@ class SortZone extends DragZone {
     }
 
     /**
+     * Ring buffer of recent drag traces (drag lifecycle observability for the Neural Link
+     * `get_drag_trace` tool). Bounded by traceLimit; zero cost beyond plain-object pushes.
+     * @member {Object[]} traces=[]
+     * @protected
+     * @static
+     */
+    static traces = []
+    /**
+     * @member {Number} traceLimit=5
+     * @protected
+     * @static
+     */
+    static traceLimit = 5
+    /**
+     * The trace record of the drag currently in flight, or null.
+     * @member {Object|null} activeTrace=null
+     * @protected
+     * @static
+     */
+    static activeTrace = null
+
+    /**
      * @member {Boolean} isOverDragging=false
      * @protected
      */
@@ -148,6 +170,20 @@ class SortZone extends DragZone {
      * @protected
      */
     isWindowDragging = false
+
+    /**
+     * Appends one event to the active drag trace. Events carry where the drag logic
+     * decided to be, not where the DOM is — pair with the `observe_motion` tool for
+     * the rendered-geometry side of the same window.
+     * @param {Object} data
+     */
+    traceEvent(data) {
+        const trace = SortZone.activeTrace;
+
+        if (trace && trace.events.length < 400) {
+            trace.events.push({...data, ts: Date.now()})
+        }
+    }
 
     /**
      * Toggles the neo-draggable cls on items inside our owner.
@@ -363,8 +399,13 @@ class SortZone extends DragZone {
                     toIndex   = me.owner.items.indexOf(me.sortableItems[me.currentIndex]);
                 }
 
+                me.traceEvent({t: 'end', from: fromIndex, to: toIndex});
                 me.moveTo(fromIndex, toIndex);
+            } else {
+                me.traceEvent({t: 'end', from: me.startIndex, to: me.currentIndex, noop: true});
             }
+
+            SortZone.activeTrace = null;
 
             Object.assign(me, {
                 currentIndex    : -1,
@@ -468,6 +509,8 @@ class SortZone extends DragZone {
                 me.switchItems(index, me.currentIndex)
             }
         }
+
+        me.traceEvent({t: 'move', x: clientX, y: clientY, i: me.currentIndex, over: isOverDragging});
 
         me.isOverDragging = isOverDragging && me.currentIndex !== 0 && me.currentIndex !== maxItems;
 
@@ -620,6 +663,22 @@ class SortZone extends DragZone {
 
             me.itemRects = itemRects;
 
+            SortZone.activeTrace = {
+                events    : [],
+                items     : sortableItems.map(item => item.id),
+                ownerId   : owner.id,
+                rects     : itemRects.map(rect => ({left: rect.left, width: rect.width})),
+                startIndex: index,
+                startedAt : Date.now(),
+                zoneId    : me.id
+            };
+
+            SortZone.traces.push(SortZone.activeTrace);
+
+            if (SortZone.traces.length > SortZone.traceLimit) {
+                SortZone.traces.shift()
+            }
+
             await me.dragStart(data);
 
             if (me.dragPlaceholder) {
@@ -668,6 +727,8 @@ class SortZone extends DragZone {
     async scrollToIndex() {
         let me = this;
 
+        me.traceEvent({t: 'scroll', i: me.currentIndex});
+
         me.isScrolling = true;
         await me.owner.scrollToIndex?.(me.currentIndex, me.itemRects[me.currentIndex]);
         me.isScrolling = false
@@ -691,6 +752,8 @@ class SortZone extends DragZone {
         let me       = this,
             reversed = me.reversedLayoutDirection,
             tmp;
+
+        me.traceEvent({t: 'switch', i1: index1, i2: index2});
 
         if ((!reversed && index2 < index1) || (reversed && index1 < index2)) {
             tmp    = index1;

--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -331,6 +331,8 @@ class SortZone extends BaseSortZone {
         me.lastDragClientX = null;
         me.regionRects     = null;
 
+        me.traceEvent({t: 'lockVerdict', field: column?.dataField || null, prev: column?.locked || null, next: newLocked});
+
         if (column && column.locked !== newLocked) {
             // This implicitly triggers grid.Container#onColumnLockChange,
             // which handles sorting, DOM syncing, and layout calculations.

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -69,6 +69,7 @@ class DomAccess extends Base {
                 'focus',
                 'getAttributes',
                 'getBoundingClientRect',
+                'getChildNodeIds',
                 'getComputedStyle',
                 'getOffscreenCanvas',
                 'getScrollingDimensions',
@@ -343,6 +344,20 @@ class DomAccess extends Base {
         }
 
         return returnData
+    }
+
+    /**
+     * Returns the ids of a node's direct element children, in DOM order.
+     * Consistency probe primitive: lets the App Worker compare its logical child order
+     * (items / vdom) against the rendered DOM truth (e.g. duplicate-node detection).
+     * @param {Object} data
+     * @param {String} data.id
+     * @returns {String[]|null} child ids (empty string for id-less nodes), or null if the node does not exist
+     */
+    getChildNodeIds(data) {
+        let node = document.getElementById(data.id);
+
+        return node ? Array.from(node.children).map(child => child.id) : null
     }
 
     /**

--- a/test/playwright/unit/ai/client/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/client/ComponentService.spec.mjs
@@ -1,0 +1,61 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import ComponentService from '../../../../../src/ai/client/ComponentService.mjs';
+
+/**
+ * @summary Tests for the pure child-surface differ behind verify_component_consistency
+ */
+test.describe.serial('Neo.ai.client.ComponentService.diffChildSurfaces', () => {
+    test('Consistent surfaces produce no mismatches', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : ['a', 'b', 'c'],
+            itemIds    : ['a', 'b', 'c'],
+            vdomIds    : ['a', 'b', 'c']
+        });
+
+        expect(result.consistent).toBe(true);
+        expect(result.mismatches).toEqual([]);
+        expect(result.counts).toEqual({dom: 3, items: 3, vdom: 3})
+    });
+
+    test('Duplicate DOM children are detected (the drop-duplication class)', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : ['a', 'b', 'a', 'c'],
+            itemIds    : ['a', 'b', 'c'],
+            vdomIds    : ['a', 'b', 'c']
+        });
+
+        expect(result.consistent).toBe(false);
+        expect(result.mismatches.some(m => m.type === 'duplicates' && m.surface === 'dom' && m.ids.includes('a'))).toBe(true);
+        expect(result.mismatches.some(m => m.type === 'order-or-membership' && m.surfaces.join() === 'vdom,dom')).toBe(true)
+    });
+
+    test('Order divergence between items and vdom is reported', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : ['a', 'c', 'b'],
+            itemIds    : ['a', 'b', 'c'],
+            vdomIds    : ['a', 'c', 'b']
+        });
+
+        expect(result.consistent).toBe(false);
+        expect(result.mismatches).toHaveLength(1);
+        expect(result.mismatches[0].surfaces.join()).toBe('items,vdom')
+    });
+
+    test('Missing DOM root is its own mismatch and skips DOM comparisons', () => {
+        const result = ComponentService.diffChildSurfaces({
+            componentId: 'container-1',
+            domIds     : null,
+            itemIds    : ['a'],
+            vdomIds    : ['a']
+        });
+
+        expect(result.consistent).toBe(false);
+        expect(result.mismatches).toEqual([{type: 'dom-root-missing'}]);
+        expect(result.counts.dom).toBe(null)
+    });
+});

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -216,4 +216,45 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
         expect(sortZone.reversedLayoutDirection).toBe(true);
         expect(sortZone.currentIndex).toBe(0)
     });
+
+    test('Drag-trace ring buffer records events, caps per-drag size and trims old drags (#12886)', () => {
+        const zone = Object.create(SortZone.prototype);
+
+        SortZone.traces.length = 0;
+        SortZone.activeTrace   = null;
+
+        // No active trace -> events are dropped silently
+        zone.traceEvent({t: 'move', x: 1});
+        expect(SortZone.traces.length).toBe(0);
+
+        // Active trace -> events accumulate with timestamps
+        SortZone.activeTrace = {events: [], startedAt: Date.now(), zoneId: 'zone-1'};
+        SortZone.traces.push(SortZone.activeTrace);
+
+        zone.traceEvent({t: 'move', x: 100, i: 0});
+        zone.traceEvent({t: 'switch', i1: 0, i2: 1});
+
+        expect(SortZone.activeTrace.events.length).toBe(2);
+        expect(SortZone.activeTrace.events[0].t).toBe('move');
+        expect(typeof SortZone.activeTrace.events[0].ts).toBe('number');
+
+        // Per-drag event cap (400) guards unbounded growth
+        SortZone.activeTrace.events.length = 400;
+        zone.traceEvent({t: 'move', x: 999});
+        expect(SortZone.activeTrace.events.length).toBe(400);
+
+        // Ring trims to traceLimit
+        for (let i = 0; i < SortZone.traceLimit + 3; i++) {
+            SortZone.traces.push({events: [], zoneId: `zone-${i}`});
+
+            if (SortZone.traces.length > SortZone.traceLimit) {
+                SortZone.traces.shift()
+            }
+        }
+
+        expect(SortZone.traces.length).toBe(SortZone.traceLimit);
+
+        SortZone.traces.length = 0;
+        SortZone.activeTrace   = null
+    });
 });


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session 567191c3-16f6-4235-914c-b51fc94d1514.

Resolves #12886
Refs #12883
Refs #12887

**Stack resolved:** PR #12888 (the revert) merged; this PR is rebased onto current dev and carries only its own two commits.

Implements the operator's PRIO-0 directive ("new NL tools to enable you to see it") — three perception surfaces so agents can SEE live drag choreography instead of asserting blind final states:

1. **`observe_motion`** — samples client rects of given components over a clamped window (≤8s/call, ≥16ms interval) via the existing batched rect path; returns the motion trace. The rendered-geometry side of drag verification.
2. **`get_drag_trace`** — capped ring buffer (5 drags × ≤400 events) in `container.SortZone`: drag-start geometry snapshot, per-move decisions (clientX/Y, resulting currentIndex, overdrag flag), `switchItems` calls, `scrollToIndex` activations (the broken-overdrag observability), end resolution, and grid-subclass lock verdicts. The logic side. Resolved via the class namespace — apps without SortZones pay nothing; routes through the existing `get_drag` prefix with zero dispatch-map changes.
3. **`verify_component_consistency`** — diffs a container's three child-order surfaces (logical `items`, `vdom.cn`, real DOM children via the new minimal `DomAccess.getChildNodeIds` remote): count/order/membership/duplicates. THE drop-duplication detector.

Evidence: L2 (14/14 related unit specs — pre-#12882 baseline set + trace-ring semantics + 4 pure-differ cases incl. duplicate detection) → L3 required (#12886 AC1–AC3 live verification needs the NL MCP server restart to load the server-side surfaces — operator/harness op, flagged by runtime-freshness). Residual: AC1–AC3 [#12886, post-restart].

## Deltas from ticket
- `get_drag_trace` lives on `client/RuntimeService` (not Interaction) — the existing `get_drag` prefix routes there, zero map changes, sibling of `getDragState`.
- The differ is a static pure function (`ComponentService.diffChildSurfaces`) for direct unit coverage.

## Test Evidence
- `npx playwright test test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs test/playwright/unit/ai/client/ComponentService.spec.mjs -c test/playwright/playwright.config.unit.mjs` → **14 passed**
- Trace instrumentation points verified against both the reverted parent shape (this stack) and the grid subclass lock path.

## Post-Merge Validation
- [ ] Restart the NL MCP server (server-side tool surfaces) — runtime-freshness healthcheck will flag until done
- [ ] #12886 AC1: `observe_motion` trace of a devindex header drag reveals the #12883 motion defect
- [ ] #12886 AC2: `get_drag_trace` captures a full lifecycle incl. overdrag scroll activations
- [ ] #12886 AC3: `verify_component_consistency` catches the live duplication case


## Commits
- `99d9e68ce` — docs(ai): route drag-motion perception tools in skill payloads (#12886 AC4: neural-link handbook §4.1 + whitebox-e2e protocol §5.1 — DELIVERED in-PR per Cycle-1 review)
- `cf3e250c0` — feat(ai): add NL drag-motion observability tools (#12886)




