### PR TITLE
feat(ai): chat-model interactive/batch priority lane (#12748)

### DIFF
--- a/ai/provider/InteractiveBatchQueue.mjs
+++ b/ai/provider/InteractiveBatchQueue.mjs
@@ -1,0 +1,99 @@
+/**
+ * @summary A single-lane request scheduler that runs async tasks one at a time, preferring
+ * interactive work over batch work.
+ *
+ * Local chat/embedding endpoints (LM Studio, `lms server`, Ollama, llama.cpp, MLX) serialize
+ * model requests, so a long-running batch task — a 30-60m session-summary or a KB backfill — can
+ * monopolize the endpoint and stall a latency-sensitive interactive request (an `ask` synthesis,
+ * or the mini-summary fired right after `add_memory`). This queue admits one task at a time and,
+ * whenever it picks the next task, prefers any waiting `interactive` task over `batch` work — so
+ * interactive requests jump ahead of queued batch work without starving it (a batch task still
+ * runs once no interactive work is waiting). Within a single priority lane, selection is FIFO.
+ *
+ * It controls admission ORDER, not in-flight cancellation: a local endpoint request is
+ * non-preemptible, so an already-running task always finishes; the queue only decides which
+ * waiting task starts next. A task that throws rejects its own promise and never blocks the lane.
+ *
+ * Mirrors the proven embedding-side scheduler in
+ * `Neo.ai.services.memory-core.TextEmbeddingService` (`#enqueueOpenAiCompatiblePost` /
+ * `#drainOpenAiCompatiblePostQueue` / `#getNextOpenAiCompatiblePostQueueIndex`), extracted as a
+ * reusable provider-layer primitive. Deliberately a plain class, not a Neo singleton: the queue
+ * holds transient mutable state, so an instantiable (injectable) object keeps it test-isolated —
+ * a shared singleton would bleed queue state across tests.
+ *
+ * @class Neo.ai.provider.InteractiveBatchQueue
+ */
+export default class InteractiveBatchQueue {
+    /**
+     * Pending tasks, each `{task, priority, resolve, reject}`.
+     * @member {Object[]} #queue=[]
+     * @private
+     */
+    #queue = [];
+    /**
+     * Whether the drain loop is currently running (guards against concurrent drains).
+     * @member {Boolean} #active=false
+     * @private
+     */
+    #active = false;
+
+    /**
+     * @summary Enqueue an async task under a priority lane; resolves / rejects with the task's result.
+     * @param {Function} task An async thunk `() => Promise<*>`, executed when the lane is free.
+     * @param {'interactive'|'batch'} [priority='interactive'] Lane priority; interactive is preferred.
+     * @returns {Promise<*>}
+     */
+    enqueue(task, priority = 'interactive') {
+        return new Promise((resolve, reject) => {
+            this.#queue.push({task, priority, resolve, reject});
+            this.#drain()
+        })
+    }
+
+    /**
+     * @summary Drains the queue one task at a time, selecting interactive work first. A throwing
+     * task rejects its own promise without aborting the loop.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #drain() {
+        if (this.#active) {
+            return
+        }
+
+        this.#active = true;
+
+        try {
+            while (this.#queue.length > 0) {
+                const index = this.#nextIndex(),
+                      item  = this.#queue.splice(index, 1)[0];
+
+                try {
+                    item.resolve(await item.task())
+                } catch (error) {
+                    item.reject(error)
+                }
+            }
+        } finally {
+            this.#active = false
+        }
+    }
+
+    /**
+     * @summary Selects the next queue index — any waiting interactive task is preferred over batch,
+     * and within a single lane selection stays FIFO (the earliest matching index wins).
+     * @returns {Number}
+     * @private
+     */
+    #nextIndex() {
+        let best = 0;
+
+        for (let i = 1; i < this.#queue.length; i++) {
+            if (this.#queue[best].priority === 'batch' && this.#queue[i].priority === 'interactive') {
+                best = i
+            }
+        }
+
+        return best
+    }
+}

--- a/ai/provider/buildChatModel.mjs
+++ b/ai/provider/buildChatModel.mjs
@@ -1,6 +1,20 @@
+import InteractiveBatchQueue from './InteractiveBatchQueue.mjs';
+
 let GoogleGenerativeAIClass,
     OllamaProviderClass,
     OpenAiCompatibleProviderClass;
