### PR TITLE
fix: scrolled-drop re-sync, single-fire lock rebuild, stale-echo gate (#12929, #12932)

### DIFF
--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -394,6 +394,26 @@ class SortZone extends BaseSortZone {
 
             me.gridBody.createViewData(false, true)
         }
+
+        // Scrolled-state drop re-sync: restoring the items out of `position: absolute` passes
+        // through a reflow frame where the owner toolbar has no scrollable overflow, so the
+        // browser clamps the toolbar element's native scrollLeft to 0 — while the dedicated
+        // scrollbar element and the body's scroll var still hold the drop-time value (the addon
+        // only re-copies on scrollbar scroll EVENTS, and a same-value scrollTo fires none).
+        // Until the next manual scroll, headers and cells render offset by the full scroll
+        // amount, and a drag started in that window has its term contradict the toolbar's
+        // actual position. Re-apply the worker-side scroll truth to the toolbar element once
+        // the restore has settled.
+        if (owner.scrollLeft > 0) {
+            await me.timeout(30);
+
+            await Neo.main.DomAccess.scrollTo({
+                direction: 'left',
+                id       : owner.id,
+                value    : owner.scrollLeft,
+                windowId : me.windowId
+            })
+        }
     }
 
     /**

--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -927,12 +927,15 @@ class GridContainer extends BaseContainer {
             sortedColumns = me.sortColumns(columnsArray);
 
         // Sync the Collection
-        // clearSilent() and add() is the safest way to reset internal indices
+        // clearSilent() and add() is the safest way to reset internal indices.
+        // add() is NON-silent: it fires the collection's mutate event, which IS this container's
+        // registered onColumnsMutate listener — the sub-grid layout sync runs exactly once through
+        // that path. An additional explicit onColumnsMutate() call here would run the rebuild
+        // twice in the same tick: two racing `view.items` assignments diff against a stale vnode
+        // and insert duplicate region-body DOM nodes (the second copy renders the same columns
+        // beside the first — "duplicated columns" after a cross-region drop).
         me.columns.clearSilent();
         me.columns.add(sortedColumns);
-
-        // Trigger Sub-grid Layout Sync
-        me.onColumnsMutate();
 
         // onColumnsMutate re-homed the header buttons across the region toolbars; each region's
         // body still holds the columnPositions / availableWidth of its OLD membership. Rebuild

--- a/src/grid/Row.mjs
+++ b/src/grid/Row.mjs
@@ -501,10 +501,20 @@ class Row extends Component {
                     let oldNode = oldCellMap.get(column.dataField);
 
                     if (oldNode && oldNode.data?.recordId === recordId) {
+                        // Identity-migration symmetry with the Pass 1 recycle: this node may have
+                        // been rendered POOLED (id `…__cell-N`) before the column flipped into
+                        // permanent territory (e.g. `locked` changed on a mounted row via a
+                        // cross-region drag re-home). Pass 1's placeholder loop has already
+                        // re-issued that pool id — keeping it here puts two nodes with one id
+                        // into a single row, and id-based diffing collapses (id-less insert
+                        // storms, the DOM accumulating both generations).
+                        oldNode.id = `${me.id}__${column.dataField}`;
+                        oldNode['aria-colindex'] = i + 1;
+
                         if (columnPosition) {
                             oldNode.style.left  = columnPosition.x + 'px';
                             oldNode.style.width = columnPosition.width + 'px';
-                            
+
                             if (isMounted || column.locked) {
                                 if (columnPosition.hidden) {
                                     oldNode.style.visibility = 'hidden'

--- a/src/grid/header/Toolbar.mjs
+++ b/src/grid/header/Toolbar.mjs
@@ -86,6 +86,16 @@ class Toolbar extends BaseToolbar {
     }
 
     /**
+     * The latest scroll value commanded by {@link #scrollToIndex} and not yet confirmed by its
+     * pipeline echo. While set (and a drag is active), {@link #beforeSetScrollLeft} rejects any
+     * non-matching incoming write as a stale out-of-order echo. Null when no command is in
+     * flight; self-clears on the first write outside an active drag.
+     * @member {Number|null} pendingScrollTarget=null
+     * @protected
+     */
+    pendingScrollTarget = null
+
+    /**
      * Triggered after the mounted config got changed
      * @param {Boolean} value
      * @param {Boolean} oldValue
@@ -133,6 +143,39 @@ class Toolbar extends BaseToolbar {
             // Term observability while a drag is in flight (itemRects = the mid-drag marker)
             sortZone.itemRects && sortZone.traceEvent({t: 'scrollSync', sl: value})
         }
+    }
+
+    /**
+     * Command/echo reconciliation for the drag overdrag loop. While a drag is active and a
+     * commanded scroll is in flight ({@link #scrollToIndex} records it), incoming config writes
+     * are echoes from the scroll pipeline — and echoes can arrive out of order under burst
+     * scrolling (one command per walk beat). A stale echo regressing the term re-arms the
+     * loop's nearest-math and force-switches the dragged column: a feedback runaway. The gate
+     * accepts only the echo matching the latest command; anything else mid-drag is stale and
+     * rejected. Outside an active drag the gate is off (and self-clears), so user scrolling is
+     * never filtered.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @returns {Number}
+     * @protected
+     */
+    beforeSetScrollLeft(value, oldValue) {
+        let me        = this,
+            {pendingScrollTarget, sortZone} = me;
+
+        if (Neo.isNumber(pendingScrollTarget) && sortZone?.itemRects) {
+            // Sub-pixel tolerance: browsers may quantize a fractional commanded scrollLeft, so
+            // the echo can differ from the command by less than a pixel and still be ours.
+            if (Math.abs(value - pendingScrollTarget) < 1) {
+                me.pendingScrollTarget = null;
+                return value
+            }
+
+            return oldValue // stale echo mid-drag
+        }
+
+        me.pendingScrollTarget = null;
+        return value
     }
 
     /**
@@ -381,9 +424,21 @@ class Toolbar extends BaseToolbar {
         }
 
         if (scrollbar && target !== null) {
-            // Optimistic worker-side mirror: afterSetScrollLeft feeds the SortZone term BEFORE the
-            // DOM scroll-event echo arrives via grid.ScrollManager (which re-sets the same value).
-            me.scrollLeft = target;
+            // Record the command FIRST: beforeSetScrollLeft gates every subsequent config write
+            // against it — only the echo matching this latest command passes; out-of-order echoes
+            // from earlier commands are rejected (they would regress the term and re-arm the
+            // overdrag loop: the runaway switch storm).
+            me.pendingScrollTarget = target;
+
+            // Optimistic worker-side mirror, deliberately BYPASSING the config gate (a config
+            // write would consume the pending command as if the echo had already arrived): the
+            // SortZone term and the backing field update directly; the trace marks the command.
+            me._scrollLeft = target;
+
+            if (me.sortZone) {
+                me.sortZone.scrollLeft = target;
+                me.sortZone.itemRects && me.sortZone.traceEvent({t: 'scrollSync', sl: target})
+            }
 
             await Neo.main.DomAccess.scrollTo({
                 direction: 'left',

--- a/src/grid/header/Toolbar.mjs
+++ b/src/grid/header/Toolbar.mjs
@@ -163,15 +163,20 @@ class Toolbar extends BaseToolbar {
         let me        = this,
             {pendingScrollTarget, sortZone} = me;
 
-        if (Neo.isNumber(pendingScrollTarget) && sortZone?.itemRects) {
-            // Sub-pixel tolerance: browsers may quantize a fractional commanded scrollLeft, so
-            // the echo can differ from the command by less than a pixel and still be ours.
-            if (Math.abs(value - pendingScrollTarget) < 1) {
+        if (sortZone?.itemRects) {
+            // Mid-drag this config is COMMAND-DRIVEN: scrollToIndex() writes the backing field
+            // directly and registers its command here; pipeline echoes may only CONFIRM the
+            // latest command. Sub-pixel tolerance: browsers may quantize a fractional
+            // commanded scrollLeft, so the echo can differ by less than a pixel and be ours.
+            if (Neo.isNumber(pendingScrollTarget) && Math.abs(value - pendingScrollTarget) < 1) {
                 me.pendingScrollTarget = null;
                 return value
             }
 
-            return oldValue // stale echo mid-drag
+            // Everything else mid-drag is stale or foreign — INCLUDING a late echo from an
+            // OLDER command arriving after the latest echo already cleared the pending state;
+            // accepting it would regress the term and re-arm the overdrag loop.
+            return oldValue
         }
 
         me.pendingScrollTarget = null;

--- a/test/playwright/unit/grid/HeaderToolbarScrollGate.spec.mjs
+++ b/test/playwright/unit/grid/HeaderToolbarScrollGate.spec.mjs
@@ -1,0 +1,96 @@
+/**
+ * @file test/playwright/unit/grid/HeaderToolbarScrollGate.spec.mjs
+ * @summary Unit tests for the grid header toolbar's command/echo scroll gate.
+ *
+ * During a drag's overdrag walk, the toolbar's `scrollLeft` config is command-driven:
+ * `scrollToIndex()` registers each commanded value and writes the backing field directly;
+ * pipeline echoes (from `grid.ScrollManager`'s mirror) may only CONFIRM the latest command.
+ * Out-of-order echoes — including a LATE echo from an OLDER command arriving after the latest
+ * echo already cleared the pending state — must be rejected, or the regressed term re-arms the
+ * overdrag loop (the runaway switch storm). Outside an active drag the gate is off and
+ * self-clears, so user scrolling is never filtered.
+ *
+ * @see Neo.grid.header.Toolbar
+ */
+
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'GridHeaderToolbarScrollGateTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Toolbar        from '../../../../src/grid/header/Toolbar.mjs';
+
+/**
+ * The gate reads only `pendingScrollTarget` and `sortZone.itemRects`; a plain fake zone keeps
+ * the probe at method level (the reviewer's original falsification shape).
+ */
+function makeToolbar(dragActive) {
+    const toolbar = Neo.create(Toolbar, {});
+    toolbar.sortZone = {itemRects: dragActive ? [{left: 0, width: 100}] : null, scrollLeft: 0};
+    return toolbar;
+}
+
+test.describe('Neo.grid.header.Toolbar scroll command/echo gate', () => {
+    test('latest command echo passes and clears the pending state', () => {
+        const tb = makeToolbar(true);
+
+        tb.pendingScrollTarget = 200;
+        expect(tb.beforeSetScrollLeft(200, 0)).toBe(200);
+        expect(tb.pendingScrollTarget).toBeNull();
+
+        tb.destroy();
+    });
+
+    test('REGRESSION (review probe): a late OLDER echo after the latest echo cleared pending is rejected mid-drag', () => {
+        const tb = makeToolbar(true);
+
+        tb.pendingScrollTarget = 200;
+        expect(tb.beforeSetScrollLeft(200, 0)).toBe(200);   // latest echo confirms + clears
+        expect(tb.beforeSetScrollLeft(100, 200)).toBe(200); // stale older echo: REJECTED (returns oldValue)
+
+        tb.destroy();
+    });
+
+    test('mid-drag, non-matching writes are rejected while a command is pending', () => {
+        const tb = makeToolbar(true);
+
+        tb.pendingScrollTarget = 500;
+        expect(tb.beforeSetScrollLeft(364, 500)).toBe(500); // out-of-order echo from an earlier command
+        expect(tb.pendingScrollTarget).toBe(500);           // the command stays armed for ITS echo
+
+        tb.destroy();
+    });
+
+    test('sub-pixel echo quantization still confirms the command', () => {
+        const tb = makeToolbar(true);
+
+        tb.pendingScrollTarget = 364.5;
+        expect(tb.beforeSetScrollLeft(364, 0)).toBe(364);   // |364 - 364.5| < 1 → ours
+        expect(tb.pendingScrollTarget).toBeNull();
+
+        tb.destroy();
+    });
+
+    test('outside an active drag the gate is off: any value passes and pending self-clears', () => {
+        const tb = makeToolbar(false);
+
+        tb.pendingScrollTarget = 999; // leftover from a drag that ended
+        expect(tb.beforeSetScrollLeft(100, 0)).toBe(100);   // user scrolling never filtered
+        expect(tb.pendingScrollTarget).toBeNull();          // self-healed
+
+        tb.destroy();
+    });
+});


