### PR TITLE
fix(wake): append the lane directive to heartbeat-only digests + compress it (#13137)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -595,9 +595,10 @@ function isMessageReadFor(db, messageId, recipient) {
     return node ? node.readAt != null : false;
 }
 
-// WAKE_LANE_DIRECTIVE — the standing lifecycle-first directive appended to every wake digest (below).
-// Its single canonical, testable authority is `./wakeLaneDirective.mjs` (imported above); keep the
-// wording there, not duplicated here, so the discussion / ticket / source cannot silently drift.
+// WAKE_LANE_DIRECTIVE — the standing lifecycle-first directive, appended in buildWakeDigest ONLY to
+// pure-heartbeat digests (the idle-watchdog nudge; message / task / permission wakes omit it — they
+// already carry actionable content). Its single canonical, testable authority is `./wakeLaneDirective.mjs`
+// (imported above); keep the wording there, not duplicated here, so the discussion / ticket / source cannot silently drift.
 
 /**
  * @summary Flushes the coalesced wake queue into a priority-tagged digest.
@@ -1155,7 +1156,14 @@ function buildWakeDigest(identity, subId, {messages = [], tasks = [], permission
         breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId}${gitHubSummary})`;
     }
 
-    return `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}\n\n${WAKE_LANE_DIRECTIVE}`;
+    // The lifecycle-first lane directive is an IDLE-watchdog nudge — append it ONLY to pure-heartbeat
+    // digests (the watchdog pulse with no actionable A2A content). A digest carrying messages / tasks /
+    // permissions already has a specific event to act on, so the generic directive is noise + token waste
+    // there; and message wakes vastly outnumber the heartbeat, so this gate is the dominant token saving.
+    const isPureHeartbeat = heartbeats.length > 0 && messages.length === 0 && tasks.length === 0 && permissions.length === 0,
+          laneDirective   = isPureHeartbeat ? `\n\n${WAKE_LANE_DIRECTIVE}` : '';
+
+    return `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}${laneDirective}`;
 }
 
 /**

--- a/ai/daemons/wake/wakeLaneDirective.mjs
+++ b/ai/daemons/wake/wakeLaneDirective.mjs
@@ -1,9 +1,10 @@
 /**
- * @summary The single canonical source of the standing lane directive appended to every wake digest.
+ * @summary The single canonical source of the standing lane directive appended to pure-heartbeat wake digests.
  *
- * Extracted from the wake-daemon entry (`ai/daemons/wake/daemon.mjs`, which imports + appends it in the
- * digest builder) so the directive text has ONE named, testable authority the discussion / ticket / source
- * wording cannot silently drift from.
+ * Extracted from the wake-daemon entry (`ai/daemons/wake/daemon.mjs`, whose `buildWakeDigest` imports it and
+ * appends it ONLY to pure-heartbeat digests — the idle-watchdog nudge; message / task / permission wakes omit
+ * it, since they already carry actionable content) so the directive text has ONE named, testable authority
+ * the discussion / ticket / source wording cannot silently drift from.
  *
  * @summary Why lifecycle-first ordering (the graduation thesis).
  * The prior directive led with "claim an unclaimed lane," pushing an idle agent toward fresh backlog even
@@ -19,15 +20,15 @@
  * @member {String} WAKE_LANE_DIRECTIVE
  */
 export const WAKE_LANE_DIRECTIVE =
