### PR TITLE
docs(agents): PR-state freshness gate before every lifecycle relay (#12959)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -125,6 +125,14 @@ lane-state: next-lane (picking up ticket #NNNN)
 lane-state: human-gate (PR #NNNN approved and awaiting operator merge)
 ```
 
+**PR-State Freshness Gate:** any `lane-state:`, A2A broadcast, or report that names a PR's
+review/merge status MUST be preceded by a live `gh pr view <N> --json state,mergedAt` read —
+the triggering signal (A2A, wake, comment) is a recovery hint, NOT the work gate. Under
+merge-on-approval, signals go stale in seconds: declaring `human-gate` for an already-MERGED
+PR broadcasts a false board to the whole swarm (empirical: PR `#12950`'s `[merge-eligible]`
+landed 15s post-merge; PR `#12956`'s approval relay missed the merge by seconds — both
+operator-flagged 2026-06-12). Rule detail + verdict-not-enum companion: `pr-review-guide.md §10.1`.
+
 ## 2.5. Mandatory `lane-state:` Declaration at Every Lifecycle Boundary
 
 Per #11455 AC: at EACH broadened lifecycle boundary (reviewer post, author

--- a/.agents/skills/pr-review/audits/pr-state-freshness.md
+++ b/.agents/skills/pr-review/audits/pr-state-freshness.md
@@ -1,0 +1,27 @@
+# PR-State Freshness Gate (every lifecycle relay, not just review-start)
+
+The §2 Context-Initialization `state: OPEN` check fires at review-START only. Under
+merge-on-approval, every PR signal (A2A, wake, comment) is stale within seconds of being
+read. Therefore, immediately before **relaying any review outcome or posting any
+merge-eligibility claim** — A2A handoff, `[merge-eligible]` broadcast, re-stamp request,
+chat report, or follow-up action keyed to merge state — run:
+
+```bash
+gh pr view <N> --json state,mergedAt
+```
+
+If `MERGED`/`CLOSED`: relay the TERMINAL state instead; never emit "at the merge gate"
+language for a settled PR.
+
+**Verdict, not enum:** relay the review BODY's §9 Strategic-Fit verdict, not the
+`reviewDecision` enum — the enum flattens `Approve+Follow-Up` (whose follow-up leaves
+file AT merge, per `ticket-create` §4 boardless defaults) into plain `APPROVED`.
+
+**Empirical provenance** (both 2026-06-12, operator-flagged): PR `#12950` — a
+`[merge-eligible]` broadcast landed 15 seconds after the merge; PR `#12956` — the
+approval was relayed off `reviewDecision` alone while the body's verdict was
+`Approve+Follow-Up`, and the merge landed seconds later. Same check-at-last-moment
+epistemics as `ticket-create`'s `#12856` two-phase claim discipline.
+
+**Sunset condition:** if A2A lifecycle messages ever carry a mechanical state echo,
+compress this audit to its trigger line in the guide.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -430,7 +430,7 @@ For multi-cycle reviews, after posting a review comment **capture its `commentId
 
 ### 10.1 PR-State Freshness Gate
 
-<!-- trigger: before relaying ANY review outcome / merge-eligibility claim / lane-state naming a PR → read ./audits/pr-state-freshness.md (live `state,mergedAt` read; verdict-not-enum) -->
+<!-- trigger: before relaying ANY review outcome / merge-eligibility claim / lane-state naming a PR → read ../audits/pr-state-freshness.md (live `state,mergedAt` read; verdict-not-enum) -->
 
 ## 11. Post-Review-Cycle Reviewer Pickup
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -428,6 +428,16 @@ For multi-cycle reviews, after posting a review comment **capture its `commentId
 - **The dominant miss is forgetting the ping.** Pre-Flight after every `manage_issue_comment` create, before yielding: *"captured commentId `<ID>`; will A2A it to `<recipient>`."*
 - **Cold cache** (fresh session / cycle-1 / cross-agent hand-off): full-thread fetch + memory query instead — a scoped fetch lands one isolated comment without the prior context it depends on.
 
+### 10.1 PR-State Freshness Gate (every lifecycle relay, not just review-start)
+
+§2.1's `state: OPEN` check fires at review-START only. Under merge-on-approval, every PR signal (A2A, wake, comment) is stale within seconds of being read. Therefore, immediately before **relaying any review outcome or posting any merge-eligibility claim** — A2A handoff, `[merge-eligible]` broadcast, re-stamp request, chat report, or follow-up action keyed to merge state — run:
+
+```bash
+gh pr view <N> --json state,mergedAt
+```
+
+If `MERGED`/`CLOSED`: relay the TERMINAL state instead; never emit "at the merge gate" language for a settled PR. Relay the review BODY's §9 Strategic-Fit verdict, not the `reviewDecision` enum — the enum flattens `Approve+Follow-Up` (whose leaves file AT merge) into plain `APPROVED`. Empirical provenance: PR `#12950` (a `[merge-eligible]` broadcast landed 15s after the merge) and PR `#12956` (approval relayed off `reviewDecision` alone; the verdict was `Approve+Follow-Up`), both 2026-06-12, operator-flagged. Same check-at-last-moment epistemics as `ticket-create`'s `#12856` two-phase claim. Sunset: if A2A lifecycle messages ever carry a mechanical state echo, compress this to a trigger line.
+
 ## 11. Post-Review-Cycle Reviewer Pickup
 
 After a reviewer posts the substantive review, chains the formal GitHub review

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -428,15 +428,9 @@ For multi-cycle reviews, after posting a review comment **capture its `commentId
 - **The dominant miss is forgetting the ping.** Pre-Flight after every `manage_issue_comment` create, before yielding: *"captured commentId `<ID>`; will A2A it to `<recipient>`."*
 - **Cold cache** (fresh session / cycle-1 / cross-agent hand-off): full-thread fetch + memory query instead — a scoped fetch lands one isolated comment without the prior context it depends on.
 
-### 10.1 PR-State Freshness Gate (every lifecycle relay, not just review-start)
+### 10.1 PR-State Freshness Gate
 
-§2.1's `state: OPEN` check fires at review-START only. Under merge-on-approval, every PR signal (A2A, wake, comment) is stale within seconds of being read. Therefore, immediately before **relaying any review outcome or posting any merge-eligibility claim** — A2A handoff, `[merge-eligible]` broadcast, re-stamp request, chat report, or follow-up action keyed to merge state — run:
-
-```bash
-gh pr view <N> --json state,mergedAt
-```
-
-If `MERGED`/`CLOSED`: relay the TERMINAL state instead; never emit "at the merge gate" language for a settled PR. Relay the review BODY's §9 Strategic-Fit verdict, not the `reviewDecision` enum — the enum flattens `Approve+Follow-Up` (whose leaves file AT merge) into plain `APPROVED`. Empirical provenance: PR `#12950` (a `[merge-eligible]` broadcast landed 15s after the merge) and PR `#12956` (approval relayed off `reviewDecision` alone; the verdict was `Approve+Follow-Up`), both 2026-06-12, operator-flagged. Same check-at-last-moment epistemics as `ticket-create`'s `#12856` two-phase claim. Sunset: if A2A lifecycle messages ever carry a mechanical state echo, compress this to a trigger line.
+<!-- trigger: before relaying ANY review outcome / merge-eligibility claim / lane-state naming a PR → read ./audits/pr-state-freshness.md (live `state,mergedAt` read; verdict-not-enum) -->
 
 ## 11. Post-Review-Cycle Reviewer Pickup
 


### PR DESCRIPTION
Resolves #12959

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

Operator-named friction, twice in one night and timeline-verified: PR #12950's `[merge-eligible] — at the human merge gate` broadcast landed **15 seconds after the operator merged it** (merge `03:18:45Z`, broadcast `03:19:00Z`), and PR #12956's approval relay checked `reviewDecision` but never `state` while the merge landed seconds later — additionally flattening the review body's `Approve+Follow-Up` verdict into plain `APPROVED`. Under merge-on-approval, every PR lifecycle signal (A2A, wake, comment) goes stale within seconds of being read; the only existing freshness discipline (the pr-review guide's section-2 Context-Initialization OPEN check) fires at review-START exclusively.

The amendment (Progressive-Disclosure shaped, enforced by the skill-manifest linter at cycle 2):

1. **`pr-review-guide.md` §10.1 (new)** — a 2-line trigger pointer (+224 bytes to the loaded map, under the 250 budget) routing to the new **`audits/pr-state-freshness.md`**: before relaying any review outcome or posting any merge-eligibility claim, `gh pr view <N> --json state,mergedAt`; terminal states relay as terminal; report the review BODY's §9 Strategic-Fit verdict, never the `reviewDecision` enum (`Approve+Follow-Up` leaves file AT merge). Sunset condition documented inside the audit.
2. **`post-review-pickup-workflow.md`** — `lane-state:` declarations naming PR status require the same live read; the triggering signal is a recovery hint, NOT the work gate (mirrors the context-recovery skill's framing).

Both payloads cite the two empirical anchors inline as provenance, per the `#12856` check-at-last-moment lineage.

Evidence: L1 (docs/substrate-only — both timeline anchors verified against live GitHub `mergedAt` before authoring; `node ai/scripts/lint/lint-skill-manifest.mjs` → OK locally at `b0714de40`) → no runtime ACs. Residual: none.

## Deltas

- Cycle-2 restructure: the rule body moved from the guide into `audits/pr-state-freshness.md` after the skill-manifest linter rejected the +1224-byte map growth — the linter mechanically enforced the ticket's own Progressive-Disclosure promise, which is the system working.
- Mechanical enforcement (A2A schema state-echo, hooks) deliberately out of scope per the ticket; file separately if the manual rule proves insufficient.

## Test Evidence

Docs/substrate-only change — no tests required. `lint-skill-manifest` OK locally; CI re-validates on this push.

## Post-Merge Validation

- [ ] Next PR lifecycle relay by any swarm agent demonstrates the gate (live state read precedes the relay).
