### PR TITLE
feat(grid): add responsive locked-column policy (#12934)

### DIFF
--- a/src/grid/Container.mjs
+++ b/src/grid/Container.mjs
@@ -168,6 +168,14 @@ class GridContainer extends BaseContainer {
          */
         role: 'grid',
         /**
+         * Declarative width breakpoints for moving columns between locked regions.
+         * Breakpoint `columns` keys match a column `dataField` or `id`; values are
+         * `'start'`, `'end'`, `null`, or `false`.
+         * @member {Object|null} responsiveLockPolicy_=null
+         * @reactive
+         */
+        responsiveLockPolicy_: null,
+        /**
          * Number in px
          * @member {Number} rowHeight_=32
          * @reactive
@@ -245,6 +253,11 @@ class GridContainer extends BaseContainer {
      * @protected
      */
     scrollManager = null
+    /**
+     * @member {Number|null} responsiveLockPolicyActiveMaxWidth=null
+     * @protected
+     */
+    responsiveLockPolicyActiveMaxWidth = null
 
     /**
      * @member {Boolean} hasLockedColumns=false
@@ -445,6 +458,18 @@ class GridContainer extends BaseContainer {
 
         if (scrollManager) {
             scrollManager.mounted = value
+        }
+    }
+
+    /**
+     * Triggered after the responsiveLockPolicy config got changed.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetResponsiveLockPolicy(value, oldValue) {
+        if (oldValue !== undefined) {
+            this.responsiveLockPolicyActiveMaxWidth = null
         }
     }
 
@@ -898,6 +923,106 @@ class GridContainer extends BaseContainer {
     }
 
     /**
+     * Applies the first matching responsive locked-column breakpoint.
+     * @param {Object|Number} data Resize payload or measured width
+     * @returns {Boolean} true when at least one column lock state changed
+     */
+    applyResponsiveLockPolicy(data) {
+        let me          = this,
+            policy      = me.responsiveLockPolicy,
+            width       = me.resolveResponsiveLockPolicyWidth(data),
+            breakpoints = me.getResponsiveLockPolicyBreakpoints(policy),
+            changed     = false;
+
+        if (!width || breakpoints.length === 0) {
+            return false
+        }
+
+        let hysteresis = Math.max(0, Number(policy.hysteresis) || 0),
+            breakpoint = me.getResponsiveLockPolicyBreakpoint(width, breakpoints, hysteresis),
+            columns    = breakpoint?.columns;
+
+        me.responsiveLockPolicyActiveMaxWidth = breakpoint?.maxWidth ?? null;
+
+        if (!columns) {
+            return false
+        }
+
+        for (let key in columns) {
+            let column = me.getResponsiveLockPolicyColumn(key),
+                locked = me.normalizeResponsiveLockValue(columns[key]);
+
+            if (column && locked !== undefined && column.locked !== locked) {
+                column.locked = locked;
+                changed       = true
+            }
+        }
+
+        return changed
+    }
+
+    /**
+     * @param {Object|null} policy
+     * @returns {Object[]}
+     * @protected
+     */
+    getResponsiveLockPolicyBreakpoints(policy) {
+        let breakpoints = policy?.breakpoints;
+
+        if (!Array.isArray(breakpoints)) {
+            return []
+        }
+
+        return breakpoints
+            .map(breakpoint => {
+                let maxWidth = Number(breakpoint?.maxWidth);
+
+                return {
+                    ...breakpoint,
+                    maxWidth
+                }
+            })
+            .filter(breakpoint =>
+                Number.isFinite(breakpoint.maxWidth) &&
+                breakpoint.maxWidth > 0 &&
+                breakpoint.columns &&
+                Neo.typeOf(breakpoint.columns) === 'Object'
+            )
+            .sort((a, b) => a.maxWidth - b.maxWidth)
+    }
+
+    /**
+     * @param {Number} width
+     * @param {Object[]} breakpoints
+     * @param {Number} hysteresis
+     * @returns {Object|null}
+     * @protected
+     */
+    getResponsiveLockPolicyBreakpoint(width, breakpoints, hysteresis) {
+        let me             = this,
+            activeMaxWidth = me.responsiveLockPolicyActiveMaxWidth,
+            active         = breakpoints.find(breakpoint => breakpoint.maxWidth === activeMaxWidth),
+            candidate      = breakpoints.find(breakpoint => width <= breakpoint.maxWidth) || null;
+
+        if (active && (!candidate || candidate.maxWidth > active.maxWidth) && width <= active.maxWidth + hysteresis) {
+            return active
+        }
+
+        return candidate
+    }
+
+    /**
+     * @param {String} key
+     * @returns {Neo.grid.column.Base|null}
+     * @protected
+     */
+    getResponsiveLockPolicyColumn(key) {
+        let {columns} = this;
+
+        return columns?.get(key) || columns?.items.find(column => column.id === key || column.dataField === key) || null
+    }
+
+    /**
      * @param args
      */
     destroy(...args) {
@@ -1054,6 +1179,8 @@ class GridContainer extends BaseContainer {
         let me = this;
 
         if (!me.initialResizeEvent) {
+            me.applyResponsiveLockPolicy(data);
+
             await me.passSizeToBody(true);
 
             me.bodyStart?.updateMountedAndVisibleColumns();
@@ -1064,6 +1191,19 @@ class GridContainer extends BaseContainer {
         } else {
             me.initialResizeEvent = false
         }
+    }
+
+    /**
+     * @param {*} value
+     * @returns {String|null|undefined}
+     * @protected
+     */
+    normalizeResponsiveLockValue(value) {
+        if (value === false || value === null) {
+            return null
+        }
+
+        return value === 'start' || value === 'end' ? value : undefined
     }
 
     /**
@@ -1141,6 +1281,25 @@ class GridContainer extends BaseContainer {
             me.bodyStart && me.bodyStart[silent ? 'setSilent' : 'set'](config);
             me.bodyEnd   && me.bodyEnd[silent ? 'setSilent' : 'set'](config)
         }
+    }
+
+    /**
+     * @param {Object|Number} data
+     * @returns {Number|null}
+     * @protected
+     */
+    resolveResponsiveLockPolicyWidth(data) {
+        let width = Neo.typeOf(data) === 'Number' ? data :
+            data?.width ??
+            data?.contentRect?.width ??
+            data?.rect?.width ??
+            data?.containerWidth ??
+            data?.borderBoxSize?.inlineSize ??
+            data?.contentBoxSize?.inlineSize;
+
+        width = Number(width);
+
+        return Number.isFinite(width) && width > 0 ? width : null
     }
 
     /**

--- a/test/playwright/unit/grid/LockedColumns.spec.mjs
+++ b/test/playwright/unit/grid/LockedColumns.spec.mjs
@@ -222,6 +222,133 @@ test.describe('Grid Locked Columns', () => {
         expect(hoverSyncActive).toBe(true);
     });
 
+    test('responsiveLockPolicy applies matching breakpoint lock states through column setters', async () => {
+        grid.responsiveLockPolicy = {
+            breakpoints: [{
+                maxWidth: 500,
+                columns : {
+                    col3: null,
+                    col5: 'end'
+                }
+            }, {
+                maxWidth: 900,
+                columns : {
+                    col3: 'start',
+                    col5: null
+                }
+            }]
+        };
+
+        expect(grid.applyResponsiveLockPolicy({width: 480})).toBe(true);
+        await grid.timeout(50);
+
+        expect(grid.columns.get('col3').locked).toBe(null);
+        expect(grid.columns.get('col5').locked).toBe('end');
+
+        expect(grid.applyResponsiveLockPolicy({width: 760})).toBe(true);
+        await grid.timeout(50);
+
+        expect(grid.columns.get('col3').locked).toBe('start');
+        expect(grid.columns.get('col5').locked).toBe(null);
+    });
+
+    test('responsiveLockPolicy leaves omitted columns user-owned and ignores invalid descriptors', async () => {
+        const col1 = grid.columns.get('col1'),
+              col2 = grid.columns.get('col2'),
+              col3 = grid.columns.get('col3');
+
+        col1.locked = 'start';
+        await grid.timeout(50);
+
+        grid.responsiveLockPolicy = {
+            breakpoints: [{
+                maxWidth: 700,
+                columns : {
+                    col2   : 'middle',
+                    col3   : false,
+                    missing: 'start'
+                }
+            }]
+        };
+
+        expect(grid.applyResponsiveLockPolicy(640)).toBe(true);
+        await grid.timeout(50);
+
+        expect(col1.locked).toBe('start');
+        expect(col2.locked).toBe('end');
+        expect(col3.locked).toBe(null);
+    });
+
+    test('responsiveLockPolicy holds the active breakpoint inside its hysteresis band', async () => {
+        const col3 = grid.columns.get('col3');
+
+        grid.responsiveLockPolicy = {
+            hysteresis : 20,
+            breakpoints: [{
+                maxWidth: 500,
+                columns : {
+                    col3: null
+                }
+            }, {
+                maxWidth: 900,
+                columns : {
+                    col3: 'start'
+                }
+            }]
+        };
+
+        expect(grid.applyResponsiveLockPolicy({width: 490})).toBe(true);
+        await grid.timeout(50);
+        expect(col3.locked).toBe(null);
+        expect(grid.responsiveLockPolicyActiveMaxWidth).toBe(500);
+
+        expect(grid.applyResponsiveLockPolicy({width: 510})).toBe(false);
+        await grid.timeout(50);
+        expect(col3.locked).toBe(null);
+        expect(grid.responsiveLockPolicyActiveMaxWidth).toBe(500);
+
+        expect(grid.applyResponsiveLockPolicy({width: 525})).toBe(true);
+        await grid.timeout(50);
+        expect(col3.locked).toBe('start');
+        expect(grid.responsiveLockPolicyActiveMaxWidth).toBe(900);
+    });
+
+    test('onResize evaluates responsiveLockPolicy before the sizing refresh', async () => {
+        let bodyUpdated    = false,
+            headerRefreshed = false,
+            passSilentArgs  = [];
+
+        grid.initialResizeEvent = false;
+        grid.responsiveLockPolicy = {
+            breakpoints: [{
+                maxWidth: 500,
+                columns : {
+                    col3: null
+                }
+            }]
+        };
+
+        grid.passSizeToBody = async silent => {
+            passSilentArgs.push(silent);
+
+            if (silent === true) {
+                expect(grid.columns.get('col3').locked).toBe(null)
+            }
+        };
+        grid.body.updateMountedAndVisibleColumns = () => {bodyUpdated = true};
+        grid.bodyStart && (grid.bodyStart.updateMountedAndVisibleColumns = () => {});
+        grid.bodyEnd   && (grid.bodyEnd.updateMountedAndVisibleColumns   = () => {});
+        grid.headerToolbar.passSizeToBody = async () => {headerRefreshed = true};
+
+        await GridContainer.prototype.onResize.call(grid, {contentRect: {width: 480}});
+        await grid.timeout(50);
+
+        expect(grid.columns.get('col3').locked).toBe(null);
+        expect(passSilentArgs).toContain(true);
+        expect(bodyUpdated).toBe(true);
+        expect(headerRefreshed).toBe(true);
+    });
+
     test('Setting a new columns array at runtime correctly sorts them', async () => {
         // Provide a completely new set of columns, out of order regarding lock state.
         grid.columns = [{


### PR DESCRIPTION
Resolves #12934

Authored by GPT-5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

Adds `Neo.grid.Container#responsiveLockPolicy` as a bounded App Worker policy for responsive locked-column states. The implementation selects the first matching width breakpoint, applies only explicitly named columns through the existing `column.locked` setter path, ignores unknown or invalid descriptors, and keeps a small hysteresis band to avoid threshold chatter.

Evidence: L2 (single-thread App Worker unit simulation for resize payloads + locked-column state transitions) -> L2 required (policy selection, lock-state mutation, and resize hook ordering are covered without requiring browser visual parity). No residuals.

## Deltas from Ticket

The first implementation slice stays on the unit-testable policy contract rather than adding a broader browser E2E in the same PR. The resize width resolver accepts the actual main-thread `ResizeObserver` payload shapes (`contentRect`, `rect`, and box-size inline widths) plus direct numeric/container-width inputs for focused tests and future call sites.

## Test Evidence

- `node --check src/grid/Container.mjs`
- `node --check test/playwright/unit/grid/LockedColumns.spec.mjs`
- `git diff --check`
- `git diff --cached --check`
- `npm run test-unit -- test/playwright/unit/grid/LockedColumns.spec.mjs` -> 10 passed
- `npm run check-reactive-tags` -> existing repo-wide baseline failure listing 75 unrelated configs; the new `Neo.grid.Container#responsiveLockPolicy_` config was not listed

## Post-Merge Validation

- [ ] Exercise a real browser resize against a grid with two `responsiveLockPolicy` breakpoints to confirm main-thread `ResizeObserver` payload parity outside the unit simulation.

## Commits

- `3a603dfc3` - `feat(grid): add responsive locked-column policy (#12934)`
