### PR TITLE
feat(state): resolve provider store source ids (#6983)

### DIFF
--- a/src/state/Provider.mjs
+++ b/src/state/Provider.mjs
@@ -211,6 +211,8 @@ class Provider extends Base {
 
     /**
      * Triggered before the stores config gets changed.
+     * @summary Normalizes provider-local store configs before instantiation, including predictable same-provider
+     * ids and sibling-key `sourceId` references.
      * @param {Object|null} value
      * @param {Object|null} oldValue
      * @returns {Object|null}
@@ -218,9 +220,21 @@ class Provider extends Base {
      */
     beforeSetStores(value, oldValue) {
         if (value) {
-            let me = this;
+            const
+                me       = this,
+                storeIds = {};
 
             Object.entries(value).forEach(([key, storeValue]) => {
+                const storeId = me.getProviderStoreId(key, storeValue);
+
+                if (storeId) {
+                    storeIds[key] = storeId
+                }
+            });
+
+            Object.entries(value).forEach(([key, storeValue]) => {
+                storeValue = me.normalizeProviderStoreConfig(key, storeValue, storeIds);
+
                 // support mapping string based listeners into the stateProvider instance
                 Object.entries(storeValue.listeners || {}).forEach(([listenerKey, listener]) => {
                     me.bindCallback(listener, listenerKey, me, storeValue.listeners)
@@ -231,6 +245,72 @@ class Provider extends Base {
         }
 
         return value
+    }
+
+    /**
+     * Resolves the id a provider-local store config will use after instantiation.
+     * @summary Store config keys become predictable instance ids unless an explicit id or existing instance id
+     * already owns the store identity.
+     * @param {String} key
+     * @param {Class|Object|Neo.core.Base} storeValue
+     * @returns {String|null}
+     * @protected
+     */
+    getProviderStoreId(key, storeValue) {
+        const type = Neo.typeOf(storeValue);
+
+        if (type === 'NeoInstance') {
+            return storeValue.id
+        }
+
+        if (type === 'Object') {
+            return storeValue.id || `${this.id}__${key}`
+        }
+
+        if (type === 'NeoClass') {
+            return `${this.id}__${key}`
+        }
+
+        return null
+    }
+
+    /**
+     * Normalizes a provider-local store declaration before the ClassSystem creates the instance.
+     * @summary Converts class shorthand to config objects, assigns missing predictable ids, and resolves
+     * sibling store-key `sourceId` values to their concrete instance ids.
+     * @param {String} key
+     * @param {Class|Object|Neo.core.Base} storeValue
+     * @param {Object} storeIds
+     * @returns {Class|Object|Neo.core.Base}
+     * @protected
+     */
+    normalizeProviderStoreConfig(key, storeValue, storeIds) {
+        let type = Neo.typeOf(storeValue);
+
+        if (type === 'NeoInstance') {
+            return storeValue
+        }
+
+        if (type === 'NeoClass') {
+            storeValue = {module: storeValue};
+            type       = 'Object'
+        }
+
+        if (type === 'Object') {
+            const config = {...storeValue};
+
+            if (!config.id) {
+                config.id = storeIds[key]
+            }
+
+            if (Neo.isString(config.sourceId) && storeIds[config.sourceId]) {
+                config.sourceId = storeIds[config.sourceId]
+            }
+
+            return config
+        }
+
+        return storeValue
     }
 
     /**

--- a/test/playwright/unit/state/Provider.spec.mjs
+++ b/test/playwright/unit/state/Provider.spec.mjs
@@ -14,6 +14,7 @@ setup({
 
 import {test, expect}  from '@playwright/test';
 import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
 import Component       from '../../../../src/component/Base.mjs';
 import InstanceManager from '../../../../src/manager/Instance.mjs';
 import StateProvider   from '../../../../src/state/Provider.mjs';
@@ -266,7 +267,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
         expect(component.testConfig).toBe('A');
         expect(component.userObject).toBe('B');
-        
+
         // Ensure both effects exist and haven't overwritten each other
         expect(effect1.isDestroyed).toBe(false);
         expect(effect2.isDestroyed).toBe(false);
@@ -276,7 +277,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
         // The old effect for 'testConfig' MUST be destroyed to prevent leaks/conflicts
         expect(effect1.isDestroyed).toBe(true);
-        
+
         // The new effect should be active
         expect(effect3.isDestroyed).toBe(false);
         expect(component.testConfig).toBe('C');
@@ -382,6 +383,100 @@ test.describe('Neo.state.Provider (Node.js)', () => {
 
         component.destroy();
         store.destroy();
+    });
+
+    test('Inline provider stores should get predictable ids and resolve sibling sourceId keys', () => {
+        const component = Neo.create(MockComponent, {
+            stateProvider: {
+                id: 'state-provider-sourceid-test',
+                stores: {
+                    users: {
+                        module: Store,
+                        data  : [{id: 1, name: 'Item 1'}],
+                        model : {fields: [{name: 'id'}, {name: 'name'}]}
+                    },
+                    activeUsers: {
+                        module  : Store,
+                        sourceId: 'users',
+                        model   : {fields: [{name: 'id'}, {name: 'name'}]}
+                    }
+                }
+            },
+            bind: {
+                testConfig: 'stores.activeUsers'
+            }
+        });
+
+        const
+            provider    = component.getStateProvider(),
+            users       = provider.getStore('users'),
+            activeUsers = provider.getStore('activeUsers');
+
+        expect(users.id).toBe('state-provider-sourceid-test__users');
+        expect(activeUsers.id).toBe('state-provider-sourceid-test__activeUsers');
+        expect(activeUsers.sourceId).toBe(users.id);
+        expect(activeUsers.getSource()).toBe(users);
+        expect(component.testConfig).toBe(activeUsers);
+        expect(activeUsers.count).toBe(1);
+
+        users.add({id: 2, name: 'Item 2'});
+        expect(activeUsers.count).toBe(2);
+
+        component.destroy();
+        activeUsers.destroy();
+        users.destroy();
+    });
+
+    test('Provider store sourceId resolution should preserve explicit and external ids', () => {
+        const externalStore = Neo.create(Store, {
+            id   : 'provider-sourceid-external-store',
+            data : [{id: 1, name: 'External 1'}],
+            model: {fields: [{name: 'id'}, {name: 'name'}]}
+        });
+
+        const component = Neo.create(MockComponent, {
+            stateProvider: {
+                id: 'state-provider-explicit-sourceid-test',
+                stores: {
+                    explicitUsers: {
+                        id    : 'provider-sourceid-explicit-users',
+                        module: Store,
+                        data  : [{id: 1, name: 'Item 1'}],
+                        model : {fields: [{name: 'id'}, {name: 'name'}]}
+                    },
+                    explicitUsersCopy: {
+                        module  : Store,
+                        sourceId: 'explicitUsers',
+                        model   : {fields: [{name: 'id'}, {name: 'name'}]}
+                    },
+                    externalUsersCopy: {
+                        module  : Store,
+                        sourceId: 'provider-sourceid-external-store',
+                        model   : {fields: [{name: 'id'}, {name: 'name'}]}
+                    }
+                }
+            }
+        });
+
+        const
+            provider          = component.getStateProvider(),
+            explicitUsers     = provider.getStore('explicitUsers'),
+            explicitUsersCopy = provider.getStore('explicitUsersCopy'),
+            externalUsersCopy = provider.getStore('externalUsersCopy');
+
+        expect(explicitUsers.id).toBe('provider-sourceid-explicit-users');
+        expect(explicitUsersCopy.sourceId).toBe('provider-sourceid-explicit-users');
+        expect(explicitUsersCopy.getSource()).toBe(explicitUsers);
+
+        expect(externalUsersCopy.sourceId).toBe('provider-sourceid-external-store');
+        expect(externalUsersCopy.getSource()).toBe(externalStore);
+        expect(externalUsersCopy.id).toBe('state-provider-explicit-sourceid-test__externalUsersCopy');
+
+        component.destroy();
+        explicitUsersCopy.destroy();
+        externalUsersCopy.destroy();
+        explicitUsers.destroy();
+        externalStore.destroy();
     });
 
     test('Provider data_ config should deep merge class and instance level data', () => {
@@ -524,7 +619,7 @@ test.describe('Neo.state.Provider (Node.js)', () => {
             }
         });
 
-        // Effect execution is asynchronous in some test contexts or deferred, 
+        // Effect execution is asynchronous in some test contexts or deferred,
         // but here they are evaluated synchronously on creation if state exists.
         expect(component.testConfig1).toBe('A');
         expect(component.testConfig2).toBe('B');


### PR DESCRIPTION
Resolves #6983

Authored by GPT-5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

StateProvider store configs now get predictable same-provider ids when no explicit id is supplied, using the provider/key shape requested by the ticket. Same-provider `sourceId` values can now reference a sibling store key while explicit ids and external instance ids continue to resolve unchanged.

Evidence: L2 (focused unit coverage + syntax/hook checks) -> L2 required (state/store contract fully covered in Node unit harness). No residuals.

## Deltas from ticket

The implementation also accepts class shorthand store declarations during provider-local normalization by converting them to config objects before instantiation. Reverse-order/topological sibling resolution is intentionally out of scope; the ticket describes same-provider references, and this PR preserves the existing declaration-order contract.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/state/Provider.spec.mjs test/playwright/unit/collection/Base.spec.mjs` -> 28 passed
- `git diff --check` -> passed
- `node --check src/state/Provider.mjs` -> passed
- `node --check test/playwright/unit/state/Provider.spec.mjs` -> passed
- `node ./buildScripts/util/check-whitespace.mjs test/playwright/unit/state/Provider.spec.mjs src/state/Provider.mjs` -> passed
- `node ./buildScripts/util/check-shorthand.mjs test/playwright/unit/state/Provider.spec.mjs src/state/Provider.mjs` -> 2 files scanned, 0 violations

## Post-Merge Validation

- [ ] A provider-local store config using `sourceId: '<sibling-key>'` resolves after merge in a downstream app without requiring manual store ids.

## Commits

- `b9b9814d6` - `feat(state): resolve provider store source ids (#6983)`
