### PR TITLE
fix(memory-core): exempt non-embedding reads (get_session_memories, query_recent_turns) from the embedder health-gate (#12978)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -421,6 +421,11 @@ class Server extends BaseServer {
      * @param {Object} health
      */
     logStartupStatus(health) {
+        // `BaseServer.runHealthcheckAndLogStatus` passes null when the health service exposes no
+        // healthcheck method — there is no health status to report in that case. Without this guard
+        // the override dereferences null on a degraded/health-serviceless boot and crashes initAsync.
+        if (!health) return;
+
         if (health.status === 'unhealthy') {
             logger.warn('⚠️  [Startup] Memory Core is unhealthy. Server will start but tools will fail until resolved.');
             health.details.forEach(detail => logger.warn(`    ${detail}`));

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -101,6 +101,14 @@ class Server extends BaseServer {
      * summarization/vector-provider incidents so agents can coordinate the recovery — as is
      * add_memory, whose never-fail WAL write is local-disk-scoped with the embed deferred to the
      * drain, so memory capture never blocks on an embedder/vector-provider outage.
+     *
+     * The non-embedding reads are exempt for the same reason. The gate trips on the embedder canary
+     * (a live `embedText` probe), but `get_session_memories` (a Chroma metadata `.get()` by
+     * sessionId) and `query_recent_turns` (a SQLite recency read over the `AGENT_MEMORY` graph, with
+     * a WAL-overlay fallback for its optional Chroma content join) call no embedder — they serve
+     * fine while it is down, so gating them only denied a read the outage never touched. NOT exempt:
+     * `query_raw_memories` / `query_summaries`, which embed the query and genuinely cannot serve
+     * during an embedder outage — exempting them would trade a clean gate-reject for an embed-timeout.
      * @returns {Array<String>}
      */
     getHealthExemptTools() {
@@ -117,7 +125,9 @@ class Server extends BaseServer {
             'grant_permission',
             'revoke_permission',
             'list_permissions',
-            'manage_wake_subscription'
+            'manage_wake_subscription',
+            'get_session_memories',
+            'query_recent_turns'
         ];
     }
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -266,6 +266,92 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
+    test('#12978: non-embedding reads (get_session_memories, query_recent_turns) bypass the embedder-degraded health gate; embed-dependent reads do not', async () => {
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const handlers = new Map();
+        const healthCalls = [];
+        const toolCalls = [];
+        const degradedError = new Error([
+            'Memory Core is not fully operational:',
+            '  - GEMINI_API_KEY not set - summarization features unavailable'
+        ].join('\n'));
+
+        const mcpServer = {
+            server: {
+                setRequestHandler(schema, handler) {
+                    handlers.set(schema, handler);
+                }
+            }
+        };
+
+        serverInstance.getToolService = () => ({
+            listTools: () => ({tools: [], nextCursor: undefined}),
+            callTool : (name, args) => {
+                toolCalls.push({name, args});
+                return {ok: true, name};
+            }
+        });
+        serverInstance.getHealthService = () => ({
+            ensureHealthy: async () => {
+                healthCalls.push('ensureHealthy');
+                throw degradedError;
+            }
+        });
+
+        serverInstance.setupRequestHandlers(mcpServer);
+
+        try {
+            const callTool = handlers.get(CallToolRequestSchema);
+
+            // get_session_memories — exempt: a Chroma metadata .get() by sessionId, no embedder call,
+            // so it serves while the embedder canary is down.
+            const sessionResult = await callTool({
+                params: {
+                    name     : 'get_session_memories',
+                    arguments: {sessionId: 's'}
+                }
+            });
+
+            expect(sessionResult.isError).toBe(false);
+            expect(sessionResult.structuredContent).toEqual({ok: true, name: 'get_session_memories'});
+
+            // query_recent_turns — exempt: a SQLite recency read over the AGENT_MEMORY graph, no
+            // embedder call (its optional Chroma content join degrades to the WAL overlay).
+            const recentResult = await callTool({
+                params: {
+                    name     : 'query_recent_turns',
+                    arguments: {limit: 5}
+                }
+            });
+
+            expect(recentResult.isError).toBe(false);
+            expect(recentResult.structuredContent).toEqual({ok: true, name: 'query_recent_turns'});
+
+            // Both exempt → neither consulted the health service; both reached the tool service.
+            expect(healthCalls).toEqual([]);
+            expect(toolCalls).toEqual([
+                {name: 'get_session_memories', args: {sessionId: 's'}},
+                {name: 'query_recent_turns',   args: {limit: 5}}
+            ]);
+
+            // query_summaries — NOT exempt: it embeds the query, so the gate must still fire (the
+            // embedder outage genuinely prevents it serving a semantic result).
+            const summariesResult = await callTool({
+                params: {
+                    name     : 'query_summaries',
+                    arguments: {query: 'q'}
+                }
+            });
+
+            expect(summariesResult.isError).toBe(true);
+            expect(summariesResult.content[0].text).toContain('Cannot execute query_summaries: Memory Core is not fully operational');
+            expect(healthCalls).toEqual(['ensureHealthy']);
+            expect(toolCalls).toHaveLength(2);
+        } finally {
+            serverInstance.destroy();
+        }
+    });
+
     test('#12752: health exemptions do not expose retired database lifecycle tools', () => {
         const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -352,6 +352,19 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
+    test('#12978: logStartupStatus tolerates a null health result (BaseServer passes null when the health service has no healthcheck)', () => {
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+
+        try {
+            // Regression pin: BaseServer.runHealthcheckAndLogStatus calls logStartupStatus(null)
+            // when the health service exposes no healthcheck method (e.g. a degraded/serviceless
+            // boot). The MC override must not dereference null — otherwise initAsync crashes.
+            expect(() => serverInstance.logStartupStatus(null)).not.toThrow();
+        } finally {
+            serverInstance.destroy();
+        }
+    });
+
     test('#12752: health exemptions do not expose retired database lifecycle tools', () => {
         const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
 


### PR DESCRIPTION
Resolves #12978

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace). Session 9eb75c03-9185-4e69-8064-1decc76c6771.

`BaseServer` gates every non-exempt MC tool through `HealthService.ensureHealthy()`, whose status is driven by the **embedder canary** (a live `embedText` probe). When the embedder times out under REM/backfill saturation, the gate trips — and takes down reads that never needed the embedder. This exempts the two confirmed embedder-independent reads so they keep serving during an embedder outage.

**Audit (the AC, V-B-A of each read-path):**
- `get_session_memories` → `MemoryService.listMemories`: a ChromaDB **metadata `.get()`** filtered by `sessionId` — no `embedText` call.
- `query_recent_turns` → `MemoryService.queryRecentTurns`: a **SQLite recency read** over the `AGENT_MEMORY` graph (`detail:summary`); the optional `detail:full` Chroma content join degrades to the **WAL overlay** on a Chroma hiccup — no `embedText` call.
- Gate failure mode confirmed embedder-specific: `ensureHealthy()` → `healthcheck()` status is driven by the `embedText` canary, so a tripped gate means the embedder is down while Chroma/SQLite stay readable. Worst case (both down) these degrade gracefully (error object / overlay), never a false success.

**Out of scope (stay gated):** `query_raw_memories` / `query_summaries` embed the query — an embedder outage genuinely prevents them serving; exempting them would only trade a clean gate-reject for an embed-timeout.

Evidence: L2 (read-path audit confirming no `embedText` call on either tool + embedder-specific canary; `#12978` `Server.spec` asserts both bypass the degraded gate while `query_summaries` still fires it — 7/7 green) → L2 required (audit + bypass-unit-test ACs). No residuals.

## Deltas from ticket
- Refined the ticket's "ID/recency graph reads" framing: `query_recent_turns` is indeed a SQLite graph read, but `get_session_memories` is a **Chroma metadata read**, not a graph read. The load-bearing invariant is "**calls no `embedText`**" (+ the canary being embedder-compute-specific), not "reads the graph" — both still qualify, no tool dropped from scope.

## Test Evidence
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` → **7 passed (2.5s)**.
- New `#12978` test mirrors the `#12838` pattern: under a thrown `ensureHealthy()`, `get_session_memories` + `query_recent_turns` reach the tool service with no health consult (`healthCalls` empty); `query_summaries` still trips the gate (`isError`, `healthCalls=[ensureHealthy]`). Pre-existing `#12838`/`#12752` tests unchanged + green.

## Post-Merge Validation
- [ ] None — the exemption behavior is fully covered by the deterministic unit test; no runtime-only AC.

## Commits
- 5804eb741 — fix(memory-core): exempt the two non-embedding reads + #12978 Server.spec