### PR TITLE
feat(github-workflow): sync-time discussion denylist + quarantine for content containment (#12995)

### DIFF
--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -147,9 +147,10 @@ class Config extends ConfigProvider {
                 droppedLabels: leaf(['dropped', 'wontfix', 'duplicate']),
                 /**
                  * Containment denylist: discussions whose `number` or `author.login` match are excluded
-                 * from sync — never written to `resources/content/**` or downstream KB chunks, and any
-                 * previously-synced copy is quarantined (removed). Policy-free mechanism; the empty
-                 * default is a no-op that preserves normal sync.
+                 * from sync — never written to `resources/content/**` or downstream KB chunks. Cached
+                 * copies are quarantined (file + content-index entry removed) by `number` even when
+                 * GitHub no longer lists them; `author` matching is fetch-time exclusion only (the sync
+                 * cache persists `number`, not author). Policy-free; the empty default is a no-op.
                  * @type {{numbers: Number[], authors: String[]}}
                  */
                 discussionDenylist: leaf({numbers: [], authors: []}),

--- a/ai/mcp/server/github-workflow/config.template.mjs
+++ b/ai/mcp/server/github-workflow/config.template.mjs
@@ -146,6 +146,14 @@ class Config extends ConfigProvider {
                  */
                 droppedLabels: leaf(['dropped', 'wontfix', 'duplicate']),
                 /**
+                 * Containment denylist: discussions whose `number` or `author.login` match are excluded
+                 * from sync — never written to `resources/content/**` or downstream KB chunks, and any
+                 * previously-synced copy is quarantined (removed). Policy-free mechanism; the empty
+                 * default is a no-op that preserves normal sync.
+                 * @type {{numbers: Number[], authors: String[]}}
+                 */
+                discussionDenylist: leaf({numbers: [], authors: []}),
+                /**
                  * The date from which to start synchronizing issues and releases.
                  * @type {string}
                  */

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -188,6 +188,20 @@ class DiscussionSyncer extends Base {
     }
 
     /**
+     * Containment gate: is this discussion on the sync denylist (by number or author)? A denylisted
+     * discussion is excluded from emission/indexing and any previously-synced copy is quarantined,
+     * so a known-contaminated artifact never reaches `resources/content/**` or downstream KB chunks.
+     * The empty default denylist makes this a no-op.
+     * @param {Object} discussion
+     * @returns {Boolean}
+     */
+    #isDenylisted(discussion) {
+        const denylist = issueSyncConfig.discussionDenylist || {};
+        return (denylist.numbers || []).includes(discussion.number) ||
+               (denylist.authors || []).includes(discussion.author?.login);
+    }
+
+    /**
      * Fetches discussions from GitHub and syncs them to local markdown.
      * @param {object} metadata The sync metadata containing cached records.
      * @returns {Promise<object>} Statistics about the operation.
@@ -244,6 +258,27 @@ class DiscussionSyncer extends Base {
         };
 
         const cachedDiscussions = metadata.discussions || {};
+
+        // Containment: partition denylisted discussions out before bucket-planning + processing.
+        // A denylisted artifact (by number or author) must never enter resources/content/** or
+        // downstream KB chunks; any previously-synced copy is quarantined (removed). The empty
+        // default denylist makes this loop a no-op.
+        const deniedNumbers = new Set();
+        for (const discussion of allDiscussions) {
+            if (this.#isDenylisted(discussion)) {
+                deniedNumbers.add(discussion.number);
+                logger.warn(`🛡️ Discussion #${discussion.number} is denylisted (containment); excluding from sync.`);
+                const cachedPath = cachedDiscussions[discussion.number]?.path;
+                if (cachedPath) {
+                    await fs.unlink(this.#resolvePath(cachedPath)).catch(() => {});
+                    logger.warn(`🛡️ Quarantined previously-synced copy of denylisted discussion #${discussion.number}.`);
+                }
+            }
+        }
+        if (deniedNumbers.size > 0) {
+            allDiscussions = allDiscussions.filter(discussion => !deniedNumbers.has(discussion.number));
+        }
+
         const planBuckets = this.#planBuckets(metadata, allDiscussions);
 
         for (const discussion of allDiscussions) {

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -188,10 +188,12 @@ class DiscussionSyncer extends Base {
     }
 
     /**
-     * Containment gate: is this discussion on the sync denylist (by number or author)? A denylisted
-     * discussion is excluded from emission/indexing and any previously-synced copy is quarantined,
-     * so a known-contaminated artifact never reaches `resources/content/**` or downstream KB chunks.
-     * The empty default denylist makes this a no-op.
+     * Containment gate: is this fetched discussion on the sync denylist (by number or author)?
+     * Denylisted fetched discussions are excluded from emission/indexing. Quarantine of an
+     * already-synced copy is driven separately in `syncDiscussions`: by `number` it removes cached
+     * copies (file + content-index entry) even when GitHub no longer lists them (the hidden /
+     * spam-hammered case); `author` matching is fetch-time only, since `metadata.discussions`
+     * persists `number` but not author login. The empty default denylist makes this a no-op.
      * @param {Object} discussion
      * @returns {Boolean}
      */
@@ -258,25 +260,32 @@ class DiscussionSyncer extends Base {
         };
 
         const cachedDiscussions = metadata.discussions || {};
+        const denylistNumbers   = new Set((issueSyncConfig.discussionDenylist?.numbers) || []);
 
-        // Containment: partition denylisted discussions out before bucket-planning + processing.
-        // A denylisted artifact (by number or author) must never enter resources/content/** or
-        // downstream KB chunks; any previously-synced copy is quarantined (removed). The empty
-        // default denylist makes this loop a no-op.
-        const deniedNumbers = new Set();
-        for (const discussion of allDiscussions) {
-            if (this.#isDenylisted(discussion)) {
-                deniedNumbers.add(discussion.number);
-                logger.warn(`🛡️ Discussion #${discussion.number} is denylisted (containment); excluding from sync.`);
-                const cachedPath = cachedDiscussions[discussion.number]?.path;
-                if (cachedPath) {
-                    await fs.unlink(this.#resolvePath(cachedPath)).catch(() => {});
-                    logger.warn(`🛡️ Quarantined previously-synced copy of denylisted discussion #${discussion.number}.`);
-                }
+        // Containment: quarantine denylisted discussions — removing both the file AND the
+        // content-index entry — for the current fetch AND for cached copies GitHub no longer lists
+        // (a hidden / spam-hammered artifact drops out of the list query while a prior local copy
+        // persists). Number-denylist is the guaranteed cached-quarantine lever: `metadata.discussions`
+        // persists `number` but not author, so author-denylist is fetch-time exclusion only. The
+        // empty default denylist makes this a no-op. `quarantineRemovals` is consumed by the
+        // post-loop `updateContentIndex` call so stale `discussions/<id>` lookups cannot survive.
+        const deniedFetchedNumbers = new Set(
+            allDiscussions.filter(discussion => this.#isDenylisted(discussion)).map(discussion => discussion.number)
+        );
+        const cachedDeniedNumbers = Object.keys(cachedDiscussions)
+            .map(Number).filter(number => denylistNumbers.has(number));
+        const quarantineRemovals = [];
+        for (const number of new Set([...cachedDeniedNumbers, ...deniedFetchedNumbers])) {
+            const cachedPath = cachedDiscussions[number]?.path;
+            if (cachedPath) {
+                await fs.unlink(this.#resolvePath(cachedPath)).catch(() => {});
             }
+            quarantineRemovals.push({type: 'discussions', id: number});
+            logger.warn(`🛡️ Discussion #${number} is denylisted (containment); quarantined + excluded from sync.`);
         }
-        if (deniedNumbers.size > 0) {
-            allDiscussions = allDiscussions.filter(discussion => !deniedNumbers.has(discussion.number));
+
+        if (deniedFetchedNumbers.size > 0) {
+            allDiscussions = allDiscussions.filter(discussion => !deniedFetchedNumbers.has(discussion.number));
         }
 
         const planBuckets = this.#planBuckets(metadata, allDiscussions);
@@ -405,7 +414,7 @@ class DiscussionSyncer extends Base {
         });
 
         try {
-            await updateContentIndex(issueSyncConfig, {upsert: indexEntries});
+            await updateContentIndex(issueSyncConfig, {upsert: indexEntries, remove: quarantineRemovals});
         } catch (e) {
             logger.warn(`⚠️ Could not update _index.json for discussions: ${e.message}`);
         }

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -31,6 +31,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
     let originalContentRoot;
     let originalQuery;
     let originalSortedReleases;
+    let originalDiscussionDenylist;
     let tmpRoot;
 
     test.beforeAll(async () => {
@@ -45,6 +46,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         originalContentRoot    = aiConfig.issueSync.contentRoot;
         originalQuery          = GraphqlService.query.bind(GraphqlService);
         originalSortedReleases = ReleaseNotesSyncer.sortedReleases;
+        originalDiscussionDenylist = aiConfig.issueSync.discussionDenylist;
     });
 
     test.beforeEach(async () => {
@@ -56,6 +58,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         aiConfig.issueSync.issuesDir      = path.join(tmpRoot, 'issues');
         aiConfig.issueSync.contentRoot    = tmpRoot;
         ReleaseNotesSyncer.sortedReleases      = [{tagName: 'v13.0.0', publishedAt: '2026-05-10T00:00:00Z'}];
+        aiConfig.issueSync.discussionDenylist  = {numbers: [], authors: []};
     });
 
     test.afterEach(async () => {
@@ -65,6 +68,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         aiConfig.issueSync.discussionsDir  = originalDiscussionsDir;
         aiConfig.issueSync.issuesDir       = originalIssuesDir;
         aiConfig.issueSync.contentRoot     = originalContentRoot;
+        aiConfig.issueSync.discussionDenylist = originalDiscussionDenylist;
 
         await fs.remove(tmpRoot).catch(() => {});
     });
@@ -296,6 +300,103 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
 
         // Stopped at page 2 (its oldest discussion predates the high-water mark); page 3 never requested.
         expect(queryCalls).toBe(2);
+    });
+
+    test('containment: skips and excludes a denylisted discussion (by number)', async () => {
+        const allowed = buildDiscussion(25001, {closed: false});
+        const denied  = buildDiscussion(25002, {closed: false});
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes: [allowed, denied],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        aiConfig.issueSync.discussionDenylist = {numbers: [25002], authors: []};
+
+        const metadata = {discussions: {}};
+        const stats = await DiscussionSyncer.syncDiscussions(metadata);
+
+        const allowedPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25001.md');
+        const deniedPath  = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25002.md');
+
+        expect(stats.synced).toEqual([25001]);                      // allowed synced, denied excluded
+        await expect(fs.pathExists(allowedPath)).resolves.toBe(true);
+        await expect(fs.pathExists(deniedPath)).resolves.toBe(false);
+        expect(metadata.discussions[25002]).toBeUndefined();        // never enters cache/index
+    });
+
+    test('containment: skips a denylisted discussion (by author)', async () => {
+        const denied = buildDiscussion(25003, {closed: false});
+        denied.author = {login: 'astroturf-account'};
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes: [denied],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        aiConfig.issueSync.discussionDenylist = {numbers: [], authors: ['astroturf-account']};
+
+        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}});
+        const deniedPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25003.md');
+
+        expect(stats.synced).toEqual([]);
+        await expect(fs.pathExists(deniedPath)).resolves.toBe(false);
+    });
+
+    test('containment: quarantines a previously-synced copy when a discussion becomes denylisted', async () => {
+        const discussion = buildDiscussion(25004, {closed: false});
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes: [discussion],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        // First run: normal sync writes the file and records it in metadata.
+        const metadata = {discussions: {}};
+        await DiscussionSyncer.syncDiscussions(metadata);
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25004.md');
+        await expect(fs.pathExists(targetPath)).resolves.toBe(true);
+
+        // Second run: now denylisted → the already-synced copy is quarantined (removed).
+        aiConfig.issueSync.discussionDenylist = {numbers: [25004], authors: []};
+        const stats = await DiscussionSyncer.syncDiscussions(metadata);
+
+        expect(stats.synced).toEqual([]);
+        await expect(fs.pathExists(targetPath)).resolves.toBe(false); // quarantined
+        expect(metadata.discussions[25004]).toBeUndefined();
+    });
+
+    test('containment: empty denylist preserves normal sync (no-op)', async () => {
+        const discussion = buildDiscussion(25005, {closed: false});
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes: [discussion],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        aiConfig.issueSync.discussionDenylist = {numbers: [], authors: []};
+
+        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}});
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25005.md');
+
+        expect(stats.synced).toEqual([25005]);
+        await expect(fs.pathExists(targetPath)).resolves.toBe(true);
     });
 });
 

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -327,6 +327,9 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await expect(fs.pathExists(allowedPath)).resolves.toBe(true);
         await expect(fs.pathExists(deniedPath)).resolves.toBe(false);
         expect(metadata.discussions[25002]).toBeUndefined();        // never enters cache/index
