### PR TITLE
fix(vdom): reject lost update replies + release in-flight state on failure (#12946)

### DIFF
--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -327,13 +327,23 @@ class Main extends core.Base {
                 queue.unshift(operation);
                 return requestAnimationFrame(me.renderFrame.bind(me))
             } else {
-                if (mode === 'read') {
-                    DomAccess.read(operation)
-                } else {
-                    DeltaUpdates.update(operation)
-                }
+                // Per-operation containment: a throwing delta must neither swallow this operation's
+                // reply nor escape the loop and drop the replies of everything still queued behind it.
+                // A dropped reply permanently wedges every component awaiting that update batch
+                // (isVdomUpdating never clears) — the failure must settle the promise (reject)
+                // and stay loud instead.
+                try {
+                    if (mode === 'read') {
+                        DomAccess.read(operation)
+                    } else {
+                        DeltaUpdates.update(operation)
+                    }
 
-                WorkerManager.resolveDomOperationPromise(operation.replyId)
+                    WorkerManager.resolveDomOperationPromise(operation.replyId)
+                } catch (err) {
+                    console.error('processQueue: DOM operation failed', mode, err, operation);
+                    WorkerManager.rejectDomOperationPromise(operation.replyId, err)
+                }
             }
         }
     }

--- a/src/manager/VDomUpdate.mjs
+++ b/src/manager/VDomUpdate.mjs
@@ -118,6 +118,24 @@ class VDomUpdate extends Collection {
      */
     preUpdateMap = new Map()
     /**
+     * The wedge-watchdog threshold in milliseconds: an in-flight update older than this is
+     * reported as wedged via `console.error`. Updates settle in milliseconds; the
+     * generous default avoids false positives on heavily loaded sessions. Mutable for tests.
+     * @member {Number} watchdogThreshold=5000
+     * @protected
+     */
+    watchdogThreshold = 5000
+    /**
+     * Maps an in-flight component id to its armed watchdog timer id; see
+     * {@link #registerInFlightUpdate} / {@link #unregisterInFlightUpdate}.
+     *
+     * Key: componentId, Value: setTimeout timer id
+     *
+     * @member {Map<String, Number>} watchdogTimerMap=new Map()
+     * @protected
+     */
+    watchdogTimerMap = new Map()
+    /**
      * A Map that stores Promise `resolve` functions associated with a component's update.
      * When a component's VDOM update is finalized, the callbacks for its ID are executed,
      * resolving the Promise returned by the component's `update()` method.
@@ -341,6 +359,13 @@ class VDomUpdate extends Collection {
     registerInFlightUpdate(ownerId, updateDepth) {
         this.inFlightUpdateMap.set(ownerId, updateDepth);
 
+        // Watchdog: an in-flight update resolves in milliseconds. One that does not is a wedged
+        // component — its flag blocks every own update and its registry entry yields every ancestor
+        // update, while nothing ever errors (a lost reply once froze a component for 25 minutes,
+        // silently). A permanently wedged component must scream; the timer is cleared on unregister,
+        // so a healthy update never pays more than one (cancelled) setTimeout.
+        this.#armWatchdog(ownerId);
+
         // Register this component as an in-flight descendant for all its parents
         const parentIds = Neo.manager.Component.getParentIds(Neo.getComponent(ownerId));
 
@@ -355,6 +380,27 @@ class VDomUpdate extends Collection {
 
             map.set(ownerId, true)
         }
+    }
+
+    /**
+     * Arms the wedge watchdog for one in-flight update; see {@link #registerInFlightUpdate}.
+     * Extracted for testability — specs can shrink {@link #watchdogThreshold}.
+     * @param {String} ownerId The `id` of the component owning the update.
+     * @private
+     */
+    #armWatchdog(ownerId) {
+        let me = this;
+
+        clearTimeout(me.watchdogTimerMap.get(ownerId));
+
+        me.watchdogTimerMap.set(ownerId, setTimeout(() => {
+            me.watchdogTimerMap.delete(ownerId);
+            console.error(
+                `vdom update wedged: "${ownerId}" has been in-flight for over ${me.watchdogThreshold}ms. ` +
+                'Its reply was likely lost — the component will not update again, and ancestor updates will yield to it. ' +
+                'See https://github.com/neomjs/neo/issues/12946'
+            )
+        }, me.watchdogThreshold))
     }
 
     /**
@@ -444,6 +490,10 @@ class VDomUpdate extends Collection {
      */
     unregisterInFlightUpdate(ownerId) {
         this.inFlightUpdateMap.delete(ownerId);
+
+        // Disarm the wedge watchdog — the update settled (resolve OR reject), so it is not wedged.
+        clearTimeout(this.watchdogTimerMap.get(ownerId));
+        this.watchdogTimerMap.delete(ownerId);
 
         // Remove this component from the in-flight descendant maps of all its parents
         // We need to iterate all registered ancestors to ensure we catch cases where

--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -317,7 +317,7 @@ class VdomLifecycle extends Base {
 
             /**
              * Optional hook that fires immediately before the VDOM payload is sent to the VDOM worker.
-             * This is useful for telemetry (e.g., Performance tracking) as it excludes the synchronous 
+             * This is useful for telemetry (e.g., Performance tracking) as it excludes the synchronous
              * queue wait time of the App worker and strictly measures the cross-thread roundtrip.
              */
             me.beforeExecuteVdomUpdate?.();
@@ -326,7 +326,7 @@ class VdomLifecycle extends Base {
 
             /**
              * Optional hook that fires immediately after the VDOM update resolves.
-             * Because of internal promise chaining (promiseForwardMessage), this hook fires *after* 
+             * Because of internal promise chaining (promiseForwardMessage), this hook fires *after*
              * the Main Thread has painted the resulting DOM deltas.
              */
             me.afterExecuteVdomUpdate?.();
@@ -361,7 +361,22 @@ class VdomLifecycle extends Base {
             me.isVdomUpdating = false;
             // Ensure state is cleaned up on error
             VDomUpdate.unregisterInFlightUpdate(me.id);
-            reject?.(err)
+
+            // Fire-and-forget updates have no reject callback — without this log the failure is
+            // fully silent and the symptom surfaces minutes later as "the DOM stopped following".
+            // Rejected updates do NOT adopt a vnode, so the next cycle re-diffs cleanly.
+            !reject && console.error('vdom update failed', me.id, err);
+
+            reject?.(err);
+
+            // Mirror of resolveVdomUpdate(): updates queued onto this flight while it was running
+            // are only ever drained by a follow-up cycle — without this, their content (and any
+            // attached promise callbacks) strand until the next organic update. A deterministic
+            // failure cannot hot-loop here: the retry consumes needsVdomUpdate, and with no new
+            // mutations a failing retry terminates after one bounded re-throw.
+            if (me.needsVdomUpdate) {
+                me.update()
+            }
         }
     }
 
@@ -404,16 +419,16 @@ class VdomLifecycle extends Base {
 
     /**
      * Generates the update payload for this component.
-     * 
+     *
      * **Meta Payload Concept:**
-     * If a component implements a `getVdomUpdateMeta()` method, its returned object will be 
-     * attached to the update payload as `meta`. This allows the App Worker to send contextual state 
-     * (e.g., the specific `scrollTop` value the VDOM was calculated against) alongside the VDOM deltas 
-     * to the Main Thread. The Main Thread's `DeltaUpdates` singleton fires an `update` event before 
-     * applying deltas, allowing addons (like optical pinning) to read this `meta` data and dynamically 
-     * adjust the deltas (like `translate3d` transforms) based on the *current* Main Thread state 
+     * If a component implements a `getVdomUpdateMeta()` method, its returned object will be
+     * attached to the update payload as `meta`. This allows the App Worker to send contextual state
+     * (e.g., the specific `scrollTop` value the VDOM was calculated against) alongside the VDOM deltas
+     * to the Main Thread. The Main Thread's `DeltaUpdates` singleton fires an `update` event before
+     * applying deltas, allowing addons (like optical pinning) to read this `meta` data and dynamically
+     * adjust the deltas (like `translate3d` transforms) based on the *current* Main Thread state
      * before they are painted.
-     * 
+     *
      * @param {Set<String>|null} mergedChildIds
      * @param {Number} [depth] Override the update depth
      * @returns {Object} opts
@@ -593,6 +608,12 @@ class VdomLifecycle extends Base {
                 return data
             }
         } catch (err) {
+            // Mirror executeVdomUpdate()'s error contract: the in-flight state MUST be released on
+            // failure, or the component wedges permanently (isVdomUpdating never clears and the
+            // registry entry blocks every ancestor update via isChildUpdating).
+            me.isVdomUpdating = false;
+            VDomUpdate.unregisterInFlightUpdate(me.id);
+
             console.error('initVnode error', err, me.id);
             throw err
         }

--- a/src/worker/Manager.mjs
+++ b/src/worker/Manager.mjs
@@ -394,6 +394,21 @@ class Manager extends Base {
         if (deltas?.length > 0) {
             me.promiseForwardMessage(data).then(msgData => {
                 me.sendMessage(replyDest, forward ? msgData : {action: 'reply', replyId: msgData.id, success: true})
+            }).catch(({originalData, error}) => {
+                // A delta failed to apply (see Main.mjs#processQueue). The reply MUST still reach the
+                // originating worker — a dropped reply permanently wedges every component awaiting the
+                // batch (isVdomUpdating never clears). We reply with the reject marker and the
+                // error INSTEAD of the computed vnodes: the App worker's executeVdomUpdate() catch then
+                // clears its in-flight state WITHOUT adopting a vnode the DOM never received, keeping
+                // the vnode truthful so the next update cycle re-diffs and self-heals.
+                let reply = forward
+                    ? {...originalData, data: {error}}
+                    : {replyId: originalData.id, data: {error}};
+
+                reply.action = 'reply';
+                reply.reject = true;
+
+                me.sendMessage(replyDest, reply)
             });
 
             me.fire('updateVdom', forward ? data : {data, replyId: data.id});
@@ -573,6 +588,29 @@ class Manager extends Base {
 
             me.promises[msgId] = {reject, resolve}
         })
+    }
+
+    /**
+     * Rejects the delayed-reply promise for a DOM operation whose delta application threw.
+     *
+     * Counterpart to {@link #resolveDomOperationPromise}: a failed operation must settle its
+     * promise too — otherwise the originating worker's update promise hangs forever and every
+     * component in that batch wedges with `isVdomUpdating: true`. The rejection value
+     * carries the error message; `handleDomUpdate`'s catch relays it as a `reject: true` reply,
+     * which the far side's `worker.Base#onMessage` turns into a promise rejection.
+     * @param {String} replyId
+     * @param {Error|String} error The reason the DOM operation failed
+     */
+    rejectDomOperationPromise(replyId, error) {
+        if (replyId) {
+            let {promises} = this,
+                promise    = promises[replyId];
+
+            if (promise) {
+                promise.reject({originalData: promise.data, error: error?.message || String(error)});
+                delete promises[replyId]
+            }
+        }
     }
 
     /**

--- a/test/playwright/unit/vdom/UpdateWedge.spec.mjs
+++ b/test/playwright/unit/vdom/UpdateWedge.spec.mjs
@@ -1,0 +1,177 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'UpdateWedgeTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false, // Required: Neo.vdom.Helper runs locally and is stubbable
+        logVdomUpdateCollisions: false
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import Container      from '../../../../src/container/Base.mjs';
+import VdomHelper     from '../../../../src/vdom/Helper.mjs';
+import VDomUpdate     from '../../../../src/manager/VDomUpdate.mjs';
+
+class WedgeChild extends Component {
+    static config = {
+        className: 'Test.WedgeChild',
+        ntype    : 'test-wedge-child',
+        _vdom    : {tag: 'div', cls: ['wedge-child']}
+    }
+}
+WedgeChild = Neo.setupClass(WedgeChild);
+
+class WedgeContainer extends Container {
+    static config = {
+        className: 'Test.WedgeContainer',
+        items    : []
+    }
+}
+WedgeContainer = Neo.setupClass(WedgeContainer);
+
+/**
+ * @summary Regression net for the permanent in-flight vdom update wedge.
+ *
+ * Convicted live: a delta that threw inside the Main thread's `processQueue` dropped its reply,
+ * leaving every component awaiting that batch with `isVdomUpdating: true` FOREVER — its own
+ * updates gated off, ancestor updates yielding to it, and the worker-side vnode lying about
+ * applied state (self-heal impossible: diffs against the lie are empty). The failure was fully
+ * silent for ~25 minutes of a production session.
+ *
+ * The fix contract pinned here:
+ * 1. A FAILED update must SETTLE (reject), never hang — and must release all in-flight state.
+ * 2. A failed update must NOT adopt a vnode the DOM never received (the vnode stays truthful,
+ *    so the next cycle re-diffs and self-heals).
+ * 3. `initVnode` failures release in-flight state too (the same leak, render-path flavor).
+ * 4. The watchdog screams about any in-flight update that outlives its threshold — wedges can
+ *    never be silent again, whatever their mechanism.
+ */
+test.describe('VdomLifecycle update wedge (#12946)', () => {
+    let testIdCounter = 0;
+    const getUniqueId = (prefix) => `${prefix}-${Date.now()}-${testIdCounter++}`;
+    let createdComponentIds = [];
+
+    const originalUpdateBatch = VdomHelper.updateBatch;
+    const originalCreate      = VdomHelper.create;
+
+    test.afterEach(() => {
+        VdomHelper.updateBatch = originalUpdateBatch;
+        VdomHelper.create      = originalCreate;
+
+        createdComponentIds.forEach(id => {
+            Neo.getComponent(id)?.destroy();
+        });
+        createdComponentIds = [];
+    });
+
+    test('a rejected update batch settles, releases in-flight state and does NOT adopt a vnode', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const containerId = getUniqueId('wedge-container');
+        const childId     = getUniqueId('wedge-child');
+        createdComponentIds.push(containerId);
+
+        const container = Neo.create(WedgeContainer, {
+            appName,
+            id   : containerId,
+            items: [{module: WedgeChild, id: childId, text: 'pristine'}]
+        });
+
+        await container.initVnode(true);
+        container.mounted = true;
+
+        const child = container.items[0];
+        await container.promiseUpdate();
+
+        const vnodeBefore = child.vnode;
+
+        // The apply boundary fails: pre-fix, this hung forever (the wedge). Post-fix it rejects.
+        // The content mutation settles first so the promiseUpdate below INITIATES its own cycle —
+        // a promise queued onto someone else's failing flight is a separate (documented) gap.
+        VdomHelper.updateBatch = () => Promise.reject({data: {error: 'test-injected apply failure'}});
+
+        child.text = 'lost-to-the-wedge';
+        await new Promise(resolve => setTimeout(resolve, 50));
+        await expect(child.promiseUpdate()).rejects.toBeTruthy();
+
+        // The in-flight state is fully released — no permanent wedge, no poisoned registry
+        expect(child.isVdomUpdating).toBe(false);
+        expect(VDomUpdate.inFlightUpdateMap.has(child.id)).toBe(false);
+
+        // The vnode was NOT adopted: it still holds the last DOM-confirmed truth, so the next
+        // diff re-sends the lost content instead of producing the empty-diff self-heal trap
+        expect(child.vnode).toBe(vnodeBefore);
+
+        // Self-heal: with the boundary healthy again, the next organic cycle delivers the content.
+        // (Deliberate contract: a rejected update does NOT auto-retry — a deterministic failure
+        // would hot-loop. The error is loud; the next triggered update re-diffs from the truthful
+        // vnode.) The re-update may merge into the parent's cycle, so we drive the parent too and
+        // assert CONTENT truth rather than reference identity.
+        VdomHelper.updateBatch = originalUpdateBatch;
+
+        child.text = 'healed';
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(child.isVdomUpdating).toBe(false);
+        expect(child.vnode.textContent ?? child.vnode.childNodes?.[0]?.textContent).toBe('healed');
+    });
+
+    test('REGRESSION: initVnode failure releases the flag and the in-flight registry entry', async () => {
+        const containerId = getUniqueId('wedge-container');
+        createdComponentIds.push(containerId);
+
+        const container = Neo.create(WedgeContainer, {
+            appName,
+            id   : containerId,
+            items: [{module: WedgeChild, id: getUniqueId('wedge-child')}]
+        });
+
+        VdomHelper.create = () => Promise.reject(new Error('test-injected create failure'));
+
+        await expect(container.initVnode(true)).rejects.toThrow('test-injected create failure');
+
+        // Pre-fix: both leaked TRUE/registered forever — the component could never update again,
+        // and every ancestor update yielded to the ghost in-flight entry
+        expect(container.isVdomUpdating).toBe(false);
+        expect(VDomUpdate.inFlightUpdateMap.has(container.id)).toBe(false);
+    });
+
+    test('the wedge watchdog screams about an in-flight update that never settles', async () => {
+        const originalThreshold = VDomUpdate.watchdogThreshold;
+        const originalError     = console.error;
+        const errors            = [];
+
+        console.error = (...args) => { errors.push(args.join(' ')) };
+        VDomUpdate.watchdogThreshold = 40;
+
+        try {
+            // A registration that never unregisters = the wedge signature
+            VDomUpdate.registerInFlightUpdate('wedged-component-x', 1);
+            await new Promise(resolve => setTimeout(resolve, 120));
+
+            expect(errors.some(e => e.includes('wedged-component-x') && e.includes('12946'))).toBe(true);
+
+            // A healthy round-trip stays silent: unregister disarms the timer
+            errors.length = 0;
+            VDomUpdate.registerInFlightUpdate('healthy-component-y', 1);
+            VDomUpdate.unregisterInFlightUpdate('healthy-component-y');
+            await new Promise(resolve => setTimeout(resolve, 120));
+
+            expect(errors.length).toBe(0);
+        } finally {
+            VDomUpdate.unregisterInFlightUpdate('wedged-component-x');
+            VDomUpdate.watchdogThreshold = originalThreshold;
+            console.error = originalError;
+        }
+    });
+});


### PR DESCRIPTION
Resolves #12946

Refs #12939

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

The permanent in-flight vdom update wedge, root-caused and fixed. Convicted live in the operator's devindex session via Neural Link forensics: `neo-grid-horizontal-scrollbar-1` sat with `isVdomUpdating: true` for ~25 minutes (a round-trip takes milliseconds) — its DOM spacer unsized, its scroll pipeline beheaded, its worker-side vnode **recording the unapplied delta as applied** (self-heal structurally impossible: re-setting the same value diffs empty against the lie). The wedge re-armed deterministically on every retry. The operator-visible symptom was "overscroll drag does still not move body cells".

## The mechanism

`Main.mjs#processQueue` ran each DOM operation bare: a delta that **throws** (the #12939 stale-baseline family produces exactly such deltas — removes chasing missing nodes, inserts into missing parents) skipped `resolveDomOperationPromise` AND escaped the `while` loop — dropping the replies of **every operation still queued behind it**. `worker/Manager.mjs#handleDomUpdate` held the App-bound reply behind a bare `.then`, so a dropped settle meant the reply never left the main thread. The App worker's `executeVdomUpdate` await then never settled: flag stuck, in-flight registry entry stuck (yielding every ancestor update), zero errors anywhere. A multi-agent sweep (6 readers × 7 live-verified constraints, adversarial kill-pass) plus hand verification convicted this as the only mechanism consistent with all observations; the runner-up (collision-filtered merged children receiving silent `_vnode` write-backs) is real but flag-free — it is the #12939 lane and stays there.

## The fix (4 surgical changes)

1. **`src/Main.mjs#processQueue`** — per-operation containment: a throwing operation logs loudly and **rejects** its reply; the rest of the queue survives.
2. **`src/worker/Manager.mjs`** — new `rejectDomOperationPromise` + a `.catch` relay in `handleDomUpdate`: the failure reply carries the protocol's `reject: true` marker and the error **instead of the computed vnodes** — the far side settles WITHOUT adopting state the DOM never received. The vnode stays truthful, so the next organic update re-diffs and self-heals (this is the AC4 honesty property for this path).
3. **`src/mixin/VdomLifecycle.mjs`** — `executeVdomUpdate`'s catch now (a) logs for fire-and-forget updates (no reject callback = previously fully silent), (b) drains updates queued onto the failed flight (mirror of `resolveVdomUpdate`; bounded — no new mutations means a failing retry terminates after one re-throw). `initVnode`'s catch releases the flag + in-flight registry entry (previously leaked both forever).
4. **`src/manager/VDomUpdate.mjs`** — the wedge watchdog: any in-flight update outliving `watchdogThreshold` (5s) reports via `console.error` with the component id and the issue URL. Healthy updates pay one cancelled `setTimeout`. Wedges can never be silent again, whatever their mechanism.

Evidence: L2 (unit: settle/release/no-adopt contract + initVnode leak + watchdog, 3/3; full suite 3233/3233 — zero regressions on the honest-green baseline) + L3 (fixture e2e 4/4: live update pipeline + overdrag/cross-region contracts clean on the changed core) → L4 required: operator session with the watchdog armed (AC5). Residual: AC5 [#12946].

## Deltas

- **AC4 scope note**: the rejection path now refuses vnode adoption (the honesty property, delivered). The OTHER write-back surface — parent-driven `syncVnodeTree` silently writing `_vnode` into collision-filtered merged children — is documented on the ticket and routed to #12939 (same stale-baseline family, its own open lane). Per AC4's explicit "or documented" clause.
- **Known follow-up gap (pre-existing, surfaced by the regression net)**: promise callbacks queued onto an in-flight update register only their RESOLVE side (`VDomUpdate.addPromiseCallback`); if the flight they queued onto fails, their reject is unreachable. The catch-drain (fix 3b) re-runs the queued update so content self-heals, but a queued `promiseUpdate()` against a deterministically-failing boundary resolves late rather than rejecting. Follow-up leaf to be filed; not release-blocking (the pre-fix behavior was strictly worse: permanent hang).
- The watchdog threshold is a mutable field (`watchdogThreshold`), not a reactive config — deliberate: it is test-tunable diagnostics, not an app-facing API.

## Test Evidence

- `npm run test-unit -- UpdateWedge.spec` → 3/3 (NEW: rejected batch settles + releases + does NOT adopt + self-heals; initVnode failure releases flag/registry; watchdog screams on a never-settling update and stays silent on healthy round-trips).
- `npm run test-unit` → **3233 passed** (the post-#12950 honest-green suite; zero regressions).
- `npx playwright test GridColumnOverdragScroll GridColumnCrossBodyDnD -c test/playwright/playwright.config.e2e.mjs` → 4/4 on the #12945 lockedColumns fixture (live pipeline sanity on the changed core).

## Post-Merge Validation

- [ ] Operator L4: fresh devindex session, drag during initial stream at human speed — body cells follow live; if anything still wedges, the watchdog now NAMES it in the page console within 5s (AC5).
- [ ] File the queued-promise-reject follow-up leaf (see Deltas).
- [ ] #12939 lane consumes the silent `_vnode` write-back finding (the second confirmed mechanism) + Grace's completion-vs-confirmation framing, both recorded on the tickets.
