### PR TITLE
feat(ai): Fleet Manager ensureAgentRepo orchestrator (#13162)

### DIFF
--- a/ai/services/fleet/ensureAgentRepo.mjs
+++ b/ai/services/fleet/ensureAgentRepo.mjs
@@ -1,0 +1,50 @@
+import {deriveAgentRepoPath} from './deriveAgentRepoPath.mjs';
+import {inspectAgentRepo}    from './inspectAgentRepo.mjs';
+import {provisionAgentRepo}  from './provisionAgentRepo.mjs';
+
+/**
+ * @summary Ensure an agent's managed repo checkout exists — the single Fleet Manager entry point that
+ * composes the repo-provisioning trio (derive the path → inspect the state → provision the action).
+ *
+ * Given an agent + repo + the managed root + a clone URL, this derives the stable checkout path,
+ * inspects what is on disk, and carries out the provisioning decision WITHOUT clobbering:
+ * - an absent / empty path → clones `cloneUrl` into it;
+ * - an existing valid checkout → reuses it as-is (no reclone — Fleet Manager auto-memory is path-keyed);
+ * - a foreign occupant (a file, a non-empty non-checkout, a symlink) → throws (never overwrite).
+ *
+ * Each step's contract is inherited from its primitive: `deriveAgentRepoPath` validates the inputs +
+ * computes a stable, collision-free, traversal-safe path; `inspectAgentRepo` classifies the on-disk
+ * state read-only; `provisionAgentRepo` executes via an injectable clone seam. The `cloneRepo` seam is
+ * passed through so the composed flow is unit-testable without a git binary; the default (un-injected)
+ * path runs a real `git clone`.
+ *
+ * Fleet Manager is single-writer (Scenario-C-zero per the MVP epic), so the inspect→provision sequence
+ * is not TOCTOU-guarded — and does not need to be: `git clone` fails safe if the directory changed
+ * underneath, and no second writer races the same checkout.
+ *
+ * @param {Object}    options
+ * @param {String}    options.managedRoot The absolute, trusted fleet-managed checkout root.
+ * @param {String}    options.agentId     The Fleet Manager agent id.
+ * @param {String}    options.repoSlug    The repo identifier, e.g. `'neomjs/neo'`.
+ * @param {String}   [options.cloneUrl]   The clone source (required only when a clone is needed).
+ * @param {Function} [options.cloneRepo]  `(cloneUrl, repoPath) => Promise<void>` — the clone executor;
+ *                                        defaults to a real `git clone`, injectable for tests.
+ * @returns {Promise<{repoPath: String, state: String, action: String, cloned: Boolean}>}
+ *   `repoPath` is the derived checkout path; `state` is the inspected on-disk state; `action` ∈
+ *   `'cloned' | 'reused'`; `cloned` is `true` only when a clone ran.
+ * @throws {Error} On invalid `managedRoot` / `agentId` / `repoSlug` (from derivation), a conflicting
+ *   occupant, or a missing `cloneUrl` when a clone is required.
+ */
+export async function ensureAgentRepo({managedRoot, agentId, repoSlug, cloneUrl, cloneRepo} = {}) {
+    const
+        repoPath   = deriveAgentRepoPath({managedRoot, agentId, repoSlug}),
+        inspection = inspectAgentRepo({repoPath}),
+        result     = await provisionAgentRepo({
+            repoPath,
+            provisioningAction: inspection.provisioningAction,
+            cloneUrl,
+            cloneRepo
+        });
+
+    return {repoPath, state: inspection.state, action: result.action, cloned: result.cloned};
+}

--- a/test/playwright/unit/ai/ensureAgentRepo.spec.mjs
+++ b/test/playwright/unit/ai/ensureAgentRepo.spec.mjs
@@ -1,0 +1,87 @@
+import {test, expect}        from '@playwright/test';
+import fs                    from 'fs';
+import os                    from 'os';
+import path                  from 'path';
+import {deriveAgentRepoPath} from '../../../../ai/services/fleet/deriveAgentRepoPath.mjs';
+import {ensureAgentRepo}     from '../../../../ai/services/fleet/ensureAgentRepo.mjs';
+
+// Integration of the provisioning trio (derive → inspect → provision) over real temp-dir fixtures, with
+// the clone executor injected as a recording stub (no git binary) — inspectAgentRepo.spec's temp-dir
+// pattern + provisionAgentRepo.spec's clone stub, composed.
+
+let suiteRoot;
+
+test.beforeAll(() => { suiteRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-agent-repo-')); });
+test.afterAll(()  => { fs.rmSync(suiteRoot, {recursive: true, force: true}); });
+
+const makeCloneStub = () => {
+    const calls = [];
+    const fn    = async (cloneUrl, repoPath) => { calls.push({cloneUrl, repoPath}) };
+    fn.calls = calls;
+    return fn
+};
+
+// the path the orchestrator will resolve — so a fixture can be staged at it before the call
+const pathFor = (managedRoot, agentId, repoSlug) => deriveAgentRepoPath({managedRoot, agentId, repoSlug});
+
+const URL = 'https://example.test/neomjs/neo.git';
+
+test.describe('ensureAgentRepo (Fleet Manager derive → inspect → provision orchestrator)', () => {
+    test('absent path → clones into the derived path and reports cloned', async () => {
+        const clone = makeCloneStub(),
+              args  = {managedRoot: suiteRoot, agentId: 'agent-absent', repoSlug: 'neomjs/neo'},
+              want  = pathFor(args.managedRoot, args.agentId, args.repoSlug),
+              r     = await ensureAgentRepo({...args, cloneUrl: URL, cloneRepo: clone});
+
+        expect(r).toEqual({repoPath: want, state: 'absent', action: 'cloned', cloned: true});
+        expect(clone.calls).toEqual([{cloneUrl: URL, repoPath: want}])
+    });
+
+    test('existing checkout → reuses it, never invoking the clone executor', async () => {
+        const clone = makeCloneStub(),
+              args  = {managedRoot: suiteRoot, agentId: 'agent-checkout', repoSlug: 'neomjs/neo'},
+              want  = pathFor(args.managedRoot, args.agentId, args.repoSlug);
+
+        fs.mkdirSync(path.join(want, '.git'), {recursive: true}); // stage a valid checkout
+
+        const r = await ensureAgentRepo({...args, cloneUrl: URL, cloneRepo: clone});
+
+        expect(r).toEqual({repoPath: want, state: 'checkout', action: 'reused', cloned: false});
+        expect(clone.calls).toHaveLength(0)
+    });
+
+    test('foreign occupant → throws (conflict), never invoking the clone executor', async () => {
+        const clone = makeCloneStub(),
+              args  = {managedRoot: suiteRoot, agentId: 'agent-occupied', repoSlug: 'neomjs/neo'},
+              want  = pathFor(args.managedRoot, args.agentId, args.repoSlug);
+
+        fs.mkdirSync(want, {recursive: true});
+        fs.writeFileSync(path.join(want, 'README.md'), '# not ours\n'); // non-checkout occupant
+
+        await expect(ensureAgentRepo({...args, cloneUrl: URL, cloneRepo: clone})).rejects.toThrow(/conflict/i);
+        expect(clone.calls).toHaveLength(0)
+    });
+
+    test('a clone is required but cloneUrl is missing → fails closed (from the provision step)', async () => {
+        const clone = makeCloneStub(),
+              args  = {managedRoot: suiteRoot, agentId: 'agent-nourl', repoSlug: 'neomjs/neo'};
+
+        await expect(ensureAgentRepo({...args, cloneRepo: clone})).rejects.toThrow(/cloneUrl/);
+        expect(clone.calls).toHaveLength(0)
+    });
+
+    test('invalid inputs throw from the derivation step (contract inherited)', async () => {
+        await expect(ensureAgentRepo({managedRoot: '',           agentId: 'a', repoSlug: 'r'})).rejects.toThrow(/managedRoot/);
+        await expect(ensureAgentRepo({managedRoot: 'relative/x', agentId: 'a', repoSlug: 'r'})).rejects.toThrow(/absolute/);
+        await expect(ensureAgentRepo({managedRoot: suiteRoot,    agentId: '',  repoSlug: 'r'})).rejects.toThrow(/agentId/)
+    });
+
+    test('two distinct agents ensure into distinct checkouts (no cross-contamination)', async () => {
+        const clone = makeCloneStub(),
+              ra    = await ensureAgentRepo({managedRoot: suiteRoot, agentId: 'agent-x', repoSlug: 'neomjs/neo', cloneUrl: URL, cloneRepo: clone}),
+              rb    = await ensureAgentRepo({managedRoot: suiteRoot, agentId: 'agent-y', repoSlug: 'neomjs/neo', cloneUrl: URL, cloneRepo: clone});
+
+        expect(ra.repoPath).not.toBe(rb.repoPath);
+        expect(clone.calls).toHaveLength(2) // both absent → both cloned, into distinct paths
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13162

The **capstone** of the Fleet Manager repo-provisioning trio — the single "ensure an agent's repo exists" entry point the FM lifecycle calls. The three primitives are now merged on dev (#13146 derive, #13149 inspect, #13156 provision); `ai/services/fleet/ensureAgentRepo.mjs` composes them:

```
ensureAgentRepo({managedRoot, agentId, repoSlug, cloneUrl, cloneRepo})
  → repoPath   = deriveAgentRepoPath({managedRoot, agentId, repoSlug})   // the stable "where"
  → inspection = inspectAgentRepo({repoPath})                            // the on-disk "what" → action
  → result     = await provisionAgentRepo({repoPath, provisioningAction, cloneUrl, cloneRepo})  // the "act"
  → {repoPath, state, action, cloned}
```

No clobbering, end to end: an absent/empty path clones; an existing valid checkout is reused (no reclone — auto-memory is path-keyed); a foreign occupant (file, non-empty non-checkout, symlink) throws. Each step inherits its primitive's contract — input validation from derive, read-only classification from inspect, the injectable clone seam from provision.

**Testability carries through:** the `cloneRepo` seam passes through to `provisionAgentRepo`, so the *composed* flow is exercised with a recording stub — **no git binary or network in tests** — while the default (un-injected) path runs a real `git clone`. Single-writer (Scenario-C-zero per #13015), so the inspect→provision sequence needs no TOCTOU guard (`git clone` fails safe if the dir changed; no second writer races the checkout).

## Deltas

None from the ticket scope. Out of scope (named in the ticket): `cloneUrl`/credential resolution (caller-supplied), wiring `ensureAgentRepo` into `FleetLifecycleService` spawn (a later lifecycle integration), and concurrency/locking (single-writer).

## Test Evidence

Evidence: L1 (integration spec over temp-dir fixtures + an injected clone stub) — the composed contract; the real `git clone` default is the same `execFile` wrapper the provision leaf ships, exercised through the same seam its consumers will integration-test.

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/ensureAgentRepo.spec.mjs
→ 6 passed (663ms)
```

The 6 cases: absent → cloned (clone seam invoked once into the derived path); existing checkout → reused (clone NOT invoked); foreign occupant → conflict throw (clone NOT invoked); a required clone with a missing `cloneUrl` → fail-closed; invalid inputs → throw (inherited from derive); two distinct agents → distinct checkouts (no cross-contamination).

## Post-Merge Validation

- [ ] `FleetLifecycleService` (or the spawn path) calls `ensureAgentRepo` before launching an agent, resolving `managedRoot`/`cloneUrl` from config + the registry, and surfaces `conflict` to the operator rather than overwriting.
- [ ] An end-to-end integration test (a later leaf) runs the real `git clone` against a local bare-repo fixture through the un-injected default seam.

## Structural Pre-Flight

`ai/services/fleet/ensureAgentRepo.mjs` — co-located with the three primitives it composes (`deriveAgentRepoPath`, `inspectAgentRepo`, `provisionAgentRepo`) + `FleetLifecycleService`, Brain side `ai/`, as a plain exported async function. Spec at `test/playwright/unit/ai/ensureAgentRepo.spec.mjs` — the flattened `ai/services/*` → `unit/ai/` mirror. Off a merged dev (the trio landed), so it targets `dev` directly with no stack.

Refs #13015 (parent), #13012 (grandparent), #13145 + #13148 + #13155 (the composed trio).
