### PR TITLE
feat(agentos): seed harness visual system (#13022)

### DIFF
--- a/apps/agentos/VisualSystem.md
+++ b/apps/agentos/VisualSystem.md
@@ -1,0 +1,40 @@
+# AgentOS Visual System
+
+Source authority: #13022 and parent epic #13012. This file is the app-local contract for the Agent Harness visual foundation while `apps/agentos` is the active shell.
+
+## Theme Pair
+
+- The harness loads `neo-theme-neo-dark` and `neo-theme-neo-light` from day one.
+- The app config lists `neo-theme-neo-dark` first, matching the harness baseline.
+- When no saved preference exists, the controller applies dark mode if the browser prefers it.
+- Theme preference is stored under `agentosTheme` via the main-thread `LocalStorage` addon.
+- Child apps load the same theme pair so detached windows stay inside the same visual system.
+
+## Surface Tokens
+
+Use the shared AgentOS CSS variables before adding component-local colors:
+
+| Surface | Background token | Accent token |
+|---|---|---|
+| Settings | `--agent-surface-settings` | `--agent-accent-settings` |
+| Chat | `--agent-surface-chat` | `--agent-accent-chat` |
+| Transcript | `--agent-surface-transcript` | `--agent-accent-transcript` |
+| Grid pane | `--agent-surface-grid` | `--agent-accent-grid` |
+
+## State Tokens
+
+Use these state tokens consistently across settings, chat, transcript, and grid panes:
+
+| State | Token |
+|---|---|
+| Focused / active | `--agent-state-focus` |
+| Muted / disabled | `--agent-state-muted` |
+| Waiting / pending | `--agent-state-waiting` |
+| Live / ready | `--agent-state-live` |
+
+## Interaction Contract
+
+- Use icon buttons with tooltips for compact toolbar actions.
+- Keep repeated pane cards at `8px` radius or less.
+- Keep fixed controls dimensioned so hover, icon, and theme changes do not resize toolbars.
+- Add new pane colors by extending the theme variable contract first, then consuming the variable in component SCSS.

--- a/apps/agentos/childapps/strategy/neo-config.json
+++ b/apps/agentos/childapps/strategy/neo-config.json
@@ -3,7 +3,7 @@
     "basePath"        : "../../../../",
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
-    "themes"          : ["neo-theme-cyberpunk"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useAiClient"     : true,
     "useSharedWorkers": true
 }

--- a/apps/agentos/childapps/swarm/neo-config.json
+++ b/apps/agentos/childapps/swarm/neo-config.json
@@ -3,7 +3,7 @@
     "basePath"                    : "../../../../",
     "environment"                 : "development",
     "mainPath"                    : "./Main.mjs",
-    "themes"                      : ["neo-theme-cyberpunk"],
+    "themes"                      : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useAiClient"                 : true,
     "useCanvasWorker"             : true,
     "useCanvasWorkerStartingPoint": true,

--- a/apps/agentos/childapps/widget/neo-config.json
+++ b/apps/agentos/childapps/widget/neo-config.json
@@ -3,7 +3,7 @@
     "basePath"        : "../../../../",
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
-    "themes"          : ["neo-theme-cyberpunk"],
+    "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useAiClient"     : true,
     "useSharedWorkers": true
 }

--- a/apps/agentos/neo-config.json
+++ b/apps/agentos/neo-config.json
@@ -3,9 +3,16 @@
     "basePath"                    : "../../",
     "environment"                 : "development",
     "mainPath"                    : "./Main.mjs",
-    "themes"                      : ["neo-theme-cyberpunk"],
+    "themes"                      : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useAiClient"                 : true,
     "useCanvasWorker"             : true,
     "useCanvasWorkerStartingPoint": true,
-    "useSharedWorkers"            : true
+    "useSharedWorkers"            : true,
+
+    "mainThreadAddons": [
+        "DragDrop",
+        "LocalStorage",
+        "Navigator",
+        "Stylesheet"
+    ]
 }

