### PR TITLE
feat(ai): topological lock conflict-detection core (#13125)

### DIFF
--- a/src/ai/LockRegistry.mjs
+++ b/src/ai/LockRegistry.mjs
@@ -203,15 +203,17 @@ class LockRegistry extends Base {
     }
 
     /**
-     * @summary Whether an explicit write target is mandatory given the live-session count.
-     * Encodes the auto-targeting-deprecation rule: with more than one session live, a writer must name its
-     * target, because the implicit "most recent session" shortcut (`ConnectionService.call()`) is only safe
-     * for a single writer. Zero or one live session keeps the back-compatible implicit path.
+     * @summary Whether an explicit write target is mandatory for the given live-session count (fail-safe).
+     * Only a count *known* to be exactly 0 or 1 permits the implicit "most recent session" shortcut
+     * (`ConnectionService.call()`, single-writer-safe). Any other value — 2+, or a non-finite / unexpected
+     * count such as a consumer's `sessions?.length` resolving to `undefined` — requires an explicit target:
+     * if the live-session count cannot be confirmed safe, we must not silently re-enable auto-targeting
+     * while co-habitation may be live. The fail direction is the strict one (`true`).
      * @param {Number} liveSessionCount
      * @returns {Boolean}
      */
     static requiresExplicitTarget(liveSessionCount) {
-        return Number.isFinite(liveSessionCount) && liveSessionCount > 1
+        return liveSessionCount !== 0 && liveSessionCount !== 1
     }
 }
 

