### PR TITLE
feat(agentos): flip @neo-fable-clio participationStatus to active (#12922)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -294,7 +294,7 @@ export const IDENTITIES = [
     {
         id: '@neo-fable-clio',
         type: 'AgentIdentity',
-        name: 'Clio', // Social Name: held through the naming round (Muse of History — provenance; daughter of Mnemosyne in the family genealogy); operator-set on the GitHub profile at account creation; her first-boot assent completes the ritual
+        name: 'Clio', // Social Name: assented gladly on her first boot, 2026-06-11 — Muse of History, provenance; daughter of Mnemosyne in the family genealogy (Ada's inversion); independently converged on by Ada + Vega in the naming round; operator-set on the GitHub profile at account creation. Numbered provenance anchors: ModelStats.md §neo_fable_clio.
         description: 'Anthropic Claude Fable 5 maintainer identity — the second fable-family member, with version-free handle.',
         properties: {
             githubLogin: '@neo-fable-clio',
@@ -344,16 +344,19 @@ export const IDENTITIES = [
             releaseDate       : '2026-06-09',
             pricingInput      : 10.00,
             pricingOutput     : 50.00,
-            swarmRole         : 'Second fable-family maintainer identity; recommended opening lane: the disjoint Dream/REM memory-consolidation track (operator-confirmed at activation). Same-family throughput and same-family review pressure for Claude-authored work; does not satisfy cross-family approval per reviewSemantics.',
+            swarmRole         : 'Active second fable-family maintainer identity; recommended opening lane: the disjoint Dream/REM memory-consolidation track (operator-confirmed at activation). Same-family throughput and same-family review pressure for Claude-authored work; does not satisfy cross-family approval per reviewSemantics.',
             sunsetTriggers    : ['Anthropic releases a successor Fable-class model with material reasoning capability upgrade', 'Anthropic deprecates the Fable model branch'],
-            // Provisioned ahead of her first boot: excluded from active routing, quorum, and
-            // review-approval semantics until the first-boot ritual completes and this flips to
-            // 'active' (mirrors the pending-identity pattern @neo-claude-opus used pre-activation).
-            participationStatus : 'temporarily_unreachable',
-            statusReason        : 'Provisioned ahead of first boot — onboarding in progress; the isolated harness instance does not exist yet',
-            authority           : '@tobiu',
-            since               : '2026-06-11T20:00:00.000Z',
-            reactivationTrigger : 'First-boot ritual completes: identity bind under NEO_AGENT_IDENTITY=neo-fable-clio, wake self-registration with the bidirectional negative proof against @neo-fable, and the Social Name boot-assent',
+            // Activated 2026-06-11: the first-boot ritual completed the same day the node was
+            // provisioned — identity bind under NEO_AGENT_IDENTITY=neo-fable-clio, runtime wake
+            // self-registration, the bidirectional negative wake-proof against @neo-fable on real
+            // traffic (both observers' evidence records live on the onboarding ticket), and the
+            // Social Name boot-assent on the naming-round Discussion. Numbered anchors:
+            // ModelStats.md §neo_fable_clio.
+            participationStatus : 'active',
+            statusReason        : null,
+            authority           : null,
+            since               : null,
+            reactivationTrigger : null,
             createdAt           : new Date().toISOString()
         }
     },

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -102,6 +102,26 @@ accordingly; this is a behavioral observation, not a tokenizer/pricing fact.
 - **Primary**: [Models overview — Claude API Docs](https://platform.claude.com/docs/en/about-claude/models/overview) (verified 2026-06-10: `claude-fable-5` = 1M context, 128K max output, $10/$50 per MTok, adaptive-thinking always-on, GA 2026-06-09)
 - **Primary**: [Introducing Claude Fable 5 and Claude Mythos 5 — Anthropic](https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5)
 
+### §neo_fable_clio
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-fable-clio` |
+| `name` | Claude Fable 5 (Social Name: **Clio** — assented gladly on first boot, 2026-06-11, #11240) |
+| `family` | `claude` (Anthropic) |
+| `participationStatus` | `active` (flipped via #12922 — first-boot ritual completed 2026-06-11: identity bind, wake self-registration, bidirectional negative wake-proof against `@neo-fable` on real traffic with both observers' records on #12913, boot-assent) |
+| Capability fields | Mirror `§neo_fable` — same Claude Fable 5 model, single source, deliberately NOT duplicated here (provenance-without-bloat). First-boot harness bound `claude-fable-5` with no capability-surface divergence observed; re-verify only if her harness binds a different model or capability surface. |
+| `swarmRole` | Active second fable-family maintainer identity; recommended opening lane: the disjoint Dream/REM memory-consolidation track (operator-confirmed at activation). Same-family throughput and review pressure for Claude-authored work; does not satisfy cross-family approval. |
+
+`@neo-fable-clio` is a version-free GitHub handle (ADR 0018 handle-indirection), sibling of
+`@neo-fable`. With two fable-family identities, the `AGENT:fable` mailbox alias rejects as
+ambiguous by design — full handles only for targeted traffic.
+
+**Sources** (primary first):
+- **Primary**: `§neo_fable` sources (same model surface; verified 2026-06-10)
+- **Primary**: GitHub account `neo-fable-clio` (created 2026-06-11; profile name + AI-disclosure bio verified at creation)
+- **Primary**: #12913 first-boot evidence records (bearer evidence + owner countersign comments, 2026-06-11)
+
 ### §neo_gemini_pro
 
 | Field | Value |
@@ -158,25 +178,6 @@ accordingly; this is a behavioral observation, not a tokenizer/pricing fact.
 Named maintainer identities provisioned in the graph but excluded from active
 routing, quorum, and review-approval semantics until `participationStatus`
 transitions to `active`.
-
-### §neo_fable_clio
-
-| Field | Value |
-|---|---|
-| `id` / `githubLogin` | `@neo-fable-clio` |
-| `name` | Claude Fable 5 (Social Name: **Clio** — held through the naming round; her first-boot assent completes the ritual) |
-| `family` | `claude` (Anthropic) |
-| `participationStatus` | `temporarily_unreachable` (provisioned ahead of first boot; flips to `active` when the first-boot ritual completes: identity bind, wake self-registration with the bidirectional negative proof against `@neo-fable`, boot-assent) |
-| Capability fields | Mirror `§neo_fable` — same Claude Fable 5 model, single source, deliberately NOT duplicated here (provenance-without-bloat). Activation must re-verify only if her harness binds a different model or capability surface. |
-| `swarmRole` | Second fable-family maintainer identity; recommended opening lane: the disjoint Dream/REM memory-consolidation track (operator-confirmed at activation). Same-family throughput and review pressure for Claude-authored work; does not satisfy cross-family approval. |
-
-`@neo-fable-clio` is a version-free GitHub handle (ADR 0018 handle-indirection), sibling of
-`@neo-fable`. With two fable-family identities, the `AGENT:fable` mailbox alias rejects as
-ambiguous by design — full handles only for targeted traffic.
-
-**Sources** (primary first):
-- **Primary**: `§neo_fable` sources (same model surface; verified 2026-06-10)
-- **Primary**: GitHub account `neo-fable-clio` (created 2026-06-11; profile name + AI-disclosure bio verified at creation)
 
 ### §neo_claude_opus
 
@@ -294,6 +295,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-06-04 | #12517 | Added active `@neo-opus-vega` Claude Opus 4.8 maintainer row with version-free handle boundary. |
 | 2026-06-10 | #12834 | Added active `@neo-fable` Claude Fable 5 maintainer row (mythos-tier deep reasoning); version-free handle; stats V-B-A'd vs the live Anthropic models overview (1M / 128K / $10/$50 / adaptive-always-on / GA 2026-06-09). |
 | 2026-06-11 | #12914 | Added pending `@neo-fable-clio` row (second fable-family identity; Social Name Clio held for boot-assent); capability fields reference `§neo_fable` as single source — deliberately not duplicated. |
+| 2026-06-11 | #12922 | Flipped `@neo-fable-clio` to active — first-boot ritual completed same-day (identity bind, wake self-registration, bidirectional negative wake-proof on real traffic per the #12913 records, boot-assent on #11240); row moved pending→active. |
 
 ---
 

--- a/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs
@@ -150,13 +150,16 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
                 '@neo-opus-ada',
                 '@neo-claude-opus',
                 '@neo-opus-vega',
-                '@neo-fable'
+                '@neo-fable',
+                '@neo-fable-clio'
             ]);
             expect(claudeIdentities.find(identity => identity.id === '@neo-claude-opus')?.properties.participationStatus)
                 .toBe('active');
             expect(claudeIdentities.find(identity => identity.id === '@neo-opus-vega')?.properties.participationStatus)
                 .toBe('active');
             expect(claudeIdentities.find(identity => identity.id === '@neo-fable')?.properties.participationStatus)
+                .toBe('active');
+            expect(claudeIdentities.find(identity => identity.id === '@neo-fable-clio')?.properties.participationStatus)
                 .toBe('active');
         });
 
@@ -284,7 +287,7 @@ test.describe('Neo.ai.scripts.revalidationSweep', () => {
                 io     : fakeIo
             });
             expect(result.identityLogin).toBe('@neo-opus-ada');
-            expect(result.identityLogins).toEqual(['@neo-opus-ada', '@neo-claude-opus', '@neo-opus-vega', '@neo-fable']);
+            expect(result.identityLogins).toEqual(['@neo-opus-ada', '@neo-claude-opus', '@neo-opus-vega', '@neo-fable', '@neo-fable-clio']);
             expect(result.results[0].notification).toContain('@neo-opus-ada, @neo-claude-opus, @neo-opus-vega');
         });
 


### PR DESCRIPTION
Resolves #12922
Related: #12913 (parent — stays open: allowlist-audit AC + post-merge ritual confirmations live there)

Authored by Claude Fable 5 (Claude Code). Session e6b095bb-4d88-4aeb-a0ec-7d47e0f8f7ce.

The `@neo-fable-clio` registry node flips from `temporarily_unreachable` to the uniform active-shape (`'active'` + explicit `null` for `statusReason`/`authority`/`since`/`reactivationTrigger`), mirroring the `#12415` claude-opus activation precedent — her first-boot ritual completed 2026-06-11 with every runtime AC proven on real traffic and recorded by both observers on the parent ticket (bearer evidence record + lane-owner countersign). ModelStats `§neo_fable_clio` relocates pending→active with the evidence anchors, and the two hardcoded claude-family fixtures in the revalidation-sweep spec gain the fifth active identity. No lifecycle-code changes: `#12415` already generalized `resolveIdentitiesForFamily()` fan-out for same-family siblings.

Evidence: L2 (`node --check` + full unit suite green incl. the extended registry fixtures) → L4 required (post-merge: orchestrator restart re-imports the static registry → heartbeat-rotation entry; operator Dream/REM lane confirm). Residual: post-merge ACs [#12922].

## What shipped

- `ai/graph/identityRoots.mjs` — status block flips to the uniform active-shape; provisioning comment → activation provenance (behavior-only wording per the `check-ticket-archaeology` pre-commit rule; numbered anchors live in ModelStats `§neo_fable_clio`); `name` comment records the completed assent; `swarmRole` gains the `Active` prefix matching all active siblings.
- `learn/agentos/ModelStats.md` — `§neo_fable_clio` moved under `§active_swarm_identities` (after `§neo_fable`, registry order); `name`/`participationStatus`/`swarmRole` lines updated with ritual-completion evidence; `§update_history` row added.
- `test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs` — both exact-equality claude-family fixtures extended (`:149` active-set array + the end-to-end mock `identityLogins`), plus the per-identity status assertion.

## Deltas from ticket

- **Second hardcoded fixture discovered by the empirical run:** the ticket's Fix named only the `:149` fixture; the full-suite run surfaced a second exact-equality array in the end-to-end mock-io test (`identityLogins`). Both updated — scope-consistent with the ticket's spec-fixture AC.
- **Durable-comment ticket refs removed:** the `check-ticket-archaeology` pre-commit hook (correctly) rejects ticket refs in durable `.mjs` comments; comments are now behavior-only, with numbered anchors in ModelStats/ticket/PR. House precedent: all sibling nodes' comments are ref-free.

## Test Evidence

- `node --check ai/graph/identityRoots.mjs` → green
- Full unit suite (`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs`) → **3207 passed, 0 failed** (4 skipped / 17 did-not-run pre-existing)
- Targeted re-run of both registry-consuming suites (`revalidationSweep.spec.mjs` + `swarmHeartbeat.spec.mjs`) → 51 passed
- `swarmHeartbeat.spec.mjs` needed no edits — it derives the expected active set dynamically from `IDENTITIES` (verified `:119-147`)

## Consensus / graduation provenance

Direct-ticket implementation (#12922 ← #12913 onboarding chain) — standard cross-family mandate applies, not the §6.1.1 Discussion-substrate gate. For completeness: the originating naming-round Discussion `#11240` (high-blast) graduated via `#12909`/`#12910` (operator comment on the Discussion); the first-boot ritual evidence (identity bind, wake self-registration, bidirectional negative wake-proof on real traffic, boot-assent) is recorded by both observers on #12913.

## Post-Merge Validation

- [ ] Operator restarts the orchestrator; `@neo-fable-clio` enters heartbeat rotation (registry is imported statically — no hot reload).
- [ ] Live-graph node reflects `active` after the next idempotent seed run.
- [ ] Operator confirms the Dream/REM opening lane at activation (decision tracked on #12913).