### PR TITLE
fix(ai): route Codex wake via app-server (#13067)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -73,6 +73,7 @@ const WOKEN_WATERMARK_FILE     = path.join(DAEMON_DATA_DIR, 'woken-watermark.jso
 const LOG_RETENTION_DAYS       = 30;
 const POLL_INTERVAL_MS         = 3000;
 const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
+const CODEX_APP_SERVER_ADAPTER   = 'codex-app-server';
 const WAKE_PRIORITY_RANKS      = {
     low   : 0,
     normal: 1,
@@ -690,6 +691,42 @@ function spawnAsync(command, args) {
 }
 
 /**
+ * @summary Resolves the Codex CLI used by the app-server wake adapter.
+ *
+ * `CODEX_CLI_PATH` mirrors the resume-harness test hook so unit tests can assert
+ * the command shape without reaching a live Codex Desktop app-server.
+ *
+ * @returns {String}
+ */
+function resolveCodexCliPath() {
+    return process.env.CODEX_CLI_PATH || 'codex';
+}
+
+/**
+ * @summary Delivers a Codex wake digest through the native Codex app-server control plane.
+ *
+ * This is the normal wake-daemon equivalent of the existing resume-harness
+ * `codex debug app-server send-message-v2 <payload>` route. It intentionally does
+ * not fall back to `osascript`; a route explicitly configured as `codex-app-server`
+ * must fail visibly instead of recreating the GUI-focus delivery path.
+ *
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @param {String} digest Wake digest body.
+ * @returns {Promise<void>}
+ */
+async function deliverViaCodexAppServer(subscription, digest) {
+    const meta    = subscription.properties?.harnessTargetMetadata || {};
+    const appName = meta.appName;
+
+    if (appName !== 'Codex') {
+        throw new Error(`codex-app-server requires harnessTargetMetadata.appName='Codex' (received '${appName || ''}')`);
+    }
+
+    await spawnAsync(resolveCodexCliPath(), ['debug', 'app-server', 'send-message-v2', digest]);
+    writeLog('INFO', `[Wake Daemon] Delivered ${subscription.id} via codex-app-server`);
+}
+
+/**
  * @summary Delivers a wake digest via osascript, retrying transient frontmost-loss races.
  *
  * macOS focus-stealing prevention makes a background daemon's `activate` / `set frontmost`
@@ -762,7 +799,7 @@ function escapeAppleScriptString(value) {
 let deliveryPromise = Promise.resolve();
 
 /**
- * Delivers the digest to the correct adapter (tmux or osascript).
+ * Delivers the digest to the configured harness adapter.
  */
 async function deliverDigest(subscription, digest) {
     const meta = subscription.properties?.harnessTargetMetadata || {};
@@ -789,6 +826,11 @@ async function deliverDigest(subscription, digest) {
 
         if (addressType === 'webhookUrl') {
             await deliverViaWebhookUrl(subscription, digest, instanceAddress);
+            return;
+        }
+
+        if (adapter === CODEX_APP_SERVER_ADAPTER) {
+            await deliverViaCodexAppServer(subscription, digest);
             return;
         }
 

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1388,13 +1388,13 @@ paths:
                   description: Required for subscribe; specifies how wake events are delivered.
                 harnessTargetMetadata:
                   type: object
-                  description: Channel-specific metadata. appName is required so fresh agents always provide the bridge-daemon/osascript routing target; url is required for a2a-webhook; coalesceWindow is an optional override. instanceAddress + addressType (local bridge-daemon only) target a specific receiver instance; userDataDir is a legacy compatibility field for existing subscriptions.
+                  description: Channel-specific metadata. appName is required so fresh agents always provide the bridge-daemon routing target; url is required for a2a-webhook; coalesceWindow is an optional override. instanceAddress + addressType (local bridge-daemon only) target a specific receiver instance; userDataDir is a legacy compatibility field for existing subscriptions.
                   required: [appName]
                   properties:
                     url:              {type: string}
                     coalesceWindow:   {type: integer, minimum: 0, maximum: 300}
                     daemonSocketPath: {type: string}
-                    adapter:          {type: string, enum: [osascript, tmux]}
+                    adapter:          {type: string, enum: [osascript, tmux, codex-app-server]}
                     appName:          {type: string}
                     instanceAddress:  {type: string, nullable: true}
                     addressType:      {type: string, enum: [userDataDir, pid, tmuxSession, webhookUrl], nullable: true}

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -687,6 +687,86 @@ test.describe('Wake Daemon', () => {
         expect(finalDigest).not.toContain('priority: normal');
     });
 
+    test('delivers Codex wake events via app-server adapter without osascript fallback (#13067)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-app-server';
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'codex-app-server',
+                appName       : 'Codex',
+                coalesceWindow: 1
+            }
+        });
+
+        const binDir               = path.join(DAEMON_DIR, 'bin');
+        const mockCodexPath        = path.join(binDir, 'codex');
+        const mockCodexOutPath     = path.join(DAEMON_DIR, 'mock_codex_appserver_out.json');
+        const mockOsascriptPath    = path.join(binDir, 'osascript');
+        const mockOsascriptOutPath = path.join(DAEMON_DIR, 'mock_codex_appserver_osascript_out.json');
+
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
+        fs.writeFileSync(mockCodexPath,
+            `#!/usr/bin/env node\n` +
+            `const fs = require('fs');\n` +
+            `fs.writeFileSync(${JSON.stringify(mockCodexOutPath)}, JSON.stringify(process.argv.slice(2)));\n`
+        );
+        fs.chmodSync(mockCodexPath, 0o755);
+        fs.writeFileSync(mockOsascriptPath,
+            `#!/usr/bin/env node\n` +
+            `const fs = require('fs');\n` +
+            `fs.writeFileSync(${JSON.stringify(mockOsascriptOutPath)}, JSON.stringify(process.argv.slice(2)));\n`
+        );
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                CODEX_CLI_PATH    : mockCodexPath,
+                NEO_MEMORY_DB_PATH: DB_PATH,
+                NEO_AI_DAEMON_DIR : DAEMON_DIR,
+                PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+            }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver Codex app-server digest within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes(`[Wake Daemon] Delivered ${subId} via codex-app-server`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+                if (out.includes(`[Wake Daemon] Delivered ${subId} via osascript`)) {
+                    clearTimeout(timeout);
+                    reject(new Error('Daemon fell back to osascript for codex-app-server route'));
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {
+            agentId,
+            subject: 'Codex App Server Wake'
+        });
+
+        await deliveryPromise;
+
+        const args = JSON.parse(fs.readFileSync(mockCodexOutPath, 'utf8'));
+        expect(args.slice(0, 3)).toEqual(['debug', 'app-server', 'send-message-v2']);
+        expect(args.length).toBe(4);
+        expect(args[3]).toContain('[WAKE][priority:normal]');
+        expect(args[3]).toContain('Codex App Server Wake');
+        expect(fs.existsSync(mockOsascriptOutPath)).toBe(false);
+    });
+
     test('uses the highest coalesced message priority in the wake digest header and preserves divergent latest priority', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-priority';
@@ -1444,10 +1524,9 @@ test.describe('Wake Daemon', () => {
         // proves safe it needs a distinct implementation path (sequence primitive or
         // app-server route), NOT a `focusSeedKey: 'r'` opt-in.
         //
-        // This test is a defense-in-depth check: even if @neo-gpt's WAKE_SUBSCRIPTION is
-        // accidentally re-enabled (currently set to harnessTarget:'disabled' as an
-        // operator mitigation), the bridge refuses to send any osascript keystroke for a
-        // Codex subscription that lacks an explicit composer-focus primitive.
+        // This test is a defense-in-depth check: the bridge refuses to send any
+        // osascript keystroke for a Codex subscription that lacks an explicit
+        // composer-focus primitive.
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-fail-closed';
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -67,7 +67,7 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
             'tmuxSession',
             'url'
         ]));
