### PR TITLE
feat(ai): unwrap the agent-message envelope + thread agent context in the NL Client (#13173)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -7,6 +7,7 @@ import InteractionService from './client/InteractionService.mjs';
 import RuntimeService     from './client/RuntimeService.mjs';
 import Socket             from '../data/connection/WebSocket.mjs';
 import WindowManager      from '../manager/Window.mjs';
+import {parseAgentEnvelope} from './parseAgentEnvelope.mjs';
 
 /**
  * The AI Client establishes a WebSocket connection to the Neural Link MCP Server.
@@ -181,9 +182,11 @@ class Client extends Base {
      * This method acts as the central dispatcher for all AI-driven commands.
      * @param {String} method The JSON-RPC method name
      * @param {Object} params The parameters associated with the method
+     * @param {Object} [context] Optional request context (e.g. `{agentId}`) threaded from the
+     * agent-message envelope; the write services key topological-lock enforcement on it.
      * @returns {Promise<*>} The result of the operation
      */
-    async handleRequest(method, params) {
+    async handleRequest(method, params, context) {
         let me      = this,
             service = null,
             prefix;
@@ -203,14 +206,14 @@ class Client extends Base {
             const fn = service[fnName];
 
             if (Neo.isFunction(fn)) {
-                return fn.call(service, params)
+                return fn.call(service, params, context)
             } else if (Neo.isPromise(fn)) {
-                return await fn.call(service, params)
+                return await fn.call(service, params, context)
             }
         }
 
         if (service && typeof service[fnName] === 'function') {
-            return service[fnName](params)
+            return service[fnName](params, context)
         }
 
         throw new Error(`Unknown method: ${method}`);
@@ -251,13 +254,15 @@ class Client extends Base {
      * @param {Object} data
      */
     async onSocketMessage({data}) {
-        if (data.method) {
+        const {jsonrpc, context} = parseAgentEnvelope(data);
+
+        if (jsonrpc?.method) {
             try {
-                const result = await this.handleRequest(data.method, data.params);
-                this.sendResponse(data.id, result)
+                const result = await this.handleRequest(jsonrpc.method, jsonrpc.params, context);
+                this.sendResponse(jsonrpc.id, result)
             } catch (e) {
                 console.error('Neo.ai.Client: Failed to handle message', e);
-                this.sendError(data.id, e.message, e.stack)
+                this.sendError(jsonrpc.id, e.message, e.stack)
             }
         }
     }

--- a/src/ai/parseAgentEnvelope.mjs
+++ b/src/ai/parseAgentEnvelope.mjs
@@ -3,10 +3,14 @@
  *
  * Backward-compatible envelope handling for the multi-writer enforcement transport. The Bridge
  * forwards either a bare JSON-RPC message (legacy / non-agent) or — once the agent identity-transport
- * lands — a Bridge-stamped `{type:'agent_message', agentId, message}` sidecar, where `agentId` is the
- * Bridge-authenticated sender (never an agent-supplied field). This returns the inner JSON-RPC plus an
- * agent context so `Neo.ai.Client` can thread a verified `agentId` to the write services for
- * topological-lock enforcement, while a legacy bare frame is dispatched exactly as before.
+ * lands — a `{type:'agent_message', agentId, message}` sidecar. **This parser does not authenticate**:
+ * it routes the frame and surfaces the agent context, but the trustworthiness of `agentId` is
+ * established UPSTREAM by the Bridge connection-auth leaf (a token verification that retires the
+ * self-claimed connection id) — not here. On current `dev` the Bridge still forwards bare JSON-RPC
+ * (no sidecar), so the `agent_message` path is dormant until the auth + emit leaves land. This returns
+ * the inner JSON-RPC plus the agent context so `Neo.ai.Client` threads the Bridge-stamped `agentId` to
+ * the write services for topological-lock enforcement, while a legacy bare frame is dispatched exactly
+ * as before.
  *
  * It is deliberately pure (no Client, no socket): `Neo.ai.Client` is a connect-on-init singleton, so
  * keeping the parsing logic free of it makes the contract unit-testable — and it lets the Client learn

--- a/src/ai/parseAgentEnvelope.mjs
+++ b/src/ai/parseAgentEnvelope.mjs
@@ -1,0 +1,40 @@
+/**
+ * @summary Parse an inbound Neural Link frame into its JSON-RPC message + an optional agent context.
+ *
+ * Backward-compatible envelope handling for the multi-writer enforcement transport. The Bridge
+ * forwards either a bare JSON-RPC message (legacy / non-agent) or — once the agent identity-transport
+ * lands — a Bridge-stamped `{type:'agent_message', agentId, message}` sidecar, where `agentId` is the
+ * Bridge-authenticated sender (never an agent-supplied field). This returns the inner JSON-RPC plus an
+ * agent context so `Neo.ai.Client` can thread a verified `agentId` to the write services for
+ * topological-lock enforcement, while a legacy bare frame is dispatched exactly as before.
+ *
+ * It is deliberately pure (no Client, no socket): `Neo.ai.Client` is a connect-on-init singleton, so
+ * keeping the parsing logic free of it makes the contract unit-testable — and it lets the Client learn
+ * to unwrap the sidecar BEFORE the Bridge starts emitting it, so an `agent_message` arriving at a
+ * Client that already understands it never breaks the live agent→app channel.
+ *
+ * @param {*} frame The parsed inbound WebSocket frame.
+ * @returns {{jsonrpc: (Object|null), context: ({agentId: (String|null)}|null)}}
+ *   `jsonrpc` is the JSON-RPC message to dispatch, or `null` if the frame carries none.
+ *   `context` is `{agentId}` for an `agent_message` — the enforcement keys on it, and a malformed /
+ *   absent agentId yields `{agentId: null}` so the write service fails closed rather than mutating —
+ *   or `null` for a bare / legacy frame (non-agent, unenforced).
+ */
+export function parseAgentEnvelope(frame) {
+    if (frame && typeof frame === 'object' && frame.type === 'agent_message') {
+        const
+            message = frame.message,
+            agentId = (typeof frame.agentId === 'string' && frame.agentId.length > 0) ? frame.agentId : null;
+
+        return {
+            jsonrpc: (message && typeof message === 'object') ? message : null,
+            context: {agentId}
+        }
+    }
+
+    // Bare JSON-RPC (legacy / non-agent) — unchanged, no agent context.
+    return {
+        jsonrpc: (frame && typeof frame === 'object') ? frame : null,
+        context: null
+    }
+}

--- a/test/playwright/unit/ai/parseAgentEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/parseAgentEnvelope.spec.mjs
@@ -1,0 +1,50 @@
+import {test, expect}       from '@playwright/test';
+import {parseAgentEnvelope} from '../../../../src/ai/parseAgentEnvelope.mjs';
+
+// Pure frame-parsing — imported directly (Neo.ai.Client is a connect-on-init singleton), so the suite
+// has no socket / Client side effects. Mirrors deriveSubtreePath.spec / resolveCallTarget.spec.
+const RPC = {jsonrpc: '2.0', id: 1, method: 'set_instance_properties', params: {id: 'c-1', properties: {}}};
+
+test.describe('parseAgentEnvelope (Neural Link agent-context unwrap)', () => {
+    test('agent_message → inner JSON-RPC + the Bridge-stamped agentId context', () => {
+        const r = parseAgentEnvelope({type: 'agent_message', agentId: 'neo-opus-ada', message: RPC});
+        expect(r.jsonrpc).toBe(RPC);
+        expect(r.context).toEqual({agentId: 'neo-opus-ada'})
+    });
+
+    test('a bare JSON-RPC frame → the frame itself, no agent context (legacy / non-agent, unenforced)', () => {
+        const r = parseAgentEnvelope(RPC);
+        expect(r.jsonrpc).toBe(RPC);
+        expect(r.context).toBe(null)
+    });
+
+    test('agent_message with a missing / empty / non-string agentId → fail-closed marker (context.agentId null)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: bad, message: RPC});
+            expect(r.context).toEqual({agentId: null}); // the write service denies on this
+            expect(r.jsonrpc).toBe(RPC)                  // still dispatched, so it is denied — not silently dropped
+        }
+    });
+
+    test('agent_message with no / non-object message → nothing to dispatch, context preserved', () => {
+        for (const bad of [undefined, null, 'x', 42]) {
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: 'a', message: bad});
+            expect(r.jsonrpc).toBe(null);
+            expect(r.context).toEqual({agentId: 'a'})
+        }
+    });
+
+    test('a non-object frame → nothing to dispatch, no context', () => {
+        for (const bad of [null, undefined, 'x', 42, true]) {
+            expect(parseAgentEnvelope(bad)).toEqual({jsonrpc: null, context: null})
+        }
+    });
+
+    test('the agent_message discriminator is exact — a frame with a foreign type is still bare', () => {
+        // a JSON-RPC message never carries type:'agent_message'; any other shape is treated as bare
+        const frame = {type: 'something_else', method: 'get_component', params: {}},
+              r     = parseAgentEnvelope(frame);
+        expect(r.context).toBe(null);
+        expect(r.jsonrpc).toBe(frame)
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13173

**Leaf B of #13167** (Extended-NL identity-transport) — the backward-compatible Client half of the multi-writer enforcement wiring. It teaches the Neural Link Client to unwrap the Bridge's `{type:'agent_message', agentId, message}` sidecar (per @neo-claude-opus's locked contract) and thread the Bridge-stamped `agentId` to the service dispatch.

**This leaf does not authenticate** — it unwraps and threads. The `agentId`'s authenticity is established **upstream** by the Bridge connection-auth leaf (Leaf A / #13172), which retires the self-claimed connection id. On current `dev` the Bridge still forwards bare JSON-RPC (no sidecar), so the `agent_message` path is **dormant** until the auth + emit leaves land; this leaf only makes the Client *ready* for that frame.

**It lands first by design.** @neo-claude-opus's ordering finding: the `(1b)` sidecar emit and the Client unwrap are one atomic wire change — if the Bridge starts emitting `agent_message` before the Client understands it, every live agent→app command breaks in the gap. So the Client unwrap (this leaf) lands **before** the Bridge emit-flip (her final leaf), and the legacy bare path is untouched throughout.

- `src/ai/parseAgentEnvelope.mjs` — a **pure** `parseAgentEnvelope(frame)` → `{jsonrpc, context}`:
  - `{type:'agent_message', agentId, message}` → `{jsonrpc: message, context: {agentId}}`; a missing / empty / non-string `agentId` → `{agentId: null}` — a **fail-closed marker** so the write service (Leaf C) denies rather than mutates (defensive; the actual authentication is Leaf A's job);
  - a bare JSON-RPC frame → `{jsonrpc: frame, context: null}` (legacy / non-agent, unenforced);
  - a non-object frame → `{jsonrpc: null, context: null}`.
- `Client.onSocketMessage` consumes it and dispatches `handleRequest(jsonrpc.method, jsonrpc.params, context)`.
- `Client.handleRequest(method, params, context)` forwards `context` to the service call; existing read services ignore the extra arg, so the legacy path is exactly as before.

Kept the parsing **pure** because `Neo.ai.Client` is a connect-on-init singleton — so the contract is unit-testable without standing up a socket (the established `deriveSubtreePath` / `resolveCallTarget` pattern). The write-service `WriteGuard` enforcement that consumes this `context` (ledger rows 4–6) is **Leaf C**.

## Deltas

None from the ticket scope. This leaf delivers #13167's Contract Ledger **row 3** (Client request dispatch gains the context) + the consume side of **row 2** (the Client unwraps the sidecar; raw read path unchanged). The Bridge auth + emit (Leaf A #13172 + the `(1b)` flip) are @neo-claude-opus's; the enforcement (rows 4–6) is Leaf C.

## Test Evidence

Evidence: L1 (pure-function unit spec) for the parsing contract — the required level for the decision logic; the Client wiring is a thin backward-compat diff, and the live dispatch (a denied cross-agent write end-to-end) is whitebox-e2e under Leaf C once the full transport lands.

```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/parseAgentEnvelope.spec.mjs
→ 6 passed (941ms)

node --check src/ai/Client.mjs        → OK
node --check src/ai/parseAgentEnvelope.mjs → OK
```

The 6 cases: `agent_message` → inner JSON-RPC + agentId context; bare frame → frame + null context; missing/empty/non-string agentId → fail-closed marker; no/non-object message → nothing-to-dispatch + context preserved; non-object frame → both null; the `agent_message` discriminator is exact (a foreign `type` is still bare).

## Post-Merge Validation

- [ ] When Leaf C lands, `InstanceService.setInstanceProperties` / `callMethod` consume the threaded `{agentId}` → `WriteGuard.requestWrite(...)`, deny-no-mutate on conflict.
- [ ] After the full transport (Leaf A's auth + `(1b)` emit), a live cross-agent write to an overlapping subtree is denied (whitebox-e2e) and legacy / read traffic is unaffected.

## Structural Pre-Flight

`src/ai/parseAgentEnvelope.mjs` — co-located with `Neo.ai.Client` (`src/ai/`, the in-heap NL Client layer) + the sibling pure helper `src/ai/deriveSubtreePath.mjs`, as a plain exported pure function. Spec at `test/playwright/unit/ai/parseAgentEnvelope.spec.mjs` (the flattened `src/ai/*` → `unit/ai/` mirror). The Client wiring is a minimal backward-compat edit to `src/ai/Client.mjs`.

Refs #13167 (umbrella + Contract Ledger), #13056 (epic), #13172 (Leaf A — the auth that makes the threaded agentId trustworthy), #13134 / #13138 (the WriteGuard + deriveSubtreePath the enforcement leaf will consume).
