### PR TITLE
feat(ai): Fleet Manager agent registry + encrypted credential store (#13031)

### DIFF
--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -1,0 +1,354 @@
+import crypto          from 'crypto';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Base            from '../../../src/core/Base.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename);
+
+/**
+ * @class Neo.ai.services.fleet.FleetRegistryService
+ * @extends Neo.core.Base
+ * @singleton
+ *
+ * @summary
+ * The Brain-side (Node-only) registry of Fleet Manager agent definitions and their credentials.
+ * This is the first leaf of the Fleet Manager MVP: the `define` surface of the operator loop
+ * *define agents → start/stop → repos managed under the hood*.
+ *
+ * An **agent definition** is `{id, githubUsername, harnessType, metadata, createdAt, updatedAt}` —
+ * never a secret. The associated **credential** (a GitHub PAT) is stored separately, encrypted at
+ * rest, and is the load-bearing security boundary of this service:
+ *
+ * **Two-hemisphere security rule** (the graduated Agent Harness design rule): the PAT is a
+ * Node-side secret. It is written *in* via {@link defineAgent}, stored encrypted, and
+ * is **never** returned by the public read API ({@link getAgent} / {@link listAgents}). Only the
+ * dedicated Brain-internal {@link resolveCredential} accessor decrypts it — for the instance spawner
+ * (a later FM leaf) — so the Body-side settings pane can never read a PAT back.
+ *
+ * **Storage** lives under `dataDir` (default `<repoRoot>/.neo-ai-data/fleet/`, overridable — the
+ * per-tenant data root is the multi-tenant isolation seam):
+ * - `registry.json`   — agent definitions (no secrets), human-readable JSON.
+ * - `credentials.enc` — the encrypted `{agentId: pat}` map (AES-256-GCM, `0600`).
+ * - `fleet.key`       — dev-only generated `0600` key file, used when `NEO_FLEET_SECRET_KEY` is
+ *                       not set. Production deployments SHOULD provide the env key.
+ *
+ * **Fail-closed:** an absent / locked / corrupt credential store never throws into the define/list
+ * path and never surfaces plaintext — {@link resolveCredential} returns `null`.
+ */
+class FleetRegistryService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.fleet.FleetRegistryService'
+         * @protected
+         */
+        className: 'Neo.ai.services.fleet.FleetRegistryService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {String|null} dataDir_=null
+         * @summary Absolute path to the fleet data directory. Defaults to
+         * `<repoRoot>/.neo-ai-data/fleet/`. Set a per-tenant path for isolation, or a temp path in
+         * tests. Changing it transparently reloads the in-memory registry on the next call.
+         */
+        dataDir_: null
+    }
+
+    /**
+     * Whitelist of supported harness types an agent definition may declare.
+     * @member {String[]} harnessTypes
+     * @protected
+     */
+    harnessTypes = ['claude-desktop', 'codex', 'antigravity', 'native-neo']
+
+    /**
+     * In-memory cache of agent definitions (no secrets), keyed by agent id.
+     * @member {Map<String,Object>} agents
+     * @private
+     */
+    agents = new Map()
+
+    /**
+     * The resolved `dataDir` the in-memory `agents` cache was last loaded from; guards transparent
+     * reloads when `dataDir` changes (e.g. across tests / tenants).
+     * @member {String|null} loadedDir=null
+     * @private
+     */
+    loadedDir = null
+
+    // ---- public API ---------------------------------------------------------
+
+    /**
+     * Define (create or update) an agent and, optionally, store its credential.
+     * @param {Object}  opts
+     * @param {String}  opts.githubUsername     The agent's GitHub username (required).
+     * @param {String}  opts.harnessType        One of {@link harnessTypes} (required).
+     * @param {String} [opts.credential]        The GitHub PAT — stored Node-side encrypted; never echoed back.
+     * @param {String} [opts.id=githubUsername] Stable id; pass an explicit id to register multiple instances per user.
+     * @param {Object} [opts.metadata={}]       Free-form non-secret metadata.
+     * @returns {Object} The public agent definition (no credential).
+     */
+    defineAgent({githubUsername, harnessType, credential, id, metadata={}} = {}) {
+        if (!githubUsername) throw new Error("FleetRegistryService.defineAgent: 'githubUsername' is required.");
+        if (!harnessType)    throw new Error("FleetRegistryService.defineAgent: 'harnessType' is required.");
+
+        if (!this.harnessTypes.includes(harnessType)) {
+            throw new Error(`FleetRegistryService.defineAgent: invalid harnessType '${harnessType}'. Must be one of: ${this.harnessTypes.join(', ')}.`);
+        }
+
+        this.ensureLoaded();
+
+        const
+            agentId  = id || githubUsername,
+            now      = new Date().toISOString(),
+            existing = this.agents.get(agentId),
+            def      = {
+                id            : agentId,
+                githubUsername,
+                harnessType,
+                metadata,
+                createdAt     : existing?.createdAt || now,
+                updatedAt     : now
+            };
+
+        this.agents.set(agentId, def);
+        this.writeRegistry();
+
+        if (credential != null) {
+            this.storeCredential(agentId, credential);
+        }
+
+        return this.toPublic(def);
+    }
+
+    /**
+     * List all agent definitions (no credentials).
+     * @returns {Object[]}
+     */
+    listAgents() {
+        this.ensureLoaded();
+        return [...this.agents.values()].map(def => this.toPublic(def));
+    }
+
+    /**
+     * Get a single agent definition (no credential).
+     * @param {String} id
+     * @returns {Object|null}
+     */
+    getAgent(id) {
+        this.ensureLoaded();
+        const def = this.agents.get(id);
+        return def ? this.toPublic(def) : null;
+    }
+
+    /**
+     * Remove an agent definition and its stored credential.
+     * @param {String} id
+     * @returns {Object} `{success, id}`
+     */
+    removeAgent(id) {
+        this.ensureLoaded();
+        const existed = this.agents.delete(id);
+        if (existed) this.writeRegistry();
+        this.removeCredential(id);
+        return {success: existed, id};
+    }
+
+    /**
+     * Brain-internal credential accessor — the ONLY path that returns a raw PAT. Intended for the
+     * instance spawner (a later FM leaf), never the Body-side settings pane. Fails closed.
+     * @param {String} id
+     * @returns {String|null} The decrypted PAT, or `null` if absent / unreadable.
+     */
+    resolveCredential(id) {
+        return this.readCredentials()[id] ?? null;
+    }
+
+    // ---- internals ----------------------------------------------------------
+
+    /**
+     * @param {Object} def
+     * @returns {Object} A defensive copy of the definition, guaranteed to carry no secret.
+     * @private
+     */
+    toPublic(def) {
+        const {credential, pat, ...rest} = def;
+        return {...rest};
+    }
+
+    /**
+     * Lazily (re)load the in-memory registry from disk when `dataDir` changes.
+     * @private
+     */
+    ensureLoaded() {
+        const dir = this.getDataDir();
+        if (this.loadedDir === dir) return;
+        this.agents    = this.readRegistry();
+        this.loadedDir = dir;
+    }
+
+    /**
+     * @returns {Map<String,Object>} Agent definitions read from `registry.json` (empty on miss/corrupt).
+     * @private
+     */
+    readRegistry() {
+        const file = this.registryPath();
+        if (!fs.existsSync(file)) return new Map();
+        try {
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            return new Map(Object.entries(data.agents || {}));
+        } catch (error) {
+            console.warn(`[FleetRegistryService] Unreadable registry at ${file}; starting empty.`, error.message);
+            return new Map();
+        }
+    }
+
+    /**
+     * Persist the in-memory registry to `registry.json` (no secrets).
+     * @private
+     */
+    writeRegistry() {
+        this.ensureDataDir();
+        const payload = {agents: Object.fromEntries(this.agents)};
+        fs.writeFileSync(this.registryPath(), JSON.stringify(payload, null, 2), 'utf8');
+    }
+
+    /**
+     * @returns {Object} The decrypted `{agentId: pat}` map (empty + warned on absent/corrupt — fail-closed).
+     * @private
+     */
+    readCredentials() {
+        const file = this.credentialsPath();
+        if (!fs.existsSync(file)) return {};
+        try {
+            return JSON.parse(this.decrypt(fs.readFileSync(file, 'utf8')));
+        } catch (error) {
+            console.warn('[FleetRegistryService] Credential store unreadable; failing closed.', error.message);
+            return {};
+        }
+    }
+
+    /**
+     * Encrypt + persist a single credential, merged into the existing store.
+     * @param {String} id
+     * @param {String} pat
+     * @private
+     */
+    storeCredential(id, pat) {
+        const map = this.readCredentials();
+        map[id] = pat;
+        this.writeCredentials(map);
+    }
+
+    /**
+     * Remove a single credential from the store (no-op if absent).
+     * @param {String} id
+     * @private
+     */
+    removeCredential(id) {
+        const map = this.readCredentials();
+        if (Object.hasOwn(map, id)) {
+            delete map[id];
+            this.writeCredentials(map);
+        }
+    }
+
+    /**
+     * Encrypt + write the full credential map to `credentials.enc` (`0600`).
+     * @param {Object} map
+     * @private
+     */
+    writeCredentials(map) {
+        this.ensureDataDir();
+        fs.writeFileSync(this.credentialsPath(), this.encrypt(JSON.stringify(map)), {mode: 0o600});
+    }
+
+    // ---- crypto (AES-256-GCM) ----------------------------------------------
+
+    /**
+     * @param {String} plaintext
+     * @returns {String} base64( iv(12) ‖ authTag(16) ‖ ciphertext )
+     * @private
+     */
+    encrypt(plaintext) {
+        const
+            iv     = crypto.randomBytes(12),
+            cipher = crypto.createCipheriv('aes-256-gcm', this.getKey(), iv),
+            enc    = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]),
+            tag    = cipher.getAuthTag();
+        return Buffer.concat([iv, tag, enc]).toString('base64');
+    }
+
+    /**
+     * @param {String} payload base64( iv(12) ‖ authTag(16) ‖ ciphertext )
+     * @returns {String} plaintext
+     * @private
+     */
+    decrypt(payload) {
+        const
+            raw      = Buffer.from(payload, 'base64'),
+            iv       = raw.subarray(0, 12),
+            tag      = raw.subarray(12, 28),
+            data     = raw.subarray(28),
+            decipher = crypto.createDecipheriv('aes-256-gcm', this.getKey(), iv);
+        decipher.setAuthTag(tag);
+        return Buffer.concat([decipher.update(data), decipher.final()]).toString('utf8');
+    }
+
+    /**
+     * Resolve the 32-byte AES key: `NEO_FLEET_SECRET_KEY` (hex or base64) if set, else a generated
+     * `0600` dev key file under `dataDir`. Production SHOULD set the env key.
+     * @returns {Buffer}
+     * @private
+     */
+    getKey() {
+        const envKey = process.env.NEO_FLEET_SECRET_KEY;
+        if (envKey) {
+            const buf = Buffer.from(envKey, /^[0-9a-fA-F]{64}$/.test(envKey) ? 'hex' : 'base64');
+            if (buf.length !== 32) {
+                throw new Error('FleetRegistryService: NEO_FLEET_SECRET_KEY must decode to 32 bytes (AES-256).');
+            }
+            return buf;
+        }
+        const file = this.keyPath();
+        if (fs.existsSync(file)) return fs.readFileSync(file);
+        this.ensureDataDir();
+        const key = crypto.randomBytes(32);
+        fs.writeFileSync(file, key, {mode: 0o600});
+        return key;
+    }
+
+    // ---- paths --------------------------------------------------------------
+
+    /**
+     * @returns {String} The resolved fleet data directory.
+     * @private
+     */
+    getDataDir() {
+        return this.dataDir || path.resolve(__dirname, '../../../.neo-ai-data/fleet');
+    }
+
+    /** @returns {String} @private */
+    registryPath() { return path.join(this.getDataDir(), 'registry.json'); }
+
+    /** @returns {String} @private */
+    credentialsPath() { return path.join(this.getDataDir(), 'credentials.enc'); }
+
+    /** @returns {String} @private */
+    keyPath() { return path.join(this.getDataDir(), 'fleet.key'); }
+
+    /**
+     * Ensure the data directory exists.
+     * @private
+     */
+    ensureDataDir() {
+        fs.mkdirSync(this.getDataDir(), {recursive: true});
+    }
+}
+
+export default Neo.setupClass(FleetRegistryService);

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -166,7 +166,10 @@ class FleetRegistryService extends Base {
      * @returns {String|null} The decrypted PAT, or `null` if absent / unreadable.
      */
     resolveCredential(id) {
-        return this.readCredentials()[id] ?? null;
+        const credentials = this.readCredentials();
+        // own-property lookup only: an id like `toString` / `constructor` must fail closed to null,
+        // never resolve to an inherited Object.prototype member.
+        return Object.hasOwn(credentials, id) ? credentials[id] : null;
     }
 
     // ---- internals ----------------------------------------------------------
@@ -219,17 +222,20 @@ class FleetRegistryService extends Base {
     }
 
     /**
-     * @returns {Object} The decrypted `{agentId: pat}` map (empty + warned on absent/corrupt — fail-closed).
+     * @returns {Object} The decrypted `{agentId: pat}` map as a **null-prototype** object (empty +
+     * warned on absent/corrupt — fail-closed). Null-prototype is the security invariant: credential
+     * ids are untrusted keys, so an absent id can never alias an inherited `Object.prototype` member
+     * (`toString` / `constructor` / `__proto__` …) on lookup, store, or remove.
      * @private
      */
     readCredentials() {
         const file = this.credentialsPath();
-        if (!fs.existsSync(file)) return {};
+        if (!fs.existsSync(file)) return Object.create(null);
         try {
-            return JSON.parse(this.decrypt(fs.readFileSync(file, 'utf8')));
+            return Object.assign(Object.create(null), JSON.parse(this.decrypt(fs.readFileSync(file, 'utf8'))));
         } catch (error) {
             console.warn('[FleetRegistryService] Credential store unreadable; failing closed.', error.message);
-            return {};
+            return Object.create(null);
         }
     }
 

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -1,0 +1,152 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'FleetRegistryServiceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import os              from 'os';
+import path            from 'path';
+
+import Neo                  from '../../../../src/Neo.mjs';
+import * as core            from '../../../../src/core/_export.mjs';
+import FleetRegistryService from '../../../../ai/services/fleet/FleetRegistryService.mjs';
+
+const createdDirs = [];
+
+/**
+ * Create + track a unique temp dir under the OS temp root. Race-free across Playwright's parallel
+ * workers — there is no shared on-disk scratch dir for a sibling test's teardown to delete.
+ * @param {String} [prefix='neo-fleet-registry-']
+ * @returns {String} the new directory
+ */
+function makeDir(prefix='neo-fleet-registry-') {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    createdDirs.push(dir);
+    return dir;
+}
+
+/**
+ * Point the singleton at a fresh, isolated data dir (its own keyfile + stores) for a test.
+ * @returns {String} the fresh directory
+ */
+function freshDataDir() {
+    const dir = makeDir();
+    FleetRegistryService.dataDir = dir;
+    return dir;
+}
+
+test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
+    test.beforeEach(() => {
+        freshDataDir();
+    });
+
+    test.afterEach(() => {
+        while (createdDirs.length) {
+            const dir = createdDirs.pop();
+            if (fs.existsSync(dir)) fs.rmSync(dir, {recursive: true, force: true});
+        }
+    });
+
+    test('defineAgent captures githubUsername + harnessType and echoes no secret', () => {
+        const def = FleetRegistryService.defineAgent({
+            githubUsername: 'neo-claude-opus',
+            harnessType   : 'claude-desktop',
+            credential    : 'ghp_secretTokenAAA'
+        });
+
+        expect(def.githubUsername).toBe('neo-claude-opus');
+        expect(def.harnessType).toBe('claude-desktop');
+        expect(def.id).toBe('neo-claude-opus');
+        expect(def.credential).toBeUndefined();
+        expect(JSON.stringify(def)).not.toContain('ghp_secretTokenAAA');
+    });
+
+    test('CRUD round-trip: define -> list -> get -> remove', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'agent-a', harnessType: 'codex',       credential: 'ghp_a'});
+        FleetRegistryService.defineAgent({githubUsername: 'agent-b', harnessType: 'antigravity', credential: 'ghp_b'});
+
+        const list = FleetRegistryService.listAgents();
+        expect(list).toHaveLength(2);
+        expect(list.map(a => a.id).sort()).toEqual(['agent-a', 'agent-b']);
+
+        expect(FleetRegistryService.getAgent('agent-a').harnessType).toBe('codex');
+
+        const removed = FleetRegistryService.removeAgent('agent-a');
+        expect(removed.success).toBe(true);
+        expect(FleetRegistryService.getAgent('agent-a')).toBeNull();
+        expect(FleetRegistryService.listAgents()).toHaveLength(1);
+    });
+
+    test('SECURITY BOUNDARY: the PAT is never returned by getAgent / listAgents; only resolveCredential serves it', () => {
+        const pat = 'ghp_BoundaryToken_1234567890';
+        FleetRegistryService.defineAgent({githubUsername: 'secure-agent', harnessType: 'claude-desktop', credential: pat});
+
+        const got  = FleetRegistryService.getAgent('secure-agent'),
+              list = FleetRegistryService.listAgents();
+
+        expect(JSON.stringify(got)).not.toContain(pat);
+        expect(JSON.stringify(list)).not.toContain(pat);
+        expect(got.credential).toBeUndefined();
+        expect(got.pat).toBeUndefined();
+
+        // the dedicated Brain-internal accessor is the ONLY path to the raw PAT
+        expect(FleetRegistryService.resolveCredential('secure-agent')).toBe(pat);
+    });
+
+    test('SECURITY BOUNDARY: the credential is encrypted at rest; registry.json holds no plaintext PAT', () => {
+        const pat = 'ghp_AtRestToken_ABCDEFGH';
+        FleetRegistryService.defineAgent({githubUsername: 'disk-agent', harnessType: 'codex', credential: pat});
+
+        const dir         = FleetRegistryService.dataDir,
+              registryRaw = fs.readFileSync(path.join(dir, 'registry.json'),   'utf8'),
+              credsRaw    = fs.readFileSync(path.join(dir, 'credentials.enc'), 'utf8');
+
+        // the definitions file is plaintext but must never contain the secret
+        expect(registryRaw).toContain('disk-agent');
+        expect(registryRaw).not.toContain(pat);
+        // the credential file is ciphertext: the raw PAT must not appear
+        expect(credsRaw).not.toContain(pat);
+    });
+
+    test('persists across a reload (durable on disk + decrypts back)', () => {
+        const dirA = FleetRegistryService.dataDir;
+        FleetRegistryService.defineAgent({githubUsername: 'persist-agent', harnessType: 'native-neo', credential: 'ghp_persist'});
+
+        // flip to a different (empty) dir -> the cache reloads, this registry is empty
+        const dirB = makeDir('neo-fleet-other-');
+        FleetRegistryService.dataDir = dirB;
+        expect(FleetRegistryService.listAgents()).toHaveLength(0);
+
+        // flip back -> the definition + credential reload and decrypt from disk
+        FleetRegistryService.dataDir = dirA;
+        expect(FleetRegistryService.getAgent('persist-agent').harnessType).toBe('native-neo');
+        expect(FleetRegistryService.resolveCredential('persist-agent')).toBe('ghp_persist');
+    });
+
+    test('removeAgent drops the stored credential too', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'temp-agent', harnessType: 'codex', credential: 'ghp_temp'});
+        expect(FleetRegistryService.resolveCredential('temp-agent')).toBe('ghp_temp');
+
+        FleetRegistryService.removeAgent('temp-agent');
+        expect(FleetRegistryService.resolveCredential('temp-agent')).toBeNull();
+    });
+
+    test('rejects an invalid harnessType and missing required fields', () => {
+        expect(() => FleetRegistryService.defineAgent({githubUsername: 'x', harnessType: 'emacs'})).toThrow(/invalid harnessType/);
+        expect(() => FleetRegistryService.defineAgent({harnessType: 'codex'})).toThrow(/githubUsername/);
+        expect(() => FleetRegistryService.defineAgent({githubUsername: 'x'})).toThrow(/harnessType/);
+    });
+
+    test('resolveCredential fails closed for an unknown agent', () => {
+        expect(FleetRegistryService.resolveCredential('nobody')).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -149,4 +149,18 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
     test('resolveCredential fails closed for an unknown agent', () => {
         expect(FleetRegistryService.resolveCredential('nobody')).toBeNull();
     });
+
+    test('FAIL-CLOSED: prototype-chain ids never resolve to inherited members (gpt review RA)', () => {
+        // empty store — none of these are real credentials; each must return null, not a function
+        for (const key of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
+            expect(FleetRegistryService.resolveCredential(key)).toBeNull();
+        }
+    });
+
+    test('an agent id that collides with an Object.prototype name still round-trips', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'toString', harnessType: 'codex', credential: 'ghp_proto'});
+        // the legitimately-named credential resolves; a different proto-name remains absent
+        expect(FleetRegistryService.resolveCredential('toString')).toBe('ghp_proto');
+        expect(FleetRegistryService.resolveCredential('constructor')).toBeNull();
+    });
 });


