### PR TITLE
feat(dashboard): add dock split resize operation (#13159)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -169,6 +169,7 @@ Future implementations should mutate the model through semantic operations inste
 |---|---|---|
 | `moveItem` | `itemId`, `targetNodeId`, `index` | Reorders an item within a tab slot or split-derived target. |
 | `splitNode` | `targetNodeId`, `orientation`, `beforeNodeId`, `afterNodeId`, `sizes` | Replaces a node with a split containing the old and new nodes. |
+| `resizeSplit` | `splitNodeId`, `sizes` | Updates an existing split node's normalized child sizes after a splitter affordance. |
 | `addTab` | `itemId`, `tabsNodeId`, `index` | Inserts an item into a tab slot and may set `activeItemId`. |
 | `detachItem` | `itemId` | Removes an item from the dock tree while preserving its item record for popup/window ownership. |
 | `closeItem` | `itemId` | Removes an item from both tree and catalog when policy permits. |
@@ -363,7 +364,7 @@ The adapter must not read `DOMRect`, `windowId`, pointer coordinates, preview pl
 | `children` | projected child configs in listed order | Ordering is model-owned and serializable. |
 | `sizes` | child `flex` values when present | Normalize or ignore invalid ratios before projection. |
 
-Resizable splitters are a later rendering affordance. When added, they should sit between projected children and write back semantic size changes through an operation, not mutate persisted `sizes` directly from pointer handlers.
+Resizable splitters are a later rendering affordance. When added, they should sit between projected children and write back semantic size changes through `resizeSplit`, not mutate persisted `sizes` directly from pointer handlers.
 
 ### Tab Projection
 

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -507,6 +507,55 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Validates and normalizes split-size ratios to sum to 1.
+     * @param {Array<Number>} sizes
+     * @param {Number} count
+     * @param {String} splitNodeId
+     * @returns {{sizes:Number[], errors:String[]}}
+     * @protected
+     * @static
+     */
+    static normalizeSplitSizes(sizes, count, splitNodeId) {
+        let errors = [];
+
+        if (!Array.isArray(sizes)) {
+            return {sizes: [], errors: ['sizes must be an array']}
+        }
+
+        if (sizes.length !== count) {
+            return {sizes: [], errors: [`split "${splitNodeId}" sizes length ${sizes.length} != children length ${count}`]}
+        }
+
+        for (let i = 0; i < sizes.length; i++) {
+            let value = sizes[i];
+
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+                errors.push(`split "${splitNodeId}" size ${i} must be a finite number`)
+            } else if (value <= 0) {
+                errors.push(`split "${splitNodeId}" size ${i} must be greater than 0`)
+            }
+        }
+
+        if (errors.length) {
+            return {sizes: [], errors}
+        }
+
+        let total = sizes.reduce((sum, value) => sum + value, 0);
+
+        if (!Number.isFinite(total) || total <= 0) {
+            return {sizes: [], errors: [`split "${splitNodeId}" sizes must sum to a finite positive value`]}
+        }
+
+        let normalized = sizes.map(value => value / total);
+
+        if (normalized.length > 1) {
+            normalized[normalized.length - 1] = 1 - normalized.slice(0, -1).reduce((sum, value) => sum + value, 0)
+        }
+
+        return {sizes: normalized, errors: []}
+    }
+
+    /**
      * @summary Wraps a valid committed dock-zone document in a JSON-only saved-layout envelope.
      *
      * The wrapper and dock-zone tree are finite-schema: unknown fields fail closed. The explicit
@@ -745,6 +794,41 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Updates an existing split node's normalized child sizes.
+     *
+     * Resizable splitter affordances can pass pixel-derived or ratio-derived positive values. This
+     * operation normalizes them to the persisted dock-zone ratio contract and commits through the
+     * same fail-closed path as the rest of the semantic model.
+     * @param {Object} document
+     * @param {Object} args {splitNodeId, sizes}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static resizeSplit(document, {splitNodeId, sizes} = {}) {
+        let split = document.nodes?.[splitNodeId];
+
+        if (!split) {
+            return {document, errors: [`unknown split node "${splitNodeId}"`]}
+        }
+
+        if (split.type !== 'split') {
+            return {document, errors: [`"${splitNodeId}" is not a split node`]}
+        }
+
+        let normalized = DockZoneModel.normalizeSplitSizes(sizes, (split.children || []).length, splitNodeId);
+
+        if (normalized.errors.length) {
+            return {document, errors: normalized.errors}
+        }
+
+        let doc = DockZoneModel.clone(document);
+
+        doc.nodes[splitNodeId].sizes = normalized.sizes;
+
+        return DockZoneModel.commit(document, doc)
+    }
+
+    /**
      * @summary Removes `itemId` from the tree but preserves its catalog record (for popup/window
      * ownership), per the contract's `detachItem`.
      * @param {Object} document
@@ -804,6 +888,8 @@ class DockZoneModel extends Base {
                 return DockZoneModel.moveItem(document, descriptor);
             case 'splitNode':
                 return DockZoneModel.splitNode(document, descriptor);
+            case 'resizeSplit':
+                return DockZoneModel.resizeSplit(document, descriptor);
             case 'detachItem':
                 return DockZoneModel.detachItem(document, descriptor);
             case 'closeItem':

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -40,6 +40,27 @@ function doc() {
     }
 }
 
+/**
+ * A canonical split document with `main-tabs` and `side-tabs` under one split, so size operations
+ * do not have to build a split through drag/drop descriptors first.
+ * @param {Array<Number>} [sizes=[0.5, 0.5]]
+ * @returns {Object}
+ */
+function splitDoc(sizes=[0.5, 0.5]) {
+    const d = doc();
+
+    d.nodes['main-split'] = {
+        type       : 'split',
+        orientation: 'horizontal',
+        children   : ['main-tabs', 'side-tabs'],
+        sizes
+    };
+    d.nodes.root.zones.center = 'main-split';
+    delete d.nodes.root.zones.right;
+
+    return d
+}
+
 /** Collects the tabs node id holding an item, across a document. */
 function tabsOf(document, itemId) {
     return DockZoneModel.findContainingTabsId(document, itemId)
@@ -404,6 +425,50 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         })
     });
 
