### PR TITLE
feat(neural-link): sample raw nodes in observe_motion (#12931)

### DIFF
--- a/.agents/skills/neural-link/references/operational-handbook.md
+++ b/.agents/skills/neural-link/references/operational-handbook.md
@@ -37,9 +37,13 @@ When verifying a fix or reproducing a bug interactively:
 When debugging drag-and-drop, animations, or any "elements move wrong" symptom, final-state
 assertions are blind to the motion layer. Three tools cover it:
 
-1. **`observe_motion`** — start it (componentIds + window ≤8s) BEFORE driving the interaction;
-   it samples client rects per tick and returns the rendered-geometry trace. Pair with any
-   dispatch path (simulate_event, in-page MouseEvent, playwright `page.mouse`).
+1. **`observe_motion`** — start it (componentIds and/or nodeIds + window ≤8s) BEFORE driving
+   the interaction; it samples client rects per tick and returns the rendered-geometry trace.
+   Use component ids for component roots and raw node ids for pooled vdom elements such as
+   grid cells. Geometry traces are the right tool for layout/transform/animation defects;
+   paint-only defects (z-order, clipping, opacity/GPU artifacts) still belong to screenshot
+   or browser-side visual inspection. Pair with any dispatch path (simulate_event, in-page
+   MouseEvent, playwright `page.mouse`).
 2. **`get_drag_trace`** — AFTER a drag, returns the SortZone lifecycle ring (start geometry,
    per-move target decisions, item switches, scroll activations, end resolution, grid lock
    verdicts). The logic side; diff it against the `observe_motion` trace to localize whether

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -658,11 +658,7 @@ paths:
       summary: Observe Motion
       operationId: observe_motion
       x-pass-as-object: true
-      description: |
-        Samples the client rects of the given components over a time window and returns the motion trace.
-
-        **When to Use:**
-        To SEE live motion (drag choreography, animations) while you or a user drive an interaction. Duration is clamped to 8000ms per call; chain calls for longer windows.
+      description: Samples component and raw DOM-node client rects over a time window for rendered-geometry motion traces. Use during drag choreography or animation debugging; duration is clamped to 8000ms per call.
       tags: [Component]
       requestBody:
         required: true
@@ -670,16 +666,29 @@ paths:
           application/json:
             schema:
               type: object
-              required: [componentIds]
               properties:
                 sessionId:
                   type: string
                   description: Target App Worker Session ID
+                windowId:
+                  type: string
+                  description: Main-thread window id for node-only sampling when no component target can provide routing context
                 componentIds:
                   type: array
                   items:
                     type: string
-                  description: Component ids to sample
+                  description: Component ids to sample; at least one of componentIds, nodeIds, or cellsOf is required
+                nodeIds:
+                  type: array
+                  items:
+                    type: string
+                  description: Raw DOM element ids to sample
+                cellsOf:
+                  type: object
+                  properties:
+                    rowId:
+                      type: string
+                      description: Raw row DOM id whose current child node ids should be sampled
                 durationMs:
                   type: number
                   description: Sampling window, clamped to [100, 8000] (default 2000)

--- a/ai/services/neural-link/InteractionService.mjs
+++ b/ai/services/neural-link/InteractionService.mjs
@@ -55,16 +55,26 @@ class InteractionService extends Base {
     }
 
     /**
-     * Samples component client rects over a time window (motion trace).
-     * @param {Object}   opts
-     * @param {String[]} opts.componentIds
-     * @param {Number}   [opts.durationMs]
-     * @param {Number}   [opts.intervalMs]
-     * @param {String}   [opts.sessionId]
+     * Samples component and raw DOM-node client rects over a time window (motion trace).
+     * @param {Object}         opts
+     * @param {String[]}       [opts.componentIds]
+     * @param {{rowId:String}} [opts.cellsOf]
+     * @param {Number}         [opts.durationMs]
+     * @param {Number}         [opts.intervalMs]
+     * @param {String[]}       [opts.nodeIds]
+     * @param {String}         [opts.sessionId]
+     * @param {String}         [opts.windowId]
      * @returns {Promise<Object>}
      */
-    async observeMotion({componentIds, durationMs, intervalMs, sessionId}) {
-        return await ConnectionService.call(sessionId, 'observe_motion', {componentIds, durationMs, intervalMs})
+    async observeMotion({cellsOf, componentIds, durationMs, intervalMs, nodeIds, sessionId, windowId}) {
+        return await ConnectionService.call(sessionId, 'observe_motion', {
+            cellsOf,
+            componentIds,
+            durationMs,
+            intervalMs,
+            nodeIds,
+            windowId
+        })
     }
 
     /**

--- a/src/ai/client/ComponentService.mjs
+++ b/src/ai/client/ComponentService.mjs
@@ -62,49 +62,74 @@ class ComponentService extends Service {
     }
 
     /**
-     * Samples the client rects of the given components over a time window, returning a motion
-     * trace. The perception side of drag verification: an agent drives the interaction through
-     * any dispatch path while this recorder observes where elements ACTUALLY render per tick.
-     * Duration is clamped below the bridge rpc timeout; chain calls for longer windows.
-     * @param {Object}   params
-     * @param {String[]} params.componentIds
-     * @param {Number}   [params.durationMs=2000] clamped to [100, 8000]
-     * @param {Number}   [params.intervalMs=100]  clamped to [16, 1000]
-     * @returns {Object} {componentIds, samples: [{t, rects}]}
+     * Samples component and raw DOM-node client rects over a time window, returning a rendered
+     * geometry motion trace. The perception side of drag verification: an agent drives the
+     * interaction through any dispatch path while this recorder observes where elements actually
+     * render per tick. Duration is clamped below the bridge rpc timeout; chain calls for longer
+     * windows.
+     * @param {Object}         params
+     * @param {String[]}       [params.componentIds]
+     * @param {{rowId:String}} [params.cellsOf] Expands a row's current child node ids
+     * @param {Number}         [params.durationMs=2000] clamped to [100, 8000]
+     * @param {Number}         [params.intervalMs=100]  clamped to [16, 1000]
+     * @param {String[]}       [params.nodeIds] Raw DOM element ids to sample
+     * @param {String}         [params.windowId] Required for deterministic node-only multi-window sampling
+     * @returns {Object} {componentIds, nodeIds, targetIds, samples: [{t, rects}]}
      */
-    async observeMotion({componentIds, durationMs = 2000, intervalMs = 100}) {
-        if (!Array.isArray(componentIds) || componentIds.length === 0) {
-            throw new Error('componentIds must be a non-empty array')
+    async observeMotion({cellsOf, componentIds, durationMs = 2000, intervalMs = 100, nodeIds, windowId}) {
+        componentIds = ComponentService.normalizeIdArray(componentIds, 'componentIds');
+        nodeIds      = ComponentService.normalizeIdArray(nodeIds,      'nodeIds');
+
+        const components = componentIds.map(id => {
+            const component = Neo.getComponent(id);
+
+            if (!component) {
+                throw new Error(`Component not found: ${id}`)
+            }
+
+            return component
+        });
+
+        windowId ??= components[0]?.windowId;
+
+        if (cellsOf?.rowId) {
+            const rowNodeIds = await Neo.main.DomAccess.getChildNodeIds({id: cellsOf.rowId, windowId});
+
+            if (rowNodeIds === null) {
+                throw new Error(`Row node not found: ${cellsOf.rowId}`)
+            }
+
+            nodeIds.push(...rowNodeIds)
         }
 
-        const component = Neo.getComponent(componentIds[0]);
-
-        if (!component) {
-            throw new Error(`Component not found: ${componentIds[0]}`)
+        if (componentIds.length === 0 && nodeIds.length === 0) {
+            throw new Error('componentIds, nodeIds, or cellsOf must provide at least one target')
         }
 
         durationMs = Math.max(100, Math.min(durationMs, 8000));
         intervalMs = Math.max(16,  Math.min(intervalMs, 1000));
 
         const
-            samples = [],
-            start   = Date.now();
+            samples   = [],
+            start     = Date.now(),
+            targetIds = componentIds.concat(nodeIds);
 
         while (Date.now() - start < durationMs) {
             const
                 t     = Date.now() - start,
-                rects = await component.getDomRect(componentIds);
+                rects = componentIds.length > 0 && nodeIds.length === 0 && !cellsOf ?
+                    await components[0].getDomRect(componentIds) :
+                    await Neo.main.DomAccess.getBoundingClientRect({id: targetIds, windowId});
 
             samples.push({
                 t,
-                rects: (Array.isArray(rects) ? rects : [rects]).map(rect =>
-                    rect ? {left: rect.left, top: rect.top, width: rect.width, height: rect.height} : null)
+                rects: (Array.isArray(rects) ? rects : [rects]).map(ComponentService.serializeMotionRect)
             });
 
             await this.timeout(intervalMs)
         }
 
-        return {componentIds, samples}
+        return {componentIds, nodeIds, targetIds, samples}
     }
 
     /**
@@ -176,6 +201,41 @@ class ComponentService extends Service {
             mismatches,
             vdomIds
         }
+    }
+
+    /**
+     * @param {*} ids
+     * @param {String} name
+     * @returns {String[]}
+     * @protected
+     */
+    static normalizeIdArray(ids, name) {
+        if (ids === undefined || ids === null) {
+            return []
+        }
+
+        if (!Array.isArray(ids)) {
+            throw new Error(`${name} must be an array`)
+        }
+
+        ids.forEach(id => {
+            if (typeof id !== 'string' || id.length === 0) {
+                throw new Error(`${name} must contain non-empty strings`)
+            }
+        });
+
+        return [...ids]
+    }
+
+    /**
+     * @param {Object|null|undefined} rect
+     * @returns {Object|null}
+     * @protected
+     */
+    static serializeMotionRect(rect) {
+        return typeof rect?.left === 'number' ?
+            {left: rect.left, top: rect.top, width: rect.width, height: rect.height} :
+            null
     }
 
     /**

--- a/test/playwright/e2e/GridLockedRegionRowRender.spec.mjs
+++ b/test/playwright/e2e/GridLockedRegionRowRender.spec.mjs
@@ -56,4 +56,47 @@ test.describe('Desktop (1920x1080): lockedColumns Fixture — every region body 
             expect(check.counts.vdom,  `body ${body.id}: vdom rows`).toBe(rowCount);
         }
     });
+
+    test('observeMotion samples a header component and raw row-cell nodes in one trace', async ({ neuralLink }) => {
+        const app = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
+
+        const
+            headers = await app.findInstances({ntype: 'grid-header-button'}, ['id', 'text', 'windowId']),
+            header  = (Array.isArray(headers) ? headers[0] : headers) || {};
+
+        expect(header.id, 'a grid-header-button component must exist for the component side of the trace').toBeTruthy();
+
+        const
+            bodies = await app.findInstances({className: 'Neo.grid.Body'}, ['id', 'items.length']),
+            body   = (Array.isArray(bodies) ? bodies.find(item => item.properties?.['items.length'] > 0) : bodies) || {};
+
+        expect(body.id, 'a rendered grid body must exist for the row-cell side of the trace').toBeTruthy();
+
+        const consistency = await app.verifyComponentConsistency(body.id);
+
+        expect(consistency.consistent, `body ${body.id}: row DOM must agree before sampling cells`).toBe(true);
+        expect(consistency.domIds?.length, `body ${body.id}: rendered row ids must be available`).toBeGreaterThan(0);
+
+        const motion = await app.observeMotion({
+            cellsOf     : {rowId: consistency.domIds[0]},
+            componentIds: [header.id],
+            durationMs  : 120,
+            intervalMs  : 60
+        });
+
+        expect(motion.componentIds).toEqual([header.id]);
+        expect(motion.nodeIds.length, 'cellsOf must expand to raw cell node ids').toBeGreaterThan(0);
+        expect(motion.targetIds).toEqual([header.id, ...motion.nodeIds]);
+        expect(motion.samples.length, 'motion trace must contain at least one rendered-geometry sample').toBeGreaterThan(0);
+
+        for (const sample of motion.samples) {
+            expect(sample.rects.length, `sample ${sample.t}: rect count must match sampled targets`).toBe(motion.targetIds.length);
+
+            for (const [index, rect] of sample.rects.entries()) {
+                expect(rect, `sample ${sample.t}: ${motion.targetIds[index]} should resolve to a rendered rect`).not.toBeNull();
+                expect(rect.width,  `sample ${sample.t}: ${motion.targetIds[index]} width`).toBeGreaterThan(0);
+                expect(rect.height, `sample ${sample.t}: ${motion.targetIds[index]} height`).toBeGreaterThan(0);
+            }
+        }
+    });
 });

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -319,13 +319,17 @@ export const test = base.extend({
                     /**
                      * Samples component client rects over a time window (motion trace) — start it
                      * BEFORE page.mouse.down() to assert mid-drag geometry (whitebox-e2e §5.1).
-                     * @param {String[]} componentIds
+                     * @param {String[]|Object} componentIds Component ids, or an options object for nodeIds/windowId/cellsOf
                      * @param {Number} [durationMs]
                      * @param {Number} [intervalMs]
                      * @returns {Promise<Object>}
                      */
                     async observeMotion(componentIds, durationMs, intervalMs) {
-                        return NeuralLink_InteractionService.observeMotion({ sessionId, componentIds, durationMs, intervalMs });
+                        const opts = Array.isArray(componentIds) ?
+                            { componentIds, durationMs, intervalMs } :
+                            { ...(componentIds || {}) };
+
+                        return NeuralLink_InteractionService.observeMotion({ sessionId, ...opts });
                     },
 
                     /**

--- a/test/playwright/unit/ai/client/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/client/ComponentService.spec.mjs
@@ -59,3 +59,154 @@ test.describe.serial('Neo.ai.client.ComponentService.diffChildSurfaces', () => {
         expect(result.counts.dom).toBe(null)
     });
 });
+
+test.describe.serial('Neo.ai.client.ComponentService.observeMotion', () => {
+    const originalNow = Date.now;
+
+    let originalGetComponent, originalMain, now, service;
+
+    test.beforeEach(() => {
+        originalGetComponent = Neo.getComponent;
+        originalMain         = Neo.main;
+        now                  = 1000;
+        Date.now             = () => now;
+        service              = Neo.create(ComponentService);
+        service.timeout      = async ms => {
+            now += ms
+        };
+    });
+
+    test.afterEach(() => {
+        Date.now         = originalNow;
+        Neo.getComponent = originalGetComponent;
+        Neo.main         = originalMain;
+        service.destroy()
+    });
+
+    test('samples raw nodeIds through DomAccess with explicit window routing', async () => {
+        const calls = [];
+
+        Neo.getComponent = () => null;
+        Neo.main = {
+            DomAccess: {
+                getBoundingClientRect: async data => {
+                    calls.push(data);
+
+                    return [
+                        {left: 10, top: 20, width: 30, height: 40},
+                        {}
+                    ]
+                }
+            }
+        };
+
+        const result = await service.observeMotion({
+            durationMs: 100,
+            intervalMs: 100,
+            nodeIds   : ['row-1__cell-0', 'missing-cell'],
+            windowId  : 'win-1'
+        });
+
+        expect(calls).toEqual([{id: ['row-1__cell-0', 'missing-cell'], windowId: 'win-1'}]);
+        expect(result.componentIds).toEqual([]);
+        expect(result.nodeIds).toEqual(['row-1__cell-0', 'missing-cell']);
+        expect(result.targetIds).toEqual(['row-1__cell-0', 'missing-cell']);
+        expect(result.samples).toEqual([{
+            t    : 0,
+            rects: [
+                {left: 10, top: 20, width: 30, height: 40},
+                null
+            ]
+        }])
+    });
+
+    test('samples mixed componentIds and nodeIds in component-first order', async () => {
+        const calls = [];
+
+        Neo.getComponent = id => id === 'toolbar-1' ? {id, windowId: 'win-c'} : null;
+        Neo.main = {
+            DomAccess: {
+                getBoundingClientRect: async data => {
+                    calls.push(data);
+
+                    return [
+                        {left: 1, top: 2, width: 3, height: 4},
+                        {left: 5, top: 6, width: 7, height: 8}
+                    ]
+                }
+            }
+        };
+
+        const result = await service.observeMotion({
+            componentIds: ['toolbar-1'],
+            durationMs  : 100,
+            intervalMs  : 100,
+            nodeIds     : ['row-1__cell-0']
+        });
+
+        expect(calls).toEqual([{id: ['toolbar-1', 'row-1__cell-0'], windowId: 'win-c'}]);
+        expect(result.componentIds).toEqual(['toolbar-1']);
+        expect(result.nodeIds).toEqual(['row-1__cell-0']);
+        expect(result.targetIds).toEqual(['toolbar-1', 'row-1__cell-0'])
+    });
+
+    test('preserves the component-only getDomRect path', async () => {
+        const calls = [];
+
+        Neo.getComponent = id => id === 'toolbar-1' ? {
+            id,
+            windowId   : 'win-c',
+            getDomRect : async ids => {
+                calls.push(ids);
+
+                return {left: 1, top: 2, width: 3, height: 4}
+            }
+        } : null;
+        Neo.main = {DomAccess: {}};
+
+        const result = await service.observeMotion({
+            componentIds: ['toolbar-1'],
+            durationMs  : 100,
+            intervalMs  : 100
+        });
+
+        expect(calls).toEqual([['toolbar-1']]);
+        expect(result.nodeIds).toEqual([]);
+        expect(result.targetIds).toEqual(['toolbar-1']);
+        expect(result.samples[0].rects).toEqual([{left: 1, top: 2, width: 3, height: 4}])
+    });
+
+    test('expands cellsOf into raw node targets', async () => {
+        Neo.getComponent = () => null;
+        Neo.main = {
+            DomAccess: {
+                getBoundingClientRect: async () => [
+                    {left: 1, top: 2, width: 3, height: 4},
+                    {left: 5, top: 6, width: 7, height: 8}
+                ],
+                getChildNodeIds: async ({id, windowId}) => {
+                    expect(id).toBe('row-1');
+                    expect(windowId).toBe('win-1');
+
+                    return ['row-1__cell-0', 'row-1__cell-1']
+                }
+            }
+        };
+
+        const result = await service.observeMotion({
+            cellsOf   : {rowId: 'row-1'},
+            durationMs: 100,
+            intervalMs: 100,
+            windowId  : 'win-1'
+        });
+
+        expect(result.nodeIds).toEqual(['row-1__cell-0', 'row-1__cell-1']);
+        expect(result.targetIds).toEqual(['row-1__cell-0', 'row-1__cell-1'])
+    });
+
+    test('requires at least one target source', async () => {
+        await expect(service.observeMotion({durationMs: 100, intervalMs: 100})).rejects.toThrow(
+            'componentIds, nodeIds, or cellsOf must provide at least one target'
+        )
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 518c54ce-5871-4ccf-8e88-6ac3b6e16ea8.

Resolves #12931

Related: #12930

`observe_motion` now accepts raw DOM node targets in addition to component ids, so Neural Link can sample rendered geometry at the grid-cell layer where pooled vdom nodes do not have component instances. The runtime keeps the legacy component-only path intact, adds `nodeIds` and `targetIds` to the returned trace, and supports `cellsOf: {rowId}` as a convenience expansion for a row's current cell nodes.

Evidence: L3 (live lockedColumns E2E on a current-worktree server: one `observeMotion` call sampled a grid-header component plus 17 row-cell node rects) -> L3 required (runtime node-granularity `observe_motion` ACs). No residual close-target ACs; exact drag-defect assertions remain with `#12930`.

## Deltas from ticket

- The public trace remains additive: existing component-only callers still receive the same component rect behavior, while mixed/node calls also receive `nodeIds` and `targetIds`.
- `cellsOf` expands via the App Worker client through Main-thread DomAccess, so callers can target grid row cells without a separate child-node lookup.
- I did not encode the open `#12930` drag defect as an expected CI failure. The live E2E proves the instrument can observe the header-plus-cell geometry in one call against the canonical lockedColumns fixture; the defect fix and permanent repro assertion stay in `#12930`.

## Turn Memory Pre-Flight

- Surface touched: `.agents/skills/neural-link/references/operational-handbook.md`.
- Placement: existing Neural Link World-Atlas payload, not `SKILL.md`, `AGENTS.md`, or a new skill. Always-loaded delta is 0 bytes.
- Disposition delta: `rewrite` of the existing §4.1 `observe_motion` row to match the new tool/runtime contract.
- 3-axis rating: trigger-frequency = conditional on Neural Link motion-forensics work; failure-severity = medium/high because stale guidance would blind agents to node-level motion evidence; enforceability = discipline-only documentation plus runtime/schema tests.
- Decay mitigation: retire or rewrite this row if a future paint-truth/screenshot primitive becomes the primary visual oracle or if `observe_motion` is renamed/replaced.
- Mechanical checks: `.codex/hooks.json`, `.codex/hooks/codex-context.mjs`, `.claude/CLAUDE.md` symlink, and `.claude/skills/neural-link` symlink were inspected; `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` passed.

## Test Evidence

- `node --check src/ai/client/ComponentService.mjs`
- `node --check ai/services/neural-link/InteractionService.mjs`
- `node --check test/playwright/fixtures.mjs`
- `node --check test/playwright/unit/ai/client/ComponentService.spec.mjs`
- `node --check test/playwright/e2e/GridLockedRegionRowRender.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/client/ComponentService.spec.mjs` -> 9/9 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 26/26 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 11/11 passed
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> OK
- Focused E2E: started this worktree's server with `npx webpack serve -c ./buildScripts/webpack/webpack.server.config.mjs --host 127.0.0.1 --port 8091 --no-open`, then ran `npx playwright test /Users/Shared/codex/neomjs/neo/test/playwright/e2e/GridLockedRegionRowRender.spec.mjs -c /private/tmp/neo-e2e-8091.config.mjs --workers=1` -> 2/2 passed

## Post-Merge Validation

- [ ] In a fresh Neural Link MCP process, confirm `listTools` exposes `observe_motion` with `nodeIds`, `cellsOf`, and optional `windowId`.
- [ ] During the `#12930` fix lane, use the new mixed header/cell trace to capture the Repro-A header/cell divergence while driving the drag reversal.

## Commit

- `5633acf2c` - `feat(neural-link): sample raw nodes in observe_motion (#12931)`
