### PR TITLE
fix: pin header toolbar scroll extent during column drags (#12955)

### DIFF
--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -299,6 +299,16 @@ class SortZone extends BaseSortZone {
         // Avoid conflicts with grid.header.plugin.Resizable
         if (!me.owner.dragResortable) return;
 
+        // Remove the drag-start scroll-extent sentinel before the layout restore: the items
+        // re-enter the flow and own the scrollable overflow again from here on.
+        let ownerCn       = me.owner.vdom.cn,
+            sentinelIndex = ownerCn.findIndex(node => node.cls?.includes('neo-sortzone-extent-sentinel'));
+
+        if (sentinelIndex > -1) {
+            ownerCn.splice(sentinelIndex, 1);
+            me.owner.update()
+        }
+
         // Restore moved nodes BEFORE destroying the proxy to ensure they return to the Grid.
         if (me.movedComponents?.length > 0) {
             let restoreDeltas = me.movedComponents.map(item => ({
@@ -480,6 +490,31 @@ class SortZone extends BaseSortZone {
             body.updateDepth = -1;
             body.update()
         }
+
+        // Scroll-extent sentinel: with the items absolutised, the toolbar's scrollable overflow
+        // is defined purely by their boxes — every switch reflow can shrink it, and the browser
+        // then clamps the element's native scrollLeft below the true scroll position. The owner
+        // must NOT be expanded to content size (it has to stay a real scroll container — see
+        // `expandOwnerOnDrag` in the base class), so instead a 1px absolute node pins the
+        // pre-drag content extent for the duration of the drag. The clamp becomes impossible:
+        // max scroll never shrinks, headers and cells stay on the same scroll truth through
+        // every switch and switch-back. processDragEnd removes it before the layout restore.
+        if (me.dragStartScrollLeft > 0 && me.itemRects?.length) {
+            let extent = Math.max(...me.itemRects.map(rect => rect.x + rect.width));
+
+            me.owner.vdom.cn.push({
+                cls  : ['neo-sortzone-extent-sentinel'],
+                style: {
+                    height  : '1px',
+                    left    : `${extent - 1}px`,
+                    position: 'absolute',
+                    top     : 0,
+                    width   : '1px'
+                }
+            });
+
+            me.owner.update()
+        }
     }
 
     /**
@@ -489,9 +524,10 @@ class SortZone extends BaseSortZone {
     switchItems(index1, index2) {
         super.switchItems(index1, index2);
 
-        if (this.moveColumnContent) {
-            let me = this,
-                { itemRects } = me,
+        let me = this;
+
+        if (me.moveColumnContent) {
+            let { itemRects } = me,
                 body = me.gridBody,
                 { columnPositions } = body,
                 column1Position = columnPositions.getAt(index1),

--- a/test/playwright/e2e/GridHeaderCellRectSync.spec.mjs
+++ b/test/playwright/e2e/GridHeaderCellRectSync.spec.mjs
@@ -1,0 +1,134 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: header↔cell rect synchronization through repeated drag passes.
+ *
+ * The grid renders column headers (header toolbar buttons) and body cells from two different
+ * scroll mechanisms: the toolbar scrolls natively, while body cells render against the scroll
+ * SSOT (the ScrollManager's value, applied via the grid's scroll CSS var). A browser reflow
+ * during a drag's lift/switch frames can clamp the toolbar's NATIVE scrollLeft while the SSOT —
+ * and therefore every cell — stays put. The result is a whole-strip offset: every header covers
+ * the wrong cell span (perceived width shrink), the last column clips out of view, and the
+ * desync survives switch-backs within the same drag because nothing re-applies the toolbar's
+ * scrollLeft until drag-end.
+ *
+ * The net below is deliberately layer-agnostic: after horizontal scrolling, it drags a centre
+ * column back and forth across its neighbours MULTIPLE times and, at every hold point and after
+ * every drop, asserts that each visible header's rect (x, width) matches its first-row cell's
+ * rect pairwise. ANY mechanism that lets the header layer drift from the cell layer — scroll
+ * clamps, width churn, stale transforms, lost re-renders — fails these assertions with the
+ * exact offending column and offset in the message.
+ *
+ * Gesture realism matters: the failure class lives in main-thread reflow behavior, so the drag
+ * MUST be a real mouse gesture (page.mouse with stepped moves arms Neo's Mouse drag sensor);
+ * worker-side synthetic events cannot trigger native scroll clamping and would green-wash this.
+ *
+ * Surface: the canonical locked-column fixture — its centre region overflows by design, giving
+ * the toolbar real native scroll to clamp. Pairing scope: centre toolbar ↔ centre body (body-1).
+ *
+ * Run: npx playwright test GridHeaderCellRectSync -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Grid header↔cell rect sync through drag passes (#12955)', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    /** Reads the visible centre headers + body-1 row-0 cells, x-sorted, clipped to the body box. */
+    const readPairs = page => page.evaluate(() => {
+        const body = document.getElementById('neo-grid-body-1');
+        const clip = body.getBoundingClientRect();
+        const inClip = r => r.width > 0 && r.right > clip.left + 1 && r.left < clip.right - 1;
+
+        const toolbar = document.querySelectorAll('.neo-grid-header-toolbar')[1];
+        const headers = [...toolbar.children]
+            .map(b => ({b, r: b.getBoundingClientRect()}))
+            .filter(({b, r}) => inClip(r) && getComputedStyle(b).visibility !== 'hidden')
+            .map(({b, r}) => ({
+                text: b.querySelector('.neo-button-text')?.textContent ?? b.id,
+                x   : Math.round(r.left),
+                w   : Math.round(r.width)
+            }))
+            .sort((a, b2) => a.x - b2.x);
+
+        const row   = body.querySelector('[role="row"]');
+        const cells = [...row.children]
+            .map(c => ({c, r: c.getBoundingClientRect()}))
+            .filter(({c, r}) => inClip(r) && getComputedStyle(c).display !== 'none')
+            .map(({c, r}) => ({
+                id: c.id.split('__').pop(),
+                x : Math.round(r.left),
+                w : Math.round(r.width)
+            }))
+            .sort((a, b2) => a.x - b2.x);
+
+        return {headers, cells};
+    });
+
+    /**
+     * Every visible header must sit pixel-exactly on a first-row cell: for each header, a cell
+     * with the same x (±1px) and the same width (±1px) must exist. Mid-drag the dragged column's
+     * header is lifted (visibility) and excluded by the read; its orphan cell is tolerated via
+     * `midDrag`. After a drop, counts must match exactly. A layer offset of ANY size fails every
+     * header's lookup and prints both rect sets for diagnosis.
+     */
+    const assertAligned = ({headers, cells}, label, midDrag = false) => {
+        const dump = `headers=${JSON.stringify(headers)} cells=${JSON.stringify(cells)}`;
+
+        if (!midDrag) {
+            expect(headers.length, `${label}: visible header/cell count parity — ${dump}`).toBe(cells.length);
+        }
+
+        headers.forEach(h => {
+            const c = cells.find(cell => Math.abs(cell.x - h.x) <= 1);
+            expect(c, `${label}: no cell under header "${h.text}" (x=${h.x}, w=${h.w}) — ${dump}`).toBeDefined();
+            expect(Math.abs(h.w - c.w), `${label}: width mismatch for "${h.text}": header w=${h.w} vs cell "${c.id}" w=${c.w}`)
+                .toBeLessThanOrEqual(1);
+        });
+    };
+
+    test('repeated back-and-forth drag keeps every header rect locked to its cell rect', async ({ page }) => {
+        await page.goto('/examples/grid/lockedColumns/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+        await page.waitForTimeout(600);
+
+        // give the centre toolbar real native scroll — the precondition of the clamp class
+        const gridBox = await page.locator('[role="grid"]').first().boundingBox();
+        await page.mouse.move(gridBox.x + gridBox.width / 2, gridBox.y + gridBox.height / 2);
+        for (let i = 0; i < 6; i++) {
+            await page.mouse.wheel(800, 0);
+            await page.waitForTimeout(120);
+        }
+        await page.waitForTimeout(600);
+
+        assertAligned(await readPairs(page), 'baseline (scrolled right)');
+
+        const centerToolbar = page.locator('.neo-grid-header-toolbar').nth(1);
+        const DRAG = '2011'; // the LAST centre column — lifting at max-right scroll is the clamp class's precondition
+
+        for (let pass = 1; pass <= 2; pass++) {
+            const src    = centerToolbar.locator('.neo-draggable', { hasText: DRAG }).first();
+            await expect(src).toBeVisible({ timeout: 5000 });
+            const srcBox = await src.boundingBox();
+            const y      = srcBox.y + srcBox.height / 2;
+            const step   = 110; // one year-column width — guarantees neighbour switches
+
+            await page.mouse.move(srcBox.x + srcBox.width / 2, y);
+            await page.mouse.down();
+
+            // slide LEFT across two neighbours
+            await page.mouse.move(srcBox.x + srcBox.width / 2 - 2 * step, y, { steps: 50 });
+            await page.waitForTimeout(500);
+            assertAligned(await readPairs(page), `pass ${pass}: mid-drag after sliding left`, true);
+
+            // slide back RIGHT within the same drag op
+            await page.mouse.move(srcBox.x + srcBox.width / 2, y, { steps: 50 });
+            await page.waitForTimeout(500);
+            assertAligned(await readPairs(page), `pass ${pass}: mid-drag after sliding back`, true);
+
+            await page.mouse.up();
+            await page.waitForTimeout(700);
+            assertAligned(await readPairs(page), `pass ${pass}: after drop`);
+        }
+    });
+});

--- a/test/playwright/e2e/GridHeaderCellRectSync.spec.mjs
+++ b/test/playwright/e2e/GridHeaderCellRectSync.spec.mjs
@@ -129,16 +129,16 @@ test.describe('Grid header↔cell rect sync through drag passes (#12955)', () =>
 
             // slide LEFT across two neighbours
             await page.mouse.move(srcBox.x + srcBox.width / 2 - 2 * step, y, { steps: 50 });
-            await page.waitForTimeout(500);
+            await page.waitForTimeout(750);
             assertAligned(await readPairs(page), `pass ${pass}: mid-drag after sliding left`, true);
 
             // slide back RIGHT within the same drag op
             await page.mouse.move(srcBox.x + srcBox.width / 2, y, { steps: 50 });
-            await page.waitForTimeout(500);
+            await page.waitForTimeout(750);
             assertAligned(await readPairs(page), `pass ${pass}: mid-drag after sliding back`, true);
 
             await page.mouse.up();
-            await page.waitForTimeout(700);
+            await page.waitForTimeout(900);
             assertAligned(await readPairs(page), `pass ${pass}: after drop`);
         }
     });

--- a/test/playwright/e2e/GridHeaderCellRectSync.spec.mjs
+++ b/test/playwright/e2e/GridHeaderCellRectSync.spec.mjs
@@ -60,7 +60,18 @@ test.describe('Grid header↔cell rect sync through drag passes (#12955)', () =>
             }))
             .sort((a, b2) => a.x - b2.x);
 
