### PR TITLE
feat(dashboard): add dock item pin state (#13164)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -130,6 +130,7 @@ Optional item fields:
 
 - `blueprint`: a serializable Neo component config when the item is created from saved state rather than a live instance.
 - `closable`, `pinnable`, `movable`: UI policy hints. Defaults are adapter-defined.
+- `pinned`: semantic pin state. `true` means pinned open; `false` means auto-hide eligible when an adapter supports that affordance. Omitted preserves the adapter-defined default. `pinnable === false` means `setItemPinned` must reject pin-state changes.
 - `metadata`: JSON-only descriptive data. It must not contain DOM nodes, functions, secrets, PATs, or live component objects.
 
 ### Stale Component References
@@ -148,7 +149,7 @@ Persist:
 - root node id
 - node ids, types, zone mapping, split orientation, split child order, normalized split sizes
 - tab item order and `activeItemId`
-- stable item ids and JSON-only item metadata
+- stable item ids, item pin state, and JSON-only item metadata
 
 Do not persist:
 
@@ -173,6 +174,7 @@ Future implementations should mutate the model through semantic operations inste
 | `addTab` | `itemId`, `tabsNodeId`, `index` | Inserts an item into a tab slot and may set `activeItemId`. |
 | `detachItem` | `itemId` | Removes an item from the dock tree while preserving its item record for popup/window ownership. |
 | `closeItem` | `itemId` | Removes an item from both tree and catalog when policy permits. |
+| `setItemPinned` | `itemId`, `pinned` | Updates an item's semantic pin state when `pinnable` policy permits it. |
 | `normalizeTree` | full model | Removes empty tabs/splits and validates references after any operation. |
 
 Every operation must maintain:
@@ -182,6 +184,7 @@ Every operation must maintain:
 - split sizes match child count and normalize to `1`
 - `tabs.activeItemId` is either null for empty tabs or one of `tabs.items`
 - empty structural nodes are collapsed before serialization
+- pin-state changes require a boolean `pinned` payload and must reject items with `pinnable === false`
 
 ## Drag Integration Boundary
 

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -61,7 +61,7 @@ class DockZoneModel extends Base {
      * @protected
      * @static
      */
-    static dockZoneItemKeys = new Set(['componentRef', 'title', 'kind', 'blueprint', 'closable', 'pinnable', 'movable', 'metadata'])
+    static dockZoneItemKeys = new Set(['componentRef', 'title', 'kind', 'blueprint', 'closable', 'pinnable', 'pinned', 'movable', 'metadata'])
 
     /**
      * Fields allowed on persisted dock-zone nodes, keyed by node type.
@@ -452,6 +452,12 @@ class DockZoneModel extends Base {
         let items   = document.items || {},
             nodes   = document.nodes || {},
             itemUse = {};
+
+        for (const [itemId, item] of Object.entries(items)) {
+            if (DockZoneModel.isJsonRecord(item) && Object.hasOwn(item, 'pinned') && typeof item.pinned !== 'boolean') {
+                errors.push(`item "${itemId}" pinned must be a boolean`)
+            }
+        }
 
         for (const [nodeId, node] of Object.entries(nodes)) {
             if (node.type === 'split') {
@@ -940,6 +946,27 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Updates an item's persisted pin state when its policy permits pinning.
+     * @param {Object} document
+     * @param {Object} args {itemId, pinned}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static setItemPinned(document, {itemId, pinned} = {}) {
+        let item = document.items?.[itemId];
+
+        if (!item) return {document, errors: [`unknown item "${itemId}"`]};
+        if (typeof pinned !== 'boolean') return {document, errors: ['pinned must be a boolean']};
+        if (item.pinnable === false) return {document, errors: [`item "${itemId}" is not pinnable`]};
+
+        let doc = DockZoneModel.clone(document);
+
+        doc.items[itemId].pinned = pinned;
+
+        return DockZoneModel.commit(document, doc)
+    }
+
+    /**
      * @summary Applies an operation descriptor (the shape `DockPreview.previewToOperation()` emits)
      * to the document, dispatching to the matching semantic operation.
      *
@@ -966,6 +993,8 @@ class DockZoneModel extends Base {
                 return DockZoneModel.detachItem(document, descriptor);
             case 'closeItem':
                 return DockZoneModel.closeItem(document, descriptor);
+            case 'setItemPinned':
+                return DockZoneModel.setItemPinned(document, descriptor);
             default:
                 return {document, errors: [`unknown operation "${descriptor.operation}"`]}
         }

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -230,6 +230,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
                 ntype: 'container',
                 text : 'Strategy'
             };
+            input.items.strategy.pinned = true;
 
             const {layout, errors} = DockZoneModel.createSavedLayout(input, {
                 layoutId: 'operator-default',
@@ -243,6 +244,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(layout.metadata.operatorNote).toBe('non-secret annotation');
             expect(layout.dockZone.items.strategy.metadata.ownerTag).toBe('operator-note');
             expect(layout.dockZone.items.strategy.blueprint.ntype).toBe('container');
+            expect(layout.dockZone.items.strategy.pinned).toBe(true);
 
             input.items.strategy.windowId = 42;
 
@@ -300,6 +302,35 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
             expect(restored.document).toBe(null);
             expect(restored.errors.join(' ')).toContain('authKey')
+        });
+
+        test('rejects non-boolean pinned state on save or restore', () => {
+            const input = doc();
+
+            input.items.strategy.pinned = 'yes';
+
+            const saved = DockZoneModel.createSavedLayout(input, {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            expect(saved.layout).toBe(null);
+            expect(saved.errors.join(' ')).toContain('pinned');
+
+            const savedLayout = {
+                schema  : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                dockZone: doc(),
+                metadata: {}
+            };
+
+            savedLayout.dockZone.items.strategy.pinned = 'yes';
+
+            const restored = DockZoneModel.restoreSavedLayout(savedLayout);
+
+            expect(restored.document).toBe(null);
+            expect(restored.errors.join(' ')).toContain('pinned')
         });
 
         test('rejects non-JSON values in metadata and item blueprints', () => {
@@ -531,6 +562,45 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         })
     });
 
+    test.describe('setItemPinned', () => {
+        test('updates pin state without mutating caller input', () => {
+            const input = doc();
+
+            input.items.terminal.pinnable = true;
+
+            const snapshot = JSON.stringify(input),
+                  pinned   = DockZoneModel.setItemPinned(input, {itemId: 'terminal', pinned: true});
+
+            expect(pinned.errors).toEqual([]);
+            expect(pinned.document.items.terminal.pinned).toBe(true);
+            expect(JSON.stringify(input)).toBe(snapshot);
+            expect(input.items.terminal.pinned).toBeUndefined();
+
+            const unpinned = DockZoneModel.setItemPinned(pinned.document, {itemId: 'terminal', pinned: false});
+
+            expect(unpinned.errors).toEqual([]);
+            expect(unpinned.document.items.terminal.pinned).toBe(false)
+        });
+
+        test('fails closed for unknown items, non-boolean state, and non-pinnable items', () => {
+            const input = doc();
+
+            input.items.terminal.pinnable = false;
+
+            const unknown = DockZoneModel.setItemPinned(input, {itemId: 'ghost', pinned: true});
+            expect(unknown.document).toBe(input);
+            expect(unknown.errors.join(' ')).toContain('ghost');
+
+            const invalid = DockZoneModel.setItemPinned(input, {itemId: 'terminal', pinned: 'true'});
+            expect(invalid.document).toBe(input);
+            expect(invalid.errors.join(' ')).toContain('boolean');
+
+            const locked = DockZoneModel.setItemPinned(input, {itemId: 'terminal', pinned: true});
+            expect(locked.document).toBe(input);
+            expect(locked.errors.join(' ')).toContain('not pinnable')
+        })
+    });
+
     test.describe('normalizeTree', () => {
         test('collapses an emptied tabs node and prunes its edge zone', () => {
             const d = doc();
@@ -581,6 +651,21 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
             expect(errors).toEqual([]);
             expect(document.nodes['main-split'].sizes).toEqual([0.25, 0.75])
+        });
+
+        test('dispatches setItemPinned descriptors', () => {
+            const input = doc();
+
+            input.items.terminal.pinnable = true;
+
+            const {document, errors} = DockZoneModel.applyOperation(input, {
+                operation: 'setItemPinned',
+                itemId   : 'terminal',
+                pinned   : true
+            });
+
+            expect(errors).toEqual([]);
+            expect(document.items.terminal.pinned).toBe(true)
         });
 
         test('rejects an unknown operation', () => {


### PR DESCRIPTION
Resolves #13164
Related: #13158
Related: #13160
Related: #13030
Related: #13012

Authored by GPT-5.5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

Adds a model-owned `pinned` item state to `DockZoneModel` so the upcoming auto-hide/sidebar renderer can persist pin state without inventing renderer-local schema. `DockZoneModel.validate()` now accepts only boolean `item.pinned` values, `setItemPinned()` clones and updates item state through the model, and `applyOperation()` exposes the semantic operation beside the existing resize and move operations. The harness dock model docs now spell out the split between capability (`pinnable`) and state (`pinned`).

Evidence: L1 (`node --check`, `git diff --check`, focused Playwright unit 52/52) -> L1 required (pure model operation, schema validation, adapter boundary unchanged). No residuals.

## Deltas from ticket

- Added `pinned` as a model-level item field rather than renderer-local state, matching the #13158 dock-zone source-of-truth direction.
- Kept `pinnable === false` as an authority guard: callers cannot pin items that explicitly opt out of pinning.
- Rebasing over #13160 preserved the `resizeSplit` operation coverage and added `setItemPinned` coverage in the same model fixture.
- No renderer, storage backend, or dock layout adapter persistence change.

Decision Record impact: none.

## Test Evidence

- `node --check src/dashboard/DockZoneModel.mjs` -> passed.
- `git diff --check` -> passed.
- `npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` -> 52 passed.
- Pre-commit hooks ran `check-whitespace`, `check-shorthand`, and `check-ticket-archaeology` on the staged files.

## Post-Merge Validation

- [ ] A future auto-hide/sidebar renderer consumes item pin state through `DockZoneModel.setItemPinned()` rather than renderer-local state.

## Commits

- `c5f47f02c` - `feat(dashboard): add dock item pin state (#13164)`
