### PR TITLE
fix(test): neuralLink fixture identity-binds to the page's own App Worker (#12897)

### DIFF
--- a/learn/guides/testing/WhiteboxE2E.md
+++ b/learn/guides/testing/WhiteboxE2E.md
@@ -49,12 +49,17 @@ test.describe('Grid BigData App (Neural Link)', () => {
         await page.goto('examples/grid/bigData/index.html');
 
         // 2. Connect the fixture to the running App Worker
-        // The intent here is to explicitly pass the application name
-        // to `connectToApp()`. While the fixture has fallback logic to infer the name
-        // from the window path, explicit declarations prevent initialization races
-        // and ensure the test strictly targets the intended App Worker environment.
         //
-        // Examples use their fully qualified namespace:
+        // Session resolution: `connectToApp()` IDENTITY-BINDS to this page's own App Worker —
+        // it polls the page's `Neo.worker.App.getWorkerId()` remote (bounded wait) and passes
+        // that id to the bridge's exact-id session match. The appName argument is a FALLBACK
+        // only (older builds without the remote, or non-Neo pages). This matters whenever a
+        // second same-named app is connected to the bridge (e.g. a developer's open dev tab):
+        // appName resolution binds the OLDEST matching session, so without the identity bind
+        // the test's worker queries would silently read the other app while `page.mouse`
+        // drives this page.
+        //
+        // Examples use their fully qualified namespace as the fallback name:
         const nlApp = await neuralLink.connectToApp('Neo.examples.grid.bigData');
 
         // Full Applications use their named string identifier:

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -43,6 +43,7 @@ class App extends Base {
                 'destroyNeoInstance',
                 'fireEvent',
                 'getConfigs',
+                'getWorkerId',
                 'loadModule',
                 'moveComponent',
                 'setConfigs',
@@ -357,6 +358,17 @@ class App extends Base {
         }
 
         return false
+    }
+
+    /**
+     * Remote method for main threads: returns this App Worker's unique id — the same value the
+     * Neural Link bridge keys its sessions by (`appWorkerId`). Lets a page (e.g. the Playwright
+     * `neuralLink` fixture) identity-bind to its OWN worker session instead of resolving by
+     * appName, which mis-binds whenever another same-named app is connected to the bridge.
+     * @returns {String}
+     */
+    getWorkerId() {
+        return this.id
     }
 
     /**

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -100,11 +100,21 @@ export const test = base.extend({
                     // Give the page a moment to initialize Neo
                     await page.waitForFunction(() => window.Neo && window.Neo.config, { timeout: 2000 }).catch(() => {});
 
-                    // Identity-bind: ask the page's own App Worker for its id (remote method,
-                    // resolves once the worker is constructed; null on older builds).
-                    workerId = await page.evaluate(() =>
-                        window.Neo?.worker?.App?.getWorkerId?.().catch?.(() => null) ?? null
-                    ).catch(() => null);
+                    // Identity-bind: ask the page's own App Worker for its id. The remote namespace
+                    // (Neo.worker.App.getWorkerId on the main thread) materializes asynchronously
+                    // after worker construction, so a single immediate evaluate RACES it on freshly
+                    // navigated pages — and a null silently degrades to the appName fallback, which
+                    // binds the OLDEST same-named session. Poll with a bounded wait instead; only
+                    // genuinely old builds (no getWorkerId remote) fall through to appName.
+                    workerId = await page.waitForFunction(async () => {
+                        const appWorker = window.Neo?.worker?.App;
+                        if (!appWorker?.getWorkerId) return null; // remote not registered yet -> keep polling
+                        try {
+                            return await appWorker.getWorkerId()
+                        } catch {
+                            return null
+                        }
+                    }, null, { timeout: 5000 }).then(handle => handle.jsonValue()).catch(() => null);
 
                     inferredAppName = await page.evaluate(() => {
                         const path = window.Neo?.config?.appPath;

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -11,10 +11,10 @@ import {
 
 export const test = base.extend({
     /**
-     * @warning The `neo` fixture uses legacy Remote Method Access (RMA). 
-     * It is retained for environments where the Neural Link is unavailable 
-     * (e.g., Neo.mjs wrapped inside a React application). 
-     * For native Neo.mjs E2E testing, you should exclusively use the `neuralLink` 
+     * @warning The `neo` fixture uses legacy Remote Method Access (RMA).
+     * It is retained for environments where the Neural Link is unavailable
+     * (e.g., Neo.mjs wrapped inside a React application).
+     * For native Neo.mjs E2E testing, you should exclusively use the `neuralLink`
      * fixture instead. See: learn/guides/testing/WhiteboxE2E.md
      */
     neo: async ({ page }, use) => {
@@ -23,7 +23,7 @@ export const test = base.extend({
 
         const neo = {
             page,
-            
+
             async createComponent(config) {
                 return RmaHelpers.createComponent(page, config);
             },
@@ -43,7 +43,7 @@ export const test = base.extend({
             async moveComponent(opts) {
                 return RmaHelpers.moveComponent(page, opts);
             },
-            
+
             async getConfig(id, keyOrKeys) {
                 return RmaHelpers.getComponentConfig(page, id, keyOrKeys);
             },
@@ -84,14 +84,28 @@ export const test = base.extend({
         const nl = {
             /**
              * Waits for the Test's specific App Worker to connect to the Bridge and returns an SDK wrapper.
-             * @param {String} [appName] Optional explicitly named app to wait for. Mostly we wait for this specific page's workerId.
+             *
+             * Resolution order: the page's OWN App Worker id (identity-bind via the `getWorkerId`
+             * remote — exact-match in `waitForSession`), falling back to the explicit / inferred
+             * appName. The identity path is what makes same-name topologies safe: appName resolution
+             * binds to the OLDEST matching session, so a persistent dev tab of the same app would
+             * silently receive the test's worker queries while `page.mouse` drives the test page.
+             * @param {String} [appName] Optional explicitly named app to wait for (fallback only).
              */
             async connectToApp(appName) {
-                let inferredAppName = null;
+                let inferredAppName = null,
+                    workerId        = null;
 
                 try {
                     // Give the page a moment to initialize Neo
                     await page.waitForFunction(() => window.Neo && window.Neo.config, { timeout: 2000 }).catch(() => {});
+
+                    // Identity-bind: ask the page's own App Worker for its id (remote method,
+                    // resolves once the worker is constructed; null on older builds).
+                    workerId = await page.evaluate(() =>
+                        window.Neo?.worker?.App?.getWorkerId?.().catch?.(() => null) ?? null
+                    ).catch(() => null);
+
                     inferredAppName = await page.evaluate(() => {
                         const path = window.Neo?.config?.appPath;
                         return path ? path.split('/').slice(-2, -1)[0] : null;
@@ -100,8 +114,8 @@ export const test = base.extend({
                     // Ignore, page might not exist or be blank
                 }
 
-                // If user passed 'Portal', prefer that, otherwise use the inferred appName like 'portal'
-                const targetId = appName || inferredAppName;
+                // Prefer the page's own worker id (exact-id match); fall back to explicit / inferred appName
+                const targetId = workerId || appName || inferredAppName;
                 if (!targetId) {
                     throw new Error('neuralLink.connectToApp requires either an initialized Neo environment or an explicit appName to wait for.');
                 }
@@ -423,7 +437,7 @@ export const test = base.extend({
                     },
 
                     /**
-                     * Manages the global Neo.config object. 
+                     * Manages the global Neo.config object.
                      * @param {String} action 'get' or 'set'
                      * @param {Object} [config]
                      * @param {String} [windowId]


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

## Summary

Implements the identity-bind fix specified in #12897 (root-caused by @neo-opus-ada; lane picked up after the original assignee's claim expired un-acked with `assignees=[]` — coordination trail on the ticket's A2A thread).

`connectToApp(appName)` resolved the bridge session by app name, and `waitForSession` returns the **oldest** matching session — so with any persistent same-named app connected (e.g. a developer's open DevIndex tab), the test's worker queries silently bound to *that* instance while `page.mouse` drove the test's own page. Two layers, two different App Workers, no error: ada's spec failures and gpt's #12893 review-hold both traced to exactly this.

Fix, per the ticket's preferred shape:
- **`src/worker/App.mjs`**: new `getWorkerId` remote method (registered in the existing `remote.main` list) returning the worker's id — the same value the Neural Link bridge keys its sessions by. Follows the established `createNeoInstance` remote precedent.
- **`test/playwright/fixtures.mjs`**: `connectToApp` asks the page's OWN App Worker for its id via a bounded `waitForFunction` poll (the remote namespace materializes asynchronously after worker construction — an immediate evaluate races it on fresh pages and silently degrades to appName→oldest; reviewer-caught) and passes it to `waitForSession`, whose exact-id branch already existed. Resolution order: own worker id → explicit appName → inferred appName (fallback for genuinely old builds / non-Neo pages).
- **`learn/guides/testing/WhiteboxE2E.md`**: documents the session-resolution order + the oldest-binding hazard (AC5).

Why identity over the alternatives (from the ticket): newest-connectedAt breaks under `--workers>1` and hot-reloads; capture-pre-existing-then-diff is racy. Identity is deterministic and parallel-safe.

Evidence: L3 (live two-session verification on the shared bridge) → L3 required (the AC's same-name-topology behavior is bridge-observable). Residual: none — AC1's exact scenario demonstrated live.

## Deltas

- Drive-by (gate-required): three legacy trailing-whitespace lines in `fixtures.mjs` cleaned (pre-commit whitespace gate fires file-wide on touch).

## Test Evidence

- **Re-verification at `39e95eee4` (gpt's exact failing command)**: `GridColumnCrossBodyDnD -g "cross-region" --workers=1` with a persistent contaminant tab connected → 1 passed; the bridge log shows a FOUR-session same-name topology with every worker call routed to the test's own fresh worker — the oldest-binding failure mode is dead.
- **AC1 live demonstration (the ticket's exact scenario)**: with TWO same-named DevIndex sessions on the bridge — a persistent older tab (`eb75f197`, the operator's) AND a fresh page — the fresh page's `Neo.worker.App.getWorkerId()` returned `e53eeb1f-…`, exactly matching its own bridge session id per `get_worker_topology`. The fixture now passes that id into `waitForSession`'s exact-id match: binding is the page's own worker, independent of session age.
- **Cross-region spec leg green under the two-session topology**: `GridColumnCrossBodyDnD.spec.mjs`'s re-home leg passed identity-bound (its worker assertions read the test page's own re-homed state — impossible under oldest-binding, where the persistent tab's pristine state would have failed it).
- The landing leg of the same spec fails for an UNRELATED, newly-root-caused engine reason (stale region-column arrays on within-region moves — #12903, separate fix in flight); its failure reads the test's OWN session (binding correct).
- Negative control: a `src/`-rollback bisect run (which removed the `getWorkerId` remote) immediately re-bound to the operator's tab (`eb75f197` visible in the bridge debug log) — demonstrating the fallback path AND the pre-fix failure mode in one artifact.

## Post-Merge Validation

- [ ] ada's #12893 spec run with a second DevIndex connected passes its pristine-state guard (AC2).
- [ ] The whitebox suite no longer requires `--workers=1` for correct binding (AC4).
- [x] ~~`WhiteboxE2E.md` identity-bind documentation~~ — **delivered in this PR** (head `39e95eee4`): the guide's connectToApp section documents the session-resolution order (identity-bind first, appName fallback) and the oldest-binding hazard (AC5 ✓).

Resolves #12897
