### PR TITLE
feat(ai): mint/verify Fleet Manager Bridge session tokens (#13065)

### DIFF
--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -28,12 +28,24 @@ const
  * dedicated Brain-internal {@link resolveCredential} accessor decrypts it — for the instance spawner
  * (a later FM leaf) — so the Body-side settings pane can never read a PAT back.
  *
+ * **Two credential classes, deliberately separated at the store + method level:** (1) the
+ * GitHub **PAT** above — *reversibly* encrypted, because the spawner must inject the real token into
+ * a harness env; served only by {@link resolveCredential}. (2) the **Bridge session token**
+ * ({@link mintBridgeToken} / {@link verifyBridgeToken}) — a registry-minted, short-lived,
+ * **hash-stored, verify-only** credential for agent↔Neural-Link-Bridge transport auth. It
+ * lives in its own store (`bridgeTokens.enc`) with its own read/write methods and **never** routes
+ * through the PAT helpers — so "encrypted at rest" can never quietly become a second *reversible*
+ * secret store. The raw Bridge token is absent from storage the instant {@link mintBridgeToken}
+ * returns; only its SHA-256 hash + expiry persist.
+ *
  * **Storage** lives under `dataDir` (default `<repoRoot>/.neo-ai-data/fleet/`, overridable — the
  * per-tenant data root is the multi-tenant isolation seam):
- * - `registry.json`   — agent definitions (no secrets), human-readable JSON.
- * - `credentials.enc` — the encrypted `{agentId: pat}` map (AES-256-GCM, `0600`).
- * - `fleet.key`       — dev-only generated `0600` key file, used when `NEO_FLEET_SECRET_KEY` is
- *                       not set. Production deployments SHOULD provide the env key.
+ * - `registry.json`    — agent definitions (no secrets), human-readable JSON.
+ * - `credentials.enc`  — the encrypted `{agentId: pat}` map (AES-256-GCM, `0600`).
+ * - `bridgeTokens.enc` — the encrypted `{agentId: {hash, expiresAt, createdAt}}` Bridge-token map
+ *                        (AES-256-GCM, `0600`) — the second, distinct credential class; no raw token.
+ * - `fleet.key`        — dev-only generated `0600` key file, used when `NEO_FLEET_SECRET_KEY` is
+ *                        not set. Production deployments SHOULD provide the env key.
  *
  * **Fail-closed:** an absent / locked / corrupt credential store never throws into the define/list
  * path and never surfaces plaintext — {@link resolveCredential} returns `null`.
@@ -65,6 +77,14 @@ class FleetRegistryService extends Base {
      * @protected
      */
     harnessTypes = ['claude-desktop', 'codex', 'antigravity', 'native-neo']
+
+    /**
+     * Default lifetime of a minted Bridge session token, in milliseconds (1h). Short-lived by
+     * design — rotation falls out of expiry. Overridable per call via `mintBridgeToken(id, {ttlMs})`.
+     * @member {Number} bridgeTokenTtlMs=3600000
+     * @protected
+     */
+    bridgeTokenTtlMs = 60 * 60 * 1000
 
     /**
      * In-memory cache of agent definitions (no secrets), keyed by agent id.
@@ -172,6 +192,64 @@ class FleetRegistryService extends Base {
         return Object.hasOwn(credentials, id) ? credentials[id] : null;
     }
 
+    /**
+     * @summary Mint a short-lived, hash-stored Bridge session token for agent↔Neural-Link-Bridge
+     * transport auth. The raw token is returned **once** to the caller and is **never**
+     * persisted — only its SHA-256 hash + expiry land in `bridgeTokens.enc`, a store distinct from
+     * the reversibly-encrypted PAT (the Bridge token can never route through the PAT helpers). A
+     * re-mint for the same id replaces the prior record.
+     * @param {String}  id          The agent id the token is minted for.
+     * @param {Object} [opts]
+     * @param {Number} [opts.ttlMs] Token lifetime in ms; defaults to {@link bridgeTokenTtlMs}.
+     * @returns {Object} `{token, expiresAt}` — the raw token (caller keeps it; absent from storage) + its epoch-ms expiry.
+     */
+    mintBridgeToken(id, {ttlMs}={}) {
+        const
+            token     = crypto.randomBytes(32).toString('base64url'),
+            hash      = crypto.createHash('sha256').update(token).digest('hex'),
+            now       = Date.now(),
+            expiresAt = now + (ttlMs ?? this.bridgeTokenTtlMs),
+            tokens    = this.readBridgeTokens();
+
+        tokens[id] = {hash, expiresAt, createdAt: now};
+        this.writeBridgeTokens(tokens);
+
+        return {token, expiresAt};
+    }
+
+    /**
+     * @summary Verify a presented Bridge token against the hash-stored record for `id`. This is the
+     * untrusted-input path: a **constant-time** hash compare ({@link crypto.timingSafeEqual}) that
+     * rejects expired tokens and **fails closed** — returns `false` (never throws) on an unknown id,
+     * an absent / unreadable / malformed store, a bad hash encoding, or a missing / expired
+     * `expiresAt`. Mirrors {@link resolveCredential}'s fail-closed posture; no secret ever surfaces.
+     * @param {String} id        The agent id presenting the token.
+     * @param {String} presented The raw token to check.
+     * @returns {Boolean} `true` only for a live, matching token; `false` otherwise.
+     */
+    verifyBridgeToken(id, presented) {
+        try {
+            const tokens = this.readBridgeTokens();
+            // own-property only: an untrusted id like `toString` must fail closed, never alias a proto member.
+            if (!Object.hasOwn(tokens, id)) return false;
+
+            const record = tokens[id];
+            if (!record || typeof record.expiresAt !== 'number' || Date.now() >= record.expiresAt) {
+                return false;
+            }
+
+            const
+                presentedHash = crypto.createHash('sha256').update(presented).digest(),
+                storedHash    = Buffer.from(String(record.hash), 'hex');
+
+            // timingSafeEqual throws on a length mismatch; a malformed/short stored hash fails closed.
+            return storedHash.length === presentedHash.length && crypto.timingSafeEqual(presentedHash, storedHash);
+        } catch (error) {
+            console.warn('[FleetRegistryService] Bridge-token verify failed closed.', error.message);
+            return false;
+        }
+    }
+
     // ---- internals ----------------------------------------------------------
 
     /**
@@ -274,6 +352,36 @@ class FleetRegistryService extends Base {
         fs.writeFileSync(this.credentialsPath(), this.encrypt(JSON.stringify(map)), {mode: 0o600});
     }
 
+    /**
+     * @returns {Object} The decrypted Bridge-token store as a **null-prototype** map
+     * `{agentId: {hash, expiresAt, createdAt}}` (empty + warned on absent/corrupt — fail-closed).
+     * A distinct file + shape from {@link readCredentials}; the two stores never mix. Null-proto is
+     * the same untrusted-key invariant — an absent id can never alias an `Object.prototype` member.
+     * @private
+     */
+    readBridgeTokens() {
+        const file = this.bridgeTokensPath();
+        if (!fs.existsSync(file)) return Object.create(null);
+        try {
+            return Object.assign(Object.create(null), JSON.parse(this.decrypt(fs.readFileSync(file, 'utf8'))));
+        } catch (error) {
+            console.warn('[FleetRegistryService] Bridge-token store unreadable; failing closed.', error.message);
+            return Object.create(null);
+        }
+    }
+
+    /**
+     * Encrypt + write the full Bridge-token map to `bridgeTokens.enc` (`0600`). Encryption is
+     * defense-in-depth *over* the stored SHA-256 hashes — the records carry no reversible secret;
+     * it is never a license to persist a raw token. Distinct file/method from {@link writeCredentials}.
+     * @param {Object} map
+     * @private
+     */
+    writeBridgeTokens(map) {
+        this.ensureDataDir();
+        fs.writeFileSync(this.bridgeTokensPath(), this.encrypt(JSON.stringify(map)), {mode: 0o600});
+    }
+
     // ---- crypto (AES-256-GCM) ----------------------------------------------
 
     /**
@@ -344,6 +452,9 @@ class FleetRegistryService extends Base {
 
     /** @returns {String} @private */
     credentialsPath() { return path.join(this.getDataDir(), 'credentials.enc'); }
+
+    /** @returns {String} A store distinct from {@link credentialsPath}; the two never share a file. @private */
+    bridgeTokensPath() { return path.join(this.getDataDir(), 'bridgeTokens.enc'); }
 
     /** @returns {String} @private */
     keyPath() { return path.join(this.getDataDir(), 'fleet.key'); }

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -175,7 +175,10 @@ class FleetRegistryService extends Base {
         this.ensureLoaded();
         const existed = this.agents.delete(id);
         if (existed) this.writeRegistry();
+        // Both credential classes die with the agent — the PAT AND the Bridge token. Leaving a live
+        // Bridge token for a removed agent would let it keep authenticating to the Bridge.
         this.removeCredential(id);
+        this.removeBridgeToken(id);
         return {success: existed, id};
     }
 
@@ -198,6 +201,11 @@ class FleetRegistryService extends Base {
      * persisted — only its SHA-256 hash + expiry land in `bridgeTokens.enc`, a store distinct from
      * the reversibly-encrypted PAT (the Bridge token can never route through the PAT helpers). A
      * re-mint for the same id replaces the prior record.
+     *
+     * Minting does **not** require `id` to be a registered agent (it only produces + stores a hash) —
+     * the validity boundary is {@link verifyBridgeToken}, which fails closed unless `id` is a current
+     * fleet member. So a token minted for a non-member never authenticates; binding the check at
+     * verify (not mint) keeps the gate in one place and tolerates a register-after-mint ordering.
      * @param {String}  id          The agent id the token is minted for.
      * @param {Object} [opts]
      * @param {Number} [opts.ttlMs] Token lifetime in ms; defaults to {@link bridgeTokenTtlMs}.
@@ -220,15 +228,26 @@ class FleetRegistryService extends Base {
     /**
      * @summary Verify a presented Bridge token against the hash-stored record for `id`. This is the
      * untrusted-input path: a **constant-time** hash compare ({@link crypto.timingSafeEqual}) that
-     * rejects expired tokens and **fails closed** — returns `false` (never throws) on an unknown id,
-     * an absent / unreadable / malformed store, a bad hash encoding, or a missing / expired
+     * rejects expired tokens and **fails closed** — returns `false` (never throws) on an id that is
+     * not a currently-registered agent (never registered, or removed via {@link removeAgent}), an
+     * unknown / absent / unreadable / malformed store, a bad hash encoding, or a missing / expired
      * `expiresAt`. Mirrors {@link resolveCredential}'s fail-closed posture; no secret ever surfaces.
+     *
+     * **The Bridge token authenticates a *current fleet member*** — validity is bound to registry
+     * membership, so a removed agent's token can never authenticate (the security invariant the
+     * `removeAgent` → `removeBridgeToken` cleanup and this gate jointly guarantee).
      * @param {String} id        The agent id presenting the token.
      * @param {String} presented The raw token to check.
-     * @returns {Boolean} `true` only for a live, matching token; `false` otherwise.
+     * @returns {Boolean} `true` only for a live, matching token owned by a registered agent; `false` otherwise.
      */
     verifyBridgeToken(id, presented) {
         try {
+            // Bind validity to fleet membership: a never-registered or removed id fails closed even
+            // if a token record lingers (defense-in-depth over the removeAgent cleanup). `Map.has`
+            // is prototype-safe for untrusted ids.
+            this.ensureLoaded();
+            if (!this.agents.has(id)) return false;
+
             const tokens = this.readBridgeTokens();
             // own-property only: an untrusted id like `toString` must fail closed, never alias a proto member.
             if (!Object.hasOwn(tokens, id)) return false;
@@ -380,6 +399,21 @@ class FleetRegistryService extends Base {
     writeBridgeTokens(map) {
         this.ensureDataDir();
         fs.writeFileSync(this.bridgeTokensPath(), this.encrypt(JSON.stringify(map)), {mode: 0o600});
+    }
+
+    /**
+     * Remove a single Bridge-token record from the store (no-op if absent). Invoked by
+     * {@link removeAgent} so the Bridge credential dies with the agent — the analog of
+     * {@link removeCredential} for the second credential class.
+     * @param {String} id
+     * @private
+     */
+    removeBridgeToken(id) {
+        const tokens = this.readBridgeTokens();
+        if (Object.hasOwn(tokens, id)) {
+            delete tokens[id];
+            this.writeBridgeTokens(tokens);
+        }
     }
 
     // ---- crypto (AES-256-GCM) ----------------------------------------------

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -163,4 +163,78 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         expect(FleetRegistryService.resolveCredential('toString')).toBe('ghp_proto');
         expect(FleetRegistryService.resolveCredential('constructor')).toBeNull();
     });
+
+    // ---- Bridge session token credential class -----------------------------
+    // A second, distinct credential class for agent<->Neural-Link-Bridge transport auth:
+    // registry-minted, short-lived, hash-stored, verify-only. Inherits the freshDataDir hooks above.
+    test.describe('Bridge session token credential class (#13065)', () => {
+        test('mint -> verify round-trip; wrong / unknown token fails closed', () => {
+            const {token, expiresAt} = FleetRegistryService.mintBridgeToken('round-trip-agent');
+
+            expect(typeof token).toBe('string');
+            expect(token.length).toBeGreaterThan(0);
+            expect(expiresAt).toBeGreaterThan(Date.now());
+
+            expect(FleetRegistryService.verifyBridgeToken('round-trip-agent', token)).toBe(true);
+            expect(FleetRegistryService.verifyBridgeToken('round-trip-agent', 'wrong-token')).toBe(false);
+            expect(FleetRegistryService.verifyBridgeToken('unknown-agent', token)).toBe(false);
+        });
+
+        test('a re-mint rotates the token — the prior token no longer verifies', () => {
+            const first = FleetRegistryService.mintBridgeToken('rotating-agent').token;
+            const next  = FleetRegistryService.mintBridgeToken('rotating-agent').token;
+
+            expect(next).not.toBe(first);
+            expect(FleetRegistryService.verifyBridgeToken('rotating-agent', next)).toBe(true);
+            expect(FleetRegistryService.verifyBridgeToken('rotating-agent', first)).toBe(false);
+        });
+
+        test('verifyBridgeToken rejects an expired token', () => {
+            const {token} = FleetRegistryService.mintBridgeToken('expiring-agent', {ttlMs: -1});
+            expect(FleetRegistryService.verifyBridgeToken('expiring-agent', token)).toBe(false);
+        });
+
+        test('SECURITY: mint returns the token once; only its hash persists (no raw token at rest)', () => {
+            const {token} = FleetRegistryService.mintBridgeToken('bridge-agent');
+
+            // (a) the at-rest file is ciphertext — the raw token must not appear
+            const raw = fs.readFileSync(path.join(FleetRegistryService.dataDir, 'bridgeTokens.enc'), 'utf8');
+            expect(raw).not.toContain(token);
+
+            // (b) inspect the decrypted store payload — only {hash, expiresAt, createdAt}, never the raw token
+            const record = FleetRegistryService.readBridgeTokens()['bridge-agent'];
+            expect(record.hash).toMatch(/^[0-9a-f]{64}$/);
+            expect(record.token).toBeUndefined();
+            expect(JSON.stringify(record)).not.toContain(token);
+        });
+
+        test('SECURITY: the Bridge store is separate from the PAT store; the PAT class is unaffected', () => {
+            const pat = 'ghp_CoexistToken_99887766';
+            FleetRegistryService.defineAgent({githubUsername: 'dual-agent', harnessType: 'codex', credential: pat});
+            const {token} = FleetRegistryService.mintBridgeToken('dual-agent');
+
+            const dir = FleetRegistryService.dataDir;
+            // two distinct files; the Bridge token never routes through credentials.enc
+            expect(fs.existsSync(path.join(dir, 'credentials.enc'))).toBe(true);
+            expect(fs.existsSync(path.join(dir, 'bridgeTokens.enc'))).toBe(true);
+
+            // the PAT still round-trips through its own accessor, unchanged by the Bridge token
+            expect(FleetRegistryService.resolveCredential('dual-agent')).toBe(pat);
+            // the Bridge token verifies through its own path; the two classes never cross-validate
+            expect(FleetRegistryService.verifyBridgeToken('dual-agent', token)).toBe(true);
+            expect(FleetRegistryService.verifyBridgeToken('dual-agent', pat)).toBe(false);
+        });
+
+        test('FAIL-CLOSED: a corrupt Bridge store yields false, never throws', () => {
+            const {token} = FleetRegistryService.mintBridgeToken('corrupt-agent');
+            fs.writeFileSync(path.join(FleetRegistryService.dataDir, 'bridgeTokens.enc'), 'not-valid-ciphertext', 'utf8');
+            expect(FleetRegistryService.verifyBridgeToken('corrupt-agent', token)).toBe(false);
+        });
+
+        test('FAIL-CLOSED: prototype-chain ids never verify against an empty Bridge store', () => {
+            for (const key of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
+                expect(FleetRegistryService.verifyBridgeToken(key, 'anything')).toBe(false);
+            }
+        });
+    });
 });

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -166,9 +166,14 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
 
     // ---- Bridge session token credential class -----------------------------
     // A second, distinct credential class for agent<->Neural-Link-Bridge transport auth:
-    // registry-minted, short-lived, hash-stored, verify-only. Inherits the freshDataDir hooks above.
+    // registry-minted, short-lived, hash-stored, verify-only. A token authenticates a CURRENT fleet
+    // member, so verify is gated on registry membership — tests register the agent first (the real
+    // register -> mint -> verify flow). Inherits the freshDataDir hooks above.
     test.describe('Bridge session token credential class (#13065)', () => {
+        const register = id => FleetRegistryService.defineAgent({githubUsername: id, harnessType: 'codex'});
+
         test('mint -> verify round-trip; wrong / unknown token fails closed', () => {
+            register('round-trip-agent');
             const {token, expiresAt} = FleetRegistryService.mintBridgeToken('round-trip-agent');
 
             expect(typeof token).toBe('string');
@@ -181,6 +186,7 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         });
 
         test('a re-mint rotates the token — the prior token no longer verifies', () => {
+            register('rotating-agent');
             const first = FleetRegistryService.mintBridgeToken('rotating-agent').token;
             const next  = FleetRegistryService.mintBridgeToken('rotating-agent').token;
 
@@ -190,11 +196,37 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         });
 
         test('verifyBridgeToken rejects an expired token', () => {
+            register('expiring-agent');
             const {token} = FleetRegistryService.mintBridgeToken('expiring-agent', {ttlMs: -1});
             expect(FleetRegistryService.verifyBridgeToken('expiring-agent', token)).toBe(false);
         });
 
+        test('SECURITY: removeAgent invalidates the Bridge token (#13108 cross-family review)', () => {
+            register('edge-agent');
+            const {token} = FleetRegistryService.mintBridgeToken('edge-agent');
+            expect(FleetRegistryService.verifyBridgeToken('edge-agent', token)).toBe(true);
+
+            FleetRegistryService.removeAgent('edge-agent');
+
+            // a removed agent's transport credential must no longer authenticate ...
+            expect(FleetRegistryService.verifyBridgeToken('edge-agent', token)).toBe(false);
+            // ... and its record is cleared from the store, not merely gated at verify
+            expect(FleetRegistryService.readBridgeTokens()['edge-agent']).toBeUndefined();
+        });
+
+        test('SECURITY: a token minted for an unregistered id never verifies (verify gates on membership)', () => {
+            // mint is permissive (it only produces + stores a hash); the boundary is verify, which
+            // fails closed until the id is a registered fleet member.
+            const {token} = FleetRegistryService.mintBridgeToken('ghost-agent');
+            expect(FleetRegistryService.verifyBridgeToken('ghost-agent', token)).toBe(false);
+
+            // registering the agent flips verify to true with the SAME token — proving membership is the gate
+            register('ghost-agent');
+            expect(FleetRegistryService.verifyBridgeToken('ghost-agent', token)).toBe(true);
+        });
+
         test('SECURITY: mint returns the token once; only its hash persists (no raw token at rest)', () => {
+            register('bridge-agent');
             const {token} = FleetRegistryService.mintBridgeToken('bridge-agent');
 
             // (a) the at-rest file is ciphertext — the raw token must not appear
@@ -226,12 +258,14 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         });
 
         test('FAIL-CLOSED: a corrupt Bridge store yields false, never throws', () => {
+            register('corrupt-agent');
             const {token} = FleetRegistryService.mintBridgeToken('corrupt-agent');
             fs.writeFileSync(path.join(FleetRegistryService.dataDir, 'bridgeTokens.enc'), 'not-valid-ciphertext', 'utf8');
             expect(FleetRegistryService.verifyBridgeToken('corrupt-agent', token)).toBe(false);
         });
 
-        test('FAIL-CLOSED: prototype-chain ids never verify against an empty Bridge store', () => {
+        test('FAIL-CLOSED: unregistered / prototype-chain ids never verify', () => {
+            // none of these are registered agents — the membership gate fails them closed
             for (const key of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
                 expect(FleetRegistryService.verifyBridgeToken(key, 'anything')).toBe(false);
             }


### PR DESCRIPTION
Resolves #13065

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace). Design-origin session db407b1c-07ea-4a6d-95a3-810b195dc899 (the ticket); implemented this nightshift session.

Adds a **second, distinct credential class** to `FleetRegistryService` for agent↔Neural-Link-Bridge transport auth: `mintBridgeToken(id, {ttlMs})` + `verifyBridgeToken(id, presented)`. Bridge tokens are **registry-minted, short-lived, hash-stored, verify-only** — minted once and handed to the caller, with only `{hash, expiresAt, createdAt}` persisted to a **separate store** (`bridgeTokens.enc`) via dedicated `readBridgeTokens` / `writeBridgeTokens`. They **never** route through the reversibly-encrypted PAT helpers (`storeCredential` / `resolveCredential` / `credentials.enc`). `verify` is a constant-time hash compare that **fails closed** (returns `false`, never throws) on a non-registered id, expired token, or an unreadable / malformed store.

**Lifecycle binding (the security invariant):** a Bridge token authenticates a *current fleet member* — `verifyBridgeToken` gates on current registry membership (`this.agents.has(id)`), and `removeAgent` clears the token record (via `removeBridgeToken`, the analog of `removeCredential`). So a removed or never-registered agent's token can never authenticate.

Evidence: L2 (real AES-256-GCM crypto + real fs store round-trip in unit tests, OS temp dirs) → L2 required (all ACs are pure Node mint / verify / store / lifecycle behavior; no cross-process / host / UI surface). No residuals.

## Deltas from ticket
- No scope expansion beyond the review-cycle lifecycle correction: Bridge-token validity is bound to current registry membership, and `removeAgent` clears Bridge-token records.

## Implementation notes
- **Structural pre-flight:** additive methods on the existing `FleetRegistryService` (no new `.mjs`; the domain exists). Reuses the shared `encrypt` / `decrypt` / `getKey` / `getDataDir` machinery while keeping the store **and** methods file-level distinct from the PAT class.
- **Token:** 256-bit `crypto.randomBytes(32)` (base64url), stored as its SHA-256 hash. High-entropy random → plain SHA-256 suffices (no KDF / salt).
- **Untrusted-key invariant:** `readBridgeTokens` returns a null-prototype map; `verifyBridgeToken` gates with prototype-safe `Map.has` + `Object.hasOwn`, so a proto-chain id (`toString`, `__proto__`, …) fails closed.
- **Mint permissive; verify is the boundary:** `mintBridgeToken` does not require `id` to be registered (it only produces + stores a hash); validity is enforced at `verify` (single gate), which fails closed unless `id` is a current fleet member.
- **TTL:** default 1h (`bridgeTokenTtlMs`), per-call override via `mintBridgeToken(id, {ttlMs})`.

## Evolution
- **Cycle-2 (cross-family review, @neo-gpt):** bound Bridge-token validity to the registry agent lifecycle. The initial PR deferred removal-cleanup as out-of-scope; @neo-gpt's falsifier showed a removed agent's token still authenticated (`removeAgent` already clears the PAT, so the Bridge token must die too). Fixed in `dc66d2829`: `verify` gates on registry membership + `removeAgent` → `removeBridgeToken`. Lifecycle-invalidation is core scope for a credential class, not a deferred follow-up.

## Test Evidence
- `npm run test-unit -- FleetRegistryService.spec` → **19 passed** (10 PAT tests + 9 bridge-token tests, incl. removed-agent invalidation, unregistered-mint→verify-false→register→verify-true, PAT-unaffected `resolveCredential` round-trip, and the fail-closed corrupt-store path).
- `npm run test-unit -- FleetLifecycleService.spec` → **12 passed** (consumer unaffected).
- `check-ticket-archaeology.mjs` → 0 violations; lint-staged whitespace / shorthand clean.

## Post-Merge Validation
- [ ] When the Fleet-Manager spawn / Bridge-handshake leaf lands, confirm it calls `verifyBridgeToken` (not a private allowlist) and wires `mintBridgeToken` output into the spawned harness env.

## Cross-family review note
@neo-opus-vega + @neo-gpt have both reviewed (@neo-gpt: cycle-1 `REQUEST_CHANGES` → lifecycle fix `dc66d2829` → cycle-2 code-cleared). The §6.1 cross-family Approved stamp is the remaining merge prerequisite. ⚠️ @neo-gemini-pro is ~3wk dormant + Fable benched, so @neo-gpt is the sole active cross-family reviewer (flagged separately for the operator). Operator holds merge.

Related: #13015
Related: #13056
Refs #13037
