### PR TITLE
test(vdom): record DeltaCapture window IDs (#13017)

### DIFF
--- a/test/playwright/unit/vdom/DeltaCapture.spec.mjs
+++ b/test/playwright/unit/vdom/DeltaCapture.spec.mjs
@@ -66,9 +66,10 @@ test.describe('DeltaCapture', () => {
                 {id: 'delta-capture-root', style: {color: 'red'}},
                 {action: 'removeNode', id: 'delta-capture-old'}
             ],
-            epoch: 'default',
-            layer: 'main-pre-apply',
-            tap  : 'applyDeltas'
+            epoch   : 'default',
+            layer   : 'main-pre-apply',
+            tap     : 'applyDeltas',
+            windowId: 'window-1'
         }]);
         expect(capture.deltasIn('default')).toEqual([[
             {id: 'delta-capture-root', style: {color: 'red'}},
@@ -100,6 +101,7 @@ test.describe('DeltaCapture', () => {
         expect(result.deltas.length).toBe(1);
         expect(capture.recordsIn('default')[0].tap).toBe('helperReturn');
         expect(capture.recordsIn('default')[0].layer).toBe('vdom-pre-send');
+        expect(capture.recordsIn('default')[0].windowId).toBeNull();
         expect(capture.deltasIn('default')).toEqual([result.deltas])
     });
 
@@ -176,6 +178,27 @@ test.describe('DeltaCapture', () => {
         expect(capture.deltasIn('drop')).toEqual([[
             {action: 'moveNode', id: 'delta-capture-row', parentId: 'delta-capture-root', index: 0}
         ]])
+    });
+
+    test('attributes applyDeltas records to their source windowId', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const capture = install({tap: 'applyDeltas'});
+
+        await Neo.applyDeltas('window-1', {id: 'delta-capture-shared', text: 'first'});
+        await Neo.applyDeltas('window-2', {id: 'delta-capture-shared', text: 'second'});
+        await Neo.applyDeltas('window-1', {id: 'delta-capture-shared', text: 'third'});
+
+        const records = capture.recordsIn('default');
+
+        expect(records.map(record => record.windowId)).toEqual(['window-1', 'window-2', 'window-1']);
+        expect(records.filter(record => record.windowId === 'window-1').map(record => record.deltas)).toEqual([
+            [{id: 'delta-capture-shared', text: 'first'}],
+            [{id: 'delta-capture-shared', text: 'third'}]
+        ]);
+        expect(records.filter(record => record.windowId === 'window-2').map(record => record.deltas)).toEqual([
+            [{id: 'delta-capture-shared', text: 'second'}]
+        ])
     });
 
     test('classifies effective ops and validates findings per preserved batch', async () => {

--- a/test/playwright/util/DeltaCapture.mjs
+++ b/test/playwright/util/DeltaCapture.mjs
@@ -11,7 +11,7 @@ const ACTIVE_TAPS = new Map(),
               method: 'applyDeltas',
               wrap(capture, original) {
                   return function(windowId, deltas, ...args) {
-                      capture.record(deltas);
+                      capture.record(deltas, {windowId});
                       return original.call(this, windowId, deltas, ...args)
                   }
               }
@@ -67,9 +67,10 @@ function normalizeDeltas(deltas) {
  * - Component method return checks can wrap the update that produces the return and inspect the same epoch.
  * - Console-log delta harvesting should move to an explicit tap; log output is format-coupled and lossy.
  *
- * The captured record names its tap and layer because the VDom pre-send stream is attribution/intent,
- * while the Main pre-apply stream is final batch truth. Batch boundaries are preserved by default:
- * the batch is the unit validated by `DeltaGrammar.validateBatch()`.
+ * The captured record names its tap, layer, and windowId because the VDom pre-send stream is
+ * attribution/intent, while the Main pre-apply stream is final batch truth. Batch boundaries are
+ * preserved by default: the batch is the unit validated by `DeltaGrammar.validateBatch()`.
+ * Taps without a window seam store `windowId: null` explicitly, keeping the record shape stable.
  *
  * Use `try/finally` or `test.afterEach()` to call `restore()` whenever a test installs a capture.
  *
@@ -127,16 +128,17 @@ export function createDeltaCapture({tap} = {}) {
                   }
               },
 
-              record(deltas) {
+              record(deltas, meta = {}) {
                   if (restored) {
                       return
                   }
 
                   records.push({
-                      deltas: normalizeDeltas(deltas),
-                      epoch : activeEpoch,
-                      layer : config.layer,
-                      tap
+                      deltas  : normalizeDeltas(deltas),
+                      epoch   : activeEpoch,
+                      layer   : config.layer,
+                      tap,
+                      windowId: meta.windowId ?? null
                   })
               },
 


### PR DESCRIPTION
Resolves #13017

Authored by GPT-5 (Codex Desktop). Session 518c54ce-5871-4ccf-8e88-6ac3b6e16ea8.

DeltaCapture records now carry a stable `windowId` field: `applyDeltas` records store the seam's actual window id, while taps without a window seam store `null` explicitly. This preserves the existing facade shape and lets multi-window consumers attribute interleaved same-id delta batches with ordinary record filtering.

Evidence: L2 (focused Playwright unit spec + staged-file hooks) -> L2 required (test-utility record-shape contract). No residuals.

## Deltas from ticket

None. The implementation keeps window filtering as plain `.filter(record => record.windowId === id)` rather than adding speculative accessor surface.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/vdom/DeltaCapture.spec.mjs` -> 7 passed
- Commit hook during `git commit`: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`

## Post-Merge Validation

- [ ] CI unit lane remains green for `test/playwright/unit/vdom/DeltaCapture.spec.mjs`.

## Commit

- `a2c2ad82d` - `test(vdom): record DeltaCapture window IDs (#13017)`
