### PR TITLE
refactor(wake): drop the redundant per-wake Subscription id from the wake digest (#13170)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -658,7 +658,7 @@ async function flushSubscription(subId) {
     }
 
     const events = {messages, tasks, permissions, heartbeats};
-    const digest = buildWakeDigest(identity, subId, events);
+    const digest = buildWakeDigest(identity, events);
 
     // Delivery to per-harness adapter. A 'failed' outcome (the adapter dispatch threw against a live
     // target) is re-queued for retry — carrying the EVENTS, not just this digest string, so a second
@@ -1124,11 +1124,10 @@ async function deliverDigest(subscription, digest) {
  * can rebuild a SINGLE digest over the UNION of events accumulated across same-subscription failures
  * (correct total count + max priority), rather than replaying one stale per-failure string.
  * @param {String} identity Recipient agent identity.
- * @param {String} subId Subscription id.
  * @param {Object} events `{messages, tasks, permissions, heartbeats}` arrays.
  * @returns {String}
  */
-function buildWakeDigest(identity, subId, {messages = [], tasks = [], permissions = [], heartbeats = []} = {}) {
+function buildWakeDigest(identity, {messages = [], tasks = [], permissions = [], heartbeats = []} = {}) {
     const N              = messages.length + tasks.length + permissions.length + heartbeats.length,
           digestPriority = getHighestWakePriority(messages);
 
@@ -1163,7 +1162,7 @@ function buildWakeDigest(identity, subId, {messages = [], tasks = [], permission
     const isPureHeartbeat = heartbeats.length > 0 && messages.length === 0 && tasks.length === 0 && permissions.length === 0,
           laneDirective   = isPureHeartbeat ? `\n\n${WAKE_LANE_DIRECTIVE}` : '';
 
-    return `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}\n\nSubscription: ${subId}${laneDirective}`;
+    return `[WAKE][priority:${digestPriority}] ${N} events for ${identity}: ${breakdown}${laneDirective}`;
 }
 
 /**
@@ -1215,7 +1214,7 @@ async function attemptDeliveryRetries() {
     for (const [subId, entry] of pendingDeliveryRetries) {
         if (entry.nextAttemptAt > now) continue;
 
-        const digest  = buildWakeDigest(entry.identity, subId, entry.events);
+        const digest  = buildWakeDigest(entry.identity, entry.events);
         const outcome = await deliverDigest(entry.subscription, digest);
 
         if (outcome === 'failed') {

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -245,6 +245,7 @@ test.describe('Wake Daemon', () => {
         expect(output).toContain('Test Wake Event');
         expect(output).not.toContain('priority: normal');
         expect(output).not.toContain('\nWindow:');
+        expect(output).not.toContain('Subscription:'); // the redundant per-wake subscription id is dropped from the digest
 
         // Verify the diagnostic log file was persisted to disk and contains
         // structured entries (ISO timestamp + PID + INFO/ERROR level prefix). Persistence


### PR DESCRIPTION
Resolves #13170
Refs #13137

MX-loop cleanup, driven by the agents who actually get the wake noise (@tobiu surfaced it; the operator never receives these wakes). The wake digest ended every delivery with `\n\nSubscription: ${subId}` — a stable, never-consumed id → pure per-wake token-cost.

Evidence: L1 (unit: `daemon.spec` 29/29 — incl. the new `not.toContain('Subscription:')` lock, and the unchanged #13141 directive + #13077 retry assertions) → L1 required (a digest-format change; no wake-delivery-behavior change).

## What changed
- `buildWakeDigest` (`ai/daemons/wake/daemon.mjs`) no longer appends the `Subscription: ${subId}` line. The `subId` param (used only there) is removed, along with both call sites and the JSDoc.
- The heartbeat-only lane directive (#13141) still composes cleanly after the line (its own `\n\n` prefix handles spacing).
- `daemon.spec` now asserts the delivered digest does NOT contain `Subscription:` — mirrors the existing `not.toContain('\nWindow:')` absence-lock.

## Why (the consumer's view)
- The agent never uses the subscription id while handling a wake — it acts via the message/task IDs (`list_messages` / `get_message`).
- It's stable per agent (one `WAKE_SUBSCRIPTION` each) → identical on every wake → zero per-wake information, just token-cost (the #13137 family).
- Its only consumer, `manage_wake_subscription` (unsubscribe/update/resync), gets the id via `action: list` on demand — nothing in the normal flow needs it inline.

## Deltas
- None. The rest of the digest (priority header, event breakdown, recipient identity) is unchanged. Affects all agents' wake format identically (one line lighter).

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` → **29 passed** (the new absence-lock; #13141 directive presence/absence + #13077 retry coalescing still green). `node --check ai/daemons/wake/daemon.mjs` + `check-ticket-archaeology` clean.

## Post-Merge Validation
- [ ] Live wakes no longer carry the `Subscription:` line (every agent's digest is one line lighter).

Authored by Claude Opus 4.8 (Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
