### PR TITLE
feat(ai): Fleet Manager repo-provisioning executor (#13155)

### DIFF
--- a/ai/services/fleet/provisionAgentRepo.mjs
+++ b/ai/services/fleet/provisionAgentRepo.mjs
@@ -66,12 +66,16 @@ export async function provisionAgentRepo({repoPath, provisioningAction, cloneUrl
             // An existing valid checkout: keep it as-is (re-cloning would fork the path-keyed memory).
             return {repoPath, action: 'reused', cloned: false};
 
-        case 'clone':
-            if (typeof cloneUrl !== 'string' || cloneUrl.length === 0) {
-                throw new Error("provisionAgentRepo: 'cloneUrl' is required for a 'clone' action.");
+        case 'clone': {
+            // Blank-check, not just empty-check: a whitespace-only cloneUrl must fail closed and never
+            // reach the clone seam. Pass the trimmed url so accidental padding doesn't break the clone.
+            const url = typeof cloneUrl === 'string' ? cloneUrl.trim() : '';
+            if (!url) {
+                throw new Error("provisionAgentRepo: 'cloneUrl' is required (a non-blank string) for a 'clone' action.");
             }
-            await cloneRepo(cloneUrl, repoPath);
+            await cloneRepo(url, repoPath);
             return {repoPath, action: 'cloned', cloned: true};
+        }
 
         default:
             throw new Error(`provisionAgentRepo: unknown provisioningAction '${provisioningAction}'.`);

--- a/ai/services/fleet/provisionAgentRepo.mjs
+++ b/ai/services/fleet/provisionAgentRepo.mjs
@@ -1,0 +1,79 @@
+import {execFile}  from 'child_process';
+import path        from 'path';
+import {promisify} from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Default clone executor: a real `git clone -- <cloneUrl> <repoPath>`. The `--` terminates git's
+ * option parsing so a hostile URL or path cannot smuggle a flag. Overridden via the `cloneRepo` seam
+ * in tests so the provisioning contract is exercised without a git binary or network — mirroring
+ * `FleetLifecycleService`'s default-real `spawnFn` seam.
+ * @param {String} cloneUrl
+ * @param {String} repoPath
+ * @returns {Promise<void>}
+ * @private
+ */
+async function gitClone(cloneUrl, repoPath) {
+    await execFileAsync('git', ['clone', '--', cloneUrl, repoPath]);
+}
+
+/**
+ * @summary Execute a Fleet Manager repo-provisioning decision — the side-effecting "act" half of the
+ * read → decide → act trio, materializing (or safely declining to touch) an agent's managed checkout.
+ *
+ * Given an already-derived `repoPath` and the `provisioningAction` an inspector decided for it, this
+ * carries it out WITHOUT clobbering:
+ * - `'clone'`    → clone `cloneUrl` into the absent / empty path.
+ * - `'reuse'`    → no-op: an existing valid checkout is kept as-is. Re-cloning is never correct —
+ *                 Fleet Manager auto-memory is path-keyed, so it would fork the agent's memory.
+ * - `'conflict'` → throw: the path holds a foreign occupant (a file, a non-empty non-checkout, a
+ *                 symlink) and must never be overwritten.
+ *
+ * The clone is a subprocess side effect, so the executor is injectable: `cloneRepo` defaults to a real
+ * `git clone` but a test passes a recording stub, so the clone / reuse / conflict contract is
+ * unit-testable without a git binary or network — the same default-real + injectable seam
+ * `FleetLifecycleService` uses for process spawning. Decoupled from the inspector (it takes the decided
+ * `provisioningAction`, not the inspector) — the composing derive → inspect → provision orchestrator
+ * is a later leaf.
+ *
+ * @param {Object}    options
+ * @param {String}    options.repoPath           The absolute, already-derived managed checkout path.
+ * @param {String}    options.provisioningAction One of `'clone'` | `'reuse'` | `'conflict'`.
+ * @param {String}   [options.cloneUrl]          The clone source (required for `'clone'`); the caller
+ *                                               supplies an already-credential-resolved URL.
+ * @param {Function} [options.cloneRepo=gitClone] `(cloneUrl, repoPath) => Promise<void>` — the clone
+ *                                               executor; defaults to a real `git clone`, injectable for tests.
+ * @returns {Promise<{repoPath: String, action: String, cloned: Boolean}>}
+ *   `action` ∈ `'cloned' | 'reused'`; `cloned` is `true` only when a clone actually ran.
+ * @throws {Error} On a `'conflict'` action, an unknown action, a missing `cloneUrl` for `'clone'`, or a
+ *   non-string / empty / non-absolute `repoPath`.
+ */
+export async function provisionAgentRepo({repoPath, provisioningAction, cloneUrl, cloneRepo=gitClone} = {}) {
+    if (typeof repoPath !== 'string' || repoPath.length === 0) {
+        throw new Error("provisionAgentRepo: 'repoPath' must be a non-empty string.");
+    }
+    if (!path.isAbsolute(repoPath)) {
+        throw new Error(`provisionAgentRepo: 'repoPath' must be an absolute path, received '${repoPath}'.`);
+    }
+
+    switch (provisioningAction) {
+        case 'conflict':
+            // The inspector found a foreign occupant — refuse rather than overwrite it.
+            throw new Error(`provisionAgentRepo: refusing to provision over a conflicting occupant at '${repoPath}'.`);
+
+        case 'reuse':
+            // An existing valid checkout: keep it as-is (re-cloning would fork the path-keyed memory).
+            return {repoPath, action: 'reused', cloned: false};
+
+        case 'clone':
+            if (typeof cloneUrl !== 'string' || cloneUrl.length === 0) {
+                throw new Error("provisionAgentRepo: 'cloneUrl' is required for a 'clone' action.");
+            }
+            await cloneRepo(cloneUrl, repoPath);
+            return {repoPath, action: 'cloned', cloned: true};
+
+        default:
+            throw new Error(`provisionAgentRepo: unknown provisioningAction '${provisioningAction}'.`);
+    }
+}

--- a/test/playwright/unit/ai/provisionAgentRepo.spec.mjs
+++ b/test/playwright/unit/ai/provisionAgentRepo.spec.mjs
@@ -49,6 +49,21 @@ test.describe('provisionAgentRepo (Fleet Manager repo-provisioning executor)', (
         expect(clone.calls).toHaveLength(0)
     });
 
+    test("'clone' rejects a whitespace-only cloneUrl (blank-check, never reaches the clone seam)", async () => {
+        const clone = makeCloneStub();
+        await expect(provisionAgentRepo({repoPath: REPO, cloneUrl: '   ', provisioningAction: 'clone', cloneRepo: clone}))
+            .rejects.toThrow(/cloneUrl/);
+        expect(clone.calls).toHaveLength(0)
+    });
+
+    test("'clone' trims surrounding whitespace from a valid cloneUrl before cloning", async () => {
+        const clone = makeCloneStub(),
+              r     = await provisionAgentRepo({repoPath: REPO, cloneUrl: `  ${URL}  `, provisioningAction: 'clone', cloneRepo: clone});
+
+        expect(clone.calls[0]).toEqual({cloneUrl: URL, repoPath: REPO});  // trimmed before the seam
+        expect(r).toEqual({repoPath: REPO, action: 'cloned', cloned: true})
+    });
+
     test('an unknown action fails closed (throws, never clones)', async () => {
         const clone = makeCloneStub();
         await expect(provisionAgentRepo({repoPath: REPO, provisioningAction: 'frobnicate', cloneRepo: clone}))

--- a/test/playwright/unit/ai/provisionAgentRepo.spec.mjs
+++ b/test/playwright/unit/ai/provisionAgentRepo.spec.mjs
@@ -1,0 +1,76 @@
+import {test, expect}        from '@playwright/test';
+import {provisionAgentRepo}  from '../../../../ai/services/fleet/provisionAgentRepo.mjs';
+
+// A recording clone stub — the injectable side-effect seam, mirroring FleetLifecycleService.spec's
+// spawn stub. It records calls so the clone/reuse/conflict contract is asserted with no git binary or
+// network. `impl` lets a case simulate a clone failure.
+const makeCloneStub = impl => {
+    const calls = [];
+    const fn    = async (cloneUrl, repoPath) => {
+        calls.push({cloneUrl, repoPath});
+        if (impl) return impl(cloneUrl, repoPath);
+    };
+    fn.calls = calls;
+    return fn
+};
+
+const REPO = '/srv/fleet/agent-a/neomjs-neo',
+      URL  = 'https://example.test/neomjs/neo.git';
+
+test.describe('provisionAgentRepo (Fleet Manager repo-provisioning executor)', () => {
+    test("'clone' invokes the clone executor exactly once and reports cloned", async () => {
+        const clone = makeCloneStub(),
+              r     = await provisionAgentRepo({repoPath: REPO, cloneUrl: URL, provisioningAction: 'clone', cloneRepo: clone});
+
+        expect(clone.calls).toHaveLength(1);
+        expect(clone.calls[0]).toEqual({cloneUrl: URL, repoPath: REPO});
+        expect(r).toEqual({repoPath: REPO, action: 'cloned', cloned: true})
+    });
+
+    test("'reuse' never invokes the clone executor (no reclone of an existing checkout)", async () => {
+        const clone = makeCloneStub(),
+              r     = await provisionAgentRepo({repoPath: REPO, provisioningAction: 'reuse', cloneRepo: clone});
+
+        expect(clone.calls).toHaveLength(0);
+        expect(r).toEqual({repoPath: REPO, action: 'reused', cloned: false})
+    });
+
+    test("'conflict' throws and never invokes the clone executor (never clobber)", async () => {
+        const clone = makeCloneStub();
+        await expect(provisionAgentRepo({repoPath: REPO, provisioningAction: 'conflict', cloneRepo: clone}))
+            .rejects.toThrow(/conflict/i);
+        expect(clone.calls).toHaveLength(0)
+    });
+
+    test("'clone' requires a cloneUrl — throws without one and never clones", async () => {
+        const clone = makeCloneStub();
+        await expect(provisionAgentRepo({repoPath: REPO, provisioningAction: 'clone', cloneRepo: clone}))
+            .rejects.toThrow(/cloneUrl/);
+        expect(clone.calls).toHaveLength(0)
+    });
+
+    test('an unknown action fails closed (throws, never clones)', async () => {
+        const clone = makeCloneStub();
+        await expect(provisionAgentRepo({repoPath: REPO, provisioningAction: 'frobnicate', cloneRepo: clone}))
+            .rejects.toThrow(/unknown/i);
+        expect(clone.calls).toHaveLength(0)
+    });
+
+    test('a clone-executor failure propagates (provisioning fails loud)', async () => {
+        const clone = makeCloneStub(() => { throw new Error('git exited 128') });
+        await expect(provisionAgentRepo({repoPath: REPO, cloneUrl: URL, provisioningAction: 'clone', cloneRepo: clone}))
+            .rejects.toThrow(/git exited 128/)
+    });
+
+    test('fails loud on repoPath contract violations', async () => {
+        await expect(provisionAgentRepo({repoPath: '',           provisioningAction: 'reuse'})).rejects.toThrow(/repoPath/);
+        await expect(provisionAgentRepo({repoPath: 42,           provisioningAction: 'reuse'})).rejects.toThrow(/repoPath/);
+        await expect(provisionAgentRepo({                        provisioningAction: 'reuse'})).rejects.toThrow(/repoPath/);
+        await expect(provisionAgentRepo({repoPath: 'relative/x', provisioningAction: 'reuse'})).rejects.toThrow(/absolute/)
+    });
+
+    test('non-clone actions work without an injected cloneRepo (the default seam is harmless off the clone path)', async () => {
+        const r = await provisionAgentRepo({repoPath: REPO, provisioningAction: 'reuse'});
+        expect(r).toEqual({repoPath: REPO, action: 'reused', cloned: false})
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13155

The side-effecting **"act"** leaf completing the Fleet Manager repo-provisioning trio: #13145 / PR #13146 derives the path (the "where"), #13148 / PR #13149 inspects the checkout state (the "what's there" → a `provisioningAction`), and `ai/services/fleet/provisionAgentRepo.mjs` **executes** that action — materializing the managed checkout under the hood, the operator's *"repos managed under the hood."*

`provisionAgentRepo({repoPath, provisioningAction, cloneUrl, cloneRepo})` carries out the decision **without clobbering**:

| `provisioningAction` | effect | result |
|---|---|---|
| `'clone'` | `git clone cloneUrl` into the absent/empty path | `{action:'cloned', cloned:true}` |
| `'reuse'` | no-op — keep the existing checkout | `{action:'reused', cloned:false}` |
| `'conflict'` | **throw** — never overwrite a foreign occupant | — |

`reuse` (not reclone) over an existing checkout is load-bearing: Fleet Manager auto-memory is checkout-path-keyed, so re-cloning a present checkout would fork its memory. Unknown action / missing `cloneUrl` for a clone / non-absolute `repoPath` all fail closed.

**Test seam — the repo's own idiom.** The clone is a subprocess side effect, so the executor follows `FleetLifecycleService`'s **default-real + injectable** pattern: `cloneRepo` defaults to a real `git clone -- <url> <dest>` (the `--` terminates git option parsing so a hostile URL/path can't smuggle a flag), but is injectable, so the spec asserts the whole clone/reuse/conflict contract with a recording stub — **no git binary or network in tests**, exactly as `FleetLifecycleService.spawnFn` + its spawn-stub spec do. The leaf is **decoupled** from the inspector (it takes the decided `provisioningAction`, not the inspector), so the composing `derive → inspect → provision` orchestrator is a clean later leaf.

## Deltas

None from the ticket scope. Out of scope (named in the ticket): the composing orchestrator, wrong-remote repair, and credential/PAT resolution into the clone URL (the caller supplies an already-resolved `cloneUrl`).

## Test Evidence

Evidence: L1 (unit spec over an injected clone stub) — the required level for the executor's decision contract; the default real `git clone` is a thin `execFile` wrapper exercised through the same seam the consuming orchestrator will integration-test.

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/provisionAgentRepo.spec.mjs
→ 8 passed (615ms)
```

The 8 cases: `clone` invokes the executor once + reports `cloned:true`; `reuse` never invokes it; `conflict` throws + never invokes it; `clone` requires a `cloneUrl`; an unknown action fails closed; a clone-executor failure propagates; `repoPath` contract violations throw; and `reuse` works with the default (un-injected) seam.

## Post-Merge Validation

- [ ] The composing `ensureAgentRepo` orchestrator (a later leaf) wires `deriveAgentRepoPath` → `inspectAgentRepo` → `provisionAgentRepo` and integration-tests the real `git clone` against a local bare-repo fixture.
- [ ] The FM lifecycle spawns an agent only after its repo is provisioned (`cloned` or `reused`), and surfaces `conflict` to the operator rather than overwriting.

## Structural Pre-Flight

`ai/services/fleet/provisionAgentRepo.mjs` — co-located with its sibling provisioning leaves (`deriveAgentRepoPath`, `inspectAgentRepo`) and `FleetLifecycleService` (whose injectable-`spawnFn` seam this mirrors), Brain side `ai/`, as a plain exported async function. Spec at `test/playwright/unit/ai/provisionAgentRepo.spec.mjs` — the flattened `ai/services/*` → `unit/ai/` mirror. Independent of #13146 / #13149 (decoupled — takes the resolved path + action), so it targets `dev` directly with no stack.

Refs #13015 (parent), #13012 (grandparent), #13145 + #13148 (sibling provisioning leaves).
