### PR TITLE
fix(devindex): remove locked-column test config (#12933)

### DIFF
--- a/apps/devindex/view/home/GridContainer.mjs
+++ b/apps/devindex/view/home/GridContainer.mjs
@@ -192,13 +192,11 @@ class GridContainer extends BaseGridContainer {
             columns          = [{
                 type     : 'index',
                 dataField: 'id',
-                locked   : 'start',
                 text     : '#',
                 width    : 60,
                 cellAlign: 'right'
             }, {
                 dataField           : 'rank',
-                locked              : 'start',
                 text                : 'Rank',
                 width               : 60,
                 cellAlign           : 'right',
@@ -206,7 +204,6 @@ class GridContainer extends BaseGridContainer {
             }, {
                 type     : 'githubUser',
                 dataField: 'login',
-                locked   : 'start',
                 text     : 'User',
                 width    : 250
             }, {
@@ -363,7 +360,6 @@ class GridContainer extends BaseGridContainer {
 
         columns.push({
             dataField: 'lastUpdated',
-            locked   : 'end',
             text     : 'Updated',
             width    : 120,
             cellAlign: 'right',
@@ -416,7 +412,7 @@ class GridContainer extends BaseGridContainer {
                 }
             }
         }
-        
+
         me.store.sort(sortOpts);
         me.removeSortingCss(opts.property)
     }

--- a/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
+++ b/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
@@ -31,7 +31,9 @@ import { test, expect } from '../fixtures.mjs';
  *
  * Run: npx playwright test GridColumnCrossBodyDnD -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-test.describe('Desktop (1920x1080): DevIndex Locked-Column DnD (#12807)', () => {
+// ticket-ref-ok: skip pointer is load-bearing — #12933 removed devindex's locked-column config this spec's region assertions require.
+// ticket-ref-ok: #12936 re-homes this spec onto the dedicated locked fixture; un-skip rides that migration.
+test.describe.skip('Desktop (1920x1080): DevIndex Locked-Column DnD (#12807)', () => {
     test.setTimeout(90000); // DevIndex is heavy; allow time for render + Neural Link mapping.
     test.use({ viewport: { width: 1920, height: 1080 } });
 

--- a/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
+++ b/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
@@ -31,9 +31,8 @@ import { test, expect } from '../fixtures.mjs';
  *
  * Run: npx playwright test GridColumnCrossBodyDnD -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-// ticket-ref-ok: skip pointer is load-bearing — #12933 removed devindex's locked-column config this spec's region assertions require.
-// ticket-ref-ok: #12936 re-homes this spec onto the dedicated locked fixture; un-skip rides that migration.
-test.describe.skip('Desktop (1920x1080): DevIndex Locked-Column DnD (#12807)', () => {
+// ticket-ref-ok: known-failing since #12933 removed devindex's locked-column config; #12936 re-homes this spec onto the dedicated locked fixture.
+test.describe('Desktop (1920x1080): DevIndex Locked-Column DnD (#12807)', () => {
     test.setTimeout(90000); // DevIndex is heavy; allow time for render + Neural Link mapping.
     test.use({ viewport: { width: 1920, height: 1080 } });
 

--- a/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
+++ b/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
@@ -37,7 +37,9 @@ import { test, expect } from '../fixtures.mjs';
  *
  * Run: npx playwright test GridColumnOverdragScroll -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-test.describe('Desktop (1920x1080): DevIndex Column Overdrag Scrolling (#12906/#12907)', () => {
+// ticket-ref-ok: skip pointer is load-bearing — #12933 removed devindex's locked-column config this spec's lockedStartWidth geometry requires.
+// ticket-ref-ok: #12936 re-homes this spec onto the dedicated locked fixture; un-skip rides that migration.
+test.describe.skip('Desktop (1920x1080): DevIndex Column Overdrag Scrolling (#12906/#12907)', () => {
     test.setTimeout(120000); // DevIndex is heavy; two overdrag legs poll-settle sequentially.
     test.use({ viewport: { width: 1920, height: 1080 } });
 

--- a/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
+++ b/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
@@ -37,9 +37,8 @@ import { test, expect } from '../fixtures.mjs';
  *
  * Run: npx playwright test GridColumnOverdragScroll -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-// ticket-ref-ok: skip pointer is load-bearing — #12933 removed devindex's locked-column config this spec's lockedStartWidth geometry requires.
-// ticket-ref-ok: #12936 re-homes this spec onto the dedicated locked fixture; un-skip rides that migration.
-test.describe.skip('Desktop (1920x1080): DevIndex Column Overdrag Scrolling (#12906/#12907)', () => {
+// ticket-ref-ok: known-failing since #12933 removed devindex's locked-column config; #12936 re-homes this spec onto the dedicated locked fixture.
+test.describe('Desktop (1920x1080): DevIndex Column Overdrag Scrolling (#12906/#12907)', () => {
     test.setTimeout(120000); // DevIndex is heavy; two overdrag legs poll-settle sequentially.
     test.use({ viewport: { width: 1920, height: 1080 } });
 


### PR DESCRIPTION
Resolves #12933
Related: #12883 (repro-env pointer comment posted per AC), #12934 (the responsive successor), #12936 (locked-fixture re-home for the affected specs)

Authored by Claude Fable 5 (Claude Code). Session e6b095bb-4d88-4aeb-a0ec-7d47e0f8f7ce.

The four `locked` config lines come out of the devindex grid (`id`/`rank`/`login` start-locks + `lastUpdated` end-lock): the config existed for multi-body testing only, the coverage now lives in fixture-driven dynamic locking (`GridBigDataMultiBodyNL.spec.mjs` creates locked topologies at runtime via the NL fixture — deeper than static config), and the static locks made mobile portrait arithmetically unusable (locked regions ≥490px vs ~390px viewport). Operator validated the no-locks state live during tonight's debugging session before this was filed.

Evidence: L2 (pure config-line removal, `node --check` green, diff review) → L3 achieved (the operator ran devindex without locks live tonight — real-browser validation precedes the PR). Residual: three devindex-bound locked e2e specs are **known-failing** until #12936 re-homes them (deliberate — see Deltas).

## Deltas from ticket

- **Spec blast radius surfaced post-filing (Ada's catch) and policy corrected by operator review**: three e2e specs assert devindex's locked state — `GridColumnCrossBodyDnD` (`#12807` oracle), `GridColumnOverdragScroll`, `GridThumbDragDevIndex`. They are left **failing-honest** (NOT skipped): e2e runs outside CI, so red costs no pipeline and is the loud, self-advertising tracker pressing #12936 to land; hardcoded `describe.skip` would be the silent state (quietly reported, rots indefinitely) and would usurp `NEO_TEST_SKIP_CI` — the repo's env-layer mechanism that owns CI-exclusion decisions if these specs ever enter CI. An earlier commit on this branch added describe-skips; reverted in `3fd1f848e` after the operator's correction. Two specs carry a one-line `ticket-ref-ok` pointer at the describe so the runner who hits the failure lands on #12936 immediately; `GridThumbDragDevIndex` needs no edit at all (its pointer lives on #12936; touching it would gate on a 28-line pre-existing whitespace cleanup that belongs to the migration commit).
- **Mechanical-hygiene rider** (first commit): pre-existing trailing whitespace at GridContainer line 415, hook-gated, cleaned.

## Test Evidence

- `node --check` green on all touched files.
- `grep -c locked` on GridContainer → 0 remaining.
- Commits: `86d91a86e` (4 config-line removals + whitespace fix) · `a07cf7485` (describe-skips — superseded) · `3fd1f848e` (skips reverted to failing-honest + pointer comments).
- Live validation: the operator ran exactly this configuration (locks removed) tonight; the #12930 repro tests were performed against it.

## Post-Merge Validation

- [ ] devindex smoke check on the deployed/rebuilt demo (single-region layout renders + scrolls).
- [ ] #12883 repro recipe continues via the bigData example (pointer comment already posted).
- [ ] #12936 lands the fixture and turns the three specs green again (tracked there).
