### PR TITLE
fix(release): publish.mjs commits bypass pre-commit hooks (#12965)

### DIFF
--- a/buildScripts/release/publish.mjs
+++ b/buildScripts/release/publish.mjs
@@ -103,10 +103,14 @@ async function main() {
     runCommand('npm run build-all', 'Failed to run npm run build-all');
 
     // Stage and Commit on Dev
+    // Release-pipeline commits bypass the husky pre-commit battery (--no-verify): these are
+    // machine-generated artifact commits over a broadly-staged tree, and developer-workflow
+    // hooks gate human-authored changes (which already passed them at PR time). A latent
+    // whitespace hit in a prepare-touched doc killed the v13 cut at this exact line.
     console.log('💾 Committing changes to dev...');
     runCommand('git add .', 'Failed to stage changes');
     try {
-        runCommand(`git commit -m "Release v${newVersion}"`, 'Failed to commit to dev');
+        runCommand(`git commit --no-verify -m "Release v${newVersion}"`, 'Failed to commit to dev');
     } catch (e) {
         // Ignore if nothing to commit (unlikely)
         console.log('No changes to commit (maybe only untracked files were added?). Continuing...');
@@ -162,7 +166,7 @@ async function main() {
         console.log('Added atomic changelog link to release notes.');
 
         runCommand(`git add ${releaseNotePath}`, 'Failed to stage release note');
-        runCommand(`git commit -m "docs: Add atomic changelog hash to release notes"`, 'Failed to commit release note update');
+        runCommand(`git commit --no-verify -m "docs: Add atomic changelog hash to release notes"`, 'Failed to commit release note update');
         runCommand('git push origin dev', 'Failed to push dev');
     } else {
         console.log('Atomic changelog link already present.');
@@ -250,7 +254,7 @@ async function main() {
 
     if (status) {
         runCommand('git add .', 'Failed to stage archive changes');
-        runCommand(`git commit -m "chore: Archive tickets for v${newVersion}"`, 'Failed to commit archive changes');
+        runCommand(`git commit --no-verify -m "chore: Archive tickets for v${newVersion}"`, 'Failed to commit archive changes');
         runCommand('git push origin dev', 'Failed to push archive changes');
     } else {
         console.log('No changes to archive.');

--- a/learn/agentos/NeuralLink.md
+++ b/learn/agentos/NeuralLink.md
@@ -294,7 +294,7 @@ Advanced tools for "Open Heart Surgery" on the running code.
 2.  Calls `get_computed_styles({componentId: 'button-1', variables: ['backgroundColor']})`.
 3.  Analyzes the result and suggests a fix.
 
-### Scenario 2: Data 
+### Scenario 2: Data
 
 **User:** "Show me the last 5 users in the grid."
 **Agent:**


### PR DESCRIPTION
Resolves #12965

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

Filed and fixed mid-cut: the v13 release died at `publish.mjs` step 2 — the husky pre-commit battery fired on the machine-generated `Release v13.0.0` commit, failed on a **latent** trailing space in `learn/agentos/NeuralLink.md:297` (staged only because `prepare.mjs` regex-updates that file's version-proof line), and lint-staged reverted the staged release tree.

Two changes:

1. **All three `publish.mjs` commit sites** (`Release vX` :109, notes-hash finalization :165, ticket archive :253) now commit with `--no-verify`, with the rationale documented in-code at the first site: release-pipeline commits are machine-generated artifact commits over a broadly-staged tree; every human-authored change in that tree already passed the hooks at PR time. This is the same sanctioned-bypass class as the data-sync pipeline.
2. **The latent whitespace itself removed** (`NeuralLink.md:297` — "### Scenario 2: Data " → "Data"), so the file is clean regardless of bypass.

Evidence: L2 (`node ./buildScripts/util/check-whitespace.mjs` → clean post-fix; the three `--no-verify` sites grep-verified) → L4 inherent: the operator's re-run of the cut IS the validation. Residual: none.

## Deltas

- The `check-shorthand` SIGKILL seen in the failure output was lint-staged's sibling-kill after the whitespace failure, not an independent fault — explicitly out of scope per the ticket.

## Test Evidence

- `node ./buildScripts/util/check-whitespace.mjs` → 0 violations post-fix.
- No runtime code touched; the e2e/unit suites are unaffected by a release-script flag.

## Post-Merge Validation

- [ ] The operator's re-run of `publish.mjs` passes step 2 and completes the cut.
