### PR TITLE
feat(ai): observe fleet repo provisioning state — inspectFleetRepos (#13179)

### DIFF
--- a/ai/services/fleet/inspectFleetRepos.mjs
+++ b/ai/services/fleet/inspectFleetRepos.mjs
@@ -1,0 +1,68 @@
+import {deriveAgentRepoPath} from './deriveAgentRepoPath.mjs';
+import {inspectAgentRepo}    from './inspectAgentRepo.mjs';
+
+/**
+ * @summary Observe the repo-provisioning state of the whole Fleet Manager fleet — the read-side mirror
+ * of spawn-time provisioning, and the repo dimension of the MVP's "observe" pillar.
+ *
+ * `FleetLifecycleService` reports *process* state (`status` / `listRunning`); this reports *repo* state.
+ * For every agent the registry knows, it derives the agent's stable checkout path and classifies what
+ * is on disk (via {@link Neo.ai.services.fleet.inspectAgentRepo}) — absent / empty / a valid checkout /
+ * an occupied conflict — so a settings pane or the operator can render fleet repo health in one read.
+ * An agent that carries no working-repo coordinates yet is reported as `configured: false` (state
+ * `'unconfigured'`, a sentinel distinct from `inspectAgentRepo`'s on-disk states), never silently
+ * omitted: observability must surface the WHOLE fleet, since a dropped agent reads as "no such agent"
+ * — a different, misleading fact.
+ *
+ * Read-only — it never provisions or mutates (provisioning is
+ * {@link Neo.ai.services.fleet.startAgentProvisioned}). `inspect` is an injectable seam (default
+ * {@link Neo.ai.services.fleet.inspectAgentRepo}) so the aggregation is unit-testable without the
+ * filesystem, mirroring the fleet services' default-real + seam idiom. `managedRoot` is a parameter
+ * (consistent with `ensureAgentRepo` / `startAgentProvisioned`), supplied by the caller from FM config.
+ *
+ * @param {Object}    options
+ * @param {Object}    options.registry    The `FleetRegistryService` (or a stub) — supplies
+ *                                         `listAgents()` (secret-stripped defs incl. `metadata.repo`).
+ * @param {String}    options.managedRoot The absolute, trusted fleet-managed checkout root (the same
+ *                                         root the provisioning chain derives paths under).
+ * @param {Function} [options.inspect]    `({repoPath}) => {repoPath, exists, isCheckout, state,
+ *                                         provisioningAction}` classifier; defaults to
+ *                                         {@link Neo.ai.services.fleet.inspectAgentRepo}.
+ * @returns {Object[]} one uniform entry per registered agent: `{agentId, configured, repoSlug,
+ *   repoPath, exists, isCheckout, state, provisioningAction}`. A repo-configured agent carries the
+ *   derived path + the `inspect` classification; an unconfigured agent carries
+ *   `{configured: false, repoSlug: null, repoPath: null, exists: false, isCheckout: false,
+ *   state: 'unconfigured', provisioningAction: null}`.
+ * @throws {Error} when `registry` or `managedRoot` is missing.
+ */
+export function inspectFleetRepos({registry, managedRoot, inspect = inspectAgentRepo} = {}) {
+    if (!registry)    throw new Error("inspectFleetRepos: 'registry' is required.");
+    if (!managedRoot) throw new Error("inspectFleetRepos: 'managedRoot' is required.");
+
+    return registry.listAgents().map(agent => {
+        const repoSlug = agent.metadata?.repo?.repoSlug;
+
+        // No working-repo coordinates ⇒ surface the agent as unconfigured rather than omit it, so the
+        // fleet view stays complete. 'unconfigured' is deliberately distinct from inspectAgentRepo's
+        // 'absent' (configured-but-not-yet-cloned) — "no repo wired" is a different fact from "wired,
+        // not yet on disk".
+        if (!repoSlug) {
+            return {
+                agentId           : agent.id,
+                configured        : false,
+                repoSlug          : null,
+                repoPath          : null,
+                exists            : false,
+                isCheckout        : false,
+                state             : 'unconfigured',
+                provisioningAction: null
+            };
+        }
+
+        const repoPath = deriveAgentRepoPath({managedRoot, agentId: agent.id, repoSlug});
+
+        // inspect() returns {repoPath, exists, isCheckout, state, provisioningAction}; spreading it
+        // yields the uniform per-agent shape alongside the configured marker + slug.
+        return {agentId: agent.id, configured: true, repoSlug, ...inspect({repoPath})};
+    });
+}

--- a/test/playwright/unit/ai/inspectFleetRepos.spec.mjs
+++ b/test/playwright/unit/ai/inspectFleetRepos.spec.mjs
@@ -1,0 +1,89 @@
+import {test, expect}      from '@playwright/test';
+import path                from 'path';
+import {inspectFleetRepos} from '../../../../ai/services/fleet/inspectFleetRepos.mjs';
+
+// Pure aggregator — `registry` + `inspect` are injected stubs (no fs / git / Neo runtime);
+// `deriveAgentRepoPath` runs real (pure path math). Mirrors deriveAgentRepoPath.spec. The inspect stub
+// records the paths it was handed so the derive→inspect threading + the read-only contract are assertable.
+
+const ROOT = '/srv/fleet';
+
+function makeRegistry(agents) {
+    return {listAgents: () => agents};
+}
+
+/** A recording inspectAgentRepo stub: returns the canonical shape (incl. the repoPath it was given). */
+function makeInspect(verdict = {exists: true, isCheckout: true, state: 'checkout', provisioningAction: 'reuse'}) {
+    const calls = [];
+    const fn    = ({repoPath}) => { calls.push(repoPath); return {repoPath, ...verdict}; };
+    fn.calls    = calls;
+    return fn;
+}
+
+const repoAgent = (id, repoSlug = 'neomjs/neo') => ({
+    id, githubUsername: id, harnessType: 'codex',
+    metadata: {repo: {cloneUrl: `https://github.com/${repoSlug}.git`, repoSlug}}
+});
+const bareAgent = id => ({id, githubUsername: id, harnessType: 'codex', metadata: {launch: {command: 'h'}}});
+
+test.describe('inspectFleetRepos (Fleet Manager fleet repo observability)', () => {
+    test('returns one status entry per registered agent, in registry order', () => {
+        const registry = makeRegistry([repoAgent('a'), bareAgent('b')]),
+              result   = inspectFleetRepos({registry, managedRoot: ROOT, inspect: makeInspect()});
+
+        expect(result).toHaveLength(2);
+        expect(result.map(r => r.agentId)).toEqual(['a', 'b']);
+    });
+
+    test('a repo-configured agent carries the derived repoPath + the inspect classification', () => {
+        const inspect  = makeInspect({exists: true, isCheckout: true, state: 'checkout', provisioningAction: 'reuse'}),
+              registry = makeRegistry([repoAgent('a', 'neomjs/neo')]),
+              [entry]  = inspectFleetRepos({registry, managedRoot: ROOT, inspect});
+
+        expect(entry.configured).toBe(true);
+        expect(entry.repoSlug).toBe('neomjs/neo');
+        // path was derived under the managed root + handed to inspect
+        expect(entry.repoPath.startsWith(ROOT + path.sep)).toBe(true);
+        expect(inspect.calls).toEqual([entry.repoPath]);
+        // the classification was threaded through
+        expect(entry.state).toBe('checkout');
+        expect(entry.isCheckout).toBe(true);
+        expect(entry.provisioningAction).toBe('reuse');
+    });
+
+    test('an agent with no metadata.repo is reported unconfigured — surfaced, not inspected', () => {
+        const inspect  = makeInspect(),
+              registry = makeRegistry([bareAgent('b')]),
+              [entry]  = inspectFleetRepos({registry, managedRoot: ROOT, inspect});
+
+        expect(entry).toMatchObject({
+            agentId: 'b', configured: false, repoSlug: null, repoPath: null,
+            exists: false, isCheckout: false, state: 'unconfigured', provisioningAction: null
+        });
+        // unconfigured agents are never handed to the fs classifier
+        expect(inspect.calls).toHaveLength(0);
+    });
+
+    test('configured + unconfigured entries share a uniform key shape', () => {
+        const registry = makeRegistry([repoAgent('a'), bareAgent('b')]),
+              [a, b]   = inspectFleetRepos({registry, managedRoot: ROOT, inspect: makeInspect()});
+
+        expect(Object.keys(a).sort()).toEqual(Object.keys(b).sort());
+    });
+
+    test('distinct agents derive distinct repo paths', () => {
+        const registry = makeRegistry([repoAgent('a'), repoAgent('b')]),
+              result   = inspectFleetRepos({registry, managedRoot: ROOT, inspect: makeInspect()});
+
+        expect(result[0].repoPath).not.toBe(result[1].repoPath);
+    });
+
+    test('an empty fleet returns an empty array', () => {
+        expect(inspectFleetRepos({registry: makeRegistry([]), managedRoot: ROOT})).toEqual([]);
+    });
+
+    test('missing registry / managedRoot throw clear errors', () => {
+        expect(() => inspectFleetRepos({managedRoot: ROOT})).toThrow(/registry/);
+        expect(() => inspectFleetRepos({registry: makeRegistry([])})).toThrow(/managedRoot/);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13179

**The repo dimension of the FM MVP's "observe" pillar** — the read-side mirror of #13177's provision-side. `FleetLifecycleService` reports *process* state (`status` / `listRunning`); nothing reported *repo* state. `inspectFleetRepos` is the single fleet-wide read a settings pane or the operator needs to render repo health — is each agent's working repo present, a valid checkout, conflicted, or not configured at all.

- **`ai/services/fleet/inspectFleetRepos.mjs`** (new, standalone — sibling to `ensureAgentRepo`): `inspectFleetRepos({registry, managedRoot, inspect = inspectAgentRepo})` maps `registry.listAgents()` → a per-agent repo-status array. A repo-configured agent (`metadata.repo.repoSlug`) → derive the stable path → `inspectAgentRepo` → `{agentId, configured: true, repoSlug, repoPath, exists, isCheckout, state, provisioningAction}`. An agent with no repo coordinates → `{configured: false, state: 'unconfigured', …}` — surfaced, never omitted (a dropped agent reads as "no such agent", a different and misleading fact). `'unconfigured'` is a sentinel distinct from `inspectAgentRepo`'s `absent` / `empty` / `checkout` / `occupied-non-checkout`.
- Read-only — never provisions or mutates. `inspect` is an injectable seam (default-real) so the aggregation unit-tests without the filesystem; `managedRoot` is a parameter (consistent with `ensureAgentRepo` / `startAgentProvisioned`), supplied by the caller from FM config.

Evidence: L1 (pure-aggregator unit spec with an injected `inspect` seam + a stub registry; `deriveAgentRepoPath` runs real) → L1 required (every AC is aggregation decision-logic, unit-verifiable). No residuals — the live filesystem classification is already covered by `inspectAgentRepo`'s own temp-dir spec; the settings-pane render that consumes this is a later UI leaf.

## Deltas from ticket (if any)
None. Delivers #13179's Contract Ledger exactly: the `inspectFleetRepos` aggregator over `registry.listAgents()`, a uniform entry shape, unconfigured-surfaced.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/inspectFleetRepos.spec.mjs
→ 7 passed (642ms)

node --check ai/services/fleet/inspectFleetRepos.mjs → OK
```
7 cases: one entry per agent in registry order; a configured agent carries the derived path + the threaded classification; an unconfigured agent is surfaced + never handed to the fs classifier; uniform key shape across configured/unconfigured; distinct agents → distinct paths; empty fleet → `[]`; missing `registry` / `managedRoot` throw.

## Post-Merge Validation
- [ ] When the settings pane (#13058) / an FM read tool consumes `inspectFleetRepos` with a real `managedRoot`, fleet repo health renders (whitebox-e2e) — present checkouts, conflicts, and unconfigured agents all surfaced.

Related: parent epic #13015 (FM MVP — define, start, **observe**); read-side mirror of #13177 (provision-side); consumes `inspectAgentRepo` (#13148) + `deriveAgentRepoPath` (#13145); reads the `metadata.repo` convention (#13177); consumer-to-be: the settings pane (#13058).
