### PR TITLE
feat(vdom): add delta capture utility (#12991)

### DIFF
--- a/test/playwright/unit/vdom/DeltaCapture.spec.mjs
+++ b/test/playwright/unit/vdom/DeltaCapture.spec.mjs
@@ -1,0 +1,227 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : 'DeltaCaptureTest',
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}       from '@playwright/test';
+import Neo                  from '../../../../src/Neo.mjs';
+import * as core            from '../../../../src/core/_export.mjs';
+import DomApiVnodeCreator   from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+import VdomHelper           from '../../../../src/vdom/Helper.mjs';
+import {createDeltaCapture} from '../../util/DeltaCapture.mjs';
+
+const baseVdom = {
+    tag : 'section',
+    id  : 'delta-capture-root',
+    cn  : [
+        {tag: 'span', id: 'delta-capture-label', text: 'before'}
+    ]
+};
+
+function createVNode(vdom = baseVdom) {
+    return VdomHelper.create({vdom, appName: 'DeltaCaptureTest', parentId: 'document.body'}).vnode
+}
+
+test.describe('DeltaCapture', () => {
+    let captures = [];
+
+    test.afterEach(() => {
+        captures.forEach(capture => capture.restore());
+        captures = [];
+        Neo.applyDeltas = async () => {}
+    });
+
+    function install(opts) {
+        const capture = createDeltaCapture(opts);
+
+        captures.push(capture);
+
+        return capture
+    }
+
+    test('captures applyDeltas batches with tap/layer metadata and restores the seam', async () => {
+        const original = async (windowId, deltas) => ({windowId, count: Array.isArray(deltas) ? deltas.length : 1});
+
+        Neo.applyDeltas = original;
+
+        const capture = install({tap: 'applyDeltas'});
+
+        await Neo.applyDeltas('window-1', [
+            {id: 'delta-capture-root', style: {color: 'red'}},
+            {action: 'removeNode', id: 'delta-capture-old'}
+        ]);
+
+        expect(capture.records).toEqual([{
+            deltas: [
+                {id: 'delta-capture-root', style: {color: 'red'}},
+                {action: 'removeNode', id: 'delta-capture-old'}
+            ],
+            epoch: 'default',
+            layer: 'main-pre-apply',
+            tap  : 'applyDeltas'
+        }]);
+        expect(capture.deltasIn('default')).toEqual([[
+            {id: 'delta-capture-root', style: {color: 'red'}},
+            {action: 'removeNode', id: 'delta-capture-old'}
+        ]]);
+
+        capture.restore();
+
+        await Neo.applyDeltas('window-1', {id: 'delta-capture-root', cls: {add: ['ignored']}});
+
+        expect(Neo.applyDeltas).toBe(original);
+        expect(capture.records.length).toBe(1)
+    });
+
+    test('captures VdomHelper.update() return batches through helperReturn', () => {
+        const capture = install({tap: 'helperReturn'}),
+              vnode   = createVNode();
+
+        const result = VdomHelper.update({
+            vnode,
+            vdom: {
+                ...baseVdom,
+                cn: [
+                    {tag: 'span', id: 'delta-capture-label', text: 'after'}
+                ]
+            }
+        });
+
+        expect(result.deltas.length).toBe(1);
+        expect(capture.recordsIn('default')[0].tap).toBe('helperReturn');
+        expect(capture.recordsIn('default')[0].layer).toBe('vdom-pre-send');
+        expect(capture.deltasIn('default')).toEqual([result.deltas])
+    });
+
+    test('subsumes component-return and console-harvest legacy patterns through explicit seams', async () => {
+        const componentCapture = install({tap: 'helperReturn'}),
+              vnode            = createVNode();
+
+        function componentSetLike(vdom) {
+            return VdomHelper.update({vnode, vdom})
+        }
+
+        const result = componentSetLike({
+            ...baseVdom,
+            cn: [
+                {tag: 'span', id: 'delta-capture-label', text: 'component'}
+            ]
+        });
+
+        expect(componentCapture.deltasIn('default')).toEqual([result.deltas]);
+
+        componentCapture.restore();
+
+        const logCalls = [],
+              original = async () => {};
+
+        Neo.applyDeltas = original;
+
+        const applyCapture = install({tap: 'applyDeltas'}),
+              originalLog   = console.log;
+
+        console.log = (...args) => logCalls.push(args);
+
+        try {
+            await Neo.applyDeltas('window-1', [
+                {id: 'delta-capture-root', cls: {add: ['final']}}
+            ])
+        } finally {
+            console.log = originalLog
+        }
+
+        expect(logCalls).toEqual([]);
+        expect(applyCapture.deltasIn('default')).toEqual([[
+            {id: 'delta-capture-root', cls: {add: ['final']}}
+        ]])
+    });
+
+    test('attributes batches to explicit epoch labels and scoped async windows', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const capture = install({tap: 'applyDeltas'});
+
+        await Neo.applyDeltas('window-1', {id: 'before-window'});
+
+        capture.epoch('drag-hold');
+        await Neo.applyDeltas('window-1', [
+            {id: 'delta-capture-row', style: {transform: 'translateY(20px)'}}
+        ]);
+
+        await capture.window('drop', async () => {
+            await Neo.applyDeltas('window-1', [
+                {action: 'moveNode', id: 'delta-capture-row', parentId: 'delta-capture-root', index: 0}
+            ])
+        });
+
+        await Neo.applyDeltas('window-1', [
+            {id: 'delta-capture-row', style: {transform: 'translateY(0px)'}}
+        ]);
+
+        expect(capture.deltasIn('default')).toEqual([[{id: 'before-window'}]]);
+        expect(capture.deltasIn('drag-hold')).toEqual([
+            [{id: 'delta-capture-row', style: {transform: 'translateY(20px)'}}],
+            [{id: 'delta-capture-row', style: {transform: 'translateY(0px)'}}]
+        ]);
+        expect(capture.deltasIn('drop')).toEqual([[
+            {action: 'moveNode', id: 'delta-capture-row', parentId: 'delta-capture-root', index: 0}
+        ]])
+    });
+
+    test('classifies effective ops and validates findings per preserved batch', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const capture = install({tap: 'applyDeltas'});
+
+        await Neo.applyDeltas('window-1', [
+            {id: 'delta-capture-root', cls: {add: ['active']}},
+            {action: 'insertNode', parentId: 'delta-capture-root', index: 0, vnode: {id: 'delta-capture-child'}}
+        ]);
+        await Neo.applyDeltas('window-1', [
+            {style: {color: 'red'}}
+        ]);
+
+        expect(capture.opsIn('default')).toEqual({
+            insertNode: 1,
+            updateNode: 2
+        });
+
+        const findings = capture.findingsIn('default', {useDomApiRenderer: true});
+
+        expect(findings[0]).toEqual({batchIndex: 0, valid: true, findings: []});
+        expect(findings[1].batchIndex).toBe(1);
+        expect(findings[1].valid).toBe(false);
+        expect(findings[1].findings[0].rule).toBe('U4')
+    });
+
+    test('guards double installs and restores the previous epoch after throwing windows', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const capture = install({tap: 'applyDeltas'});
+
+        expect(() => createDeltaCapture({tap: 'applyDeltas'})).toThrow(/already installed/);
+
+        capture.epoch('steady');
+
+        await expect(capture.window('throwing', async () => {
+            await Neo.applyDeltas('window-1', {id: 'inside-throwing-window'});
+            throw new Error('boom')
+        })).rejects.toThrow('boom');
+
+        await Neo.applyDeltas('window-1', {id: 'after-throwing-window'});
+
+        expect(capture.activeEpoch).toBe('steady');
+        expect(capture.deltasIn('throwing')).toEqual([[{id: 'inside-throwing-window'}]]);
+        expect(capture.deltasIn('steady')).toEqual([[{id: 'after-throwing-window'}]])
+    });
+});

