### PR TITLE
fix: route column-drag overdrag scrolling through the scrollbar pipeline (#12906)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -72,6 +72,19 @@ class SortZone extends DragZone {
          */
         enableProxyToPopup: false,
         /**
+         * While a drag is active, force the owner's width to the full content size of its items
+         * (they leave the layout flow via `position: absolute`, so an auto-sized owner would
+         * collapse and reflow its surroundings).
+         *
+         * Subclasses whose owner is a real scroll container (e.g. the grid header toolbar) opt OUT:
+         * expanding such an owner destroys its scrollable overflow, turning the next programmatic
+         * scroll into a scroll of whatever ancestor can still move — in a locked-columns grid that
+         * is the grid container, which drags the frozen regions off-screen. The owner's height is
+         * always pinned, independent of this config.
+         * @member {Boolean} expandOwnerOnDrag=true
+         */
+        expandOwnerOnDrag: true,
+        /**
          * A CSS selector to ignore drag starts on (e.g. '.neo-resizable').
          * @member {String|null} ignoreDragSelector=null
          */
@@ -127,6 +140,16 @@ class SortZone extends DragZone {
          */
         reversedLayoutDirection: false,
         /**
+         * The owner's absolute horizontal scroll position, in owner-content pixels.
+         *
+         * Seeded at drag start from `owner.scrollLeft` (0 for owners without the config) and kept
+         * live during the drag by the owner — for grids: `grid.ScrollManager` mirrors every
+         * horizontal scroll into `grid.header.Toolbar#scrollLeft`, whose afterSet writes it here;
+         * the overdrag path additionally sets it optimistically (`Toolbar#scrollToIndex`).
+         *
+         * The move-delta math pairs it with `itemRects`, which subclasses snapshot in owner-CONTENT
+         * space (see `adjustProxyRectToParent`): `clientX - ownerX + scrollLeft` is the pointer's
+         * content-space position, comparable against `itemRects[i].left` at any scroll state.
          * @member {Number} scrollLeft=0
          */
         scrollLeft: 0,
@@ -567,6 +590,12 @@ class SortZone extends DragZone {
             if (index > 0) {
                 me.currentIndex--;
                 await me.scrollToIndex();
+
+                // The drag can end while the scroll is awaited; the end-reset nulls itemRects
+                if (!me.itemRects) {
+                    return
+                }
+
                 me.switchItems(index, me.currentIndex)
             }
         }
@@ -575,6 +604,12 @@ class SortZone extends DragZone {
             if (index < maxItems) {
                 me.currentIndex++;
                 await me.scrollToIndex();
+
+                // See the isOverDraggingStart branch: bail when the drag ended mid-await
+                if (!me.itemRects) {
+                    return
+                }
+
                 me.switchItems(index, me.currentIndex)
             }
         }
@@ -696,7 +731,7 @@ class SortZone extends DragZone {
                 lastIntersectionRatio  : 1,
                 ownerStyle             : {height: ownerStyle.height, minWidth: ownerStyle.minWidth, position: ownerStyle.position, width: ownerStyle.width},
                 reversedLayoutDirection: layout.direction === 'column-reverse' || layout.direction === 'row-reverse',
-                scrollLeft             : 0, // scroll-since-drag-start; the itemRects snapshot below bakes in any pre-existing scroll
+                scrollLeft             : owner.scrollLeft || 0, // absolute owner scroll; subclasses snapshot itemRects in owner-content space
                 sortableItems,
                 sortDirection          : layout.direction?.includes('column') ? 'vertical' : 'horizontal',
                 startIndex             : index
@@ -745,10 +780,9 @@ class SortZone extends DragZone {
 
             owner.style = {
                 ...ownerStyle,
-                height  : `${me.ownerRect.height}px`,
-                minWidth: `${me.ownerRect.width}px`,
-                width   : `${me.ownerRect.width}px`,
-                ...(me.positionOwnerRelative && {position: 'relative'})
+                height: `${me.ownerRect.height}px`,
+                ...(me.expandOwnerOnDrag      && {minWidth: `${me.ownerRect.width}px`, width: `${me.ownerRect.width}px`}),
+                ...(me.positionOwnerRelative  && {position: 'relative'})
             };
 
             adjustItemRectsToParent && itemRects.forEach(rect => {
@@ -817,29 +851,21 @@ class SortZone extends DragZone {
     onWindowDragContinue(intersectionRatio, data) {}
 
     /**
-     * Scrolls the owner so the current index is reachable, then re-derives the zone's
-     * scroll-correction term. The overdrag path scrolls programmatically (scrollIntoView on the
-     * grid container), which bypasses the normal scroll-sync pipeline — nothing else writes
-     * `me.scrollLeft`, and with a stale term every post-scroll move delta is off by the scrolled
-     * amount (switch avalanches, body cells written in the wrong space). The term's semantics
-     * are scroll-SINCE-DRAG-START (the itemRects snapshot bakes in any pre-existing scroll), so
-     * the correct source is the owner's viewport-x shift relative to the drag-start ownerRect.
+     * Scrolls the owner so the current index becomes reachable. The owner performs the actual
+     * scroll through its production scroll pipeline (for grids: driving the dedicated horizontal
+     * scrollbar element — `grid.header.Toolbar#scrollToIndex`), which also keeps `me.scrollLeft`
+     * current: optimistically via the owner's reactive `scrollLeft` config, and authoritatively
+     * via the scroll-event echo (`grid.ScrollManager` → `Toolbar#afterSetScrollLeft` → this zone).
+     * Move processing is latched off (`isScrolling`) for the duration of the owner call.
      * @returns {Promise<void>}
      */
     async scrollToIndex() {
         let me = this;
 
-        me.traceEvent({t: 'scroll', i: me.currentIndex});
+        me.traceEvent({t: 'scroll', i: me.currentIndex, sl: me.scrollLeft});
 
         me.isScrolling = true;
         await me.owner.scrollToIndex?.(me.currentIndex, me.itemRects[me.currentIndex]);
-
-        if (me.ownerRect) {
-            const [liveOwnerRect] = await me.owner.getDomRect([me.owner.id]);
-            me.scrollLeft = me.ownerRect.x - liveOwnerRect.x;
-            me.traceEvent({t: 'scrollSync', sl: me.scrollLeft})
-        }
-
         me.isScrolling = false
     }
 

--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -475,6 +475,7 @@ class SortZone extends DragZone {
                 lastInBoundX    : null,
                 lastInBoundY    : null,
                 ownerRect       : null,
+                scrollLeft      : 0,
                 startIndex      : -1,
                 sortableItems   : null
             });
@@ -695,6 +696,7 @@ class SortZone extends DragZone {
                 lastIntersectionRatio  : 1,
                 ownerStyle             : {height: ownerStyle.height, minWidth: ownerStyle.minWidth, position: ownerStyle.position, width: ownerStyle.width},
                 reversedLayoutDirection: layout.direction === 'column-reverse' || layout.direction === 'row-reverse',
+                scrollLeft             : 0, // scroll-since-drag-start; the itemRects snapshot below bakes in any pre-existing scroll
                 sortableItems,
                 sortDirection          : layout.direction?.includes('column') ? 'vertical' : 'horizontal',
                 startIndex             : index
@@ -815,6 +817,13 @@ class SortZone extends DragZone {
     onWindowDragContinue(intersectionRatio, data) {}
 
     /**
+     * Scrolls the owner so the current index is reachable, then re-derives the zone's
+     * scroll-correction term. The overdrag path scrolls programmatically (scrollIntoView on the
+     * grid container), which bypasses the normal scroll-sync pipeline — nothing else writes
+     * `me.scrollLeft`, and with a stale term every post-scroll move delta is off by the scrolled
+     * amount (switch avalanches, body cells written in the wrong space). The term's semantics
+     * are scroll-SINCE-DRAG-START (the itemRects snapshot bakes in any pre-existing scroll), so
+     * the correct source is the owner's viewport-x shift relative to the drag-start ownerRect.
      * @returns {Promise<void>}
      */
     async scrollToIndex() {
@@ -824,6 +833,13 @@ class SortZone extends DragZone {
 
         me.isScrolling = true;
         await me.owner.scrollToIndex?.(me.currentIndex, me.itemRects[me.currentIndex]);
+
+        if (me.ownerRect) {
+            const [liveOwnerRect] = await me.owner.getDomRect([me.owner.id]);
+            me.scrollLeft = me.ownerRect.x - liveOwnerRect.x;
+            me.traceEvent({t: 'scrollSync', sl: me.scrollLeft})
+        }
+
         me.isScrolling = false
     }
 

--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -36,6 +36,17 @@ class SortZone extends BaseSortZone {
          */
         ntype: 'grid-header-toolbar-sortzone',
         /**
+         * The owner toolbar is a real horizontal scroll container (clipped by the header wrapper,
+         * scrolled in lockstep with the grid via `Neo.main.addon.GridHorizontalScrollSync`).
+         * Expanding it to content size mid-drag would destroy its scrollable overflow, so the
+         * overdrag scroll would fall through to the grid container — dragging the locked regions
+         * off-screen and detaching the body from the scroll pipeline. The absolutely positioned
+         * drag items keep the toolbar's scrollable overflow alive instead (their containing block
+         * is the toolbar via {@link #positionOwnerRelative}).
+         * @member {Boolean} expandOwnerOnDrag=false
+         */
+        expandOwnerOnDrag: false,
+        /**
          * @member {String|null} itemMargin='1px'
          * @protected
          */
@@ -58,6 +69,16 @@ class SortZone extends BaseSortZone {
          */
         positionOwnerRelative: true
     }
+
+    /**
+     * The owner toolbar's absolute scrollLeft at drag start. {@link #adjustProxyRectToParent}
+     * re-bases the drag-start snapshot rects (items and proxy alike) from owner-relative into
+     * owner-CONTENT space with it, so they align with `columnPositions.x` and the zone's absolute
+     * `scrollLeft` term at any mid-drag scroll position.
+     * @member {Number} dragStartScrollLeft=0
+     * @protected
+     */
+    dragStartScrollLeft = 0
 
     /**
      * Resolves the `grid.Body` paired with this SortZone's owner header toolbar, keyed by the
@@ -119,14 +140,17 @@ class SortZone extends BaseSortZone {
     }
 
     /**
-     * Converts a viewport-space item rect into owner(toolbar)-relative space. The owner toolbar is
+     * Converts a viewport-space item rect into owner(toolbar)-CONTENT space. The owner toolbar is
      * the containing block during the drag (see {@link #positionOwnerRelative}), so the conversion
-     * is a pure origin subtraction — no border compensation, the toolbar has none.
+     * is the origin subtraction (no border compensation, the toolbar has none) plus the toolbar's
+     * drag-start scroll: absolutely positioned children resolve against the padding box and move
+     * with the scrolled content, so content-space left values render correctly at any scroll state
+     * — and match `columnPositions.x`, which lives in the same space.
      * @param {Neo.util.Rectangle} rect
      * @param {Neo.util.Rectangle} parentRect
      */
     adjustProxyRectToParent(rect, parentRect) {
-        rect.x = rect.x - parentRect.x;
+        rect.x = rect.x - parentRect.x + this.dragStartScrollLeft;
         rect.y = rect.y - parentRect.y
     }
 
@@ -395,6 +419,10 @@ class SortZone extends BaseSortZone {
 
         // Avoid conflicts with grid.header.plugin.Resizable
         if (!me.owner.dragResortable) return;
+
+        // Freeze the drag-start scroll BEFORE the base class snapshots and adjusts the item and
+        // proxy rects: adjustProxyRectToParent re-bases them all into owner-content space with it.
+        me.dragStartScrollLeft = me.owner.scrollLeft || 0;
 
         await super.onDragStart(data);
 

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -402,14 +402,21 @@ class GridBody extends Component {
      */
     afterSetAvailableWidth(value, oldValue) {
         if (value > 0) {
-            let me = this;
+            let me              = this,
+                {gridContainer} = me,
+                scrollbar       = gridContainer?.horizontalScrollbar;
 
             me.vdom.width = value + 'px';
             me.update();
 
-            // Only sync the center body's width to the Scroller addon
-            if (me === me.gridContainer?.body && me.gridContainer.horizontalScrollbar) {
-                me.gridContainer.horizontalScrollbar.centerWidth = value;
+            // Per-region sync into the horizontal scrollbar: the center feeds the spacer (the
+            // scrollable content), the locked bodies feed the flanking margins which scope the
+            // scrollbar's scrollport to the center clip width — keeping its scrollLeft range
+            // identical to the center toolbar's, so the addon's verbatim copy stays exact.
+            if (scrollbar) {
+                if      (me === gridContainer.body)      {scrollbar.centerWidth = value}
+                else if (me === gridContainer.bodyStart) {scrollbar.startWidth  = value}
+                else if (me === gridContainer.bodyEnd)   {scrollbar.endWidth    = value}
             }
         }
     }

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -823,7 +823,11 @@ class GridContainer extends BaseContainer {
             }
         } else if (me.bodyStart) {
             me.bodyStart.destroy();
-            me.bodyStart = null
+            me.bodyStart = null;
+
+            // The margin feed lives in Body#afterSetAvailableWidth; a destroyed region must
+            // release its scrollbar-scrollport margin explicitly.
+            me.horizontalScrollbar && (me.horizontalScrollbar.startWidth = 0)
         }
 
         // --- End body (Right) ---
@@ -844,7 +848,10 @@ class GridContainer extends BaseContainer {
             }
         } else if (me.bodyEnd) {
             me.bodyEnd.destroy();
-            me.bodyEnd = null
+            me.bodyEnd = null;
+
+            // See the bodyStart branch: release the scrollport margin of a removed region.
+            me.horizontalScrollbar && (me.horizontalScrollbar.endWidth = 0)
         }
 
         // Synchronize the body sub-grids into the grid.View.

--- a/src/grid/HorizontalScrollbar.mjs
+++ b/src/grid/HorizontalScrollbar.mjs
@@ -26,6 +26,24 @@ class HorizontalScrollbar extends Base {
          */
         cls: ['neo-grid-horizontal-scrollbar'],
         /**
+         * The width in pixels of the locked-end (right) column region.
+         *
+         * Applied as `margin-right`, so the scrollbar's scrollport covers ONLY the center region.
+         * The spacer ({@link #centerWidth}) models the center content, while
+         * `Neo.main.addon.GridHorizontalScrollSync` copies this element's `scrollLeft` verbatim onto
+         * the center header toolbar — that 1:1 mapping is only exact when scrollport equals the
+         * center clip width. Without the margins, the max `scrollLeft` falls short by exactly the
+         * locked-region widths, leaving the last center columns unreachable.
+         * @member {Number} endWidth_=0
+         */
+        endWidth_: 0,
+        /**
+         * The width in pixels of the locked-start (left) column region.
+         * Applied as `margin-left`; see {@link #endWidth} for the scrollport-scoping rationale.
+         * @member {Number} startWidth_=0
+         */
+        startWidth_: 0,
+        /**
          * @member {Object} _vdom
          */
         _vdom:
@@ -44,6 +62,30 @@ class HorizontalScrollbar extends Base {
         if (value || value === 0) {
             this.vdom.cn[0].style.width = `${value}px`;
             this.update();
+        }
+    }
+
+    /**
+     * Triggered after the endWidth config got changed
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetEndWidth(value, oldValue) {
+        if (value || value === 0) {
+            this.style = {...this.style, marginRight: `${value}px`}
+        }
+    }
+
+    /**
+     * Triggered after the startWidth config got changed
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetStartWidth(value, oldValue) {
+        if (value || value === 0) {
+            this.style = {...this.style, marginLeft: `${value}px`}
         }
     }
 }

--- a/src/grid/ScrollManager.mjs
+++ b/src/grid/ScrollManager.mjs
@@ -154,10 +154,10 @@ class ScrollManager extends Base {
         let me        = this,
             container = me.gridContainer,
             isView    = target.id === container.view?.id;
-        
+
         if (isView) {
             me.scrollTop = target.scrollTop ?? scrollTop;
-            
+
             let startedScrolling = !container.body.isScrolling;
 
             if (container.bodyStart) container.bodyStart.isScrolling = true;
@@ -172,7 +172,14 @@ class ScrollManager extends Base {
             me.syncGridBody()
         } else if (target.id === container.horizontalScrollbar?.id || target.id.includes('grid-container')) {
             me.scrollLeft = target.scrollLeft ?? scrollLeft;
-            
+
+            // Mirror into the center header toolbar's reactive config. Its afterSetScrollLeft
+            // feeds the drag SortZone's scroll-correction term — without this write the config
+            // (and the term) never move, corrupting post-scroll drag math. The DOM-side header
+            // sync happens main-thread in Neo.main.addon.GridHorizontalScrollSync; this is the
+            // worker-side state mirror.
+            container.headerToolbar && (container.headerToolbar.scrollLeft = me.scrollLeft);
+
             let startedScrolling = !container.body.isScrolling;
 
             if (container.bodyStart) container.bodyStart.isScrolling = true;

--- a/src/grid/header/Toolbar.mjs
+++ b/src/grid/header/Toolbar.mjs
@@ -50,6 +50,11 @@ class Toolbar extends BaseToolbar {
          */
         role: 'row',
         /**
+         * Worker-side mirror of the grid's horizontal scroll position (absolute, in center-content
+         * pixels). Fed by `grid.ScrollManager#onContainerScroll` on every horizontal scroll, and
+         * optimistically by {@link #scrollToIndex} during drag overdrag. {@link #afterSetScrollLeft}
+         * forwards it into the column-drag SortZone's scroll-correction term. The DOM-side header
+         * scroll itself is synced main-thread by `Neo.main.addon.GridHorizontalScrollSync`.
          * @member {Number} scrollLeft_=0
          * @reactive
          */
@@ -113,14 +118,20 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
-     * Triggered after the scrollLeft config got changed
+     * Triggered after the scrollLeft config got changed.
+     * Forwards the absolute scroll position into the column-drag SortZone's correction term.
      * @param {Number} value
      * @param {Number} oldValue
      * @protected
      */
     afterSetScrollLeft(value, oldValue) {
-        if (oldValue !== undefined && this.sortZone) {
-            this.sortZone.scrollLeft = value
+        let {sortZone} = this;
+
+        if (oldValue !== undefined && sortZone) {
+            sortZone.scrollLeft = value;
+
+            // Term observability while a drag is in flight (itemRects = the mid-drag marker)
+            sortZone.itemRects && sortZone.traceEvent({t: 'scrollSync', sl: value})
         }
     }
 
@@ -327,15 +338,60 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
-     * @param {Number}  index
+     * @summary Scrolls the grid horizontally so the column slot at `index` becomes fully visible,
+     * by driving the dedicated horizontal scrollbar element — the grid's single scroll SSOT.
+     *
+     * Consumer: the column-drag overdrag loop (`draggable.container.SortZone#scrollToIndex`).
+     * Routing through the scrollbar (instead of a scrollIntoView on a header button, which scrolls
+     * whatever ancestor can move — in a locked grid that is the grid container, dragging the locked
+     * regions off-screen and never re-rendering the body) means the production pipeline performs
+     * the sync: `Neo.main.addon.GridHorizontalScrollSync` mirrors the value onto this toolbar's
+     * element and the body's `--grid-scroll-left` var in-frame, while `grid.ScrollManager` ingests
+     * it for buffered column mounting. Locked regions stay frozen; both scroll directions work.
+     *
+     * Only the center (unlocked) toolbar scrolls — locked-region toolbars no-op, since their
+     * content never overflows their region.
+     *
+     * @param {Number} index The slot index inside this toolbar
+     * @param {Object} [itemRect] The slot's rect in center-content space (the drag snapshot)
+     * @param {Number} itemRect.left
+     * @param {Number} itemRect.width
      * @returns {Promise<void>}
      */
-    async scrollToIndex(index) {
-        await Neo.main.DomAccess.scrollIntoView({
-            delay: 125,
-            id: this.items[index].id,
-            windowId: this.windowId
-        })
+    async scrollToIndex(index, itemRect) {
+        let me = this;
+
+        if (me.layoutLock || !itemRect) {
+            return
+        }
+
+        let {gridContainer} = me,
+            scrollbar       = gridContainer.horizontalScrollbar,
+            current         = me.scrollLeft,
+            // The center clip width: the grid minus the locked regions (= the scrollbar's scrollport)
+            clipWidth       = gridContainer.body.containerWidth
+                - (gridContainer.bodyStart?.availableWidth || 0)
+                - (gridContainer.bodyEnd?.availableWidth   || 0),
+            target          = null;
+
+        if (itemRect.left < current) {
+            target = itemRect.left
+        } else if (itemRect.left + itemRect.width > current + clipWidth) {
+            target = itemRect.left + itemRect.width - clipWidth
+        }
+
+        if (scrollbar && target !== null) {
+            // Optimistic worker-side mirror: afterSetScrollLeft feeds the SortZone term BEFORE the
+            // DOM scroll-event echo arrives via grid.ScrollManager (which re-sets the same value).
+            me.scrollLeft = target;
+
+            await Neo.main.DomAccess.scrollTo({
+                direction: 'left',
+                id       : scrollbar.id,
+                value    : target,
+                windowId : me.windowId
+            })
+        }
     }
 
     /**

--- a/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
+++ b/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
@@ -1,0 +1,283 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * Whitebox-e2e for locked-grid column-drag OVERDRAG scrolling and the horizontal scrollbar
+ * scrollport — the operator's manual repro, automated:
+ *
+ *   Drag a centre column right until the pointer crosses the centre region's edge → the grid
+ *   auto-scrolls (overdrag). Then, in the SAME gesture, drag back left across the centre region
+ *   and hold past its left edge → the grid must auto-scroll back — all the way home — and the
+ *   drop must land at centre index 0.
+ *
+ * Pre-fix failure modes this spec pins (all convicted live via the drag trace):
+ *   - Overdrag scrolled the GRID CONTAINER via scrollIntoView (not the scroll pipeline): the
+ *     locked regions were dragged off-screen, the body never re-rendered, and the SortZone's
+ *     scroll term stayed 0 → switch avalanches.
+ *   - The back leg hard-stopped with `gridScrollLeft = lockedStartWidth`: scrollIntoView's
+ *     'nearest' was satisfied with centre column 0 flush at the GRID's edge — locked columns
+ *     hidden, index 0 unreachable, drops landing at the wrong slot.
+ *   - The scrollbar's scrollport spanned the full grid width while its spacer modelled centre
+ *     content → max scrollLeft fell short by exactly the locked widths; the last centre columns
+ *     were unreachable by ANY scrolling.
+ *
+ * Post-fix contract (what we assert):
+ *   - The dedicated horizontal scrollbar element is the ONLY scroll surface that moves; the
+ *     grid container's own scrollLeft stays 0 and the locked-start toolbar's viewport rect is
+ *     frozen for the whole gesture.
+ *   - The trace's `scrollSync` events show the zone's term tracking the scroll in BOTH
+ *     directions, returning to exactly 0 on the back leg.
+ *   - The drop resolves `end {from: 2, to: 0}` with a null lock verdict (no spurious re-home),
+ *     and nothing switches after `end` (the mid-await drag-end race).
+ *   - Worker truth (region column arrays) and the rendered DOM agree on the landing.
+ *
+ * Gesture notes: page.mouse with `{steps}` arms Neo's Mouse drag sensor (see
+ * GridColumnCrossBodyDnD.spec.mjs). While the pointer HOLDS past a region edge, the worker-side
+ * overdrag loop self-feeds — no further mouse events are needed; the spec polls the scrollbar
+ * element until each leg settles instead of sleeping fixed amounts.
+ *
+ * Run: npx playwright test GridColumnOverdragScroll -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Desktop (1920x1080): DevIndex Column Overdrag Scrolling (#12906/#12907)', () => {
+    test.setTimeout(120000); // DevIndex is heavy; two overdrag legs poll-settle sequentially.
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/apps/devindex/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+        const stopButton = page.locator('.devindex-stop-stream-button');
+        try {
+            await expect(stopButton).toBeVisible({ timeout: 5000 });
+            await stopButton.click({ timeout: 2000, force: true }); // stop the stream so we don't wait for all rows
+        } catch {
+            // stream settled instantly — button never appeared / already hid
+        }
+        await page.waitForTimeout(1000);
+    });
+
+    test('overdrag right then back left to index 0 — scrollbar-routed, locked region frozen, exact landing', async ({ page, neuralLink }) => {
+        const app    = await neuralLink.connectToApp('DevIndex');
+        const gridId = await resolveGridId(app);
+
+        // Worker preconditions: pristine layout + the dragged column's identity (centre index 2)
+        const preRegion = await regionColumns(app, gridId);
+        expect(preRegion.lockedStart).toEqual(['id', 'rank', 'login']);
+        const draggedField = preRegion.center[2];
+        expect(draggedField).toBeTruthy();
+
+        const centerToolbar = page.locator('.neo-grid-header-toolbar').nth(1);
+        const startToolbar  = page.locator('.neo-grid-header-toolbar').nth(0);
+        const dragHeader    = centerToolbar.locator('.neo-draggable').nth(2);
+        await expect(dragHeader).toBeVisible({ timeout: 5000 });
+
+        const dragBox      = await dragHeader.boundingBox();
+        const centerBox    = await centerToolbar.boundingBox();
+        const startBoxPre  = await startToolbar.boundingBox();
+        const y            = dragBox.y + dragBox.height / 2;
+
+        // --- Leg 1: drag right past the centre region's edge; HOLD until the auto-scroll settles
+        await page.mouse.move(dragBox.x + dragBox.width / 2, y);
+        await page.mouse.down();
+        await page.mouse.move(Math.min(centerBox.x + centerBox.width + 40, 1910), y, { steps: 40 });
+
+        const maxScroll = await pollScrollbar(page, sl => sl > 0, 'stable');
+        expect(maxScroll, 'overdrag right must scroll the dedicated scrollbar element').toBeGreaterThan(0);
+
+        // Mid-gesture invariants: the scrollbar is the ONLY moving scroll surface
+        const midState = await scrollSurfaces(page);
+        expect(midState.gridScrollLeft,  'the grid container must never scroll during overdrag').toBe(0);
+        const startBoxMid = await startToolbar.boundingBox();
+        expect(Math.round(startBoxMid.x), 'the locked-start region must stay frozen during overdrag').toBe(Math.round(startBoxPre.x));
+
+        // --- Leg 2: same gesture, drag back left past the centre region's left edge; HOLD until home
+        await page.mouse.move(startBoxPre.x + startBoxPre.width - 40, y, { steps: 40 });
+        const homeScroll = await pollScrollbar(page, sl => sl === 0, 'value');
+        expect(homeScroll, 'the back leg must scroll all the way home — no hard cut at the locked width').toBe(0);
+
+        // Land just inside the centre region's left edge → centre index 0
+        await page.mouse.move(centerBox.x + 30, y, { steps: 5 });
+        await page.waitForTimeout(250);
+        await page.mouse.up();
+        await page.waitForTimeout(700);
+
+        // --- Logic-layer oracle: the drag trace
+        const traceData = await app.getDragTrace();
+        const traces    = traceData?.traces || traceData?.result?.traces || [];
+        const trace     = traces[traces.length - 1];
+        expect(trace, 'the SortZone must have recorded a trace for the gesture').toBeTruthy();
+
+        const events      = trace.events;
+        const endIndex    = events.findIndex(e => e.t === 'end');
+        const endEvent    = events[endIndex];
+        const lockVerdict = events.find(e => e.t === 'lockVerdict');
+        const scrollSyncs = events.filter(e => e.t === 'scrollSync');
+
+        expect(endEvent, 'the gesture must resolve with an end event').toBeTruthy();
+        expect(endEvent.from, 'the drag started at centre index 2').toBe(2);
+        expect(endEvent.to,   'the drop must land at centre index 0 — the pre-fix run landed at 3').toBe(0);
+        expect(lockVerdict?.next, 'a within-centre drop must not re-home the column').toBeNull();
+
+        expect(scrollSyncs.length, 'the zone term must sync on both legs').toBeGreaterThanOrEqual(5);
+        expect(scrollSyncs.some(e => e.sl > 0), 'the term must track the rightward scroll').toBe(true);
+        expect(scrollSyncs[scrollSyncs.length - 1].sl, 'the term must return to 0 on the back leg').toBe(0);
+
+        const postEndSwitches = events.slice(endIndex + 1).filter(e => e.t === 'switch');
+        expect(postEndSwitches, 'no switch may fire after the end event (mid-await drag-end race)').toEqual([]);
+
+        // --- Worker + DOM oracles: the landing
+        const region   = await regionColumns(app, gridId);
+        const domOrder = await getColumnOrder(page, 1);
+        expect(region.center[0], 'worker truth: the dragged column owns centre index 0').toBe(draggedField);
+        expect(region.lockedStart, 'the locked-start region membership must be untouched').toEqual(['id', 'rank', 'login']);
+        expect(domOrder[0], 'DOM truth: the dragged column renders first in the centre toolbar').toBe(await headerLabel(page, 1, 0));
+
+        // --- Three-surface consistency: items / vdom / DOM agree, zero duplicates
+        const toolbars   = await app.findInstances({ ntype: 'grid-header-toolbar' }, ['id', 'layoutLock']);
+        const centerTb   = (Array.isArray(toolbars) ? toolbars : [toolbars]).find(t => !t.layoutLock && !t.properties?.layoutLock);
+        if (centerTb?.id) {
+            const consistency = await app.verifyComponentConsistency(centerTb.id);
+            const mismatches  = consistency?.mismatches || consistency?.result?.mismatches || [];
+            expect(mismatches, 'post-drop items/vdom/DOM surfaces must agree').toEqual([]);
+        }
+
+        // --- Clean restore: every scroll surface back at origin
+        const endState = await scrollSurfaces(page);
+        expect(endState.scrollbarScrollLeft).toBe(0);
+        expect(endState.gridScrollLeft).toBe(0);
+    });
+
+    test('scrollbar scrollport is scoped to the centre region — full range, margins = locked widths (#12907)', async ({ page, neuralLink }) => {
+        await neuralLink.connectToApp('DevIndex'); // session-bind keeps the page's worker authoritative
+
+        const result = await page.evaluate(async () => {
+            const sleep   = ms => new Promise(r => setTimeout(r, ms));
+            const sb      = document.querySelector('.neo-grid-horizontal-scrollbar');
+            const tbs     = document.querySelectorAll('.neo-grid-header-toolbar');
+            const startTb = tbs[0], centerTb = tbs[1], endTb = tbs[2];
+            const cs      = getComputedStyle(sb);
+
+            sb.scrollLeft = 999999;
+            await sleep(400);
+
+            const lastBtn  = centerTb.children[centerTb.children.length - 1];
+            const atMax    = {
+                scrollbar : sb.scrollLeft,
+                toolbar   : centerTb.scrollLeft,
+                needed    : centerTb.scrollWidth - centerTb.clientWidth,
+                lastFlush : Math.abs(lastBtn.getBoundingClientRect().right - centerTb.getBoundingClientRect().right) < 2
+            };
+
+            sb.scrollLeft = 0;
+            await sleep(300);
+
+            return {
+                marginLeft : cs.marginLeft,
+                marginRight: cs.marginRight,
+                startWidth : Math.round(startTb.getBoundingClientRect().width),
+                endWidth   : Math.round(endTb.getBoundingClientRect().width),
+                scrollport : sb.clientWidth,
+                centerClip : centerTb.clientWidth,
+                atMax,
+                reset      : { scrollbar: sb.scrollLeft, toolbar: centerTb.scrollLeft }
+            };
+        });
+
+        expect(result.marginLeft,  'margin-left must equal the locked-start width').toBe(`${result.startWidth}px`);
+        expect(result.marginRight, 'margin-right must equal the locked-end width').toBe(`${result.endWidth}px`);
+        expect(result.scrollport,  'the scrollport must equal the centre clip width').toBe(result.centerClip);
+
+        expect(result.atMax.scrollbar, 'max scrollLeft must reach the full centre overflow (pre-fix: short by the locked widths)').toBe(result.atMax.needed);
+        expect(result.atMax.toolbar,   'the header sync must reach the same max').toBe(result.atMax.needed);
+        expect(result.atMax.lastFlush, 'the last centre column must be flush with the centre region edge at max scroll').toBe(true);
+
+        expect(result.reset.scrollbar).toBe(0);
+        expect(result.reset.toolbar).toBe(0);
+    });
+});
+
+/**
+ * Resolves the DevIndex grid-container instance id from the App Worker.
+ * @returns {Promise<String>}
+ */
+async function resolveGridId(app) {
+    const grids  = await app.findInstances({ ntype: 'grid-container' }, ['id']);
+    const gridId = Array.isArray(grids) ? grids[0]?.id : grids?.id;
+    expect(gridId, 'a grid-container instance must exist in the bound App Worker').toBeTruthy();
+    return gridId;
+}
+
+/**
+ * Reads the grid's three region-grouped column arrays from the App Worker as ordered dataField
+ * lists — the engine's authoritative region+index model (see GridColumnCrossBodyDnD.spec.mjs).
+ * @returns {Promise<{center: String[], lockedStart: String[], lockedEnd: String[]}>}
+ */
+async function regionColumns(app, gridId) {
+    const props  = await app.getComponent(gridId, ['centerColumns', 'lockedStartColumns', 'lockedEndColumns']);
+    const fields = arr => (arr || []).map(col => col.dataField);
+    return {
+        center     : fields(props.centerColumns),
+        lockedStart: fields(props.lockedStartColumns),
+        lockedEnd  : fields(props.lockedEndColumns)
+    };
+}
+
+/**
+ * Reads the header column labels in order for a region toolbar (DOM oracle layer).
+ * Region order: 0 = locked-start, 1 = centre, 2 = locked-end.
+ */
+async function getColumnOrder(page, toolbarIndex) {
+    return page.evaluate(idx => {
+        const tb = document.querySelectorAll('.neo-grid-header-toolbar')[idx];
+        if (!tb) return [];
+        return Array.from(tb.querySelectorAll('.neo-button-text'))
+            .map(el => (el.textContent || '').trim())
+            .filter(Boolean);
+    }, toolbarIndex);
+}
+
+/**
+ * Reads a single header label by region toolbar index + button index.
+ */
+async function headerLabel(page, toolbarIndex, buttonIndex) {
+    const order = await getColumnOrder(page, toolbarIndex);
+    return order[buttonIndex];
+}
+
+/**
+ * Snapshot of every horizontal scroll surface the fix routes (or pins).
+ */
+async function scrollSurfaces(page) {
+    return page.evaluate(() => ({
+        scrollbarScrollLeft: document.querySelector('.neo-grid-horizontal-scrollbar')?.scrollLeft ?? -1,
+        gridScrollLeft     : document.querySelector('.neo-grid-container')?.scrollLeft ?? -1
+    }));
+}
+
+/**
+ * Polls the dedicated horizontal scrollbar element while the mouse HOLDS in an overdrag zone.
+ * mode 'stable': resolves once `accept(sl)` holds AND the value stops changing across 3
+ * consecutive samples (the overdrag walk settled — e.g. at the content end). mode 'value':
+ * resolves as soon as `accept(sl)` holds. Returns the final sampled value; bounded at ~8s.
+ */
+async function pollScrollbar(page, accept, mode) {
+    let last = -1, stable = 0;
+
+    for (let i = 0; i < 40; i++) {
+        await page.waitForTimeout(200);
+
+        const sl = await page.evaluate(() =>
+            document.querySelector('.neo-grid-horizontal-scrollbar')?.scrollLeft ?? -1);
+
+        if (mode === 'value' && accept(sl)) return sl;
+
+        if (mode === 'stable') {
+            stable = (sl === last) ? stable + 1 : 0;
+            if (accept(sl) && stable >= 3) return sl;
+        }
+
+        last = sl;
+    }
+
+    return last;
+}

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -305,6 +305,39 @@ export const test = base.extend({
                         return NeuralLink_InteractionService.simulateEvent({ sessionId, events: Array.isArray(events) ? events : [events] });
                     },
 
+                    /**
+                     * Retrieves the recent SortZone drag-lifecycle traces (start geometry, per-move
+                     * decisions, switches, scroll activations + term syncs, end resolution, grid lock
+                     * verdicts). The logic-layer oracle for drag-and-drop specs (whitebox-e2e §5.1).
+                     * @param {Boolean} [clear=false] Empty the trace ring buffer after reading
+                     * @returns {Promise<Object>}
+                     */
+                    async getDragTrace(clear = false) {
+                        return NeuralLink_InteractionService.getDragTrace({ sessionId, clear });
+                    },
+
+                    /**
+                     * Samples component client rects over a time window (motion trace) — start it
+                     * BEFORE page.mouse.down() to assert mid-drag geometry (whitebox-e2e §5.1).
+                     * @param {String[]} componentIds
+                     * @param {Number} [durationMs]
+                     * @param {Number} [intervalMs]
+                     * @returns {Promise<Object>}
+                     */
+                    async observeMotion(componentIds, durationMs, intervalMs) {
+                        return NeuralLink_InteractionService.observeMotion({ sessionId, componentIds, durationMs, intervalMs });
+                    },
+
+                    /**
+                     * Diffs a container's logical items / vdom / rendered DOM child surfaces —
+                     * the post-drop duplication & order-drift detector (whitebox-e2e §5.1).
+                     * @param {String} componentId
+                     * @returns {Promise<Object>}
+                     */
+                    async verifyComponentConsistency(componentId) {
+                        return NeuralLink_InteractionService.verifyComponentConsistency({ sessionId, componentId });
+                    },
+
                     // --- Data & State Methods ---
 
                     /**

--- a/test/playwright/unit/grid/HorizontalScrollbar.spec.mjs
+++ b/test/playwright/unit/grid/HorizontalScrollbar.spec.mjs
@@ -1,0 +1,95 @@
+/**
+ * @file test/playwright/unit/grid/HorizontalScrollbar.spec.mjs
+ * @summary Unit tests for the horizontal scrollbar's scrollport scoping in locked grids.
+ *
+ * In a locked-columns grid the scrollbar element historically spanned the FULL grid width while
+ * its inner spacer modelled only the center content — so its max scrollLeft fell short of the
+ * center toolbar's by exactly the locked-region widths, leaving the last center columns
+ * unreachable by any scrolling. The fix scopes the scrollport to the center region: the locked
+ * widths apply as flanking margins (`startWidth_` / `endWidth_`), fed per region from
+ * `grid.Body#afterSetAvailableWidth` exactly like the existing `centerWidth` spacer feed.
+ *
+ * @see Neo.grid.HorizontalScrollbar
+ * @see Neo.grid.Body
+ * @see Neo.main.addon.GridHorizontalScrollSync
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridHorizontalScrollbarTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Body               from '../../../../src/grid/Body.mjs';
+import HorizontalScrollbar from '../../../../src/grid/HorizontalScrollbar.mjs';
+
+test.describe('Neo.grid.HorizontalScrollbar scrollport scoping', () => {
+    test('locked-region widths apply as scrollport margins; defaults stay 0', () => {
+        const scrollbar = Neo.create(HorizontalScrollbar, {});
+
+        // Single-region default: both margins explicitly 0 — zero behavior change
+        expect(scrollbar.style.marginLeft).toBe('0px');
+        expect(scrollbar.style.marginRight).toBe('0px');
+
+        scrollbar.startWidth = 370;
+        scrollbar.endWidth   = 120;
+
+        expect(scrollbar.style.marginLeft).toBe('370px');
+        expect(scrollbar.style.marginRight).toBe('120px');
+
+        // Runtime unlock path: a removed region releases its margin
+        scrollbar.startWidth = 0;
+        expect(scrollbar.style.marginLeft).toBe('0px');
+
+        scrollbar.destroy();
+    });
+
+    test('centerWidth still drives the spacer width', () => {
+        const scrollbar = Neo.create(HorizontalScrollbar, {centerWidth: 3036});
+
+        expect(scrollbar.vdom.cn[0].style.width).toBe('3036px');
+
+        scrollbar.destroy();
+    });
+
+    test('Body#afterSetAvailableWidth routes per region: center → spacer, locked → margins', () => {
+        // Plain objects borrowing the prototype method under test (see BodyCellMapping.spec.mjs:
+        // Object.create(Body.prototype) trips the #configs private-brand check, while a plain
+        // `this` only needs the members the method reads).
+        const scrollbar     = {centerWidth: -1, startWidth: -1, endWidth: -1};
+        const gridContainer = {horizontalScrollbar: scrollbar};
+        const makeBody      = () => ({gridContainer, vdom: {}, update() {}});
+
+        const center = makeBody();
+        const start  = makeBody();
+        const end    = makeBody();
+
+        gridContainer.body      = center;
+        gridContainer.bodyStart = start;
+        gridContainer.bodyEnd   = end;
+
+        Body.prototype.afterSetAvailableWidth.call(center, 3036, 0);
+        Body.prototype.afterSetAvailableWidth.call(start,  370,  0);
+        Body.prototype.afterSetAvailableWidth.call(end,    120,  0);
+
+        expect(scrollbar.centerWidth).toBe(3036);
+        expect(scrollbar.startWidth).toBe(370);
+        expect(scrollbar.endWidth).toBe(120);
+
+        // No scrollbar present (e.g. teardown ordering): the feed must be a silent no-op
+        const orphan = {gridContainer: {horizontalScrollbar: null}, vdom: {}, update() {}};
+        expect(() => Body.prototype.afterSetAvailableWidth.call(orphan, 500, 0)).not.toThrow();
+    });
+});


### PR DESCRIPTION
Resolves #12906
Resolves #12907

Refs #12883

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

Column-drag overdrag scrolling now drives the grid's dedicated horizontal scrollbar element — the same scroll SSOT user scrolling drives — instead of a `scrollIntoView` that scrolled the grid container. The production pipeline does the rest: `Neo.main.addon.GridHorizontalScrollSync` mirrors the value onto the center header toolbar and the body's `--grid-scroll-left` var in-frame, `grid.ScrollManager` ingests it for buffered column mounting, and a new one-line worker-side mirror revives the previously-dead `Toolbar#afterSetScrollLeft → sortZone.scrollLeft` wiring so the zone's correction term stays live for every scroll source. The locked regions stay frozen through both overdrag directions, the body follows visually and logically, the back leg scrolls all the way home (the operator's "hard cut at a left position" was `scrollIntoView`'s 'nearest' being satisfied at `gridScrollLeft = lockedStartWidth`), and drops land at the slot the pointer indicates.

The reroute surfaced a pre-existing, drag-independent range bug (#12907): the scrollbar's scrollport spanned the full grid width while its spacer modeled only center content, so max `scrollLeft` fell short by exactly the locked widths — the last ~5 devindex center columns were unreachable by ANY user scrolling. Fixed by scoping the scrollport to the center region: locked-region widths apply as flanking margins (`startWidth_` / `endWidth_` on `grid.HorizontalScrollbar`), fed per region from `grid.Body#afterSetAvailableWidth` exactly like the existing `centerWidth` spacer feed, released on region teardown in `grid.Container#createOrUpdateSubGrids`. The scrollbar track now renders under the center region only — the freeze-pane convention (Excel / AG Grid pinned columns). The addon's verbatim 1:1 copy becomes exact for every region split.

Evidence: L4 (live two-leg gesture in real Chromium — in-page dispatch + drag-trace conviction + per-phase scroll-surface sampling; headless e2e replay) → L4 required (runtime trace ACs on both close-targets). No residuals on the close-targets; the parent gate keeps the operator's manual L4 re-pass (#12883).

## Deltas from ticket

The fix shape evolved from the ticket's original prescription (re-deriving the zone term from the owner's viewport shift — commit 1 on this branch) to the pipeline reroute, after the operator's back-leg report reproduced ON the committed first fix and convicted the deeper mechanism. Full evidence trail: https://github.com/neomjs/neo/issues/12906#issuecomment-4682468815. The branch keeps both commits — the readback approach remains as the intermediate state it was, fully superseded by the reroute (the `getDomRect` readback block is removed again in commit 3).

Scope additions vs the ticket:
- #12907 (filed during this work) is co-resolved — the reroute functionally depends on the corrected scroll range; overdrag-right would otherwise stop ~5 columns early.
- `expandOwnerOnDrag` opt-out (base `SortZone` config, default `true` = no behavior change): the grid header zone keeps its owner a real clipped scroller mid-drag, so the toolbar's scrollable overflow survives and no ancestor can hijack programmatic scrolling. The absolutely positioned drag items keep the overflow alive (their containing block is the toolbar via `positionOwnerRelative`).
- The zone's `scrollLeft` term semantics are now ABSOLUTE owner scroll (seeded from `owner.scrollLeft` at drag start); the grid subclass re-bases its `itemRects` snapshot into owner-CONTENT space (`adjustProxyRectToParent` + frozen `dragStartScrollLeft`), aligning the drag math with `columnPositions.x` at any scroll state — drags starting from an already-scrolled grid are now correct by construction (previously a latent space mismatch flagged in the ticket's out-of-scope notes; the live term feed made it load-bearing).
- Post-await `itemRects` re-checks in both overdrag branches close the drag-end-mid-await race (the trace's post-end trailing switch).
- The drag-start `regionRects` snapshot (drop-region verdicts) is now valid for the entire gesture by construction — the locked bodies never move during overdrag, dissolving the scrolled-drop verdict corruption observed pre-fix.
- Test-infra: the `neuralLink` fixture gains the three whitebox-e2e §5.1 perception passthroughs (`getDragTrace`, `observeMotion`, `verifyComponentConsistency`) — `getDragTrace` is the new spec's logic-layer oracle (operator-requested repro path).

## Test Evidence

- Live rig (devindex @1680×1000, locked 3+1): two-leg gesture replay with per-phase sampling — grid container `scrollLeft` pinned 0 throughout; locked-start toolbar frozen at x=17 through both legs; scrollbar 0→1878 (content max)→0; body var tracks 1:1. Trace: walk 2→32→0, `scrollSync` in-beat with each scroll (the optimistic mirror), constant bounded deltas (no avalanche), left-overdrag nearest-math no-ops while targets visible then aligns `ir === sl` pixel-exact each beat, `end {from: 2, to: 0}` (pre-fix run landed at 3), `lockVerdict null`, zero post-end switches. Post-drop: 5/5 sampled headers match body cells field-for-field at identical x; `#12907` at-max: last center column flush with the center edge (pre-fix: 410px past it, unreachable).
- `npx playwright test GridColumnOverdragScroll -c test/playwright/playwright.config.e2e.mjs --workers=1` → 2/2 (the two-leg gesture spec + the scrollport-range spec; poll-settled holds, no fixed-sleep flakiness; ran against a 3×-same-named-session bridge topology — the #12904 identity-bind held).
- `npx playwright test GridColumnCrossBodyDnD -c test/playwright/playwright.config.e2e.mjs --workers=1` → 2/2 (existing locked-column DnD behavior intact under the new internals).
- `npm run test-unit -- test/playwright/unit/grid/ test/playwright/unit/draggable/` → 41/41 incl. the new `HorizontalScrollbar.spec.mjs` (margin scoping, spacer feed, per-region Body routing, no-scrollbar no-op).

## Post-Merge Validation

- [ ] Operator manual L4 re-pass on devindex (parent #12883's human gate): overdrag right ≥5 columns, drag back left to index 0 in the same gesture, verify locked columns never move and cells track headers both directions.
- [ ] The scrollbar track rendering under the center region only is an intentional UX change (freeze-pane convention) — operator veto reverts to a spacer-inflation variant without touching the pipeline.

## Commits

- 04d465f5d — fix(draggable): derive the zone scroll term from owner viewport shift during overdrag (#12906) — the intermediate readback approach; convicted insufficient by the operator's back-leg repro
- 37b4013c7 — fix(grid): scope the horizontal scrollbar scrollport to the center region (#12907)
- 53561564d — fix(draggable): route column-drag overdrag scrolling through the scrollbar pipeline (#12906) — supersedes the readback (removes it) with the pipeline reroute

## Evolution

The ticket prescribed deriving the zone's term from the owner's rect shift after each overdrag scroll. That fix verified green on the rightward leg, but the operator's same-gesture back-leg test exposed the structural truth: the term was a symptom — the overdrag was scrolling the WRONG ELEMENT entirely (the grid container via 'nearest'-satisfied `scrollIntoView`), which no term correction can heal: locked regions shifted off-screen, the body pipeline never fired, and the back leg hard-stopped at the locked width. Routing the scroll through the scrollbar SSOT makes overdrag indistinguishable from user scrolling — every downstream consumer (addon sync, ScrollManager ingestion, body buffering, zone term) works because it is the production path, not a parallel one.