### PR TITLE
refactor(memory-core): relocate healthcheck migration-census to an on-demand surface (#13074)

### DIFF
--- a/ai/scripts/maintenance/migrationCensusReport.mjs
+++ b/ai/scripts/maintenance/migrationCensusReport.mjs
@@ -1,0 +1,148 @@
+import 'dotenv/config';
+import {Command}       from 'commander';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+import {
+    Memory_GraphService as GraphService,
+    Memory_HealthService as HealthService,
+    Memory_LifecycleService
+} from '../../services.mjs';
+
+/**
+ * @summary On-demand Memory Core migration census (multi-tenant userId-tagging debt).
+ *
+ * Thin operator entrypoint over {@link HealthService#getMigrationCensus}. This lives in a script —
+ * NOT the healthcheck payload and NOT an MCP tool — because the ChromaDB-side count batch-scans the
+ * full memory + summary collections (`O(records)`, multi-second at scale), and because an MCP-tool
+ * response schema would load into every agent's context unconditionally. Run it when an operator
+ * wants the census; nothing pays the scan cost otherwise. The cheap SQLite graph counts are always
+ * included; `--chroma` opts into the slow ChromaDB metadata scan.
+ *
+ * @module ai/scripts/maintenance/migrationCensusReport
+ */
+
+/**
+ * @summary Build the Commander parser for the census runner.
+ * @returns {Command}
+ */
+function createArgParser() {
+    const program = new Command();
+
+    program
+        .name('ai:migration-census-report')
+        .description('On-demand Memory Core migration census (multi-tenant userId-tagging debt).')
+        .exitOverride()
+        .configureOutput({writeErr: () => {}, writeOut: () => {}})
+        .helpOption(false)
+        .allowExcessArguments(false)
+        .option('--chroma', 'Include the O(records) ChromaDB metadata scan (slow at scale).', false)
+        .option('--json', 'Emit the raw census JSON only.', false)
+        .option('-h, --help', 'Show help');
+
+    return program;
+}
+
+/**
+ * @summary Parse CLI argv for the census runner.
+ * @param {String[]} argv CLI argv slice.
+ * @returns {Object}
+ */
+export function parseArgs(argv) {
+    const program = createArgParser();
+
+    program.parse(argv, {from: 'user'});
+
+    const options = program.opts(),
+          args    = {includeChroma: options.chroma === true, json: options.json === true};
+
+    if (options.help) args.help = true;
+
+    return args;
+}
+
+/**
+ * @summary Format a migration census payload as a human-readable report.
+ * @param {Object} census The {@link HealthService#getMigrationCensus} payload.
+ * @returns {String}
+ */
+export function formatCensus(census) {
+    const g     = census.graph || {},
+          lines = [`[migrationCensusReport] measured ${census.measuredAt}`];
+
+    if (g.available === false) {
+        lines.push(`  SQLite graph: unavailable${g.error ? ` (${g.error})` : ''}`);
+    } else {
+        lines.push(`  SQLite untagged MEMORY  : ${g.memory}`);
+        lines.push(`  SQLite untagged SESSION : ${g.session}`);
+        lines.push(`  SQLite untagged total   : ${g.total}`);
+    }
+
+    if (census.chromadb) {
+        const c = census.chromadb;
+        if (c.available === false) {
+            lines.push(`  ChromaDB: unavailable${c.error ? ` (${c.error})` : ''}`);
+        } else {
+            lines.push(`  Chroma migration-debt total : ${c.total} (untagged ${c.untagged?.total ?? 0})`);
+        }
+    } else {
+        lines.push('  (Chroma scan omitted — rerun with --chroma for the O(records) scan)');
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * @summary Run the census against live Memory Core services and print it.
+ * @param {Object} options
+ * @param {Object} [options.healthService] HealthService singleton or test double.
+ * @param {Object} [options.graphService] GraphService singleton (mounts the SQLite graph) or double.
+ * @param {Object} [options.lifecycle] LifecycleService used to await readiness.
+ * @param {Boolean} [options.includeChroma=false] Run the O(records) ChromaDB metadata scan.
+ * @param {Boolean} [options.json=false] Emit raw JSON instead of the formatted report.
+ * @param {Object} [options.logger=console] Output sink.
+ * @returns {Promise<Object>} The census payload.
+ */
+export async function runReport({
+    healthService = HealthService,
+    graphService  = GraphService,
+    lifecycle     = Memory_LifecycleService,
+    includeChroma = false,
+    json          = false,
+    logger        = console
+} = {}) {
+    await lifecycle.ready();
+    await graphService.initAsync();
+
+    const census = await healthService.getMigrationCensus({includeChroma});
+
+    logger.log(json ? JSON.stringify(census, null, 2) : formatCensus(census));
+
+    return census;
+}
+
+function printHelp() {
+    console.log(createArgParser().helpInformation().trimEnd());
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.help) {
+        printHelp();
+        return {exitCode: 0};
+    }
+
+    const census = await runReport(args);
+
+    return {exitCode: census.graph?.available ? 0 : 1};
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+    main()
+        .then(({exitCode}) => process.exit(exitCode))
+        .catch(error => {
+            console.error('[migrationCensusReport] Fatal:', error);
+            process.exit(2);
+        });
+}

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1117,14 +1117,15 @@ class HealthService extends Base {
     }
 
     /**
-     * Computes the untagged-legacy-node counts for the multi-tenant migration observability
-     * surface. Operators scrape `healthcheck.migration.untaggedCount.total` to track
+     * Computes the untagged-legacy-node counts for the multi-tenant migration census. Reached via
+     * the on-demand `getMigrationCensus()` (the `ai:migration-census-report` script) — NOT the
+     * healthcheck (the census was relocated off the hot path). Operators read `graph.total` to track
      * how much pre-tenant-aware-era data remains as natural query patterns move writes toward
      * 100% tagged coverage. A zero total is the signal that defaults can be flipped from
      * `'legacy'` to `'private'` for the deployment.
      *
      * Implementation is pure SQLite aggregation via `GraphService.db.storage.db`. Two
-     * `COUNT(*)` queries (one per tracked node label), negligible cost per healthcheck.
+     * `COUNT(*)` queries (one per tracked node label), negligible cost.
      * Filters for `userId` absent OR empty in the node's `properties` JSON.
      *
      * Returns `{available: false, ...zeros}` when the SQLite graph is not yet mounted

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -1271,6 +1271,33 @@ class HealthService extends Base {
     }
 
     /**
+     * @summary On-demand migration census: SQLite graph untagged-userId counts, plus the
+     *          ChromaDB-side actionable migration-debt scan when `includeChroma` is set.
+     *
+     * Relocated off the healthcheck payload: the Chroma count batch-reads the full memory + summary
+     * collections (`#scanChromaMetadata`), an `O(records)` cost that should not run on every liveness
+     * probe. Operators run `ai:migration-census-report` (or call this) when they want the census;
+     * nothing pays the scan cost otherwise. The cheap SQLite graph counts are always included;
+     * `includeChroma` opts into the batch scan.
+     *
+     * @param {Object} [options]
+     * @param {Boolean} [options.includeChroma=false] Run the `O(records)` ChromaDB metadata scan.
+     * @returns {Promise<{graph: Object, chromadb: Object|undefined, measuredAt: String}>}
+     */
+    async getMigrationCensus({includeChroma = false} = {}) {
+        const census = {
+            graph     : await this.#checkMigrationState(),
+            measuredAt: new Date().toISOString()
+        };
+
+        if (includeChroma) {
+            census.chromadb = await this.#checkChromaMigrationState();
+        }
+
+        return census;
+    }
+
+    /**
      * Resolves the live runtime freshness diagnostic for the attached Memory Core MCP process.
      *
      * A stale runtime is a warning, not a service outage: callers can still use healthy read
@@ -1416,7 +1443,6 @@ class HealthService extends Base {
             },
             mailboxPreview: await MailboxService.getHealthcheckPreview(),
             identity : buildIdentityBlock(this.#stdioIdentityState),
-            migration: await this.#checkMigrationState(),
             providers: {
                 embedding: buildEmbeddingProviderBlock(aiConfig),
                 summary  : buildSummaryProviderBlock(aiConfig),
@@ -1438,14 +1464,6 @@ class HealthService extends Base {
             payload.details.push(connectionCheck.error);
             return payload;
         }
-
-        // Step 1.5: ChromaDB-side migration observability.
-        // MUST run AFTER #checkDatabaseConnections so `ChromaManager.connected` is established.
-        // Earlier ordering (initialized at payload-construction time) cached `available: false`
-        // on cold-process healthchecks even when the same payload reported `database.connected: true`.
-        // This ordering keeps the migration counters consistent with the connection status
-        // surfaced in the same payload.
-        payload.migration.chromadb = await this.#checkChromaMigrationState();
 
         // Step 2: Check collections
         const collectionsCheck = await this.#checkCollections();

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -404,7 +404,7 @@ Without these normalizations, `GraphService.linkNodes`' FK-style guard would sil
 - `ai/scripts/seedAgentIdentities.mjs` — AgentIdentity node seed script (#10144)
 - `learn/agentos/tooling/Authorization.md` — Server Authorization overview
 - `learn/agentos/tooling/MemoryCoreMcpApi.md` — Memory Core tool surface
-- `learn/agentos/tooling/MultiTenantMigrationGuide.md` — #10017 lazy-tag-on-read migration design; `memorySharing` flag semantics; `healthcheck.migration.untaggedCount` operator guidance
+- `learn/agentos/tooling/MultiTenantMigrationGuide.md` — #10017 lazy-tag-on-read migration design; `memorySharing` flag semantics; on-demand migration-census operator guidance (`ai:migration-census-report`)
 
 ## Related Tickets
 

--- a/learn/agentos/tooling/MultiTenantMigrationGuide.md
+++ b/learn/agentos/tooling/MultiTenantMigrationGuide.md
@@ -64,48 +64,46 @@ This is a deliberate architectural choice, not a temporary state. The absence of
 
 The `memorySharing` default flips from `'legacy'` to `'private'` when operators decide the untagged-surface-area has shrunk enough that default-legacy semantics no longer match the deployment's tenant-awareness expectations. Signals that guide the flip:
 
-- **`healthcheck.migration.untaggedCount` trending toward zero** — observability surface shipped in point 5 below. Operators watch the trend and decide based on their deployment's write volume and legacy-data relevance.
+- **The migration-census untagged total trending toward zero** — the on-demand observability surface in point 5 below (`npm run ai:migration-census-report`). Operators watch the trend and decide based on their deployment's write volume and legacy-data relevance.
 - **Roadmap milestone** — the first real multi-user Memory Core deployment under `#9999` is a natural trigger for the flip on that deployment.
 
 The flip itself is config-gated (`aiConfig.memorySharing?.defaultPolicy` — pattern borrowed from `#10253`'s `mailbox.defaultReplyPolicy`). No hard cutoff of legacy reads. Legacy rows remain queryable forever via explicit `memorySharing: 'legacy'` even after the default flips.
 
-### 5. `healthcheck.migration.untaggedCount` observability
+### 5. Migration-census observability (on-demand)
 
-The Memory Core healthcheck surfaces a migration status block:
+The migration census is an **on-demand** surface — run `npm run ai:migration-census-report` (or call `HealthService.getMigrationCensus({includeChroma})`). It was deliberately relocated off the healthcheck hot path: the Chroma-side count batch-scans the full collections, so it runs only when an operator asks for it, not on every liveness probe. The cheap SQLite graph counts are always included; `--chroma` / `includeChroma` opts into the Chroma scan.
 
 ```json
 {
-  "migration": {
-    "untaggedCount": {
-      "memory":  <integer>,
-      "session": <integer>,
-      "total":   <integer>
-    },
+  "graph": {
+    "memory":  <integer>,
+    "session": <integer>,
+    "total":   <integer>,
     "available": true
-  }
+  },
+  "measuredAt": "<ISO-timestamp>"
 }
 ```
 
-Computed at healthcheck time via direct SQLite queries against `Nodes` table, filtering for `label IN ('MEMORY', 'SESSION')` with null or empty `userId` in properties JSON. Negligible cost (two `COUNT(*)` queries per healthcheck). Operators can scrape this field to track legacy-surface-area reduction over time as natural query-pattern shifts move writes toward 100% tagged coverage.
+The SQLite graph counts come from direct queries against the `Nodes` table, filtering for `label IN ('MEMORY', 'SESSION')` with null or empty `userId` in properties JSON (two `COUNT(*)` queries). Operators run the report to track legacy-surface-area reduction over time as natural query-pattern shifts move writes toward 100% tagged coverage.
 
-`available: false` is returned when the SQLite graph is not yet mounted (e.g., during pre-init healthchecks). This is a substrate-readiness signal, not a migration error.
+`graph.available: false` is returned when the SQLite graph is not yet mounted (e.g., during pre-init runs). This is a substrate-readiness signal, not a migration error.
 
 ## Operator Runbook
 
 ### Verifying a healthy migration baseline
 
-After upgrading to the post-#10017 substrate, run:
+After upgrading to the post-#10017 substrate, run the on-demand census:
 
 ```bash
-# Via MCP tool
-mcp call neo-mjs-memory-core.healthcheck
+npm run ai:migration-census-report
 ```
 
-Inspect the `migration` block. Healthy states:
+Inspect the census output. Healthy states:
 
-- `migration.untaggedCount.total: 0` with `available: true` → fully tagged; safe to flip default to `'private'` at any time.
-- `migration.untaggedCount.total > 0` with `available: true` → legacy surface area present; keep default at `'legacy'` or flip based on operator judgment (see Operational Window above).
-- `migration.available: false` → SQLite graph not yet mounted; retry after `GraphService.initAsync` completes.
+- `graph.total: 0` with `graph.available: true` → fully tagged; safe to flip default to `'private'` at any time.
+- `graph.total > 0` with `graph.available: true` → legacy surface area present; keep default at `'legacy'` or flip based on operator judgment (see Operational Window above).
+- `graph.available: false` → SQLite graph not yet mounted; retry after `GraphService.initAsync` completes.
 
 ### Flipping the default policy (post-migration)
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "ai:mcp-server-knowledge-base" : "node ./ai/mcp/server/knowledge-base/mcp-server.mjs",
         "ai:mcp-server-memory-core"    : "node ./ai/mcp/server/memory-core/mcp-server.mjs",
         "ai:mcp-server-neural-link"    : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
+        "ai:migration-census-report"   : "node ./ai/scripts/maintenance/migrationCensusReport.mjs",
         "ai:probe-keep-alive"          : "node ./ai/scripts/benchmark/keep-alive-probe.mjs",
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:prune-worktrees:dry-run"   : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run",

--- a/test/playwright/unit/ai/scripts/maintenance/migrationCensusReport.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/migrationCensusReport.spec.mjs
@@ -1,0 +1,83 @@
+import {setup} from '../../../../setup.mjs';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+
+const appName = 'MigrationCensusReportTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+
+test.describe('migrationCensusReport.mjs (#12768)', () => {
+    let mod;
+
+    test.beforeAll(async () => {
+        mod = await import('../../../../../../ai/scripts/maintenance/migrationCensusReport.mjs');
+    });
+
+    test('parseArgs defaults to the cheap SQLite census; --chroma + --json opt in', () => {
+        expect(mod.parseArgs([])).toEqual({includeChroma: false, json: false});
+        expect(mod.parseArgs(['--chroma', '--json'])).toEqual({includeChroma: true, json: true});
+    });
+
+    test('formatCensus renders the SQLite counts and flags the omitted Chroma scan', () => {
+        const out = mod.formatCensus({
+            graph     : {memory: 3, session: 2, total: 5, available: true},
+            measuredAt: '2026-06-13T07:00:00.000Z'
+        });
+
+        expect(out).toContain('SQLite untagged MEMORY  : 3');
+        expect(out).toContain('SQLite untagged total   : 5');
+        expect(out).toContain('--chroma');  // tells the operator the O(records) scan was skipped
+    });
+
+    test('formatCensus surfaces the Chroma debt when the scan was run', () => {
+        const out = mod.formatCensus({
+            graph     : {memory: 0, session: 0, total: 0, available: true},
+            chromadb  : {memory: 1, session: 2, total: 3, available: true, untagged: {total: 4}},
+            measuredAt: 'x'
+        });
+
+        expect(out).toContain('Chroma migration-debt total : 3');
+        expect(out).toContain('untagged 4');
+    });
+
+    test('formatCensus surfaces an unavailable graph', () => {
+        const out = mod.formatCensus({graph: {available: false, error: 'graph not mounted'}, measuredAt: 'x'});
+        expect(out).toContain('unavailable');
+    });
+
+    test('runReport awaits readiness, inits the graph, calls getMigrationCensus, and prints', async () => {
+        const calls  = [],
+              lines  = [],
+              census = {graph: {memory: 1, session: 0, total: 1, available: true}, measuredAt: 'x'};
+
+        const result = await mod.runReport({
+            lifecycle    : {ready: async () => { calls.push('ready'); }},
+            graphService : {initAsync: async () => { calls.push('init'); }},
+            healthService: {
+                getMigrationCensus: async opts => { calls.push(['census', opts.includeChroma]); return census; }
+            },
+            includeChroma: true,
+            json         : true,
+            logger       : {log: line => lines.push(line)}
+        });
+
+        expect(result).toBe(census);
+        // Readiness + graph init happen before the census query; the opt-in flag threads through.
+        expect(calls).toEqual(['ready', 'init', ['census', true]]);
+        expect(lines[0]).toContain('"memory": 1');  // --json emits raw payload
+    });
+});


### PR DESCRIPTION
## Summary

Relocates the Memory Core healthcheck's migration census **off the hot path** — the compute companion to #13069 / #13071's context-tax trim.

The healthcheck ran the census on every call: `#checkChromaMigrationState` → `#scanChromaMetadata` **batch-reads the full memory + summary Chroma collections** (`batchSize 2000`, ~17.9k records), an `O(records)` cost on a probe fired at boot, self-repair, and monitoring intervals. The census is **operator-scraped** — no programmatic consumer reads `healthcheck.migration` — so it doesn't belong on a liveness probe.

Mirrors the established on-demand pattern (`graphLifecycleReport.mjs` + `GraphService.getLifecycleCensus`):
- **`HealthService.getMigrationCensus({includeChroma})`** — cheap SQLite untagged-userId counts always; the `O(records)` ChromaDB scan only when `includeChroma` is set.
- **`ai/scripts/maintenance/migrationCensusReport.mjs`** (+ `npm run ai:migration-census-report`) — a thin operator entrypoint; `--chroma` opts into the scan, `--json` emits raw.
- **Removed** the `migration` field + the Step-1.5 `payload.migration.chromadb` mutation from `#performHealthCheck`. The private census methods + `buildChromaMigrationStats` remain (now reached via `getMigrationCensus`) — no logic lost, just relocated.

Resolves #13074. Refs #12768 (the `features.wake.gateReason` trim — a separate, debatable block — remains there).

Evidence: the healthcheck no longer batch-scans collections per call; **+259 / −9** across 4 files (the bulk is the new script + its spec).

## Test Evidence

- `npm run test-unit -- migrationCensusReport.spec.mjs HealthService.spec.mjs` → **66 passed (1.3s)**: the new script spec (parseArgs / formatCensus / runReport via injected doubles — 5 tests) + the existing HealthService spec (61) green, confirming the `migration`-field removal broke nothing (no spec asserted `payload.migration`).
- `git grep` confirms **zero** residual `payload.migration`; the private methods + `buildChromaMigrationStats` stay wired behind `getMigrationCensus`.

## Post-Merge Validation

- CI Linux unit run green.
- Live: `npm run ai:migration-census-report` (and `--chroma`) prints the census; a live MC `healthcheck` confirms `migration` is absent and the probe no longer batch-scans.

## Deltas from #13074

None — delivers the leaf's ACs exactly (`getMigrationCensus` + the script + npm wiring; field + batch-scan removed; private methods retained; specs green).

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace).
