### PR TITLE
fix(memory-core): exempt add_memory from the MC health-gate (#12972)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -98,12 +98,15 @@ class Server extends BaseServer {
     /**
      * @summary Tools allowed without the healthcheck gate. The A2A
      * mailbox/permission surface is graph/SQLite-scoped and must remain reachable during
-     * summarization/vector-provider incidents so agents can coordinate the recovery.
+     * summarization/vector-provider incidents so agents can coordinate the recovery — as is
+     * add_memory, whose never-fail WAL write is local-disk-scoped with the embed deferred to the
+     * drain, so memory capture never blocks on an embedder/vector-provider outage.
      * @returns {Array<String>}
      */
     getHealthExemptTools() {
         return [
             'healthcheck',
+            'add_memory',
             'add_message',
             'list_messages',
             'get_message',

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -172,7 +172,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
-    test('#12752: mailbox tools bypass summary-degraded health gate, memory writes do not', async () => {
+    test('#12838: mailbox + add_memory bypass the summary-degraded health gate (never-fail WAL); embed-dependent reads do not', async () => {
         const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
         const handlers = new Map();
         const healthCalls = [];
@@ -227,6 +227,9 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 args: {status: 'unread'}
             }]);
 
+            // add_memory — exempt since the WAL decouple: its never-fail local-disk write must run
+            // during a vector/summary outage (the embed is deferred to the drain), so it bypasses
+            // the gate exactly like the mailbox surface.
             const memoryResult = await callTool({
                 params: {
                     name     : 'add_memory',
@@ -234,11 +237,30 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 }
             });
 
-            expect(memoryResult.isError).toBe(true);
-            expect(memoryResult.content[0].text).toContain('Cannot execute add_memory: Memory Core is not fully operational');
-            expect(memoryResult.content[0].text).toContain('GEMINI_API_KEY not set - summarization features unavailable');
+            expect(memoryResult.isError).toBe(false);
+            expect(memoryResult.structuredContent).toEqual({ok: true, name: 'add_memory'});
+
+            // Both exempt → neither consulted the health service; both reached the tool service.
+            expect(healthCalls).toEqual([]);
+            expect(toolCalls).toEqual([
+                {name: 'list_messages', args: {status: 'unread'}},
+                {name: 'add_memory',    args: {prompt: 'p', thought: 't', response: 'r'}}
+            ]);
+
+            // query_raw_memories — NOT exempt: it embeds the query, so it genuinely cannot serve a
+            // result while the embedder is down. The gate must still fire for it.
+            const queryResult = await callTool({
+                params: {
+                    name     : 'query_raw_memories',
+                    arguments: {query: 'q'}
+                }
+            });
+
+            expect(queryResult.isError).toBe(true);
+            expect(queryResult.content[0].text).toContain('Cannot execute query_raw_memories: Memory Core is not fully operational');
+            expect(queryResult.content[0].text).toContain('GEMINI_API_KEY not set - summarization features unavailable');
             expect(healthCalls).toEqual(['ensureHealthy']);
-            expect(toolCalls).toHaveLength(1);
+            expect(toolCalls).toHaveLength(2);
         } finally {
             serverInstance.destroy();
         }


### PR DESCRIPTION
Resolves #12972

Authored by Claude Opus 4.8 (Claude Code) / @neo-claude-opus (Grace). Session bc844800-dd66-4dca-b6de-8f5264fdf957.

`add_memory` was missing from the MC server's `getHealthExemptTools()`, so `BaseServer.mjs:324`'s health-gate blocked it whenever the embedding write-canary failed (`Cannot execute add_memory: Memory Core is not fully operational …`) — even though #12838 made the WAL write never-fail (durable JSONL write-ahead, deferred embed). This adds `'add_memory'` to the exempt list so the never-fail path actually runs during an embedder/vector-provider outage. The gating was *correct* at #12752 time (add_memory still embedded inline); the #12838 WAL decouple is what made it stale. One-line source change + a JSDoc rationale extension.

Evidence: L2 (unit — MC `Server.spec` asserts `add_memory` bypasses the health-gate and reaches the tool service under a mocked summary-degraded failure; `query_raw_memories` stays gated) → L4 required (`add_memory` writing the WAL during a *real* embedder outage + recall after the drain catches up, on the running MC post-restart). Residual: the L4 runtime ACs are annotated post-merge on #12972.

## Deltas from ticket
- #12972's **secondary** audit scope (auditing `get_session_memories` / `query_recent_turns` for the same gate over-reach) is **split to #12978** (self-assigned follow-up) per @neo-gpt's cross-family review — so this PR's `Resolves #12972` now matches #12972's re-scoped *gating* ACs (the `add_memory` exemption + the L2 unit proof) exactly, with no orphaned residual.
- The L4 runtime ACs (embedder-down→WAL reproducer + recall-after-recovery on the running MC) are annotated on #12972 as **post-merge operator-handoff** — the sandbox ceiling here is L2; the real embedder-outage runtime confirmation can't run in CI (see Post-Merge Validation).

## Test Evidence
- `npx playwright test memory-core/Server.spec -c test/playwright/playwright.config.unit.mjs --workers=1` → **6 passed**, including the rewritten `#12838: mailbox + add_memory bypass the summary-degraded health gate (never-fail WAL); embed-dependent reads do not`.
- Rebased onto the merged portal fix (#12976) → full PR CI green: `unit` + `integration-unified` + all checks **SUCCESS** on head `924d866d4`. The pre-rebase `unit` red was the inherited portal ENOENT (now fixed on dev via #12976) + the known `Server.spec` import-race flake — not this change (`3169 passed`).

## Post-Merge Validation
- [ ] On the running MC server (after a restart to pick up the change): with the embedding provider down / timing out, `add_memory` returns success and the payload lands in the WAL; recall returns it once the embedder recovers and the drain runs. (This is the resilience the change exists for — the live failure mode that motivated #12972. The flapping embedder observed this session — `add_memory` timing out on the canary at ~09:07Z / ~09:20Z / ~09:24Z while exempt messaging tools worked — is exactly this case.)

## Test inversion rationale
The MC `Server.spec` test that asserted "memory writes do NOT bypass" (`#12752`-era) encoded the pre-decouple invariant — correct when `add_memory` embedded inline. Post-#12838 it no longer needs the embedder, so the test now asserts it DOES bypass, with `query_raw_memories` (which embeds the query, so it genuinely cannot serve a result during an embedder outage) as the new genuinely-gated example. The gate mechanism itself stays tested generically in `BaseServer.spec`.
