### PR TITLE
feat(ai): deprecate NL auto-targeting under multiple live sessions (#13129)

### DIFF
--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -3,8 +3,9 @@ import {spawn}   from 'child_process';
 import crypto    from 'crypto';
 import fs        from 'fs';
 import WebSocket from 'ws';
-import Base      from '../../../src/core/Base.mjs';
-import logger    from '../../mcp/server/neural-link/logger.mjs';
+import Base              from '../../../src/core/Base.mjs';
+import logger            from '../../mcp/server/neural-link/logger.mjs';
+import {resolveCallTarget} from './resolveCallTarget.mjs';
 
 /**
  * @summary Manages the connection to the Neural Link Bridge and orchestrates RPC calls.
@@ -100,16 +101,8 @@ class ConnectionService extends Base {
             throw new Error('Not connected to Neural Link Bridge');
         }
 
-        // If no sessionId, pick the most recent one (Auto-Targeting)
-        if (!sessionId) {
-            if (this.sessionData.size > 0) {
-                sessionId = Array.from(this.sessionData.keys()).pop();
-                logger.warn(`No sessionId provided. Defaulting to ${sessionId}`);
-            } else {
-                // Wait for a session?
-                throw new Error('No active App Worker sessions found.');
-            }
-        }
+        // Resolve the target session (explicit target honored; silent multi-session auto-targeting denied).
+        sessionId = resolveCallTarget(sessionId, Array.from(this.sessionData.keys()));
 
         const id = ++this.msgId;
         const rpcMessage = {

--- a/ai/services/neural-link/resolveCallTarget.mjs
+++ b/ai/services/neural-link/resolveCallTarget.mjs
@@ -1,0 +1,35 @@
+/**
+ * @summary Resolve the target session for an outbound Neural Link call, deprecating silent auto-targeting.
+ *
+ * Pure target-resolution rule for `ConnectionService.call()`, extracted as a side-effect-free function so it
+ * is testable without standing up the Bridge-connected service singleton.
+ *
+ * An explicit `sessionId` is always honored. With no explicit target the legacy path auto-picked the
+ * most-recently-connected session — safe for a single writer, but a silent cross-writer footgun once two
+ * agents share the Bridge (a call meant for one session could land on whichever connected last). So when
+ * **more than one** session is live an explicit target is now mandatory and this throws rather than guessing;
+ * a single live session still resolves implicitly (back-compatible), and zero live sessions throws as before.
+ *
+ * @param {String|null} sessionId    The explicit target session id, or a falsy value to resolve implicitly.
+ * @param {String[]} liveSessionIds  Currently-live session ids (e.g. `[...connectionService.sessionData.keys()]`).
+ * @returns {String} The resolved target session id.
+ * @throws {Error} When no explicit target is given and either zero or more-than-one sessions are live.
+ */
+export function resolveCallTarget(sessionId, liveSessionIds) {
+    if (sessionId) {
+        return sessionId
+    }
+
+    if (liveSessionIds.length === 0) {
+        throw new Error('No active App Worker sessions found.')
+    }
+
+    if (liveSessionIds.length > 1) {
+        throw new Error(
+            `Auto-targeting is disabled with ${liveSessionIds.length} live sessions: pass an explicit ` +
+            'sessionId. Silent most-recent targeting is unsafe with concurrent writers.'
+        )
+    }
+
+    return liveSessionIds[0]
+}

--- a/test/playwright/unit/ai/resolveCallTarget.spec.mjs
+++ b/test/playwright/unit/ai/resolveCallTarget.spec.mjs
@@ -1,0 +1,31 @@
+import {test, expect}      from '@playwright/test';
+import {resolveCallTarget} from '../../../../ai/services/neural-link/resolveCallTarget.mjs';
+
+// Pure function — imported directly (not via the Bridge-connected ConnectionService singleton), so the
+// suite has no host-runtime side effects and each case is fully isolated.
+test.describe('resolveCallTarget (Neural Link auto-targeting deprecation)', () => {
+    test('honors an explicit target regardless of the live-session count', () => {
+        expect(resolveCallTarget('s2', ['s1', 's2', 's3'])).toBe('s2');
+        // explicit wins even with zero live sessions — the Bridge owns existence checks
+        expect(resolveCallTarget('only', [])).toBe('only');
+    });
+
+    test('resolves implicitly to the single live session (back-compat)', () => {
+        expect(resolveCallTarget(null,      ['solo'])).toBe('solo');
+        expect(resolveCallTarget(undefined, ['solo'])).toBe('solo');
+    });
+
+    test('throws the no-sessions error when none are live and no target is given', () => {
+        expect(() => resolveCallTarget(null, [])).toThrow(/No active App Worker sessions/);
+    });
+
+    test('denies silent auto-targeting when more than one session is live', () => {
+        expect(() => resolveCallTarget(null, ['a', 'b'])).toThrow(/explicit/i);
+        expect(() => resolveCallTarget(null, ['a', 'b', 'c'])).toThrow(/Auto-targeting is disabled/);
+    });
+
+    test('the boundary is strictly greater-than-one (1 implicit, 2 explicit-required)', () => {
+        expect(() => resolveCallTarget(null, ['a'])).not.toThrow();
+        expect(() => resolveCallTarget(null, ['a', 'b'])).toThrow();
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13129

Deprecates the Neural Link's silent auto-targeting (#13056 audit finding #2). `ConnectionService.call()` defaulted to the *most-recently-connected* session when no `sessionId` was passed — correct for a single writer, but a silent cross-writer footgun once two agents share the Bridge: a call meant for session A could land on whichever session connected last.

The target-resolution rule is extracted into a pure `resolveCallTarget(sessionId, liveSessionIds)`:

- **explicit target** → always honored (the Bridge owns existence checks);
- **zero live sessions** → the existing `No active App Worker sessions found.` throw, unchanged;
- **more than one live session** → an explicit-target-required throw (the deprecation — no more silent guessing);
- **exactly one live session** → resolved implicitly (back-compatible single-writer path).

`call()` delegates to it; the only behavioral change is that the *multi-session implicit* case now throws instead of guessing.

## Deltas from ticket

- Extracted the rule into its own pure module (`ai/services/neural-link/resolveCallTarget.mjs`) rather than a method on the singleton, so it is testable **without importing the Bridge-connected `ConnectionService`** — importing that singleton auto-connects (and in CI, with no Bridge present, would *spawn* one), which a unit test must not do. The pure function has zero host side-effects (verified: the suite logs no Bridge connection).
- Decoupled from #13125: the `> 1` threshold is inlined rather than importing `LockRegistry.requiresExplicitTarget`, so this PR is independently mergeable (LockRegistry is not yet on `dev`). Single-sourcing the threshold once #13125/#13126 lands is a trivial named follow-up.

Evidence: L1 (5 unit tests — explicit / zero / one / many sessions; pure-function logic, no host-runtime ACs) → L1 required (internal target-resolution rule). Residual: the live two-session Bridge behavior (a real concurrent-writer call being denied) is the named e2e residual — a unit test of the resolver is not a live two-writer test.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/resolveCallTarget.spec.mjs
→ 5 passed (906ms)
```

No Bridge connection occurs during the suite (the pure module is imported directly, not via `ConnectionService`). Pre-commit hooks green (`check-whitespace`, `check-shorthand`, `check-ticket-archaeology`).

## Post-Merge Validation

- [ ] With two live App-Worker sessions on the Bridge, a `call()` with no explicit `sessionId` is denied with the explicit-target-required error (whitebox-e2e); a single-session call still resolves implicitly.
- [ ] Once #13125 / #13126 (`LockRegistry`) lands on `dev`, fold `resolveCallTarget`'s `> 1` threshold to delegate to `LockRegistry.requiresExplicitTarget` for a single source of truth.

## Structural Pre-Flight

Fast-path (sibling-lift): `ai/services/neural-link/resolveCallTarget.mjs` sits beside `ConnectionService.mjs` (its sole consumer) — a pure helper co-located with the service it serves, mirroring the existing non-class `logger.mjs` module in the same directory. Spec at `test/playwright/unit/ai/resolveCallTarget.spec.mjs` per the flat `unit/ai/` convention the sibling service specs use. Map-maintenance: not-needed.

Refs #13056, #13012, #13125. Source of authority: the #13056 body (audit finding #2).
