### PR TITLE
feat(ai): stable, traversal-safe Fleet Manager agent repo-path derivation (#13145)

### DIFF
--- a/ai/services/fleet/deriveAgentRepoPath.mjs
+++ b/ai/services/fleet/deriveAgentRepoPath.mjs
@@ -1,0 +1,97 @@
+import crypto from 'crypto';
+import path   from 'path';
+
+/**
+ * @summary Derive the stable, collision-free, traversal-safe managed checkout path for a Fleet
+ * Manager agent's clone of a given repo.
+ *
+ * The pure half of Fleet Manager repo provisioning: given a trusted `managedRoot` and an agent +
+ * repo, decide *where* that agent's checkout belongs — deterministic path math only, with no fs /
+ * git / env / config access. The side-effectful clone / locate / health-check (a later leaf)
+ * consumes this; isolating the decision makes the correctness-and-security-critical rule fully
+ * unit-testable.
+ *
+ * Two invariants are load-bearing because Fleet Manager auto-memory is **checkout-path-keyed**:
+ * - **Stable:** identical inputs always map to the identical path — an unstable path would silently
+ *   fork an agent's path-keyed memory across restarts.
+ * - **Collision-free:** distinct agents (or repos) never share a path — a collision would
+ *   cross-contaminate two agents' memory. Distinctness holds even when two ids sanitize to the same
+ *   readable form, because each segment carries a deterministic hash of the *raw* value.
+ *
+ * And one security invariant, mirroring the untrusted-key posture of `FleetRegistryService` (an
+ * agent id may be an arbitrary explicit string, not just a GitHub username): the untrusted value is
+ * sanitized and the resolved path is asserted to stay **contained** under `managedRoot`, so a value
+ * like `../../etc` can never escape the managed tree.
+ *
+ * `managedRoot` is a required argument — never defaulted, derived, or read from env / fs here (the
+ * config-is-SSOT contract); the consuming service resolves it from config and passes it in.
+ *
+ * @param {Object} options
+ * @param {String} options.managedRoot An absolute path to the trusted fleet-managed checkout root.
+ * @param {String} options.agentId     The Fleet Manager agent id (untrusted; any non-empty string).
+ * @param {String} options.repoSlug    The repo identifier, e.g. `'neomjs/neo'` (untrusted; non-empty).
+ * @returns {String} `<managedRoot>/<agentSegment>/<repoSegment>` — absolute, stable, contained.
+ * @throws {Error} If `managedRoot` is not a non-empty absolute string, or `agentId` / `repoSlug` is
+ * not a non-empty string, or (defense-in-depth) the resolved path escapes `managedRoot`.
+ */
+export function deriveAgentRepoPath({managedRoot, agentId, repoSlug} = {}) {
+    assertNonEmptyString(managedRoot, 'managedRoot');
+    assertNonEmptyString(agentId,     'agentId');
+    assertNonEmptyString(repoSlug,    'repoSlug');
+
+    if (!path.isAbsolute(managedRoot)) {
+        throw new Error(`deriveAgentRepoPath: 'managedRoot' must be an absolute path, received '${managedRoot}'.`);
+    }
+
+    const
+        root   = path.resolve(managedRoot),
+        target = path.resolve(root, safeSegment(agentId), safeSegment(repoSlug)),
+        rel    = path.relative(root, target);
+
+    // Defense-in-depth over safeSegment: the resolved path must stay strictly within the managed
+    // root. A silently-wrong path would clone into the wrong place, so an escape is a loud failure,
+    // not a quietly-returned bad path. `path.relative` is the robust containment idiom (handles a
+    // root of `/` and cross-drive targets that a `startsWith` check would mis-handle).
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`deriveAgentRepoPath: derived path escaped the managed root (agentId='${agentId}', repoSlug='${repoSlug}').`);
+    }
+
+    return target;
+}
+
+/**
+ * Build a filesystem-safe, human-readable, collision-free path segment from an untrusted raw value:
+ * a sanitized + length-bounded readable prefix joined to a deterministic 12-hex-char SHA-256 suffix.
+ * The hash makes the segment stable AND keeps distinct raw values distinct even when sanitization is
+ * lossy (e.g. `a/b` and `a-b` sanitize alike but hash differently). Sanitization collapses unsafe
+ * characters and dot-runs and trims leading/trailing separators, so `.` / `..` can never survive as
+ * a bare traversal segment.
+ * @param {String} raw
+ * @returns {String} `<readable>-<sha256(raw)[0..12]>`
+ * @private
+ */
+function safeSegment(raw) {
+    const
+        hash      = crypto.createHash('sha256').update(raw).digest('hex').slice(0, 12),
+        sanitized = raw
+            .replace(/[^a-zA-Z0-9._-]+/g, '-') // collapse runs of unsafe chars (incl. `/` and `\`) to one dash
+            .replace(/\.{2,}/g, '.')           // collapse dot-runs — kills `..`
+            .replace(/^[.\-]+|[.\-]+$/g, '')   // trim leading/trailing dots + dashes — kills a bare `.` / `-`
+            .slice(0, 40),                     // bound the readable prefix
+        readable  = sanitized || 'x';          // fallback when sanitization empties the value
+
+    return `${readable}-${hash}`;
+}
+
+/**
+ * Guard a required string argument.
+ * @param {*}      value
+ * @param {String} name
+ * @throws {Error} If `value` is not a non-empty string.
+ * @private
+ */
+function assertNonEmptyString(value, name) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`deriveAgentRepoPath: '${name}' must be a non-empty string.`);
+    }
+}

