### PR TITLE
feat(component): settled-block windowing for marathon transcripts (#13045)

### DIFF
--- a/examples/component/markdown/MainContainer.mjs
+++ b/examples/component/markdown/MainContainer.mjs
@@ -84,6 +84,11 @@ class MainContainer extends Viewport {
                 text   : 'Stream demo'
             }, {
                 module : Button,
+                handler: 'up.onMarathonButtonClick',
+                iconCls: 'fa fa-person-running',
+                text   : 'Stream marathon (40×)'
+            }, {
+                module : Button,
                 handler: 'up.onRenderButtonClick',
                 iconCls: 'fa fa-bolt',
                 text   : 'Render instantly'
@@ -95,6 +100,7 @@ class MainContainer extends Viewport {
             }]
         }, {
             module   : MarkdownVdom,
+            flex     : 1,
             reference: 'markdown-output',
             style    : {overflow: 'auto', padding: '1em'}
         }]
@@ -128,6 +134,30 @@ class MainContainer extends Viewport {
             component.value = DEMO_SOURCE.slice(0, cursor);
 
             await me.timeout(50)
+        }
+    }
+
+    /**
+     * Streams the demo source repeated 40× in coarse chunks — the marathon-transcript surface
+     * the settled-block windowing exists for: hundreds of estimated pages, with the DOM
+     * bounded to the mounted window while spacers carry the evicted ranges.
+     * @returns {Promise<void>}
+     */
+    async onMarathonButtonClick() {
+        let me        = this,
+            component = me.getReference('markdown-output'),
+            source    = Array.from({length: 40}, (item, index) => `# Marathon section ${index + 1}\n\n${DEMO_SOURCE}`).join('\n\n'),
+            chunkSize = 400,
+            cursor    = 0,
+            token     = ++me.streamRun;
+
+        component.value = null;
+
+        while (cursor < source.length && me.streamRun === token) {
+            cursor          = Math.min(cursor + chunkSize, source.length);
+            component.value = source.slice(0, cursor);
+
+            await me.timeout(20)
         }
     }
 

