### PR TITLE
docs(lead-role): add AC6 session evidence marker (#13122)

### DIFF
--- a/.agents/skills/lead-role/references/lead-role-mode.md
+++ b/.agents/skills/lead-role/references/lead-role-mode.md
@@ -118,6 +118,24 @@ When opening a `/lead-role` posture publicly, lead MUST name a strategic focus i
 
 **Empirical-anchor for verification**: #11195 30-day Step 2.5 validation tracker AC6 extension audits next 3 lead-role sessions for focus-naming compliance (focus-named Y/N + scope-correct Y/N).
 
+### 2.4 AC6 Evidence Marker
+
+*(Codified per #13122 after #11195 AC6 proved unscorable from free-form Memory Core recall.)*
+
+When opening a `/lead-role` posture publicly, include a compact `lead-role-session` marker in the lead-intake A2A (or send it as an immediate follow-up if the intake message already exists). The marker is the audit surface for #11195-style retrospective validation; future reviewers sort markers by `sentAt` instead of reconstructing the sample from vague semantic search.
+
+Required marker fields:
+- `leadRoleSessionId`: Memory Core session id when known, otherwise the A2A message id becomes the session anchor.
+- `lead`: canonical `@<identity>` of the lead.
+- `focus`: the named strategic focus from §2.3.
+- `focusGrain`: `sample-correct`, `too-broad`, or `too-narrow`, with one sentence of rationale.
+- `ownLane`: the lead's own visible lane, or `coordination-only` with rationale.
+- `peerRoleTargets`: artifacts where the lead explicitly used the literal `use /peer-role on X` trigger phrase; use `none` only when no substrate-validation peer request was made.
+- `peerEvidenceExpected`: short pointer to the peer-role §6.6 source-of-authority collision-check duty; do not duplicate that protocol here.
+- `authorityHierarchyOutcomes`: `none observed yet` at intake, then a closeout list of any conflicts resolved by `Current Public Authority > Handoff A2A > Recent Lane Claim`.
+
+Closeout discipline: before sunset or baton handoff, post a second `lead-role-session` marker that updates `authorityHierarchyOutcomes` and names any peer-role trigger that went unanswered. If no conflicts occurred, say `none observed` explicitly. A missing marker makes the session **unscorable for AC6**; do not infer compliance from scattered prose unless a marker is unavailable because the messaging substrate itself failed.
+
 ## 3. Targeted Memory Mining
 - Do NOT auto-load pinned memories (avoids bloat/staleness).
 - Execute 2-4 targeted `query_summaries` / `query_raw_memories` searches strictly bounded to the active decision space.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

Resolves #13122

Adds a compact `lead-role-session` evidence marker to the lead-role workflow payload so #11195-style retrospectives can score lead/peer coordination compliance from an explicit audit surface instead of broad semantic recall. The marker records focus, focus-grain, lead identity, own lane, peer-role trigger targets, peer evidence expectations, and Authority-hierarchy outcomes.

Evidence: L1 (workflow payload diff + skill-manifest lint + whitespace checks) -> L1 required (documentation/workflow-substrate contract; no runtime behavior ACs). No residuals for #13122.

## Deltas from ticket

Implementation stayed narrower than the ticket's broad expected shape:

- Updated only `.agents/skills/lead-role/references/lead-role-mode.md`.
- Left `.agents/skills/lead-role/SKILL.md` unchanged to keep the router lean.
- Cross-referenced peer-role §6.6 instead of duplicating source-of-authority collision-check mechanics.
- No code, daemon, scheduler, wake-cadence, or scoreboard changes.

## Substrate Slot Rationale

`/turn-memory-pre-flight` result: this is skill-loaded memory substrate. The rule governs a specific `/lead-role` lifecycle event, so the correct placement is the existing lead-role World-Atlas payload, not `AGENTS.md` and not the `SKILL.md` router.

- Added section: `lead-role-mode.md` §2.4 AC6 Evidence Marker.
- Disposition: `compress-to-trigger` / atlas-contained. The lead-role skill already loads this payload when `/lead-role` is active; no always-loaded router expansion was needed.
- Trigger-frequency: edge-case / lifecycle-specific — only lead-role intake and closeout.
- Failure-severity: moderate-high for validation integrity — missing this marker makes #11195 AC6 unscorable and causes repeated re-derivation.
- Enforceability: discipline-only today, but graph-readable marker shape creates a future mechanical-enforcement candidate.
- Decay mitigation: if a future A2A Task envelope or Memory Core session summary natively exposes these fields, this prose marker should compress to a one-line pointer or retire.

Load-effect audit:

- `cat .codex/hooks.json` and `cat .codex/hooks/codex-context.mjs` show Codex loads `.codex/CODEX.md` via hook, not this lead-role payload every turn.
- `readlink .claude/CLAUDE.md` resolves to `../AGENTS.md`; no Claude router change was made.
- `SKILL.md` unchanged; the net always-loaded skill-router delta is 0 bytes.

## Test Evidence

- `git diff --check` -> pass.
- `git diff --cached --check` -> pass before commit.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> pass.
- Husky staged-file whitespace check ran during commit -> pass.

No Playwright tests were run: this PR changes documentation/workflow substrate only and has no runtime code path.

## Post-Merge Validation

- [ ] The next public `/lead-role` intake includes a `lead-role-session` marker.
- [ ] The next lead-role sunset/baton handoff includes the closeout marker with Authority-hierarchy outcomes.
- [ ] #11195 AC6 can be scored from markers going forward; historical sessions without markers remain explicitly unscorable rather than inferred from scattered prose.

## Commits

- `8b05920cb` — `docs(lead-role): add AC6 session evidence marker (#13122)`

Related: #11195, #11209, PR #11223.
