### PR TITLE
feat(ai): add memory quarantine export helper (#13093)

### DIFF
--- a/ai/scripts/maintenance/exportMemoryQuarantine.mjs
+++ b/ai/scripts/maintenance/exportMemoryQuarantine.mjs
@@ -1,0 +1,543 @@
+import {Command}       from 'commander';
+import fs              from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+// Neo namespace bootstrap for SDK singletons consumed by operator-run maintenance scripts.
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
+import InstanceManager from '../../../src/manager/Instance.mjs';
+
+import mcConfig        from '../../mcp/server/memory-core/config.mjs';
+
+import {
+    Memory_LifecycleService,
+    Memory_StorageRouter
+} from '../../services.mjs';
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+
+export const DEFAULT_QUARANTINE_ROOT = path.join(PROJECT_ROOT, '.neo-ai-data', 'backups');
+
+const PAYLOAD_FIELDS = ['prompt', 'thought', 'response'];
+
+/**
+ * @module ai/scripts/maintenance/exportMemoryQuarantine
+ * @summary Selected-record Memory Core quarantine exporter.
+ *
+ * Exports exact `neo-agent-memory` ids into restore-compatible JSONL files without mutating
+ * Chroma or SQLite. The output is intentionally shaped for rollback through the existing
+ * `Memory_DatabaseService.manageDatabaseBackup({action: 'import', mode: 'merge'})` path:
+ *
+ * ```
+ * .neo-ai-data/backups/quarantine-<ISO-timestamp>/
+ * ├── mc/memory-backup-quarantine-<timestamp>.jsonl
+ * ├── graph/graph-backup-quarantine-<timestamp>.jsonl
+ * └── quarantine-manifest-<timestamp>.json
+ * ```
+ *
+ * The JSONL backup contains full selected records for rollback. The manifest is public-safe:
+ * it contains ids, classes, timestamps, session ids, graph/provenance status, and file paths,
+ * but never raw prompt/thought/response payload content.
+ */
+
+/**
+ * Parses CLI arguments for selected-record quarantine export.
+ *
+ * @param {String[]} argv CLI argv slice.
+ * @param {Object} [env=process.env] Environment source.
+ * @returns {Object}
+ */
+export function parseArgs(argv, env = process.env) {
+    const program = new Command();
+
+    program
+        .name('ai:export-memory-quarantine')
+        .description('Export exact Memory Core memory ids into restore-compatible quarantine artifacts.')
+        .exitOverride()
+        .configureOutput({
+            writeErr: () => {},
+            writeOut: () => {}
+        })
+        .helpOption(false)
+        .allowExcessArguments(false)
+        .argument('[ids...]', 'Memory ids to export. Comma-separated values are accepted.')
+        .option('--ids <csv>', 'Comma-separated memory ids.')
+        .option('--ids-file <path>', 'File containing ids as JSON array/object or newline/CSV text.')
+        .option('--output-dir <path>', 'Output directory.', env.NEO_MEMORY_QUARANTINE_OUTPUT_DIR || null)
+        .option('--graph-db <path>', 'Memory Core graph SQLite path.', env.NEO_MEMORY_GRAPH_DB_PATH || mcConfig.storagePaths.graph)
+        .option('--page-size <n>', 'Chroma id fetch batch size.', value => parsePositiveInt(value, 100), 100)
+        .option('--timestamp <iso>', 'Timestamp override for deterministic tests.', null)
+        .option('-h, --help', 'Show help');
+
+    program.parse(argv, {from: 'user'});
+
+    const opts = program.opts();
+
+    return {
+        ids      : flattenIdTokens([opts.ids, ...program.args]),
+        idsFile  : opts.idsFile || null,
+        outputDir: opts.outputDir || null,
+        graphDb  : opts.graphDb || null,
+        pageSize : opts.pageSize,
+        timestamp: opts.timestamp || null,
+        help     : opts.help === true
+    }
+}
+
+/**
+ * Resolves target ids from CLI tokens and/or an ids file.
+ *
+ * @param {Object} options
+ * @param {String[]} [options.ids=[]] Inline ids.
+ * @param {String} [options.idsFile=null] Optional ids file.
+ * @param {Object} [options.fsModule=fs] Filesystem seam.
+ * @returns {Promise<String[]>}
+ */
+export async function resolveTargetIds({ids = [], idsFile = null, fsModule = fs} = {}) {
+    const out = new Set(flattenIdTokens(ids));
+
+    if (idsFile) {
+        const fileText = await fsModule.readFile(idsFile, 'utf8');
+        for (const id of parseIdsText(fileText)) {
+            out.add(id);
+        }
+    }
+
+    const resolved = [...out].filter(Boolean);
+
+    if (resolved.length === 0) {
+        throw new Error('No target memory ids supplied. Use --ids, --ids-file, or positional ids.');
+    }
+
+    return resolved
+}
+
+/**
+ * Parses ids from JSON array/object or newline/CSV text.
+ *
+ * @param {String} text
+ * @returns {String[]}
+ */
+export function parseIdsText(text) {
+    const trimmed = text.trim();
+
+    if (!trimmed) return [];
+
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+            return flattenIdTokens(parsed);
+        }
+        if (parsed && typeof parsed === 'object') {
+            if (Array.isArray(parsed.ids)) {
+                return flattenIdTokens(parsed.ids);
+            }
+            if (Array.isArray(parsed.records)) {
+                return flattenIdTokens(parsed.records.map(record => record?.id));
+            }
+            if (Array.isArray(parsed.targets)) {
+                return flattenIdTokens(parsed.targets);
+            }
+        }
+    } catch {
+        // Fall through to plain text parsing.
+    }
+
+    return flattenIdTokens(trimmed.split(/[\s,]+/))
+}
+
+/**
+ * Runs the selected-record quarantine export.
+ *
+ * @param {Object} options
+ * @param {String[]} [options.ids=[]]
+ * @param {String} [options.idsFile=null]
+ * @param {String} [options.outputDir=null]
+ * @param {String} [options.graphDb=mcConfig.storagePaths.graph]
+ * @param {Number} [options.pageSize=100]
+ * @param {String} [options.timestamp=null]
+ * @param {Object} [options.memoryCollection] Test seam for Chroma collection.
+ * @param {Object} [options.lifecycleService=Memory_LifecycleService] Lifecycle seam.
+ * @param {Object} [options.storageRouter=Memory_StorageRouter] Storage seam.
+ * @param {Object} [options.logger=console]
+ * @returns {Promise<Object>}
+ */
+export async function runExport({
+    ids              = [],
+    idsFile          = null,
+    outputDir        = null,
+    graphDb          = mcConfig.storagePaths.graph,
+    pageSize         = 100,
+    timestamp        = null,
+    memoryCollection = null,
+    lifecycleService = Memory_LifecycleService,
+    storageRouter    = Memory_StorageRouter,
+    logger           = console
+} = {}) {
+    const
+        targetIds     = await resolveTargetIds({ids, idsFile}),
+        generatedAt   = timestamp || new Date().toISOString(),
+        fileTimestamp = toFileTimestamp(generatedAt),
+        resolvedRoot  = path.resolve(outputDir || path.join(DEFAULT_QUARANTINE_ROOT, `quarantine-${fileTimestamp}`)),
+        mcDir         = path.join(resolvedRoot, 'mc'),
+        graphDir      = path.join(resolvedRoot, 'graph');
+
+    await Promise.all([fs.ensureDir(mcDir), fs.ensureDir(graphDir)]);
+
+    if (!memoryCollection) {
+        await lifecycleService.ready();
+        memoryCollection = await storageRouter.getMemoryCollection();
+    }
+
+    const memoryResult = await collectSelectedMemoryRecords(memoryCollection, targetIds, {pageSize});
+    const memoryFile   = path.join(mcDir, `memory-backup-quarantine-${fileTimestamp}.jsonl`);
+    await writeJsonl(memoryFile, memoryResult.records);
+
+    const graphResult = await collectSelectedGraphRecords({dbPath: graphDb, ids: targetIds});
+    const graphFile   = path.join(graphDir, `graph-backup-quarantine-${fileTimestamp}.jsonl`);
+    await writeJsonl(graphFile, graphResult.records);
+
+    const manifest = buildManifest({
+        ids          : targetIds,
+        memoryResult,
+        graphResult,
+        generatedAt,
+        outputDir    : resolvedRoot,
+        memoryFile,
+        graphFile
+    });
+
+    const manifestFile = path.join(resolvedRoot, `quarantine-manifest-${fileTimestamp}.json`);
+    await fs.writeJson(manifestFile, manifest, {spaces: 2});
+
+    logger.log?.(`[exportMemoryQuarantine] wrote ${memoryResult.records.length} memory record(s), ${graphResult.records.length} graph record(s), manifest=${manifestFile}`);
+
+    return {
+        outputDir: resolvedRoot,
+        files    : {memory: memoryFile, graph: graphFile, manifest: manifestFile},
+        counts   : manifest.counts,
+        manifest
+    }
+}
+
+/**
+ * Fetches exact ids from a Chroma-compatible collection.
+ *
+ * @param {Object} collection
+ * @param {String[]} ids
+ * @param {Object} [options]
+ * @param {Number} [options.pageSize=100]
+ * @returns {Promise<{records: Object[], missingIds: String[]}>}
+ */
+export async function collectSelectedMemoryRecords(collection, ids, {pageSize = 100} = {}) {
+    const byId = new Map();
+
+    for (let i = 0; i < ids.length; i += pageSize) {
+        const chunk = ids.slice(i, i + pageSize);
+        const page  = await collection.get({
+            ids    : chunk,
+            include: ['documents', 'embeddings', 'metadatas']
+        });
+
+        for (let idx = 0; idx < (page.ids || []).length; idx++) {
+            byId.set(page.ids[idx], {
+                id       : page.ids[idx],
+                embedding: page.embeddings?.[idx] ?? null,
+                metadata : page.metadatas?.[idx] ?? null,
+                document : page.documents?.[idx] ?? null
+            });
+        }
+    }
+
+    return {
+        records   : ids.map(id => byId.get(id)).filter(Boolean),
+        missingIds: ids.filter(id => !byId.has(id))
+    }
+}
+
+/**
+ * Collects graph nodes with matching ids and directly connected edges.
+ *
+ * @param {Object} options
+ * @param {String} options.dbPath
+ * @param {String[]} options.ids
+ * @param {Function} [options.DatabaseClass] Test seam.
+ * @returns {Promise<{records: Object[], nodeIds: String[], edges: Object[], unavailable: Boolean, error: String|null}>}
+ */
+export async function collectSelectedGraphRecords({dbPath, ids, DatabaseClass = null}) {
+    if (!ids.length) {
+        return {records: [], nodeIds: [], edges: [], unavailable: false, error: null}
+    }
+
+    if (!dbPath || !await fs.pathExists(dbPath)) {
+        return {records: [], nodeIds: [], edges: [], unavailable: true, error: dbPath ? `graph db not found: ${dbPath}` : 'graph db path not configured'}
+    }
+
+    const Database = DatabaseClass || (await import('better-sqlite3')).default;
+    const db       = new Database(dbPath, {readonly: true, fileMustExist: true});
+
+    try {
+        const nodes = new Map();
+        const edges = new Map();
+
+        for (const chunk of chunkArray(ids, 200)) {
+            const placeholders = chunk.map(() => '?').join(', ');
+            const nodeRows = db.prepare(`SELECT id, data FROM Nodes WHERE id IN (${placeholders})`).all(...chunk);
+            for (const row of nodeRows) {
+                nodes.set(row.id, safeParseJson(row.data, {id: row.id}));
+            }
+
+            const edgeRows = db.prepare(`
+                SELECT id, source, target, type, data
+                FROM Edges
+                WHERE source IN (${placeholders}) OR target IN (${placeholders})
+            `).all(...chunk, ...chunk);
+            for (const row of edgeRows) {
+                const data = safeParseJson(row.data, {});
+                edges.set(row.id, {
+                    id    : data.id || row.id,
+                    source: data.source || row.source,
+                    target: data.target || row.target,
+                    type  : data.type || row.type,
+                    ...data
+                });
+            }
+        }
+
+        const records = [
+            ...[...nodes.values()].map(data => ({type: 'node', data})),
+            ...[...edges.values()].map(data => ({type: 'edge', data}))
+        ];
+
+        return {
+            records,
+            nodeIds    : [...nodes.keys()],
+            edges      : [...edges.values()],
+            unavailable: false,
+            error      : null
+        }
+    } finally {
+        db.close();
+    }
+}
+
+/**
+ * Builds the public-safe manifest.
+ *
+ * @param {Object} options
+ * @returns {Object}
+ */
+export function buildManifest({ids, memoryResult, graphResult, generatedAt, outputDir, memoryFile, graphFile}) {
+    const
+        recordsById = new Map(memoryResult.records.map(record => [record.id, record])),
+        graphNodeIds = new Set(graphResult.nodeIds),
+        authoredByMemoryIds = new Set();
+
+    for (const edge of graphResult.edges) {
+        if (edge.type !== 'AUTHORED_BY') continue;
+        if (ids.includes(edge.source)) authoredByMemoryIds.add(edge.source);
+        if (ids.includes(edge.target)) authoredByMemoryIds.add(edge.target);
+    }
+
+    const entries = ids.map(id => {
+        const
+            record          = recordsById.get(id),
+            metadata        = record?.metadata || {},
+            classification  = classifyMemoryPayload(metadata),
+            timestamp       = normalizeMetadataTimestamp(metadata.timestamp) || extractTimestampFromId(id),
+            provenance      = classifyProvenance({metadata, id, authoredByMemoryIds});
+
+        return {
+            id,
+            exported        : Boolean(record),
+            candidateClass  : record ? classification.candidateClass : 'missing-from-memory-collection',
+            invalidFields   : record ? classification.invalidFields : [],
+            timestamp,
+            month           : timestamp ? timestamp.slice(0, 7) : null,
+            sessionId       : metadata.sessionId || null,
+            graphMatch      : graphNodeIds.has(id),
+            provenanceStatus: provenance.status,
+            provenanceSources: provenance.sources
+        }
+    });
+
+    const counts = {
+        requested       : ids.length,
+        memoryExported  : memoryResult.records.length,
+        memoryMissing   : memoryResult.missingIds.length,
+        graphNodes      : graphResult.nodeIds.length,
+        graphEdges      : graphResult.edges.length,
+        byCandidateClass: countBy(entries, 'candidateClass')
+    };
+
+    return {
+        manifestVersion: 1,
+        generatedAt,
+        outputDir,
+        files: {
+            memory: memoryFile,
+            graph : graphFile
+        },
+        safety: {
+            mutationPerformed: false,
+            destructiveAction: 'not-supported-by-this-script',
+            publicPayloadPolicy: 'manifest omits raw prompt/thought/response; full payload exists only in local backup JSONL for rollback'
+        },
+        rollback: {
+            mode: 'merge',
+            memoryCoreImport: `Memory_DatabaseService.manageDatabaseBackup({ action: 'import', file: '${path.dirname(memoryFile)}', mode: 'merge' })`,
+            graphImport     : `Memory_DatabaseService.manageDatabaseBackup({ action: 'import', file: '${path.dirname(graphFile)}', mode: 'merge' })`
+        },
+        graph: {
+            unavailable: graphResult.unavailable,
+            error      : graphResult.error
+        },
+        counts,
+        missingIds: memoryResult.missingIds,
+        entries
+    }
+}
+
+/**
+ * Classifies the Chroma metadata payload predicate without reading document text.
+ *
+ * @param {Object} metadata
+ * @returns {{candidateClass: String, invalidFields: String[]}}
+ */
+export function classifyMemoryPayload(metadata = {}) {
+    const invalidFields = PAYLOAD_FIELDS.filter(field => isBlankPayload(metadata[field]));
+
+    if (invalidFields.length === 0) {
+        return {candidateClass: 'not-corrupt-by-payload-predicate', invalidFields}
+    }
+    if (invalidFields.length === PAYLOAD_FIELDS.length) {
+        return {candidateClass: 'all-fields-empty', invalidFields}
+    }
+    if (invalidFields.length === 1 && invalidFields[0] === 'prompt') {
+        return {candidateClass: 'prompt-only-empty', invalidFields}
+    }
+
+    return {candidateClass: 'partial-empty', invalidFields}
+}
+
+function classifyProvenance({metadata, id, authoredByMemoryIds}) {
+    const sources = [];
+
+    if (metadata.agentIdentity) sources.push('metadata.agentIdentity');
+    if (metadata.userId)        sources.push('metadata.userId');
+    if (metadata.agent)         sources.push('metadata.agent');
+    if (authoredByMemoryIds.has(id)) sources.push('graph.AUTHORED_BY');
+
+    return {
+        status : sources.length > 0 ? 'known' : 'unknown',
+        sources
+    }
+}
+
+async function writeJsonl(filePath, records) {
+    await fs.ensureDir(path.dirname(filePath));
+
+    const stream = fs.createWriteStream(filePath);
+    for (const record of records) {
+        stream.write(JSON.stringify(record) + '\n');
+    }
+    await new Promise(resolve => stream.end(resolve));
+}
+
+function flattenIdTokens(tokens) {
+    return tokens
+        .flatMap(token => String(token || '').split(','))
+        .map(token => token.trim())
+        .filter(Boolean)
+}
+
+function isBlankPayload(value) {
+    return typeof value !== 'string' || value.trim().length === 0
+}
+
+function parsePositiveInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`Expected a positive integer, got: ${value}`);
+    }
+    return parsed || fallback
+}
+
+function toFileTimestamp(timestamp) {
+    return timestamp.replace(/:/g, '-')
+}
+
+function normalizeMetadataTimestamp(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return new Date(value).toISOString()
+    }
+    if (typeof value === 'string' && value.trim()) {
+        const parsed = new Date(value);
+        if (!Number.isNaN(parsed.valueOf())) {
+            return parsed.toISOString()
+        }
+    }
+    return null
+}
+
+function extractTimestampFromId(id) {
+    const match = /^mem_(\d{4}-\d{2}-\d{2}T[^_]+Z)$/.exec(id);
+    if (!match) return null;
+    const parsed = new Date(match[1]);
+    return Number.isNaN(parsed.valueOf()) ? null : parsed.toISOString()
+}
+
+function countBy(entries, key) {
+    return entries.reduce((out, entry) => {
+        out[entry[key]] = (out[entry[key]] || 0) + 1;
+        return out
+    }, {})
+}
+
+function chunkArray(items, size) {
+    const chunks = [];
+    for (let i = 0; i < items.length; i += size) {
+        chunks.push(items.slice(i, i + size));
+    }
+    return chunks
+}
+
+function safeParseJson(text, fallback) {
+    try {
+        return JSON.parse(text)
+    } catch {
+        return fallback
+    }
+}
+
+function printUsage() {
+    console.log([
+        'Usage: node ./ai/scripts/maintenance/exportMemoryQuarantine.mjs --ids-file <path> [--output-dir <path>]',
+        '       node ./ai/scripts/maintenance/exportMemoryQuarantine.mjs --ids mem_1,mem_2',
+        '',
+        'This script is read-only against Memory Core. It exports selected records for quarantine/rollback and performs no deletion.'
+    ].join('\n'));
+}
+
+async function main() {
+    try {
+        const args = parseArgs(process.argv.slice(2));
+        if (args.help) {
+            printUsage();
+            return
+        }
+
+        const result = await runExport(args);
+        console.log(JSON.stringify({outputDir: result.outputDir, files: result.files, counts: result.counts}, null, 2));
+    } catch (error) {
+        console.error(`[exportMemoryQuarantine] Fatal: ${error.message}`);
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] === __filename) {
+    main();
+}