--- a/test/playwright/unit/ai/deriveAgentRepoPath.spec.mjs
+++ b/test/playwright/unit/ai/deriveAgentRepoPath.spec.mjs
@@ -1,0 +1,89 @@
+import {test, expect}        from '@playwright/test';
+import path                  from 'path';
+import {deriveAgentRepoPath} from '../../../../ai/services/fleet/deriveAgentRepoPath.mjs';
+
+// Pure function — imported directly (no fs / git / Neo runtime), so the suite has no host-runtime
+// side effects and each case is fully isolated. Mirrors resolveCallTarget.spec / LockRegistry.spec.
+
+const ROOT = path.resolve('/srv/fleet');
+
+// Convenience: the resolved managed root + the OS separator, for containment assertions.
+const underRoot = p => p === ROOT || p.startsWith(ROOT + path.sep);
+
+test.describe('deriveAgentRepoPath (Fleet Manager repo-provisioning path derivation)', () => {
+    test('derives an absolute <root>/<agent>/<repo> path contained under the managed root', () => {
+        const result = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'neo-opus-ada', repoSlug: 'neomjs/neo'});
+
+        expect(path.isAbsolute(result)).toBe(true);
+        expect(underRoot(result)).toBe(true);
+        // exactly two segments below the root: <agent>/<repo>
+        expect(path.relative(ROOT, result).split(path.sep)).toHaveLength(2);
+    });
+
+    test('is stable — identical inputs always map to the identical path (memory is path-keyed)', () => {
+        const args = {managedRoot: '/srv/fleet', agentId: 'neo-gpt', repoSlug: 'neomjs/neo'};
+        expect(deriveAgentRepoPath(args)).toBe(deriveAgentRepoPath(args));
+    });
+
+    test('is collision-free across distinct agents and distinct repos', () => {
+        const
+            a = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'alice', repoSlug: 'neomjs/neo'}),
+            b = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'bob',   repoSlug: 'neomjs/neo'}),
+            c = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'alice', repoSlug: 'neomjs/other'});
+
+        expect(a).not.toBe(b); // distinct agents
+        expect(a).not.toBe(c); // distinct repos
+    });
+
+    test('stays collision-free even when two ids sanitize to the same readable form (hash-disambiguated)', () => {
+        // `a/b` and `a-b` both sanitize to the readable form `a-b`; the raw-value hash keeps them apart.
+        const
+            slash = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'a/b', repoSlug: 'r'}),
+            dash  = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'a-b', repoSlug: 'r'});
+
+        expect(slash).not.toBe(dash);
+    });
+
+    test('contains every traversal-bearing or unsafe id under the managed root (security invariant)', () => {
+        for (const agentId of ['../../etc/passwd', '..', '/abs', 'a/b/../..', '__proto__', '.', '....//....']) {
+            const result = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId, repoSlug: 'r'});
+            expect(underRoot(result)).toBe(true);                              // never escapes upward
+            expect(path.relative(ROOT, result).startsWith('..')).toBe(false);  // not above the root
+        }
+        // a traversal-bearing repoSlug is contained too
+        const r = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'a', repoSlug: '../../../root'});
+        expect(underRoot(r)).toBe(true);
+    });
+
+    test('keeps a human-readable prefix so the operator can navigate the managed tree', () => {
+        const result  = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'neo-opus-ada', repoSlug: 'neomjs/neo'}),
+              agentSeg = path.relative(ROOT, result).split(path.sep)[0];
+        // readable prefix preserved, hash suffix appended
+        expect(agentSeg.startsWith('neo-opus-ada-')).toBe(true);
+
+        // a fully-unsafe id still yields a non-empty, readable-ish segment (sanitized `etc-passwd`)
+        const sneaky = deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: '../../etc/passwd', repoSlug: 'r'});
+        expect(path.relative(ROOT, sneaky).split(path.sep)[0]).toContain('etc-passwd');
+    });
+
+    test('the managed root is honored verbatim — same agent/repo under different roots diverges', () => {
+        const
+            a = deriveAgentRepoPath({managedRoot: '/srv/fleet',  agentId: 'x', repoSlug: 'r'}),
+            b = deriveAgentRepoPath({managedRoot: '/data/fleet', agentId: 'x', repoSlug: 'r'});
+
+        expect(a).not.toBe(b);
+        expect(a.startsWith(path.resolve('/srv/fleet')  + path.sep)).toBe(true);
+        expect(b.startsWith(path.resolve('/data/fleet') + path.sep)).toBe(true);
+    });
+
+    test('fails loud on contract violations (no silent default path)', () => {
+        // missing / empty / non-string required args
+        expect(() => deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: '',   repoSlug: 'r'})).toThrow(/agentId/);
+        expect(() => deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 'a',  repoSlug: '' })).toThrow(/repoSlug/);
+        expect(() => deriveAgentRepoPath({managedRoot: '',           agentId: 'a',  repoSlug: 'r'})).toThrow(/managedRoot/);
+        expect(() => deriveAgentRepoPath({managedRoot: '/srv/fleet', agentId: 42,   repoSlug: 'r'})).toThrow(/agentId/);
+        expect(() => deriveAgentRepoPath({})).toThrow(/managedRoot/);
+        // a non-absolute managed root is a caller contract violation
+        expect(() => deriveAgentRepoPath({managedRoot: 'relative/dir', agentId: 'a', repoSlug: 'r'})).toThrow(/absolute/);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13145

