### PR TITLE
test(grid): dedicated locked-column whitebox-e2e fixture; migrate CrossBodyDnD + OverdragScroll (#12936)

### DIFF
--- a/examples/grid/lockedColumns/MainContainer.mjs
+++ b/examples/grid/lockedColumns/MainContainer.mjs
@@ -1,0 +1,52 @@
+import GridContainer from '../../../src/grid/Container.mjs';
+import MainStore     from './MainStore.mjs';
+import Viewport      from '../../../src/container/Viewport.mjs';
+
+/**
+ * A purpose-built locked-column grid fixture for whitebox-e2e. Provides a stable multi-region grid —
+ * a frozen locked-start region, a horizontally-scrollable centre, and a frozen locked-end region —
+ * that test specs can drive and assert against, decoupled from any product app. The geometry is owned
+ * here for test math, so it has no reason to churn the way a demo app's columns do.
+ *
+ * GEOMETRY CONTRACT (stable — chosen for test math, never demo aesthetics):
+ *   locked-start : id(60) + rank(60) + login(250)                = 370px frozen left region
+ *   centre       : totalContributions(100) + commitRatio(90) + privateContributionsRatio(90)
+ *                  + an overflow tail of 14 year columns y2024..y2011 (@110px) = 1820px total, which
+ *                  OVERFLOWS the ~1410px centre viewport (1920 - 370 lockedStart - 140 lockedEnd).
+ *                  The overflow is what gives the centre a dedicated horizontal scrollbar + overdrag
+ *                  auto-scroll to exercise. The first THREE centre dataFields stay fixed
+ *                  (totalContributions/commitRatio/privateContributionsRatio) so cross-region
+ *                  drag-and-drop landing math is unaffected by the tail.
+ *   locked-end   : lastUpdated(140)                              = frozen right region
+ *
+ * @class Neo.examples.grid.lockedColumns.MainContainer
+ * @extends Neo.container.Viewport
+ */
+class MainContainer extends Viewport {
+    static config = {
+        className: 'Neo.examples.grid.lockedColumns.MainContainer',
+        layout   : {ntype: 'fit'},
+
+        items: [{
+            module : GridContainer,
+            store  : MainStore,
+
+            columns: [
+                {dataField: 'id',                        locked: 'start', text: '#',         width: 60},
+                {dataField: 'rank',                      locked: 'start', text: 'Rank',      width: 60},
+                {dataField: 'login',                     locked: 'start', text: 'User',      width: 250},
+                {dataField: 'totalContributions',                         text: 'Total',     width: 100},
+                {dataField: 'commitRatio',                                text: 'Commits %', width: 90},
+                {dataField: 'privateContributionsRatio',                  text: 'Private %', width: 90},
+                // overflow tail — enough centre width to exercise the horizontal scrollbar + overdrag
+                ...Array.from({length: 14}, (_, i) => {
+                    const year = 2024 - i;
+                    return {dataField: `y${year}`, text: `${year}`, width: 110}
+                }),
+                {dataField: 'lastUpdated',               locked: 'end',   text: 'Updated',   width: 140}
+            ]
+        }]
+    }
+}
+
+export default Neo.setupClass(MainContainer);

--- a/examples/grid/lockedColumns/MainModel.mjs
+++ b/examples/grid/lockedColumns/MainModel.mjs
@@ -1,0 +1,25 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * @class Neo.examples.grid.lockedColumns.MainModel
+ * @extends Neo.data.Model
+ */
+class MainModel extends Model {
+    static config = {
+        className: 'Neo.examples.grid.lockedColumns.MainModel',
+
+        fields: [
+            {name: 'id',                        type: 'Integer'},
+            {name: 'rank',                      type: 'Integer'},
+            {name: 'login',                     type: 'String'},
+            {name: 'totalContributions',        type: 'Integer'},
+            {name: 'commitRatio',               type: 'Number'},
+            {name: 'privateContributionsRatio', type: 'Number'},
+            // overflow-tail fields that widen the centre region past its viewport (scroll coverage)
+            ...Array.from({length: 14}, (_, i) => ({name: `y${2024 - i}`, type: 'Integer'})),
+            {name: 'lastUpdated',               type: 'String'}
+        ]
+    }
+}
+
+export default Neo.setupClass(MainModel);

--- a/examples/grid/lockedColumns/MainStore.mjs
+++ b/examples/grid/lockedColumns/MainStore.mjs
@@ -1,0 +1,27 @@
+import Model from './MainModel.mjs';
+import Store from '../../../src/data/Store.mjs';
+
+/**
+ * @class Neo.examples.grid.lockedColumns.MainStore
+ * @extends Neo.data.Store
+ */
+class MainStore extends Store {
+    static config = {
+        className  : 'Neo.examples.grid.lockedColumns.MainStore',
+        keyProperty: 'id',
+        model      : Model,
+
+        data: [
+            {id: 1, rank: 1, login: 'octocat',   totalContributions: 9100, commitRatio: 0.82, privateContributionsRatio: 0.10, lastUpdated: '2026-06-01'},
+            {id: 2, rank: 2, login: 'hubot',     totalContributions: 7400, commitRatio: 0.71, privateContributionsRatio: 0.22, lastUpdated: '2026-05-28'},
+            {id: 3, rank: 3, login: 'monalisa',  totalContributions: 6800, commitRatio: 0.66, privateContributionsRatio: 0.31, lastUpdated: '2026-05-30'},
+            {id: 4, rank: 4, login: 'devbot',    totalContributions: 6100, commitRatio: 0.59, privateContributionsRatio: 0.18, lastUpdated: '2026-05-21'},
+            {id: 5, rank: 5, login: 'codecat',   totalContributions: 5400, commitRatio: 0.74, privateContributionsRatio: 0.27, lastUpdated: '2026-06-02'},
+            {id: 6, rank: 6, login: 'mergecat',  totalContributions: 4900, commitRatio: 0.63, privateContributionsRatio: 0.12, lastUpdated: '2026-05-19'},
+            {id: 7, rank: 7, login: 'pullbot',   totalContributions: 4200, commitRatio: 0.55, privateContributionsRatio: 0.40, lastUpdated: '2026-05-25'},
+            {id: 8, rank: 8, login: 'forkcat',   totalContributions: 3700, commitRatio: 0.68, privateContributionsRatio: 0.09, lastUpdated: '2026-05-14'}
+        ]
+    }
+}
+
+export default Neo.setupClass(MainStore);

--- a/examples/grid/lockedColumns/app.mjs
+++ b/examples/grid/lockedColumns/app.mjs
@@ -1,0 +1,6 @@
+import MainContainer from './MainContainer.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: MainContainer,
+    name    : 'Neo.examples.grid.lockedColumns'
+});

