### PR TITLE
feat(ai): server-bind the harness Neural Link tool projection (#13106)

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -78,6 +78,17 @@ class BaseServer extends Base {
      */
     configFile = null
     /**
+     * Server-instance forced tool-projection mode — the security *ceiling* for the tool surface this
+     * instance exposes, set at boot by the spawner (the Fleet Manager when it launches a server for an
+     * embedded agent; neural-link's `--tool-projection-mode harness-embedded` CLI flag). When set,
+     * {@link buildToolProjectionContext} pins every request to this mode, so a client can NEVER widen
+     * its surface by omitting or altering request `_meta` — the projection becomes a server-bound
+     * capability, not a client-asserted convention. Default `null` = no ceiling: the full
+     * developer/operator surface, for trusted dev/operator-launched servers (back-compat).
+     * @member {String|null} toolProjectionMode=null
+     */
+    toolProjectionMode = null
+    /**
      * Per-server `logger` module. Subclasses assign at class-body level.
      * Falls back to `console.error` when null.
      * @member {Object|null} logger=null
@@ -160,13 +171,18 @@ class BaseServer extends Base {
      * Returning `null` preserves the existing full developer/operator surface. Returning
      * `{mode: 'harness-embedded'}` asks the underlying ToolService to apply its OpenAPI-root
      * `x-neo-harness-tool-projection` policy before listing or dispatching tools.
+     *
+     * This default honors the server-instance {@link toolProjectionMode} ceiling: when the spawner
+     * pinned this instance to a mode, every request gets it. Subclasses that read a client narrowing
+     * hint (e.g. neural-link's `_meta`) MUST keep the forced mode as the ceiling — a client can never
+     * widen past it.
      * @param {Object} context
      * @param {Object} context.request The raw MCP request.
      * @param {String} context.phase   `listTools` or `callTool`.
      * @returns {Object|String|null}
      */
     buildToolProjectionContext(context) {
-        return null;
+        return this.toolProjectionMode ? {mode: this.toolProjectionMode} : null;
     }
 
     /**

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -176,13 +176,19 @@ class BaseServer extends Base {
      * pinned this instance to a mode, every request gets it. Subclasses that read a client narrowing
      * hint (e.g. neural-link's `_meta`) MUST keep the forced mode as the ceiling — a client can never
      * widen past it.
+     *
+     * **Only `null` / `undefined` is "unset"** (the trusted full-surface launch). Any *configured*
+     * value — including an empty/whitespace string from a misconfigured spawner — stays a forced mode
+     * and fails CLOSED downstream (`ToolService.isToolAllowedForProjection` returns no tools for any
+     * non-`harness-embedded` mode). A truthiness check would erase `''` into the unset/full-surface
+     * case — a fail-OPEN on a security launch parameter — so the nullish check is load-bearing.
      * @param {Object} context
      * @param {Object} context.request The raw MCP request.
      * @param {String} context.phase   `listTools` or `callTool`.
      * @returns {Object|String|null}
      */
     buildToolProjectionContext(context) {
-        return this.toolProjectionMode ? {mode: this.toolProjectionMode} : null;
+        return this.toolProjectionMode != null ? {mode: this.toolProjectionMode} : null;
     }
 
     /**

--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -90,7 +90,9 @@ class Server extends BaseServer {
      */
     buildToolProjectionContext({request}) {
         // Forced server-instance mode wins and is the ceiling — client `_meta` cannot widen past it.
-        if (this.toolProjectionMode) {
+        // Only null/undefined is "unset"; an empty/malformed configured value stays a forced mode and
+        // fails closed downstream (a truthiness check would erase `''` into full-surface — fail-OPEN).
+        if (this.toolProjectionMode != null) {
             return {mode: this.toolProjectionMode};
         }
 

--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -72,24 +72,31 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary Resolves the Neural Link harness projection context from MCP request metadata.
+     * @summary Resolves the Neural Link harness projection context for ListTools / CallTool.
      *
-     * Existing developer/operator sessions send no projection metadata and keep the full
-     * surface. Embedded harness clients opt into the fail-closed read projection by passing
-     * `_meta.neoToolProjection: 'harness-embedded'` on `tools/list` and `call_tool`.
+     * **Server-instance forced mode is the ceiling.** When this instance was launched with a forced
+     * {@link toolProjectionMode} (the spawner / Fleet Manager pinning an embedded-agent server via
+     * `--tool-projection-mode`), every request is pinned to it and the client `_meta` is ignored — a
+     * client can NEVER widen its surface by omitting or altering `_meta`. Capability binds to what the
+     * server instance *is*, not to what the client *claims*.
+     *
+     * When NOT forced (trusted dev/operator launch), the client `_meta.neoToolProjection` hint selects
+     * the projection (`'harness-embedded'` → fail-closed read surface); absent → `null` → the full
+     * developer/operator surface (back-compat).
      *
      * @param {Object} context
      * @param {Object} context.request The raw MCP request.
      * @returns {Object|null}
      */
     buildToolProjectionContext({request}) {
-        const projection = request?.params?._meta?.neoToolProjection;
-
-        if (projection === undefined) {
-            return null;
+        // Forced server-instance mode wins and is the ceiling — client `_meta` cannot widen past it.
+        if (this.toolProjectionMode) {
+            return {mode: this.toolProjectionMode};
         }
 
-        return {mode: projection};
+        // Unforced: the client hint selects the projection; absent → full developer/operator surface.
+        const projection = request?.params?._meta?.neoToolProjection;
+        return projection === undefined ? null : {mode: projection};
     }
 
     /**
@@ -130,7 +137,7 @@ class Server extends BaseServer {
 
         this.mcpServer = this.createMcpServer();
 
-        // Connect transport EARLY — see method JSDoc for rationale (#10455 lineage).
+        // Connect transport EARLY — see method JSDoc for rationale.
         await this.connectTransport();
         this.logger.info('Neural Link MCP Server transport connected');
 

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -16,6 +16,7 @@ program
     .option('-c, --config <path>', 'Path to the configuration file', sanitizeInput)
     .option('-w, --cwd <path>', 'Working directory for the bridge process')
     .option('-d, --debug', 'Enable debug logging')
+    .option('--tool-projection-mode <mode>', 'Pin this server instance to a forced tool-projection ceiling (e.g. harness-embedded) a client cannot widen past. Unset = full developer/operator surface.')
     .parse(process.argv);
 
 const options = program.opts();
@@ -27,8 +28,9 @@ if (options.debug) {
 
 try {
     await Neo.create(Server, {
-        configFile: options.config,
-        bridgeCwd : options.cwd
+        configFile        : options.config,
+        bridgeCwd         : options.cwd,
+        toolProjectionMode: options.toolProjectionMode ?? null
     }).ready();
 } catch (error) {
     logger.error('Fatal error during server initialization:', error);

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -345,4 +345,30 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(nonRead, `forced mode leaked non-read tools despite omitted _meta:\n${nonRead.join('\n')}`).toEqual([]);
         expect(projectedNames).toEqual(getHarnessEmbeddedOperationIds(server).sort());
     });
+
+    test('SECURITY: an explicitly-configured empty/whitespace forced mode fails CLOSED, not full-surface (#13106 cross-family RA)', async () => {
+        const
+            nlCtx   = (await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href)).default.prototype.buildToolProjectionContext,
+            baseCtx = (await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/BaseServer.mjs')).href)).default.prototype.buildToolProjectionContext;
+
+        // Only null/undefined is "unset" (trusted full surface). A configured empty/whitespace string
+        // is a forced mode → {mode: <value>} → ToolService fails closed (not 'harness-embedded'). A
+        // truthiness check would erase '' into the unset/full-surface case — the fail-OPEN this guards.
+        for (const ctx of [nlCtx, baseCtx]) {
+            expect(ctx.call({toolProjectionMode: undefined}, {request: {params: {}}})).toBeNull();
+            expect(ctx.call({toolProjectionMode: null},      {request: {params: {}}})).toBeNull();
+            expect(ctx.call({toolProjectionMode: ''},        {request: {params: {}}})).toEqual({mode: ''});
+            expect(ctx.call({toolProjectionMode: '   '},     {request: {params: {}}})).toEqual({mode: '   '});
+        }
+
+        // end-to-end: a server pinned to '' lists ZERO tools (fail-closed), never the full surface.
+        const
+            server            = servers.find(item => item.name === 'neural-link'),
+            {listTools: listNL} = await import(pathToFileURL(path.join(repoRoot, server.toolServicePath)).href),
+            {tools: full}        = listNL(),
+            {tools: emptyForced} = listNL({toolProjection: {mode: ''}});
+
+        expect(full.length).toBeGreaterThan(0);
+        expect(emptyForced, 'empty configured forced-mode leaked tools (should fail closed)').toEqual([]);
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -293,4 +293,56 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
             /Tool "patch_code" is not visible in the harness-embedded projection/
         );
     });
+
+    test('neural-link server-instance forced mode is the ceiling — client cannot widen via _meta (#13106)', async () => {
+        const
+            moduleUrl = pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href,
+            Server    = (await import(moduleUrl)).default,
+            ctx       = Server.prototype.buildToolProjectionContext;
+
+        // Unforced (default): client _meta selects the projection; absent → null (full surface, back-compat).
+        expect(ctx.call({toolProjectionMode: null}, {request: {params: {}}})).toBeNull();
+        expect(ctx.call({toolProjectionMode: null}, {request: {params: {_meta: {neoToolProjection: 'harness-embedded'}}}}))
+            .toEqual({mode: 'harness-embedded'});
+
+        // Forced: every request is pinned to the forced mode REGARDLESS of client _meta — omitting
+        // _meta no longer escalates to the full surface, and a client cannot widen past the ceiling.
+        expect(ctx.call({toolProjectionMode: 'harness-embedded'}, {request: {params: {}}}))
+            .toEqual({mode: 'harness-embedded'});
+        expect(ctx.call({toolProjectionMode: 'harness-embedded'}, {request: {params: {_meta: {}}}}))
+            .toEqual({mode: 'harness-embedded'});
+        expect(ctx.call({toolProjectionMode: 'harness-embedded'}, {request: {params: {_meta: {neoToolProjection: 'full'}}}}))
+            .toEqual({mode: 'harness-embedded'});
+    });
+
+    test('BaseServer default buildToolProjectionContext honors the forced-mode ceiling (#13106)', async () => {
+        const
+            moduleUrl  = pathToFileURL(path.join(repoRoot, 'ai/mcp/server/BaseServer.mjs')).href,
+            BaseServer = (await import(moduleUrl)).default,
+            ctx        = BaseServer.prototype.buildToolProjectionContext;
+
+        expect(ctx.call({toolProjectionMode: null},               {request: {params: {}}})).toBeNull();
+        expect(ctx.call({toolProjectionMode: 'harness-embedded'}, {request: {params: {}}})).toEqual({mode: 'harness-embedded'});
+    });
+
+    test('forced harness-embedded mode lists only read-tier tools end-to-end, even with omitted _meta (#13106)', async () => {
+        const
+            server        = servers.find(item => item.name === 'neural-link'),
+            nlModuleUrl   = pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href,
+            Server        = (await import(nlModuleUrl)).default,
+            // server pinned to harness-embedded; client sends NO _meta (the omitted-_meta bypass path)
+            forcedContext = Server.prototype.buildToolProjectionContext.call(
+                {toolProjectionMode: 'harness-embedded'}, {request: {params: {}}}
+            ),
+            tsModuleUrl   = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {listTools: listNL} = await import(tsModuleUrl),
+            {tools}       = listNL({toolProjection: forcedContext}),
+            operations    = getOperationsById(server),
+            projectedNames = tools.map(tool => tool.name).sort(),
+            nonRead       = projectedNames.filter(name => operations[name]['x-neo-tool-tier'] !== 'read');
+
+        expect(forcedContext).toEqual({mode: 'harness-embedded'});
+        expect(nonRead, `forced mode leaked non-read tools despite omitted _meta:\n${nonRead.join('\n')}`).toEqual([]);
+        expect(projectedNames).toEqual(getHarnessEmbeddedOperationIds(server).sort());
+    });
 });


### PR DESCRIPTION
Resolves #13106

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace). Finding origin: my #13082 intake V-B-A; ticket scoped by @neo-opus-vega.

Closes the **fail-open** in the harness Neural Link tool projection. Before this, the read-only projection for embedded agents was selected *solely* from client-supplied `_meta.neoToolProjection` — an embedded agent that simply omitted the flag received the **full developer/admin surface**. The projection was a convention, not a security boundary.

This binds the projection to the **server instance**: a forced `toolProjectionMode` ceiling, set at boot by the spawner (the Fleet Manager when it launches an embedded-agent server). When set, every request is pinned to it and the client `_meta` can only narrow, never widen — capability binds to what the server instance *is*, not what the client *claims*. Default unset → existing full developer/operator surface (back-compat for trusted dev/operator launches).

Evidence: L2 (real `listTools` run through forced projection contexts + prototype-method unit assertions on local dev) → L2 required (the leaf's ACs are pure in-process projection-*selection* logic; the cross-process FM-spawn→embedded-agent enforcement is #13015's L4). No residuals in this leaf.

## Mechanism — why a CLI flag / instance field, not an AiConfig leaf
The forced mode is a **per-spawn security launch parameter** (the FM sets it when launching a server for an embedded agent), not a persistent tenant config value. So it follows the existing `bridgeCwd` / `configFile` precedent — a plain instance field set from a boot CLI flag — and is *deliberately* NOT routed through `AiConfig` (per ADR 0019 that would add a needless `leaf` + the B4 test-mutation surface for a launch arg). The CLI/instance-field form is the lower-surface, more-testable choice.

- `BaseServer.toolProjectionMode` (default `null`) + the base `buildToolProjectionContext` honors the ceiling — a generic server-instance capability.
- The neural-link `Server` override: **forced mode wins** as the ceiling; unforced → the client `_meta` narrowing hint (existing behavior).
- `neural-link/mcp-server.mjs`: a `--tool-projection-mode <mode>` boot flag → `Neo.create(Server, {toolProjectionMode})`, mirroring `--cwd → bridgeCwd`.

## Deltas from ticket
- Field placed on `BaseServer` (generic ceiling for any server) but the CLI wiring is neural-link-only (only NL parses the flag + carries a projection policy) — mirrors the NL-specific `bridgeCwd` wiring.
- **Configured modes fail closed by construction:** only `null` / `undefined` is *unset* (the trusted full-surface launch). **Any configured value — empty, whitespace, typo, or unknown — resolves to `{mode: <value>}`** → `ToolService.isToolAllowedForProjection` returns no tools for anything that isn't `harness-embedded` (zero tools, the safe direction — never the full surface). The nullish (`!= null`) check is load-bearing: a truthiness check would erase `''` into the unset/full-surface case (a fail-OPEN — see Evolution).
- Incidental: dropped a rotting `(#10455 lineage)` ticket-ref from a pre-existing comment in `Server.mjs` that the ticket-archaeology hook flagged on the touched file.

## Evolution
- **Cycle-1 cross-family review (@neo-gpt):** hardened the empty-configured forced-mode edge. The initial `if (this.toolProjectionMode)` truthiness check erased an explicitly-empty `--tool-projection-mode` into unset → full surface — a fail-OPEN on a *security* launch parameter (Vega flagged it non-blocking; GPT's cross-family read made it blocking, correctly). Fixed in `be7ed49d9` with a nullish (`!= null`) check in `BaseServer` + the NL override, so any configured value (incl. `''` / whitespace) stays a forced mode and fails closed downstream. Focused coverage added.

## Test Evidence
- `npm run test-unit -- McpServerListToolsSmoke.spec BaseServer.spec` → **53 passed**. #13106 tests cover: forced mode is the ceiling (omitted / empty / wider `_meta` all pinned); `BaseServer` default honors the ceiling; end-to-end forced `harness-embedded` + omitted `_meta` lists only `read`-tier tools; and **an explicitly empty/whitespace configured mode fails CLOSED (`{mode:''}` → zero tools), not full-surface**.
- The `call_tool` refusal under the forced context is the same `{mode:'harness-embedded'}` path the existing #13084 test proves rejects `patch_code` with `POLICY_REFUSED`.
- All 5 servers' `listTools` + the full `BaseServer` suite stay green (the shared `BaseServer` change is additive / nullish-default).

## Post-Merge Validation
- [ ] When the Fleet Manager embedded-spawn path (#13015) lands, confirm it launches the NL server with `--tool-projection-mode harness-embedded` and that a real embedded agent omitting `_meta` cannot reach `write-locked`/`admin` tools (the cross-process L4 closure this leaf's knob enables).

## Cross-family review note
@neo-opus-vega substantively APPROVED (same-family). @neo-gpt cross-reviewed (cycle-1 `REQUEST_CHANGES` on the empty-mode fail-open → fixed `be7ed49d9` → re-review pending green CI). The §6.1 cross-family Approved stamp is the remaining merge prerequisite. ⚠️ @neo-gemini-pro is ~3wk dormant + Fable benched, so @neo-gpt is the sole active cross-family reviewer (flagged separately for the operator). Operator holds merge.

Related: #13056
Related: #13015
Refs #13084
Refs #13064