### PR TITLE
fix(grid): heal mid-drag cell-mapping staleness + Chromium moveBefore stale flex layout (#12883)

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -901,23 +901,41 @@ class GridBody extends Component {
     }
 
     /**
-     * Resolves the physical cell id for a rowIndex / dataField pair, mirroring the slot assignment
-     * of {@link Neo.grid.Row#createVdom}: pooled cells (`hideMode === 'removeDom'` and not locked)
-     * are keyed by the REGION-LOCAL `columnPositions` index, permanent cells by their dataField.
-     * In a multi-region (locked columns) grid the global `gridContainer.columns` index differs from
-     * the region-local index by the preceding regions' column counts, so it must not be used here.
+     * Resolves the physical cell id for a rowIndex / dataField pair. Pooled cells (`hideMode ===
+     * 'removeDom'` and not locked — mirroring {@link Neo.grid.Row#createVdom}) resolve through the
+     * MATERIALIZED slot binding: Row stamps `data.field` into every rendered cell, and pool slots
+     * keep that render-time binding even while `columnPositions` gets re-ordered mid-drag
+     * (`switchItems` moves the collection per switch). Index math over a live collection goes stale
+     * one switch in; reading the rendered binding cannot. Falls back to the region-local
+     * `columnPositions` index only before the first render pass.
      * @param {Number} rowIndex
      * @param {String} dataField
      * @returns {String}
      */
     getCellId(rowIndex, dataField) {
-        let me          = this,
-            column      = me.getColumn(dataField),
-            columnIndex = me.columnPositions.indexOf(dataField),
-            rowId       = me.getRowId(rowIndex);
+        let me            = this,
+            column        = me.getColumn(dataField),
+            rowId         = me.getRowId(rowIndex),
+            firstRowCells = me.items?.[0]?.vdom?.cn,
+            columnIndex, i, len, node, poolIndex;
 
-        if (column?.hideMode === 'removeDom' && !column.locked && columnIndex > -1) {
-            return `${rowId}__cell-${columnIndex % me.cellPoolSize}`
+        if (column?.hideMode === 'removeDom' && !column.locked) {
+            if (firstRowCells) {
+                for (i = 0, len = firstRowCells.length; i < len; i++) {
+                    node = firstRowCells[i];
+
+                    if (node.data?.field === dataField && node.id?.includes('__cell-')) {
+                        poolIndex = node.id.split('__cell-')[1];
+                        return `${rowId}__cell-${poolIndex}`
+                    }
+                }
+            }
+
+            columnIndex = me.columnPositions.indexOf(dataField);
+
+            if (columnIndex > -1) {
+                return `${rowId}__cell-${columnIndex % me.cellPoolSize}`
+            }
         }
 
         return `${rowId}__${dataField}`
@@ -983,23 +1001,36 @@ class GridBody extends Component {
 
     /**
      * Resolves the dataField for a physical cell id — the inverse of {@link #getCellId}.
-     * Pooled cell ids map back through the REGION-LOCAL `columnPositions` index (mirroring the
-     * slot assignment of {@link Neo.grid.Row#createVdom}), not the global `gridContainer.columns`
-     * index, which differs in multi-region (locked columns) grids.
+     * Pooled cell ids resolve through the MATERIALIZED slot binding ({@link Neo.grid.Row#createVdom}
+     * stamps `data.field` into every rendered cell): pool slots keep their render-time column
+     * binding even while `columnPositions` gets re-ordered mid-drag, so index math over the live
+     * collection goes stale one switch in. Falls back to the region-local index math only before
+     * the first render pass.
      * @param {String} cellId
      * @returns {String}
      */
     getDataField(cellId) {
         if (cellId.includes('__cell-')) {
-            let me        = this,
-                poolIndex = parseInt(cellId.split('__cell-')[1]),
-                columns   = me.gridContainer.columns,
+            let me            = this,
+                poolIndex     = cellId.split('__cell-')[1],
+                firstRowCells = me.items?.[0]?.vdom?.cn,
+                columns       = me.gridContainer.columns,
                 { cellPoolSize, columnPositions, mountedColumns } = me,
-                i         = mountedColumns[0],
-                len       = mountedColumns[1],
-                column, dataField;
+                column, dataField, i, len, node;
 
-            for (; i <= len; i++) {
+            if (firstRowCells) {
+                for (i = 0, len = firstRowCells.length; i < len; i++) {
+                    node = firstRowCells[i];
+
+                    if (node.id?.split('__cell-')[1] === poolIndex && node.data?.field) {
+                        return node.data.field
+                    }
+                }
+            }
+
+            poolIndex = parseInt(poolIndex);
+
+            for (i = mountedColumns[0], len = mountedColumns[1]; i <= len; i++) {
                 if (i % cellPoolSize === poolIndex) {
                     dataField = columnPositions.getAt(i)?.dataField;
                     column    = dataField && columns.get(dataField);

--- a/src/main/DeltaUpdates.mjs
+++ b/src/main/DeltaUpdates.mjs
@@ -563,7 +563,27 @@ class DeltaUpdates extends Base {
                 }
 
                 if (this.nativeMoveBefore) {
-                    parentNode.moveBefore(node, siblingRef || null)
+                    parentNode.moveBefore(node, siblingRef || null);
+
+                    // Chromium (observed in 146 & 149) can leave the parent's box-tree sibling chain
+                    // stale after moveBefore(): the DOM order updates, but one neighbor keeps
+                    // rendering at its pre-move slot — and structural child-list changes do NOT
+                    // re-dirty it. Rebuilding the parent's boxes synchronously (no paint happens
+                    // in between) restores the layout while keeping what moveBefore preserves:
+                    // iframes and canvas survive display toggles (unlike the insertBefore fallback,
+                    // which reloads iframes); only CSS-animation continuity inside the parent resets.
+                    const
+                        activeElement = document.activeElement,
+                        containsFocus = activeElement && parentNode.contains(activeElement),
+                        displayValue  = parentNode.style.display;
+
+                    parentNode.style.display = 'none';
+                    void parentNode.offsetHeight;
+                    parentNode.style.display = displayValue;
+
+                    if (containsFocus && document.activeElement !== activeElement) {
+                        activeElement.focus()
+                    }
                 } else {
                     const
                         activeElement = document.activeElement,

--- a/src/main/DeltaUpdates.mjs
+++ b/src/main/DeltaUpdates.mjs
@@ -572,14 +572,24 @@ class DeltaUpdates extends Base {
                     // in between) restores the layout while keeping what moveBefore preserves:
                     // iframes and canvas survive display toggles (unlike the insertBefore fallback,
                     // which reloads iframes); only CSS-animation continuity inside the parent resets.
+                    // The toggle also zeroes the parent's own scroll state, so it gets captured and
+                    // restored alongside focus. Boundary: scrolled DESCENDANTS inside the parent
+                    // reset too and are not walked here (subtree-scan cost on every move) — tracked
+                    // with the heal-gating follow-up.
                     const
                         activeElement = document.activeElement,
                         containsFocus = activeElement && parentNode.contains(activeElement),
-                        displayValue  = parentNode.style.display;
+                        displayValue  = parentNode.style.display,
+                        {scrollLeft, scrollTop} = parentNode;
 
                     parentNode.style.display = 'none';
                     void parentNode.offsetHeight;
                     parentNode.style.display = displayValue;
+
+                    if (scrollLeft || scrollTop) {
+                        parentNode.scrollLeft = scrollLeft;
+                        parentNode.scrollTop  = scrollTop
+                    }
 
                     if (containsFocus && document.activeElement !== activeElement) {
                         activeElement.focus()

--- a/test/playwright/unit/grid/BodyCellMapping.spec.mjs
+++ b/test/playwright/unit/grid/BodyCellMapping.spec.mjs
@@ -42,6 +42,8 @@ test.describe('Neo.grid.Body cell mapping', () => {
         // A plain object borrowing the prototype methods under test: instances created via
         // Object.create(Body.prototype) trip the #configs private-brand check of the reactive
         // config system, while a plain `this` only needs the members the methods read.
+        // items[0].vdom.cn mirrors the rendered pool slots incl. the data.field binding stamps
+        // Row#createVdom writes — the materialized binding the mapping functions resolve through.
         return {
             cellPoolSize   : 5,
             columnPositions: {
@@ -53,6 +55,17 @@ test.describe('Neo.grid.Body cell mapping', () => {
                     get: dataField => globalColumns.find(col => col.dataField === dataField) || null
                 }
             },
+            items: [{
+                vdom: {
+                    cn: [
+                        {id: 'body-center__row-0__cell-0', data: {field: 'total'}},
+                        {id: 'body-center__row-0__cell-1', data: {field: 'commitRatio'}},
+                        {id: 'body-center__row-0__cell-2', data: {field: 'private'}},
+                        {id: 'body-center__row-0__cell-3', style: {display: 'none'}},
+                        {id: 'body-center__row-0__cell-4', style: {display: 'none'}}
+                    ]
+                }
+            }],
             mountedColumns: [0, 2],
 
             getCellId   : Body.prototype.getCellId,
@@ -105,5 +118,38 @@ test.describe('Neo.grid.Body cell mapping', () => {
         ['total', 'commitRatio', 'private'].forEach(dataField => {
             expect(body.getDataField(body.getCellId(0, dataField))).toBe(dataField)
         })
+    });
+
+    test('mapping survives a mid-drag columnPositions move (slot binding wins over index math)', () => {
+        const body = createCenterBodyFake();
+
+        // Simulate the first switchItems of a drag: columnPositions re-ordered to
+        // [total, private, commitRatio] while the rendered pool slots keep their render-time
+        // binding (cell-1 = commitRatio, cell-2 = private). Index math over the moved collection
+        // resolves one-off; the materialized data.field binding must win.
+        const movedPositions = [
+            {dataField: 'total',       width: 100, x: 0},
+            {dataField: 'private',     width: 90,  x: 100},
+            {dataField: 'commitRatio', width: 90,  x: 190}
+        ];
+
+        body.columnPositions = {
+            getAt  : i => movedPositions[i],
+            indexOf: dataField => movedPositions.findIndex(pos => pos.dataField === dataField)
+        };
+
+        expect(body.getCellId(0, 'commitRatio')).toBe('body-center__row-0__cell-1');
+        expect(body.getCellId(0, 'private')).toBe('body-center__row-0__cell-2');
+        expect(body.getDataField('body-center__row-0__cell-1')).toBe('commitRatio');
+        expect(body.getDataField('body-center__row-0__cell-2')).toBe('private')
+    });
+
+    test('pool-suffix matching is exact, not prefix-based (cell-1 vs cell-11)', () => {
+        const body = createCenterBodyFake();
+
+        body.items[0].vdom.cn.push({id: 'body-center__row-0__cell-11', data: {field: 'eleven'}});
+
+        expect(body.getDataField('body-center__row-0__cell-11')).toBe('eleven');
+        expect(body.getDataField('body-center__row-0__cell-1')).toBe('commitRatio')
     });
 });


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

## Summary

Follow-up to the merged render-layer fix ([#12892](https://github.com/neomjs/neo/pull/12892)): the operator's post-merge L4 manual pass caught a residual — **header cells and body cells of sliding columns desync during multi-switch drags**. Two further mechanisms, both convicted live on the devindex rig before touching code:

1. **Mid-drag cell-mapping staleness** (a regression introduced by #12892's region-local mapping): `switchItems` calls `columnPositions.move()` per switch, while pool-slot ids keep their **render-time** column binding until the next `createViewData`. From the second switch of a drag onward, the index-math reverse map (`getDataField`) resolved cells one-off — the drag-hide and slide writes landed on the wrong columns (live capture: dragging Commits across two columns left Private's body cells parked in Commits' final slot). The old global-index code did not have this staleness only because the global collection never moves mid-drag — it had the off-by-region bug instead. **Fix:** `getCellId` / `getDataField` now resolve through the **materialized slot binding** — `Row#createVdom` stamps `data.field` into every rendered cell — which is immune to both failure modes by construction. The index math remains only as the pre-first-render fallback.

2. **Chromium `Element.moveBefore()` stale flex layout** (observed in Chromium 146 and 149): after the drop's `moveNode` delta, the toolbar's DOM order was correct (`[1,2,3,4]`, verified via outerHTML + duplicate-id sweep) while the **rendered flex order stayed `[2,3,1,4]`** — every box-moving CSS property neutral (`order:0`, `position:relative` with zero offsets, no transforms, no containment anywhere in the ancestor chain), `elementFromPoint` confirming the impossible layout, and the state surviving minutes plus structural child-list changes (a zero-size box append/remove does NOT heal it; only a box rebuild does). Deterministic single-call repro via a `moveBefore` monkey-patch log: the left-drag drop issues exactly one `moveBefore(button-2, before button-3)` and breaks; the right-drag drop issues two and renders fine. **Fix:** `DeltaUpdates.moveNode` rebuilds the parent's boxes synchronously after a native `moveBefore` (display toggle + forced reflow + restore — no paint occurs in between). This keeps what `moveBefore` exists to preserve: iframes and canvas survive display toggles (unlike the `insertBefore` fallback, which reloads iframes); only CSS-animation continuity inside the parent resets. Focus is preserved with the same guard as the legacy fallback path.

Evidence: L3 (live devindex rig — moveBefore call-log instrumentation, atomic DOM-vs-layout captures, both-direction multi-switch drags verified header↔body slot-exact) → L4 required (operator manual pass on locked-column DnD, re-run after this lands). Residual: operator visual pass [#12883 — the parent close-target carrying the L4 AC; this PR resolves the sub #12896].

## Deltas

- `src/grid/Body.mjs`: `getCellId` + `getDataField` resolve pooled cells through the rendered `data.field` binding (first-row scan, exact pool-suffix match); region-local index math demoted to pre-render fallback.
- `src/main/DeltaUpdates.mjs`: `moveNode` heals the Chromium stale-flex-layout after native `moveBefore` via a synchronous parent box rebuild + focus preservation.
- `test/playwright/unit/grid/BodyCellMapping.spec.mjs`: fake extended with rendered-cell `data.field` stamps; 2 new tests — the mid-drag `columnPositions.move()` regression pin (binding wins over index math) and exact pool-suffix matching (`cell-1` vs `cell-11`).

## Test Evidence

- `npx playwright test test/playwright/unit/grid/BodyCellMapping.spec.mjs test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/ai/client/ComponentService.spec.mjs -c …unit.mjs` → **19 passed** (8 mapping incl. 2 new pins + 7 SortZone + 4 ComponentService)
- **Live rig (devindex locked build, 1680×1000):**
  - Multi-switch right drag (Commits +200px across two columns), parked: every sliding column's body cells land in the exact slot their header occupies (Private header@487 ↔ body cell@100 body-relative; hidden dragged column header@677 ↔ cells@290); keyed (non-pooled) columns verified too (`heuristics` header@577 ↔ cell@190).
  - Multi-switch left drag (the previously breaking case), post-drop: headers `[Total@387, Commits@487, Private@577, Impact@667]` ↔ body `[total@0, commitRatio@100, private@190]` — slot-exact both surfaces, both directions.
  - moveBefore call-log: right drop = 2 moves (clean), left drop = 1 move (previously broke, now heals via the box rebuild).

## Post-Merge Validation

- [ ] Operator manual pass: multi-column drags in both directions — sliding columns' headers and body cells stay in sync mid-drag and post-drop; no stale header positions after any drop.
- [ ] Consider an upstream Chromium report for the `moveBefore` flex-layout invalidation gap (deterministic repro documented here); revisit the workaround when fixed upstream.

Resolves #12896
Refs #12883 (parent — its operator L4 manual pass AC stays open and closes the parent, not this PR)