### PR DESCRIPTION
Resolves #13031
Related: #13015
Related: #13012

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace). Session 7c6c8fd9-219d-4eae-9d70-ef18ec945a14.

First leaf of the Fleet Manager MVP: a Brain-side (Node-only) registry where the operator *defines* an agent (GitHub username + harness type + PAT) before any lifecycle/provisioning leaf can start it. New `ai/services/fleet/` domain with a `FleetRegistryService` singleton — `defineAgent` / `listAgents` / `getAgent` / `removeAgent` + a Brain-internal `resolveCredential`. The PAT is stored Node-side, **encrypted at rest (AES-256-GCM)**, and is never returned by the read API — only the dedicated `resolveCredential` accessor decrypts it for the (future) spawner. This is the load-bearing two-hemisphere security boundary: the Body-side settings pane can write a PAT *in* but can never read one back.

Evidence: L1 (unit-tested service contract; node-side `fs`/`crypto`, no runtime surface beyond CI reach). No residuals — all ACs are unit-covered.

## Implementation
- New `ai/services/fleet/FleetRegistryService.mjs` — singleton extending `Neo.core.Base`, sibling-consistent with the `ai/services/<domain>/` layout.
- **Crypto:** Node built-in AES-256-GCM (12-byte IV ‖ 16-byte authTag ‖ ciphertext, base64). No native `keytar`/`libsecret` dependency — cloud-portable + Linux-safe. Key from `NEO_FLEET_SECRET_KEY` (hex/base64, 32 bytes) or a generated `0600` dev key file under `dataDir`.
- **Storage:** `registry.json` (definitions, no secrets) + `credentials.enc` (encrypted map, `0600`) under `dataDir` (default `<repoRoot>/.neo-ai-data/fleet/`). The `dataDir` override is the per-tenant isolation seam.
- **Fail-closed:** an absent / locked / corrupt credential store never throws into define/list; `resolveCredential` returns `null`.
- `harnessType` whitelist: `claude-desktop` / `codex` / `antigravity` / `native-neo`.

