### PR TITLE
feat(agentos): add dock-zone semantic operations executor (#13115)

### DIFF
--- a/apps/agentos/dock/DockZoneModel.mjs
+++ b/apps/agentos/dock/DockZoneModel.mjs
@@ -333,14 +333,18 @@ class DockZoneModel extends Base {
      * @summary Splits `targetNodeId` against a new pane holding `itemId`.
      *
      * Wraps `itemId` in a fresh single-tab node and replaces `targetNodeId` in its parent with a new
-     * `split` whose children are `[new, target]` (position `before`) or `[target, new]` (position
-     * `after`). When `targetNodeId` is the root, the new split becomes the root.
+     * `split` whose children are `[new, target]` (leading) or `[target, new]` (trailing). When
+     * `targetNodeId` is the root, the new split becomes the root.
+     *
+     * The leading/trailing side comes from an explicit `position` (`before` / `after`) when given;
+     * otherwise it is derived from the descriptor's `edge` — `top` / `left` lead (before), `bottom` /
+     * `right` trail (after) — so a `DockPreview.previewToOperation()` edge descriptor places correctly.
      * @param {Object} document
-     * @param {Object} args {itemId, targetNodeId, orientation, position, sizes}
+     * @param {Object} args {itemId, targetNodeId, orientation, position, sizes, edge}
      * @returns {{document:Object, errors:String[]}}
      * @static
      */
-    static splitNode(document, {itemId, targetNodeId, orientation, position = 'after', sizes} = {}) {
+    static splitNode(document, {edge, itemId, orientation, position, sizes, targetNodeId} = {}) {
         if (!document.items?.[itemId])     return {document, errors: [`unknown item "${itemId}"`]};
         if (!document.nodes?.[targetNodeId]) return {document, errors: [`unknown target node "${targetNodeId}"`]};
         if (orientation !== 'horizontal' && orientation !== 'vertical') {
@@ -353,7 +357,10 @@ class DockZoneModel extends Base {
 
         let newTabsId  = DockZoneModel.genId(doc, `tabs-${itemId}`),
             newSplitId = DockZoneModel.genId(doc, `split-${targetNodeId}`),
-            ratio      = (Array.isArray(sizes) && sizes.length === 2) ? sizes : [0.5, 0.5];
+            ratio      = (Array.isArray(sizes) && sizes.length === 2) ? sizes : [0.5, 0.5],
+            // Edge descriptors encode the side in `edge`, not `position`: top / left lead (before),
+            // bottom / right trail (after). An explicit `position` always wins.
+            atPosition = position || ((edge === 'top' || edge === 'left') ? 'before' : 'after');
 
         // Resolve the target's parent BEFORE inserting the new split — otherwise the new split
         // (which references the target) would be found as the target's own parent.
@@ -363,7 +370,7 @@ class DockZoneModel extends Base {
         doc.nodes[newSplitId] = {
             type    : 'split',
             orientation,
-            children: position === 'before' ? [newTabsId, targetNodeId] : [targetNodeId, newTabsId],
+            children: atPosition === 'before' ? [newTabsId, targetNodeId] : [targetNodeId, newTabsId],
             // `sizes` maps positionally to `children` in their final order; the caller
             // (DockPreview.previewToOperation) supplies them already in that order.
             sizes   : ratio

--- a/apps/agentos/dock/DockZoneModel.mjs
+++ b/apps/agentos/dock/DockZoneModel.mjs
@@ -38,13 +38,17 @@ class DockZoneModel extends Base {
     }
 
     /**
-     * @summary Deep-clones a JSON-only dock-zone document.
+     * @summary Type-aware deep clone of a dock-zone document.
+     *
+     * Uses `Neo.clone` (deep, ignoring Neo instances) rather than a `JSON.parse(JSON.stringify())`
+     * round-trip: the round-trip corrupts `Date` values into strings and silently drops `undefined`,
+     * functions, `Map`/`Set`, and symbol keys, whereas `Neo.clone`'s type map preserves them.
      * @param {Object} document
      * @returns {Object}
      * @static
      */
     static clone(document) {
-        return JSON.parse(JSON.stringify(document))
+        return Neo.clone(document, true, true)
     }
 
     /**

--- a/apps/agentos/dock/DockZoneModel.mjs
+++ b/apps/agentos/dock/DockZoneModel.mjs
@@ -1,0 +1,453 @@
+import Base from '../../../src/core/Base.mjs';
+
+/**
+ * @class AgentOS.dock.DockZoneModel
+ * @extends Neo.core.Base
+ *
+ * @summary Executor for the harness dock-zone semantic operations (`neo.harness.dockZone.v1`).
+ *
+ * The "missing middle" of the harness docking line: `AgentOS.view.DockPreview.previewToOperation()`
+ * produces an operation descriptor on drop, this executor applies it to mutate the persisted
+ * dock-zone tree, and `Neo.dashboard.DockLayoutAdapter` renders the committed result. The contract
+ * and data model are defined in `learn/agentos/HarnessDockZoneModel.md` (§Data Model + §Operations);
+ * this class is the code realization of §Operations.
+ *
+ * All operations are **pure static functions** over a `dockZone.v1` document: each deep-clones the
+ * input, applies the mutation, normalizes, then validates. They are **fail-closed** — an operation
+ * with an invalid reference or one that would violate an invariant returns the ORIGINAL document
+ * unchanged plus a non-empty `errors` array, never a partially-mutated tree. The model persists
+ * semantic splits/tabs/order only; runtime pixels, DOMRects and preview state never enter it.
+ *
+ * Return shape for every operation: `{document, errors}` — `errors` empty means the operation
+ * committed; non-empty means it was rejected and `document` is the untouched input.
+ */
+class DockZoneModel extends Base {
+    /**
+     * The persisted dock-zone document schema this executor operates on.
+     * @member {String} SCHEMA='neo.harness.dockZone.v1'
+     * @static
+     */
+    static SCHEMA = 'neo.harness.dockZone.v1'
+
+    static config = {
+        /**
+         * @member {String} className='AgentOS.dock.DockZoneModel'
+         * @protected
+         */
+        className: 'AgentOS.dock.DockZoneModel'
+    }
+
+    /**
+     * @summary Deep-clones a JSON-only dock-zone document.
+     * @param {Object} document
+     * @returns {Object}
+     * @static
+     */
+    static clone(document) {
+        return JSON.parse(JSON.stringify(document))
+    }
+
+    /**
+     * @summary Mints a node id not yet present in the document.
+     * @param {Object} document
+     * @param {String} prefix
+     * @returns {String}
+     * @static
+     */
+    static genId(document, prefix) {
+        let n = 0,
+            id;
+
+        do {
+            id = `${prefix}-${n++}`
+        } while (document.nodes[id]);
+
+        return id
+    }
+
+    /**
+     * @summary Returns the id of the tabs node currently holding `itemId`, or null.
+     * @param {Object} document
+     * @param {String} itemId
+     * @returns {String|null}
+     * @static
+     */
+    static findContainingTabsId(document, itemId) {
+        for (const [nodeId, node] of Object.entries(document.nodes)) {
+            if (node.type === 'tabs' && Array.isArray(node.items) && node.items.includes(itemId)) {
+                return nodeId
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Finds the parent node id + the slot key pointing at `nodeId`.
+     *
+     * For a `split` parent the slot is the child index (Number); for an `edge-zone` parent it is the
+     * zone key (String). Returns null when `nodeId` is the root or unreferenced.
+     * @param {Object} document
+     * @param {String} nodeId
+     * @returns {{parentId:String, slot:(Number|String)}|null}
+     * @static
+     */
+    static findParentSlot(document, nodeId) {
+        for (const [parentId, node] of Object.entries(document.nodes)) {
+            if (node.type === 'split' && Array.isArray(node.children)) {
+                const index = node.children.indexOf(nodeId);
+                if (index > -1) return {parentId, slot: index}
+            } else if (node.type === 'edge-zone' && node.zones) {
+                for (const [zone, target] of Object.entries(node.zones)) {
+                    if (target === nodeId) return {parentId, slot: zone}
+                }
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Mutating helper: removes `itemId` from whatever tabs node holds it, fixing activeItemId.
+     * @param {Object} document the working (already-cloned) document
+     * @param {String} itemId
+     * @protected
+     * @static
+     */
+    static detachFromTabs(document, itemId) {
+        let tabsId = DockZoneModel.findContainingTabsId(document, itemId);
+
+        if (!tabsId) return;
+
+        let node = document.nodes[tabsId];
+
+        node.items = node.items.filter(id => id !== itemId);
+
+        if (node.activeItemId === itemId) {
+            node.activeItemId = node.items[0] ?? null
+        }
+    }
+
+    /**
+     * @summary Set of node ids reachable from the document root.
+     * @param {Object} document
+     * @returns {Set<String>}
+     * @static
+     */
+    static reachableNodeIds(document) {
+        let seen = new Set(),
+            walk = nodeId => {
+                if (!nodeId || seen.has(nodeId)) return;
+
+                let node = document.nodes[nodeId];
+
+                if (!node) return;
+
+                seen.add(nodeId);
+
+                if (node.type === 'split') {
+                    (node.children || []).forEach(walk)
+                } else if (node.type === 'edge-zone') {
+                    Object.values(node.zones || {}).forEach(walk)
+                }
+            };
+
+        walk(document.root);
+
+        return seen
+    }
+
+    /**
+     * @summary Validates a dock-zone document against the contract invariants.
+     *
+     * Checks: schema, root presence, reference integrity (split children / edge-zone zones / tabs
+     * items all resolve), each item appears at most once across the tree, split sizes match child
+     * count and sum to 1, and `tabs.activeItemId` is null or one of `tabs.items`.
+     * @param {Object} document
+     * @returns {String[]} the (possibly empty) list of invariant violations
+     * @static
+     */
+    static validate(document) {
+        let errors = [];
+
+        if (!document || typeof document !== 'object') return ['document is not an object'];
+        if (document.schema !== DockZoneModel.SCHEMA)   errors.push(`schema must be ${DockZoneModel.SCHEMA}`);
+        if (!document.nodes || !document.nodes[document.root]) errors.push(`root node "${document.root}" is missing`);
+
+        let items   = document.items || {},
+            nodes   = document.nodes || {},
+            itemUse = {};
+
+        for (const [nodeId, node] of Object.entries(nodes)) {
+            if (node.type === 'split') {
+                (node.children || []).forEach(childId => {
+                    if (!nodes[childId]) errors.push(`split "${nodeId}" references missing node "${childId}"`)
+                });
+
+                let sizes = node.sizes || [];
+
+                if (sizes.length !== (node.children || []).length) {
+                    errors.push(`split "${nodeId}" sizes length ${sizes.length} != children length ${(node.children || []).length}`)
+                } else if (sizes.length && Math.abs(sizes.reduce((a, b) => a + b, 0) - 1) > 1e-6) {
+                    errors.push(`split "${nodeId}" sizes do not sum to 1`)
+                }
+            } else if (node.type === 'edge-zone') {
+                Object.values(node.zones || {}).forEach(targetId => {
+                    if (!nodes[targetId]) errors.push(`edge-zone "${nodeId}" references missing node "${targetId}"`)
+                })
+            } else if (node.type === 'tabs') {
+                (node.items || []).forEach(itemId => {
+                    if (!items[itemId]) errors.push(`tabs "${nodeId}" references missing item "${itemId}"`);
+                    itemUse[itemId] = (itemUse[itemId] || 0) + 1
+                });
+
+                if (node.activeItemId !== null && node.activeItemId !== undefined && !(node.items || []).includes(node.activeItemId)) {
+                    errors.push(`tabs "${nodeId}" activeItemId "${node.activeItemId}" is not one of its items`)
+                }
+            }
+        }
+
+        Object.entries(itemUse).forEach(([itemId, count]) => {
+            if (count > 1) errors.push(`item "${itemId}" appears ${count} times in the tree (must be at most once)`)
+        });
+
+        return errors
+    }
+
+    /**
+     * @summary Normalizes a document: collapses empty/redundant structural nodes, repairs split
+     * sizes, prunes orphaned nodes, and repairs each `tabs.activeItemId`.
+     *
+     * An empty tabs or split node is removed from its parent; a split with a single child is replaced
+     * by that child; split sizes are evened when their count/sum is invalid; nodes unreachable from
+     * the root are dropped.
+     * @param {Object} document
+     * @returns {Object} a normalized clone
+     * @static
+     */
+    static normalizeTree(document) {
+        let doc = DockZoneModel.clone(document);
+
+        const collapse = nodeId => {
+            let node = doc.nodes[nodeId];
+
+            if (!node) return nodeId;
+
+            if (node.type === 'split') {
+                node.children = (node.children || []).map(collapse).filter(id => doc.nodes[id]);
+
+                if (node.children.length === 0) { delete doc.nodes[nodeId]; return null }
+                if (node.children.length === 1) {
+                    let only = node.children[0];
+                    delete doc.nodes[nodeId];
+                    return only
+                }
+
+                let count = node.children.length;
+                if (!Array.isArray(node.sizes) || node.sizes.length !== count || Math.abs(node.sizes.reduce((a, b) => a + b, 0) - 1) > 1e-6) {
+                    node.sizes = node.children.map(() => 1 / count)
+                }
+            } else if (node.type === 'edge-zone') {
+                for (const [zone, target] of Object.entries(node.zones || {})) {
+                    let resolved = collapse(target);
+                    if (resolved && doc.nodes[resolved]) { node.zones[zone] = resolved } else { delete node.zones[zone] }
+                }
+            } else if (node.type === 'tabs') {
+                if (!node.items || node.items.length === 0) { delete doc.nodes[nodeId]; return null }
+                if (node.activeItemId === undefined || (node.activeItemId !== null && !node.items.includes(node.activeItemId))) {
+                    node.activeItemId = node.items[0]
+                }
+            }
+
+            return nodeId
+        };
+
+        let newRoot = collapse(doc.root);
+        doc.root = newRoot ?? doc.root;
+
+        // prune nodes unreachable from the (possibly new) root
+        let reachable = DockZoneModel.reachableNodeIds(doc);
+        Object.keys(doc.nodes).forEach(nodeId => {
+            if (!reachable.has(nodeId)) delete doc.nodes[nodeId]
+        });
+
+        return doc
+    }
+
+    /**
+     * @summary Normalizes + validates a mutated document; returns it only if valid (fail-closed).
+     * @param {Object} original the untouched input document
+     * @param {Object} mutated the working document after a mutation
+     * @returns {{document:Object, errors:String[]}}
+     * @protected
+     * @static
+     */
+    static commit(original, mutated) {
+        let normalized = DockZoneModel.normalizeTree(mutated),
+            errors     = DockZoneModel.validate(normalized);
+
+        return errors.length ? {document: original, errors} : {document: normalized, errors: []}
+    }
+
+    /**
+     * @summary Inserts `itemId` into the target tabs node at `index` (relocating it if already in
+     * the tree) and makes it the active tab.
+     * @param {Object} document
+     * @param {Object} args {itemId, tabsNodeId, index}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static addTab(document, {itemId, tabsNodeId, index} = {}) {
+        if (!document.items?.[itemId])           return {document, errors: [`unknown item "${itemId}"`]};
+        if (document.nodes?.[tabsNodeId]?.type !== 'tabs') return {document, errors: [`"${tabsNodeId}" is not a tabs node`]};
+
+        let doc = DockZoneModel.clone(document);
+
+        DockZoneModel.detachFromTabs(doc, itemId);
+
+        let node = doc.nodes[tabsNodeId],
+            at   = Number.isInteger(index) ? Math.max(0, Math.min(index, node.items.length)) : node.items.length;
+
+        node.items.splice(at, 0, itemId);
+        node.activeItemId = itemId;
+
+        return DockZoneModel.commit(document, doc)
+    }
+
+    /**
+     * @summary Relocates an in-tree `itemId` into the target tabs node at `index`.
+     * @param {Object} document
+     * @param {Object} args {itemId, targetNodeId, index}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static moveItem(document, {itemId, targetNodeId, index} = {}) {
+        if (!DockZoneModel.findContainingTabsId(document, itemId)) {
+            return {document, errors: [`item "${itemId}" is not in the tree`]}
+        }
+
+        return DockZoneModel.addTab(document, {itemId, tabsNodeId: targetNodeId, index})
+    }
+
+    /**
+     * @summary Splits `targetNodeId` against a new pane holding `itemId`.
+     *
+     * Wraps `itemId` in a fresh single-tab node and replaces `targetNodeId` in its parent with a new
+     * `split` whose children are `[new, target]` (position `before`) or `[target, new]` (position
+     * `after`). When `targetNodeId` is the root, the new split becomes the root.
+     * @param {Object} document
+     * @param {Object} args {itemId, targetNodeId, orientation, position, sizes}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static splitNode(document, {itemId, targetNodeId, orientation, position = 'after', sizes} = {}) {
+        if (!document.items?.[itemId])     return {document, errors: [`unknown item "${itemId}"`]};
+        if (!document.nodes?.[targetNodeId]) return {document, errors: [`unknown target node "${targetNodeId}"`]};
+        if (orientation !== 'horizontal' && orientation !== 'vertical') {
+            return {document, errors: [`invalid split orientation "${orientation}"`]}
+        }
+
+        let doc = DockZoneModel.clone(document);
+
+        DockZoneModel.detachFromTabs(doc, itemId);
+
+        let newTabsId  = DockZoneModel.genId(doc, `tabs-${itemId}`),
+            newSplitId = DockZoneModel.genId(doc, `split-${targetNodeId}`),
+            ratio      = (Array.isArray(sizes) && sizes.length === 2) ? sizes : [0.5, 0.5];
+
+        // Resolve the target's parent BEFORE inserting the new split — otherwise the new split
+        // (which references the target) would be found as the target's own parent.
+        let parentSlot = DockZoneModel.findParentSlot(doc, targetNodeId);
+
+        doc.nodes[newTabsId] = {type: 'tabs', items: [itemId], activeItemId: itemId};
+        doc.nodes[newSplitId] = {
+            type    : 'split',
+            orientation,
+            children: position === 'before' ? [newTabsId, targetNodeId] : [targetNodeId, newTabsId],
+            // `sizes` maps positionally to `children` in their final order; the caller
+            // (DockPreview.previewToOperation) supplies them already in that order.
+            sizes   : ratio
+        };
+
+        if (!parentSlot) {
+            doc.root = newSplitId
+        } else if (typeof parentSlot.slot === 'number') {
+            doc.nodes[parentSlot.parentId].children[parentSlot.slot] = newSplitId
+        } else {
+            doc.nodes[parentSlot.parentId].zones[parentSlot.slot] = newSplitId
+        }
+
+        return DockZoneModel.commit(document, doc)
+    }
+
+    /**
+     * @summary Removes `itemId` from the tree but preserves its catalog record (for popup/window
+     * ownership), per the contract's `detachItem`.
+     * @param {Object} document
+     * @param {Object} args {itemId}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static detachItem(document, {itemId} = {}) {
+        if (!DockZoneModel.findContainingTabsId(document, itemId)) {
+            return {document, errors: [`item "${itemId}" is not in the tree`]}
+        }
+
+        let doc = DockZoneModel.clone(document);
+
+        DockZoneModel.detachFromTabs(doc, itemId);
+
+        return DockZoneModel.commit(document, doc)
+    }
+
+    /**
+     * @summary Removes `itemId` from both the tree and the `items` catalog, per the contract's
+     * `closeItem`.
+     * @param {Object} document
+     * @param {Object} args {itemId}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static closeItem(document, {itemId} = {}) {
+        if (!document.items?.[itemId]) return {document, errors: [`unknown item "${itemId}"`]};
+
+        let doc = DockZoneModel.clone(document);
+
+        DockZoneModel.detachFromTabs(doc, itemId);
+        delete doc.items[itemId];
+
+        return DockZoneModel.commit(document, doc)
+    }
+
+    /**
+     * @summary Applies an operation descriptor (the shape `DockPreview.previewToOperation()` emits)
+     * to the document, dispatching to the matching semantic operation.
+     *
+     * A `tab-*` descriptor (`operation: 'addTab'`) is dispatched as a move when its item already
+     * lives in the tree — the contract's "addTab or moveItem" downgrade, decided here.
+     * @param {Object} document
+     * @param {Object} descriptor {operation, ...}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static applyOperation(document, descriptor = {}) {
+        switch (descriptor.operation) {
+            case 'addTab':
+                return DockZoneModel.findContainingTabsId(document, descriptor.itemId)
+                    ? DockZoneModel.moveItem(document, {itemId: descriptor.itemId, targetNodeId: descriptor.tabsNodeId, index: descriptor.index})
+                    : DockZoneModel.addTab(document, descriptor);
+            case 'moveItem':
+                return DockZoneModel.moveItem(document, descriptor);
+            case 'splitNode':
+                return DockZoneModel.splitNode(document, descriptor);
+            case 'detachItem':
+                return DockZoneModel.detachItem(document, descriptor);
+            case 'closeItem':
+                return DockZoneModel.closeItem(document, descriptor);
+            default:
+                return {document, errors: [`unknown operation "${descriptor.operation}"`]}
+        }
+    }
+}
+
+export default Neo.setupClass(DockZoneModel);

--- a/test/playwright/unit/apps/agentos/dock/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/dock/DockZoneModel.spec.mjs
@@ -1,0 +1,255 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSDockZoneModelTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import DockZoneModel  from '../../../../../../apps/agentos/dock/DockZoneModel.mjs';
+
+/**
+ * @summary Tests for AgentOS.dock.DockZoneModel — the dock-zone semantic operations executor.
+ * Pure-JSON: validity invariants, each operation, fail-closed behavior, normalizeTree collapse,
+ * and the previewToOperation descriptor seam. No component construction needed.
+ */
+
+/**
+ * A fresh canonical dockZone.v1 document. `inspector` is a catalog-only item (not yet in the tree),
+ * used to exercise insert/split of a brand-new pane.
+ * @returns {Object}
+ */
+function doc() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'root',
+        items : {
+            strategy : {componentRef: 'strategy',  title: 'Strategy',  kind: 'panel'},
+            swarm    : {componentRef: 'swarm',     title: 'Swarm',     kind: 'panel'},
+            terminal : {componentRef: 'terminal',  title: 'Terminal',  kind: 'terminal'},
+            inspector: {componentRef: 'inspector', title: 'Inspector', kind: 'inspector'}
+        },
+        nodes: {
+            root        : {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}},
+            'main-tabs' : {type: 'tabs', items: ['strategy', 'swarm'], activeItemId: 'swarm'},
+            'side-tabs' : {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+        }
+    }
+}
+
+/** Collects the tabs node id holding an item, across a document. */
+function tabsOf(document, itemId) {
+    return DockZoneModel.findContainingTabsId(document, itemId)
+}
+
+test.describe('AgentOS.dock.DockZoneModel', () => {
+    test.describe('validate (invariants)', () => {
+        test('accepts the canonical document', () => {
+            expect(DockZoneModel.validate(doc())).toEqual([])
+        });
+
+        test('rejects a wrong schema', () => {
+            const d = doc();
+            d.schema = 'neo.harness.dockZone.v2';
+            expect(DockZoneModel.validate(d).length).toBeGreaterThan(0)
+        });
+
+        test('rejects a missing root', () => {
+            const d = doc();
+            d.root = 'ghost';
+            expect(DockZoneModel.validate(d).length).toBeGreaterThan(0)
+        });
+
+        test('rejects a dangling node reference', () => {
+            const d = doc();
+            d.nodes.root.zones.center = 'does-not-exist';
+            expect(DockZoneModel.validate(d).length).toBeGreaterThan(0)
+        });
+
+        test('rejects an item used in two tabs nodes', () => {
+            const d = doc();
+            d.nodes['side-tabs'].items.push('strategy'); // strategy now in main-tabs AND side-tabs
+            expect(DockZoneModel.validate(d).join(' ')).toContain('strategy');
+            expect(DockZoneModel.validate(d).length).toBeGreaterThan(0)
+        });
+
+        test('rejects split sizes that mismatch or do not sum to 1', () => {
+            const d = doc();
+            d.nodes.split = {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-tabs'], sizes: [0.5]};
+            d.nodes.root.zones.center = 'split';
+            delete d.nodes.root.zones.right;
+            expect(DockZoneModel.validate(d).length).toBeGreaterThan(0);
+
+            d.nodes.split.sizes = [0.5, 0.9];
+            expect(DockZoneModel.validate(d).join(' ')).toContain('sum to 1')
+        });
+
+        test('rejects an activeItemId not among the tab items', () => {
+            const d = doc();
+            d.nodes['main-tabs'].activeItemId = 'terminal';
+            expect(DockZoneModel.validate(d).length).toBeGreaterThan(0)
+        })
+    });
+
+    test.describe('addTab', () => {
+        test('inserts a catalog-only item at index and makes it active', () => {
+            const {document, errors} = DockZoneModel.addTab(doc(), {itemId: 'inspector', tabsNodeId: 'main-tabs', index: 1});
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-tabs'].items).toEqual(['strategy', 'inspector', 'swarm']);
+            expect(document.nodes['main-tabs'].activeItemId).toBe('inspector')
+        });
+
+        test('relocates an item already in the tree without duplicating it', () => {
+            const {document, errors} = DockZoneModel.addTab(doc(), {itemId: 'terminal', tabsNodeId: 'main-tabs', index: 0});
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-tabs'].items).toEqual(['terminal', 'strategy', 'swarm']);
+            // side-tabs emptied -> collapsed by normalizeTree, and its edge zone pruned
+            expect(document.nodes['side-tabs']).toBeUndefined();
+            expect(document.nodes.root.zones.right).toBeUndefined();
+            // terminal appears exactly once
+            expect(DockZoneModel.validate(document)).toEqual([])
+        });
+
+        test('fails closed on an unknown item (document untouched)', () => {
+            const input = doc();
+            const {document, errors} = DockZoneModel.addTab(input, {itemId: 'ghost', tabsNodeId: 'main-tabs'});
+            expect(errors.length).toBeGreaterThan(0);
+            expect(document).toBe(input)
+        });
+
+        test('fails closed when the target is not a tabs node', () => {
+            const {errors} = DockZoneModel.addTab(doc(), {itemId: 'inspector', tabsNodeId: 'root'});
+            expect(errors.length).toBeGreaterThan(0)
+        })
+    });
+
+    test.describe('moveItem', () => {
+        test('relocates an in-tree item to another tabs node', () => {
+            const {document, errors} = DockZoneModel.moveItem(doc(), {itemId: 'strategy', targetNodeId: 'side-tabs', index: 0});
+            expect(errors).toEqual([]);
+            expect(document.nodes['side-tabs'].items).toEqual(['strategy', 'terminal']);
+            expect(document.nodes['main-tabs'].items).toEqual(['swarm'])
+        });
+
+        test('fails closed when the item is not in the tree', () => {
+            const {errors} = DockZoneModel.moveItem(doc(), {itemId: 'inspector', targetNodeId: 'main-tabs'});
+            expect(errors.length).toBeGreaterThan(0)
+        })
+    });
+
+    test.describe('splitNode', () => {
+        test('splits a node after the target, wrapping the item in a new pane', () => {
+            const {document, errors} = DockZoneModel.splitNode(doc(), {
+                itemId: 'inspector', targetNodeId: 'main-tabs', orientation: 'horizontal', position: 'after', sizes: [0.6, 0.4]
+            });
+            expect(errors).toEqual([]);
+            // root.zones.center now points at a split holding [main-tabs, <new tabs with inspector>]
+            const splitId = document.nodes.root.zones.center,
+                  split   = document.nodes[splitId];
+            expect(split.type).toBe('split');
+            expect(split.orientation).toBe('horizontal');
+            expect(split.children[0]).toBe('main-tabs');
+            expect(document.nodes[split.children[1]].items).toEqual(['inspector']);
+            expect(split.sizes).toEqual([0.6, 0.4])
+        });
+
+        test('splits before the target (new pane first)', () => {
+            const {document, errors} = DockZoneModel.splitNode(doc(), {
+                itemId: 'inspector', targetNodeId: 'side-tabs', orientation: 'vertical', position: 'before', sizes: [0.3, 0.7]
+            });
+            expect(errors).toEqual([]);
+            const splitId = document.nodes.root.zones.right,
+                  split   = document.nodes[splitId];
+            expect(document.nodes[split.children[0]].items).toEqual(['inspector']);
+            expect(split.children[1]).toBe('side-tabs')
+        });
+
+        test('splitting the root makes the new split the root', () => {
+            const {document, errors} = DockZoneModel.splitNode(doc(), {
+                itemId: 'inspector', targetNodeId: 'root', orientation: 'vertical', position: 'after'
+            });
+            expect(errors).toEqual([]);
+            expect(document.nodes[document.root].type).toBe('split');
+            expect(document.nodes[document.root].children).toContain('root')
+        });
+
+        test('detaches the item from its old location (no duplication)', () => {
+            const {document, errors} = DockZoneModel.splitNode(doc(), {
+                itemId: 'swarm', targetNodeId: 'side-tabs', orientation: 'vertical', position: 'after'
+            });
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-tabs'].items).toEqual(['strategy']);
+            expect(DockZoneModel.validate(document)).toEqual([])
+        });
+
+        test('fails closed on an unknown item, unknown target, or bad orientation', () => {
+            expect(DockZoneModel.splitNode(doc(), {itemId: 'ghost', targetNodeId: 'main-tabs', orientation: 'horizontal'}).errors.length).toBeGreaterThan(0);
+            expect(DockZoneModel.splitNode(doc(), {itemId: 'inspector', targetNodeId: 'ghost', orientation: 'horizontal'}).errors.length).toBeGreaterThan(0);
+            expect(DockZoneModel.splitNode(doc(), {itemId: 'inspector', targetNodeId: 'main-tabs', orientation: 'diagonal'}).errors.length).toBeGreaterThan(0)
+        })
+    });
+
+    test.describe('detachItem / closeItem', () => {
+        test('detachItem removes from the tree but keeps the catalog record', () => {
+            const {document, errors} = DockZoneModel.detachItem(doc(), {itemId: 'terminal'});
+            expect(errors).toEqual([]);
+            expect(DockZoneModel.findContainingTabsId(document, 'terminal')).toBe(null);
+            expect(document.items.terminal).toBeDefined()
+        });
+
+        test('closeItem removes from both the tree and the catalog', () => {
+            const {document, errors} = DockZoneModel.closeItem(doc(), {itemId: 'terminal'});
+            expect(errors).toEqual([]);
+            expect(document.items.terminal).toBeUndefined()
+        })
+    });
+
+    test.describe('normalizeTree', () => {
+        test('collapses an emptied tabs node and prunes its edge zone', () => {
+            const d = doc();
+            d.nodes['side-tabs'].items = [];
+            const out = DockZoneModel.normalizeTree(d);
+            expect(out.nodes['side-tabs']).toBeUndefined();
+            expect(out.nodes.root.zones.right).toBeUndefined()
+        });
+
+        test('collapses a single-child split into its child', () => {
+            const d = doc();
+            d.nodes.split = {type: 'split', orientation: 'horizontal', children: ['main-tabs'], sizes: [1]};
+            d.nodes.root.zones.center = 'split';
+            const out = DockZoneModel.normalizeTree(d);
+            expect(out.nodes.split).toBeUndefined();
+            expect(out.nodes.root.zones.center).toBe('main-tabs')
+        });
+
+        test('prunes nodes unreachable from the root', () => {
+            const d = doc();
+            d.nodes.orphan = {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'};
+            const out = DockZoneModel.normalizeTree(d);
+            expect(out.nodes.orphan).toBeUndefined()
+        })
+    });
+
+    test.describe('applyOperation (DockPreview descriptor seam)', () => {
+        test('dispatches addTab, downgrading to a move when the item is already in the tree', () => {
+            const {document, errors} = DockZoneModel.applyOperation(doc(), {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs', index: 0});
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-tabs'].items).toEqual(['terminal', 'strategy', 'swarm']);
+            expect(DockZoneModel.validate(document)).toEqual([])
+        });
+
+        test('dispatches splitNode from a previewToOperation-shaped descriptor', () => {
+            const descriptor = {operation: 'splitNode', itemId: 'inspector', targetNodeId: 'main-tabs', orientation: 'horizontal', position: 'after', sizes: [0.5, 0.5]};
+            const {document, errors} = DockZoneModel.applyOperation(doc(), descriptor);
+            expect(errors).toEqual([]);
+            expect(document.nodes[document.nodes.root.zones.center].type).toBe('split')
+        });
+
+        test('rejects an unknown operation', () => {
+            expect(DockZoneModel.applyOperation(doc(), {operation: 'frobnicate'}).errors.length).toBeGreaterThan(0)
+        })
+    })
+});

--- a/test/playwright/unit/apps/agentos/dock/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/dock/DockZoneModel.spec.mjs
@@ -251,5 +251,33 @@ test.describe('AgentOS.dock.DockZoneModel', () => {
         test('rejects an unknown operation', () => {
             expect(DockZoneModel.applyOperation(doc(), {operation: 'frobnicate'}).errors.length).toBeGreaterThan(0)
         })
+    });
+
+    test.describe('edge descriptor seam (previewToOperation edges — top/left lead, bottom/right trail)', () => {
+        const cases = [
+            {edge: 'top',    orientation: 'vertical',   target: 'main-tabs', zone: 'center', lead: true},
+            {edge: 'left',   orientation: 'horizontal', target: 'main-tabs', zone: 'center', lead: true},
+            {edge: 'bottom', orientation: 'vertical',   target: 'side-tabs', zone: 'right',  lead: false},
+            {edge: 'right',  orientation: 'horizontal', target: 'side-tabs', zone: 'right',  lead: false}
+        ];
+
+        for (const c of cases) {
+            test(`edge-${c.edge} places the new pane ${c.lead ? 'before (leading)' : 'after (trailing)'}`, () => {
+                // exact previewToOperation edge-descriptor shape: carries `edge`, no `position`
+                const descriptor = {operation: 'splitNode', itemId: 'inspector', targetNodeId: c.target, edge: c.edge, orientation: c.orientation, sizes: [0.5, 0.5]};
+                const {document, errors} = DockZoneModel.applyOperation(doc(), descriptor);
+                expect(errors).toEqual([]);
+
+                const split   = document.nodes[document.nodes.root.zones[c.zone]],
+                      newPane = c.lead ? split.children[0] : split.children[1],
+                      keep    = c.lead ? split.children[1] : split.children[0];
+
+                expect(split.type).toBe('split');
+                expect(split.orientation).toBe(c.orientation);
+                expect(document.nodes[newPane].items).toEqual(['inspector']);
+                expect(keep).toBe(c.target);
+                expect(DockZoneModel.validate(document)).toEqual([])
+            })
+        }
     })
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13115

Adds `AgentOS.dock.DockZoneModel`, the executor that applies the `neo.harness.dockZone.v1` semantic operations (`learn/agentos/HarnessDockZoneModel.md` §Operations). It is the **missing middle** of the harness docking line: `AgentOS.view.DockPreview.previewToOperation()` produces an operation descriptor on drop → this applies it to mutate the persisted dock-zone tree → `Neo.dashboard.DockLayoutAdapter` renders the committed result. No code dependency on either neighbour — all three bind to the same merged contract.

Operations: `moveItem`, `splitNode`, `addTab`, `detachItem`, `closeItem`, plus `normalizeTree` / `validate` / `applyOperation` (the descriptor-dispatch seam):

- **Pure-JSON, static, immutable-friendly** — each op deep-clones, mutates, normalizes, validates; the model persists semantic splits/tabs/order only (no runtime pixels / DOMRects / preview state).
- **Fail-closed** — an op with an invalid reference (or one that would break an invariant) returns the *original* document plus a non-empty `errors` array, never a partially-mutated tree.
- **Invariants enforced** by `normalizeTree` + `validate`: referenced ids exist; each item appears at most once; split sizes match child count and sum to 1; `tabs.activeItemId` is null-or-member; empty structural nodes collapse (single-child splits + orphan nodes are pruned).
- **Descriptor seam** — `applyOperation` consumes the exact shape `previewToOperation` emits, downgrading a tab `addTab` to a move when the item is already in the tree (the contract's "addTab or moveItem").

Evidence: L1 (26 unit tests — validity invariants, each operation, fail-closed paths, `normalizeTree` collapse/prune, and the `previewToOperation` descriptor seam; pure-JSON, no host-runtime ACs) → L1 required (internal tree-operation contract only). No residuals.

## Deltas from ticket

`splitNode`'s `sizes` is defined to map positionally to the resulting `children` in their final order (the order `previewToOperation` already supplies) — resolving a double-position-handling ambiguity in the terse contract signature; documented inline.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/apps/agentos/dock/DockZoneModel.spec.mjs
→ 26 passed
```

Pre-commit hooks green (`check-whitespace`, `check-shorthand`, `check-ticket-archaeology`).

## Post-Merge Validation

- [ ] Once the preview renderer (PR #13109) and `DockLayoutAdapter` both land, confirm an end-to-end drop applies a `previewToOperation` descriptor through `applyOperation` and the adapter renders the committed tree (whitebox-e2e).

## Structural Pre-Flight

Full pre-flight (novel directory): chose `apps/agentos/dock/DockZoneModel.mjs` — a new harness-docking-subsystem folder in the harness app, per `HarnessDockZoneModel.md` Ownership Boundary ("place in the harness app layer" until a second independent consumer lifts to dashboard substrate). Rejected `apps/agentos/model/` (that holds `Neo.data.Model` records), and `src/dashboard/` (the adapter's own dashboard-owned placement — no import dependency between them). Map-maintenance: not-needed (a module within the existing harness app).

Refs #13012
Refs #13030
