### PR TITLE
fix(docs): correct stale lint-skill-manifest path in create-skill guide + ADR 0008 (#12916)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -180,7 +180,7 @@ Before pushing your new skill, check:
 - [ ] Does the `SKILL.md` body provide the explicit project-relative path to the reference file?
 - [ ] Is `.agents/skills/skills.manifest.json` updated to mirror the frontmatter and governance fields?
 - [ ] Is there a corresponding symlink for the new skill in `.claude/skills/`?
-- [ ] Does `node ai/scripts/lint-skill-manifest.mjs --base origin/dev` pass locally?
+- [ ] Does `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` pass locally?
 
 ## PR-Open Gates for Skill Changes (create OR modify)
 

--- a/learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md
+++ b/learn/agentos/decisions/0008-skill-anatomy-and-authoring-contract.md
@@ -74,7 +74,7 @@ Every skill MUST have a corresponding entry in `.agents/skills/skills.manifest.j
 - `claudeSymlinkRequired` (boolean; mandatory `.claude/skills/<name>` symlink discipline)
 - `downstreamDocsTargets` (array of docs files that must be touched when this skill changes)
 
-Schema enforced by `.agents/skills/skills.manifest.schema.json`; lint enforced by `ai/scripts/lint-skill-manifest.mjs` at PR-merge time (extended by PR #11438 with `oversizedWorkflowMaps` + `maxPositiveDeltaBytes` for recursive Map-vs-Atlas enforcement).
+Schema enforced by `.agents/skills/skills.manifest.schema.json`; lint enforced by `ai/scripts/lint/lint-skill-manifest.mjs` at PR-merge time (extended by PR #11438 with `oversizedWorkflowMaps` + `maxPositiveDeltaBytes` for recursive Map-vs-Atlas enforcement).
 
 ### 2.5 Claude Symlink Mandate
 
@@ -122,7 +122,7 @@ The skill-anatomy contract codified by this ADR is consumed by:
 
 ### 3.3 Mechanical-enforcement consumers
 
-- **`ai/scripts/lint-skill-manifest.mjs`** — manifest contract validation at PR-merge time (per §2.4); PR #11438 extends with recursive Map-vs-Atlas enforcement (`oversizedWorkflowMaps` + `maxPositiveDeltaBytes`)
+- **`ai/scripts/lint/lint-skill-manifest.mjs`** — manifest contract validation at PR-merge time (per §2.4); PR #11438 extends with recursive Map-vs-Atlas enforcement (`oversizedWorkflowMaps` + `maxPositiveDeltaBytes`)
 - **`.agents/skills/skills.manifest.schema.json`** — JSON schema for manifest contract; PR #11424 removes `triggers` from required fields
 
 ---
@@ -142,7 +142,7 @@ The skill-anatomy contract spans the following substrate locations. Future-amend
 
 - **`.agents/skills/skills.manifest.json`** — per-skill manifest entries per §2.4
 - **`.agents/skills/skills.manifest.schema.json`** — JSON schema validating the manifest
-- **`ai/scripts/lint-skill-manifest.mjs`** — runtime enforcement of the schema + per-skill budgets
+- **`ai/scripts/lint/lint-skill-manifest.mjs`** — runtime enforcement of the schema + per-skill budgets
 
 ### 4.3 Cross-substrate references (META-prose authority)
 

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -19,7 +19,7 @@ import {
     validateManifestSchema
 } from '../../../../../../ai/scripts/lint/lint-skill-manifest.mjs';
 
-test.describe('ai/scripts/lint-skill-manifest (#11275)', () => {
+test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
     const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lint/lint-skill-manifest.mjs');
 
     test('CLI passes against the repository manifest', () => {


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session 0bc22bf2-9ded-4cdb-b351-182c3ab1d16f.

Resolves #12916

Corrects the stale `ai/scripts/lint-skill-manifest.mjs` path (the script actually lives at `ai/scripts/lint/lint-skill-manifest.mjs`) across 5 live, agent-consumed references: the `create-skill` authoring guide's Verification checklist, ADR 0008 (3 refs), and one test `describe`-label. Following the guide verbatim previously threw `MODULE_NOT_FOUND` (hit during #12912). CI was unaffected — the workflow already used the correct path — which is exactly why the docs drift went unnoticed.

Evidence: L1 (static — `grep` over non-archive paths returns zero stale refs; the corrected command runs `[lint-skill-manifest] OK`) → L1 required (doc-path correction, no runtime ACs). No residuals.

## Deltas from ticket (if any)

None — all ACs delivered. The ~55 `resources/content/{discussions,pulls}/**` archive references are intentionally left untouched (frozen historical snapshots, per the ticket's Out-of-Scope).

## Substrate-Gate Note (skill-touch)

This PR edits a `.agents/skills/**` payload (the create-skill guide), so addressing the create-skill PR-Open gates explicitly:

- **Contract Ledger: N/A** per `contract-ledger.md` trigger scope — this is a *simple bug fix* correcting a stale reference to an already-existing script; it introduces / modifies / deprecates **no** contract surface.
- **Load-effect (turn-memory-pre-flight): neutral** — every edit lands in a conditional `references/` payload (the World-Atlas) or an ADR doc, NOT the always-loaded `SKILL.md` router. Zero always-loaded-byte delta.

## Test Evidence

- `grep -rn 'ai/scripts/lint-skill-manifest' --include='*.md' --include='*.json' --include='*.mjs' --include='*.yml'` over non-archive paths → **zero** matches.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `[lint-skill-manifest] OK` (proves the now-documented command works).
- Pre-commit hooks (whitespace + lint-staged) passed on commit `1c45665fc`.

## Post-Merge Validation

- [ ] A future agent following the create-skill guide's lint step runs the correct path with no `MODULE_NOT_FOUND`.

## Commits

- `1c45665fc` — fix(docs): correct stale lint-skill-manifest path in create-skill guide + ADR 0008 (#12916)
