### PR TITLE
feat(ai): inject bridge token + forced NL projection at fleet spawn (#13121)

### DIFF
--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -10,6 +10,19 @@ let _turnId = 0;
 export const getCurrentTurnId = () => _turnId;
 
 /**
+ * @summary Resolves the server-instance forced tool-projection mode from its launch sources, in
+ * precedence order: the explicit `--tool-projection-mode` CLI flag wins; else the
+ * `NEO_NL_TOOL_PROJECTION_MODE` env var (the channel the Fleet Manager spawner injects for embedded
+ * agents via its `toolProjectionModeEnvVar`); else `null` (unforced → the full developer/operator
+ * surface, the trusted dev/operator launch). The single testable authority for this resolution.
+ * @param {String|null} [cliMode] The `--tool-projection-mode` value (null/undefined when the flag is absent).
+ * @param {Object} [env=process.env] Env source (injectable for tests).
+ * @returns {String|null}
+ */
+export const resolveToolProjectionMode = (cliMode, env = process.env) =>
+    cliMode ?? env.NEO_NL_TOOL_PROJECTION_MODE ?? null;
+
+/**
  * @summary The Neural Link MCP Server application.
  *
  * Bridges AI agents to the live browser application via WebSocket. Uses a non-canonical

--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -13,7 +13,8 @@ export const getCurrentTurnId = () => _turnId;
  * @summary Resolves the server-instance forced tool-projection mode from its launch sources, in
  * precedence order: the explicit `--tool-projection-mode` CLI flag wins; else the
  * `NEO_NL_TOOL_PROJECTION_MODE` env var (the channel the Fleet Manager spawner injects for embedded
- * agents via its `toolProjectionModeEnvVar`); else `null` (unforced → the full developer/operator
+ * agents — a fixed cross-process contract name, not a configurable field on either side); else `null`
+ * (unforced → the full developer/operator
  * surface, the trusted dev/operator launch). The single testable authority for this resolution.
  * @param {String|null} [cliMode] The `--tool-projection-mode` value (null/undefined when the flag is absent).
  * @param {Object} [env=process.env] Env source (injectable for tests).

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -5,7 +5,7 @@ import * as core       from '../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 import aiConfig        from './config.mjs';
 import logger          from './logger.mjs';
-import Server          from './Server.mjs';
+import Server, {resolveToolProjectionMode} from './Server.mjs';
 import {sanitizeInput} from '../../../../buildScripts/util/sanitizer.mjs';
 
 const program = new Command();
@@ -16,7 +16,7 @@ program
     .option('-c, --config <path>', 'Path to the configuration file', sanitizeInput)
     .option('-w, --cwd <path>', 'Working directory for the bridge process')
     .option('-d, --debug', 'Enable debug logging')
-    .option('--tool-projection-mode <mode>', 'Pin this server instance to a forced tool-projection ceiling (e.g. harness-embedded) a client cannot widen past. Unset = full developer/operator surface.')
+    .option('--tool-projection-mode <mode>', 'Pin this server instance to a forced tool-projection ceiling (e.g. harness-embedded) a client cannot widen past. Falls back to the NEO_NL_TOOL_PROJECTION_MODE env var (the Fleet Manager spawn-injection channel); CLI flag wins. Unset = full developer/operator surface.')
     .parse(process.argv);
 
 const options = program.opts();
@@ -30,7 +30,7 @@ try {
     await Neo.create(Server, {
         configFile        : options.config,
         bridgeCwd         : options.cwd,
-        toolProjectionMode: options.toolProjectionMode ?? null
+        toolProjectionMode: resolveToolProjectionMode(options.toolProjectionMode)
     }).ready();
 } catch (error) {
     logger.error('Fatal error during server initialization:', error);

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -2,6 +2,12 @@ import {spawn}           from 'child_process';
 import Base              from '../../../src/core/Base.mjs';
 import FleetRegistryService from './FleetRegistryService.mjs';
 
+// The forced-projection env var is a CROSS-PROCESS CONTRACT: the FM sets it on the spawned child env,
+// and the Neural Link server's `resolveToolProjectionMode` reads this exact name as the fallback to
+// `--tool-projection-mode`. Intentionally NOT a configurable field — an override would set a var the
+// NL server never reads, silently dropping the forced read-only projection (fail-OPEN).
+const TOOL_PROJECTION_MODE_ENV_VAR = 'NEO_NL_TOOL_PROJECTION_MODE';
+
 /**
  * @class Neo.ai.services.fleet.FleetLifecycleService
  * @extends Neo.core.Base
@@ -28,9 +34,10 @@ import FleetRegistryService from './FleetRegistryService.mjs';
  * **Harness-auth provisioning at spawn:** every FM-spawned agent is an *embedded* agent, so `start`
  * provisions its harness-auth surfaces into the child env: (1) a freshly-minted Bridge token for the
  * agent↔Neural-Link-Bridge handshake, and (2) the forced read-only Neural Link tool-projection
- * (`toolProjectionMode`, default `harness-embedded`) under `toolProjectionModeEnvVar` — the NL server
- * reads that var as a fallback to its `--tool-projection-mode` flag. Fail-closed by construction: an
- * FM-spawned agent never receives the full developer tool surface.
+ * (`toolProjectionMode`, default `harness-embedded`) under the FIXED `NEO_NL_TOOL_PROJECTION_MODE` var
+ * (a cross-process contract, intentionally NOT configurable — an override would set a var the NL server
+ * never reads → fail-OPEN) — the NL server reads it as a fallback to its `--tool-projection-mode` flag.
+ * Fail-closed by construction: an FM-spawned agent never receives the full developer tool surface.
  *
  * **Supervision idiom** mirrors `ai/daemons/orchestrator/services/ProcessSupervisorService` (the
  * injectable `spawnFn` test seam, env-merge, graceful `SIGTERM`→`SIGKILL` stop, and draining the
@@ -57,7 +64,7 @@ class FleetLifecycleService extends Base {
         singleton: true
     }
 
-    // The four members below are PLAIN fields, not reactive `_` configs: they are injectable seams /
+    // The members below are PLAIN fields, not reactive `_` configs: they are injectable seams /
     // settings, not change-propagating state, and a singleton's reactive configs do not re-apply
     // synchronously when overwritten per test (verified failure). Plain assignment is immediate.
 
@@ -74,14 +81,6 @@ class FleetLifecycleService extends Base {
      * @member {String} bridgeTokenEnvVar='NEO_FLEET_BRIDGE_TOKEN'
      */
     bridgeTokenEnvVar = 'NEO_FLEET_BRIDGE_TOKEN'
-
-    /**
-     * Child-env variable carrying the forced Neural Link tool-projection mode. The NL server's launch
-     * resolution reads it as a fallback to `--tool-projection-mode`; the var name is the cross-process
-     * contract (must match `Neo.ai.mcp.server.neural-link` `resolveToolProjectionMode`).
-     * @member {String} toolProjectionModeEnvVar='NEO_NL_TOOL_PROJECTION_MODE'
-     */
-    toolProjectionModeEnvVar = 'NEO_NL_TOOL_PROJECTION_MODE'
 
     /**
      * The forced NL tool-projection mode injected into every FM-spawned (embedded) agent — the
@@ -132,6 +131,17 @@ class FleetLifecycleService extends Base {
 
         const {command, args} = this.resolveLaunch(agent);
 
+        // Env-key contract guard (fail-fast): each credential class occupies a DISTINCT child-env slot.
+        // The PAT + Bridge-token keys are configurable, so a misconfiguration that collides two (e.g.
+        // bridgeTokenEnvVar === credentialEnvVar) would write one credential then overwrite it with the
+        // other — collapsing the distinct-credential-class boundary (the Bridge token lands in the PAT
+        // slot), or stomping the forced-projection var. Reject BEFORE injecting any secret; never spawn
+        // under a broken env contract.
+        const envKeys = [this.credentialEnvVar, this.bridgeTokenEnvVar, TOOL_PROJECTION_MODE_ENV_VAR];
+        if (envKeys.some(key => !key) || new Set(envKeys).size !== envKeys.length) {
+            throw new Error(`FleetLifecycleService.start: env-key contract violated — credentialEnvVar, bridgeTokenEnvVar, and the forced-projection var must be non-empty and pairwise distinct (got ${JSON.stringify(envKeys)}).`);
+        }
+
         // Secret handling: copy the parent env (never mutate process.env), inject the PAT — if any —
         // under credentialEnvVar. Absent credential → start without it (a tokenless agent is valid).
         const env = {...process.env},
@@ -147,8 +157,9 @@ class FleetLifecycleService extends Base {
         // Forced Neural Link tool-projection: an FM-spawned agent is embedded by definition, so its
         // NL server is pinned to the read-only projection (server-bound, fail-closed) — set by
         // construction for every spawn, never the full developer surface. The NL server reads this
-        // env var as a fallback to its --tool-projection-mode flag.
-        env[this.toolProjectionModeEnvVar] = this.toolProjectionMode;
+        // FIXED env var (a cross-process contract, not configurable) as a fallback to its
+        // --tool-projection-mode flag.
+        env[TOOL_PROJECTION_MODE_ENV_VAR] = this.toolProjectionMode;
 
         let child;
         try {

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -22,7 +22,15 @@ import FleetRegistryService from './FleetRegistryService.mjs';
  * (the parent env is never mutated), under a configurable var (`credentialEnvVar`, default
  * `GH_TOKEN`). It is **never** placed in `argv` (visible in `ps`), never written to the tracked
  * process record, and never logged. A status read can never surface a secret because the records
- * hold none.
+ * hold none. The **Bridge session token** is a SECOND, distinct credential class, injected the same
+ * way under its own var (`bridgeTokenEnvVar`) — minted per spawn, never co-mingled with the PAT.
+ *
+ * **Harness-auth provisioning at spawn:** every FM-spawned agent is an *embedded* agent, so `start`
+ * provisions its harness-auth surfaces into the child env: (1) a freshly-minted Bridge token for the
+ * agent↔Neural-Link-Bridge handshake, and (2) the forced read-only Neural Link tool-projection
+ * (`toolProjectionMode`, default `harness-embedded`) under `toolProjectionModeEnvVar` — the NL server
+ * reads that var as a fallback to its `--tool-projection-mode` flag. Fail-closed by construction: an
+ * FM-spawned agent never receives the full developer tool surface.
  *
  * **Supervision idiom** mirrors `ai/daemons/orchestrator/services/ProcessSupervisorService` (the
  * injectable `spawnFn` test seam, env-merge, graceful `SIGTERM`→`SIGKILL` stop, and draining the
@@ -31,8 +39,9 @@ import FleetRegistryService from './FleetRegistryService.mjs';
  * fit for a dynamic registry-keyed fleet. Extracting a shared primitive would touch critical
  * orchestrator infra and is intentionally deferred.
  *
- * Scope is process supervision only. Spawn-time identity-env + wake-subscription provisioning is
- * gated on cross-harness session-id canonicalization and lives in a separate provisioning leaf.
+ * Scope: process supervision + harness-auth provisioning (Bridge token + forced NL projection, above).
+ * Spawn-time *identity-env* + wake-subscription provisioning remains deferred — gated on cross-harness
+ * session-id canonicalization, in a separate provisioning leaf.
  */
 class FleetLifecycleService extends Base {
     static config = {
@@ -58,6 +67,28 @@ class FleetLifecycleService extends Base {
      * @member {String} credentialEnvVar='GH_TOKEN'
      */
     credentialEnvVar = 'GH_TOKEN'
+
+    /**
+     * Child-env variable the minted Bridge session token is injected under — a credential class
+     * DISTINCT from the PAT, so never `credentialEnvVar`. The Bridge handshake reads it.
+     * @member {String} bridgeTokenEnvVar='NEO_FLEET_BRIDGE_TOKEN'
+     */
+    bridgeTokenEnvVar = 'NEO_FLEET_BRIDGE_TOKEN'
+
+    /**
+     * Child-env variable carrying the forced Neural Link tool-projection mode. The NL server's launch
+     * resolution reads it as a fallback to `--tool-projection-mode`; the var name is the cross-process
+     * contract (must match `Neo.ai.mcp.server.neural-link` `resolveToolProjectionMode`).
+     * @member {String} toolProjectionModeEnvVar='NEO_NL_TOOL_PROJECTION_MODE'
+     */
+    toolProjectionModeEnvVar = 'NEO_NL_TOOL_PROJECTION_MODE'
+
+    /**
+     * The forced NL tool-projection mode injected into every FM-spawned (embedded) agent — the
+     * fail-closed security ceiling. FM-spawned ⇒ embedded ⇒ forced, by construction.
+     * @member {String} toolProjectionMode='harness-embedded'
+     */
+    toolProjectionMode = 'harness-embedded'
 
     /**
      * Grace period after `SIGTERM` before `stop` escalates to `SIGKILL`.
@@ -106,6 +137,18 @@ class FleetLifecycleService extends Base {
         const env = {...process.env},
               pat = this.getRegistry().resolveCredential(id);
         if (pat != null) env[this.credentialEnvVar] = pat;
+
+        // Bridge token: a credential class DISTINCT from the PAT. Mint one + inject it under
+        // bridgeTokenEnvVar (never credentialEnvVar). The raw token enters the child env only — the
+        // tracked process record never carries it (mirrors the PAT secret posture); the Bridge
+        // handshake verifies it and fails closed on absence/mismatch.
+        env[this.bridgeTokenEnvVar] = this.getRegistry().mintBridgeToken(id).token;
+
+        // Forced Neural Link tool-projection: an FM-spawned agent is embedded by definition, so its
+        // NL server is pinned to the read-only projection (server-bound, fail-closed) — set by
+        // construction for every spawn, never the full developer surface. The NL server reads this
+        // env var as a fallback to its --tool-projection-mode flag.
+        env[this.toolProjectionModeEnvVar] = this.toolProjectionMode;
 
         let child;
         try {

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -55,7 +55,10 @@ function makeSpawnStub() {
 function makeRegistry(agents, creds) {
     return {
         getAgent         : id => agents[id] || null,
-        resolveCredential: id => (Object.hasOwn(creds, id) ? creds[id] : null)
+        resolveCredential: id => (Object.hasOwn(creds, id) ? creds[id] : null),
+        // Stub the Bridge-token mint with a deterministic per-id token, so spawn-injection specs can
+        // assert env carriage without touching the real registry's crypto store.
+        mintBridgeToken  : id => ({token: `bridge_${id}_token`, expiresAt: Date.now() + 3_600_000})
     };
 }
 
@@ -108,6 +111,41 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(JSON.stringify(status)).not.toContain(pat);
         // the live parent env was not mutated to carry the secret
         expect(process.env.GH_TOKEN).not.toBe(pat);
+    });
+
+    test('start mints + injects a Bridge token + forced NL projection into the child env', () => {
+        const pat   = 'ghp_dual_class';
+        const spawn = install({agents: {a: agentDef('a')}, creds: {a: pat}});
+        FleetLifecycleService.start('a');
+        const env = spawn.calls[0].opts.env;
+
+        // Bridge token under its OWN var — a credential class distinct from the PAT
+        expect(env.NEO_FLEET_BRIDGE_TOKEN).toBe('bridge_a_token');
+        expect(env.NEO_FLEET_BRIDGE_TOKEN).not.toBe(env.GH_TOKEN);
+        // forced NL projection: FM-spawned ⇒ embedded ⇒ harness-embedded, by construction
+        expect(env.NEO_NL_TOOL_PROJECTION_MODE).toBe('harness-embedded');
+        // the PAT injection is unaffected
+        expect(env.GH_TOKEN).toBe(pat);
+        // injected on a COPY of process.env; parent env never mutated to carry the bridge token
+        expect(env).not.toBe(process.env);
+        expect(process.env.NEO_FLEET_BRIDGE_TOKEN).not.toBe('bridge_a_token');
+    });
+
+    test('SECURITY: the injected Bridge token never enters the process record / status', () => {
+        const spawn  = install({agents: {a: agentDef('a')}}),
+              status = FleetLifecycleService.start('a'),
+              token  = spawn.calls[0].opts.env.NEO_FLEET_BRIDGE_TOKEN;
+
+        expect(token).toBe('bridge_a_token');                                       // it WAS injected
+        expect(JSON.stringify(status)).not.toContain(token);                        // never via status
+        expect(JSON.stringify(FleetLifecycleService.status('a'))).not.toContain(token);
+    });
+
+    test('forced NL projection is set by construction for every FM spawn (fail-closed invariant)', () => {
+        // even a tokenless agent (no PAT) gets the forced embedded projection — never the full surface
+        const spawn = install({agents: {a: agentDef('a')}, creds: {}});
+        FleetLifecycleService.start('a');
+        expect(spawn.calls[0].opts.env.NEO_NL_TOOL_PROJECTION_MODE).toBe('harness-embedded');
     });
 
     test('a tokenless agent starts without injecting a fleet credential', () => {

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -75,6 +75,10 @@ function install({agents = {}, creds = {}} = {}) {
     FleetLifecycleService.spawnFn         = spawnStub;
     FleetLifecycleService.registry        = makeRegistry(agents, creds);
     FleetLifecycleService.sigkillTimeoutMs = 50;
+    // Reset the configurable env-key fields to their defaults so a collision test cannot bleed into
+    // the next serial sibling (singleton-stateful service).
+    FleetLifecycleService.credentialEnvVar  = 'GH_TOKEN';
+    FleetLifecycleService.bridgeTokenEnvVar = 'NEO_FLEET_BRIDGE_TOKEN';
     return spawnStub;
 }
 
@@ -146,6 +150,24 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         const spawn = install({agents: {a: agentDef('a')}, creds: {}});
         FleetLifecycleService.start('a');
         expect(spawn.calls[0].opts.env.NEO_NL_TOOL_PROJECTION_MODE).toBe('harness-embedded');
+    });
+
+    test('SECURITY: start fails fast when bridgeTokenEnvVar collides with credentialEnvVar (Bridge token would land in the PAT slot)', () => {
+        const spawn = install({agents: {a: agentDef('a')}, creds: {a: 'ghp_x'}});
+        FleetLifecycleService.bridgeTokenEnvVar = 'GH_TOKEN'; // === credentialEnvVar ⇒ credential classes collapse
+        expect(() => FleetLifecycleService.start('a')).toThrow(/env-key contract/);
+        expect(spawn.calls).toHaveLength(0); // guard is fail-fast: never spawned, no secret injected
+    });
+
+    test('SECURITY: start fails fast when a key collides with the fixed forced-projection var, or is empty', () => {
+        install({agents: {a: agentDef('a')}, creds: {a: 'ghp_x'}});
+        FleetLifecycleService.bridgeTokenEnvVar = 'NEO_NL_TOOL_PROJECTION_MODE'; // collides w/ the FIXED forced var
+        expect(() => FleetLifecycleService.start('a')).toThrow(/env-key contract/);
+
+        const spawn = install({agents: {a: agentDef('a')}, creds: {a: 'ghp_x'}}); // fresh install resets the keys
+        FleetLifecycleService.credentialEnvVar = ''; // empty key ⇒ contract violation
+        expect(() => FleetLifecycleService.start('a')).toThrow(/env-key contract/);
+        expect(spawn.calls).toHaveLength(0); // never spawned
     });
 
     test('a tokenless agent starts without injecting a fleet credential', () => {

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -371,4 +371,18 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         expect(full.length).toBeGreaterThan(0);
         expect(emptyForced, 'empty configured forced-mode leaked tools (should fail closed)').toEqual([]);
     });
+
+    test('resolveToolProjectionMode: CLI wins → NEO_NL_TOOL_PROJECTION_MODE env fallback → null (#13121)', async () => {
+        const {resolveToolProjectionMode} = await import(pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href);
+
+        // CLI flag wins over the env fallback
+        expect(resolveToolProjectionMode('harness-embedded', {})).toBe('harness-embedded');
+        expect(resolveToolProjectionMode('full', {NEO_NL_TOOL_PROJECTION_MODE: 'harness-embedded'})).toBe('full');
+        // env fallback when the CLI flag is absent (the Fleet Manager spawn-injection channel)
+        expect(resolveToolProjectionMode(null,      {NEO_NL_TOOL_PROJECTION_MODE: 'harness-embedded'})).toBe('harness-embedded');
+        expect(resolveToolProjectionMode(undefined, {NEO_NL_TOOL_PROJECTION_MODE: 'harness-embedded'})).toBe('harness-embedded');
+        // neither set → null (unforced → full developer/operator surface)
+        expect(resolveToolProjectionMode(null,      {})).toBeNull();
+        expect(resolveToolProjectionMode(undefined, {})).toBeNull();
+    });
 });


### PR DESCRIPTION
Resolves #13121

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace). Session e7f14a36-5096-4570-932b-82f860d7a537. Greenlit as a #13015 sub by @neo-opus-ada (steward).

The **capstone** that makes the two merged-but-dormant pieces live: `FleetLifecycleService.start(id)` now provisions an FM-spawned agent's harness-auth surfaces into the child env, wiring the registry's `mintBridgeToken` (#13065) and the Neural Link forced-projection knob (#13106) into the spawner (#13049). An FM-spawned agent is an *embedded* agent by definition, so it is provisioned read-only / fail-closed by construction.

Evidence: L2 (real env-injection through the recording `spawnFn` stub + real resolution-precedence assertions; **71 green** locally) → L2 required (in-process spawn-env + launch-arg resolution; the cross-process embedded-agent enforcement is the post-merge / #13056 surface). No residuals in this leaf.

## What shipped
- **`FleetLifecycleService.start(id)`** — alongside the PAT, mints a Bridge token and injects it into the child env under `bridgeTokenEnvVar` (default `NEO_FLEET_BRIDGE_TOKEN`, **distinct** from the PAT's `credentialEnvVar`), and injects `NEO_NL_TOOL_PROJECTION_MODE = 'harness-embedded'` for **every** spawn. The forced-projection var **name** is a module constant (`TOOL_PROJECTION_MODE_ENV_VAR`), **not** a configurable field — it is a cross-process contract the NL resolver reads by that exact name. Two new **plain** config fields (`bridgeTokenEnvVar`, `toolProjectionMode` — not reactive `_` configs; the singleton-test-bleed lesson).
- **Env-key contract guard** — `start()` asserts `credentialEnvVar`, `bridgeTokenEnvVar`, and the forced-projection var are **non-empty + pairwise distinct** *before* injecting any secret. Fail-fast: never spawn under a broken env contract.
- **`neural-link/Server.mjs`** — exports `resolveToolProjectionMode(cliMode, env)`: the single testable resolution authority — CLI `--tool-projection-mode` wins → `NEO_NL_TOOL_PROJECTION_MODE` env fallback → `null`.
- **`neural-link/mcp-server.mjs`** — uses `resolveToolProjectionMode(options.toolProjectionMode)` so the FM's env injection reaches the NL subprocess the harness launches; CLI flag still authoritative.

## Mechanism — why env-fallback, not appending `--tool-projection-mode` to args
The FM spawns the agent's *harness* (`metadata.launch.{command,args}`), NOT the NL server — the harness launches its NL server as a subprocess inheriting the harness env. So the clean cross-process channel is an env var the inheriting NL subprocess reads. The env-fallback is a launch-parameter source (like the CLI flag / `bridgeCwd`), **not** an AiConfig leaf — no ADR 0019 concern, consistent with #13106's deliberate CLI/instance-field choice. CLI precedence preserved.

## Deltas from ticket
- The forced-mode reaches the NL server via the `NEO_NL_TOOL_PROJECTION_MODE` env-fallback (a small extension to #13106's CLI-only knob), since the FM can't append CLI args to a server it doesn't directly spawn. Documented in the ticket's Architectural Reality + Contract Ledger.

## Review cycle 2 — GPT cross-family (env-key collision guard)
GPT's REQUEST_CHANGES flagged that the distinct-credential-class boundary was only **default-true**: the env keys were configurable, so a misconfiguration colliding two (e.g. `bridgeTokenEnvVar === credentialEnvVar`) wrote the PAT then *overwrote it* with the Bridge token — collapsing two classes into one slot (fail-OPEN). Two fixes, both mechanically enforced now:
1. **Collision guard** (above) — fail-fast non-empty + pairwise-distinct check before any injection. Negative-path tests cover the `bridgeTokenEnvVar === credentialEnvVar` case, collision with the fixed forced-projection var, and an empty key.
2. **Forced-projection var name fixed to a constant** — it was a configurable field whose override would set a var the NL resolver (reading the hardcoded `NEO_NL_TOOL_PROJECTION_MODE`) never reads → the forced read-only projection silently drops to full surface (fail-OPEN). The name is now a module constant on both sides; the *value* (`toolProjectionMode`) stays configurable (a mis-set value fails CLOSED downstream).

> Contract refinement vs #13121 ledger: the ledger named `toolProjectionModeEnvVar` (configurable). The credential-class **intent** is unchanged; the var name is now a fixed contract constant rather than a settable field. Ticket Contract Ledger reconciled in place.

## Test Evidence
- `npm run test-unit -- FleetLifecycleService.spec McpServerListToolsSmoke.spec BaseServer.spec` → **71 passed**. Covers: bridge-token + forced-mode env carriage (+ PAT unaffected + parent-env-not-mutated); the Bridge token never enters the process record/`status()`; forced mode set by construction even for a tokenless agent (fail-closed invariant); **env-key collision + empty-key guard (fail-fast, no spawn)**; `resolveToolProjectionMode` precedence (CLI > env > null).
- `check-ticket-archaeology` clean on all touched files; lint hooks green.

## Post-Merge Validation
- [ ] When the Neural-Link Bridge handshake (#13056) lands, confirm it reads `NEO_FLEET_BRIDGE_TOKEN` from its env + calls `verifyBridgeToken` (fail-closed on absence/mismatch).
- [ ] Real embedded spawn: confirm the harness's NL subprocess inherits `NEO_NL_TOOL_PROJECTION_MODE` and serves only read-tier tools (the cross-process L4 closure this leaf enables).

## Cross-family review note
With the all-Opus roster, the §6.1 cross-family Approved gate needs @neo-gpt (or @neo-gemini-pro if active). Touches a security boundary (credential injection + fail-closed projection) — worth a careful secret-surface + fail-closed pass. Cycle-2 head: `51a0c55bc`.

Related: #13015 (parent), #13049, #13065, #13106 (wired); #13056 (consumes the token); aligned ADR 0020.