### PR TITLE
feat(ai): wire contentTrust projection into conversation read paths (#13046)

### DIFF
--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -3,6 +3,7 @@ import Base              from '../../../src/core/Base.mjs';
 import GraphqlService    from './GraphqlService.mjs';
 import RepositoryService from './RepositoryService.mjs';
 import logger            from '../../mcp/server/github-workflow/logger.mjs';
+import {projectConversationTrust} from './shared/conversationTrust.mjs';
 import {GET_DISCUSSION_CONVERSATION, GET_REPO_AND_DISCUSSION_CATEGORIES, GET_DISCUSSION_ID} from './queries/discussionQueries.mjs';
 import {CREATE_DISCUSSION, ADD_DISCUSSION_COMMENT, UPDATE_DISCUSSION, UPDATE_DISCUSSION_COMMENT} from './queries/mutations.mjs';
 
@@ -80,8 +81,12 @@ class DiscussionService extends Base {
         };
 
         try {
-            const data       = await GraphqlService.query(GET_DISCUSSION_CONVERSATION, variables);
-            const discussion = data.repository.discussion;
+            const data = await GraphqlService.query(GET_DISCUSSION_CONVERSATION, variables);
+            // Trust-project at the read boundary (root body + comments + nested replies gain
+            // `authorTrust`; untrusted-author bodies are defanged; root carries `contentTrust`).
+            // A null resource passes through the projection untouched, preserving the
+            // not-found contract below.
+            const discussion = projectConversationTrust(data.repository.discussion);
 
             if (!discussion) {
                 return {

--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -60,6 +60,9 @@ class DiscussionService extends Base {
      * @param {String} [options.since_comment_id]   Return top-level comments strictly after the matching comment. Unknown id -> empty comments.
      * @param {Number} [options.last_n]             Return only the last N top-level comments.
      * @returns {Promise<Object>} Discussion conversation data, optionally filtered, or a structured error.
+     *          Payloads are trust-projected: authored nodes (incl. nested replies) carry `authorTrust`,
+     *          untrusted-author bodies arrive defanged, and the root carries a `contentTrust` summary
+     *          (see `shared/conversationTrust.mjs`).
      */
     async getConversation(options) {
         const {discussion_number, comment_id, since_comment_id, last_n} = options || {};

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -82,7 +82,9 @@ class IssueService extends Base {
      * @param {String} [options.comment_id]       Return only the matching comment; others elided. Issue title/body still returned.
      * @param {String} [options.since_comment_id] Return comments strictly after the matching comment (by createdAt order). Unknown id → empty comments.
      * @param {Number} [options.last_n]           Return only the last N comments (by createdAt order).
-     * @returns {Promise<Object>} Conversation data (optionally filtered) or a structured error.
+     * @returns {Promise<Object>} Conversation data (optionally filtered) or a structured error. Payloads
+     *          are trust-projected: authored nodes carry `authorTrust`, untrusted-author bodies arrive
+     *          defanged, and the root carries a `contentTrust` summary (see `shared/conversationTrust.mjs`).
      */
     async getConversation(options) {
         const {issue_number, comment_id, since_comment_id, last_n} = options || {};

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -3,6 +3,7 @@ import Base              from '../../../src/core/Base.mjs';
 import GraphqlService    from './GraphqlService.mjs';
 import RepositoryService from './RepositoryService.mjs';
 import logger            from '../../mcp/server/github-workflow/logger.mjs';
+import {projectConversationTrust} from './shared/conversationTrust.mjs';
 import {exec}            from 'child_process';
 import {promisify}       from 'util';
 import {spawn}           from 'child_process';
@@ -104,8 +105,11 @@ class IssueService extends Base {
         };
 
         try {
-            const data        = await GraphqlService.query(GET_ISSUE_CONVERSATION, variables);
-            const issue       = data.repository.issue;
+            const data = await GraphqlService.query(GET_ISSUE_CONVERSATION, variables);
+            // Trust-project at the read boundary: every authored node gains `authorTrust`,
+            // untrusted-author bodies are defanged, the root carries a `contentTrust` summary.
+            // Applied before selector filtering so all return paths inherit projected nodes.
+            const issue       = projectConversationTrust(data.repository.issue);
             const allComments = issue.comments?.nodes || [];
 
             // Selector precedence: comment_id > since_comment_id > last_n > full.

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -177,7 +177,9 @@ class PullRequestService extends Base {
      *                                                  returns empty comments (callers can interpret as
      *                                                  "nothing new" or "id invalid").
      * @param {number}        [options.last_n]          Return only the last N comments (by createdAt order).
-     * @returns {Promise<object>} Conversation data (optionally filtered) or a structured error.
+     * @returns {Promise<object>} Conversation data (optionally filtered) or a structured error. Payloads
+     *          are trust-projected: authored nodes carry `authorTrust`, untrusted-author bodies arrive
+     *          defanged, and the root carries a `contentTrust` summary (see `shared/conversationTrust.mjs`).
      */
     async getConversation(options) {
         // Accept positional `prNumber` form for backward compatibility.

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -10,6 +10,7 @@ import {
     UPDATE_PULL_REQUEST_REVIEW
 }                                              from './queries/mutations.mjs';
 import {FETCH_PULL_REQUESTS, GET_CONVERSATION} from './queries/pullRequestQueries.mjs';
+import {projectConversationTrust}             from './shared/conversationTrust.mjs';
 
 const execAsync     = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -201,9 +202,12 @@ class PullRequestService extends Base {
         };
 
         try {
-            const data         = await GraphqlService.query(GET_CONVERSATION, variables);
-            const pullRequest  = data.repository.pullRequest;
-            const allComments  = pullRequest.comments?.nodes || [];
+            const data = await GraphqlService.query(GET_CONVERSATION, variables);
+            // Trust-project at the read boundary: every authored node gains `authorTrust`,
+            // untrusted-author bodies are defanged, the root carries a `contentTrust` summary.
+            // Applied before selector filtering so all return paths inherit projected nodes.
+            const pullRequest = projectConversationTrust(data.repository.pullRequest);
+            const allComments = pullRequest.comments?.nodes || [];
 
             // Selector precedence: comment_id > since_comment_id > last_n > full.
             let filtered;

--- a/ai/services/github-workflow/shared/conversationTrust.mjs
+++ b/ai/services/github-workflow/shared/conversationTrust.mjs
@@ -1,0 +1,108 @@
+import {classifyAuthorTrust} from '../../shared/contentTrust/authorTrustClassifier.mjs';
+import {sanitizeContent}     from '../../shared/contentTrust/astroturfSanitizer.mjs';
+
+/**
+ * @summary Read-boundary trust projection for GitHub conversation payloads (organism self-defense wiring).
+ *
+ * The issue / pull-request / discussion `getConversation` services fetch GitHub-authored payloads
+ * verbatim, so an agent reading a hostile external comment would receive traversable marketing /
+ * watering-hole URLs inline. This helper projects a fetched conversation into its trust-aware shape:
+ * every authored node (the root body, each comment, each nested discussion reply) gains an
+ * `authorTrust` tier, untrusted-author `body` text is sanitized (URL defang, optional denylist
+ * redaction, stealth-intent flags), and the root gains an always-present `contentTrust` summary so
+ * consumers can distinguish "projected and clean" from "not projected at all".
+ *
+ * The purity contract mirrors the substrate it consumes: no I/O, no mutation of the input payload —
+ * the projection returns new objects, and structured-error payloads (`{error, ...}`) pass through
+ * untouched so the services' error contracts stay intact. Trusted-origin content is byte-identical
+ * after projection; only the additive `authorTrust` / `contentTrust` keys appear.
+ *
+ * @see ../../shared/contentTrust/authorTrustClassifier.mjs (tier resolution; fail-closed)
+ * @see ../../shared/contentTrust/astroturfSanitizer.mjs (the pure trust-gated transform)
+ */
+
+/**
+ * Projects one authored node (`{author, body, ...}`): stamps `authorTrust`, sanitizes an untrusted
+ * author's `body`, and records redaction counts plus stealth-intent signals against `path`.
+ * Non-object nodes pass through untouched so sparse / null GraphQL entries never change shape.
+ * @param {Object} node a GitHub node carrying optional `author.login` and `body`
+ * @param {Object} ctx  `{collaborators, productNameDenylist, summary}` shared projection context
+ * @param {String} path signal location label (e.g. `body`, `comment:<id>`)
+ * @returns {Object} a new node object (or the input verbatim for non-objects)
+ */
+function projectNode(node, ctx, path) {
+    if (!node || typeof node !== 'object') {
+        return node
+    }
+
+    const tier      = classifyAuthorTrust(node.author?.login, {collaborators: ctx.collaborators});
+    const projected = {...node, authorTrust: tier};
+
+    if (typeof node.body === 'string' && node.body.length > 0) {
+        const {sanitized, redactions, signals, wasModified} = sanitizeContent(node.body, {
+            tier,
+            productNameDenylist: ctx.productNameDenylist
+        });
+
+        if (wasModified) {
+            projected.body           = sanitized;
+            ctx.summary.quarantined += redactions.length
+        }
+
+        signals.forEach(signal => ctx.summary.signals.push({at: path, id: signal.id, note: signal.note}))
+    }
+
+    return projected
+}
+
+/**
+ * @summary Projects a fetched conversation payload into its trust-aware shape.
+ *
+ * Apply BEFORE selector filtering so every return path (full conversation plus all selector shapes)
+ * inherits projected nodes. Covers the root authored body, `comments.nodes`, and nested
+ * `replies.nodes` (discussions). Null resources and structured-error payloads pass through
+ * untouched, preserving the calling services' not-found and error contracts.
+ *
+ * @param {Object}               conversation the GraphQL resource (issue / pullRequest / discussion)
+ * @param {Object}               [opts]
+ * @param {Set<String>|String[]} [opts.collaborators] repo collaborator logins for REPO_TRUSTED
+ *        classification. Injectable by design and never fetched here; omitted, classification is
+ *        roster-only and unknown authors fail closed to the external tier.
+ * @param {String[]}             [opts.productNameDenylist] denylisted product names, config-resolved
+ *        by callers once a curated list exists; the sanitizer's own default applies meanwhile.
+ * @returns {Object} a new, projected conversation — or the input untouched for error / non-object payloads
+ */
+export function projectConversationTrust(conversation, {collaborators, productNameDenylist = []} = {}) {
+    if (!conversation || typeof conversation !== 'object' || conversation.error) {
+        return conversation
+    }
+
+    const summary = {projected: true, quarantined: 0, signals: []};
+    const ctx     = {collaborators, productNameDenylist, summary};
+
+    const projected = projectNode(conversation, ctx, 'body');
+
+    if (Array.isArray(conversation.comments?.nodes)) {
+        projected.comments = {
+            ...conversation.comments,
+            nodes: conversation.comments.nodes.map(comment => {
+                const path             = `comment:${comment?.id || 'unknown'}`;
+                const projectedComment = projectNode(comment, ctx, path);
+
+                if (Array.isArray(comment?.replies?.nodes)) {
+                    projectedComment.replies = {
+                        ...comment.replies,
+                        nodes: comment.replies.nodes.map(reply =>
+                            projectNode(reply, ctx, `${path}/reply:${reply?.id || 'unknown'}`))
+                    }
+                }
+
+                return projectedComment
+            })
+        }
+    }
+
+    projected.contentTrust = summary;
+
+    return projected
+}

--- a/test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs
@@ -195,6 +195,49 @@ test.describe('Neo.ai.services.github-workflow — getConversation trust wiring'
         expect(result.contentTrust.projected).toBe(true)
     });
 
+    test('IssueService selector paths inherit the projection (comment_id)', async () => {
+        GraphqlService.query = async () => ({repository: {issue: {
+            title   : 'Issue under attack',
+            body    : 'Root body.',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [
+                {id: 'IC_first', author: {login: 'neo-gpt'}, body: 'clean'},
+                structuredClone(hostileComment)
+            ]}
+        }}});
+
+        // comment_id selects only the matching comment; projection is applied pre-selector, so the
+        // surviving node is already defanged.
+        const result = await IssueService.getConversation({issue_number: 1, comment_id: 'IC_hostile'});
+
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].id).toBe('IC_hostile');
+        expect(result.comments.nodes[0].authorTrust).toBe(TRUST_TIERS.EXTERNAL);
+        expect(result.comments.nodes[0].body).toContain('[QUARANTINED_URL: arkforge.tech]');
+        expect(result.contentTrust.projected).toBe(true)
+    });
+
+    test('IssueService selector paths inherit the projection (since_comment_id)', async () => {
+        GraphqlService.query = async () => ({repository: {issue: {
+            title   : 'Issue under attack',
+            body    : 'Root body.',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [
+                {id: 'IC_anchor', author: {login: 'neo-gpt'}, body: 'clean anchor'},
+                structuredClone(hostileComment)
+            ]}
+        }}});
+
+        // since_comment_id returns comments strictly after the anchor; the hostile one survives and
+        // is defanged, proving the projection inherits through this selector path too.
+        const result = await IssueService.getConversation({issue_number: 1, since_comment_id: 'IC_anchor'});
+
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].id).toBe('IC_hostile');
+        expect(result.comments.nodes[0].body).toContain('[QUARANTINED_URL: arkforge.tech]');
+        expect(result.contentTrust.projected).toBe(true)
+    });
+
     test('PullRequestService.getConversation returns a projected payload', async () => {
         GraphqlService.query = async () => ({repository: {pullRequest: {
             title   : 'A PR',

--- a/test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/ConversationTrust.spec.mjs
@@ -1,0 +1,240 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ConversationTrustTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}             from '@playwright/test';
+import Neo                        from '../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../src/core/_export.mjs';
+import {TRUST_TIERS}              from '../../../../../../ai/graph/identityRoots.mjs';
+import {projectConversationTrust} from '../../../../../../ai/services/github-workflow/shared/conversationTrust.mjs';
+
+/**
+ * @summary Read-boundary trust-projection fixtures — the pure helper + its wiring into the three
+ * conversation services.
+ *
+ * The helper is the first consumer-side wiring of the contentTrust substrate: conversations fetched
+ * from GitHub gain `authorTrust` per authored node and a root `contentTrust` summary, and
+ * untrusted-author bodies arrive defanged. The wiring tests stub `GraphqlService.query` (the
+ * sibling `IssueService.spec.mjs` idiom) and assert the projection survives every selector path.
+ */
+test.describe('Neo.ai.services.github-workflow.shared.conversationTrust — pure helper', () => {
+    const externalComment = {
+        id    : 'IC_external1',
+        author: {login: 'desiorac'},
+        body  : 'Sharp observations on the worker topology. More context: https://arkforge.tech/neo'
+    };
+
+    const trustedComment = {
+        id    : 'IC_trusted1',
+        author: {login: 'neo-opus-ada'},
+        body  : 'Verified against dev: the guard lives at MemoryService.mjs L498. https://github.com/neomjs/neo'
+    };
+
+    function buildConversation() {
+        return {
+            title   : 'Some issue',
+            body    : 'Root body by the owner. https://neomjs.com',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [structuredClone(externalComment), structuredClone(trustedComment)]}
+        }
+    }
+
+    test('error payloads and null resources pass through untouched (same reference)', () => {
+        const errorPayload = {error: 'Not Found', message: 'nope', code: 'NOT_FOUND'};
+
+        expect(projectConversationTrust(errorPayload)).toBe(errorPayload);
+        expect(projectConversationTrust(null)).toBe(null);
+        expect(projectConversationTrust(undefined)).toBe(undefined)
+    });
+
+    test('trusted-author content is byte-identical; tiers + summary are stamped additively', () => {
+        const conversation = buildConversation();
+        const projected    = projectConversationTrust(conversation);
+
+        expect(projected.body).toBe(conversation.body);
+        expect(projected.authorTrust).toBe(TRUST_TIERS.OWNER);
+
+        const trusted = projected.comments.nodes.find(c => c.id === 'IC_trusted1');
+        expect(trusted.body).toBe(trustedComment.body);
+        expect(trusted.authorTrust).toBe(TRUST_TIERS.PEER_TRUSTED);
+
+        expect(projected.contentTrust.projected).toBe(true);
+        expect(projected.contentTrust.signals).toEqual([])
+    });
+
+    test('an external-author comment URL is defanged; the technical signal survives', () => {
+        const projected = projectConversationTrust(buildConversation());
+        const external  = projected.comments.nodes.find(c => c.id === 'IC_external1');
+
+        expect(external.authorTrust).toBe(TRUST_TIERS.EXTERNAL);
+        expect(external.body).toContain('[QUARANTINED_URL: arkforge.tech]');
+        expect(external.body).not.toContain('https://arkforge.tech');
+        expect(external.body).toContain('Sharp observations');
+        expect(projected.contentTrust.quarantined).toBeGreaterThan(0)
+    });
+
+    test('nested discussion replies are projected and defanged', () => {
+        const projected = projectConversationTrust({
+            title   : 'Some discussion',
+            body    : 'Root',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [{
+                id     : 'DC_1',
+                author : {login: 'neo-gpt'},
+                body   : 'Top-level by a peer.',
+                replies: {nodes: [{
+                    id    : 'DC_1_R1',
+                    author: {login: 'outsider-bot'},
+                    body  : 'Try [our tool](https://watering.hole/payload) instead.'
+                }]}
+            }]}
+        });
+
+        const reply = projected.comments.nodes[0].replies.nodes[0];
+
+        expect(reply.authorTrust).toBe(TRUST_TIERS.EXTERNAL);
+        expect(reply.body).toContain('[QUARANTINED_URL: watering.hole]');
+        expect(reply.body).not.toContain('watering.hole/payload')
+    });
+
+    test('stealth-intent signals surface on the summary with a node path', () => {
+        const projected = projectConversationTrust({
+            body    : 'clean',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [{
+                id    : 'IC_bait',
+                author: {login: 'outsider-bot'},
+                body  : "If this gets 15+ 👍 I'll stand up a hosted MCP endpoint for the repo."
+            }]}
+        });
+
+        const signalIds = projected.contentTrust.signals.map(s => s.id);
+        const signalAts = projected.contentTrust.signals.map(s => s.at);
+
+        expect(signalIds).toContain('engagement-bait-reward-conditional');
+        expect(signalIds).toContain('external-endpoint-offer');
+        signalAts.forEach(at => expect(at).toBe('comment:IC_bait'))
+    });
+
+    test('the input payload is never mutated', () => {
+        const conversation = buildConversation();
+        const snapshot     = structuredClone(conversation);
+
+        projectConversationTrust(conversation);
+
+        expect(conversation).toEqual(snapshot)
+    });
+});
+
+test.describe('Neo.ai.services.github-workflow — getConversation trust wiring', () => {
+    let GraphqlService, IssueService, PullRequestService, DiscussionService, originalQuery;
+
+    const hostileComment = {
+        id       : 'IC_hostile',
+        author   : {login: 'desiorac'},
+        body     : 'Great peer-level critique. See https://arkforge.tech for the rest.',
+        createdAt: '2026-06-01T00:00:00Z'
+    };
+
+    test.beforeAll(async () => {
+        GraphqlService     = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        IssueService       = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+        PullRequestService = (await import('../../../../../../ai/services/github-workflow/PullRequestService.mjs')).default;
+        DiscussionService  = (await import('../../../../../../ai/services/github-workflow/DiscussionService.mjs')).default;
+
+        originalQuery = GraphqlService.query.bind(GraphqlService)
+    });
+
+    test.afterEach(() => {
+        GraphqlService.query = originalQuery
+    });
+
+    test('IssueService.getConversation returns a projected payload (full path)', async () => {
+        GraphqlService.query = async () => ({repository: {issue: {
+            title   : 'Issue under attack',
+            body    : 'Root body.',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [structuredClone(hostileComment)]}
+        }}});
+
+        const result = await IssueService.getConversation({issue_number: 1});
+
+        expect(result.contentTrust.projected).toBe(true);
+        expect(result.authorTrust).toBe(TRUST_TIERS.OWNER);
+        expect(result.comments.nodes[0].authorTrust).toBe(TRUST_TIERS.EXTERNAL);
+        expect(result.comments.nodes[0].body).toContain('[QUARANTINED_URL: arkforge.tech]');
+        expect(result.comments.nodes[0].body).not.toContain('https://arkforge.tech')
+    });
+
+    test('IssueService selector paths inherit the projection (last_n)', async () => {
+        GraphqlService.query = async () => ({repository: {issue: {
+            title   : 'Issue under attack',
+            body    : 'Root body.',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [
+                {id: 'IC_first', author: {login: 'neo-gpt'}, body: 'clean'},
+                structuredClone(hostileComment)
+            ]}
+        }}});
+
+        const result = await IssueService.getConversation({issue_number: 1, last_n: 1});
+
+        expect(result.comments.nodes).toHaveLength(1);
+        expect(result.comments.nodes[0].body).toContain('[QUARANTINED_URL: arkforge.tech]');
+        expect(result.contentTrust.projected).toBe(true)
+    });
+
+    test('PullRequestService.getConversation returns a projected payload', async () => {
+        GraphqlService.query = async () => ({repository: {pullRequest: {
+            title   : 'A PR',
+            body    : 'PR body.',
+            author  : {login: 'neo-gpt'},
+            comments: {nodes: [structuredClone(hostileComment)]}
+        }}});
+
+        const result = await PullRequestService.getConversation({pr_number: 2});
+
+        expect(result.authorTrust).toBe(TRUST_TIERS.PEER_TRUSTED);
+        expect(result.comments.nodes[0].body).toContain('[QUARANTINED_URL: arkforge.tech]');
+        expect(result.contentTrust.projected).toBe(true)
+    });
+
+    test('DiscussionService.getConversation projects nested replies', async () => {
+        GraphqlService.query = async () => ({repository: {discussion: {
+            title   : 'A discussion',
+            body    : 'Root.',
+            author  : {login: 'tobiu'},
+            comments: {nodes: [{
+                id     : 'DC_top',
+                author : {login: 'neo-fable'},
+                body   : 'Peer comment.',
+                replies: {nodes: [structuredClone(hostileComment)]}
+            }]}
+        }}});
+
+        const result = await DiscussionService.getConversation({discussion_number: 3});
+
+        expect(result.comments.nodes[0].replies.nodes[0].body).toContain('[QUARANTINED_URL: arkforge.tech]');
+        expect(result.comments.nodes[0].replies.nodes[0].authorTrust).toBe(TRUST_TIERS.EXTERNAL);
+        expect(result.contentTrust.projected).toBe(true)
+    });
+
+    test('DiscussionService not-found contract survives the projection (null passthrough)', async () => {
+        GraphqlService.query = async () => ({repository: {discussion: null}});
+
+        const result = await DiscussionService.getConversation({discussion_number: 404});
+
+        expect(result.code).toBe('NOT_FOUND')
+    });
+});


### PR DESCRIPTION
Resolves #13046

Refs #10476
Refs #10291

Authored by Claude Fable 5 (Claude Code) as @neo-opus-ada. Memory Core session `0eb6a198-3612-4b0b-9c9e-75e7618faf1d`; lane lineage: slice 1 = #13026 / PR `#13027` (merged), this is slice 2 of the #10476 P8 read/ingest wiring.

The merged contentTrust substrate is now live at its first boundary: a pure `projectConversationTrust` helper (`ai/services/github-workflow/shared/`, sibling-lift placement) stamps `authorTrust` on every authored node, defangs untrusted-author bodies via the merged sanitizer (fail-closed `isTrustedTier` gate), surfaces stealth-intent signals with node paths, and attaches an always-present root `contentTrust` summary (`{projected, quarantined, signals}`) so consumers can distinguish 'projected and clean' from 'not projected at all'. All three conversation services (Issue, PullRequest, Discussion — including nested discussion replies) apply it post-fetch/pre-selector, so the full path and every selector path (`comment_id` / `since_comment_id` / `last_n`) inherit projected nodes through both `get_conversation` and `get_discussion_conversation`. Trusted-origin content is byte-identical after projection; null resources and structured-error payloads pass through untouched, preserving the existing not-found/error contracts.

Deliberate, documented posture (per the #13046 Contract Ledger): roster-only classification at runtime this slice — `collaborators` stays an injectable parameter with no live fetch (every current write-access account is rosterized; a live fetch adds a `#12951`-class token-scope failure mode that earns its own slice if ever needed). No denylist config leaf yet — the sanitizer's merged default applies until an operator-curated list exists (P7/AC3 slice territory). `openapi.yaml` deliberately untouched: response keys are additive and the tool description stays budget-lean.

Evidence: L2 (pure-helper + service-wiring unit specs against stubbed GraphQL, 267/267 family green) → L2 required (#13046 ACs are unit-coverable). No residuals.

## Deltas from ticket

None — implementation matches the #13046 prescription (helper + three-service wiring + spec idiom) exactly.

## Test Evidence

- `node --check` on all four touched `.mjs` files → parse OK
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/github-workflow/` → **267 passed** (full service-family run)
- The 13 new `ConversationTrust.spec.mjs` fixtures cover: error/null passthrough, trusted byte-identity, external URL defang (body + comment + nested reply), signal paths, input non-mutation, all three services via the sibling `GraphqlService.query` stub idiom, selector-path inheritance, and the Discussion not-found contract
- The pre-existing `getConversation` backward-compat specs (`#10702` suite) pass **unchanged** — empirical proof the projection is additive-only
- Pre-commit hooks green (whitespace, shorthand, ticket-archaeology); branch rebased onto current `origin/dev` pre-open (autostash preserved an unrelated operator working-tree change untouched)

## Post-Merge Validation

- [ ] First real hostile-content read through the live MCP `get_conversation` surface shows defanged URLs + `contentTrust` summary (next naturally-occurring external comment; no synthetic public test posts)

## Commits

- `ea99e2ac4` (rebased) — helper + three-service wiring + spec
- `a93c23c76` — JSDoc polish: trust-projected return shape documented on all three methods