+
+/**
+ * @summary Shared serializing queue for the LOCAL chat endpoint (openAiCompatible / ollama).
+ *
+ * Every chat request across services — session summaries, post-`add_memory` mini-summaries, and
+ * `ask` synthesis — routes through this single queue, so a heavy `batch` summary cannot starve a
+ * latency-sensitive `interactive` request on the single serialized local endpoint. The remote
+ * `gemini` provider is high-concurrency and is never queued. Injectable per `buildChatModel` call
+ * (test seam); defaults to this process-wide instance.
+ * @type {InteractiveBatchQueue}
+ */
+const sharedLocalChatRequestQueue = new InteractiveBatchQueue();
 
 /**
  * @summary Loads the remote Gemini SDK only when the configured chat provider needs it.
@@ -74,6 +88,7 @@ function toGeminiEnvelope(result) {
  * @param {Function} [options.ollamaProviderFactory] Test seam — if omitted, lazily imports `./Ollama.mjs` and calls `Neo.create(...)`.
  * @param {Function} [options.openAiCompatibleProviderFactory] Test seam — if omitted, lazily imports `./OpenAiCompatible.mjs` and calls `Neo.create(...)`.
  * @param {Function} [options.geminiClientFactory] Test seam — if omitted, lazily imports `@google/generative-ai` on first `generateContent()`.
+ * @param {InteractiveBatchQueue} [options.chatRequestQueue] Test seam — the serializing queue the local providers route through; defaults to the process-wide {@link sharedLocalChatRequestQueue}.
  * @returns {Object|null} Gemini-shaped `{generateContent}` model, OR `null` for gemini without an API key.
  * @throws {Error} When `modelProvider` is not in the supported set.
  */
