### PR TITLE
feat(agentos): classify Neural Link tool tiers (#13064)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -2,11 +2,24 @@ openapi: 3.0.0
 info:
   title: Neo.mjs Neural Link MCP Server
   version: 1.0.0
+x-neo-harness-tool-projection:
+  defaultVisibleTiers:
+    - read
+  withheldUntilTopologicalLocking:
+    - write-locked
+  operatorOnlyTiers:
+    - admin
+  description: >
+    Harness-embedded agents receive read-tier Neural Link tools by default.
+    Write-locked tools are withheld until Topological Locking and explicit-target
+    semantics exist. Admin tools stay operator-only unless a later authorization
+    leaf grants them deliberately.
 paths:
   /health:
     post:
       summary: Health Check
       operationId: healthcheck
+      x-neo-tool-tier: read
       x-annotations:
         readOnlyHint: true
       description: |
@@ -39,6 +52,7 @@ paths:
     post:
       summary: Checks if a namespace exists in the current environment.
       operationId: check_namespace
+      x-neo-tool-tier: read
       x-handler: check_namespace
       requestBody:
         required: true
@@ -70,6 +84,7 @@ paths:
     post:
       summary: Find Instances
       operationId: find_instances
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Finds instances matching a set of properties.
@@ -113,6 +128,7 @@ paths:
     post:
       summary: Retrieves the loaded namespace tree from the runtime.
       operationId: get_namespace_tree
+      x-neo-tool-tier: read
       x-handler: get_namespace_tree
       requestBody:
         required: true
@@ -144,6 +160,7 @@ paths:
     post:
       summary: Get Instance Properties
       operationId: get_instance_properties
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves properties from a specific instance by its ID.
@@ -181,6 +198,7 @@ paths:
     post:
       summary: Get Computed Styles
       operationId: get_computed_styles
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the computed styles for a component.
@@ -221,6 +239,7 @@ paths:
     post:
       summary: Get Component DOM Rects
       operationId: get_dom_rect
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the DOM rectangles for one or more components.
@@ -263,6 +282,7 @@ paths:
     post:
       summary: Get DOM Event Listeners
       operationId: get_dom_event_listeners
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves detailed DOM event listeners for a specific component.
@@ -305,6 +325,7 @@ paths:
     post:
       summary: Get DOM Event Summary
       operationId: get_dom_event_summary
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves a high-level summary of the DomEvent manager state.
@@ -348,6 +369,7 @@ paths:
     post:
       summary: Get Component Tree
       operationId: get_component_tree
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the full component tree of the application.
@@ -385,6 +407,7 @@ paths:
     post:
       summary: Inspect Component Render Tree
       operationId: inspect_component_render_tree
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the render tree (VDOM/VNode) of a component.
@@ -438,6 +461,7 @@ paths:
     post:
       summary: Inspect Store
       operationId: inspect_store
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Inspects a specific data store.
@@ -482,6 +506,7 @@ paths:
     post:
       summary: List Stores
       operationId: list_stores
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Lists all active data stores.
@@ -515,6 +540,7 @@ paths:
     post:
       summary: Get Record
       operationId: get_record
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves a specific data record.
@@ -540,6 +566,7 @@ paths:
     post:
       summary: Inspect State Provider
       operationId: inspect_state_provider
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Inspects a specific state provider.
@@ -570,6 +597,7 @@ paths:
     post:
       summary: Modify State Provider
       operationId: modify_state_provider
+      x-neo-tool-tier: write-locked
       x-pass-as-object: true
       description: |
         Modifies the data of a specific state provider.
@@ -598,6 +626,7 @@ paths:
     post:
       summary: Get Drag State
       operationId: get_drag_state
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the state of the DragCoordinator.
@@ -626,6 +655,7 @@ paths:
     post:
       summary: Get Drag Trace
       operationId: get_drag_trace
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the recent drag-lifecycle traces recorded by SortZone (start geometry, per-move decisions, item switches, scroll activations, end resolution, grid lock verdicts).
@@ -657,6 +687,7 @@ paths:
     post:
       summary: Observe Motion
       operationId: observe_motion
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: Samples component and raw DOM-node client rects over a time window for rendered-geometry motion traces. Use during drag choreography or animation debugging; duration is clamped to 8000ms per call.
       tags: [Component]
@@ -707,6 +738,7 @@ paths:
     post:
       summary: Verify Component Consistency
       operationId: verify_component_consistency
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Diffs a container's three child-order surfaces — logical items, vdom child nodes, and the rendered DOM — reporting count, order, membership and duplicate mismatches.
@@ -740,6 +772,7 @@ paths:
     post:
       summary: Query Components
       operationId: query_component
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Finds components matching a set of properties (semantic query).
@@ -771,6 +804,7 @@ paths:
     post:
       summary: Query VDOM
       operationId: query_vdom
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Finds the first VDOM node matching a set of attributes (e.g. CSS classes).
@@ -804,6 +838,7 @@ paths:
     post:
       summary: Reload Page
       operationId: reload_page
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       description: |
         Reloads the application page.
@@ -836,6 +871,7 @@ paths:
     post:
       summary: Get Route History
       operationId: get_route_history
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the navigation history stack and current route information.
@@ -881,6 +917,7 @@ paths:
     post:
       summary: Set Route
       operationId: set_route
+      x-neo-tool-tier: write-locked
       x-pass-as-object: true
       description: |
         Navigates the application to a specific route (hash).
@@ -923,6 +960,7 @@ paths:
     post:
       summary: Manage WebSocket Server
       operationId: manage_connection
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       description: |
         Manages the WebSocket server connection (start/stop).
@@ -970,6 +1008,7 @@ paths:
     post:
       summary: Get Console Logs
       operationId: get_console_logs
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the console logs from the App Worker.
@@ -1017,6 +1056,7 @@ paths:
     post:
       summary: Get Worker Topology
       operationId: get_worker_topology
+      x-neo-tool-tier: read
       description: |
         Retrieves the topology of all connected App Workers.
 
@@ -1056,6 +1096,7 @@ paths:
     post:
       summary: Get Window Topology
       operationId: get_window_topology
+      x-neo-tool-tier: read
       description: |
         Retrieves the topology of all connected windows.
 
@@ -1093,6 +1134,7 @@ paths:
     post:
       summary: Set Instance Properties
       operationId: set_instance_properties
+      x-neo-tool-tier: write-locked
       x-pass-as-object: true
       description: |
         Sets properties on a specific instance by its ID.
@@ -1126,6 +1168,7 @@ paths:
     post:
       summary: Call Instance Method
       operationId: call_method
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       description: |
         Calls a method on a specific instance.
@@ -1166,6 +1209,7 @@ paths:
     post:
       summary: Highlight Component
       operationId: highlight_component
+      x-neo-tool-tier: write-locked
       x-pass-as-object: true
       description: |
         Highlights a component visually for debugging purposes.
@@ -1199,6 +1243,7 @@ paths:
     post:
       summary: Inspect Class
       operationId: inspect_class
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Inspects a Neo.mjs class to retrieve its **Rich Blueprint**.
@@ -1233,6 +1278,7 @@ paths:
     post:
       summary: Get Method Source
       operationId: get_method_source
+      x-neo-tool-tier: read
       x-pass-as-object: true
       description: |
         Retrieves the source code of a class method.
@@ -1275,6 +1321,7 @@ paths:
     post:
       summary: Patch Code
       operationId: patch_code
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       description: |
         Replaces a method implementation on a class prototype at runtime.
@@ -1319,6 +1366,7 @@ paths:
     post:
       summary: Manage Neo Config
       operationId: manage_neo_config
+      x-neo-tool-tier: admin
       x-pass-as-object: true
       description: |
         Manages the global Neo.config object (get/set).
@@ -1372,6 +1420,7 @@ paths:
     post:
       summary: Simulate DOM Event
       operationId: simulate_event
+      x-neo-tool-tier: write-locked
       x-pass-as-object: true
       description: |
         Simulates a native DOM event on a specific component or a sequence of events.

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -86,6 +86,96 @@ function findSilentlyStrippingOpenBags(node, pathLabel = '') {
     return findings;
 }
 
+const neuralLinkToolTiers = ['read', 'write-locked', 'admin'];
+
+const expectedNeuralLinkToolTiers = {
+    call_method                 : 'admin',
+    check_namespace              : 'read',
+    find_instances               : 'read',
+    get_component_tree           : 'read',
+    get_computed_styles          : 'read',
+    get_console_logs             : 'read',
+    get_dom_event_listeners      : 'read',
+    get_dom_event_summary        : 'read',
+    get_dom_rect                 : 'read',
+    get_drag_state               : 'read',
+    get_drag_trace               : 'read',
+    get_instance_properties      : 'read',
+    get_method_source            : 'read',
+    get_namespace_tree           : 'read',
+    get_record                   : 'read',
+    get_route_history            : 'read',
+    get_window_topology          : 'read',
+    get_worker_topology          : 'read',
+    healthcheck                  : 'read',
+    highlight_component          : 'write-locked',
+    inspect_class                : 'read',
+    inspect_component_render_tree: 'read',
+    inspect_state_provider       : 'read',
+    inspect_store                : 'read',
+    list_stores                  : 'read',
+    manage_connection            : 'admin',
+    manage_neo_config            : 'admin',
+    modify_state_provider        : 'write-locked',
+    observe_motion               : 'read',
+    patch_code                   : 'admin',
+    query_component              : 'read',
+    query_vdom                   : 'read',
+    reload_page                  : 'admin',
+    set_instance_properties      : 'write-locked',
+    set_route                    : 'write-locked',
+    simulate_event               : 'write-locked',
+    verify_component_consistency : 'read'
+};
+
+const neuralLinkDangerousReadForbidden = [
+    'call_method',
+    'highlight_component',
+    'manage_connection',
+    'manage_neo_config',
+    'modify_state_provider',
+    'patch_code',
+    'reload_page',
+    'set_instance_properties',
+    'set_route',
+    'simulate_event'
+];
+
+/**
+ * Reads OpenAPI operations by operationId.
+ * @param {object} doc Parsed OpenAPI document.
+ * @returns {Object<string, object>} Operation map.
+ */
+function getOperationsById(doc) {
+    const operations = {};
+
+    for (const [, pathItem] of Object.entries(doc.paths || {})) {
+        for (const [, op] of Object.entries(pathItem)) {
+            if (op?.operationId) {
+                operations[op.operationId] = op;
+            }
+        }
+    }
+
+    return operations;
+}
+
+/**
+ * Extracts Neural Link serviceMapping keys so OpenAPI tier metadata cannot drift from
+ * the callable server surface.
+ * @returns {string[]} Sorted serviceMapping operation ids.
+ */
+function getNeuralLinkServiceMappingKeys() {
+    const
+        toolServicePath = path.join(repoRoot, 'ai/mcp/server/neural-link/toolService.mjs'),
+        source          = fs.readFileSync(toolServicePath, 'utf8'),
+        match           = source.match(/const serviceMapping = \{([\s\S]*?)\n\};/);
+
+    expect(match, 'Could not locate neural-link serviceMapping object').toBeTruthy();
+
+    return [...match[1].matchAll(/^\s+([a-z0-9_]+)\s*:/gm)].map(item => item[1]).sort();
+}
+
 test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
     /**
      * Direct regression for https://github.com/neomjs/neo/issues/10064. Prior to the fix,
@@ -210,6 +300,50 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(queryType.description).toContain('`concept`');
         expect(querySchema.properties.type.enum).toEqual(expectedTypes);
         expect(askSchema.properties.type.enum).toEqual(expectedTypes);
+    });
+
+    test('neural-link declares the harness-visible projection policy (#13064)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
+            projection = doc['x-neo-harness-tool-projection'];
+
+        expect(projection, 'Missing x-neo-harness-tool-projection contract').toBeTruthy();
+        expect(projection.defaultVisibleTiers).toEqual(['read']);
+        expect(projection.withheldUntilTopologicalLocking).toEqual(['write-locked']);
+        expect(projection.operatorOnlyTiers).toEqual(['admin']);
+        expect(projection.description).toContain('Harness-embedded agents receive read-tier Neural Link tools by default');
+    });
+
+    test('neural-link classifies every operation into one harness tool tier (#13064)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
+            operations = getOperationsById(doc),
+            tiers      = Object.fromEntries(Object.entries(operations).map(([id, op]) => [id, op['x-neo-tool-tier']]));
+
+        const missing = Object.entries(tiers).filter(([, tier]) => tier === undefined).map(([id]) => id);
+        const invalid = Object.entries(tiers).filter(([, tier]) => tier !== undefined && !neuralLinkToolTiers.includes(tier));
+
+        expect(missing, `Neural Link operations missing x-neo-tool-tier:\n${missing.join('\n')}`).toEqual([]);
+        expect(invalid, `Invalid Neural Link x-neo-tool-tier values:\n${invalid.map(([id, tier]) => `${id}: ${tier}`).join('\n')}`).toEqual([]);
+        expect(tiers).toEqual(expectedNeuralLinkToolTiers);
+    });
+
+    test('neural-link mutation and admin operations cannot be tiered as read (#13064)', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
+            operations = getOperationsById(doc),
+            offenders  = neuralLinkDangerousReadForbidden.filter(id => operations[id]?.['x-neo-tool-tier'] === 'read');
+
+        expect(offenders, `Dangerous Neural Link operations mislabeled read:\n${offenders.join('\n')}`).toEqual([]);
+    });
+
+    test('neural-link OpenAPI operations stay aligned with serviceMapping keys (#13064)', () => {
+        const
+            doc          = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
+            operationIds = Object.keys(getOperationsById(doc)).sort(),
+            mappingIds   = getNeuralLinkServiceMappingKeys();
+
+        expect(operationIds).toEqual(mappingIds);
     });
 
     for (const server of servers) {


### PR DESCRIPTION
Resolves #13064
Related: #13056, #13012, #12984, #13037, #13049

Authored by GPT-5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Defines the Neural Link harness tool-surface contract by adding explicit operation-tier metadata to the Neural Link OpenAPI surface and static validation that keeps the contract complete. Embedded harness agents can now consume a graph-reviewable projection rule instead of inheriting the full developer-grade Neural Link surface by default or inventing private allowlists.

Evidence: L1 (static OpenAPI contract + validator coverage) -> L1 required (metadata/projection contract). No residuals.

## Deltas from ticket

- Encodes the source of authority directly in `ai/mcp/server/neural-link/openapi.yaml` with `x-neo-tool-tier: read | write-locked | admin` on all 37 Neural Link operations.
- Adds root `x-neo-harness-tool-projection` declaring:
  - `read`: default-visible to embedded harness agents.
  - `write-locked`: withheld until Topological Locking / explicit target semantics exist.
  - `admin`: explicit operator/admin-only.
- Classifies `observe_motion` as `read` based on bounded sampling behavior confirmed in the issue discussion.
- Classifies `call_method` as `admin` because the operation shape is unbounded and can invoke arbitrary methods.
- Adds static validation for projection policy presence, missing/invalid tiers, mutation/admin operations mislabeled as `read`, and OpenAPI `operationId` alignment with Neural Link `toolService` mappings.

## Test Evidence

- `node --check test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 30/30 passed
- `git diff --check` -> passed
- `git diff --cached --check` -> passed
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `7b46f9315 feat(agentos): classify neural-link tool tiers (#13064)`

## Post-Merge Validation

- [ ] Future Topological Locking / identity-bound transport leaves consume `x-neo-tool-tier` instead of creating private allowlists.
- [ ] If a later Neural Link operation needs a fourth tier, amend this contract and validator deliberately rather than bypassing the enum.

## Commits

- `7b46f9315` — `feat(agentos): classify neural-link tool tiers (#13064)`

## Evolution

The initial implementation was committed locally earlier but publication was blocked by git HTTPS credential resolution. After the current session restored a GitHub-compatible publish path, the branch was rebased onto current `origin/dev`, reverified, and published without content changes beyond the rebase SHA.
