### PR TITLE
feat(ai): Fleet Manager checkout-state inspector (locate + health-check) (#13148)

### DIFF
--- a/ai/services/fleet/inspectAgentRepo.mjs
+++ b/ai/services/fleet/inspectAgentRepo.mjs
@@ -1,0 +1,72 @@
+import fs   from 'fs';
+import path from 'path';
+
+/**
+ * @summary Classify the on-disk state of an agent's managed repo checkout into a
+ * provisioning-relevant verdict — the read-only "locate + health-check" half of Fleet Manager repo
+ * provisioning.
+ *
+ * Given the already-derived checkout path, inspect what is actually on disk so the later
+ * side-effecting clone/repair leaf can decide WITHOUT clobbering: an absent path is safe to clone
+ * into; an existing valid checkout is reused as-is (path stability is load-bearing — Fleet Manager
+ * auto-memory is path-keyed, so a reclone would fork it); a path occupied by a non-checkout is a
+ * conflict that must never be overwritten.
+ *
+ * Read-only and **fs-only** by design (no git binary, no network, no writes) — `existsSync` /
+ * `statSync` / `readdirSync` only — so the classification is deterministic and unit-testable against
+ * temp-dir fixtures. It is deliberately decoupled from the path-derivation helper (it takes the
+ * resolved `repoPath` rather than importing it), so each concern is independently testable and the
+ * composition (derive → inspect → act) lives in the consuming I/O shell.
+ *
+ * Presence + checkout-validity only; remote-URL match / repair is a later refinement.
+ *
+ * @param {Object} options
+ * @param {String} options.repoPath The absolute, already-derived managed checkout path to inspect.
+ * @returns {{repoPath: String, exists: Boolean, isCheckout: Boolean, state: String, provisioningAction: String}}
+ *   `state` ∈ `'absent' | 'empty' | 'occupied-non-checkout' | 'checkout'`;
+ *   `provisioningAction` ∈ `'clone' | 'reuse' | 'conflict'`.
+ * @throws {Error} If `repoPath` is not a non-empty absolute string.
+ */
+export function inspectAgentRepo({repoPath} = {}) {
+    if (typeof repoPath !== 'string' || repoPath.length === 0) {
+        throw new Error("inspectAgentRepo: 'repoPath' must be a non-empty string.");
+    }
+    if (!path.isAbsolute(repoPath)) {
+        throw new Error(`inspectAgentRepo: 'repoPath' must be an absolute path, received '${repoPath}'.`);
+    }
+
+    if (!fs.existsSync(repoPath)) {
+        return result(repoPath, false, false, 'absent', 'clone');
+    }
+
+    // A path occupied by a non-directory (a file, a symlink to one) is a hard conflict — never clobber.
+    if (!fs.statSync(repoPath).isDirectory()) {
+        return result(repoPath, true, false, 'occupied-non-checkout', 'conflict');
+    }
+
+    // A directory carrying `.git` (a dir for a clone, a file for a linked worktree) is a usable checkout.
+    if (fs.existsSync(path.join(repoPath, '.git'))) {
+        return result(repoPath, true, true, 'checkout', 'reuse');
+    }
+
+    // A directory without `.git`: empty is safe to clone into; non-empty is foreign content → conflict.
+    const isEmpty = fs.readdirSync(repoPath).length === 0;
+
+    return isEmpty
+        ? result(repoPath, true, false, 'empty',                 'clone')
+        : result(repoPath, true, false, 'occupied-non-checkout', 'conflict');
+}
+
+/**
+ * Shape the inspection verdict.
+ * @param {String}  repoPath
+ * @param {Boolean} exists
+ * @param {Boolean} isCheckout
+ * @param {String}  state
+ * @param {String}  provisioningAction
+ * @returns {{repoPath: String, exists: Boolean, isCheckout: Boolean, state: String, provisioningAction: String}}
+ * @private
+ */
+function result(repoPath, exists, isCheckout, state, provisioningAction) {
+    return {repoPath, exists, isCheckout, state, provisioningAction};
+}

--- a/ai/services/fleet/inspectAgentRepo.mjs
+++ b/ai/services/fleet/inspectAgentRepo.mjs
@@ -9,11 +9,13 @@ import path from 'path';
  * Given the already-derived checkout path, inspect what is actually on disk so the later
  * side-effecting clone/repair leaf can decide WITHOUT clobbering: an absent path is safe to clone
  * into; an existing valid checkout is reused as-is (path stability is load-bearing — Fleet Manager
- * auto-memory is path-keyed, so a reclone would fork it); a path occupied by a non-checkout is a
- * conflict that must never be overwritten.
+ * auto-memory is path-keyed, so a reclone would fork it); any other occupant is a conflict that must
+ * never be overwritten. A **symlink** at the path is always a conflict regardless of its target: it
+ * could redirect a reuse or clone outside the managed root, defeating the containment the derived
+ * path guarantees — so it fails closed (and a dangling symlink is a conflict too, never `absent`).
  *
