### PR TITLE
docs(agentos): cap epic-review comments (#13019)

### DIFF
--- a/.agents/skills/epic-review/references/epic-review-workflow.md
+++ b/.agents/skills/epic-review/references/epic-review-workflow.md
@@ -11,23 +11,26 @@ Fire this skill when **either** condition holds:
 1. You are about to pick up your first sub from an epic your model-identity has not yet reviewed.
 2. A user explicitly asks for an epic review (pre-validation before sub work begins).
 
+**Review artifact cap:** at most two structured `epic-review` comments may exist on an epic across all model-identities. Before posting, count existing epic comments whose header matches this skill's output shape (`Epic Review by ...` or `Epic Review — Stage ... Challenge by ...`). If two already exist, do not post a third structured epic-review.
+
 **Per-agent-per-epic one-shot semantics:** once your model-identity (e.g. `@neo-opus-ada`, `@neo-gemini-pro`) has posted an epic-review comment on epic #N, subsequent sub pickups from #N by the same identity cite the prior review by URL reference rather than re-running this skill.
 
-Different model-identities reviewing the same epic independently is **encouraged** — cross-model readback of architectural intent is the primary value. Two identities reviewing epic #N = two comments. Do not attempt deduplication.
+Different model-identities reviewing the same epic independently is **encouraged only while the two-review cap has an open slot** — cross-model readback of architectural intent is the primary value, but artifact count is bounded. If exactly one epic-review exists, prefer filling the second slot with a different active model-family when a reviewer from that family is available. If the cap is full before your first review, cite the two existing epic-review URLs during sub pickup and proceed with `ticket-intake`; route only unique blockers, corrections, or missing-family-coverage concerns through targeted A2A/commentary rather than a third full review.
 
-If the epic body has materially changed since your prior review (check `updatedAt` vs your comment's timestamp), re-run this skill and post an updated review.
+If the epic body has materially changed since your prior review (check `updatedAt` vs your comment's timestamp), re-run this skill and update your existing comment when possible. If you cannot update the existing comment, post a replacement only while the two-review cap has an open slot; once the cap is full, add a targeted correction/blocker note instead of a new structured epic-review.
 
 ## 2. Pre-Review Context Pull
 
 Before running the six-stage chain, pull the following context:
 
 1. **The epic body.** Use the `mcp_neo-mjs-github-workflow_get_conversation` tool to fetch the live epic issue body and comment thread directly from GitHub.
-2. **All sub-issues under the epic.** Titles, labels, blocking relationships — the epic's frontmatter `subIssues` list is the canonical source. Read each sub's body if sub-structure coherence review (stage 3) will run.
-3. **Roadmap alignment.** Query the Memory Core for current strategic direction:
+2. **Existing epic-review comments.** Count structured epic-review comments already present on the epic and identify their model-families when visible. If one slot remains, prefer a reviewer from a not-yet-represented active family; if the cap is full, stop before the six-stage chain and use the cap-full citation path in §5.
+3. **All sub-issues under the epic.** Titles, labels, blocking relationships — the epic's frontmatter `subIssues` list is the canonical source. Read each sub's body if sub-structure coherence review (stage 3) will run.
+4. **Roadmap alignment.** Query the Memory Core for current strategic direction:
    - `get_context_frontier()` — Golden Path authoritative routing
    - `query_summaries({query: '<epic-subject>'})` — historical session context on the topic
    - `query_raw_memories({query: '<epic-subject>'})` — finer-grained reasoning trails
-4. **Duplicate sweep.** Has a similar epic been filed and either closed or superseded? Check `resources/content/issues/` (active and archived) before running stage 1.
+5. **Duplicate sweep.** Has a similar epic been filed and either closed or superseded? Check `resources/content/issues/` (active and archived) before running stage 1.
 
 ## 3. The Six-Stage Chain
 
@@ -144,7 +147,7 @@ Missing traps are an **extension opportunity**, not a blocker — flag them in t
 
 ## 4. Comment Output Format
 
-Post the review as a comment on the epic ticket using `manage_issue_comment` with action `create`. Use the template at `.agents/skills/epic-review/assets/epic-review-comment-template.md` as the structural skeleton.
+Post the review as a comment on the epic ticket using `manage_issue_comment` with action `create` only if the two-review cap is not full. Use the template at `.agents/skills/epic-review/assets/epic-review-comment-template.md` as the structural skeleton.
 
 **Short form** (stage 1, 2, or 2.5 failure):
 - Header: `Epic Review — Stage [1|2|2.5] Challenge by [model-identity]`
@@ -166,13 +169,19 @@ Post the review as a comment on the epic ticket using `manage_issue_comment` wit
 
 Use the agent field on `manage_issue_comment` to self-identify: format `"[Model Name] ([Harness])"` — matches the `pr-review` self-identification pattern.
 
-## 5. Per-Agent-Per-Epic One-Shot Citation
+## 5. Per-Agent-Per-Epic One-Shot And Cap-Full Citation
 
 Once your model-identity has posted an epic-review comment, subsequent sub pickups from the same epic by the same identity cite the prior review by URL reference:
 
 > *Previously reviewed this epic: [comment URL]. Proceeding with sub pickup per `ticket-intake`.*
 
-This citation belongs in the `ticket-intake` reflection step for the sub, not as a new epic comment.
+If the epic already has two structured epic-review comments and your identity has not posted one, cite the capped reviews instead of posting a third:
+
+> *Epic-review cap already satisfied by: [comment URL 1], [comment URL 2]. Proceeding with sub pickup per `ticket-intake`; no third structured epic-review posted.*
+
+If both capped reviews are from the same model-family and cross-family coverage is materially needed, do not bypass the cap. Name the missing-coverage concern in a targeted A2A or narrow correction/blocker comment to the epic lead/operator instead of posting a third structured review.
+
+These citations belong in the `ticket-intake` reflection step for the sub, not as a new epic comment.
 
 ## 6. Relationship to Sibling Skills
 
@@ -192,6 +201,8 @@ This citation belongs in the `ticket-intake` reflection step for the sub, not as
 | Skipping epic-review because "I already read the epic body" | Epic-review is an **artifact**, not just comprehension — cross-model readback depends on the comment existing |
 | Sub agent picks up Epic body directly (Epic-vs-Sub-Issue discipline failure) | Agents MUST NOT pick up the Epic directly without checking for prior epic-review comments. Epics are coordination structures; sub-issues are the units of execution. Working on an epic directly bypasses the entire validation chain. |
 | Per-sub-pickup epic-review | Per-agent-per-epic; cite the prior review, don't re-run |
+| Posting a third structured epic-review on an epic | The review cap is two per epic; cite existing reviews or route a targeted blocker/correction instead |
+| Spending the second slot on same-family redundancy when another active family is available | The cap preserves cross-model value only if the remaining slot prioritizes family-diverse readback |
 | Posting review as an issue body edit | Comments, not body edits — provenance and attribution live in comments |
 | Missing session ID footer | Breaks A2A provenance; the reviewer's Memory Core session is not queryable from the epic |
 | Heavyweight "approval" language | Epic-review is a discipline gate, not a formal sign-off — author and agent negotiate on comment thread |
@@ -204,7 +215,9 @@ Different model families exhibit statistically-different failure modes when revi
 - **Claude-family reviewers** tend toward over-rigor — may mark stage 5 gaps that don't need flagging, or question stage 2 elegance on subjective grounds.
 - **Gemini-family reviewers** tend toward quick-win framing — may pass stages 1-2 too quickly when an elegance concern warrants deeper review.
 
-These are **complementary** failure modes. Cross-model epic-review (same epic reviewed by a Claude identity and a Gemini identity) surfaces different dimensions of architectural risk. This is the value of per-model-identity independent reviews rather than deduplication.
+These are **complementary** failure modes. Cross-model epic-review (the same epic reviewed by up to two distinct model-identities) surfaces different dimensions of architectural risk. This is the value of bounded independent readback.
+
+When one review exists, prefer the second structured review from a different active model-family. After two structured epic-review comments exist, preserve asymmetry through targeted blocker/correction comments or A2A handoffs, not by adding another full epic-review artifact.
 
 Do not calibrate your review to the "other model's style" — be the reviewer you are, and trust the asymmetry to compensate. If one model-family's reviews consistently miss a failure mode, the right fix is a skill enhancement (a new check in stages 1-5), not style mimicry.
 


### PR DESCRIPTION
Resolves #13019

Authored by GPT-5 (Codex Desktop). Session 518c54ce-5871-4ccf-8e88-6ac3b6e16ea8.

Caps `epic-review` at two structured review comments per epic. The change preserves the first two cross-model/asymmetry readbacks, prioritizes a different active model-family for the second slot when possible, and changes the cap-full path to cite existing reviews and route only unique blockers/corrections through targeted A2A/commentary instead of posting a third full epic-review artifact.

Evidence: L1 (static workflow diff + skill-manifest lint + whitespace check + load-effect audit) -> L1 required (skill-substrate workflow text ACs). No residuals.

## Deltas from ticket

- Kept the top-level `epic-review/SKILL.md` router untouched.
- Implemented the cap in `.agents/skills/epic-review/references/epic-review-workflow.md`, where the existing per-agent and cross-model semantics already lived.
- Added cap-full citation wording so later agents still preserve review provenance without creating a third structured epic-review.

## Contract Ledger

The source ticket #13019 contains the required Contract Ledger matrix for this agent-consumed governance-surface change. Implementation matches that matrix:

- `epic-review-workflow.md` now declares a max of two structured epic-review comments per epic.
- Same-identity one-shot citation remains intact and now composes with cap-full citation.
- Cross-model asymmetry is preserved as bounded independent readback; the remaining second slot prefers not-yet-represented active families, with post-cap concerns routed as targeted blocker/correction notes.

## Turn-Memory Pre-Flight / Slot Rationale

`/turn-memory-pre-flight` classification:

- Scope: `.agents/skills/**` skill-loaded memory substrate.
- Placement: conditional skill workflow payload (`.agents/skills/epic-review/references/epic-review-workflow.md`), not global `AGENTS.md` and not the always-loaded `SKILL.md` router.
- Runtime load effect: no always-loaded delta. `epic-review/SKILL.md` remains 1117 bytes and unchanged. The modified workflow payload is 21476 bytes, still below the default 25000-byte per-file payload budget.

Mechanical load-effect probes run:

- `cat .codex/hooks.json` -> Codex hook loads `.codex/hooks/codex-context.mjs`.
- `cat .codex/hooks/codex-context.mjs` -> hook reads `.codex/CODEX.md`, not skill payloads.
- `rg -n "context\\.fileName|fileName|CODEX|AGENTS|\\.agents/skills" .codex/hooks/codex-context.mjs .codex/hooks.json .codex/CODEX.md .agents/skills/skills.manifest.json` -> no Codex hook `context.fileName` skill-loading path found; skill discovery remains manifest/router-based.
- `readlink .claude/CLAUDE.md` -> `../AGENTS.md`.

Slot-rationale for modified sections:

- `§1 When to Invoke`: disposition `rewrite`; trigger-frequency = only when `epic-review` is invoked, failure-severity = high coordination noise / artifact pile-up, enforceability = discipline-only today. The cap is hard two; family-diversity is a second-slot priority, not permission for a third review.
- `§2 Pre-Review Context Pull`: disposition `rewrite`; adds the cap-counting and visible model-family identification step before the six-stage chain.
- `§4 Comment Output Format`: disposition `rewrite`; binds `manage_issue_comment` creation to cap availability.
- `§5 Citation`: disposition `rewrite`; adds cap-full citation while preserving same-identity citation.
- `§7/§8`: disposition `rewrite`; anti-pattern and asymmetry language now match the cap.

Substrate accretion defense: net always-loaded bytes = 0; the rule body lives in the conditional payload that already owns the workflow.

## Test Evidence

- `rg -n "Do not attempt deduplication|two comments|third structured|two-review cap|Review artifact cap|cap already satisfied" .agents/skills/epic-review/references/epic-review-workflow.md` -> old contradiction absent; new cap anchors present.
- `wc -c .agents/skills/epic-review/SKILL.md .agents/skills/epic-review/references/epic-review-workflow.md` -> router 1117 bytes; payload 21476 bytes.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> OK.
- `git diff --check` -> passed.
- Commit hook ran `node ./buildScripts/util/check-whitespace.mjs` -> passed.
- Pre-push freshness before initial push: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `ea817aea8 docs(agentos): cap epic-review comments (#13019)`.

## Post-Merge Validation

- [ ] Next one-slot-remaining `epic-review` pickup prefers an active family not yet represented when available.
- [ ] Next cap-full `epic-review` pickup cites the two existing structured reviews instead of posting a third full epic-review artifact.

## Commit

- `1f591dbf8` — `docs(agentos): cap epic-review comments (#13019)`
