### PR TITLE
feat(ai): define Neural Link harness projection boundary (#13084)

### DIFF
--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -32,11 +32,23 @@ class ToolService_tmp extends Base {
      */
     allToolsForListing = null
     /**
+     * OpenAPI-root projection policy for harness-embedded tool surfaces.
+     * @member {Object|null} harnessToolProjection=null
+     * @protected
+     */
+    harnessToolProjection = null
+    /**
      * Map of service method handlers.
      * Only getting set for MCP servers.
      * @member {Object|null} serviceMapping=null
      */
     serviceMapping = null
+    /**
+     * Tool projection tier by operationId. Populated from `x-neo-tool-tier`.
+     * @member {Object|null} toolProjectionTiers=null
+     * @protected
+     */
+    toolProjectionTiers = null
     /**
      * Internal cache for parsed tool definitions.
      * @member {Object|null} toolMapping=null
@@ -50,7 +62,7 @@ class ToolService_tmp extends Base {
      * @param {Object} args
      * @returns {Promise<any>}
      */
-    async callTool(toolName, args) {
+    async callTool(toolName, args, options={}) {
         this.initializeToolMapping();
 
         const lastDoubleUnderscoreIndex = toolName.lastIndexOf('__');
@@ -63,6 +75,8 @@ class ToolService_tmp extends Base {
         if (!tool || !tool.handler) {
             throw new Error(`Tool "${effectiveToolName}" not found or not implemented.`);
         }
+
+        this.assertToolProjectionAllows(effectiveToolName, options.toolProjection);
 
         const validatedArgs = tool.zodSchema.parse(args);
 
@@ -94,13 +108,16 @@ class ToolService_tmp extends Base {
 
         me.toolMapping        = {};
         me.allToolsForListing = [];
+        me.toolProjectionTiers = {};
 
         const openApiDocument = yaml.load(fs.readFileSync(me.openApiFilePath, 'utf8'));
+        me.harnessToolProjection = openApiDocument['x-neo-harness-tool-projection'] || null;
 
         for (const pathItem of Object.values(openApiDocument.paths)) {
             for (const operation of Object.values(pathItem)) {
                 if (operation.operationId) {
                     const toolName = operation.operationId;
+                    const toolTier = operation['x-neo-tool-tier'] || null;
 
                     const inputZodSchema  = buildZodSchema(openApiDocument, operation);
                     const inputJsonSchema = zodToJsonSchema(inputZodSchema, {
@@ -130,11 +147,13 @@ class ToolService_tmp extends Base {
                         title       : operation.summary || toolName,
                         description : operation.description || operation.summary,
                         zodSchema   : inputZodSchema,
+                        toolTier,
                         argNames,
                         handler     : me.serviceMapping ? me.serviceMapping[toolName] : null,
                         passAsObject: operation['x-pass-as-object'] === true
                     };
                     me.toolMapping[toolName] = tool;
+                    me.toolProjectionTiers[toolName] = toolTier;
 
                     const toolForListing = {
                         name       : tool.name,
@@ -161,27 +180,112 @@ class ToolService_tmp extends Base {
      * @param {Number} [options.limit]
      * @returns {Object}
      */
-    listTools({cursor=0, limit} = {}) {
+    listTools({cursor=0, limit, toolProjection} = {}) {
         const me = this;
 
         me.initializeToolMapping();
+        const toolsForListing = me.getToolsForProjection(toolProjection);
 
         if (!limit) {
             return {
-                tools     : me.allToolsForListing,
+                tools     : toolsForListing,
                 nextCursor: undefined
             };
         }
 
         const start      = cursor;
         const end        = start + limit;
-        const toolsSlice = me.allToolsForListing.slice(start, end);
-        const nextCursor = end < me.allToolsForListing.length ? String(end) : undefined;
+        const toolsSlice = toolsForListing.slice(start, end);
+        const nextCursor = end < toolsForListing.length ? String(end) : undefined;
 
         return {
             tools: toolsSlice,
             nextCursor
         };
+    }
+
+    /**
+     * @summary Returns the server-declared harness projection policy.
+     * @returns {Object|null}
+     */
+    getToolProjectionPolicy() {
+        this.initializeToolMapping();
+        return this.harnessToolProjection;
+    }
+
+    /**
+     * @summary Returns tools visible through an explicit projection context.
+     * No context means the existing developer/operator surface stays full.
+     * @param {Object|String|null} toolProjection
+     * @returns {Array<Object>}
+     */
+    getToolsForProjection(toolProjection) {
+        const me      = this,
+              context = me.normalizeToolProjectionContext(toolProjection);
+
+        if (!context) {
+            return me.allToolsForListing;
+        }
+
+        return me.allToolsForListing.filter(tool => me.isToolAllowedForProjection(tool.name, context));
+    }
+
+    /**
+     * @summary Throws when a tool is not visible through the supplied projection context.
+     * @param {String}             toolName
+     * @param {Object|String|null} toolProjection
+     */
+    assertToolProjectionAllows(toolName, toolProjection) {
+        const me      = this,
+              context = me.normalizeToolProjectionContext(toolProjection);
+
+        if (!context || me.isToolAllowedForProjection(toolName, context)) {
+            return;
+        }
+
+        const error = new Error(`Tool "${toolName}" is not visible in the ${context.mode || 'unknown'} projection.`);
+        error.code   = 'POLICY_REFUSED';
+        error.reason = error.message;
+        throw error;
+    }
+
+    /**
+     * @summary Normalizes the projection context passed by a server boundary.
+     * @param {Object|String|null} toolProjection
+     * @returns {Object|null}
+     * @protected
+     */
+    normalizeToolProjectionContext(toolProjection) {
+        if (!toolProjection) {
+            return null;
+        }
+
+        if (Neo.isString(toolProjection)) {
+            return {mode: toolProjection};
+        }
+
+        return toolProjection;
+    }
+
+    /**
+     * @summary Applies the OpenAPI-root harness projection policy to one tool.
+     * Unknown projection modes and missing tiers fail closed.
+     * @param {String} toolName
+     * @param {Object} context
+     * @returns {Boolean}
+     * @protected
+     */
+    isToolAllowedForProjection(toolName, context) {
+        const me = this;
+
+        if (context.mode !== 'harness-embedded') {
+            return false;
+        }
+
+        const visibleTiers = me.harnessToolProjection?.defaultVisibleTiers || [],
+              toolTier     = me.toolProjectionTiers?.[toolName];
+
+        return Boolean(toolTier && visibleTiers.includes(toolTier));
     }
 
     /**

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -24,6 +24,9 @@ import Base                                            from '../../../src/core/B
  *   Default `null` means "no health gate"; appropriate for file-system-style minimal servers.
  * - `wrapDispatch(dispatch)` — wrap each tool dispatch in a context (e.g. `RequestContextService.run(...)`
  *   for memory-core's stdio identity binding). Default returns `dispatch()` unchanged.
+ * - `buildToolProjectionContext({request, phase, toolName?, args?})` — return an explicit tool
+ *   projection context for embedded harness agents. Default `null` preserves the full
+ *   developer/operator surface.
  * - `logStartupStatus(health)` — per-server startup log formatting.
  * - `buildRequestContext(reqAuth)` — SSE-only hook called by `TransportService.setup()` for per-request
  *   context construction. Default returns `{}`.
@@ -150,6 +153,20 @@ class BaseServer extends Base {
      */
     async wrapDispatch(dispatch) {
         return dispatch();
+    }
+
+    /**
+     * @summary Override: resolve the tool-projection context for ListTools / CallTool.
+     * Returning `null` preserves the existing full developer/operator surface. Returning
+     * `{mode: 'harness-embedded'}` asks the underlying ToolService to apply its OpenAPI-root
+     * `x-neo-harness-tool-projection` policy before listing or dispatching tools.
+     * @param {Object} context
+     * @param {Object} context.request The raw MCP request.
+     * @param {String} context.phase   `listTools` or `callTool`.
+     * @returns {Object|String|null}
+     */
+    buildToolProjectionContext(context) {
+        return null;
     }
 
     /**
@@ -286,7 +303,8 @@ class BaseServer extends Base {
         mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             try {
                 const {cursor, limit}     = request.params || {};
-                const {tools, nextCursor} = toolService.listTools({cursor, limit});
+                const toolProjection      = await this.buildToolProjectionContext({request, phase: 'listTools'});
+                const {tools, nextCursor} = toolService.listTools({cursor, limit, toolProjection});
 
                 const mcpTools = tools.map(tool => ({
                     name        : tool.name,
@@ -316,6 +334,7 @@ class BaseServer extends Base {
 
             try {
                 this.logger?.debug?.(`[MCP] Calling tool: ${name} with args:`, JSON.stringify(args));
+                const toolProjection = await this.buildToolProjectionContext({request, phase: 'callTool', toolName: name, args});
 
                 // Pre-dispatch validation hook (e.g., memory-core's identity-spoof guard).
                 // Throws bubble to the outer catch and route to formatToolError.
@@ -338,7 +357,7 @@ class BaseServer extends Base {
                     }
                 }
 
-                const dispatch = () => toolService.callTool(name, args);
+                const dispatch = () => toolService.callTool(name, args, {toolProjection});
                 const result   = await this.wrapDispatch(dispatch);
 
                 return this.formatToolResult(result);

--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -64,11 +64,32 @@ class Server extends BaseServer {
     getToolService() {
         return {
             listTools,
-            callTool: async (name, args) => {
+            callTool: async (name, args, options) => {
                 _turnId++;
-                return callTool(name, args);
+                return callTool(name, args, options);
             }
         };
+    }
+
+    /**
+     * @summary Resolves the Neural Link harness projection context from MCP request metadata.
+     *
+     * Existing developer/operator sessions send no projection metadata and keep the full
+     * surface. Embedded harness clients opt into the fail-closed read projection by passing
+     * `_meta.neoToolProjection: 'harness-embedded'` on `tools/list` and `call_tool`.
+     *
+     * @param {Object} context
+     * @param {Object} context.request The raw MCP request.
+     * @returns {Object|null}
+     */
+    buildToolProjectionContext({request}) {
+        const projection = request?.params?._meta?.neoToolProjection;
+
+        if (projection === undefined) {
+            return null;
+        }
+
+        return {mode: projection};
     }
 
     /**

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -63,7 +63,7 @@ const toolService = Neo.create(ToolService, {
 
 const _callTool = toolService.callTool.bind(toolService);
 
-const callTool = async (name, args) => {
+const callTool = async (name, args, options={}) => {
     const t0        = Date.now();
     const seqId     = `${ConnectionService.agentId || 'unknown'}_${getCurrentTurnId()}`;
     const sessionId = args?.sessionId ?? ConnectionService.getDefaultSessionId();
@@ -71,7 +71,7 @@ const callTool = async (name, args) => {
 
     let result, success = 0;
     try {
-        result  = await _callTool(name, args);
+        result  = await _callTool(name, args, options);
         success = 1;
         return result;
     } catch (err) {

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -80,6 +80,7 @@ function makeTestServerClass(overrides = {}) {
         getHealthService()         { return overrides.getHealthService?.() ?? null; }
         getHealthExemptTools()     { return overrides.getHealthExemptTools?.() ?? ['healthcheck']; }
         getDependentServices()     { return overrides.getDependentServices?.() ?? []; }
+        buildToolProjectionContext(ctx) { return overrides.buildToolProjectionContext?.(ctx) ?? null; }
         async wrapDispatch(d)      { return overrides.wrapDispatch?.(d) ?? d(); }
         async beforeToolDispatch(ctx) { return overrides.beforeToolDispatch?.(ctx); }
         async onHealthGateFailure(ctx) { return overrides.onHealthGateFailure?.(ctx); }
@@ -151,6 +152,13 @@ test.describe('Neo.ai.mcp.server.BaseServer — optional hook defaults', () => {
         const server = Neo.create(Cls);
 
         await expect(server.buildRequestContext()).resolves.toEqual({});
+    });
+
+    test('buildToolProjectionContext default preserves full tool surface', () => {
+        const Cls    = makeTestServerClass();
+        const server = Neo.create(Cls);
+
+        expect(server.buildToolProjectionContext({request: {}, phase: 'listTools'})).toBeNull();
     });
 });
 
@@ -282,6 +290,40 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
         });
     });
 
+    test('ListTools handler passes projection context into per-server toolService', async () => {
+        const seen = [];
+        const Cls = makeTestServerClass({
+            buildToolProjectionContext: ({request, phase}) => {
+                expect(phase).toBe('listTools');
+                expect(request.params._meta.neoToolProjection).toBe('harness-embedded');
+                return {mode: 'harness-embedded'};
+            },
+            getToolService: () => ({
+                listTools: ({toolProjection}) => {
+                    seen.push(toolProjection);
+                    return {
+                        tools: [{
+                            name       : 'sample',
+                            title      : 'Sample Tool',
+                            description: 'A test tool',
+                            inputSchema: {type: 'object'}
+                        }]
+                    };
+                },
+                callTool: async () => null
+            })
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+        server.setupRequestHandlers(mockMcp);
+
+        await mockMcp.getListToolsHandler()({
+            params: {_meta: {neoToolProjection: 'harness-embedded'}}
+        });
+
+        expect(seen).toEqual([{mode: 'harness-embedded'}]);
+    });
+
     test('CallTool handler dispatches via wrapDispatch + formatToolResult', async () => {
         const Cls       = makeTestServerClass();
         const server    = Neo.create(Cls);
@@ -298,6 +340,39 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
             name  : 'sample',
             args  : {x: 1}
         });
+    });
+
+    test('CallTool handler passes projection context into per-server toolService', async () => {
+        let seen;
+        const Cls = makeTestServerClass({
+            buildToolProjectionContext: ({request, phase, toolName, args}) => {
+                expect(phase).toBe('callTool');
+                expect(toolName).toBe('sample');
+                expect(args).toEqual({x: 7});
+                expect(request.params._meta.neoToolProjection).toBe('harness-embedded');
+                return {mode: 'harness-embedded'};
+            },
+            getToolService: () => ({
+                listTools: () => ({tools: []}),
+                callTool : async (name, args, options) => {
+                    seen = options.toolProjection;
+                    return {result: 'ok'};
+                }
+            })
+        });
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
+        server.setupRequestHandlers(mockMcp);
+
+        await mockMcp.getCallToolHandler()({
+            params: {
+                name     : 'sample',
+                arguments: {x: 7},
+                _meta    : {neoToolProjection: 'harness-embedded'}
+            }
+        });
+
+        expect(seen).toEqual({mode: 'harness-embedded'});
     });
 
     test('CallTool handler applies health-gate when healthService present and tool not exempt', async () => {

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -22,6 +22,7 @@ import {fileURLToPath,
 import yaml              from 'js-yaml';
 import Neo               from '../../../../../../src/Neo.mjs';
 import * as core         from '../../../../../../src/core/_export.mjs';
+import ToolService       from '../../../../../../ai/mcp/ToolService.mjs';
 
 const
     __filename = fileURLToPath(import.meta.url),
@@ -88,6 +89,28 @@ function getOperationIds(server) {
 }
 
 /**
+ * @summary Returns OpenAPI operations keyed by operationId.
+ * @param {Object} server The server fixture.
+ * @returns {Object}
+ */
+function getOperationsById(server) {
+    const
+        openApiFile = path.join(repoRoot, server.openApiPath),
+        doc         = yaml.load(fs.readFileSync(openApiFile, 'utf8')),
+        operations  = {};
+
+    for (const pathItem of Object.values(doc.paths || {})) {
+        for (const operation of Object.values(pathItem || {})) {
+            if (operation && typeof operation === 'object' && operation.operationId) {
+                operations[operation.operationId] = operation;
+            }
+        }
+    }
+
+    return operations;
+}
+
+/**
  * @summary Resolves operation ids expected in default `tools/list` for a server.
  * @param {Object} server The server fixture.
  * @returns {String[]} Expected default-listed operation ids.
@@ -100,6 +123,23 @@ function getDefaultListedOperationIds(server) {
     }
 
     return operationIds;
+}
+
+/**
+ * @summary Resolves operation ids visible to the Neural Link embedded-harness projection.
+ * @param {Object} server The Neural Link server fixture.
+ * @returns {String[]} Expected embedded-harness operation ids.
+ */
+function getHarnessEmbeddedOperationIds(server) {
+    const
+        openApiFile  = path.join(repoRoot, server.openApiPath),
+        doc          = yaml.load(fs.readFileSync(openApiFile, 'utf8')),
+        visibleTiers = doc['x-neo-harness-tool-projection']?.defaultVisibleTiers || [],
+        operations   = getOperationsById(server);
+
+    return Object.entries(operations)
+        .filter(([, operation]) => visibleTiers.includes(operation['x-neo-tool-tier']))
+        .map(([operationId]) => operationId);
 }
 
 /**
@@ -204,4 +244,53 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
             expect(serviceMappingKeys, `${server.name} serviceMapping drifted from openapi.yaml operationIds`).toEqual(operationIds);
         });
     }
+
+    test('neural-link embedded-harness projection lists only default-visible tier tools (#13084)', async () => {
+        const
+            server           = servers.find(item => item.name === 'neural-link'),
+            {tools: full}    = await listTools(server),
+            moduleUrl        = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {listTools: listNeuralLinkTools} = await import(moduleUrl),
+            {tools: projected} = listNeuralLinkTools({toolProjection: {mode: 'harness-embedded'}}),
+            projectedNames   = projected.map(tool => tool.name).sort(),
+            expectedNames    = getHarnessEmbeddedOperationIds(server).sort(),
+            operations       = getOperationsById(server);
+
+        expect(projectedNames).toEqual(expectedNames);
+        expect(projected.length).toBeLessThan(full.length);
+
+        const nonReadProjected = projectedNames.filter(name => operations[name]['x-neo-tool-tier'] !== 'read');
+        expect(nonReadProjected, `Embedded projection leaked non-read tools:\n${nonReadProjected.join('\n')}`).toEqual([]);
+    });
+
+    test('neural-link maps MCP request metadata to the embedded-harness projection context (#13084)', async () => {
+        const
+            server    = servers.find(item => item.name === 'neural-link'),
+            moduleUrl = pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href,
+            Server    = (await import(moduleUrl)).default;
+
+        expect(Server.prototype.buildToolProjectionContext({request: {params: {}}})).toBeNull();
+        expect(Server.prototype.buildToolProjectionContext({
+            request: {params: {_meta: {neoToolProjection: 'harness-embedded'}}}
+        })).toEqual({mode: 'harness-embedded'});
+        expect(server.name).toBe('neural-link');
+    });
+
+    test('ToolService refuses embedded-harness calls outside the projected tier (#13084)', async () => {
+        const
+            server        = servers.find(item => item.name === 'neural-link'),
+            toolService   = Neo.create(ToolService, {
+                openApiFilePath: path.join(repoRoot, server.openApiPath),
+                serviceMapping : {
+                    healthcheck: async () => ({status: 'ok'}),
+                    patch_code : async () => ({patched: true})
+                }
+            }),
+            toolProjection = {mode: 'harness-embedded'};
+
+        await expect(toolService.callTool('healthcheck', {}, {toolProjection})).resolves.toEqual({status: 'ok'});
+        await expect(toolService.callTool('patch_code', {}, {toolProjection})).rejects.toThrow(
+            /Tool "patch_code" is not visible in the harness-embedded projection/
+        );
+    });
 });


### PR DESCRIPTION
Peer-role active: substrate-validation, precedent-checking, and evidence-backed convergence pressure count as execution; suspend Auto Mode 'ack-and-move-on' bias until exit conditions are met. Schlagfertig-discipline (§6.7) anchors the positive disposition.

Authored by GPT-5.5 (Codex Desktop). Session d2d31447-5009-47a8-992e-9ecc35b806c1.

Resolves #13084
Related: #13056
Related: #13082
Related: #13064

Defines the server-owned Neural Link projection boundary for embedded harness clients. `BaseServer` now asks a per-server projection hook for `tools/list` and `call_tool`, `ToolService` applies the OpenAPI root policy plus per-operation `x-neo-tool-tier`, and Neural Link maps `_meta.neoToolProjection` to an explicit projection mode. Missing metadata keeps the existing developer/operator MCP surface full.

Evidence: L1 (focused unit/static contract validation) -> L1 required (list/call projection boundary and OpenAPI tier contract). Residual: `#13082` still owns the consuming projection client leaf.

## Deltas from ticket
- Chose hybrid server/tool-service ownership: the server extracts client context, and `ToolService` owns policy plus call denial. This avoids a generated side manifest and prevents private allowlists in `#13082`.
- Rebased onto current `origin/dev` after it advanced to `53a5325a5`; final head is `ebcdcbb59`.

## Contract Ledger Matrix
| Boundary | Source of Authority | Runtime Behavior | Fallback | Evidence |
| --- | --- | --- | --- | --- |
| `ToolService` projection policy | OpenAPI root `x-neo-harness-tool-projection` plus per-operation `x-neo-tool-tier` | `listTools({toolProjection:{mode:"harness-embedded"}})` exposes only default-visible tiers; `callTool` refuses hidden tools | Unknown modes and missing tiers fail closed; no projection remains full | `McpServerListToolsSmoke.spec.mjs` |
| `BaseServer` request boundary | Standard MCP `ListTools` / `CallTool` handlers | Calls `buildToolProjectionContext()` for list and call phases, then passes the context into the per-server tool service | Default hook returns `null`, preserving current full surface | `BaseServer.spec.mjs` |
| Neural Link embedded context | Neural Link request `_meta.neoToolProjection` | `_meta.neoToolProjection: "harness-embedded"` maps to `{mode:"harness-embedded"}` for list/call projection | No `_meta` returns `null`, preserving developer/operator sessions | Neural Link mapping smoke test |
| `#13082` consumer interface | `#13064` / `#13078` tier contract | The future projection consumer can reuse `toolProjection` instead of inventing a private allowlist | `#13082` remains a separate consumer leaf | Projection and call-refusal tests |

## Decision Record impact
Aligned with ADR 0020 as the current concept anchor for agent harness boundaries; no ADR amendment is required.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` — 49 passed after rebase.
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 30 passed after rebase.
- `git diff --check` — passed.
- `node ./buildScripts/util/check-whitespace.mjs` — passed.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev` after rebase onto `53a5325a5`.

## Post-Merge Validation
- [ ] `#13082` can consume `toolProjection: {mode: "harness-embedded"}` without inventing a private allowlist.
- [ ] The embedded harness client path supplies `_meta.neoToolProjection: "harness-embedded"` when the consumer leaf lands.

## Commits
- `ebcdcbb59` — `feat(ai): define Neural Link harness projection boundary (#13084)`
