### PR TITLE
feat(ai): derive absolute subtree-path for NL lock enforcement (#13138)

### DIFF
--- a/src/ai/deriveSubtreePath.mjs
+++ b/src/ai/deriveSubtreePath.mjs
@@ -1,0 +1,46 @@
+/**
+ * @summary Derive the absolute root→node component-id path for a component, for topological-lock enforcement.
+ *
+ * `Neo.ai.LockRegistry.pathsOverlap` decides whether two locked subtrees overlap by prefix-containment, which
+ * is sound *only* for **absolute** root→node paths — a relative path would let two unrelated subtrees that
+ * happen to share a head id false-overlap (or nested ones false-disjoin). This is the function the in-heap
+ * enforcement layer uses to turn a live component id into that absolute `subtreePath`.
+ *
+ * It is pure: the parent lookup is **injected** as `parentOf`, so the derivation is unit-testable against a
+ * mock tree with no live-heap or Bridge dependency. The wiring supplies the live lookup
+ * (`id => Neo.getComponent(id)?.parentId`, built on `Neo.component.Base#parentId` / `#up`).
+ *
+ * The walk climbs from `componentId` to the root, stopping at a falsy parent or Neo's top-level sentinel
+ * `'document.body'` (the top-most component is the subtree root; the body element is not a component). It is
+ * cycle-guarded and fails closed (`null`) on a malformed id or a cyclic chain rather than looping or
+ * returning a partial path that could be mistaken for absolute.
+ *
+ * @param {String} componentId          The id of the target component (the subtree's node).
+ * @param {Function} parentOf           `(id: String) => String|null|undefined` — the parent id of `id`, or a
+ *                                      falsy value at the root.
+ * @returns {String[]|null} The absolute path `[rootId, …, componentId]`, or `null` if the id is malformed or
+ *                          the chain contains a cycle.
+ */
+export function deriveSubtreePath(componentId, parentOf) {
+    if (typeof componentId !== 'string' || componentId === '' || componentId === 'document.body') {
+        return null
+    }
+
+    const path = [],
+          seen = new Set();
+
+    let current = componentId;
+
+    while (current && current !== 'document.body') {
+        if (seen.has(current)) {
+            return null // cyclic chain — fail closed rather than loop or return a corrupt path
+        }
+
+        seen.add(current);
+        path.unshift(current);
+
+        current = parentOf(current)
+    }
+
+    return path
+}

--- a/test/playwright/unit/ai/deriveSubtreePath.spec.mjs
+++ b/test/playwright/unit/ai/deriveSubtreePath.spec.mjs
@@ -1,0 +1,45 @@
+import {test, expect}      from '@playwright/test';
+import {deriveSubtreePath} from '../../../../src/ai/deriveSubtreePath.mjs';
+
+// Pure function — imported directly; no Neo globals, no setup, no host side-effects.
+test.describe('deriveSubtreePath (absolute root→node id path for NL lock enforcement)', () => {
+    // {childId: parentId} map → an injectable parentOf(id) lookup
+    const treeLookup = tree => id => tree[id];
+
+    test('derives the absolute root→node path from a linear chain', () => {
+        const parentOf = treeLookup({button: 'panel', panel: 'viewport', viewport: null});
+
+        expect(deriveSubtreePath('button', parentOf)).toEqual(['viewport', 'panel', 'button']);
+    });
+
+    test('a root component (no parent) is its own single-element path', () => {
+        expect(deriveSubtreePath('viewport', treeLookup({viewport: null}))).toEqual(['viewport']);
+    });
+
+    test("stops at Neo's top-level 'document.body' sentinel (the body is not a component)", () => {
+        const parentOf = treeLookup({panel: 'viewport', viewport: 'document.body'});
+
+        expect(deriveSubtreePath('panel', parentOf)).toEqual(['viewport', 'panel']);
+    });
+
+    test('fails closed to null on a cyclic chain rather than looping', () => {
+        const parentOf = treeLookup({a: 'b', b: 'c', c: 'a'});
+
+        expect(deriveSubtreePath('a', parentOf)).toBeNull();
+    });
+
+    test('fails closed to null for a malformed component id', () => {
+        const parentOf = treeLookup({});
+
+        expect(deriveSubtreePath('',              parentOf)).toBeNull();
+        expect(deriveSubtreePath(null,            parentOf)).toBeNull();
+        expect(deriveSubtreePath('document.body', parentOf)).toBeNull();
+    });
+
+    test('stops at a falsy (absent) parent — best-effort for a caller-held tree', () => {
+        // parentOf('missingParent') has no entry → undefined → the walk ends there
+        const parentOf = treeLookup({child: 'missingParent'});
+
+        expect(deriveSubtreePath('child', parentOf)).toEqual(['missingParent', 'child']);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13138

Adds `deriveSubtreePath(componentId, parentOf)`, the pure **absolute root→node id-path builder** the #13056 in-heap enforcement requires — the concrete answer to the absolute-`subtreePath` contract the #13126 cross-family review named (`LockRegistry.pathsOverlap` is prefix-containment, sound only for absolute paths; a relative path would let unrelated subtrees sharing a head id false-overlap).

- walks the parent chain from `componentId` to the root via an **injected** `parentOf(id) → parentId|null` lookup, returning `[rootId, …, componentId]`;
- stops at a falsy parent or Neo's top-level sentinel `'document.body'` (the body element is not a component);
- **cycle-guarded** (a repeated id → fail-closed `null`, never an infinite loop) and fail-closed on a malformed id.

`parentOf` is injected, so the function is pure and unit-testable against a mock tree — no live-heap, no Bridge import. The live lookup (`id => Neo.getComponent(id)?.parentId`, on `Neo.component.Base#parentId` / `#up`) and the write-site interception are the named enforcement-wiring follow-up.

**Unblocked / not stacked:** imports neither `LockRegistry` nor `WriteGuard`, so it branches off `dev` and merges independently; the wiring consumes it after #13126 / #13135 land.

## Deltas from ticket

None. The injected-`parentOf` boundary keeps it pure; the live `Neo.getComponent` lookup is the named wiring slice.

Evidence: L1 (6 unit tests — linear chain, single root, `document.body` stop, cycle→null, malformed→null, falsy-parent best-effort) → L1 required (pure derivation contract). Residual: the live `Neo.getComponent`-backed derivation at the real write site is the named e2e residual.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/deriveSubtreePath.spec.mjs
→ 6 passed (538ms)
```

Pure function imported directly — no Bridge connection during the suite. Pre-commit hooks green.

## Post-Merge Validation

- [ ] The enforcement-wiring slice supplies `parentOf = id => Neo.getComponent(id)?.parentId` and feeds the result as `WriteGuard.requestWrite`'s `subtreePath`, so a real component's lock key is its true root→node path.

## Structural Pre-Flight

Fast-path: `src/ai/deriveSubtreePath.mjs` joins the in-heap Neural Link layer — `src/ai/Client.mjs` + the `src/ai/client/` services (both on `dev`), the hemisphere that owns live-component interaction, which is where this lock-key derivation belongs. It is a plain pure-function module (no Neo class machinery is needed for a stateless derivation; `parentOf` is injected to keep it framework-free). Its consumers — `LockRegistry.pathsOverlap` (#13126) and the enforcement wiring (#13135) — land in separate, still-open PRs; this module imports neither, so it stands alone on `dev`. Spec at `test/playwright/unit/ai/`. Map-maintenance: not-needed.

Refs #13056, #13012, #13125 / PR #13126, #13134 / PR #13135.
