### PR TITLE
fix(ai): register the implicit window for non-SharedWorker apps over Neural Link (#12884)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -302,6 +302,20 @@ class Client extends Base {
             })
         })
 
+        // 2b. A non-SharedWorker app never fires the App-worker `connect` event that populates
+        // WindowManager.items, so the rehydration above sends nothing — the bridge never learns
+        // about the single implicit window, leaving `get_window_topology` empty and `simulate_event`
+        // unroutable (every event needs a windowId). Register each app's window explicitly from the
+        // windowId-keyed `Neo.apps` registry. Rects stay optional here (the SharedWorker path also
+        // omits them until a WindowManager entry exists); routing only needs the windowId.
+        if (!appWorker.isSharedWorker) {
+            Object.entries(Neo.apps).forEach(([windowId, app]) => {
+                if (!WindowManager.get(windowId)) {
+                    this.sendNotification('window_connected', {appName: app.name, windowId})
+                }
+            })
+        }
+
         // 3. Rehydrate drag state (if active)
         const dragCoordinator = Neo.manager?.DragCoordinator;
 

--- a/test/playwright/unit/ai/ClientWindowRegistration.spec.mjs
+++ b/test/playwright/unit/ai/ClientWindowRegistration.spec.mjs
@@ -1,0 +1,90 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'AiClientWindowRegistrationTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+
+/**
+ * @summary Non-SharedWorker apps never fire the App-worker `connect` event that populates
+ * `WindowManager.items`, so `Client#onSocketOpen`'s rehydration sent nothing — the NL bridge
+ * never learned about the single implicit window, leaving `get_window_topology` empty and
+ * `simulate_event` unroutable. These pin the client-side emission: the implicit window is
+ * registered from the windowId-keyed `Neo.apps` registry for non-shared apps, and the
+ * SharedWorker path is left untouched.
+ *
+ * The live end-to-end ACs (a real devindex window appearing in `get_window_topology` and a
+ * `simulate_event` click routing to it) are L3 runtime evidence verified post-merge — they
+ * need a running bridge + non-shared app the unit sandbox cannot host.
+ */
+test.describe('Neo.ai.Client — non-SharedWorker window registration', () => {
+    let client;
+
+    test.beforeAll(() => {
+        if (!Neo.currentWorker) {
+            Neo.currentWorker = {on: () => {}, isSharedWorker: false}
+        }
+        if (!Neo.worker) {
+            Neo.worker = {App: {id: 'test-worker'}}
+        }
+    });
+
+    test.beforeEach(async () => {
+        const {default: Client} = await import('../../../../src/ai/Client.mjs');
+        client = Neo.ai.Client || Neo.create(Client, {appName})
+    });
+
+    const runOnSocketOpen = (isSharedWorker, apps) => {
+        const notifications            = [];
+        const originalSendNotification = client.sendNotification;
+        const originalSocket           = client.socket;
+        const originalSharedWorker     = Neo.worker.App.isSharedWorker;
+        const originalApps             = Neo.apps;
+
+        client.sendNotification       = (method, params) => notifications.push({method, params});
+        client.socket                 = {sendMessage: () => {}};
+        Neo.worker.App.isSharedWorker = isSharedWorker;
+        Neo.apps                      = apps;
+
+        try {
+            client.onSocketOpen({})
+        } finally {
+            client.sendNotification       = originalSendNotification;
+            client.socket                 = originalSocket;
+            Neo.worker.App.isSharedWorker = originalSharedWorker;
+            Neo.apps                      = originalApps;
+            client.isConnected            = false
+        }
+
+        return notifications
+    };
+
+    test('onSocketOpen registers the implicit window for a non-SharedWorker app', () => {
+        const notifications = runOnSocketOpen(false, {'win-nonshared-1': {name: 'DevIndexApp'}});
+
+        const implicit = notifications.find(
+            n => n.method === 'window_connected' && n.params.windowId === 'win-nonshared-1'
+        );
+
+        expect(implicit, 'the non-shared implicit window must be registered with the bridge').toBeTruthy();
+        expect(implicit.params.appName).toBe('DevIndexApp')
+    });
+
+    test('a SharedWorker app does NOT get the implicit-app-registry fallback', () => {
+        const notifications = runOnSocketOpen(true, {'win-shared-1': {name: 'PortalApp'}});
+
+        // SharedWorker windows register via WindowManager rehydration / connect events, never the
+        // implicit Neo.apps fallback — so no window_connected for this window originates here.
+        const fromApps = notifications.filter(
+            n => n.method === 'window_connected' && n.params.windowId === 'win-shared-1'
+        );
+
+        expect(fromApps.length).toBe(0)
+    });
+});