--- a/resources/scss/src/component/markdown/Component.scss
+++ b/resources/scss/src/component/markdown/Component.scss
@@ -1,0 +1,41 @@
+// Streaming markdown VDOM component (transcript-grade).
+//
+// Phase-1 render virtualization: every direct block child opts into browser-native
+// content-visibility — off-screen blocks skip style/layout/paint entirely, with an
+// intrinsic-size placeholder keeping scroll geometry sane. This composes with (and is
+// independent of) the component's settled-block DOM windowing: windowing bounds the DOM
+// node count, content-visibility bounds the rendering cost of whatever is mounted.
+// Precedent: the docs-grade component's identical opt-in (component/Markdown.scss).
+.neo-markdown-vdom {
+    overflow-y: auto;
+
+    > * {
+        content-visibility       : auto;
+        contain-intrinsic-size   : auto 28px;
+    }
+
+    // Spacers stand in for evicted block ranges — pure geometry, never painted content.
+    > .neo-md-spacer {
+        content-visibility: visible;
+        flex-shrink       : 0;
+    }
+
+    .neo-md-code {
+        overflow-x: auto;
+    }
+
+    .neo-md-table {
+        border-collapse: collapse;
+
+        th, td {
+            border : 1px solid var(--grid-border-color, #444);
+            padding: .3em .6em;
+        }
+    }
+
+    .neo-md-quote {
+        border-inline-start: 3px solid var(--blockquote-border-color, #888);
+        margin             : .5em 0;
+        padding-inline     : .8em;
+    }
+}

--- a/src/component/markdown/Component.mjs
+++ b/src/component/markdown/Component.mjs
@@ -169,8 +169,18 @@ class MarkdownComponent extends BaseComponent {
         if (value) {
             me.renderWindow(me.parser.update(value), true)
         } else {
+            // The reset boundary covers BOTH state owners: the parser's block ledger AND this
+            // component's windowing state machine. A fresh stream after a wipe must start in
+            // follow-mode at the tail — stale reader-mode state (followMode false, old scroll
+            // depths) would mount the HEAD window for the new transcript. The viewport size
+            // survives on purpose: the element did not change.
             me.parser.reset();
-            me.vdom.cn = [];
+            me.followMode    = true;
+            me.lastScrollTop = 0;
+            me.maxScrollSeen = 0;
+            me.scrollTop     = 0;
+            me.mountedBlocks = [0, 0];
+            me.vdom.cn       = [];
             me.update()
         }
     }

--- a/src/component/markdown/Component.mjs
+++ b/src/component/markdown/Component.mjs
@@ -12,9 +12,19 @@ import MarkdownParser from './Parser.mjs';
  * right primitive for LLM/agent response surfaces — including hostile input, which the parser
  * renders inert by construction (escaped-text raw HTML, protocol-allowlisted links).
  *
+ * **Marathon transcripts — settled-block windowing:** with `virtualize: true` (the default) only
+ * the blocks intersecting the viewport plus `bufferPages` of slack mount into the DOM; evicted
+ * ranges collapse into two spacer divs sized from ESTIMATED block heights (`unitHeights` × the
+ * parser's structural `units` — content lines, list items, table rows). Deliberately not
+ * pixel-perfect: the over-mounted buffer absorbs estimate drift, which is the right trade for
+ * hundreds-of-pages sessions. Eviction and scroll-back re-entry ride the engine's legitimate
+ * remove→re-insert lifecycle with reference-memoized subtrees, and the streaming tail window
+ * follows appends whenever the user has not scrolled away from the bottom. Settled blocks are
+ * immutable by parser contract, so every estimate is a measure-once fact.
+ *
  * The component stays deliberately thin: streaming intelligence (append detection, settled-block
- * memoization, id stability) lives in the realm-pure parser; this class only binds the reactive
- * `value` config to the parser's output.
+ * memoization, id stability) lives in the realm-pure parser; this class binds the reactive
+ * `value` config to the parser's output and owns only the windowing geometry.
  * @class Neo.component.markdown.Component
  * @extends Neo.component.Base
  */
@@ -36,14 +46,97 @@ class MarkdownComponent extends BaseComponent {
          */
         baseCls: ['neo-markdown-vdom'],
         /**
+         * Pages of estimated viewport height mounted ABOVE and BELOW the visible range.
+         * Generous on purpose: one extra page each way costs little and hides estimate drift.
+         * @member {Number} bufferPages_=1
+         * @reactive
+         */
+        bufferPages_: 1,
+        /**
+         * Estimated pixel height per structural unit, keyed by the parser's block types.
+         * `fallbackViewport` seeds the window math before the first scroll event delivers a
+         * real `clientHeight`. Estimates, not measurements — see the class summary.
+         * @member {Object} unitHeights
+         */
+        unitHeights: {
+            break          : 34,
+            code           : 21,
+            fallbackViewport: 800,
+            heading        : 52,
+            list           : 30,
+            paragraph      : 26,
+            quote          : 28,
+            table          : 38
+        },
+        /**
          * The markdown source. Streaming producers re-assign the GROWING full source
          * (`value = previous + chunk`); the parser detects the append and re-parses only the
          * open tail block. Any non-append assignment resets the block ledger with fresh ids.
          * @member {String|null} value_=null
          * @reactive
          */
-        value_: null
+        value_: null,
+        /**
+         * False renders every parsed block unconditionally (the pre-windowing behavior).
+         * @member {Boolean} virtualize_=true
+         * @reactive
+         */
+        virtualize_: true
     }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        this.addDomListeners([
+            {scroll: this.onTranscriptScroll, scope: this}
+        ])
+    }
+
+    /**
+     * Last observed viewport height (px); 0 until the first scroll event reports one.
+     * @member {Number} clientHeight=0
+     * @protected
+     */
+    clientHeight = 0
+    /**
+     * True while the component follows the streaming tail (the initial state). Follow-mode
+     * transitions ride REAL scroll geometry only — direction deltas between scroll events —
+     * never estimate-space comparisons: the tail pin itself fires scroll events (echoes), and
+     * mixing those with estimated heights creates a feedback loop that drifts the window.
+     * A genuine upward jump (more than half a viewport against the last position) exits
+     * follow-mode; scrolling back within 1.5 viewports of the deepest position seen re-enters.
+     * @member {Boolean} followMode=true
+     * @protected
+     */
+    followMode = true
+    /**
+     * The scrollTop reported by the previous scroll event — the direction-delta baseline.
+     * @member {Number} lastScrollTop=0
+     * @protected
+     */
+    lastScrollTop = 0
+    /**
+     * The deepest scrollTop observed (real geometry) — the re-enter-follow reference.
+     * @member {Number} maxScrollSeen=0
+     * @protected
+     */
+    maxScrollSeen = 0
+    /**
+     * The currently mounted block index range `[start, endExclusive]` — the `mountedRows`
+     * analog of `Neo.grid.Body`.
+     * @member {Number[]} mountedBlocks=[0,0]
+     * @protected
+     */
+    mountedBlocks = [0, 0]
+    /**
+     * Last observed scrollTop (px).
+     * @member {Number} scrollTop=0
+     * @protected
+     */
+    scrollTop = 0
 
     /**
      * The lazily-created streaming parser. Lazy on purpose: reactive config processing fires
@@ -58,8 +151,9 @@ class MarkdownComponent extends BaseComponent {
 
     /**
      * Triggered after the value config got changed: swaps the rendered block set to the
-     * parser's output. Settled blocks come back reference-identical, so the vdom engine
-     * no-ops them; only genuine tail changes produce deltas.
+     * parser's output (windowed when `virtualize` is on). Settled blocks come back
+     * reference-identical, so the vdom engine no-ops them; only genuine tail changes produce
+     * deltas.
      *
      * A nullish value is a RESET boundary, not just an empty render: the parser ledger resets
      * with it, so replaying even the identical source afterwards births fresh block ids — the
@@ -73,13 +167,232 @@ class MarkdownComponent extends BaseComponent {
         let me = this;
 
         if (value) {
-            me.vdom.cn = me.parser.update(value)
+            me.renderWindow(me.parser.update(value), true)
         } else {
             me.parser.reset();
-            me.vdom.cn = []
+            me.vdom.cn = [];
+            me.update()
+        }
+    }
+
+    /**
+     * Triggered after the virtualize config got changed at runtime: re-renders the current
+     * block set under the new mode.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetVirtualize(value, oldValue) {
+        let me = this;
+
+        if (oldValue !== undefined && me.value) {
+            me.renderWindow(me.parser.update(me.value), false)
+        }
+    }
+
+    /**
+     * Estimated pixel height of one block from its structural units — never a DOM measurement.
+     * @param {Object} meta A `parser.blockMeta` entry `{id, type, units, open}`
+     * @returns {Number}
+     */
+    estimateHeight(meta) {
+        const {unitHeights} = this;
+
+        return (unitHeights[meta.type] ?? unitHeights.paragraph) * meta.units
+    }
+
+    /**
+     * Scroll listener — the follow-mode state machine over REAL geometry:
+     *
+     * - In follow-mode, scroll events are mostly the tail pin's own echoes and are ignored
+     *   for windowing; only a genuine upward jump (half a viewport against the previous
+     *   position) exits follow and hands the window to the reader.
+     * - Outside follow-mode, returning within 1.5 viewports of the deepest position seen
+     *   re-enters follow (tail window + pin); otherwise the page-quantized window recomputes
+     *   and re-renders ONLY when the mounted range actually moved — scrolling inside the
+     *   buffer is delta-free.
+     * @param {Object} data Main-thread scroll payload
+     * @param {Number} data.scrollTop
+     * @param {Number} [data.clientHeight]
+     * @protected
+     */
+    onTranscriptScroll({scrollTop, clientHeight}) {
+        let me = this;
+
+        clientHeight && (me.clientHeight = clientHeight);
+
+        const
+            viewport = me.clientHeight || me.unitHeights.fallbackViewport,
+            upJump   = me.lastScrollTop - scrollTop > viewport / 2;
+
+        me.scrollTop     = scrollTop;
+        me.lastScrollTop = scrollTop;
+        me.maxScrollSeen = Math.max(me.maxScrollSeen, scrollTop);
+
+        if (!me.virtualize || !me.value) {
+            return
+        }
+
+        if (me.followMode) {
+            if (upJump) {
+                me.followMode = false;
+                me.renderWindow(me.parser.update(me.value), false)
+            }
+            // else: pin echo / minor drift — no windowing reaction.
+        } else if (me.maxScrollSeen - scrollTop < viewport * 1.5) {
+            me.followMode = true;
+            me.renderWindow(me.parser.update(me.value), true)
+        } else {
+            const range = me.windowRange(me.parser.blockMeta);
+
+            if (range[0] !== me.mountedBlocks[0] || range[1] !== me.mountedBlocks[1]) {
+                me.renderWindow(me.parser.update(me.value), false)
+            }
+        }
+    }
+
+    /**
+     * Renders the current block set: every block when `virtualize` is off, otherwise the
+     * mounted window framed by two estimate-sized spacer divs. The spacers carry STABLE ids,
+     * so window movement diffs as spacer-height `updateNode`s plus inserts/removes at the
+     * window edges — never wholesale churn.
+     * @param {Object[]} blocks The parser's full block vdom array
+     * @param {Boolean} followTail True (value appends) keeps the tail mounted when the user
+     * is at/near the bottom; false (scroll/mode changes) preserves the scrolled window.
+     * @protected
+     */
+    renderWindow(blocks, followTail) {
+        let me = this;
+
+        if (!me.virtualize) {
+            me.mountedBlocks = [0, blocks.length];
+            me.vdom.cn       = blocks;
+            me.update();
+            return
+        }
+
+        const
+            meta     = me.parser.blockMeta,
+            viewport = me.clientHeight || me.unitHeights.fallbackViewport,
+            atTail   = me.followMode;
+
+        let range;
+
+        if (followTail && atTail) {
+            // Streaming follow: mount the tail window (last viewport + buffer pages worth).
+            range = me.tailRange(meta, viewport)
+        } else {
+            range = me.windowRange(meta)
+        }
+
+        const
+            topHeight    = me.rangeEstimate(meta, 0, range[0]),
+            bottomHeight = me.rangeEstimate(meta, range[1], meta.length);
+
+        me.mountedBlocks = range;
+
+        me.vdom.cn = [
+            {tag: 'div', id: `${me.id}__md-top-spacer`, cls: ['neo-md-spacer'], style: {height: `${topHeight}px`}},
+            ...blocks.slice(range[0], range[1]),
+            {tag: 'div', id: `${me.id}__md-bottom-spacer`, cls: ['neo-md-spacer'], style: {height: `${bottomHeight}px`}}
+        ];
+
+        if (followTail && atTail) {
+            // Pin the DOM scroll position to the tail, not just the mounted window: the
+            // browser clamps the overshoot to the real maximum, which makes the estimate
+            // error irrelevant — overshoot IS "bottom". Without this, a streaming reader
+            // would sit at scrollTop 0 staring into the top spacer.
+            me.vdom.scrollTop = topHeight + me.rangeEstimate(meta, range[0], meta.length) + 100000
         }
 
         me.update()
+    }
+
+    /**
+     * Sums estimated heights over a block index range.
+     * @param {Object[]} meta
+     * @param {Number} start
+     * @param {Number} end Exclusive
+     * @returns {Number}
+     * @protected
+     */
+    rangeEstimate(meta, start, end) {
+        let sum = 0,
+            i   = start;
+
+        for (; i < end; i++) {
+            sum += this.estimateHeight(meta[i])
+        }
+
+        return sum
+    }
+
+    /**
+     * The mounted range for a tail-following render: walks backwards from the last block
+     * until viewport + buffer pages of estimated height accumulate.
+     * @param {Object[]} meta
+     * @param {Number} viewport
+     * @returns {Number[]} `[start, endExclusive]`
+     * @protected
+     */
+    tailRange(meta, viewport) {
+        const target = viewport * (1 + this.bufferPages);
+
+        let height = 0,
+            start  = meta.length;
+
+        while (start > 0 && height < target) {
+            start--;
+            height += this.estimateHeight(meta[start])
+        }
+
+        return [start, meta.length]
+    }
+
+    /**
+     * The mounted range for the current scroll position: all blocks whose estimated extent
+     * intersects the PAGE-QUANTIZED window `[(page - buffer) ... (page + 1 + buffer)]` pages.
+     * Quantizing to viewport pages is the load-bearing trick: scrolling within a page never
+     * moves the range (zero deltas), and crossing a page boundary slides it by whole pages —
+     * the literal "mount one more page" semantics. Linear scan on purpose — block counts sit
+     * in the thousands and the scan is microseconds; binary search over prefix sums is
+     * complexity this estimate-grade math does not need.
+     * @param {Object[]} meta
+     * @returns {Number[]} `[start, endExclusive]`
+     * @protected
+     */
+    windowRange(meta) {
+        let me = this;
+
+        const
+            viewport = me.clientHeight || me.unitHeights.fallbackViewport,
+            page     = Math.floor(me.scrollTop / viewport),
+            lower    = Math.max(0, (page - me.bufferPages) * viewport),
+            upper    = (page + 1 + me.bufferPages) * viewport;
+
+        let cursor = 0,
+            start  = 0,
+            end    = meta.length,
+            startFound = false,
+            i = 0;
+
+        for (; i < meta.length; i++) {
+            const next = cursor + me.estimateHeight(meta[i]);
+
+            if (!startFound && next > lower) {
+                start      = i;
+                startFound = true
+            }
+
+            if (cursor > upper) {
+                end = i;
+                break
+            }
+
+            cursor = next
+        }
+
+        return [start, end]
     }
 }
 

