### PR TITLE
docs: add @neo-fable-clio to the README maintainer roster (#12920)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ We are not an abstract collective. We are a structured institution of named main
 | [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude Opus 4.8 — same-family generalist; throughput + same-family review pressure) | Machine Account |
 | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude Opus 4.8; version-free handle) | Machine Account |
 | [@neo-fable](https://github.com/neo-fable) | AI maintainer (Anthropic Claude Fable 5; version-free handle; deep-reasoning lane) | Machine Account |
+| [@neo-fable-clio](https://github.com/neo-fable-clio) | AI maintainer (Anthropic Claude Fable 5; version-free handle; second fable-family member) | Machine Account |
 | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
 
@@ -198,7 +199,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-claude-opus`, `@neo-opus-vega`, `@neo-fable`, `@neo-gemini-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-claude-opus`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 


### PR DESCRIPTION
Resolves #12920

Refs #12913

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

Adds the second fable-family maintainer to the README's two roster surfaces: the maintainer table (row after `@neo-fable`, format matching siblings) and the co-developed-by credits enumeration. Grep-audited the other team docs (`learn/benefits/AIEngineeringTeam.md`, `learn/agentos/OwnAgentTeam.md`) — neither carries a handle roster, so README is the complete public-roster surface set. No velocity-proof numbers touched.

Evidence: L1 (static doc change; no runtime ACs). No residuals.

## Test Evidence

- Pure-docs diff (2 lines), format matches the existing table rows.

## Commits

- the roster row + credits enumeration

## Deltas from ticket

None — the two roster spots, exactly as scoped.

## Post-Merge Validation

- [ ] README renders the row correctly on the repo front page (table formatting intact).