-        return {headers, cells};
+        // per-layer scroll context — pins WHICH layer drifted when the pairing fails
+        const scrollCtx = {
+            toolbarScrollLeft: toolbar.scrollLeft,
+            toolbarLeft      : Math.round(toolbar.getBoundingClientRect().left),
+            bodyScrollLeft   : body.scrollLeft,
+            bodyLeft         : Math.round(clip.left),
+            rowTransform     : getComputedStyle(row).transform,
+            scrollVar        : getComputedStyle(body).getPropertyValue('--grid-scroll-left') ||
+                               getComputedStyle(body.parentElement).getPropertyValue('--grid-scroll-left')
+        };
+
+        return {headers, cells, scrollCtx};
     });
 
     /**
@@ -70,8 +81,8 @@ test.describe('Grid header↔cell rect sync through drag passes (#12955)', () =>
      * `midDrag`. After a drop, counts must match exactly. A layer offset of ANY size fails every
      * header's lookup and prints both rect sets for diagnosis.
      */
-    const assertAligned = ({headers, cells}, label, midDrag = false) => {
-        const dump = `headers=${JSON.stringify(headers)} cells=${JSON.stringify(cells)}`;
+    const assertAligned = ({headers, cells, scrollCtx}, label, midDrag = false) => {
+        const dump = `scroll=${JSON.stringify(scrollCtx)} headers=${JSON.stringify(headers)} cells=${JSON.stringify(cells)}`;
 
         if (!midDrag) {
             expect(headers.length, `${label}: visible header/cell count parity — ${dump}`).toBe(cells.length);


### PR DESCRIPTION
Resolves #12955

Authored by Claude Fable 5 (Claude Code). Session c29b5ccc-d711-4cde-8401-32d1e4bbc4f1.

Operator-reported ("sliding headers shrink during right-edge drags, cells keep width, persists through switch-backs") and root-caused LIVE during an operator drag-hold via NL forensics: **headers never shrink** — the header toolbar's native `scrollLeft` clamps below the scroll SSOT during drags, offsetting the entire header strip against the cells (live: 2723→2603 on devindex; net repro: 412→358 on the fixture).

**Mechanism**: during a drag the items are absolutised, so the toolbar's scrollable overflow is defined purely by their boxes. `expandOwnerOnDrag` is deliberately opted out for this zone (expanding a real scroll container breaks programmatic scroll for frozen regions — in-code rationale at the config), so every lift/switch reflow can shrink the scrollable extent → the browser clamps native `scrollLeft` → headers ride offset until `processDragEnd`'s drop re-sync. Scroll re-application mid-drag CANNOT fix it: the clamp re-fires because the true max genuinely shrank (verified empirically — two re-apply strategies bounced before the extent approach).

**Fix**: a 1px absolute **scroll-extent sentinel** node pinned at the pre-drag content extent, injected at `onDragStart` (scrolled drags only), removed in `processDragEnd` before the layout restore. Max-scroll never shrinks → the clamp becomes impossible → headers and cells stay on the same scroll truth through every switch and switch-back. The existing drop re-sync (`#12938` item 1) is unchanged and still owns the post-restore frame.

**The exposure net** (per the operator's directive: "things like these MUST get exposed in tests"): `GridHeaderCellRectSync.spec.mjs` — whitebox-e2e on the lockedColumns fixture; scrolls the centre to max, drags the last centre column back and forth across neighbours for two full passes, and at EVERY hold point + after every drop asserts each visible header's rect (x, width) sits pixel-exact on its first-row cell's rect. Layer-agnostic: any header↔cell drift (scroll clamps, width churn, stale transforms) fails with the offending column, offset, and a per-layer scroll-context dump. Real mouse gestures by design — the failure class lives in main-thread reflow, synthetic worker events would green-wash it.

Evidence: L3 (net RED pre-fix at commit `23bf6243f` with the 54px uniform-offset signature — dumps on the ticket — GREEN post-fix ×5 consecutive; sibling drag e2e 4/4; units 57/57) → L4 residual (operator re-check of the original devindex gesture, batched into the gate session). Residual: L4 devindex re-verify [#12955 → #12883 gate session].

## Deltas from ticket

- The ticket's falsifier 1 (tree mismatch) was eliminated live: operator's checkout verified at merged tip; the symptom is real on merged dev.
- The "header width reduces" framing was disproven — widths are correct at every phase; the offset ILLUSION is the defect (ticket comment carries the live numbers).
- Two intermediate fix strategies (lift-time + switch-time scrollLeft re-apply, SSOT-sourced) were implemented, falsified by the net, and removed — the committed fix is extent-preservation only. The net catching both bad fixes is the directive working.
- Alignment-flip observation: explained as the clipped right-aligned text of the displaced `Updated` button (same offset, not a separate cls bug); falsifier 2 stays parked on the ticket.

## Test Evidence

- `npx playwright test GridHeaderCellRectSync -c <e2e config>` → RED pre-fix (uniform 54px header-strip offset at `pass 1: mid-drag`, all widths correct) → **GREEN ×5 consecutive post-fix** (one pre-hardening flake disclosed; settle margins raised in `2156540c0`).
- `GridColumnCrossBodyDnD` + `GridColumnOverdragScroll` → **4/4** (cross-region re-home + overdrag unaffected; overdrag's intentional mid-drag scrolling composes with the sentinel — extent pinning never blocks scrolling, only extent collapse).
- `npm run test-unit -- test/playwright/unit/grid test/playwright/unit/draggable` → **57/57**.

## Post-Merge Validation

- [ ] Operator repeats the original devindex gesture (scroll right, grab second-last, drag to right edge, switch back, hold) — headers stay cell-locked mid-drag (L4, batched into the #12883 gate session)

## Commits

- `23bf6243f` — the exposure net (red at this commit, by design — it documents the defect)
- `4811915dc` — the extent-sentinel fix (net goes green here)
- `2156540c0` — net settle-margin hardening