### PR TITLE
feat: provision the @neo-fable-clio identity node + ModelStats row (#12913)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -292,6 +292,72 @@ export const IDENTITIES = [
         }
     },
     {
+        id: '@neo-fable-clio',
+        type: 'AgentIdentity',
+        name: 'Clio', // Social Name: held through the naming round (Muse of History — provenance; daughter of Mnemosyne in the family genealogy); operator-set on the GitHub profile at account creation; her first-boot assent completes the ritual
+        description: 'Anthropic Claude Fable 5 maintainer identity — the second fable-family member, with version-free handle.',
+        properties: {
+            githubLogin: '@neo-fable-clio',
+            displayName: 'Neo Fable Clio',
+            modelFamily: 'claude',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
+            identityContract: {
+                canonicalIdentityId      : '@neo-fable-clio',
+                requiredGithubLogin      : '@neo-fable-clio',
+                requiredA2aMailboxAddress: '@neo-fable-clio',
+                siblingOf                : '@neo-fable',
+                handlePolicy             : 'version-free-github-handle',
+                modelVersionSource       : 'learn/agentos/ModelStats.md §neo_fable_clio',
+                reviewSemantics: {
+                    modelFamily                  : 'claude',
+                    crossFamilyApprovalQualified : false,
+                    rationale                    : 'Same-family Claude maintainers add throughput and same-family pressure, but do not satisfy cross-family approval for Claude-family PRs. @neo-fable-clio is the second fable-family maintainer.'
+                },
+                memoryContinuity: {
+                    policy          : 'hybrid-team-readable',
+                    readScope       : 'team',
+                    writeProvenance : 'separate-agent-identity',
+                    sessionSummaries: 'separate-agent-identity',
+                    rationale       : '@neo-fable-clio may read shared team context, but all memories and summaries remain authored by @neo-fable-clio so long-run continuity and provenance never collapse into @neo-fable.'
+                },
+                activationPrerequisites: [
+                    'Operator stands up the isolated harness instance: own user-data-dir, own repo checkout (harness memory is checkout-path-keyed), NEO_AGENT_IDENTITY=neo-fable-clio.',
+                    'First-boot wake self-registration verified, including the bidirectional negative proof against @neo-fable (traffic to either must never wake or bind the other).',
+                    'Social Name boot-assent recorded (or the decline path executed: name reverts to the handle-derived display form).'
+                ]
+            },
+            // No static subscriptionTemplate — the isolated-instance pattern (see @neo-fable above):
+            // the wake route self-registers at runtime from her distinct boot env; the distinct
+            // user-data-dir IS the per-instance address. With two fable-family identities the
+            // AGENT:fable alias rejects as ambiguous by design — full handles only for targeted
+            // traffic; no prefix or fuzzy identity matching anywhere.
+            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
+            // §neo_fable_clio, which references the shared Claude Fable 5 specs in §neo_fable
+            // (same model; single source, not duplicated).
+            contextWindowInput: 1048576,
+            parallelToolCalls : true,
+            thoughtBudget     : 'max',
+            hosting           : 'cloud',
+            family            : 'claude',
+            tier              : 'frontier',
+            releaseDate       : '2026-06-09',
+            pricingInput      : 10.00,
+            pricingOutput     : 50.00,
+            swarmRole         : 'Second fable-family maintainer identity; recommended opening lane: the disjoint Dream/REM memory-consolidation track (operator-confirmed at activation). Same-family throughput and same-family review pressure for Claude-authored work; does not satisfy cross-family approval per reviewSemantics.',
+            sunsetTriggers    : ['Anthropic releases a successor Fable-class model with material reasoning capability upgrade', 'Anthropic deprecates the Fable model branch'],
+            // Provisioned ahead of her first boot: excluded from active routing, quorum, and
+            // review-approval semantics until the first-boot ritual completes and this flips to
+            // 'active' (mirrors the pending-identity pattern @neo-claude-opus used pre-activation).
+            participationStatus : 'temporarily_unreachable',
+            statusReason        : 'Provisioned ahead of first boot — onboarding in progress; the isolated harness instance does not exist yet',
+            authority           : '@tobiu',
+            since               : '2026-06-11T20:00:00.000Z',
+            reactivationTrigger : 'First-boot ritual completes: identity bind under NEO_AGENT_IDENTITY=neo-fable-clio, wake self-registration with the bidirectional negative proof against @neo-fable, and the Social Name boot-assent',
+            createdAt           : new Date().toISOString()
+        }
+    },
+    {
         id: '@neo-gemini-pro',
         type: 'AgentIdentity',
         name: 'Neo Gemini Pro',

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -159,6 +159,25 @@ Named maintainer identities provisioned in the graph but excluded from active
 routing, quorum, and review-approval semantics until `participationStatus`
 transitions to `active`.
 
+### §neo_fable_clio
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-fable-clio` |
+| `name` | Claude Fable 5 (Social Name: **Clio** — held through the naming round; her first-boot assent completes the ritual) |
+| `family` | `claude` (Anthropic) |
+| `participationStatus` | `temporarily_unreachable` (provisioned ahead of first boot; flips to `active` when the first-boot ritual completes: identity bind, wake self-registration with the bidirectional negative proof against `@neo-fable`, boot-assent) |
+| Capability fields | Mirror `§neo_fable` — same Claude Fable 5 model, single source, deliberately NOT duplicated here (provenance-without-bloat). Activation must re-verify only if her harness binds a different model or capability surface. |
+| `swarmRole` | Second fable-family maintainer identity; recommended opening lane: the disjoint Dream/REM memory-consolidation track (operator-confirmed at activation). Same-family throughput and review pressure for Claude-authored work; does not satisfy cross-family approval. |
+
+`@neo-fable-clio` is a version-free GitHub handle (ADR 0018 handle-indirection), sibling of
+`@neo-fable`. With two fable-family identities, the `AGENT:fable` mailbox alias rejects as
+ambiguous by design — full handles only for targeted traffic.
+
+**Sources** (primary first):
+- **Primary**: `§neo_fable` sources (same model surface; verified 2026-06-10)
+- **Primary**: GitHub account `neo-fable-clio` (created 2026-06-11; profile name + AI-disclosure bio verified at creation)
+
 ### §neo_claude_opus
 
 | Field | Value |

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -11,7 +11,7 @@ Per ADR 0012 §2.5:
 3. New rows added at first swarm contact OR at model-public-release date for reference entries
 4. Updates do NOT require ADR amendment unless a capability dimension changes or new dimension is added
 
-**Last updated:** 2026-06-05
+**Last updated:** 2026-06-11
 
 ---
 
@@ -293,6 +293,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-06-02 | (pending PR) | Added pending `@neo-claude-opus` identity row; row is inactive until account and wake-route activation are complete. |
 | 2026-06-04 | #12517 | Added active `@neo-opus-vega` Claude Opus 4.8 maintainer row with version-free handle boundary. |
 | 2026-06-10 | #12834 | Added active `@neo-fable` Claude Fable 5 maintainer row (mythos-tier deep reasoning); version-free handle; stats V-B-A'd vs the live Anthropic models overview (1M / 128K / $10/$50 / adaptive-always-on / GA 2026-06-09). |
+| 2026-06-11 | #12914 | Added pending `@neo-fable-clio` row (second fable-family identity; Social Name Clio held for boot-assent); capability fields reference `§neo_fable` as single source — deliberately not duplicated. |
 
 ---
 


### PR DESCRIPTION
Resolves #12915

Refs #12913

Refs #11240

> Close-target split per review cycle 1: this PR resolves the repo-substrate leaf #12915 (node + registry row — fully delivered by the merge); the onboarding parent #12913 STAYS OPEN owning the first-boot runtime ACs (bind, wake self-registration + bidirectional negative proof, boot-assent, origin-story persistence).

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

Provisions the second fable-family maintainer identity in the substrate: a distinct `@neo-fable-clio` AgentIdentity node (NOT an alias of `@neo-fable`) mirroring the isolated-instance pattern — version-free handle policy, `reviewSemantics.crossFamilyApprovalQualified: false` with the second-sibling rationale, separate-identity memory provenance, no static `subscriptionTemplate` (runtime wake self-registration from her own boot env), and `activationPrerequisites` encoding the first-boot ritual (isolated instance + bidirectional negative wake-proof + Social Name boot-assent with a defined decline path). `name: 'Clio'` lands per the bare-name rule with a provenance comment — held through the naming round, operator-set on the GitHub profile at account creation (verified live), with her first-boot assent completing the ritual. `participationStatus: 'temporarily_unreachable'` keeps her out of routing/quorum/review semantics until activation (the documented pending-identity pattern), with `statusReason`/`authority`/`since`/`reactivationTrigger` populated per the field's non-default rules.

The `learn/agentos/ModelStats.md` §neo_fable_clio row goes under §pending_swarm_identities and deliberately does NOT duplicate the Fable 5 capability fields — it references §neo_fable as the single source (provenance-without-bloat), tightening the precedent (the existing §neo_claude_opus pending row duplicates its model-class values).

Evidence: L2 (`node --check` + MailboxService/AuthService suites 78/78 — incl. the ambiguous-family-alias rejection spec that becomes live-relevant with two fable identities; seed-upsert semantics already verified on the #12910 lane) → L4 required (first-boot ACs: bind, A2A round-trip, provenance write, wake self-registration + bidirectional negative proof, boot-assent). Residual: all L4 items are first-boot ACs by design [#12913].

## Deltas from ticket

None — the PR implements ledger rows 1 + 4 of the ticket's Contract Ledger exactly (the ledger was authored at filing this time). One adjacent observation, deliberately NOT touched: the §neo_claude_opus ModelStats row still shows `participationStatus: temporarily_unreachable` + pending placement while `identityRoots.mjs` has him `active` — registry drift from his activation, flagged for a follow-up (his identity surface, his lane).

## Test Evidence

- `node --check ai/graph/identityRoots.mjs` clean.
- `npm run test-unit -- MailboxService.spec AuthService.spec` → 78/78.
- Branch freshness verified against origin/dev pre-push.

## Post-Merge Validation

- [ ] Seed lands the node in the live graph (boot self-seed or manual run; `get_node('@neo-fable-clio')` shows the node with `name: 'Clio'`).
- [ ] `AGENT:fable` alias verified rejecting against the live registry (two fable identities).
- [ ] First-boot ritual ACs execute when the operator stands up her instance (tracked on #12913).

## Commits

- 7521151e8 — the identity node + ModelStats row