--- a/apps/agentos/view/Viewport.mjs
+++ b/apps/agentos/view/Viewport.mjs
@@ -47,8 +47,19 @@ class Viewport extends BaseViewport {
                 ntype: 'label',
                 text : 'Agent OS Command Center'
             }, '->', {
+                ntype    : 'button',
+                cls      : ['agent-button', 'agent-theme-button'],
+                handler  : 'onSwitchTheme',
+                iconCls  : 'fa-solid fa-moon',
+                reference: 'theme-switch-button',
+                tooltip  : {
+                    text     : 'Switch theme',
+                    showDelay: 0,
+                    hideDelay: 0
+                }
+            }, {
                 ntype  : 'button',
-                cls    : ['agent-button'],
+                cls    : ['agent-button', 'agent-detach-button'],
                 iconCls: 'fa fa-window-restore',
                 text   : 'Detach Swarm View',
                 handler: 'onOpenSwarmClick'

--- a/apps/agentos/view/ViewportController.mjs
+++ b/apps/agentos/view/ViewportController.mjs
@@ -10,6 +10,25 @@ class ViewportController extends Controller {
     }
 
     /**
+     * @summary Applies the persisted harness theme before the viewport settles.
+     */
+    onComponentConstructed() {
+        let me = this;
+
+        Neo.main.addon.LocalStorage.readLocalStorageItem({
+            key     : 'agentosTheme',
+            windowId: me.windowId
+        }).then(({value}) => {
+            if (value) {
+                me.setTheme(value, false)
+            } else if (Neo.config.prefersDarkTheme) {
+                me.setTheme('neo-theme-neo-dark', false)
+            }
+        })
+    }
+
+    /**
+     * @summary Opens the swarm child app in a detached window.
      * @param {Object} data
      */
     async onOpenSwarmClick(data) {
@@ -32,6 +51,71 @@ class ViewportController extends Controller {
             windowName    : name,
             windowFeatures: 'height=600,width=800,left=50,top=50'
         });
+    }
+
+    /**
+     * @summary Toggles the harness between the Neo dark and light themes.
+     * @param {Object} data
+     */
+    async onSwitchTheme(data) {
+        let me       = this,
+            viewport = me.component,
+            oldTheme = viewport.theme || 'neo-theme-neo-light',
+            newTheme = oldTheme === 'neo-theme-neo-light' ? 'neo-theme-neo-dark' : 'neo-theme-neo-light',
+            radius, x, y;
+
+        if (data.clientX !== undefined && data.clientY !== undefined) {
+            x      = data.clientX;
+            y      = data.clientY;
+            radius = Math.hypot(Math.max(x, 3000 - x), Math.max(y, 3000 - y))
+        } else {
+            x      = 0;
+            y      = 0;
+            radius = 3000
+        }
+
+        await Neo.main.DomAccess.startViewTransition({
+            animate: {
+                keyframes: [
+                    {clipPath: `circle(0px at ${x}px ${y}px)`},
+                    {clipPath: `circle(${radius}px at ${x}px ${y}px)`}
+                ],
+                options: {
+                    duration     : 500,
+                    easing       : 'ease-in',
+                    pseudoElement: '::view-transition-new(root)'
+                }
+            },
+            delay   : 100,
+            windowId: me.windowId
+        });
+
+        me.setTheme(newTheme)
+    }
+
+    /**
+     * @summary Applies and persists the active harness theme.
+     * @param {String} theme
+     * @param {Boolean} [updateStorage=true]
+     */
+    setTheme(theme, updateStorage=true) {
+        let me      = this,
+            btn     = me.getReference('theme-switch-button'),
+            iconCls = theme === 'neo-theme-neo-dark' ? 'fa-solid fa-sun' : 'fa-solid fa-moon';
+
+        me.component.theme = theme;
+
+        if (btn) {
+            btn.iconCls = iconCls
+        }
+
+        if (updateStorage) {
+            Neo.main.addon.LocalStorage.updateLocalStorageItem({
+                key     : 'agentosTheme',
+                value   : theme,
+                windowId: me.windowId
+            })
+        }
     }
 }
 

--- a/resources/scss/src/apps/agentos/StrategyCardPanel.scss
+++ b/resources/scss/src/apps/agentos/StrategyCardPanel.scss
@@ -34,14 +34,21 @@
         flex-direction : column;
         height         : 100%;
         justify-content: center;
-        padding        : 20px;
+        padding        : 6px 12px;
         width          : 100%;
 
         .agent-kpi-value {
             color      : var(--agent-accent-strategy);
-            font-size  : 2.5rem;
+            font-size  : 2rem;
             font-weight: 700;
+            line-height: 1;
             text-shadow: 0 0 10px rgba(241, 196, 15, 0.3);
         }
+    }
+}
+
+@media (max-width: 480px) {
+    .agent-kpi-card-panel.neo-panel .agent-kpi-card .agent-kpi-value {
+        font-size: 1.6rem;
     }
 }

--- a/resources/scss/src/apps/agentos/StrategyPanel.scss
+++ b/resources/scss/src/apps/agentos/StrategyPanel.scss
@@ -9,7 +9,7 @@
 
     .agent-kpi-dashboard {
         background-color: transparent;
-        padding         : 20px;
+        padding         : 12px 20px;
 
         // Remove default dashboard styles if needed
         &.neo-dashboard {

--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -25,12 +25,21 @@
             text-transform : uppercase;
             font-family    : var(--agent-font-mono);
             font-weight    : bold;
+            min-height     : 36px;
             transition     : all 0.3s ease;
 
             &:hover {
                 background : rgba(0, 210, 255, 0.1);
                 box-shadow : 0 0 10px var(--agent-accent-swarm);
             }
+        }
+
+        .agent-theme-button {
+            align-items     : center;
+            display         : inline-flex;
+            justify-content : center;
+            min-width       : 40px;
+            padding         : 0;
         }
     }
 
