### PR TITLE
fix(vdom): reject promise callbacks parked on a failed update flight (#12957)

### DIFF
--- a/src/manager/VDomUpdate.mjs
+++ b/src/manager/VDomUpdate.mjs
@@ -140,7 +140,7 @@ class VDomUpdate extends Collection {
      * When a component's VDOM update is finalized, the callbacks for its ID are executed,
      * resolving the Promise returned by the component's `update()` method.
      *
-     * The structure is: `Map<'component-id', [callback1, callback2, ...]>`
+     * The structure is: `Map<'component-id', [{resolve, reject}, ...]>`
      *
      * @member {Map|null} promiseCallbackMap=null
      * @protected
@@ -164,20 +164,24 @@ class VDomUpdate extends Collection {
     }
 
     /**
-     * Registers a callback function to be executed when a specific component's
-     * VDOM update completes. This is the mechanism that resolves the Promise
-     * returned by `Component#update()`.
-     * @param {String}   ownerId  The `id` of the component owning the update.
-     * @param {Function} callback The function to execute upon completion.
+     * Registers a `{resolve, reject}` settlement pair to be settled when a specific
+     * component's VDOM update completes. This is the mechanism that settles the Promise
+     * returned by `Component#promiseUpdate()`: `resolve` fires from `executeCallbacks`
+     * (success), `reject` from `rejectCallbacks` (a failed flight). Either side may be
+     * `undefined` (fire-and-forget `update()` registers neither; a legacy resolve-only
+     * post-update entry registers a `reject`-less pair).
+     * @param {String}    ownerId  The `id` of the component owning the update.
+     * @param {Function} [resolve] Settles the promise on update success.
+     * @param {Function} [reject]  Settles the promise when the flight it is parked on fails.
      */
-    addPromiseCallback(ownerId, callback) {
+    addPromiseCallback(ownerId, resolve, reject) {
         let me = this;
 
         if (!me.promiseCallbackMap.has(ownerId)) {
             me.promiseCallbackMap.set(ownerId, [])
         }
 
-        me.promiseCallbackMap.get(ownerId).push(callback)
+        me.promiseCallbackMap.get(ownerId).push({resolve, reject})
     }
 
     /**
@@ -242,10 +246,61 @@ class VDomUpdate extends Collection {
 
         if (callbacks) {
             for (let i = 0, len = callbacks.length; i < len; i++) {
-                callbacks[i](data)
+                callbacks[i].resolve?.(data)
             }
             me.promiseCallbackMap.delete(ownerId);
         }
+    }
+
+    /**
+     * Rejects all registered promise callbacks for a given `ownerId` — the error-path twin
+     * of {@link #executePromiseCallbacks}. Fires each parked `reject` (resolve-only / legacy
+     * entries are skipped via optional chaining) and clears the queue.
+     * @param {String} ownerId The `id` of the component whose flight failed.
+     * @param {*}       error   The error to reject the parked promises with.
+     */
+    rejectPromiseCallbacks(ownerId, error) {
+        let me        = this,
+            callbacks = me.promiseCallbackMap.get(ownerId);
+
+        if (callbacks) {
+            for (let i = 0, len = callbacks.length; i < len; i++) {
+                callbacks[i].reject?.(error)
+            }
+            me.promiseCallbackMap.delete(ownerId)
+        }
+    }
+
+    /**
+     * Rejects the promise callbacks for a failed update flight — the error-path twin of
+     * {@link #executeCallbacks}. A failed flight has no `processedChildIds` (nothing was
+     * applied), so every child merged into `ownerId` is rejected alongside the owner.
+     * @param {String} ownerId The `id` of the component whose update flight failed.
+     * @param {*}       error   The error to reject the parked promises with.
+     */
+    rejectCallbacks(ownerId, error) {
+        let me   = this,
+            item = me.mergedCallbackMap.get(ownerId);
+
+        if (item) {
+            for (const childId of item.children.keys()) {
+                me.rejectPromiseCallbacks(childId, error)
+            }
+            me.mergedCallbackMap.remove(ownerId)
+        }
+
+        me.rejectPromiseCallbacks(ownerId, error)
+    }
+
+    /**
+     * Whether any promise callbacks are currently parked for the given `ownerId`. Used by the
+     * update catch to distinguish a genuinely fire-and-forget failure (which must log, since
+     * nothing else surfaces it) from one whose attached promise will reject.
+     * @param {String}  ownerId The component `id`.
+     * @returns {Boolean}
+     */
+    hasPromiseCallbacks(ownerId) {
+        return this.promiseCallbackMap.has(ownerId)
     }
 
     /**
@@ -474,7 +529,7 @@ class VDomUpdate extends Collection {
                 component = Neo.getComponent(entry.childId);
 
                 if (component) {
-                    entry.resolve && me.addPromiseCallback(component.id, entry.resolve);
+                    (entry.resolve || entry.reject) && me.addPromiseCallback(component.id, entry.resolve, entry.reject);
                     component.update()
                 }
             }

--- a/src/mixin/VdomLifecycle.mjs
+++ b/src/mixin/VdomLifecycle.mjs
@@ -212,7 +212,7 @@ class VdomLifecycle extends Base {
     async executeVdomUpdate(resolve, reject) {
         let me = this;
 
-        resolve && VDomUpdate.addPromiseCallback(me.id, resolve);
+        (resolve || reject) && VDomUpdate.addPromiseCallback(me.id, resolve, reject);
 
         me.isVdomUpdating = true;
         // Centralize in-flight state
@@ -362,12 +362,15 @@ class VdomLifecycle extends Base {
             // Ensure state is cleaned up on error
             VDomUpdate.unregisterInFlightUpdate(me.id);
 
-            // Fire-and-forget updates have no reject callback — without this log the failure is
-            // fully silent and the symptom surfaces minutes later as "the DOM stopped following".
-            // Rejected updates do NOT adopt a vnode, so the next cycle re-diffs cleanly.
-            !reject && console.error('vdom update failed', me.id, err);
+            // A failed flight must reject every promise parked on it — the initiator AND any
+            // children merged into the cycle (rejectCallbacks is the error-path twin of the
+            // resolveVdomUpdate -> executeCallbacks success path). Detect the fire-and-forget case
+            // first (no parked promise), so a genuinely silent failure still logs rather than
+            // vanishing — the symptom otherwise surfaces minutes later as "the DOM stopped
+            // following". Rejected updates do NOT adopt a vnode, so the next cycle re-diffs cleanly.
+            VDomUpdate.hasPromiseCallbacks(me.id) || console.error('vdom update failed', me.id, err);
 
-            reject?.(err);
+            VDomUpdate.rejectCallbacks(me.id, err);
 
             // Mirror of resolveVdomUpdate(): updates queued onto this flight while it was running
             // are only ever drained by a follow-up cycle — without this, their content (and any
@@ -949,9 +952,14 @@ class VdomLifecycle extends Base {
 
         me.ensureStableIds();
 
-        // If there's a promise, register it against this component's ID immediately.
-        // The manager will ensure it's called when the appropriate update cycle completes.
-        resolve && VDomUpdate.addPromiseCallback(me.id, resolve);
+        // If there's a promise, register its {resolve, reject} pair against this component's ID
+        // immediately — BEFORE the merge / in-flight / initiator branching below. The manager
+        // settles it when the owning cycle completes: resolve on success (executeCallbacks),
+        // reject when the flight it parks on fails (rejectCallbacks). Registering the pair here —
+        // rather than carrying reject as a lone param on the initiator path — is what lets a
+        // promiseUpdate() queued onto an already-in-flight or parent-merged cycle reject honestly
+        // if that cycle fails, instead of stranding resolve-only.
+        (resolve || reject) && VDomUpdate.addPromiseCallback(me.id, resolve, reject);
 
         // Attempt to merge into a parent's update cycle.
         // We do this even if silent, to ensure we catch the bus if a parent is departing.
@@ -995,7 +1003,9 @@ class VdomLifecycle extends Base {
                             me.updateVdom(resolve, reject)
                         }, me, {once: true})
                     } else {
-                        me.executeVdomUpdate(null, reject)
+                        // The {resolve, reject} pair is already parked under me.id above; the catch
+                        // settles it via VDomUpdate.rejectCallbacks, so no reject param is threaded here.
+                        me.executeVdomUpdate()
                     }
                 }
             }

--- a/test/playwright/unit/vdom/UpdateWedge.spec.mjs
+++ b/test/playwright/unit/vdom/UpdateWedge.spec.mjs
@@ -126,6 +126,49 @@ test.describe('VdomLifecycle update wedge (#12946)', () => {
         expect(child.vnode.textContent ?? child.vnode.childNodes?.[0]?.textContent).toBe('healed');
     });
 
+    test('#12957: a promiseUpdate() queued onto a failing in-flight flight rejects, not resolve-only', async () => {
+        Neo.applyDeltas = async () => {};
+
+        const containerId = getUniqueId('wedge-container');
+        const childId     = getUniqueId('wedge-child');
+        createdComponentIds.push(containerId);
+
+        const container = Neo.create(WedgeContainer, {
+            appName,
+            id   : containerId,
+            items: [{module: WedgeChild, id: childId, text: 'pristine'}]
+        });
+
+        await container.initVnode(true);
+        container.mounted = true;
+
+        const child = container.items[0];
+        await container.promiseUpdate();
+
+        // The apply boundary fails for the in-flight flight below.
+        VdomHelper.updateBatch = () => Promise.reject({data: {error: 'test-injected apply failure'}});
+
+        // Flight 1 enters in-flight synchronously (executeVdomUpdate flips isVdomUpdating before its
+        // macrotask yield), so flight 2 — issued with no await between — parks ONTO flight 1's cycle.
+        const flight1 = child.promiseUpdate();
+        expect(child.isVdomUpdating).toBe(true);
+
+        // Flight 2 lands while flight 1 is in-flight. Previously this parked resolve-only with no
+        // reject: if flight 1 failed, flight 2 could never settle (resolve-late at best, permanent
+        // hang at worst). It must now reject honestly off the shared failed flight.
+        const flight2 = child.promiseUpdate();
+
+        await expect(flight1).rejects.toBeTruthy();
+        await expect(flight2).rejects.toBeTruthy();
+
+        // Let the bounded post-failure drain (needsVdomUpdate set by flight 2) settle.
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // No wedge: the shared in-flight state is released.
+        expect(child.isVdomUpdating).toBe(false);
+        expect(VDomUpdate.inFlightUpdateMap.has(child.id)).toBe(false);
+    });
+
     test('REGRESSION: initVnode failure releases the flag and the in-flight registry entry', async () => {
         const containerId = getUniqueId('wedge-container');
         createdComponentIds.push(containerId);


### PR DESCRIPTION
## Summary

A `promiseUpdate()` that lands while its component is already in-flight (the `isVdomUpdating` branch) — or merges into a parent's cycle — parked **only its `resolve` side** in `VDomUpdate.promiseCallbackMap`. The `reject` side travelled solely as the initiator's `executeVdomUpdate(resolve, reject)` param, consumed by that one call chain's catch. So a promise queued onto a flight that subsequently **failed** had no reachable reject: it resolved late against a transient failure (post-#12956 catch-drain) or **never settled** against a deterministic one.

This is the documented Delta of PR #12956 (the wedge fix) — the prior `UpdateWedge.spec.mjs` rejection test deliberately routed around the queued-onto-failing-flight case (its own comment names it a "separate (documented) gap").

## Deltas

- `src/manager/VDomUpdate.mjs` — `addPromiseCallback(ownerId, resolve, reject)` stores `{resolve, reject}` records (was bare callbacks); `executePromiseCallbacks` fires `record.resolve?.(data)`; **new** `rejectPromiseCallbacks` (error-path twin) + `rejectCallbacks(ownerId, err)` (twin of `executeCallbacks`: rejects owner + every merged child) + `hasPromiseCallbacks` (gates the fire-and-forget log); `triggerPostUpdates` carries `entry.reject` through.
- `src/mixin/VdomLifecycle.mjs` — `updateVdom` registers the `{resolve, reject}` **pair** under `me.id` up front (before the merge / in-flight / initiator branching, so all paths inherit it); the initiator path calls `executeVdomUpdate()` without threading `reject` as a lone param; the catch settles via `VDomUpdate.rejectCallbacks(me.id, err)` and logs only genuinely fire-and-forget failures.
- `test/playwright/unit/vdom/UpdateWedge.spec.mjs` — the queued-onto-failing-flight rejection case the prior wedge test deferred.

Evidence: code + test — a pure App-Worker promise-settlement change, fully covered by the vdom unit collection (no runtime/sandbox-only ACs).

## Contract Ledger

| Target Surface | Contract detail |
|---|---|
| `VDomUpdate.addPromiseCallback()` / callback storage | Stores `{resolve, reject}` records (was bare functions). Either side may be `undefined` (fire-and-forget `update()` registers neither; legacy resolve-only post-update entries register a `reject`-less pair). Signature: `addPromiseCallback(ownerId, resolve, reject)`. |
| `executeCallbacks()` / `rejectCallbacks()` symmetry | Success: `executePromiseCallbacks` fires `record.resolve?.(data)` for owner + `processedChildIds` merged children. Failure: `rejectPromiseCallbacks` fires `record.reject?.(err)`; `rejectCallbacks` rejects owner + **all** merged children (a failed flight has no `processedChildIds`). Both delete the map entry after firing. |
| `VdomLifecycle#updateVdom()` queue paths | The pair is registered once, under `me.id`, before branching — the merge (`mergeIntoParentUpdate`) and in-flight (`isVdomUpdating`) paths inherit it. The owning cycle's `executeVdomUpdate` catch calls `rejectCallbacks(me.id, err)` **before** the bounded `needsVdomUpdate` drain, so retried content still heals while promises on the failed flight reject. |
| `promiseUpdate()` observable behavior | A promise queued onto an in-flight or parent-merged cycle now **rejects** if that cycle fails (was resolve-only). Initiator + merged-child promises both reject on the failed flight. **Out of scope:** the post-update-queue paths (`isParentUpdating` / `isChildUpdating` → `registerPostUpdate`) remain resolve-only — a separate reject-symmetry gap, follow-up below. |
| Evidence | `UpdateWedge.spec.mjs` new case + full vdom unit collection 154/154. |

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/vdom/
→ 154 passed
```

Includes the new `#12957: a promiseUpdate() queued onto a failing in-flight flight rejects, not resolve-only` case (flight 2 parks onto flight 1's failing in-flight cycle; both reject; in-flight state released).

## Post-Merge Validation

- Follow-up: post-update-queue reject symmetry (`isParentUpdating` / `isChildUpdating` → `registerPostUpdate` still resolve-only). I'll file it as a leaf — same bug class, narrower path, out of this AC's scope.

Resolves #12957
Refs #12956

Authored by Ada (@neo-opus-ada, Claude Opus 4.8)
