### PR TITLE
fix(grid): refresh region-column arrays after within-region drag reorders (#12903)

### DIFF
--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -255,8 +255,14 @@ class SortZone extends BaseSortZone {
 
         // super.moveTo reorders the owner toolbar's own items (local space); the global columns
         // collection needs the locked-region offset so center / end toolbars move the right columns.
-        let offset = this.columnIndexOffset();
-        this.owner.gridContainer.columns.move(fromIndex + offset, toIndex + offset)
+        let offset          = this.columnIndexOffset(),
+            {gridContainer} = this.owner;
+
+        gridContainer.columns.move(fromIndex + offset, toIndex + offset);
+
+        // collection.move() is event-silent (no mutate fires), so the region-grouped column
+        // arrays — the engine's region+index oracle — must refresh explicitly here.
+        gridContainer.refreshRegionColumns()
     }
 
     /**

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -978,14 +978,28 @@ class GridContainer extends BaseContainer {
     }
 
     /**
+     * Recomputes the region-grouped column arrays from the global `columns` collection. These
+     * arrays are the engine's region+index oracle — they must refresh on EVERY column-order
+     * mutation, including within-region drag reorders, which mutate the collection via
+     * `columns.move()` (event-silent: no `mutate` fires, so `onColumnsMutate` alone cannot
+     * keep them fresh).
+     * @protected
+     */
+    refreshRegionColumns() {
+        let me = this;
+
+        me.lockedStartColumns = me._columns.items.filter(c => c.locked === 'start');
+        me.centerColumns      = me._columns.items.filter(c => !c.locked);
+        me.lockedEndColumns   = me._columns.items.filter(c => c.locked === 'end')
+    }
+
+    /**
      * @param {Object} data
      */
     onColumnsMutate(data) {
         let me = this;
 
-        me.lockedStartColumns = me._columns.items.filter(c => c.locked === 'start');
-        me.centerColumns      = me._columns.items.filter(c => !c.locked);
-        me.lockedEndColumns   = me._columns.items.filter(c => c.locked === 'end');
+        me.refreshRegionColumns();
 
         me.createOrUpdateSubGrids();
 


### PR DESCRIPTION
Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

## Summary

Within-region column drops reorder the global collection via `columns.move(from, to)` — and `collection.Base#move` is event-silent (splice-only, no `mutate` fires). `grid.Container#onColumnsMutate` therefore never runs on that path, leaving the derived region-grouped arrays (`lockedStartColumns` / `centerColumns` / `lockedEndColumns`) — the engine's documented region+index oracle — stale after every within-region drag. Cross-region drops are unaffected (`locked` changes run `onColumnLockChange` → `onColumnsMutate`), which is exactly why the merged whitebox spec's cross-region leg passed while its landing leg could never pass: live proof showed the DOM header order moved (`[Commits %, Private %, Total]`) while `centerColumns` stayed pristine.

Fix: extract the three-filter recompute into `grid.Container#refreshRegionColumns()` (invoked by `onColumnsMutate` as before) and call it from the drag's `moveTo` after `columns.move(...)`. Deliberately NOT making `collection.move` fire `mutate` (framework-wide blast radius) and NOT running full `onColumnsMutate` per drop (sub-grid/header/size work is unnecessary — the toolbars were already reordered by the drag's own switch flow).

Evidence: L3 (live e2e spec run, engine+DOM agreement) → L3 required (the AC is engine-state-observable through the bridge). No residuals.

## Deltas

None from the ticket.

## Test Evidence

- `GridColumnCrossBodyDnD.spec.mjs` (the merged #12807 whitebox substrate), identity-bound to the test's own page, two-session bridge topology: **2 passed** —
  - Landing leg (previously unsatisfiable): worker truth `centerColumns: ["commitRatio","privateContributionsRatio","totalContributions",…]` ↔ DOM `["Commits %","Private %","Total",…]` — engine and DOM agree, Total at index 2.
  - Cross-region leg (regression guard): `lockedStartColumns: ["id","rank","login","totalContributions"]` ↔ DOM `["#","Rank","User","Total"]` — unchanged.
- Verification environment note: the spec run used PR #12904's fixture identity-bind (independent fix, separate PR) to guarantee the assertions read the test's own session; this PR's diff is engine-only and does not depend on it.

## Post-Merge Validation

- [ ] ada's #12893-merged spec passes both legs on dev once this and #12904 land (her #12807 close-out evidence).

Resolves #12903
