### PR TITLE
test(grid): restore real locked-cell horizontal-stability coverage on the fixture (#12949)

### DIFF
--- a/test/playwright/e2e/GridLockedCellHorizontalStability.spec.mjs
+++ b/test/playwright/e2e/GridLockedCellHorizontalStability.spec.mjs
@@ -1,0 +1,110 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: under horizontal scroll the centre cells translate optically while the locked-region
+ * cells (start AND end) stay visually stationary — and they stay frozen through a large scroll that
+ * recycles the centre's mounted-column window (virtualization), not just a small optical nudge.
+ *
+ * This restores REAL locked-cell coverage. The original probe lived in GridThumbDragDevIndex against
+ * the devindex app, whose locked columns were since removed — there `.neo-locked-start` /
+ * `.neo-locked-end` cells no longer exist, so the stability assertions passed vacuously (null === null).
+ * On the lockedColumns fixture the locked regions are real, and the single-column locked-end region
+ * renders its cells (the engine fix for the zero-row locked-end body), so both stability checks assert
+ * against actual rendered cells. The test fails loudly if either locked region is absent — no vacuous pass.
+ *
+ * Run: npx playwright test GridLockedCellHorizontalStability -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('Desktop (1920x1080): lockedColumns Fixture — locked cells stay frozen under horizontal scroll', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/examples/grid/lockedColumns/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+        await page.waitForTimeout(500); // settle render before measuring
+    });
+
+    test('locked-start AND locked-end cells stay put through optical + large (recycling) horizontal scroll', async ({ page, neuralLink }) => {
+        // Worker precondition: the locked-end body actually rendered rows (the regression this builds on),
+        // and identify the centre body (the overflowing region — most columns) for the recycle check.
+        const app    = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
+        const bodies = await app.findInstances({ className: 'Neo.grid.Body' }, ['id', 'items.length', 'mountedColumns', 'columnPositions.count']);
+        expect(bodies.length, 'three region bodies').toBe(3);
+        bodies.forEach(b => expect(b.properties?.['items.length'], `body ${b.id} rows`).toBeGreaterThan(0));
+
+        const centre        = bodies.map(b => b.properties).sort((a, b) => b['columnPositions.count'] - a['columnPositions.count'])[0];
+        const centreId      = centre.id;
+        const mountedBefore = JSON.stringify(centre.mountedColumns);
+
+        const result = await page.evaluate(async () => {
+            const hScrollbar = document.querySelector('.neo-grid-horizontal-scrollbar');
+            if (!hScrollbar) return { error: 'horizontal scrollbar not found' };
+
+            const firstCenterLeft = () => {
+                const c = document.querySelector('.neo-grid-row .neo-grid-cell:not(.neo-locked-start):not(.neo-locked-end)');
+                return c ? c.getBoundingClientRect().left : null;
+            };
+            const lockedLefts = () => {
+                const s = document.querySelector('.neo-grid-row .neo-grid-cell.neo-locked-start');
+                const e = document.querySelector('.neo-grid-row .neo-grid-cell.neo-locked-end');
+                return { startLeft: s ? s.getBoundingClientRect().left : null, endLeft: e ? e.getBoundingClientRect().left : null };
+            };
+
+            const initialCenter = firstCenterLeft();
+            const initialLocked = lockedLefts();
+
+            // 1. Moderate horizontal scroll → optical CSS translation of the centre region.
+            hScrollbar.scrollLeft += 100;
+            await new Promise(r => requestAnimationFrame(r));
+            await new Promise(r => requestAnimationFrame(r));
+
+            const instantCenter = firstCenterLeft();
+            const instantLocked = lockedLefts();
+
+            // 2. Large scroll → recycle the centre's mounted-column window (virtualization) via the
+            //    app-worker round-trip. Locked cells must stay frozen through this too.
+            hScrollbar.scrollLeft += 2000;
+            await new Promise(r => setTimeout(r, 500));
+
+            const afterLargeLocked = lockedLefts();
+
+            return {
+                centerPresent         : initialCenter !== null,
+                lockedStartPresent    : initialLocked.startLeft !== null,
+                lockedEndPresent      : initialLocked.endLeft !== null,
+                pixelShift            : (initialCenter !== null && instantCenter !== null) ? initialCenter - instantCenter : null,
+                lockedStartStable     : initialLocked.startLeft === instantLocked.startLeft,
+                lockedEndStable       : initialLocked.endLeft === instantLocked.endLeft,
+                lockedStartStableLarge: initialLocked.startLeft === afterLargeLocked.startLeft,
+                lockedEndStableLarge  : initialLocked.endLeft === afterLargeLocked.endLeft
+            };
+        });
+
+        // Recycle signal (worker oracle): the centre's mounted-column window shifted after the large scroll.
+        const mountedAfter = JSON.stringify((await app.getComponent(centreId, ['mountedColumns']))['mountedColumns']);
+
+        console.log('[locked-cell-hscroll]', JSON.stringify({ ...result, mountedBefore, mountedAfter }));
+
+        expect(result.error).toBeUndefined();
+
+        // Non-vacuity: all three regions must have rendered cells (esp. locked-end — the regression target).
+        expect(result.centerPresent,      'centre cells present').toBe(true);
+        expect(result.lockedStartPresent, 'locked-start cells present').toBe(true);
+        expect(result.lockedEndPresent,   'locked-end cells present (no vacuous pass)').toBe(true);
+
+        // Centre cells physically shifted left as we scrolled right (optical translation).
+        expect(result.pixelShift,         'centre cells translated left under optical scroll').toBeGreaterThan(0);
+
+        // Locked regions stayed stationary through BOTH the optical scroll and the large/recycling scroll.
+        expect(result.lockedStartStable,      'locked-start stayed put (optical scroll)').toBe(true);
+        expect(result.lockedEndStable,        'locked-end stayed put (optical scroll)').toBe(true);
+        expect(result.lockedStartStableLarge, 'locked-start stayed put through the large/recycling scroll').toBe(true);
+        expect(result.lockedEndStableLarge,   'locked-end stayed put through the large/recycling scroll').toBe(true);
+
+        // The large scroll actually recycled the centre's mounted-column window — backs the large-scroll
+        // leg with evidence rather than claiming virtualization without asserting it.
+        expect(mountedAfter, 'centre mounted-column window shifted after the large scroll (recycle)').not.toBe(mountedBefore);
+    });
+});