The pure, foundational half of the Fleet Manager repo-provisioning leaf that #13015 names but hasn't built. `ai/services/fleet/deriveAgentRepoPath.mjs` exports a pure `deriveAgentRepoPath({managedRoot, agentId, repoSlug})` → a stable, collision-free, traversal-safe managed checkout path of shape `<managedRoot>/<agentSegment>/<repoSegment>`. No fs / git / env / config access — the side-effectful clone / locate / health-check is a *later* leaf that consumes this (foundation-first, mirroring `#13126` LockRegistry → `#13135` WriteGuard → wiring).

**Why path-derivation is a correctness boundary, not a convenience.** Fleet Manager auto-memory is checkout-path-keyed (the operator's recorded reality at the epic: *"one repo clone per peer … paths are load-bearing"*). So:
- **Stable** — identical inputs always map to the identical path; an unstable path would silently *fork* an agent's path-keyed memory across restarts.
- **Collision-free** — distinct agents (or repos) never share a path; a collision would *cross-contaminate* two agents' memory. Holds even when two ids sanitize to the same readable form, because each segment carries a deterministic `sha256(raw).slice(0,12)` suffix.

**Why it is also a security boundary.** `FleetRegistryService` already treats agent ids as untrusted keys (null-prototype maps + `Object.hasOwn`), because `defineAgent({id})` accepts an arbitrary explicit string. The moment that untrusted id is interpolated into a filesystem path, the untrusted-key posture must extend to path-traversal safety: each segment is sanitized (unsafe chars + dot-runs collapsed; leading/trailing separators trimmed, so `.` / `..` can never survive as a bare segment) **and** the resolved path is asserted contained under `managedRoot` (defense-in-depth, via the `path.relative` idiom). A value like `../../etc/passwd` resolves to `<root>/etc-passwd-<hash>/…` — never an escape.

`managedRoot` is a required argument — never defaulted / derived / read-from-env here (the config-is-SSOT contract); the consuming service resolves it from config and passes it in.

## Deltas

None from the ticket scope — the ticket prescribed exactly this pure module + flattened unit spec, delivered as specified. Not blocked on #12984 (keys on `(agentId, repoSlug)`, never a session id), so it lands ahead of the identity-env / wake-subscription provisioning leaves that do carry that blocker.

## Test Evidence

Evidence: L1 (pure-function unit spec) — the required level for a side-effect-free module; there are no runtime / integration ACs to exercise (the side-effectful provisioning that would have them is a later leaf).

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/deriveAgentRepoPath.spec.mjs
→ 8 passed (606ms)
```

The 8 cases: absolute-shape / containment, stability (idempotent across calls), collision-freeness across distinct agents + repos, sanitize-alike-id disambiguation (`a/b` vs `a-b`), traversal-containment (`../../etc/passwd`, `..`, `/abs`, `a/b/../..`, `__proto__`, `.`, `....//....`), human-readable prefix preservation, managed-root-honored-verbatim, and fail-loud contract violations (empty / non-string / non-absolute inputs throw).

## Post-Merge Validation

- [ ] The later side-effectful repo-provisioning leaf (clone / locate / health-check) imports `deriveAgentRepoPath` from `ai/services/fleet/` and resolves `managedRoot` from config — never re-deriving the path nor defaulting the root.
- [ ] A second agent defined for the same repo provisions to a distinct path (no memory cross-contamination) — observable once the lifecycle leaf wires provisioning into spawn.

## Structural Pre-Flight

`ai/services/fleet/deriveAgentRepoPath.mjs` — co-located with `FleetRegistryService` / `FleetLifecycleService` (the fleet-service home, Brain side `ai/`), authored as a plain exported pure function (no Neo class machinery), matching the established pure-helper shape (`ai/services/neural-link/resolveCallTarget.mjs`, `src/ai/deriveSubtreePath.mjs`). Spec at `test/playwright/unit/ai/deriveAgentRepoPath.spec.mjs` — the flattened `ai/services/*` → `unit/ai/` mirror (as `FleetRegistryService.spec.mjs` / `resolveCallTarget.spec.mjs`). Rejected `src/` (a Brain-only Node concern, not Body-reusable) and a new `src/fleet/`-style dir (would split the helper from the fleet services that own the concern).

Refs #13015 (parent), #13012 (grandparent).
