### PR TITLE
fix(grid): render single-column locked-end body once measured (#12954)

### DIFF
--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -466,7 +466,19 @@ class GridBody extends Component {
      * @protected
      */
     afterSetContainerWidth(value, oldValue) {
-        value > 0 && this.updateMountedAndVisibleColumns()
+        if (value > 0) {
+            let me = this;
+
+            // updateMountedAndVisibleColumns only re-renders rows as a side effect of mountedColumns
+            // *changing*. A width-invariant region — e.g. a single-column locked-end body whose
+            // mounted range is always [0, 0] regardless of width — would otherwise never render its
+            // rows once measured. Recompute with the row render suppressed, then fire exactly one
+            // explicit createViewData (mirroring the afterSetBufferColumnRange pattern above).
+            me.skipCreateViewData = true;
+            me.updateMountedAndVisibleColumns();
+            me.skipCreateViewData = false;
+            me.createViewData()
+        }
     }
 
     /**

--- a/test/playwright/e2e/GridLockedRegionRowRender.spec.mjs
+++ b/test/playwright/e2e/GridLockedRegionRowRender.spec.mjs
@@ -1,0 +1,59 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * Whitebox-e2e regression guard: every grid region body renders its rows — including a
+ * single-column locked-end region.
+ *
+ * A single-column region has a width-invariant mounted-column range of [0, 0]. The row render
+ * used to be reachable only as a side effect of that range *changing* when the body was measured,
+ * so a single-column locked-end body mounted 0 rows while the multi-column center / locked-start
+ * bodies rendered all of them. This spec pins each region body to the store's row count via the
+ * App-Worker consistency oracle (logical items / vdom / rendered DOM must agree).
+ *
+ * Run: npx playwright test GridLockedRegionRowRender -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Desktop (1920x1080): lockedColumns Fixture — every region body renders its rows', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/examples/grid/lockedColumns/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+        await page.waitForTimeout(500); // settle render before measuring
+    });
+
+    test('all three region bodies — incl. single-column locked-end — mount every store row (items/vdom/DOM agree)', async ({ page, neuralLink }) => {
+        const app = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
+
+        // Worker precondition: a genuine three-region topology with a non-empty locked-end region
+        // (the bug's surface). The region column arrays are the engine's own region model.
+        // findInstances returns each match as {className, id, properties:{...requested...}}.
+        const grids = await app.findInstances({ ntype: 'grid-container' }, ['id', 'store.count', 'lockedStartColumns', 'lockedEndColumns']);
+        const grid  = (Array.isArray(grids) ? grids[0] : grids) || {};
+        const gp    = grid.properties || {};
+        expect(grid.id, 'a grid-container must exist in the bound App Worker').toBeTruthy();
+
+        const rowCount = gp['store.count'];
+        expect(rowCount, 'fixture store must have rows').toBeGreaterThan(0);
+        expect((gp.lockedStartColumns || []).length, 'fixture has a locked-start region').toBeGreaterThan(0);
+        expect((gp.lockedEndColumns   || []).length, 'fixture has a locked-end region (the regression surface)').toBeGreaterThan(0);
+
+        // The three region bodies: locked-start, center, locked-end.
+        const bodies = await app.findInstances({ className: 'Neo.grid.Body' }, ['id', 'items.length']);
+        expect(bodies.length, 'three region bodies expected (locked-start / center / locked-end)').toBe(3);
+
+        // Worker oracle: each body's logical row pool, vdom and rendered DOM all hold every store row.
+        // The single-column locked-end body is the regression target — it used to report 0 here.
+        for (const body of bodies) {
+            expect(body.properties?.['items.length'], `body ${body.id}: logical row pool`).toBe(rowCount);
+
+            const check = await app.verifyComponentConsistency(body.id);
+            expect(check.consistent,   `body ${body.id}: items/vdom/DOM must agree`).toBe(true);
+            expect(check.counts.dom,   `body ${body.id}: rendered DOM rows`).toBe(rowCount);
+            expect(check.counts.items, `body ${body.id}: logical rows`).toBe(rowCount);
+            expect(check.counts.vdom,  `body ${body.id}: vdom rows`).toBe(rowCount);
+        }
+    });
+});


### PR DESCRIPTION
Resolves #12954
Refs #12936

Authored by Opus 4.8 (Claude Code). Session 63f0aced-9b17-4aa7-bd30-a2592dba2c97.

The single-column locked-end body on the `examples/grid/lockedColumns` fixture mounted **0 of 8 rows** while the multi-column center and locked-start bodies rendered all 8. Root cause, proven live via the Neural Link: a region body's row render is triggered by the `mountedColumns` afterSet, which only fires on a value *change* (`Neo.isEqual`). A single-column region's mounted range is invariantly `[0, 0]`, so once the body is measured (`containerWidth` set), `afterSetContainerWidth` → `updateMountedAndVisibleColumns` recomputes `[0, 0] → [0, 0]` — no change, no afterSet, no render call. Multi-column bodies escaped the bug only because their mounted range widens when measured. The fix makes `afterSetContainerWidth` recompute columns with the render suppressed, then fire exactly one explicit `createViewData` (the same `skipCreateViewData` idiom `afterSetBufferColumnRange` already uses) — so a body renders once measured regardless of whether its mounted range changed, with no double render for multi-column bodies.

Evidence: L3 (live Neural Link introspection on local Chromium — body-3 went 0→8 rows, `verify_component_consistency {dom:8, items:8, vdom:8}`; an instrumented `createViewData` call-trace pinned the missing render call) → L3 required (AC: fixture renders 8 rows in all three regions, asserted by whitebox-e2e). No residuals on this leaf.

## Deltas from ticket (if any)
- Root cause is a refinement of the ticket's hypothesis: the failure is **not** a guard *inside* `createViewData` (all guards pass for the locked-end body) — it is `createViewData` never being **called** for a width-invariant single-column body. The fix is at the trigger (`afterSetContainerWidth`), not the guard chain.
- The fix is general: it repairs **any** single-column grid body, not only locked-end. Confirmed it also fixes the dynamic-lock path (`GridBigDataMultiBodyNL`, see Test Evidence).
- Ticket AC3 ("re-check on a locked-END grid with row overflow / scrolling") is left as a Post-Merge item — this fixture's locked-end is a single non-overflowing column by design.

## Test Evidence
All runs local against the worktree dev-server (this is the worktree's fix; canonical :8080 serves a different checkout).
- **New regression** `test/playwright/e2e/GridLockedRegionRowRender.spec.mjs` — **1 passed**. All three region bodies (incl. single-column locked-end) report `items.length === 8` and `verify_component_consistency {dom:8, items:8, vdom:8}`.
- **Existing fixture specs (regression)** — `GridColumnCrossBodyDnD` **2 passed**, `GridColumnOverdragScroll` **2 passed**. Unchanged.
- **Grid unit suite** — **45 passed** (`LockedColumns`, `Pooling`, `PoolingRuntimeUpdates`, `BodyCellMapping`, `StoreInteractions`, `Teleportation`, `ViewOwnedSelectionModel`, …), `--workers=1`. No regression.
- **Dynamic-lock corroboration** — `GridBigDataMultiBodyNL` (locks `progress` → `end`, a single-column locked-end region) now **progresses past its historically-failing locked-end row assertion (line 48)** and the multi-body selection-sync assertions (lines 54-58); it fails only on a pre-existing dead-code call (`app.getInstanceProperties` at line 63 — not a fixture method; a known stale "God Mode" assertion unrelated to this fix).

## Post-Merge Validation
- [ ] Re-run the grid e2e + unit suites against the merged code on a server that serves this checkout.
- [ ] Re-check locked-end row rendering on a locked-END grid **with vertical row overflow / scrolling** once such a surface exists (ticket AC3).
- [ ] (Out of scope here) repair `GridBigDataMultiBodyNL`'s line-63 `app.getInstanceProperties` dead code so the full multi-body selection-sync test can run green.
