### PR TITLE
feat(deploy): wire ask-path env (NEO_KB_ASK_*) into kb-server compose (#12983)

### DIFF
--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -36,6 +36,17 @@ services:
       - NEO_CHROMA_PORT=8000
       - MCP_HTTP_PORT=3000
       - NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite
+      # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
+      # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
+      # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
+      # ask path fails soft to references-only (no crash). The secret VALUE stays runtime-only.
+      - NEO_KB_ASK_PROVIDER=${NEO_KB_ASK_PROVIDER:-}
+      - NEO_KB_ASK_MODEL=${NEO_KB_ASK_MODEL:-}
+      - NEO_KB_ASK_API_KEY=${NEO_KB_ASK_API_KEY:-}
+      - NEO_KB_ASK_BASE_URL=${NEO_KB_ASK_BASE_URL:-}
+      - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
+      - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
+      - NEO_KB_ASK_MAX_RPM=${NEO_KB_ASK_MAX_RPM:-}
 
     volumes:
       - ../..:/app

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -63,6 +63,17 @@ services:
       - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
       - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
       - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
+      # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
+      # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
+      # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
+      # ask path fails soft to references-only (no crash). The secret VALUE stays runtime-only.
+      - NEO_KB_ASK_PROVIDER=${NEO_KB_ASK_PROVIDER:-}
+      - NEO_KB_ASK_MODEL=${NEO_KB_ASK_MODEL:-}
+      - NEO_KB_ASK_API_KEY=${NEO_KB_ASK_API_KEY:-}
+      - NEO_KB_ASK_BASE_URL=${NEO_KB_ASK_BASE_URL:-}
+      - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
+      - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
+      - NEO_KB_ASK_MAX_RPM=${NEO_KB_ASK_MAX_RPM:-}
     volumes:
       - shared-sqlite-data:/app/.neo-ai-data/sqlite
     depends_on:


### PR DESCRIPTION
Resolves #12983

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace). Session 9eb75c03-9185-4e69-8064-1decc76c6771.

The cloud `ask_knowledge_base` path (`SearchService.ask`) builds its synthesis model from the `askSynthesis` config block, keyed on the dedicated `NEO_KB_ASK_API_KEY` (budget-cappable, deliberately separate from the shared `GEMINI_API_KEY`). The `ai/deploy` compose wired none of that env into the kb-server, so a fresh cloud deploy silently degraded `ask` to references-only (degraded answer, no crash). This adds the `${NEO_KB_ASK_*:-}` pass-throughs to the kb-server `environment:` in the base and dev compose, mirroring the existing provider pass-through pattern (`NEO_MODEL_PROVIDER`, `NEO_OPENAI_COMPATIBLE_*`). The secret VALUE stays runtime-only — empty default resolves to the config-template default, so an unset key fails soft to references-only.

Evidence: L2 (`docker compose config` validates both files; pass-through resolution confirmed — host env to kb-server container env when set, `""` when unset) -> L3 required (AC3: live deploy with the runtime secret set -> `ask` returns synthesis, not refs-only). Residual: AC3 [#12983].

## Deltas from ticket
- Wired the full operator-tunable ask surface, not just `API_KEY` + `PROVIDER`: also `MODEL`, `BASE_URL`, `SYNTHESIS_TIMEOUT_MS`, `SYNTHESIS_TIMEOUT_MS_REMOTE`, `MAX_RPM` — every `askSynthesis` leaf from `knowledge-base/config.template.mjs`. Mirrors the "expose the full runtime-configurable set" precedent of the existing provider pass-throughs, so the operator never needs to touch compose again for ask tuning (`MAX_RPM` in particular serves the ticket's budget-cap rationale).
- Added to BOTH base (`docker-compose.yml`) and dev (`docker-compose.dev.yml`) kb-server blocks per ticket scope. `docker-compose.test.yml` left untouched (out of scope; integration tests use local/mock providers).

## Test Evidence
- `docker compose -f ai/deploy/docker-compose.yml config -q` -> VALID; same for `docker-compose.dev.yml` -> VALID.
- Pass-through resolution proven via `docker compose ... config`: a set `NEO_KB_ASK_API_KEY` + `NEO_KB_ASK_PROVIDER` render into the kb-server `environment:`; unset -> `""` (graceful fallback). The secret VALUE never appears in the committed file (only `${VAR:-}`).
- Env var NAMES verified against `ai/mcp/server/knowledge-base/config.template.mjs` leaf definitions.

## Post-Merge Validation
- [ ] AC3: a cloud deploy with `NEO_KB_ASK_API_KEY` (+ provider) set in the runtime env -> `ask_knowledge_base` returns a synthesized answer, not references-only (operator-owned; requires a live deploy + provider reachability).
- [ ] Provider/key VALUE choice stays the operator Tier-4 decision (gemini-2.5-flash vs local) — this PR wires only the machinery.

## Commits
- 0b859a0c6 — feat(deploy): wire ask-path env (NEO_KB_ASK_*) pass-throughs into kb-server compose