### PR TITLE
fix(grid): restore locked-grid drag landing accuracy (#12880)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -414,6 +414,8 @@ class SortZone extends DragZone {
                 isWindowDragging: false,
                 itemRects       : null,
                 itemStyles      : null,
+                lastInBoundX    : null,
+                lastInBoundY    : null,
                 ownerRect       : null,
                 startIndex      : -1,
                 sortableItems   : null
@@ -460,8 +462,16 @@ class SortZone extends DragZone {
             index              = me.currentIndex,
             {itemRects}        = me,
             maxItems           = itemRects.length - 1,
-            ownerX             = me.adjustItemRectsToParent ? me.ownerRect.x : 0,
-            ownerY             = me.adjustItemRectsToParent ? me.ownerRect.y : 0,
+            // itemRects leave viewport space through EITHER conversion mechanism: the
+            // adjustItemRectsToParent flag (parent-managed) or a subclass-provided
+            // adjustProxyRectToParent (grid / table header toolbars). The delta math must
+            // shift clientX/Y into the same owner-relative space in both cases — comparing
+            // viewport cursor coordinates against owner-relative rects inflates delta by the
+            // owner's viewport origin (~the locked-start region width in a locked grid),
+            // making every in-bound move exceed every switch threshold.
+            rectsAreOwnerRelative = me.adjustItemRectsToParent || !!me.adjustProxyRectToParent,
+            ownerX             = rectsAreOwnerRelative ? me.ownerRect.x : 0,
+            ownerY             = rectsAreOwnerRelative ? me.ownerRect.y : 0,
             reversed           = me.reversedLayoutDirection,
             delta, isOverDragging, isOverDraggingEnd, isOverDraggingStart, itemHeightOrWidth, moveFactor;
 
@@ -479,6 +489,20 @@ class SortZone extends DragZone {
 
         isOverDragging = isOverDraggingEnd || isOverDraggingStart;
         moveFactor     = isOverDragging ? 0.02 : 0.55; // We can not use 0.5, since items would jump back & forth
+
+        // Duplicate-delivery guard (in-bound only): the same pointer position can reach this
+        // zone more than once — stacked delegated drag listeners along the DOM path deliver one
+        // move per matching node, and sensor fallbacks re-fire the last position. In-bound switch
+        // decisions are position-driven: re-processing an unchanged position re-qualifies the
+        // delta against already-mutated itemRects and over-switches. The overdrag branches stay
+        // exempt — their auto-scroll loop deliberately re-feeds the same position.
+        if (!isOverDragging && clientX === me.lastInBoundX && clientY === me.lastInBoundY) {
+            me.traceEvent({t: 'dup', x: clientX, y: clientY});
+            return
+        }
+
+        me.lastInBoundX = clientX;
+        me.lastInBoundY = clientY;
 
         if (isOverDraggingStart) {
             if (index > 0) {
@@ -510,7 +534,17 @@ class SortZone extends DragZone {
             }
         }
 
-        me.traceEvent({t: 'move', x: clientX, y: clientY, i: me.currentIndex, over: isOverDragging});
+        me.traceEvent({
+            t   : 'move',
+            x   : clientX,
+            y   : clientY,
+            i   : me.currentIndex,
+            over: isOverDragging,
+            d   : Math.round(delta),
+            ox  : Math.round(me.offsetX || 0),
+            sl  : me.scrollLeft,
+            ir  : itemRects[me.currentIndex] ? Math.round(itemRects[me.currentIndex].left) : null
+        });
 
         me.isOverDragging = isOverDragging && me.currentIndex !== 0 && me.currentIndex !== maxItems;
 

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -6,6 +6,7 @@ import ScrollManager       from './ScrollManager.mjs';
 import Store               from '../data/Store.mjs';
 import FooterToolbar       from './footer/Toolbar.mjs';
 import HorizontalScrollbar from './HorizontalScrollbar.mjs';
+import NeoArray            from '../util/Array.mjs';
 import VerticalScrollbar   from './VerticalScrollbar.mjs';
 import View                from './View.mjs';
 import * as column         from './column/_export.mjs';


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session 567191c3-16f6-4235-914c-b51fc94d1514.

Resolves #12880
Refs #12883
Refs #12886

**The first fix produced WITH the #12886 eyes — every defect below was localized by trace evidence, not code-reading.** Two root causes, both verified live on devindex (locked AND no-locked):

1. **Duplicate drag:move delivery** (`container.SortZone`): the same pointer position reaches the owning zone more than once (stacked delegated drag listeners along the DOM path — the listener census shows drag:move registered on every header button AND its toolbar). Re-processing an unchanged position re-qualifies delta against already-mutated itemRects → one spurious extra switch per duplicate. Fix: in-bound same-position guard (trace-visible as `dup` suppression events); the overdrag auto-scroll path is explicitly exempt (its recursion deliberately re-feeds the same position — the regression class that killed PR #12882 is structurally avoided).
2. **Coordinate-space mismatch** (the locked-only mechanism): grid/table header SortZones convert `itemRects` to owner-relative space via `adjustProxyRectToParent`, but the delta math only honored the `adjustItemRectsToParent` flag → viewport cursor compared against owner-relative rects → delta inflated by the toolbar's viewport origin (~388px for a locked grid's center region = every move switches; ~17px unlocked = imperceptible — **exactly the operator's "only with locked columns" datum**). Fix: the delta space-shift now fires when EITHER conversion mechanism is active.
3. Rides along: `NeoArray` import added to `grid/Container.mjs` (`updateColCount`'s end-region-removal branch threw `ReferenceError: NeoArray is not defined` — caught live by the new eyes; it killed every end-region lock-change: gpt's deterministic end→center no-op and the C5 re-home race). The remaining cross-toolbar **DOM-move gap** (engine+vdom re-home correctly, the rendered DOM doesn't apply the move — `verify_component_consistency`'s first real catch) stays on #12883 as a precisely-bounded follow-on leg.

Also upgrades the `get_drag_trace` move events with `delta/offsetX/scrollLeft/slotLeft` fields — the observability that convicted defect 2.

Evidence: L3 (live matrix on devindex via the #12886 eyes — get_drag_trace decision traces with dup-suppression visible, landing assertions, verify_component_consistency three-surface checks): **Case 1 within-center: Total → index 2 EXACT intent (was 5)**; Case 2 within-start: `[#, User, Rank]` no ejection; no-locked control: +1 slot, geometry-equivalent parity with locked; end-column unlock: the exact op that threw ReferenceError now succeeds. → L3 required (#12880 AC2/AC3/AC4). Residual: none for #12880; the DOM-move leg is #12883's.

## Test Evidence
- `npx playwright test test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs test/playwright/unit/ai/client/ComponentService.spec.mjs -c test/playwright/playwright.config.unit.mjs` → **14 passed**
- Decision traces (pre/post-fix) + the listener census + consistency reports: documented on #12880 / #12883

## Deltas from ticket
- #12880's instrumentation-first AC1 is satisfied by the merged #12886 `get_drag_trace` (permanent substrate instead of throwaway logging) — the traces in this PR's evidence ARE that instrumentation.
- The fix landed in the parent for the delivery/space bugs (affects table headers too — same latent class at small offsets) with zero grid-subclass changes; gpt's #12882 resolver concept was ultimately unnecessary for landing accuracy once the REAL mechanisms were visible.

## Post-Merge Validation
- [ ] Operator: locked devindex drag matches the no-locked feel (within-region landings at the drop band)
- [ ] #12883's DOM-move leg picks up from the consistency-probe evidence