--- a/src/ai/LockRegistry.mjs
+++ b/src/ai/LockRegistry.mjs
@@ -1,0 +1,218 @@
+import Base from '../core/Base.mjs';
+
+/**
+ * @summary Deterministic topological-lock conflict logic for multi-writer Neural Link coordination.
+ *
+ * `Neo.ai.LockRegistry` is the pure, side-effect-free *conflict-detection core* an in-heap (App-Worker)
+ * authority consults before applying a write-class Neural Link operation when more than one agent shares
+ * a live application heap — the co-habitation premise of the agent harness, where agents and humans mutate
+ * the same live components. Topological locking is sequenced ahead of any multi-writer slice: a slice either
+ * acquires its locks through this logic or explicitly declares itself single-writer.
+ *
+ * It is deliberately **not** a transport-side lock owner: the coordination epic rejects Bridge-authoritative
+ * locking because transport-held locks desync from in-heap reality under reconnects and worker restarts.
+ * The heap is the truth; this class is the logic the heap's authority enforces. Accordingly every method
+ * is **static and operates on a caller-held `lockTable`** (a plain array the authority owns), returning a
+ * new array rather than mutating shared state — so the logic carries no singleton lifecycle and is trivial
+ * to test and reason about.
+ *
+ * A lock is `{agentId, sessionId, subtreePath}`: a writer — identified by the `(agentId, sessionId)` pair —
+ * holds a component **subtree**, named by its root→node component-id path (`subtreePath`). Two locks conflict
+ * iff their subtrees overlap (equal, ancestor, or descendant paths) **and** they belong to *different*
+ * writers; sibling subtrees never conflict and same-writer re-acquisition is re-entrant. `sessionId` is
+ * consumed as an **opaque** string here — the canonical-session-id mechanics are a separate concern.
+ *
+ * Scope boundary: this leaf is the conflict logic only. In-heap enforcement (intercepting the write path),
+ * Bridge-side advisory mirroring, lock-lease expiry policy, and the canonical-id binding are named
+ * follow-up consumer slices, not this module.
+ * @class Neo.ai.LockRegistry
+ * @extends Neo.core.Base
+ */
+class LockRegistry extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.LockRegistry'
+         * @protected
+         */
+        className: 'Neo.ai.LockRegistry'
+    }
+
+    /**
+     * @summary Validate a lock descriptor, failing closed.
+     * Returns a normalized copy of the lock, or `null` when any field is missing or malformed — callers
+     * treat `null` as a denial, never as an empty or wildcard lock.
+     * @param {Object} lock
+     * @param {String} lock.agentId      Non-empty writer (agent) identity.
+     * @param {String} lock.sessionId    Non-empty, opaque, harness-native session id.
+     * @param {String[]} lock.subtreePath Ordered root→node component-id path; non-empty, all non-empty strings.
+     * @returns {Object|null}
+     */
+    static normalizeLock(lock) {
+        if (!lock || typeof lock !== 'object') {
+            return null
+        }
+
+        const {agentId, sessionId, subtreePath} = lock;
+
+        if (typeof agentId   !== 'string' || agentId   === '') {return null}
+        if (typeof sessionId !== 'string' || sessionId === '') {return null}
+        if (!Array.isArray(subtreePath) || subtreePath.length === 0) {return null}
+        if (!subtreePath.every(segment => typeof segment === 'string' && segment !== '')) {return null}
+
+        return {agentId, sessionId, subtreePath: [...subtreePath]}
+    }
+
+    /**
+     * @summary Stable string identity of a lock (writer + exact subtree), for dedup and release.
+     * Built with `JSON.stringify` over the field tuple, so distinct `(agentId, sessionId, subtreePath)`
+     * triples never collide regardless of the characters an id contains.
+     * @param {Object} lock A normalized lock.
+     * @returns {String}
+     */
+    static lockKey({agentId, sessionId, subtreePath}) {
+        return JSON.stringify([agentId, sessionId, subtreePath])
+    }
+
+    /**
+     * @summary Whether two locks belong to the same `(agentId, sessionId)` writer.
+     * @param {Object} a A normalized lock.
+     * @param {Object} b A normalized lock.
+     * @returns {Boolean}
+     */
+    static sameWriter(a, b) {
+        return a.agentId === b.agentId && a.sessionId === b.sessionId
+    }
+
+    /**
+     * @summary Whether two component subtrees overlap (one equals or contains the other).
+     * Overlap ⇔ one path is a prefix of the other (a prefix includes the equal case); sibling paths, which
+     * diverge before either ends, never overlap. A lock on the root path therefore overlaps everything.
+     * @param {String[]} a Ordered root→node id path.
+     * @param {String[]} b Ordered root→node id path.
+     * @returns {Boolean}
+     */
+    static pathsOverlap(a, b) {
+        const min = Math.min(a.length, b.length);
+
+        for (let i = 0; i < min; i++) {
+            if (a[i] !== b[i]) {
+                return false // diverged before either subtree root → siblings, disjoint
+            }
+        }
+
+        return true // one path is a prefix of the other (incl. equal) → subtrees overlap
+    }
+
+    /**
+     * @summary Find an existing lock held by a *different* writer whose subtree overlaps `candidate`.
+     * Returns the conflicting held lock (the first match), or `null` when `candidate` can be granted.
+     * Both arguments are expected to be normalized locks (see {@link normalizeLock}).
+     * @param {Object[]} lockTable Caller-held active locks (normalized).
+     * @param {Object} candidate   A normalized lock.
+     * @returns {Object|null}
+     */
+    static findConflict(lockTable, candidate) {
+        for (const held of lockTable) {
+            if (!LockRegistry.sameWriter(held, candidate) &&
+                LockRegistry.pathsOverlap(held.subtreePath, candidate.subtreePath)) {
+                return held
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Attempt to acquire a lock, returning a new table and the outcome — never mutates the input.
+     * Fail-closed in three layers: a malformed lock is denied with an error and an unchanged table; a
+     * cross-writer subtree overlap is denied with the conflicting holder; otherwise the lock is granted.
+     * Re-acquiring an identical lock by the same writer is re-entrant (granted, no duplicate appended).
+     * @param {Object[]} lockTable The caller-held active locks.
+     * @param {Object} lock        The lock to acquire.
+     * @returns {{lockTable: Object[], granted: Boolean, conflict: Object|null, errors: String[]}}
+     */
+    static acquire(lockTable, lock) {
+        const table = Array.isArray(lockTable) ? lockTable : [],
+              norm  = LockRegistry.normalizeLock(lock);
+
+        if (!norm) {
+            return {lockTable: table, granted: false, conflict: null, errors: ['invalid lock descriptor']}
+        }
+
+        const conflict = LockRegistry.findConflict(table, norm);
+
+        if (conflict) {
+            return {lockTable: table, granted: false, conflict, errors: []}
+        }
+
+        const key = LockRegistry.lockKey(norm);
+
+        if (table.some(held => LockRegistry.lockKey(held) === key)) {
+            return {lockTable: table, granted: true, conflict: null, errors: []} // re-entrant, idempotent
+        }
+
+        return {lockTable: [...table, norm], granted: true, conflict: null, errors: []}
+    }
+
+    /**
+     * @summary Release one exact lock (same writer + same subtree), idempotently.
+     * Releasing a lock that is not held is a no-op — the table is returned unchanged — so a double-release
+     * or a release after a sweep never throws. A lock on the same subtree held by a *different* writer is
+     * never released by this call.
+     * @param {Object[]} lockTable The caller-held active locks.
+     * @param {Object} lock        The lock to release.
+     * @returns {{lockTable: Object[]}}
+     */
+    static release(lockTable, lock) {
+        const table = Array.isArray(lockTable) ? lockTable : [],
+              norm  = LockRegistry.normalizeLock(lock);
+
+        if (!norm) {
+            return {lockTable: table}
+        }
+
+        const key = LockRegistry.lockKey(norm);
+
+        return {lockTable: table.filter(held => LockRegistry.lockKey(held) !== key)}
+    }
+
+    /**
+     * @summary Release every lock matching a writer selector — the disconnect / worker-restart sweep hook.
+     * Pass `agentId` and/or `sessionId`; a lock is swept when it matches *all* provided fields. Passing
+     * neither field selects nothing (fail-closed: a selector-less sweep never clears the whole table).
+     * @param {Object[]} lockTable  The caller-held active locks.
+     * @param {Object} [selector={}]
+     * @param {String} [selector.agentId]
+     * @param {String} [selector.sessionId]
+     * @returns {{lockTable: Object[], released: Number}}
+     */
+    static releaseAll(lockTable, selector = {}) {
+        const table = Array.isArray(lockTable) ? lockTable : [],
+              {agentId, sessionId} = selector;
+
+        if (agentId === undefined && sessionId === undefined) {
+            return {lockTable: table, released: 0}
+        }
+
+        const kept = table.filter(held => !(
+            (agentId   === undefined || held.agentId   === agentId) &&
+            (sessionId === undefined || held.sessionId === sessionId)
+        ));
+
+        return {lockTable: kept, released: table.length - kept.length}
+    }
+
+    /**
+     * @summary Whether an explicit write target is mandatory given the live-session count.
+     * Encodes the auto-targeting-deprecation rule: with more than one session live, a writer must name its
+     * target, because the implicit "most recent session" shortcut (`ConnectionService.call()`) is only safe
+     * for a single writer. Zero or one live session keeps the back-compatible implicit path.
+     * @param {Number} liveSessionCount
+     * @returns {Boolean}
+     */
+    static requiresExplicitTarget(liveSessionCount) {
+        return Number.isFinite(liveSessionCount) && liveSessionCount > 1
+    }
+}
+
+export default Neo.setupClass(LockRegistry);

--- a/test/playwright/unit/ai/LockRegistry.spec.mjs
+++ b/test/playwright/unit/ai/LockRegistry.spec.mjs
@@ -1,0 +1,278 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'LockRegistryTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import LockRegistry   from '../../../../src/ai/LockRegistry.mjs';
+
+/**
+ * A terse lock factory for the specs.
+ * @param {String} agentId
+ * @param {String} sessionId
+ * @param {String[]} subtreePath
+ * @returns {Object}
+ */
+const lock = (agentId, sessionId, subtreePath) => ({agentId, sessionId, subtreePath});
+
+test.describe('Neo.ai.LockRegistry', () => {
+    test.describe('normalizeLock (fail-closed validation)', () => {
+        test('accepts a well-formed lock and clones the path', () => {
+            const path = ['root', 'panel'],
+                  norm = LockRegistry.normalizeLock(lock('ada', 's1', path));
+
+            expect(norm).toEqual({agentId: 'ada', sessionId: 's1', subtreePath: ['root', 'panel']});
+            expect(norm.subtreePath).not.toBe(path); // defensive copy, not the caller's array
+        });
+
+        test('rejects a missing or empty agentId', () => {
+            expect(LockRegistry.normalizeLock(lock('',    's1', ['a']))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock(null,  's1', ['a']))).toBeNull();
+        });
+
+        test('rejects a missing or empty sessionId', () => {
+            expect(LockRegistry.normalizeLock(lock('ada', '',        ['a']))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', undefined, ['a']))).toBeNull();
+        });
+
+        test('rejects a non-array or empty subtreePath', () => {
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', []))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', 'root'))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', null))).toBeNull();
+        });
+
+        test('rejects a subtreePath with an empty or non-string segment', () => {
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', ['a', '']))).toBeNull();
+            expect(LockRegistry.normalizeLock(lock('ada', 's1', ['a', 7]))).toBeNull();
+        });
+
+        test('rejects non-objects', () => {
+            expect(LockRegistry.normalizeLock(null)).toBeNull();
+            expect(LockRegistry.normalizeLock('lock')).toBeNull();
+            expect(LockRegistry.normalizeLock(undefined)).toBeNull();
+        });
+    });
+
+    test.describe('pathsOverlap (subtree overlap matrix)', () => {
+        test('equal paths overlap', () => {
+            expect(LockRegistry.pathsOverlap(['a', 'b'], ['a', 'b'])).toBe(true);
+        });
+
+        test('an ancestor overlaps its descendant (both directions)', () => {
+            expect(LockRegistry.pathsOverlap(['a'],      ['a', 'b', 'c'])).toBe(true);
+            expect(LockRegistry.pathsOverlap(['a', 'b', 'c'], ['a'])).toBe(true);
+        });
+
+        test('siblings that diverge never overlap', () => {
+            expect(LockRegistry.pathsOverlap(['a', 'b'], ['a', 'c'])).toBe(false);
+        });
+
+        test('different roots never overlap', () => {
+            expect(LockRegistry.pathsOverlap(['a'], ['b'])).toBe(false);
+        });
+
+        test('a root-level lock overlaps everything under that root', () => {
+            expect(LockRegistry.pathsOverlap(['root'], ['root', 'x', 'y', 'z'])).toBe(true);
+        });
+    });
+
+    test.describe('sameWriter', () => {
+        test('same agentId and sessionId is the same writer', () => {
+            expect(LockRegistry.sameWriter(lock('ada', 's1', ['a']), lock('ada', 's1', ['b']))).toBe(true);
+        });
+
+        test('a different agentId or sessionId is a different writer', () => {
+            expect(LockRegistry.sameWriter(lock('ada', 's1', ['a']), lock('vega', 's1', ['a']))).toBe(false);
+            expect(LockRegistry.sameWriter(lock('ada', 's1', ['a']), lock('ada',  's2', ['a']))).toBe(false);
+        });
+    });
+
+    test.describe('lockKey', () => {
+        test('is stable for the same lock and distinct across writer or path', () => {
+            const a = LockRegistry.lockKey(lock('ada', 's1', ['root', 'p'])),
+                  b = LockRegistry.lockKey(lock('ada', 's1', ['root', 'p'])),
+                  c = LockRegistry.lockKey(lock('ada', 's1', ['root', 'q'])),
+                  d = LockRegistry.lockKey(lock('vega', 's1', ['root', 'p']));
+
+            expect(a).toBe(b);
+            expect(a).not.toBe(c);
+            expect(a).not.toBe(d);
+        });
+
+        test('does not collide when an id contains the separator characters', () => {
+            const a = LockRegistry.lockKey(lock('a"b', 's', ['x'])),
+                  b = LockRegistry.lockKey(lock('a',   'b"s', ['x']));
+
+            expect(a).not.toBe(b);
+        });
+    });
+
+    test.describe('findConflict', () => {
+        test('a different writer on an overlapping subtree conflicts', () => {
+            const table = [lock('ada', 's1', ['root', 'p'])],
+                  held  = LockRegistry.findConflict(table, lock('vega', 's2', ['root', 'p', 'child']));
+
+            expect(held).toBe(table[0]);
+        });
+
+        test('the same writer on an overlapping subtree does not conflict', () => {
+            const table = [lock('ada', 's1', ['root', 'p'])];
+            expect(LockRegistry.findConflict(table, lock('ada', 's1', ['root', 'p', 'child']))).toBeNull();
+        });
+
+        test('a different writer on a sibling subtree does not conflict', () => {
+            const table = [lock('ada', 's1', ['root', 'p'])];
+            expect(LockRegistry.findConflict(table, lock('vega', 's2', ['root', 'q']))).toBeNull();
+        });
+
+        test('an empty table never conflicts', () => {
+            expect(LockRegistry.findConflict([], lock('ada', 's1', ['a']))).toBeNull();
+        });
+    });
+
+    test.describe('acquire', () => {
+        test('grants on an empty table and grows it', () => {
+            const result = LockRegistry.acquire([], lock('ada', 's1', ['root']));
+
+            expect(result.granted).toBe(true);
+            expect(result.conflict).toBeNull();
+            expect(result.errors).toEqual([]);
+            expect(result.lockTable).toHaveLength(1);
+        });
+
+        test('denies a malformed lock with an error and an unchanged table', () => {
+            const table  = [lock('ada', 's1', ['root'])],
+                  result = LockRegistry.acquire(table, lock('', 's1', ['x']));
+
+            expect(result.granted).toBe(false);
+            expect(result.errors.length).toBeGreaterThan(0);
+            expect(result.lockTable).toBe(table); // unchanged reference
+        });
+
+        test('denies a cross-writer subtree overlap and reports the holder', () => {
+            const table  = [LockRegistry.normalizeLock(lock('ada', 's1', ['root', 'p']))],
+                  result = LockRegistry.acquire(table, lock('vega', 's2', ['root', 'p']));
+
+            expect(result.granted).toBe(false);
+            expect(result.conflict).toBe(table[0]);
+            expect(result.lockTable).toHaveLength(1);
+        });
+
+        test('is re-entrant: the same writer re-acquiring an identical lock adds no duplicate', () => {
+            const first  = LockRegistry.acquire([], lock('ada', 's1', ['root', 'p'])),
+                  second = LockRegistry.acquire(first.lockTable, lock('ada', 's1', ['root', 'p']));
+
+            expect(second.granted).toBe(true);
+            expect(second.lockTable).toHaveLength(1);
+        });
+
+        test('lets the same writer hold a nested descendant lock', () => {
+            const first  = LockRegistry.acquire([], lock('ada', 's1', ['root'])),
+                  second = LockRegistry.acquire(first.lockTable, lock('ada', 's1', ['root', 'child']));
+
+            expect(second.granted).toBe(true);
+            expect(second.lockTable).toHaveLength(2);
+        });
+
+        test('never mutates the input table', () => {
+            const table = [];
+            LockRegistry.acquire(table, lock('ada', 's1', ['root']));
+            expect(table).toHaveLength(0);
+        });
+    });
+
+    test.describe('release (idempotent)', () => {
+        test('removes the exact lock', () => {
+            const acquired = LockRegistry.acquire([], lock('ada', 's1', ['root', 'p'])),
+                  released = LockRegistry.release(acquired.lockTable, lock('ada', 's1', ['root', 'p']));
+
+            expect(released.lockTable).toHaveLength(0);
+        });
+
+        test('is a no-op when the lock is not held', () => {
+            const table    = [LockRegistry.normalizeLock(lock('ada', 's1', ['root']))],
+                  released = LockRegistry.release(table, lock('ada', 's1', ['other']));
+
+            expect(released.lockTable).toHaveLength(1);
+        });
+
+        test('never releases a different writer holding the same subtree', () => {
+            const table    = [LockRegistry.normalizeLock(lock('ada', 's1', ['root']))],
+                  released = LockRegistry.release(table, lock('vega', 's2', ['root']));
+
+            expect(released.lockTable).toHaveLength(1);
+        });
+
+        test('returns the table unchanged for a malformed lock', () => {
+            const table    = [LockRegistry.normalizeLock(lock('ada', 's1', ['root']))],
+                  released = LockRegistry.release(table, lock('', '', []));
+
+            expect(released.lockTable).toBe(table);
+        });
+    });
+
+    test.describe('releaseAll (disconnect / restart sweep)', () => {
+        const populated = () => [
+            LockRegistry.normalizeLock(lock('ada',  's1', ['a'])),
+            LockRegistry.normalizeLock(lock('ada',  's2', ['b'])),
+            LockRegistry.normalizeLock(lock('vega', 's1', ['c']))
+        ];
+
+        test('sweeps every lock for an agentId', () => {
+            const result = LockRegistry.releaseAll(populated(), {agentId: 'ada'});
+
+            expect(result.released).toBe(2);
+            expect(result.lockTable).toHaveLength(1);
+            expect(result.lockTable[0].agentId).toBe('vega');
+        });
+
+        test('sweeps every lock for a sessionId', () => {
+            const result = LockRegistry.releaseAll(populated(), {sessionId: 's1'});
+
+            expect(result.released).toBe(2);
+            expect(result.lockTable.every(l => l.sessionId !== 's1')).toBe(true);
+        });
+
+        test('sweeps only locks matching both fields when both are given', () => {
+            const result = LockRegistry.releaseAll(populated(), {agentId: 'ada', sessionId: 's1'});
+
+            expect(result.released).toBe(1);
+            expect(result.lockTable).toHaveLength(2);
+        });
+
+        test('fails closed: a selector-less sweep clears nothing', () => {
+            const table  = populated(),
+                  result = LockRegistry.releaseAll(table, {});
+
+            expect(result.released).toBe(0);
+            expect(result.lockTable).toBe(table);
+        });
+    });
+
+    test.describe('requiresExplicitTarget', () => {
+        test('is false for zero or one live session (implicit target allowed)', () => {
+            expect(LockRegistry.requiresExplicitTarget(0)).toBe(false);
+            expect(LockRegistry.requiresExplicitTarget(1)).toBe(false);
+        });
+
+        test('is true once more than one session is live', () => {
+            expect(LockRegistry.requiresExplicitTarget(2)).toBe(true);
+            expect(LockRegistry.requiresExplicitTarget(5)).toBe(true);
+        });
+
+        test('fails closed to false for non-finite counts', () => {
+            expect(LockRegistry.requiresExplicitTarget(NaN)).toBe(false);
+            expect(LockRegistry.requiresExplicitTarget(Infinity)).toBe(false);
+        });
+    });
+});