@@ -74,6 +83,24 @@
 
         .neo-panel-header-text {
             color : var(--agent-accent-swarm);
+        }
+    }
+}
+
+@media (max-width: 560px) {
+    .agent-os-viewport.neo-viewport .agent-top-toolbar {
+        padding: 0 12px;
+
+        .agent-detach-button {
+            align-items     : center;
+            display         : inline-flex;
+            justify-content : center;
+            min-width       : 40px;
+            padding         : 0;
+
+            .neo-button-text {
+                display: none;
+            }
         }
     }
 }

--- a/resources/scss/theme-neo-dark/apps/agentos/Viewport.scss
+++ b/resources/scss/theme-neo-dark/apps/agentos/Viewport.scss
@@ -8,6 +8,20 @@
     --agent-accent-strategy         : #d3a600;
     --agent-accent-swarm            : #0095b3;
     --agent-accent-intervention     : #cf222e;
+    --agent-accent-settings         : #7c3aed;
+    --agent-accent-chat             : #2da44e;
+    --agent-accent-transcript       : #bf8700;
+    --agent-accent-grid             : #0969da;
+
+    --agent-surface-settings        : #151322;
+    --agent-surface-chat            : #0f1a14;
+    --agent-surface-transcript      : #1f1a0d;
+    --agent-surface-grid            : #101827;
+
+    --agent-state-focus             : #58a6ff;
+    --agent-state-muted             : #6e7681;
+    --agent-state-waiting           : #d29922;
+    --agent-state-live              : #3fb950;
 
     --agent-font-mono               : 'Courier New', monospace;
     --agent-font-ui                 : system-ui, -apple-system, sans-serif;

--- a/resources/scss/theme-neo-light/apps/agentos/Viewport.scss
+++ b/resources/scss/theme-neo-light/apps/agentos/Viewport.scss
@@ -11,6 +11,20 @@
     /* Darker Cyan for contrast */
     --agent-accent-intervention     : #cf222e;
     /* Red */
+    --agent-accent-settings         : #8250df;
+    --agent-accent-chat             : #1a7f37;
+    --agent-accent-transcript       : #9a6700;
+    --agent-accent-grid             : #0969da;
+
+    --agent-surface-settings        : #f5f0ff;
+    --agent-surface-chat            : #eefcf3;
+    --agent-surface-transcript      : #fff8e5;
+    --agent-surface-grid            : #eef5ff;
+
+    --agent-state-focus             : #0969da;
+    --agent-state-muted             : #6e7781;
+    --agent-state-waiting           : #9a6700;
+    --agent-state-live              : #1a7f37;
 
     --agent-font-mono               : 'Courier New', monospace;
     --agent-font-ui                 : system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
Resolves #13022

Authored by GPT-5 (Codex Desktop). Session 518c54ce-5871-4ccf-8e88-6ac3b6e16ea8.

Seeds the Agent Harness visual-system foundation in `apps/agentos`: main and child configs now load `neo-theme-neo-dark` and `neo-theme-neo-light`, the parent shell persists a theme toggle with `LocalStorage`, app-scoped tokens define settings/chat/transcript/grid surfaces and shared states, and current KPI/toolbar sizing no longer clips at desktop or phone widths.

Evidence: L3 (browser-rendered local AgentOS verification on Chromium via Browser at 1280x720 and 390x844, plus static JSON/module/SCSS checks) -> L3 required (visual-system ACs require renderable UI verification). No residuals.

Related: #13012

## Deltas from ticket

- Used the current `apps/agentos` shell deliberately; no new harness path invented.
- Added app-local `apps/agentos/VisualSystem.md` as the settings/chat/transcript/grid-pane token contract.
- Included a small responsive cleanup for existing KPI cards and toolbar actions because visual verification found clipped text in the renderable shell.

## Test Evidence

- `node -e "const fs=require('fs'); for (const f of ['apps/agentos/neo-config.json','apps/agentos/childapps/swarm/neo-config.json','apps/agentos/childapps/widget/neo-config.json','apps/agentos/childapps/strategy/neo-config.json']) JSON.parse(fs.readFileSync(f,'utf8')); console.log('json ok')"` -> `json ok`.
- `node --check apps/agentos/view/ViewportController.mjs` -> passed.
- `node --check apps/agentos/view/Viewport.mjs` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.
- `rg -n '"themes"\\s*:\\s*\\["neo-theme-cyberpunk"\\]' apps/agentos` -> no matches.
- `node ./buildScripts/build/themes.mjs -f -n -e dev -t all` -> passed for local render CSS.
- Browser verification at `http://127.0.0.1:8092/apps/agentos/`:
  - desktop: dark render, theme toggle to light, no browser console errors, KPI values fit.
  - mobile `390x844`: toolbar buttons stay inside the viewport, detach action text is hidden behind the icon button, KPI values fit.
- Commit hook ran `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology` on staged files.

## Post-Merge Validation

- [ ] Open the deployed harness shell and verify dark/light toggle after assets are rebuilt in the target deployment.
- [ ] Consume the visual tokens from first settings/chat/transcript/grid pane implementations instead of introducing one-off colors.

## Commit

- `a67fdf962` — `feat(agentos): seed harness visual system (#13022)`