### PR DESCRIPTION
Resolves #12949
Refs #12936

Authored by Opus 4.8 (Claude Code). Session 63f0aced-9b17-4aa7-bd30-a2592dba2c97.

Restores real locked-cell horizontal-stability coverage on the `examples/grid/lockedColumns` fixture, via a new `GridLockedCellHorizontalStability` whitebox-e2e: under horizontal scroll the centre cells translate optically while the locked-start AND locked-end cells stay visually stationary, and a large scroll triggers data virtualization. The locked-END assertion is meaningful because the single-column locked-end body now renders its cells (the #12954 engine fix, on dev as of `46dd9eedc` / v13.0.0).

**Premise correction (the substantive finding):** #12949 was filed on the assumption that `GridThumbDragDevIndex` *fails* after devindex lost its locked columns and needs migrating. Empirically it does **not** — it passes 2/2. Its vertical scroll-telemetry test never used locked columns, and its horizontal locked-cell test passed **vacuously** (lock-less devindex → `.neo-locked-start` / `.neo-locked-end` cells are `null` → `null === null`). So the real gap was not a red spec but *silently lost* locked-cell coverage. This PR restores it with non-vacuous assertions (it fails loudly if a locked region is absent).

Evidence: L3 (local Chromium e2e against the fixture: `pixelShift=100`, locked-start/end present + stable; `GridThumbDragDevIndex` verified still green 2/2) → L3 required (locked-cell stability asserted against real rendered cells). No residuals on this leaf.

## Deltas from ticket (if any)
- The ticket's failing-spec premise is corrected (above) — `GridThumbDragDevIndex` passes; there is no red spec to migrate.
- The vertical scroll-telemetry test **stays on devindex** (verified passing — devindex still streams many rows; it only lost its locked columns, which that test never used). The ticket's "re-home scroll-telemetry to a many-row grid" is already satisfied by it living on one.
- `GridThumbDragDevIndex`'s now-redundant horizontal test (whose locked-cell assertions are vacuous on lock-less devindex) is **left in place**: removing it forces the disproportionate 28-line pre-existing-trailing-whitespace cleanup the umbrella flagged, for no coverage gain (this PR supersedes its real coverage). Tracked below as optional cleanup.
- This effectively completes #12936 AC2 — all three original specs are green and locked-column coverage is now real on the fixture. Closing #12936 is the umbrella author's call (@neo-fable-clio); flagged via A2A.

## Test Evidence
Local against the worktree dev-server (the #12954 fix this relies on is on dev as of `46dd9eedc`).
- **New** `GridLockedCellHorizontalStability` — **1 passed**: non-vacuity (`centerPresent`/`lockedStartPresent`/`lockedEndPresent` all true), `pixelShift=100`, locked-start + locked-end stable through BOTH the optical (100px) and the large (2000px, recycling) scroll, and the centre's `mountedColumns` window shifts after the large scroll (`[0,16] → [4,16]` — recycle evidenced, per @neo-gpt's review).
- `GridThumbDragDevIndex` (premise check) — **2 passed** (scroll-telemetry 25.2s, horizontal 6.2s): confirms it never broke.

## Post-Merge Validation
- [ ] Re-run the new spec against the merged code on a server that serves this checkout.
- [ ] (Optional, deferred) remove the now-redundant horizontal test from `GridThumbDragDevIndex` + its 28-line trailing-whitespace cleanup, if the umbrella wants the split fully completed.

## Retrospective / Graph Notes
`[RETROSPECTIVE]` `[KB_GAP]` **Vacuous-pass coverage-loss pattern.** A spec asserting stability on an *optional/conditional* surface via `a.left === b.left` silently degrades to a no-op when that surface is removed: both lookups return `null`, `null === null` passes, and the spec stays green through the entire migration while testing nothing. That is exactly how the devindex locked-cell coverage was lost invisibly when its locked columns were removed. **Reflex for spec authors: assert PRESENCE before asserting equality on optional surfaces** — this spec asserts `lockedEndPresent === true` before any stability check, so it fails loudly rather than passing vacuously.