--- a/test/playwright/util/DeltaCapture.mjs
+++ b/test/playwright/util/DeltaCapture.mjs
@@ -1,0 +1,186 @@
+import {resolveAction, validateBatch} from '../../../src/vdom/util/DeltaGrammar.mjs';
+
+const ACTIVE_TAPS = new Map(),
+      DEFAULT_EPOCH = 'default',
+      TAP_CONFIGS = {
+          applyDeltas: {
+              layer: 'main-pre-apply',
+              getTarget() {
+                  return globalThis.Neo
+              },
+              method: 'applyDeltas',
+              wrap(capture, original) {
+                  return function(windowId, deltas, ...args) {
+                      capture.record(deltas);
+                      return original.call(this, windowId, deltas, ...args)
+                  }
+              }
+          },
+          helperReturn: {
+              layer: 'vdom-pre-send',
+              getTarget() {
+                  return globalThis.Neo?.vdom?.Helper
+              },
+              method: 'update',
+              wrap(capture, original) {
+                  return function(...args) {
+                      const result = original.apply(this, args);
+
+                      if (result?.deltas) {
+                          capture.record(result.deltas)
+                      }
+
+                      return result
+                  }
+              }
+          }
+      };
+
+function assertLabel(label) {
+    if (typeof label !== 'string' || label.length === 0) {
+        throw new Error('DeltaCapture epoch labels must be non-empty strings')
+    }
+}
+
+function getTapConfig(tap) {
+    const config = TAP_CONFIGS[tap];
+
+    if (!config) {
+        throw new Error(`Unknown DeltaCapture tap "${tap}"`)
+    }
+
+    return config
+}
+
+function normalizeDeltas(deltas) {
+    return Array.isArray(deltas) ? deltas.slice() : [deltas]
+}
+
+/**
+ * Captures Neo's VDOM delta stream through one explicit test seam.
+ *
+ * @summary Creates a scoped test facade for recording and classifying VDOM delta batches.
+ *
+ * Migration map:
+ * - Direct `Neo.applyDeltas` monkey-patches use `tap: 'applyDeltas'` for final app-worker boundary batches.
+ * - Direct `VdomHelper.update()` return assertions use `tap: 'helperReturn'` for diff-engine intent batches.
+ * - Component method return checks can wrap the update that produces the return and inspect the same epoch.
+ * - Console-log delta harvesting should move to an explicit tap; log output is format-coupled and lossy.
+ *
+ * The captured record names its tap and layer because the VDom pre-send stream is attribution/intent,
+ * while the Main pre-apply stream is final batch truth. Batch boundaries are preserved by default:
+ * the batch is the unit validated by `DeltaGrammar.validateBatch()`.
+ *
+ * Use `try/finally` or `test.afterEach()` to call `restore()` whenever a test installs a capture.
+ *
+ * @param {Object} opts
+ * @param {'applyDeltas'|'helperReturn'} opts.tap The seam to wrap
+ * @returns {Object} capture facade
+ */
+export function createDeltaCapture({tap} = {}) {
+    const config = getTapConfig(tap),
+          target = config.getTarget();
+
+    if (!target || typeof target[config.method] !== 'function') {
+        throw new Error(`DeltaCapture tap "${tap}" is unavailable; load the target seam before installing`)
+    }
+
+    if (ACTIVE_TAPS.has(tap)) {
+        throw new Error(`DeltaCapture tap "${tap}" is already installed`)
+    }
+
+    let activeEpoch = DEFAULT_EPOCH,
+        restored = false;
+
+    const original = target[config.method],
+          records = [],
+          capture = {
+              get activeEpoch() {
+                  return activeEpoch
+              },
+
+              get records() {
+                  return records.slice()
+              },
+
+              epoch(label) {
+                  assertLabel(label);
+                  activeEpoch = label;
+                  return this
+              },
+
+              async window(label, fn) {
+                  assertLabel(label);
+
+                  if (typeof fn !== 'function') {
+                      throw new Error('DeltaCapture.window() requires a callback function')
+                  }
+
+                  const previousEpoch = activeEpoch;
+
+                  activeEpoch = label;
+
+                  try {
+                      return await fn()
+                  } finally {
+                      activeEpoch = previousEpoch
+                  }
+              },
+
+              record(deltas) {
+                  if (restored) {
+                      return
+                  }
+
+                  records.push({
+                      deltas: normalizeDeltas(deltas),
+                      epoch : activeEpoch,
+                      layer : config.layer,
+                      tap
+                  })
+              },
+
+              recordsIn(label = activeEpoch) {
+                  assertLabel(label);
+                  return records.filter(record => record.epoch === label)
+              },
+
+              deltasIn(label = activeEpoch) {
+                  return this.recordsIn(label).map(record => record.deltas.slice())
+              },
+
+              flatDeltasIn(label = activeEpoch) {
+                  return this.deltasIn(label).flat()
+              },
+
+              opsIn(label = activeEpoch) {
+                  return this.flatDeltasIn(label).reduce((counts, delta) => {
+                      const action = resolveAction(delta);
+
+                      counts[action] = (counts[action] || 0) + 1;
+
+                      return counts
+                  }, {})
+              },
+
+              findingsIn(label = activeEpoch, opts = {}) {
+                  return this.deltasIn(label).map((batch, batchIndex) => ({
+                      batchIndex,
+                      ...validateBatch(batch, opts)
+                  }))
+              },
+
+              restore() {
+                  if (!restored) {
+                      target[config.method] = original;
+                      ACTIVE_TAPS.delete(tap);
+                      restored = true
+                  }
+              }
+          };
+
+    target[config.method] = config.wrap(capture, original);
+    ACTIVE_TAPS.set(tap, capture);
+
+    return capture
+}


