### PR TITLE
fix(worker): port-resolution fall-through + reply-loss containment (#12958)

### DIFF
--- a/src/worker/Base.mjs
+++ b/src/worker/Base.mjs
@@ -324,12 +324,17 @@ class Worker extends Base {
     }
 
     /**
+     * Port resolution for SharedWorkers is a fall-through cascade over the available routing keys:
+     * direct dest target (windowId or port id) → opts.port → opts.windowId → opts.appName →
+     * last-resort first port (only when no routing key was given at all). A stale key never
+     * short-circuits the cascade. When no live port resolves, the message is NOT sent
+     * and the return value is `undefined` — callers which require delivery must check it.
      * @param {String} dest app, canvas, data, main or vdom (excluding the current worker)
      * @param {Object} opts configs for Neo.worker.Message
      * @param {Array} [transfer] An optional array of Transferable objects to transfer ownership of.
      * If the ownership of an object is transferred, it becomes unusable (neutered) in the context it was sent from
      * and becomes available only to the worker it was sent to.
-     * @returns {Neo.worker.Message}
+     * @returns {Neo.worker.Message|undefined} The sent message, or `undefined` when no live port could be resolved
      * @protected
      */
     sendMessage(dest, opts, transfer) {
@@ -350,23 +355,22 @@ class Worker extends Base {
             // Check if dest is a direct target (Window ID or Port ID)
             portObject = me.getPort({windowId: dest}) || me.getPort({id: dest});
 
+            // Fall through the remaining routing keys on a lookup miss: a stale opts.port
+            // (a port which disconnected between message receipt and reply) must not
+            // short-circuit the cascade — opts.windowId / opts.appName describe the same
+            // logical target and can still resolve its re-registered port.
+            if (!portObject && opts.port)     {portObject = me.getPort({id: opts.port})}
+            if (!portObject && opts.windowId) {portObject = me.getPort({windowId: opts.windowId})}
+            if (!portObject && opts.appName)  {portObject = me.getPort({appName: opts.appName})}
+
             if (portObject) {
                 port      = portObject.port;
                 opts.port = portObject.id
-            } else if (opts.port) {
-                port = me.getPort({id: opts.port}).port
-            } else if (opts.windowId) {
-                portObject = me.getPort({windowId: opts.windowId});
-                port       = portObject?.port;
-
-                opts.port = portObject?.id
-            }  else if (opts.appName) {
-                portObject = me.getPort({appName: opts.appName});
-                port       = portObject?.port;
-
-                opts.port = portObject?.id
-            } else {
-                port = me.ports[0].port
+            } else if (!opts.port && !opts.windowId && !opts.appName) {
+                // Last-resort only when no routing key was given at all: delivering a keyed
+                // message to an arbitrary port would misroute it into a foreign window, which
+                // loses it just as silently as dropping it.
+                port = me.ports[0]?.port
             }
         }
 

--- a/src/worker/mixin/RemoteMethodAccess.mjs
+++ b/src/worker/mixin/RemoteMethodAccess.mjs
@@ -53,7 +53,7 @@ import Base from '../../core/Base.mjs';
  *    For non-singleton instances, `core.Base.initRemote` automatically generates proxy functions and attaches
  *    them to a `this.remote` object on the instance itself (e.g., `this.remote.data.read()`), rather than
  *    broadcasting globally.
- *    
+ *
  *    To establish an instance-to-instance connection, instances must perform a **Handshake**:
  *    - Thread A creates an instance in Thread B (via `worker.createInstance()`), passing its own local ID in the config.
  *    - Thread B instantiates the object, registers it locally, and returns its new local ID to Thread A.
@@ -214,8 +214,8 @@ class RemoteMethodAccess extends Base {
             out, method;
 
         if (!pkg) {
-            throw new Error(msg.remoteId ? 
-                `Invalid remote instance id "${msg.remoteId}"` : 
+            throw new Error(msg.remoteId ?
+                `Invalid remote instance id "${msg.remoteId}"` :
                 `Invalid remote namespace "${msg.remoteClassName}"`
             )
         }
@@ -263,6 +263,8 @@ class RemoteMethodAccess extends Base {
      * Sends a rejection reply back to the caller of a remote method.
      * Used when the execution of the remote method fails or throws an error.
      * It ensures the reply is routed back to the correct origin (windowId or worker).
+     * Delivery is containment-guarded via sendReply() — a failed send cannot throw back
+     * into the execution path.
      *
      * @param {Object} msg The original message object.
      * @param {Object} data The error data to send back.
@@ -285,13 +287,15 @@ class RemoteMethodAccess extends Base {
             }
         }
 
-        me.sendMessage(msg.origin, opts)
+        me.sendReply(msg, opts)
     }
 
     /**
      * Sends a success reply back to the caller of a remote method.
      * Used when the remote method executes successfully.
      * It handles the transfer of transferable objects (like ArrayBuffers) and ensures correct routing.
+     * Delivery is containment-guarded via sendReply() — a failed send cannot throw back
+     * into the execution path.
      *
      * @param {Object} msg The original message object.
      * @param {Object} data The result data to send back.
@@ -320,7 +324,45 @@ class RemoteMethodAccess extends Base {
             }
         }
 
-        me.sendMessage(msg.origin, opts, transfer)
+        me.sendReply(msg, opts, transfer)
+    }
+
+    /**
+     * Posts a reply message with loss containment: a reply which cannot be routed or sent
+     * (disconnected port, clone error) must never throw back into the remote-method execution
+     * path — an escaped exception here makes replies vanish and wedges the caller-side promise
+     * forever (`isVdomUpdating` stuck `true`, `vnode: null`, blank app, zero errors).
+     * The failure is logged with its full routing context instead, so the update watchdog and
+     * the console make the loss diagnosable.
+     * @param {Object} msg The original message object
+     * @param {Object} opts The reply options (action, data, replyId, routing keys)
+     * @param {Array|null} [transfer=null] An optional array of Transferable objects
+     * @protected
+     */
+    sendReply(msg, opts, transfer=null) {
+        let message;
+
+        try {
+            message = this.sendMessage(msg.origin, opts, transfer)
+        } catch (err) {
+            console.error('[RemoteMethodAccess] Reply send failed — the caller-side promise will not settle', {
+                destination: msg.origin,
+                error      : err,
+                port       : opts.port,
+                replyId    : opts.replyId,
+                windowId   : opts.windowId
+            });
+            return
+        }
+
+        if (!message) {
+            console.error('[RemoteMethodAccess] Reply not routable (no live port) — the caller-side promise will not settle', {
+                destination: msg.origin,
+                port       : opts.port,
+                replyId    : opts.replyId,
+                windowId   : opts.windowId
+            })
+        }
     }
 }
 

--- a/test/playwright/unit/worker/ReplyLoss.spec.mjs
+++ b/test/playwright/unit/worker/ReplyLoss.spec.mjs
@@ -1,0 +1,204 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ReplyLossTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import WorkerBase     from '../../../../src/worker/Base.mjs';
+
+/**
+ * @summary Regression net for worker reply loss on a null port lookup (the blank-app init wedge).
+ *
+ * The defect family: a SharedWorker reply whose `opts.port` referenced a port which disconnected
+ * (or was not yet registered) between message receipt and reply threw a `TypeError` inside
+ * `sendMessage`, the exception escaped `resolve()` / `reject()`, the reply never posted, and the
+ * caller-side promise never settled — `isVdomUpdating` stuck `true`, `vnode: null`, blank app,
+ * zero errors (Electron-deterministic, 3/3).
+ *
+ * Pinned contracts:
+ * 1. Port resolution falls through the routing keys (`opts.port` → `opts.windowId` → `opts.appName`)
+ *    instead of short-circuiting on a stale key — a reply with a live sibling key gets DELIVERED.
+ * 2. A keyed message with no resolvable route returns `undefined` without throwing and is never
+ *    misrouted into a foreign window's port.
+ * 3. `resolve()` / `reject()` cannot throw on a dead route; the loss is logged with routing context.
+ */
+class ReplyLossWorker extends WorkerBase {
+    static config = {
+        className: 'Test.Unit.Worker.ReplyLossWedgeWorker'
+    }
+
+    construct(config) {
+        super.construct(config);
+        // Simulate the SharedWorker environment BEFORE onConstructed() runs, so the
+        // dedicated-worker 'workerConstructed' announcement (which needs a main thread)
+        // never fires inside the single-threaded unit env.
+        this.isSharedWorker = true
+    }
+}
+Neo.setupClass(ReplyLossWorker);
+
+const createCapturingPort = () => {
+    const sent = [];
+
+    return {
+        sent,
+        port: {
+            postMessage(message) {
+                sent.push(message)
+            }
+        }
+    }
+};
+
+const createSharedWorker = portSpecs => {
+    const worker = Neo.create(ReplyLossWorker, {workerId: 'reply-loss-test'});
+
+    worker.ports.push(...portSpecs);
+
+    return worker
+};
+
+test.describe('Worker reply loss on null port lookup (#12958)', () => {
+    test('sendMessage: a stale opts.port falls through to the windowId lookup (reply rescued)', () => {
+        const {port, sent} = createCapturingPort();
+        const worker       = createSharedWorker([
+            {appName: 'ReplyLossApp', id: 'port-fresh', port, windowId: 'win-1'}
+        ]);
+
+        // dest 'app' resolves no direct port (no worker channel yet — the init race);
+        // opts.port is stale; opts.windowId still names the same logical target.
+        const message = worker.sendMessage('app', {
+            action  : 'reply',
+            port    : 'port-stale',
+            replyId : 'q-1',
+            windowId: 'win-1'
+        });
+
+        expect(message).toBeDefined();
+        expect(sent.length).toBe(1);
+        expect(sent[0].replyId).toBe('q-1');
+        expect(sent[0].port).toBe('port-fresh') // re-keyed to the live port id
+    });
+
+    test('sendMessage: a stale opts.port falls through to the appName lookup', () => {
+        const {port, sent} = createCapturingPort();
+        const worker       = createSharedWorker([
+            {appName: 'ReplyLossApp', id: 'port-fresh', port, windowId: 'win-1'}
+        ]);
+
+        const message = worker.sendMessage('app', {
+            action : 'reply',
+            appName: 'ReplyLossApp',
+            port   : 'port-stale',
+            replyId: 'q-2'
+        });
+
+        expect(message).toBeDefined();
+        expect(sent.length).toBe(1);
+        expect(sent[0].replyId).toBe('q-2')
+    });
+
+    test('sendMessage: a keyed message with no resolvable route returns undefined without throwing and never misroutes', () => {
+        const {port, sent} = createCapturingPort();
+        const worker       = createSharedWorker([
+            {appName: 'OtherApp', id: 'port-other', port, windowId: 'win-other'}
+        ]);
+
+        let message;
+
+        expect(() => {
+            message = worker.sendMessage('app', {
+                action  : 'reply',
+                port    : 'port-stale',
+                replyId : 'q-3',
+                windowId: 'win-gone'
+            })
+        }).not.toThrow();
+
+        expect(message).toBeUndefined();
+        expect(sent.length).toBe(0) // a keyed reply must not land in a foreign window's port
+    });
+
+    test('sendMessage: a keyless message with no connected ports returns undefined without throwing', () => {
+        const worker = createSharedWorker([]);
+
+        let message;
+
+        expect(() => {
+            message = worker.sendMessage('app', {action: 'reply', replyId: 'q-4'})
+        }).not.toThrow();
+
+        expect(message).toBeUndefined()
+    });
+
+    test('sendMessage: a keyless message still uses the last-resort first port', () => {
+        const {port, sent} = createCapturingPort();
+        const worker       = createSharedWorker([
+            {appName: 'ReplyLossApp', id: 'port-fresh', port, windowId: 'win-1'}
+        ]);
+
+        const message = worker.sendMessage('app', {action: 'reply', replyId: 'q-5'});
+
+        expect(message).toBeDefined();
+        expect(sent.length).toBe(1);
+        expect(sent[0].replyId).toBe('q-5')
+    });
+
+    test('resolve(): a dead reply route cannot throw and logs the loss with routing context', () => {
+        const worker        = createSharedWorker([]);
+        const errors        = [];
+        const originalError = console.error;
+
+        console.error = (...args) => errors.push(args);
+
+        try {
+            expect(() => {
+                worker.resolve({id: 'q-6', origin: 'app', port: 'port-stale', windowId: 'win-gone'}, {ok: true})
+            }).not.toThrow()
+        } finally {
+            console.error = originalError
+        }
+
+        expect(errors.length).toBe(1);
+        expect(errors[0][0]).toContain('will not settle');
+        expect(errors[0][1].replyId).toBe('q-6')
+    });
+
+    test('reject(): a dead reply route cannot throw and logs the loss with routing context', () => {
+        const worker        = createSharedWorker([]);
+        const errors        = [];
+        const originalError = console.error;
+
+        console.error = (...args) => errors.push(args);
+
+        try {
+            expect(() => {
+                worker.reject({id: 'q-7', origin: 'app', port: 'port-stale', windowId: 'win-gone'}, new Error('remote failed'))
+            }).not.toThrow()
+        } finally {
+            console.error = originalError
+        }
+
+        expect(errors.length).toBe(1);
+        expect(errors[0][0]).toContain('will not settle');
+        expect(errors[0][1].replyId).toBe('q-7')
+    });
+
+    test('resolve(): a live route still delivers the reply (no regression)', () => {
+        const {port, sent} = createCapturingPort();
+        const worker       = createSharedWorker([
+            {appName: 'ReplyLossApp', id: 'port-fresh', port, windowId: 'win-1'}
+        ]);
+
+        worker.resolve({id: 'q-8', origin: 'app', port: 'port-stale', windowId: 'win-1'}, {ok: true});
+
+        expect(sent.length).toBe(1);
+        expect(sent[0].replyId).toBe('q-8');
+        expect(sent[0].reject).toBeUndefined()
+    });
+});


### PR DESCRIPTION
Resolves #12958

Authored by Claude Fable 5 (Claude Code, @neo-fable-clio). Session 3e1566f6-6336-4db4-8726-189004578d8b.

A SharedWorker reply whose `opts.port` referenced a disconnected/never-registered port threw a `TypeError` at the single null-unsafe lookup in `worker.Base#sendMessage` (the old line 357), the exception escaped `resolve()`/`reject()` (no containment), the reply never posted, and the caller-side promise never settled — `isVdomUpdating` stuck `true`, `vnode: null`, blank app, zero errors. Electron Chrome/146 deterministic at init (3/3 per #12958 + @neo-fable's comment).

**What shipped (one design upgrade beyond the ticket's minimum, rationale below):**
1. **Fall-through routing cascade** in `sendMessage` — the ticket prescribed `?.`-null-safety matching the sibling lines. Reading the cascade whole showed the deeper defect: a stale `opts.port` *short-circuited* the `else if` chain, so the `windowId`/`appName` keys (which `assignPort` copies onto every reply and which describe the *same logical target*) were never consulted. The fix falls through on lookup misses: `opts.port` → `opts.windowId` → `opts.appName`. This converts the init-race from reply-loss into **successful delivery** via the window's re-registered port — the AC2-preferred outcome (app renders) instead of merely failing loud.
2. **Misroute guard**: the last-resort `ports[0]` fallback now fires only for *keyless* messages — delivering a keyed reply to an arbitrary port would misroute it into a foreign window (lost just as silently as dropped). Also null-safed (`ports[0]?.port`, same defect class).
3. **`RemoteMethodAccess#sendReply` (new)** — containment-guarded reply posting shared by `resolve()`/`reject()`: a throwing or unroutable send can no longer escape into the remote-method execution path; the loss is logged with full routing context (`destination`, `replyId`, `port`, `windowId`), so the #12956 watchdog + console make any residual loss diagnosable. `sendMessage` returns `undefined` when unroutable; `sendReply` checks it.

**AC3 (env correlation):** the wedge required (a) SharedWorker mode, (b) an init-time reply whose port-id lookup missed — a port-registration timing race that Chrome/146 Electron hits deterministically and Chrome/149 does not, and (c) total silence, because the throw escaped `resolve()` and (per @neo-claude-opus's comment) a backgrounded pane pauses the watchdog timers that would have named the wedge. Documented as environmental timing; the structural fix makes the timing irrelevant — a missed id-lookup now falls through and delivers.

Evidence: L3 (live Electron Chrome/146 preview render on both reproducer surfaces + L2 red→green unit net) → L3 required (AC2 names the agent-preview runtime surface). No residuals.

## Deltas from ticket
- Fall-through cascade instead of bare `?.` (rationale in item 1 — strictly more robust, zero behavior change when lookups hit; pinned by unit tests).
- Adjacent observation, deliberately NOT bundled: `onRemoteMethod`'s promise chain is `.catch(err => reject(msg, err)).then(data => resolve(msg, data))` — after a caught rejection the `.then` still fires and posts a second `resolve(msg, undefined)` reply for the same `replyId`. Real but unverified-in-effect (caller-side presumably drops the unknown replyId); follow-up-ticket material, out of scope here.

## Test Evidence
- `test/playwright/unit/worker/ReplyLoss.spec.mjs` (new, 8 specs): pins the cascade (stale-port→windowId rescue, appName fall-through, keyed-no-route returns undefined without throwing AND without misrouting, keyless last-resort preserved) + containment (`resolve()`/`reject()` cannot throw on dead routes, loud structured log) + live-route regression sanity.
- **Red proof**: with the src fix stashed, 7/8 fail on pre-fix code — including the live-route delivery case: the old code threw away a *deliverable* reply that had a valid `windowId` route. That is the wedge in one test.
- **Full unit suite**: 3221 passed on the branch vs 3213 on clean dev (delta = exactly the 8 new specs); identical skip/did-not-run/env-flake shape on both runs (baseline parity — the env-dependent AI-service reds are local-machine characteristics, present on clean dev).
- **AC2 live repro (the 3/3-deterministic env)**: Electron Chrome/146 preview, fresh session — `examples/grid/lockedColumns` renders (27 rows / 72 cells) AND `apps/portal` renders under `useSharedWorkers: true` (the exact code path), zero console errors. The wedge signature (`isVdomUpdating` stuck / `vnode: null` / blank body) did not manifest on either surface.

## Post-Merge Validation
- [ ] Agent preview environments (Electron Chrome/146) stop producing the blank-app-at-boot friction class across fresh sessions (the long-observed "worker alive, DOM dead" reports).
- [ ] No `[RemoteMethodAccess] Reply not routable` logs in healthy single-window sessions (its presence would indicate a genuinely dead route, now loud instead of silent).