### PR TITLE
fix(ci): engage npm Trusted Publishing — id-token grant, drop expired token (#12970)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,10 +2,21 @@ name: Publish Package to npmjs
 on:
   release:
     types: [ published ]
+  # Manual re-publish path: a failed release-event run re-executes the workflow as committed at
+  # the ORIGINAL ref, so fixes here can never reach it — dispatching from dev publishes whatever
+  # version dev's package.json carries (the release pipeline bumps it before tagging).
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # npm Trusted Publishing (OIDC): the id-token grant lets GitHub mint the per-run credential
+    # the npmjs-side trusted publisher (neomjs/neo + this filename) exchanges for publish rights.
+    # No NODE_AUTH_TOKEN — a token env takes precedence over OIDC and reintroduces the expiring-
+    # token failure class that killed the v13.0.0 publish (token expired 2026-03-27 → masked E404).
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       # Setup .npmrc file to publish to npm
@@ -15,5 +26,3 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Resolves #12970

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

The npmjs-side Trusted Publisher for `neo.mjs` (`neomjs/neo` / `npm-publish.yml`) was already configured by the operator — the workflow simply never engaged it: (1) the job lacked `permissions: id-token: write`, so GitHub never minted the OIDC credential; (2) `NODE_AUTH_TOKEN: secrets.NPM_TOKEN` was still passed, and a token env takes precedence over OIDC — that token expired 2026-03-27, producing the masked `E404` that killed the v13.0.0 publish leg.

One file: add the OIDC permissions block, remove the token env, add `workflow_dispatch` (a re-run of the failed release-event run would execute the workflow as committed at the original ref — the dispatch path publishes from dev tip, whose `package.json` already carries 13.0.0). In-file comments document both the OIDC engagement and the precedence trap.

Evidence: L1 (workflow semantics verified against the failure log: tarball built clean, `PUT` failed auth-masked; npmjs trusted-publisher config operator-confirmed). The dispatch outcome + provenance badge are operator-credentialed post-merge verification — tracked in Post-Merge Validation below + the #12696 runbook (#12970 re-scoped accordingly in cycle 2; the `Resolves`-mandate lint forbids Refs-only close-targets, and the sanctioned shape for the operator-executed half is post-merge verification, not a close-gating AC).

## Deltas

- The dead `NPM_TOKEN` secret deletion is deliberately left as operator housekeeping post-success (also enables the npmjs "trusted publisher only" posture).

## Test Evidence

- Workflow-only change; YAML validated by GitHub at push. The publish run itself is the test (post-merge).

## Post-Merge Validation

- [ ] Operator: `gh workflow run npm-publish.yml --ref dev` → registry shows 13.0.0 → pages step unblocks.
- [ ] Provenance badge visible on the npm package page.
- [ ] Delete the expired `NPM_TOKEN` secret.
