### PR TITLE
feat(dashboard): render dock split tab layouts (#13105)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -32,8 +32,8 @@ Initial durable surface: this document.
 
 Future code ownership should follow this decision tree:
 
-1. If the first implementation only proves Agent Harness workspace persistence, place the adapter in the harness app layer and keep the model documented here.
-2. If a second independent in-repo use lands, lift the reusable model/parser into the dashboard/container substrate. Candidate second use: the Portal learning workspace, where docs, Monaco/live preview, output panes, and inspectors benefit from saveable split/tab workspaces.
+1. If the first implementation only proves Agent Harness workspace persistence with app-specific pane wiring or persistence glue, place that app-specific code in the harness app layer and keep the model documented here.
+2. If the first implementation is a reusable projection adapter that consumes dashboard/container/tab primitives and emits ordinary Neo configs, place the adapter in the dashboard layer while keeping the model contract here. A second independent in-repo use is still required before lifting the model/parser or public API beyond dashboard adaptation. Candidate second use: the Portal learning workspace, where docs, Monaco/live preview, output panes, and inspectors benefit from saveable split/tab workspaces.
 3. Only after reusable behavior exceeds dashboard adaptation should a generic core layout primitive be considered.
 
 Rejected alternatives:

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -1,0 +1,357 @@
+import Base from '../core/Base.mjs';
+
+/**
+ * @summary Projects Agent Harness dock-zone model nodes into existing Neo layout and tab configs.
+ *
+ * The adapter consumes committed dock-zone state only. Transient drag preview fields such as `dockPreview`,
+ * pointer coordinates, window geometry, or DOM rectangles belong to the drag/drop pipeline and are rejected here.
+ *
+ * @class Neo.dashboard.DockLayoutAdapter
+ * @extends Neo.core.Base
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockLayoutAdapter extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockLayoutAdapter'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockLayoutAdapter'
+    }
+
+    /**
+     * Preview-only fields must not leak into committed layout projection.
+     * @member {Set<String>} forbiddenPreviewKeys
+     * @protected
+     * @static
+     */
+    static forbiddenPreviewKeys = new Set([
+        'dockPreview',
+        'domRect',
+        'DOMRect',
+        'placement',
+        'pointer',
+        'pointerX',
+        'pointerY',
+        'previewId',
+        'windowId'
+    ])
+
+    /**
+     * Builds a recoverable placeholder config for a dock item whose live component and blueprint cannot be resolved.
+     * @param {String} itemId
+     * @param {Object|null} item
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static createPlaceholder(itemId, item) {
+        let title = item?.title || itemId;
+
+        return {
+            cls       : ['neo-dashboard-dock-placeholder'],
+            data      : {
+                componentRef       : item?.componentRef || null,
+                dockItemId         : itemId,
+                missingComponentRef: true
+            },
+            dockItemId: itemId,
+            header    : {text: title},
+            ntype     : 'dashboard-panel'
+        }
+    }
+
+    /**
+     * Returns a cloned config object for JSON-compatible configs.
+     * @param {*} value
+     * @returns {*}
+     * @protected
+     * @static
+     */
+    static cloneConfig(value) {
+        if (Array.isArray(value)) {
+            return value.map(item => this.cloneConfig(item))
+        }
+
+        if (value && value.constructor === Object) {
+            let clone = {};
+
+            Object.entries(value).forEach(([key, val]) => {
+                clone[key] = this.cloneConfig(val)
+            });
+
+            return clone
+        }
+
+        return value
+    }
+
+    /**
+     * Decorates a resolved component config with stable dock-item metadata without mutating the source item record.
+     * @param {*} component
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {*}
+     * @protected
+     * @static
+     */
+    static decorateItemConfig(component, itemId, item) {
+        if (!component || component.constructor !== Object) {
+            return component
+        }
+
+        let config = {...component},
+            data   = {...(config.data || {})};
+
+        data.componentRef = item.componentRef || null;
+        data.dockItemId   = itemId;
+
+        config.data       = data;
+        config.dockItemId = itemId;
+        config.header     = config.header || {text: item.title || itemId};
+
+        return config
+    }
+
+    /**
+     * Returns the first preview-only key found in an arbitrary object graph.
+     * @param {*} value
+     * @returns {String|null}
+     * @protected
+     * @static
+     */
+    static findForbiddenPreviewKey(value) {
+        if (!value || typeof value !== 'object') {
+            return null
+        }
+
+        if (Array.isArray(value)) {
+            for (let i = 0; i < value.length; i++) {
+                let match = this.findForbiddenPreviewKey(value[i]);
+
+                if (match) {
+                    return match
+                }
+            }
+
+            return null
+        }
+
+        for (let key of Object.keys(value)) {
+            if (this.forbiddenPreviewKeys.has(key)) {
+                return key
+            }
+
+            let match = this.findForbiddenPreviewKey(value[key]);
+
+            if (match) {
+                return match
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Returns normalized flex values for split children.
+     * @param {Number[]} sizes
+     * @param {Number} count
+     * @returns {Number[]}
+     * @protected
+     * @static
+     */
+    static getFlexValues(sizes, count) {
+        if (!Array.isArray(sizes) || sizes.length !== count) {
+            return Array(count).fill(1)
+        }
+
+        let values = sizes.map(Number);
+
+        if (values.some(value => !Number.isFinite(value) || value <= 0)) {
+            return Array(count).fill(1)
+        }
+
+        return values
+    }
+
+    /**
+     * Projects the model root into a Neo-compatible config tree.
+     * @param {Object} model
+     * @param {Object} [options={}]
+     * @param {Function} [options.resolveComponentRef]
+     * @returns {Object}
+     * @static
+     */
+    static project(model, options={}) {
+        let forbiddenKey = this.findForbiddenPreviewKey(model);
+
+        if (forbiddenKey) {
+            throw new Error(`DockLayoutAdapter input must be committed dock-zone model; preview-only field "${forbiddenKey}" is not allowed.`)
+        }
+
+        if (!model?.nodes || !model.root) {
+            throw new Error('DockLayoutAdapter requires a model with `root` and `nodes`.')
+        }
+
+        return this.projectNode(model.root, {
+            items              : model.items || {},
+            nodes              : model.nodes,
+            resolveComponentRef: options.resolveComponentRef || (() => null)
+        })
+    }
+
+    /**
+     * Projects an edge-zone node into nested ordinary container configs.
+     * @param {String} nodeId
+     * @param {Object} node
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static projectEdgeZoneNode(nodeId, node, context) {
+        let {zones={}} = node,
+            middleItems = ['left', 'center', 'right']
+                .filter(zone => zones[zone])
+                .map(zone => this.projectNode(zones[zone], context)),
+            rows = [];
+
+        if (zones.top) {
+            rows.push(this.projectNode(zones.top, context))
+        }
+
+        if (middleItems.length === 1) {
+            rows.push(middleItems[0])
+        } else if (middleItems.length > 1) {
+            rows.push({
+                cls          : ['neo-dashboard-dock-edge-row'],
+                dockNodeType : 'edge-zone-row',
+                items        : middleItems,
+                layout       : {ntype: 'hbox', align: 'stretch'},
+                ntype        : 'container'
+            })
+        }
+
+        if (zones.bottom) {
+            rows.push(this.projectNode(zones.bottom, context))
+        }
+
+        return {
+            cls         : ['neo-dashboard-dock-edge-zone'],
+            dockNodeId  : nodeId,
+            dockNodeType: 'edge-zone',
+            items       : rows,
+            layout      : {ntype: 'vbox', align: 'stretch'},
+            ntype       : 'container'
+        }
+    }
+
+    /**
+     * Projects one dock item id into a Neo config or recoverable placeholder.
+     * @param {String} itemId
+     * @param {Object} context
+     * @returns {*}
+     * @protected
+     * @static
+     */
+    static projectItem(itemId, context) {
+        let item      = context.items[itemId],
+            component = null;
+
+        if (!item) {
+            return this.createPlaceholder(itemId, null)
+        }
+
+        component = context.resolveComponentRef(item.componentRef, item, itemId);
+
+        if (!component && item.blueprint) {
+            component = this.cloneConfig(item.blueprint)
+        }
+
+        return component ? this.decorateItemConfig(component, itemId, item) : this.createPlaceholder(itemId, item)
+    }
+
+    /**
+     * Projects a dock-zone node by id.
+     * @param {String} nodeId
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static projectNode(nodeId, context) {
+        let node = context.nodes[nodeId];
+
+        if (!node) {
+            throw new Error(`DockLayoutAdapter could not find dock-zone node "${nodeId}".`)
+        }
+
+        switch (node.type) {
+            case 'edge-zone':
+                return this.projectEdgeZoneNode(nodeId, node, context)
+            case 'split':
+                return this.projectSplitNode(nodeId, node, context)
+            case 'tabs':
+                return this.projectTabsNode(nodeId, node, context)
+            default:
+                throw new Error(`DockLayoutAdapter does not support dock-zone node type "${node.type}".`)
+        }
+    }
+
+    /**
+     * Projects a split node into an ordinary container using hbox or vbox.
+     * @param {String} nodeId
+     * @param {Object} node
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static projectSplitNode(nodeId, node, context) {
+        let children    = Array.isArray(node.children) ? node.children : [],
+            flexValues  = this.getFlexValues(node.sizes, children.length),
+            orientation = node.orientation === 'vertical' ? 'vertical' : 'horizontal',
+            layoutNtype = orientation === 'vertical' ? 'vbox' : 'hbox';
+
+        return {
+            cls         : ['neo-dashboard-dock-split', `neo-dashboard-dock-split-${orientation}`],
+            dockNodeId  : nodeId,
+            dockNodeType: 'split',
+            items       : children.map((childId, index) => ({
+                ...this.projectNode(childId, context),
+                flex: flexValues[index]
+            })),
+            layout      : {ntype: layoutNtype, align: 'stretch'},
+            ntype       : 'container'
+        }
+    }
+
+    /**
+     * Projects a tabs node into a tab.Container-compatible config.
+     * @param {String} nodeId
+     * @param {Object} node
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static projectTabsNode(nodeId, node, context) {
+        let items       = Array.isArray(node.items) ? node.items : [],
+            activeIndex = items.length ? items.indexOf(node.activeItemId) : null;
+
+        if (activeIndex < 0) {
+            activeIndex = items.length ? 0 : null
+        }
+
+        return {
+            activeIndex,
+            cls         : ['neo-dashboard-dock-tabs'],
+            dockNodeId  : nodeId,
+            dockNodeType: 'tabs',
+            items       : items.map(itemId => this.projectItem(itemId, context)),
+            ntype       : 'tab-container'
+        }
+    }
+}
+
+export default Neo.setupClass(DockLayoutAdapter);

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -26,14 +26,20 @@ class DockLayoutAdapter extends Base {
      * @static
      */
     static forbiddenPreviewKeys = new Set([
+        'appName',
+        'currentIndex',
+        'draggedItem',
         'dockPreview',
         'domRect',
         'DOMRect',
+        'isWindowDragging',
         'placement',
         'pointer',
         'pointerX',
         'pointerY',
         'previewId',
+        'sourceSortZone',
+        'targetSortZone',
         'windowId'
     ])
 

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -67,6 +67,63 @@ const createModel = () => ({
     }
 });
 
+const createEdgeZoneModel = () => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        strategy: {
+            componentRef: 'strategy',
+            title       : 'Strategy',
+            kind        : 'panel'
+        },
+        swarm: {
+            componentRef: 'swarm',
+            title       : 'Swarm',
+            kind        : 'panel'
+        },
+        terminal: {
+            componentRef: 'terminal',
+            title       : 'Terminal',
+            kind        : 'terminal'
+        },
+        inspector: {
+            componentRef: 'inspector',
+            title       : 'Inspector',
+            kind        : 'inspector'
+        }
+    },
+    nodes: {
+        root: {
+            type : 'edge-zone',
+            zones: {
+                center: 'main-tabs',
+                right : 'side-split'
+            }
+        },
+        'main-tabs': {
+            type        : 'tabs',
+            items       : ['strategy', 'swarm'],
+            activeItemId: 'swarm'
+        },
+        'side-split': {
+            type       : 'split',
+            orientation: 'vertical',
+            children   : ['terminal-tabs', 'inspector-tabs'],
+            sizes      : [0.55, 0.45]
+        },
+        'terminal-tabs': {
+            type        : 'tabs',
+            items       : ['terminal'],
+            activeItemId: 'terminal'
+        },
+        'inspector-tabs': {
+            type        : 'tabs',
+            items       : ['inspector'],
+            activeItemId: 'inspector'
+        }
+    }
+});
+
 test.describe('Neo.dashboard.DockLayoutAdapter', () => {
     test('projects split nodes to existing hbox and vbox layout primitives', () => {
         let model  = createModel(),
@@ -97,6 +154,31 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(result.items[0].activeIndex).toBe(1);
         expect(result.items[0].items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
         expect(result.items[0].items.map(item => item.data.dockItemId)).toEqual(['strategy', 'swarm']);
+    });
+
+    test('projects the documented edge-zone root model through the dashboard adapter', () => {
+        let result = DockLayoutAdapter.project(createEdgeZoneModel(), {
+                resolveComponentRef: componentRef => ({
+                    ntype    : 'dashboard-panel',
+                    reference: componentRef
+                })
+            }),
+            row    = result.items[0],
+            center = row.items[0],
+            right  = row.items[1];
+
+        expect(result.dockNodeType).toBe('edge-zone');
+        expect(result.layout).toEqual({ntype: 'vbox', align: 'stretch'});
+        expect(row.dockNodeType).toBe('edge-zone-row');
+        expect(row.layout).toEqual({ntype: 'hbox', align: 'stretch'});
+
+        expect(center.ntype).toBe('tab-container');
+        expect(center.activeIndex).toBe(1);
+        expect(center.items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
+
+        expect(right.layout).toEqual({ntype: 'vbox', align: 'stretch'});
+        expect(right.items.map(item => item.flex)).toEqual([0.55, 0.45]);
+        expect(right.items.map(item => item.items[0].data.dockItemId)).toEqual(['terminal', 'inspector']);
     });
 
     test('falls back to recoverable placeholders without mutating the source model', () => {
@@ -145,5 +227,15 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         };
 
         expect(() => DockLayoutAdapter.project(model)).toThrow(/preview-only field "dockPreview"/);
+    });
+
+    test('rejects runtime-only drag metadata from the full contract list', () => {
+        let model = createModel();
+
+        model.items.strategy.metadata = {
+            sourceSortZone: 'left'
+        };
+
+        expect(() => DockLayoutAdapter.project(model)).toThrow(/preview-only field "sourceSortZone"/);
     });
 });

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -1,0 +1,149 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockLayoutAdapterTest'
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+
+const createModel = () => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        strategy: {
+            componentRef: 'strategy',
+            title       : 'Strategy',
+            kind        : 'panel'
+        },
+        swarm: {
+            componentRef: 'swarm',
+            title       : 'Swarm',
+            kind        : 'panel'
+        },
+        terminal: {
+            componentRef: 'terminal',
+            title       : 'Terminal',
+            kind        : 'terminal'
+        },
+        missing: {
+            componentRef: 'missing',
+            title       : 'Missing',
+            kind        : 'panel'
+        }
+    },
+    nodes: {
+        root: {
+            type       : 'split',
+            orientation: 'horizontal',
+            children   : ['main-tabs', 'side-split'],
+            sizes      : [0.7, 0.3]
+        },
+        'main-tabs': {
+            type        : 'tabs',
+            items       : ['strategy', 'swarm'],
+            activeItemId: 'swarm'
+        },
+        'side-split': {
+            type       : 'split',
+            orientation: 'vertical',
+            children   : ['terminal-tabs', 'missing-tabs'],
+            sizes      : [0.55, 0.45]
+        },
+        'terminal-tabs': {
+            type        : 'tabs',
+            items       : ['terminal'],
+            activeItemId: 'terminal'
+        },
+        'missing-tabs': {
+            type        : 'tabs',
+            items       : ['missing'],
+            activeItemId: 'missing'
+        }
+    }
+});
+
+test.describe('Neo.dashboard.DockLayoutAdapter', () => {
+    test('projects split nodes to existing hbox and vbox layout primitives', () => {
+        let model  = createModel(),
+            result = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => componentRef === 'missing' ? null : {
+                    ntype    : 'dashboard-panel',
+                    reference: componentRef
+                }
+            });
+
+        expect(result.ntype).toBe('container');
+        expect(result.layout).toEqual({ntype: 'hbox', align: 'stretch'});
+        expect(result.items.map(item => item.flex)).toEqual([0.7, 0.3]);
+
+        expect(result.items[1].layout).toEqual({ntype: 'vbox', align: 'stretch'});
+        expect(result.items[1].items.map(item => item.flex)).toEqual([0.55, 0.45]);
+    });
+
+    test('projects tab nodes to tab.Container-compatible configs', () => {
+        let result = DockLayoutAdapter.project(createModel(), {
+            resolveComponentRef: componentRef => ({
+                ntype    : 'dashboard-panel',
+                reference: componentRef
+            })
+        });
+
+        expect(result.items[0].ntype).toBe('tab-container');
+        expect(result.items[0].activeIndex).toBe(1);
+        expect(result.items[0].items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
+        expect(result.items[0].items.map(item => item.data.dockItemId)).toEqual(['strategy', 'swarm']);
+    });
+
+    test('falls back to recoverable placeholders without mutating the source model', () => {
+        let model    = createModel(),
+            snapshot = JSON.parse(JSON.stringify(model)),
+            result   = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => componentRef === 'missing' ? null : {
+                    ntype    : 'dashboard-panel',
+                    reference: componentRef
+                }
+            }),
+            placeholder = result.items[1].items[1].items[0];
+
+        expect(placeholder.ntype).toBe('dashboard-panel');
+        expect(placeholder.data).toEqual({
+            componentRef       : 'missing',
+            dockItemId         : 'missing',
+            missingComponentRef: true
+        });
+        expect(placeholder.header.text).toBe('Missing');
+        expect(model).toEqual(snapshot);
+    });
+
+    test('normalizes invalid split sizes without rewriting the model', () => {
+        let model = createModel();
+
+        model.nodes.root.sizes = [0, Number.NaN];
+
+        let result = DockLayoutAdapter.project(model, {
+            resolveComponentRef: componentRef => ({
+                ntype    : 'dashboard-panel',
+                reference: componentRef
+            })
+        });
+
+        expect(result.items.map(item => item.flex)).toEqual([1, 1]);
+        expect(model.nodes.root.sizes.length).toBe(2);
+    });
+
+    test('rejects preview-only fields at the adapter boundary', () => {
+        let model = {
+            ...createModel(),
+            dockPreview: {
+                previewId: 'preview-1'
+            }
+        };
+
+        expect(() => DockLayoutAdapter.project(model)).toThrow(/preview-only field "dockPreview"/);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 019ec1bf-997c-7113-a082-d36c84ec5439.

Resolves #13105
Related: #13012
Related: #13030
Related: #13104

Adds `Neo.dashboard.DockLayoutAdapter`, a dashboard-owned adapter that projects committed dock-zone model nodes into existing Neo layout and tab configs. Split nodes map to `hbox`/`vbox`, tab nodes map to `tab-container` compatible configs, stale `componentRef` records produce recoverable placeholders, edge-zone roots compose through ordinary containers, and runtime-only preview/drag fields are rejected at the adapter boundary.

Evidence: L1 (static adapter contract plus focused unit tests; no host-runtime ACs) -> L1 required (internal config projection only). No residuals.

## Deltas from ticket

- Kept reusable projection ownership in `src/dashboard/` and reconciled `HarnessDockZoneModel.md` to make that boundary explicit: app-specific harness persistence glue belongs in the harness app layer, while adapters that consume dashboard/container/tab primitives and emit ordinary Neo configs start in the dashboard layer. A second independent in-repo consumer is still required before lifting the model/parser or public API beyond dashboard adaptation.
- Added edge-zone composition support so the documented root model projects through ordinary container configs without broadening into persistence or drag-preview rendering.
- Expanded runtime-only rejection to the full contract list for drag/window metadata such as `sourceSortZone`, `targetSortZone`, `currentIndex`, `draggedItem`, `appName`, and `isWindowDragging`.
- No layout persistence, preview rendering, DOMRect/pointer/window geometry, or generic core `Dock` primitive is introduced.

## Test Evidence

- `node --check src/dashboard/DockLayoutAdapter.mjs` -> pass.
- `node --check test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` -> pass.
- `npm run test-unit -- test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` -> 7 passed.
- `git diff --check` passed before review-response commit.
- Commit hook ran `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology`.
- Pre-push freshness check passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only the #13105 commit series.

## Post-Merge Validation

- [ ] Future preview-renderer and persistence leaves can consume the adapter without importing transient `dockPreview` fields or mutating persisted model records.

## Commits

- `b812a9d22` - `feat(dashboard): render dock split tab layouts (#13105)`
- `c1b82cebd` - `chore(ci): refresh dock layout checks (#13105)`
- `93576a666` - `fix(dashboard): cover dock edge-zone projection (#13105)`

## Evolution

Cycle-1 cross-family review found that the source contract contradicted itself on first-adapter placement and that the documented `edge-zone` root path was not covered. The response commit keeps the dashboard adapter home, updates the contract decision tree to state why that home is correct for reusable dashboard-primitive projection, and adds the missing edge-zone-root projection test plus full runtime-only metadata rejection.