+    test.describe('resizeSplit', () => {
+        test('updates split sizes with normalized finite positive values', () => {
+            const input    = splitDoc(),
+                  snapshot = JSON.stringify(input),
+                  ratios   = [3, 1],
+                  {document, errors} = DockZoneModel.resizeSplit(input, {
+                      splitNodeId: 'main-split',
+                      sizes      : ratios
+                  });
+
+            expect(errors).toEqual([]);
+            expect(document).not.toBe(input);
+            expect(document.nodes['main-split'].sizes).toEqual([0.75, 0.25]);
+            expect(DockZoneModel.validate(document)).toEqual([]);
+            expect(JSON.stringify(input)).toBe(snapshot);
+
+            ratios[0] = 1;
+            expect(document.nodes['main-split'].sizes).toEqual([0.75, 0.25])
+        });
+
+        test('fails closed for invalid targets and invalid size payloads', () => {
+            const input    = splitDoc(),
+                  snapshot = JSON.stringify(input),
+                  cases    = [
+                      {splitNodeId: 'ghost', sizes: [1, 1]},
+                      {splitNodeId: 'root', sizes: [1, 1]},
+                      {splitNodeId: 'main-split'},
+                      {splitNodeId: 'main-split', sizes: [1]},
+                      {splitNodeId: 'main-split', sizes: [1, 0]},
+                      {splitNodeId: 'main-split', sizes: [1, -1]},
+                      {splitNodeId: 'main-split', sizes: [1, Infinity]},
+                      {splitNodeId: 'main-split', sizes: [1, '1']}
+                  ];
+
+            for (const args of cases) {
+                const {document, errors} = DockZoneModel.resizeSplit(input, args);
+
+                expect(errors.length).toBeGreaterThan(0);
+                expect(document).toBe(input);
+                expect(JSON.stringify(input)).toBe(snapshot)
+            }
+        })
+    });
+
     test.describe('detachItem / closeItem', () => {
         test('detachItem removes from the tree but keeps the catalog record', () => {
             const {document, errors} = DockZoneModel.detachItem(doc(), {itemId: 'terminal'});
@@ -458,6 +523,17 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             const {document, errors} = DockZoneModel.applyOperation(doc(), descriptor);
             expect(errors).toEqual([]);
             expect(document.nodes[document.nodes.root.zones.center].type).toBe('split')
+        });
+
+        test('dispatches resizeSplit descriptors', () => {
+            const {document, errors} = DockZoneModel.applyOperation(splitDoc(), {
+                operation  : 'resizeSplit',
+                splitNodeId: 'main-split',
+                sizes      : [1, 3]
+            });
+
+            expect(errors).toEqual([]);
+            expect(document.nodes['main-split'].sizes).toEqual([0.25, 0.75])
         });
 
         test('rejects an unknown operation', () => {


### PR DESCRIPTION
Resolves #13159
Related: #13158

Authored by GPT-5.5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

Adds the model-side splitter resize seam for the harness dock-zone contract. `DockZoneModel.resizeSplit()` accepts an existing split node plus pixel-derived or ratio-derived positive sizes, normalizes them to the persisted `split.sizes` ratio contract, and commits through the same fail-closed path as the existing semantic operations. `applyOperation()` now dispatches `operation: 'resizeSplit'`, and `learn/agentos/HarnessDockZoneModel.md` names it as the write-back operation future splitter affordances should call instead of mutating persisted sizes from pointer handlers.

Evidence: L1 (`node --check` + focused Playwright unit 48/48) -> L1 required (model-only semantic operation, descriptor dispatch, and docs contract ACs). No residuals.

## Deltas from ticket

- No scope expansion: no splitter UI, pointer handling, adapter projection change, persistence storage, or named-perspective work.
- Added a protected `normalizeSplitSizes()` helper so fail-closed size validation is isolated before `commit()` normalizes the tree.
- `HarnessDockZoneModel.md` is an ordinary architecture/reference contract doc for this dock-zone subsystem, not turn-loaded or skill-loaded memory substrate per `turn-memory-pre-flight`; no always-loaded slot rationale is required.

Decision Record impact: aligned-with ADR 0020.

## Test Evidence

- `node --check src/dashboard/DockZoneModel.mjs` -> passed.
- `npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` -> 48 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-commit hooks ran `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology` on the staged files.

## Post-Merge Validation

- [ ] A future splitter UI can feed pixel-derived ratios into `resizeSplit` and render the updated flex values through `DockLayoutAdapter` without persisting pointer state.

## Commits

- `ddd04e494` — `feat(dashboard): add dock split resize operation (#13159)`