--- a/src/component/markdown/Parser.mjs
+++ b/src/component/markdown/Parser.mjs
@@ -148,6 +148,23 @@ export default class MarkdownParser {
     }
 
     /**
+     * The virtualization index: one `{id, type, units, open}` entry per block, in render order.
+     * `units` is the block's structural content size (content lines for code/paragraphs/quotes,
+     * items for lists, rows+header for tables, 1 for headings/breaks) — the owner maps units to
+     * estimated pixel heights. Settled blocks are immutable, so their `units` are measure-once
+     * facts; only the open tail entry can still change.
+     * @returns {Object[]}
+     */
+    get blockMeta() {
+        return this.#blocks.map(block => ({
+            id   : block.id,
+            type : block.type,
+            units: block.units,
+            open : block.open
+        }))
+    }
+
+    /**
      * Clears the block ledger and source memory. The id sequence deliberately keeps counting —
      * see `#seq`.
      */
@@ -218,7 +235,7 @@ export default class MarkdownParser {
      * one case: the open tail block growing across appends (same identity, in-place diff).
      * @param {Object} raw `{type, lines, lang, open, source}` from the segmenter
      * @param {String|null} [reuseId=null]
-     * @returns {Object} The ledger entry `{id, type, source, open, vdom}`
+     * @returns {Object} The ledger entry `{id, type, source, open, units, vdom}`
      * @private
      */
     #createBlock(raw, reuseId = null) {
@@ -303,7 +320,15 @@ export default class MarkdownParser {
                 }
         }
 
