### PR TITLE
feat(dashboard): infer native popup reintegration (#13028)

### DIFF
--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -257,6 +257,33 @@ class DashboardSortZone extends SortZone {
     }
 
     /**
+     * @summary Returns a terminal detached popup item for geometry-only reintegration.
+     *
+     * Returns the detached terminal popup item represented by a native OS window.
+     * This is the source side of geometry-only titlebar drag reintegration.
+     * @param {String} windowId
+     * @returns {Object|null}
+     */
+    getNativeWindowDrag(windowId) {
+        let me = this;
+
+        if (!me.owner.detachedItems) {
+            return null
+        }
+
+        for (const [widgetName, detachedItem] of me.owner.detachedItems.entries()) {
+            if (detachedItem.windowId === windowId && detachedItem.terminalDrop && detachedItem.widget) {
+                return {
+                    draggedItem: detachedItem.widget,
+                    widgetName
+                }
+            }
+        }
+
+        return null
+    }
+
+    /**
      * Completes dashboard drag cleanup under the base drag-end latch.
      * @param {Object} data The drag end event data.
      */

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -20,6 +20,18 @@ class DragCoordinator extends Manager {
          */
         singleton: true,
         /**
+         * Minimum time a native popup must remain over a remote dashboard target before
+         * geometry-only reintegration can commit.
+         * @member {Number} nativeWindowDropDwellMs=450
+         */
+        nativeWindowDropDwellMs: 450,
+        /**
+         * Quiescence delay after the last native window-position update before committing
+         * a geometry-only drop. The browser has no mouseup during OS-titlebar drags.
+         * @member {Number} nativeWindowDropSettleMs=250
+         */
+        nativeWindowDropSettleMs: 250,
+        /**
          * @member {Map} sortZones=new Map()
          * @protected
          */
@@ -31,6 +43,187 @@ class DragCoordinator extends Manager {
      * @protected
      */
     activeTargetZone = null
+
+    /**
+     * @member {Map<String,Object>} nativeWindowDropCandidates=new Map()
+     * @protected
+     */
+    nativeWindowDropCandidates = new Map()
+
+    /**
+     * @summary Clears a pending geometry-only native window-drop candidate.
+     *
+     * Clears a pending geometry-only native window-drop candidate.
+     * @param {String} windowId
+     */
+    clearNativeWindowDropCandidate(windowId) {
+        let candidate = this.nativeWindowDropCandidates.get(windowId);
+
+        if (candidate) {
+            clearTimeout(candidate.timeoutId);
+            this.nativeWindowDropCandidates.delete(windowId)
+        }
+    }
+
+    /**
+     * @summary Commits an inferred native-titlebar popup drop into the remote dashboard path.
+     *
+     * Commits a conservative geometry-only native titlebar drop into the existing remote
+     * dashboard drop path. The popup is closed only after dwell/settle intent has been inferred.
+     * @param {String} windowId
+     * @param {Object} candidate
+     * @returns {Promise<void>}
+     */
+    async commitNativeWindowDrop(windowId, candidate) {
+        let me      = this,
+            current = me.nativeWindowDropCandidates.get(windowId);
+
+        if (!current || current !== candidate) {
+            return
+        }
+
+        me.nativeWindowDropCandidates.delete(windowId);
+
+        let {
+            draggedItem,
+            localX,
+            localY,
+            offsetX,
+            offsetY,
+            proxyRect,
+            sourceSortZone,
+            targetSortZone,
+            widgetName
+        } = candidate;
+
+        if (sourceSortZone.getNativeWindowDrag?.(windowId)?.draggedItem !== draggedItem) {
+            return
+        }
+
+        if (!targetSortZone.acceptsRemoteDrag(localX, localY)) {
+            return
+        }
+
+        await sourceSortZone.suspendWindowDrag(widgetName);
+
+        await targetSortZone.onRemoteDragMove({
+            draggedItem,
+            localX,
+            localY,
+            offsetX,
+            offsetY,
+            proxyRect
+        });
+
+        await targetSortZone.onRemoteDrop(draggedItem);
+        sourceSortZone.onRemoteDropOut(draggedItem);
+
+        if (me.activeTargetZone === targetSortZone) {
+            me.activeTargetZone = null
+        }
+    }
+
+    /**
+     * @summary Finds the terminal detached dashboard item represented by a native popup window.
+     *
+     * Finds the terminal detached dashboard item represented by a native popup window.
+     * @param {String} windowId
+     * @returns {Object|null}
+     */
+    getNativeWindowDragSource(windowId) {
+        let me = this;
+
+        for (const group of me.sortZones.values()) {
+            for (const sortZone of group.values()) {
+                let drag = sortZone.getNativeWindowDrag?.(windowId);
+
+                if (drag) {
+                    return {
+                        ...drag,
+                        sourceSortZone: sortZone
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Resolves a window at a point while excluding invalid native-titlebar targets.
+     *
+     * Resolves the first window at a global point while ignoring window ids that
+     * cannot be valid native-titlebar drop targets, especially the popup being moved.
+     * @param {Number} x
+     * @param {Number} y
+     * @param {Set<String>} excludedWindowIds
+     * @returns {String|null}
+     */
+    getWindowAtExcept(x, y, excludedWindowIds) {
+        let item = Window.items?.find(item => !excludedWindowIds.has(item.id) &&
+            item.outerRect?.intersects({bottom: y, right: x, x, y}));
+
+        return item ? item.id : null
+    }
+
+    /**
+     * @summary Resolves native popup geometry to a remote dashboard drop candidate.
+     *
+     * Resolves a native popup's current geometry to a remote dashboard drop candidate.
+     * @param {Object} data
+     * @param {String} data.windowId
+     * @param {Object} sourceDrag
+     * @returns {Object|null}
+     */
+    getNativeWindowDropCandidate(data, sourceDrag) {
+        let me             = this,
+            {sourceSortZone} = sourceDrag,
+            popupWindow    = Window.get(data.windowId),
+            popupRect      = popupWindow?.innerRect,
+            {sortGroup}    = sourceSortZone,
+            targetWindowId, targetSortZone, targetWindow, localX, localY, width, height;
+
+        if (!popupRect || !sortGroup) {
+            return null
+        }
+
+        localX = popupRect.x + popupRect.width  / 2;
+        localY = popupRect.y + popupRect.height / 2;
+
+        targetWindowId = me.getWindowAtExcept(localX, localY, new Set([data.windowId, sourceSortZone.windowId]));
+
+        if (!targetWindowId) {
+            return null
+        }
+
+        targetSortZone = me.sortZones.get(sortGroup)?.get(targetWindowId);
+        targetWindow   = Window.get(targetWindowId);
+
+        if (!targetSortZone || !targetWindow?.innerRect) {
+            return null
+        }
+
+        localX = localX - targetWindow.innerRect.x;
+        localY = localY - targetWindow.innerRect.y;
+
+        if (!targetSortZone.acceptsRemoteDrag(localX, localY)) {
+            return null
+        }
+
+        width  = popupRect.width;
+        height = popupRect.height;
+
+        return {
+            ...sourceDrag,
+            localX,
+            localY,
+            offsetX  : width  / 2,
+            offsetY  : height / 2,
+            proxyRect: new Rectangle(localX - width / 2, localY - height / 2, width, height),
+            targetSortZone,
+            targetWindowId
+        }
+    }
 
     /**
      * @param {Neo.draggable.container.SortZone} sourceSortZone
@@ -115,6 +308,57 @@ class DragCoordinator extends Manager {
     }
 
     /**
+     * @summary Handles geometry updates for native OS-titlebar popup reintegration.
+     *
+     * Consumes high-frequency window geometry updates for native OS-titlebar popup drags,
+     * where the browser does not emit pointer move/up events. A terminal detached popup
+     * reintegrates only after it remains over a remote dashboard target long enough to
+     * satisfy the settle/dwell intent contract.
+     * @param {Object} data
+     * @param {String} data.windowId
+     */
+    onWindowPositionChange(data) {
+        let me         = this,
+            {windowId} = data,
+            sourceDrag = me.getNativeWindowDragSource(windowId),
+            candidate, current, dwellRemaining, firstSeenAt, delay, now;
+
+        if (!sourceDrag) {
+            me.clearNativeWindowDropCandidate(windowId);
+            return
+        }
+
+        candidate = me.getNativeWindowDropCandidate(data, sourceDrag);
+
+        if (!candidate) {
+            me.clearNativeWindowDropCandidate(windowId);
+            return
+        }
+
+        now     = Date.now();
+        current = me.nativeWindowDropCandidates.get(windowId);
+
+        firstSeenAt = current?.targetSortZone === candidate.targetSortZone &&
+            current?.draggedItem === candidate.draggedItem
+                ? current.firstSeenAt
+                : now;
+
+        me.clearNativeWindowDropCandidate(windowId);
+
+        dwellRemaining = Math.max(0, me.nativeWindowDropDwellMs - (now - firstSeenAt));
+        delay          = Math.max(me.nativeWindowDropSettleMs, dwellRemaining);
+
+        candidate.firstSeenAt = firstSeenAt;
+        candidate.timeoutId   = setTimeout(() => {
+            me.commitNativeWindowDrop(windowId, candidate).catch(error => {
+                (Neo.logError || console.error)('Native window drop failed', error)
+            })
+        }, delay);
+
+        me.nativeWindowDropCandidates.set(windowId, candidate)
+    }
+
+    /**
      * Finalizes a dashboard window drag by either dropping into the active target
      * or leaving the source popup as the terminal drop state.
      * @param {Object} data
@@ -166,6 +410,12 @@ class DragCoordinator extends Manager {
 
             if (group.size === 0) {
                 me.sortZones.delete(sortGroup)
+            }
+        }
+
+        for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {
+            if (candidate.sourceSortZone === sortZone || candidate.targetSortZone === sortZone) {
+                me.clearNativeWindowDropCandidate(windowId)
             }
         }
     }

--- a/src/worker/App.mjs
+++ b/src/worker/App.mjs
@@ -812,6 +812,7 @@ class App extends Base {
     onWindowPositionChange({data}) {
         // Only available in shared workers
         Neo.manager.Window?.onWindowPositionChange(data);
+        Neo.manager.DragCoordinator?.onWindowPositionChange(data);
 
         this.fireMainViewsEvent('windowPositionChange', data)
     }

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -17,7 +17,8 @@ import InstanceManager from '../../../../../src/manager/Instance.mjs';
  * @summary Tests for Neo.draggable.dashboard.SortZone directional thresholds
  */
 test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () => {
-    let DashboardContainer, DashboardSortZone, Rectangle, realDragCoordinatorOnDragEnd, sortZone;
+    let DashboardContainer, DashboardSortZone, Rectangle, realDragCoordinatorOnDragEnd,
+        realDragCoordinatorOnWindowPositionChange, sortZone;
 
     test.beforeAll(async () => {
         const containerModule = await import('../../../../../src/dashboard/Container.mjs');
@@ -30,6 +31,7 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         Rectangle = rectModule.default;
 
         realDragCoordinatorOnDragEnd = Object.getPrototypeOf(Neo.manager.DragCoordinator).onDragEnd;
+        realDragCoordinatorOnWindowPositionChange = Object.getPrototypeOf(Neo.manager.DragCoordinator).onWindowPositionChange;
     });
 
     test.beforeEach(() => {
@@ -50,6 +52,25 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
     });
 
     test.afterEach(() => {
+        const DragCoordinator = Neo.manager?.DragCoordinator;
+
+        if (DragCoordinator?.nativeWindowDropCandidates) {
+            for (const candidate of DragCoordinator.nativeWindowDropCandidates.values()) {
+                clearTimeout(candidate.timeoutId)
+            }
+            DragCoordinator.nativeWindowDropCandidates.clear()
+        }
+        if (DragCoordinator) {
+            DragCoordinator.nativeWindowDropDwellMs  = 450;
+            DragCoordinator.nativeWindowDropSettleMs = 250;
+            DragCoordinator.sortZones = new Map();
+            delete DragCoordinator.onWindowPositionChange
+        }
+        if (Neo.manager?.Window) {
+            Neo.manager.Window.items = [];
+            Neo.manager.Window.map   = new Map()
+        }
+
         sortZone?.destroy();
     });
 
@@ -365,5 +386,175 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
 
         expect(dragEndCalls).toHaveLength(1);
         expect(sortZone.dragEndActive).toBe(false)
+    });
+
+    test('exposes only terminal detached popups as native window drag sources (#13028)', () => {
+        const
+            item          = {id: 'item1', reference: 'item1'},
+            detachedItems = new Map([
+                ['item1', {index: 0, terminalDrop: true,  widget: item, windowId: 'popup-item1'}],
+                ['item2', {index: 1, terminalDrop: false, widget: {id: 'item2'}, windowId: 'popup-item2'}]
+            ]),
+            mockOwner     = {
+                detachedItems
+            },
+            nativeSortZone = Object.create(DashboardSortZone.prototype);
+
+        nativeSortZone.owner = mockOwner;
+
+        expect(nativeSortZone.getNativeWindowDrag('popup-item1')).toEqual({
+            draggedItem: item,
+            widgetName : 'item1'
+        });
+        expect(nativeSortZone.getNativeWindowDrag('popup-item2')).toBe(null);
+        expect(nativeSortZone.getNativeWindowDrag('unknown')).toBe(null)
+    });
+
+    test('reintegrates terminal popup after native titlebar dwell/settle (#13028)', async () => {
+        const
+            DragCoordinator = Neo.manager.DragCoordinator,
+            WindowManager   = Neo.manager.Window,
+            item            = {id: 'item1', reference: 'item1'},
+            calls           = [],
+            sourceSortZone  = {
+                getNativeWindowDrag: windowId => windowId === 'popup-item1' ? {
+                    draggedItem: item,
+                    widgetName : 'item1'
+                } : null,
+                onRemoteDropOut   : draggedItem => calls.push({draggedItem, type: 'dropOut'}),
+                sortGroup         : 'dashboards',
+                suspendWindowDrag : widgetName => {
+                    calls.push({type: 'suspend', widgetName});
+                    return Promise.resolve()
+                },
+                windowId: 'source-window'
+            },
+            targetSortZone  = {
+                acceptsRemoteDrag: (x, y) => x >= 0 && y >= 0 && x <= 300 && y <= 300,
+                onRemoteDragMove : data => {
+                    calls.push({data, type: 'move'});
+                    return Promise.resolve()
+                },
+                onRemoteDrop: draggedItem => {
+                    calls.push({draggedItem, type: 'drop'});
+                    return Promise.resolve()
+                },
+                sortGroup: 'dashboards',
+                windowId : 'target-window'
+            };
+
+        Object.assign(DragCoordinator, {
+            nativeWindowDropDwellMs : 0,
+            nativeWindowDropSettleMs: 0,
+            onWindowPositionChange  : data => realDragCoordinatorOnWindowPositionChange.call(DragCoordinator, data),
+            sortZones               : new Map([['dashboards', new Map([
+                ['source-window', sourceSortZone],
+                ['target-window', targetSortZone]
+            ])]])
+        });
+
+        WindowManager.items = [
+            {
+                id       : 'popup-item1',
+                innerRect: new Rectangle(150, 150, 100, 80),
+                outerRect: new Rectangle(150, 130, 100, 100)
+            },
+            {
+                id       : 'target-window',
+                innerRect: new Rectangle(100, 100, 300, 300),
+                outerRect: new Rectangle(100, 100, 300, 300)
+            },
+            {
+                id       : 'source-window',
+                innerRect: new Rectangle(600, 100, 300, 300),
+                outerRect: new Rectangle(600, 100, 300, 300)
+            }
+        ];
+        WindowManager.map = new Map(WindowManager.items.map(item => [item.id, item]));
+
+        DragCoordinator.onWindowPositionChange({windowId: 'popup-item1'});
+
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        expect(calls.map(call => call.type)).toEqual(['suspend', 'move', 'drop', 'dropOut']);
+
+        const move = calls.find(call => call.type === 'move').data;
+
+        expect(move.draggedItem).toBe(item);
+        expect(move.localX).toBe(100);
+        expect(move.localY).toBe(90);
+        expect(move.proxyRect.width).toBe(100);
+        expect(move.proxyRect.height).toBe(80);
+        expect(DragCoordinator.nativeWindowDropCandidates.size).toBe(0)
+    });
+
+    test('clears native titlebar candidate when popup leaves before settle (#13028)', async () => {
+        const
+            DragCoordinator = Neo.manager.DragCoordinator,
+            WindowManager   = Neo.manager.Window,
+            item            = {id: 'item1', reference: 'item1'},
+            calls           = [],
+            sourceSortZone  = {
+                getNativeWindowDrag: windowId => windowId === 'popup-item1' ? {
+                    draggedItem: item,
+                    widgetName : 'item1'
+                } : null,
+                sortGroup        : 'dashboards',
+                suspendWindowDrag: () => {
+                    calls.push('suspend');
+                    return Promise.resolve()
+                },
+                windowId: 'source-window'
+            },
+            targetSortZone  = {
+                acceptsRemoteDrag: () => true,
+                onRemoteDragMove : () => {
+                    calls.push('move');
+                    return Promise.resolve()
+                },
+                onRemoteDrop: () => {
+                    calls.push('drop');
+                    return Promise.resolve()
+                },
+                sortGroup: 'dashboards',
+                windowId : 'target-window'
+            };
+
+        Object.assign(DragCoordinator, {
+            nativeWindowDropDwellMs : 0,
+            nativeWindowDropSettleMs: 50,
+            onWindowPositionChange  : data => realDragCoordinatorOnWindowPositionChange.call(DragCoordinator, data),
+            sortZones               : new Map([['dashboards', new Map([
+                ['source-window', sourceSortZone],
+                ['target-window', targetSortZone]
+            ])]])
+        });
+
+        WindowManager.items = [
+            {
+                id       : 'popup-item1',
+                innerRect: new Rectangle(150, 150, 100, 80),
+                outerRect: new Rectangle(150, 130, 100, 100)
+            },
+            {
+                id       : 'target-window',
+                innerRect: new Rectangle(100, 100, 300, 300),
+                outerRect: new Rectangle(100, 100, 300, 300)
+            }
+        ];
+        WindowManager.map = new Map(WindowManager.items.map(item => [item.id, item]));
+
+        DragCoordinator.onWindowPositionChange({windowId: 'popup-item1'});
+        expect(DragCoordinator.nativeWindowDropCandidates.size).toBe(1);
+
+        WindowManager.items[0].innerRect = new Rectangle(700, 700, 100, 80);
+        WindowManager.items[0].outerRect = new Rectangle(700, 680, 100, 100);
+
+        DragCoordinator.onWindowPositionChange({windowId: 'popup-item1'});
+
+        await new Promise(resolve => setTimeout(resolve, 70));
+
+        expect(calls).toEqual([]);
+        expect(DragCoordinator.nativeWindowDropCandidates.size).toBe(0)
     });
 });


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session unavailable in current Codex Desktop MCP context.

Resolves #13028

Implements the geometry-only native titlebar reintegration entry point for terminal dashboard popups. Window-position updates now flow from the App worker into `Neo.manager.DragCoordinator`; the coordinator identifies terminal detached popups, ignores the moving popup when resolving the target window underneath it, waits for a conservative dwell/settle intent window, then reuses the existing remote dashboard drag/drop path to close the popup and reinsert the live widget.

Evidence: L2 (focused unit coverage for terminal-popup source detection, popup-self target exclusion, dwell/settle commit, and leave-before-settle no-op) -> L4 required (real OS titlebar drag over browser/shell windows with visual slide-resort). Residual: manual/live host validation [#13028].

## Deltas from ticket

- The web-mode drop-intent mechanism is dwell + settle over a remote dashboard target, using the detached popup content rect center as the conservative intent point.
- Non-terminal detached popups are ignored, so ordinary in-app window dragging keeps using the existing DragCoordinator pointer stream.
- The target lookup explicitly excludes the popup being moved; otherwise the God View returns the popup itself before the underlying app window.
- The implementation reuses `onRemoteDragMove()` / `onRemoteDrop()` instead of adding a parallel reintegration path. In sandbox coverage the slide-resort contract is represented by the synthesized remote move immediately before drop; full visual continuity remains live-host validation.

## Contract Ledger Reconciliation

| Target Surface | Implemented Behavior | Evidence |
|---|---|---|
| `Neo.main.addon.WindowPosition` geometry stream | Existing `windowPositionChange` payload remains unchanged. `Neo.worker.App#onWindowPositionChange()` now forwards the updated geometry to `DragCoordinator` after `Window` refreshes the God View. | Unit path exercises `DragCoordinator` directly; no payload mutation. |
| `Neo.manager.Window` God View | `DragCoordinator` uses Window manager geometry and adds popup-self exclusion for native-titlebar target lookup. | `reintegrates terminal popup after native titlebar dwell/settle` covers underlying target selection. |
| Drop-intent inference | Commit is timer-gated by `nativeWindowDropDwellMs` and `nativeWindowDropSettleMs`; leaving the target clears the candidate. | `clears native titlebar candidate when popup leaves before settle`. |
| Existing popup -> pane pipeline | Terminal popup handoff calls source `suspendWindowDrag()`, target `onRemoteDragMove()`, target `onRemoteDrop()`, then source `onRemoteDropOut()`. | Focused unit call-order assertion. |

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `npm run test-unit -- test/playwright/unit/draggable/dashboard/SortZone.spec.mjs` -> 9/9 passed

## Post-Merge Validation

- [ ] In a SharedWorker browser app, terminal-drop a dashboard pane into a popup, drag the real OS titlebar over a connected dashboard, hold until dwell/settle, and verify the pane reintegrates.
- [ ] Move a terminal popup across a dashboard without settling over it and verify it remains detached.
- [ ] In Electron/shell mode, confirm move/moved events can feed the same App-worker geometry contract without changing the reintegration path.

## Commit

- `87d8c96a8` - `feat(dashboard): infer native popup reintegration (#13028)`
