### PR TITLE
feat(ai): route GitHub notifications into heartbeat wakes (#12937)

### DIFF
--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -12,6 +12,7 @@ import {
     Memory_GraphService     as GraphService,
     Memory_LifecycleService as LifecycleService
 }                    from '../../../services.mjs';
+import {getWakeRelevantNotifications} from '../../../services/github-workflow/HealthService.mjs';
 import MailboxService from '../../../services/memory-core/MailboxService.mjs';
 import RequestContextService from '../../../mcp/server/shared/services/RequestContextService.mjs';
 import logger        from '../../../mcp/server/memory-core/logger.mjs';
@@ -59,6 +60,52 @@ const PUSH_CAPABLE_TARGETS     = Object.freeze(['mcp-notifications', 'a2a-webhoo
  */
 function heartbeatAlivePath() {
     return AiConfig.wakeDaemonHeartbeatAlivePath;
+}
+
+/**
+ * @summary Durable dedup state path for GitHub-notification heartbeat wakes.
+ *
+ * Reuses the wake-daemon data directory resolved by the existing heartbeat
+ * liveness path, avoiding a new config leaf while keeping the state alongside
+ * the other wake-delivery cursors.
+ * @returns {String}
+ */
+function githubNotificationWakeStatePath() {
+    return path.join(path.dirname(heartbeatAlivePath()), 'github-notification-wake-ids.json')
+}
+
+/**
+ * @summary Whether a git remote URL points at GitHub.
+ * @param {String} remoteUrl
+ * @returns {Boolean}
+ */
+function isGitHubRemoteUrl(remoteUrl = '') {
+    return /(?:^|@|\/\/)github\.com[:/][^/:\s]+\/[^/\s]+/.test(String(remoteUrl).trim())
+}
+
+/**
+ * @summary Builds a compact heartbeat-pulse payload for GitHub notification wake digests.
+ *
+ * The heartbeat-pulse GraphLog row has no JSON payload column, so source content rides inside the
+ * pulse id as URL-safe base64. The wake daemon decodes only this `github-notification.` prefix; all
+ * other heartbeat pulses keep their existing opaque UUID semantics.
+ * @param {Object[]} notifications Wake-relevant GitHub notification projections.
+ * @returns {String}
+ */
+function buildGitHubNotificationPulseId(notifications = []) {
+    const latest = notifications[notifications.length - 1] || {};
+    const json   = JSON.stringify({
+        source: 'github-notification',
+        count : notifications.length,
+        latest: {
+            id    : latest.id,
+            reason: latest.reason,
+            type  : latest.type,
+            title : latest.title,
+            url   : latest.url
+        }
+    });
+    return `github-notification.${Buffer.from(json).toString('base64url')}`
 }
 
 /**
@@ -251,7 +298,12 @@ class SwarmHeartbeatService extends Base {
      *        reality rather than by the Orchestrator process owner's env var.
      *   4. All-agent-idle detection via `checkAllAgentIdle.mjs` direct export.
      *      - allIdle=true + gate-open → `swarmWakeCooldown.mjs` direct export.
-     *   5. Per-identity 3-signal-decision-gated heartbeat-pulse emit. For each
+     *   5. GitHub notification wake-content ingestion. When the current workspace
+     *      is GitHub-backed, unread `mention` / `review_requested` notifications
+     *      are deduped by GitHub notification id and emitted once through the
+     *      same Shape B heartbeat-pulse transport. Non-GitHub deployments log and
+     *      no-op.
+     *   6. Per-identity 3-signal-decision-gated heartbeat-pulse emit. For each
      *      identity in `pulseIdentities`, query A2A activity
      *      timestamps + readiness sentinels + orchestrator-local backoff window,
      *      compose via `WakeDecisionService.decideWake({active, idle, ready})`, and
@@ -339,7 +391,12 @@ class SwarmHeartbeatService extends Base {
             }
         }
 
-        // Step 5: Per-identity 3-signal-decision-gated heartbeat-pulse emit.
+        // Step 5: GitHub notification wake-content ingestion. The notification
+        // source is gated by repo remote and deduped by GitHub notification id;
+        // it never mutates GitHub's own notification read/unread state.
+        await this.emitGitHubNotificationWakes(pulseIdentities);
+
+        // Step 6: Per-identity 3-signal-decision-gated heartbeat-pulse emit.
         // Replaces old push-capability bypass + token-economy gate + tmux-inject
         // with a unified Shape B emit path.
         // Wake = active AND idle AND ready (per WakeDecisionService.decideWake).
@@ -691,6 +748,132 @@ class SwarmHeartbeatService extends Base {
     }
 
     /**
+     * @summary Ingest GitHub mention/review-request notifications as once-per-id
+     * heartbeat wake signals.
+     *
+     * The GitHub notification feed belongs to the current local GitHub account, so
+     * this first slice maps it only to the configured primary `identity` when that
+     * identity is part of the current heartbeat target set. Multi-agent username
+     * routing is intentionally left out of this PR rather than guessing from
+     * maintainer handles.
+     *
+     * @param {String[]} pulseIdentities Identities active for this heartbeat pulse.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async emitGitHubNotificationWakes(pulseIdentities = []) {
+        const targetIdentity = this.identity;
+        if (!targetIdentity || !pulseIdentities.includes(targetIdentity)) {
+            logger.debug('[SwarmHeartbeatService] GitHub notification ingestion skipped: primary identity is not in pulse target set.');
+            return
+        }
+
+        if (!await this.hasGitHubRemote()) return;
+
+        const state = await this.readGitHubNotificationWakeState();
+        if (!state) return; // corrupt/unreadable state: fail closed to avoid wake storms
+
+        const notifications = await this.getGitHubNotifications();
+        if (notifications.length === 0) return;
+
+        const seenIds = new Set(Array.isArray(state[targetIdentity]) ? state[targetIdentity] : []);
+        const unseen  = notifications.filter(notification => !seenIds.has(notification.id));
+        if (unseen.length === 0) return;
+
+        const result = await WakeSubscriptionService.emitHeartbeatPulse({
+            targetIdentity,
+            pulseId: buildGitHubNotificationPulseId(unseen)
+        });
+        if (result?.status !== 'emitted') {
+            logger.info(`[SwarmHeartbeatService] GitHub notification wake skipped for ${targetIdentity}: heartbeat pulse ${result?.status || 'unknown'} (${result?.reason || 'no reason'}).`);
+            return
+        }
+
+        for (const notification of unseen) {
+            seenIds.add(notification.id)
+        }
+
+        state[targetIdentity] = [...seenIds].slice(-200);
+        await this.writeGitHubNotificationWakeState(state);
+
+        logger.info(`[SwarmHeartbeatService] GitHub notification wake emitted for ${targetIdentity}: ${unseen.length} new notification(s).`)
+    }
+
+    /**
+     * @summary Whether the current workspace is backed by a GitHub remote.
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async hasGitHubRemote() {
+        try {
+            const remoteUrl = await this.getGitRemoteUrl();
+            const enabled   = isGitHubRemoteUrl(remoteUrl);
+            if (!enabled) {
+                logger.info('[SwarmHeartbeatService] GitHub notification ingestion disabled: no GitHub remote detected.')
+            }
+            return enabled
+        } catch (err) {
+            logger.info(`[SwarmHeartbeatService] GitHub notification ingestion disabled: failed to resolve git remote (${err.message}).`);
+            return false
+        }
+    }
+
+    /**
+     * Test-stubbable seam over git remote detection.
+     * @returns {Promise<String>}
+     * @protected
+     */
+    async getGitRemoteUrl() {
+        return (await this.runCmd('git', ['config', '--get', 'remote.origin.url'])).trim()
+    }
+
+    /**
+     * Test-stubbable seam over GitHub notification fetch.
+     * @returns {Promise<Object[]>}
+     * @protected
+     */
+    async getGitHubNotifications() {
+        try {
+            const output = await this.runCmd('gh', ['api', 'notifications?participating=true']);
+            return getWakeRelevantNotifications(JSON.parse(output || '[]'))
+        } catch (err) {
+            logger.warn(`[SwarmHeartbeatService] GitHub notification fetch failed: ${err.message}`);
+            return []
+        }
+    }
+
+    /**
+     * @summary Reads durable GitHub notification wake-state.
+     * @returns {Promise<Object|null>} Object map, `{}` when missing, or null when malformed.
+     * @protected
+     */
+    async readGitHubNotificationWakeState() {
+        const statePath = githubNotificationWakeStatePath();
+        try {
+            const parsed = JSON.parse(await fs.readFile(statePath, 'utf8'));
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+            logger.error('[SwarmHeartbeatService] GitHub notification wake-state malformed; ingestion disabled for this pulse.');
+            return null
+        } catch (err) {
+            if (err.code === 'ENOENT') return {};
+            logger.error(`[SwarmHeartbeatService] Failed to read GitHub notification wake-state: ${err.message}`);
+            return null
+        }
+    }
+
+    /**
+     * @summary Persists durable GitHub notification wake-state.
+     * @param {Object} state
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async writeGitHubNotificationWakeState(state) {
+        const statePath = githubNotificationWakeStatePath();
+        await fs.mkdir(path.dirname(statePath), {recursive: true});
+        await fs.writeFile(statePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+    }
+
+    /**
      * Test-stubbable seam over the SDK GraphService database handle.
      * @returns {Object} better-sqlite3 database handle
      * @protected
@@ -949,4 +1132,4 @@ class SwarmHeartbeatService extends Base {
 
 export default Neo.setupClass(SwarmHeartbeatService);
 
-export {HEARTBEAT_LOCK_PATH, DEFAULT_POLL_INTERVAL_MS, heartbeatAlivePath};
+export {HEARTBEAT_LOCK_PATH, DEFAULT_POLL_INTERVAL_MS, heartbeatAlivePath, githubNotificationWakeStatePath, isGitHubRemoteUrl};

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -776,7 +776,9 @@ class SwarmHeartbeatService extends Base {
         const notifications = await this.getGitHubNotifications();
         if (notifications.length === 0) return;
 
-        const seenIds = new Set(Array.isArray(state[targetIdentity]) ? state[targetIdentity] : []);
+        const durableSeenIds = Array.isArray(state[targetIdentity]) ? state[targetIdentity] : [],
+              volatileSeenIds = this.getVolatileGitHubNotificationSeenIds(targetIdentity),
+              seenIds = new Set([...durableSeenIds, ...volatileSeenIds]);
         const unseen  = notifications.filter(notification => !seenIds.has(notification.id));
         if (unseen.length === 0) return;
 
@@ -794,9 +796,62 @@ class SwarmHeartbeatService extends Base {
         }
 
         state[targetIdentity] = [...seenIds].slice(-200);
-        await this.writeGitHubNotificationWakeState(state);
+        try {
+            await this.writeGitHubNotificationWakeState(state);
+            this.clearVolatileGitHubNotificationSeenIds(targetIdentity)
+        } catch (err) {
+            this.rememberVolatileGitHubNotificationSeenIds(targetIdentity, state[targetIdentity]);
+            logger.error(
+                `[SwarmHeartbeatService] Failed to persist GitHub notification wake-state after emitting for ${targetIdentity}; ` +
+                `retaining ids in process memory to avoid wake storms: ${err.message}`
+            )
+        }
 
         logger.info(`[SwarmHeartbeatService] GitHub notification wake emitted for ${targetIdentity}: ${unseen.length} new notification(s).`)
+    }
+
+    /**
+     * @summary Returns process-local GitHub notification ids retained after persist failures.
+     *
+     * Durable state is the source of truth. This fallback covers the post-emit /
+     * pre-persist failure window so a transient or persistent filesystem failure
+     * cannot re-emit the same GitHub notification on every heartbeat until the
+     * orchestrator restarts.
+     * @param {String} identity
+     * @returns {Set<String>}
+     * @protected
+     */
+    getVolatileGitHubNotificationSeenIds(identity) {
+        const map = this._volatileGitHubNotificationSeenIds;
+        return new Set(map?.get(identity) || [])
+    }
+
+    /**
+     * @summary Retains emitted GitHub notification ids in process memory after a persist failure.
+     * @param {String} identity
+     * @param {String[]} ids
+     * @returns {void}
+     * @protected
+     */
+    rememberVolatileGitHubNotificationSeenIds(identity, ids = []) {
+        if (!this._volatileGitHubNotificationSeenIds) {
+            this._volatileGitHubNotificationSeenIds = new Map()
+        }
+
+        const previous = this._volatileGitHubNotificationSeenIds.get(identity) || [],
+              merged   = [...new Set([...previous, ...ids].filter(Boolean))].slice(-200);
+
+        this._volatileGitHubNotificationSeenIds.set(identity, merged)
+    }
+
+    /**
+     * @summary Clears process-local GitHub notification ids once durable persist succeeds.
+     * @param {String} identity
+     * @returns {void}
+     * @protected
+     */
+    clearVolatileGitHubNotificationSeenIds(identity) {
+        this._volatileGitHubNotificationSeenIds?.delete(identity)
     }
 
     /**

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -416,9 +416,26 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
         case 'permission_granted':
             return {type: 'permission', scope: payload.scope, grantedBy: payload.grantedBy, logId};
         case 'heartbeat_pulse':
-            return {type: 'heartbeat', targetIdentity: payload.targetIdentity, pulseId: payload.pulseId, logId};
+            return {type: 'heartbeat', targetIdentity: payload.targetIdentity, pulseId: payload.pulseId, summary: decodeHeartbeatPulseSummary(payload.pulseId), logId};
         default:
             return null;
+    }
+}
+
+/**
+ * @summary Decodes optional content embedded in heartbeat-pulse ids.
+ * @param {String} pulseId
+ * @returns {Object|null}
+ */
+function decodeHeartbeatPulseSummary(pulseId = '') {
+    if (!pulseId.startsWith('github-notification.')) return null;
+    try {
+        const encoded = pulseId.slice('github-notification.'.length);
+        const parsed  = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+        if (parsed?.source !== 'github-notification') return null;
+        return parsed
+    } catch {
+        return null
     }
 }
 
@@ -650,7 +667,10 @@ async function flushSubscription(subId) {
     }
     if (heartbeats.length > 0) {
         const latest = heartbeats[heartbeats.length - 1];
-        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId})`;
+        const gitHubSummary = latest.summary?.source === 'github-notification'
+            ? `; latest GitHub ${latest.summary.latest?.reason || 'notification'}: "${latest.summary.latest?.title || latest.summary.latest?.id || 'untitled'}"${latest.summary.latest?.url ? ` (${latest.summary.latest.url})` : ''}`
+            : '';
+        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId}${gitHubSummary})`;
     }
 
     const digest = `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}`;

--- a/ai/services/github-workflow/HealthService.mjs
+++ b/ai/services/github-workflow/HealthService.mjs
@@ -24,6 +24,57 @@ const
     });
 
 /**
+ * GitHub notification reasons that should become active wake-content signals.
+ * `review_requested` is included alongside direct mentions because both are
+ * user-addressed GitHub notification primitives an agent must discover in-session.
+ * @type {String[]}
+ */
+export const GITHUB_WAKE_NOTIFICATION_REASONS = Object.freeze(['mention', 'review_requested']);
+
+/**
+ * @summary Projects a raw GitHub notification into the wake-safe shape shared by
+ * the health preview and swarm-heartbeat ingestion.
+ * @param {Object} notification Raw `gh api notifications` entry.
+ * @returns {Object}
+ */
+export function projectWakeNotification(notification = {}) {
+    return {
+        id    : notification.id,
+        reason: notification.reason,
+        type  : notification.subject?.type,
+        title : notification.subject?.title,
+        url   : notification.subject?.url
+    }
+}
+
+/**
+ * @summary Filters raw GitHub notifications down to wake-relevant reasons.
+ * @param {Object[]} notifications Raw `gh api notifications` payload.
+ * @returns {Object[]} Wake-safe projected notifications.
+ */
+export function getWakeRelevantNotifications(notifications = []) {
+    if (!Array.isArray(notifications)) return [];
+    return notifications
+        .filter(notification => GITHUB_WAKE_NOTIFICATION_REASONS.includes(notification?.reason))
+        .map(projectWakeNotification)
+        .filter(notification => notification.id)
+}
+
+/**
+ * @summary Builds the passive healthcheck preview from the same notification
+ * projection that the heartbeat lane consumes.
+ * @param {Object[]} notifications Raw `gh api notifications` payload.
+ * @returns {{unreadCount:Number,latest:Object[]}}
+ */
+export function buildNotificationPreview(notifications = []) {
+    const relevant = getWakeRelevantNotifications(notifications);
+    return {
+        unreadCount: relevant.length,
+        latest     : relevant.slice(0, 5)
+    }
+}
+
+/**
  * @summary Monitors and validates the GitHub CLI dependency for the MCP server.
  *
  * This service acts as a gatekeeper, ensuring that the GitHub CLI (`gh`) is properly
@@ -465,18 +516,7 @@ class HealthService extends Base {
             try {
                 const { stdout } = await execAsync("gh api 'notifications?participating=true'");
                 const notifications = JSON.parse(stdout);
-                const mentions = notifications.filter(n => n.reason === 'mention');
-
-                payload.notificationPreview = {
-                    unreadCount: mentions.length,
-                    latest: mentions.slice(0, 5).map(n => ({
-                        id: n.id,
-                        reason: n.reason,
-                        type: n.subject?.type,
-                        title: n.subject?.title,
-                        url: n.subject?.url
-                    }))
-                };
+                payload.notificationPreview = buildNotificationPreview(notifications);
             } catch (e) {
                 logger.warn(`[HealthService] Failed to fetch notifications for preview: ${e.message}`);
                 // Don't fail the healthcheck if notifications fail, just omit the preview

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -848,9 +848,10 @@ class WakeSubscriptionService extends Base {
      *
      * @param {Object} opts
      * @param {String} opts.targetIdentity AgentIdentity node id that should receive the pulse.
+     * @param {String} [opts.pulseId] Optional caller-owned pulse id payload.
      * @returns {Promise<Object>} Emission status and optional `logId`.
      */
