### PR TITLE
fix(wake): clamp stale-high wake cursors (#12862)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -63,7 +63,7 @@ import {
     isHeavyDeltaPoll,
     shouldDeferFlush
 } from './flushDeferPolicy.mjs';
-import {filterEventsByWatermark, maxLogId} from './wokenWatermark.mjs';
+import {clampWatermark, filterEventsByWatermark, maxLogId} from './wokenWatermark.mjs';
 
 const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
 const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
@@ -342,6 +342,7 @@ async function pollLoop() {
         if (logs.length > 0) {
             const invalidNodes = new Set();
             const invalidEdges = new Set();
+            const batchBaseSyncId = lastSyncId;
             let maxId = lastSyncId;
 
             for (const trace of logs) {
@@ -370,7 +371,7 @@ async function pollLoop() {
                     for (const sub of subscriptions) {
                         const eventPayload = evaluateSubscription(sub, trace, entity, nodesMap, edgesMap);
                         if (eventPayload) {
-                            queueEvent(sub, eventPayload);
+                            queueEvent(sub, eventPayload, batchBaseSyncId, maxId);
                         }
                     }
                 }
@@ -441,17 +442,30 @@ function daemonHasDeliveryReceipts(messageId, edgesMap) {
  * Queues an event for coalescing.
  * Applies tuple-based deduplication (type + identity-tuple) to prevent duplicate
  * wake event triggers within a single coalescing window.
- * @param {Object} subscription - The target subscription node
- * @param {Object} eventPayload - The wake event to queue
+ * @param {Object} subscription          The target subscription node.
+ * @param {Object} eventPayload          The wake event to queue.
+ * @param {Number} watermarkResetCeiling Highest trusted GraphLog id before this batch.
+ * @param {Number} watermarkGraphTip     Highest trusted GraphLog id observed in this batch.
  */
-function queueEvent(subscription, eventPayload) {
+function queueEvent(subscription, eventPayload, watermarkResetCeiling = 0, watermarkGraphTip = watermarkResetCeiling) {
     const subId = subscription.id;
     if (!coalesceState[subId]) {
         coalesceState[subId] = {
             subscription,
             queue: [],
-            timer: null
+            timer: null,
+            watermarkGraphTip,
+            watermarkResetCeiling
         };
+    } else {
+        coalesceState[subId].watermarkGraphTip = Math.min(
+            coalesceState[subId].watermarkGraphTip ?? watermarkGraphTip,
+            watermarkGraphTip
+        );
+        coalesceState[subId].watermarkResetCeiling = Math.min(
+            coalesceState[subId].watermarkResetCeiling ?? watermarkResetCeiling,
+            watermarkResetCeiling
+        );
     }
 
     // Deduplicate within the coalescing window
@@ -579,7 +593,7 @@ async function flushSubscription(subId) {
         return;
     }
 
-    const { queue, subscription } = state;
+    const { queue, subscription, watermarkGraphTip, watermarkResetCeiling } = state;
     delete coalesceState[subId]; // reset
 
     if (queue.length === 0) return;
@@ -604,7 +618,7 @@ async function flushSubscription(subId) {
     // (logId <= the per-subscription watermark) so a re-queued backlog can't inflate the "N new" count
     // or spoof a HIGH digest from a stale message. Composes with the readAt reconcile above + the
     // heavy-delta defer at the top — reconciling on the right axis (already-woken, not merely unread).
-    const watermark = wokenWatermark[subId] ?? 0;
+    const watermark = clampWatermark(wokenWatermark[subId] ?? 0, watermarkGraphTip, watermarkResetCeiling);
     messages    = filterEventsByWatermark(messages,    watermark);
     tasks       = filterEventsByWatermark(tasks,       watermark);
     permissions = filterEventsByWatermark(permissions, watermark);

--- a/ai/daemons/wake/queries.mjs
+++ b/ai/daemons/wake/queries.mjs
@@ -24,22 +24,26 @@ export function initializeDatabase(dbPath) {
  * backlog as one volume-escalated HIGH wake (the full-backlog wake-flood this guards against).
  * Only a genuinely-parseable non-negative integer is trusted as a cursor: a legitimately
  * persisted `0` is preserved, while `NaN` (truncated/empty file) or a negative value falls
- * through to the safe tip.
+ * through to the safe tip. A cursor ahead of the current tip is also clamped back to the tip:
+ * stale wake-daemon state can survive graph restore/rebuild, and trusting that future cursor
+ * would silence the daemon until GraphLog catches up.
  *
  * @param {Database} db        SQLite database handle.
  * @param {String}   stateFile Path to the persisted cursor file.
  * @returns {Number} The log id to resume tail-sync from.
  */
 export function getLastSyncId(db, stateFile) {
+    const maxLogId = getMaxLogId(db);
+
     if (fs.existsSync(stateFile)) {
         const parsed = parseInt(fs.readFileSync(stateFile, 'utf8'), 10);
         // A valid cursor is a non-negative integer; anything else (NaN from a truncated/empty
         // file, or a negative value) is corruption → fail to the tip, never replay from 0.
-        return Number.isInteger(parsed) && parsed >= 0 ? parsed : getMaxLogId(db);
+        return Number.isInteger(parsed) && parsed >= 0 ? Math.min(parsed, maxLogId) : maxLogId;
     }
 
     // Missing cursor (first boot / fresh data dir) → resume at the tip, skip the backlog.
-    return getMaxLogId(db);
+    return maxLogId;
 }
 
 /**

--- a/ai/daemons/wake/wokenWatermark.mjs
+++ b/ai/daemons/wake/wokenWatermark.mjs
@@ -9,11 +9,40 @@
  * right axis — the GraphLog `logId` high-water-mark of what the recipient has already been woken
  * for — and compose with (do NOT replace) the `readAt` reconcile + `flushDeferPolicy` defer.
  *
- * `logId` is the append-only GraphLog position, so it is monotonic: an event at or below the
- * per-subscription watermark has already been included in a prior digest; only events strictly
- * above it are genuinely-new-since-last-wake. The daemon owns the durable, per-subscription
+ * `logId` is the append-only GraphLog position inside one graph epoch, so it is monotonic while
+ * that epoch survives. Graph restore/rebuild can reset the log while wake-daemon state survives;
+ * callers must detect a stale-high watermark against graph-tip evidence, then clamp it to a
+ * trusted pre-batch cursor before filtering. The daemon owns the durable, per-subscription
  * watermark map + its persistence; this module is the pure, unit-testable decision core.
  */
+
+/**
+ * @summary Caps a persisted already-woken watermark only when it sits ahead of graph-tip evidence.
+ *
+ * If graph state is restored/rebuilt while `.neo-ai-data/wake-daemon/woken-watermark.json`
+ * survives, the persisted watermark can sit ahead of the current GraphLog epoch and suppress every
+ * new event. The safe read-side behavior mirrors the daemon cursor clamp, but uses the pre-batch
+ * cursor as the reset ceiling so the first post-reset event (`ceiling + 1`) is still delivered.
+ * In a normal graph epoch where a low cursor replays old events, the persisted watermark remains
+ * authoritative as long as it is not ahead of the batch's trusted GraphLog tip.
+ *
+ * @param {Number} watermark       Persisted per-subscription already-woken watermark.
+ * @param {Number} maxTrustedLogId Highest trusted GraphLog id observed for the current queue.
+ * @param {Number} resetCeiling    Highest trusted GraphLog id before the reset-suspect batch.
+ * @returns {Number}
+ */
+export function clampWatermark(watermark, maxTrustedLogId, resetCeiling = maxTrustedLogId) {
+    const mark = Number(watermark);
+    if (!Number.isFinite(mark) || mark < 0) return 0;
+
+    const trustedMax = Number(maxTrustedLogId);
+    if (!Number.isFinite(trustedMax) || trustedMax < 0 || mark <= trustedMax) return mark;
+
+    const ceiling = Number(resetCeiling);
+    if (!Number.isFinite(ceiling) || ceiling < 0) return trustedMax;
+
+    return Math.min(ceiling, trustedMax);
+}
 
 /**
  * @summary Keeps only the coalesced events that are genuinely new since the last wake — those

--- a/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
@@ -164,6 +164,17 @@ test.describe('ai/daemons/wake/queries', () => {
                 expect(getLastSyncId(db, stateFile)).toBe(42);
             });
 
+            test('cursor ahead of MAX(log_id) clamps to the current tip', () => {
+                seedLog(99);
+                fs.writeFileSync(stateFile, '150', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(99);
+            });
+
+            test('cursor ahead of an empty GraphLog clamps to 0', () => {
+                fs.writeFileSync(stateFile, '150', 'utf8');
+                expect(getLastSyncId(db, stateFile)).toBe(0);
+            });
+
             test('valid 0 cursor is preserved (not treated as corruption)', () => {
                 seedLog(99);
                 fs.writeFileSync(stateFile, '0', 'utf8');

--- a/test/playwright/unit/ai/daemons/wake/wokenWatermark.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wokenWatermark.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                      from '@playwright/test';
-import {filterEventsByWatermark, maxLogId} from '../../../../../../ai/daemons/wake/wokenWatermark.mjs';
+import {clampWatermark, filterEventsByWatermark, maxLogId} from '../../../../../../ai/daemons/wake/wokenWatermark.mjs';
 
 test.describe('wake wokenWatermark (#12850)', () => {
     test('filterEventsByWatermark keeps only events strictly above the watermark', () => {
@@ -33,6 +33,24 @@ test.describe('wake wokenWatermark (#12850)', () => {
 
         expect(filterEventsByWatermark(events, undefined).map(e => e.messageId)).toEqual(['a', 'b']);
         expect(filterEventsByWatermark(events, NaN).map(e => e.messageId)).toEqual(['a', 'b']);
+    });
+
+    test('clampWatermark caps stale-high watermarks to the trusted pre-batch cursor', () => {
+        expect(clampWatermark(150, 99)).toBe(99);
+        expect(clampWatermark(150, 200, 99)).toBe(150);
+        expect(clampWatermark(42, 99)).toBe(42);
+        expect(clampWatermark('bad', 99)).toBe(0);
+        expect(clampWatermark(-1, 99)).toBe(0);
+    });
+
+    test('AC for #12862 — stale-high watermark no longer suppresses the first post-reset event', () => {
+        // GraphLog was restored/reset while woken-watermark.json survived at 150. The wake cursor
+        // has self-healed to the new pre-batch tip (99); the next event at 100 must wake.
+        const restoredEpochEvents = [{type: 'message', messageId: 'm-new-epoch', logId: 100}];
+        const effectiveWatermark  = clampWatermark(150, 99);
+
+        expect(filterEventsByWatermark(restoredEpochEvents, effectiveWatermark))
+            .toEqual(restoredEpochEvents);
     });
 
     test('maxLogId returns the highest finite logId, or null when none', () => {


### PR DESCRIPTION
Resolves #12862

Authored by GPT-5 (Codex Desktop). Session 019eba1b-f70e-74c0-9dfb-8666901c3c0d.

Clamps wake-daemon state that survives a GraphLog reset/rebuild so stale future cursors self-heal instead of suppressing wakes until IDs catch up. The poll cursor now caps a persisted `lastSyncId` at the current GraphLog tip, and the per-subscription woken watermark only clamps when it is actually ahead of trusted graph-tip evidence, preserving normal replay dedup inside a valid graph epoch.

Evidence: L2 (targeted Playwright unit slice with daemon subprocess coverage) -> L2 required (cursor and watermark ACs are unit-verifiable). No residuals.

## Deltas from ticket

The issue comment extended scope from `lastSyncId` to `woken-watermark.json`; this PR covers both. The watermark repair is stricter than a blind `Math.min`: it keeps a valid already-woken watermark authoritative during stale-low cursor replay, and only clamps when the persisted watermark sits ahead of the batch's trusted GraphLog tip.

AC1 reachability was verified before implementation: maintenance backup/restore preserve graph state separately from `.neo-ai-data/wake-daemon`, and worktree bootstrap can link wake-daemon state across graph epochs. That makes `lastSyncId` / `woken-watermark.json` surviving a restored or rebuilt GraphLog reachable.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/queries.spec.mjs test/playwright/unit/ai/daemons/wake/wokenWatermark.spec.mjs` -> 26 passed
- `node ai/scripts/migrations/bootstrapWorktree.mjs --canonical-root <canonical-checkout>` -> hydrated gitignored config overlays for daemon subprocess specs in the temp worktree
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake` -> 74 passed

## Post-Merge Validation

- [ ] Restart the wake daemon after a GraphLog restore/rebuild with surviving wake-daemon state and confirm the first post-reset event wakes immediately.

## Commits

- `7ce2a286c` - `fix(wake): clamp stale-high wake cursors (#12862)`
