### PR TITLE
feat(agentos): render harness dock preview affordances during drag (#13104)

### DIFF
--- a/apps/agentos/view/DockPreview.mjs
+++ b/apps/agentos/view/DockPreview.mjs
@@ -356,7 +356,10 @@ class DockPreview extends Component {
     }
 
     /**
-     *
+     * @summary Unbinds the drag-source lifecycle listeners before delegating to the base destroy,
+     * so the overlay never leaves dangling `dragEnd` / `dragBoundaryExit` handlers on the drag
+     * surface it was bound to.
+     * @param {...*} args forwarded to {@link Neo.component.Base#destroy}
      */
     destroy(...args) {
         this.unbindDragSource();

--- a/apps/agentos/view/DockPreview.mjs
+++ b/apps/agentos/view/DockPreview.mjs
@@ -1,0 +1,404 @@
+import Component from '../../../src/component/Base.mjs';
+
+/**
+ * @class AgentOS.view.DockPreview
+ * @extends Neo.component.Base
+ *
+ * @summary Drag-time dock preview renderer for the Agent Harness.
+ *
+ * Consumes the runtime-only `dockPreview` contract object
+ * (schema `neo.harness.dockPreview.v1`, specified in `learn/agentos/HarnessDockZoneModel.md`)
+ * and projects its candidate `placement` into a single transient visual affordance — an edge
+ * band, a split guide, or a tab indicator — over the harness workspace while a pane is dragged.
+ *
+ * Boundaries (binding, per the dock-zone model contract):
+ *
+ * - **Visual only.** This overlay never owns pointer events and never adds a parallel drag
+ *   system. The existing dashboard / sort-zone drag lifecycle is the single event source; the
+ *   overlay is purely reactive to a `dockPreview` produced upstream and to drag-lifecycle
+ *   terminals (drag end / boundary exit) wired via {@link AgentOS.view.DockPreview#bindDragSource}.
+ * - **Runtime only.** `dockPreview` payloads, `DOMRect`s, screen coordinates and overlay nodes are
+ *   never written into the persisted dock-zone model. This component has no write path to a
+ *   persisted model — it reads a preview and emits transient VDOM plus operation descriptors.
+ * - **Fail closed.** A missing, malformed, stale or `rejected`-placement preview clears the
+ *   affordance and performs no model mutation ({@link AgentOS.view.DockPreview.isValidPreview}).
+ * - **Semantic drop.** On an accepted drop the owning adapter converts the preview into a semantic
+ *   operation (`moveItem` / `splitNode` / `addTab`); {@link AgentOS.view.DockPreview.previewToOperation}
+ *   yields that operation DESCRIPTOR — this overlay never mutates the dock tree itself.
+ *
+ * The producer (raw drag geometry -> `dockPreview`) and the operation executor (descriptor ->
+ * persisted-tree mutation) are deliberately out of scope: they are separate docking leaves.
+ */
+class DockPreview extends Component {
+    /**
+     * The dockPreview contract schema this renderer accepts.
+     * @member {String} PREVIEW_SCHEMA='neo.harness.dockPreview.v1'
+     * @static
+     */
+    static PREVIEW_SCHEMA = 'neo.harness.dockPreview.v1'
+    /**
+     * Every candidate `placement.kind` the contract defines.
+     * @member {Set<String>} VALID_PLACEMENT_KINDS
+     * @static
+     */
+    static VALID_PLACEMENT_KINDS = new Set([
+        'edge-top', 'edge-right', 'edge-bottom', 'edge-left',
+        'split-before', 'split-after',
+        'tab-before', 'tab-after', 'tab-into',
+        'rejected'
+    ])
+    /**
+     * @member {Set<String>} EDGE_KINDS
+     * @static
+     */
+    static EDGE_KINDS = new Set(['edge-top', 'edge-right', 'edge-bottom', 'edge-left'])
+    /**
+     * @member {Set<String>} SPLIT_KINDS
+     * @static
+     */
+    static SPLIT_KINDS = new Set(['split-before', 'split-after'])
+    /**
+     * @member {Set<String>} TAB_KINDS
+     * @static
+     */
+    static TAB_KINDS = new Set(['tab-before', 'tab-after', 'tab-into'])
+    /**
+     * Thickness in px of an edge-zone affordance band.
+     * @member {Number} edgeBandSize=24
+     * @static
+     */
+    static edgeBandSize = 24
+    /**
+     * Thickness in px of a split / tab guide line.
+     * @member {Number} splitLineSize=6
+     * @static
+     */
+    static splitLineSize = 6
+
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.DockPreview'
+         * @protected
+         */
+        className: 'AgentOS.view.DockPreview',
+        /**
+         * @member {String} ntype='dock-preview'
+         * @protected
+         */
+        ntype: 'dock-preview',
+        /**
+         * @member {String[]} baseCls=['neo-dock-preview']
+         * @protected
+         */
+        baseCls: ['neo-dock-preview'],
+        /**
+         * The transient dockPreview contract object to render, or null to clear the overlay.
+         * Runtime-only state — never serialized into the persisted dock-zone model.
+         * @member {Object|null} dockPreview_=null
+         * @reactive
+         */
+        dockPreview_: null
+    }
+
+    /**
+     * The drag surface this overlay listens to for lifecycle-terminal cleanup. Wired via
+     * {@link AgentOS.view.DockPreview#bindDragSource}; never a pointer-owning surface of our own.
+     * @member {Object|null} dragSource=null
+     * @protected
+     */
+    dragSource = null
+
+    /**
+     * @summary Structural validity gate for a dockPreview object (fail-closed).
+     *
+     * Returns true only for a well-formed `neo.harness.dockPreview.v1` payload that carries a
+     * stable `itemId`, a `target.nodeId`, a known `placement.kind`, an accept/reject
+     * `feedback.state`, and (for split placements) a valid `placement.orientation`. Anything
+     * malformed, partial or unknown returns false so the renderer clears rather than guesses.
+     * @param {Object|null} preview
+     * @returns {Boolean}
+     * @static
+     */
+    static isValidPreview(preview) {
+        if (!preview || typeof preview !== 'object')                  return false;
+        if (preview.schema !== this.PREVIEW_SCHEMA)                   return false;
+        if (typeof preview.itemId !== 'string' || !preview.itemId)    return false;
+
+        let {feedback, placement, target} = preview;
+
+        if (!target || typeof target.nodeId !== 'string' || !target.nodeId) return false;
+        if (!placement || !this.VALID_PLACEMENT_KINDS.has(placement.kind))  return false;
+        if (!feedback || (feedback.state !== 'accepted' && feedback.state !== 'rejected')) return false;
+
+        // Split placements MUST carry an orientation (contract: required for split previews).
+        if (this.SPLIT_KINDS.has(placement.kind) &&
+            placement.orientation !== 'horizontal' && placement.orientation !== 'vertical') {
+            return false
+        }
+
+        return true
+    }
+
+    /**
+     * @summary Maps a dockPreview into a renderable affordance descriptor, or null.
+     *
+     * Returns null for an invalid preview or a `rejected` placement (no candidate to draw).
+     * Otherwise returns a descriptor naming the affordance `group` (edge / split / tab), the
+     * concrete `kind`, the target ids, and whether the hover is `accepted` (a `feedback.state`
+     * of `rejected` still renders the candidate, flagged so the UI can show a denied state).
+     * @param {Object|null} preview
+     * @returns {Object|null}
+     * @static
+     */
+    static mapPreviewToAffordance(preview) {
+        if (!this.isValidPreview(preview)) return null;
+
+        let {feedback, itemId, placement, target} = preview,
+            {kind}                                = placement;
+
+        if (kind === 'rejected') return null;
+
+        let base = {
+            accepted    : feedback.state === 'accepted',
+            containerId : target.containerId ?? null,
+            itemId,
+            kind,
+            targetNodeId: target.nodeId
+        };
+
+        if (this.EDGE_KINDS.has(kind)) {
+            return {...base, group: 'edge', edge: kind.slice('edge-'.length)}
+        }
+
+        if (this.SPLIT_KINDS.has(kind)) {
+            return {...base, group: 'split', orientation: placement.orientation, position: kind.slice('split-'.length)}
+        }
+
+        return {...base, group: 'tab', index: Number.isInteger(placement.index) ? placement.index : null, position: kind.slice('tab-'.length)}
+    }
+
+    /**
+     * @summary Converts an ACCEPTED drop into a semantic dock-zone operation descriptor, or null.
+     *
+     * The renderer never mutates the dock tree; it routes an accepted preview into one of the
+     * contract's semantic operations (`addTab` / `splitNode`) so the owning adapter can commit it.
+     * Invalid previews, `rejected` placements, and non-accepted feedback all yield null (no commit).
+     * Tab placements emit `addTab`; the adapter downgrades to `moveItem` when the item already
+     * lives in the tree. Edge placements route to `splitNode` (the adapter may instead realise an
+     * edge-zone insertion, then `normalizeTree`).
+     * @param {Object|null} preview
+     * @returns {Object|null}
+     * @static
+     */
+    static previewToOperation(preview) {
+        if (!this.isValidPreview(preview)) return null;
+
+        let {feedback, itemId, placement, target} = preview,
+            {kind}                                = placement;
+
+        if (kind === 'rejected' || feedback.state !== 'accepted') return null;
+
+        let nodeId = target.nodeId;
+
+        if (this.TAB_KINDS.has(kind)) {
+            return {operation: 'addTab', itemId, tabsNodeId: nodeId, index: Number.isInteger(placement.index) ? placement.index : null}
+        }
+
+        if (this.SPLIT_KINDS.has(kind)) {
+            let position = kind.slice('split-'.length);
+            return {operation: 'splitNode', itemId, targetNodeId: nodeId, orientation: placement.orientation, position, sizes: this.ratioToSizes(placement.ratio, position)}
+        }
+
+        let edge = kind.slice('edge-'.length);
+        return {
+            operation   : 'splitNode',
+            itemId,
+            targetNodeId: nodeId,
+            edge,
+            orientation : (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
+            sizes       : this.ratioToSizes(placement.ratio, edge === 'bottom' || edge === 'right' ? 'after' : 'before')
+        }
+    }
+
+    /**
+     * @summary Normalizes an optional split ratio into a two-child, sum-to-one size pair.
+     * @param {Number} [ratio] the new node's fraction; defaults to an even split when absent/invalid
+     * @param {String} position 'before' | 'after' — which child the new node becomes
+     * @returns {Number[]} normalized [first, second] sizes summing to 1
+     * @static
+     */
+    static ratioToSizes(ratio, position) {
+        let r = (typeof ratio === 'number' && ratio > 0 && ratio < 1) ? ratio : 0.5;
+        return position === 'after' ? [1 - r, r] : [r, 1 - r]
+    }
+
+    /**
+     * @summary Pure geometry: projects an affordance onto a target node rect.
+     *
+     * Given an affordance descriptor and the target node's runtime rect, returns the overlay box
+     * ({x, y, width, height}) for the edge band, split guide line, or tab indicator. Returns null
+     * when the rect is absent or non-numeric — the renderer simply skips positioning, never throws.
+     * The rect is runtime-only input; it is never persisted.
+     * @param {Object|null} affordance
+     * @param {Object|null} targetRect {x, y, width, height}
+     * @returns {Object|null}
+     * @static
+     */
+    static affordanceGeometry(affordance, targetRect) {
+        if (!affordance || !targetRect) return null;
+
+        let {height, width, x, y} = targetRect;
+
+        if ([height, width, x, y].some(v => typeof v !== 'number' || Number.isNaN(v))) return null;
+
+        let band = Math.min(this.edgeBandSize, width, height),
+            line = this.splitLineSize;
+
+        if (affordance.group === 'edge') {
+            switch (affordance.edge) {
+                case 'top'   : return {x, y, width, height: band};
+                case 'bottom': return {x, y: y + height - band, width, height: band};
+                case 'left'  : return {x, y, width: band, height};
+                case 'right' : return {x: x + width - band, y, width: band, height}
+            }
+        }
+
+        if (affordance.group === 'split') {
+            if (affordance.orientation === 'horizontal') {
+                // children side-by-side -> a vertical guide on the left (before) / right (after)
+                return {x: affordance.position === 'after' ? x + width - line : x, y, width: line, height}
+            }
+            // stacked -> a horizontal guide on the top (before) / bottom (after)
+            return {x, y: affordance.position === 'after' ? y + height - line : y, width, height: line}
+        }
+
+        // tab: 'into' highlights the whole tabs node; before/after is a marker at the node edge
+        if (affordance.position === 'into') {
+            return {x, y, width, height}
+        }
+
+        return {x: affordance.position === 'after' ? x + width - line : x, y, width: line, height}
+    }
+
+    /**
+     * @summary Re-renders the overlay whenever the dockPreview changes (or clears it when null).
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetDockPreview(value, oldValue) {
+        let me         = this,
+            affordance = DockPreview.mapPreviewToAffordance(value);
+
+        me.vdom.cn = affordance ? [me.getAffordanceVdom(affordance)] : [];
+        me.update()
+    }
+
+    /**
+     * @summary Positions the current affordance over a supplied target rect (runtime-only).
+     *
+     * The producer / live-drag integration calls this with the target node's measured rect so the
+     * overlay aligns to the real dock zone. No-op when there is no active affordance or the rect
+     * cannot be mapped — geometry never throws and the rect is never persisted.
+     * @param {Object|null} targetRect {x, y, width, height}
+     */
+    applyTargetGeometry(targetRect) {
+        let me         = this,
+            affordance = DockPreview.mapPreviewToAffordance(me.dockPreview),
+            node       = me.vdom.cn?.[0];
+
+        if (!affordance || !node) return;
+
+        let geo = DockPreview.affordanceGeometry(affordance, targetRect);
+
+        if (!geo) return;
+
+        node.style = {
+            ...node.style,
+            height  : `${geo.height}px`,
+            left    : `${geo.x}px`,
+            position: 'absolute',
+            top     : `${geo.y}px`,
+            width   : `${geo.width}px`
+        };
+
+        me.update()
+    }
+
+    /**
+     * @summary Wires the overlay's cleanup to an existing drag surface's lifecycle terminals.
+     *
+     * Listens to `dragEnd` (release or cancel) and `dragBoundaryExit` (leave) on the supplied drag
+     * surface and clears the transient overlay on either. This is the ONLY coupling to the drag
+     * lifecycle: the overlay consumes existing signals and owns no pointer events of its own.
+     * @param {Object|null} dragSource a Neo.draggable sort/drag zone (or any Observable)
+     * @returns {AgentOS.view.DockPreview} this, for chaining
+     */
+    bindDragSource(dragSource) {
+        let me = this;
+
+        me.unbindDragSource();
+        me.dragSource = dragSource || null;
+
+        if (me.dragSource?.on) {
+            me.dragSource.on('dragEnd',          me.clearPreview, me);
+            me.dragSource.on('dragBoundaryExit', me.clearPreview, me)
+        }
+
+        return me
+    }
+
+    /**
+     * @summary Clears the transient overlay. Performs no model mutation.
+     */
+    clearPreview() {
+        this.dockPreview = null
+    }
+
+    /**
+     *
+     */
+    destroy(...args) {
+        this.unbindDragSource();
+        super.destroy(...args)
+    }
+
+    /**
+     * @summary Builds the transient affordance VDOM node from a descriptor.
+     *
+     * The node carries semantic classes (group + concrete kind + accept/reject) and the target
+     * node id as a data attribute; positioning is applied separately via
+     * {@link AgentOS.view.DockPreview#applyTargetGeometry}. The overlay is pointer-transparent so
+     * it never intercepts the live drag.
+     * @param {Object} affordance
+     * @returns {Object} VDOM node
+     */
+    getAffordanceVdom(affordance) {
+        return {
+            cls: [
+                'neo-dock-preview-affordance',
+                `neo-dock-preview-${affordance.group}`,
+                `neo-dock-preview-${affordance.kind}`,
+                affordance.accepted ? 'neo-dock-preview-accepted' : 'neo-dock-preview-rejected'
+            ],
+            'data-dock-target': affordance.targetNodeId,
+            style             : {pointerEvents: 'none'}
+        }
+    }
+
+    /**
+     * @summary Removes any previously bound drag-surface listeners.
+     */
+    unbindDragSource() {
+        let me = this;
+
+        if (me.dragSource?.un) {
+            me.dragSource.un('dragEnd',          me.clearPreview, me);
+            me.dragSource.un('dragBoundaryExit', me.clearPreview, me)
+        }
+
+        me.dragSource = null
+    }
+}
+
+export default Neo.setupClass(DockPreview);

--- a/resources/scss/src/apps/agentos/DockPreview.scss
+++ b/resources/scss/src/apps/agentos/DockPreview.scss
@@ -1,0 +1,44 @@
+.neo-dock-preview {
+    pointer-events : none;
+
+    .neo-dock-preview-affordance {
+        border-radius  : 3px;
+        box-sizing     : border-box;
+        opacity        : 0.85;
+        pointer-events : none;
+        position       : absolute;
+        transition     : opacity 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
+    }
+
+    // Zone highlights — edge bands and whole-node tab targets — read as a translucent filled region.
+    .neo-dock-preview-edge,
+    .neo-dock-preview-tab-into {
+        &.neo-dock-preview-accepted {
+            background-color : var(--agent-dock-preview-accept-fill, rgba(88, 166, 255, 0.22));
+            border           : 2px solid var(--agent-dock-preview-accept, #58a6ff);
+        }
+
+        &.neo-dock-preview-rejected {
+            background-color : var(--agent-dock-preview-reject-fill, rgba(207, 34, 46, 0.16));
+            border           : 2px dashed var(--agent-dock-preview-reject, #cf222e);
+            opacity          : 0.55;
+        }
+    }
+
+    // Insertion guides — split lines and tab before/after markers — read as a solid bar.
+    .neo-dock-preview-split,
+    .neo-dock-preview-tab-before,
+    .neo-dock-preview-tab-after {
+        border-radius : 2px;
+
+        &.neo-dock-preview-accepted {
+            background-color : var(--agent-dock-preview-accept, #58a6ff);
+            box-shadow       : 0 0 6px var(--agent-dock-preview-accept, #58a6ff);
+        }
+
+        &.neo-dock-preview-rejected {
+            background-color : var(--agent-dock-preview-reject, #cf222e);
+            opacity          : 0.55;
+        }
+    }
+}

--- a/resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss
+++ b/resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss
@@ -1,0 +1,6 @@
+:root .neo-theme-neo-dark {
+    --agent-dock-preview-accept      : var(--agent-state-focus, #58a6ff);
+    --agent-dock-preview-accept-fill : rgba(88, 166, 255, 0.22);
+    --agent-dock-preview-reject      : var(--agent-accent-intervention, #cf222e);
+    --agent-dock-preview-reject-fill : rgba(207, 34, 46, 0.16);
+}

--- a/resources/scss/theme-neo-light/apps/agentos/DockPreview.scss
+++ b/resources/scss/theme-neo-light/apps/agentos/DockPreview.scss
@@ -1,0 +1,6 @@
+:root .neo-theme-neo-light {
+    --agent-dock-preview-accept      : var(--agent-state-focus, #0969da);
+    --agent-dock-preview-accept-fill : rgba(9, 105, 218, 0.16);
+    --agent-dock-preview-reject      : var(--agent-accent-intervention, #cf222e);
+    --agent-dock-preview-reject-fill : rgba(207, 34, 46, 0.12);
+}

--- a/test/playwright/unit/apps/agentos/DockPreview.spec.mjs
+++ b/test/playwright/unit/apps/agentos/DockPreview.spec.mjs
@@ -1,0 +1,287 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSDockPreviewTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import DockPreview    from '../../../../../apps/agentos/view/DockPreview.mjs';
+
+/**
+ * @summary Tests for AgentOS.view.DockPreview — the drag-time dock preview renderer.
+ * Covers the pure contract logic (validity / affordance mapping / semantic-drop conversion /
+ * geometry) plus the component lifecycle (render, fail-closed cleanup, drag-source binding).
+ */
+
+/**
+ * Builds a well-formed `neo.harness.dockPreview.v1` object, with optional field overrides.
+ * @param {Object} [overrides]
+ * @returns {Object}
+ */
+function preview(overrides = {}) {
+    return {
+        schema   : 'neo.harness.dockPreview.v1',
+        previewId: 'preview:strategy:main-tabs:tab-after:1',
+        itemId   : 'strategy',
+        source   : {surface: 'dashboard-sort-zone', sortZoneId: 'left-workspace'},
+        target   : {containerId: 'workspace', nodeId: 'main-tabs'},
+        placement: {kind: 'tab-after', index: 1},
+        feedback : {state: 'accepted'},
+        ...overrides
+    }
+}
+
+test.describe('AgentOS.view.DockPreview', () => {
+    test.describe('isValidPreview (fail-closed)', () => {
+        test('accepts a well-formed preview', () => {
+            expect(DockPreview.isValidPreview(preview())).toBe(true)
+        });
+
+        test('rejects null, undefined and non-objects', () => {
+            expect(DockPreview.isValidPreview(null)).toBe(false);
+            expect(DockPreview.isValidPreview(undefined)).toBe(false);
+            expect(DockPreview.isValidPreview('preview')).toBe(false)
+        });
+
+        test('rejects a wrong or missing schema', () => {
+            expect(DockPreview.isValidPreview(preview({schema: 'neo.harness.dockPreview.v2'}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({schema: undefined}))).toBe(false)
+        });
+
+        test('rejects a missing itemId', () => {
+            expect(DockPreview.isValidPreview(preview({itemId: ''}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({itemId: undefined}))).toBe(false)
+        });
+
+        test('rejects a missing target.nodeId', () => {
+            expect(DockPreview.isValidPreview(preview({target: {containerId: 'workspace'}}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({target: {nodeId: ''}}))).toBe(false)
+        });
+
+        test('rejects an unknown placement.kind', () => {
+            expect(DockPreview.isValidPreview(preview({placement: {kind: 'corner-top-left'}}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({placement: {}}))).toBe(false)
+        });
+
+        test('rejects a split placement without a valid orientation', () => {
+            expect(DockPreview.isValidPreview(preview({placement: {kind: 'split-before'}}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({placement: {kind: 'split-after', orientation: 'diagonal'}}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({placement: {kind: 'split-after', orientation: 'vertical'}}))).toBe(true)
+        });
+
+        test('rejects a missing or invalid feedback.state', () => {
+            expect(DockPreview.isValidPreview(preview({feedback: {}}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({feedback: {state: 'maybe'}}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({feedback: undefined}))).toBe(false)
+        });
+
+        test('treats a rejected placement as structurally valid', () => {
+            expect(DockPreview.isValidPreview(preview({placement: {kind: 'rejected'}, feedback: {state: 'rejected'}}))).toBe(true)
+        })
+    });
+
+    test.describe('mapPreviewToAffordance', () => {
+        test('maps every edge kind to an edge affordance', () => {
+            for (const edge of ['top', 'right', 'bottom', 'left']) {
+                const affordance = DockPreview.mapPreviewToAffordance(preview({placement: {kind: `edge-${edge}`}}));
+                expect(affordance.group).toBe('edge');
+                expect(affordance.edge).toBe(edge);
+                expect(affordance.kind).toBe(`edge-${edge}`);
+                expect(affordance.targetNodeId).toBe('main-tabs')
+            }
+        });
+
+        test('maps split kinds with orientation and position', () => {
+            const affordance = DockPreview.mapPreviewToAffordance(preview({placement: {kind: 'split-after', orientation: 'horizontal'}}));
+            expect(affordance.group).toBe('split');
+            expect(affordance.position).toBe('after');
+            expect(affordance.orientation).toBe('horizontal')
+        });
+
+        test('maps tab kinds with position and index', () => {
+            const affordance = DockPreview.mapPreviewToAffordance(preview({placement: {kind: 'tab-before', index: 2}}));
+            expect(affordance.group).toBe('tab');
+            expect(affordance.position).toBe('before');
+            expect(affordance.index).toBe(2)
+        });
+
+        test('defaults a non-integer tab index to null', () => {
+            const affordance = DockPreview.mapPreviewToAffordance(preview({placement: {kind: 'tab-into'}}));
+            expect(affordance.index).toBe(null)
+        });
+
+        test('still renders a rejected-feedback candidate but flags it not accepted', () => {
+            const affordance = DockPreview.mapPreviewToAffordance(preview({feedback: {state: 'rejected'}}));
+            expect(affordance).not.toBe(null);
+            expect(affordance.group).toBe('tab');
+            expect(affordance.accepted).toBe(false)
+        });
+
+        test('returns null for a rejected placement (no candidate to draw)', () => {
+            expect(DockPreview.mapPreviewToAffordance(preview({placement: {kind: 'rejected'}, feedback: {state: 'rejected'}}))).toBe(null)
+        });
+
+        test('returns null for an invalid preview', () => {
+            expect(DockPreview.mapPreviewToAffordance(preview({schema: 'nope'}))).toBe(null);
+            expect(DockPreview.mapPreviewToAffordance(null)).toBe(null)
+        })
+    });
+
+    test.describe('previewToOperation (semantic drop, never mutates)', () => {
+        test('tab placements route to addTab with the target tabs node and index', () => {
+            const op = DockPreview.previewToOperation(preview({placement: {kind: 'tab-after', index: 1}}));
+            expect(op.operation).toBe('addTab');
+            expect(op.tabsNodeId).toBe('main-tabs');
+            expect(op.itemId).toBe('strategy');
+            expect(op.index).toBe(1)
+        });
+
+        test('split placements route to splitNode with orientation and normalized sizes', () => {
+            const op = DockPreview.previewToOperation(preview({placement: {kind: 'split-before', orientation: 'vertical', ratio: 0.3}}));
+            expect(op.operation).toBe('splitNode');
+            expect(op.orientation).toBe('vertical');
+            expect(op.position).toBe('before');
+            expect(op.sizes).toEqual([0.3, 0.7])
+        });
+
+        test('edge placements route to splitNode with a derived orientation', () => {
+            const left = DockPreview.previewToOperation(preview({placement: {kind: 'edge-left'}}));
+            expect(left.operation).toBe('splitNode');
+            expect(left.edge).toBe('left');
+            expect(left.orientation).toBe('horizontal');
+
+            const bottom = DockPreview.previewToOperation(preview({placement: {kind: 'edge-bottom'}}));
+            expect(bottom.orientation).toBe('vertical')
+        });
+
+        test('returns null for rejected feedback', () => {
+            expect(DockPreview.previewToOperation(preview({feedback: {state: 'rejected'}}))).toBe(null)
+        });
+
+        test('returns null for a rejected placement', () => {
+            expect(DockPreview.previewToOperation(preview({placement: {kind: 'rejected'}, feedback: {state: 'rejected'}}))).toBe(null)
+        });
+
+        test('returns null for an invalid preview', () => {
+            expect(DockPreview.previewToOperation(preview({itemId: ''}))).toBe(null)
+        });
+
+        test('never leaks a runtime-only field into the operation descriptor', () => {
+            const op = DockPreview.previewToOperation(preview());
+            expect(op).not.toHaveProperty('previewId');
+            expect(op).not.toHaveProperty('source');
+            expect(op).not.toHaveProperty('feedback');
+            expect(JSON.stringify(op)).not.toContain('dashboard-sort-zone')
+        })
+    });
+
+    test.describe('ratioToSizes', () => {
+        test('defaults to an even split for an absent or invalid ratio', () => {
+            expect(DockPreview.ratioToSizes(undefined, 'before')).toEqual([0.5, 0.5]);
+            expect(DockPreview.ratioToSizes(0, 'before')).toEqual([0.5, 0.5]);
+            expect(DockPreview.ratioToSizes(1.5, 'after')).toEqual([0.5, 0.5])
+        });
+
+        test('honors a valid ratio for before and after positions', () => {
+            expect(DockPreview.ratioToSizes(0.25, 'before')).toEqual([0.25, 0.75]);
+            expect(DockPreview.ratioToSizes(0.25, 'after')).toEqual([0.75, 0.25])
+        })
+    });
+
+    test.describe('affordanceGeometry (pure, never throws)', () => {
+        const rect = {x: 10, y: 20, width: 200, height: 100};
+
+        test('returns null for an absent or non-numeric rect', () => {
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'}, null)).toBe(null);
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'}, {x: 'a', y: 0, width: 1, height: 1})).toBe(null);
+            expect(DockPreview.affordanceGeometry(null, rect)).toBe(null)
+        });
+
+        test('an edge-top affordance is a band across the top', () => {
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'top'}, rect)).toEqual({x: 10, y: 20, width: 200, height: 24})
+        });
+
+        test('an edge-right affordance is a band down the right side', () => {
+            expect(DockPreview.affordanceGeometry({group: 'edge', edge: 'right'}, rect)).toEqual({x: 186, y: 20, width: 24, height: 100})
+        });
+
+        test('a tab-into affordance highlights the whole node', () => {
+            expect(DockPreview.affordanceGeometry({group: 'tab', position: 'into'}, rect)).toEqual(rect)
+        });
+
+        test('a horizontal split-after affordance is a guide line on the right edge', () => {
+            const geo = DockPreview.affordanceGeometry({group: 'split', orientation: 'horizontal', position: 'after'}, rect);
+            expect(geo).toEqual({x: 204, y: 20, width: 6, height: 100})
+        })
+    });
+
+    test.describe('component lifecycle', () => {
+        let instance;
+
+        test.afterEach(() => {
+            instance?.destroy();
+            instance = null
+        });
+
+        test('renders an affordance node for a valid preview and clears on null', () => {
+            instance = Neo.create(DockPreview, {id: 'dock-preview-render-test'});
+
+            instance.dockPreview = preview();
+            expect(instance.vdom.cn.length).toBe(1);
+            expect(instance.vdom.cn[0].cls).toContain('neo-dock-preview-tab');
+            expect(instance.vdom.cn[0].cls).toContain('neo-dock-preview-accepted');
+            expect(instance.vdom.cn[0]['data-dock-target']).toBe('main-tabs');
+
+            instance.clearPreview();
+            expect(instance.dockPreview).toBe(null);
+            expect(instance.vdom.cn.length).toBe(0)
+        });
+
+        test('an invalid preview fails closed to an empty overlay', () => {
+            instance = Neo.create(DockPreview, {id: 'dock-preview-failclosed-test'});
+
+            instance.dockPreview = {schema: 'wrong'};
+            expect(instance.vdom.cn.length).toBe(0)
+        });
+
+        test('bindDragSource clears the overlay on a drag-lifecycle terminal', () => {
+            const handlers   = {};
+            const mockSource = {
+                on(name, fn, scope) { handlers[name] = {fn, scope} },
+                un(name, fn, scope) { if (handlers[name]?.fn === fn) delete handlers[name] },
+                fire(name)          { handlers[name]?.fn.call(handlers[name].scope) }
+            };
+
+            instance = Neo.create(DockPreview, {id: 'dock-preview-bind-test'});
+            instance.bindDragSource(mockSource);
+
+            instance.dockPreview = preview();
+            expect(instance.vdom.cn.length).toBe(1);
+
+            mockSource.fire('dragEnd');
+            expect(instance.dockPreview).toBe(null);
+            expect(instance.vdom.cn.length).toBe(0);
+
+            mockSource.fire('dragBoundaryExit');
+            expect(instance.dockPreview).toBe(null)
+        });
+
+        test('applyTargetGeometry positions the active affordance from a runtime rect', () => {
+            instance = Neo.create(DockPreview, {id: 'dock-preview-geometry-test'});
+
+            instance.dockPreview = preview({placement: {kind: 'edge-top'}, feedback: {state: 'accepted'}});
+            instance.applyTargetGeometry({x: 10, y: 20, width: 200, height: 100});
+
+            const {style} = instance.vdom.cn[0];
+            expect(style.position).toBe('absolute');
+            expect(style.left).toBe('10px');
+            expect(style.top).toBe('20px');
+            expect(style.width).toBe('200px');
+            expect(style.height).toBe('24px')
+        })
+    })
+});

--- a/test/playwright/unit/apps/agentos/DockPreview.spec.mjs
+++ b/test/playwright/unit/apps/agentos/DockPreview.spec.mjs
@@ -10,6 +10,9 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
 import DockPreview    from '../../../../../apps/agentos/view/DockPreview.mjs';
+import fs             from 'fs';
+import path           from 'path';
+import {fileURLToPath} from 'url';
 
 /**
  * @summary Tests for AgentOS.view.DockPreview — the drag-time dock preview renderer.
@@ -35,7 +38,39 @@ function preview(overrides = {}) {
     }
 }
 
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    repoRoot   = path.resolve(__dirname, '../../../../..');
+
 test.describe('AgentOS.view.DockPreview', () => {
+    test.describe('stylesheet contract (visible affordances)', () => {
+        test('the structural scss backs the emitted affordance classes with visible styling', () => {
+            const scss = fs.readFileSync(path.join(repoRoot, 'resources/scss/src/apps/agentos/DockPreview.scss'), 'utf8');
+
+            expect(scss).toContain('.neo-dock-preview-affordance');
+            expect(scss).toContain('.neo-dock-preview-accepted');
+            expect(scss).toContain('.neo-dock-preview-rejected');
+            // accepted/rejected states carry real visual treatment, not just class names
+            expect(scss).toContain('background-color');
+            expect(scss).toContain('border');
+            expect(scss).toContain('opacity')
+        });
+
+        test('both harness themes define the accept/reject affordance tokens', () => {
+            const dark  = fs.readFileSync(path.join(repoRoot, 'resources/scss/theme-neo-dark/apps/agentos/DockPreview.scss'), 'utf8');
+            const light = fs.readFileSync(path.join(repoRoot, 'resources/scss/theme-neo-light/apps/agentos/DockPreview.scss'), 'utf8');
+
+            expect(dark).toContain('neo-theme-neo-dark');
+            expect(dark).toContain('--agent-dock-preview-accept');
+            expect(dark).toContain('--agent-dock-preview-reject');
+
+            expect(light).toContain('neo-theme-neo-light');
+            expect(light).toContain('--agent-dock-preview-accept');
+            expect(light).toContain('--agent-dock-preview-reject')
+        })
+    });
+
     test.describe('isValidPreview (fail-closed)', () => {
         test('accepts a well-formed preview', () => {
             expect(DockPreview.isValidPreview(preview())).toBe(true)


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13104

Adds `AgentOS.view.DockPreview`, the drag-time renderer for the harness docking line: it consumes the runtime-only `dockPreview` contract (`neo.harness.dockPreview.v1`, per `learn/agentos/HarnessDockZoneModel.md`) and projects its candidate `placement` into a single transient, **visibly-styled** affordance — an edge band, split guide, or tab indicator — failing closed on any invalid, stale, or `rejected`-placement preview.

The renderer is deliberately bounded to **visual preview rendering + cleanup only**:

- **Visual only** — no parallel pointer system. `bindDragSource()` listens to the existing sort-zone `dragEnd` / `dragBoundaryExit` lifecycle solely to clear the overlay; the overlay owns no pointer events of its own.
- **Runtime only** — no write path to the persisted dock-zone model. It reads a preview and emits transient VDOM plus operation descriptors; a `DOMRect` supplied to `applyTargetGeometry()` is used transiently and never persisted.
- **Fail closed** — `isValidPreview()` rejects malformed, partial, unknown-kind, orientation-less-split, or stale payloads; the overlay clears rather than guessing.
- **Semantic drop** — `previewToOperation()` converts an accepted preview into an `addTab` / `splitNode` descriptor per the contract's conversion table; the overlay never mutates the tree. (Executor: #13115 / PR #13116.)
- **Visibly styled** — the `neo-dock-preview-*` classes are backed by SCSS: edge bands + `tab-into` as translucent filled zones, split + tab markers as solid guide bars, distinct accepted (focus-blue) vs rejected (intervention-red) states, in `theme-neo-dark` + `theme-neo-light`.

Evidence: L1 (36 unit tests — validity fail-closed, affordance mapping across every edge/split/tab kind, semantic-drop conversion, pure geometry, component render/clear, drag-source cleanup, **and a static stylesheet-contract check that the `neo-dock-preview-*` classes carry visible styling in both themes**; `build-themes` compiles `DockPreview.css` for both themes with zero errors) → L1 required (every #13104 AC is unit- or static-contract-covered at the renderer boundary). Residual: the live visible affordance during a real drag (AC1 end-to-end) needs the upstream producer feeding `dockPreview` plus a rendered workspace — explicitly out of scope here, a separate docking leaf.

## Deltas from ticket

Visible styling was added in review (commit `cf7b3281b`): the initial diff emitted affordance classes with no stylesheet, so the affordances were invisible — the ticket's first AC is *visible* affordances, so the SCSS (structural + `theme-neo-dark` + `theme-neo-light`) is part of this leaf, not downstream. The producer (drag geometry → `dockPreview`) and the operation executor remain separate docking leaves (the executor is now #13115 / PR #13116); `previewToOperation()` provides the semantic-drop descriptor seam.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/apps/agentos/DockPreview.spec.mjs
→ 36 passed
```

Includes the static stylesheet-contract assertions (the structural SCSS backs the affordance classes; both themes define the accept/reject tokens). Theme build: `node ./buildScripts/build/themes.mjs -n -e dev -t theme-neo-dark` + `-t theme-neo-light` → compile `DockPreview.css` for both, zero errors. Full AgentOS unit dir: **38 passed**. Pre-commit hooks green (`check-whitespace`, `check-shorthand`, `check-ticket-archaeology`).

## Post-Merge Validation

- [ ] When the upstream `dockPreview` producer leaf lands, wire `DockPreview` into the harness workspace overlay and confirm a live drag renders + clears the styled affordance (whitebox-e2e).
- [ ] When the dock-zone operation executor (#13115 / PR #13116) merges, confirm `previewToOperation()` descriptors route through `DockZoneModel.applyOperation()` with no overlay-side tree surgery.

## Structural Pre-Flight

Fast-path (sibling-file-lift): `apps/agentos/view/DockPreview.mjs` sits beside the existing `AgentOS.view.*` harness view components; `HarnessDockZoneModel.md` Ownership Boundary mandates harness-app-layer placement. The SCSS follows the existing structural (`resources/scss/src/apps/agentos/`) + per-theme directory split. Map-maintenance: not-needed.

Refs #13012
Related: #13030
