### PR TITLE
test(benchmark): marathon-scale verdict — Neo virtualization + worker-topology at 100+ pages (#13032)

### DIFF
--- a/ai/examples/harnessEndurance/README.md
+++ b/ai/examples/harnessEndurance/README.md
@@ -1,0 +1,45 @@
+# Harness Endurance Benchmark (#13032)
+
+A falsifier for the **session-age latency thesis**: *does Neo's worker topology keep the main thread MORE responsive than a single-main-thread renderer as a session grows to marathon length (10+ context compactions ≈ 100+ pages of chat)?*
+
+Run as published, with its numbers — and **the negative result published with equal prominence** (falsifier honesty). The thesis did not survive a fair test.
+
+## Method
+
+- **Load** — `shared/LoadProfile.mjs`: a deterministic, seeded markdown-append stream (same `seed` + config → byte-identical stream on every run). Both subjects consume the **identical** sequence, so any delta is the engine's, not the input's.
+- **Subject A — Neo** (`neo/`): the transcript renders through `Neo.component.markdown.Component` (`MarkdownVdom`) — **off-thread** parse + diff (App + VDom workers; the main thread is a thin DOM-applicator) and **`virtualize: true`** (only viewport-intersecting blocks + `bufferPages` mount).
+- **Subject B — comparator** (`comparator/`): an honest **best-practice** single-main-thread page — incremental parse + tail-incremental render **and DOM-windowed** (`RENDER_WINDOW` blocks; older evicted). It is bounded at scale **like a virtualized list**. The only variable it lacks vs Neo is **where the parse/render runs** (on-thread vs off-thread).
+- **Why both window** — an earlier cut left the comparator *non-virtualized*; at marathon scale its DOM bloated to ~130k nodes, and the resulting lag/heap gap was a **virtualization asymmetry**, not worker-topology (the conflation @neo-gpt flagged in the #13176 review). Windowing both isolates the one variable the benchmark claims to test.
+- **Metrics** — main-thread event-loop lag sampled *while appending* at scale (the worker-topology signal; low = good), plus rendered DOM-node-count, heap, and full-vs-rendered transcript length. Captured by `test/playwright/e2e/HarnessEnduranceBenchmark.spec.mjs`.
+
+## Results
+
+**At small scale** (~390k transcript, ~10s window): **null.** Lag delta ≈ 0.1 ms (both ~1 ms). A competent incremental main-thread renderer keeps pace.
+
+**At marathon scale** (multi-MB transcript / 100+ pages, **both subjects DOM-windowed**): **also null.** Representative run:
+
+| Metric (marathon scale, both windowed) | Neo (off-thread) | best-practice comparator (on-thread) |
+| :--- | :--- | :--- |
+| Accumulated transcript | ~5.7M chars | ~15.6M chars |
+| On-append event-loop lag (median) | **~1.0 ms** | **~0.7 ms** |
+| Rendered DOM nodes (windowed) | ~100 | ~520 |
+
+Both keep the main thread at the sampler floor (~1 ms); the difference is within noise (the comparator is, if anything, marginally ahead). Neo's off-thread topology provides **no raw main-thread-lag advantage** over a best-practice (incremental + windowed) main-thread renderer.
+
+## Verdict
+
+**The session-age worker-topology thesis is REFUTED for main-thread lag.** Across small and marathon scale, a competently-built main-thread renderer (incremental parse + windowed DOM) stays equally responsive. The dramatic "decisive win" an earlier cut reported was a **virtualization confound** — Neo virtualizes by default and that earlier comparator did not — corrected here by windowing both subjects.
+
+What remains true, and is the honest claim: Neo's value at scale is **correct-by-construction**, not raw-lag superiority. You get off-thread parse/diff **and** transcript virtualization **for free** from `MarkdownVdom`; the comparator had to hand-roll incremental parsing *and* DOM windowing to merely keep pace. The engineering win is "you don't have to build any of that and it won't degrade," not "the main thread is faster under load."
+
+## Reproduce
+
+```
+npm run test-e2e -- test/playwright/e2e/HarnessEnduranceBenchmark.spec.mjs
+```
+
+The `worker-topology at marathon scale` test logs `[endurance:marathon]` with the numbers above; the small-scale tests log `[endurance:neo|comparator|delta]`.
+
+## Public-surface guardrail
+
+These are **repo docs**. Any public-facing claim derived from this benchmark is a **separate, later step** and must be framed with the team — especially because the honest result is a *negative* (worker-topology gives no main-thread-lag edge vs a competent renderer), which is easy to mis-state in either direction.

--- a/ai/examples/harnessEndurance/comparator/comparator.mjs
+++ b/ai/examples/harnessEndurance/comparator/comparator.mjs
@@ -9,8 +9,12 @@ import {LoadProfile}             from '../shared/LoadProfile.mjs';
  * runner samples the SAME event-loop-lag metric here as for the Neo subject; the lag delta isolates
  * the worker-topology effect. The runner triggers a run via `globalThis.__enduranceComparator.start(cfg)`.
  *
- * RENDER (best-practice shape): tail-incremental — settled blocks are written once then frozen, only
- * the open last block re-renders as it grows; NOT an O(n²) full-`innerHTML` rewrite.
+ * RENDER (best-practice shape): tail-incremental + WINDOWED — settled blocks are written once then
+ * frozen; only the open last block re-renders as it grows; and only the last `RENDER_WINDOW` blocks
+ * stay mounted (older blocks evicted), so the DOM stays bounded at marathon scale — matching Neo's
+ * MarkdownVdom virtualization. NOT an O(n²) full-`innerHTML` rewrite, and NOT an unbounded DOM:
+ * windowing both subjects is what makes the lag delta isolate worker-topology rather than a
+ * virtualization asymmetry (a non-virtualized comparator would conflate the two axes at scale).
  *
  * PARSE (best-practice shape): incremental — settled blocks (everything before the last blank line) are
  * parsed ONCE and only the open region re-parses from each delta (`createIncrementalBlocks`), mirroring
@@ -30,33 +34,54 @@ transcript.className = 'endurance-transcript';
 
 document.body.append(probe, transcript);
 
+/**
+ * Bounded DOM window. A best-practice main-thread renderer does NOT accumulate unbounded DOM at
+ * marathon scale — it windows like a virtualized list. Only the last `RENDER_WINDOW` blocks stay
+ * mounted (older evicted), matching Neo's MarkdownVdom virtualization so the lag delta isolates the
+ * worker-topology variable (WHERE parse/render runs), not a virtualization asymmetry.
+ * @type {Number}
+ */
+const RENDER_WINDOW = 120;
+
 let
     runToken   = 0,
-    containers = [];
+    totalChars = 0,
+    containers = new Map();
 
 /**
- * Tail-incremental apply: settled blocks (all but the last) are written ONCE then frozen via a
- * `data-settled` flag; only the open last block re-renders each tick as it grows.
+ * Tail-incremental + WINDOWED apply: settled blocks (all but the last) are written ONCE then frozen;
+ * only the open last block re-renders each tick as it grows; and only the last `RENDER_WINDOW` blocks
+ * stay mounted (older evicted), so the DOM is bounded at marathon scale.
  * @param {String[]} blocks
  * @private
  */
 function applyBlocks(blocks) {
-    for (let i = 0; i < blocks.length; i++) {
-        let container = containers[i];
+    const start = Math.max(0, blocks.length - RENDER_WINDOW);
 
-        if (!container) {
-            container = document.createElement('div');
-            transcript.appendChild(container);
-            containers[i] = container
+    // Evict settled blocks that have scrolled out of the window (bounded DOM — best-practice at scale).
+    for (const index of [...containers.keys()]) {
+        if (index < start) {
+            containers.get(index).el.remove();
+            containers.delete(index)
+        }
+    }
+
+    for (let i = start; i < blocks.length; i++) {
+        let entry = containers.get(i);
+
+        if (!entry) {
+            entry = {el: document.createElement('div'), settled: false};
+            transcript.appendChild(entry.el);
+            containers.set(i, entry)
         }
 
         const isOpenTail = i === blocks.length - 1;
 
-        if (isOpenTail || container.dataset.settled !== '1') {
-            container.innerHTML = blocks[i];
+        if (isOpenTail || !entry.settled) {
+            entry.el.innerHTML = blocks[i];
 
             if (!isOpenTail) {
-                container.dataset.settled = '1'
+                entry.settled = true
             }
         }
     }
@@ -64,7 +89,9 @@ function applyBlocks(blocks) {
 
 /**
  * Drives the deterministic `LoadProfile` append stream, parsing the open block + rendering each delta
- * synchronously on the main thread (settled blocks memoized). A run token prevents overlapping runs.
+ * synchronously on the main thread (settled blocks memoized, DOM windowed). A run token prevents
+ * overlapping runs. `getTotalChars()` reports the full accumulated transcript length (vs the windowed
+ * DOM) so the runner can confirm the comparator also reached marathon scale.
  * @param {Object} [config] forwarded to `LoadProfile` (seed, durationMs, cadences).
  * @returns {Promise<void>}
  */
@@ -74,20 +101,22 @@ async function start(config = {}) {
         token   = ++runToken,
         blocks  = createIncrementalBlocks();
 
-    containers.forEach(container => container.remove());
-    containers = [];
+    containers.forEach(entry => entry.el.remove());
+    containers.clear();
+    totalChars = 0;
 
     for (const {text} of profile.appendEvents()) {
         if (runToken !== token) {
             break
         }
 
+        totalChars += text.length;
         applyBlocks(blocks.push(text));
 
         await new Promise(resolve => setTimeout(resolve, profile.appendCadenceMs))
     }
 }
 
-globalThis.__enduranceComparator = {engine: 'main-thread', start};
+globalThis.__enduranceComparator = {engine: 'main-thread', start, getTotalChars: () => totalChars};
 
 export {start};

--- a/ai/examples/harnessEndurance/neo/MainContainer.mjs
+++ b/ai/examples/harnessEndurance/neo/MainContainer.mjs
@@ -85,28 +85,41 @@ class MainContainer extends Viewport {
      * Runner entry point and the "Start load" handler. Drives the deterministic `LoadProfile`
      * append stream into the transcript — each tick re-assigns the GROWING full source (the
      * parser's incremental-append path), exactly the producer shape of a streamed model response.
+     *
+     * Fire-and-forget: returns immediately after scheduling the first tick, so an NL
+     * `call_method('startLoad')` RPC resolves NOW instead of hanging for the whole run. The stream
+     * continues off the call stack via self-scheduled ticks, yielding to a newer run / reset through
+     * the `loadRun` token. (Button-driven runs are unaffected — the handler never awaited it.)
      * @param {Object} [config] forwarded to {@link LoadProfile} (seed, durationMs, cadences).
-     * @returns {Promise<void>}
      */
-    async startLoad(config = {}) {
+    startLoad(config = {}) {
         let me          = this,
             transcript  = me.getReference('transcript'),
             profile     = new LoadProfile(config),
             token       = ++me.loadRun,
+            iterator    = profile.appendEvents(),
             accumulated = '';
 
         transcript.value = null;
 
-        for (const {text} of profile.appendEvents()) {
+        const tick = () => {
             if (me.loadRun !== token) {
-                break
+                return
             }
 
-            accumulated     += text;
+            const next = iterator.next();
+
+            if (next.done) {
+                return
+            }
+
+            accumulated     += next.value.text;
             transcript.value = accumulated;
 
-            await me.timeout(profile.appendCadenceMs)
-        }
+            me.timeout(profile.appendCadenceMs).then(tick)
+        };
+
+        tick()
     }
 
     /**
@@ -124,6 +137,16 @@ class MainContainer extends Viewport {
 
         me.loadRun++;
         me.getReference('transcript').value = null
+    }
+
+    /**
+     * Runner/test helper: the full accumulated transcript length (the App-Worker `value`), as opposed
+     * to the RENDERED DOM. Under virtualization the two diverge sharply — the value reaches marathon
+     * scale while only a viewport window mounts — which is exactly the property the benchmark proves.
+     * @returns {Number}
+     */
+    getTranscriptLength() {
+        return this.getReference('transcript').value?.length ?? 0
     }
 }
 

--- a/test/playwright/e2e/HarnessEnduranceBenchmark.spec.mjs
+++ b/test/playwright/e2e/HarnessEnduranceBenchmark.spec.mjs
@@ -120,4 +120,68 @@ test.describe('Harness Endurance Benchmark', () => {
         expect(neo.lags.length).toBeGreaterThan(50);
         expect(comparator.lags.length).toBeGreaterThan(50);
     });
+
+    test('worker-topology at marathon scale — both subjects DOM-windowed (fair isolation)', async ({page, neuralLink}) => {
+        test.setTimeout(180000);
+
+        // Fast/big deterministic load → drive each transcript toward marathon scale (multi-MB) within the test.
+        // durationMs stays long so the stream is STILL appending when we sample (on-append lag, not at-rest).
+        // BOTH subjects window their DOM at scale (Neo via MarkdownVdom virtualize:true; the comparator via
+        // RENDER_WINDOW), so the on-append event-loop lag isolates the worker-topology variable (WHERE parse/
+        // render runs) rather than a virtualization asymmetry — the comparator's worker-topology contract.
+        const loadCfg  = {seed: 1, appendCadenceMs: 4, maxTokensPerAppend: 600, durationMs: 90000},
+              growMs   = 30000,   // let the transcript accumulate to scale
+              sampleMs = 6000;
+
+        // --- Subject A (Neo: MarkdownVdom, virtualize:true + off-thread parse) ---
+        await page.goto('/ai/examples/harnessEndurance/neo/index.html');
+        const app     = await neuralLink.connectToApp('Neo.examples.harnessEndurance.neo'),
+              matches = await app.queryComponent({ntype: 'viewport'}, ['id']),
+              mainId  = matches?.components?.[0]?.id ?? matches?.[0]?.id ?? matches?.id;
+
+        expect(mainId, `could not resolve the MainContainer id (got ${JSON.stringify(matches)})`).toBeTruthy();
+
+        await app.callMethod(mainId, 'startLoad', [loadCfg]); // fire-and-forget → resolves immediately
+        await page.waitForTimeout(growMs);
+
+        const neoLag = await sampleEventLoopLag(page, {windowMs: sampleMs}); // sampled WHILE appending at scale
+        const neo    = await page.evaluate(() => ({
+            chars   : document.querySelector('.neo-markdown-vdom')?.innerText.length ?? -1,
+            domNodes: document.querySelector('.neo-markdown-vdom')?.querySelectorAll('*').length ?? -1,
+            heapMB  : performance.memory ? +(performance.memory.usedJSHeapSize / 1048576).toFixed(1) : null
+        }));
+
+        // Full accumulated transcript length (App-Worker value), NOT the rendered window — the two
+        // diverge under virtualization, proving the DOM stays windowed while the value reaches scale.
+        const neoTotalRaw = await app.callMethod(mainId, 'getTranscriptLength'),
+              neoTotal    = typeof neoTotalRaw === 'number' ? neoTotalRaw : (neoTotalRaw?.result ?? neoTotalRaw?.value ?? 0);
+
+        // --- Subject B (best-practice main-thread comparator: incremental parse/render + DOM-windowed) ---
+        await page.goto('/ai/examples/harnessEndurance/comparator/index.html');
+        await page.waitForFunction(() => globalThis.__enduranceComparator?.start);
+        await page.evaluate(cfg => { globalThis.__enduranceComparator.start(cfg) }, loadCfg);
+        await page.waitForTimeout(growMs);
+
+        const cmpLag   = await sampleEventLoopLag(page, {windowMs: sampleMs});
+        const cmp      = await page.evaluate(() => ({
+            chars   : document.querySelector('.endurance-transcript')?.innerText.length ?? -1,
+            domNodes: document.querySelector('.endurance-transcript')?.querySelectorAll('*').length ?? -1,
+            heapMB  : performance.memory ? +(performance.memory.usedJSHeapSize / 1048576).toFixed(1) : null
+        }));
+        const cmpTotal = await page.evaluate(() => globalThis.__enduranceComparator.getTotalChars());
+
+        console.log(`[endurance:marathon] Neo: totalChars=${neoTotal} renderedChars=${neo.chars} DOM=${neo.domNodes} heap=${neo.heapMB}MB onAppendLag med/p95=${median(neoLag.lags).toFixed(2)}/${percentile(neoLag.lags, 0.95).toFixed(2)}ms`);
+        console.log(`[endurance:marathon] cmp: totalChars=${cmpTotal} renderedChars=${cmp.chars} DOM=${cmp.domNodes} heap=${cmp.heapMB}MB onAppendLag med/p95=${median(cmpLag.lags).toFixed(2)}/${percentile(cmpLag.lags, 0.95).toFixed(2)}ms`);
+
+        // Both subjects reached marathon scale (the full transcript) while WINDOWING the rendered DOM
+        // (rendered << total). With virtualization matched on both sides, the on-append event-loop lag
+        // (logged above; low = good) isolates the worker-topology variable — it is NOT asserted to a
+        // threshold (the honest delta is the finding, published in the benchmark README).
+        expect(neoTotal, 'Neo transcript should reach marathon scale').toBeGreaterThan(1_000_000);
+        expect(cmpTotal, 'comparator transcript should reach marathon scale').toBeGreaterThan(1_000_000);
+        expect(neo.chars, 'Neo rendered window << full value (virtualization)').toBeLessThan(neoTotal / 10);
+        expect(cmp.chars, 'comparator rendered window << full value (windowing)').toBeLessThan(cmpTotal / 10);
+        expect(neo.domNodes).toBeGreaterThan(0);
+        expect(cmp.domNodes).toBeGreaterThan(0);
+    });
 });


### PR DESCRIPTION
Resolves #13032

The Harness Endurance falsifier, run fairly to a verdict: at marathon scale, with both subjects DOM-windowed, **the worker-topology thesis is REFUTED** — no main-thread-lag advantage. Published as a negative result per AC5 (falsifier honesty). This addresses @neo-gpt's #13176 RA1 by restoring the comparator contract (a fair, windowed comparator) rather than narrowing.

Evidence: L1 (e2e: `HarnessEnduranceBenchmark.spec` 5/5; the worker-topology test drives both subjects to marathon scale, both DOM-windowed, and logs the on-append lag — reproduced across 2 runs) → L1 required (measurement + repo-docs verdict; no runtime behavior change).

## AC mapping (close-target)
- AC1 (deterministic load) + AC2 (both subjects, comparator now windowed = best-practice at scale) — #13066 + this PR.
- AC3 (metrics auto-captured, reproducible) — the spec.
- AC4 (published numbers + methodology) + **AC5 (negative result, equal prominence)** — `ai/examples/harnessEndurance/README.md`.

## The verdict (honest, negative)
At marathon scale (~6M / ~16M-char transcripts, **both DOM-windowed**): on-append main-thread lag is **null** — Neo ~1.0 ms vs the best-practice comparator ~0.6–0.7 ms (within the sampler floor; comparator marginally ahead). Worker-topology gives **no** raw main-thread-lag advantage over a competent (incremental + windowed) main-thread renderer. Consistent with the small-scale null. The thesis is **refuted**.

## What changed since the first cut (RA1 + RA2)
- **RA1 (comparator fairness):** the comparator now **windows** its DOM (`RENDER_WINDOW`), making it genuinely best-practice at scale — matching Neo's virtualization so the lag isolates worker-topology, not a virtualization asymmetry. The earlier "decisive win" (~25× lag / ~1000× DOM) was that confound; removing it flips the verdict to the honest null.
- **RA2 (branch stack):** rebased onto clean `dev` (the #13170 wake commit dropped); the diff is #13032-only.
- Squashed to one honest commit (the prior commit messages claimed the over-reach).

## Honest takeaway
Neo's scale value is **correct-by-construction** (off-thread parse + virtualization for free), not raw-lag superiority — the comparator had to hand-roll incremental parsing **and** DOM windowing to merely keep pace. The README frames this, plus a public-surface guardrail (a negative result is easy to mis-state).

## Decision Record impact
`none` — extends the existing benchmark (#13066) and publishes the (negative) verdict.

## Deltas
- The verdict is **negative** (thesis refuted), published with equal prominence per AC5. The dramatic earlier numbers were a measurement confound, now corrected.

## Test Evidence
- `npm run test-e2e -- test/playwright/e2e/HarnessEnduranceBenchmark.spec.mjs` → **5 passed** (incl. the worker-topology marathon test, reproduced across 2 runs; both subjects reach marathon scale and DOM-window). `node --check` + `check-ticket-archaeology` clean.

## Post-Merge Validation
- [ ] Any public-facing claim from this is framed with the team first (the README guardrail) — the honest result is a negative (no worker-topology lag edge vs a competent renderer).

Authored by Claude Opus 4.8 (Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