+        const index = await fs.readJson(path.join(tmpRoot, '_index.json'));
+        expect(index.some(e => e.type === 'discussions' && e.id === 25001)).toBe(true);
+        expect(index.some(e => e.type === 'discussions' && e.id === 25002)).toBe(false);
     });
 
     test('containment: skips a denylisted discussion (by author)', async () => {
@@ -351,7 +354,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await expect(fs.pathExists(deniedPath)).resolves.toBe(false);
     });
 
-    test('containment: quarantines a previously-synced copy when a discussion becomes denylisted', async () => {
+    test('containment: quarantines a fetched denylisted previously-synced copy (file + metadata + index)', async () => {
         const discussion = buildDiscussion(25004, {closed: false});
 
         GraphqlService.query = async () => ({
@@ -363,19 +366,52 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
             }
         });
 
-        // First run: normal sync writes the file and records it in metadata.
+        // First run: normal sync writes the file, metadata, and index entry.
         const metadata = {discussions: {}};
         await DiscussionSyncer.syncDiscussions(metadata);
         const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25004.md');
+        const indexPath  = path.join(tmpRoot, '_index.json');
         await expect(fs.pathExists(targetPath)).resolves.toBe(true);
+        expect((await fs.readJson(indexPath)).some(e => e.type === 'discussions' && e.id === 25004)).toBe(true);
 
-        // Second run: now denylisted → the already-synced copy is quarantined (removed).
+        // Second run: now denylisted → file, metadata, AND index entry are quarantined/removed.
         aiConfig.issueSync.discussionDenylist = {numbers: [25004], authors: []};
         const stats = await DiscussionSyncer.syncDiscussions(metadata);
 
         expect(stats.synced).toEqual([]);
-        await expect(fs.pathExists(targetPath)).resolves.toBe(false); // quarantined
+        await expect(fs.pathExists(targetPath)).resolves.toBe(false);
         expect(metadata.discussions[25004]).toBeUndefined();
+        expect((await fs.readJson(indexPath)).some(e => e.type === 'discussions' && e.id === 25004)).toBe(false);
+    });
+
+    test('containment: quarantines a cached denylisted number absent from the current GitHub list (hidden/spam-hammered)', async () => {
+        // Run 1: 25006 syncs normally (file + metadata + index entry).
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes: [buildDiscussion(25006, {closed: false})],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+        const metadata = {discussions: {}};
+        await DiscussionSyncer.syncDiscussions(metadata);
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25006.md');
+        const indexPath  = path.join(tmpRoot, '_index.json');
+        await expect(fs.pathExists(targetPath)).resolves.toBe(true);
+        expect((await fs.readJson(indexPath)).some(e => e.type === 'discussions' && e.id === 25006)).toBe(true);
+
+        // Run 2: 25006 is now denylisted AND GitHub no longer returns it in the list query.
+        // The cached copy must still be quarantined by number — file + metadata + index entry.
+        aiConfig.issueSync.discussionDenylist = {numbers: [25006], authors: []};
+        GraphqlService.query = async () => ({
+            repository: {discussions: {nodes: [], pageInfo: {hasNextPage: false, endCursor: null}}}
+        });
+        await DiscussionSyncer.syncDiscussions(metadata);
+
+        await expect(fs.pathExists(targetPath)).resolves.toBe(false);
+        expect(metadata.discussions[25006]).toBeUndefined();
+        expect((await fs.readJson(indexPath)).some(e => e.type === 'discussions' && e.id === 25006)).toBe(false);
     });
 
     test('containment: empty denylist preserves normal sync (no-op)', async () => {


### PR DESCRIPTION
Resolves #12995

Adds a sync-time **discussion denylist + quarantine** to `DiscussionSyncer` — the containment lever (Slice A) of the KB trust-tier work under epic #10291. A known-contaminated discussion (matched by `number` or `author.login`) is excluded before it is written to `resources/content/**` or reaches downstream KB chunks, and any previously-synced copy is removed (quarantined). The mechanism is policy-free: the empty default denylist is a no-op, so normal sync is unchanged until an entry is populated.

This is the urgent containment response to the #12992 astroturf / corpus-poisoning attempt (OWASP ASI06), per @neo-gpt's intake split (he yielded the lane). Slices B (KB chunk provenance `trustTier`) and C (retrieval `minTrustTier`) are deferred to converge with the Memory-Core trust taxonomy (#10292 P1) into one cross-substrate model — tracked on the #12995 thread, not this PR.

Authored by Vega — Claude Opus 4.8 (Claude Code). Session 08004f64-fccc-45b5-85cf-1853f7ce6520.

Evidence: L2 (unit: mock `GraphqlService` dispatch + real `fs` writes in a tmp dir; 11/11 pass) → L2 required (the AC is the sync-skip / quarantine behavior, fully unit-covered). No residuals.

## MCP config template change

Per the config-template-change guide (this PR changes `ai/mcp/server/github-workflow/config.template.mjs`):
- **Changed key:** `issueSync.discussionDenylist` (new) — `{numbers: [], authors: []}` default.
- **Local `config.mjs` follow-up:** each clone's gitignored `config.mjs` picks up the new key on the next `prepare` (`initServerConfigs.mjs`); no manual edit required, and CI regenerates it. No gitignored `config.mjs` is committed.
- **Harness restart:** unnecessary — the empty default is a no-op, and the syncer reads the leaf at sync-time.

## Deltas from ticket

- Scoped #12995 to **Slice A (containment)** per @neo-gpt's intake split; B/C explicitly deferred to the cross-substrate trust-tier convergence (so the KB taint model reuses #10292's taxonomy rather than forking a parallel one).
- Added **quarantine** (removing an already-synced copy) beyond bare skip — a contaminated artifact already on disk is contained, not just blocked from re-sync.
- Design note: denied discussions are partitioned out of `allDiscussions` **before** bucket-planning + the post-loop index rebuild; a bare in-loop `continue` would have leaked them into the rebuild with undefined path data.

## Test Evidence

`npm run test-unit -- test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs` → **11 passed** (7 pre-existing + 4 new):
- `containment: skips and excludes a denylisted discussion (by number)`
- `containment: skips a denylisted discussion (by author)`
- `containment: quarantines a previously-synced copy when a discussion becomes denylisted`
- `containment: empty denylist preserves normal sync (no-op)`

Warn-log confirms the gate fires: `🛡️ Discussion #25002 is denylisted (containment); excluding from sync.` / `🛡️ Quarantined previously-synced copy of denylisted discussion #25004.`

## Post-Merge Validation

- [ ] Peers regenerate `config.mjs` (next `prepare`) so the `discussionDenylist` key is present locally.
- [ ] A populated denylist (by number or author) observably excludes + quarantines that discussion in a real sync run.

## Commits

- `eacf6d9e8` — feat(github-workflow): sync-time discussion denylist + quarantine for content containment (#12995).

Related: #10291 (self-defense epic), #12996 (quarantine-skill sibling), #10292 (P1 trust taxonomy that B/C will extend).