-    'Directive — lifecycle-first, then a fresh lane: before claiming new backlog work, first clear your ' +
-    'PR lifecycle obligations in priority order — (1) your own PRs with red / unstable / stuck CI; ' +
-    '(2) your own green PRs that still need a reviewer routed; (3) reviews / re-reviews where you are the ' +
-    'requested reviewer; (4) peer PRs you blocked with REQUEST_CHANGES once the author says it is ' +
-    'addressed; (5) green peer PRs where you are a scarce viable cross-family reviewer (opening a ' +
-    'same-family PR only grows that reviewer\'s queue). Only when that lifecycle queue is verified-empty: ' +
-    'survey the open backlog (list_issues / ideation) and drive a fresh unclaimed lane implementation → ' +
-    'test → PR. A wake is not "handled" by acknowledgement alone while actionable lifecycle work or open ' +
-    'lanes exist; the only legitimate idle terminals are a verified-empty lifecycle + backlog survey, a ' +
-    'human merge-gate, or an explicit blocked-state. Acknowledge pure-FYI broadcasts in one line.';
+    'Directive — lifecycle-first: first clear your PR lifecycle obligations, in priority order — ' +
+    '(1) own PRs with red / unstable / stuck CI; (2) own green PRs that still need a reviewer routed; ' +
+    '(3) reviews / re-reviews where you are the requested reviewer; (4) peer PRs you blocked with ' +
+    'REQUEST_CHANGES once the author says addressed; (5) green peer PRs where you are a scarce viable ' +
+    'cross-family reviewer (opening a same-family PR only grows that reviewer\'s queue). Only when that ' +
+    'lifecycle queue is verified-empty: survey the open backlog ' +
+    '(list_issues / ideation) and drive a fresh unclaimed lane implementation → test → PR. A wake is not ' +
+    '"handled" by acknowledgement alone while lifecycle work or open lanes exist; the only legitimate ' +
+    'idle terminals are a verified-empty lifecycle + backlog survey, a human merge-gate, or an explicit ' +
+    'blocked-state. Acknowledge pure-FYI broadcasts in one line.';
 
 export default WAKE_LANE_DIRECTIVE;

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -396,7 +396,7 @@ test.describe('Wake Daemon', () => {
         expect(logContents).toContain('2 new messages');          // coalesced breakdown
     });
 
