### PR TITLE
fix(dashboard): reject secret-like dock layout metadata (#13153)

### DIFF
--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -197,6 +197,64 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Returns true when a metadata key name is likely to carry credential material.
+     * @param {String} key
+     * @returns {Boolean}
+     * @protected
+     * @static
+     */
+    static isSecretMetadataKey(key) {
+        let normalized = key
+            .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+            .replace(/[^a-z0-9]+/gi, '_')
+            .replace(/^_+|_+$/g, '')
+            .toLowerCase();
+
+        return /(^|_)(secret|secrets|token|tokens|credential|credentials|password|passwords|pat|pats)$/.test(normalized) ||
+            /(^|_)(api|auth|session|access|refresh|bridge|github|private|personal_access)_?(key|token|secret|credential|password)$/.test(normalized)
+    }
+
+    /**
+     * @summary Returns the first metadata key that looks like credential material.
+     * @param {*} value
+     * @param {String} [path='metadata']
+     * @returns {{key:String, path:String, reason:String}|null}
+     * @protected
+     * @static
+     */
+    static findSecretMetadataKey(value, path='metadata') {
+        if (Array.isArray(value)) {
+            for (let i = 0; i < value.length; i++) {
+                let match = DockZoneModel.findSecretMetadataKey(value[i], `${path}[${i}]`);
+
+                if (match) {
+                    return match
+                }
+            }
+
+            return null
+        }
+
+        if (!DockZoneModel.isJsonRecord(value)) {
+            return null
+        }
+
+        for (const [key, child] of Object.entries(value)) {
+            if (DockZoneModel.isSecretMetadataKey(key)) {
+                return {key, path: `${path}.${key}`, reason: 'metadata must not contain credentials or secrets'}
+            }
+
+            let match = DockZoneModel.findSecretMetadataKey(child, `${path}.${key}`);
+
+            if (match) {
+                return match
+            }
+        }
+
+        return null
+    }
+
+    /**
      * @summary Returns the first field in a dock-zone document that is outside the persisted schema.
      *
      * `metadata` and `blueprint` are explicit opaque JSON-only extension points. They are caller-owned
@@ -564,6 +622,12 @@ class DockZoneModel extends Base {
             errors.push('metadata must be a JSON object')
         }
 
+        let secretKey = DockZoneModel.findSecretMetadataKey(layout.metadata, 'savedLayout.metadata');
+
+        if (secretKey) {
+            errors.push(`saved layout metadata contains secret-like field "${secretKey.key}" at ${secretKey.path}: ${secretKey.reason}`)
+        }
+
         unexpectedKey = DockZoneModel.findUnexpectedKey(layout, DockZoneModel.savedLayoutKeys, 'savedLayout') ||
             DockZoneModel.findUnexpectedDockZoneKey(layout.dockZone, 'savedLayout.dockZone');
 
@@ -615,6 +679,14 @@ class DockZoneModel extends Base {
 
         if (Object.hasOwn(savedLayout, 'metadata') && !DockZoneModel.isJsonRecord(savedLayout.metadata)) {
             errors.push('metadata must be a JSON object')
+        }
+
+        let secretKey = Object.hasOwn(savedLayout, 'metadata')
+            ? DockZoneModel.findSecretMetadataKey(savedLayout.metadata, 'savedLayout.metadata')
+            : null;
+
+        if (secretKey) {
+            errors.push(`saved layout metadata contains secret-like field "${secretKey.key}" at ${secretKey.path}: ${secretKey.reason}`)
         }
 
         let unexpectedKey = DockZoneModel.findUnexpectedKey(savedLayout, DockZoneModel.savedLayoutKeys, 'savedLayout') ||

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -234,6 +234,53 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(rejected.errors.join(' ')).toContain('windowId')
         });
 
+        test('rejects secret-like saved-layout metadata keys on save or restore', () => {
+            for (const key of ['apiKey', 'sessionKey', 'authKey']) {
+                const metadata = {[key]: 'secret-value'},
+                      saved    = DockZoneModel.createSavedLayout(doc(), {
+                          layoutId: 'operator-default',
+                          title   : 'Operator Default',
+                          metadata
+                      });
+
+                expect(saved.layout).toBe(null);
+                expect(saved.errors.join(' ')).toContain(key);
+                expect(metadata[key]).toBe('secret-value')
+            }
+
+            const nested = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                metadata: {
+                    operatorNote: {
+                        apiToken: 'secret-value'
+                    }
+                }
+            });
+
+            expect(nested.layout).toBe(null);
+            expect(nested.errors.join(' ')).toContain('apiToken');
+
+            const {layout} = DockZoneModel.createSavedLayout(doc(), {
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                metadata: {
+                    operatorNote: 'non-secret annotation'
+                }
+            });
+
+            layout.metadata = {
+                recovery: {
+                    authKey: 'secret-value'
+                }
+            };
+
+            const restored = DockZoneModel.restoreSavedLayout(layout);
+
+            expect(restored.document).toBe(null);
+            expect(restored.errors.join(' ')).toContain('authKey')
+        });
+
         test('rejects non-JSON values in metadata and item blueprints', () => {
             const badMetadata = DockZoneModel.createSavedLayout(doc(), {
                 layoutId: 'operator-default',


### PR DESCRIPTION
Resolves #13153
Related: #13152
Related: #13147

Authored by GPT-5.5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

Tightens the saved-layout helper boundary from "JSON-only metadata" to "JSON-only metadata with secret-like key names rejected" for the `neo.harness.dockLayout.v1` wrapper. `DockZoneModel.createSavedLayout()` and `restoreSavedLayout()` now fail closed when wrapper metadata contains secret-like key names such as `apiKey`, `sessionKey`, `authKey`, nested token fields, credential fields, password fields, or PAT aliases. The guard does not inspect metadata values, so callers must still avoid placing credential values under innocuous keys. Non-secret operator annotations still round-trip unchanged, and the helper remains pure and storage-backend-free.

Evidence: L1 (`node --check` + focused Playwright unit 46/46) -> L1 required (pure helper contract, fail-closed restore/create ACs). No residuals.

## Deltas from ticket

- Chose a recursive suspicious-key-name policy rather than a full metadata allowlist, preserving the existing free-form annotation channel while blocking common credential-key aliases.
- Kept the existing `HarnessDockZoneModel.md` caller obligation that metadata must not contain credentials, PATs, access tokens, or harness bridge tokens; this PR enforces secret-like key names and deliberately does not inspect values.
- No storage backend, layout UI, or broader dock-zone schema rewrite.

Decision Record impact: none.

## Test Evidence

- `node --check src/dashboard/DockZoneModel.mjs` -> passed.
- `npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` -> 46 passed.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed.
- Pre-commit hooks ran `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology` on the staged files.

## Post-Merge Validation

- [ ] Saved-layout storage/UI consumers treat helper-produced wrapper metadata as JSON-only descriptive annotations with secret-like key names rejected; metadata values are not inspected and must not carry credential material.

## Commits

- `4837942a1` — `fix(dashboard): reject secret-like dock layout metadata (#13153)`