- * Read-only and **fs-only** by design (no git binary, no network, no writes) — `existsSync` /
- * `statSync` / `readdirSync` only — so the classification is deterministic and unit-testable against
+ * Read-only and **fs-only** by design (no git binary, no network, no writes) — `lstatSync` /
+ * `existsSync` / `readdirSync` only — so the classification is deterministic and unit-testable against
  * temp-dir fixtures. It is deliberately decoupled from the path-derivation helper (it takes the
  * resolved `repoPath` rather than importing it), so each concern is independently testable and the
  * composition (derive → inspect → act) lives in the consuming I/O shell.
@@ -35,12 +37,26 @@ export function inspectAgentRepo({repoPath} = {}) {
         throw new Error(`inspectAgentRepo: 'repoPath' must be an absolute path, received '${repoPath}'.`);
     }
 
-    if (!fs.existsSync(repoPath)) {
+    let stats;
+
+    try {
+        // lstatSync does NOT follow symlinks — so a symlink at repoPath is observed as itself, not its
+        // target. Probing with the symlink-following existsSync/statSync would classify a symlink-to-a-
+        // checkout as a reusable checkout, redirecting a reuse/clone outside the managed root.
+        stats = fs.lstatSync(repoPath);
+    } catch {
+        // Nothing readable at the path (ENOENT is the expected case) — safe to clone into.
         return result(repoPath, false, false, 'absent', 'clone');
     }
 
-    // A path occupied by a non-directory (a file, a symlink to one) is a hard conflict — never clobber.
-    if (!fs.statSync(repoPath).isDirectory()) {
+    // A symlink occupant is a hard conflict regardless of its target (including a dangling one): it can
+    // redirect writes outside managedRoot, defeating the derived path's containment guarantee. Fail closed.
+    if (stats.isSymbolicLink()) {
+        return result(repoPath, true, false, 'occupied-non-checkout', 'conflict');
+    }
+
+    // Any non-directory occupant (a regular file, socket, device) is also a hard conflict — never clobber.
+    if (!stats.isDirectory()) {
         return result(repoPath, true, false, 'occupied-non-checkout', 'conflict');
     }
 

--- a/test/playwright/unit/ai/inspectAgentRepo.spec.mjs
+++ b/test/playwright/unit/ai/inspectAgentRepo.spec.mjs
@@ -1,0 +1,86 @@
+import {test, expect}     from '@playwright/test';
+import fs                 from 'fs';
+import os                 from 'os';
+import path               from 'path';
+import {inspectAgentRepo} from '../../../../ai/services/fleet/inspectAgentRepo.mjs';
+
+// Read-only fs classifier — exercised against real temp-dir fixtures (no git binary), mirroring
+// FleetRegistryService.spec's temp-dir pattern. All fixtures live under one suite root removed in
+// afterAll; each case names its own subdirectory.
+
+let suiteRoot;
+
+test.beforeAll(() => {
+    suiteRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'inspect-agent-repo-'));
+});
+
+test.afterAll(() => {
+    fs.rmSync(suiteRoot, {recursive: true, force: true});
+});
+
+// make a fresh directory under the suite root and return its absolute path
+const freshDir = name => {
+    const p = path.join(suiteRoot, name);
+    fs.mkdirSync(p, {recursive: true});
+    return p;
+};
+
+test.describe('inspectAgentRepo (Fleet Manager checkout-state classification)', () => {
+    test('absent path → clone', () => {
+        const r = inspectAgentRepo({repoPath: path.join(suiteRoot, 'does-not-exist')});
+        expect(r.exists).toBe(false);
+        expect(r.isCheckout).toBe(false);
+        expect(r.state).toBe('absent');
+        expect(r.provisioningAction).toBe('clone');
+    });
+
+    test('empty directory → clone', () => {
+        const r = inspectAgentRepo({repoPath: freshDir('empty')});
+        expect(r.state).toBe('empty');
+        expect(r.isCheckout).toBe(false);
+        expect(r.provisioningAction).toBe('clone');
+    });
+
+    test('directory containing a .git dir → reuse (never reclone an existing checkout)', () => {
+        const dir = freshDir('checkout');
+        fs.mkdirSync(path.join(dir, '.git'));
+        const r = inspectAgentRepo({repoPath: dir});
+        expect(r.state).toBe('checkout');
+        expect(r.isCheckout).toBe(true);
+        expect(r.provisioningAction).toBe('reuse');
+    });
+
+    test('a linked-worktree .git FILE also counts as a checkout', () => {
+        const dir = freshDir('worktree');
+        fs.writeFileSync(path.join(dir, '.git'), 'gitdir: /elsewhere/.git/worktrees/x\n');
+        const r = inspectAgentRepo({repoPath: dir});
+        expect(r.isCheckout).toBe(true);
+        expect(r.provisioningAction).toBe('reuse');
+    });
+
+    test('non-empty directory without .git → conflict (never clobber foreign content)', () => {
+        const dir = freshDir('occupied');
+        fs.writeFileSync(path.join(dir, 'README.md'), '# not ours\n');
+        const r = inspectAgentRepo({repoPath: dir});
+        expect(r.state).toBe('occupied-non-checkout');
+        expect(r.isCheckout).toBe(false);
+        expect(r.provisioningAction).toBe('conflict');
+    });
+
+    test('a non-directory file at the path → conflict', () => {
+        const file = path.join(suiteRoot, 'a-file');
+        fs.writeFileSync(file, 'x');
+        const r = inspectAgentRepo({repoPath: file});
+        expect(r.exists).toBe(true);
+        expect(r.isCheckout).toBe(false);
+        expect(r.state).toBe('occupied-non-checkout');
+        expect(r.provisioningAction).toBe('conflict');
+    });
+
+    test('fails loud on contract violations (no silent default)', () => {
+        expect(() => inspectAgentRepo({repoPath: ''})).toThrow(/repoPath/);
+        expect(() => inspectAgentRepo({repoPath: 42})).toThrow(/repoPath/);
+        expect(() => inspectAgentRepo({})).toThrow(/repoPath/);
+        expect(() => inspectAgentRepo({repoPath: 'relative/dir'})).toThrow(/absolute/);
+    });
+});