### PR DESCRIPTION
Resolves #12929
Resolves #12932

Refs #12930 — the id-migration FIX lands here; the ticket stays OPEN for its regression-net half (@neo-fable-clio's scoped lane: the pool-born→permanent one-live-cell invariant spec) and closes when that net lands.

Refs #12883

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

Three verified fixes from tonight's forensic hunt on the v13 gate family — each independent of the still-open stale-baseline collision defect (tracked on the #12929/#12930 trail), each relevant to lock-less grids too:

1. **Scrolled-state drop desync** (#12929): the drag-end `wrapperStyle` restore passes a reflow frame with no scrollable overflow, so the browser clamps the header toolbar's native scrollLeft to 0 while the scrollbar element and the body's `--grid-scroll-left` var keep the drop-time value — headers and cells render offset by the full scroll until the next manual scroll, and a drag started in that window has its term contradict the toolbar (switch storms, wrong landings: the operator's "header movements broken"). Fix: drag-end re-applies `owner.scrollLeft` to the toolbar element after the restore settles (`processDragEnd`, both branches).
2. **Double rebuild on lock change** (#12929 trail): `onColumnLockChange` ran the sub-grid layout sync twice — the non-silent `columns.add()` fires the registered `mutate` listener AND an explicit `onColumnsMutate()` call followed. Two racing `view.items` assignments diff against stale vnodes. Removed the explicit call; the event contract is documented in-code.
3a. **Pool→permanent id migration** (#12930, added at head `0c6d5cf8e` after @neo-fable-clio's keystone analysis): Pass 2's cell recycle kept the stale POOL id when a column flipped into permanent territory (a cross-region re-home changing `locked` on a mounted row) while Pass 1's placeholder loop re-issued that same id — two nodes, one id, single row; id-based diffing collapsed (the id-less insertNode storms). Fix mirrors Pass 1's re-id symmetrically (`oldNode.id = rowId__dataField` + aria-colindex). Probe-verified: region-body DOM duplication drops from ×8-14 per walk to a ×1-2 per-drop residual (that residual = the stale-baseline mechanism, tracked open on #12939 — explicitly NOT claimed by this PR).

3. **Stale-echo gate** (#12932): out-of-order scroll echoes falsified the `#12908` optimistic-mirror idempotency claim — a stale echo regressing the term re-arms the overdrag loop (the live-session runaway: term 0→1884 in 370ms, twenty involuntary switches; evidence preserved in the ring buffer, recorded on #12932). Fix (hardened at `bc6a6ba7d` per review cycle 1): mid-drag the config is **command-driven** — `scrollToIndex()` writes the backing field directly and registers its command; `beforeSetScrollLeft` admits ONLY the latest command's echo (±1px sub-pixel tolerance) and rejects every other mid-drag write — **including a late echo from an older command arriving after the latest echo cleared the pending state** (the review's direct-probe finding). The gate is off and self-clears outside drags, so user scrolling is never filtered. The reviewer's probe is encoded verbatim as the regression net (`HeaderToolbarScrollGate.spec.mjs`, 5 tests). The trace's `dup` markers were characterized as the `#12901` count-compression instrumentation (not double-dispatch) per @neo-fable-clio's source correction — #12932's secondary AC closed.

Evidence: L2 (the gate's full contract unit-proven: latest-echo-confirms, late-older-echo-rejected, pending-stays-armed-for-its-echo, sub-pixel quantization, gate-off-outside-drags) + L3 (headless forensic probe: within-region scrolled drop aligns immediately, drag-in-desync-window lands clean, two-leg overdrag walk + exact landing green, GridColumnCrossBodyDnD green; region-body duplication reduced ×8-14 → ×1-2 per-drop by the id-migration fix) → L4 required: the operator's human-speed runaway re-test (#12932 AC, batched gate session). Residuals, by close-target: #12929 — within-region ACs delivered; the cross-region AC's remaining corruption is the stale-baseline collision, tracked open on #12939. #12930 — the duplicate-id seed is fixed here; the per-drop ×1-2 body-copy residual is the #12939 mechanism, NOT this seam (verified by the probe's before/after). #12932 — complete pending the L4 re-test.

## Deltas from ticket

#12929's cross-region scrolled-drop AC remains affected by the OPEN collision defect (duplicated bodies corrupt layout post-re-home) — explicitly carried to the collision lane rather than silently claimed here. The within-region ACs are fully delivered and probe-verified.

## Test Evidence

- Exploration probe (uncommitted, on the branch trail): forensics clean for baseline, 4 heterogeneous-width drags, scroll cycles, overdrag+scrolled drop, drag-in-window; view-consistency clean through all in-bound legs; the id-migration commit drops region-body DOM duplication from ×8-14 per walk to the ×1-2 per-drop #12939 residual.
- `npm run test-unit -- HeaderToolbarScrollGate.spec` → 5/5 (NEW: the gate contract incl. the review's late-older-echo probe verbatim).
- `npx playwright test GridColumnOverdragScroll -c playwright.config.e2e.mjs` → 2/2 re-run at `bc6a6ba7d` (post-gate-hardening); `GridColumnCrossBodyDnD` 2/2 at the prior head (file-disjoint from the gate change).
- `npm run test-unit -- unit/grid unit/draggable` at head: **46 passed / 7 failed — the 7 are PRE-EXISTING on dev tip** (identical set in a control run on clean dev, 2026-06-12 ~01:40Z; they match the unowned-failures record from the #12892-era session and predate this branch). Now owned + triage-scoped as #12941. Every test that passes on dev passes at this head; the head adds 5 passing gate tests and breaks none.

## Post-Merge Validation

- [ ] Operator runaway re-test at human speed (overdrag walks produce no involuntary switch storms) — batched into the gate verification session.

## Commits

- `aafa9cc8b`-equivalent (rebased) — drag-end scroll re-sync + single-fire lock rebuild
- `172a6272b`-equivalent (rebased) — the stale-echo gate

Note: supersedes branch `agent/12929-scrolled-drop-resync` (rebased onto current dev; old branch prunable — force-push is soft-blocked in this harness).


