### PR TITLE
docs(agentos): clarify stale dock restore (#13063)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -128,6 +128,14 @@ Optional item fields:
 - `closable`, `pinnable`, `movable`: UI policy hints. Defaults are adapter-defined.
 - `metadata`: JSON-only descriptive data. It must not contain DOM nodes, functions, secrets, PATs, or live component objects.
 
+### Stale Component References
+
+`componentRef` is a stable lookup key, not a guarantee that a live component instance or constructable blueprint still exists.
+
+When a rendering adapter cannot resolve `componentRef` to a live component, and cannot instantiate from `item.blueprint`, restore behavior is adapter-defined until a concrete renderer or persistence slice owns a stricter policy. The adapter must still fail non-silently: preserve the item record and its semantic placement long enough for validation, explicit user recovery, or an intentional close/remove operation.
+
+Allowed fallback shapes include a validation error tied to the item id or a recoverable placeholder pane. The adapter must not silently drop the item, synthesize live runtime references into persisted state, or rewrite the dock tree in a way that corrupts the saved layout. A future adapter may narrow this policy, but it must cite or update this contract rather than inventing incompatible restore semantics.
+
 ## Serializable vs Runtime State
 
 Persist:
@@ -202,6 +210,8 @@ The contract is deliberately JSON-first. A future renderer can project the model
 - `activeItemId` -> active card index derived from `items.indexOf(activeItemId)`
 
 The adapter must treat `componentRef` as the stable bridge between persisted layout and live component ownership. When no live component exists, the adapter may instantiate from `item.blueprint`; when a live component exists, it should move/re-parent the instance without destroying it, matching the existing dashboard and multi-window precedent.
+
+If neither a live component nor a valid `item.blueprint` exists, the adapter must follow the stale-component-reference policy above instead of silently dropping the item.
 
 ## Demand Validation
 


### PR DESCRIPTION
Resolves #13063
Related: #13030, #13061, #13062

Authored by GPT-5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Clarifies the dock-zone model contract for stale or unresolvable `componentRef` values. Restore remains adapter-defined until a renderer/persistence slice owns a stricter policy, but adapters must fail non-silently by preserving semantic item metadata and placement for validation, recovery, or explicit removal instead of corrupting or silently dropping saved layout state.

Evidence: L1 (static contract review + whitespace checks) -> L1 required (docs-contract ACs only). No residuals.

## Deltas from ticket

No scope expansion. The change stays in `learn/agentos/HarnessDockZoneModel.md` and does not prescribe renderer UI, drag-preview behavior, split/tab rendering, or persistence mechanics.

Decision Record impact: aligned-with ADR 0020.

## Test Evidence

- `git diff --check` -> passed
- `git diff --cached --check` -> passed
- Static contract review confirmed the serializable-vs-runtime boundary remains intact: no DOM/window/live instance/function/credential material added to persisted state.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `96557f46c docs(agentos): clarify stale dock restore (#13063)`.

## Post-Merge Validation

- [ ] First dock rendering/persistence adapter cites or follows the stale-`componentRef` policy instead of inventing incompatible restore behavior.

## Commits

- `96557f46c` — `docs(agentos): clarify stale dock restore (#13063)`

## Evolution

The docs-contract fix was committed locally earlier but branch publication was blocked by git HTTPS credential resolution. After the current session restored a GitHub-compatible publish path, the branch was verified fresh against current `origin/dev`, published, and opened without content changes.
