### PR TITLE
feat(ai): KB artifact download leaves npm prepare — explicit opt-in (#12969)

### DIFF
--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -264,8 +264,17 @@ class SearchService extends Base {
         const queryResult = await QueryService.queryDocuments({query, type, limit, includeMetadata: true});
 
         if (queryResult.message || !queryResult.results || queryResult.results.length === 0) {
+            // An EMPTY collection is the common cold-start cause since the KB artifact download
+            // left the npm `prepare` chain (it is opt-in now) — name the one-liner so the absence
+            // is discoverable instead of reading like a bad query.
+            const count = await ChromaManager.getKnowledgeBaseCollection()
+                .then(collection => collection.count())
+                .catch(() => null);
+
             return {
-                answer    : "No relevant documents found in the knowledge base.",
+                answer: count === 0
+                    ? "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb')."
+                    : "No relevant documents found in the knowledge base.",
                 references: []
             };
         }

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -279,6 +279,14 @@ If the template evolves and your local file falls out of shape-parity, the
 `npm run prepare -- --migrate-config` to refresh `ai/config.mjs` from the
 template (drops local edits — re-apply them afterward).
 
+Note that `npm install` deliberately does NOT populate the Knowledge Base:
+the release artifact carries pre-computed embedding vectors and weighs
+hundreds of MB, so fetching it is an explicit opt-in. Run
+`npm run ai:download-kb` once (release artifact, no re-embedding) or
+`npm run ai:sync-kb` (build the corpus locally) before relying on
+`ask_knowledge_base`-class tools — an empty collection answers with exactly
+this pointer.
+
 Then start the existing local orchestrator command:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "devindex:spider"              : "node ./apps/devindex/services/cli.mjs spider",
         "devindex:update"              : "node ./apps/devindex/services/cli.mjs update --limit 500",
         "generate-docs-json"           : "node ./buildScripts/docs/jsdocx.mjs",
-        "prepare"                      : "husky && node ./ai/scripts/setup/initServerConfigs.mjs && node ./ai/scripts/maintenance/downloadKnowledgeBase.mjs",
+        "prepare"                      : "husky && node ./ai/scripts/setup/initServerConfigs.mjs",
         "server-start"                 : "webpack serve -c ./buildScripts/webpack/webpack.server.config.mjs --open",
         "test"                         : "playwright test -c test/playwright/playwright.config.mjs",
         "test-components"              : "playwright test -c test/playwright/playwright.config.component.mjs",

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -331,4 +331,55 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
         expect(result.degraded).toBe(true);
         expect(result.degradedCode).toBe('synthesis_timeout');
     });
+
+    test('ask names the download/sync one-liners when the collection is EMPTY (post npm-prepare decouple cold-start)', async () => {
+        const ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
+
+        QueryService.queryDocuments = async () => ({results: []});
+        ChromaManager.getKnowledgeBaseCollection = async () => ({count: async () => 0});
+
+        try {
+            const result = await SearchService.ask({query: 'anything'});
+
+            expect(result.answer).toContain('npm run ai:download-kb');
+            expect(result.answer).toContain('npm run ai:sync-kb');
+            expect(result.references).toEqual([]);
+        } finally {
+            ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+        }
+    });
+
+    test('ask falls back to the generic no-documents answer when the count probe errors', async () => {
+        const ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
+
+        QueryService.queryDocuments = async () => ({results: []});
+        ChromaManager.getKnowledgeBaseCollection = async () => { throw new Error('chroma down'); };
+
+        try {
+            const result = await SearchService.ask({query: 'anything'});
+
+            expect(result.answer).toBe('No relevant documents found in the knowledge base.');
+            expect(result.references).toEqual([]);
+        } finally {
+            ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+        }
+    });
+
+    test('ask keeps the generic no-documents answer when the collection has documents but none match', async () => {
+        const ChromaManager = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        const originalGetCollection = ChromaManager.getKnowledgeBaseCollection;
+
+        QueryService.queryDocuments = async () => ({results: []});
+        ChromaManager.getKnowledgeBaseCollection = async () => ({count: async () => 28398});
+
+        try {
+            const result = await SearchService.ask({query: 'anything'});
+
+            expect(result.answer).toBe('No relevant documents found in the knowledge base.');
+        } finally {
+            ChromaManager.getKnowledgeBaseCollection = originalGetCollection;
+        }
+    });
 });


### PR DESCRIPTION
Resolves #12969
Refs #12967

Authored by Claude Fable 5 (Claude Code). Session e605ce21-3668-445c-bc00-45896aa9a092.

Operator scope decision from the #12967 forensics: the KB release artifact stays exactly as built (pre-computed qwen3-8b vectors, no re-embedding — that is its point), but it leaves the npm `prepare` chain. At 12.1.0's 2.3MB the install-time pull was invisible; at 13.0.0's 583MB (28,398 chunks × 4,096-dim vectors, census on #12967) every fresh checkout, agent workspace, and **the trial deployment's container builds** pay half a gigabyte of registry egress per install.

Three small changes:

1. **`package.json:89`** — `prepare` keeps husky + `initServerConfigs`; the `downloadKnowledgeBase.mjs` member is removed. The opt-in already existed: `npm run ai:download-kb` (`:35`, untouched).
2. **`SearchService#ask`** — an EMPTY collection (the cold-start state every fresh install now has) answers with the explicit pointer (`ai:download-kb` / `ai:sync-kb`) instead of the generic "no relevant documents", via a `ChromaManager.getKnowledgeBaseCollection().count()` probe that degrades to the generic message on any error. Discoverability replaces the removed default.
3. **`DeploymentCookbook.md`** — the fresh-clone section documents the deliberate non-population + the one-liner.

Evidence: L2 (SearchService.spec extended to 13/13 — the empty-collection hint, the count-probe error fallback, and the populated-no-match branch all pinned; `npm run prepare` executed on the branch: runs ONLY husky + initServerConfigs, no KB download — AC1's install-side half demonstrated live). The v13-asset round-trip verification moved to #12967's matrix in cycle 2 (#12969 re-scoped accordingly): the artifact rework's v1-auto-detect import AC inherently verifies v1-asset import, and a live import into the shared unified-Chroma dev instance would be the ⭐ B4 live-DB-bleed hazard — it belongs in #12967's isolated verification setup. The `Resolves`-mandate lint forbids Refs-only close-targets; split is the sanctioned shape (operator rule #12367).

## Deltas

- The AC3 "hint" lands in `ask()` only — the QueryService/list paths return raw shapes consumed programmatically; injecting setup prose there would pollute structured consumers. If a broader surface wants the hint later, it composes on the same count-probe.

## Test Evidence

- `node --check` clean on the touched service; docs + package.json otherwise.
- SearchService.spec 13/13 (the 3 hint branches pinned: count=0 names both one-liners; count-probe error → generic; populated-no-match → generic).
- Suite impact: none (no spec exercises the prepare chain; CI validates the JSON).

## Post-Merge Validation

- [ ] Fresh-clone `npm install` completes with no KB download; `ask` on the empty collection names the one-liner.
- [ ] `npm run ai:download-kb` round-trip — verified under #12967's matrix (isolated Chroma, v1-auto-detect path).
