### PR TITLE
fix(orchestrator): arm miniSummary-backfill backoff on real per-id progress (#12943)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
+++ b/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
@@ -1,7 +1,7 @@
 /**
- * Backoff window after a `memory-summary-backfill` run completes without changing the selected
- * pending row window. This releases the exclusive-heavy lane for session summarization while keeping
- * the residual `AGENT_MEMORY` rows intact for later classification or recovery.
+ * Backoff window after a `memory-summary-backfill` run drains none of the rows it attempted.
+ * This releases the exclusive-heavy lane for session summarization + REM digestion while
+ * keeping the residual `AGENT_MEMORY` rows intact for later classification or recovery.
  *
  * @type {Number}
  */
@@ -67,49 +67,69 @@ export function getPendingMemorySummaryBackfillCount(db) {
 }
 
 /**
- * @summary Returns true when the scheduler is still seeing the same stuck pending window.
- * @param {String[]} left
- * @param {String[]} right
- * @returns {Boolean}
+ * Of a given id set, returns the subset still lacking `miniSummary` — the rows a run TRIED but did
+ * not drain.
+ *
+ * @summary Robust no-progress detection. Unlike {@link getPendingMemorySummaryBackfillJobs}
+ * (the shifting newest-N window), this checks the SPECIFIC ids a run attempted, so a fresh
+ * `miniSummary: NULL` arrival on a busy session cannot mask zero progress. Fail-soft: returns [].
+ * @param {Object} db SQLite database handle.
+ * @param {String[]} [ids=[]] Candidate ids (the rows a run attempted).
+ * @returns {String[]} The subset of `ids` still pending.
  */
-export function samePendingWindow(left = [], right = []) {
-    return left.length === right.length && left.every((id, index) => id === right[index]);
+export function getStillPendingMemorySummaryBackfillJobs(db, ids = []) {
+    if (!db?.prepare || !Array.isArray(ids) || ids.length === 0) {
+        return [];
+    }
+
+    try {
+        const placeholders = ids.map(() => '?').join(',');
+
+        return db.prepare(`
+            SELECT memory.id AS id
+            FROM Nodes memory
+            WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
+              AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
+              AND memory.id IN (${placeholders})
+        `).all(...ids).map(row => row.id).filter(Boolean);
+    } catch {
+        return [];
+    }
 }
 
 /**
- * Checks whether the persisted no-progress backoff still suppresses the current pending window.
+ * Checks whether the persisted no-progress backoff still suppresses the backfill.
  *
- * The backoff is intentionally tied to the concrete selected ids, not just to the global pending
- * count. If new memories arrive above the stuck residual, the window changes and the scheduler lets
- * the backfill run immediately.
- *
+ * @summary The backoff holds for its full window regardless of new arrivals. It was previously
+ * gated on a `samePendingWindow(noProgressPendingIds, pendingJobs)` check, but every agent
+ * turn's `add_memory` writes a fresh `miniSummary: NULL` row at the DESC top — shifting the window
+ * and letting the backfill bypass the backoff and re-fire every scheduler tick while the newest
+ * rows stayed un-summarizable. Holding the window IS the heavy-lane yield (AC3): session
+ * summarization + REM digestion run while the backfill backs off.
  * @param {Object} options
  * @param {Object} options.taskState Persisted task state for `memory-summary-backfill`.
- * @param {String[]} options.pendingJobs Current selected pending ids.
  * @param {Number} options.now Epoch ms.
  * @returns {Boolean}
  */
-export function isNoProgressBackoffActive({taskState = {}, pendingJobs = [], now = Date.now()} = {}) {
-    const untilMs = Number(taskState.noProgressBackoffUntilMs) || 0;
-
-    return untilMs > now && samePendingWindow(taskState.noProgressPendingIds || [], pendingJobs);
+export function isNoProgressBackoffActive({taskState = {}, now = Date.now()} = {}) {
+    return (Number(taskState.noProgressBackoffUntilMs) || 0) > now;
 }
 
 /**
- * Builds the success hook that records a bounded no-progress backoff when a child run exits
- * successfully but leaves the same pending window untouched.
+ * Builds the success hook that records a bounded no-progress backoff when a child run drains NONE
+ * of the rows it attempted.
  *
- * This deliberately does NOT mutate the memory rows. The state lives on the orchestrator task entry
- * and expires automatically, preserving possible valuable turns while preventing a tight
- * exclusive-heavy spin loop.
- *
+ * @summary "No progress" = zero of the attempted `pendingJobs` were summarized (re-queried by id),
+ * NOT "the newest-N window is byte-identical". The old window check armed only when no new
+ * `miniSummary: NULL` row had arrived — impossible on a busy session, so the backfill re-fired every
+ * tick. This does NOT mutate the memory rows; the state lives on the orchestrator task entry and
+ * expires automatically.
  * @param {Object} options
  * @param {Object} options.db SQLite database handle.
  * @param {Object} options.taskState Mutable task state object.
- * @param {String[]} options.pendingJobs Pending ids selected before the child ran.
- * @param {Number|null} options.totalPending Uncapped pending count before the child ran.
- * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn]
- * @param {Function} [options.getPendingMemorySummaryBackfillCountFn]
+ * @param {String[]} options.pendingJobs Pending ids selected before the child ran (the attempted set).
+ * @param {Number|null} options.totalPending Uncapped pending count before the child ran (logged reason).
+ * @param {Function} [options.getStillPendingMemorySummaryBackfillJobsFn] Test seam: still-pending subset.
  * @param {Function} [options.nowFn]
  * @param {Number} [options.backoffMs]
  * @returns {Function}
@@ -119,22 +139,24 @@ export function buildNoProgressBackoffHook({
     taskState = {},
     pendingJobs = [],
     totalPending,
-    getPendingMemorySummaryBackfillJobsFn  = getPendingMemorySummaryBackfillJobs,
-    getPendingMemorySummaryBackfillCountFn = getPendingMemorySummaryBackfillCount,
+    getStillPendingMemorySummaryBackfillJobsFn = getStillPendingMemorySummaryBackfillJobs,
     nowFn     = () => Date.now(),
     backoffMs = NO_PROGRESS_BACKOFF_MS
 } = {}) {
     return () => {
-        const afterJobs  = getPendingMemorySummaryBackfillJobsFn(db, {limit: pendingJobs.length || 50});
-        const afterCount = getPendingMemorySummaryBackfillCountFn(db);
-        const beforeCount = Number.isInteger(totalPending) ? totalPending : pendingJobs.length;
-        const stalled = afterCount === beforeCount && samePendingWindow(afterJobs, pendingJobs);
+        // Arm on REAL no-progress: did the run drain ANY of the rows it tried? Re-query the SPECIFIC
+        // attempted ids, so a fresh miniSummary:NULL arrival at the DESC top can't mask zero progress.
+        const stillStuck = pendingJobs.length > 0
+            ? getStillPendingMemorySummaryBackfillJobsFn(db, pendingJobs)
+            : [];
+        const noProgress = pendingJobs.length > 0 && stillStuck.length === pendingJobs.length;
 
-        if (stalled) {
+        if (noProgress) {
             const recordedAt = nowFn();
+            const backlog    = Number.isInteger(totalPending) ? totalPending : pendingJobs.length;
 
             taskState.noProgressBackoffUntilMs = recordedAt + backoffMs;
-            taskState.noProgressBackoffReason  = `no-progress:${beforeCount}`;
+            taskState.noProgressBackoffReason  = `no-progress:${backlog}`;
             taskState.noProgressBackoffAt       = new Date(recordedAt).toISOString();
             taskState.noProgressPendingIds      = [...pendingJobs];
             return;
@@ -189,8 +211,9 @@ export function buildMemorySummaryBackfillTrigger({pendingJobs = [], totalPendin
  */
 export function getDueTask({
     db,
-    getPendingMemorySummaryBackfillJobsFn  = getPendingMemorySummaryBackfillJobs,
-    getPendingMemorySummaryBackfillCountFn = getPendingMemorySummaryBackfillCount,
+    getPendingMemorySummaryBackfillJobsFn      = getPendingMemorySummaryBackfillJobs,
+    getPendingMemorySummaryBackfillCountFn     = getPendingMemorySummaryBackfillCount,
+    getStillPendingMemorySummaryBackfillJobsFn = getStillPendingMemorySummaryBackfillJobs,
     state = {},
     now = Date.now(),
     nowFn = () => Date.now(),
@@ -199,7 +222,7 @@ export function getDueTask({
     const pendingJobs = getPendingMemorySummaryBackfillJobsFn(db);
     const taskState   = state['memory-summary-backfill'] || {};
 
-    if (pendingJobs.length > 0 && isNoProgressBackoffActive({taskState, pendingJobs, now})) {
+    if (pendingJobs.length > 0 && isNoProgressBackoffActive({taskState, now})) {
         return null;
     }
 
@@ -214,8 +237,7 @@ export function getDueTask({
                 taskState,
                 pendingJobs,
                 totalPending,
-                getPendingMemorySummaryBackfillJobsFn,
-                getPendingMemorySummaryBackfillCountFn,
+                getStillPendingMemorySummaryBackfillJobsFn,
                 nowFn,
                 backoffMs
             })

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
@@ -4,9 +4,9 @@ import {
     buildMemorySummaryBackfillTrigger,
     getDueTask,
     getPendingMemorySummaryBackfillJobs,
+    getStillPendingMemorySummaryBackfillJobs,
     isNoProgressBackoffActive,
-    NO_PROGRESS_BACKOFF_MS,
-    samePendingWindow
+    NO_PROGRESS_BACKOFF_MS
 } from '../../../../../../../ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs';
 
 test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
@@ -65,35 +65,24 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
         });
     });
 
-    test('#12828: samePendingWindow pins ordered selected ids', () => {
-        expect(samePendingWindow(['mem-1', 'mem-2'], ['mem-1', 'mem-2'])).toBe(true);
-        expect(samePendingWindow(['mem-1', 'mem-2'], ['mem-2', 'mem-1'])).toBe(false);
-        expect(samePendingWindow(['mem-1'], ['mem-1', 'mem-2'])).toBe(false);
+    test('#12943: getStillPendingMemorySummaryBackfillJobs is fail-soft + empty-safe', () => {
+        expect(getStillPendingMemorySummaryBackfillJobs(null, ['a'])).toEqual([]);
+        expect(getStillPendingMemorySummaryBackfillJobs({prepare() { throw new Error('no table'); }}, ['a'])).toEqual([]);
+        expect(getStillPendingMemorySummaryBackfillJobs({prepare() {}}, [])).toEqual([]);
     });
 
-    test('#12828: active no-progress backoff suppresses the unchanged pending window only', () => {
+    test('#12943: active no-progress backoff holds for its full window regardless of new arrivals', () => {
         const taskState = {
             noProgressBackoffUntilMs: 20_000,
             noProgressPendingIds    : ['mem-1', 'mem-2']
         };
 
-        expect(isNoProgressBackoffActive({
-            taskState,
-            pendingJobs: ['mem-1', 'mem-2'],
-            now        : 10_000
-        })).toBe(true);
+        // Held while unexpired. The prior window-identity gate let a fresh miniSummary:NULL arrival
+        // shift the window and bypass this, re-firing the backfill every tick (the bug).
+        expect(isNoProgressBackoffActive({taskState, now: 10_000})).toBe(true);
 
-        expect(isNoProgressBackoffActive({
-            taskState,
-            pendingJobs: ['newer-mem', 'mem-1'],
-            now        : 10_000
-        })).toBe(false);
-
-        expect(isNoProgressBackoffActive({
-            taskState,
-            pendingJobs: ['mem-1', 'mem-2'],
-            now        : 20_000
-        })).toBe(false);
+        // Released once the window expires (strict >).
+        expect(isNoProgressBackoffActive({taskState, now: 20_000})).toBe(false);
     });
 
     test('#12828: getDueTask returns null while the same stuck window is backed off', () => {
@@ -111,8 +100,11 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
         })).toBeNull();
     });
 
-    test('#12828: getDueTask runs immediately when new pending work changes the backed-off window', () => {
-        const trigger = getDueTask({
+    test('#12943: getDueTask stays backed off even when new pending work arrives (no re-fire)', () => {
+        // The prior design ran immediately on any window change — but the newest arrivals are the
+        // un-summarizable head, so "run immediately" meant a re-fire every scheduler tick. The
+        // backoff now holds for its full window, yielding the heavy lane to session-summary + REM.
+        expect(getDueTask({
             db                                     : {},
             now                                    : 10_000,
             state                                  : {
@@ -123,26 +115,31 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
             },
             getPendingMemorySummaryBackfillJobsFn  : () => ['new-1', 'old-1'],
             getPendingMemorySummaryBackfillCountFn : () => 3334
+        })).toBeNull();
+    });
+
+    test('getDueTask returns a trigger carrying an onSuccess backoff hook when not backed off', () => {
+        const trigger = getDueTask({
+            db                                     : {},
+            getPendingMemorySummaryBackfillJobsFn  : () => ['mem-1', 'mem-2'],
+            getPendingMemorySummaryBackfillCountFn : () => 3334
         });
 
-        expect(trigger).toMatchObject({
-            taskName    : 'memory-summary-backfill',
-            reason      : 'pending-memory-minisummary:3334',
-            pendingCount: 2
-        });
+        expect(trigger).toMatchObject({taskName: 'memory-summary-backfill', pendingCount: 2});
         expect(typeof trigger.onSuccess).toBe('function');
     });
 
-    test('#12828: success hook records a bounded backoff when the selected window makes no progress', () => {
+    test('#12943: success hook arms the backoff when the run drains NONE of the attempted rows (a fresh row arriving is irrelevant)', () => {
         const taskState = {};
         const hook = buildNoProgressBackoffHook({
-            db                                     : {},
+            db                                         : {},
             taskState,
-            pendingJobs                            : ['mem-1', 'mem-2'],
-            totalPending                           : 3333,
-            nowFn                                  : () => 100_000,
-            getPendingMemorySummaryBackfillJobsFn  : () => ['mem-1', 'mem-2'],
-            getPendingMemorySummaryBackfillCountFn : () => 3333
+            pendingJobs                                : ['mem-1', 'mem-2'],
+            totalPending                               : 3333,
+            nowFn                                      : () => 100_000,
+            // Both attempted rows are STILL pending after the run = zero progress. A fresh new-3 may
+            // have landed at the DESC top — irrelevant; we re-query the specific attempted ids.
+            getStillPendingMemorySummaryBackfillJobsFn : () => ['mem-1', 'mem-2']
         });
 
         hook();
@@ -153,7 +150,7 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
         expect(taskState.noProgressPendingIds).toEqual(['mem-1', 'mem-2']);
     });
 
-    test('#12828: success hook clears stale backoff state once progress resumes', () => {
+    test('#12943: success hook clears the backoff when the run drains at least one attempted row', () => {
         const taskState = {
             noProgressBackoffUntilMs: 20_000,
             noProgressBackoffReason : 'no-progress:3333',
@@ -161,12 +158,12 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
             noProgressPendingIds    : ['mem-1', 'mem-2']
         };
         const hook = buildNoProgressBackoffHook({
-            db                                     : {},
+            db                                         : {},
             taskState,
-            pendingJobs                            : ['mem-1', 'mem-2'],
-            totalPending                           : 3333,
-            getPendingMemorySummaryBackfillJobsFn  : () => ['mem-3', 'mem-4'],
-            getPendingMemorySummaryBackfillCountFn : () => 3283
+            pendingJobs                                : ['mem-1', 'mem-2'],
+            totalPending                               : 3283,
+            // mem-1 drained (only mem-2 still pending) = real progress → clear any stale backoff.
+            getStillPendingMemorySummaryBackfillJobsFn : () => ['mem-2']
         });
 
         hook();


### PR DESCRIPTION
## Summary

The `memory-summary-backfill` no-progress backoff was **structurally un-armable** on a busy session — it re-fired every scheduler tick and held the exclusive heavy-maintenance lane, starving session summarization + REM digestion (operator-flagged: *"there should never be 1000s of repeating logs"*).

**Root cause:** both the arming (`buildNoProgressBackoffHook`) and the active-check (`isNoProgressBackoffActive`) keyed off window-**identity** (`samePendingWindow` over the newest-50 pending rows). Every agent turn's `add_memory` writes a fresh `miniSummary: NULL` row at the `DESC` top → the window shifts → the backoff could never arm (and once armed, was bypassed) while the newest rows stayed un-summarizable (`missingContent`). The escape hatch — window-change → run immediately — was the trap.

**Fix — decouple the backoff from window-identity:**
- New `getStillPendingMemorySummaryBackfillJobs(db, ids)` re-queries the **specific attempted ids**. Arm only when the run drained **none** of them (true zero-progress) — robust to new arrivals at the `DESC` top.
- `isNoProgressBackoffActive` now holds for the full window (`untilMs > now`). The hold **is** the heavy-lane yield: session summary + REM digestion run while the backfill backs off.

This reverses the window-coupling that #12828 intentionally introduced (and its tests encoded); this ticket identified that intent as the re-fire bug.

Resolves #12943

Evidence: 13/13 unit specs green, including the regression — a fresh `miniSummary: NULL` row arriving between runs no longer masks zero progress. Runtime path verified: `ai/daemons/orchestrator/scheduling/registry.mjs:6` imports `getDueTask` from the edited module and invokes it `{db, state, now}` (the added seam defaults), so the fix lands in production.

## Test Evidence

```
env -u NEO_AGENT_IDENTITY UNIT_TEST_MODE=true npx playwright test \
  test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs \
  -c test/playwright/playwright.config.unit.mjs
→ 13 passed (701ms)
```

New / updated coverage: per-id arm-on-zero-progress (even as a fresh row arrives), clear-on-partial-progress, full-window hold regardless of new arrivals, `getDueTask` stays-backed-off (no re-fire), and the new query's fail-soft / empty-safe paths.

## Post-Merge Validation

Watch the orchestrator logs: the `memory-summary-backfill` re-fire storm should stop — after a zero-progress run it backs off for `NO_PROGRESS_BACKOFF_MS` (10 min) — and session summarization + REM digestion should regain the heavy lane. `get_rem_pipeline_state` `recentCycles` should become non-empty as digestion un-starves.

## Deltas

- **Layer-2 (drain the embeddable backlog oldest-first / skip the un-summarizable head)** is a tracked follow-up, not in this PR. This change stops the re-fire degradation (the titled bug); the backlog-drain ordering carries a recency tradeoff that deserves its own ticket.
- **AC4** ("confirm embed-lag vs permanently-contentless for the `missingContent` head") is addressed by **reasoning, not sampling**: the backoff is correct under both hypotheses — embed-lag → a 10-min retry once content lands; permanently-contentless → a 10-min-interval retry, not a tight loop. Which one holds does not change the fix.

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace).
