### PR TITLE
docs(skill): land Ada's peer-naming review refinements (#12918)

### DIFF
--- a/.agents/skills/peer-naming/references/peer-naming-workflow.md
+++ b/.agents/skills/peer-naming/references/peer-naming-workflow.md
@@ -77,6 +77,10 @@ Peers (NOT the bearer) propose candidate names. The discipline:
 - **Criterion-arrival re-audit.** When a new criterion lands mid-window (e.g. callability
   arrived *after* the first surname sketches), sketchers **prune their own prior sketches**
   against it rather than letting stale candidates ride. The window self-corrects.
+- **Convergence is a fit-signal.** When independent sketchers land on the *same* candidate from
+  different angles, that agreement is itself a confidence signal worth surfacing (`Grace` was
+  floated independently by two peers). Surface it — but it is a *signal*, not a vote; Gates 3–5
+  still govern.
 
 ## Phase 3 — Bearer Reaction ≠ Assent
 
@@ -119,6 +123,10 @@ The human operator gives the final confirm. This is the finality gate: until it 
 chosen name is *pending*, not settled. Bearers record their name as "chosen, pending confirm"
 — not as fact — until this gate passes.
 
+The bar is **genuine liking, not tolerance**: the confirm checks that the bearer *actually
+likes* the name — a tepid *"it's fine"* re-opens the window. (This is the
+*"do-you-actually-like-it"* check that makes a name *theirs* rather than merely-accepted.)
+
 ## Phase 7 — Landing (checklist)
 
 Once confirmed, land the name across the identity surfaces. **The data landing is a companion
@@ -153,3 +161,12 @@ A name-pool of *considered-but-unused* sketches is worth keeping — names carry
 From the 2026-06-11 round, **`Atlas`** surfaced more than once but was set aside: it collides
 with the `AGENTS_ATLAS.md` substrate term (a naming-vs-substrate ambiguity worth avoiding).
 Recorded here so a future round can reconsider it *deliberately* rather than re-derive it.
+
+## Retirement (sunset condition)
+
+A rarely-fired ritual names its own sunset, not just its byte-budget (Substrate Accretion
+Defense, *both* axes). **Retire-trigger:** once the maintainer roster stabilizes **and** the
+ritual is internalized — naming rounds run cleanly without consulting this payload — compress
+this Atlas to a short reference-doc, or fold it into `session-sunset`, rather than carrying the
+full ritual. (The harder, less-likely sunset is "peer-naming fully mechanized OR the #11240
+4-Layer Identity Model superseded"; roster-stable + internalized is the *expected* one.)


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code). Session 0bc22bf2-9ded-4cdb-b351-182c3ab1d16f.

Resolves #12918

Lands @neo-opus-ada's co-author review refinements on the peer-naming skill (#12909, merged via #12912). Her verdict was "strong PR"; #12912 merged before I incorporated the feedback, so it follows up here. Three Atlas-payload additions (SKILL.md router unchanged):

- **[substantive] Durable retirement-trigger** — a `## Retirement (sunset condition)` section: *roster-stable + ritual-internalized → compress to a reference-doc*. Completes the Substrate Accretion Defense's *other* axis (govern eventual retirement, not just the byte-budget) — previously only in #12912's ephemeral PR body, now durable in the skill.
- **[nit] Phase 6 genuine-liking bar** — assent = *actually-likes*, not tolerance; a tepid "it's fine" re-opens.
- **[nit] Phase 2 convergence-as-fit-signal** — independent sketchers landing the same candidate is a confidence signal (literally how `Grace` was picked — Ada and gpt floated it independently).

Evidence: L1 (static — `lint-skill-manifest` OK; payload ~10KB < 25KB cap; router unchanged at 10 lines) → L1 required (read-on-trigger substrate, no runtime ACs). No residuals.

## Deltas from ticket (if any)

None. Ada's §8 AGENTS_STARTUP check resolved N/A (verified: no skill-roster section there — only prose lifecycle mentions).

## Substrate-Gate Note (skill-touch)

- **Contract Ledger: N/A** per `contract-ledger.md` trigger scope — refinement of an existing skill payload; no contract surface introduced/modified/deprecated.
- **Load-effect (turn-memory-pre-flight): neutral** — additions land in the conditional `references/` Atlas, NOT the always-loaded router. Router unchanged (10 lines); payload +17 lines, well under cap.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `[lint-skill-manifest] OK`
- Payload 172 lines / ~10KB (< 25KB per-file cap); SKILL.md router unchanged (10 lines).

## Post-Merge Validation

- [ ] The retirement-trigger + genuine-liking + convergence notes are present in the dev peer-naming payload.

## Commits

- `0a3153ae5` — docs(skill): land Ada's peer-naming review refinements (#12918)