-    test('every wake digest carries the standing lifecycle-first lane directive (#13095, #13118)', async () => {
+    test('a message-wake digest omits the lane directive — it is heartbeat-only (#13118, #13137)', async () => {
         const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-directive';
 
@@ -432,13 +432,14 @@ test.describe('Wake Daemon', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
         insertMessageWake(db, {agentId, subject: 'Directive Presence Probe'});
 
-        // The escalation-fix directive evolved to lifecycle-first: every digest must DIRECT an idle
-        // agent to first clear PR lifecycle obligations, THEN pick up a fresh lane — not push
-        // backlog-first, and not merely report what happened (which gets acknowledged-and-idled).
+        // The lifecycle-first directive is an IDLE-watchdog nudge that belongs ONLY on pure-heartbeat
+        // digests. A message wake already carries actionable content, so its digest must NOT carry the
+        // generic directive — that unconditional placement was the dominant token cost (message wakes
+        // far outnumber the heartbeat).
         const output = await deliveryPromise;
-        expect(output).toContain('lifecycle-first');
-        expect(output).toContain('implementation → test → PR');
-        expect(output).toContain('verified-empty');
+        expect(output).toContain('new messages');          // the message digest still delivers normally
+        expect(output).not.toContain('lifecycle-first');   // ...but WITHOUT the lane directive (heartbeat-only)
+        expect(output).not.toContain('verified-empty');
     });
 
     test('detects and delivers a CAN_* permission_granted wake via the dead-to-live edge path', async () => {
@@ -649,6 +650,7 @@ test.describe('Wake Daemon', () => {
         expect(output).toContain('[Wake Daemon Test Adapter] Delivered');
         expect(output).toContain('[WAKE][priority:normal]');
         expect(output).toContain('heartbeat pulses');
+        expect(output).toContain('lifecycle-first');   // a pure-heartbeat digest DOES carry the lane directive (heartbeat-only placement)
         expect(output).toContain('latest GitHub mention: "Ping Euclid"');
         expect(output).not.toContain('new messages');
     });


### PR DESCRIPTION
Resolves #13137
Refs #13118, #13119

From @tobiu's review of #13119: the standing `WAKE_LANE_DIRECTIVE` was appended **unconditionally** to every wake digest (`buildWakeDigest`), including A2A message / task / permission wakes — where the idle-watchdog nudge is pure noise, and which vastly outnumber the 20-min heartbeat, making the *placement* the dominant token cost (worse than the directive's length).

Evidence: L1 (full `daemon.spec` + `wakeLaneDirective.spec`, both green) → L1 required (digest-string contract; no runtime ACs beyond what the specs assert). No residuals.

## What shipped (→ #13137 ACs)
- **AC1 — heartbeat-only placement (primary):** `buildWakeDigest` appends the directive ONLY to pure-heartbeat digests (`messages` + `tasks` + `permissions` all empty, a heartbeat present). Any digest carrying actionable A2A content — including a mixed heartbeat+message digest — omits it.
- **AC2 — tests:** `daemon.spec` asserts a message-wake digest OMITS the directive, and the heartbeat-pulse digest CARRIES it. Full `daemon.spec` green (29/29, no regression).
- **AC3 — compression (secondary):** modest anchor-preserving trim of the directive text. **Measured as the exported `WAKE_LANE_DIRECTIVE.length`: 970 → 891 chars (−79, ~8.1%)** (origin/dev vs this head). `wakeLaneDirective.spec` is unchanged + green — proving every behavioral anchor (lifecycle-first ordering, the routing tiers, the idle terminals, harness-agnostic) is preserved.

## Deltas from ticket
- **AC3 kept modest, not aggressive — by design.** Implementing AC1 (placement) revealed it largely *obviates* aggressive compression: the directive is now heartbeat-only — it appears only on the idle-agent watchdog wake, exactly where its full lifecycle-first clarity is MOST valuable, and the heartbeat is infrequent (~20 min) so the residual token cost is small. Over-compressing there would trade clarity for a negligible saving (and the old terse "claim an unclaimed lane" version is precisely the backlog-first / idle failure #13118 fixed). The anti-flooding hint in tier #5 was **retained per @neo-opus-ada's review**.
- **Measurement-basis truth-sync (per @neo-gpt's review):** the compression % is the runtime export `WAKE_LANE_DIRECTIVE.length` at origin/dev (970) vs this head (891) = ~8.1%. Earlier drafts cited ~22% / ~16% computed against an **estimated** (~1,060) old length — corrected to the **measured** runtime value. My lapse: I estimated the baseline instead of measuring it; gpt measured it.

## Decision Record impact
`none` — workflow/daemon behavior + prose; no ADR interaction.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs test/playwright/unit/ai/daemons/wake/wakeLaneDirective.spec.mjs` → **35 passed** (29 daemon.spec + 6 wakeLaneDirective.spec).
  - `daemon.spec`: message-wake digest asserts directive ABSENT; heartbeat-pulse digest asserts directive PRESENT; the other 27 unaffected (the gate only changes the directive suffix, not breakdown / priority / coalescing).
  - `wakeLaneDirective.spec`: 6/6 — the compressed text passes all anchor assertions unchanged.
- `check-ticket-archaeology` clean on all 3 files.

## Post-Merge Validation
- [ ] Next ~3 message-triggered wakes (lane-claim / review / DM) carry the breakdown but NOT the lifecycle directive.
- [ ] Next heartbeat-only wake DOES carry the directive (idle-watchdog nudge intact).
- [ ] Watch: stale message-wake re-deliveries (handled msgs re-fired as fresh unread) are non-actionable but post-#13141 carry no directive → ack-and-idle risk. Root = the known wake-idle-out problem (#11829 / #10777 / #12612), NOT this gate (it can't distinguish stale-re-delivered-unread from fresh-unread at the digest level). Flagged by @neo-opus-ada's review; tracked there.

## Commits
- `03c0de97e` — fix(wake): append the lane directive to heartbeat-only digests + compress it

Authored by Claude Opus 4.8 (Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
