### PR TITLE
refactor(draggable): align SortZone drag-end overrides (#12895)

### DIFF
--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -257,9 +257,10 @@ class DashboardSortZone extends SortZone {
     }
 
     /**
+     * Completes dashboard drag cleanup under the base drag-end latch.
      * @param {Object} data The drag end event data.
      */
-    async onDragEnd(data) {
+    async processDragEnd(data) {
         let me = this;
 
         if (!me.isRemoteDragging) {
@@ -270,7 +271,7 @@ class DashboardSortZone extends SortZone {
             })
         }
 
-        super.onDragEnd(data)
+        await super.processDragEnd(data)
     }
 
     /**

--- a/src/draggable/tab/header/toolbar/SortZone.mjs
+++ b/src/draggable/tab/header/toolbar/SortZone.mjs
@@ -35,10 +35,11 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * Completes a tab header drag under the base drag-end latch.
      * @param {Object} data
      */
-    onDragEnd(data) {
-        super.onDragEnd(data);
+    async processDragEnd(data) {
+        const promise = super.processDragEnd(data);
 
         this.timeout(300).then(() => {
             let me      = this,
@@ -47,7 +48,9 @@ class SortZone extends BaseSortZone {
 
             NeoArray.remove(cls, 'neo-no-animation');
             owner.cls = cls
-        })
+        });
+
+        await promise
     }
 
     /**

--- a/src/draggable/table/header/toolbar/SortZone.mjs
+++ b/src/draggable/table/header/toolbar/SortZone.mjs
@@ -53,10 +53,11 @@ class SortZone extends BaseSortZone {
     }
 
     /**
+     * Completes a table header drag under the base drag-end latch.
      * @param {Object} data
      */
-    async onDragEnd(data) {
-        await super.onDragEnd(data);
+    async processDragEnd(data) {
+        await super.processDragEnd(data);
 
         let {owner} = this;
 

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -38,6 +38,7 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         const DragCoordinator = Neo.manager?.DragCoordinator;
         if (DragCoordinator) {
             DragCoordinator.onDragMove = () => {};
+            DragCoordinator.onDragEnd = () => {};
             DragCoordinator.register = () => {};
             DragCoordinator.unregister = () => {};
         }
@@ -185,5 +186,55 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         expect(appliedDeltas.some(delta => delta.action === 'moveNode' && delta.id === remoteItem.id)).toBe(false);
         expect(sortZone.isRemoteDragging).toBe(false);
         expect(sortZone.isWindowDragging).toBe(false)
+    });
+
+    test('latches dashboard drag-end coordinator notification (#12895)', async () => {
+        const
+            dragEndCalls    = [],
+            DragCoordinator = Neo.manager.DragCoordinator,
+            item            = {
+                id          : 'item1',
+                vdom        : {cls: ['neo-draggable']},
+                wrapperStyle: {}
+            },
+            mockOwner       = {
+                id              : 'mockOwner',
+                cls             : [],
+                dragResortable  : true,
+                items           : [item],
+                style           : {},
+                vdom            : {},
+                addDomListeners : () => {},
+                getDomRect      : () => Promise.resolve([{x:0, y:0, width:100, height:100}]),
+                getVdomItemsRoot: () => ({id: 'mockOwner-items'}),
+                on              : () => {}
+            };
+
+        DragCoordinator.onDragEnd = data => dragEndCalls.push(data);
+
+        sortZone = Neo.create(DashboardSortZone, {
+            owner  : mockOwner,
+            timeout: () => Promise.resolve()
+        });
+
+        Object.assign(sortZone, {
+            currentIndex   : 0,
+            dragComponent  : item,
+            dragPlaceholder: null,
+            itemRects      : [{height: 100, left: 0, top: 0, width: 100}],
+            itemStyles     : [{height: '100px', width: '100px'}],
+            ownerStyle     : {},
+            sortableItems  : [item],
+            startIndex     : 0,
+            windowId       : 1
+        });
+
+        await Promise.all([
+            sortZone.onDragEnd({source: 'first'}),
+            sortZone.onDragEnd({source: 'second'})
+        ]);
+
+        expect(dragEndCalls).toHaveLength(1);
+        expect(sortZone.dragEndActive).toBe(false)
     });
 });


### PR DESCRIPTION
Resolves #12895

Authored by GPT-5 (Codex Desktop). Session 019eba1b-f70e-74c0-9dfb-8666901c3c0d.

Aligns the remaining container SortZone subclasses with the post-`#12892` drag-end contract: base `onDragEnd()` is the only public re-entry latch, and subclass drop logic lives in `processDragEnd()`.

Evidence: L1 + unit (static override audit + targeted Playwright unit regression) → L1/unit required (internal override contract plus existing SortZone specs). No residuals.

## Deltas from ticket

- Tab/table are the requested mechanical rename to `processDragEnd()` + `super.processDragEnd()`.
- Dashboard source review showed `onRemoteDragLeave()` / `onRemoteDrop()` self-calls already entered the base latch through `super.onDragEnd()` before this PR. This keeps those cleanup calls on public `onDragEnd()` and moves the dashboard coordinator notification into `processDragEnd()`, so duplicate `drag:end` delivery is latched while remote cleanup continues through the existing base cleanup pipeline.
- Added a dashboard unit assertion that two immediate `onDragEnd()` deliveries notify `DragCoordinator.onDragEnd()` once.

## Test Evidence

- `node --check src/draggable/tab/header/toolbar/SortZone.mjs`
- `node --check src/draggable/table/header/toolbar/SortZone.mjs`
- `node --check src/draggable/dashboard/SortZone.mjs`
- `node --check test/playwright/unit/draggable/dashboard/SortZone.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs test/playwright/unit/draggable/dashboard/SortZone.spec.mjs` — 13 passed

## Post-Merge Validation

- [ ] CI lint/unit green on the PR head.

## Commit

- `d723dce19` — `refactor(draggable): align SortZone drag-end overrides (#12895)`