### PR TITLE
docs(agentos): chart close-target and healthcheck seams (#12990)

### DIFF
--- a/.agents/skills/pr-review/references/close-target-remediation.md
+++ b/.agents/skills/pr-review/references/close-target-remediation.md
@@ -1,0 +1,26 @@
+# Close-Target Remediation
+
+This payload fires when a PR close-target over-claims delivery, or when
+`agent-pr-body-lint` appears to contradict a recent PR-body edit.
+
+## Split, Do Not Downgrade
+
+For Neo agent / `ai` PRs, `Resolves #N` is the required closing keyword. If the
+PR cannot honestly resolve its named ticket, the reviewer prescription is to
+split or re-scope the ticket so the PR can name a fully delivered leaf ticket
+with a truthful newline-isolated `Resolves #M`.
+
+Do not prescribe a bare `Refs #N` downgrade for an agent PR. `Refs` and
+`Related` are allowed only as additional non-closing references, and
+`agent-pr-body-lint` rejects them as substitutes for the mandatory close target.
+
+## Payload-Sensitive Lint Runs
+
+`agent-pr-body-lint` evaluates the PR body from the GitHub event payload for
+that workflow run. A queued or failing run may therefore be checking the body
+snapshot from before a PR-body edit, while a later run may evaluate different
+text.
+
+When close-target lint fails around an over-claim, resolve the ticket/PR body
+shape first. Do not prescribe "rerun CI" as the fix unless the current PR body
+and branch commit bodies are already close-target clean.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -127,6 +127,8 @@ When reviewing a PR, audit every issue named as a close-target via GitHub's magi
 - **Resolves-only for agent PRs:** author-side discipline (`pull-request §9`) mandates newline-isolated `Resolves #N`; `Closes` means no-delivery/no-PR, `Fixes` is ambiguous, and `Refs` / `Related` do not satisfy the close-target requirement.
 - **Syntax-exact:** prose-embedded close targets and comma-separated lists are forbidden.
 
+<!-- trigger: close-target over-claim or lint/body contradiction -> read ./close-target-remediation.md -->
+
 **Reviewer-side check:**
 
 1. Parse the PR body + commit messages for `Closes #N` / `Resolves #N` / `Fixes #N` patterns (case-insensitive). For local checkout reviews, use `git log origin/dev..HEAD --format='%h%x09%s%n%b'` or an equivalent exact-head commit-message fetch; do not rely on PR body or `closingIssuesReferences` alone.

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -83,6 +83,9 @@ services:
       - neo-mcp-network
     expose:
       - "3000"
+    # If this deployment opts into NEO_AUTH_MODE=gitlab-pat, the in-container MCP
+    # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
+    # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
     healthcheck:
       test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
       interval: 10s
@@ -141,6 +144,9 @@ services:
       - neo-mcp-network
     expose:
       - "3001"
+    # If this deployment opts into NEO_AUTH_MODE=gitlab-pat, the in-container MCP
+    # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
+    # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
     healthcheck:
       test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck"]
       interval: 10s


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Resolves #12990

This narrows the #12990 implementation to the two still-live seams: reviewer-side close-target remediation guidance and the gitlab-pat container healthcheck note. The ticket-create Contract Ledger trigger leg is already satisfied on `dev`, so this PR deliberately does not re-edit that payload.

Evidence: L1 (static substrate/docs validation: `lint-skill-manifest`, `docker compose config --quiet`, staged whitespace check) -> L1 required (docs/process substrate and compose comments; no runtime behavior changed). No residuals.

## Deltas from ticket

- Added a `pr-review` close-target remediation Atlas payload that tells reviewers to split/re-scope over-claimed tickets so a truthful newline-isolated `Resolves #M` remains possible, rather than prescribing a bare `Refs #N` downgrade that agent PR lint rejects.
- Added a one-line trigger pointer from `pr-review-guide.md` §5.2 to the new payload. The detailed rule body stays out of the oversized workflow map.
- Added the two `ai/deploy/docker-compose.yml` healthcheck comments for the `NEO_AUTH_MODE=gitlab-pat` / `NEO_MCP_HEALTHCHECK_TOKEN` bearer seam on `kb-server` and `mc-server`.
- Did not edit `ticket-create-workflow.md`; live V-B-A showed the consumed-surface Contract Ledger trigger is already present there.

## Turn-Memory Pre-Flight / Slot Rationale

Substrate scope: `.agents/skills/pr-review/references/**` is skill-loaded memory substrate, and `ai/deploy/docker-compose.yml` is operator-consumed deployment reference substrate.

- `pr-review-guide.md` delta: `compress-to-trigger`. Trigger-frequency is close-target-overclaim review only, failure-severity is medium-high because wrong prescriptions create ungreenable PR cycles, enforceability is CI-assisted but reviewer-side discipline still needs the pointer. The always-loaded workflow map grows by one trigger pointer only.
- `close-target-remediation.md` delta: `move` into a conditionally loaded World Atlas payload. It holds the substantive remediation guidance and payload-sensitive lint-run warning, loaded only when the pointer fires.
- `docker-compose.yml` comments: ordinary operator/deploy reference comments, not turn-loaded memory. They chart an already-existing healthcheck bearer seam without changing runtime behavior.

Substrate Accretion Defense: the initial inline shape exceeded `lint-skill-manifest`'s workflow-map delta cap; this PR uses the lint-directed Map/Atlas split, so future agents pay only the one-line trigger cost until the edge case fires. Retirement trigger: remove the Atlas payload/pointer if `agent-pr-body-lint` gains a mechanically surfaced close-target remediation message covering split/re-scope and payload-sensitive reruns.

Decision Record impact: aligned-with ADR 0007 (Compaction Taxonomy / Progressive Disclosure); no ADR text change required.

## Test Evidence

```text
node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev
-> [lint-skill-manifest] OK

env NEO_KB_ASK_API_KEY= docker compose -f ai/deploy/docker-compose.yml config --quiet
-> passed

git diff --cached --check
-> passed

git log origin/dev..HEAD --format=%h%x09%s%n%b
-> a7234e38b docs(agentos): chart close-target and healthcheck seams (#12990)
```

## Post-Merge Validation

- [ ] The next close-target overclaim review loads `close-target-remediation.md` from the §5.2 trigger instead of prescribing a bare `Refs #N` downgrade.
- [ ] A gitlab-pat deployment operator sees the `NEO_MCP_HEALTHCHECK_TOKEN` healthcheck seam beside both MCP server healthcheck blocks.

## Commit

- `a7234e38b` - `docs(agentos): chart close-target and healthcheck seams (#12990)`
