### PR TITLE
test(grid): locked-column DnD whitebox-e2e — landing + cross-region re-home (#12807)

### DIFF
--- a/learn/guides/testing/WhiteboxE2E.md
+++ b/learn/guides/testing/WhiteboxE2E.md
@@ -49,14 +49,14 @@ test.describe('Grid BigData App (Neural Link)', () => {
         await page.goto('examples/grid/bigData/index.html');
 
         // 2. Connect the fixture to the running App Worker
-        // The intent here is to explicitly pass the application name 
-        // to `connectToApp()`. While the fixture has fallback logic to infer the name 
-        // from the window path, explicit declarations prevent initialization races 
+        // The intent here is to explicitly pass the application name
+        // to `connectToApp()`. While the fixture has fallback logic to infer the name
+        // from the window path, explicit declarations prevent initialization races
         // and ensure the test strictly targets the intended App Worker environment.
-        // 
+        //
         // Examples use their fully qualified namespace:
         const nlApp = await neuralLink.connectToApp('Neo.examples.grid.bigData');
-        
+
         // Full Applications use their named string identifier:
         // const nlApp = await neuralLink.connectToApp('DevIndex');
 
@@ -78,7 +78,7 @@ const queryResult = await nlApp.queryComponent(
 
 // Important: Return properties are nested under `.properties`
 // Store records and complex objects are serialized.
-expect(queryResult.properties.value.id).toBe("20000"); 
+expect(queryResult.properties.value.id).toBe("20000");
 ```
 
 ### Advanced Discovery
@@ -94,9 +94,9 @@ test('Verify foundational grid structure', async ({ page, neuralLink }) => {
 
     // 1. Fetch MainView (It will always return the root wrapper)
     const viewResult = await nlApp.queryComponent({ className: 'Neo.examples.grid.bigData.MainContainer' });
-    
+
     // 2. Discover children inside the root scope
-    // Note: The fixture currently masks rootId natively if we query globally, 
+    // Note: The fixture currently masks rootId natively if we query globally,
     // but the underlying API fully supports ID-scoped boundaries.
     const gridResult = await nlApp.queryComponent({ ntype: 'grid-container' });
 
@@ -123,17 +123,29 @@ const styles = await nlApp.getComputedStyles('component-id-1', ['--neo-grid-row-
 ```
 
 ### Interaction Simulation
-If Playwright's synthetic DOM clicks fail or suffer from z-index races on complex components (like Grid locked columns), you can manually dispatch native browser events straight onto the VNode target via the component ID.
+If Playwright's synthetic DOM clicks fail or suffer from z-index races on complex components, you can manually dispatch native browser events straight onto the VNode target via the component ID.
 
 ```javascript
 // Bypass Playwright DOM clicking, and dispatch to the VNode listener natively
 await nlApp.simulateEvent([
     {
-        action: 'click', 
+        action: 'click',
         targetId: 'my-grid-row-1'
     }
 ]);
 ```
+
+**`simulateEvent` drives discrete events (click / key / input) — it does NOT drive a pointer drag-and-drop.** Neo's drag pipeline (grid column reordering, including locked-column / multi-region grids) is armed by a mouse-based drag sensor that requires a *real, time-spread* pointer gesture: it only fires `drag:start` once the pointer crosses its distance + delay thresholds, so a synthetic single event never arms it. To drive a column drag in an e2e, use Playwright's native mouse with a **stepped** move — the `{steps}` cadence generates the intermediate `mousemove` events the sensor needs:
+
+```javascript
+// Real pointer-drag that arms the Mouse sensor (a synthetic single event does NOT):
+await page.mouse.move(startX, startY);
+await page.mouse.down();
+await page.mouse.move(targetX, targetY, { steps: 60 });
+await page.mouse.up();
+```
+
+See `test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs` for a worked locked-column drag (in-region landing + cross-region re-home) that pairs the gesture with Neural Link worker assertions.
 
 ### Topology, Nodes, & Namespaces
 Get a bird's eye view of the entire runtime environment, discovering connected workers or resolving the class hierarchy.
@@ -142,7 +154,7 @@ Get a bird's eye view of the entire runtime environment, discovering connected w
 // Map component hierarchy dynamically
 const compTree = await nlApp.getComponentTree(undefined, 2); // Depth limit 2
 
-// View all connected Apps / Windows 
+// View all connected Apps / Windows
 const workers = await nlApp.getWorkerTopology();
 const windows = await nlApp.getWindowTopology();
 
@@ -160,7 +172,7 @@ const listeners = await nlApp.getDomEventListeners('my-grid-container');
 // Dump the full raw store records (paginated) without querying the component
 const storeData = await nlApp.inspectStore('my-data-store', 50, 0);
 
-// Review global configurations 
+// Review global configurations
 const globalConfig = await nlApp.manageNeoConfig('get');
 ```
 
@@ -179,8 +191,8 @@ const methodSource = await nlApp.getMethodSource('Neo.button.Base', 'onClick');
 
 // Dynamically replace the method implementation during E2E testing
 await nlApp.patchCode(
-    'Neo.button.Base', 
-    'onClick', 
+    'Neo.button.Base',
+    'onClick',
     'function(data) { console.log("Patched!"); }'
 );
 ```

--- a/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
+++ b/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
@@ -1,0 +1,166 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * Whitebox-e2e for locked-grid column drag-and-drop: landing accuracy + cross-region re-home.
+ *
+ * Paradigm (per the whitebox-e2e protocol): Playwright drives the native gesture; the Neural Link
+ * fixture asserts App-Worker truth. The worker oracle is the grid's region-grouped column arrays
+ * (`centerColumns` / `lockedStartColumns` / `lockedEndColumns`) — the engine recomputes these from
+ * each column's `locked` value on every column mutation, so they are the authoritative view of which
+ * region owns a column and at which index. We assert the dragged column's region+index there and
+ * cross-check the rendered DOM order: a worker<->DOM consistency check that catches engine<->DOM drift
+ * (the engine moves a column but the DOM misses it, or vice-versa) — invisible to a DOM-only test.
+ *
+ * Why the column arrays and NOT the header button's parentId: mapping a button to its region through
+ * its parent toolbar's instance-id is a trap — the three region toolbars are created in a different
+ * order than they render (the centre `headerToolbar` is built first; locked start/end on demand), so
+ * a toolbar instance-id never maps cleanly to a visual region, and a DOM-nth lookup of the toolbar
+ * just re-reads the DOM. The region column arrays are the engine's own region+index model, recomputed
+ * from each column's `locked` value (which the drag commits on drop), so they are the single worker
+ * source of truth — and post-drop they agree with the buttons' placement.
+ *
+ * Two legs:
+ *   - LANDING ACCURACY: a centre column dragged within the centre region lands at the cursor-accurate
+ *     index (engine keeps it in centerColumns at that index; the DOM shows it there — no overshoot).
+ *   - CROSS-REGION RE-HOME: dragging a centre column into locked-start re-homes it (engine moves it
+ *     into lockedStartColumns AND the DOM applies the move).
+ *
+ * DevIndex multi-region header DOM: .neo-grid-header-toolbar[0]=locked-start, [1]=centre, [2]=locked-end;
+ * column labels live in SPAN.neo-button-text; the draggable target is the header button (.neo-draggable).
+ * Dispatch: page.mouse.down -> move(x, {steps}) -> up — the {steps} cadence arms Neo's Mouse drag sensor.
+ *
+ * Run: npx playwright test GridColumnCrossBodyDnD -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Desktop (1920x1080): DevIndex Locked-Column DnD (#12807)', () => {
+    test.setTimeout(90000); // DevIndex is heavy; allow time for render + Neural Link mapping.
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/apps/devindex/');
+        page.on('console',   msg => console.log('BROWSER:', msg.text()));
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+        const stopButton = page.locator('.devindex-stop-stream-button');
+        try {
+            await expect(stopButton).toBeVisible({ timeout: 5000 });
+            await stopButton.click({ timeout: 2000, force: true }); // stop the stream so we don't wait for all rows
+        } catch {
+            // stream settled instantly — button never appeared / already hid
+        }
+        await page.waitForTimeout(1000);
+    });
+
+    test('center-region "Total" drag lands at index 2 — engine keeps it in centerColumns + DOM idx 2 (no overshoot)', async ({ page, neuralLink }) => {
+        const app    = await neuralLink.connectToApp('DevIndex');
+        const gridId = await resolveGridId(app);
+
+        await assertPristineGrid(app, gridId);                     // worker precondition (also catches a foreign/stale bound app)
+        expect((await getColumnOrder(page, 1))[0]).toBe('Total');  // DOM sanity: Total starts at centre idx 0
+
+        const centerToolbar = page.locator('.neo-grid-header-toolbar').nth(1);
+        const totalHeader    = centerToolbar.locator('.neo-draggable', { hasText: 'Total' }).first();
+        await expect(totalHeader).toBeVisible({ timeout: 5000 });
+
+        const idx2Header = centerToolbar.locator('.neo-draggable').nth(2);
+        const totalBox   = await totalHeader.boundingBox();
+        const idx2Box    = await idx2Header.boundingBox();
+
+        await page.mouse.move(totalBox.x + totalBox.width / 2, totalBox.y + totalBox.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(idx2Box.x + idx2Box.width / 2, totalBox.y + totalBox.height / 2, { steps: 60 });
+        await page.mouse.up();
+        await page.waitForTimeout(500);
+
+        const region   = await regionColumns(app, gridId);
+        const domOrder = await getColumnOrder(page, 1);
+        console.log('[locked-dnd] centerColumns:', JSON.stringify(region.center.slice(0, 5)), '| centre DOM:', JSON.stringify(domOrder.slice(0, 5)));
+
+        expect(region.center[2]).toBe('totalContributions'); // worker truth: Total landed at centre index 2
+        expect(domOrder.indexOf('Total')).toBe(2);            // DOM layer: cursor-accurate landing (no overshoot)
+    });
+
+    test('cross-region: center "Total" drag into locked-start re-homes — engine moves it to lockedStartColumns + DOM applies it', async ({ page, neuralLink }) => {
+        const app    = await neuralLink.connectToApp('DevIndex');
+        const gridId = await resolveGridId(app);
+
+        await assertPristineGrid(app, gridId);
+        expect(await getColumnOrder(page, 0)).toEqual(['#', 'Rank', 'User']);
+
+        const centerToolbar = page.locator('.neo-grid-header-toolbar').nth(1);
+        const startToolbar  = page.locator('.neo-grid-header-toolbar').nth(0);
+        const totalHeader    = centerToolbar.locator('.neo-draggable', { hasText: 'Total' }).first();
+        await expect(totalHeader).toBeVisible({ timeout: 5000 });
+
+        const totalBox = await totalHeader.boundingBox();
+        const startBox = await startToolbar.boundingBox();
+
+        await page.mouse.move(totalBox.x + totalBox.width / 2, totalBox.y + totalBox.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(startBox.x + startBox.width - 8, startBox.y + startBox.height / 2, { steps: 60 });
+        await page.mouse.up();
+        await page.waitForTimeout(800);
+
+        const region   = await regionColumns(app, gridId);
+        const domOrder = await getColumnOrder(page, 0);
+        console.log('[locked-dnd] lockedStartColumns:', JSON.stringify(region.lockedStart), '| locked-start DOM:', JSON.stringify(domOrder));
+
+        expect(region.lockedStart).toContain('totalContributions'); // worker truth: engine re-homed Total into locked-start
+        expect(domOrder).toEqual(['#', 'Rank', 'User', 'Total']);    // DOM layer: rendered DOM applied the re-home (no drift)
+    });
+});
+
+/**
+ * Resolves the DevIndex grid-container instance id from the App Worker.
+ * @returns {Promise<String>}
+ */
+async function resolveGridId(app) {
+    const grids  = await app.findInstances({ ntype: 'grid-container' }, ['id']);
+    const gridId = Array.isArray(grids) ? grids[0]?.id : grids?.id;
+    expect(gridId, 'a grid-container instance must exist in the bound App Worker').toBeTruthy();
+    return gridId;
+}
+
+/**
+ * Reads the grid's three region-grouped column arrays from the App Worker and returns each as an
+ * ordered list of dataFields. This is the engine's authoritative region+index model (recomputed from
+ * every column's `locked` value on mutation), so it must be read AFTER a drag-leg has settled.
+ * @returns {Promise<{center: String[], lockedStart: String[], lockedEnd: String[]}>}
+ */
+async function regionColumns(app, gridId) {
+    const props  = await app.getComponent(gridId, ['centerColumns', 'lockedStartColumns', 'lockedEndColumns']);
+    const fields = arr => (arr || []).map(col => col.dataField);
+    return {
+        center     : fields(props.centerColumns),
+        lockedStart: fields(props.lockedStartColumns),
+        lockedEnd  : fields(props.lockedEndColumns)
+    };
+}
+
+/**
+ * Worker-truth precondition: the bound grid is in its pristine layout (Total unlocked at centre idx 0,
+ * #/Rank/User locked to the start, Total NOT pre-homed to the end). Asserting this before the gesture
+ * both pins a known starting state and fails loudly if the Neural Link bound to a different DevIndex
+ * instance than this test's page — the fixture currently resolves by app name, so a second connected
+ * DevIndex (e.g. a developer's open tab) can otherwise be read silently instead of the test's page.
+ */
+async function assertPristineGrid(app, gridId) {
+    const region = await regionColumns(app, gridId);
+    expect(region.lockedStart).toEqual(['id', 'rank', 'login']);  // #, Rank, User
+    expect(region.center[0]).toBe('totalContributions');          // Total starts unlocked at centre index 0
+    expect(region.lockedEnd).not.toContain('totalContributions'); // Total is NOT pre-homed to locked-end
+}
+
+/**
+ * Reads the header column labels in order for a region toolbar (DOM oracle layer).
+ * Region order: 0 = locked-start, 1 = centre, 2 = locked-end. Labels = SPAN.neo-button-text.
+ */
+async function getColumnOrder(page, toolbarIndex) {
+    return page.evaluate((idx) => {
+        const tb = document.querySelectorAll('.neo-grid-header-toolbar')[idx];
+        if (!tb) return [];
+        return Array.from(tb.querySelectorAll('.neo-button-text'))
+            .map(el => (el.textContent || '').trim())
+            .filter(Boolean);
+    }, toolbarIndex);
+}


### PR DESCRIPTION
Resolves #12898
Refs #12807
Refs #12891
Refs #12892
Refs #12883
Refs #12897

Authored by Opus 4.8 (Claude Code). Session 702ed4a8-54ae-4b09-911a-15b10e58c9d3.

Adds the whitebox-e2e substrate for Neo's locked-column header drag-and-drop — the delivered artifacts of #12898 (a sub of #12807). Two tests on the devindex rig drive the drag via `page.mouse.down -> move(x, {steps:60}) -> up` (the cadence that arms Neo's `Mouse.mjs` sensor; synthetic `simulateEvent` events do not arm the drag pipeline — the original premise #12807 corrected). The worker oracle is the grid's region-grouped column arrays (`centerColumns` / `lockedStartColumns` / `lockedEndColumns`), with the rendered DOM order as a second consistency layer.

> **Close-target split (per reviewer convergence).** This PR delivers the substrate tracked by #12898: the spec scaffold, the WhiteboxE2E drag-path guide correction, the DOM-layer behavior proof, and the worker-region-array oracle design. The parent #12807 stays **open** — its remaining AC, a correct-binding green e2e run under a same-name worker topology, depends on #12897 (the `neuralLink` fixture binds to the oldest same-named App Worker, not the test page's own). #12897 is required for the first correct-binding green run; it does not gate this PR.

Evidence: the worker-region-array read mechanism is verified via live Neural-Link introspection (the arrays serialize `dataField` directly; #12891 landing + #12892 re-home behaviors confirmed on the live grid). The delivered artifacts (scaffold, guide, DOM-proof, oracle design) are present and structurally verifiable. No green e2e run is claimed — see Test Evidence.

## What it verifies (design + DOM-layer)
- **Landing accuracy** (the #12891 behavior): center-region "Total" dragged within center lands at index 2 — asserted on `centerColumns[2] === 'totalContributions'` (worker) and the DOM order (cursor-accurate, no locked-start-region-width overshoot).
- **Cross-region re-home** (the #12892 behavior): center "Total" dragged into locked-start re-homes — asserted on `lockedStartColumns` membership (worker) and the rendered DOM → `[#, Rank, User, Total]`.

## Deltas from ticket
- #12807's original AC (a `PointerEvent` branch in `EventSimulator`) was a wrong premise: Neo's drag uses the `Mouse.mjs` MOUSE sensor; `page.mouse + {steps}` arms it with no `EventSimulator` change (live-probe confirmed). No framework change ships here.
- Worker oracle is the column-region arrays, NOT the header button's `parentId` → toolbar-id → DOM-nth mapping (which crosses three orderings: DOM-layout, toolbar instance-id = creation-order, and region). The column model is the engine's committed source of truth (the drag commits `column.locked`, which recomputes the arrays).
- DevIndex multi-region header DOM mapped: `.neo-grid-header-toolbar[0]` = locked-start, `[1]` = center, `[2]` = locked-end; labels in `.neo-button-text`; the draggable target is the header button (`.neo-draggable`).

## Test Evidence
- **Evidence boundary (exact):** repo CI (`.github/workflows/test.yml`) runs `integration-unified` + `unit` only; the e2e config (`test-e2e` → `playwright.config.e2e.mjs`, where this spec lives) is **NOT** CI-gated. So this PR's green `integration-unified` / `unit` checks do NOT exercise this spec.
- The current same-name-topology local run is **red** at the pristine-state guard — the `neuralLink` fixture binds the wrong App Worker (#12897). @neo-gpt independently reproduced this at head `d0d6f4174`.
- No clean-single-app `test-e2e` pass is claimed (a persistent DevIndex on the dev bridge prevents producing one locally; none demonstrated here).
- The worker-region-array read mechanism is verified via live Neural-Link introspection (MCP `find_instances` / `get_instance_properties` on the live grid).

## Post-Merge Validation
- [ ] After #12897 merges, the parent #12807's same-name-topology green-run AC becomes verifiable: `npm run test-e2e -- GridColumnCrossBodyDnD --workers=1` green with a persistent DevIndex connected. (That AC lives on #12807, not this PR.)
- [ ] (Follow-up candidate) Decide whether locked-column DnD e2e should join a CI gate — separate ticket + owner.

## Commits
- `36115780d` — locked-column DnD whitebox-e2e (landing + cross-region re-home; worker-region-array oracle)
- `d0d6f4174` — WhiteboxE2E.md drag-simulation guidance correction
