### PR TITLE
feat(draggable): trace ring keeps the drag tail — dup count-compression + oldest-drop at cap (#12883)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -184,14 +184,37 @@ class SortZone extends DragZone {
      * Appends one event to the active drag trace. Events carry where the drag logic
      * decided to be, not where the DOM is — pair with the `observe_motion` tool for
      * the rendered-geometry side of the same window.
+     *
+     * Duplicate-delivery events get COUNT-COMPRESSED onto the previous event (`dup: n`)
+     * instead of logged individually — per-occurrence dup entries used to consume most
+     * of the buffer. At the cap the buffer drops the OLDEST event, not the newest: a
+     * drag's tail (overdrag, scroll, drop resolution) is its most diagnostic part.
      * @param {Object} data
      */
     traceEvent(data) {
         const trace = SortZone.activeTrace;
 
-        if (trace && trace.events.length < 400) {
-            trace.events.push({...data, ts: Date.now()})
+        if (!trace) {
+            return
         }
+
+        const {events} = trace;
+
+        if (data.t === 'dup') {
+            const last = events[events.length - 1];
+
+            if (last) {
+                last.dup = (last.dup || 0) + 1
+            }
+
+            return
+        }
+
+        if (events.length >= 400) {
+            events.shift()
+        }
+
+        events.push({...data, ts: Date.now()})
     }
 
     /**

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -238,10 +238,21 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
         expect(SortZone.activeTrace.events[0].t).toBe('move');
         expect(typeof SortZone.activeTrace.events[0].ts).toBe('number');
 
-        // Per-drag event cap (400) guards unbounded growth
-        SortZone.activeTrace.events.length = 400;
-        zone.traceEvent({t: 'move', x: 999});
+        // Duplicate deliveries count-compress onto the previous event instead of appending
+        zone.traceEvent({t: 'dup', x: 100});
+        zone.traceEvent({t: 'dup', x: 100});
+        expect(SortZone.activeTrace.events.length).toBe(2);
+        expect(SortZone.activeTrace.events[1].dup).toBe(2);
+
+        // Per-drag event cap (400) guards unbounded growth — dropping the OLDEST event,
+        // keeping the tail (a drag's drop resolution is its most diagnostic part)
+        SortZone.activeTrace.events.length = 0;
+        for (let i = 0; i < 401; i++) {
+            zone.traceEvent({t: 'move', x: i});
+        }
         expect(SortZone.activeTrace.events.length).toBe(400);
+        expect(SortZone.activeTrace.events[399].x).toBe(400);
+        expect(SortZone.activeTrace.events[0].x).toBe(1);
 
         // Ring trims to traceLimit
         for (let i = 0; i < SortZone.traceLimit + 3; i++) {


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

## Summary

Instrumentation hardening for the drag eyes, driven by a live investigation gap: the operator reported a drag-scroll body-rendering regression, and his session's trace — the primary forensic artifact — was **missing exactly the diagnostic part**. The 400-event cap drops the NEWEST events, so a long drag's tail (overdrag, scroll engagement, drop resolution) is what gets truncated; worse, the duplicate-delivery guard logs one `dup` event per occurrence, and real human drags (continuous small deltas, double listener fan-out) flood ~⅔ of the buffer with dup spam before the interesting part begins.

Two fixes in `SortZone#traceEvent`:
1. **Dup count-compression**: duplicate deliveries increment a `dup` counter on the previous event instead of appending entries — the delivery-pattern information survives at ~zero buffer cost.
2. **Oldest-drop at the cap**: at 400 events the buffer shifts the oldest instead of refusing the newest — the tail is always retained.

Evidence: L2 (unit) → L2 required (instrumentation-only; no runtime-behavior ACs). No residuals.

## Deltas

- `src/draggable/container/SortZone.mjs`: `traceEvent` rewritten per the two rules above (JSDoc documents both).
- `test/playwright/unit/draggable/container/SortZone.spec.mjs`: trace test extended — dup-compression assertion + tail-retention assertion (401 pushes → length 400, last event is the newest, oldest dropped).

## Test Evidence

- `npx playwright test test/playwright/unit/draggable/container/SortZone.spec.mjs -c …unit.mjs` → **7 passed** (incl. the two new assertions).
- Motivating artifact: a live operator drag trace (session `eb75f197`, 13:01Z) hit the cap with dup-pairs on every move event; the drag's end/scroll events were absent from the buffer.

## Post-Merge Validation

- [ ] The next manual drag reproduction captures its full tail (`end`, `scroll`, `lockVerdict` events present; `dup` counters on moves instead of paired entries).

Refs #12883 (the open L4 investigation this instrumentation serves)

Resolves #12902
