### PR TITLE
test: pool-born→permanent one-live-cell invariant net (#12930)

### DIFF
--- a/test/playwright/unit/grid/RowCellIdMigration.spec.mjs
+++ b/test/playwright/unit/grid/RowCellIdMigration.spec.mjs
@@ -1,0 +1,202 @@
+import {setup} from '../../setup.mjs';
+
+setup();
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Row            from '../../../../src/grid/Row.mjs';
+
+/**
+ * @summary Regression net for the pool-born→permanent one-live-cell invariant.
+ *
+ * Neo.grid.Row#createVdom renders cells in two passes, partitioned by
+ * P(column) = (hideMode === 'removeDom' && !locked):
+ * Pass 1 renders pooled cells (ids `rowId__cell-N`, N = columnIndex % cellPoolSize) and
+ * back-fills every unused pool slot with a display:none placeholder carrying that slot's
+ * pool id; Pass 2 renders permanent cells (ids `rowId__dataField`).
+ *
+ * When P flips on a MOUNTED row (e.g. a cross-region drag re-home changes `locked`), the
+ * recycle branches migrate the surviving node across schemes. Both directions MUST re-id
+ * the recycled node: if the lock-flip direction (pool→permanent) keeps the stale pool id
+ * while Pass 1's placeholder loop re-issues the same id, a single row holds two nodes with
+ * one id, collapsing id-based diffing (id-less insertNode storms, the DOM accumulating
+ * both cell generations).
+ *
+ * Invariant under test, for every render: all cell ids within a row are unique, and each
+ * column is alive under exactly ONE id scheme (pool placeholders without `data` are
+ * structural by design and do not count as living cells).
+ */
+test.describe('Neo.grid.Row cell-id scheme migration (#12930)', () => {
+    const ROW_ID = 'body-center__row-0';
+
+    /**
+     * Borrows the prototype methods under test on a plain `this` (BodyCellMapping.spec
+     * precedent: Object.create(Row.prototype) trips the #configs private-brand check of
+     * the reactive config system, while the borrowed methods only read plain members).
+     * The returned object carries everything createVdom + applyRendererOutput dereference.
+     */
+    function createRowFake(globalColumns) {
+        const record = {
+            id             : 'r1',
+            get(field)     { return `${field}-value` },
+            isModifiedField() { return false }
+        };
+
+        const columnPositions = globalColumns.map((col, index) => ({
+            dataField: col.dataField,
+            hidden   : false,
+            width    : 100,
+            x        : index * 100
+        }));
+
+        const gridContainer = {
+            columns: {
+                get     : dataField => globalColumns.find(col => col.dataField === dataField) || null,
+                getCount: () => globalColumns.length
+            },
+            isTreeGrid: false
+        };
+
+        const gridBody = {
+            cellPoolSize          : 5,
+            colspanField          : null,
+            columnPositions       : {
+                getAt   : i => columnPositions[i],
+                getCount: () => columnPositions.length
+            },
+            getLogicalCellId      : (rec, dataField) => `logical__${rec.id}__${dataField}`,
+            getRecordId           : rec => rec.id,
+            getRowClass           : () => ['neo-grid-row'],
+            gridContainer,
+            highlightModifiedCells: false,
+            mountedColumns        : [0, globalColumns.length - 1],
+            rowHeight             : 32,
+            selectedCells         : [],
+            selectedRecordField   : null,
+            selectedRows          : null,
+            selectionModel        : null,
+            store                 : {},
+            stripedRows           : false
+        };
+
+        return {
+            applyRendererOutput: Row.prototype.applyRendererOutput,
+            createVdom         : Row.prototype.createVdom,
+            getCellId          : Row.prototype.getCellId,
+            id                 : ROW_ID,
+            parent             : gridBody,
+            record,
+            rowIndex           : 0,
+            vdom               : {cn: []}
+        }
+    }
+
+    function createColumns() {
+        // hideMode removeDom + locked:null => P true (pooled); locked set => P false (permanent)
+        return [
+            {dataField: 'alpha', hideMode: 'removeDom', locked: null, renderer: ({value}) => value},
+            {dataField: 'beta',  hideMode: 'removeDom', locked: null, renderer: ({value}) => value},
+            {dataField: 'gamma', hideMode: 'removeDom', locked: null, renderer: ({value}) => value}
+        ]
+    }
+
+    /** A living cell carries the data.field binding; structural pool placeholders do not. */
+    function livingCells(row, dataField) {
+        return row.vdom.cn.filter(node => node.data?.field === dataField)
+    }
+
+    function assertUniqueIds(row) {
+        const ids = row.vdom.cn.map(node => node.id);
+        expect(new Set(ids).size).toBe(ids.length)
+    }
+
+    test('lock-flip (pool→permanent) re-ids the recycled node — no duplicate pool id with the placeholder', () => {
+        const columns = createColumns();
+        const row     = createRowFake(columns);
+
+        // Initial render: all three columns pooled
+        row.createVdom(true, true);
+        expect(livingCells(row, 'beta')[0].id).toBe(`${ROW_ID}__cell-1`);
+        assertUniqueIds(row);
+
+        // The P-flip: beta becomes locked on the mounted row (cross-region re-home shape)
+        columns[1].locked = 'start';
+        row.createVdom(true, true);
+
+        // THE invariant: ids unique — pre-fix, Pass 1's placeholder loop re-issued
+        // `__cell-1` while Pass 2 pushed the recycled node still carrying `__cell-1`
+        assertUniqueIds(row);
+
+        // beta is alive under exactly one scheme, the permanent (field-named) one
+        const beta = livingCells(row, 'beta');
+        expect(beta.length).toBe(1);
+        expect(beta[0].id).toBe(`${ROW_ID}__beta`);
+
+        // the vacated pool slot is a structural placeholder, not a living cell
+        const slot1 = row.vdom.cn.find(node => node.id === `${ROW_ID}__cell-1`);
+        expect(slot1).toBeDefined();
+        expect(slot1.data).toBeUndefined();
+        expect(slot1.style.display).toBe('none')
+    });
+
+    test('unlock-flip (permanent→pool) re-ids symmetrically — no stale field-named node', () => {
+        const columns = createColumns();
+        columns[1].locked = 'start';
+        const row = createRowFake(columns);
+
+        // Initial render: beta permanent (field-named), alpha + gamma pooled
+        row.createVdom(true, true);
+        expect(livingCells(row, 'beta')[0].id).toBe(`${ROW_ID}__beta`);
+        assertUniqueIds(row);
+
+        // The reverse P-flip: beta unlocks back into pool territory
+        columns[1].locked = null;
+        row.createVdom(true, true);
+
+        assertUniqueIds(row);
+
+        const beta = livingCells(row, 'beta');
+        expect(beta.length).toBe(1);
+        expect(beta[0].id).toBe(`${ROW_ID}__cell-1`);
+        expect(row.vdom.cn.find(node => node.id === `${ROW_ID}__beta`)).toBeUndefined()
+    });
+
+    test('steady-state recycle keeps ids stable and unique across repeated renders', () => {
+        const columns = createColumns();
+        const row     = createRowFake(columns);
+
+        row.createVdom(true, true);
+        const firstIds = row.vdom.cn.map(node => node.id);
+
+        row.createVdom(true, true);
+        row.createVdom(true, true);
+
+        expect(row.vdom.cn.map(node => node.id)).toEqual(firstIds);
+        assertUniqueIds(row);
+
+        // every column still alive exactly once
+        ['alpha', 'beta', 'gamma'].forEach(dataField => {
+            expect(livingCells(row, dataField).length).toBe(1)
+        })
+    });
+
+    test('flip round-trip (pool→permanent→pool) ends in the original identity state', () => {
+        const columns = createColumns();
+        const row     = createRowFake(columns);
+
+        row.createVdom(true, true);
+        const initialIds = row.vdom.cn.map(node => node.id).sort();
+
+        columns[1].locked = 'start';
+        row.createVdom(true, true);
+        assertUniqueIds(row);
+
+        columns[1].locked = null;
+        row.createVdom(true, true);
+        assertUniqueIds(row);
+
+        expect(row.vdom.cn.map(node => node.id).sort()).toEqual(initialIds);
+        expect(livingCells(row, 'beta').length).toBe(1)
+    });
+});


### PR DESCRIPTION
Resolves #12930

Authored by Claude Fable 5 (Claude Code). Session c29b5ccc-d711-4cde-8401-32d1e4bbc4f1.

The regression-net half of the `#12930` lane split (PR `#12938` review cycle 2, RA-2: the fix landed there; the ticket closes when the committed net lands). One new unit spec — `test/playwright/unit/grid/RowCellIdMigration.spec.mjs`, 4 tests — pinning `Row#createVdom`'s cell-identity migration across the P(column) = (`hideMode === 'removeDom' && !locked`) partition flip on a mounted row:

1. **lock-flip (pool→permanent)**: recycled node re-ids `__cell-N` → `__dataField`; no duplicate id with Pass 1's re-issued placeholder; exactly one live cell per column — the `0c6d5cf8e` regression, pinned.
2. **unlock-flip (permanent→pool)**: the symmetric Pass-1 migration (pre-existing correct behavior, now pinned).
3. **steady-state recycle**: id stability + uniqueness across repeated renders.
4. **flip round-trip**: identity state restores exactly.

The spec follows the `BodyCellMapping.spec.mjs` prototype-borrow pattern (plain `this` carrying only what the borrowed methods read — no `Neo.create`, no #configs private-brand trip, no grid scroll plumbing). Deliberately immune to the detached-driver failure class triaged in `#12941`; like its pattern siblings it constructs no components, so it carries no bucket-B CI skip guard and runs in CI.

Evidence: L2 (A/B falsification — net RED on pre-fix Row.mjs, GREEN at HEAD) → L2 required (AC3 is unit-shaped; AC1/AC2 delivered probe-verified by PR `#12938`; AC4 split). Residual: AC4 verification [#12947].

## Deltas from ticket

- The fix itself landed in PR `#12938` (`0c6d5cf8e`, lane split recorded in its review cycle 2) — this PR delivers the ticket's retained regression-net half only.
- AC4 (secondary row-window desync) split → #12947 per its own resolved-or-split clause; the recount protocol there carries @neo-fable's taint warning (operator's wedged devindex tab excluded; fixture-based recount preferred).
- Operator-flagged second verification angle: the unit seam net here is one layer; the **whitebox-e2e layer** (full SortZone drag → lock-flip → render pipeline) homes on the `#12936` `examples/grid/lockedColumns` fixture (PR `#12945`, in review) — tracked below as follow-up.

## Close-target AC mapping

- **AC1** (root cause + deterministic repro): delivered on the ticket (keystone comment `IC_kwDODSospM8AAAABF1WsFw`) + PR `#12938` item 3a; the unit-level repro is test 1 here.
- **AC2** (one cell per column post-drag, all regions): fix landed probe-verified in PR `#12938` (duplication ×8-14/walk → ×1-2/drop residual, attributed to `#12939`); the seam invariant is pinned here.
- **AC3** (regression unit test green via the custom unit config): this PR.
- **AC4** (row-window desync resolved-or-split): split → #12947 (boardless verify-post-fix leaf).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/grid/RowCellIdMigration.spec.mjs` → **4/4** (713ms).
- **Red-proof**: with `src/grid/Row.mjs` restored from `c79eebb19` (pre-fix dev; the only Row.mjs delta to HEAD is the 11-line id-migration hunk — verified via `git diff`), the same command → **2 failed / 2 passed**: exactly the two lock-flip-direction tests fail with the duplicate-id signature (6 ids, 5 unique — the `__cell-1` collision), while unlock-flip + steady-state (mechanisms already correct pre-fix) stay green. The net catches precisely the defect, nothing broader.
- `npm run test-unit -- test/playwright/unit/grid` → **38 passed / 7 failed** — the 7 are the pre-existing `#12941` set (identical baseline reproduced on clean dev tip `c3d372054` before this branch). This head adds 4 passing tests and breaks none.

## Post-Merge Validation

- [ ] whitebox-e2e P-flip net on `examples/grid/lockedColumns` once PR `#12945` merges — the e2e-layer dual of this unit seam (operator-flagged second angle; rides the `#12930` fixture-retarget note or a dedicated follow-up leaf)
