### PR TITLE
feat(neural-link): add the create_component write-locked NL tool (#9846)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -800,6 +800,43 @@ paths:
                     items:
                       type: object
 
+  /component/create:
+    post:
+      summary: Create Component
+      operationId: create_component
+      x-neo-tool-tier: write-locked
+      x-pass-as-object: true
+      description: |
+        Creates a component inside a target container at runtime — a schema-validated, CONSTRAINED
+        alternative to the admin-tier `call_method(container.add(...))`.
+
+        **When to Use:**
+        To add a new component to a live container (e.g. add a `Button` to a `Toolbar`) without granting
+        admin method-call access. The `config` must declare a `module`, `ntype`, or `className`; the
+        target container is resolved by `parentId`.
+      tags: [Component]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateComponentRequest'
+      responses:
+        '200':
+          description: Component added to the container
+        '400':
+          description: Invalid request body (config not an object, or missing module / ntype / className)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /component/vdom/query:
     post:
       summary: Query VDOM
@@ -1727,6 +1764,22 @@ components:
           type: array
           items: {}
           description: Arguments to pass to the method (heterogeneous — any JSON-serializable value)
+        sessionId:
+          type: string
+          description: The target App Worker Session ID
+
+    CreateComponentRequest:
+      type: object
+      required:
+        - parentId
+        - config
+      properties:
+        parentId:
+          type: string
+          description: The target container's component ID (the parent to add into)
+        config:
+          type: object
+          description: The component configuration; must declare a `module`, `ntype`, or `className`
         sessionId:
           type: string
           description: The target App Worker Session ID

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -19,6 +19,7 @@ import RecorderService    from '../../../services/neural-link/RecorderService.mj
 const serviceMapping = {
     call_method                 : InstanceService   .callMethod              .bind(InstanceService),
     check_namespace              : RuntimeService    .checkNamespace            .bind(RuntimeService),
+    create_component             : ComponentService  .createComponent           .bind(ComponentService),
     find_instances               : InstanceService   .findInstances             .bind(InstanceService),
     get_component_tree           : ComponentService  .getComponentTree          .bind(ComponentService),
     get_computed_styles          : ComponentService  .getComputedStyles         .bind(ComponentService),

--- a/ai/services/neural-link/ComponentService.mjs
+++ b/ai/services/neural-link/ComponentService.mjs
@@ -146,6 +146,35 @@ class ComponentService extends Base {
     async setComponentProperty({id, property, value, sessionId}) {
         return await ConnectionService.call(sessionId, 'set_component_property', {id, property, value});
     }
+
+    /**
+     * Creates a component inside a target container at runtime — a first-class, schema-validated,
+     * `write-locked` alternative to the generic `admin`-tier `call_method(container.add(...))`.
+     *
+     * Validates the config server-side (fail-fast with a semantic message, no dispatch on bad input),
+     * then delegates to the existing `call_method` dispatch — `container.add(config)` — reusing the
+     * worker-side handler (no new worker op). Pinning the method to `add` is exactly what keeps this
+     * a CONSTRAINED write tool (`write-locked`) rather than the arbitrary-method `admin` `call_method`:
+     * an agent can create components without being granted admin method-call access.
+     * @param {Object} opts             The options object.
+     * @param {String} opts.parentId    The target container's component ID.
+     * @param {Object} opts.config      The component configuration; must declare a `module`, `ntype`, or `className`.
+     * @param {String} [opts.sessionId] The target session ID.
+     * @returns {Promise<Object>} The result of adding the component to the container.
+     */
+    async createComponent({parentId, config, sessionId}) {
+        if (!parentId) {
+            throw new Error('create_component: `parentId` (the target container id) is required.');
+        }
+        if (!config || typeof config !== 'object' || Array.isArray(config)) {
+            throw new Error('create_component: `config` must be a component configuration object.');
+        }
+        if (!config.module && !config.ntype && !config.className) {
+            throw new Error('create_component: `config` must declare a `module`, `ntype`, or `className` to instantiate.');
+        }
+
+        return await ConnectionService.call(sessionId, 'call_method', {id: parentId, method: 'add', args: [config]});
+    }
 }
 
 export default Neo.setupClass(ComponentService);

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -36,7 +36,7 @@ function findArraysWithoutItems(node, pathLabel = '') {
 
 /**
  * Walks a JSON Schema node and returns every dotted path where a `type: "object"` node
- * sets `additionalProperties: false`. For OUTPUT schemas this is the #9837 drift bug —
+ * sets `additionalProperties: false`. For OUTPUT schemas this is the additional-properties drift bug —
  * server implementations return fields the OpenAPI contract forgot to declare, and
  * strict MCP clients (GitHub Copilot) reject the payload with
  * "data/result/0 must NOT have additional properties". OUTPUT schemas should stay
@@ -61,7 +61,7 @@ function findStrictObjects(node, pathLabel = '') {
 
 /**
  * Walks a JSON Schema node looking for INPUT "open-bag" objects that would silently
- * strip their payload to `{}` — the #10070 regression. An open-bag is a `type: "object"`
+ * strip their payload to `{}` — the open-bag-stripping regression. An open-bag is a `type: "object"`
  * node that declares NO child `properties` (the author signaled "caller decides the
  * shape") AND strict `additionalProperties: false` (Zod then drops every unknown key).
  * The root of an input schema is excluded — top-level inputs with declared fields
@@ -91,6 +91,7 @@ const neuralLinkToolTiers = ['read', 'write-locked', 'admin'];
 const expectedNeuralLinkToolTiers = {
     call_method                 : 'admin',
     check_namespace              : 'read',
+    create_component             : 'write-locked',
     find_instances               : 'read',
     get_component_tree           : 'read',
     get_computed_styles          : 'read',
@@ -130,6 +131,7 @@ const expectedNeuralLinkToolTiers = {
 
 const neuralLinkDangerousReadForbidden = [
     'call_method',
+    'create_component',
     'highlight_component',
     'manage_connection',
     'manage_neo_config',

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -1,0 +1,96 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ComponentServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Coverage for `ComponentService.createComponent` — the `create_component` Neural Link tool.
+ *
+ * The tool is a `write-locked`, schema-validated alternative to the admin-tier `call_method(container.add())`:
+ * it validates the config server-side (fail-fast, no dispatch on bad input) and delegates a valid create to
+ * the existing `call_method` transport op as `parent.add(config)`. These tests mock `ConnectionService.call`
+ * so they assert the server-side validation + the exact delegated dispatch, without a live App Worker.
+ */
+test.describe('Neo.ai.services.neural-link.ComponentService — createComponent', () => {
+    let ComponentService, ConnectionService, calls, originalCall, originalReady;
+
+    test.beforeAll(async () => {
+        ConnectionService = (await import('../../../../../../ai/services/neural-link/ConnectionService.mjs')).default;
+        // Stub the readiness gate so the ComponentService singleton's initAsync resolves without a live bridge.
+        originalReady          = ConnectionService.ready;
+        ConnectionService.ready = async () => {};
+        ComponentService = (await import('../../../../../../ai/services/neural-link/ComponentService.mjs')).default;
+    });
+
+    test.afterAll(() => {
+        ConnectionService.ready = originalReady;
+    });
+
+    test.beforeEach(() => {
+        calls        = [];
+        originalCall = ConnectionService.call;
+        // Mock the transport: record the dispatch and return a canned success.
+        ConnectionService.call = async (sessionId, op, payload) => {
+            calls.push({sessionId, op, payload});
+            return {success: true, id: 'neo-created-1'};
+        };
+    });
+
+    test.afterEach(() => {
+        ConnectionService.call = originalCall;
+    });
+
+    test('rejects a missing parentId without dispatching', async () => {
+        await expect(ComponentService.createComponent({config: {module: 'X'}, sessionId: 's1'}))
+            .rejects.toThrow(/parentId/);
+        expect(calls.length).toBe(0);
+    });
+
+    test('rejects a non-object config without dispatching', async () => {
+        await expect(ComponentService.createComponent({parentId: 'p1', config: 'nope', sessionId: 's1'}))
+            .rejects.toThrow(/config/);
+        await expect(ComponentService.createComponent({parentId: 'p1', config: ['arr'], sessionId: 's1'}))
+            .rejects.toThrow(/config/);
+        expect(calls.length).toBe(0);
+    });
+
+    test('rejects a config with no module / ntype / className without dispatching', async () => {
+        await expect(ComponentService.createComponent({parentId: 'p1', config: {flex: 1}, sessionId: 's1'}))
+            .rejects.toThrow(/module.*ntype.*className/);
+        expect(calls.length).toBe(0);
+    });
+
+    test('delegates a valid config to call_method as parent.add(config)', async () => {
+        const config = {module: 'Neo.button.Base', text: 'Save'};
+        const result = await ComponentService.createComponent({parentId: 'toolbar-1', config, sessionId: 's1'});
+
+        expect(calls.length).toBe(1);
+        expect(calls[0]).toEqual({
+            sessionId: 's1',
+            op       : 'call_method',
+            payload  : {id: 'toolbar-1', method: 'add', args: [config]}
+        });
+        expect(result).toEqual({success: true, id: 'neo-created-1'});
+    });
+
+    test('accepts ntype-only and className-only configs', async () => {
+        await ComponentService.createComponent({parentId: 'p1', config: {ntype: 'button'},          sessionId: 's1'});
+        await ComponentService.createComponent({parentId: 'p1', config: {className: 'Neo.x.Y'}, sessionId: 's1'});
+        expect(calls.length).toBe(2);
+        expect(calls.every(c => c.op === 'call_method' && c.payload.method === 'add')).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -29,8 +29,15 @@ test.describe('Neo.ai.services.neural-link.ComponentService — createComponent'
     let ComponentService, ConnectionService, calls, originalCall, originalReady;
 
     test.beforeAll(async () => {
+        // Prevent the ConnectionService singleton from auto-spawning a Bridge process at import time
+        // (autoConnect → initAsync → spawnBridge) — it pollutes the unit run (port 8081 EPERM / bridge.log)
+        // and is the isolation blocker. Set autoConnect=false on the shared NL config BEFORE importing
+        // ConnectionService (mirrors McpServerListToolsSmoke.spec). A post-import ready-stub alone is too
+        // late: the spawn fires from ConnectionService's own initAsync, gated by this config leaf.
+        (await import('../../../../../../ai/mcp/server/neural-link/config.mjs')).default.data.autoConnect = false;
+
         ConnectionService = (await import('../../../../../../ai/services/neural-link/ConnectionService.mjs')).default;
-        // Stub the readiness gate so the ComponentService singleton's initAsync resolves without a live bridge.
+        // Also stub the readiness gate so the ComponentService singleton's initAsync resolves without a live bridge.
         originalReady          = ConnectionService.ready;
         ConnectionService.ready = async () => {};
         ComponentService = (await import('../../../../../../ai/services/neural-link/ComponentService.mjs')).default;


### PR DESCRIPTION
Resolves #9846
Refs #13106, #13157

A first-class, schema-validated `create_component` Neural Link tool — the constrained, `write-locked` alternative to creating components via the generic `admin`-tier `call_method(container.add(...))`.

**Close-target shape (per @neo-gpt's #13154 review):** #9846 is re-scoped to **Slice 1 — this tool + server-side schema-validation** (its two remaining ACs), which this PR `Resolves`. The live-runtime ACs (`get_component_tree` visibility, multi-window targeting, E2E proof) graduated to **Slice 2 → #13157**; `needs-re-triage` on #9846 is cleared. #9846 carries the T3 Contract Ledger for Slice 1 as shipped.

Evidence: L1 (unit: `ComponentService.createComponent` 5/5; governance: `OpenApiValidatorCompliance` tier-map `toEqual` + `McpServerListToolsSmoke` 19/19; focused scope **54/54**) → L1 required (server-side validation + dispatch + tier-registration contract; the live-app create is exercised in the Slice-2 e2e, #13157). **GitHub CI green on `f82da4993`** (`unit` + `integration-unified`). No residuals blocking the tool.

## What shipped (Slice 1 of #9846)
- **`ComponentService.createComponent({parentId, config, sessionId})`** — validates `config` server-side (must be an object declaring `module` / `ntype` / `className`, else a semantic error with **no dispatch**), then delegates to the existing `call_method` op as `parent.add(config)` — reusing the worker-side handler (no new worker op). Satisfies #9846 AC1 (tool registered) + AC2 (schema-validation + semantic errors).
- **`write-locked` tier (the security shape):** pinning the delegated method to `add` makes this a CONSTRAINED component-creation write, strictly less privileged than the arbitrary-method `admin` `call_method`. An agent gets schema-validated component creation **without** being granted admin method-call access. The existing tool-projection forced-mode (#13106) enforces the tier ceiling — verified end-to-end by the listTools smoke.
- **Wiring:** openapi `/component/create` path + `CreateComponentRequest` schema (`write-locked`); `toolService` dispatch-map entry; `create_component` registered in the `OpenApiValidatorCompliance` governance fixtures.

## Deltas from ticket → Slice 2 (#13157)
- **Targeting is session-based (parity with every NL tool), not yet auto-multi-window.** Slice 1 resolves the target via `sessionId` (session → its App Worker), exactly like `call_method` / `set_instance_properties` / all NL tools. Explicit `windowId` auto-resolution, `get_component_tree` visibility verification, and a **live e2e** (drive a real app, create a component, verify it renders + is queryable) are tracked in **#13157** (#9846 AC3/AC4/AC5). The tool itself — the ticket's core, Slice 1 — is delivered here.

## Decision Record impact
`none` — a new NL tool reusing the existing transport + the #13106 tier-projection model.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` → **54 passed** (the governance scope: `create_component` is in `expectedNeuralLinkToolTiers` as `write-locked` + in `neuralLinkDangerousReadForbidden`; the tier-map `toEqual` holds; registration + tier-projection confirmed). No spawn / EPERM / isolation bleed.
- `npm run test-unit -- test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs` → **5 passed** (missing `parentId` / non-object config / missing `module`|`ntype`|`className` all reject without dispatch; valid config delegates `call_method {id, method:'add', args:[config]}`; ntype-only + className-only accepted). Runs with **no Bridge spawn** — the spec sets the NL config `autoConnect=false` before importing `ConnectionService`.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` → **19 passed** (`create_component` registers; the embedded-harness tier-projection tests confirm `write-locked` gating).
- **GitHub CI green on `f82da4993`:** `unit` (5m49s) + `integration-unified` (6m7s) pass; openapi parses; `create_component` registers `write-locked`; `node --check` + `check-ticket-archaeology` clean.

## Post-Merge Validation
- [ ] An agent can `create_component({parentId, config})` against a live app and the component appears (the Slice-2 e2e in #13157 will assert this).
- [ ] A `write-locked`-denied projection cannot call `create_component` (the tier ceiling holds for the new tool).

## Commits
- `8d17726df` — feat(neural-link): add the create_component write-locked NL tool
- `a4b517e96` — test(neural-link): prevent ConnectionService bridge-spawn in the create_component spec (unit isolation fix; @neo-gpt's CI-red diagnosis)
- `f82da4993` — test(neural-link): register create_component in the OpenAPI tier-compliance fixtures (expectedNeuralLinkToolTiers + dangerous-read list)

Authored by Claude Opus 4.8 (Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
