### PR TITLE
feat(vdom): add delta grammar guards (#12994)

### DIFF
--- a/src/DefaultConfig.mjs
+++ b/src/DefaultConfig.mjs
@@ -137,6 +137,16 @@ const DefaultConfig = {
      */
     logDeltaUpdates: false,
     /**
+     * true will validate VDom delta batches in the main thread before applying them.
+     * Guard-grade findings reject the whole batch before the first DOM mutation; candidate
+     * structural findings are logged for measurement only.
+     * @default false
+     * @memberOf! module:Neo
+     * @name config.useDeltaGrammarGuards
+     * @type Boolean
+     */
+    useDeltaGrammarGuards: false,
+    /**
      * true will log console warnings, in case a component tries to update() while a parent update is running.
      * A parent update results in a short delay, so you might want to resolve these collisions.
      * @default false

--- a/src/main/DeltaUpdates.mjs
+++ b/src/main/DeltaUpdates.mjs
@@ -2,6 +2,7 @@ import Base             from '../core/Base.mjs';
 import DomAccess        from './DomAccess.mjs';
 import Observable       from '../core/Observable.mjs';
 import {voidAttributes} from '../vdom/domConstants.mjs';
+import {checkStructuralUniqueness, validateBatch} from '../vdom/util/DeltaGrammar.mjs';
 
 const NeoConfig = Neo.config;
 
@@ -860,6 +861,42 @@ class DeltaUpdates extends Base {
     }
 
     /**
+     * @summary Validates a final pre-apply delta batch before dispatch.
+     *
+     * Runs the guard-grade delta grammar predicates over the post-event batch. Guard findings
+     * throw before dispatch so the operation rejects atomically; U5 structural uniqueness
+     * remains observe-only until its real-world corpus has been falsified.
+     * @param {Object[]} deltas The normalized batch after `update` listeners had their mutation window.
+     * @throws {Error} If guard-grade delta grammar findings are present.
+     * @protected
+     */
+    validateDeltaGrammarBatch(deltas) {
+        const
+            validation = validateBatch(deltas, {useDomApiRenderer: NeoConfig.useDomApiRenderer}),
+            context    = {
+                deltas,
+                useDomApiRenderer: NeoConfig.useDomApiRenderer
+            };
+
+        if (!validation.valid) {
+            const error = new Error('Neo.main.DeltaUpdates: delta grammar validation failed');
+
+            error.code = 'NEO_DELTA_GRAMMAR_INVALID';
+            error.findings = validation.findings;
+
+            console.error('Delta grammar validation failed', {...context, findings: validation.findings});
+
+            throw error
+        }
+
+        const candidateFindings = checkStructuralUniqueness(deltas);
+
+        if (candidateFindings.length > 0) {
+            console.warn('Delta grammar candidate findings', {...context, findings: candidateFindings})
+        }
+    }
+
+    /**
      * Applies a set of VDom delta updates to the real DOM.
      * This method is the core entry point for rendering changes initiated from the VDom worker.
      * It iterates through the provided deltas and dispatches them to specific DOM manipulation
@@ -893,6 +930,15 @@ class DeltaUpdates extends Base {
         // Addons (like GridRowPinning) can safely mutate the deltas array or individual delta
         // properties here, and those modifications will be consumed directly by the update loop below.
         me.fire('update', data);
+
+        if (NeoConfig.useDeltaGrammarGuards) {
+            // Keep the enabled guard path aligned with post-event array mutations.
+            len = deltas.length;
+
+            if (len > 0) {
+                me.validateDeltaGrammarBatch(deltas)
+            }
+        }
 
         if (NeoConfig.logDeltaUpdates && len > 0) {
             me.countDeltas += len;

--- a/src/worker/Manager.mjs
+++ b/src/worker/Manager.mjs
@@ -494,9 +494,13 @@ class Manager extends Base {
                         let deltas = payload.deltas;
 
                         if (payload.autoMount) {
+                            // Parent-less automounts previously appended via an undefined childNodes
+                            // index. Keep append semantics while making the wire field explicit.
+                            const index = payload.parentIndex ?? Number.MAX_SAFE_INTEGER;
+
                             deltas = [{
                                 action   : 'insertNode',
-                                index    : payload.parentIndex,
+                                index,
                                 outerHTML: payload.outerHTML,
                                 parentId : payload.parentId,
                                 vnode    : payload.vnode

--- a/test/playwright/e2e/GridLockedDnDDuplication.spec.mjs
+++ b/test/playwright/e2e/GridLockedDnDDuplication.spec.mjs
@@ -13,8 +13,9 @@ import { test, expect } from '../fixtures.mjs';
  *
  *   1. zero duplicate DOM ids anywhere under the grid (the keystone signature)
  *   2. zero id-less `insertNode` deltas, harvested via `Neo.config.logDeltaUpdates`
- *   3. exactly three region-body elements (ghost-body copies counted directly)
- *   4. items/vdom/DOM consistency on every region body (worker-truth vs rendered truth)
+ *   3. zero delta-grammar guard errors and U5 candidate findings
+ *   4. exactly three region-body elements (ghost-body copies counted directly)
+ *   5. items/vdom/DOM consistency on every region body (worker-truth vs rendered truth)
  *
  * Gestures are the three convicted corruption triggers, run twice (repeat-gesture accumulation
  * was part of the original signature): a centre overdrag walk with return leg, a cross-region
@@ -41,7 +42,11 @@ test.describe('Locked-grid DnD duplication net (#12939)', () => {
         // Harvest id-less insertNode deltas at the main-thread apply boundary
         await page.evaluate(() => {
             Neo.config.logDeltaUpdates = true;
+            Neo.config.useDeltaGrammarGuards = true;
             window.__idlessInserts = 0;
+            window.__deltaGrammarErrors = 0;
+            window.__deltaGrammarErrorDetails = [];
+            window.__deltaGrammarU5Findings = 0;
             const orig = console.log.bind(console);
             console.log = (...args) => {
                 try {
@@ -54,6 +59,28 @@ test.describe('Locked-grid DnD duplication net (#12939)', () => {
                     }
                 } catch (e) {}
                 orig(...args);
+            };
+            const origError = console.error.bind(console);
+            console.error = (...args) => {
+                try {
+                    if (args[0] === 'Delta grammar validation failed') {
+                        window.__deltaGrammarErrors++;
+                        window.__deltaGrammarErrorDetails.push({
+                            findings         : args[1]?.findings,
+                            useDomApiRenderer: args[1]?.useDomApiRenderer
+                        });
+                    }
+                } catch (e) {}
+                origError(...args);
+            };
+            const origWarn = console.warn.bind(console);
+            console.warn = (...args) => {
+                try {
+                    if (args[0] === 'Delta grammar candidate findings') {
+                        window.__deltaGrammarU5Findings += args[1]?.findings?.length || 1;
+                    }
+                } catch (e) {}
+                origWarn(...args);
             };
         });
 
@@ -69,12 +96,17 @@ test.describe('Locked-grid DnD duplication net (#12939)', () => {
                 return {
                     dups: dups.slice(0, 10),
                     bodyCount: document.querySelectorAll('.neo-grid-body').length,
-                    idless: window.__idlessInserts
+                    guardDetails: window.__deltaGrammarErrorDetails,
+                    guardErrors: window.__deltaGrammarErrors,
+                    idless: window.__idlessInserts,
+                    u5Findings: window.__deltaGrammarU5Findings
                 };
             });
 
             expect(dom.dups, `${label}: duplicate DOM ids under the grid`).toEqual([]);
             expect(dom.idless, `${label}: id-less insertNode deltas at the apply boundary`).toBe(0);
+            expect(dom.guardErrors, `${label}: delta-grammar guard errors ${JSON.stringify(dom.guardDetails)}`).toBe(0);
+            expect(dom.u5Findings, `${label}: U5 candidate findings`).toBe(0);
             expect(dom.bodyCount, `${label}: region-body element count (ghost-body copies)`).toBe(3);
 
             const bodies = await app.findInstances({ ntype: 'grid-body' }, ['id']);

--- a/test/playwright/unit/vdom/DeltaUpdatesGrammarGuard.spec.mjs
+++ b/test/playwright/unit/vdom/DeltaUpdatesGrammarGuard.spec.mjs
@@ -1,0 +1,177 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'DeltaUpdatesGrammarGuardTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true,
+        useDomApiRenderer: true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary Tests the Main-thread delta grammar guard wiring.
+ *
+ * The pure grammar predicates live in `DeltaGrammar.spec.mjs`; this suite pins the runtime
+ * boundary: guard-off behavior stays untouched, guard-on failures throw before dispatch,
+ * legal batches still dispatch without U5 noise, renderer mode reaches the insertNode payload
+ * rule, and U5 remains observe-only.
+ */
+test.describe('Neo.main.DeltaUpdates grammar guard', () => {
+    let DeltaUpdates, applied, originalConsoleError, originalConsoleWarn,
+        originalInsertNode, originalMoveNode, originalRemoveAll, originalRemoveNode,
+        originalUpdateNode, originalUpdateVtext;
+
+    test.beforeAll(async () => {
+        Neo.worker.Manager.on ??= () => {};
+        globalThis.document ??= {
+            addEventListener   : () => {},
+            body               : {},
+            createElement      : () => ({addEventListener: () => {}}),
+            getElementById     : () => null,
+            querySelector      : () => null,
+            removeEventListener: () => {}
+        };
+
+        delete Neo.main.DomAccess;
+        delete Neo.main.DeltaUpdates;
+        Neo.main.render ??= {};
+        Neo.main.render.DomApiRenderer ??= {};
+        Neo.main.render.StringBasedRenderer ??= {};
+
+        DeltaUpdates = (await import('../../../../src/main/DeltaUpdates.mjs')).default;
+        originalInsertNode = DeltaUpdates.insertNode;
+        originalMoveNode   = DeltaUpdates.moveNode;
+        originalRemoveAll  = DeltaUpdates.removeAll;
+        originalRemoveNode = DeltaUpdates.removeNode;
+        originalUpdateNode = DeltaUpdates.updateNode
+        originalUpdateVtext = DeltaUpdates.updateVtext
+    });
+
+    test.beforeEach(() => {
+        applied = [];
+        originalConsoleError = console.error;
+        originalConsoleWarn  = console.warn;
+
+        Neo.config.useDeltaGrammarGuards = false;
+        Neo.config.useDomApiRenderer = true;
+
+        DeltaUpdates.updateNode = delta => applied.push(delta);
+        DeltaUpdates.moveNode   = delta => applied.push(delta);
+        DeltaUpdates.removeAll  = delta => applied.push(delta);
+        DeltaUpdates.removeNode = delta => applied.push(delta);
+        DeltaUpdates.insertNode = delta => applied.push(delta)
+        DeltaUpdates.updateVtext = delta => applied.push(delta)
+    });
+
+    test.afterEach(() => {
+        console.error = originalConsoleError;
+        console.warn  = originalConsoleWarn;
+
+        DeltaUpdates.insertNode = originalInsertNode;
+        DeltaUpdates.moveNode   = originalMoveNode;
+        DeltaUpdates.removeAll  = originalRemoveAll;
+        DeltaUpdates.removeNode = originalRemoveNode;
+        DeltaUpdates.updateNode = originalUpdateNode;
+        DeltaUpdates.updateVtext = originalUpdateVtext;
+
+        Neo.config.useDeltaGrammarGuards = false;
+        Neo.config.useDomApiRenderer = true
+    });
+
+    test('default-off leaves the existing dispatch path untouched', () => {
+        const batch = [
+            {id: 'neo-valid-1', style: {color: 'green'}},
+            {action: 'unknownAction', id: 'neo-invalid-1'}
+        ];
+
+        expect(() => DeltaUpdates.update({deltas: batch})).toThrow();
+        expect(applied).toEqual([batch[0]])
+    });
+
+    test('enabled guard rejects illegal batches before the first dispatch', () => {
+        const
+            batch      = [
+                {id: 'neo-valid-1', style: {color: 'green'}},
+                {action: 'unknownAction', id: 'neo-invalid-1'}
+            ],
+            errorCalls = [];
+
+        Neo.config.useDeltaGrammarGuards = true;
+        console.error = (...args) => errorCalls.push(args);
+
+        expect(() => DeltaUpdates.update({deltas: batch})).toThrow(/delta grammar validation failed/);
+        expect(applied).toEqual([]);
+        expect(errorCalls).toHaveLength(1);
+        expect(errorCalls[0][1].findings.map(finding => finding.rule)).toContain('U1');
+
+        try {
+            DeltaUpdates.update({deltas: batch})
+        } catch (error) {
+            expect(error.code).toBe('NEO_DELTA_GRAMMAR_INVALID');
+            expect(error.findings.map(finding => finding.rule)).toContain('U1')
+        }
+    });
+
+    test('enabled guard passes legal batches through unchanged', () => {
+        const
+            batch = [
+                {id: 'neo-grid-row-1', cls: {add: ['selected']}, style: {transform: 'translateY(32px)'}},
+                {id: 'neo-grid-row-2', attributes: {'aria-rowindex': '7', title: null}},
+                {action: 'insertNode', parentId: 'neo-grid-body-1', index: 3, vnode: {id: 'neo-cell-9'}},
+                {action: 'moveNode', id: 'neo-cell-4', parentId: 'neo-grid-row-1', index: 0},
+                {action: 'updateVtext', id: 'neo-vtext-2', parentId: 'neo-label-1', value: 'Total: 42'},
+                {action: 'removeAll', parentId: 'neo-list-1'},
+                {action: 'removeNode', id: 'neo-tooltip-7'},
+                {action: 'removeNode', id: 'neo-vtext-9', parentId: 'neo-label-2'}
+            ],
+            warnCalls = [];
+
+        Neo.config.useDeltaGrammarGuards = true;
+        console.warn = (...args) => warnCalls.push(args);
+
+        expect(() => DeltaUpdates.update({deltas: batch})).not.toThrow();
+        expect(applied).toEqual(batch);
+        expect(warnCalls).toEqual([])
+    });
+
+    test('forwards useDomApiRenderer into the insertNode payload contract', () => {
+        const htmlOnly = [{action: 'insertNode', parentId: 'neo-parent', index: 0, outerHTML: '<div></div>'}];
+
+        Neo.config.useDeltaGrammarGuards = true;
+        Neo.config.useDomApiRenderer = true;
+        console.error = () => {};
+
+        expect(() => DeltaUpdates.update({deltas: htmlOnly})).toThrow(/delta grammar validation failed/);
+        expect(applied).toEqual([]);
+
+        Neo.config.useDomApiRenderer = false;
+
+        expect(() => DeltaUpdates.update({deltas: htmlOnly})).not.toThrow();
+        expect(applied).toEqual(htmlOnly)
+    });
+
+    test('logs U5 candidate findings without blocking dispatch', () => {
+        const
+            batch     = [
+                {action: 'moveNode', id: 'neo-reused-1', parentId: 'neo-parent', index: 0},
+                {action: 'moveNode', id: 'neo-reused-1', parentId: 'neo-parent', index: 1}
+            ],
+            warnCalls = [];
+
+        Neo.config.useDeltaGrammarGuards = true;
+        console.warn = (...args) => warnCalls.push(args);
+
+        expect(() => DeltaUpdates.update({deltas: batch})).not.toThrow();
+        expect(applied).toEqual(batch);
+        expect(warnCalls).toHaveLength(1);
+        expect(warnCalls[0][1].findings.map(finding => finding.rule)).toEqual(['U5'])
+    });
+});


### PR DESCRIPTION
Resolves #12994
Related: #12986

Authored by GPT-5 (Codex Desktop). Session 019eba1b-f70e-74c0-9dfb-8666901c3c0d.

Wires the delta grammar kernel into the main-thread pre-apply boundary behind `Neo.config.useDeltaGrammarGuards`. With the flag off, the dispatch path remains unchanged. With the flag on, U1-U4 findings reject the whole batch before any DOM mutation, structured findings are logged with batch context, `useDomApiRenderer` is forwarded into U2, and U5 structural uniqueness remains observe-only.

Evidence: L3 (unit/vdom corpus plus local Chromium locked-grid Neural Link interaction pass) -> L3 required (atomic guard behavior and U5 falsification corpus). No residuals.

## Deltas from ticket

- Added `useDeltaGrammarGuards: false` to `src/DefaultConfig.mjs` as a dev/test lever.
- Added `DeltaUpdates.validateDeltaGrammarBatch()` after the mutable `update` event and before dispatch.
- Kept U5 as a candidate observer and recorded the promotion decision here: keep candidate for now. The current run produced zero U5 findings across `test/playwright/unit/vdom` and the locked-grid interaction pass, but the evidence is still a bounded corpus, not a broad capture sweep across arbitrary app traffic. Promotion should wait for wider capture/telemetry coverage rather than making one positive corpus run a universal guard-grade rule.
- Made `worker.Manager` automount inserts carry an explicit append index when `parentIndex` is absent. This preserves previous append behavior while satisfying the U2 required-field contract exposed by guard-on example-app execution.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/vdom/DeltaUpdatesGrammarGuard.spec.mjs` -> 5 passed.
- `npm run test-unit -- test/playwright/unit/vdom/DeltaGrammar.spec.mjs` -> 19 passed.
- `npm run test-unit -- test/playwright/unit/vdom` -> 110 passed.
- `npx playwright test test/playwright/e2e/GridLockedDnDDuplication.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` -> 1 passed (52.1s). Initial sandbox run failed before tests on `listen EPERM 0.0.0.0:8080`; rerun outside the sandbox passed.
- `git diff --check origin/dev...HEAD` -> passed.

## Post-Merge Validation

- [ ] CI confirms full unit + integration pass on the remote PR head.

## Commit

- `c111b089` — `feat(vdom): add delta grammar guards (#12994)`
