### PR TITLE
test: re-plumb grid scroll drivers + successor contracts, suite green (#12941)

### DIFF
--- a/test/playwright/unit/grid/LockedColumns.spec.mjs
+++ b/test/playwright/unit/grid/LockedColumns.spec.mjs
@@ -173,39 +173,53 @@ test.describe('Grid Locked Columns', () => {
         expect(actualOrderAfterEnd).toEqual(expectedOrderAfterEnd);
     });
 
-    test('Header Toolbar items are synchronized with column collection order', async () => {
-        const headerToolbar = grid.headerToolbar;
+    test('Header toolbars are synchronized with column collection order across regions', async () => {
+        const {headerWrapper} = grid;
 
-        const expectedOrder = ['col3', 'col4', 'col1', 'col5', 'col2'];
-        const headerOrder = headerToolbar.items.map(item => item.dataField);
-        expect(headerOrder).toEqual(expectedOrder);
+        // Region membership: locked-start columns live in headerWrapper.headerStart,
+        // unlocked columns in the center grid.headerToolbar, locked-end in headerWrapper.headerEnd
+        expect(headerWrapper.headerStart.items.map(item => item.dataField)).toEqual(['col3', 'col4']);
+        expect(grid.headerToolbar.items.map(item => item.dataField)).toEqual(['col1', 'col5']);
+        expect(headerWrapper.headerEnd.items.map(item => item.dataField)).toEqual(['col2']);
 
+        // The synchronization invariant: regions concatenated equal the collection order
+        const concatOrder = [
+            ...headerWrapper.headerStart.items,
+            ...grid.headerToolbar.items,
+            ...headerWrapper.headerEnd.items
+        ].map(item => item.dataField);
+
+        expect(concatOrder).toEqual(grid.columns.items.map(col => col.dataField));
+
+        // Cross-region re-home: locking col1 moves its button out of the center toolbar
+        // into headerStart, preserving collection order within each region
         const col1 = grid.columns.get('col1');
         col1.locked = 'start';
         await grid.timeout(50);
 
-        const expectedOrderAfterLock = ['col3', 'col4', 'col1', 'col5', 'col2'];
-        const headerOrderAfterLock = headerToolbar.items.map(item => item.dataField);
-        expect(headerOrderAfterLock).toEqual(expectedOrderAfterLock);
+        expect(headerWrapper.headerStart.items.map(item => item.dataField)).toEqual(['col3', 'col4', 'col1']);
+        expect(grid.headerToolbar.items.map(item => item.dataField)).toEqual(['col5']);
+        expect(grid.getButton('col1')).toBeDefined();
     });
 
-    test('ScrollManager scroll pinning addon is updated on lock state change', async () => {
-        const scrollManager = grid.scrollManager;
-        let updateCalled = false;
+    test('ScrollManager row addons are re-synced on lock state change', async () => {
+        const {scrollManager} = grid;
 
-        // Mock the method to intercept the call
-        const originalUpdate = scrollManager.updateColumnScrollPinningAddon.bind(scrollManager);
-        scrollManager.updateColumnScrollPinningAddon = (active, windowId) => {
-            updateCalled = true;
-            return originalUpdate(active, windowId);
-        };
+        let hoverSyncActive = null,
+            pinningCalled   = false;
+
+        // Stub the addon-sync methods (main-thread addon round-trips are out of unit scope)
+        scrollManager.updateRowScrollPinningAddon = ()     => {pinningCalled = true};
+        scrollManager.updateGridRowHoverSyncAddon = active => {hoverSyncActive = active};
 
         const col1 = grid.columns.get('col1');
-        col1.locked = 'start'; // This triggers afterSetLocked -> grid.onColumnLockChange -> scrollManager.update...
+        col1.locked = 'start'; // afterSetLocked -> grid.onColumnLockChange -> sub-grid sync -> scrollManager addon re-sync
 
         await grid.timeout(50);
 
-        expect(updateCalled).toBe(true);
+        expect(pinningCalled).toBe(true);
+        expect(hoverSyncActive).toBe(grid.hasLockedColumns);
+        expect(hoverSyncActive).toBe(true);
     });
 
     test('Setting a new columns array at runtime correctly sorts them', async () => {

--- a/test/playwright/unit/grid/Pooling.spec.mjs
+++ b/test/playwright/unit/grid/Pooling.spec.mjs
@@ -181,9 +181,11 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
         const scrollAmount = 400; // Scroll down 10 rows (one full page)
 
         const deltas = await captureDeltas(async () => {
-            body.scrollTop = scrollAmount;
-            // Wait for update
-            await body.promiseUpdate();
+            // Vertical scrolling is orchestrated by grid.View (the scroll SSOT): the DOM scroll
+            // event reaches View.syncBodies via the ScrollManager; body.scrollTop is a passive
+            // mirror. Driving syncBodies directly exercises the real recycle path deterministically.
+            grid.view.syncBodies(scrollAmount);
+            await grid.view.promiseUpdate();
         });
 
         // Analyze Deltas
@@ -304,8 +306,10 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
         const maxScroll = totalHeight - 400;
 
         await captureDeltas(async () => {
-            body.scrollTop = maxScroll;
-            await body.promiseUpdate();
+            // Driving the View-level scroll SSOT directly also asserts the engine-side clamping:
+            // no browser is present to clamp scrollTop, so the startIndex math must do it.
+            grid.view.syncBodies(maxScroll);
+            await grid.view.promiseUpdate();
         });
 
         // Check the last visible row
@@ -332,16 +336,16 @@ test.describe('Grid Pooling & Fixed-DOM-Order', () => {
         const body = grid.body;
 
         // Reset to top
-        body.scrollTop = 0;
-        await body.promiseUpdate();
+        grid.view.syncBodies(0);
+        await grid.view.promiseUpdate();
         await grid.timeout(50);
 
         const deltas = await captureDeltas(async () => {
             // Jump 4 rows (160px) to be absolutely sure we cross the buffer (2 rows)
             // Start 0 (Mounted 0..12) -> Start 4 (Mounted 2..14)
             // Rows 0, 1 recycle to Rows 13, 14.
-            body.scrollTop = 160;
-            await body.promiseUpdate();
+            grid.view.syncBodies(160);
+            await grid.view.promiseUpdate();
         });
 
         // Analysis

--- a/test/playwright/unit/grid/Teleportation.spec.mjs
+++ b/test/playwright/unit/grid/Teleportation.spec.mjs
@@ -162,14 +162,13 @@ test.describe('Grid Teleportation & VDOM Deltas', () => {
 
         // console.log('--- SCROLLING ---');
 
+        // Vertical scrolling is orchestrated by grid.View (the scroll SSOT): the DOM scroll event
+        // reaches View.syncBodies via the ScrollManager; body.scrollTop is a passive mirror.
         // Capture the update promise BEFORE triggering the change
-        const updatePromise = body.promiseUpdate();
+        const updatePromise = grid.view.promiseUpdate();
         updatePromise.catch(() => {}); // Handle potential isDestroyed rejection
 
-        body.scrollTop = scrollAmount;
-
-        // FUTURE: To test race conditions, trigger another scroll here immediately:
-        // body.scrollTop = scrollAmount + 40;
+        grid.view.syncBodies(scrollAmount);
 
         // Wait for the update to complete
         await updatePromise;
@@ -294,16 +293,16 @@ test.describe('Grid Teleportation & VDOM Deltas', () => {
 
             // console.log('--- SCROLLING (RACE) ---');
 
-            // Trigger first scroll
-            body.scrollTop = scrollAmount;
+            // Trigger first scroll through the View-level scroll SSOT
+            grid.view.syncBodies(scrollAmount);
 
             // Trigger second scroll immediately (Race Condition)
             // With buffer=0, this GUARANTEES a second 'createViewData' call on overlapping rows.
             // We capture the update promise to synchronize the test with the completion of the update cycle.
-            const updatePromise = body.promiseUpdate();
+            const updatePromise = grid.view.promiseUpdate();
             updatePromise.catch(() => {}); // Handle potential isDestroyed rejection
 
-            body.scrollTop = scrollAmount + 40;
+            grid.view.syncBodies(scrollAmount + 40);
 
             // Wait for the updates to complete (handles the 20ms latency)
             await updatePromise;
@@ -330,14 +329,10 @@ test.describe('Grid Teleportation & VDOM Deltas', () => {
                 expect(insertNodes.length).toBe(0);
                 expect(textUpdates.length).toBe(8);
 
-                // Diagnosis: The test currently PASSES because 'VdomLifecycle' correctly serializes the updates
+                // Diagnosis: The test PASSES because 'VdomLifecycle' correctly serializes the updates
                 // via 'isVdomUpdating' / 'needsVdomUpdate'. The second scroll waits for the first to finish.
                 // To reproduce the bug, we likely need to trigger a disjoint component update (e.g. Button text)
                 // that falsely believes it does not collide with the Grid update.
-                // We observe 0 moves (Fixed-DOM-Order), 0 row insertions (pure recycling!), and 8 text updates.
-                expect(moveNodes.length).toBe(0);
-                expect(insertNodes.length).toBe(0);
-                expect(textUpdates.length).toBe(8);
 
                 // Specific check: We should NOT be inserting 'text' vtypes (span wrapper for text).
                 // The duplication bug manifests as inserting a NEW text span instead of updating the existing one.


### PR DESCRIPTION
Resolves #12941

Authored by Claude Fable 5 (Claude Code). Session c29b5ccc-d711-4cde-8401-32d1e4bbc4f1.

Delivers AC2 of the close-target on top of the triage matrix already posted there (comment `IC_kwDODSospM8AAAABF1ykeg`: 7/7 attributed, 0 real regressions, each verdict adversarially verified, 0/7 refuted). All 7 pre-existing grid unit failures are now green via contract-honest rewrites — **no engine code touched, no assertion weakened**:

- **LockedColumns ×2 (stale-expectation)**: the header-sync test now asserts the three-region contract (`headerWrapper.headerStart` / center `headerToolbar` / `headerWrapper.headerEnd`) including the regions-concat-equals-collection-order invariant and the cross-region button re-home on lock change — preserving the original test's intent across the multi-body split (`36b45d700`). The addon test now stubs the successor APIs (`updateRowScrollPinningAddon` / `updateGridRowHoverSyncAddon`, asserting `active === hasLockedColumns`) — `updateColumnScrollPinningAddon` was deleted with its addon in `95d736724`.
- **Pooling ×3 + Teleportation ×2 (broken-fixture-plumbing)**: scroll driver re-plumbed from the dead `body.scrollTop` setter (gutted to a passive mirror by `286a8db10`; in-code: "Controlled externally by Grid.Container.syncBodies()") to the real vertical-scroll SSOT `grid.view.syncBodies(scrollTop)`. Every original contract assertion kept verbatim — zero structural deltas, engine-side clamping at store end, exact perf-audit delta counts (1 row/6 cells/7 total), race-condition no-duplication including both magic text-update counts (14, 8), which all **hold unchanged** under the View-batched pipeline. The race test's verbatim-duplicated assertion block (single-body-era copy-paste) was deduplicated.

This closes the verifier-flagged coverage gap from the triage: previously **zero** unit specs drove `syncBodies` at all — the vertical scroll-axis recycle/clamp/race contracts had no unit coverage since the multi-body migration.

Evidence: L2 (re-plumbed drivers exercise the real engine path; full collection green) → L2 required (close-target ACs are test-suite-shaped). No residuals.

## Deltas from ticket

- The ticket's "escalate if real regression" branch was never taken: all 7 verdicts survived adversarial verification as stale/plumbing, and every re-plumbed test passes against the CURRENT engine with original assertions — empirical confirmation the engine never lost these behaviors.
- The exact-count recalibration the triage anticipated (perf-audit 1/6/7, race counts 14/8) proved unnecessary — counts hold under the View-batched pipeline; they remain strict.
- Evidence-layer note (operator-flagged): unit specs are one angle; the whitebox-e2e layer covers the full DOM-event→ScrollManager→syncBodies pipeline on the `#12936` fixture (PR `#12945`) — these rewrites cover the App-Worker-side contract deterministically, the e2e layer owns the browser-side truth.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/grid/LockedColumns.spec.mjs` → 6/6 · `Pooling.spec.mjs` → 5/5 · `Teleportation.spec.mjs` → 2/2.
- `npm run test-unit -- test/playwright/unit/grid test/playwright/unit/draggable` → **53 passed / 0 failed** (1.5s) — the exact collection that produced 46/7 in PR `#12938`'s review gate.
- Branch contains ONLY the 3 spec files (+57/−44); engine untouched by design.

## Post-Merge Validation

- [ ] CI unit job green on merged dev (bucket-B specs skip in CI via `NEO_TEST_SKIP_CI`; local full-run evidence above is the binding check)