--- a/test/playwright/unit/ai/scripts/maintenance/exportMemoryQuarantine.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/exportMemoryQuarantine.spec.mjs
@@ -1,0 +1,240 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ExportMemoryQuarantineTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+import Database       from 'better-sqlite3';
+import fsExtra        from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+
+test.describe.configure({mode: 'serial'});
+
+test.describe('exportMemoryQuarantine.mjs (#13093)', () => {
+    let mod, workRoot;
+
+    test.beforeAll(async () => {
+        mod      = await import('../../../../../../ai/scripts/maintenance/exportMemoryQuarantine.mjs');
+        workRoot = await fsExtra.mkdtemp(path.join(os.tmpdir(), 'export-memory-quarantine-'));
+    });
+
+    test.afterAll(async () => {
+        if (workRoot) await fsExtra.remove(workRoot);
+    });
+
+    test('parseArgs accepts inline ids, ids-file, graph path, and page size', () => {
+        const args = mod.parseArgs([
+            '--ids', 'mem-a,mem-b',
+            '--ids-file', '/tmp/ids.json',
+            '--output-dir', '/tmp/out',
+            '--graph-db', '/tmp/graph.sqlite',
+            '--page-size', '25',
+            'mem-c'
+        ], {});
+
+        expect(args).toMatchObject({
+            ids      : ['mem-a', 'mem-b', 'mem-c'],
+            idsFile  : '/tmp/ids.json',
+            outputDir: '/tmp/out',
+            graphDb  : '/tmp/graph.sqlite',
+            pageSize : 25
+        });
+    });
+
+    test('parseIdsText reads public manifest-shaped JSON without raw payload assumptions', () => {
+        expect(mod.parseIdsText('{"ids":["a","b,c"]}')).toEqual(['a', 'b', 'c']);
+        expect(mod.parseIdsText('{"records":[{"id":"r1"},{"id":"r2"}]}')).toEqual(['r1', 'r2']);
+        expect(mod.parseIdsText('one\ntwo,three')).toEqual(['one', 'two', 'three']);
+    });
+
+    test('classifyMemoryPayload keeps prompt-only separate from all-empty', () => {
+        expect(mod.classifyMemoryPayload({prompt: '', thought: ' ', response: null})).toEqual({
+            candidateClass: 'all-fields-empty',
+            invalidFields : ['prompt', 'thought', 'response']
+        });
+
+        expect(mod.classifyMemoryPayload({prompt: ' ', thought: 'valuable thought', response: 'valuable response'})).toEqual({
+            candidateClass: 'prompt-only-empty',
+            invalidFields : ['prompt']
+        });
+
+        expect(mod.classifyMemoryPayload({prompt: 'p', thought: 't', response: 'r'})).toEqual({
+            candidateClass: 'not-corrupt-by-payload-predicate',
+            invalidFields : []
+        });
+    });
+
+    test('runExport writes restore-compatible selected backups and redacted manifest', async () => {
+        const
+            graphPath = path.join(workRoot, 'graph.sqlite'),
+            outputDir = path.join(workRoot, 'quarantine-out'),
+            timestamp = '2026-06-13T12:00:00.000Z';
+
+        seedGraph(graphPath);
+
+        const collection = fakeCollection([
+            {
+                id       : 'mem-all-empty',
+                embedding: [0.1, 0.2],
+                metadata : {
+                    prompt   : '',
+                    thought  : ' ',
+                    response : null,
+                    timestamp: Date.parse('2026-04-02T03:04:05.000Z'),
+                    sessionId: 'session-a'
+                },
+                document: 'rollback document for all-empty'
+            },
+            {
+                id       : 'mem-prompt-only',
+                embedding: [0.3, 0.4],
+                metadata : {
+                    prompt   : '',
+                    thought  : 'valuable thought must not enter manifest',
+                    response : 'valuable response must not enter manifest',
+                    timestamp: '2025-10-06T10:43:04.945Z',
+                    sessionId: 'session-b'
+                },
+                document: 'rollback document for prompt-only'
+            }
+        ]);
+
+        const result = await mod.runExport({
+            ids             : ['mem-all-empty', 'mem-prompt-only', 'mem-missing'],
+            outputDir,
+            graphDb         : graphPath,
+            timestamp,
+            memoryCollection: collection,
+            logger          : {log: () => {}}
+        });
+
+        expect(result.files.memory).toBe(path.join(outputDir, 'mc', 'memory-backup-quarantine-2026-06-13T12-00-00.000Z.jsonl'));
+        expect(result.files.graph).toBe(path.join(outputDir, 'graph', 'graph-backup-quarantine-2026-06-13T12-00-00.000Z.jsonl'));
+        expect(await fsExtra.pathExists(result.files.manifest)).toBe(true);
+
+        const memoryLines = (await fsExtra.readFile(result.files.memory, 'utf8')).trim().split('\n').map(JSON.parse);
+        expect(memoryLines.map(row => row.id)).toEqual(['mem-all-empty', 'mem-prompt-only']);
+        expect(memoryLines[1].metadata.thought).toBe('valuable thought must not enter manifest');
+
+        const graphLines = (await fsExtra.readFile(result.files.graph, 'utf8')).trim().split('\n').map(JSON.parse);
+        expect(graphLines).toEqual([
+            {type: 'node', data: {id: 'mem-all-empty', label: 'AGENT_MEMORY'}},
+            {
+                type: 'edge',
+                data: {
+                    id    : 'edge-authored',
+                    source: 'mem-all-empty',
+                    target: '@neo-gpt',
+                    type  : 'AUTHORED_BY',
+                    weight: 1
+                }
+            }
+        ]);
+
+        expect(result.counts).toMatchObject({
+            requested     : 3,
+            memoryExported: 2,
+            memoryMissing : 1,
+            graphNodes    : 1,
+            graphEdges    : 1
+        });
+        expect(result.counts.byCandidateClass).toMatchObject({
+            'all-fields-empty'              : 1,
+            'prompt-only-empty'             : 1,
+            'missing-from-memory-collection': 1
+        });
+
+        const manifestText = await fsExtra.readFile(result.files.manifest, 'utf8');
+        expect(manifestText).not.toContain('valuable thought must not enter manifest');
+        expect(manifestText).not.toContain('valuable response must not enter manifest');
+
+        const manifest = JSON.parse(manifestText);
+        expect(manifest.safety).toMatchObject({
+            mutationPerformed: false,
+            destructiveAction: 'not-supported-by-this-script'
+        });
+        expect(manifest.entries.find(entry => entry.id === 'mem-all-empty')).toMatchObject({
+            candidateClass   : 'all-fields-empty',
+            graphMatch       : true,
+            provenanceStatus : 'known',
+            provenanceSources: ['graph.AUTHORED_BY']
+        });
+        expect(manifest.entries.find(entry => entry.id === 'mem-prompt-only')).toMatchObject({
+            candidateClass  : 'prompt-only-empty',
+            graphMatch      : false,
+            provenanceStatus: 'unknown'
+        });
+    });
+});
+
+function fakeCollection(rows) {
+    const byId = new Map(rows.map(row => [row.id, row]));
+
+    return {
+        get: async ({ids}) => {
+            const selected = ids.map(id => byId.get(id)).filter(Boolean);
+            return {
+                ids       : selected.map(row => row.id),
+                embeddings: selected.map(row => row.embedding),
+                metadatas : selected.map(row => row.metadata),
+                documents : selected.map(row => row.document)
+            }
+        }
+    }
+}
+
+function seedGraph(dbPath) {
+    const db = new Database(dbPath);
+
+    try {
+        db.exec(`
+            CREATE TABLE Nodes (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            );
+            CREATE TABLE Edges (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                target TEXT NOT NULL,
+                type TEXT NOT NULL,
+                data TEXT NOT NULL
+            );
+        `);
+
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(
+            'mem-all-empty',
+            JSON.stringify({id: 'mem-all-empty', label: 'AGENT_MEMORY'})
+        );
+        db.prepare('INSERT INTO Edges (id, source, target, type, data) VALUES (?, ?, ?, ?, ?)').run(
+            'edge-authored',
+            'mem-all-empty',
+            '@neo-gpt',
+            'AUTHORED_BY',
+            JSON.stringify({
+                id    : 'edge-authored',
+                source: 'mem-all-empty',
+                target: '@neo-gpt',
+                type  : 'AUTHORED_BY',
+                weight: 1
+            })
+        );
+    } finally {
+        db.close();
+    }
+}


