### PR TITLE
feat(ai): in-heap WriteGuard held-lock authority (#13134)

### DIFF
--- a/src/ai/WriteGuard.mjs
+++ b/src/ai/WriteGuard.mjs
@@ -2,6 +2,14 @@ import Base         from '../core/Base.mjs';
 import LockRegistry from './LockRegistry.mjs';
 
 /**
+ * Defensive copy of a lock descriptor — the lock object **and** its `subtreePath` array — so the in-heap
+ * authority never hands a caller a reference into its live held-lock state.
+ * @param {Object} lock
+ * @returns {Object}
+ */
+const copyLock = lock => ({agentId: lock.agentId, sessionId: lock.sessionId, subtreePath: [...lock.subtreePath]});
+
+/**
  * @summary The in-heap authoritative layer that holds the live topological-lock state for one App-Worker
  * heap and enforces it on write-class Neural Link operations.
  *
@@ -47,7 +55,8 @@ class WriteGuard extends Base {
      * in the live table (held until {@link releaseWrite} or {@link releaseAgent}), so a later overlapping
      * write by a *different* writer is denied for as long as the holder keeps it. Re-acquiring an identical
      * lock by the same writer is re-entrant (granted, no duplicate). A malformed lock or a cross-writer
-     * conflict is denied and the table is left unchanged (fail-closed).
+     * conflict is denied and the table is left unchanged (fail-closed). The returned `conflict` is a
+     * defensive copy of the blocking holder, never a live reference into the held table.
      * @param {Object} lock
      * @param {String} lock.agentId
      * @param {String} lock.sessionId
@@ -61,7 +70,7 @@ class WriteGuard extends Base {
             this.locks = lockTable
         }
 
-        return {granted, conflict, errors}
+        return {granted, conflict: conflict ? copyLock(conflict) : null, errors}
     }
 
     /**
@@ -97,11 +106,13 @@ class WriteGuard extends Base {
     }
 
     /**
-     * @summary A snapshot copy of the currently-held locks (introspection; never the live array).
+     * @summary A deep snapshot of the currently-held locks (introspection).
+     * Every returned lock — including its `subtreePath` array — is a copy, so a caller cannot mutate the
+     * live held-lock state through the result (neither the array nor the lock objects nor their paths).
      * @returns {Object[]}
      */
     heldLocks() {
-        return [...this.locks]
+        return this.locks.map(copyLock)
     }
 }
 

