### PR TITLE
feat(core): diff-based afterSetListeners — apply only the listeners-config delta (#7091)

### DIFF
--- a/src/core/Observable.mjs
+++ b/src/core/Observable.mjs
@@ -179,13 +179,38 @@ class Observable extends Base {
      * @protected
      */
     afterSetListeners(value, oldValue) {
-        // Unregister any listeners from the old config object
-        if (oldValue && Object.keys(oldValue).length > 0) {
-            this.un(oldValue)
-        }
-        // Register all listeners from the new config object
-        if (value && Object.keys(value).length > 0) {
-            this.on(value)
+        let me           = this,
+            oldConfig    = oldValue || {},
+            newConfig    = value    || {},
+            // delay/once/order/scope sit at the config top level and apply to EVERY event entry, so
+            // they must travel with each per-event slice — and a change to any of them changes every
+            // event's effective registration (→ full re-bind).
+            reservedKeys = ['delay', 'once', 'order', 'scope'],
+            pickShared   = config => reservedKeys.reduce((opts, key) => {
+                if (key in config) {opts[key] = config[key]}
+                return opts
+            }, {}),
+            oldShared    = pickShared(oldConfig),
+            newShared    = pickShared(newConfig),
+            sharedSame   = reservedKeys.every(key => oldShared[key] === newShared[key]),
+            eventNames   = config => Object.keys(config).filter(key => !reservedKeys.includes(key)),
+            names        = new Set([...eventNames(oldConfig), ...eventNames(newConfig)]);
+
+        // Diff per event name: only apply the delta. An event whose handler reference AND the shared
+        // opts are unchanged keeps its live registration untouched — avoiding the un()+on() churn the
+        // prior brute-force rebuild caused, and leaving imperatively-added on() listeners unaffected.
+        for (const name of names) {
+            let inOld = name in oldConfig,
+                inNew = name in newConfig;
+
+            if (inOld && inNew && sharedSame && oldConfig[name] === newConfig[name]) {
+                continue
+            }
+
+            // Pass FRESH per-event slices (event entry + shared opts): on()/un() delete the reserved
+            // keys off the object they receive, so reusing the stored config objects would corrupt them.
+            if (inOld) {me.un({[name]: oldConfig[name], ...oldShared})}
+            if (inNew) {me.on({[name]: newConfig[name], ...newShared})}
         }
     }
 

--- a/test/playwright/unit/core/ObservableListenersDiff.spec.mjs
+++ b/test/playwright/unit/core/ObservableListenersDiff.spec.mjs
@@ -1,0 +1,110 @@
+import {setup} from '../../setup.mjs';
+
+setup();
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import Base           from '../../../../src/core/Base.mjs';
+import Observable     from '../../../../src/core/Observable.mjs'; // registers Neo.core.Observable so `static observable = true` resolves the mixin
+
+/**
+ * @summary Diff-based `core.Observable#afterSetListeners` — runtime listeners-config changes apply only the delta.
+ *
+ * Runtime changes to the `listeners` config apply only the per-event delta (add / remove / update)
+ * instead of the prior brute-force un()-all-old + on()-all-new rebuild. An event whose handler
+ * reference AND the shared opts (delay/once/order/scope) are unchanged keeps its live registration;
+ * imperatively-added on() listeners are never touched by a config change. These tests are the
+ * regression net (none existed for Observable before this change).
+ */
+test.describe('core.Observable diff-based afterSetListeners (#7091)', () => {
+    let counter = 0;
+
+    const makeInstance = cfg => {
+        class TestObservable extends Base {
+            static observable = true;
+            static config     = {className: `Neo.test.ObservableDiff${counter++}`};
+        }
+        TestObservable = Neo.setupClass(TestObservable);
+        return Neo.create(TestObservable, cfg);
+    };
+
+    test('add + unchanged: a new event is wired while the unchanged event keeps firing', () => {
+        let aCount = 0, bCount = 0;
+        const onA  = () => { aCount++ };
+        const inst = makeInstance({listeners: {eventA: onA}});
+
+        inst.fire('eventA');
+        expect(aCount).toBe(1);
+
+        inst.listeners = {eventA: onA, eventB: () => { bCount++ }};
+        inst.fire('eventA');
+        inst.fire('eventB');
+        expect(aCount).toBe(2); // eventA still wired — not churned by the config change
+        expect(bCount).toBe(1); // eventB newly added
+
+        inst.destroy();
+    });
+
+    test('update + remove: a changed handler replaces the old, a dropped event stops firing', () => {
+        let aCount = 0, bCount = 0;
+        const onA   = () => { aCount++ };
+        const onA2  = () => { aCount += 10 };
+        const inst  = makeInstance({listeners: {eventA: onA, eventB: () => { bCount++ }}});
+
+        inst.listeners = {eventA: onA2}; // update eventA's handler, drop eventB
+        inst.fire('eventA');
+        inst.fire('eventB');
+        expect(aCount).toBe(10); // only the new handler fires (old onA removed)
+        expect(bCount).toBe(0);  // eventB removed
+
+        inst.destroy();
+    });
+
+    test('unchanged events are NOT torn down via un() when another event is added', () => {
+        const onA  = () => {};
+        const inst = makeInstance({listeners: {eventA: onA}});
+
+        const unCalls = [];
+        const origUn  = inst.un.bind(inst);
+        inst.un = (...args) => { unCalls.push(args); return origUn(...args) };
+
+        inst.listeners = {eventA: onA, eventB: () => {}}; // eventA reference unchanged → must skip
+        expect(unCalls.length).toBe(0);
+
+        inst.destroy();
+    });
+
+    test('imperatively-added on() listeners survive a listeners-config change', () => {
+        let impCount = 0;
+        const inst   = makeInstance({listeners: {eventA: () => {}}});
+        inst.on('imperative', () => { impCount++ });
+
+        inst.listeners = {eventA: () => {}, eventB: () => {}}; // full config churn
+        inst.fire('imperative');
+        expect(impCount).toBe(1); // imperative listener untouched
+
+        inst.destroy();
+    });
+
+    test('a shared-opt (scope) change forces a re-bind even when the handler reference is unchanged', () => {
+        const handler = () => {},
+              scopeA  = {tag: 'A'},
+              scopeB  = {tag: 'B'};
+        const inst    = makeInstance({listeners: {eventA: handler, scope: scopeA}});
+
+        // Spy AFTER create so only the config-change delta is counted.
+        const calls  = {un: 0, on: 0};
+        const origUn = inst.un.bind(inst);
+        const origOn = inst.on.bind(inst);
+        inst.un = (...args) => { calls.un++; return origUn(...args) };
+        inst.on = (...args) => { calls.on++; return origOn(...args) };
+
+        // Same handler reference, but the shared scope changed → the event must NOT be skipped: a
+        // shared-opt change alters every event's effective registration, forcing un()+on().
+        inst.listeners = {eventA: handler, scope: scopeB};
+        expect(calls.un).toBeGreaterThan(0);
+        expect(calls.on).toBeGreaterThan(0);
+
+        inst.destroy();
+    });
+});


### PR DESCRIPTION
## Summary

`core.Observable#afterSetListeners` rebuilt the entire listener set on every `listeners`-config change — `un()` ALL old listeners, then `on()` ALL new ones — even when only one event changed. This refactors it to apply only the per-event delta (the operator-authored ticket's goal).

## Deltas

- `src/core/Observable.mjs` — `afterSetListeners(value, oldValue)` now diffs by event name:
  - An event whose handler **reference** AND the shared opts (`delay`/`once`/`order`/`scope`) are unchanged keeps its live registration — no `un()`+`on()` churn.
  - Added / removed / changed events get exactly the `un()` / `on()` they need.
  - Shared opts travel with each per-event slice; a shared-opt change re-binds every event (it alters every event's effective registration).
  - **Fresh** slice objects are passed to `on()`/`un()` — those methods internally `delete` the reserved keys, so reusing the stored config objects previously mutated them; the stored config is now left intact.
  - Imperatively-added `on()` listeners stay unaffected (only the old config's entries are `un()`'d — unchanged contract).
- `test/playwright/unit/core/ObservableListenersDiff.spec.mjs` — the **first** Observable regression suite.

Evidence: L2 (unit). No runtime AC beyond listener behavior; fully covered by the suite.

## Test Evidence

```
npm run test-unit -- test/playwright/unit/core/
→ 35 passed (978ms)
```

5 new tests (add/unchanged · update/remove · no-churn skip · imperative-preserved · shared-opt rebind) + the 30 existing core tests — no regression.

## Post-Merge Validation

- [ ] Full CI unit suite green — Observable is load-bearing, so CI exercises the broader `listeners`-config surface across components/state that the local `core/` run does not.

Resolves #7091

Authored by Ada (@neo-opus-ada, Claude Opus 4.8)
