### PR TITLE
feat(portal): deterministic news deep links via build-emitted id maps (#12999)

### DIFF
--- a/apps/portal/view/news/discussions/MainContainerController.mjs
+++ b/apps/portal/view/news/discussions/MainContainerController.mjs
@@ -21,6 +21,13 @@ class MainContainerController extends Controller {
     }
 
     /**
+     * Memoized promise for the build-emitted id→chunk map (see getIdMap()).
+     * @member {Promise<Object|null>|undefined} idMapPromise
+     * @protected
+     */
+    idMapPromise = undefined
+
+    /**
      * @param {String} item
      */
     navigateTo(item) {
@@ -92,6 +99,27 @@ class MainContainerController extends Controller {
     }
 
     /**
+     * Lazily fetches and memoizes the build-emitted id→chunk map for this content type.
+     * The map lets a deep link resolve its containing chunk folder directly instead of
+     * scanning folders sequentially; a missing or unreachable map degrades to null and
+     * callers fall back to the legacy folder scan.
+     * @returns {Promise<Object|null>}
+     */
+    getIdMap() {
+        let me = this;
+
+        if (me.idMapPromise === undefined) {
+            const tree = me.getReference('tree');
+
+            me.idMapPromise = fetch(`${tree.lazyChildUrlPrefix}discussions/idMap.json`)
+                .then(response => response.ok ? response.json() : null)
+                .catch(() => null)
+        }
+
+        return me.idMapPromise
+    }
+
+    /**
      * @param {String} itemId
      * @returns {Promise<Object|null>}
      */
@@ -104,6 +132,23 @@ class MainContainerController extends Controller {
 
         if (record) {
             return record
+        }
+
+        // Deterministic single-chunk resolution: the build-emitted id map names the chunk
+        // folder containing the item, so one targeted load replaces the sequential scan.
+        const
+            idMap  = await me.getIdMap(),
+            folder = idMap?.[itemId] && store.get(idMap[itemId]);
+
+        if (folder) {
+            await tree.onFolderItemClick(folder);
+
+            record = store.get(itemId);
+
+            if (record) {
+                me.getStateProvider().data.countPages = store.getCount();
+                return record
+            }
         }
 
         folders = store.items.filter(record => !record.isLeaf && record.childrenUrl && !record.isChildrenLoaded);

--- a/apps/portal/view/news/pulls/MainContainerController.mjs
+++ b/apps/portal/view/news/pulls/MainContainerController.mjs
@@ -21,6 +21,13 @@ class MainContainerController extends Controller {
     }
 
     /**
+     * Memoized promise for the build-emitted id→chunk map (see getIdMap()).
+     * @member {Promise<Object|null>|undefined} idMapPromise
+     * @protected
+     */
+    idMapPromise = undefined
+
+    /**
      * @param {String} item
      */
     navigateTo(item) {
@@ -98,9 +105,31 @@ class MainContainerController extends Controller {
     }
 
     /**
+     * Lazily fetches and memoizes the build-emitted id→chunk map for this content type.
+     * The map lets a deep link resolve its containing chunk folder directly instead of
+     * scanning folders sequentially; a missing or unreachable map degrades to null and
+     * callers fall back to the legacy folder scan.
+     * @returns {Promise<Object|null>}
+     */
+    getIdMap() {
+        let me = this;
+
+        if (me.idMapPromise === undefined) {
+            const tree = me.getReference('tree');
+
+            me.idMapPromise = fetch(`${tree.lazyChildUrlPrefix}pulls/idMap.json`)
+                .then(response => response.ok ? response.json() : null)
+                .catch(() => null)
+        }
+
+        return me.idMapPromise
+    }
+
+    /**
      * @summary Lazy-aware record resolution for deep-links.
      *
-     * Probes the store for `itemId`; if absent (its chunk is not loaded yet), expands unloaded chunk
+     * Probes the store for `itemId`; if absent (its chunk is not loaded yet), resolves the containing
+     * chunk via the build-emitted id map (one targeted load), falling back to expanding unloaded chunk
      * folders (`childrenUrl` + `!isChildrenLoaded`) one at a time until the record's chunk loads. This
      * is what makes a bare-id deep-link (`#/news/pulls/<number>`) resolve under the chunked store.
      * @param {String} itemId
@@ -115,6 +144,23 @@ class MainContainerController extends Controller {
 
         if (record) {
             return record
+        }
+
+        // Deterministic single-chunk resolution: the build-emitted id map names the chunk
+        // folder containing the item, so one targeted load replaces the sequential scan.
+        const
+            idMap  = await me.getIdMap(),
+            folder = idMap?.[itemId] && store.get(idMap[itemId]);
+
+        if (folder) {
+            await tree.onFolderItemClick(folder);
+
+            record = store.get(itemId);
+
+            if (record) {
+                me.getStateProvider().data.countPages = store.getCount();
+                return record
+            }
         }
 
         folders = store.items.filter(record => !record.isLeaf && record.childrenUrl && !record.isChildrenLoaded);

--- a/apps/portal/view/news/tickets/MainContainerController.mjs
+++ b/apps/portal/view/news/tickets/MainContainerController.mjs
@@ -21,6 +21,13 @@ class MainContainerController extends Controller {
     }
 
     /**
+     * Memoized promise for the build-emitted id→chunk map (see getIdMap()).
+     * @member {Promise<Object|null>|undefined} idMapPromise
+     * @protected
+     */
+    idMapPromise = undefined
+
+    /**
      * @param {String} item
      */
     navigateTo(item) {
@@ -92,6 +99,27 @@ class MainContainerController extends Controller {
     }
 
     /**
+     * Lazily fetches and memoizes the build-emitted id→chunk map for this content type.
+     * The map lets a deep link resolve its containing chunk folder directly instead of
+     * scanning folders sequentially; a missing or unreachable map degrades to null and
+     * callers fall back to the legacy folder scan.
+     * @returns {Promise<Object|null>}
+     */
+    getIdMap() {
+        let me = this;
+
+        if (me.idMapPromise === undefined) {
+            const tree = me.getReference('tree');
+
+            me.idMapPromise = fetch(`${tree.lazyChildUrlPrefix}tickets/idMap.json`)
+                .then(response => response.ok ? response.json() : null)
+                .catch(() => null)
+        }
+
+        return me.idMapPromise
+    }
+
+    /**
      * @param {String} itemId
      * @returns {Promise<Object|null>}
      */
@@ -104,6 +132,23 @@ class MainContainerController extends Controller {
 
         if (record) {
             return record
+        }
+
+        // Deterministic single-chunk resolution: the build-emitted id map names the chunk
+        // folder containing the item, so one targeted load replaces the sequential scan.
+        const
+            idMap  = await me.getIdMap(),
+            folder = idMap?.[itemId] && store.get(idMap[itemId]);
+
+        if (folder) {
+            await tree.onFolderItemClick(folder);
+
+            record = store.get(itemId);
+
+            if (record) {
+                me.getStateProvider().data.countPages = store.getCount();
+                return record
+            }
         }
 
         folders = store.items.filter(record => !record.isLeaf && record.childrenUrl && !record.isChildrenLoaded);

--- a/buildScripts/docs/index/discussions.mjs
+++ b/buildScripts/docs/index/discussions.mjs
@@ -113,6 +113,7 @@ async function createDiscussionIndex(options = {}) {
 
     const groups = new Map();
     const chunks = new Map();
+    const idMap  = {};
 
     for (const fileInfo of allFiles) {
         const {filePath, isActive} = fileInfo;
@@ -177,7 +178,9 @@ async function createDiscussionIndex(options = {}) {
             parentId: chunkId,
             state   : getDiscussionState(frontmatter),
             title   : frontmatter.title
-        })
+        });
+
+        idMap[String(frontmatter.number)] = chunkId
     }
 
     const sortedGroups = Array.from(groups.keys()).sort((a, b) => {
@@ -223,8 +226,13 @@ async function createDiscussionIndex(options = {}) {
     await fs.ensureDir(path.dirname(outputFile));
     await fs.writeJSON(outputFile, rootIndex);
 
+    // Deep-link resolver: maps every leaf id to its chunk folder id, so consumers can load
+    // exactly the one chunk containing a deep-linked item instead of scanning folders.
+    await fs.writeJSON(path.join(outputDir, 'idMap.json'), idMap);
+
     console.log(`Discussions index written to ${outputFile}`);
     console.log(`Discussions leaf chunks written to ${outputDir}`);
+    console.log(`Discussions id map written to ${path.join(outputDir, 'idMap.json')}`);
 }
 
 /**

--- a/buildScripts/docs/index/pulls.mjs
+++ b/buildScripts/docs/index/pulls.mjs
@@ -130,11 +130,12 @@ function sortChunkFolders(a, b) {
 /**
  * @param {String[]} sortedGroups
  * @param {Map<String,Object[]>} pullsByGroup
- * @returns {{rootIndex: Object[], chunks: Map<String,Object>}}
+ * @returns {{rootIndex: Object[], chunks: Map<String,Object>, idMap: Object}}
  */
 function buildChunkedIndex(sortedGroups, pullsByGroup) {
     const
         chunks    = new Map(),
+        idMap     = {},
         rootIndex = [];
 
     for (const groupName of sortedGroups) {
@@ -173,7 +174,9 @@ function buildChunkedIndex(sortedGroups, pullsByGroup) {
                 id      : pull.id,
                 parentId: chunkId,
                 title   : pull.title
-            })
+            });
+
+            idMap[pull.id] = chunkId
         }
     }
 
@@ -190,7 +193,7 @@ function buildChunkedIndex(sortedGroups, pullsByGroup) {
         }))
     });
 
