### PR TITLE
fix(core): remove object-valued listeners symmetrically (#13102)

### DIFF
--- a/src/core/Observable.mjs
+++ b/src/core/Observable.mjs
@@ -300,6 +300,8 @@ class Observable extends Base {
     }
 
     /**
+     * @summary Remove listeners by id, handler, or object-valued listener specs.
+     *
      * There are different syntax's how you can use this method.
      * Using the eventId:
      * ```
@@ -340,6 +342,11 @@ class Observable extends Base {
             }
 
             Object.entries(name).forEach(([key, value]) => {
+                const
+                    valueObject = Neo.isObject(value),
+                    fn          = valueObject ? value.fn : value,
+                    entryScope  = valueObject && Object.hasOwn(value, 'scope') ? value.scope : scope;
+
                 listeners = me[eventMapSymbol][key] || [];
                 i         = 0;
                 len       = listeners.length;
@@ -348,8 +355,11 @@ class Observable extends Base {
                     listener = listeners[i];
 
                     if (
-                        listener.fn.name === (Neo.isString(value) ? value : value.name) &&
-                        listener.scope   === scope
+                        (
+                            listener.fn === fn ||
+                            listener.fn?.name === (Neo.isString(fn) ? fn : fn?.name)
+                        ) &&
+                        listener.scope === entryScope
                     ) {
                         listeners.splice(i, 1);
                         break

--- a/test/playwright/unit/core/ObservableListenersDiff.spec.mjs
+++ b/test/playwright/unit/core/ObservableListenersDiff.spec.mjs
@@ -107,4 +107,60 @@ test.describe('core.Observable diff-based afterSetListeners (#7091)', () => {
 
         inst.destroy();
     });
+
+    test('object-valued listener specs are removed when the listeners config drops the event', () => {
+        let count = 0;
+
+        const
+            onA  = () => { count++ },
+            inst = makeInstance({listeners: {eventA: {fn: onA}}});
+
+        inst.fire('eventA');
+        expect(count).toBe(1);
+
+        inst.listeners = {};
+        inst.fire('eventA');
+        expect(count).toBe(1);
+
+        inst.destroy();
+    });
+
+    test('object-valued un() specs match their own scope', () => {
+        let count = 0;
+
+        const
+            onA        = () => { count++ },
+            rightScope = {id: 'right-scope'},
+            wrongScope = {id: 'wrong-scope'},
+            inst       = makeInstance({});
+
+        inst.on({eventA: {fn: onA, scope: rightScope}});
+        inst.un({eventA: {fn: onA, scope: wrongScope}});
+
+        inst.fire('eventA');
+        expect(count).toBe(1);
+
+        inst.un({eventA: {fn: onA, scope: rightScope}});
+        inst.fire('eventA');
+        expect(count).toBe(1);
+
+        inst.destroy();
+    });
+
+    test('string-valued listener specs still remove by handler name', () => {
+        let count = 0;
+
+        const inst = makeInstance({});
+        inst.onA = () => { count++ };
+
+        inst.listeners = {eventA: 'onA'};
+        inst.fire('eventA');
+        expect(count).toBe(1);
+
+        inst.listeners = {};
+        inst.fire('eventA');
+        expect(count).toBe(1);
+
+        inst.destroy();
+    });
 });


### PR DESCRIPTION
Resolves #13102

Authored by GPT-5 (Codex Desktop). Session 019ec1bf-997c-7113-a082-d36c84ec5439.

Restores `core.Observable#removeListener()` symmetry for object-valued listener specs by normalizing `{fn, scope}` before matching, while preserving legacy function-name and string-handler removal paths. The regression net now covers dropped object-valued config listeners, object-valued `un()` scope matching, and string-valued listener removal.

Evidence: L1 (focused unit regression plus full `unit/core` slice) → L1 required. No residuals.

## Deltas from ticket
Added a string-valued listener regression alongside the requested object-valued `{fn}` coverage because the same matcher branch also governs string handler removal.

## Test Evidence
- `node --check src/core/Observable.mjs`
- `node --check test/playwright/unit/core/ObservableListenersDiff.spec.mjs`
- `npm run test-unit -- test/playwright/unit/core/ObservableListenersDiff.spec.mjs` — 8 passed
- `npm run test-unit -- test/playwright/unit/core` — 38 passed
- `git diff --check`
- `git diff --cached --check`

## Post-Merge Validation
- [ ] Verify #13102 auto-closes after squash merge.