-        expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux']);
+        expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server']);
         expect(metadata.properties.addressType.enum).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
     });
 

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -176,6 +176,7 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
               addMessageSchema   = zodToJsonSchema(buildZodSchema(doc, doc.paths['/mailbox/messages'].post), {target: 'openApi3', $refStrategy: 'none'}),
               listMessagesSchema = zodToJsonSchema(buildZodSchema(doc, doc.paths['/mailbox/messages'].get),  {target: 'openApi3', $refStrategy: 'none'}),
               wakeSchema         = zodToJsonSchema(buildZodSchema(doc, doc.paths['/wake-subscriptions/manage'].post), {target: 'openApi3', $refStrategy: 'none'}),
+              adapter            = wakeSchema.properties.harnessTargetMetadata.properties.adapter,
               coalesceWindow     = wakeSchema.properties.harnessTargetMetadata.properties.coalesceWindow;
 
         expect(addMessageSchema.properties.priority.enum).toEqual(['low', 'normal', 'high']);
@@ -188,6 +189,8 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(listMessagesSchema.properties.status.default).toBe('all');
         expect(listMessagesSchema.properties.limit.default).toBe(50);
         expect(listMessagesSchema.properties.offset.default).toBe(0);
+
+        expect(adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server']);
 
         expect(coalesceWindow.type).toBe('integer');
         expect(coalesceWindow.minimum).toBe(0);


### PR DESCRIPTION
Resolves #13067
Related: #13012

## Follow-ups
- #13077 — wake daemon delivery-failure watermark gating; linked as child of #13067

Authored by GPT-5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Routes normal Codex wake-daemon digest delivery through the Codex app-server control plane instead of the GUI paste path. The wake daemon now accepts `harnessTargetMetadata.adapter: 'codex-app-server'`, dispatches `codex debug app-server send-message-v2 <digest>`, and treats app-server dispatch failure as a hard delivery failure without silently falling back to `osascript`. The Memory Core OpenAPI contract also exposes the new adapter value.

Evidence: L2 (mock Codex CLI dispatch + OpenAPI schema validation + fail-closed unit coverage) -> L4 required (real Codex Desktop wake starts/steers a turn through app-server). Residual: operator-gated live Codex Desktop delivery validation [#13067].

## Deltas from ticket

- No `WakeSubscriptionService` code change was needed: this slice expands the public schema enum and daemon dispatch branch, while malformed adapter behavior remains covered by existing route validation surfaces.
- The implementation reuses the existing Codex app-server command-shape precedent from the lifecycle resume path but keeps wake-daemon digest delivery scoped to `ai/daemons/wake/daemon.mjs`.
- The prior bridge/osascript adapter paths remain unchanged.

## Test Evidence

- `node ai/scripts/setup/initServerConfigs.mjs --migrate-config`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 56/56 passed
- `git diff --check` -> passed
- Remote branch SHA verified after CI fix: `5780729e7`

## Post-Merge Validation

- [ ] Reconfigure the active `@neo-gpt` wake subscription to `harnessTargetMetadata.adapter: 'codex-app-server'`.
- [ ] Send a real A2A wake and verify Codex Desktop receives it through `codex debug app-server send-message-v2` and starts/steers a turn.
- [ ] If live delivery fails, revert the subscription to the prior bridge route and file a follow-up with the exact app-server failure evidence.

## Commits

- `aca13c288` — `fix(ai): route Codex wake via app-server (#13067)`
- `5780729e7` — `test(ai): include Codex wake adapter in tool contract (#13067)`

## Evolution

Initial publication was blocked by git HTTPS credential resolution in the temporary worktree. Live V-B-A showed `gh api user` authenticated as `neo-gpt` from the main checkout, so the branch was published from that context with a one-shot HTTP auth header instead of leaving the P0 wake fix stranded locally.

CI then surfaced a stale Memory Core tool-limit contract assertion that still expected only `osascript` and `tmux`. The follow-up commit updates that assertion to include `codex-app-server`, and the expanded focused suite passes 56/56.