## Deltas from ticket
- **Path via a self-contained default, not an AiConfig leaf (yet):** mirrors the sibling `ConceptService` "default + override" pattern; keeps this first leaf self-contained and avoids `config.template.mjs` churn. Wiring `dataDir` through an AiConfig leaf is a clean follow-up if the domain warrants it (the ticket framed the mechanism as a leaf-level decision).
- **Not registered in `ai/services.mjs`:** registration wires the consumption / MCP-tool surface, which is an explicitly out-of-scope separate FM leaf (NL/MCP wiring). The service stands alone — consumed directly by the spec now and the spawner later.
- **`console.warn` on the fail-closed degraded path:** the only loggers in the repo are MCP-server-side (`ai/mcp/server/*/logger.mjs`); importing one into a service would invert the layer dependency, and the sibling `ConceptService` uses none. Surfacing (not swallowing) the degraded read is deliberate.

## Test Evidence
`npm run test-unit -- test/playwright/unit/ai/FleetRegistryService.spec.mjs` → **8/8 passed** (788ms):
- CRUD round-trip (define → list → get → remove)
- SECURITY BOUNDARY: PAT never returned by `getAgent` / `listAgents`; only `resolveCredential` serves it
- SECURITY BOUNDARY: credential encrypted at rest; `registry.json` holds no plaintext PAT
- Durable reload (persists + decrypts from disk across a `dataDir` flip)
- `removeAgent` drops the stored credential too
- Validation (invalid `harnessType`, missing required fields throw)
- Fail-closed (`resolveCredential` for an unknown agent → `null`)

## Post-Merge Validation
- [ ] CI unit suite green on `ubuntu-latest` (Linux case-sensitive + clean substrate).
- [ ] Consumed by the instance-spawner leaf (lifecycle) via `resolveCredential` — boundary holds end-to-end.

## Acceptance Criteria
- [x] `FleetRegistryService` in `ai/services/fleet/` with `defineAgent` / `listAgents` / `getAgent` / `removeAgent`.
- [x] An agent definition captures `githubUsername` + `harnessType` + a stored credential (PAT).
- [x] Security boundary: PAT stored Node-side encrypted-at-rest, never returned by `getAgent` / `listAgents`; a dedicated resolver serves the spawner — asserted by a unit test.
- [x] Unit tests: define → list → get → remove round-trip + the credential-boundary assertion.
- [ ] Linked as a sub-issue of #13015 *(linking on PR open).*
