### PR TITLE
test(grid): locked-DnD duplication net; the #12939 class verified dead (#12939)

### DIFF
--- a/test/playwright/e2e/GridLockedDnDDuplication.spec.mjs
+++ b/test/playwright/e2e/GridLockedDnDDuplication.spec.mjs
@@ -1,0 +1,136 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * Whitebox-e2e regression net for the locked-grid DnD duplication class: stale-vnode-baseline
+ * update races spawning duplicate DOM ids, ghost region bodies, and id-less `insertNode` births.
+ *
+ * The corruption family expressed as: two cell generations holding one id after a cross-region
+ * re-home (the pool→permanent identity-migration seam in `grid.Row`'s two-pass recycle), ghost
+ * copies of an entire region body accumulating per overdrag walk, and id-less `insertNode`
+ * deltas at the main-thread apply boundary. The class is invisible to end-state sampling —
+ * each individual surface looks internally consistent — so this net checks FOUR stateful
+ * oracles after EVERY gesture:
+ *
+ *   1. zero duplicate DOM ids anywhere under the grid (the keystone signature)
+ *   2. zero id-less `insertNode` deltas, harvested via `Neo.config.logDeltaUpdates`
+ *   3. exactly three region-body elements (ghost-body copies counted directly)
+ *   4. items/vdom/DOM consistency on every region body (worker-truth vs rendered truth)
+ *
+ * Gestures are the three convicted corruption triggers, run twice (repeat-gesture accumulation
+ * was part of the original signature): a centre overdrag walk with return leg, a cross-region
+ * re-home (centre → locked-start: a column FLIPS into permanent cell territory on mounted
+ * rows — the exact seam), and the reverse re-home back out.
+ *
+ * A/B-falsified sensitivity: knocking out the Pass-2 re-id in `grid.Row` (the identity-migration
+ * symmetry) makes oracle 1 count 73 duplicates and oracle 3 count 4 bodies from the first
+ * overdrag walk on a locked 37-column grid — this net sees the class loudly when it exists.
+ *
+ * Run: npx playwright test GridLockedDnDDuplication -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Locked-grid DnD duplication net (#12939)', () => {
+    test.setTimeout(180000);
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test('overdrag walk + cross-region re-homes leave zero duplicate ids, zero id-less inserts, three bodies, consistent surfaces', async ({ page, neuralLink }) => {
+        await page.goto('/examples/grid/lockedColumns/');
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+        await page.waitForTimeout(800);
+
+        const app = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
+
+        // Harvest id-less insertNode deltas at the main-thread apply boundary
+        await page.evaluate(() => {
+            Neo.config.logDeltaUpdates = true;
+            window.__idlessInserts = 0;
+            const orig = console.log.bind(console);
+            console.log = (...args) => {
+                try {
+                    if (typeof args[0] === 'string' && args[0].startsWith('update ')) {
+                        const data = args[3];
+                        const deltas = Array.isArray(data) ? data : (data?.deltas || []);
+                        for (const d of deltas) {
+                            if (d.action === 'insertNode' && !d.id && !d.vnode?.id) window.__idlessInserts++;
+                        }
+                    }
+                } catch (e) {}
+                orig(...args);
+            };
+        });
+
+        const assertClean = async (label) => {
+            const dom = await page.evaluate(() => {
+                const grid = document.querySelector('.neo-grid-container');
+                const seen = new Set();
+                const dups = [];
+                grid.querySelectorAll('[id]').forEach(el => {
+                    if (seen.has(el.id)) dups.push(el.id);
+                    seen.add(el.id);
+                });
+                return {
+                    dups: dups.slice(0, 10),
+                    bodyCount: document.querySelectorAll('.neo-grid-body').length,
+                    idless: window.__idlessInserts
+                };
+            });
+
+            expect(dom.dups, `${label}: duplicate DOM ids under the grid`).toEqual([]);
+            expect(dom.idless, `${label}: id-less insertNode deltas at the apply boundary`).toBe(0);
+            expect(dom.bodyCount, `${label}: region-body element count (ghost-body copies)`).toBe(3);
+
+            const bodies = await app.findInstances({ ntype: 'grid-body' }, ['id']);
+            for (const b of (Array.isArray(bodies) ? bodies : [bodies])) {
+                const id = b.id || b.properties?.id;
+                const c = await app.verifyComponentConsistency(id);
+                const counts = c?.counts || c?.result?.counts || {};
+                // items/vdom may legitimately differ in shape (raw vdom rows vs component items);
+                // the duplication class shows as DOM exceeding vdom — assert that axis exactly.
+                expect(counts.dom, `${label}: ${id} DOM children vs vdom children`).toBe(counts.vdom);
+            }
+        };
+
+        await assertClean('baseline');
+
+        const headerBox = async (tbIdx, btnIdx) => page.evaluate(([t, b]) => {
+            const tb = [...document.querySelectorAll('.neo-grid-header-toolbar')][t];
+            const r = tb.getBoundingClientRect();
+            const btn = tb.children[b].getBoundingClientRect();
+            return { x: btn.x + btn.width / 2, y: btn.y + btn.height / 2, tbLeft: r.left, tbRight: r.right };
+        }, [tbIdx, btnIdx]);
+
+        for (let round = 1; round <= 2; round++) {
+            // (a) centre overdrag walk right + return leg, drop mid-centre
+            let g = await headerBox(1, 2);
+            await page.mouse.move(g.x, g.y);
+            await page.mouse.down();
+            await page.mouse.move(Math.min(g.tbRight + 40, 1910), g.y, { steps: 30 });
+            await page.waitForTimeout(2000);
+            await page.mouse.move(g.tbLeft + 200, g.y, { steps: 30 });
+            await page.waitForTimeout(800);
+            await page.mouse.up();
+            await page.waitForTimeout(1000);
+            await assertClean(`round ${round}: overdrag walk`);
+
+            // (b) cross-region re-home: centre column -> locked-start (the pool→permanent seam)
+            g = await headerBox(1, 0);
+            const startTarget = await headerBox(0, 1);
+            await page.mouse.move(g.x, g.y);
+            await page.mouse.down();
+            await page.mouse.move(startTarget.x, startTarget.y, { steps: 30 });
+            await page.waitForTimeout(600);
+            await page.mouse.up();
+            await page.waitForTimeout(1200);
+            await assertClean(`round ${round}: re-home to locked-start`);
+
+            // (c) reverse re-home: locked-start -> centre
+            const backSrc = await headerBox(0, 1);
+            const centreTarget = await headerBox(1, 1);
+            await page.mouse.move(backSrc.x, backSrc.y);
+            await page.mouse.down();
+            await page.mouse.move(centreTarget.x, centreTarget.y, { steps: 30 });
+            await page.waitForTimeout(600);
+            await page.mouse.up();
+            await page.waitForTimeout(1200);
+            await assertClean(`round ${round}: re-home back out`);
+        }
+    });
+});


