### PR TITLE
docs(agentos): define dock preview state (#13086)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -8,6 +8,8 @@ This contract is the first concrete slice of the QT-grade docking line under the
 
 This document does not implement drag previews, split/tab rendering, layout persistence, or cross-window choreography. Those are follow-up leaves. This slice exists so those leaves do not invent incompatible object models.
 
+The preview-state section below records the follow-up drag-to-dock contract. It still defines data shape only: no renderer, event listener, persistence writer, or drag manager lives here.
+
 ## Existing Substrates
 
 The contract composes with these current Neo substrates:
@@ -141,6 +143,7 @@ Persist:
 Do not persist:
 
 - `DOMRect`, screen coordinates, hover rectangles, and preview overlays
+- `dockPreview` payloads, preview ids, rejection reasons, and placement hints
 - `windowId`, `appName`, `sourceSortZone`, `targetSortZone`, `currentIndex`, `draggedItem`
 - live `Neo.component.Base` instances
 - functions, controllers, event listeners, PATs, or harness credentials
@@ -177,10 +180,24 @@ Future drag-to-dock preview slices should listen to existing drag surfaces and p
 
 ```json
 {
+  "schema": "neo.harness.dockPreview.v1",
+  "previewId": "preview:strategy:main-tabs:tab-after:1",
   "itemId": "strategy",
-  "targetNodeId": "main-tabs",
-  "placement": "tab-after",
-  "index": 1
+  "source": {
+    "surface": "dashboard-sort-zone",
+    "sortZoneId": "left-workspace"
+  },
+  "target": {
+    "containerId": "workspace",
+    "nodeId": "main-tabs"
+  },
+  "placement": {
+    "kind": "tab-after",
+    "index": 1
+  },
+  "feedback": {
+    "state": "accepted"
+  }
 }
 ```
 
@@ -190,6 +207,56 @@ Future drag-to-dock preview slices should listen to existing drag surfaces and p
 - `DragCoordinator` keeps cross-window source/target arbitration.
 - `Window` keeps screen-coordinate to window-id lookup.
 - The dock model records the accepted workspace shape after the drop.
+
+## Preview State Contract
+
+`dockPreview` is the only transient payload a docking adapter should expose while a drag is in progress. It is produced by existing drag/sort/window signals and consumed by visual affordances or drop handlers. It is never serialized into the dock-zone model.
+
+Required fields:
+
+| Field | Meaning | Persistence |
+|---|---|---|
+| `schema` | Preview payload version, initially `neo.harness.dockPreview.v1`. | Runtime only. |
+| `previewId` | Stable-enough id for one hover frame or dwell window; useful for renderer diffing. | Runtime only. |
+| `itemId` | Stable dock item id from `items`. | Serializable only after a drop commits an operation. |
+| `source.surface` | Existing producer surface, e.g. `dashboard-sort-zone`, `drag-coordinator`, or `window-geometry`. | Runtime only. |
+| `source.sortZoneId` | Optional source sort-zone identity when the drag starts inside a dashboard zone. | Runtime only. |
+| `target.containerId` | Stable id for the dock workspace/container being hovered. | Runtime only unless a drop commits into that container. |
+| `target.nodeId` | Candidate dock-zone node id receiving the drop. | Runtime only until converted into an operation. |
+| `placement.kind` | Candidate intent: `edge-top`, `edge-right`, `edge-bottom`, `edge-left`, `split-before`, `split-after`, `tab-before`, `tab-after`, `tab-into`, or `rejected`. | Runtime only. |
+| `placement.orientation` | Required for split previews: `horizontal` or `vertical`. | Runtime only; accepted split operations persist orientation. |
+| `placement.ratio` | Optional normalized split preview ratio. | Runtime only; accepted split operations persist normalized sizes. |
+| `placement.index` | Optional tab or child insertion index. | Runtime only; accepted operations persist item order. |
+| `feedback.state` | `accepted` or `rejected`. | Runtime only. |
+| `feedback.reason` | Optional rejection reason such as `same-source`, `locked-target`, `invalid-node`, or `policy-denied`. | Runtime only. |
+
+Allowed producers:
+
+- `src/draggable/dashboard/SortZone.mjs` and base sort-zone drag lifecycle for in-window drags.
+- `src/manager/DragCoordinator.mjs` for cross-window or popup-to-pane arbitration.
+- `src/manager/Window.mjs` / `src/main/addon/WindowPosition.mjs` geometry when OS-window movement has no pointer events.
+
+Forbidden producers:
+
+- A new docking-specific pointer-event manager that bypasses the existing drag lifecycle.
+- Persisted hover rectangles or screen coordinates as blueprint data.
+- A private adapter allowlist that maps visual zones without referencing dock-zone node ids.
+
+Conversion rules on drop:
+
+| Preview placement | Semantic operation |
+|---|---|
+| `tab-before`, `tab-after`, `tab-into` | `addTab` or `moveItem` into the target `tabs` node. |
+| `split-before`, `split-after` | `splitNode` with the preview orientation and normalized sizes. |
+| `edge-top`, `edge-right`, `edge-bottom`, `edge-left` | `splitNode` or edge-zone insertion chosen by the adapter, then `normalizeTree`. |
+| `rejected` | No model mutation; the renderer clears the preview. |
+
+Consumer boundaries:
+
+- Rendering consumes `dockPreview` to draw edge/split/tab affordances.
+- Drop handling consumes `dockPreview` once, then converts it into a semantic operation.
+- Persistence consumes only the normalized dock-zone model after operations run.
+- Tests should prove preview-only fields disappear before serialization.
 
 ## Blueprint Compatibility
 
@@ -221,5 +288,13 @@ This contract satisfies the model-contract leaf when:
 - serializable fields are separated from drag/preview/window runtime state
 - a second independent use shape is named
 - no preview UI, persistence implementation, or split/tab rendering is bundled into this slice
+
+The preview-state follow-up satisfies its leaf when:
+
+- `dockPreview` covers edge targets, split orientation/ratio, tab placement, rejected targets, stable item identity, and target container identity
+- allowed producers are existing drag, sort-zone, drag-coordinator, and window-geometry signals
+- forbidden producers prevent a parallel docking drag system
+- preview-only fields are explicitly runtime-only and are not serialized
+- downstream consumers for rendering, drop handling, and persistence are named
 
 If a future PR introduces new `.mjs` files for this contract, it must run `structural-pre-flight` before choosing the destination.

--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -230,6 +230,8 @@ Required fields:
 | `feedback.state` | `accepted` or `rejected`. | Runtime only. |
 | `feedback.reason` | Optional rejection reason such as `same-source`, `locked-target`, `invalid-node`, or `policy-denied`. | Runtime only. |
 
+`feedback.state` is the canonical accept/reject verdict for a hover frame. `placement.kind = rejected` is reserved for hovers that do not have a meaningful candidate placement; otherwise the adapter should keep the candidate `placement.kind` and set `feedback.state = rejected` with a reason.
+
 Allowed producers:
 
 - `src/draggable/dashboard/SortZone.mjs` and base sort-zone drag lifecycle for in-window drags.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session unavailable in current Codex Desktop MCP context.

Resolves #13086
Related: #13012
Related: #13030
Related: #13061

Defines the drag-to-dock preview-state contract inside the existing Agent Harness dock-zone model document. The change expands `dockPreview` from a sketch into a runtime-only payload contract with required fields, allowed producers, forbidden parallel drag paths, conversion rules, consumer boundaries, and acceptance boundaries.

Evidence: L1 (static docs-contract diff + tree-json lint) -> L1 required (docs-only contract ACs). No residuals.

## Deltas from ticket

The implementation stays docs-only in `learn/agentos/HarnessDockZoneModel.md`. It does not introduce `.mjs` files, renderer code, persistence code, or split/tab container implementation.

Substrate note: this is an ordinary `learn/agentos` reference doc, not a turn-loaded rule/skill surface. The in-doc scope boundaries now state that the preview-state section defines data shape only and remains non-implementation substrate.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- `npm run ai:lint-tree-json`

## Post-Merge Validation

- [ ] Confirm #13086 auto-closes and remains linked under #13012.

## Commit

- `4e9a77c8e` - `docs(agentos): define dock preview state (#13086)`
