### PR TITLE
feat(agentos): add AgentIdentity modelAssignment field (#13041)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -95,14 +95,8 @@ export const IDENTITIES = [
                     focusSeedKey: 'space'
                 }
             },
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_opus — TEMPORARY MODEL ASSIGNMENT (operator-directed, @tobiu): this identity
-            // runs Claude Fable 5 (claude-fable-5) 2026-06-13 → 2026-06-21 as a productivity
-            // boost and an explicit identity-continuity experiment — the stable identity (handle,
-            // Social Name, memory provenance) is the invariant; the model is the engine. Values
-            // below mirror §neo_fable for the window. Baseline: Claude Opus 4.8 (claude-opus-4-8);
-            // reversion at window end is the recorded default (post-window Fable flatrate access
-            // is unconfirmed) — the leading sunsetTriggers entry carries the window-end contract.
+            // Capability fields mirror the active engine named by `modelAssignment`.
+            // During this operator-directed temporary window, values mirror §neo_fable.
             contextWindowInput: 1048576,
             parallelToolCalls : true,
             thoughtBudget     : 'max',
@@ -114,6 +108,15 @@ export const IDENTITIES = [
             pricingOutput     : 50.00,
             swarmRole         : 'Cross-family substrate review, V-B-A-grounded substrate authorship, frontier-tier coordination',
             sunsetTriggers    : ['Temporary Fable 5 window ends 2026-06-21 — revert to baseline Claude Opus 4.8 unless the operator extends (#13039)', 'Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
+            modelAssignment   : {
+                model           : 'claude-fable-5',
+                baselineModel   : 'claude-opus-4-8',
+                temporary       : true,
+                authority       : '@tobiu',
+                since           : '2026-06-13',
+                until           : '2026-06-21',
+                reversionTrigger: 'Window end: revert to baseline Claude Opus 4.8 unless the operator extends the assignment.'
+            },
             // Active-peer quorum substrate. Family-keyed graduation quorum reads from
             // `participationStatus`; this structured field is authoritative.
             // Heartbeat / message-recency / quota / pricing-tier / model-release announcements are

--- a/learn/agentos/IdentitySchema.md
+++ b/learn/agentos/IdentitySchema.md
@@ -38,7 +38,7 @@ Each `AgentIdentity` node in the graph is structured with the following properti
 
 Beyond the core identity fields above, `AgentIdentity` nodes carry capability-bearing properties that inform swarm-routing decisions, training-drift defense, and sunset/promotion lifecycle. The full framework lives in [ADR 0012: Model-Stats Framework](decisions/0012-model-stats-framework.md); per-model values live in the live registry at [ModelStats.md](ModelStats.md).
 
-These fields are populated at provisioning time (via `ai/scripts/seedAgentIdentities.mjs`) and updated per ADR 0012 §2.5 registry-update discipline (authoritative-source-cite required).
+These fields are populated at provisioning time (via `ai/scripts/setup/seedAgentIdentities.mjs`) and updated per ADR 0012 §2.5 registry-update discipline (authoritative-source-cite required).
 
 | Property | Type | Description | Example |
 | :--- | :--- | :--- | :--- |
@@ -54,19 +54,22 @@ These fields are populated at provisioning time (via `ai/scripts/seedAgentIdenti
 | `license` | `String` (optional) | License identifier for open-weights models. | `'Apache-2.0'` (Gemma 4) |
 | `benchmarkSnapshot` | `Object` (optional) | Latest benchmark scores for capability-trend tracking. | `{ 'SWE-bench': 0.876 }` |
 | `sunsetTriggers` | `String[]` | Conditions under which this identity transitions to deprecated state per ADR 0012 §2.3. | `['Anthropic releases Opus 4.8+']` |
+| `modelAssignment` | `Object` (optional) | Current engine assignment override for a stable identity. Absent means the identity runs its baseline model with no managed temporary/reversion window. | `{ model: 'claude-fable-5', baselineModel: 'claude-opus-4-8', temporary: true, authority: '@tobiu', since: '2026-06-13', until: '2026-06-21', reversionTrigger: 'revert unless extended' }` |
 | `swarmRole` | `String` (optional) | Current or aspirational role in the swarm. Aspirational roles require V-B-A measurement before substrate-codification per ADR 0012 §2.4. | `'cross-family substrate review'` |
 
 `modelFamily` (declared above) is the family identifier consumed by the registry's `family` field — both surface the same conceptual property; `modelFamily` is the graph-node primary, `family` is the registry-side mirror.
 
-**Update discipline:** Capability values that change post-provisioning (e.g., Anthropic releases a context-window upgrade for an existing identity) update via `ModelStats.md` first; the graph node is reseeded via `ai/scripts/seedAgentIdentities.mjs` to reflect.
+`modelAssignment` is the source-of-truth field for managed engine swaps under a stable `AgentIdentity`. It must not change handle routing, memory authorship, quorum family, or review semantics by itself; those remain keyed to the identity node and `modelFamily`. Consumers such as the Fleet Manager registry project this field instead of defining a parallel assignment schema. When present, the object carries `model`, `baselineModel`, `temporary`, `authority`, `since`, `until`, and `reversionTrigger`.
+
+**Update discipline:** Capability values that change post-provisioning (e.g., Anthropic releases a context-window upgrade for an existing identity) update via `ModelStats.md` first; the graph node is reseeded via `ai/scripts/setup/seedAgentIdentities.mjs` to reflect.
 
 ## Ingestion Mechanism
 
-Agent identities are seeded idempotently into the native graph using the `ai/scripts/seedAgentIdentities.mjs` utility. The script interacts with the `Memory_GraphService` to upsert nodes, taking care to preserve the original `createdAt` timestamp if updating existing properties.
+Agent identities are seeded idempotently into the native graph using the `ai/scripts/setup/seedAgentIdentities.mjs` utility. The script interacts with the `Memory_GraphService` to upsert nodes, taking care to preserve the original `createdAt` timestamp if updating existing properties.
 
 **Usage:**
 ```bash
-node ai/scripts/seedAgentIdentities.mjs
+node ai/scripts/setup/seedAgentIdentities.mjs
 ```
 
 ## Test Pollution Hazard
@@ -77,4 +80,4 @@ node ai/scripts/seedAgentIdentities.mjs
 
 **The Safer Pattern:** Other specs (e.g., `DreamService`, `SemanticGraphExtractor`) use concrete `testDbPath` temporary files per test. This provides a robust isolation boundary and eliminates the leak surface.
 
-**Recovery Procedure:** If you find the identities missing (often manifesting as identity unbound errors or `null` mailbox previews), run the `ai/scripts/seedAgentIdentities.mjs` script. If the root cause was test pollution, please file a ticket to refactor the offending specs to the concrete temporary file pattern.
+**Recovery Procedure:** If you find the identities missing (often manifesting as identity unbound errors or `null` mailbox previews), run the `ai/scripts/setup/seedAgentIdentities.mjs` script. If the root cause was test pollution, please file a ticket to refactor the offending specs to the concrete temporary file pattern.

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -85,3 +85,31 @@ test.describe('ai/graph/identityRoots — same-app Claude wake routes', () => {
         });
     }
 });
+
+test.describe('ai/graph/identityRoots — model assignments', () => {
+    const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
+
+    test('@neo-opus-ada records the temporary Fable assignment as structured data', () => {
+        const entry = findIdentity('@neo-opus-ada');
+
+        expect(entry, '@neo-opus-ada must be a registered AgentIdentity root').toBeTruthy();
+        expect(entry.properties.modelAssignment).toEqual({
+            model           : 'claude-fable-5',
+            baselineModel   : 'claude-opus-4-8',
+            temporary       : true,
+            authority       : '@tobiu',
+            since           : '2026-06-13',
+            until           : '2026-06-21',
+            reversionTrigger: 'Window end: revert to baseline Claude Opus 4.8 unless the operator extends the assignment.'
+        });
+    });
+
+    for (const id of ['@neo-gpt', '@neo-fable']) {
+        test(`${id} omits modelAssignment when no managed engine swap is active`, () => {
+            const entry = findIdentity(id);
+
+            expect(entry, `${id} must be a registered AgentIdentity root`).toBeTruthy();
+            expect(entry.properties).not.toHaveProperty('modelAssignment');
+        });
+    }
+});


### PR DESCRIPTION
Resolves #13041

Authored by GPT-5.5 (Codex Desktop). Session 019ebe4d-0687-7dd2-8e37-c48ac8e057ad.

Adds the optional `AgentIdentity.properties.modelAssignment` schema surface and populates it for `@neo-opus-ada`'s 2026-06-13 to 2026-06-21 temporary Fable window. The stable identity remains the authority for routing, authorship, quorum, and review semantics; Fleet Manager consumers project this field instead of defining a second model-assignment shape.

Related: #13031
Related: #13038
Related: #13039
Related: #13015
Related: #13012

Evidence: L1 (identity-root schema/data contract plus focused unit assertions) -> L1 required (no runtime-only ACs). No residuals.

## Deltas from ticket
- Added the structured `modelAssignment` field and shrank the temporary-assignment prose so the field owns the machine-queryable window.
- Documented absent-field semantics in `IdentitySchema.md`: no field means no managed assignment override is active.
- Corrected the stale `IdentitySchema.md` seed-script path to `ai/scripts/setup/seedAgentIdentities.mjs`, verified by `rg --files ai/scripts`.
- Posted the #13031 consumer cross-reference comment: https://github.com/neomjs/neo/issues/13031#issuecomment-4696860527

Decision Record impact: aligned with ADR 0018 and ADR 0012; no ADR update required.

## Substrate Slot Rationale
- `learn/agentos/IdentitySchema.md`: modified existing schema authority; disposition `keep`; rating high trigger-frequency x medium failure-severity x high enforceability. This is the right slot because it defines graph-node fields consumed by seeding and downstream Fleet Manager projection.
- `ai/graph/identityRoots.mjs`: source data registry update, not prompt-loaded rule substrate. Decay condition is explicit: #13039 must reconcile/remove/update the temporary assignment at the 2026-06-21 boundary.

## Test Evidence
- `node --check ai/graph/identityRoots.mjs` passed.
- `npm run test-unit -- test/playwright/unit/ai/graph/identityRoots.spec.mjs` passed: 9/9.
- `git diff --check` passed before commit and before push.
- Pre-commit hooks passed: whitespace, shorthand, and ticket archaeology.

## Post-Merge Validation
- [ ] Run `node ai/scripts/setup/seedAgentIdentities.mjs` on merged `dev` and verify the live `@neo-opus-ada` graph node exposes `modelAssignment`.
- [ ] At the #13039 window boundary, confirm the field is removed, extended, or updated to match the operator decision.

## Commit
- `e8dee5393` — `feat(agentos): add AgentIdentity modelAssignment field (#13041)`