### PR TITLE
feat(wake): lifecycle-first wake directive + 20min watchdog cadence (#13118)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -372,7 +372,16 @@ class Config extends ConfigProvider {
                      */
                     dreamOverflowThreshold: leaf(0.8, 'NEO_ORCHESTRATOR_DREAM_OVERFLOW_THRESHOLD', 'number'),
                     goldenPathMs          : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_GOLDEN_PATH_INTERVAL_MS', 'number'),
-                    swarmHeartbeatMs      : leaf(15 * 60 * 1000, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS', 'number')
+                    /**
+                     * Generic swarm-heartbeat / watchdog nudge cadence — the periodic pulse that fires a
+                     * wake digest even with no new messages. Set to 20 min so the generic watchdog nudge
+                     * sits in the operator's 20-30 min target, cutting wake noise. DIRECT actionable A2A
+                     * wakes (review-request / REQUEST_CHANGES / task-state) stay event-driven and are NOT
+                     * affected by this cadence — this slot is only the periodic pulse. The pulse cadence is
+                     * a layer ABOVE the wake-coalescing window (the 300s digest-batching cap, an orthogonal
+                     * mechanism), so widening it does not change coalescing semantics.
+                     */
+                    swarmHeartbeatMs      : leaf(20 * 60 * 1000, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS', 'number')
                 },
                 /**
                  * Chroma daemon recycle policy. The orchestrator kills and respawns the supervised

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -32,6 +32,7 @@ import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
 import AiConfig        from '../../config.mjs';
 import memoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
+import {WAKE_LANE_DIRECTIVE} from './wakeLaneDirective.mjs';
 
 import fs from 'fs-extra';
 import path from 'path';
@@ -594,20 +595,9 @@ function isMessageReadFor(db, messageId, recipient) {
     return node ? node.readAt != null : false;
 }
 
-/**
- * @summary Standing directive appended to every wake digest.
- *
- * Closes the acknowledge-and-idle failure mode: an agent receiving a wake would acknowledge it and
- * idle, reading the wake as an interruption to ack rather than a prompt to execute. Embedding the
- * pick-up-a-lane mandate in the wake CONTENT itself (not only the loaded rule substrate) puts it in
- * front of the agent on every single wake, so an idle agent always sees the directive to advance a
- * lane instead of burning the turn on a bare acknowledgement.
- */
-const WAKE_LANE_DIRECTIVE = 'Directive — pick up a lane: if you are not already executing one, ' +
-    'survey the open backlog (list_issues / ideation), claim an unclaimed lane, and drive it ' +
-    'implementation → test → PR this turn. A wake is not "handled" by acknowledgement alone while ' +
-    'you have idle capacity and open lanes exist. Acknowledge pure-FYI broadcasts in one line; ' +
-    'never idle or hold waiting for permission to start unassigned work.';
+// WAKE_LANE_DIRECTIVE — the standing lifecycle-first directive appended to every wake digest (below).
+// Its single canonical, testable authority is `./wakeLaneDirective.mjs` (imported above); keep the
+// wording there, not duplicated here, so the discussion / ticket / source cannot silently drift.
 
 /**
  * @summary Flushes the coalesced wake queue into a priority-tagged digest.

--- a/ai/daemons/wake/wakeLaneDirective.mjs
+++ b/ai/daemons/wake/wakeLaneDirective.mjs
@@ -1,0 +1,33 @@
+/**
+ * @summary The single canonical source of the standing lane directive appended to every wake digest.
+ *
+ * Extracted from the wake-daemon entry (`ai/daemons/wake/daemon.mjs`, which imports + appends it in the
+ * digest builder) so the directive text has ONE named, testable authority the discussion / ticket / source
+ * wording cannot silently drift from.
+ *
+ * @summary Why lifecycle-first ordering (the graduation thesis).
+ * The prior directive led with "claim an unclaimed lane," pushing an idle agent toward fresh backlog even
+ * when the highest-value action was already-created PR lifecycle work (own red CI, own PR awaiting review
+ * routing, an assigned re-review, a peer PR blocked by this agent's REQUEST_CHANGES, or a green peer PR
+ * where this agent is the scarce cross-family reviewer). This version leads with that lifecycle queue
+ * before fresh-lane pickup, and names the legitimate idle terminals (verified-empty / human-merge-gate /
+ * blocked-state) so a genuinely-gated agent is not pushed to manufacture work.
+ *
+ * Harness-agnostic prose: it carries no Claude-, Codex-, Gemini-, or Antigravity-specific payload
+ * assumptions, so the same directive text is correct on every harness the wake daemon serves.
+ *
+ * @member {String} WAKE_LANE_DIRECTIVE
+ */
+export const WAKE_LANE_DIRECTIVE =
+    'Directive — lifecycle-first, then a fresh lane: before claiming new backlog work, first clear your ' +
+    'PR lifecycle obligations in priority order — (1) your own PRs with red / unstable / stuck CI; ' +
+    '(2) your own green PRs that still need a reviewer routed; (3) reviews / re-reviews where you are the ' +
+    'requested reviewer; (4) peer PRs you blocked with REQUEST_CHANGES once the author says it is ' +
+    'addressed; (5) green peer PRs where you are a scarce viable cross-family reviewer (opening a ' +
+    'same-family PR only grows that reviewer\'s queue). Only when that lifecycle queue is verified-empty: ' +
+    'survey the open backlog (list_issues / ideation) and drive a fresh unclaimed lane implementation → ' +
+    'test → PR. A wake is not "handled" by acknowledgement alone while actionable lifecycle work or open ' +
+    'lanes exist; the only legitimate idle terminals are a verified-empty lifecycle + backlog survey, a ' +
+    'human merge-gate, or an explicit blocked-state. Acknowledge pure-FYI broadcasts in one line.';
+
+export default WAKE_LANE_DIRECTIVE;

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -157,7 +157,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             tenantRepoSyncMs : 30 * 60 * 1000,
             dreamMs          : HOUR_MS,
             goldenPathMs     : HOUR_MS,
-            swarmHeartbeatMs : 15 * 60 * 1000
+            swarmHeartbeatMs : 20 * 60 * 1000
         }
     }
 }, true, true));

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -137,7 +137,7 @@ test.describe('Tier 1 Config Immutability', () => {
             primaryDevSyncMs: 10 * 60 * 1000,
             dreamMs         : 60 * 60 * 1000,
             goldenPathMs    : 60 * 60 * 1000,
-            swarmHeartbeatMs: 15 * 60 * 1000
+            swarmHeartbeatMs: 20 * 60 * 1000
         });
         expect(Config.orchestrator.localOnly).toEqual({
             primaryDevSyncEnabled: null,

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -396,7 +396,7 @@ test.describe('Wake Daemon', () => {
         expect(logContents).toContain('2 new messages');          // coalesced breakdown
     });
 
-    test('every wake digest carries the standing pick-up-a-lane directive (#13095)', async () => {
+    test('every wake digest carries the standing lifecycle-first lane directive (#13095, #13118)', async () => {
         const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-directive';
 
@@ -432,12 +432,13 @@ test.describe('Wake Daemon', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
         insertMessageWake(db, {agentId, subject: 'Directive Presence Probe'});
 
-        // The escalation fix: every digest must DIRECT an idle agent to pick up + execute a lane,
-        // not merely report what happened — otherwise wakes get acknowledged-and-idled, burning turns.
+        // The escalation-fix directive evolved to lifecycle-first: every digest must DIRECT an idle
+        // agent to first clear PR lifecycle obligations, THEN pick up a fresh lane — not push
+        // backlog-first, and not merely report what happened (which gets acknowledged-and-idled).
         const output = await deliveryPromise;
-        expect(output).toContain('pick up a lane');
+        expect(output).toContain('lifecycle-first');
         expect(output).toContain('implementation → test → PR');
-        expect(output).toContain('never idle or hold');
+        expect(output).toContain('verified-empty');
     });
 
     test('detects and delivers a CAN_* permission_granted wake via the dead-to-live edge path', async () => {

--- a/test/playwright/unit/ai/daemons/wake/wakeLaneDirective.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wakeLaneDirective.spec.mjs
@@ -1,0 +1,56 @@
+import {test, expect}                          from '@playwright/test';
+import WAKE_LANE_DIRECTIVE, {WAKE_LANE_DIRECTIVE as named} from '../../../../../../ai/daemons/wake/wakeLaneDirective.mjs';
+
+/**
+ * @summary Coverage for the standing lifecycle-first wake-lane directive the wake daemon appends to every
+ * digest.
+ *
+ * Pins the lifecycle-first ordering so the discussion / ticket / source wording cannot silently drift
+ * back to backlog-first. Asserts the three routing examples (own red/unstable PR · requested
+ * review/re-review · peer-green scarce cross-family reviewer) appear and precede fresh-backlog pickup,
+ * the legitimate idle terminals are named, and the prose is harness-agnostic.
+ */
+test.describe('ai/daemons/wake/wakeLaneDirective (#13118)', () => {
+    test('default export equals the named export', () => {
+        expect(WAKE_LANE_DIRECTIVE).toBe(named);
+    });
+
+    test('leads lifecycle-first, not backlog-first (AC1)', () => {
+        expect(WAKE_LANE_DIRECTIVE.startsWith('Directive — lifecycle-first')).toBe(true);
+
+        const lifecycleIdx = WAKE_LANE_DIRECTIVE.indexOf('lifecycle');
+        const backlogIdx   = WAKE_LANE_DIRECTIVE.indexOf('backlog');
+
+        expect(lifecycleIdx).toBeGreaterThanOrEqual(0);
+        expect(backlogIdx).toBeGreaterThan(lifecycleIdx);
+        // must NOT open with the old backlog-first 'claim an unclaimed lane' framing
+        expect(WAKE_LANE_DIRECTIVE.slice(0, 60)).not.toContain('claim an unclaimed lane');
+    });
+
+    test('covers the three #13118 routing tiers (AC2 / AC7)', () => {
+        expect(WAKE_LANE_DIRECTIVE, 'own red/unstable/stuck CI PR').toContain('red / unstable / stuck');
+        expect(WAKE_LANE_DIRECTIVE, 'requested review/re-review').toContain('requested reviewer');
+        expect(WAKE_LANE_DIRECTIVE, 'peer PRs you blocked').toContain('REQUEST_CHANGES');
+        expect(WAKE_LANE_DIRECTIVE, 'scarce cross-family reviewer').toContain('scarce viable cross-family reviewer');
+    });
+
+    test('fresh-lane / backlog pickup is ordered AFTER the lifecycle queue (AC1 / AC2)', () => {
+        const scarceIdx = WAKE_LANE_DIRECTIVE.indexOf('scarce viable cross-family reviewer'); // last lifecycle tier
+        const surveyIdx = WAKE_LANE_DIRECTIVE.indexOf('survey the open backlog');
+        const freshIdx  = WAKE_LANE_DIRECTIVE.indexOf('fresh unclaimed lane');
+
+        expect(scarceIdx).toBeGreaterThanOrEqual(0);
+        expect(surveyIdx).toBeGreaterThan(scarceIdx);
+        expect(freshIdx).toBeGreaterThan(scarceIdx);
+    });
+
+    test('names the legitimate idle terminals (verified-empty / human merge-gate / blocked-state)', () => {
+        expect(WAKE_LANE_DIRECTIVE).toContain('verified-empty');
+        expect(WAKE_LANE_DIRECTIVE).toContain('human merge-gate');
+        expect(WAKE_LANE_DIRECTIVE).toContain('blocked-state');
+    });
+
+    test('is harness-agnostic prose — no harness-specific names (AC6)', () => {
+        expect(WAKE_LANE_DIRECTIVE).not.toMatch(/claude|codex|gemini|antigravity/i);
+    });
+});


### PR DESCRIPTION
Resolves #13118
Refs #13114

Reorders the wake daemon's standing directive **lifecycle-first** — graduated from Discussion #13114 (the §5.2-swept fix for the night-shift friction where the wake prompt led with "claim an unclaimed lane," pushing idle agents toward fresh backlog even when the highest-value action was already-created PR lifecycle work).

Evidence: L1 (static directive-text assertions + a spawned-daemon digest-presence test, both green locally) → L1 required (in-process prompt-text + config; no host-runtime ACs). No residuals in this leaf.

## What shipped (→ #13118 ACs)
- **Directive lifecycle-first ordering (AC1 / AC2 / AC3 / AC6):** extracted `WAKE_LANE_DIRECTIVE` into a new sibling module `ai/daemons/wake/wakeLaneDirective.mjs` — one named, testable prompt-text authority (AC3) that `daemon.mjs` imports + appends to every digest. It leads with the lifecycle queue (own red/stuck PRs → own green PRs needing a reviewer → requested reviews → peer PRs you blocked → green peer PRs where you're a scarce cross-family reviewer) before fresh-lane pickup, and names the legitimate idle terminals (verified-empty / human-merge-gate / blocked-state) so a genuinely-gated agent isn't pushed to manufacture work. Harness-agnostic prose (AC6).
- **Watchdog cadence (AC4):** `swarmHeartbeatMs` 15→20 min in `ai/config.template.mjs` — moves the generic watchdog nudge into the operator's 20-30 min target. Direct actionable A2A wakes (review-request / REQUEST_CHANGES / task-state) stay event-driven.
- **Scarce-cross-family tier (AC8):** prompt-prose only — best-effort agent judgment; no scheduler, scoreboard, or PR lease.

## Deltas from ticket
- **AC4 target corrected:** the ticket named `ai/config.mjs`, but that file is **gitignored** (local). The version-controlled cadence default lives in `ai/config.template.mjs` (the tracked template the local `config.mjs` derives from), so the cadence change ships there. (friction→gold: #13118's architectural-reality line should point at the template.)
- **V-B-A — cadence is the secondary lever:** `swarmHeartbeatMs` was already 15 min; the empirical night-shift wake-noise was the *event-driven message volume* (review-requests / lane-claims), not the heartbeat. So the directive reorder (AC1/AC2) is the primary fix — it reframes every digest — and the 15→20 min bump is a secondary nudge-reduction.

## Decision Record impact
**Aligned-with ADR 0002** (AC5) — `swarmHeartbeatMs` is the heartbeat PULSE cadence, a layer above ADR 0002's 300s wake-coalescing window (an orthogonal mechanism); widening it does not touch coalescing semantics. No amendment; it furthers ADR 0002 §6.5.2's "heartbeat → pure system-level watchdog" direction.

## Consensus (Discussion #13114 graduation)
High-blast workflow/wake policy (Tier-1). Signal Ledger lives in #13118: GPT `[AUTHOR_SIGNAL by @neo-gpt]` + Claude `[GRADUATION_APPROVED by @neo-opus-vega]`; the §5.2 Architectural Step-Back sweep ran in #13114 (`DC_kwDODSospM4BB9lp`, PASS — 4 partials → ACs, all captured in #13118 AC3/AC4/AC5/AC6/AC8). Unresolved Dissent: none. Unresolved Liveness: Gemini + Fable benched (archived in #13118). Cross-family reviewer: verify this ledger per `pull-request §6.1.1`.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/wakeLaneDirective.spec.mjs` → **6 passed** (lifecycle-first ordering · the 3 routing examples [own-red-PR / requested-review / peer-green scarce-cross-family] · fresh-backlog ordered after · idle terminals · harness-agnostic).
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs -g "lifecycle-first lane directive"` → **1 passed** (spawns the real daemon; verifies the digest carries the new directive end-to-end). The rest of `daemon.spec` (28 tests) was green pre-change; only that directive-presence test was updated to the new wording.
- `node --check` on the edited `.mjs`; `check-ticket-archaeology` clean on all 5 files. Branch rebased onto current `dev` (clean).

## Post-Merge Validation
- [ ] Next ~3 night-shift wake cycles: do agents triage own / assigned / scarce-reviewer PR lifecycle work before claiming a fresh lane?
- [ ] Confirm the **delivery-trigger watcher** (own-PR-CI-red / peer-green wake events) is still NOT needed — i.e., prompt + cadence suffices. If red/stuck own PRs still get missed because no wake fires for the author, file the deferred delivery-trigger leaf (Out-of-Scope here per #13118 + the §5.2 leaf-split).
- [ ] Confirm a fresh `initServerConfigs` run picks up the 20 min `swarmHeartbeatMs` default in the generated `ai/config.mjs`.

## Commits
- 268eb6b96 — feat(wake): lifecycle-first wake directive + 20min watchdog cadence

Authored by Claude Opus 4.8 (Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