### PR DESCRIPTION
Resolves #12991
Related: #12986
Related: #12987

Authored by GPT-5 (Codex Desktop). Session 518c54ce-5871-4ccf-8e88-6ac3b6e16ea8.

Adds a shared Playwright delta-capture utility with explicit `applyDeltas` and `helperReturn` taps, named epoch windows, batch-preserving accessors, DeltaGrammar-backed operation counts/findings, and restore/double-install hygiene. The paired unit spec covers the four legacy capture patterns at behavior level without migrating existing specs.

Evidence: L2 (focused Playwright unit coverage over both test seams + syntax/static checks) -> L2 required (test-substrate utility contract). No residuals.

## Deltas from ticket

- Kept scope to the new shared utility and its spec; existing delta-asserting specs remain organic-adoption follow-ups.
- No runtime surfaces are modified; the utility observes existing test seams only.

## Test Evidence

- `node --check test/playwright/util/DeltaCapture.mjs` -> passed.
- `node --check test/playwright/unit/vdom/DeltaCapture.spec.mjs` -> passed.
- `npm run test-unit -- test/playwright/unit/vdom/DeltaCapture.spec.mjs test/playwright/unit/vdom/DeltaGrammar.spec.mjs test/playwright/unit/vdom/DeltaUpdatesGrammarGuard.spec.mjs` -> 30 passed.
- `git diff --check origin/dev...HEAD` -> passed before remote publication.

## Post-Merge Validation

- [ ] CI confirms the remote branch against current `dev`.

## Commit

- `cc9b1a21` — `feat(vdom): add delta capture utility (#12991)`
