### PR TITLE
fix(grid): repair locked-column drag render layer — cell mapping, containing block, cross-toolbar moves (#12883)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -107,6 +107,15 @@ class SortZone extends DragZone {
          */
         ownerStyle: null,
         /**
+         * Applies an inline `position: relative` to the owner for the duration of a drag, making the
+         * owner the containing block for the absolutely positioned items. Required whenever the item
+         * rects get converted into owner-relative space (adjustItemRectsToParent / adjustProxyRectToParent)
+         * but the owner is not otherwise a positioned element — without it, the written left/top values
+         * resolve against an arbitrary positioned ancestor and render offset by the owner's own origin.
+         * @member {Boolean} positionOwnerRelative=false
+         */
+        positionOwnerRelative: false,
+        /**
          * The intersection ratio (0-1) required to re-attach a window-dragged item back into the container.
          * Higher values mean the item must be dragged further in.
          * @member {Number} reattachThreshold=0.6
@@ -298,7 +307,31 @@ class SortZone extends DragZone {
     }
 
     /**
-     * Handles the completion of the drag operation.
+     * Drag:end entry point. The drag listeners fan out across the owner and its child items, so one
+     * native release can deliver multiple drag:end events. This entry latches synchronously and routes
+     * exactly one delivery into {@link #processDragEnd} — without it, the async drop pipeline runs
+     * twice (double traces, double layout refreshes, double lock verdicts in grids).
+     * @param {Object} data - The drag end event data.
+     */
+    async onDragEnd(data) {
+        let me = this;
+
+        if (me.dragEndActive) {
+            return
+        }
+
+        me.dragEndActive = true;
+
+        try {
+            await me.processDragEnd(data)
+        } finally {
+            me.dragEndActive = false
+        }
+    }
+
+    /**
+     * Handles the completion of the drag operation. Invoked exactly once per drag via the
+     * {@link #onDragEnd} re-entry latch; subclasses extend this method, not `onDragEnd`.
      *
      * This method is responsible for:
      * 1.  **Finalizing the Drop:** If valid, it moves the DOM nodes to their final positions (via `Neo.applyDeltas`).
@@ -309,7 +342,7 @@ class SortZone extends DragZone {
      *
      * @param {Object} data - The drag end event data.
      */
-    async onDragEnd(data) {
+    async processDragEnd(data) {
         let me                  = this,
             {itemStyles, owner} = me,
             ownerStyle          = owner.style || {},
@@ -353,6 +386,7 @@ class SortZone extends DragZone {
 
             ownerStyle.height   = me.ownerStyle.height    || null;
             ownerStyle.minWidth = me.ownerStyle.minWidth  || null;
+            ownerStyle.position = me.ownerStyle.position  || null;
             ownerStyle.width    = me.ownerStyle.width     || null;
 
             owner.style = ownerStyle;
@@ -405,7 +439,8 @@ class SortZone extends DragZone {
                 me.traceEvent({t: 'end', from: me.startIndex, to: me.currentIndex, noop: true});
             }
 
-            SortZone.activeTrace = null;
+            // activeTrace stays set until the next onDragStart replaces it: subclasses record
+            // post-drop resolution events (e.g. the grid lock verdict) after this method returns.
 
             Object.assign(me, {
                 currentIndex    : -1,
@@ -635,7 +670,7 @@ class SortZone extends DragZone {
                 dragProxyConfig        : me.getDragProxyConfig(),
                 indexMap,
                 lastIntersectionRatio  : 1,
-                ownerStyle             : {height: ownerStyle.height, minWidth: ownerStyle.minWidth, width: ownerStyle.width},
+                ownerStyle             : {height: ownerStyle.height, minWidth: ownerStyle.minWidth, position: ownerStyle.position, width: ownerStyle.width},
                 reversedLayoutDirection: layout.direction === 'column-reverse' || layout.direction === 'row-reverse',
                 sortableItems,
                 sortDirection          : layout.direction?.includes('column') ? 'vertical' : 'horizontal',
@@ -687,7 +722,8 @@ class SortZone extends DragZone {
                 ...ownerStyle,
                 height  : `${me.ownerRect.height}px`,
                 minWidth: `${me.ownerRect.width}px`,
-                width   : `${me.ownerRect.width}px`
+                width   : `${me.ownerRect.width}px`,
+                ...(me.positionOwnerRelative && {position: 'relative'})
             };
 
             adjustItemRectsToParent && itemRects.forEach(rect => {

--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -47,7 +47,16 @@ class SortZone extends BaseSortZone {
         /**
          * @member {Boolean} moveVertical=false
          */
-        moveVertical: false
+        moveVertical: false,
+        /**
+         * The item rects get converted into owner(toolbar)-relative space via {@link #adjustProxyRectToParent},
+         * so the owner toolbar must become the containing block for the drag. In a multi-region (locked
+         * columns) grid the toolbars sit at different x-origins inside the positioned grid container —
+         * without this, the owner-relative left values resolve against the grid container and every
+         * header item renders shifted by its toolbar's own origin.
+         * @member {Boolean} positionOwnerRelative=true
+         */
+        positionOwnerRelative: true
     }
 
     /**
@@ -110,12 +119,15 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * Converts a viewport-space item rect into owner(toolbar)-relative space. The owner toolbar is
+     * the containing block during the drag (see {@link #positionOwnerRelative}), so the conversion
+     * is a pure origin subtraction — no border compensation, the toolbar has none.
      * @param {Neo.util.Rectangle} rect
      * @param {Neo.util.Rectangle} parentRect
      */
     adjustProxyRectToParent(rect, parentRect) {
-        rect.x = rect.x - parentRect.x - 1;
-        rect.y = rect.y - parentRect.y - 1
+        rect.x = rect.x - parentRect.x;
+        rect.y = rect.y - parentRect.y
     }
 
     /**
@@ -248,9 +260,10 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * Runs exactly once per drag via the {@link Neo.draggable.container.SortZone#onDragEnd} re-entry latch.
      * @param {Object} data
      */
-    async onDragEnd(data) {
+    async processDragEnd(data) {
         let me = this;
 
         // Avoid conflicts with grid.header.plugin.Resizable
@@ -269,7 +282,7 @@ class SortZone extends BaseSortZone {
             me.movedComponents = null
         }
 
-        await super.onDragEnd(data);
+        await super.processDragEnd(data);
 
         if (!me.dragElement) {
             return
@@ -434,12 +447,12 @@ class SortZone extends BaseSortZone {
 
             Object.assign(column1Position, {
                 width: itemRects[index2].width,
-                x: itemRects[index2].x + 1
+                x: itemRects[index2].x
             });
 
             Object.assign(column2Position, {
                 width: itemRects[index1].width,
-                x: itemRects[index1].x + 1
+                x: itemRects[index1].x
             });
 
             columnPositions.move(index1, index2);

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -901,17 +901,22 @@ class GridBody extends Component {
     }
 
     /**
+     * Resolves the physical cell id for a rowIndex / dataField pair, mirroring the slot assignment
+     * of {@link Neo.grid.Row#createVdom}: pooled cells (`hideMode === 'removeDom'` and not locked)
+     * are keyed by the REGION-LOCAL `columnPositions` index, permanent cells by their dataField.
+     * In a multi-region (locked columns) grid the global `gridContainer.columns` index differs from
+     * the region-local index by the preceding regions' column counts, so it must not be used here.
      * @param {Number} rowIndex
      * @param {String} dataField
      * @returns {String}
      */
     getCellId(rowIndex, dataField) {
-        let me = this,
-            column = me.getColumn(dataField),
-            columnIndex = me.getColumn(dataField, true),
-            rowId = me.getRowId(rowIndex);
+        let me          = this,
+            column      = me.getColumn(dataField),
+            columnIndex = me.columnPositions.indexOf(dataField),
+            rowId       = me.getRowId(rowIndex);
 
-        if (column.hideMode === 'removeDom') {
+        if (column?.hideMode === 'removeDom' && !column.locked && columnIndex > -1) {
             return `${rowId}__cell-${columnIndex % me.cellPoolSize}`
         }
 
@@ -977,24 +982,30 @@ class GridBody extends Component {
     }
 
     /**
+     * Resolves the dataField for a physical cell id — the inverse of {@link #getCellId}.
+     * Pooled cell ids map back through the REGION-LOCAL `columnPositions` index (mirroring the
+     * slot assignment of {@link Neo.grid.Row#createVdom}), not the global `gridContainer.columns`
+     * index, which differs in multi-region (locked columns) grids.
      * @param {String} cellId
      * @returns {String}
      */
     getDataField(cellId) {
         if (cellId.includes('__cell-')) {
-            let me = this,
+            let me        = this,
                 poolIndex = parseInt(cellId.split('__cell-')[1]),
-                columns = me.gridContainer.columns,
-                { cellPoolSize, mountedColumns } = me,
-                i = mountedColumns[0],
-                len = mountedColumns[1],
-                column;
+                columns   = me.gridContainer.columns,
+                { cellPoolSize, columnPositions, mountedColumns } = me,
+                i         = mountedColumns[0],
+                len       = mountedColumns[1],
+                column, dataField;
 
             for (; i <= len; i++) {
                 if (i % cellPoolSize === poolIndex) {
-                    column = columns.getAt(i);
+                    dataField = columnPositions.getAt(i)?.dataField;
+                    column    = dataField && columns.get(dataField);
+
                     // Sanity check: ensure this column is actually pooled
-                    if (column && column.hideMode === 'removeDom') {
+                    if (column && column.hideMode === 'removeDom' && !column.locked) {
                         return column.dataField
                     }
                 }

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -914,7 +914,7 @@ class GridContainer extends BaseContainer {
      * Re-sorts the internal columns collection, the header items, and triggers a layout refresh.
      * @param {Neo.grid.column.Base} column
      */
-    onColumnLockChange(column) {
+    async onColumnLockChange(column) {
         let me            = this,
             columnsArray  = [...me.columns.items],
             sortedColumns = me.sortColumns(columnsArray);
@@ -926,6 +926,15 @@ class GridContainer extends BaseContainer {
 
         // Trigger Sub-grid Layout Sync
         me.onColumnsMutate();
+
+        // onColumnsMutate re-homed the header buttons across the region toolbars; each region's
+        // body still holds the columnPositions / availableWidth of its OLD membership. Rebuild
+        // them from the new toolbar memberships before re-rendering the rows, or the gaining
+        // region renders without the column and the losing region keeps a hidden ghost position.
+        let {headerWrapper} = me,
+            toolbars        = [headerWrapper.headerStart, me.headerToolbar, headerWrapper.headerEnd].filter(Boolean);
+
+        await Promise.all(toolbars.map(toolbar => toolbar.passSizeToBody()));
 
         // Force a full row re-render to apply the new column order and styles
         if (me.body)      me.body.createViewData();

--- a/src/grid/header/Wrapper.mjs
+++ b/src/grid/header/Wrapper.mjs
@@ -71,61 +71,58 @@ class Wrapper extends BaseContainer {
      * Re-homes and re-orders the column header buttons across the locked-start, centre and locked-end
      * toolbars to match the current column-collection order. Invoked by
      * {@link Neo.grid.Container#onColumnsMutate} after a column mutation.
+     *
+     * Cross-toolbar moves delegate to {@link Neo.container.Base#insert}, whose cross-parent handling
+     * silently detaches the button from its old toolbar (keepMounted) and flushes a single update at
+     * the lowest common ancestor (this Wrapper). The vdom diff then sees the move as a move and keeps
+     * the DOM node alive — an uncoordinated remove + add pair diffs the two toolbars independently,
+     * which destroys the node on the source side before the target side can adopt it.
      * @param {Object[]} lockedStartColumns
      * @param {Object[]} centerColumns
      * @param {Object[]} lockedEndColumns
      */
     applyColumnButtonOrder(lockedStartColumns, centerColumns, lockedEndColumns) {
-        let me              = this,
-            {headerToolbar} = me.gridContainer;
+        let me       = this,
+            toolbars = [me.headerStart, me.gridContainer.headerToolbar, me.headerEnd];
 
-        lockedStartColumns.forEach((col, targetIndex) => {
-            let btn = me.getButton(col.dataField);
+        const applyRegion = (columns, toolbar) => {
+            columns.forEach((col, targetIndex) => {
+                let btn = me.getButton(col.dataField);
 
-            if (btn) {
-                if (btn.parentId !== me.headerStart.id) {
-                    Neo.getComponent(btn.parentId).remove(btn, false);
-                    me.headerStart.add(btn)
+                if (btn) {
+                    if (btn.parentId !== toolbar.id) {
+                        toolbar.insert(targetIndex, btn)
+                    } else {
+                        let currentIndex = toolbar.indexOf(btn);
+
+                        if (currentIndex !== targetIndex) {
+                            toolbar.moveTo(currentIndex, targetIndex)
+                        }
+                    }
                 }
+            })
+        };
 
-                let currentIndex = me.headerStart.indexOf(btn);
+        applyRegion(lockedStartColumns, me.headerStart);
+        applyRegion(centerColumns,      me.gridContainer.headerToolbar);
+        applyRegion(lockedEndColumns,   me.headerEnd);
 
-                if (currentIndex !== targetIndex) {
-                    me.headerStart.moveTo(currentIndex, targetIndex)
-                }
-            }
-        });
+        // Buttons carry a toolbar-local aria-colindex, which the header SortZone resolves column
+        // positions through at drag start — re-homed and shifted buttons must re-sync it.
+        toolbars.forEach(toolbar => {
+            if (toolbar) {
+                let dirty = false;
 
-        centerColumns.forEach((col, targetIndex) => {
-            let btn = me.getButton(col.dataField);
+                toolbar.items.forEach((item, index) => {
+                    if (item.vdom['aria-colindex'] !== index + 1) {
+                        item.vdom['aria-colindex'] = index + 1; // 1 based
+                        dirty = true
+                    }
+                });
 
-            if (btn) {
-                if (btn.parentId !== headerToolbar.id) {
-                    Neo.getComponent(btn.parentId).remove(btn, false);
-                    headerToolbar.add(btn)
-                }
-
-                let currentIndex = headerToolbar.indexOf(btn);
-
-                if (currentIndex !== targetIndex) {
-                    headerToolbar.moveTo(currentIndex, targetIndex)
-                }
-            }
-        });
-
-        lockedEndColumns.forEach((col, targetIndex) => {
-            let btn = me.getButton(col.dataField);
-
-            if (btn) {
-                if (btn.parentId !== me.headerEnd.id) {
-                    Neo.getComponent(btn.parentId).remove(btn, false);
-                    me.headerEnd.add(btn)
-                }
-
-                let currentIndex = me.headerEnd.indexOf(btn);
-
-                if (currentIndex !== targetIndex) {
-                    me.headerEnd.moveTo(currentIndex, targetIndex)
+                if (dirty) {
+                    toolbar.updateDepth = 2;
+                    toolbar.update()
                 }
             }
         })

--- a/test/playwright/unit/grid/BodyCellMapping.spec.mjs
+++ b/test/playwright/unit/grid/BodyCellMapping.spec.mjs
@@ -1,0 +1,109 @@
+import {setup} from '../../setup.mjs';
+
+setup();
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Body           from '../../../../src/grid/Body.mjs';
+
+/**
+ * @summary Unit tests for the grid.Body dataField ↔ cell-id mapping family.
+ *
+ * The renderer (Neo.grid.Row#createVdom) assigns pooled cell slots by the REGION-LOCAL
+ * columnPositions index, and treats locked columns as permanent (keyed) cells regardless of
+ * their hideMode. getCellId / getDataField must mirror both rules: in a multi-region
+ * (locked columns) grid the global gridContainer.columns index differs from the region-local
+ * index by the preceding regions' column counts, so a global-index mapping resolves pool
+ * slots belonging to other columns.
+ */
+test.describe('Neo.grid.Body cell mapping', () => {
+    /**
+     * Mirrors the devindex shape: 3 locked-start columns precede the center region, so every
+     * center column's global index is local index + 3.
+     */
+    function createCenterBodyFake() {
+        const globalColumns = [
+            {dataField: 'id',          hideMode: 'removeDom', locked: 'start'},
+            {dataField: 'rank',        hideMode: 'removeDom', locked: 'start'},
+            {dataField: 'login',       hideMode: 'removeDom', locked: 'start'},
+            {dataField: 'total',       hideMode: 'removeDom', locked: null},
+            {dataField: 'commitRatio', hideMode: 'removeDom', locked: null},
+            {dataField: 'private',     hideMode: 'removeDom', locked: null},
+            {dataField: 'updated',     hideMode: 'removeDom', locked: 'end'}
+        ];
+
+        const centerPositions = [
+            {dataField: 'total',       width: 100, x: 0},
+            {dataField: 'commitRatio', width: 90,  x: 100},
+            {dataField: 'private',     width: 90,  x: 190}
+        ];
+
+        // A plain object borrowing the prototype methods under test: instances created via
+        // Object.create(Body.prototype) trip the #configs private-brand check of the reactive
+        // config system, while a plain `this` only needs the members the methods read.
+        return {
+            cellPoolSize   : 5,
+            columnPositions: {
+                getAt  : i => centerPositions[i],
+                indexOf: dataField => centerPositions.findIndex(pos => pos.dataField === dataField)
+            },
+            gridContainer: {
+                columns: {
+                    get: dataField => globalColumns.find(col => col.dataField === dataField) || null
+                }
+            },
+            mountedColumns: [0, 2],
+
+            getCellId   : Body.prototype.getCellId,
+            getColumn   : Body.prototype.getColumn,
+            getDataField: Body.prototype.getDataField,
+            getRowId    : rowIndex => `body-center__row-${rowIndex}`
+        }
+    }
+
+    test('getCellId resolves pooled slots by the region-local index', () => {
+        const body = createCenterBodyFake();
+
+        // commitRatio: region-local index 1, global index 4 — the pool slot is the local one
+        expect(body.getCellId(0, 'commitRatio')).toBe('body-center__row-0__cell-1');
+        expect(body.getCellId(0, 'total')).toBe('body-center__row-0__cell-0');
+        expect(body.getCellId(0, 'private')).toBe('body-center__row-0__cell-2')
+    });
+
+    test('getCellId keys locked columns by dataField (Row parity: locked never pools)', () => {
+        const body = createCenterBodyFake();
+
+        // locked columns render as permanent cells even with hideMode removeDom
+        expect(body.getCellId(0, 'id')).toBe('body-center__row-0__id')
+    });
+
+    test('getCellId falls back to the keyed form for fields outside the region', () => {
+        const body = createCenterBodyFake();
+
+        // updated lives in the locked-end region; this body's columnPositions do not contain it
+        expect(body.getCellId(0, 'updated')).toBe('body-center__row-0__updated')
+    });
+
+    test('getDataField resolves pooled cell ids through the region-local positions', () => {
+        const body = createCenterBodyFake();
+
+        expect(body.getDataField('body-center__row-0__cell-0')).toBe('total');
+        expect(body.getDataField('body-center__row-0__cell-1')).toBe('commitRatio');
+        expect(body.getDataField('body-center__row-0__cell-2')).toBe('private')
+    });
+
+    test('getDataField returns the suffix for keyed cell ids', () => {
+        const body = createCenterBodyFake();
+
+        expect(body.getDataField('body-center__row-0__login')).toBe('login')
+    });
+
+    test('getCellId and getDataField round-trip for every region column', () => {
+        const body = createCenterBodyFake();
+
+        ['total', 'commitRatio', 'private'].forEach(dataField => {
+            expect(body.getDataField(body.getCellId(0, dataField))).toBe(dataField)
+        })
+    });
+});


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

## Summary

Repairs the three remaining render-layer legs of locked-column header drag & drop (#12883), each convicted live via the Neural-Link drag eyes (#12886) on the devindex rig before touching code:

1. **Wrong-position neighbor slides** (operator: "columns slide like Chrome tabs, but DOM rects at wrong positions") — two stacked space mismatches:
   - **Containing block:** `onDragStart` writes owner(toolbar)-relative `left` into `position: absolute` items, but the toolbars are `position: static` — the values resolved against the positioned grid container, shifting every center-region item left by exactly 371px (toolbar origin − container origin). The legacy `-1` in `adjustProxyRectToParent` was a hand-tuned compensation for the container's 1px border that only held in the single-toolbar world.
   - **Cell mapping:** `grid.Body#getCellId` / `#getDataField` map pool slots through the **global** `gridContainer.columns` index, while `Row#createVdom` pools by the **region-local** `columnPositions` index (and treats locked columns as permanent/keyed). In the locked devindex grid every mapping was off by 3 (= locked-start count): the drag-start hide, the body-cell slides and the proxy clone all hit `display:none` pool cells while the real cells sat untouched.

2. **Empty drag proxy** (operator: "dragproxy no longer contains the content of the column") — same mapping root cause: `getColumnCells` cloned the wrong (empty, hidden) pool cells.

3. **Cross-toolbar DOM move lost** (`verify_component_consistency`: items `[2,37]` / vdom `[2,37]` / DOM `[37]`) — `header.Wrapper#applyColumnButtonOrder` re-homed buttons via non-silent `remove()` + `add()`: two independent per-toolbar diffs, so the source side destroyed the DOM node before the target could adopt it. `container.Base#insert` already owns the correct machinery (silent cross-parent detach + single lowest-common-ancestor flush → `moveNode`); the fix is to use it. Two follow-on gaps in the same path: the lock-change pipeline never rebuilt the per-region `columnPositions`/`availableWidth` (gaining region rendered without the column; losing region kept a hidden ghost), and re-homed buttons kept their stale toolbar-local `aria-colindex` — which the SortZone resolves columns through at drag start, silently corrupting the *next* drag.

Plus one hardening fix the eyes surfaced during verification: `drag:end` deliveries fan out across the owner's child items and `onDragEnd` re-entered concurrently (double traces, double layout refreshes, double lock verdicts). The base `onDragEnd` is now a synchronous re-entry latch routing exactly one delivery into `processDragEnd`; the trace's `lockVerdict` event also now lands inside the drag's trace (activeTrace is replaced at next drag-start instead of nulled at end).

Evidence: L3 (live devindex + bigData rig — in-page drag dispatch, NL drag traces, consistency probes, exact-pixel DOM assertions mid-drag and post-drop) → L4 required (operator manual visual pass on locked-column DnD, the hard-gate AC). Residual: operator visual pass [#12883].

## Deltas

- `src/grid/Body.mjs`: `getCellId` + `getDataField` resolve pool slots via the region-local `columnPositions` index and mirror `Row#createVdom`'s pooling condition (`hideMode === 'removeDom' && !locked`).
- `src/draggable/container/SortZone.mjs`: new opt-in `positionOwnerRelative` config — applies inline `position: relative` to the owner during a drag (captured/restored with the owner style); `onDragEnd` split into a re-entry latch + `processDragEnd`; `activeTrace` lifetime extended to next drag-start so post-drop resolution events get recorded.
- `src/draggable/grid/header/toolbar/SortZone.mjs`: opts into `positionOwnerRelative`; `adjustProxyRectToParent` drops the `-1` border compensation; `switchItems` drops the paired `+1`; `onDragEnd` renamed to `processDragEnd`.
- `src/grid/Container.mjs`: `onColumnLockChange` awaits each region toolbar's `passSizeToBody()` after the button re-home, rebuilding region `columnPositions`/`availableWidth` before the row re-render.
- `src/grid/header/Wrapper.mjs`: `applyColumnButtonOrder` delegates cross-toolbar moves to `insert()` (LCA machinery), de-duplicates the three region loops, and re-syncs `aria-colindex` (drift-detected) on all toolbars.
- `test/playwright/unit/grid/BodyCellMapping.spec.mjs` (new): 6 tests pinning the region-local mapping contract (pool-slot resolution, locked-column Row parity, keyed fallback, round-trip).

## Test Evidence

- `npx playwright test test/playwright/unit/grid/BodyCellMapping.spec.mjs -c test/playwright/playwright.config.unit.mjs` → **6 passed**
- `npx playwright test test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/ai/client/ComponentService.spec.mjs -c …unit.mjs` → **11 passed** (the `onDragEnd` latch is transparent to the existing drop-path specs)
- `test/playwright/unit/grid/` suite: **18 passed, 7 failed — identical 7 failures on the clean dev baseline** (verified via stash/run/pop; pre-existing, unrelated to this diff)
- **Live rig (devindex, locked columns, 1680×1000), parked-drag probes via in-page dispatch + NL eyes:**
  - Mid-drag (drag Commits +120px): every center item `offsetParent` = its toolbar (was: grid container), unmoved items at exact original x (387/667/767), slid neighbor at exactly 487 (the vacated slot; was 116, off by 371). Proxy text length 9 → **103**, cells `display:flex` with real values (`79.07`, `100.00`, …).
  - Body choreography: the *real* commits cell hidden + slid (was: untouched while pool cells got the writes).
  - Post-drop: committed order + positions exact; `get_drag_trace` shows single `switch(1↔2)`, single `end{from:1,to:2}`; `verify_component_consistency` → `consistent: true` (items/vdom/DOM `[1,3,2,4…]`).
  - Cross-region (drag Total into locked-start): start toolbar DOM `[#, Rank, User, Total]`, `consistent: true` on **both** toolbars; start body w 370→**470** with `19,698,677` at left 370 under its header; center body x 387→487, w→1056, zero ghost remnants; Total's `aria-colindex` = 4; trace shows **single** `end` + **single** `lockVerdict {totalContributions, null→start}` (was: everything ×2 incl. a ghost null verdict).
  - **Single-body regression guard (examples/grid/bigData, 50 columns, no locked regions):** mid-drag slide lands on the exact vacated slot, `#` renders at exactly 1 (the old `-1` produced a 1px jump at drag start), proxy full (245 chars), drop + body order exact, toolbar `position` restored to `static`.

## Post-Merge Validation

- Operator manual pass on devindex (locked build): proxy carries column content; neighbor slides land on slot boundaries; within-region and cross-region drops both correct; no duplication after drop.
- `get_drag_trace` after any manual drag should show exactly one `end` and (grids) one `lockVerdict` per drag.
- Pre-existing `test/playwright/unit/grid/` failures (LockedColumns ×2, Pooling ×3, Teleportation ×2) are unchanged by this PR and tracked separately.

Resolves #12883