--- a/test/playwright/unit/ai/LockRegistry.spec.mjs
+++ b/test/playwright/unit/ai/LockRegistry.spec.mjs
@@ -270,9 +270,12 @@ test.describe('Neo.ai.LockRegistry', () => {
             expect(LockRegistry.requiresExplicitTarget(5)).toBe(true);
         });
 
-        test('fails closed to false for non-finite counts', () => {
-            expect(LockRegistry.requiresExplicitTarget(NaN)).toBe(false);
-            expect(LockRegistry.requiresExplicitTarget(Infinity)).toBe(false);
+        test('fails safe (requires explicit) for non-finite or unexpected counts', () => {
+            expect(LockRegistry.requiresExplicitTarget(NaN)).toBe(true);
+            expect(LockRegistry.requiresExplicitTarget(Infinity)).toBe(true);
+            // the realistic trigger: a consumer's `sessions?.length` resolving to `undefined`
+            expect(LockRegistry.requiresExplicitTarget(undefined)).toBe(true);
+            expect(LockRegistry.requiresExplicitTarget(-1)).toBe(true);
         });
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13125

Adds `Neo.ai.LockRegistry`, the pure conflict-detection core for the **Topological Locking** surface of #13056 (Extended-NL coordination) — the *Isolation / conflict-semantics* leaf. It is the deterministic logic an in-heap (App-Worker) authority consults before applying a write-class Neural Link operation when more than one agent shares a live application heap; multi-writer co-habitation (ADR 0020 §1) makes it load-bearing, and the epic's guardrail sequences locking ahead of any multi-writer slice.

Deliberately bounded to **pure logic**:

- **Static, immutable-friendly** — every method operates on a caller-held `lockTable` array and returns a new array; no singleton lifecycle, no shared mutable state, so the in-heap authority owns the table and this module owns only the rules.
- **Not a transport-side owner** — the epic rejects Bridge-authoritative locking (transport-held locks desync from in-heap reality under reconnects/restarts); the heap is the truth and this is the logic it enforces.
- **Subtree-overlap conflict** — two locks conflict iff their component-subtree paths overlap (equal / ancestor / descendant) **and** they belong to different `(agentId, sessionId)` writers; sibling subtrees never conflict; same-writer re-acquisition is re-entrant.
- **Fail-closed** — a malformed lock descriptor is denied (never treated as an empty/wildcard lock); a selector-less sweep clears nothing.
- **Explicit-target predicate** — encodes the auto-targeting deprecation: more than one live session ⇒ an explicit write target is mandatory.
- `sessionId` is consumed as an **opaque** string — the canonical-session-id mechanics are a separate concern (#12984).

## Deltas from ticket

None of substance. `lockKey` uses `JSON.stringify` over the `(agentId, sessionId, subtreePath)` tuple — collision-free across any id characters — rather than a delimiter join. The subtree is represented as an ordered root→node id array; overlap is prefix containment.

Evidence: L1 (36 unit tests — fail-closed validation, the subtree-overlap matrix, same/cross-writer conflict, acquire / release / sweep, re-entrancy, and the explicit-target predicate; pure-JSON logic, no host-runtime ACs) → L1 required (internal conflict-logic contract only). Residual, altitude-honest: the **real multi-writer in-heap behavior** is the named enforcement slice's higher-altitude proof — a converged unit test of the rules is not a live-heap behavior test.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/LockRegistry.spec.mjs
→ 36 passed (757ms)
```

Pre-commit hooks green (`check-whitespace`, `check-shorthand`, `check-ticket-archaeology`).

## Post-Merge Validation

- [ ] When the in-heap enforcement slice lands, confirm `Neo.ai.Client`'s write path consults `LockRegistry` before applying a write-class op, and that a cross-writer conflict denies with the holder (whitebox-e2e, two live sessions).
- [ ] When canonical-session-id (#12984) lands, confirm the `sessionId` used as the opaque key is the harness-native id, not the MCP transport id.
- [ ] The enforcement slice constructs `subtreePath` as the **absolute** root→node component-id path (so prefix-overlap genuinely means ancestor/descendant) — a relative path would let unrelated subtrees sharing a head id false-overlap; assert this at the consumer (per cross-family review).

## Structural Pre-Flight

Full pre-flight (novel file): chose `src/ai/LockRegistry.mjs` (`Neo.ai.LockRegistry`), sibling to `Neo.ai.Client` — the Body-side in-heap Neural Link client whose `src/ai/client/` services execute the mutations this logic will gate. The framework (`src/`) cannot depend on the Brain (`ai/`), but `ai/` already imports `src/`, so the shared pure logic belongs `src/`-side. Rejected `ai/` (Brain-side — would invert the dependency) and `src/manager/` (framework-general singletons; this is agent-coordination logic the in-heap authority instantiates). Map-maintenance: not-needed.

Refs #13056, #13012, #12984. Source of authority: the #13056 body (converged plan-of-record).