--- a/src/ai/WriteGuard.mjs
+++ b/src/ai/WriteGuard.mjs
@@ -1,0 +1,108 @@
+import Base         from '../core/Base.mjs';
+import LockRegistry from './LockRegistry.mjs';
+
+/**
+ * @summary The in-heap authoritative layer that holds the live topological-lock state for one App-Worker
+ * heap and enforces it on write-class Neural Link operations.
+ *
+ * Where `Neo.ai.LockRegistry` is the *stateless* conflict math over a caller-held table, `WriteGuard` is the
+ * *stateful authority*: it owns the live lock table for one application heap (the shared truth, per the
+ * co-habitation premise) and exposes the write-lifecycle API the in-app Neural Link client calls before it
+ * applies a write-class operation. A write **acquires and holds** a subtree lock; a *different* agent's
+ * overlapping write is denied while that lock is held; the lock is released explicitly, or swept on
+ * disconnect. Held-until-release — not per-op — is the minimum that prevents cross-writer corruption while
+ * two agents share one heap.
+ *
+ * It is deliberately a heap-side authority: the heap is the truth, and any Bridge-level check is advisory
+ * routing, never the lock owner. `subtreePath` is supplied by the caller (the client derives the absolute
+ * root→node component path from the live tree), so this class stays pure over its inputs and is unit-testable
+ * via event sequences with no live-heap or socket dependency.
+ *
+ * Scope boundary: this is the authority + its lock-state API. The client write-path wiring (intercepting
+ * write-class ops, deriving the path, surfacing a denial), Bridge advisory mirroring, and lock leases (TTL
+ * expiry for silent holders) are named follow-up slices.
+ * @class Neo.ai.WriteGuard
+ * @extends Neo.core.Base
+ */
+class WriteGuard extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.WriteGuard'
+         * @protected
+         */
+        className: 'Neo.ai.WriteGuard'
+    }
+
+    /**
+     * The live held-lock table — the authoritative truth for this heap. Each entry is a normalized
+     * `{agentId, sessionId, subtreePath}` lock currently held by a writer.
+     * @member {Object[]} locks=[]
+     * @protected
+     */
+    locks = []
+
+    /**
+     * @summary Acquire-and-hold a write lock for a target component subtree.
+     * Delegates the conflict decision to `Neo.ai.LockRegistry.acquire`; on a grant the lock is **retained**
+     * in the live table (held until {@link releaseWrite} or {@link releaseAgent}), so a later overlapping
+     * write by a *different* writer is denied for as long as the holder keeps it. Re-acquiring an identical
+     * lock by the same writer is re-entrant (granted, no duplicate). A malformed lock or a cross-writer
+     * conflict is denied and the table is left unchanged (fail-closed).
+     * @param {Object} lock
+     * @param {String} lock.agentId
+     * @param {String} lock.sessionId
+     * @param {String[]} lock.subtreePath  Absolute root→node component-id path, supplied by the caller.
+     * @returns {{granted: Boolean, conflict: Object|null, errors: String[]}}
+     */
+    requestWrite(lock) {
+        const {lockTable, granted, conflict, errors} = LockRegistry.acquire(this.locks, lock);
+
+        if (granted) {
+            this.locks = lockTable
+        }
+
+        return {granted, conflict, errors}
+    }
+
+    /**
+     * @summary Release one held lock (same writer + same subtree), idempotently.
+     * Releasing a lock that is not held is a no-op; a *different* writer's lock on the same subtree is
+     * never released by this call.
+     * @param {Object} lock The same descriptor shape passed to {@link requestWrite}.
+     * @returns {{released: Boolean}}
+     */
+    releaseWrite(lock) {
+        const before = this.locks.length;
+
+        this.locks = LockRegistry.release(this.locks, lock).lockTable;
+
+        return {released: this.locks.length < before}
+    }
+
+    /**
+     * @summary Release every lock a writer holds — the disconnect / worker-restart sweep hook.
+     * Pass `agentId` and/or `sessionId`; a lock is swept when it matches all provided fields. A
+     * selector-less call sweeps nothing (fail-closed).
+     * @param {Object} selector
+     * @param {String} [selector.agentId]
+     * @param {String} [selector.sessionId]
+     * @returns {{released: Number}}
+     */
+    releaseAgent(selector) {
+        const {lockTable, released} = LockRegistry.releaseAll(this.locks, selector);
+
+        this.locks = lockTable;
+
+        return {released}
+    }
+
+    /**
+     * @summary A snapshot copy of the currently-held locks (introspection; never the live array).
+     * @returns {Object[]}
+     */
+    heldLocks() {
+        return [...this.locks]
+    }
+}
+
+export default Neo.setupClass(WriteGuard);