--- a/test/playwright/unit/ai/inspectAgentRepo.spec.mjs
+++ b/test/playwright/unit/ai/inspectAgentRepo.spec.mjs
@@ -77,6 +77,31 @@ test.describe('inspectAgentRepo (Fleet Manager checkout-state classification)', 
         expect(r.provisioningAction).toBe('conflict');
     });
 
+    test('a symlink occupant fails closed even when it points to an outside checkout (no reuse escape)', () => {
+        // the link target is itself a valid checkout (.git present) sitting OUTSIDE the managed path
+        const outsideCheckout = freshDir('outside-checkout');
+        fs.mkdirSync(path.join(outsideCheckout, '.git'));
+
+        const link = path.join(suiteRoot, 'symlink-to-checkout');
+        fs.symlinkSync(outsideCheckout, link);
+
+        const r = inspectAgentRepo({repoPath: link});
+        // must NOT follow the symlink into the target's .git and report a reusable checkout
+        expect(r.isCheckout).toBe(false);
+        expect(r.state).toBe('occupied-non-checkout');
+        expect(r.provisioningAction).toBe('conflict')
+    });
+
+    test('a dangling symlink is a conflict, not absent (never clone into a redirected path)', () => {
+        const link = path.join(suiteRoot, 'dangling-symlink');
+        fs.symlinkSync(path.join(suiteRoot, 'no-such-target'), link);
+
+        const r = inspectAgentRepo({repoPath: link});
+        expect(r.exists).toBe(true);
+        expect(r.state).toBe('occupied-non-checkout');
+        expect(r.provisioningAction).toBe('conflict')
+    });
+
     test('fails loud on contract violations (no silent default)', () => {
         expect(() => inspectAgentRepo({repoPath: ''})).toThrow(/repoPath/);
         expect(() => inspectAgentRepo({repoPath: 42})).toThrow(/repoPath/);


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13148

The read-only **"locate + health-check"** half of Fleet Manager repo provisioning, continuing the path-derivation leaf (#13145 / PR #13146 gave the "where"; this gives the "what's actually there"). `ai/services/fleet/inspectAgentRepo.mjs` exports `inspectAgentRepo({repoPath})` → `{repoPath, exists, isCheckout, state, provisioningAction}`, classifying the on-disk state of an already-derived checkout path so the later side-effecting clone/repair leaf can decide **without clobbering**:

| on disk | `state` | `provisioningAction` |
|---|---|---|
| nothing | `absent` | `clone` |
| empty directory | `empty` | `clone` |
| directory with `.git` (dir, or a linked-worktree `.git` file) | `checkout` | `reuse` |
| a file, or a non-empty directory without `.git` | `occupied-non-checkout` | `conflict` |

`reuse` (not reclone) over an existing checkout is load-bearing: Fleet Manager auto-memory is checkout-path-keyed, so re-cloning a present checkout would fork its path-keyed memory. `conflict` (never overwrite) over foreign content is the safety floor.

**Read-only + fs-only by design** (`existsSync` / `statSync` / `readdirSync` — no git binary, no network, no writes), so the classification is deterministic and unit-testable against temp-dir fixtures. **Deliberately decoupled** from the path-derivation helper — it takes the resolved `repoPath` rather than importing it, so each concern is independently testable (the same decoupling the `resolveCallTarget` review established) and the `derive → inspect → act` composition lives in the consuming I/O shell.

## Deltas

None from the ticket scope. This slice is presence + checkout-validity only; remote-URL match / repair (which needs `.git/config` parsing) is explicitly a later refinement, and the side-effecting clone/repair execution is the next leaf that consumes this + `deriveAgentRepoPath`.

## Test Evidence

Evidence: L1 (fs-only unit spec over temp-dir fixtures) — the required level for a read-only classifier; the side-effecting provisioning that would carry integration ACs is a later leaf.

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/inspectAgentRepo.spec.mjs
→ 7 passed (615ms)
```

The 7 cases (each a real temp-dir fixture, no git binary): absent → clone, empty → clone, `.git`-dir checkout → reuse, linked-worktree `.git`-file checkout → reuse, non-empty non-checkout → conflict, non-directory file → conflict, and the fail-loud contract (non-string / empty / non-absolute `repoPath` throw).

## Post-Merge Validation

- [ ] The later side-effecting repo-provisioning leaf branches on `inspectAgentRepo(...).provisioningAction` — `clone` for `absent`/`empty`, `reuse` for `checkout`, and surfaces `conflict` to the operator rather than overwriting.
- [ ] The FM status surface can render per-agent repo state (`missing` / `present` / `conflict`) from the same inspection — observable once the status dashboard lands.

## Structural Pre-Flight

`ai/services/fleet/inspectAgentRepo.mjs` — co-located with `deriveAgentRepoPath.mjs` (its sibling provisioning helper, on the #13146 branch) and `FleetRegistryService` / `FleetLifecycleService` (the fleet-service home, Brain side `ai/`), as a plain exported function. Spec at `test/playwright/unit/ai/inspectAgentRepo.spec.mjs` — the flattened `ai/services/*` → `unit/ai/` mirror, using `FleetRegistryService.spec`'s temp-dir fixture pattern. Independent of #13146 (decoupled — takes `repoPath`), so it targets `dev` directly with no stack.

Refs #13015 (parent), #13012 (grandparent), #13145 (sibling path-derivation leaf).