### PR DESCRIPTION
Resolves #12939

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

The #12939 duplication class is **dead on current dev** — verified tonight on both relevant surfaces, with the probe's sensitivity itself A/B-falsified. This PR closes the ticket with the committed regression net that keeps it dead.

## The verdict, with evidence

The class (duplicate cell ids after cross-region re-homes, ghost region-body copies accumulating per overdrag walk, id-less `insertNode` births from stale vnode baselines) was last measured at ×1-2 per drop at the #12938 head. Since then, dev accumulated: the five #12938 fixes (the Pass-2 identity-migration keystone among them), the #12948 one-live-cell invariant net, the #12950 scroll-driver re-plumb, and the #12956 reply-rejection fix (failed updates no longer adopt vnodes — the stale-baseline feeder for THAT path is gone). Tonight's measurement at `dceab0b17`:

1. **lockedColumns fixture** (the committed surface): three convicted corruption gestures (centre overdrag walk + return leg; cross-region re-home centre→locked-start — the pool→permanent seam; reverse re-home back out) × two rounds → **zero duplicate ids, zero id-less inserts, three bodies, consistent surfaces at all seven checkpoints**.
2. **Re-locked devindex** (the ORIGINAL measurement surface — 37 columns, 50k rows; locked config reverse-applied to the working tree for the probe, then reverted): identical gestures → **clean at all seven checkpoints**.
3. **Sensitivity A/B**: knocking out the Pass-2 re-id in `grid.Row` (`src/grid/Row.mjs:511`) and re-running on surface 2 → **73 duplicate ids + a fourth ghost body from the first overdrag walk** — the original signature, loud. The oracles see the class when it exists; the clean runs are therefore meaningful, and the keystone is proven load-bearing.

## What ships

`test/playwright/e2e/GridLockedDnDDuplication.spec.mjs` — four stateful oracles asserted after EVERY gesture (not end-state sampling, which this class evades): zero duplicate DOM ids under the grid, zero id-less `insertNode` deltas harvested at the main-thread apply boundary (`logDeltaUpdates`), exactly three region-body elements, and DOM==vdom child counts on every region body via the consistency differ. Green in 47s against the merged fixture.

## Mechanism disposition (the ticket's open falsifiers, honestly mapped)

- Falsifier (a) — `vdom.cn` reset-vs-accumulate: subsumed; the expression it fed is dead and the net pins the observable.
- Falsifier (b) — the `syncVnodeTree` write-back question: ANSWERED by the #12946 hunt — parent-driven silent `_vnode` writes into collision-filtered merged children are real and recorded on #12946's trail; the wedge half is fixed (PR #12956); a duplication expression through that path no longer reproduces and would now trip both the 5s watchdog and this net.
- Falsifier (c) — drop-moment delta capture: executed (the probe wraps the apply boundary); the structural tail during all gestures is id-carrying and healthy.

Evidence: L3 (two-surface probe matrix + knockout A/B + the committed net 1/1 green) → L4 optional: the operator's locked-drag pass doubles as confirmation (#12883's existing gate). Residual: none on this ticket.

## Deltas

- The exploratory probes remain uncommitted by design (this net is their distilled, asserting form).
- No engine code changes in this PR — the fixes that killed the class are already merged; this PR is the closure evidence + the net.

## Test Evidence

- `npx playwright test GridLockedDnDDuplication -c test/playwright/playwright.config.e2e.mjs` → 1/1 (19.9s test time).
- Probe matrix + A/B detail: see ticket comment trail on #12939 (posted with this PR).

## Post-Merge Validation

- [ ] Operator's #12883 L4 locked-drag pass doubles as the human-eyes confirmation of this closure.