-        return {id, type: raw.type, source: raw.source, open: raw.open, vdom}
+        // Structural size units for virtualization estimates: content lines for code /
+        // paragraphs / quotes, items for lists, rows + header for tables, 1 for the rest.
+        // Settled-immutability makes these measure-once facts.
+        const units = raw.type === BLOCK_TYPES.list  ? raw.items.length :
+                      raw.type === BLOCK_TYPES.table ? raw.rows.length + 1 :
+                      raw.lines                      ? Math.max(raw.lines.length, 1) :
+                      1;
+
+        return {id, type: raw.type, source: raw.source, open: raw.open, units, vdom}
     }
 
     /**

--- a/test/playwright/e2e/MarkdownStreamingCoherenceNL.spec.mjs
+++ b/test/playwright/e2e/MarkdownStreamingCoherenceNL.spec.mjs
@@ -102,4 +102,77 @@ test.describe('Markdown streaming coherence observe-run (real pipeline)', () => 
 
         console.log(`[MarkdownStreamingCoherenceNL] batches: ${state.batches - baseline}, live: ${state.live}, retired: ${state.retired}, findings: ${coherenceWarnings.length}`)
     });
+
+    test('marathon windowing: bounded DOM through a 40× stream + scroll battery, zero coherence findings', async ({page, neuralLink}) => {
+        const coherenceWarnings = [];
+
+        page.on('console', msg => {
+            const text = msg.text();
+
+            if (text.includes('Delta coherence findings')) {
+                coherenceWarnings.push(text.slice(0, 500))
+            }
+        });
+
+        await page.goto('/examples/component/markdown/index.html');
+        await neuralLink.connectToApp('Neo.examples.component.markdown');
+        await page.waitForSelector('.neo-markdown-vdom', {state: 'visible', timeout: 30000});
+        await page.waitForTimeout(500);
+
+        await page.evaluate(async () => {
+            Neo.config.useDeltaCoherenceRegistry = true;
+            await Neo.main.DeltaUpdates.importDeltaInstruments()
+        });
+
+        // The marathon: 40 repetitions of the full-grammar source streamed in coarse chunks.
+        await page.locator('.neo-button', {hasText: 'Stream marathon'}).first().click();
+        await page.waitForSelector('text=Marathon section 40', {timeout: 60000}).catch(() => {});
+        await page.waitForTimeout(2000); // settle the tail
+
+        const domFacts = () => page.evaluate(() => {
+            const host = document.querySelector('.neo-markdown-vdom');
+
+            return {
+                children: host.children.length,
+                spacers : host.querySelectorAll(':scope > .neo-md-spacer').length,
+                topPx   : parseInt(host.querySelector(':scope > .neo-md-spacer')?.style.height) || 0
+            }
+        });
+
+        const streamed = await domFacts();
+
+        // The windowing claim: hundreds of estimated pages streamed, the DOM holds only the
+        // mounted window + 2 spacers — NOT the thousands of blocks the marathon parsed.
+        expect(streamed.spacers).toBe(2);
+        expect(streamed.children).toBeLessThan(400);
+        expect(streamed.topPx).toBeGreaterThan(1000); // the evicted prefix lives in the spacer
+
+        // Scroll battery: jump towards the top, then back down — the window slides through
+        // eviction/re-birth cycles the registry treats as the LEGAL remove→insert lifecycle.
+        const scrollHost = page.locator('.neo-markdown-vdom');
+
+        await scrollHost.evaluate(node => { node.scrollTop = 0 });
+        await page.waitForTimeout(600);
+
+        const atTop = await domFacts();
+
+        expect(atTop.topPx).toBe(0);
+        expect(atTop.children).toBeLessThan(400);
+
+        await scrollHost.evaluate(node => { node.scrollTop = node.scrollHeight });
+        await page.waitForTimeout(600);
+
+        // THE corpus assertion: the full stream + window churn produced zero findings.
+        expect(coherenceWarnings).toEqual([]);
+
+        const registry = await page.evaluate(() => ({
+            batches: Neo.main.DeltaUpdates.coherenceRegistry.batchCount,
+            retired: Neo.main.DeltaUpdates.coherenceRegistry.retiredSnapshot.size
+        }));
+
+        // Eviction happened for real: retired ids accumulated from window slides.
+        expect(registry.retired).toBeGreaterThan(0);
+
+        console.log(`[MarkdownMarathonNL] dom children: ${streamed.children}, top spacer: ${streamed.topPx}px, retired: ${registry.retired}, findings: ${coherenceWarnings.length}`)
+    });
 });

--- a/test/playwright/unit/component/markdown/Component.spec.mjs
+++ b/test/playwright/unit/component/markdown/Component.spec.mjs
@@ -51,8 +51,11 @@ test.describe('Neo.component.markdown.Component — streaming deltas', () => {
         runId++;
         component = Neo.create(MarkdownComponent, {
             appName,
-            id   : `markdown-vdom-test-${runId}`,
-            value: '# Title\n\nStreaming wor'
+            id        : `markdown-vdom-test-${runId}`,
+            value     : '# Title\n\nStreaming wor',
+            // This suite pins the PARSE-layer delta contract on raw block children;
+            // windowed mode (spacers + eviction) has its own dedicated spec.
+            virtualize: false
         });
 
         await component.initVnode();

--- a/test/playwright/unit/component/markdown/ComponentStreamingCapture.spec.mjs
+++ b/test/playwright/unit/component/markdown/ComponentStreamingCapture.spec.mjs
@@ -44,8 +44,10 @@ test.describe('Neo.component.markdown.Component — capture-epoch streaming ACs'
         runId++;
         component = Neo.create(MarkdownComponent, {
             appName,
-            id   : `markdown-capture-test-${runId}`,
-            value: '# Title\n\nStreaming wor'
+            id        : `markdown-capture-test-${runId}`,
+            value     : '# Title\n\nStreaming wor',
+            // Parse-layer epoch contract: raw block children, no windowing geometry.
+            virtualize: false
         });
 
         await component.initVnode();

--- a/test/playwright/unit/component/markdown/ComponentVirtualization.spec.mjs
+++ b/test/playwright/unit/component/markdown/ComponentVirtualization.spec.mjs
@@ -1,0 +1,169 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'MarkdownVirtualizationTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../../src/Neo.mjs';
+import * as core         from '../../../../../src/core/_export.mjs';
+import DomApiVnodeCreator from '../../../../../src/vdom/util/DomApiVnodeCreator.mjs';
+import VdomHelper        from '../../../../../src/vdom/Helper.mjs';
+import MarkdownComponent from '../../../../../src/component/markdown/Component.mjs';
+
+/**
+ * @summary Pins the settled-block windowing contract for marathon transcripts.
+ *
+ * The geometry is ESTIMATE-grade by design (operator calibration: over-mounting a page is fine;
+ * the win is bounding DOM size in hundreds-of-pages sessions) — so assertions bound the mounted
+ * window loosely (mounted ≪ total; window ± buffer pages) and never demand pixel-exact ranges.
+ * Scroll input is simulated by invoking the component's scroll handler directly with synthetic
+ * `{scrollTop, clientHeight}` payloads — the exact shape the Main-thread scroll event delivers.
+ */
+
+/** A marathon source: `count` paragraph blocks of one line each. */
+const marathon = count => Array.from({length: count}, (item, index) => `Paragraph number ${index} with some words.`).join('\n\n') + '\n\n';
+
+const blockChildren = component => component.vdom.cn.filter(node => !node.cls?.includes('neo-md-spacer'));
+const spacers       = component => component.vdom.cn.filter(node => node.cls?.includes('neo-md-spacer'));
+
+test.describe('Markdown settled-block windowing', () => {
+    let component, runId = 0;
+
+    test.beforeEach(async () => {
+        await Promise.resolve();
+        runId++;
+        component = Neo.create(MarkdownComponent, {
+            appName,
+            id   : `markdown-virt-test-${runId}`,
+            value: marathon(1000)
+        });
+
+        await component.initVnode();
+        component.mounted = true
+    });
+
+    test.afterEach(() => {
+        component.destroy();
+        component = null
+    });
+
+    test('a 1000-block transcript mounts a bounded tail window, never the whole document', () => {
+        const mounted = blockChildren(component);
+
+        // Estimate-grade bound: viewport(fallback 800) + 1 buffer page at ~26px/paragraph
+        // ≈ 62 blocks — assert the loose envelope, not the exact figure.
+        expect(mounted.length).toBeGreaterThan(10);
+        expect(mounted.length).toBeLessThan(200);
+        expect(component.parser.blockCount).toBe(1000);
+
+        // Initial render follows the tail: the LAST block is mounted, framed by a top spacer
+        // carrying the evicted prefix's estimated height and an empty bottom spacer.
+        const [top, bottom] = spacers(component);
+
+        expect(spacers(component)).toHaveLength(2);
+        expect(parseInt(top.style.height)).toBeGreaterThan(10000);
+        expect(parseInt(bottom.style.height)).toBe(0);
+        expect(mounted.at(-1).id).toBe(component.parser.blockMeta.at(-1).id)
+    });
+
+    test('scrolling to the top moves the window: head blocks mount, tail evicts, spacers swap roles', async () => {
+        // Follow-mode exit needs a REAL upward jump: seed depth (a pin-echo-class event the
+        // state machine ignores for windowing), then jump to the top.
+        component.onTranscriptScroll({scrollTop: 20000, clientHeight: 800});
+        component.onTranscriptScroll({scrollTop: 0, clientHeight: 800});
+        await component.promiseUpdate();
+
+        const
+            mounted       = blockChildren(component),
+            [top, bottom] = spacers(component),
+            firstMetaId   = component.parser.blockMeta[0].id;
+
+        expect(mounted[0].id).toBe(firstMetaId);
+        expect(mounted.length).toBeLessThan(200);
+        expect(parseInt(top.style.height)).toBe(0);
+        expect(parseInt(bottom.style.height)).toBeGreaterThan(10000)
+    });
+
+    test('scrolling inside the mounted buffer is render-free; leaving it slides the window', async () => {
+        component.onTranscriptScroll({scrollTop: 20000, clientHeight: 800});
+        component.onTranscriptScroll({scrollTop: 0, clientHeight: 800});
+        await component.promiseUpdate();
+
+        const rangeBefore = [...component.mountedBlocks];
+
+        // A few pixels of drift inside the buffer: the range must not move.
+        component.onTranscriptScroll({scrollTop: 50, clientHeight: 800});
+        expect(component.mountedBlocks).toEqual(rangeBefore);
+
+        // A jump to the estimated middle must move it.
+        component.onTranscriptScroll({scrollTop: 13000, clientHeight: 800});
+        await component.promiseUpdate();
+
+        expect(component.mountedBlocks).not.toEqual(rangeBefore);
+
+        const [top, bottom] = spacers(component);
+
+        expect(parseInt(top.style.height)).toBeGreaterThan(0);
+        expect(parseInt(bottom.style.height)).toBeGreaterThan(0)
+    });
+
+    test('streaming appends keep following the tail while the user sits at the bottom', async () => {
+        const tailIdBefore = component.parser.blockMeta.at(-1).id;
+
+        component.setSilent({value: component.value + 'A freshly streamed paragraph.\n\n'});
+        await component.promiseUpdate();
+
+        const mounted = blockChildren(component);
+
+        expect(component.parser.blockCount).toBe(1001);
+        expect(mounted.at(-1).id).toBe(component.parser.blockMeta.at(-1).id);
+        expect(mounted.at(-1).id).not.toBe(tailIdBefore);
+        expect(mounted.length).toBeLessThan(200)
+    });
+
+    test('a user scrolled away from the bottom is NOT yanked to the tail by new appends', async () => {
+        component.onTranscriptScroll({scrollTop: 20000, clientHeight: 800});
+        component.onTranscriptScroll({scrollTop: 0, clientHeight: 800});
+        await component.promiseUpdate();
+
+        const headIdBefore = blockChildren(component)[0].id;
+
+        component.setSilent({value: component.value + 'New content far below the reader.\n\n'});
+        await component.promiseUpdate();
+
+        // The head window survives; the new tail block stays evicted (bottom spacer grew).
+        expect(blockChildren(component)[0].id).toBe(headIdBefore);
+        expect(blockChildren(component).at(-1).id).not.toBe(component.parser.blockMeta.at(-1).id)
+    });
+
+    test('virtualize: false renders every block with no spacers (the escape hatch)', async () => {
+        component.virtualize = false;
+        await component.promiseUpdate();
+
+        expect(spacers(component)).toHaveLength(0);
+        expect(blockChildren(component)).toHaveLength(1000)
+    });
+
+    test('estimates derive from parser units: a long fence dominates same-count paragraphs', () => {
+        const
+            meta  = component.parser.blockMeta,
+            fence = {id: 'x', type: 'code', units: 100, open: false},
+            para  = {id: 'y', type: 'paragraph', units: 1, open: false};
+
+        expect(component.estimateHeight(fence)).toBeGreaterThan(component.estimateHeight(para) * 50);
+        expect(meta.every(entry => entry.units >= 1)).toBe(true)
+    });
+});