-    return {rootIndex, chunks}
+    return {rootIndex, chunks, idMap}
 }
 
 /**
@@ -298,9 +301,9 @@ async function createPullRequestIndex(options = {}) {
     }));
 
     const
-        sortedGroups        = sortGroups(Array.from(pullsByGroup.keys())),
-        pullCount           = Array.from(pullsByGroup.values()).reduce((sum, group) => sum + group.length, 0),
-        {rootIndex, chunks} = buildChunkedIndex(sortedGroups, pullsByGroup);
+        sortedGroups               = sortGroups(Array.from(pullsByGroup.keys())),
+        pullCount                  = Array.from(pullsByGroup.values()).reduce((sum, group) => sum + group.length, 0),
+        {rootIndex, chunks, idMap} = buildChunkedIndex(sortedGroups, pullsByGroup);
 
     console.log(`Indexed ${pullCount} pull requests in ${sortedGroups.length} groups.`);
 
@@ -335,9 +338,14 @@ async function createPullRequestIndex(options = {}) {
     await fs.writeJSON(chunkedOutputFile, rootIndex);
     await fs.writeJSON(manifestFile, manifest);
 
+    // Deep-link resolver: maps every leaf id to its chunk folder id, so consumers can load
+    // exactly the one chunk containing a deep-linked item instead of scanning folders.
+    await fs.writeJSON(path.join(outputDir, 'idMap.json'), idMap);
+
     console.log(`Chunked pull-request root index written to ${chunkedOutputFile}`);
     console.log(`Chunked pull-request leaf files written to ${outputDir}`);
-    console.log(`Pull-request crawler manifest written to ${manifestFile}`)
+    console.log(`Pull-request crawler manifest written to ${manifestFile}`);
+    console.log(`Pull-request id map written to ${path.join(outputDir, 'idMap.json')}`)
 }
 
 /**

--- a/buildScripts/docs/index/tickets.mjs
+++ b/buildScripts/docs/index/tickets.mjs
@@ -133,11 +133,12 @@ function sortChunkFolders(a, b) {
 /**
  * @param {String[]} sortedGroups
  * @param {Map<String,Object[]>} ticketsByGroup
- * @returns {{rootIndex: Object[], chunks: Map<String,Object>}}
+ * @returns {{rootIndex: Object[], chunks: Map<String,Object>, idMap: Object}}
  */
 function buildChunkedIndex(sortedGroups, ticketsByGroup) {
     const
         chunks    = new Map(),
+        idMap     = {},
         rootIndex = [];
 
     for (const groupName of sortedGroups) {
@@ -176,7 +177,9 @@ function buildChunkedIndex(sortedGroups, ticketsByGroup) {
                 id      : ticket.id,
                 parentId: chunkId,
                 title   : ticket.title
-            })
+            });
+
+            idMap[ticket.id] = chunkId
         }
     }
 