### PR DESCRIPTION
Resolves #13093

Authored by GPT-5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Adds a preservation-first selected-record quarantine exporter for Memory Core cleanup gates. The script accepts exact memory ids, exports matching Chroma `neo-agent-memory` records into restore-compatible `memory-backup-*.jsonl`, exports matching graph nodes plus directly connected edges into `graph-backup-*.jsonl`, and writes a public-safe manifest that omits raw prompt/thought/response content while preserving rollback evidence locally.

Evidence: L2 (focused Playwright unit coverage + adjacent merge-import rollback parity spec + static syntax/whitespace checks) -> L4 required (operator-run live quarantine/export and any destructive cleanup on production Memory Core). Residual: operator-gated live cleanup validation remains post-merge under #13093.

## Deltas from ticket

- No deletion path is implemented. This PR creates only the reversible selected-record export primitive needed before any destructive action can be considered.
- The manifest classifies `all-fields-empty`, `prompt-only-empty`, `partial-empty`, and `not-corrupt-by-payload-predicate` from Chroma metadata fields only; it does not inspect or publish raw payload text.
- Rollback guidance points at the existing Memory Core `mode: merge` import path so live rows are preserved and only missing ids are restored.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/exportMemoryQuarantine.spec.mjs` -> 4 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs` -> 6 passed.
- `node --check ai/scripts/maintenance/exportMemoryQuarantine.mjs` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev` at `b26bb586ad130c1c814f4334df0fa311e81b83ed`; outgoing log contained only `ec41d0823 feat(ai): add memory quarantine export helper (#13093)`.

## Post-Merge Validation

- [ ] Run the exporter against the operator-approved #13093 candidate id file and preserve the local `.neo-ai-data/backups/quarantine-*` bundle path.
- [ ] Confirm the manifest count split matches the selected target class before any cleanup request.
- [ ] If deletion is later approved by the operator, perform it in a separate gated step only after full backup + selected-record quarantine evidence exists.

## Commits

- `ec41d0823` - `feat(ai): add memory quarantine export helper (#13093)`

## Evolution

The lane started as a cleanup-gate design after the #12830 characterization addendum. Source V-B-A showed that full logical backup and merge restore already exist, but arbitrary selected-record quarantine export did not. The implementation therefore stops at a reversible export primitive and leaves destructive mutation outside this PR.