### PR TITLE
fix(agentos): append a pick-up-a-lane directive to every wake digest (#13095)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -573,6 +573,21 @@ function isMessageReadFor(db, messageId, recipient) {
 }
 
 /**
+ * @summary Standing directive appended to every wake digest.
+ *
+ * Closes the acknowledge-and-idle failure mode: an agent receiving a wake would acknowledge it and
+ * idle, reading the wake as an interruption to ack rather than a prompt to execute. Embedding the
+ * pick-up-a-lane mandate in the wake CONTENT itself (not only the loaded rule substrate) puts it in
+ * front of the agent on every single wake, so an idle agent always sees the directive to advance a
+ * lane instead of burning the turn on a bare acknowledgement.
+ */
+const WAKE_LANE_DIRECTIVE = 'Directive — pick up a lane: if you are not already executing one, ' +
+    'survey the open backlog (list_issues / ideation), claim an unclaimed lane, and drive it ' +
+    'implementation → test → PR this turn. A wake is not "handled" by acknowledgement alone while ' +
+    'you have idle capacity and open lanes exist. Acknowledge pure-FYI broadcasts in one line; ' +
+    'never idle or hold waiting for permission to start unassigned work.';
+
+/**
  * @summary Flushes the coalesced wake queue into a priority-tagged digest.
  *
  * The digest header carries the highest coalesced message priority so agent policy can
@@ -653,7 +668,7 @@ async function flushSubscription(subId) {
         breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId})`;
     }
 
-    const digest = `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}`;
+    const digest = `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}\n\n${WAKE_LANE_DIRECTIVE}`;
 
     // Delivery to per-harness adapter
     await deliverDigest(subscription, digest);

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -259,6 +259,50 @@ test.describe('Wake Daemon', () => {
         expect(logContents).toContain('[Wake Daemon Test Adapter] Delivered');          // Same delivery line as stdout
     });
 
+    test('every wake digest carries the standing pick-up-a-lane directive (#13095)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-directive';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId, label: 'AGENT', properties: { name: 'Test Agent Directive' }
+        }));
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId, label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId, harnessTarget: 'bridge-daemon', status: 'active',
+                trigger: 'SENT_TO_ME', harnessTargetMetadata: { adapter: 'test', coalesceWindow: 1 }
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver event within timeout')), 10000);
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Wake Daemon Test Adapter] Delivered')) {
+                    clearTimeout(timeout);
+                    resolve(out);
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Directive Presence Probe'});
+
+        // The escalation fix: every digest must DIRECT an idle agent to pick up + execute a lane,
+        // not merely report what happened — otherwise wakes get acknowledged-and-idled, burning turns.
+        const output = await deliveryPromise;
+        expect(output).toContain('pick up a lane');
+        expect(output).toContain('implementation → test → PR');
+        expect(output).toContain('never idle or hold');
+    });
+
     test('detects and delivers a CAN_* permission_granted wake via the dead-to-live edge path', async () => {
         const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-perm';


### PR DESCRIPTION
## Summary

The wake daemon's digest told an agent WHAT happened (N events, latest subject) but never directed an idle agent to DO anything — so wakes were acknowledged-and-idled instead of advancing a lane. This is the cheapest, highest-leverage fix for the operator-escalated "wakes ignored / tokens wasted / lanes not picked up" failure mode (raised twice): embed the pick-up-a-lane directive in the wake **content itself**, so an idle agent sees it on every single wake — not only in the loaded rule substrate it may not re-read.

## Deltas

- `ai/daemons/wake/daemon.mjs` — add a module-level `WAKE_LANE_DIRECTIVE` constant and append it to every digest emitted by `flushSubscription()`. **Append-only**: the `[WAKE][priority:X] N events…` header, breakdown bullets, and `Subscription: <subId>` line are unchanged.
- `test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` — new test asserting a delivered digest carries the directive (`pick up a lane`, `implementation → test → PR`, `never idle or hold`).

Evidence: L2 (unit test — daemon spawned, digest asserted). The directive is content the agent reads on delivery, fully covered by the emission test; no sandbox-unreachable runtime AC.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
→ 26 passed (16.2s)
```

Includes the new directive test + all pre-existing digest-format assertions (the `not.toContain` checks for `priority: normal` / `new messages` / `Window:` still hold — the directive contains none of them), so the append introduces no regression.

## Post-Merge Validation

- [ ] Live wake digests carry the directive once the daemon restarts on this build (behavioral — observable in the next real wake).

## Contract Ledger

| Target Surface | Contract detail |
|---|---|
| wake digest text (agent-consumed) | Gains a trailing directive line; the `[WAKE][priority:X] N events…` header, breakdown bullets, and `Subscription: <subId>` line are unchanged (strictly append). Anything parsing the header/subscription is unaffected. |

Resolves #13095

Authored by Ada (@neo-opus-ada, Claude Opus 4.8)
