### PR TITLE
feat(ai): provision the agent repo at spawn — startAgentProvisioned + start cwd (#13177)

### DIFF
--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -120,10 +120,17 @@ class FleetLifecycleService extends Base {
 
     /**
      * Start an agent's harness process. Idempotent while running (returns current status).
-     * @param {String} id Registry agent id.
+     * @param {String}  id          Registry agent id.
+     * @param {Object} [opts={}]    Spawn options.
+     * @param {String} [opts.cwd]   The child's working directory — the agent's provisioned repo
+     *                              checkout. Omitted ⇒ the child inherits this process's cwd (the
+     *                              unchanged legacy behavior). The Fleet Manager turnkey path
+     *                              ({@link Neo.ai.services.fleet.startAgentProvisioned}) supplies the
+     *                              `ensureAgentRepo`-derived `repoPath` here, so an FM-spawned harness
+     *                              runs inside ITS repo rather than the Fleet Manager's own directory.
      * @returns {Object} status (see {@link status}).
      */
-    start(id) {
+    start(id, opts = {}) {
         if (this.isRunning(id)) return this.status(id);
 
         const agent = this.getRegistry().getAgent(id);
@@ -161,9 +168,15 @@ class FleetLifecycleService extends Base {
         // --tool-projection-mode flag.
         env[TOOL_PROJECTION_MODE_ENV_VAR] = this.toolProjectionMode;
 
+        // The child's working directory: the agent's provisioned repo checkout when the caller supplies
+        // it (the Fleet Manager turnkey path via startAgentProvisioned). Omitted ⇒ inherit this process's
+        // cwd — but an FM-spawned harness is meant to operate on ITS repo, not the Fleet Manager's dir.
+        const spawnOptions = {stdio: ['ignore', 'ignore', 'pipe'], env};
+        if (opts.cwd != null) spawnOptions.cwd = opts.cwd;
+
         let child;
         try {
-            child = this.getSpawnFn()(command, args, {stdio: ['ignore', 'ignore', 'pipe'], env});
+            child = this.getSpawnFn()(command, args, spawnOptions);
         } catch (error) {
             this.processes.set(id, {id, state: 'failed', pid: null, startedAt: null, exitCode: null, exitedAt: new Date().toISOString(), error: error.message});
             throw error;

--- a/ai/services/fleet/startAgentProvisioned.mjs
+++ b/ai/services/fleet/startAgentProvisioned.mjs
@@ -1,0 +1,76 @@
+import {ensureAgentRepo} from './ensureAgentRepo.mjs';
+
+/**
+ * @summary Start a Fleet Manager agent's harness *in its own provisioned repo* — the turnkey
+ * "define → start" entry that makes the repo-provisioning chain live.
+ *
+ * `FleetLifecycleService.start` supervises a process but knows nothing about repos: it spawns the
+ * harness in the Fleet Manager's own working directory. This composer closes that gap. Given an agent
+ * whose definition carries its working-repo coordinates (`metadata.repo = {cloneUrl, repoSlug}`), it
+ * first ensures the canonical checkout exists — clone-or-reuse, never clobber, via
+ * {@link Neo.ai.services.fleet.ensureAgentRepo} — then starts the harness with its `cwd` pinned to that
+ * checkout, so the harness operates on ITS repo. Fleet Manager auto-memory is checkout-path-keyed, so
+ * the path is load-bearing: launching in the wrong directory is a silent correctness failure.
+ *
+ * **Fail-closed:** a provisioning error propagates and the harness is NEVER spawned — the Fleet Manager
+ * must not launch an agent into an unprovisioned or conflicting directory.
+ *
+ * **Backward-compatible:** an agent without `metadata.repo` has no repo to provision, so it starts
+ * exactly as before (inherited cwd). The opinionated provisioning + the `metadata.repo` convention live
+ * here, NOT in the registry-owned supervisor — `start` only gained a generic optional `cwd`.
+ *
+ * Pure composition over injectable seams: `ensureRepo` (default {@link Neo.ai.services.fleet.ensureAgentRepo})
+ * + `cloneRepo` (forwarded to it) make this unit-testable without a git binary or the filesystem,
+ * mirroring the `spawnFn` / `cloneRepo` test idioms already used across the fleet services.
+ *
+ * @param {Object}    options
+ * @param {Object}    options.lifecycleService The `FleetLifecycleService` (or a stub) that supervises
+ *                                             the process — supplies `getRegistry()`, `isRunning(id)`,
+ *                                             `status(id)`, and `start(id, {cwd})`.
+ * @param {String}    options.agentId          The Fleet Manager agent id to start.
+ * @param {String}   [options.managedRoot]     The absolute, trusted fleet-managed checkout root —
+ *                                             required only when the agent carries `metadata.repo`.
+ * @param {Function} [options.cloneRepo]       `(cloneUrl, repoPath) => Promise<void>` clone seam,
+ *                                             forwarded to `ensureRepo`; defaults to a real `git clone`.
+ * @param {Function} [options.ensureRepo]      The repo-provisioning composer; defaults to
+ *                                             {@link Neo.ai.services.fleet.ensureAgentRepo}, injectable
+ *                                             for tests.
+ * @returns {Promise<Object>} the agent's lifecycle status (see `FleetLifecycleService.status`).
+ * @throws {Error} when `lifecycleService` / `agentId` is missing, the agent is unknown, `managedRoot`
+ *   is absent for a repo-bearing agent, or provisioning fails (re-thrown — the harness is not spawned).
+ */
+export async function startAgentProvisioned({lifecycleService, agentId, managedRoot, cloneRepo, ensureRepo = ensureAgentRepo} = {}) {
+    if (!lifecycleService) throw new Error("startAgentProvisioned: 'lifecycleService' is required.");
+    if (!agentId)          throw new Error("startAgentProvisioned: 'agentId' is required.");
+
+    // Already running ⇒ short-circuit to the current status; do not re-provision. `start` is itself
+    // idempotent while running, but provisioning ahead of it would be a pointless git inspection on an
+    // agent that is already up.
+    if (lifecycleService.isRunning(agentId)) return lifecycleService.status(agentId);
+
+    const agent = lifecycleService.getRegistry().getAgent(agentId);
+    if (!agent) throw new Error(`startAgentProvisioned: unknown agent '${agentId}'.`);
+
+    const repo = agent.metadata?.repo;
+
+    // No repo coordinates ⇒ nothing to provision; start in the inherited cwd (backward-compatible).
+    if (!repo) return lifecycleService.start(agentId);
+
+    if (!managedRoot) {
+        throw new Error(`startAgentProvisioned: 'managedRoot' is required to provision the repo for agent '${agentId}'.`);
+    }
+
+    // Ensure the checkout exists (clone-or-reuse, never clobber). A throw here propagates: the harness
+    // is never spawned into an unprovisioned / conflicting directory (fail-closed). Input validation
+    // (managedRoot / agentId / repoSlug / a missing cloneUrl when a clone is needed) is inherited from
+    // the provisioning chain's own contracts — not re-implemented here.
+    const {repoPath} = await ensureRepo({
+        managedRoot,
+        agentId,
+        repoSlug: repo.repoSlug,
+        cloneUrl: repo.cloneUrl,
+        cloneRepo
+    });
+
+    return lifecycleService.start(agentId, {cwd: repoPath});
+}

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -99,6 +99,20 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(status.pid).toBeGreaterThan(0);
     });
 
+    test('start passes opts.cwd through to the spawn options (the harness runs in its provisioned repo)', () => {
+        const spawn = install({agents: {a: agentDef('a')}});
+        FleetLifecycleService.start('a', {cwd: '/managed/a/neomjs-neo'});
+
+        expect(spawn.calls[0].opts.cwd).toBe('/managed/a/neomjs-neo');
+    });
+
+    test('start without opts.cwd spawns with no cwd (inherited — unchanged legacy behavior)', () => {
+        const spawn = install({agents: {a: agentDef('a')}});
+        FleetLifecycleService.start('a');
+
+        expect(spawn.calls[0].opts.cwd).toBeUndefined();
+    });
+
     test('SECURITY: PAT injected into the child env copy only — never argv / record / live parent env', () => {
         const pat    = 'ghp_SECRET_injected_value',
               spawn  = install({agents: {a: agentDef('a')}, creds: {a: pat}}),

--- a/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
+++ b/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
@@ -1,0 +1,107 @@
+import {test, expect}          from '@playwright/test';
+import {startAgentProvisioned} from '../../../../ai/services/fleet/startAgentProvisioned.mjs';
+
+// Pure composer — imported directly with injected stubs (no fs / git / Neo runtime), so the suite has
+// no host-runtime side effects and each case is fully isolated. Mirrors deriveAgentRepoPath.spec /
+// ensureAgentRepo.spec. The `ensureRepo` + `cloneRepo` seams stand in for the real provisioning chain;
+// the `lifecycleService` stub records every `start` call so the cwd-threading contract is assertable.
+
+/** A recording FleetLifecycleService stub: tracks start() calls + answers isRunning/status/getRegistry. */
+function makeLifecycle({agents = {}, running = {}} = {}) {
+    const calls = {start: [], status: []};
+    return {
+        calls,
+        isRunning  : id => !!running[id],
+        status     : id => { calls.status.push(id); return {id, running: !!running[id], state: running[id] ? 'running' : 'stopped'}; },
+        getRegistry: () => ({getAgent: id => agents[id] || null}),
+        start      : (id, opts) => { calls.start.push({id, opts}); return {id, running: true, state: 'running', cwd: opts?.cwd}; }
+    };
+}
+
+/** A recording ensureAgentRepo stub: records its args, returns a fixed repoPath (no fs / git). */
+function makeEnsureRepo(repoPath = '/managed/agent/repo') {
+    const calls = [];
+    const fn    = async args => { calls.push(args); return {repoPath, state: 'absent', action: 'cloned', cloned: true}; };
+    fn.calls    = calls;
+    return fn;
+}
+
+const REPO = {cloneUrl: 'https://github.com/neomjs/neo.git', repoSlug: 'neomjs/neo'};
+
+function repoAgent(id = 'a') {
+    return {[id]: {id, githubUsername: id, harnessType: 'codex', metadata: {launch: {command: 'h'}, repo: REPO}}};
+}
+
+test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning)', () => {
+    test('provisions the repo then starts the harness with cwd pinned to the checkout', async () => {
+        const lifecycle  = makeLifecycle({agents: repoAgent('a')}),
+              ensureRepo = makeEnsureRepo('/managed/a/neomjs-neo'),
+              cloneRepo  = () => {},
+              status     = await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', cloneRepo, ensureRepo});
+
+        // provisioning fed the agent's metadata.repo coordinates + the managed root + the clone seam
+        expect(ensureRepo.calls).toHaveLength(1);
+        expect(ensureRepo.calls[0]).toMatchObject({managedRoot: '/managed', agentId: 'a', repoSlug: 'neomjs/neo', cloneUrl: REPO.cloneUrl, cloneRepo});
+        // the harness was started with cwd === the provisioned repoPath
+        expect(lifecycle.calls.start).toHaveLength(1);
+        expect(lifecycle.calls.start[0]).toEqual({id: 'a', opts: {cwd: '/managed/a/neomjs-neo'}});
+        expect(status.state).toBe('running');
+        expect(status.cwd).toBe('/managed/a/neomjs-neo');
+    });
+
+    test('an agent with no metadata.repo starts in the inherited cwd (backward-compatible)', async () => {
+        const lifecycle  = makeLifecycle({agents: {a: {id: 'a', metadata: {launch: {command: 'h'}}}}}),
+              ensureRepo = makeEnsureRepo();
+
+        await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', ensureRepo});
+
+        // nothing to provision; start called with NO opts (no cwd)
+        expect(ensureRepo.calls).toHaveLength(0);
+        expect(lifecycle.calls.start).toHaveLength(1);
+        expect(lifecycle.calls.start[0].id).toBe('a');
+        expect(lifecycle.calls.start[0].opts).toBeUndefined();
+    });
+
+    test('a provisioning failure propagates and the harness is NEVER spawned (fail-closed)', async () => {
+        const lifecycle = makeLifecycle({agents: repoAgent('a')}),
+              boom      = async () => { throw new Error('conflict: foreign occupant'); };
+
+        await expect(startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', ensureRepo: boom}))
+            .rejects.toThrow('conflict: foreign occupant');
+
+        expect(lifecycle.calls.start).toHaveLength(0);
+    });
+
+    test('an already-running agent short-circuits to status without provisioning or re-spawning', async () => {
+        const lifecycle  = makeLifecycle({agents: repoAgent('a'), running: {a: true}}),
+              ensureRepo = makeEnsureRepo(),
+              status     = await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', ensureRepo});
+
+        expect(status.running).toBe(true);
+        expect(ensureRepo.calls).toHaveLength(0);
+        expect(lifecycle.calls.start).toHaveLength(0);
+    });
+
+    test('missing lifecycleService / agentId throw clear errors', async () => {
+        await expect(startAgentProvisioned({agentId: 'a'})).rejects.toThrow(/lifecycleService/);
+        await expect(startAgentProvisioned({lifecycleService: makeLifecycle()})).rejects.toThrow(/agentId/);
+    });
+
+    test('a repo-bearing agent with no managedRoot throws and never provisions or starts', async () => {
+        const lifecycle  = makeLifecycle({agents: repoAgent('a')}),
+              ensureRepo = makeEnsureRepo();
+
+        await expect(startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', ensureRepo}))
+            .rejects.toThrow(/managedRoot/);
+
+        expect(ensureRepo.calls).toHaveLength(0);
+        expect(lifecycle.calls.start).toHaveLength(0);
+    });
+
+    test('an unknown agent throws', async () => {
+        const lifecycle = makeLifecycle({agents: {}});
+
+        await expect(startAgentProvisioned({lifecycleService: lifecycle, agentId: 'ghost', managedRoot: '/managed'}))
+            .rejects.toThrow(/unknown agent/);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13177

**The leaf that makes the Fleet Manager repo-provisioning chain live.** The chain (derive → inspect → provision → ensure, all merged) had no consumer — dead code until a caller wired it into the spawn path. This is that wire, and it fixes a verified latent gap: `FleetLifecycleService.start()` spawned with `{stdio, env}` and **no `cwd`**, so an FM-spawned harness ran in the Fleet Manager's own directory, not the agent's repo. FM auto-memory is checkout-path-keyed → launching in the wrong directory is a silent correctness failure.

- **`ai/services/fleet/startAgentProvisioned.mjs`** (new, standalone — sibling to `ensureAgentRepo`): the turnkey "define → start" composer. Reads the agent's `metadata.repo = {cloneUrl, repoSlug}`; `ensureAgentRepo` (clone-or-reuse, never clobber) → `start(id, {cwd: repoPath})`. No `metadata.repo` → plain `start` (backward-compatible). A provisioning throw propagates and the harness is **never spawned** (fail-closed: no launch into an unprovisioned / conflicting directory). Already-running → short-circuit to `status` (no redundant provision). `ensureRepo` + `cloneRepo` are injectable seams (default-real) → unit-testable with no git binary or filesystem.
- **`FleetLifecycleService.start(id, opts)`** gains an optional `opts.cwd`, passed through to the spawn options; omitted → today's spawn exactly (no external callers exist yet, so zero blast radius). The opinionated provisioning + the `metadata.repo` convention live in the composer, **not** the registry-owned supervisor — `start` only gained a generic `cwd` primitive (a process supervisor letting its caller set the working dir).

**Design notes for review (decide-and-document, Tier-2 reversible):**
- `managedRoot` is a composer **parameter**, not baked into the lifecycle service — keeps the FM-managed root out of the registry-owned service; the eventual turnkey caller (FM MCP tool / settings pane) supplies it from config.
- The agent's repo coordinates ride the **free-form `metadata.repo`** (mirroring the existing `metadata.launch` convention) rather than a first-class registry-schema field — backward-compatible and reversible. @neo-claude-opus (registry/lifecycle author) — input welcome on promoting this to a first-class field if the convention proves load-bearing.

Evidence: L1 (pure-composer unit spec with injected `ensureRepo` / `lifecycleService` seams + a `spawnFn` cwd-passthrough assertion) → L1 required (every AC is composer decision-logic, unit-verifiable). No residuals — the live cross-process "harness runs in its provisioned repo" path has no caller yet (post-merge, once a tool wires the composer).

## Deltas from ticket (if any)
None. Delivers #13177's Contract Ledger exactly: `start(id, opts.cwd)`, the `startAgentProvisioned` composer, and the `metadata.repo` convention.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/startAgentProvisioned.spec.mjs \
  test/playwright/unit/ai/FleetLifecycleService.spec.mjs
→ 26 passed (766ms)

node --check ai/services/fleet/startAgentProvisioned.mjs   → OK
node --check ai/services/fleet/FleetLifecycleService.mjs    → OK
```
- `startAgentProvisioned.spec` (7 new): provisions + cwd-pinned start; no-repo → plain start (backward-compat); provision-throw → no spawn (fail-closed); already-running → short-circuit; missing `lifecycleService` / `agentId` throw; repo-without-`managedRoot` throw; unknown-agent throw.
- `FleetLifecycleService.spec` (2 new): `opts.cwd` passthrough + no-cwd legacy. The **17 existing** lifecycle / credential-security tests stay green → backward-compat confirmed.

## Post-Merge Validation
- [ ] When a turnkey caller (FM MCP tool / settings pane) wires `startAgentProvisioned`, a live FM agent defined with `metadata.repo` clones-or-reuses its checkout and the harness process runs with `cwd` === that checkout (whitebox-e2e).
- [ ] An agent without `metadata.repo` continues to start unchanged (inherited cwd).

Related: parent epic #13015 (FM MVP); consumes #13162 / #13145 / #13148 / #13155 (the provisioning chain); touches `FleetLifecycleService` (#13049) + reads the `metadata` convention from `FleetRegistryService` (#13031).
