### PR TITLE
fix(ci): scope-classifier triggers integration only on relevant paths (#12980)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,23 @@ jobs:
               file.startsWith('resources/content/discussions/') ||
               file.startsWith('apps/portal/resources/data/');
 
-            const runIntegration = normalizedFiles.some(file => !isDocsOnlyPath(file));
+            // Whitelist: integration runs only on changes that can affect the integration
+            // stack — engine (src/), Agent OS (ai/, incl. ai/deploy compose), the integration
+            // specs/fixtures + shared test infra, dep manifests, or this workflow. Keep this
+            // COMPLETE — a missed path silently skips integration (false-negative).
+            const isIntegrationRelevantPath = file =>
+              file.startsWith('src/') ||
+              file.startsWith('ai/') ||
+              file.startsWith('test/playwright/integration/') ||
+              file.startsWith('test/playwright/util/') ||
+              file === 'test/playwright/fixtures.mjs' ||
+              file === 'test/playwright/setup.mjs' ||
+              file === 'test/playwright/playwright.config.integration.mjs' ||
+              file === 'package.json' ||
+              file === 'package-lock.json' ||
+              file === '.github/workflows/test.yml';
+
+            const runIntegration = normalizedFiles.some(isIntegrationRelevantPath);
             const runUnit        = normalizedFiles.some(file => !isDocsOnlyPath(file) || requiresUnitForContent(file));
 
             core.info(`Changed files: ${normalizedFiles.join(', ')}`);
@@ -99,7 +115,7 @@ jobs:
             core.setOutput('run_unit', String(runUnit));
             core.setOutput(
               'skip_reason',
-              'docs/content-only change without matching heavy-suite dependency'
+              'change does not touch relevant paths for this suite (docs/content/config or unrelated test suite)'
             );
 
   test:


### PR DESCRIPTION
Resolves #12980

Replaces `test.yml`'s "run integration unless docs-only" blacklist with a whitelist: the integration suite now runs only when a change can actually affect the integration stack. Fixes the operator-flagged friction where a unit-test-only PR (#12976 — a unit spec + a `.md` fixture) triggered the heavy integration suite for no reason.

Authored by Claude Opus 4.8 (Claude Code). Session 3e808a22-50ef-484b-83c9-477ad47e9087.

Evidence: L2 (predicate-logic verification over 9 representative changed-path sets + `ruby -ryaml` parse of the workflow) → L1 required (the AC is the classifier's static path→suite mapping). Residual: observable suite-gating on a real follow-up PR (Post-Merge).

## The change

`run_integration` flips from `some(file => !isDocsOnlyPath(file))` (trigger unless docs-only — so every non-docs path-type defaults to triggering) to `some(isIntegrationRelevantPath)`, where a path is integration-relevant iff it is under:
- `src/` — the engine the Agent-OS stack runs on
- `ai/` — the Agent OS the integration suite exercises (incl. `ai/deploy/docker-compose.test.yml`, the integration Chroma stack)
- `test/playwright/integration/` — the integration specs + fixtures themselves
- `test/playwright/util/` + `fixtures.mjs` / `setup.mjs` / `playwright.config.integration.mjs` — shared test infra integration uses
- `package.json` / `package-lock.json` — dep changes can break the integration stack
- `.github/workflows/test.yml` — CI-logic changes run the full suite to validate

`run_unit` is unchanged.

## Why a *complete* whitelist (not a tight `src/`+`ai/` list)

The prior blacklist over-triggers — wasteful but **safe** (it never misses). A whitelist's failure mode is the opposite and worse: skip-when-it-was-needed → an integration regression merges green. So the membership is deliberately complete (deps, the integration tests themselves, shared infra, CI-logic) to avoid false-negatives. Source-scope verified: the integration suite is Agent-OS/cloud integration (KB tenant-isolation, MCP transport, OIDC, heartbeat, backup/restore, multi-tenant ingestion, daemon safety) under `ai/`, and it runs the engine — `BackupRestoreWipe.integration.spec.mjs` imports `src/Neo.mjs` + `src/core/_export.mjs`.

## Deltas from ticket

None — implements the whitelist exactly as specified in #12980.

## Test Evidence

Predicate logic verified over 9 representative path-sets:
- `#12976` shape (unit spec + `.md` fixture) → **SKIP** integration ✓ (the fix)
- `src/`, `ai/`, `ai/deploy/...compose`, `package.json`, an integration spec, this workflow → **RUN** ✓ (no false-negative)
- docs-only, `resources/content/` → **SKIP** ✓

`ruby -ryaml` parse of `.github/workflows/test.yml` → valid. And this PR changes `test.yml` itself, so by the new rule it runs the full suite (unit + integration) — self-validating.

## Post-Merge Validation

- [ ] A subsequent unit-test-only PR observably **skips** the `integration-unified` check (reports present-but-skipped, not missing — protected-branch gating preserved).
- [ ] A `src/` or `ai/` PR still **runs** `integration-unified`.

## Follow-up (out of scope)

The symmetric `run_unit` per-suite whitelist (so an integration-only/e2e-only change doesn't drag in the unit suite) is the broader root-fix — deferred to bound this PR to the reported integration friction. Worth a follow-up ticket; `run_unit` over-triggers too, but unit is cheap and over-running it is safe.

## Commits

- `a831cbdba` — whitelist `run_integration` + accurate `skip_reason`.
