### PR TITLE
fix(memory-core): make boot heartbeat non-empty (#12879)

### DIFF
--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -292,8 +292,10 @@ export async function resolveResumeHarnessInstancePid({
 }
 
 /**
- * Build a boot-grounding prompt that instructs the fresh agent to read
- * AGENTS_STARTUP.md and pick up prior context via Memory Core + sandman_handoff.
+ * @summary Builds the fresh-session boot prompt used by resume recovery.
+ *
+ * Instructs the fresh agent to read AGENTS_STARTUP.md, persist a meaningful
+ * non-empty boot heartbeat, and pick up prior context via Memory Core + sandman_handoff.
  * @param {string} identity        Agent identity (e.g. '@neo-opus-ada').
  * @param {string} reason          Human-readable sunset cause from checkSunsetted.
  * @param {string} originSessionId Memory Core session ID of the just-sunsetted run; falsy → omitted gracefully.
@@ -304,7 +306,7 @@ function buildBootGroundingPrompt(identity, reason, originSessionId) {
         ? `Origin Session ID: ${originSessionId}.`
         : 'Origin Session ID unavailable in recovery payload — pull most recent SUNSET-tagged memory for this identity instead.';
     return [
-        `hi ${identity}, please read @AGENTS_STARTUP.md, then call add_memory once as a boot heartbeat, then proceed normally.`,
+        `hi ${identity}, please read @AGENTS_STARTUP.md, then call add_memory once as a boot heartbeat with explicit non-empty prompt/thought/response fields (for example: prompt="Boot heartbeat for ${identity}", thought="Fresh recovery boot after AGENTS_STARTUP.md read; Memory Core write-path health check.", response="Boot heartbeat saved; continuing recovery."), then proceed normally.`,
         `Recovery context: ${reason}.`,
         `${sessionAnchor} Read resources/content/sandman_handoff.md and your Memory Core context to resume swarm coordination from the prior session anchor.`
     ].join(' ');

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -392,6 +392,9 @@ test.describe('ai/scripts/resumeHarness', () => {
         // prose payload. Static-read the prompt builder to verify the shape.
         const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
         expect(scriptContent).toContain('@AGENTS_STARTUP.md');
+        expect(scriptContent).toContain('explicit non-empty prompt/thought/response fields');
+        expect(scriptContent).toContain('Boot heartbeat for ${identity}');
+        expect(scriptContent).not.toContain('call add_memory once as a boot heartbeat, then proceed normally');
         expect(scriptContent).toContain('resources/content/sandman_handoff.md');
         expect(scriptContent).toContain('Origin Session ID');
         // Negative assertion: the old Q1a prose payload must be gone


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019eba1b-f70e-74c0-9dfb-8666901c3c0d.

Resolves #12879

This resolves the narrowed #12879 residual by changing the resume-harness boot prompt from a thin "call add_memory once" instruction into an explicit meaningful boot heartbeat with non-empty `prompt`, `thought`, and `response` fields. That keeps the resume liveness write compatible with the existing `MemoryService.getInvalidMemoryFields()` guard and with future stricter `memoryWal.minFieldLength` settings, without adding a new liveness channel or changing the Memory Core write schema.

Evidence: L1 (static prompt-shape unit guard + source audit) -> L3 live recovery observation would be needed to prove an actual resumed harness persisted the heartbeat. Residual: post-merge live resume observation in the operator harness [#12879].

## Deltas from ticket

The original ticket still describes two fixes. The add-memory write-path guard already shipped in #12844, and the issue thread narrowed this ticket to part 2 only: the boot-heartbeat prompt carve-out. This PR deliberately does not touch `MemoryService.mjs`, the WAL schema, or the embed path.

## Test Evidence

- `git diff --cached --check`
- `NEO_TEST_SKIP_CI=1 npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs` -> 20 passed, 9 skipped
- Attempted the same focused spec without `NEO_TEST_SKIP_CI`; the changed prompt-shape test passed before a later existing live-substrate test failed in this sandbox with `EPERM` writing `.neo-ai-data/wake-daemon/inflight-sunset_restart-neo-gemini-pro.txt`.
- Commit hook ran `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology`.

## Post-Merge Validation

- [ ] Trigger or observe one real resume-harness recovery and confirm the first boot heartbeat memory carries non-empty `prompt`, `thought`, and `response` content.

## Commit

- `3784b89d2` — `fix(memory-core): make boot heartbeat non-empty (#12879)`