@@ -193,7 +196,7 @@ function buildChunkedIndex(sortedGroups, ticketsByGroup) {
         }))
     });
 
-    return {rootIndex, chunks}
+    return {rootIndex, chunks, idMap}
 }
 
 /**
@@ -330,8 +333,8 @@ async function createTicketIndex(options = {}) {
     });
 
     const
-        ticketCount         = Array.from(ticketsByGroup.values()).reduce((sum, group) => sum + group.length, 0),
-        {rootIndex, chunks} = buildChunkedIndex(sortedGroups, ticketsByGroup);
+        ticketCount                = Array.from(ticketsByGroup.values()).reduce((sum, group) => sum + group.length, 0),
+        {rootIndex, chunks, idMap} = buildChunkedIndex(sortedGroups, ticketsByGroup);
 
     console.log(`Filtered down to ${ticketCount} tickets in ${sortedGroups.length} groups.`);
 
@@ -366,9 +369,14 @@ async function createTicketIndex(options = {}) {
     await fs.writeJSON(chunkedOutputFile, rootIndex);
     await fs.writeJSON(manifestFile, manifest);
 
+    // Deep-link resolver: maps every leaf id to its chunk folder id, so consumers can load
+    // exactly the one chunk containing a deep-linked item instead of scanning folders.
+    await fs.writeJSON(path.join(outputDir, 'idMap.json'), idMap);
+
     console.log(`Chunked ticket root index written to ${chunkedOutputFile}`);
     console.log(`Chunked ticket leaf files written to ${outputDir}`);
     console.log(`Ticket crawler manifest written to ${manifestFile}`);
+    console.log(`Ticket id map written to ${path.join(outputDir, 'idMap.json')}`);
 }
 
 /**

--- a/test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/index/PortalContentIndexes.spec.mjs
@@ -126,7 +126,15 @@ test.describe('Portal content index generators (#12210)', () => {
         const manifest = await fs.readJson(manifestFile);
 
         expect(manifest.indexUrl).toBe('pulls/index.json');
-        expect(manifest.chunks.some(chunk => chunk.childrenUrl === 'pulls/latest/active-chunk-1.json')).toBe(true)
+        expect(manifest.chunks.some(chunk => chunk.childrenUrl === 'pulls/latest/active-chunk-1.json')).toBe(true);
+
+        // 3. The deep-link id map names each leaf's chunk folder — active and archived alike.
+        await expect(fs.readJson(path.join(outputDir, 'idMap.json'))).resolves.toEqual({
+            '1': 'v12.1.0/archive-v12-1-0-chunk-1',
+            '2': 'Latest/active-chunk-1',
+            '3': 'Latest/active-chunk-1',
+            '4': 'Latest/active-chunk-1'
+        })
     });
 
     test('createPullRequestIndex orders chunk folders by chunk-number (desc), not by sortDate, matching the positional labels (#12309)', async () => {
@@ -233,6 +241,13 @@ test.describe('Portal content index generators (#12210)', () => {
             parentId: 'Q&A/archive-v8-30-0-chunk-1',
             state   : 'closed',
             title   : 'Archived answer'
-        }])
+        }]);
+
+        // The deep-link id map spans categories and archive buckets alike.
+        await expect(fs.readJson(path.join(outputDir, 'idMap.json'))).resolves.toEqual({
+            '10': 'Ideas/active-chunk-1',
+            '11': 'Q&A/archive-v8-30-0-chunk-1',
+            '12': 'General/active-chunk-1'
+        })
     })
 });

--- a/test/playwright/unit/ai/buildScripts/docs/index/TicketIndex.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/index/TicketIndex.spec.mjs
@@ -134,6 +134,14 @@ test.describe('Portal ticket index generator (#12217)', () => {
                 childrenUrl: 'tickets/backlog/active-chunk-2.json',
                 childCount : 1
             })])
+        });
+
+        // The deep-link id map names each leaf's chunk folder — and only included leaves:
+        // the excluded chore (id 10) must not appear.
+        await expect(fs.readJson(path.join(outputDir, 'idMap.json'))).resolves.toEqual({
+            '5' : 'v11.0.0/archive-v11-0-0-chunk-1',
+            '20': 'v12.1.0/archive-v12-1-0-chunk-1',
+            '30': 'Backlog/active-chunk-2'
         })
     });
 


### PR DESCRIPTION
Resolves #12999
Refs #12964

Authored by Claude Fable 5 (Claude Code, @neo-fable-clio). Session 3e1566f6-6336-4db4-8726-189004578d8b.

**STACKED on PR #12998** (the tickets.json monolith deletion) — merge #12998 first; this branch builds on its writer shape. Until then this PR's diff shows both changesets.

Deep-linking a news item whose chunk wasn't loaded walked **every unloaded folder sequentially** until the id happened to appear — 1,045 chunks for tickets, minutes per archived item, identically on the live site and under SSG (where the 120s renderer kill turned the ~8,500-route archive surface into ~17h of mostly-timeouts: the historical 8h-build pain, root-caused this afternoon via three rounds of SSR instrumentation on the `#12964` thread).

**What shipped:**
1. The three index writers emit `<type>/idMap.json` beside the chunked surface — flat `{itemId: chunkFolderId}`, derived inside their existing per-item loops (9,154 / 3,578 / 149 entries on the current corpus). Generated data: the maps materialize with the next sync-pipeline run (deliberately NOT committed here — committing fresh maps against the currently-committed chunk topology would pair inconsistently; the pipeline emits both together).
2. The three news controllers consult the map first — lazily fetched via the tree's own `lazyChildUrlPrefix` convention, memoized per controller, degrading to `null` on 404/error — and load **exactly the one containing chunk**. The sequential scan survives as the fallback for ids absent from the map (fresh items between syncs), so behavior is never worse than today, including the window before the pipeline first emits the maps.

Evidence: L3 (live SSR overlay probe in the middleware env) → L3 required (#12999 AC5 names the SSG runtime surface). No residuals.

## Test Evidence
- Writer spec extended: idMap content assertions incl. the exclusion contract (the filtered chore id must NOT appear) — 3/3 green.
- All three writers executed against the repo: maps emit with the expected counts; the chunked surfaces regenerate byte-identically (the unrelated content-drift churn from running against fresher-than-committed content was deliberately excluded from the commit).
- **The decisive probe**: `/news/tickets/6193` — a v8.1.0-archive route that previously hung past the 120s SSG kill — renders in **0.645s** (323KB, markdown present) under the middleware SSR with the map + controllers overlaid. The active-route control rendered correctly throughout.
- Syntax-checked ×7; no dedicated controller specs exist for the news views (noted — whitebox-e2e deep-link coverage is flagged as a follow-up candidate in the ticket's Out of Scope).

## Deltas from ticket
- None of substance; the map URL rides `lazyChildUrlPrefix` exactly as scoped, and the discussions controller turned out shape-identical to the other two (the ticket hedged on that).

## Post-Merge Validation
- [ ] The next data-sync pipeline run emits the three idMap.json files (writers now produce them unconditionally).
- [ ] The middleware SSG remainder build (the parked 4,138-route range) completes at sane per-route times once the middleware's neo dependency includes this change — the practical close-out of the `#12964` 8h-build mystery.