### PR TITLE
fix(agentos): B4-safe debug activation via setEnvOverride (#12889)

### DIFF
--- a/ai/scripts/maintenance/ingestTenant.mjs
+++ b/ai/scripts/maintenance/ingestTenant.mjs
@@ -182,7 +182,9 @@ async function ingestTenant() {
         process.exit(1);
     }
 
-    KB_Config.data.debug = true;
+    // Enable debug logging for ingest visibility. B4-safe activation: drive NEO_DEBUG via the
+    // Provider override API, never mutate the read-only reactive Provider.
+    KB_Config.setEnvOverride('NEO_DEBUG', true);
     console.log(`⏳ ai:ingest-tenant — tenant='${args.tenantId}', source=${args.fromStdin ? 'stdin' : args.fromFile}, batchSize=${args.batchSize}`);
 
     let outcome;

--- a/ai/scripts/maintenance/syncKnowledgeBase.mjs
+++ b/ai/scripts/maintenance/syncKnowledgeBase.mjs
@@ -15,8 +15,9 @@ import {withHeavyMaintenanceLease}  from '../../daemons/orchestrator/services/He
  */
 
 async function syncKnowledgeBase() {
-    // Enable debug logging to see progress
-    KB_Config.data.debug = true;
+    // Enable debug logging to see progress. B4-safe activation: drive NEO_DEBUG via the Provider
+    // override API, never mutate the read-only reactive Provider.
+    KB_Config.setEnvOverride('NEO_DEBUG', true);
     const staleStrategy   = process.env.NEO_KB_STALE_STRATEGY || undefined;
 
     console.log('⏳ Initializing Knowledge Base Services...');

--- a/ai/scripts/migrations/migrateMemoryCore.mjs
+++ b/ai/scripts/migrations/migrateMemoryCore.mjs
@@ -59,8 +59,9 @@ async function migrate() {
         process.exit(1);
     }
 
-    // Enable debug logging for visibility
-    MC_Config.data.debug = true;
+    // Enable debug logging for visibility. B4-safe activation: drive NEO_DEBUG via the Provider
+    // override API, never mutate the read-only reactive Provider.
+    MC_Config.setEnvOverride('NEO_DEBUG', true);
 
     try {
         console.log('⏳ Initializing Services...');

--- a/ai/scripts/runners/runSandman.mjs
+++ b/ai/scripts/runners/runSandman.mjs
@@ -90,8 +90,9 @@ export async function runSandman({
     output           = console,
     exit             = code => process.exit(code)
 } = {}) {
-    // Keep manual Sandman runs verbose so lease and REM progress are visible.
-    Memory_Config.data.debug = true;
+    // Keep manual Sandman runs verbose (lease + REM progress). B4-safe activation: drive NEO_DEBUG
+    // via the Provider override API, never mutate the read-only reactive Provider.
+    Memory_Config.setEnvOverride('NEO_DEBUG', true);
 
     output.log('⏳ Initializing Sandman REM Extraction Pipeline...');
 


### PR DESCRIPTION
Resolves #12889

Replaces the ADR-0019 B4 write-class consumer mutation of the read-only reactive AiConfig Provider singleton (`<Config>.data.debug = true`) with the Provider's sanctioned runtime env-override API (`<Config>.setEnvOverride('NEO_DEBUG', true)`) at the 4 remaining lifecycle/maintenance scripts. PR #12885 (#12812) removed this hazard from the two summary/backfill children; this completes the cleanup. Same observable behavior (debug logging activates) via the read-only-safe path, eliminating the #12335/#12435 shared-singleton-bleed hazard class.

Authored by Claude Opus 4.8 (Claude Code). Session 3e808a22-50ef-484b-83c9-477ad47e9087.

Decision Record impact: aligned-with ADR 0019 (reactive Provider SSOT — consumers read resolved leaves, never mutate).

Evidence: L2 (`setEnvOverride` unit-green — 17/17 `ConfigProvider.spec` incl. the keyed-override-wins + `createConfigProxy` method-binding cases; 4× `node --check`) → L1 required for the static-contract ACs (no bare `data.debug` consumer-mutation remains; grep-clean). Residual: per-script runtime debug-emission is host-behavior (Post-Merge manual).

## Why `setEnvOverride`, not a raw `process.env.NEO_DEBUG` set
The `debug` leaf IS env-backed (`leaf(false, 'NEO_DEBUG', 'boolean')`), but env resolution is **bounded, not live-per-read** (`ai/ConfigProvider.mjs` — re-resolved only at construct / `setEnvOverride` / `load`). The Config is already constructed at import (before the script body runs), so a raw runtime `process.env.NEO_DEBUG` set would silently no-op. `setEnvOverride(envName, value)` validates against the leaf type, registers the override in the runtime-override registry, and re-applies the env layer immediately — and it's reachable on the imported default export (`createConfigProxy` binds instance methods through the proxy). `data.debug` reads `true` afterward, so no read-back regression.

## Affected sites
- `ai/scripts/runners/runSandman.mjs`
- `ai/scripts/maintenance/syncKnowledgeBase.mjs`
- `ai/scripts/migrations/migrateMemoryCore.mjs`
- `ai/scripts/maintenance/ingestTenant.mjs`

## Deltas from ticket
- Observed out-of-scope sibling (NOT fixed here — scope discipline): `migrateMemoryCore.mjs` also mutates `MC_Config.data.collections.{memory,session}` (same B4 consumer-mutation class, but test-collection targeting, not debug-activation). Flagging for a separate follow-up rather than folding in.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/ConfigProvider.spec.mjs` → **17/17 passed**, including `setEnvOverride() is keyed by env var name and wins over the default`, `createConfigProxy: .data getter + method calls bind to the real instance`, and `refreshEnv() re-resolves env; runtime override persists`.
- `node --check` on all 4 edited scripts → clean.
- `grep -nE "data\.debug\s*=\s*true"` across the 4 scripts → 0 remaining bare consumer-mutations.

## Post-Merge Validation
- [ ] Run each script and confirm verbose debug output still emits via the new activation path (`node ai/scripts/runners/runSandman.mjs`, `syncKnowledgeBase`, `migrateMemoryCore`, `ingestTenant`) — debug-level lines appear as before.
- [ ] Confirm no shared-singleton bleed across in-process consumers (inherent here: these are standalone CLI processes).

## Commits
- `deff617c2` — B4-safe debug activation via `setEnvOverride` across the 4 lifecycle scripts.