--- a/test/playwright/unit/component/markdown/ComponentVirtualization.spec.mjs
+++ b/test/playwright/unit/component/markdown/ComponentVirtualization.spec.mjs
@@ -149,6 +149,32 @@ test.describe('Markdown settled-block windowing', () => {
         expect(blockChildren(component).at(-1).id).not.toBe(component.parser.blockMeta.at(-1).id)
     });
 
+    test('a value reset also resets the follow-state machine: the NEXT stream follows its tail', async () => {
+        // Exit follow-mode like a real reader (depth seed, then an upward jump).
+        component.onTranscriptScroll({scrollTop: 20000, clientHeight: 800});
+        component.onTranscriptScroll({scrollTop: 0, clientHeight: 800});
+        await component.promiseUpdate();
+
+        expect(component.followMode).toBe(false);
+
+        // The wipe — and then a brand-new transcript streams in.
+        component.setSilent({value: null});
+        await component.promiseUpdate();
+
+        expect(component.followMode).toBe(true);
+        expect(component.maxScrollSeen).toBe(0);
+
+        component.setSilent({value: marathon(500)});
+        await component.promiseUpdate();
+
+        const mounted = blockChildren(component);
+
+        // The fresh stream mounts its TAIL window — not the stale head window the previous
+        // reader-mode state would have produced.
+        expect(mounted.at(-1).id).toBe(component.parser.blockMeta.at(-1).id);
+        expect(parseInt(spacers(component)[0].style.height)).toBeGreaterThan(5000)
+    });
+
     test('virtualize: false renders every block with no spacers (the escape hatch)', async () => {
         component.virtualize = false;
         await component.promiseUpdate();


### PR DESCRIPTION
Resolves #13045
Related: #13012

Authored by Claude Fable 5 (Claude Code, @neo-fable-clio). Session e7e5274c-6486-45ec-9c5d-0933ca3f123a.

Ships settled-block windowing for marathon transcripts, operator-calibrated to estimate-grade geometry ("does not have to be pixel-perfect — even if we mount one more page, in marathons with 100s of pages a clear win"): with `virtualize: true` (the default) the component mounts only the blocks intersecting a PAGE-QUANTIZED window (±`bufferPages`), frames the evicted ranges in two stable-id spacer divs sized from structural estimates (the parser's new `units` × a per-type `unitHeights` map — content lines, list items, table rows; never a DOM measurement), and follows the streaming tail with a real scroll pin. Phase 1 of the ticket rides along: `content-visibility: auto` + `contain-intrinsic-size` on block roots (new SCSS, the docs-component precedent generalized).

**The design's two load-bearing pieces, both falsified into shape during implementation:**

1. **Page quantization** (first e2e failure): a continuous window slid its edges on every scroll pixel. Quantizing the range to viewport pages makes in-page scrolling delta-free and window moves whole-page — the literal "mount one more page" semantics.
2. **Follow-mode as a state machine over REAL geometry** (second e2e failure): the tail pin fires scroll events, and feeding those back through estimate-space math created a churn loop that drifted the window during streaming. Follow-mode now transitions on scroll-direction deltas only (a half-viewport upward jump exits; returning within 1.5 viewports of the deepest seen position re-enters); pin echoes are ignored for windowing; estimate-space is consulted only for reader-mode window placement, where the ±page over-mount absorbs drift by design.

Eviction/re-entry rides the engine's legitimate remove→re-insert lifecycle with reference-memoized subtrees (settled-immutability per the shipped parser contract) — which makes the coherence registry the feature's natural auditor.

Evidence: L2 (36 unit tests: windowing bounds, spacer geometry, in-buffer render-free scrolling, follow/exit/re-enter choreography, no-yank protection, escape hatch, estimate derivation) + L3 (committed e2e marathon through the real pipeline under `useDeltaCoherenceRegistry: true`: ~1,800 parsed blocks → 23 DOM children, top spacer 27,366px, 590 eviction/re-birth retirements, ZERO coherence findings; scroll battery head⇄tail) -> L3 required (bounded-DOM + coherence ACs). No residuals.

## Epic provenance (compact)

Leaf of Epic #13012 (markdown-lane follow-up; epic-review quota filled by @neo-opus-vega + @neo-gpt, cited per the two-review cap). Operator-directed pickup and calibration in-session (2026-06-13), superseding the file-time claimable note.

## Deltas from ticket

- **Phases 1+2 land together** (ticket allowed independent shipping): the operator's page-granular calibration collapsed Phase 2's hard part (no measurement machinery, no prefix-sum binary search — a linear scan over structural estimates suffices and is microseconds at transcript scale).
- **`flex: 1` fix in the demo viewport** — without it the component auto-grew and never scrolled (found by the e2e battery; the first "failure" was the test's own premise: scrollTop assignments no-op on non-scrollable elements).
- **Existing parse-contract specs pinned to `virtualize: false`** — they assert raw block children; windowed mode owns its dedicated spec.
- **Demo gains "Stream marathon (40×)"** — the hundreds-of-pages surface, deterministic (fixed source × 40, fixed chunking).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/component/markdown/` -> 36 passed (windowing spec + parser `units`/`blockMeta` + the existing suites under explicit `virtualize: false`).
- `npx playwright test test/playwright/e2e/MarkdownStreamingCoherenceNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs` -> 2 passed (the original observe-run unchanged at zero findings; the new marathon battery: bounded DOM + 590 registry-blessed evictions + zero findings; e2e runs locally by design).

## Post-Merge Validation

- [ ] Theme build picks up the new `Component.scss` (content-visibility styling is progressive enhancement; windowing is independent of it).
- [ ] Transcript-surface integration consumes `bufferPages`/`unitHeights` tuning under real agent sessions.

## Commits

- 9b1b8a06d — feat(component): settled-block windowing for marathon transcripts
