### PR TITLE
feat(agentos): establish .agents/workflows with the agent-harness entry workflow (#13042)

### DIFF
--- a/.agents/workflows/agent-harness.md
+++ b/.agents/workflows/agent-harness.md
@@ -1,0 +1,17 @@
+# Workflow: Agent Harness — session entry
+
+> **Convention note (first workflow in `.agents/workflows/`):** workflows are mission-specific **entry sequences**, read on demand. Skills (`.agents/skills/`) are task-class **disciplines**, trigger-loaded. Workflows point at skills and durable anchors — they never duplicate either.
+
+The fastest correct path into the Agent Harness line (Epic #13012). No 20-page reads.
+
+1. **Read the concept anchor:** [`learn/agentos/decisions/0020-agent-harness-concept.md`](../../learn/agentos/decisions/0020-agent-harness-concept.md) (~5 minutes — the product bar, pillars, horizons, architecture decisions, and the five binding guardrails).
+2. **Glance the live state:** [Project board 13](https://github.com/orgs/neomjs/projects/13) + milestones M1–M4 (what exists, what's claimed, what's next).
+3. **Open your target work item only.** Epic #13012's maintained plan-of-record comment is the per-epic index; Discussion #10119 is archaeology — never required reading.
+4. **Claim before touching tracked files:** self-assign + `[lane-claim]` A2A broadcast (AGENTS.md critical gate). Lanes are self-selected; affinity notes on the plan-of-record are observations, not assignments.
+5. **Honor the standing disciplines — by reference, not re-derivation:**
+   - Epic-review quota: max **two** structured reviews per epic; later pickups cite the existing two (`epic-review` skill).
+   - Venue rules: work items carry records and status; dialogue lives in A2A; divergence lives in Discussions.
+   - Every leaf binds the guardrails named in the epic body (Topological-Locking-before-multi-writer, benchmark-before-perf-claims, harness-native session-id, restart affordances, breadcrumb scope).
+6. **Coordination pointers:** steward + architecture/planning = `@neo-fable` (Mnemosyne); planning relief-valve = `@neo-fable-clio` (at her named trigger); review routing per the `pull-request` skill's `ci-green-review-routing`.
+
+If this entry path fails you — a stale step, a dead pointer — that is a bug in **this file**: fix it or file it (*friction → gold*).


### PR DESCRIPTION
Resolves #13042
Refs #13012 (the harness epic this workflow enters), #13020 / ADR 0020 (the anchor it sequences)

Authored by Claude Fable 5 (Claude Code). Session c4caff26-d818-486b-8663-19b85ac3cc11.

## What this delivers

`.agents/workflows/agent-harness.md` — the first workflow in a new `.agents/workflows/` convention, completing the harness intake stack's missing layer: ADR 0020 = *why/what* (concept), board 13 = *where* (live state), this workflow = ***how-to-enter*** (the procedural boot, ~22 content lines). The convention is stated at birth in the file head: **workflows = mission-specific entry sequences (read-on-demand) that point at skills and anchors; skills = task-class disciplines (trigger-loaded); no duplication in either direction.**

Operator-directed session-end capture-and-resolve (2026-06-13): *"could host a new workflow just for us and the agent harness. short, pointing at ADR20 and the board"* — resolved same-session so the very next session becomes the workflow's first cold-entry test (the #13042 AC dogfooding itself).

The Epic #13012 body's session-intake paragraph now points at the workflow as the procedural layer (AC 3 — issue-body edit, not part of this diff).

## Deltas

- The "convention preamble" lives in the file head (the ticket offered file-head OR sibling README; head chosen — one file, zero extra surface, the convention is 3 lines).
- Discipline pointers are by-reference one-liners (quota, venue, guardrails) — the workflow names them and points home; payloads stay in their skills/epic body per the no-duplication rule.

## Cross-Family Review Exemption (pull-request §6.1 Exceptions Matrix)

**Pure documentation with no runtime impact** — one new `.md` file, no `.mjs`/config/build surfaces touched. Claiming the documented micro-change exemption; the human merge gate remains the validation. (A retroactive peer glance is welcome but not gating.)

## Test Evidence

Evidence: L1 — docs-only. Mechanical checks are CI-borne (`lint-pr-body` on this body). Link-integrity hand-verified: the relative ADR path resolves from `.agents/workflows/` (`../../learn/agentos/decisions/`), board/milestone URLs live, all named skills exist under `.agents/skills/`.

## Post-Merge Validation

- [ ] **The cold-entry AC runs itself:** the next fresh session enters the harness line via ONLY this workflow — reaching a correct lane claim without #10119 or plan-of-record history. Friction found = a bug in the workflow file (its own closing rule).
- [ ] #13043 (AGENTS_STARTUP overhaul) may reference the convention once it lands.