--- a/examples/grid/lockedColumns/index.html
+++ b/examples/grid/lockedColumns/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>Neo Locked-Column Grid Fixture</title>
+</head>
+<body>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/examples/grid/lockedColumns/neo-config.json
+++ b/examples/grid/lockedColumns/neo-config.json
@@ -1,0 +1,9 @@
+{
+    "appPath"         : "examples/grid/lockedColumns/app.mjs",
+    "basePath"        : "../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Navigator", "ResizeObserver", "Stylesheet"],
+    "themes"          : ["neo-theme-dark", "neo-theme-light"],
+    "useAiClient"     : true
+}

--- a/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
+++ b/test/playwright/e2e/GridColumnCrossBodyDnD.spec.mjs
@@ -31,29 +31,21 @@ import { test, expect } from '../fixtures.mjs';
  *
  * Run: npx playwright test GridColumnCrossBodyDnD -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-// ticket-ref-ok: known-failing since #12933 removed devindex's locked-column config; #12936 re-homes this spec onto the dedicated locked fixture.
-test.describe('Desktop (1920x1080): DevIndex Locked-Column DnD (#12807)', () => {
-    test.setTimeout(90000); // DevIndex is heavy; allow time for render + Neural Link mapping.
+test.describe('Desktop (1920x1080): lockedColumns Fixture Locked-Column DnD (#12807)', () => {
+    test.setTimeout(90000); // allow time for render + Neural Link mapping.
     test.use({ viewport: { width: 1920, height: 1080 } });
 
     test.beforeEach(async ({ page }) => {
-        await page.goto('/apps/devindex/');
+        await page.goto('/examples/grid/lockedColumns/');
         page.on('console',   msg => console.log('BROWSER:', msg.text()));
         page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
 
         await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
-        const stopButton = page.locator('.devindex-stop-stream-button');
-        try {
-            await expect(stopButton).toBeVisible({ timeout: 5000 });
-            await stopButton.click({ timeout: 2000, force: true }); // stop the stream so we don't wait for all rows
-        } catch {
-            // stream settled instantly — button never appeared / already hid
-        }
-        await page.waitForTimeout(1000);
+        await page.waitForTimeout(500); // settle render before measuring
     });
 
     test('center-region "Total" drag lands at index 2 — engine keeps it in centerColumns + DOM idx 2 (no overshoot)', async ({ page, neuralLink }) => {
-        const app    = await neuralLink.connectToApp('DevIndex');
+        const app    = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
         const gridId = await resolveGridId(app);
 
         await assertPristineGrid(app, gridId);                     // worker precondition (also catches a foreign/stale bound app)
@@ -82,7 +74,7 @@ test.describe('Desktop (1920x1080): DevIndex Locked-Column DnD (#12807)', () => 
     });
 
     test('cross-region: center "Total" drag into locked-start re-homes — engine moves it to lockedStartColumns + DOM applies it', async ({ page, neuralLink }) => {
-        const app    = await neuralLink.connectToApp('DevIndex');
+        const app    = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
         const gridId = await resolveGridId(app);
 
         await assertPristineGrid(app, gridId);

--- a/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
+++ b/test/playwright/e2e/GridColumnOverdragScroll.spec.mjs
@@ -37,28 +37,20 @@ import { test, expect } from '../fixtures.mjs';
  *
  * Run: npx playwright test GridColumnOverdragScroll -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
-// ticket-ref-ok: known-failing since #12933 removed devindex's locked-column config; #12936 re-homes this spec onto the dedicated locked fixture.
-test.describe('Desktop (1920x1080): DevIndex Column Overdrag Scrolling (#12906/#12907)', () => {
-    test.setTimeout(120000); // DevIndex is heavy; two overdrag legs poll-settle sequentially.
+test.describe('Desktop (1920x1080): lockedColumns Fixture Column Overdrag Scrolling (#12906/#12907)', () => {
+    test.setTimeout(120000); // two overdrag legs poll-settle sequentially.
     test.use({ viewport: { width: 1920, height: 1080 } });
 
     test.beforeEach(async ({ page }) => {
-        await page.goto('/apps/devindex/');
+        await page.goto('/examples/grid/lockedColumns/');
         page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
 
         await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
-        const stopButton = page.locator('.devindex-stop-stream-button');
-        try {
-            await expect(stopButton).toBeVisible({ timeout: 5000 });
-            await stopButton.click({ timeout: 2000, force: true }); // stop the stream so we don't wait for all rows
-        } catch {
-            // stream settled instantly — button never appeared / already hid
-        }
-        await page.waitForTimeout(1000);
+        await page.waitForTimeout(500); // settle render before measuring
     });
 
     test('overdrag right then back left to index 0 — scrollbar-routed, locked region frozen, exact landing', async ({ page, neuralLink }) => {
-        const app    = await neuralLink.connectToApp('DevIndex');
+        const app    = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
         const gridId = await resolveGridId(app);
 
         // Worker preconditions: pristine layout + the dragged column's identity (centre index 2)
@@ -149,7 +141,7 @@ test.describe('Desktop (1920x1080): DevIndex Column Overdrag Scrolling (#12906/#
     });
 
     test('scrollbar scrollport is scoped to the centre region — full range, margins = locked widths (#12907)', async ({ page, neuralLink }) => {
-        await neuralLink.connectToApp('DevIndex'); // session-bind keeps the page's worker authoritative
+        await neuralLink.connectToApp('Neo.examples.grid.lockedColumns'); // session-bind keeps the page's worker authoritative
 
         const result = await page.evaluate(async () => {
             const sleep   = ms => new Promise(r => setTimeout(r, ms));


### PR DESCRIPTION
Resolves #12953
Refs #12936

Authored by Opus 4.8 (Claude Code). Session 63f0aced-9b17-4aa7-bd30-a2592dba2c97.

Stands up a dedicated locked-column grid fixture (`examples/grid/lockedColumns`) so the locked-column whitebox-e2e specs no longer depend on the devindex app, whose locked-column config was removed. The fixture is a minimal `Viewport` + `GridContainer` with a stable, test-owned geometry: a frozen 3-column locked-start region (id/rank/login), a horizontally-overflowing centre (3 stat columns + a 14-column year tail), and a frozen 1-column locked-end region (lastUpdated). Geometry is chosen for test math, not demo aesthetics.

Two of the three skipped specs are retargeted onto it and pass green locally:
- `GridColumnCrossBodyDnD` — landing accuracy + cross-region re-home, via the column/region worker-oracle.
- `GridColumnOverdragScroll` — overdrag auto-scroll + scrollbar-scoping (the centre overflow tail gives them something to scroll).

Both migrations were minimal — only the entry points changed (navigate to the fixture, connect to its app, drop the devindex stream-stop) — because the fixture mirrors the canonical locked-column dataFields the specs assert on.

## Deltas
- **Close-target is the delivered leaf #12953, not the #12936 umbrella** (per review — close-target integrity). #12936 stays OPEN and tracks its residual: this PR delivers the #12953 core (the fixture + the two DnD specs); `GridThumbDragDevIndex` is deferred to #12949; the #12930 / #12883 consumer-home comments remain on #12936.
- `GridThumbDragDevIndex` is intentionally not in this PR — it is a *mixed* spec (one locked-cell horizontal-stability test that fits the fixture, one vertical scroll-telemetry / row-pinning test that needs a many-row streaming grid). The e2e suite is not in the PR-blocking CI gate, so its skipped state does not block.
- The fixture is decoupled from any product app by design (the forcing event was devindex losing its locks).

Evidence: both migrated specs verified green against a worktree dev-server (the canonical port served a different checkout); worker-oracle and DOM assertions agree on each leg. Independently re-verified 4/4 green by two reviewers — the migrated-specs contract owner and a cross-family checkout-isolated run.

## Test Evidence
- `GridColumnCrossBodyDnD` — `2 passed`. Landing: centerColumns index 2 === totalContributions + DOM index 2. Re-home: lockedStartColumns = [id, rank, login, totalContributions] + DOM [#, Rank, User, Total].
- `GridColumnOverdragScroll` — `2 passed`. Overdrag right then back to index 0 with the dedicated scrollbar as the only moving surface and the locked-start region frozen; scrollport margins = locked widths, max scroll = centre overflow.
- A throwaway fixture smoke (since deleted) confirmed the canonical region arrays + 3 header toolbars before the migrations.
- Repo CI runs `integration-unified` + `unit`; the e2e config (where these specs live) is NOT CI-gated, so CI green here does not exercise them — the green runs above are local + the two reviewer re-runs.

## Post-Merge Validation
- [ ] Re-run the two migrated specs against the merged code on a server that serves this checkout.
- [ ] Land #12949 (the `GridThumbDragDevIndex` migration) so the locked-cell coverage returns and that spec un-skips.
- [ ] Point the cell-doubling regression test and the locked-end re-home repro at this fixture (comments on #12930 / #12883).
