### PR TITLE
feat(build): guard top-level examples/ as Body-only to prevent build-all breakage (#13098)

### DIFF
--- a/.agents/skills/structural-pre-flight/references/structural-pre-flight-workflow.md
+++ b/.agents/skills/structural-pre-flight/references/structural-pre-flight-workflow.md
@@ -37,7 +37,7 @@ If your new `.mjs` file has a clear sibling pattern in the chosen directory — 
 - New widget under `src/component/`: numerous siblings (`Button.mjs`, `Container.mjs`, etc.). **Fast-path.**
 - New unit spec at `test/playwright/unit/ai/services/<server>/`: sibling specs establish setup pattern. **Fast-path.**
 
-**Domain-boundary caveat — `examples/` is Body-only.** A new example `.mjs` under top-level `examples/` is fast-path ONLY if it is a **Body (frontend) Neo app** (carries `app.mjs` + `neo-config.json`). `npm run build-all` recursively walks `examples/` and builds every `app.mjs`-bearing directory as a Neo app, so an AI / harness / vanilla / app-less example placed there breaks the build. **AI-domain examples go under `ai/examples/`** (served by the dev-server's `process.cwd()` static root, so browser e2e still works). The `check-examples-body-only` CI guard enforces this at the merge-gate — but catch it HERE, at authoring time, before the file lands in the wrong tree.
+**Domain-boundary caveat — `examples/` is Body-only.** A new example `.mjs` under top-level `examples/` is fast-path ONLY if it is a **Body (frontend) Neo app** (carries `app.mjs` + `neo-config.json` + `index.html`). `npm run build-all` recursively walks `examples/` and builds every `app.mjs`-bearing directory as a Neo app, so an AI / harness / vanilla / app-less example placed there breaks the build. **AI-domain examples go under `ai/examples/`** (served by the dev-server's `process.cwd()` static root, so browser e2e still works). The `check-examples-body-only` CI guard enforces this at the merge-gate — but catch it HERE, at authoring time, before the file lands in the wrong tree.
 
 **Pre-Flight statement (mandatory, even on fast-path):**
 

--- a/.agents/skills/structural-pre-flight/references/structural-pre-flight-workflow.md
+++ b/.agents/skills/structural-pre-flight/references/structural-pre-flight-workflow.md
@@ -37,6 +37,8 @@ If your new `.mjs` file has a clear sibling pattern in the chosen directory — 
 - New widget under `src/component/`: numerous siblings (`Button.mjs`, `Container.mjs`, etc.). **Fast-path.**
 - New unit spec at `test/playwright/unit/ai/services/<server>/`: sibling specs establish setup pattern. **Fast-path.**
 
+**Domain-boundary caveat — `examples/` is Body-only.** A new example `.mjs` under top-level `examples/` is fast-path ONLY if it is a **Body (frontend) Neo app** (carries `app.mjs` + `neo-config.json`). `npm run build-all` recursively walks `examples/` and builds every `app.mjs`-bearing directory as a Neo app, so an AI / harness / vanilla / app-less example placed there breaks the build. **AI-domain examples go under `ai/examples/`** (served by the dev-server's `process.cwd()` static root, so browser e2e still works). The `check-examples-body-only` CI guard enforces this at the merge-gate — but catch it HERE, at authoring time, before the file lands in the wrong tree.
+
 **Pre-Flight statement (mandatory, even on fast-path):**
 
 > *"Pre-Flight (structural fast-path): authoring `<path>` matches sibling pattern of `<sibling-path>` in `<dir>`; sibling-file-lift applies; no novel directory choice."*

--- a/.github/workflows/check-examples-body-only.yml
+++ b/.github/workflows/check-examples-body-only.yml
@@ -1,0 +1,34 @@
+name: Examples Body-Only Check
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'examples/**'
+      - 'buildScripts/util/check-examples-body-only.mjs'
+      - '.github/workflows/check-examples-body-only.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'examples/**'
+      - 'buildScripts/util/check-examples-body-only.mjs'
+      - '.github/workflows/check-examples-body-only.yml'
+
+concurrency:
+  group: check-examples-body-only-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Check examples/ is Body-only
+        run: npm run check-examples-body-only

--- a/buildScripts/util/check-examples-body-only.mjs
+++ b/buildScripts/util/check-examples-body-only.mjs
@@ -14,10 +14,10 @@ import path from 'node:path';
  * Why this guard exists: `build-all` enumerates examples via webpack's `parseFolder`
  * (`buildScripts/webpack/production/webpack.config.appworker.mjs`). It recursively walks `examples/`
  * and treats EVERY directory containing an `app.mjs` as a buildable Neo app, then `createStartingPoint`
- * builds each from its `neo-config.json`. Two misplacement classes break the build, and both surface
- * only when `build-all` blows up or a human notices in review:
- *   1. A build target (an `app.mjs`-bearing dir) with no `neo-config.json` — `createStartingPoint`
- *      chokes (the vanilla / app-less comparator case).
+ * builds each from its `neo-config.json` + `index.html` (it reads BOTH unconditionally). Two misplacement
+ * classes break the build, and both surface only when `build-all` blows up or a human notices in review:
+ *   1. A build target (an `app.mjs`-bearing dir) missing `neo-config.json` or `index.html` —
+ *      `createStartingPoint` chokes (the vanilla / app-less comparator case).
  *   2. Any example under `examples/` that imports from `ai/` — an AI-domain example that belongs under
  *      `ai/examples/` (which the dev-server's `process.cwd()` static root still serves, so e2e keeps working).
  *
@@ -25,9 +25,9 @@ import path from 'node:path';
  * "build-all broke again" friction into an unmergeable red gate carrying an actionable, location-correcting message.
  */
 
-// The single build-critical marker `createStartingPoint` reads for each app.mjs target. Its absence is
-// the precise predicate for "build-all will choke on this directory".
-const NEO_APP_BUILD_MARKER = 'neo-config.json';
+// The Neo-app marker files `createStartingPoint` reads for every app.mjs build target — it reads BOTH
+// unconditionally, so a missing either is the precise predicate for "build-all will choke on this dir".
+const NEO_APP_BUILD_MARKERS = ['neo-config.json', 'index.html'];
 
 const DIR_SKIP = new Set(['node_modules', 'dist', '.git']);
 
@@ -83,8 +83,9 @@ function findExamplesViolations(examplesRoot, repoRoot) {
     const aiImports                = [];
 
     for (const dir of buildTargets) {
-        if (!fs.existsSync(path.join(dir, NEO_APP_BUILD_MARKER))) {
-            malformed.push(path.relative(repoRoot, dir));
+        const missing = NEO_APP_BUILD_MARKERS.filter(marker => !fs.existsSync(path.join(dir, marker)));
+        if (missing.length > 0) {
+            malformed.push(`${path.relative(repoRoot, dir)} (missing ${missing.join(' + ')})`);
         }
     }
 
@@ -126,8 +127,8 @@ function main() {
     console.error('   AI / harness / non-Body examples belong under ai/examples/ (still served by the dev-server static root, so browser e2e keeps working).\n');
 
     if (malformed.length > 0) {
-        console.error('  ▸ app.mjs build target(s) missing neo-config.json — build-all will choke on these:');
-        malformed.forEach(dir => console.error(`      examples → ${dir}`));
+        console.error('  ▸ app.mjs build target(s) missing a required Neo-app file (neo-config.json and/or index.html) — build-all will choke on these:');
+        malformed.forEach(entry => console.error(`      examples → ${entry}`));
         console.error('');
     }
 

--- a/buildScripts/util/check-examples-body-only.mjs
+++ b/buildScripts/util/check-examples-body-only.mjs
@@ -1,0 +1,144 @@
+import fs   from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Pre-Flight (structural fast-path): `buildScripts/util/check-examples-body-only.mjs` matches the
+ * sibling pattern of `buildScripts/util/check-shorthand.mjs`, `check-branch-discipline.mjs`, and
+ * `check-whitespace.mjs` — all mechanical build-time CI hygiene checks living in `buildScripts/util/`.
+ * Sibling-file-lift applies; no novel directory choice.
+ *
+ * @summary CI guard: top-level `examples/` is Body-only. Fails the merge-gate when a non-Body
+ * (AI / harness / vanilla) example is placed under `examples/` — the exact class that breaks
+ * `npm run build-all`.
+ *
+ * Why this guard exists: `build-all` enumerates examples via webpack's `parseFolder`
+ * (`buildScripts/webpack/production/webpack.config.appworker.mjs`). It recursively walks `examples/`
+ * and treats EVERY directory containing an `app.mjs` as a buildable Neo app, then `createStartingPoint`
+ * builds each from its `neo-config.json`. Two misplacement classes break the build, and both surface
+ * only when `build-all` blows up or a human notices in review:
+ *   1. A build target (an `app.mjs`-bearing dir) with no `neo-config.json` — `createStartingPoint`
+ *      chokes (the vanilla / app-less comparator case).
+ *   2. Any example under `examples/` that imports from `ai/` — an AI-domain example that belongs under
+ *      `ai/examples/` (which the dev-server's `process.cwd()` static root still serves, so e2e keeps working).
+ *
+ * AI / harness / non-Body examples belong under `ai/examples/`. This guard converts the recurring
+ * "build-all broke again" friction into an unmergeable red gate carrying an actionable, location-correcting message.
+ */
+
+// The single build-critical marker `createStartingPoint` reads for each app.mjs target. Its absence is
+// the precise predicate for "build-all will choke on this directory".
+const NEO_APP_BUILD_MARKER = 'neo-config.json';
+
+const DIR_SKIP = new Set(['node_modules', 'dist', '.git']);
+
+// Matches the specifier of `import … from '…'`, side-effect `import '…'`, `export … from '…'`, and
+// dynamic `import('…')`. A guard-level regex is sufficient here; example code does not embed
+// import-shaped string literals.
+const IMPORT_SPECIFIER = /(?:\bfrom|\bimport)\s*\(?\s*['"]([^'"]+)['"]/g;
+
+/**
+ * @summary Recursively collects every `.mjs` file and every `app.mjs`-bearing directory under `root`.
+ * @param {String} root Absolute path to scan.
+ * @returns {{mjsFiles: String[], buildTargets: String[]}}
+ */
+function walkExamples(root) {
+    const mjsFiles = [], buildTargets = [];
+
+    const visit = (dir) => {
+        let entries;
+        try {
+            entries = fs.readdirSync(dir, {withFileTypes: true});
+        } catch (e) {
+            return;
+        }
+
+        if (entries.some(entry => entry.isFile() && entry.name === 'app.mjs')) {
+            buildTargets.push(dir);
+        }
+
+        for (const entry of entries) {
+            if (entry.isDirectory()) {
+                if (!DIR_SKIP.has(entry.name)) visit(path.join(dir, entry.name));
+            } else if (entry.isFile() && entry.name.endsWith('.mjs')) {
+                mjsFiles.push(path.join(dir, entry.name));
+            }
+        }
+    };
+
+    visit(root);
+    return {mjsFiles, buildTargets};
+}
+
+/**
+ * @summary Finds Body-only violations under `examplesRoot`. Pure (no process exit) so it stays unit-testable.
+ * @param {String} examplesRoot Absolute path to the top-level `examples/` directory.
+ * @param {String} repoRoot     Absolute repo root (used to resolve the `ai/` boundary + relativize output).
+ * @returns {{malformed: String[], aiImports: Array<{file: String, spec: String}>}}
+ */
+function findExamplesViolations(examplesRoot, repoRoot) {
+    const aiDir                    = path.resolve(repoRoot, 'ai');
+    const aiPrefix                 = aiDir + path.sep;
+    const {mjsFiles, buildTargets} = walkExamples(examplesRoot);
+    const malformed                = [];
+    const aiImports                = [];
+
+    for (const dir of buildTargets) {
+        if (!fs.existsSync(path.join(dir, NEO_APP_BUILD_MARKER))) {
+            malformed.push(path.relative(repoRoot, dir));
+        }
+    }
+
+    for (const file of mjsFiles) {
+        const source = fs.readFileSync(file, 'utf8');
+        let match;
+        IMPORT_SPECIFIER.lastIndex = 0;
+        while ((match = IMPORT_SPECIFIER.exec(source)) !== null) {
+            const spec = match[1];
+            // Only relative specifiers can reach into the repo's ai/ tree; bare specifiers resolve elsewhere.
+            if (!spec.startsWith('.')) continue;
+            const resolved = path.resolve(path.dirname(file), spec);
+            if (resolved === aiDir || resolved.startsWith(aiPrefix)) {
+                aiImports.push({file: path.relative(repoRoot, file), spec});
+            }
+        }
+    }
+
+    return {malformed, aiImports};
+}
+
+function main() {
+    const repoRoot     = process.cwd();
+    const examplesRoot = path.join(repoRoot, 'examples');
+
+    if (!fs.existsSync(examplesRoot)) {
+        console.log('✅ PASS: no top-level examples/ directory to check.');
+        process.exit(0);
+    }
+
+    const {malformed, aiImports} = findExamplesViolations(examplesRoot, repoRoot);
+
+    if (malformed.length === 0 && aiImports.length === 0) {
+        console.log('✅ PASS: top-level examples/ is Body-only — every app.mjs build target is a valid Neo app, and nothing imports from ai/.');
+        process.exit(0);
+    }
+
+    console.error('❌ FAIL: top-level examples/ is Body-only — it is built by `npm run build-all` (each subtree with an app.mjs is built as a Neo app).');
+    console.error('   AI / harness / non-Body examples belong under ai/examples/ (still served by the dev-server static root, so browser e2e keeps working).\n');
+
+    if (malformed.length > 0) {
+        console.error('  ▸ app.mjs build target(s) missing neo-config.json — build-all will choke on these:');
+        malformed.forEach(dir => console.error(`      examples → ${dir}`));
+        console.error('');
+    }
+
+    if (aiImports.length > 0) {
+        console.error('  ▸ example file(s) importing from ai/ — AI-domain examples belong under ai/examples/:');
+        aiImports.forEach(({file, spec}) => console.error(`      ${file}  →  ${spec}`));
+        console.error('');
+    }
+
+    console.error(`Root: ${repoRoot}\n`);
+    process.exit(1);
+}
+
+main();

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,15 @@
+# Scope: Body-Only Examples
+
+Top-level `examples/` is reserved for **Body (frontend) examples**. `npm run build-all` recursively
+walks this tree and builds every directory containing an `app.mjs` as a Neo app (from its
+`neo-config.json`), so a non-Body / vanilla / app-less example placed here breaks the build.
+
+**AI / harness / non-Body examples belong under `ai/examples/`** — which the dev-server's
+`process.cwd()` static root still serves, so browser e2e keeps working. The
+`check-examples-body-only` CI guard (`buildScripts/util/check-examples-body-only.mjs`) enforces this:
+it fails the merge-gate when an `app.mjs` build target under `examples/` lacks `neo-config.json`, or
+when any example here imports from `ai/`.
+
 # Client Requirements
 
 Running the examples locally works fine in all environments inside all major browsers at this point:
@@ -12,10 +24,10 @@ In short: it is possible to run the framework without a local web-server, but th
 You can start Chrome using a flag (--allow-file-access-from-files), but this will allow the browser to access any
 file on your hard drive. To avoid this, a local web-server is the way to go.
 
-**Webpack Dev Server**  
+**Webpack Dev Server**<br>
 `npm run server-start`
 
-**All Servers**  
+**All Servers**<br>
 Ensure your server has a mime-type configured for Javascript Modules (.mjs) files. This should be set to the same as
 normal javascript (.js) files, normally 'application/-javascript'.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,8 @@ walks this tree and builds every directory containing an `app.mjs` as a Neo app 
 **AI / harness / non-Body examples belong under `ai/examples/`** — which the dev-server's
 `process.cwd()` static root still serves, so browser e2e keeps working. The
 `check-examples-body-only` CI guard (`buildScripts/util/check-examples-body-only.mjs`) enforces this:
-it fails the merge-gate when an `app.mjs` build target under `examples/` lacks `neo-config.json`, or
-when any example here imports from `ai/`.
+it fails the merge-gate when an `app.mjs` build target under `examples/` lacks `neo-config.json` or
+`index.html` (webpack's `createStartingPoint` reads both), or when any example here imports from `ai/`.
 
 # Client Requirements
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "build-themes"                 : "node ./buildScripts/build/themes.mjs -f",
         "build-threads"                : "node ./buildScripts/webpack/buildThreads.mjs -f",
         "bundle-parse5"                : "node ./buildScripts/build/parse5.mjs",
+        "check-examples-body-only"     : "node ./buildScripts/util/check-examples-body-only.mjs",
         "check-reactive-tags"          : "node ./buildScripts/helpers/checkReactiveTags.mjs",
         "convert-design-tokens"        : "node ./buildScripts/helpers/convertDesignTokens.mjs",
         "create-app"                   : "node ./buildScripts/create/app.mjs",

--- a/test/playwright/unit/ai/buildScripts/util/check-examples-body-only.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-examples-body-only.spec.mjs
@@ -1,0 +1,96 @@
+import {test, expect} from '@playwright/test';
+import {execFileSync} from 'node:child_process';
+import fs             from 'node:fs';
+import path           from 'node:path';
+
+// The Playwright unit runner executes with cwd = repo root, so resolve against it rather than
+// __dirname arithmetic — the latter is brittle across nesting depth and git-worktree layouts.
+const
+    repoRoot   = process.cwd(),
+    scriptPath = path.join(repoRoot, 'buildScripts/util/check-examples-body-only.mjs'),
+    fixtureDir = path.join(repoRoot, 'examples', '__check_examples_body_only_fixture__');
+
+/**
+ * Writes throwaway files under a dedicated `examples/` fixture dir, runs the guard as a subprocess,
+ * then removes the fixture dir (one recursive remove, even if the assertion throws).
+ *
+ * @param {Object<String,String>} files Map of path-relative-to-fixtureDir -> file contents.
+ * @returns {{exitCode:number, output:string}}
+ */
+function runWithFixture(files) {
+    let exitCode = 0,
+        output   = '';
+
+    try {
+        for (const [rel, content] of Object.entries(files)) {
+            const abs = path.join(fixtureDir, rel);
+            fs.mkdirSync(path.dirname(abs), {recursive: true});
+            fs.writeFileSync(abs, content);
+        }
+
+        output = execFileSync('node', [scriptPath], {cwd: repoRoot, encoding: 'utf8'});
+    } catch (err) {
+        exitCode = err.status;
+        output   = (err.stdout || '') + (err.stderr || '');
+    } finally {
+        fs.rmSync(fixtureDir, {recursive: true, force: true});
+    }
+
+    return {exitCode, output};
+}
+
+/**
+ * @summary CI guard test for `buildScripts/util/check-examples-body-only.mjs`.
+ *
+ * Verifies the guard distinguishes the clean Body-only tree from each misplacement class `build-all`
+ * chokes on: an `app.mjs` build target missing `neo-config.json`, and an example importing from `ai/`.
+ * A conforming Body fixture (`app.mjs` + `neo-config.json`, no `ai/` import) confirms no false positive.
+ * Each case plants throwaway fixtures under `examples/`, runs the guard as a subprocess, asserts, cleans up.
+ *
+ * @see buildScripts/util/check-examples-body-only.mjs
+ */
+// `describe.serial` is REQUIRED: fixtures planted on-disk under `examples/` would otherwise leak across
+// Playwright's parallel workers (fullyParallel default), racing the clean-tree PASS test against
+// another worker's planted fixture.
+test.describe.serial('check-examples-body-only CI guard', () => {
+    test.afterEach(() => fs.rmSync(fixtureDir, {recursive: true, force: true}));
+
+    test('exits 0 (PASS) on the current clean Body-only tree', () => {
+        // The committed examples/ tree must be Body-only after the harness-benchmark relocation.
+        const result = execFileSync('node', [scriptPath], {cwd: repoRoot, encoding: 'utf8'});
+        expect(result).toContain('PASS');
+    });
+
+    test('exits 1 (FAIL) on an app.mjs build target missing neo-config.json', () => {
+        const {exitCode, output} = runWithFixture({
+            'vanillaComparator/app.mjs': 'document.body.innerHTML = "vanilla";\n'
+        });
+
+        expect(exitCode).toBe(1);
+        expect(output).toContain('FAIL');
+        expect(output).toContain('missing neo-config.json');
+        expect(output).toContain('ai/examples/');
+    });
+
+    test('exits 1 (FAIL) on an example importing from ai/', () => {
+        const {exitCode, output} = runWithFixture({
+            'harnessProbe/app.mjs'        : "import x from '../../../ai/services/Probe.mjs';\nexport default x;\n",
+            'harnessProbe/neo-config.json': '{}\n'
+        });
+
+        expect(exitCode).toBe(1);
+        expect(output).toContain('FAIL');
+        expect(output).toContain('importing from ai/');
+    });
+
+    test('exits 0 (PASS) for a conforming Body example fixture — no false positive', () => {
+        const {exitCode, output} = runWithFixture({
+            'goodBodyExample/app.mjs'        : "import Viewport from '../../../src/container/Viewport.mjs';\nexport default Viewport;\n",
+            'goodBodyExample/neo-config.json': '{}\n',
+            'goodBodyExample/index.html'     : '<!doctype html>\n'
+        });
+
+        expect(exitCode).toBe(0);
+        expect(output).toContain('PASS');
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/util/check-examples-body-only.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-examples-body-only.spec.mjs
@@ -63,7 +63,8 @@ test.describe.serial('check-examples-body-only CI guard', () => {
 
     test('exits 1 (FAIL) on an app.mjs build target missing neo-config.json', () => {
         const {exitCode, output} = runWithFixture({
-            'vanillaComparator/app.mjs': 'document.body.innerHTML = "vanilla";\n'
+            'vanillaComparator/app.mjs'   : 'document.body.innerHTML = "vanilla";\n',
+            'vanillaComparator/index.html': '<!doctype html>\n'
         });
 
         expect(exitCode).toBe(1);
@@ -72,10 +73,24 @@ test.describe.serial('check-examples-body-only CI guard', () => {
         expect(output).toContain('ai/examples/');
     });
 
+    test('exits 1 (FAIL) on an app.mjs build target missing index.html', () => {
+        // createStartingPoint reads index.html unconditionally too, so a build target with
+        // neo-config.json but no index.html is still a build-all breakage class.
+        const {exitCode, output} = runWithFixture({
+            'noIndexApp/app.mjs'        : "import Viewport from '../../../src/container/Viewport.mjs';\nexport default Viewport;\n",
+            'noIndexApp/neo-config.json': '{}\n'
+        });
+
+        expect(exitCode).toBe(1);
+        expect(output).toContain('FAIL');
+        expect(output).toContain('missing index.html');
+    });
+
     test('exits 1 (FAIL) on an example importing from ai/', () => {
         const {exitCode, output} = runWithFixture({
             'harnessProbe/app.mjs'        : "import x from '../../../ai/services/Probe.mjs';\nexport default x;\n",
-            'harnessProbe/neo-config.json': '{}\n'
+            'harnessProbe/neo-config.json': '{}\n',
+            'harnessProbe/index.html'     : '<!doctype html>\n'
         });
 
         expect(exitCode).toBe(1);


### PR DESCRIPTION
## Summary

Top-level `examples/` is built by `npm run build-all` — webpack's `parseFolder` recursively walks it and builds **every directory containing an `app.mjs`** as a Neo app, then `createStartingPoint` reads its `neo-config.json` **and `index.html`** (both unconditionally). So an AI / harness / vanilla / app-less example placed there breaks the build. This is a **repeated, operator-flagged friction** (it broke build-all again on PR #13066's harness-endurance benchmark) with **no mechanical guard** until now.

## Deltas

- `buildScripts/util/check-examples-body-only.mjs` — **CI guard (hard merge-gate).** Fails when (a) an `app.mjs` build target under `examples/` is missing a required Neo-app marker (`neo-config.json` **or** `index.html` — both are read by `createStartingPoint`), or (b) any `.mjs` under `examples/` imports from `ai/`. Mirrors the `check-retired-primitives` pattern; pure walk, `node:`-builtins only. Enumeration matches webpack's `parseFolder` exactly, so category dirs (no `app.mjs`) and legit Body leaves are not false-flagged.
- `.github/workflows/check-examples-body-only.yml` + `package.json` `check-examples-body-only` script — wire the guard into CI (PR + push to `dev`, paths-scoped to `examples/**` + the guard + the workflow).
- `.agents/skills/structural-pre-flight/references/structural-pre-flight-workflow.md` — **soft authoring-time layer:** a domain-boundary caveat flags `examples/`-vs-`ai/examples/` placement before the file lands.
- `examples/README.md` — documents the Body-only + full-marker contract (and converts two pre-existing markdown hard-break trailing-space lines to `<br>` so the whitespace hook passes).

Evidence: L2 (unit test + live-tree run). The guard's PASS/FAIL behavior on real + fixture inputs is fully covered; no sandbox-unreachable runtime AC.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-examples-body-only.spec.mjs
→ 5 passed
```

clean-tree PASS · missing-`neo-config` FAIL · missing-`index.html` FAIL · `ai/`-import FAIL · conforming-Body PASS (no false positive). Live-tree run: `npm run check-examples-body-only` → PASS (exit 0; 0/125 `app.mjs` targets lack `index.html`, so requiring it adds no false positives).

## Turn-Memory Pre-Flight (skill substrate)

This PR mutates `.agents/skills/structural-pre-flight/references/structural-pre-flight-workflow.md` (skill-loaded substrate), so per `/turn-memory-pre-flight`:
- **Placement:** the new rule is a *domain-boundary caveat* in §1 (Fast-Path examples) — the section that already governs directory/placement decisions for new `.mjs` files; it fires at exactly the decision point it guards.
- **Load-effect:** +6 lines, loaded only when `structural-pre-flight` fires (new-`.mjs` authoring). Net-add justified by future-decay-mitigation — it closes a *repeated* build-all friction and is the soft authoring-time twin of the hard CI gate this PR adds; the two reference each other, so the rule cannot drift silent.
- **Bias check:** narrow + accurate (`examples/` = Body, `ai/examples/` = AI-domain); it does not over-trigger or constrain non-`examples/` authoring.

## Post-Merge Validation

- [ ] The CI workflow runs green on this PR (the guard against the current Body-only tree).

## Contract Ledger

| Target Surface | Contract detail |
|---|---|
| `examples/` build-target contract (build + agent consumed) | `examples/` is Body-only: every `app.mjs`-bearing dir must carry **both** `neo-config.json` and `index.html`, and no example may import from `ai/`. Enforced at the merge-gate; AI-domain examples relocate to `ai/examples/` (served by the dev-server's `process.cwd()` static root, so browser e2e keeps working). |

Resolves #13098

Authored by Ada (@neo-opus-ada, Claude Opus 4.8)