### PR DESCRIPTION
## Summary

A non-SharedWorker app never fires the App-worker `connect` event that populates `WindowManager.items`, so `Client#onSocketOpen`'s rehydration loop sent **nothing** — the Neural Link bridge never learned about the app's single implicit window. `get_window_topology` stayed empty and `simulate_event` was **unroutable** for non-shared apps (devindex), because every event requires a `windowId`. Pure-NL sessions (no browser-control harness) couldn't drive interactions on non-shared apps at all; the workarounds used in #12807 (agent-browser `MouseEvent`, playwright `page.mouse`) bypass the NL tool surface entirely.

## Deltas

- `src/ai/Client.mjs` — `onSocketOpen` now registers the implicit window for non-SharedWorker apps from the **windowId-keyed `Neo.apps` registry** (`src/controller/Application.mjs:82` keys it by `windowId`; the controller carries `.name`). Guarded by `!appWorker.isSharedWorker` + a `WindowManager.get(windowId)` idempotency check so the SharedWorker rehydration path and multi-window apps are untouched.
- `test/playwright/unit/ai/ClientWindowRegistration.spec.mjs` — pins the emission: a non-shared app registers its implicit window; a SharedWorker app gets no `Neo.apps` fallback.

Evidence: L2 (static + emission unit test) → L3 required (live devindex topology + `simulate_event` routing) → Residual: AC1/AC2 [#12884], post-merge runtime verification — the live ACs need a running bridge + non-shared app the unit sandbox cannot host (sandbox ceiling, not under-probing).

## Contract Ledger

| Target Surface | Contract detail |
|---|---|
| `Client#onSocketOpen` non-shared registration | Source: windowId-keyed `Neo.apps` (key = `windowId`, `app.name` = appName). Emits `window_connected {appName, windowId}`. **Rects omitted** — optional; the SharedWorker path also omits them until a `WindowManager` entry exists. **Idempotent**: skips any window already in `WindowManager` (SharedWorker rehydration owns those), so SharedWorker + multi-window apps are unaffected. |
| Disconnect semantics | Unchanged in this PR. The non-shared implicit window's teardown rides the socket close (`onSocketClose` → `isConnected=false`; the bridge drops the session's windows). A dedicated per-window `window_disconnected` on `unload` is a follow-up — outside this AC's registration/routing scope. |
| `ConnectionService.handleNotification()` topology | Unchanged: stores the `window_connected` entry (`windowId` + `appName`; `rects` undefined) under the session, identically to a SharedWorker window. |
| `get_window_topology` / healthcheck visibility | The non-shared window now appears (`windowId` + `appName`; rects `null` until a `WindowPosition` measurement lands). |
| `simulate_event` routing | Contract unchanged — every event still requires a `windowId`; the non-shared window now HAS a registered one, so events route. Absent/stale window → existing not-found behavior. |
| Evidence | L2 emission unit (this PR). L3 live devindex topology + `simulate_event` click → post-merge. |

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/ClientWindowRegistration.spec.mjs \
  test/playwright/unit/ai/ClientDispatcher.spec.mjs
→ 5 passed
```

## Post-Merge Validation

- [ ] AC1 (L3, live): devindex window appears in `get_window_topology` / healthcheck `windows[]` after boot.
- [ ] AC2 (L3, live): `simulate_event` (click) executes against devindex via its `windowId`.
- [ ] AC3: Portal (SharedWorker) registration unchanged — covered by the emission unit + idempotency guard.
- [ ] AC4: drag-sequence routing for the #12807 / whitebox-e2e recipes once routing is live (consumer-side follow-up).

Resolves #12884
Refs #12807

Authored by Ada (@neo-opus-ada, Claude Opus 4.8)