-    async emitHeartbeatPulse({targetIdentity} = {}) {
+    async emitHeartbeatPulse({targetIdentity, pulseId} = {}) {
         if (!targetIdentity) throw new Error("Missing 'targetIdentity' parameter.");
 
         // Heartbeat pulses ride the existing bridge-daemon route; a dedicated
@@ -869,7 +870,7 @@ class WakeSubscriptionService extends Base {
             throw new Error('Cannot emit heartbeat pulse: GraphLog storage unavailable.');
         }
 
-        const entityId = this._createHeartbeatPulseEntityId(targetIdentity);
+        const entityId = this._createHeartbeatPulseEntityId(targetIdentity, pulseId);
         sqlite.prepare('INSERT INTO GraphLog(entity_id, entity_type) VALUES (?, ?)').run(entityId, this.heartbeatPulseEntityType);
 
         const logId = this._getEntityLogId(entityId);
@@ -1100,10 +1101,14 @@ class WakeSubscriptionService extends Base {
      * Creates the stable GraphLog entity id for a heartbeat pulse.
      * @protected
      * @param {String} targetIdentity AgentIdentity node id.
+     * @param {String} [pulseId] Optional caller-owned id payload. Must not contain `:`.
      * @returns {String} Encoded heartbeat pulse entity id.
      */
-    _createHeartbeatPulseEntityId(targetIdentity) {
-        return `${this.heartbeatPulseEntityPrefix}:${targetIdentity}:${crypto.randomUUID()}`;
+    _createHeartbeatPulseEntityId(targetIdentity, pulseId = crypto.randomUUID()) {
+        if (String(pulseId).includes(':')) {
+            throw new Error("Heartbeat pulse id must not contain ':'.")
+        }
+        return `${this.heartbeatPulseEntityPrefix}:${targetIdentity}:${pulseId}`;
     }
 
     /**

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -145,6 +145,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.checkAllAgentIdle  = async () => null;
         SwarmHeartbeatService.swarmWakeCooldown  = async () => {};
         SwarmHeartbeatService.emitGitHubNotificationWakes = async () => {};
+        delete SwarmHeartbeatService._volatileGitHubNotificationSeenIds;
         SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => [];
         SwarmHeartbeatService.runScriptJson      = async () => null;
         SwarmHeartbeatService.runScript          = async () => '';
@@ -173,6 +174,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.pollIntervalMs  = 5 * 60 * 1000;
         SwarmHeartbeatService.targetSource    = null;
         SwarmHeartbeatService.explicitTargets = null;
+        delete SwarmHeartbeatService._volatileGitHubNotificationSeenIds;
         delete SwarmHeartbeatService.getGraphDb;
     });
 
@@ -927,6 +929,32 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         await SwarmHeartbeatService.emitGitHubNotificationWakes(['@test']);
 
         expect(state).toEqual({});
+    });
+
+    test('emitGitHubNotificationWakes keeps emitted ids volatile when wake-state persist fails (#12937)', async () => {
+        applyDefaultStubs();
+        delete SwarmHeartbeatService.emitGitHubNotificationWakes;
+
+        const emitted = [];
+
+        SwarmHeartbeatService.getGitRemoteUrl = async () => 'https://github.com/acme/repo.git';
+        SwarmHeartbeatService.getGitHubNotifications = async () => [{id: 'ghn-1', reason: 'mention'}];
+        SwarmHeartbeatService.readGitHubNotificationWakeState  = async () => ({});
+        SwarmHeartbeatService.writeGitHubNotificationWakeState = async () => {
+            throw new Error('simulated persist failure')
+        };
+        WakeSubscriptionService.emitHeartbeatPulse = async ({targetIdentity, pulseId}) => {
+            emitted.push({targetIdentity, pulseId});
+            return {status: 'emitted', targetIdentity, pulseId}
+        };
+
+        await expect(SwarmHeartbeatService.emitGitHubNotificationWakes(['@test'])).resolves.toBeUndefined();
+        await expect(SwarmHeartbeatService.emitGitHubNotificationWakes(['@test'])).resolves.toBeUndefined();
+
+        // First pulse is delivered, then the failed persist is retained in process
+        // memory so a persistent fs failure cannot re-emit the same id every heartbeat.
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].targetIdentity).toBe('@test');
     });
 
     test('heartbeatAlivePath() reads AiConfig.wakeDaemonHeartbeatAlivePath verbatim (#11872)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs
@@ -70,6 +70,8 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
     let WakeSubscriptionService;
     let originalEmitHeartbeatPulse;
     let heartbeatAlivePath;
+    let githubNotificationWakeStatePath;
+    let isGitHubRemoteUrl;
     let GraphService;
     let originalLifecycleInit;
     let originalGraphServiceInit;
@@ -79,8 +81,10 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
 
     test.beforeAll(async () => {
         const swarmHeartbeatModule = await import('../../../../../../../ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs');
-        SwarmHeartbeatService = swarmHeartbeatModule.default;
-        heartbeatAlivePath    = swarmHeartbeatModule.heartbeatAlivePath;
+        SwarmHeartbeatService            = swarmHeartbeatModule.default;
+        heartbeatAlivePath               = swarmHeartbeatModule.heartbeatAlivePath;
+        githubNotificationWakeStatePath  = swarmHeartbeatModule.githubNotificationWakeStatePath;
+        isGitHubRemoteUrl                = swarmHeartbeatModule.isGitHubRemoteUrl;
 
         const wakeSubscriptionModule = await import('../../../../../../../ai/services/memory-core/WakeSubscriptionService.mjs');
         WakeSubscriptionService      = wakeSubscriptionModule.default;
@@ -140,6 +144,7 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         SwarmHeartbeatService.idleOutNudge       = async () => {};
         SwarmHeartbeatService.checkAllAgentIdle  = async () => null;
         SwarmHeartbeatService.swarmWakeCooldown  = async () => {};
+        SwarmHeartbeatService.emitGitHubNotificationWakes = async () => {};
         SwarmHeartbeatService.getWakeSubscriptionIdentities = async () => [];
         SwarmHeartbeatService.runScriptJson      = async () => null;
         SwarmHeartbeatService.runScript          = async () => '';
@@ -789,6 +794,141 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
         expect(capturedArgs[0]).toEqual(['@neo-gpt', 'mcp-notifications', 'a2a-webhook', 'bridge-daemon']);
     });
 
+    test('isGitHubRemoteUrl gates GitHub remotes without Neo-team coupling (#12937)', async () => {
+        expect(isGitHubRemoteUrl('git@github.com:some-org/some-repo.git')).toBe(true);
+        expect(isGitHubRemoteUrl('https://github.com/some-org/some-repo.git')).toBe(true);
+        expect(isGitHubRemoteUrl('git@gitlab.com:some-org/some-repo.git')).toBe(false);
+        expect(isGitHubRemoteUrl('/Users/example/local-repo')).toBe(false);
+        expect(isGitHubRemoteUrl('')).toBe(false);
+    });
+
+    test('getGitHubNotifications consumes the shared mention/review-request projection (#12937)', async () => {
+        applyDefaultStubs();
+        delete SwarmHeartbeatService.getGitHubNotifications;
+
+        SwarmHeartbeatService.runCmd = async () => JSON.stringify([{
+            id     : 'ghn-mention',
+            reason : 'mention',
+            subject: {type: 'Issue', title: 'Ping Euclid', url: 'https://api.github.com/repos/acme/repo/issues/1'}
+        }, {
+            id     : 'ghn-review',
+            reason : 'review_requested',
+            subject: {type: 'PullRequest', title: 'Review me', url: 'https://api.github.com/repos/acme/repo/pulls/2'}
+        }, {
+            id     : 'ghn-noise',
+            reason : 'subscribed',
+            subject: {type: 'Issue', title: 'Noise', url: 'https://api.github.com/repos/acme/repo/issues/3'}
+        }]);
+
+        const serviceProto = Object.getPrototypeOf(SwarmHeartbeatService);
+        const result       = await serviceProto.getGitHubNotifications.call(SwarmHeartbeatService);
+
+        expect(result).toEqual([{
+            id    : 'ghn-mention',
+            reason: 'mention',
+            type  : 'Issue',
+            title : 'Ping Euclid',
+            url   : 'https://api.github.com/repos/acme/repo/issues/1'
+        }, {
+            id    : 'ghn-review',
+            reason: 'review_requested',
+            type  : 'PullRequest',
+            title : 'Review me',
+            url   : 'https://api.github.com/repos/acme/repo/pulls/2'
+        }]);
+    });
+
+    test('emitGitHubNotificationWakes disables on non-GitHub remotes (#12937)', async () => {
+        applyDefaultStubs();
+        delete SwarmHeartbeatService.emitGitHubNotificationWakes;
+
+        let fetched = false;
+        const emitted = [];
+
+        SwarmHeartbeatService.getGitRemoteUrl = async () => 'git@gitlab.com:acme/repo.git';
+        SwarmHeartbeatService.getGitHubNotifications = async () => {
+            fetched = true;
+            return [{id: 'ghn-1', reason: 'mention'}]
+        };
+        WakeSubscriptionService.emitHeartbeatPulse = async ({targetIdentity}) => {
+            emitted.push(targetIdentity);
+            return {status: 'emitted'}
+        };
+
+        await SwarmHeartbeatService.emitGitHubNotificationWakes(['@test']);
+
+        expect(fetched).toBe(false);
+        expect(emitted).toEqual([]);
+    });
+
+    test('emitGitHubNotificationWakes emits once per unseen GitHub notification id (#12937)', async () => {
+        applyDefaultStubs();
+        delete SwarmHeartbeatService.emitGitHubNotificationWakes;
+
+        let state = {};
+        const emitted = [];
+
+        SwarmHeartbeatService.getGitRemoteUrl = async () => 'https://github.com/acme/repo.git';
+        SwarmHeartbeatService.getGitHubNotifications = async () => [{
+            id    : 'ghn-1',
+            reason: 'mention',
+            title : 'Ping Euclid'
+        }, {
+            id    : 'ghn-2',
+            reason: 'review_requested',
+            title : 'Review request'
+        }];
+        SwarmHeartbeatService.readGitHubNotificationWakeState  = async () => state;
+        SwarmHeartbeatService.writeGitHubNotificationWakeState = async (nextState) => {
+            state = JSON.parse(JSON.stringify(nextState))
+        };
+        WakeSubscriptionService.emitHeartbeatPulse = async ({targetIdentity, pulseId}) => {
+            emitted.push({targetIdentity, pulseId});
+            return {status: 'emitted', targetIdentity, pulseId, logId: emitted.length}
+        };
+
+        await SwarmHeartbeatService.emitGitHubNotificationWakes(['@test']);
+        await SwarmHeartbeatService.emitGitHubNotificationWakes(['@test']);
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].targetIdentity).toBe('@test');
+        expect(emitted[0].pulseId).toMatch(/^github-notification\./);
+        const summary = JSON.parse(Buffer.from(emitted[0].pulseId.slice('github-notification.'.length), 'base64url').toString('utf8'));
+        expect(summary).toMatchObject({
+            source: 'github-notification',
+            count : 2,
+            latest: {
+                id    : 'ghn-2',
+                reason: 'review_requested',
+                title : 'Review request'
+            }
+        });
+        expect(state['@test']).toEqual(['ghn-1', 'ghn-2']);
+    });
+
+    test('emitGitHubNotificationWakes leaves ids unconsumed when no wake route emits (#12937)', async () => {
+        applyDefaultStubs();
+        delete SwarmHeartbeatService.emitGitHubNotificationWakes;
+
+        let state = {};
+
+        SwarmHeartbeatService.getGitRemoteUrl = async () => 'git@github.com:acme/repo.git';
+        SwarmHeartbeatService.getGitHubNotifications = async () => [{id: 'ghn-1', reason: 'mention'}];
+        SwarmHeartbeatService.readGitHubNotificationWakeState  = async () => state;
+        SwarmHeartbeatService.writeGitHubNotificationWakeState = async (nextState) => {
+            state = JSON.parse(JSON.stringify(nextState))
+        };
+        WakeSubscriptionService.emitHeartbeatPulse = async ({targetIdentity}) => ({
+            status: 'skipped',
+            reason: 'no-active-bridge-daemon-subscription',
+            targetIdentity
+        });
+
+        await SwarmHeartbeatService.emitGitHubNotificationWakes(['@test']);
+
+        expect(state).toEqual({});
+    });
+
     test('heartbeatAlivePath() reads AiConfig.wakeDaemonHeartbeatAlivePath verbatim (#11872)', async () => {
         const original = AiConfig.wakeDaemonHeartbeatAlivePath;
 
@@ -803,6 +943,30 @@ test.describe('Neo.ai.daemons.SwarmHeartbeatService', () => {
             expect(heartbeatAlivePath()).toBe(overridePath);
         } finally {
             AiConfig.wakeDaemonHeartbeatAlivePath = original;
+        }
+    });
+
+    test('GitHub notification wake-state lives beside the heartbeat liveness file (#12937)', async () => {
+        const original = AiConfig.wakeDaemonHeartbeatAlivePath;
+        const tmpDir   = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-github-notification-state-'));
+
+        try {
+            AiConfig.wakeDaemonHeartbeatAlivePath = path.join(tmpDir, 'heartbeat.alive');
+            expect(githubNotificationWakeStatePath()).toBe(path.join(tmpDir, 'github-notification-wake-ids.json'));
+
+            applyDefaultStubs();
+            delete SwarmHeartbeatService.readGitHubNotificationWakeState;
+            delete SwarmHeartbeatService.writeGitHubNotificationWakeState;
+
+            const serviceProto = Object.getPrototypeOf(SwarmHeartbeatService);
+            await serviceProto.writeGitHubNotificationWakeState.call(SwarmHeartbeatService, {'@test': ['ghn-1']});
+
+            await expect(serviceProto.readGitHubNotificationWakeState.call(SwarmHeartbeatService)).resolves.toEqual({
+                '@test': ['ghn-1']
+            });
+        } finally {
+            AiConfig.wakeDaemonHeartbeatAlivePath = original;
+            await fs.rm(tmpDir, {recursive: true, force: true});
         }
     });
 

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -450,13 +450,24 @@ test.describe('Wake Daemon', () => {
 
         await new Promise(resolve => setTimeout(resolve, 1000));
 
-        const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
+        const pulseSummary = Buffer.from(JSON.stringify({
+            source: 'github-notification',
+            count : 1,
+            latest: {
+                id    : 'ghn-test-1',
+                reason: 'mention',
+                title : 'Ping Euclid',
+                url   : 'https://api.github.com/repos/neomjs/neo/issues/12937'
+            }
+        })).toString('base64url');
+        const pulseId = `HEARTBEAT_PULSE:${agentId}:github-notification.${pulseSummary}`;
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
 
         const output = await deliveryPromise;
         expect(output).toContain('[Wake Daemon Test Adapter] Delivered');
         expect(output).toContain('[WAKE][priority:normal]');
         expect(output).toContain('heartbeat pulses');
+        expect(output).toContain('latest GitHub mention: "Ping Euclid"');
         expect(output).not.toContain('new messages');
     });
 

--- a/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs
@@ -128,3 +128,55 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - runtimeFre
         expect(result.details).toContain('current gitHead unavailable: fixture');
     });
 });
+
+test.describe('Neo.ai.services.github-workflow.HealthService notification projection (#12937)', () => {
+    let buildNotificationPreview;
+    let getWakeRelevantNotifications;
+    let GITHUB_WAKE_NOTIFICATION_REASONS;
+
+    test.beforeAll(async () => {
+        ({
+            buildNotificationPreview,
+            getWakeRelevantNotifications,
+            GITHUB_WAKE_NOTIFICATION_REASONS
+        } = await import('../../../../../../ai/services/github-workflow/HealthService.mjs'));
+    });
+
+    test('wake notification projection includes mentions and review requests only', () => {
+        expect(GITHUB_WAKE_NOTIFICATION_REASONS).toEqual(['mention', 'review_requested']);
+
+        const notifications = [{
+            id     : 'ghn-mention',
+            reason : 'mention',
+            subject: {type: 'Issue', title: 'Mentioned', url: 'https://api.github.com/repos/acme/repo/issues/1'}
+        }, {
+            id     : 'ghn-review',
+            reason : 'review_requested',
+            subject: {type: 'PullRequest', title: 'Review requested', url: 'https://api.github.com/repos/acme/repo/pulls/2'}
+        }, {
+            id     : 'ghn-noise',
+            reason : 'subscribed',
+            subject: {type: 'Issue', title: 'Noise', url: 'https://api.github.com/repos/acme/repo/issues/3'}
+        }];
+
+        const relevant = getWakeRelevantNotifications(notifications);
+        expect(relevant).toEqual([{
+            id    : 'ghn-mention',
+            reason: 'mention',
+            type  : 'Issue',
+            title : 'Mentioned',
+            url   : 'https://api.github.com/repos/acme/repo/issues/1'
+        }, {
+            id    : 'ghn-review',
+            reason: 'review_requested',
+            type  : 'PullRequest',
+            title : 'Review requested',
+            url   : 'https://api.github.com/repos/acme/repo/pulls/2'
+        }]);
+
+        expect(buildNotificationPreview(notifications)).toEqual({
+            unreadCount: 2,
+            latest     : relevant
+        });
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Resolves #12937

This promotes GitHub mentions/review requests from a passive healthcheck preview into the heartbeat wake path. `HealthService` now owns a shared GitHub notification projection, `SwarmHeartbeatService` repo-gates and dedups unseen notification ids per identity, and the wake daemon renders a compact latest-notification summary from the Shape-B heartbeat pulse without creating A2A messages or mutating GitHub read state.

Evidence: L2 (unit-covered GitHub remote gate, notification projection, dedup state, heartbeat pulse summary encoding, and wake-daemon digest rendering) → L2 required (close-target ACs are contract/unit-verifiable in the sandbox). Residual: live GitHub mention delivery remains post-merge validation on a running bridge-daemon subscription.

## Deltas from ticket

- Kept `notificationPreview`, but routed it through the shared GitHub notification projection so it is no longer an orphan fetch/filter primitive.
- No OpenAPI/config-template change: the gate auto-detects GitHub remotes and stays disabled for non-GitHub/local remotes.
- Uses existing Shape-B heartbeat pulses with compact GitHub notification summary data encoded in the pulse id; the wake daemon decodes that summary for digest text.
- Multi-agent GitHub username mapping stays out of scope; the default delivery target is the configured heartbeat identity set, with ambiguous mapping left for a later overview layer.

## Test Evidence

- `node --check ai/services/memory-core/WakeSubscriptionService.mjs && node --check ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs && node --check ai/daemons/wake/daemon.mjs` passed.
- `git diff --check` passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/SwarmHeartbeatService.spec.mjs test/playwright/unit/ai/services/github-workflow/HealthService.spec.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs --workers=1` passed: 123/123.

## Post-Merge Validation

- [ ] On a GitHub-backed checkout with an active bridge-daemon subscription, trigger a real GitHub mention or review request and verify the wake digest names the latest GitHub reason, title, and URL.
- [ ] Re-run heartbeat after the same notification id and confirm it does not re-wake.
- [ ] Switch to a non-GitHub/local remote and confirm the GitHub notification source stays disabled/no-op.

## Contract Ledger

The implementation follows the #12937 Contract Ledger backfill posted on the issue before pickup, including the shared projection, GitHub remote gate, heartbeat injection point, durable dedup key, and no-OpenAPI-delta decision.

## Commits

- `6cae4e74b` — `feat(ai): route GitHub notifications into heartbeat wakes (#12937)`
