### PR TITLE
feat(vdom): delta-grammar kernel — op vocabulary + universal batch predicates (#12987)

### DIFF
--- a/src/vdom/util/DeltaGrammar.mjs
+++ b/src/vdom/util/DeltaGrammar.mjs
@@ -1,0 +1,388 @@
+/**
+ * The delta-stream wire contract, as a consumable vocabulary plus universal batch predicates.
+ *
+ * Every DOM change in Neo crosses the VDom→Main boundary as a serialized JSON delta. This module
+ * names that wire format's grammar — the action set, per-action field contracts, sentinel
+ * encodings, the reserved-target id allowlist, and the three-sorted id space — and provides
+ * pure, never-throwing predicates over a delta batch for the invariants which hold universally
+ * (independent of which feature operation produced the batch).
+ *
+ * **Plain-module discipline:** like `src/vdom/domConstants.mjs`, this file exports plain data and
+ * functions with no class lifecycle and no `Neo` globals required at import time, so it is equally
+ * importable from the Main thread, the VDom worker, and the Node unit-test environment.
+ *
+ * **Boundary semantics this module encodes (but does not modify):**
+ * - The consumer dispatches by `delta.action || 'updateNode'` — an absent `action` IS the wire
+ *   spelling of `updateNode`, and it is the dominant spelling: the differ never sets `action`
+ *   on attribute/class/style/content updates.
+ * - `updateNode` resolves its target via a body-defaulting lookup: an `undefined` id silently
+ *   targets `document.body`. The U4 predicate exists to make that misdirection visible — an
+ *   updateNode must either carry an explicit id or name a reserved target on purpose.
+ * - The producer keeps two queues and concatenates `default` then `remove`, because removed
+ *   trees can contain nodes which concurrently move out of them — so within one batch, no
+ *   `removeNode` may precede a non-remove delta (U3).
+ * - Validators must never throw: an exception escaping mid-batch leaves the DOM partially
+ *   applied while the worker's vnode model assumes full application — the precise stale-baseline
+ *   hazard a grammar layer exists to prevent. Predicates return findings; callers decide.
+ * @module vdom/util/DeltaGrammar
+ */
+
+/**
+ * The complete set of consumer-dispatched delta actions.
+ * @type {Set<String>}
+ */
+export const ACTIONS = new Set([
+    'focusNode',
+    'insertNode',
+    'moveNode',
+    'removeAll',
+    'removeNode',
+    'replaceChild',
+    'updateNode',
+    'updateVtext'
+]);
+
+/**
+ * The action a delta resolves to when its `action` property is absent.
+ * The differ emits its attribute/class/style/content updates without an `action` key,
+ * so this implicit spelling is the most common form on the wire.
+ * @type {String}
+ */
+export const IMPLICIT_ACTION = 'updateNode';
+
+/**
+ * Target ids which resolve to global objects instead of element lookups.
+ * An updateNode naming one of these is an intentional global write — anything else
+ * must carry an explicit element id (see `checkExplicitTarget`).
+ * @type {Set<String>}
+ */
+export const RESERVED_TARGET_IDS = new Set([
+    'body',
+    'document',
+    'document.body',
+    'window'
+]);
+
+/**
+ * The three sorts of the delta id space. An id's sort is NOT recoverable from the id string —
+ * it is determined by how the node was rendered:
+ * - `element`: a real DOM element, resolvable via id lookup.
+ * - `fragment`: a comment-anchored RANGE (`<!-- id-start -->` … `<!-- id-end -->`) with no
+ *   single DOM node; insert/move/remove address it via its parent + anchors.
+ * - `vtext`: a text node wrapped in a comment pair carrying the id.
+ * Existence checks against the document therefore depend on the sort: a failed element lookup
+ * does not imply the id is not live. Classifying an arbitrary id requires live-tree context
+ * and is deliberately outside this module's scope.
+ * @type {Object}
+ */
+export const ID_SORTS = Object.freeze({
+    element : 'element',
+    fragment: 'fragment',
+    vtext   : 'vtext'
+});
+
+/**
+ * Per-action field contracts.
+ * - `required`: fields every well-formed delta of this action carries.
+ * - `payloadOneOf`: exactly one of these fields must be present (renderer-dependent for
+ *   insertNode: the DomApi renderer consumes `vnode`, the string-based renderer `outerHTML`).
+ * - `optional`: fields with documented conditional meaning. `removeNode.parentId` is REQUIRED
+ *   when the id is fragment- or vtext-sorted (the comment-anchor removal paths need the parent)
+ *   — a condition which needs live context and is therefore documented here, not enforced by U2.
+ * - `targetRule: 'explicit-or-reserved'`: the action resolves an id-less delta against
+ *   `document.body`; U4 owns the check.
+ * - `addressableSorts`: which id sorts the action's consumer paths can address.
+ * @type {Object}
+ */
+export const FIELD_CONTRACTS = Object.freeze({
+    focusNode: Object.freeze({
+        addressableSorts: [ID_SORTS.element],
+        required        : ['id']
+    }),
+    insertNode: Object.freeze({
+        addressableSorts: [ID_SORTS.element, ID_SORTS.fragment],
+        // `id` is emitted by some manual producers and ignored by the consumer —
+        // the inserted node's identity lives inside `vnode.id` / the HTML string.
+        optional        : ['hasLeadingTextChildren', 'id', 'postMountUpdates'],
+        payloadOneOf    : ['vnode', 'outerHTML'],
+        required        : ['index', 'parentId']
+    }),
+    moveNode: Object.freeze({
+        addressableSorts: [ID_SORTS.element, ID_SORTS.fragment],
+        required        : ['id', 'index', 'parentId']
+    }),
+    removeAll: Object.freeze({
+        addressableSorts: [ID_SORTS.element],
+        required        : ['parentId']
+    }),
+    removeNode: Object.freeze({
+        addressableSorts: [ID_SORTS.element, ID_SORTS.fragment, ID_SORTS.vtext],
+        optional        : ['parentId'],
+        required        : ['id']
+    }),
+    replaceChild: Object.freeze({
+        addressableSorts: [ID_SORTS.element],
+        required        : ['fromId', 'parentId', 'toId']
+    }),
+    updateNode: Object.freeze({
+        addressableSorts: [ID_SORTS.element],
+        required        : [],
+        targetRule      : 'explicit-or-reserved'
+    }),
+    updateVtext: Object.freeze({
+        addressableSorts: [ID_SORTS.vtext],
+        required        : ['id', 'parentId', 'value']
+    })
+});
+
+/**
+ * The actions which mutate tree structure (as opposed to mutating a node in place).
+ * Used by the U5 candidate predicate.
+ * @type {Set<String>}
+ */
+export const STRUCTURAL_ACTIONS = new Set([
+    'insertNode',
+    'moveNode',
+    'removeNode',
+    'replaceChild'
+]);
+
+/**
+ * Inside `updateNode.attributes`, these values are in-band deletion sentinels: the consumer
+ * removes the attribute instead of writing the value. Exception: the `value` pseudo-attribute
+ * of input fields is cleared (set to `''`), never removed. Void attributes (e.g. `checked`)
+ * are boolean-coerced from their string form.
+ * @type {ReadonlyArray<null|String>}
+ */
+export const ATTRIBUTE_REMOVAL_SENTINELS = Object.freeze([null, '']);
+
+/**
+ * Resolves a delta's effective action, applying the implicit-updateNode wire spelling.
+ * @param {Object} delta
+ * @returns {String|undefined} The effective action, or `undefined` for a non-object delta
+ */
+export function resolveAction(delta) {
+    if (!delta || typeof delta !== 'object') {
+        return undefined
+    }
+
+    return delta.action || IMPLICIT_ACTION
+}
+
+/**
+ * Normalizes the consumer's accepted input shapes (a single delta object or an array)
+ * into an array, mirroring the dispatch boundary's own normalization.
+ * @param {Object|Object[]} deltas
+ * @returns {Object[]}
+ */
+export function normalizeBatch(deltas) {
+    if (Array.isArray(deltas)) {
+        return deltas
+    }
+
+    return deltas && typeof deltas === 'object' ? [deltas] : []
+}
+
+/**
+ * U1 — action validity. Every delta's effective action must be a member of the dispatched
+ * action set. An unknown action string is not ignored by the consumer: it aborts the batch
+ * mid-loop, leaving every prior delta applied — the partial-application hazard.
+ * @param {Object|Object[]} deltas
+ * @returns {Object[]} findings `{rule: 'U1', deltaIndex, detail}`
+ */
+export function checkActionValidity(deltas) {
+    const findings = [];
+
+    normalizeBatch(deltas).forEach((delta, deltaIndex) => {
+        const action = resolveAction(delta);
+
+        if (!delta || typeof delta !== 'object') {
+            findings.push({rule: 'U1', deltaIndex, detail: 'delta is not an object'})
+        } else if (!ACTIONS.has(action)) {
+            findings.push({rule: 'U1', deltaIndex, detail: `unknown action "${delta.action}"`})
+        }
+    });
+
+    return findings
+}
+
+/**
+ * U2 — per-action required fields.
+ * For `insertNode`, the payload contract is renderer-dependent: pass
+ * `opts.useDomApiRenderer` to pin the expected payload key (`vnode` for `true`,
+ * `outerHTML` for `false`); without the flag, exactly one of the two must be present.
+ * @param {Object|Object[]} deltas
+ * @param {Object} [opts]
+ * @param {Boolean} [opts.useDomApiRenderer] Pins the insertNode payload key when given
+ * @returns {Object[]} findings `{rule: 'U2', deltaIndex, detail}`
+ */
+export function checkRequiredFields(deltas, opts = {}) {
+    const findings = [];
+
+    normalizeBatch(deltas).forEach((delta, deltaIndex) => {
+        const action = resolveAction(delta);
+
+        if (!delta || typeof delta !== 'object' || !ACTIONS.has(action)) {
+            return // U1 territory; do not double-report
+        }
+
+        const contract = FIELD_CONTRACTS[action];
+
+        contract.required.forEach(field => {
+            if (delta[field] === undefined || delta[field] === null) {
+                findings.push({rule: 'U2', deltaIndex, detail: `${action} is missing required field "${field}"`})
+            }
+        });
+
+        if (contract.payloadOneOf) {
+            const present = contract.payloadOneOf.filter(field => delta[field] !== undefined && delta[field] !== null);
+
+            // Carrying BOTH payload keys is legal (manual producers do; the consumer picks by
+            // renderer config) — the defect classes are "none at all" and "missing the key the
+            // pinned renderer will actually consume".
+            if (opts.useDomApiRenderer === true && !present.includes('vnode')) {
+                findings.push({rule: 'U2', deltaIndex, detail: `${action} requires "vnode" under the DomApi renderer`})
+            } else if (opts.useDomApiRenderer === false && !present.includes('outerHTML')) {
+                findings.push({rule: 'U2', deltaIndex, detail: `${action} requires "outerHTML" under the string-based renderer`})
+            } else if (opts.useDomApiRenderer === undefined && present.length === 0) {
+                findings.push({
+                    rule      : 'U2',
+                    deltaIndex,
+                    detail    : `${action} requires at least one of ${contract.payloadOneOf.join(', ')}`
+                })
+            }
+        }
+    });
+
+    return findings
+}
+
+/**
+ * U3 — remove-last ordering. The producer emits its `default` queue (inserts, moves, updates)
+ * followed by its `remove` queue, because a removed tree can contain nodes which concurrently
+ * move out of it. Within one batch, a `removeNode` must therefore never precede a
+ * non-`removeNode` delta. (`removeAll` is a children-clearing write belonging to the default
+ * queue, not part of the remove tail.)
+ * @param {Object|Object[]} deltas
+ * @returns {Object[]} findings `{rule: 'U3', deltaIndex, detail}`
+ */
+export function checkRemoveLastOrdering(deltas) {
+    const findings = [];
+
+    let removeTailStartedAt = null;
+
+    normalizeBatch(deltas).forEach((delta, deltaIndex) => {
+        const action = resolveAction(delta);
+
+        if (action === 'removeNode') {
+            removeTailStartedAt ??= deltaIndex
+        } else if (removeTailStartedAt !== null && ACTIONS.has(action)) {
+            findings.push({
+                rule      : 'U3',
+                deltaIndex,
+                detail    : `${action} follows the removeNode tail which started at index ${removeTailStartedAt}`
+            })
+        }
+    });
+
+    return findings
+}
+
+/**
+ * U4 — explicit-target updateNode. The consumer resolves an updateNode's target through a
+ * body-defaulting lookup: an `undefined` id silently writes to `document.body`. A well-formed
+ * updateNode therefore either carries an explicit non-empty string id, or names a reserved
+ * global target on purpose.
+ * @param {Object|Object[]} deltas
+ * @returns {Object[]} findings `{rule: 'U4', deltaIndex, detail}`
+ */
+export function checkExplicitTarget(deltas) {
+    const findings = [];
+
+    normalizeBatch(deltas).forEach((delta, deltaIndex) => {
+        if (resolveAction(delta) !== 'updateNode' || !delta || typeof delta !== 'object') {
+            return
+        }
+
+        const {id} = delta;
+
+        if (typeof id !== 'string' || id === '') {
+            findings.push({
+                rule      : 'U4',
+                deltaIndex,
+                detail    : 'updateNode without an explicit id silently targets document.body'
+            })
+        }
+    });
+
+    return findings
+}
+
+/**
+ * U5 (CANDIDATE) — within-batch structural uniqueness: at most one structural delta
+ * (insertNode, moveNode, removeNode, replaceChild) per node id per batch. The differ
+ * accumulates all of a node's in-place changes into a single updateNode, and the pooled
+ * rendering architecture never double-touches an id within one batch — but manually
+ * constructed multi-producer batches are unproven territory, so this predicate is exported
+ * for measurement and is NOT part of `validateBatch`'s default rule set. Promotion to
+ * guard-grade requires a falsification run over real-world batches first.
+ * For insertNode (which carries no top-level id), the identity is taken from `vnode.id`
+ * when present; string-rendered inserts without a vnode are skipped.
+ * @param {Object|Object[]} deltas
+ * @returns {Object[]} findings `{rule: 'U5', deltaIndex, detail}`
+ */
+export function checkStructuralUniqueness(deltas) {
+    const findings = [],
+          seen     = new Map();
+
+    normalizeBatch(deltas).forEach((delta, deltaIndex) => {
+        const action = resolveAction(delta);
+
+        if (!STRUCTURAL_ACTIONS.has(action)) {
+            return
+        }
+
+        const id = delta?.id ?? delta?.vnode?.id;
+
+        if (typeof id !== 'string' || id === '') {
+            return
+        }
+
+        if (seen.has(id)) {
+            findings.push({
+                rule      : 'U5',
+                deltaIndex,
+                detail    : `structural ${action} for id "${id}" already touched structurally at index ${seen.get(id)}`
+            })
+        } else {
+            seen.set(id, deltaIndex)
+        }
+    });
+
+    return findings
+}
+
+checkStructuralUniqueness.candidate = true;
+
+/**
+ * Runs the guard-grade universal predicates (U1–U4) over a batch and aggregates their findings.
+ * U5 is a measurement candidate and deliberately excluded — run `checkStructuralUniqueness`
+ * directly when collecting evidence for its promotion.
+ *
+ * Never throws; designed to run BEFORE the first delta applies, so a caller can reject a
+ * grammatically illegal batch atomically instead of discovering the violation mid-application.
+ * @param {Object|Object[]} deltas A delta batch (array) or a single delta object
+ * @param {Object} [opts]
+ * @param {Boolean} [opts.useDomApiRenderer] Pins the insertNode payload contract when given
+ * @returns {Object} `{valid: Boolean, findings: Object[]}`
+ */
+export function validateBatch(deltas, opts = {}) {
+    const findings = [
+        ...checkActionValidity(deltas),
+        ...checkRequiredFields(deltas, opts),
+        ...checkRemoveLastOrdering(deltas),
+        ...checkExplicitTarget(deltas)
+    ];
+
+    return {valid: findings.length === 0, findings}
+}

--- a/src/vdom/util/DeltaGrammar.mjs
+++ b/src/vdom/util/DeltaGrammar.mjs
@@ -84,8 +84,10 @@ export const ID_SORTS = Object.freeze({
 /**
  * Per-action field contracts.
  * - `required`: fields every well-formed delta of this action carries.
- * - `payloadOneOf`: exactly one of these fields must be present (renderer-dependent for
- *   insertNode: the DomApi renderer consumes `vnode`, the string-based renderer `outerHTML`).
+ * - `payloadAnyOf`: at least one of these fields must be present. Carrying BOTH is legal —
+ *   manual producers do, and the consumer picks by renderer config (the DomApi renderer
+ *   consumes `vnode`, the string-based renderer `outerHTML`). When the renderer is pinned,
+ *   the active renderer's key must be present.
  * - `optional`: fields with documented conditional meaning. `removeNode.parentId` is REQUIRED
  *   when the id is fragment- or vtext-sorted (the comment-anchor removal paths need the parent)
  *   — a condition which needs live context and is therefore documented here, not enforced by U2.
@@ -104,7 +106,7 @@ export const FIELD_CONTRACTS = Object.freeze({
         // `id` is emitted by some manual producers and ignored by the consumer —
         // the inserted node's identity lives inside `vnode.id` / the HTML string.
         optional        : ['hasLeadingTextChildren', 'id', 'postMountUpdates'],
-        payloadOneOf    : ['vnode', 'outerHTML'],
+        payloadAnyOf    : ['vnode', 'outerHTML'],
         required        : ['index', 'parentId']
     }),
     moveNode: Object.freeze({
@@ -171,16 +173,16 @@ export function resolveAction(delta) {
 
 /**
  * Normalizes the consumer's accepted input shapes (a single delta object or an array)
- * into an array, mirroring the dispatch boundary's own normalization.
+ * into an array, mirroring the dispatch boundary's own normalization EXACTLY: any
+ * non-array input is wrapped, including `null` / `undefined` / primitives — because that
+ * is what the runtime does before dereferencing `delta.action` on each entry. A wrapped
+ * garbage entry then surfaces as a U1 finding (the runtime equivalent is a throw), instead
+ * of vanishing into a false-valid empty batch.
  * @param {Object|Object[]} deltas
  * @returns {Object[]}
  */
 export function normalizeBatch(deltas) {
-    if (Array.isArray(deltas)) {
-        return deltas
-    }
-
-    return deltas && typeof deltas === 'object' ? [deltas] : []
+    return Array.isArray(deltas) ? deltas : [deltas]
 }
 
 /**
@@ -210,7 +212,8 @@ export function checkActionValidity(deltas) {
  * U2 — per-action required fields.
  * For `insertNode`, the payload contract is renderer-dependent: pass
  * `opts.useDomApiRenderer` to pin the expected payload key (`vnode` for `true`,
- * `outerHTML` for `false`); without the flag, exactly one of the two must be present.
+ * `outerHTML` for `false`); without the flag, at least one of the two must be
+ * present (carrying both is legal — the consumer disambiguates by config).
  * @param {Object|Object[]} deltas
  * @param {Object} [opts]
  * @param {Boolean} [opts.useDomApiRenderer] Pins the insertNode payload key when given
@@ -234,8 +237,8 @@ export function checkRequiredFields(deltas, opts = {}) {
             }
         });
 
-        if (contract.payloadOneOf) {
-            const present = contract.payloadOneOf.filter(field => delta[field] !== undefined && delta[field] !== null);
+        if (contract.payloadAnyOf) {
+            const present = contract.payloadAnyOf.filter(field => delta[field] !== undefined && delta[field] !== null);
 
             // Carrying BOTH payload keys is legal (manual producers do; the consumer picks by
             // renderer config) — the defect classes are "none at all" and "missing the key the
@@ -248,7 +251,7 @@ export function checkRequiredFields(deltas, opts = {}) {
                 findings.push({
                     rule      : 'U2',
                     deltaIndex,
-                    detail    : `${action} requires at least one of ${contract.payloadOneOf.join(', ')}`
+                    detail    : `${action} requires at least one of ${contract.payloadAnyOf.join(', ')}`
                 })
             }
         }

--- a/test/playwright/unit/vdom/DeltaGrammar.spec.mjs
+++ b/test/playwright/unit/vdom/DeltaGrammar.spec.mjs
@@ -1,0 +1,241 @@
+import {test, expect} from '@playwright/test';
+import {
+    ACTIONS,
+    ATTRIBUTE_REMOVAL_SENTINELS,
+    FIELD_CONTRACTS,
+    ID_SORTS,
+    IMPLICIT_ACTION,
+    RESERVED_TARGET_IDS,
+    STRUCTURAL_ACTIONS,
+    checkActionValidity,
+    checkExplicitTarget,
+    checkRemoveLastOrdering,
+    checkRequiredFields,
+    checkStructuralUniqueness,
+    normalizeBatch,
+    resolveAction,
+    validateBatch
+} from '../../../../src/vdom/util/DeltaGrammar.mjs';
+
+/**
+ * @summary Pins the delta-stream wire vocabulary and the universal batch predicates.
+ *
+ * The exemplar batches mirror the real producer shapes: the differ's action-less updateNode
+ * accumulation, payload-split insertNode (vnode vs outerHTML by renderer), the conditional
+ * removeNode parentId for comment-anchored sorts, and the remove-last two-queue ordering.
+ * Findings are asserted by rule identity and presence — never by exact counts of unrelated
+ * rules — so the spec survives vocabulary growth.
+ *
+ * Note this spec imports the module directly WITHOUT the shared setup helper: the kernel's
+ * pure-module discipline (no Neo globals at import time) is itself one of the pinned contracts.
+ */
+
+const rulesOf = findings => findings.map(finding => finding.rule);
+
+test.describe('DeltaGrammar vocabulary', () => {
+    test('names the complete dispatched action set', () => {
+        expect([...ACTIONS].sort()).toEqual([
+            'focusNode', 'insertNode', 'moveNode', 'removeAll',
+            'removeNode', 'replaceChild', 'updateNode', 'updateVtext'
+        ]);
+
+        expect(IMPLICIT_ACTION).toBe('updateNode')
+    });
+
+    test('resolveAction applies the implicit-updateNode wire spelling', () => {
+        expect(resolveAction({id: 'neo-1', style: {color: 'red'}})).toBe('updateNode');
+        expect(resolveAction({action: 'moveNode', id: 'neo-1'})).toBe('moveNode');
+        expect(resolveAction(null)).toBeUndefined()
+    });
+
+    test('every action carries a field contract with addressable id sorts', () => {
+        [...ACTIONS].forEach(action => {
+            const contract = FIELD_CONTRACTS[action];
+
+            expect(contract).toBeDefined();
+            expect(Array.isArray(contract.required)).toBe(true);
+            expect(contract.addressableSorts.length).toBeGreaterThan(0);
+            contract.addressableSorts.forEach(sort => {
+                expect(Object.values(ID_SORTS)).toContain(sort)
+            })
+        })
+    });
+
+    test('exposes the sentinel and reserved-target encodings', () => {
+        expect(ATTRIBUTE_REMOVAL_SENTINELS).toEqual([null, '']);
+        expect(RESERVED_TARGET_IDS.has('document.body')).toBe(true);
+        expect(RESERVED_TARGET_IDS.has('neo-component-1')).toBe(false);
+        expect(STRUCTURAL_ACTIONS.has('updateNode')).toBe(false);
+        expect(STRUCTURAL_ACTIONS.has('moveNode')).toBe(true)
+    });
+
+    test('normalizeBatch mirrors the dispatch boundary input shapes', () => {
+        expect(normalizeBatch([{id: 'a'}])).toEqual([{id: 'a'}]);
+        expect(normalizeBatch({id: 'a'})).toEqual([{id: 'a'}]);
+        expect(normalizeBatch(null)).toEqual([]);
+        expect(normalizeBatch(undefined)).toEqual([])
+    });
+});
+
+test.describe('Universal predicates — legal batches stay clean', () => {
+    test('a differ-shaped mixed batch passes all guard-grade rules', () => {
+        // Mirrors a real update: action-less updateNode accumulation, an insert with its
+        // payload, moves, a vtext write, then the remove tail — default queue before removes.
+        const batch = [
+            {id: 'neo-grid-row-1', cls: {add: ['selected']}, style: {transform: 'translateY(32px)'}},
+            {id: 'neo-grid-row-2', attributes: {'aria-rowindex': '7', title: null}},
+            {action: 'insertNode', parentId: 'neo-grid-body-1', index: 3, outerHTML: '<div id="neo-cell-9"></div>'},
+            {action: 'moveNode', id: 'neo-cell-4', parentId: 'neo-grid-row-1', index: 0},
+            {action: 'updateVtext', id: 'neo-vtext-2', parentId: 'neo-label-1', value: 'Total: 42'},
+            {action: 'removeAll', parentId: 'neo-list-1'},
+            {action: 'removeNode', id: 'neo-tooltip-7'},
+            {action: 'removeNode', id: 'neo-vtext-9', parentId: 'neo-label-2'}
+        ];
+
+        const {valid, findings} = validateBatch(batch);
+
+        expect(findings).toEqual([]);
+        expect(valid).toBe(true)
+    });
+
+    test('recycling-shaped updateNode runs are clean (pooled ids, in-place rewrites)', () => {
+        const batch = [
+            {id: 'body__row-0', cls: {add: ['neo-even']}, style: {transform: 'translateY(0px)'}},
+            {id: 'body__row-0__cell-3', attributes: {'aria-colindex': '4'}, style: {display: null}},
+            {id: 'body__row-1', cls: {remove: ['neo-even']}, style: {transform: 'translateY(28px)'}}
+        ];
+
+        expect(validateBatch(batch).valid).toBe(true);
+        // The same pooled id updated in place is also invisible to the structural candidate.
+        expect(checkStructuralUniqueness(batch)).toEqual([])
+    });
+
+    test('reserved global targets are sanctioned updateNode ids', () => {
+        const batch = [
+            {id: 'document.body', cls: {add: ['neo-theme-dark']}},
+            {id: 'body', style: {overflow: 'hidden'}}
+        ];
+
+        expect(validateBatch(batch).valid).toBe(true)
+    });
+
+    test('insertNode payload contract follows the pinned renderer', () => {
+        const vnodeOnly = [{action: 'insertNode', parentId: 'p', index: 0, vnode: {id: 'neo-x'}}];
+        const htmlOnly  = [{action: 'insertNode', parentId: 'p', index: 0, outerHTML: '<div id="neo-x"></div>'}];
+        const both      = [{action: 'insertNode', parentId: 'p', index: 0, vnode: {id: 'neo-x'}, outerHTML: '<div id="neo-x"></div>'}];
+
+        expect(validateBatch(vnodeOnly, {useDomApiRenderer: true}).valid).toBe(true);
+        expect(validateBatch(htmlOnly,  {useDomApiRenderer: false}).valid).toBe(true);
+        // Manual producers legally carry both payloads; the consumer picks by config.
+        expect(validateBatch(both, {useDomApiRenderer: true}).valid).toBe(true);
+        expect(validateBatch(both, {useDomApiRenderer: false}).valid).toBe(true);
+        expect(validateBatch(both).valid).toBe(true)
+    });
+});
+
+test.describe('Universal predicates — illegal shapes produce findings', () => {
+    test('U1: unknown action strings are flagged (the mid-batch abort class)', () => {
+        const findings = checkActionValidity([
+            {action: 'insertnode', parentId: 'p', index: 0, vnode: {id: 'x'}},
+            {action: 'focusNode', id: 'neo-field-1'}
+        ]);
+
+        expect(rulesOf(findings)).toContain('U1');
+        expect(findings[0].deltaIndex).toBe(0);
+        expect(findings[0].detail).toContain('insertnode')
+    });
+
+    test('U1: non-object batch entries are flagged instead of throwing', () => {
+        expect(rulesOf(checkActionValidity([null]))).toContain('U1');
+        expect(rulesOf(checkActionValidity(['removeNode']))).toContain('U1')
+    });
+
+    test('U2: missing required fields are flagged per action', () => {
+        const findings = checkRequiredFields([
+            {action: 'moveNode', id: 'neo-1', parentId: 'p'},          // missing index
+            {action: 'updateVtext', id: 'neo-2', parentId: 'p'},       // missing value
+            {action: 'replaceChild', parentId: 'p', toId: 'neo-3'},    // missing fromId
+            {action: 'removeNode', parentId: 'p'}                      // missing id
+        ]);
+
+        expect(rulesOf(findings)).toEqual(['U2', 'U2', 'U2', 'U2']);
+        expect(findings.map(finding => finding.deltaIndex)).toEqual([0, 1, 2, 3])
+    });
+
+    test('U2: moveNode index 0 is present, not missing', () => {
+        expect(checkRequiredFields([{action: 'moveNode', id: 'neo-1', parentId: 'p', index: 0}])).toEqual([])
+    });
+
+    test('U2: insertNode with no payload at all is flagged in every renderer mode', () => {
+        const bare = [{action: 'insertNode', parentId: 'p', index: 0}];
+
+        expect(rulesOf(checkRequiredFields(bare))).toContain('U2');
+        expect(rulesOf(checkRequiredFields(bare, {useDomApiRenderer: true}))).toContain('U2');
+        expect(rulesOf(checkRequiredFields(bare, {useDomApiRenderer: false}))).toContain('U2')
+    });
+
+    test('U2: insertNode missing the pinned renderer payload is flagged', () => {
+        const htmlOnly = [{action: 'insertNode', parentId: 'p', index: 0, outerHTML: '<div></div>'}];
+
+        const findings = checkRequiredFields(htmlOnly, {useDomApiRenderer: true});
+
+        expect(rulesOf(findings)).toContain('U2');
+        expect(findings[0].detail).toContain('vnode')
+    });
+
+    test('U3: a non-remove delta after the remove tail is flagged', () => {
+        const findings = checkRemoveLastOrdering([
+            {id: 'neo-1', style: {opacity: '0'}},
+            {action: 'removeNode', id: 'neo-2'},
+            {action: 'moveNode', id: 'neo-3', parentId: 'p', index: 1},
+            {action: 'removeNode', id: 'neo-4'}
+        ]);
+
+        expect(rulesOf(findings)).toEqual(['U3']);
+        expect(findings[0].deltaIndex).toBe(2);
+        expect(findings[0].detail).toContain('moveNode')
+    });
+
+    test('U4: an id-less updateNode is flagged (the document.body misdirection)', () => {
+        const findings = checkExplicitTarget([
+            {style: {background: 'red'}},
+            {id: '', cls: {add: ['x']}},
+            {id: 'neo-ok-1', cls: {add: ['x']}}
+        ]);
+
+        expect(rulesOf(findings)).toEqual(['U4', 'U4']);
+        expect(findings.map(finding => finding.deltaIndex)).toEqual([0, 1]);
+        expect(findings[0].detail).toContain('document.body')
+    });
+
+    test('validateBatch aggregates U1-U4, never throws, and accepts single-object input', () => {
+        expect(() => validateBatch(null)).not.toThrow();
+        expect(validateBatch(null).valid).toBe(true);
+
+        const single = validateBatch({style: {color: 'red'}});
+
+        expect(single.valid).toBe(false);
+        expect(rulesOf(single.findings)).toEqual(['U4'])
+    });
+});
+
+test.describe('U5 stays a measurement candidate', () => {
+    test('is marked candidate and excluded from validateBatch', () => {
+        expect(checkStructuralUniqueness.candidate).toBe(true);
+
+        const doubleTouch = [
+            {action: 'removeNode', id: 'neo-1'},
+            {action: 'insertNode', parentId: 'p', index: 0, vnode: {id: 'neo-1'}}
+        ];
+
+        // Direct invocation reports the double structural touch (via vnode.id for the insert) ...
+        const findings = checkStructuralUniqueness(doubleTouch);
+
+        expect(rulesOf(findings)).toEqual(['U5']);
+        expect(findings[0].detail).toContain('neo-1');
+
+        // ... but the guard-grade aggregate stays silent about U5 (U3 fires here instead:
+        // the insert follows the remove tail — itself census-suspect ordering).
+        expect(rulesOf(validateBatch(doubleTouch, {useDomApiRenderer: true}).findings)).toEqual(['U3'])
+    });
+});

--- a/test/playwright/unit/vdom/DeltaGrammar.spec.mjs
+++ b/test/playwright/unit/vdom/DeltaGrammar.spec.mjs
@@ -69,11 +69,13 @@ test.describe('DeltaGrammar vocabulary', () => {
         expect(STRUCTURAL_ACTIONS.has('moveNode')).toBe(true)
     });
 
-    test('normalizeBatch mirrors the dispatch boundary input shapes', () => {
+    test('normalizeBatch mirrors the dispatch boundary EXACTLY — non-arrays wrap, including garbage', () => {
         expect(normalizeBatch([{id: 'a'}])).toEqual([{id: 'a'}]);
         expect(normalizeBatch({id: 'a'})).toEqual([{id: 'a'}]);
-        expect(normalizeBatch(null)).toEqual([]);
-        expect(normalizeBatch(undefined)).toEqual([])
+        // The runtime wraps null/undefined too (and would then throw dereferencing
+        // delta.action) — the validator must see the same entry, not an empty batch.
+        expect(normalizeBatch(null)).toEqual([null]);
+        expect(normalizeBatch(undefined)).toEqual([undefined])
     });
 });
 
@@ -209,8 +211,17 @@ test.describe('Universal predicates — illegal shapes produce findings', () => 
     });
 
     test('validateBatch aggregates U1-U4, never throws, and accepts single-object input', () => {
+        // A null/undefined "batch" is NOT valid: the runtime would wrap it and throw on
+        // delta.action — the validator reports the U1 finding instead of blessing it.
         expect(() => validateBatch(null)).not.toThrow();
-        expect(validateBatch(null).valid).toBe(true);
+        expect(validateBatch(null).valid).toBe(false);
+        expect(rulesOf(validateBatch(null).findings)).toEqual(['U1']);
+        expect(validateBatch(undefined).valid).toBe(false);
+
+        // The empty ARRAY is the one legitimately valid empty input: the runtime loop
+        // simply does not execute.
+        expect(validateBatch([]).valid).toBe(true);
+        expect(validateBatch([]).findings).toEqual([]);
 
         const single = validateBatch({style: {color: 'red'}});
 


### PR DESCRIPTION
Resolves #12987
Refs #12986

Authored by Claude Fable 5 (Claude Code, @neo-fable-clio). Session 3e1566f6-6336-4db4-8726-189004578d8b.

First leaf of Epic #12986: the delta-stream wire contract as a consumable artifact. New pure module `src/vdom/util/DeltaGrammar.mjs` (domConstants-style plain exports, zero Neo globals at import — Stage-1 sibling placement next to the vnode utils, cross-realm import precedent already established by `DeltaUpdates.mjs` importing `vdom/domConstants.mjs`) encoding the census-grounded vocabulary, plus never-throwing universal predicates:

- **Vocabulary**: the 8-action set + the implicit-updateNode wire spelling (`action` absent IS the dominant spelling of the most common op); per-op field contracts incl. the renderer-split insertNode payload (`vnode` / `outerHTML`) and removeNode's conditional `parentId` (required for fragment/vtext sorts — documented, not statically enforceable); sentinel encodings (`null`/`''` attribute removal, the `value`-clears exception); the reserved-target allowlist (`window`/`document`/`document.body`/`body`); the three-sorted id model (element / fragment comment-anchor ranges / vtext comment pairs) with per-op addressable sorts.
- **U1–U4 predicates + `validateBatch()`**: action-validity, per-op required fields, remove-last ordering, explicit-target updateNode (the `getElementOrBody(undefined)` → `document.body` misdirection made visible). Findings out (`{rule, deltaIndex, detail}`), never throws — designed to run BEFORE the first delta applies so the future guards sub can reject illegal batches atomically instead of partially applying them.
- **U5 stays a measurement candidate** (`checkStructuralUniqueness.candidate === true`, excluded from `validateBatch`) per the #12942 Step-Back carry-through — promotion requires a falsification run over real-world batches first.

Evidence: L2 (19-spec unit coverage incl. pure-import contract) → L2 required (all ACs unit/static-verifiable). No residuals.

## Deltas from ticket
- One census correction discovered while encoding: manual producers (e.g. `VdomLifecycle`) legally emit insertNode with BOTH payload keys — the consumer picks by renderer config. The flagless U2 mode therefore requires *at least one* payload (the ticket's draft said exactly-one), and `id` is documented as an optional consumer-ignored field on insertNode. Renderer-pinned modes still require the key the active renderer will consume.

## Test Evidence
- `test/playwright/unit/vdom/DeltaGrammar.spec.mjs`: 19/19 green — vocabulary completeness, legal exemplars mirroring real producer shapes (differ-style action-less runs, recycling-shaped pooled-id updates, reserved targets, payload-by-renderer matrix), illegal shapes per rule (unknown action, missing fields incl. the index-0-is-present guard, remove-tail violation, id-less updateNode, no-payload insertNode), never-throw + single-object normalization, and U5's candidate-exclusion contract.
- The spec deliberately imports the module WITHOUT the shared setup helper — the pure-module discipline (AC: no Neo globals at import) is itself pinned by the import succeeding in a bare spec file.
- Existing suite: untouched by construction (two new files, zero modified) — the same-day full-suite baseline (3221 passed) covers the surrounding state; CI re-verifies.

## Post-Merge Validation
- [ ] The guards / capture / signature subs import the kernel unmodified (any needed kernel change is a contract gap to surface, not silently patch).

## Consensus-source note
This PR implements a leaf of Discussion-graduated substrate: #12942 graduated with family-keyed quorum (Claude author-signal + family endorsement; GPT `GRADUATION_APPROVED` renewed at the post-census anchor) + §5.2 Step-Back (pass, by @neo-gpt) — full Signal Ledger archived in Epic #12986 and the closed Discussion. Step-Back carry-throughs binding this leaf: U5-as-candidate (honored), sequenced kernel-first scope (this PR is that first step).