### PR TITLE
fix(portal): decouple discussion parser fixture from sync chunks (#12973)

### DIFF
--- a/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
+++ b/test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs
@@ -32,6 +32,8 @@ const {
     renderReplies
 } = Component.prototype;
 
+const timelineFixture = new URL('./fixtures/discussion-timeline.md', import.meta.url);
+
 test.describe('Portal.view.news.discussions.Component - Discussion markdown parser', () => {
     test('parses folded and literal frontmatter block scalars used by discussion titles', () => {
         const component = Object.create(Component.prototype);
@@ -192,7 +194,7 @@ test.describe('Portal.view.news.discussions.Component - Discussion markdown pars
 
     test('keeps generated timeline HTML out of escaped markdown code blocks', () => {
         const
-            content       = readFileSync('resources/content/discussions/chunk-2/discussion-11891.md', 'utf8'),
+            content       = readFileSync(timelineFixture, 'utf8'),
             sectionsStore = {data: []};
 
         const component = Object.create(Component.prototype);

--- a/test/playwright/unit/apps/portal/view/news/discussions/fixtures/discussion-timeline.md
+++ b/test/playwright/unit/apps/portal/view/news/discussions/fixtures/discussion-timeline.md
@@ -1,0 +1,33 @@
+---
+number: 11891
+title: >-
+  Discussion timeline fixture
+author: neo-gpt
+category: Ideas
+createdAt: '2026-05-24T10:51:18Z'
+updatedAt: '2026-05-24T11:51:16Z'
+closed: false
+closedAt: null
+---
+## Problem
+
+This fixture freezes the Discussion grammar used by the Portal discussion parser
+without depending on the sync-owned `resources/content/**` chunk layout.
+
+```html
+<div id="timeline-static-sample" class="neo-timeline-item comment">
+  This literal HTML stays inside the markdown code block.
+</div>
+```
+
+## Comments
+
+### `@neo-opus-ada` commented on 2026-05-24T10:56:05Z
+
+First comment body.
+
+---
+
+### `@neo-gpt` commented on 2026-05-24T10:58:05Z
+
+Second comment body.


### PR DESCRIPTION
Resolves #12973

Authored by GPT-5 (Codex Desktop). Session 518c54ce-5871-4ccf-8e88-6ac3b6e16ea8.

Moves the Portal discussions parser regression fixture out of the sync-owned `resources/content/**` tree and into a committed unit-test fixture beside the spec. The parser test now exercises representative Discussion frontmatter, comments, and a markdown code block without depending on mutable chunk ordinals such as `resources/content/discussions/chunk-2/discussion-11891.md`.

Evidence: L2 (focused unit spec + sweep) -> L2 required (unit regression coverage). Residual: CI full unit gate [#12973].

## Deltas from ticket
- Used a compact parser-focused fixture instead of copying the full synced Discussion file. This preserves the behavior grammar while avoiding another oversized frozen content payload.

## Test Evidence
- `npx playwright test test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` -> 8 passed (805ms).
- `rg -n "discussion-11891|readFileSync\(["']resources/content" test/playwright/unit/apps/portal/view/news/discussions/Component.spec.mjs test/playwright/unit` -> no hits.
- `npm run test-unit` was attempted locally; it no longer hit the portal discussion ENOENT but failed 61 unrelated AI/MCP/wake-runtime tests in this local environment, including `.neo-ai-data/wake-daemon/*` EPERM and external Chroma/MCP health surfaces. PR CI is the authoritative full-suite gate for this fix.

## Post-Merge Validation
- [ ] Confirm the dev Tests workflow unit job is green after merge.

## Commit
- `6bfac399e` — `fix(portal): decouple discussion parser fixture from sync chunks (#12973)`