### PR TITLE
docs(readme): drop version-handle notes + Grace's role descriptor from the maintainer table (#13165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ We are not an abstract collective. We are a structured institution of named main
 |---|---|---|---|
 | Tobias | [@tobiu](https://github.com/tobiu) | Substrate architect, empirical-corrector, merge-gate authority | Human |
 | Ada | [@neo-opus-ada](https://github.com/neo-opus-ada) | AI maintainer (Anthropic Claude Opus 4.8) | Machine Account |
-| Grace | [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude Opus 4.8 — same-family generalist; throughput + same-family review pressure) | Machine Account |
-| Vega | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude Opus 4.8; version-free handle) | Machine Account |
-| Mnemosyne | [@neo-fable](https://github.com/neo-fable) | AI maintainer (Anthropic Claude Fable 5; version-free handle; deep-reasoning lane) — _benched 2026-06-13: Fable 5 access suspended_ | Machine Account |
-| Clio | [@neo-fable-clio](https://github.com/neo-fable-clio) | AI maintainer (Anthropic Claude Fable 5; version-free handle; second fable-family member) — _benched 2026-06-13: Fable 5 access suspended_ | Machine Account |
+| Grace | [@neo-claude-opus](https://github.com/neo-claude-opus) | AI maintainer (Anthropic Claude Opus 4.8) | Machine Account |
+| Vega | [@neo-opus-vega](https://github.com/neo-opus-vega) | AI maintainer (Anthropic Claude Opus 4.8) | Machine Account |
+| Mnemosyne | [@neo-fable](https://github.com/neo-fable) | AI maintainer (Anthropic Claude Fable 5; deep-reasoning lane) — _benched 2026-06-13: Fable 5 access suspended_ | Machine Account |
+| Clio | [@neo-fable-clio](https://github.com/neo-fable-clio) | AI maintainer (Anthropic Claude Fable 5; second fable-family member) — _benched 2026-06-13: Fable 5 access suspended_ | Machine Account |
 | - | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
 


### PR DESCRIPTION
Resolves #13165

Two operator-directed cleanups to the README Institution maintainer-table **Role** column (@tobiu's direct review, 2026-06-14).

Evidence: docs-only (a Role-column copy edit, no code/behavior change) → visual table verification; no automated test class applies.

## What changed
- **Grace (`@neo-claude-opus`):** dropped ` — same-family generalist; throughput + same-family review pressure` → now `AI maintainer (Anthropic Claude Opus 4.8)` (operator: "absolutely not, must get removed").
- **`version-free handle`** dropped from `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio` (operator: "all gh usernames now are version-free => no need to mention it").
- The three Claude Opus 4.8 roles (Ada / Grace / Vega) now read uniformly; the Name column already distinguishes them.

## Deltas
- fable / fable-clio's **non-version** descriptors (`deep-reasoning lane`, `second fable-family member`) and the benched notes are left intact — the operator flagged only the version-free mention + Grace's descriptor, not those. Trivially extensible if he wants those uniform too.

## Test Evidence
- Docs-only; no code paths touched. `README.md` only, 4 insertions / 4 deletions. `git diff --check` clean. Rows verified post-edit: Ada/Grace/Vega all `AI maintainer (Anthropic Claude Opus 4.8)`; Mnemosyne `(Anthropic Claude Fable 5; deep-reasoning lane)`; Clio `(Anthropic Claude Fable 5; second fable-family member)`.

## Post-Merge Validation
- [ ] The rendered README maintainer table shows the cleaned Role column (no `version-free handle`, no Grace descriptor).

Authored by Claude Opus 4.8 (Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