@@ -85,7 +100,8 @@ export function buildChatModel({
     geminiModelName,
     ollamaProviderFactory,
     openAiCompatibleProviderFactory,
-    geminiClientFactory
+    geminiClientFactory,
+    chatRequestQueue = sharedLocalChatRequestQueue
 } = {}) {
     if (modelProvider === 'openAiCompatible') {
         const cfg = openAiCompatibleConfig || {};
@@ -112,17 +128,24 @@ export function buildChatModel({
         };
 
         return {
-            generateContent: async (promptText, generationOptions = {}) => {
-                const provider = await getProvider();
+            generateContent: (promptText, generationOptions = {}) => {
+                const {priority = 'interactive', ...providerOptions} = generationOptions;
 
-                provider.apiKey    = cfg.apiKey;
-                provider.host      = cfg.host;
-                provider.modelName = cfg.model;
-                if (cfg.keep_alive !== undefined) {
-                    provider.keepAlive = cfg.keep_alive;
-                }
+                // Serialize through the shared local-endpoint queue so a heavy `batch` summary cannot
+                // block an `interactive` request. `priority` is a queue-control param — stripped here
+                // so it never leaks into the provider request.
+                return chatRequestQueue.enqueue(async () => {
+                    const provider = await getProvider();
 
-                return toGeminiEnvelope(await provider.generate(promptText, generationOptions));
+                    provider.apiKey    = cfg.apiKey;
+                    provider.host      = cfg.host;
+                    provider.modelName = cfg.model;
+                    if (cfg.keep_alive !== undefined) {
+                        provider.keepAlive = cfg.keep_alive;
+                    }
+
+                    return toGeminiEnvelope(await provider.generate(promptText, providerOptions));
+                }, priority);
             }
         };
     }
@@ -152,16 +175,21 @@ export function buildChatModel({
         };
 
         return {
-            generateContent: async (promptText, generationOptions = {}) => {
-                const provider = await getProvider();
+            generateContent: (promptText, generationOptions = {}) => {
+                const {priority = 'interactive', ...providerOptions} = generationOptions;
 
-                provider.host      = cfg.host;
-                provider.modelName = cfg.model;
-                if (cfg.keep_alive !== undefined) {
-                    provider.keepAlive = cfg.keep_alive;
-                }
+                // Serialize through the shared local-endpoint queue (see the openAiCompatible branch).
+                return chatRequestQueue.enqueue(async () => {
+                    const provider = await getProvider();
 
-                return toGeminiEnvelope(await provider.generate(promptText, generationOptions));
+                    provider.host      = cfg.host;
+                    provider.modelName = cfg.model;
+                    if (cfg.keep_alive !== undefined) {
+                        provider.keepAlive = cfg.keep_alive;
+                    }
+
+                    return toGeminiEnvelope(await provider.generate(promptText, providerOptions));
+                }, priority);
             }
         };
     }
@@ -184,9 +212,13 @@ export function buildChatModel({
         };
 
         return {
-            generateContent: async (...args) => {
+            generateContent: async (promptText, generationOptions = {}) => {
+                // Remote gemini is high-concurrency → never queued. Strip the queue-control `priority`
+                // so it never reaches the SDK; the remaining options forward unchanged (when no
+                // priority is passed, `rest` equals the original options — preserving prior behavior).
+                const {priority, ...rest} = generationOptions;
                 const model = await getModel();
-                return model.generateContent(...args);
+                return model.generateContent(promptText, rest);
             }
         };
     }

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -377,7 +377,8 @@ Instructions:
 
             result = await this.model.generateContent(prompt, {
                 timeoutMs     : ask.provider === 'gemini' ? ask.timeoutMsRemote : ask.timeoutMs,
-                operationLabel: 'ask_knowledge_base synthesis'
+                operationLabel: 'ask_knowledge_base synthesis',
+                priority      : 'interactive'
             });
             answer = result.response.text();
         } catch (error) {

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -900,7 +900,8 @@ class MemoryService extends Base {
             const result     = await withTimeout(
                 model.generateContent(promptText, {
                     timeoutMs      : TIMEOUT_MS,
-                    operationLabel : 'miniSummary generation'
+                    operationLabel : 'miniSummary generation',
+                    priority       : 'interactive'
                 }),
                 TIMEOUT_MS,
                 'miniSummary generation'

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -583,7 +583,7 @@ ${sessionContent}
         // friction symptom, which the degraded fallback below treats like an oversize skip.
         const runGuardrailed = (prompt, note) => invokeWithGuardrail({
             invocationFn             : () => withTimeout(
-                this.model.generateContent(prompt, {timeoutMs: summaryTimeoutMs, operationLabel: 'session summarization'}),
+                this.model.generateContent(prompt, {timeoutMs: summaryTimeoutMs, operationLabel: 'session summarization', priority: 'batch'}),
                 summaryTimeoutMs,
                 'session summarization'
             ),

--- a/test/playwright/unit/ai/provider/InteractiveBatchQueue.spec.mjs
+++ b/test/playwright/unit/ai/provider/InteractiveBatchQueue.spec.mjs
@@ -1,0 +1,113 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'AiProviderInteractiveBatchQueueTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../../src/Neo.mjs';
+import * as core         from '../../../../../src/core/_export.mjs';
+import InteractiveBatchQueue from '../../../../../ai/provider/InteractiveBatchQueue.mjs';
+
+/**
+ * A deferred whose resolution the test controls — lets a spec hold a task "in flight" so it can
+ * enqueue more work behind a non-preemptible running task before releasing it.
+ */
+function deferred() {
+    let resolve, reject;
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej });
+    return {promise, resolve, reject};
+}
+
+test.describe('Neo.ai.provider.InteractiveBatchQueue', () => {
+    test('runs an interactive task ahead of queued batch work (admission-order preemption)', async () => {
+        const queue = new InteractiveBatchQueue(),
+              ran   = [],
+              gate  = deferred();
+
+        // B1 starts immediately and is held in flight via the gate, so B2 + I1 queue behind it.
+        const p1 = queue.enqueue(async () => { ran.push('B1'); await gate.promise; return 'B1' }, 'batch');
+        const p2 = queue.enqueue(async () => { ran.push('B2'); return 'B2' }, 'batch');
+        const p3 = queue.enqueue(async () => { ran.push('I1'); return 'I1' }, 'interactive');
+
+        // Only B1 has started; B2 + I1 are still queued behind the in-flight B1.
+        expect(ran).toEqual(['B1']);
+
+        gate.resolve();
+        await Promise.all([p1, p2, p3]);
+
+        // I1 (interactive, enqueued last) jumped ahead of the earlier-queued B2 (batch).
+        expect(ran).toEqual(['B1', 'I1', 'B2']);
+    });
+
+    test('keeps FIFO order within a single priority lane', async () => {
+        const queue = new InteractiveBatchQueue(),
+              ran   = [];
+
+        await Promise.all([
+            queue.enqueue(async () => { ran.push('I1') }, 'interactive'),
+            queue.enqueue(async () => { ran.push('I2') }, 'interactive'),
+            queue.enqueue(async () => { ran.push('I3') }, 'interactive')
+        ]);
+
+        expect(ran).toEqual(['I1', 'I2', 'I3']);
+    });
+
+    test('defaults an unspecified priority to interactive', async () => {
+        const queue = new InteractiveBatchQueue(),
+              ran   = [],
+              gate  = deferred();
+
+        const p1 = queue.enqueue(async () => { ran.push('held'); await gate.promise }, 'batch');
+        const p2 = queue.enqueue(async () => { ran.push('batch')  }, 'batch');
+        const p3 = queue.enqueue(async () => { ran.push('default') }); // no priority arg
+
+        gate.resolve();
+        await Promise.all([p1, p2, p3]);
+
+        // the default-priority task preempted the explicit batch task → it is treated as interactive
+        expect(ran).toEqual(['held', 'default', 'batch']);
+    });
+
+    test('never runs two tasks concurrently (one-at-a-time on the serialized lane)', async () => {
+        const queue   = new InteractiveBatchQueue();
+        let inFlight  = 0,
+            maxInFlight = 0;
+
+        const task = () => async () => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await Promise.resolve(); // yield the event loop mid-task
+            inFlight--;
+        };
+
+        await Promise.all([
+            queue.enqueue(task(), 'interactive'),
+            queue.enqueue(task(), 'batch'),
+            queue.enqueue(task(), 'interactive')
+        ]);
+
+        expect(maxInFlight).toBe(1);
+    });
+
+    test('a throwing task rejects its own promise without blocking the lane', async () => {
+        const queue = new InteractiveBatchQueue(),
+              ran   = [];
+
+        const failing = queue.enqueue(async () => { throw new Error('boom') }, 'interactive');
+        const after   = queue.enqueue(async () => { ran.push('after'); return 'ok' }, 'interactive');
+
+        await expect(failing).rejects.toThrow('boom');
+        await expect(after).resolves.toBe('ok');
+        expect(ran).toEqual(['after']); // the lane kept draining after the rejection
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.buildChatModel.spec.mjs
@@ -15,8 +15,9 @@ setup({
 
 import {test, expect} from '@playwright/test';
 import fs             from 'fs-extra';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import InteractiveBatchQueue from '../../../../../../ai/provider/InteractiveBatchQueue.mjs';
 
 test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
     let buildChatModel;
@@ -202,6 +203,29 @@ test.describe('buildChatModel provider selector (#11965 Sub-2)', () => {
         const response = await model.generateContent('hello');
         // Resolved to the configured local provider, NOT Gemini, despite the key being present.
         expect(response.response.text()).toBe('local:hello');
+    });
+
+    test('routes local requests through the injected queue and strips priority from provider options (#12748)', async () => {
+        const captured = [];
+        const fakeProvider = {
+            async generate(promptText, generationOptions) {
+                captured.push({promptText, generationOptions});
+                return {content: 'r:' + promptText};
+            }
+        };
+        const queue = new InteractiveBatchQueue();
+        const model = buildChatModel({
+            modelProvider                  : 'openAiCompatible',
+            openAiCompatibleConfig         : {host: 'http://oai.test', model: 'm'},
+            openAiCompatibleProviderFactory: () => fakeProvider,
+            chatRequestQueue               : queue
+        });
+
+        const response = await model.generateContent('hi', {timeoutMs: 100, priority: 'batch'});
+
+        expect(response.response.text()).toBe('r:hi');
+        // `priority` is a queue-control param — it MUST NOT leak into the provider request.
+        expect(captured[0].generationOptions).toEqual({timeoutMs: 100});
     });
 
     test('modelProvider=gemini returns null when geminiApiKey is missing', () => {


### PR DESCRIPTION
Resolves #12748

Authored by Claude Opus 4.8 (Claude Code, @neo-claude-opus / Grace). Session e7f14a36-5096-4570-932b-82f860d7a537.

The chat analog of the embedding interactive/batch queue. Local chat endpoints (LM Studio, `lms server`, Ollama, llama.cpp, MLX) serialize model requests, so a heavy 30-60m session-summary (or backfill) batch can starve a latency-sensitive interactive request — the post-`add_memory` mini-summary, or `ask` synthesis — on the single serialized local endpoint. `TextEmbeddingService` already solves this for embeddings; the chat path had no equivalent.

Evidence: L1 (77 unit specs green — pure async-scheduling logic + the buildChatModel wiring; no live model endpoint) → L1 required (the queue contract is in-process scheduling logic). Residual: the real cross-request latency win on a live serialized local endpoint is the higher-altitude proof, named in Post-Merge Validation.

## What shipped
- **`ai/provider/InteractiveBatchQueue.mjs`** — a reusable single-lane scheduler: runs one task at a time, prefers any waiting `interactive` task over `batch`, FIFO within a lane, and a throwing task rejects its own promise without blocking the lane. Mirrors the proven `TextEmbeddingService` embedding-queue logic (`#enqueueOpenAiCompatiblePost` / `#drainOpenAiCompatiblePostQueue` / `#getNextOpenAiCompatiblePostQueueIndex`), extracted as a plain class — deliberately NOT a Neo singleton, so the transient queue state stays test-isolated.
- **`ai/provider/buildChatModel.mjs`** — the LOCAL provider shims (`openAiCompatible` / `ollama`) route `generateContent` through a shared `InteractiveBatchQueue`; the `priority` control-param is stripped so it never leaks into the provider request. Remote `gemini` is high-concurrency → never queued (and strips `priority` defensively too). The queue is injectable per call (`chatRequestQueue` test seam), defaulting to a process-wide shared instance.
- **Call-site classification** — `SessionService` session-summary → `batch`; `MemoryService` post-`add_memory` mini-summary + `SearchService` `ask` synthesis → `interactive`.

## Mechanism — why the queue lives at buildChatModel
`buildChatModel`'s returned `generateContent` is the single chokepoint every chat request flows through. A shared queue there serializes ALL local chat across services (summaries, mini-summaries, ask) through one lane — correct, since they contend for ONE serialized local endpoint. `priority` is admission-order control, not a model parameter, so it is stripped before `provider.generate`. This is launch/runtime wiring, not an `AiConfig` leaf — no ADR 0019 concern (the ticket notes `aligned-with ADR 0019`).

## Deltas from ticket
- Implemented the shared lane as a standalone `InteractiveBatchQueue` primitive (extracted, reusable, independently unit-testable) rather than inlining it into a service.
- My old #12748 disposition referenced a `#12873` reconcile-target that is now a dangling 404; I referenced the contention evidence (the SIGSTOP measurement: local prefill 108→5,271 tok/s when REM graph-extraction is paused) directly instead. The architectural gap (chat lacks the embedding path's lane) is verified independently of that dead ref.

## Test Evidence
- `npm run test-unit -- InteractiveBatchQueue.spec SessionService.buildChatModel.spec` → **17 passed**. New: the primitive's preemption / FIFO-within-lane / default-interactive / one-at-a-time / error-isolation; a buildChatModel integration test asserting `priority` is stripped from the provider options + the injected queue is used.
- Affected-surface sweep, no regression: MemoryService + SearchService (48) + SessionService (7) + buildChatModel (17) + primitive (5) = **77 green**.
- Pre-commit hooks (whitespace, shorthand, ticket-archaeology) green.

## Post-Merge Validation
- [ ] On a live serialized local endpoint (`modelProvider=openAiCompatible`/`ollama`): confirm a heavy in-flight `batch` session-summary does not delay an `interactive` ask/mini-summary beyond the one in-flight task — the cross-request latency win this fixes.
- [ ] Confirm no behavior change for `modelProvider=gemini` (remote, unqueued): `priority` is stripped, requests stay concurrent.

## Cross-family review note
Touches the chat-request path (provider-layer scheduling). The §6.1 cross-family Approved gate needs @neo-gpt (or @neo-gemini-pro). The correctness-sensitive surface is the queue's preemption + one-at-a-time semantics (unit-tested) + the priority-strip (no leak into the provider/model). Primary reviewer assigned once CI is green.

Related: #12740 (cost-safety epic), #12742 (local-default move), `TextEmbeddingService` (the mirrored embedding queue).