### PR TITLE
feat(dashboard): persist dock layouts (#13147)

### DIFF
--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -18,8 +18,8 @@ import Base from '../core/Base.mjs';
  * unchanged plus a non-empty `errors` array, never a partially-mutated tree. The model persists
  * semantic splits/tabs/order only; runtime pixels, DOMRects and preview state never enter it.
  *
- * Saved-layout helpers wrap the same committed model in `neo.harness.dockLayout.v1` after rejecting
- * runtime-only fields and non-JSON values. They deliberately do not choose a storage backend.
+ * Saved-layout helpers wrap the same committed model in `neo.harness.dockLayout.v1` after enforcing
+ * the finite saved-layout schema and JSON-only values. They deliberately do not choose a storage backend.
  *
  * Return shape for every operation: `{document, errors}` — `errors` empty means the operation
  * committed; non-empty means it was rejected and `document` is the untouched input.
@@ -40,48 +40,48 @@ class DockZoneModel extends Base {
     static LAYOUT_SCHEMA = 'neo.harness.dockLayout.v1'
 
     /**
-     * Runtime, preview, live-component, or credential fields forbidden in saved layouts.
-     * @member {Set<String>} forbiddenSavedLayoutKeys
+     * Top-level fields allowed in a saved-layout wrapper.
+     * @member {Set<String>} savedLayoutKeys
      * @protected
      * @static
      */
-    static forbiddenSavedLayoutKeys = new Set([
-        'accessToken',
-        'appName',
-        'bridgeToken',
-        'component',
-        'componentInstance',
-        'controller',
-        'controllers',
-        'credential',
-        'credentials',
-        'currentIndex',
-        'domRect',
-        'DOMRect',
-        'draggedItem',
-        'dockPreview',
-        'eventListener',
-        'eventListeners',
-        'handler',
-        'handlers',
-        'isWindowDragging',
-        'listener',
-        'listeners',
-        'pat',
-        'PAT',
-        'password',
-        'placement',
-        'pointer',
-        'pointerX',
-        'pointerY',
-        'previewId',
-        'secret',
-        'secrets',
-        'sourceSortZone',
-        'targetSortZone',
-        'token',
-        'windowId'
-    ].map(key => key.toLowerCase()))
+    static savedLayoutKeys = new Set(['schema', 'layoutId', 'title', 'dockZone', 'metadata', 'revision'])
+
+    /**
+     * Top-level fields allowed in a persisted dock-zone document.
+     * @member {Set<String>} dockZoneDocumentKeys
+     * @protected
+     * @static
+     */
+    static dockZoneDocumentKeys = new Set(['schema', 'root', 'items', 'nodes'])
+
+    /**
+     * Fields allowed on persisted dock-zone item records.
+     * @member {Set<String>} dockZoneItemKeys
+     * @protected
+     * @static
+     */
+    static dockZoneItemKeys = new Set(['componentRef', 'title', 'kind', 'blueprint', 'closable', 'pinnable', 'movable', 'metadata'])
+
+    /**
+     * Fields allowed on persisted dock-zone nodes, keyed by node type.
+     * @member {Object<String, Set<String>>} dockZoneNodeKeys
+     * @protected
+     * @static
+     */
+    static dockZoneNodeKeys = {
+        'edge-zone': new Set(['type', 'zones']),
+        split      : new Set(['type', 'orientation', 'children', 'sizes']),
+        tabs       : new Set(['type', 'items', 'activeItemId'])
+    }
+
+    /**
+     * Zone names allowed in an `edge-zone` node.
+     * @member {Set<String>} dockZoneEdgeKeys
+     * @protected
+     * @static
+     */
+    static dockZoneEdgeKeys = new Set(['top', 'right', 'bottom', 'left', 'center'])
 
     static config = {
         /**
@@ -103,64 +103,6 @@ class DockZoneModel extends Base {
      */
     static clone(document) {
         return Neo.clone(document, true, true)
-    }
-
-    /**
-     * @summary Deep-clones a value after JSON-only validation has passed.
-     * @param {*} value
-     * @returns {*}
-     * @protected
-     * @static
-     */
-    static cloneJson(value) {
-        return JSON.parse(JSON.stringify(value))
-    }
-
-    /**
-     * @summary Returns the first forbidden runtime/persistence key in an object graph.
-     * @param {*} value
-     * @param {String} [path='value']
-     * @param {WeakSet<Object>} [seen=new WeakSet()]
-     * @returns {{key:String, path:String}|null}
-     * @protected
-     * @static
-     */
-    static findForbiddenSavedLayoutKey(value, path='value', seen=new WeakSet()) {
-        if (!value || typeof value !== 'object') {
-            return null
-        }
-
-        if (seen.has(value)) {
-            return null
-        }
-
-        seen.add(value);
-
-        if (Array.isArray(value)) {
-            for (let i = 0; i < value.length; i++) {
-                let match = DockZoneModel.findForbiddenSavedLayoutKey(value[i], `${path}[${i}]`, seen);
-
-                if (match) {
-                    return match
-                }
-            }
-
-            return null
-        }
-
-        for (const key of Object.keys(value)) {
-            if (DockZoneModel.forbiddenSavedLayoutKeys.has(key.toLowerCase())) {
-                return {key, path: `${path}.${key}`}
-            }
-
-            let match = DockZoneModel.findForbiddenSavedLayoutKey(value[key], `${path}.${key}`, seen);
-
-            if (match) {
-                return match
-            }
-        }
-
-        return null
     }
 
     /**
@@ -229,6 +171,93 @@ class DockZoneModel extends Base {
 
             if (match) {
                 return match
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Returns the first own string key outside a finite schema allowlist.
+     * @param {Object} record
+     * @param {Set<String>} allowedKeys
+     * @param {String} path
+     * @returns {{key:String, path:String, reason:String}|null}
+     * @protected
+     * @static
+     */
+    static findUnexpectedKey(record, allowedKeys, path) {
+        for (const key of Object.keys(record)) {
+            if (!allowedKeys.has(key)) {
+                return {key, path: `${path}.${key}`, reason: 'field is outside the saved-layout schema'}
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Returns the first field in a dock-zone document that is outside the persisted schema.
+     *
+     * `metadata` and `blueprint` are explicit opaque JSON-only extension points. They are caller-owned
+     * descriptive/config payloads and must not carry secrets or runtime authority; the helper enforces
+     * their JSON value shape, while this allowlist rejects runtime fields added beside the known model.
+     * @param {Object} document
+     * @param {String} [path='dockZone']
+     * @returns {{key:String, path:String, reason:String}|null}
+     * @protected
+     * @static
+     */
+    static findUnexpectedDockZoneKey(document, path='dockZone') {
+        if (!DockZoneModel.isJsonRecord(document)) {
+            return null
+        }
+
+        let unexpected = DockZoneModel.findUnexpectedKey(document, DockZoneModel.dockZoneDocumentKeys, path);
+
+        if (unexpected) {
+            return unexpected
+        }
+
+        if (DockZoneModel.isJsonRecord(document.items)) {
+            for (const [itemId, item] of Object.entries(document.items)) {
+                if (!DockZoneModel.isJsonRecord(item)) {
+                    return {key: itemId, path: `${path}.items.${itemId}`, reason: 'item record must be a JSON object'}
+                }
+
+                unexpected = DockZoneModel.findUnexpectedKey(item, DockZoneModel.dockZoneItemKeys, `${path}.items.${itemId}`);
+
+                if (unexpected) {
+                    return unexpected
+                }
+            }
+        }
+
+        if (DockZoneModel.isJsonRecord(document.nodes)) {
+            for (const [nodeId, node] of Object.entries(document.nodes)) {
+                if (!DockZoneModel.isJsonRecord(node)) {
+                    return {key: nodeId, path: `${path}.nodes.${nodeId}`, reason: 'node record must be a JSON object'}
+                }
+
+                let allowedNodeKeys = DockZoneModel.dockZoneNodeKeys[node.type];
+
+                if (!allowedNodeKeys) {
+                    return {key: 'type', path: `${path}.nodes.${nodeId}.type`, reason: `unsupported dock-zone node type "${node.type}"`}
+                }
+
+                unexpected = DockZoneModel.findUnexpectedKey(node, allowedNodeKeys, `${path}.nodes.${nodeId}`);
+
+                if (unexpected) {
+                    return unexpected
+                }
+
+                if (node.type === 'edge-zone' && DockZoneModel.isJsonRecord(node.zones)) {
+                    unexpected = DockZoneModel.findUnexpectedKey(node.zones, DockZoneModel.dockZoneEdgeKeys, `${path}.nodes.${nodeId}.zones`);
+
+                    if (unexpected) {
+                        return unexpected
+                    }
+                }
             }
         }
 
@@ -479,7 +508,11 @@ class DockZoneModel extends Base {
 
     /**
      * @summary Wraps a valid committed dock-zone document in a JSON-only saved-layout envelope.
-     * @param {Object} document
+     *
+     * The wrapper and dock-zone tree are finite-schema: unknown fields fail closed. The explicit
+     * `metadata` field is an opaque JSON-only non-secret annotation channel; callers must not place
+     * credentials or runtime authority inside it.
+     * @param {Object} document The committed dock-zone document to normalize and wrap.
      * @param {Object} [metadata={}] {layoutId, title, revision, metadata}
      * @returns {{layout:Object|null, errors:String[]}}
      * @static
@@ -495,12 +528,12 @@ class DockZoneModel extends Base {
             return {layout: null, errors}
         }
 
-        let forbiddenKey = DockZoneModel.findForbiddenSavedLayoutKey(document);
+        let unexpectedKey = DockZoneModel.findUnexpectedDockZoneKey(document, 'document');
 
-        if (forbiddenKey) {
+        if (unexpectedKey) {
             return {
                 layout: null,
-                errors: [`saved layout contains forbidden runtime field "${forbiddenKey.key}" at ${forbiddenKey.path}`]
+                errors: [`saved layout contains unexpected field "${unexpectedKey.key}" at ${unexpectedKey.path}: ${unexpectedKey.reason}`]
             }
         }
 
@@ -531,10 +564,11 @@ class DockZoneModel extends Base {
             errors.push('metadata must be a JSON object')
         }
 
-        forbiddenKey = DockZoneModel.findForbiddenSavedLayoutKey(layout);
+        unexpectedKey = DockZoneModel.findUnexpectedKey(layout, DockZoneModel.savedLayoutKeys, 'savedLayout') ||
+            DockZoneModel.findUnexpectedDockZoneKey(layout.dockZone, 'savedLayout.dockZone');
 
-        if (forbiddenKey) {
-            errors.push(`saved layout contains forbidden runtime field "${forbiddenKey.key}" at ${forbiddenKey.path}`)
+        if (unexpectedKey) {
+            errors.push(`saved layout contains unexpected field "${unexpectedKey.key}" at ${unexpectedKey.path}: ${unexpectedKey.reason}`)
         }
 
         let nonJson = DockZoneModel.findNonJsonValue(layout);
@@ -543,11 +577,15 @@ class DockZoneModel extends Base {
             errors.push(`saved layout ${nonJson.path} is not JSON-only: ${nonJson.reason}`)
         }
 
-        return errors.length ? {layout: null, errors} : {layout: DockZoneModel.cloneJson(layout), errors: []}
+        return errors.length ? {layout: null, errors} : {layout: DockZoneModel.clone(layout), errors: []}
     }
 
     /**
      * @summary Restores a saved-layout wrapper into a validated dock-zone document.
+     *
+     * The wrapper and dock-zone tree must match the finite persisted schema. The explicit `metadata`
+     * and item `blueprint` fields are opaque JSON-only non-secret payloads; runtime fields beside the
+     * known model are rejected rather than filtered or repaired.
      * @param {Object} savedLayout
      * @returns {{document:Object|null, errors:String[]}}
      * @static
@@ -579,10 +617,11 @@ class DockZoneModel extends Base {
             errors.push('metadata must be a JSON object')
         }
 
-        let forbiddenKey = DockZoneModel.findForbiddenSavedLayoutKey(savedLayout);
+        let unexpectedKey = DockZoneModel.findUnexpectedKey(savedLayout, DockZoneModel.savedLayoutKeys, 'savedLayout') ||
+            DockZoneModel.findUnexpectedDockZoneKey(savedLayout.dockZone, 'savedLayout.dockZone');
 
-        if (forbiddenKey) {
-            errors.push(`saved layout contains forbidden runtime field "${forbiddenKey.key}" at ${forbiddenKey.path}`)
+        if (unexpectedKey) {
+            errors.push(`saved layout contains unexpected field "${unexpectedKey.key}" at ${unexpectedKey.path}: ${unexpectedKey.reason}`)
         }
 
         let nonJson = DockZoneModel.findNonJsonValue(savedLayout);
@@ -604,7 +643,7 @@ class DockZoneModel extends Base {
 
         return normalizedErrors.length
             ? {document: null, errors: normalizedErrors}
-            : {document: DockZoneModel.cloneJson(normalized), errors: []}
+            : {document: DockZoneModel.clone(normalized), errors: []}
     }
 
     /**

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -18,6 +18,9 @@ import Base from '../core/Base.mjs';
  * unchanged plus a non-empty `errors` array, never a partially-mutated tree. The model persists
  * semantic splits/tabs/order only; runtime pixels, DOMRects and preview state never enter it.
  *
+ * Saved-layout helpers wrap the same committed model in `neo.harness.dockLayout.v1` after rejecting
+ * runtime-only fields and non-JSON values. They deliberately do not choose a storage backend.
+ *
  * Return shape for every operation: `{document, errors}` — `errors` empty means the operation
  * committed; non-empty means it was rejected and `document` is the untouched input.
  */
@@ -28,6 +31,57 @@ class DockZoneModel extends Base {
      * @static
      */
     static SCHEMA = 'neo.harness.dockZone.v1'
+
+    /**
+     * The saved layout wrapper schema around a normalized dock-zone document.
+     * @member {String} LAYOUT_SCHEMA='neo.harness.dockLayout.v1'
+     * @static
+     */
+    static LAYOUT_SCHEMA = 'neo.harness.dockLayout.v1'
+
+    /**
+     * Runtime, preview, live-component, or credential fields forbidden in saved layouts.
+     * @member {Set<String>} forbiddenSavedLayoutKeys
+     * @protected
+     * @static
+     */
+    static forbiddenSavedLayoutKeys = new Set([
+        'accessToken',
+        'appName',
+        'bridgeToken',
+        'component',
+        'componentInstance',
+        'controller',
+        'controllers',
+        'credential',
+        'credentials',
+        'currentIndex',
+        'domRect',
+        'DOMRect',
+        'draggedItem',
+        'dockPreview',
+        'eventListener',
+        'eventListeners',
+        'handler',
+        'handlers',
+        'isWindowDragging',
+        'listener',
+        'listeners',
+        'pat',
+        'PAT',
+        'password',
+        'placement',
+        'pointer',
+        'pointerX',
+        'pointerY',
+        'previewId',
+        'secret',
+        'secrets',
+        'sourceSortZone',
+        'targetSortZone',
+        'token',
+        'windowId'
+    ].map(key => key.toLowerCase()))
 
     static config = {
         /**
@@ -49,6 +103,136 @@ class DockZoneModel extends Base {
      */
     static clone(document) {
         return Neo.clone(document, true, true)
+    }
+
+    /**
+     * @summary Deep-clones a value after JSON-only validation has passed.
+     * @param {*} value
+     * @returns {*}
+     * @protected
+     * @static
+     */
+    static cloneJson(value) {
+        return JSON.parse(JSON.stringify(value))
+    }
+
+    /**
+     * @summary Returns the first forbidden runtime/persistence key in an object graph.
+     * @param {*} value
+     * @param {String} [path='value']
+     * @param {WeakSet<Object>} [seen=new WeakSet()]
+     * @returns {{key:String, path:String}|null}
+     * @protected
+     * @static
+     */
+    static findForbiddenSavedLayoutKey(value, path='value', seen=new WeakSet()) {
+        if (!value || typeof value !== 'object') {
+            return null
+        }
+
+        if (seen.has(value)) {
+            return null
+        }
+
+        seen.add(value);
+
+        if (Array.isArray(value)) {
+            for (let i = 0; i < value.length; i++) {
+                let match = DockZoneModel.findForbiddenSavedLayoutKey(value[i], `${path}[${i}]`, seen);
+
+                if (match) {
+                    return match
+                }
+            }
+
+            return null
+        }
+
+        for (const key of Object.keys(value)) {
+            if (DockZoneModel.forbiddenSavedLayoutKeys.has(key.toLowerCase())) {
+                return {key, path: `${path}.${key}`}
+            }
+
+            let match = DockZoneModel.findForbiddenSavedLayoutKey(value[key], `${path}.${key}`, seen);
+
+            if (match) {
+                return match
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Returns true for JSON object records only.
+     * @param {*} value
+     * @returns {Boolean}
+     * @protected
+     * @static
+     */
+    static isJsonRecord(value) {
+        return value !== null &&
+            typeof value === 'object' &&
+            (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)
+    }
+
+    /**
+     * @summary Returns the first value that cannot round-trip as JSON.
+     * @param {*} value
+     * @param {String} [path='value']
+     * @param {WeakSet<Object>} [seen=new WeakSet()]
+     * @returns {{path:String, reason:String}|null}
+     * @protected
+     * @static
+     */
+    static findNonJsonValue(value, path='value', seen=new WeakSet()) {
+        if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+            return null
+        }
+
+        if (typeof value === 'number') {
+            return Number.isFinite(value) ? null : {path, reason: 'number must be finite'}
+        }
+
+        if (typeof value !== 'object') {
+            return {path, reason: `${typeof value} is not JSON-serializable`}
+        }
+
+        if (seen.has(value)) {
+            return {path, reason: 'cyclic object graph is not JSON-serializable'}
+        }
+
+        seen.add(value);
+
+        if (Array.isArray(value)) {
+            for (let i = 0; i < value.length; i++) {
+                let match = DockZoneModel.findNonJsonValue(value[i], `${path}[${i}]`, seen);
+
+                if (match) {
+                    return match
+                }
+            }
+
+            return null
+        }
+
+        if (!DockZoneModel.isJsonRecord(value)) {
+            return {path, reason: `${value.constructor?.name || 'object'} is not a JSON record`}
+        }
+
+        for (const key of Reflect.ownKeys(value)) {
+            if (typeof key === 'symbol') {
+                return {path: `${path}.${String(key)}`, reason: 'symbol keys are not JSON-serializable'}
+            }
+
+            let match = DockZoneModel.findNonJsonValue(value[key], `${path}.${key}`, seen);
+
+            if (match) {
+                return match
+            }
+        }
+
+        return null
     }
 
     /**
@@ -291,6 +475,136 @@ class DockZoneModel extends Base {
             errors     = DockZoneModel.validate(normalized);
 
         return errors.length ? {document: original, errors} : {document: normalized, errors: []}
+    }
+
+    /**
+     * @summary Wraps a valid committed dock-zone document in a JSON-only saved-layout envelope.
+     * @param {Object} document
+     * @param {Object} [metadata={}] {layoutId, title, revision, metadata}
+     * @returns {{layout:Object|null, errors:String[]}}
+     * @static
+     */
+    static createSavedLayout(document, metadata={}) {
+        if (!DockZoneModel.isJsonRecord(metadata)) {
+            return {layout: null, errors: ['metadata must be a JSON object']}
+        }
+
+        let errors = DockZoneModel.validate(document);
+
+        if (errors.length) {
+            return {layout: null, errors}
+        }
+
+        let forbiddenKey = DockZoneModel.findForbiddenSavedLayoutKey(document);
+
+        if (forbiddenKey) {
+            return {
+                layout: null,
+                errors: [`saved layout contains forbidden runtime field "${forbiddenKey.key}" at ${forbiddenKey.path}`]
+            }
+        }
+
+        let normalized = DockZoneModel.normalizeTree(document),
+            layoutId   = Object.hasOwn(metadata, 'layoutId') ? metadata.layoutId : 'default',
+            title      = Object.hasOwn(metadata, 'title') ? metadata.title : layoutId,
+            layout     = {
+                schema  : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId,
+                title,
+                dockZone: normalized,
+                metadata: Object.hasOwn(metadata, 'metadata') ? metadata.metadata : {}
+            };
+
+        if (Object.hasOwn(metadata, 'revision')) {
+            layout.revision = metadata.revision
+        }
+
+        if (typeof layout.layoutId !== 'string' || !layout.layoutId.trim()) {
+            errors.push('layoutId must be a non-empty string')
+        }
+
+        if (typeof layout.title !== 'string' || !layout.title.trim()) {
+            errors.push('title must be a non-empty string')
+        }
+
+        if (!DockZoneModel.isJsonRecord(layout.metadata)) {
+            errors.push('metadata must be a JSON object')
+        }
+
+        forbiddenKey = DockZoneModel.findForbiddenSavedLayoutKey(layout);
+
+        if (forbiddenKey) {
+            errors.push(`saved layout contains forbidden runtime field "${forbiddenKey.key}" at ${forbiddenKey.path}`)
+        }
+
+        let nonJson = DockZoneModel.findNonJsonValue(layout);
+
+        if (nonJson) {
+            errors.push(`saved layout ${nonJson.path} is not JSON-only: ${nonJson.reason}`)
+        }
+
+        return errors.length ? {layout: null, errors} : {layout: DockZoneModel.cloneJson(layout), errors: []}
+    }
+
+    /**
+     * @summary Restores a saved-layout wrapper into a validated dock-zone document.
+     * @param {Object} savedLayout
+     * @returns {{document:Object|null, errors:String[]}}
+     * @static
+     */
+    static restoreSavedLayout(savedLayout) {
+        let errors = [];
+
+        if (!DockZoneModel.isJsonRecord(savedLayout)) {
+            return {document: null, errors: ['saved layout must be a JSON object']}
+        }
+
+        if (savedLayout.schema !== DockZoneModel.LAYOUT_SCHEMA) {
+            errors.push(`schema must be ${DockZoneModel.LAYOUT_SCHEMA}`)
+        }
+
+        if (typeof savedLayout.layoutId !== 'string' || !savedLayout.layoutId.trim()) {
+            errors.push('layoutId must be a non-empty string')
+        }
+
+        if (typeof savedLayout.title !== 'string' || !savedLayout.title.trim()) {
+            errors.push('title must be a non-empty string')
+        }
+
+        if (!DockZoneModel.isJsonRecord(savedLayout.dockZone)) {
+            errors.push('dockZone must be a JSON object')
+        }
+
+        if (Object.hasOwn(savedLayout, 'metadata') && !DockZoneModel.isJsonRecord(savedLayout.metadata)) {
+            errors.push('metadata must be a JSON object')
+        }
+
+        let forbiddenKey = DockZoneModel.findForbiddenSavedLayoutKey(savedLayout);
+
+        if (forbiddenKey) {
+            errors.push(`saved layout contains forbidden runtime field "${forbiddenKey.key}" at ${forbiddenKey.path}`)
+        }
+
+        let nonJson = DockZoneModel.findNonJsonValue(savedLayout);
+
+        if (nonJson) {
+            errors.push(`saved layout ${nonJson.path} is not JSON-only: ${nonJson.reason}`)
+        }
+
+        if (!errors.length) {
+            errors.push(...DockZoneModel.validate(savedLayout.dockZone));
+        }
+
+        if (errors.length) {
+            return {document: null, errors}
+        }
+
+        let normalized = DockZoneModel.normalizeTree(savedLayout.dockZone),
+            normalizedErrors = DockZoneModel.validate(normalized);
+
+        return normalizedErrors.length
+            ? {document: null, errors: normalizedErrors}
+            : {document: DockZoneModel.cloneJson(normalized), errors: []}
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -171,10 +171,10 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(errors.join(' ')).toContain('missing-tabs')
         });
 
-        test('rejects forbidden runtime fields before save or restore', () => {
+        test('rejects fields outside the saved-layout schema before save or restore', () => {
             const input = doc();
 
-            input.items.strategy.metadata = {
+            input.items.strategy.dockPreview = {
                 dockPreview: {placement: 'split-after'}
             };
 
@@ -191,12 +191,47 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
                 title   : 'Operator Default'
             });
 
-            layout.metadata.windowId = 7;
+            layout.windowId = 7;
 
             const restored = DockZoneModel.restoreSavedLayout(layout);
 
             expect(restored.document).toBe(null);
             expect(restored.errors.join(' ')).toContain('windowId')
+        });
+
+        test('allows opaque JSON metadata and blueprints only through explicit extension fields', () => {
+            const input = doc();
+
+            input.items.strategy.metadata = {
+                ownerTag: 'operator-note'
+            };
+            input.items.strategy.blueprint = {
+                ntype: 'container',
+                text : 'Strategy'
+            };
+
+            const {layout, errors} = DockZoneModel.createSavedLayout(input, {
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                metadata: {
+                    operatorNote: 'non-secret annotation'
+                }
+            });
+
+            expect(errors).toEqual([]);
+            expect(layout.metadata.operatorNote).toBe('non-secret annotation');
+            expect(layout.dockZone.items.strategy.metadata.ownerTag).toBe('operator-note');
+            expect(layout.dockZone.items.strategy.blueprint.ntype).toBe('container');
+
+            input.items.strategy.windowId = 42;
+
+            const rejected = DockZoneModel.createSavedLayout(input, {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            expect(rejected.layout).toBe(null);
+            expect(rejected.errors.join(' ')).toContain('windowId')
         });
 
         test('rejects non-JSON values in metadata and item blueprints', () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -94,6 +94,183 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         })
     });
 
+    test.describe('saved layout persistence', () => {
+        test('creates and restores a versioned saved-layout wrapper', () => {
+            const {layout, errors} = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                revision: 3,
+                metadata: {
+                    workspace: 'agent-harness'
+                }
+            });
+
+            expect(errors).toEqual([]);
+            expect(layout.schema).toBe(DockZoneModel.LAYOUT_SCHEMA);
+            expect(layout.layoutId).toBe('operator-default');
+            expect(layout.title).toBe('Operator Default');
+            expect(layout.revision).toBe(3);
+            expect(layout.metadata.workspace).toBe('agent-harness');
+            expect(layout.dockZone.schema).toBe(DockZoneModel.SCHEMA);
+            expect(DockZoneModel.validate(layout.dockZone)).toEqual([]);
+
+            const restored = DockZoneModel.restoreSavedLayout(layout);
+
+            expect(restored.errors).toEqual([]);
+            expect(restored.document).toEqual(layout.dockZone);
+            expect(restored.document).not.toBe(layout.dockZone)
+        });
+
+        test('fails closed for unsupported wrapper schema', () => {
+            const {layout} = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            layout.schema = 'neo.harness.dockLayout.v2';
+
+            const {document, errors} = DockZoneModel.restoreSavedLayout(layout);
+
+            expect(document).toBe(null);
+            expect(errors.join(' ')).toContain(DockZoneModel.LAYOUT_SCHEMA)
+        });
+
+        test('fails closed for malformed wrapper identity fields', () => {
+            const created = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: '',
+                title   : 'Operator Default'
+            });
+
+            expect(created.layout).toBe(null);
+            expect(created.errors.join(' ')).toContain('layoutId');
+
+            const restored = DockZoneModel.restoreSavedLayout({
+                schema  : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId: 'operator-default',
+                title   : '',
+                dockZone: doc(),
+                metadata: []
+            });
+
+            expect(restored.document).toBe(null);
+            expect(restored.errors.join(' ')).toContain('title');
+            expect(restored.errors.join(' ')).toContain('metadata')
+        });
+
+        test('fails closed for an invalid dock-zone document', () => {
+            const {layout} = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            layout.dockZone.nodes.root.zones.center = 'missing-tabs';
+
+            const {document, errors} = DockZoneModel.restoreSavedLayout(layout);
+
+            expect(document).toBe(null);
+            expect(errors.join(' ')).toContain('missing-tabs')
+        });
+
+        test('rejects forbidden runtime fields before save or restore', () => {
+            const input = doc();
+
+            input.items.strategy.metadata = {
+                dockPreview: {placement: 'split-after'}
+            };
+
+            const saved = DockZoneModel.createSavedLayout(input, {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            expect(saved.layout).toBe(null);
+            expect(saved.errors.join(' ')).toContain('dockPreview');
+
+            const {layout} = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            layout.metadata.windowId = 7;
+
+            const restored = DockZoneModel.restoreSavedLayout(layout);
+
+            expect(restored.document).toBe(null);
+            expect(restored.errors.join(' ')).toContain('windowId')
+        });
+
+        test('rejects non-JSON values in metadata and item blueprints', () => {
+            const badMetadata = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                metadata: {
+                    onRestore: () => {}
+                }
+            });
+
+            expect(badMetadata.layout).toBe(null);
+            expect(badMetadata.errors.join(' ')).toContain('JSON-only');
+
+            const input = doc();
+
+            input.items.strategy.blueprint = {
+                ntype    : 'container',
+                listeners: {
+                    click: () => {}
+                }
+            };
+
+            const badBlueprint = DockZoneModel.createSavedLayout(input, {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            expect(badBlueprint.layout).toBe(null);
+            expect(badBlueprint.errors.join(' ')).toContain('listeners')
+        });
+
+        test('does not mutate caller input or expose caller-owned nested objects', () => {
+            const input = doc(),
+                  meta  = {workspace: 'agent-harness'};
+
+            input.nodes.split = {
+                type       : 'split',
+                orientation: 'horizontal',
+                children   : ['main-tabs', 'side-tabs'],
+                sizes      : [0.2, 0.8]
+            };
+            input.nodes.root.zones.center = 'split';
+            delete input.nodes.root.zones.right;
+
+            const snapshot = JSON.stringify(input),
+                  {layout, errors} = DockZoneModel.createSavedLayout(input, {
+                      layoutId: 'operator-default',
+                      title   : 'Operator Default',
+                      metadata: meta
+                  });
+
+            expect(errors).toEqual([]);
+            expect(JSON.stringify(input)).toBe(snapshot);
+
+            meta.workspace = 'mutated-by-caller';
+            input.items.strategy.title = 'Caller Mutated Strategy';
+            layout.metadata.workspace = 'mutated-layout';
+            layout.dockZone.nodes.split.sizes[0] = 0.4;
+
+            expect(layout.metadata.workspace).toBe('mutated-layout');
+            expect(layout.dockZone.nodes.split.sizes[0]).toBe(0.4);
+
+            const {layout: freshLayout} = DockZoneModel.createSavedLayout(input, {
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                metadata: meta
+            });
+
+            expect(freshLayout.metadata.workspace).toBe('mutated-by-caller');
+            expect(freshLayout.dockZone.items.strategy.title).toBe('Caller Mutated Strategy')
+        })
+    });
+
     test.describe('addTab', () => {
         test('inserts a catalog-only item at index and makes it active', () => {
             const {document, errors} = DockZoneModel.addTab(doc(), {itemId: 'inspector', tabsNodeId: 'main-tabs', index: 1});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

Resolves #13147
Related: #13030
Related: #13012
Related: #13142

Adds DockZoneModel saved-layout helpers for neo.harness.dockLayout.v1: finite-schema JSON-only wrapper creation, fail-closed restore into validated dock-zone documents, and reject-by-default persisted-model boundaries for runtime-only fields.

Evidence: L2 (focused Playwright unit coverage of pure helper behavior) -> L2 required (pure helper-contract ACs). No residuals.

## Deltas from ticket
- Implemented in src/dashboard/ because live dev after #13142 relocated the dock-zone subsystem from the stale apps/agentos/dock/ path named in the ticket body.
- Cycle 2 review response: deleted the JSON round-trip clone helper, returned through DockZoneModel.clone(), replaced the brittle runtime-field denylist with finite schema allowlists for the saved wrapper, dock-zone document, item records, nodes, and edge-zone names, and documented metadata/blueprint as explicit opaque JSON-only non-secret extension fields.

## Test Evidence
- node --check src/dashboard/DockZoneModel.mjs
- npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs -> 45 passed
- git diff --check
- git diff --cached --check
- npm run test-unit -> broad suite reached 3604 passed, 62 failed, 52 did not run; failures are outside the dashboard dock layout surface (AI MCP/lifecycle/provider/memory-core/sandbox EPERM areas).

## Post-Merge Validation
- [ ] Later storage/UI leaf consumes createSavedLayout() / restoreSavedLayout() without duplicating wrapper validation.

## Commits
- 0ee51e0cc — feat(dashboard): persist dock layouts (#13147)
- 3b4f589e2 — fix(dashboard): harden saved layout schema boundary (#13147)
