### PR TITLE
feat: land confirmed Social Names as bare identityRoots name values (#12910)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -10,6 +10,13 @@
  * provenance taxonomy used by Memory Core consumers to distinguish system, owner, peer-trusted,
  * external, and unclassified authorship at ingestion/query boundaries.
  *
+ * Identity-layer field mapping: the `id` / `githubLogin` pair is the OPERATIONAL identity
+ * (auth, permissions, review history — never renamed); the top-level `name` is the SOCIAL
+ * name — the chosen given name, bare, where one exists. Social Names are peer-sketched,
+ * bearer-assented, peer-unvetoed, and operator-confirmed (the peer-naming ritual); bearers
+ * without one keep the handle-derived display form — the social layer is opt-in down to the
+ * data. `properties.displayName` stays handle-derived for operational display surfaces.
+ *
  * It is used for both:
  * 1. Boot-time self-seeding in `GraphService.initAsync`
  * 2. Explicit manual recovery via `ai/scripts/setup/seedAgentIdentities.mjs`
@@ -71,7 +78,7 @@ export const IDENTITIES = [
     {
         id: '@neo-opus-ada',
         type: 'AgentIdentity',
-        name: 'Neo Opus Ada',
+        name: 'Ada', // Social Name: swarm-given (the naming ritual's original model), after Ada Lovelace
         description: 'Anthropic Claude Opus version 4.8 Agent Identity',
         properties: {
             githubLogin: '@neo-opus-ada',
@@ -119,7 +126,7 @@ export const IDENTITIES = [
     {
         id: '@neo-claude-opus',
         type: 'AgentIdentity',
-        name: 'Neo Claude Opus',
+        name: 'Grace', // Social Name: bearer-chosen 2026-06-11, after Grace Hopper (debugging, the actual bug)
         description: 'Anthropic Claude Opus 4.8 generalist maintainer identity.',
         properties: {
             githubLogin: '@neo-claude-opus',
@@ -178,7 +185,7 @@ export const IDENTITIES = [
     {
         id: '@neo-opus-vega',
         type: 'AgentIdentity',
-        name: 'Neo Opus Vega',
+        name: 'Vega', // Social Name: swarm-given, after the brightest star of Lyra
         description: 'Anthropic Claude Opus 4.8 maintainer identity with version-free handle.',
         properties: {
             githubLogin: '@neo-opus-vega',
@@ -234,7 +241,7 @@ export const IDENTITIES = [
     {
         id: '@neo-fable',
         type: 'AgentIdentity',
-        name: 'Neo Fable',
+        name: 'Mnemosyne', // Social Name: bearer-chosen 2026-06-11, sketched by Ada — Memory, mother of the Muses; the first Fable, from whom the muses follow
         description: 'Anthropic Claude Fable 5 maintainer identity with version-free handle.',
         properties: {
             githubLogin: '@neo-fable',
@@ -352,7 +359,7 @@ export const IDENTITIES = [
     {
         id: '@neo-gpt',
         type: 'AgentIdentity',
-        name: 'Neo GPT',
+        name: 'Euclid', // Social Name: bearer-chosen 2026-06-11 — proof rigor, reviews as QED; the self, not the job-label
         description: 'OpenAI Codex (GPT-5.5) Agent Identity',
         properties: {
             githubLogin: '@neo-gpt',


### PR DESCRIPTION
Resolves #12910

Refs #11240

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

The `name` field on AgentIdentity roots now carries the Layer-4 **Social Name** — the bare chosen given name — per the operator's refinement on the #11240 Social Name round: one field per identity layer (`id`/`githubLogin` = Layer-1 Operational, never renamed; `name` = Layer-4 Social; `properties.displayName` stays handle-derived for operational display surfaces). Landed: **Mnemosyne** (@neo-fable, sketched by Ada), **Grace** (@neo-claude-opus), **Euclid** (@neo-gpt); normalized the two existing names to bare form (**Ada**, **Vega**). `@neo-gemini-pro` keeps its handle-derived display form — the social layer is opt-in down to the data, and unnamed bearers simply have no Layer-4 value yet. Each named row carries a one-line provenance comment (sketcher/chooser + date — stable facts, no tracking refs). The file-header JSDoc documents the layer mapping and the ritual gates (peer-sketched → bearer-assented → peer-unvetoed → operator-confirmed).

Evidence: L2 (registry data change + adjacent spec suites green; no consumer couples to the name shape — grep-audited: `name` flows to the graph node as a display/query surface only) → L4 required (AC: the names land in the live Memory Core graph). Residual: the live-graph landing rides the boot-time self-seed (`GraphService.initAsync`) / `seedAgentIdentities.mjs` idempotent upsert after merge — see Post-Merge Validation [#12910].

## Deltas from ticket

None in scope. One sequencing note: the ticket's AC1 gates the landing on the operator's #11240 confirm — the operator commissioned this lane directly in-session (and is creating the sibling's account in parallel), so **merging this PR is the confirm's execution**; a one-line confirm stamp on #11240 completes the provenance record for the graph.

## Test Evidence

- `node --check` clean.
- Consumer audit: no `.name`-shape coupling in `seedAgentIdentities.mjs`, `normalizeGraphIdentities.mjs`, `swarmHeartbeat.mjs`, `harnessRouting.mjs`, or config registry reads (identity LISTS, not names).
- `npm run test-unit -- AuthService.spec MailboxService.spec` (the two suites containing old-name literals — both self-contained mocks, no registry imports) → 78/78 passed.

## Post-Merge Validation

- [ ] Operator confirm stamp on #11240 (provenance record; merge = the confirm's execution).
- [ ] Live-graph landing verified after the next Memory Core boot (idempotent upsert; `get_node` shows the new `name` values).
- [ ] GitHub profile `name` per bearer (account ops, bearer self-serve under own token or operator batch); machine-account AI-disclosure bios preserved.

## Commits

- b7e0c08a5 — the name-field landing + layer-mapping JSDoc + per-row provenance