--- a/test/playwright/unit/ai/WriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/WriteGuard.spec.mjs
@@ -1,0 +1,123 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'WriteGuardTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import WriteGuard     from '../../../../src/ai/WriteGuard.mjs';
+
+/**
+ * A terse lock factory.
+ * @param {String} agentId
+ * @param {String} sessionId
+ * @param {String[]} subtreePath
+ * @returns {Object}
+ */
+const lock = (agentId, sessionId, subtreePath) => ({agentId, sessionId, subtreePath});
+
+test.describe('Neo.ai.WriteGuard', () => {
+    let guard;
+
+    test.beforeEach(() => {
+        guard = Neo.create('Neo.ai.WriteGuard');
+    });
+
+    test('grants and holds a write lock', () => {
+        const result = guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+
+        expect(result.granted).toBe(true);
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('denies a different writer overlapping a held lock, holding nothing for them', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        const result = guard.requestWrite(lock('vega', 's2', ['root', 'panel', 'child']));
+
+        expect(result.granted).toBe(false);
+        expect(result.conflict.agentId).toBe('ada');
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('the held lock blocks the second writer until released, then grants', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(false);
+
+        guard.releaseWrite(lock('ada', 's1', ['root', 'panel']));
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(true);
+    });
+
+    test('is re-entrant for the same writer (no duplicate held lock)', () => {
+        guard.requestWrite(lock('ada', 's1', ['root']));
+        const result = guard.requestWrite(lock('ada', 's1', ['root']));
+
+        expect(result.granted).toBe(true);
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('lets the same writer hold two sibling subtrees', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'a']));
+        guard.requestWrite(lock('ada', 's1', ['root', 'b']));
+
+        expect(guard.heldLocks()).toHaveLength(2);
+    });
+
+    test('releaseWrite is a no-op for a lock that is not held', () => {
+        guard.requestWrite(lock('ada', 's1', ['root']));
+        const result = guard.releaseWrite(lock('ada', 's1', ['other']));
+
+        expect(result.released).toBe(false);
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('releaseWrite never releases a different writer holding the same subtree', () => {
+        guard.requestWrite(lock('ada', 's1', ['root']));
+        const result = guard.releaseWrite(lock('vega', 's2', ['root']));
+
+        expect(result.released).toBe(false);
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+
+    test('releaseAgent sweeps every lock for a disconnected writer', () => {
+        guard.requestWrite(lock('ada',  's1', ['a']));
+        guard.requestWrite(lock('ada',  's1', ['b']));
+        guard.requestWrite(lock('vega', 's2', ['c']));
+
+        const result = guard.releaseAgent({agentId: 'ada', sessionId: 's1'});
+
+        expect(result.released).toBe(2);
+        expect(guard.heldLocks()).toHaveLength(1);
+        expect(guard.heldLocks()[0].agentId).toBe('vega');
+    });
+
+    test('after a disconnect-sweep the freed subtree is grantable to another writer', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        guard.releaseAgent({sessionId: 's1'});
+
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(true);
+    });
+
+    test('denies a malformed lock (fail-closed) and holds nothing', () => {
+        const result = guard.requestWrite(lock('', 's1', ['root']));
+
+        expect(result.granted).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(guard.heldLocks()).toHaveLength(0);
+    });
+
+    test('heldLocks returns a snapshot that cannot mutate the live state', () => {
+        guard.requestWrite(lock('ada', 's1', ['root']));
+        guard.heldLocks().push('tampered');
+
+        expect(guard.heldLocks()).toHaveLength(1);
+    });
+});

--- a/test/playwright/unit/ai/WriteGuard.spec.mjs
+++ b/test/playwright/unit/ai/WriteGuard.spec.mjs
@@ -114,10 +114,28 @@ test.describe('Neo.ai.WriteGuard', () => {
         expect(guard.heldLocks()).toHaveLength(0);
     });
 
-    test('heldLocks returns a snapshot that cannot mutate the live state', () => {
-        guard.requestWrite(lock('ada', 's1', ['root']));
-        guard.heldLocks().push('tampered');
+    test('heldLocks is a deep snapshot — neither the array, the lock objects, nor their paths leak', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
 
-        expect(guard.heldLocks()).toHaveLength(1);
+        const snap = guard.heldLocks();
+        snap.push('tampered');               // array-level
+        snap[0].agentId = 'mallory';         // object-level
+        snap[0].subtreePath.push('injected'); // nested-array-level
+
+        const live = guard.heldLocks();
+        expect(live).toHaveLength(1);
+        expect(live[0].agentId).toBe('ada');
+        expect(live[0].subtreePath).toEqual(['root', 'panel']);
+    });
+
+    test('a returned conflict is a copy — mutating it cannot free the live held lock', () => {
+        guard.requestWrite(lock('ada', 's1', ['root', 'panel']));
+        const denied = guard.requestWrite(lock('vega', 's2', ['root', 'panel']));
+
+        denied.conflict.subtreePath.push('injected'); // tamper with the reported holder
+
+        // the live lock still blocks vega on the original subtree
+        expect(guard.requestWrite(lock('vega', 's2', ['root', 'panel'])).granted).toBe(false);
+        expect(guard.heldLocks()[0].subtreePath).toEqual(['root', 'panel']);
     });
 });


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13134

> ⚠️ **Stacked PR — base is the #13126 branch (`agent/13125-lock-registry`), not `dev`.** `WriteGuard` consumes `LockRegistry` (#13126), which isn't on `dev` yet, so this PR's diff is only the 2 new WriteGuard files. **Retarget to `dev` and rebase once #13126 merges** (then it's a clean 2-file delta).

Adds `Neo.ai.WriteGuard`, the **in-heap authoritative layer** for the #13056 multi-writer enforcement surface — the consumer that makes #13126's `LockRegistry` actually enforce. Where `LockRegistry` is the stateless conflict math over a *caller-held* table, `WriteGuard` **holds** the live lock table for one App-Worker heap and exposes the write-lifecycle API the in-app Neural Link client calls before applying a write-class operation:

- `requestWrite(lock)` → acquire-and-**hold** (the lock stays in the table until released); a *different* writer's overlapping write is denied while it is held.
- `releaseWrite(lock)` → release one held lock, idempotently (a different writer's same-subtree lock is never released).
- `releaseAgent({agentId, sessionId})` → the disconnect / worker-restart sweep.
- `heldLocks()` → a snapshot for introspection.

**Held-until-release + disconnect-sweep** (the convergence A2A's Option B): per-op was rejected (too weak to coordinate alternating writers); a lease/TTL is an *additive* follow-up. @neo-opus-vega / @neo-claude-opus — the lock-lifetime is decide-and-documented here; your convergence input lands on this review.

`subtreePath` is **supplied by the caller** (the client derives the absolute root→node path from the live component tree), so `WriteGuard` is pure over its inputs and unit-testable via event sequences — no live-heap, and no Bridge import (the connect-on-init-singleton trap is avoided).

## Deltas from ticket

None of substance. The `subtreePath`-passed-in boundary keeps the authority pure; the live-tree derivation is the named Client-wiring slice.

Evidence: L1 (11 unit tests — held-lock event sequences: grant/hold, cross-writer deny, hold-blocks-until-release, re-entrancy, sibling holds, idempotent + cross-writer-safe release, disconnect-sweep, fail-closed, snapshot isolation) → L1 required (internal authority-logic contract). Residual: the live two-session Client-wired enforcement (a real concurrent-writer denial in the heap) is the named e2e residual.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/WriteGuard.spec.mjs
→ 11 passed (687ms)
```

No Bridge connection occurs during the suite (`WriteGuard` imports only the pure `LockRegistry`). Pre-commit hooks green.

## Post-Merge Validation

- [ ] The Client write-path wiring slice intercepts write-class ops, derives `subtreePath` from the true component-tree root, and routes through `WriteGuard.requestWrite`; a live two-session overlapping write is denied (whitebox-e2e).
- [ ] On agent disconnect, `WriteGuard.releaseAgent` is invoked so held locks don't leak.

## Structural Pre-Flight

Fast-path (sibling-lift): `src/ai/WriteGuard.mjs` sits beside `src/ai/LockRegistry.mjs` (the math it consumes) and `src/ai/Client.mjs` (the in-heap client that will call it) — the Body-side Neural Link layer. Spec at `test/playwright/unit/ai/WriteGuard.spec.mjs` per the flat `unit/ai/` convention. Map-maintenance: not-needed.

Refs #13056, #13012 (guardrail #1), #13125 / PR #13126 (LockRegistry).
