### PR TITLE
fix(memory-core): exclude archived messages from unread counts (#13091)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1256,6 +1256,8 @@ class MailboxService extends Base {
      * me with `readAt` on the DELIVERY edge), and legacy broadcasts
      * (`SENT_TO AGENT:*` with the shared-read fallback when no `DELIVERED_TO`
      * edges exist). Mirrors `buildMailboxDelta`'s unread-count taxonomy exactly.
+     * Default counts exclude archived inbox messages, matching `listMessages`;
+     * opt in with `includeArchived: true` when a caller needs the persisted archive.
      *
      * **Outbox path:** count of `SENT_BY` edges from the caller's identity.
      * `status` filter is a no-op for outbox — outbox messages have per-recipient
@@ -1280,9 +1282,12 @@ class MailboxService extends Base {
      *   reads require `CAN_READ_INBOX_OF` permission, mirroring `listMessages`.
      * @param {String} [args.fromIdentity] Filter inbox messages by sender identity.
      *   Ignored for outbox (no inverse-of-sender semantic).
+     * @param {Boolean} [args.includeArchived=false] Include archived inbox messages.
+     *   Default excludes MESSAGE-level direct/legacy archives and DELIVERED_TO
+     *   per-recipient broadcast archives, matching `listMessages`.
      * @returns {Promise<{count: Number}>}
      */
-    async countMessages({ box = 'inbox', status = 'all', to, fromIdentity } = {}) {
+    async countMessages({ box = 'inbox', status = 'all', to, fromIdentity, includeArchived = false } = {}) {
         const me = RequestContextService.getAgentIdentityNodeId();
         if (!me) {
             throw new Error("Cannot count messages: no agent identity context bound.");
@@ -1321,6 +1326,14 @@ class MailboxService extends Base {
                 ? `AND json_extract(e.data, '$.properties.readAt') IS NOT NULL`
                 : '';
 
+        const messageArchivedAtClause = includeArchived
+            ? ''
+            : `AND json_extract(n.data, '$.properties.archivedAt') IS NULL`;
+
+        const edgeArchivedAtClause = includeArchived
+            ? ''
+            : `AND json_extract(e.data, '$.properties.archivedAt') IS NULL`;
+
         // Optional sender filter — applies to inbox only.
         const senderFilterSql = fromIdentity
             ? `AND EXISTS (SELECT 1 FROM Edges sb WHERE sb.source = n.id AND sb.type = 'SENT_BY' AND sb.target = ?)`
@@ -1350,6 +1363,7 @@ class MailboxService extends Base {
                       AND e.target = ?
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       ${messageReadAtClause}
+                      ${messageArchivedAtClause}
                       ${senderFilterSql}
 
                     UNION
@@ -1361,6 +1375,7 @@ class MailboxService extends Base {
                       AND e.target = ?
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       ${edgeReadAtClause}
+                      ${edgeArchivedAtClause}
                       ${senderFilterSql}
 
                     UNION
@@ -1372,6 +1387,7 @@ class MailboxService extends Base {
                       AND e.target = 'AGENT:*'
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       ${messageReadAtClause}
+                      ${messageArchivedAtClause}
                       ${senderFilterSql}
                       AND NOT EXISTS (
                           SELECT 1 FROM Edges de

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -77,7 +77,9 @@ function buildMailboxDelta() {
     try {
         // Unread-count: direct DMs still use MESSAGE.properties.readAt. Receipt-backed broadcasts use
         // per-recipient DELIVERED_TO.readAt edges; legacy broadcasts without DELIVERY edges keep
-        // the historical shared-read fallback. DISTINCT defends against duplicate edge rows.
+        // the historical shared-read fallback. Archived messages stay out of the default delta,
+        // matching MailboxService.listMessages' default inbox view. DISTINCT defends against
+        // duplicate edge rows.
         const unreadRow = sqlite.prepare(`
             WITH unread_messages AS (
                 SELECT n.id AS messageId
@@ -87,6 +89,7 @@ function buildMailboxDelta() {
                   AND e.target = ?
                   AND json_extract(n.data, '$.label') = 'MESSAGE'
                   AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND json_extract(n.data, '$.properties.archivedAt') IS NULL
 
                 UNION
 
@@ -97,6 +100,7 @@ function buildMailboxDelta() {
                   AND e.target = ?
                   AND json_extract(n.data, '$.label') = 'MESSAGE'
                   AND json_extract(e.data, '$.properties.readAt') IS NULL
+                  AND json_extract(e.data, '$.properties.archivedAt') IS NULL
 
                 UNION
 
@@ -107,6 +111,7 @@ function buildMailboxDelta() {
                   AND e.target = 'AGENT:*'
                   AND json_extract(n.data, '$.label') = 'MESSAGE'
                   AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND json_extract(n.data, '$.properties.archivedAt') IS NULL
                   AND NOT EXISTS (
                       SELECT 1 FROM Edges de
                       WHERE de.source = n.id AND de.type = 'DELIVERED_TO'
@@ -128,6 +133,7 @@ function buildMailboxDelta() {
                   AND e.target = ?
                   AND json_extract(n.data, '$.label') = 'MESSAGE'
                   AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND json_extract(n.data, '$.properties.archivedAt') IS NULL
 
                 UNION
 
@@ -138,6 +144,7 @@ function buildMailboxDelta() {
                   AND e.target = ?
                   AND json_extract(n.data, '$.label') = 'MESSAGE'
                   AND json_extract(e.data, '$.properties.readAt') IS NULL
+                  AND json_extract(e.data, '$.properties.archivedAt') IS NULL
 
                 UNION
 
@@ -148,6 +155,7 @@ function buildMailboxDelta() {
                   AND e.target = 'AGENT:*'
                   AND json_extract(n.data, '$.label') = 'MESSAGE'
                   AND json_extract(n.data, '$.properties.readAt') IS NULL
+                  AND json_extract(n.data, '$.properties.archivedAt') IS NULL
                   AND NOT EXISTS (
                       SELECT 1 FROM Edges de
                       WHERE de.source = n.id AND de.type = 'DELIVERED_TO'

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -105,6 +105,12 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
     });
 
+    function persistMessageNode(messageId) {
+        GraphService.db.storage.db.prepare(`
+            UPDATE Nodes SET data = ? WHERE id = ?
+        `).run(JSON.stringify(GraphService.db.nodes.get(messageId)), messageId);
+    }
+
     test('addMessage enforces identity and routes correctly', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
@@ -713,6 +719,80 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
     });
 
+    test('#13091: countMessages excludes archived direct-DMs by default', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let archivedId;
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            archivedId = (await MailboxService.addMessage({ to: '@bob', subject: 'done', body: 'body' })).messageId;
+            await MailboxService.addMessage({ to: '@bob', subject: 'still-open', body: 'body' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.archiveMessage({ messageId: archivedId });
+
+            const list = await MailboxService.listMessages({ box: 'inbox', status: 'unread' });
+            expect(list.messages.map(msg => msg.messageId)).not.toContain(archivedId);
+
+            const count = await MailboxService.countMessages({ box: 'inbox', status: 'unread' });
+            expect(count.count).toBe(list.messages.length);
+            expect(count.count).toBe(1);
+
+            const withArchived = await MailboxService.countMessages({
+                box            : 'inbox',
+                status         : 'unread',
+                includeArchived: true
+            });
+            expect(withArchived.count).toBe(2);
+
+            const preview = await MailboxService.getHealthcheckPreview();
+            expect(preview.unreadCount).toBe(1);
+            expect(preview.inbox.map(msg => msg.id)).not.toContain(archivedId);
+        });
+    });
+
+    test('#13091: countMessages excludes archived per-recipient broadcasts by default', async () => {
+        const
+            senderIdentity    = '@neo-mailbox-archive-broadcast-sender',
+            archivedIdentity  = '@neo-mailbox-archive-broadcast-recipient',
+            unreadIdentity    = '@neo-mailbox-archive-broadcast-unread';
+
+        GraphService.upsertNode({ id: senderIdentity,   type: 'AgentIdentity', name: 'ArchiveBroadcastSender',    properties: { accountType: 'agent' } });
+        GraphService.upsertNode({ id: archivedIdentity, type: 'AgentIdentity', name: 'ArchiveBroadcastRecipient', properties: { accountType: 'agent' } });
+        GraphService.upsertNode({ id: unreadIdentity,   type: 'AgentIdentity', name: 'ArchiveBroadcastUnread',    properties: { accountType: 'agent' } });
+
+        let messageId;
+
+        await RequestContextService.run({ agentIdentityNodeId: senderIdentity }, async () => {
+            messageId = (await MailboxService.addMessage({ to: 'AGENT:*', subject: 'broadcast done', body: 'body' })).messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: archivedIdentity }, async () => {
+            await MailboxService.archiveMessage({ messageId });
+
+            const list = await MailboxService.listMessages({ box: 'inbox', status: 'unread' });
+            expect(list.messages.map(msg => msg.messageId)).not.toContain(messageId);
+
+            const count = await MailboxService.countMessages({ box: 'inbox', status: 'unread' });
+            expect(count.count).toBe(0);
+
+            const withArchived = await MailboxService.countMessages({
+                box            : 'inbox',
+                status         : 'unread',
+                includeArchived: true
+            });
+            expect(withArchived.count).toBe(1);
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: unreadIdentity }, async () => {
+            const count = await MailboxService.countMessages({ box: 'inbox', status: 'unread' });
+            expect(count.count).toBe(1);
+        });
+    });
+
     test('#10148 AC1: archiveMessage rejects non-recipient (sender + third-party)', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
@@ -1235,12 +1315,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 // Persist the patched sentAt to SQLite so the SELECT json_extract(...) read
                 // matches. addMessage wrote the original sentAt; we patched the in-memory copy
                 // but still need to write that through.
-                GraphService.db.storage.db.prepare(`
-                    UPDATE Nodes SET data = ? WHERE id = ?
-                `).run(JSON.stringify(GraphService.db.nodes.get(first.messageId)),  first.messageId);
-                GraphService.db.storage.db.prepare(`
-                    UPDATE Nodes SET data = ? WHERE id = ?
-                `).run(JSON.stringify(GraphService.db.nodes.get(second.messageId)), second.messageId);
+                persistMessageNode(first.messageId);
+                persistMessageNode(second.messageId);
             });
 
             const delta = await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, () => {
@@ -1253,6 +1329,35 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(delta.latestPreview.subject).toBe('two');  // newest-first ordering
             expect(delta.latestPreview.from).toBe('@opus');
             expect(delta.latestPreview.messageId).toMatch(/^MESSAGE:/);
+        });
+
+        test('#13091: buildMailboxDelta excludes archived direct-DMs from count and preview', async () => {
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                await PermissionService.grantPermission({ to: '@opus', scope: 'CAN_REPLY_TO' });
+            });
+
+            let visibleId, archivedId;
+
+            await RequestContextService.run({ agentIdentityNodeId: '@opus' }, async () => {
+                visibleId = (await MailboxService.addMessage({ to: '@gemini', subject: 'visible', body: '1' })).messageId;
+                GraphService.db.nodes.get(visibleId).properties.sentAt = '2026-04-22T13:00:00.000Z';
+                persistMessageNode(visibleId);
+
+                archivedId = (await MailboxService.addMessage({ to: '@gemini', subject: 'archived-newer', body: '2' })).messageId;
+                GraphService.db.nodes.get(archivedId).properties.sentAt = '2026-04-22T14:00:00.000Z';
+                persistMessageNode(archivedId);
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@gemini' }, async () => {
+                await MailboxService.archiveMessage({ messageId: archivedId });
+
+                const delta = buildMailboxDelta();
+
+                expect(delta).not.toBeNull();
+                expect(delta.unreadCount).toBe(1);
+                expect(delta.latestPreview.messageId).toBe(visibleId);
+                expect(delta.latestPreview.subject).toBe('visible');
+            });
         });
 
         test('buildMailboxDelta returns null when identity is unbound (single-tenant fallthrough)', async () => {
@@ -1275,6 +1380,44 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             expect(delta).not.toBeNull();
             expect(delta.unreadCount).toBe(1);
             expect(delta.latestPreview.subject).toBe('hello all');
+        });
+
+        test('#13091: buildMailboxDelta excludes archived per-recipient broadcasts', async () => {
+            const
+                senderIdentity    = '@neo-mailbox-delta-broadcast-sender',
+                archivedIdentity  = '@neo-mailbox-delta-broadcast-recipient',
+                unreadIdentity    = '@neo-mailbox-delta-broadcast-unread';
+
+            GraphService.upsertNode({ id: senderIdentity,   type: 'AgentIdentity', name: 'DeltaBroadcastSender',    properties: { accountType: 'agent' } });
+            GraphService.upsertNode({ id: archivedIdentity, type: 'AgentIdentity', name: 'DeltaBroadcastRecipient', properties: { accountType: 'agent' } });
+            GraphService.upsertNode({ id: unreadIdentity,   type: 'AgentIdentity', name: 'DeltaBroadcastUnread',    properties: { accountType: 'agent' } });
+
+            let visibleId, archivedId;
+
+            await RequestContextService.run({ agentIdentityNodeId: senderIdentity }, async () => {
+                visibleId = (await MailboxService.addMessage({ to: 'AGENT:*', subject: 'visible broadcast', body: '1' })).messageId;
+                GraphService.db.nodes.get(visibleId).properties.sentAt = '2026-04-22T13:00:00.000Z';
+                persistMessageNode(visibleId);
+
+                archivedId = (await MailboxService.addMessage({ to: 'AGENT:*', subject: 'archived broadcast', body: '2' })).messageId;
+                GraphService.db.nodes.get(archivedId).properties.sentAt = '2026-04-22T14:00:00.000Z';
+                persistMessageNode(archivedId);
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: archivedIdentity }, async () => {
+                await MailboxService.archiveMessage({ messageId: archivedId });
+
+                const delta = buildMailboxDelta();
+
+                expect(delta).not.toBeNull();
+                expect(delta.unreadCount).toBe(1);
+                expect(delta.latestPreview.messageId).toBe(visibleId);
+                expect(delta.latestPreview.subject).toBe('visible broadcast');
+            });
+
+            const unreadDelta = await RequestContextService.run({ agentIdentityNodeId: unreadIdentity }, () => buildMailboxDelta());
+            expect(unreadDelta.unreadCount).toBe(2);
+            expect(unreadDelta.latestPreview.messageId).toBe(archivedId);
         });
 
         test('BLOCKED_BY overrides CAN_REPLY_TO in blocked mode', async () => {


### PR DESCRIPTION
Resolves #13091
Related: #13012

Authored by GPT-5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Aligns the direct-SQL mailbox count surfaces with the default `listMessages` archive contract. `countMessages` now excludes archived direct/legacy messages and per-recipient broadcast deliveries by default, while `includeArchived: true` keeps the opt-in archive view available. `buildMailboxDelta` now applies the same default archive filter so `add_memory.mailbox.unreadCount` and wake-drain previews no longer report archived backlog as actionable unread work.

Evidence: L2 (focused Playwright unit regressions over Memory Core SQLite-backed mailbox surfaces) -> L2 required (the close-target ACs are direct count/list/delta parity checks inside the unit-testable service boundary). No residuals.

## Deltas from ticket

None. The implementation keeps archive-as-hidden-not-deleted semantics and does not change outbox, sender delete/retraction, or read-receipt behavior.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — 66 passed.
- `git diff --check` — clean.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `03e19ecd33b336876a550674f078de0cdcde89c5 fix(memory-core): exclude archived messages from unread counts (#13091)`.

## Post-Merge Validation

- [ ] After archived unread backlog cleanup, verify default and `includeArchived: true` unread mailbox lists remain empty and `add_memory.mailbox.unreadCount` stays 0 across a turn save.

## Commits

- `03e19ecd33b336876a550674f078de0cdcde89c5` — `fix(memory-core): exclude archived messages from unread counts (#13091)`