### PR TITLE
feat(dashboard): add dock named-layout helpers (#13169)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -161,6 +161,37 @@ Do not persist:
 
 If a future slice needs to restore detached windows, it should persist semantic placement plus an optional window placement hint separately. The dock-zone model remains the component-layout authority, not an OS-window session dump.
 
+## Named Layout Collections / Perspectives
+
+Named perspectives collect multiple saved layouts without choosing a storage backend or rendering a switcher. The model shape is pure JSON:
+
+```json
+{
+  "schema": "neo.harness.dockLayoutCollection.v1",
+  "activeLayoutId": "operator-default",
+  "layouts": {
+    "operator-default": {
+      "schema": "neo.harness.dockLayout.v1",
+      "layoutId": "operator-default",
+      "title": "Operator Default",
+      "dockZone": {}
+    }
+  },
+  "metadata": {},
+  "revision": 1
+}
+```
+
+Rules:
+
+- `layouts` is keyed by each saved layout's `layoutId`; the key and wrapper id must match.
+- `activeLayoutId` must name an existing layout whenever the collection contains layouts.
+- Collection and saved-layout metadata are JSON-only and must not contain secrets, PATs, credentials, functions, DOM nodes, or live components.
+- Restoring a perspective must go through `restoreSavedLayout()` so the saved-layout schema, dock-zone schema, and JSON-only checks stay shared.
+- Removing the active layout requires an explicit replacement id. Do not silently pick a different active layout.
+
+Storage remains out of scope for this layer. Browser preferences, Memory Core persistence, import/export, and rendered layout switchers consume this collection contract later; they must not fork their own collection shape.
+
 ## Operations
 
 Future implementations should mutate the model through semantic operations instead of direct tree surgery in UI handlers:
@@ -174,6 +205,11 @@ Future implementations should mutate the model through semantic operations inste
 | `detachItem` | `itemId` | Removes an item from the dock tree while preserving its item record for popup/window ownership. |
 | `closeItem` | `itemId` | Removes an item from both tree and catalog when policy permits. |
 | `normalizeTree` | full model | Removes empty tabs/splits and validates references after any operation. |
+| `createSavedLayoutCollection` | saved-layout wrappers, metadata | Creates a named perspective collection from valid saved-layout wrappers. |
+| `upsertSavedLayout` | collection, saved-layout wrapper, `activate` | Adds or replaces a named saved layout and optionally selects it. |
+| `selectSavedLayout` | collection, `layoutId` | Selects an existing saved layout id as active. |
+| `removeSavedLayout` | collection, `layoutId`, `replacementLayoutId` | Removes a named saved layout; active removals require an explicit replacement. |
+| `restoreActiveSavedLayout` | collection | Restores the active saved layout through `restoreSavedLayout()`. |
 
 Every operation must maintain:
 

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -20,6 +20,8 @@ import Base from '../core/Base.mjs';
  *
  * Saved-layout helpers wrap the same committed model in `neo.harness.dockLayout.v1` after enforcing
  * the finite saved-layout schema and JSON-only values. They deliberately do not choose a storage backend.
+ * Named-layout collection helpers wrap multiple saved-layout envelopes in
+ * `neo.harness.dockLayoutCollection.v1` while keeping the active-layout choice pure and storage-free.
  *
  * Return shape for every operation: `{document, errors}` — `errors` empty means the operation
  * committed; non-empty means it was rejected and `document` is the untouched input.
@@ -40,12 +42,27 @@ class DockZoneModel extends Base {
     static LAYOUT_SCHEMA = 'neo.harness.dockLayout.v1'
 
     /**
+     * The saved layout collection schema for named layout perspectives.
+     * @member {String} LAYOUT_COLLECTION_SCHEMA='neo.harness.dockLayoutCollection.v1'
+     * @static
+     */
+    static LAYOUT_COLLECTION_SCHEMA = 'neo.harness.dockLayoutCollection.v1'
+
+    /**
      * Top-level fields allowed in a saved-layout wrapper.
      * @member {Set<String>} savedLayoutKeys
      * @protected
      * @static
      */
     static savedLayoutKeys = new Set(['schema', 'layoutId', 'title', 'dockZone', 'metadata', 'revision'])
+
+    /**
+     * Top-level fields allowed in a named saved-layout collection.
+     * @member {Set<String>} savedLayoutCollectionKeys
+     * @protected
+     * @static
+     */
+    static savedLayoutCollectionKeys = new Set(['schema', 'activeLayoutId', 'layouts', 'metadata', 'revision'])
 
     /**
      * Top-level fields allowed in a persisted dock-zone document.
@@ -765,6 +782,278 @@ class DockZoneModel extends Base {
         return normalizedErrors.length
             ? {document: null, errors: normalizedErrors}
             : {document: DockZoneModel.clone(normalized), errors: []}
+    }
+
+    /**
+     * @summary Validates a named saved-layout collection and each contained saved-layout wrapper.
+     * @param {Object} collection
+     * @returns {String[]} the (possibly empty) list of invariant violations
+     * @static
+     */
+    static validateSavedLayoutCollection(collection) {
+        let errors = [];
+
+        if (!DockZoneModel.isJsonRecord(collection)) {
+            return ['saved layout collection must be a JSON object']
+        }
+
+        if (collection.schema !== DockZoneModel.LAYOUT_COLLECTION_SCHEMA) {
+            errors.push(`schema must be ${DockZoneModel.LAYOUT_COLLECTION_SCHEMA}`)
+        }
+
+        if (!Object.hasOwn(collection, 'activeLayoutId')) {
+            errors.push('activeLayoutId is required')
+        } else if (collection.activeLayoutId !== null && (typeof collection.activeLayoutId !== 'string' || !collection.activeLayoutId.trim())) {
+            errors.push('activeLayoutId must be a non-empty string or null')
+        }
+
+        if (!DockZoneModel.isJsonRecord(collection.layouts)) {
+            errors.push('layouts must be a JSON object')
+        }
+
+        if (Object.hasOwn(collection, 'metadata') && !DockZoneModel.isJsonRecord(collection.metadata)) {
+            errors.push('metadata must be a JSON object')
+        }
+
+        let secretKey = Object.hasOwn(collection, 'metadata')
+            ? DockZoneModel.findSecretMetadataKey(collection.metadata, 'layoutCollection.metadata')
+            : null;
+
+        if (secretKey) {
+            errors.push(`layout collection metadata contains secret-like field "${secretKey.key}" at ${secretKey.path}: ${secretKey.reason}`)
+        }
+
+        let unexpectedKey = DockZoneModel.findUnexpectedKey(collection, DockZoneModel.savedLayoutCollectionKeys, 'layoutCollection');
+
+        if (unexpectedKey) {
+            errors.push(`layout collection contains unexpected field "${unexpectedKey.key}" at ${unexpectedKey.path}: ${unexpectedKey.reason}`)
+        }
+
+        let nonJson = DockZoneModel.findNonJsonValue(collection, 'layoutCollection');
+
+        if (nonJson) {
+            errors.push(`layout collection ${nonJson.path} is not JSON-only: ${nonJson.reason}`)
+        }
+
+        if (DockZoneModel.isJsonRecord(collection.layouts)) {
+            for (const [layoutId, savedLayout] of Object.entries(collection.layouts)) {
+                if (!layoutId.trim()) {
+                    errors.push('layout keys must be non-empty strings');
+                    continue
+                }
+
+                if (!DockZoneModel.isJsonRecord(savedLayout)) {
+                    errors.push(`layout "${layoutId}" must be a JSON object`);
+                    continue
+                }
+
+                if (savedLayout.layoutId !== layoutId) {
+                    errors.push(`layout key "${layoutId}" must match saved layout id "${savedLayout.layoutId}"`)
+                }
+
+                let restored = DockZoneModel.restoreSavedLayout(savedLayout);
+
+                if (restored.errors.length) {
+                    errors.push(...restored.errors.map(error => `layout "${layoutId}": ${error}`))
+                }
+            }
+        }
+
+        let layoutCount = DockZoneModel.isJsonRecord(collection.layouts) ? Object.keys(collection.layouts).length : 0;
+
+        if (collection.activeLayoutId === null && layoutCount > 0) {
+            errors.push('activeLayoutId must name an existing layout when layouts are present')
+        } else if (typeof collection.activeLayoutId === 'string' && DockZoneModel.isJsonRecord(collection.layouts) && !Object.hasOwn(collection.layouts, collection.activeLayoutId)) {
+            errors.push(`activeLayoutId "${collection.activeLayoutId}" does not exist`)
+        }
+
+        return errors
+    }
+
+    /**
+     * @summary Creates a storage-free collection of named saved-layout wrappers.
+     * @param {Array<Object>|Object<String,Object>} [layouts=[]]
+     * @param {Object} [options={}] {activeLayoutId, metadata, revision}
+     * @returns {{collection:Object|null, errors:String[]}}
+     * @static
+     */
+    static createSavedLayoutCollection(layouts=[], options={}) {
+        if (!Array.isArray(layouts) && !DockZoneModel.isJsonRecord(layouts)) {
+            return {collection: null, errors: ['layouts must be an array or JSON object']}
+        }
+
+        if (!DockZoneModel.isJsonRecord(options)) {
+            return {collection: null, errors: ['options must be a JSON object']}
+        }
+
+        let collection = {
+                schema        : DockZoneModel.LAYOUT_COLLECTION_SCHEMA,
+                activeLayoutId: Object.hasOwn(options, 'activeLayoutId') ? options.activeLayoutId : null,
+                layouts       : {},
+                metadata      : Object.hasOwn(options, 'metadata') ? options.metadata : {}
+            },
+            entries    = Array.isArray(layouts)
+                ? layouts.map((layout, index) => [DockZoneModel.isJsonRecord(layout) ? layout.layoutId : `index-${index}`, layout])
+                : Object.entries(layouts),
+            errors     = [];
+
+        for (const [layoutId, savedLayout] of entries) {
+            if (typeof layoutId !== 'string' || !layoutId.trim()) {
+                errors.push('layoutId must be a non-empty string');
+                continue
+            }
+
+            collection.layouts[layoutId] = DockZoneModel.clone(savedLayout)
+        }
+
+        if (!Object.hasOwn(options, 'activeLayoutId')) {
+            collection.activeLayoutId = Object.keys(collection.layouts)[0] ?? null
+        }
+
+        if (Object.hasOwn(options, 'revision')) {
+            collection.revision = options.revision
+        }
+
+        errors.push(...DockZoneModel.validateSavedLayoutCollection(collection));
+
+        return errors.length
+            ? {collection: null, errors}
+            : {collection: DockZoneModel.clone(collection), errors: []}
+    }
+
+    /**
+     * @summary Adds or replaces a saved-layout wrapper in a collection.
+     * @param {Object} collection
+     * @param {Object} savedLayout
+     * @param {Object} [options={}] {activate}
+     * @returns {{collection:Object, errors:String[]}}
+     * @static
+     */
+    static upsertSavedLayout(collection, savedLayout, options={}) {
+        let errors = DockZoneModel.validateSavedLayoutCollection(collection);
+
+        if (errors.length) {
+            return {collection, errors}
+        }
+
+        let restored = DockZoneModel.restoreSavedLayout(savedLayout);
+
+        if (restored.errors.length) {
+            return {collection, errors: restored.errors}
+        }
+
+        let doc      = DockZoneModel.clone(collection),
+            layoutId = savedLayout.layoutId;
+
+        doc.layouts[layoutId] = DockZoneModel.clone(savedLayout);
+
+        if (options?.activate === true || doc.activeLayoutId === null) {
+            doc.activeLayoutId = layoutId
+        }
+
+        errors = DockZoneModel.validateSavedLayoutCollection(doc);
+
+        return errors.length ? {collection, errors} : {collection: DockZoneModel.clone(doc), errors: []}
+    }
+
+    /**
+     * @summary Selects the active saved layout by id without restoring it.
+     * @param {Object} collection
+     * @param {String} layoutId
+     * @returns {{collection:Object, errors:String[]}}
+     * @static
+     */
+    static selectSavedLayout(collection, layoutId) {
+        let errors = DockZoneModel.validateSavedLayoutCollection(collection);
+
+        if (errors.length) {
+            return {collection, errors}
+        }
+
+        if (typeof layoutId !== 'string' || !layoutId.trim()) {
+            return {collection, errors: ['layoutId must be a non-empty string']}
+        }
+
+        if (!Object.hasOwn(collection.layouts, layoutId)) {
+            return {collection, errors: [`layoutId "${layoutId}" does not exist`]}
+        }
+
+        let doc = DockZoneModel.clone(collection);
+
+        doc.activeLayoutId = layoutId;
+
+        return {collection: DockZoneModel.clone(doc), errors: []}
+    }
+
+    /**
+     * @summary Removes a saved layout and requires an explicit replacement when removing the active one.
+     * @param {Object} collection
+     * @param {Object} args {layoutId, replacementLayoutId}
+     * @returns {{collection:Object, errors:String[]}}
+     * @static
+     */
+    static removeSavedLayout(collection, {layoutId, replacementLayoutId} = {}) {
+        let errors = DockZoneModel.validateSavedLayoutCollection(collection);
+
+        if (errors.length) {
+            return {collection, errors}
+        }
+
+        if (typeof layoutId !== 'string' || !layoutId.trim()) {
+            return {collection, errors: ['layoutId must be a non-empty string']}
+        }
+
+        if (!Object.hasOwn(collection.layouts, layoutId)) {
+            return {collection, errors: [`layoutId "${layoutId}" does not exist`]}
+        }
+
+        let removingActive = collection.activeLayoutId === layoutId;
+
+        if (removingActive) {
+            if (typeof replacementLayoutId !== 'string' || !replacementLayoutId.trim()) {
+                return {collection, errors: ['removing the active layout requires replacementLayoutId']}
+            }
+
+            if (replacementLayoutId === layoutId) {
+                return {collection, errors: ['replacementLayoutId must differ from the removed layoutId']}
+            }
+
+            if (!Object.hasOwn(collection.layouts, replacementLayoutId)) {
+                return {collection, errors: [`replacementLayoutId "${replacementLayoutId}" does not exist`]}
+            }
+        }
+
+        let doc = DockZoneModel.clone(collection);
+
+        delete doc.layouts[layoutId];
+
+        if (removingActive) {
+            doc.activeLayoutId = replacementLayoutId
+        }
+
+        errors = DockZoneModel.validateSavedLayoutCollection(doc);
+
+        return errors.length ? {collection, errors} : {collection: DockZoneModel.clone(doc), errors: []}
+    }
+
+    /**
+     * @summary Restores the active saved-layout wrapper from a named layout collection.
+     * @param {Object} collection
+     * @returns {{document:Object|null, errors:String[]}}
+     * @static
+     */
+    static restoreActiveSavedLayout(collection) {
+        let errors = DockZoneModel.validateSavedLayoutCollection(collection);
+
+        if (errors.length) {
+            return {document: null, errors}
+        }
+
+        if (typeof collection.activeLayoutId !== 'string' || !Object.hasOwn(collection.layouts, collection.activeLayoutId)) {
+            return {document: null, errors: ['activeLayoutId must name an existing layout']}
+        }
+
+        return DockZoneModel.restoreSavedLayout(collection.layouts[collection.activeLayoutId])
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -66,6 +66,18 @@ function tabsOf(document, itemId) {
     return DockZoneModel.findContainingTabsId(document, itemId)
 }
 
+/** Creates a valid saved-layout wrapper for collection tests. */
+function savedLayout(layoutId, title=layoutId, mutate=()=>{}) {
+    const d = doc();
+
+    mutate(d);
+
+    return DockZoneModel.createSavedLayout(d, {
+        layoutId,
+        title
+    }).layout
+}
+
 test.describe('Neo.dashboard.DockZoneModel', () => {
     test.describe('validate (invariants)', () => {
         test('accepts the canonical document', () => {
@@ -371,6 +383,168 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
             expect(freshLayout.metadata.workspace).toBe('mutated-by-caller');
             expect(freshLayout.dockZone.items.strategy.title).toBe('Caller Mutated Strategy')
+        })
+    });
+
+    test.describe('named saved-layout collections', () => {
+        test('creates and validates a versioned collection from valid saved layouts', () => {
+            const operator = savedLayout('operator-default', 'Operator Default'),
+                  review   = savedLayout('review-layout', 'Review Layout', d => {
+                      d.nodes['main-tabs'].activeItemId = 'strategy'
+                  }),
+                  {collection, errors} = DockZoneModel.createSavedLayoutCollection([operator, review], {
+                      activeLayoutId: 'review-layout',
+                      revision      : 2,
+                      metadata      : {
+                          workspace: 'agent-harness'
+                      }
+                  });
+
+            expect(errors).toEqual([]);
+            expect(collection.schema).toBe(DockZoneModel.LAYOUT_COLLECTION_SCHEMA);
+            expect(collection.activeLayoutId).toBe('review-layout');
+            expect(collection.revision).toBe(2);
+            expect(collection.metadata.workspace).toBe('agent-harness');
+            expect(Object.keys(collection.layouts)).toEqual(['operator-default', 'review-layout']);
+            expect(DockZoneModel.validateSavedLayoutCollection(collection)).toEqual([]);
+
+            operator.title = 'Mutated By Caller';
+            expect(collection.layouts['operator-default'].title).toBe('Operator Default');
+            expect(collection.layouts['operator-default']).not.toBe(operator)
+        });
+
+        test('rejects wrong collection schema and mismatched layout keys', () => {
+            const operator = savedLayout('operator-default', 'Operator Default'),
+                  created  = DockZoneModel.createSavedLayoutCollection([operator]);
+
+            expect(created.errors).toEqual([]);
+
+            const wrongSchema = DockZoneModel.clone(created.collection);
+
+            wrongSchema.schema = 'neo.harness.dockLayoutCollection.v2';
+
+            expect(DockZoneModel.validateSavedLayoutCollection(wrongSchema).join(' ')).toContain(DockZoneModel.LAYOUT_COLLECTION_SCHEMA);
+            expect(DockZoneModel.restoreActiveSavedLayout(wrongSchema).document).toBe(null);
+
+            const mismatched = DockZoneModel.clone(created.collection);
+
+            mismatched.layouts.alias = mismatched.layouts['operator-default'];
+            delete mismatched.layouts['operator-default'];
+            mismatched.activeLayoutId = 'alias';
+
+            expect(DockZoneModel.validateSavedLayoutCollection(mismatched).join(' ')).toContain('must match')
+        });
+
+        test('upserts layouts by layoutId, clones replacements, and optionally activates them', () => {
+            const operator = savedLayout('operator-default', 'Operator Default'),
+                  review   = savedLayout('review-layout', 'Review Layout'),
+                  {collection} = DockZoneModel.createSavedLayoutCollection([operator]),
+                  updated = DockZoneModel.upsertSavedLayout(collection, review, {activate: true});
+
+            expect(updated.errors).toEqual([]);
+            expect(updated.collection.activeLayoutId).toBe('review-layout');
+            expect(updated.collection.layouts['review-layout'].title).toBe('Review Layout');
+            expect(collection.layouts['review-layout']).toBeUndefined();
+
+            review.title = 'Mutated Review';
+            expect(updated.collection.layouts['review-layout'].title).toBe('Review Layout');
+
+            const invalid = DockZoneModel.clone(review);
+
+            invalid.dockZone.nodes.root.zones.center = 'missing-tabs';
+
+            const rejected = DockZoneModel.upsertSavedLayout(collection, invalid, {activate: true});
+
+            expect(rejected.collection).toBe(collection);
+            expect(rejected.errors.join(' ')).toContain('missing-tabs')
+        });
+
+        test('selects an existing active layout and fails closed for missing ids', () => {
+            const operator = savedLayout('operator-default', 'Operator Default'),
+                  review   = savedLayout('review-layout', 'Review Layout'),
+                  {collection} = DockZoneModel.createSavedLayoutCollection([operator, review]),
+                  selected = DockZoneModel.selectSavedLayout(collection, 'review-layout');
+
+            expect(selected.errors).toEqual([]);
+            expect(selected.collection.activeLayoutId).toBe('review-layout');
+            expect(collection.activeLayoutId).toBe('operator-default');
+
+            const missing = DockZoneModel.selectSavedLayout(collection, 'ghost-layout');
+
+            expect(missing.collection).toBe(collection);
+            expect(missing.errors.join(' ')).toContain('ghost-layout')
+        });
+
+        test('removes layouts and requires an explicit replacement for the active layout', () => {
+            const operator = savedLayout('operator-default', 'Operator Default'),
+                  review   = savedLayout('review-layout', 'Review Layout'),
+                  {collection} = DockZoneModel.createSavedLayoutCollection([operator, review]),
+                  denied = DockZoneModel.removeSavedLayout(collection, {layoutId: 'operator-default'});
+
+            expect(denied.collection).toBe(collection);
+            expect(denied.errors.join(' ')).toContain('replacementLayoutId');
+
+            const removedActive = DockZoneModel.removeSavedLayout(collection, {
+                layoutId            : 'operator-default',
+                replacementLayoutId : 'review-layout'
+            });
+
+            expect(removedActive.errors).toEqual([]);
+            expect(removedActive.collection.activeLayoutId).toBe('review-layout');
+            expect(removedActive.collection.layouts['operator-default']).toBeUndefined();
+
+            const removedInactive = DockZoneModel.removeSavedLayout(collection, {layoutId: 'review-layout'});
+
+            expect(removedInactive.errors).toEqual([]);
+            expect(removedInactive.collection.activeLayoutId).toBe('operator-default');
+            expect(removedInactive.collection.layouts['review-layout']).toBeUndefined()
+        });
+
+        test('restores the selected saved layout through the existing restore path', () => {
+            const operator = savedLayout('operator-default', 'Operator Default'),
+                  review   = savedLayout('review-layout', 'Review Layout', d => {
+                      d.nodes['main-tabs'].activeItemId = 'strategy'
+                  }),
+                  {collection} = DockZoneModel.createSavedLayoutCollection([operator, review], {
+                      activeLayoutId: 'review-layout'
+                  }),
+                  restored = DockZoneModel.restoreActiveSavedLayout(collection);
+
+            expect(restored.errors).toEqual([]);
+            expect(restored.document).toEqual(review.dockZone);
+            expect(restored.document).not.toBe(review.dockZone);
+
+            const invalid = DockZoneModel.clone(collection);
+
+            invalid.activeLayoutId = 'ghost-layout';
+
+            const rejected = DockZoneModel.restoreActiveSavedLayout(invalid);
+
+            expect(rejected.document).toBe(null);
+            expect(rejected.errors.join(' ')).toContain('ghost-layout')
+        });
+
+        test('rejects invalid saved layouts and secret-like collection metadata', () => {
+            const operator = savedLayout('operator-default', 'Operator Default'),
+                  invalid  = DockZoneModel.clone(operator);
+
+            invalid.metadata = {
+                authKey: 'secret-value'
+            };
+
+            const rejectedLayout = DockZoneModel.createSavedLayoutCollection([invalid]);
+
+            expect(rejectedLayout.collection).toBe(null);
+            expect(rejectedLayout.errors.join(' ')).toContain('authKey');
+
+            const rejectedCollection = DockZoneModel.createSavedLayoutCollection([operator], {
+                metadata: {
+                    apiToken: 'secret-value'
+                }
+            });
+
+            expect(rejectedCollection.collection).toBe(null);
+            expect(rejectedCollection.errors.join(' ')).toContain('apiToken')
         })
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop). Session 0ed5b1b0-739e-40e5-93e6-21a2e567ec24.

Resolves #13169
Related: #13158
Related: #13147
Related: #13153
Related: #13030
Related: #13012

Adds a pure named-layout collection layer around existing `neo.harness.dockLayout.v1` saved-layout wrappers. The new `neo.harness.dockLayoutCollection.v1` helpers create and validate collections, upsert named layouts, select an active layout, remove layouts with explicit active replacement, and restore the active saved layout through the existing `restoreSavedLayout()` validator. Storage and UI switchers remain out of scope.

Evidence: L1 (`node --check`, focused Playwright unit, static diff check) -> L1 required (pure model/docs/unit contract). No residuals.

## Deltas from ticket
None. The implementation stays below storage/UI and reuses saved-layout validation for every contained wrapper.

## Test Evidence
- `node --check src/dashboard/DockZoneModel.mjs`
- `node --check test/playwright/unit/dashboard/DockZoneModel.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs` -> 49 passed

## Post-Merge Validation
- [ ] Future named-perspective switcher/storage leaves consume `neo.harness.dockLayoutCollection.v1` rather than introducing an app-private collection shape.

## Decision Record impact
Aligned with ADR 0020: the helpers stay in the Body-side dock model contract and do not move Agent Harness app state into a storage backend.

## Commit
- `2ca43fed8` - `feat(dashboard): add dock named-layout helpers (#13169)`