### PR TITLE
refactor(dashboard): relocate dock-zone model to src/ as Neo.dashboard.DockZoneModel (#13120)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -26,11 +26,13 @@ No dedicated dock manager exists today. ADR 0020 names QT-grade docking as a gap
 
 ## Ownership Boundary
 
-The model is a harness product contract now, not a new core layout primitive yet.
+The model is a harness product contract that lives in the dashboard layer (`src/dashboard/`), not a new core layout primitive yet.
 
 Initial durable surface: this document.
 
-Future code ownership should follow this decision tree:
+**Resolved (operator, 2026-06-13):** the dock-zone subsystem lives in `src/dashboard/` — `Neo.dashboard.DockZoneModel` (the executor) co-located with `Neo.dashboard.DockLayoutAdapter` (the renderer) — reusable across apps. Dock zones are a Neo layout topic available to other apps, not a harness-app-private concern; only app-specific pane wiring / persistence glue stays in the harness app. The decision tree below is the rationale that led here — its conditional "harness app layer" model placement (option 1) and the "second independent in-repo consumer required before lifting" gate (option 2) are superseded by this decision.
+
+The rationale that resolved to the dashboard layer:
 
 1. If the first implementation only proves Agent Harness workspace persistence with app-specific pane wiring or persistence glue, place that app-specific code in the harness app layer and keep the model documented here.
 2. If the first implementation is a reusable projection adapter that consumes dashboard/container/tab primitives and emits ordinary Neo configs, place the adapter in the dashboard layer while keeping the model contract here. A second independent in-repo use is still required before lifting the model/parser or public API beyond dashboard adaptation. Candidate second use: the Portal learning workspace, where docs, Monaco/live preview, output panes, and inspectors benefit from saveable split/tab workspaces.
@@ -286,7 +288,7 @@ If neither a live component nor a valid `item.blueprint` exists, the adapter mus
 
 The first rendering slice is an adapter, not a new layout engine. It consumes the dock-zone model and emits ordinary Neo child configs and live component moves that existing containers can own.
 
-Adapter ownership starts in the Agent Harness / dashboard layer because the current proof surface is a harness workspace. A later lift into dashboard/container substrate requires a second independent in-repo consumer and source evidence that the adapter logic is reusable outside the harness.
+Adapter and model both live in the dashboard layer (`src/dashboard/`) — per the operator's 2026-06-13 placement decision (see §Ownership Boundary), the dock-zone subsystem is a reusable Neo layout topic, not harness-app-private. A *further* lift into a generic core layout primitive (beyond dashboard adaptation) still requires a second independent in-repo consumer and source evidence that the logic is reusable outside dashboard adaptation.
 
 Rejected placements for the first adapter:
 

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -1,7 +1,7 @@
-import Base from '../../../src/core/Base.mjs';
+import Base from '../core/Base.mjs';
 
 /**
- * @class AgentOS.dock.DockZoneModel
+ * @class Neo.dashboard.DockZoneModel
  * @extends Neo.core.Base
  *
  * @summary Executor for the harness dock-zone semantic operations (`neo.harness.dockZone.v1`).
@@ -31,10 +31,10 @@ class DockZoneModel extends Base {
 
     static config = {
         /**
-         * @member {String} className='AgentOS.dock.DockZoneModel'
+         * @member {String} className='Neo.dashboard.DockZoneModel'
          * @protected
          */
-        className: 'AgentOS.dock.DockZoneModel'
+        className: 'Neo.dashboard.DockZoneModel'
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1,18 +1,18 @@
-import {setup} from '../../../../setup.mjs';
+import {setup} from '../../setup.mjs';
 
 setup({
     appConfig: {
-        name: 'AgentOSDockZoneModelTest'
+        name: 'NeoDashboardDockZoneModelTest'
     }
 });
 
 import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import DockZoneModel  from '../../../../../../apps/agentos/dock/DockZoneModel.mjs';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import DockZoneModel  from '../../../../src/dashboard/DockZoneModel.mjs';
 
 /**
- * @summary Tests for AgentOS.dock.DockZoneModel — the dock-zone semantic operations executor.
+ * @summary Tests for Neo.dashboard.DockZoneModel — the dock-zone semantic operations executor.
  * Pure-JSON: validity invariants, each operation, fail-closed behavior, normalizeTree collapse,
  * and the previewToOperation descriptor seam. No component construction needed.
  */
@@ -45,7 +45,7 @@ function tabsOf(document, itemId) {
     return DockZoneModel.findContainingTabsId(document, itemId)
 }
 
-test.describe('AgentOS.dock.DockZoneModel', () => {
+test.describe('Neo.dashboard.DockZoneModel', () => {
     test.describe('validate (invariants)', () => {
         test('accepts the canonical document', () => {
             expect(DockZoneModel.validate(doc())).toEqual([])


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13120

Operator-directed (the PR #13116 review: *"dock zones sounds more like a neo layout topic, and should be available to other apps => src folder"*), now unblocked by #13116 landing. Relocates the dock-zone **model** to the dashboard layer:

- `AgentOS.dock.DockZoneModel` (`apps/agentos/dock/`) → **`Neo.dashboard.DockZoneModel`** (`src/dashboard/`), co-located with the already-merged `Neo.dashboard.DockLayoutAdapter` and the dashboard subsystem (`Container`, `Panel`). The dock-zone subsystem is now a reusable `src/` layout topic, available to other apps — not a harness-app-private concern.
- The unit spec moves with it (`test/playwright/unit/apps/agentos/dock/` → `test/playwright/unit/dashboard/`), with import depths + class refs updated.
- Reconciles the `HarnessDockZoneModel.md` **Ownership Boundary inconsistency** the operator flagged — the decision-tree's conditional "harness app layer" model placement (+ the "second independent consumer required before lifting" gate) vs the "dashboard layer" statement — both now resolved to the dashboard layer per the operator's decision. A *further* lift to a generic `src/layout/` core primitive still requires a second consumer (that gate is preserved, correctly scoped to the core-primitive lift).

**Pure relocation — zero behavior change.** No code imports `DockZoneModel` (it's contract-consumed via `HarnessDockZoneModel.md`, confirmed by `git grep`), so `DockPreview` and `DockLayoutAdapter` are untouched; only app-specific glue would ever live in the harness app.

## Deltas from ticket

The ticket scoped relocating "the model + the adapter" to a unified `src/` home — but the adapter (`Neo.dashboard.DockLayoutAdapter`) already merged into `src/dashboard/` via #13107, so only the model needed to move (to join it). The exact home is `src/dashboard/` (structural pre-flight below), co-locating the model with its adapter + the dashboard primitives.

Evidence: L1 (30 unit specs pass unchanged at the new location — the relocation is a move + namespace rename + import-path fix, no logic touched) → L1 required (pure refactor; the contract is unchanged). No residuals.

## Test Evidence

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/dashboard/DockZoneModel.spec.mjs
→ 30 passed (776ms)
```

`git mv` preserves history (98% / 96% rename similarity). `git grep` confirms no remaining `AgentOS.dock` / `agentos/dock` references in `apps/ src/ ai/ learn/`. Pre-commit hooks green.

## Post-Merge Validation

- [ ] When the docking-line wiring leaf lands (preview → `DockZoneModel.applyOperation` → adapter), it imports `Neo.dashboard.DockZoneModel` from `src/dashboard/`, not the old `apps/agentos` path.
- [ ] A second consumer (e.g. the Portal learning workspace) can import `Neo.dashboard.DockZoneModel` without an `apps/agentos` dependency — the reusability the relocation enables.

## Structural Pre-Flight

Full pre-flight (relocation): chose `src/dashboard/DockZoneModel.mjs` (`Neo.dashboard.DockZoneModel`) — co-located with `Neo.dashboard.DockLayoutAdapter` (the renderer that consumes the committed model) and the dashboard subsystem (`Container`/`Panel`), the existing reusable layout home. Rejected a new `src/dock/` (would split the model from its adapter) and `src/layout/` (a generic core primitive — the doc's option 3 still gates that on a second consumer + reuse-beyond-dashboard evidence). Map-maintenance: not-needed (the spec mirror moves to `test/playwright/unit/dashboard/`).

Refs #13030 (parent), #13116 (created the model), #13107 (the co-located adapter), #13012. Source of authority: `learn/agentos/HarnessDockZoneModel.md` (reconciled here).
