### PR TITLE
feat(ai): authenticate Bridge agent connections via asymmetric-signed tokens (#13172)

### DIFF
--- a/ai/mcp/server/neural-link/Bridge.mjs
+++ b/ai/mcp/server/neural-link/Bridge.mjs
@@ -1,6 +1,8 @@
-import {WebSocketServer} from 'ws';
-import Base              from '../../../../src/core/Base.mjs';
-import logger            from './logger.mjs';
+import {WebSocketServer}  from 'ws';
+import crypto             from 'crypto';
+import Base               from '../../../../src/core/Base.mjs';
+import logger             from './logger.mjs';
+import {verifyBridgeToken} from './verifyBridgeToken.mjs';
 
 /**
  * @summary The central WebSocket Hub (Bridge) for Neural Link.
@@ -117,6 +119,42 @@ class Bridge extends Base {
     }
 
     /**
+     * Lazily-resolved Ed25519 **public** verify key from `NEO_FLEET_BRIDGE_PUBLIC_KEY` (a trusted,
+     * harness/operator-set SPKI PEM — never agent-supplied). `undefined` = not yet resolved, `null` =
+     * no key configured (legacy unauthenticated dev mode), else the `crypto.KeyObject`.
+     * @member {Object|null} bridgePublicKey
+     * @protected
+     */
+    bridgePublicKey = undefined
+
+    /**
+     * @summary Resolve (once, cached) the Bridge's token-verify public key, or null when unset.
+     * @returns {Object|null}
+     * @protected
+     */
+    getBridgePublicKey() {
+        if (this.bridgePublicKey === undefined) {
+            const pem = process.env.NEO_FLEET_BRIDGE_PUBLIC_KEY;
+            this.bridgePublicKey = pem ? crypto.createPublicKey(pem) : null;
+        }
+        return this.bridgePublicKey;
+    }
+
+    /**
+     * @summary Verify a presented signed Bridge token; return the **signed** agentId or null.
+     *
+     * Thin wrapper over the pure {@link verifyBridgeToken} (kept Bridge-free so the security gate is
+     * unit-testable without the WebSocket singleton — mirrors `src/ai/parseAgentEnvelope.mjs`). The
+     * returned identity is the FM-signed `agentId`, trusted from the signature, never the `?id=` claim.
+     * @param {String} token `<base64url(payload)>.<base64url(signature)>`.
+     * @returns {String|null}
+     * @protected
+     */
+    verifyAgentToken(token) {
+        return verifyBridgeToken(token, this.getBridgePublicKey());
+    }
+
+    /**
      * Handles new connections.
      * @param {WebSocket} ws
      * @param {IncomingMessage} req
@@ -127,6 +165,7 @@ class Bridge extends Base {
             const role    = url.searchParams.get('role'); // 'app' or 'agent'
             const id      = url.searchParams.get('id') || url.searchParams.get('appWorkerId'); // Support legacy param
             const appName = url.searchParams.get('appName');
+            const token   = url.searchParams.get('token');
 
             if (!id) {
                 logger.warn('Bridge: Connection rejected. No ID provided.');
@@ -135,7 +174,21 @@ class Bridge extends Base {
             }
 
             if (role === 'agent') {
-                this.registerAgent(id, ws);
+                // Authenticate the agent when a verify key is provisioned (fleet mode): the identity
+                // is the agentId SIGNED into the token, never the untrusted `?id=` query claim (the
+                // spoofing hole this closes). With no key configured (no-FM dev), fall back to the
+                // legacy unauthenticated path — auth and multi-writer enforcement are a matched pair.
+                if (this.getBridgePublicKey()) {
+                    const verifiedId = this.verifyAgentToken(token);
+                    if (!verifiedId) {
+                        logger.warn('Bridge: Agent connection rejected — invalid or missing token.');
+                        ws.close(1008, 'Authentication required');
+                        return;
+                    }
+                    this.registerAgent(verifiedId, ws);
+                } else {
+                    this.registerAgent(id, ws);
+                }
             } else if (role === 'test') {
                 logger.info(`Bridge: Test client connected [${id}]`);
                 this.registerAgent(id, ws);

--- a/ai/mcp/server/neural-link/Bridge.mjs
+++ b/ai/mcp/server/neural-link/Bridge.mjs
@@ -62,6 +62,9 @@ class Bridge extends Base {
      * @returns {Promise<void>}
      */
     async initAsync() {
+        // Skip the port bind under unitTestMode — tests instantiate the singleton (for handleConnection
+        // handshake-auth + verify coverage) without standing up a real WebSocket server.
+        if (Neo.config.unitTestMode) return;
         await this.startServer();
     }
 

--- a/ai/mcp/server/neural-link/verifyBridgeToken.mjs
+++ b/ai/mcp/server/neural-link/verifyBridgeToken.mjs
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+
+/**
+ * @summary Verify a signed Neural-Link Bridge token; return the SIGNED agentId or null (fail-closed).
+ *
+ * Pure + Bridge-free (mirrors `src/ai/parseAgentEnvelope.mjs`) so the security gate is unit-testable
+ * without the WebSocket singleton. The token is the FM-minted `<base64url(payload)>.<base64url(sig)>`
+ * (`Neo.ai.services.fleet.FleetRegistryService.mintBridgeToken`): an Ed25519 signature over the exact
+ * `{agentId, expiresAt}` payload bytes. The identity is taken from the **verified** payload, never
+ * from any connection-supplied `?id=` claim — closing the raw-claim spoofing path.
+ *
+ * Returns null on: a missing public key (no fleet auth configured → caller falls back to legacy
+ * unauthenticated mode), a non-string / malformed token, a bad or forged signature, an expired or
+ * malformed payload, or any thrown error. Never throws.
+ *
+ * @param {String}      token     `<base64url(payload)>.<base64url(signature)>`.
+ * @param {Object|null} publicKey The Ed25519 verify key (a `crypto.KeyObject`), or null/undefined.
+ * @returns {String|null} the verified agentId, or null.
+ */
+export function verifyBridgeToken(token, publicKey) {
+    try {
+        if (!publicKey || typeof token !== 'string') return null;
+
+        const dot = token.indexOf('.');
+        if (dot < 1) return null;
+
+        const
+            payload   = Buffer.from(token.slice(0, dot), 'base64url'),
+            signature = Buffer.from(token.slice(dot + 1), 'base64url');
+
+        // Ed25519 verify over the exact signed payload bytes; a forged or altered token → false.
+        if (!crypto.verify(null, payload, publicKey, signature)) return null;
+
+        const {agentId, expiresAt} = JSON.parse(payload.toString('utf8'));
+
+        if (typeof agentId !== 'string'  || !agentId)                return null;
+        if (typeof expiresAt !== 'number' || Date.now() >= expiresAt) return null;
+
+        return agentId;
+    } catch {
+        return null;
+    }
+}

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -31,21 +31,21 @@ const
  * **Two credential classes, deliberately separated at the store + method level:** (1) the
  * GitHub **PAT** above — *reversibly* encrypted, because the spawner must inject the real token into
  * a harness env; served only by {@link resolveCredential}. (2) the **Bridge session token**
- * ({@link mintBridgeToken} / {@link verifyBridgeToken}) — a registry-minted, short-lived,
- * **hash-stored, verify-only** credential for agent↔Neural-Link-Bridge transport auth. It
- * lives in its own store (`bridgeTokens.enc`) with its own read/write methods and **never** routes
- * through the PAT helpers — so "encrypted at rest" can never quietly become a second *reversible*
- * secret store. The raw Bridge token is absent from storage the instant {@link mintBridgeToken}
- * returns; only its SHA-256 hash + expiry persist.
+ * ({@link mintBridgeToken}) — a registry-minted, short-lived, **asymmetrically-signed** credential
+ * for agent↔Neural-Link-Bridge transport auth. It is stateless (nothing persisted): an Ed25519
+ * signature over `{agentId, expiresAt}` that the network-facing Bridge verifies with only the
+ * **public** key ({@link getBridgePublicKey}) — so a Bridge compromise can neither read the PAT
+ * store nor forge a token. The private signing key ({@link getSigningKey}) never decrypts the PAT
+ * store; the two credential classes stay key-separated.
  *
  * **Storage** lives under `dataDir` (default `<repoRoot>/.neo-ai-data/fleet/`, overridable — the
  * per-tenant data root is the multi-tenant isolation seam):
  * - `registry.json`    — agent definitions (no secrets), human-readable JSON.
  * - `credentials.enc`  — the encrypted `{agentId: pat}` map (AES-256-GCM, `0600`).
- * - `bridgeTokens.enc` — the encrypted `{agentId: {hash, expiresAt, createdAt}}` Bridge-token map
- *                        (AES-256-GCM, `0600`) — the second, distinct credential class; no raw token.
- * - `fleet.key`        — dev-only generated `0600` key file, used when `NEO_FLEET_SECRET_KEY` is
- *                        not set. Production deployments SHOULD provide the env key.
+ * - `fleet.key`        — dev-only generated `0600` AES key file, used when `NEO_FLEET_SECRET_KEY`
+ *                        is not set. Production deployments SHOULD provide the env key.
+ * - `signing.key`      — dev-only generated `0600` Ed25519 signing key (PKCS8 PEM), used when
+ *                        `NEO_FLEET_SIGNING_KEY` is not set. Only its PUBLIC half goes to the Bridge.
  *
  * **Fail-closed:** an absent / locked / corrupt credential store never throws into the define/list
  * path and never surfaces plaintext — {@link resolveCredential} returns `null`.
@@ -175,10 +175,12 @@ class FleetRegistryService extends Base {
         this.ensureLoaded();
         const existed = this.agents.delete(id);
         if (existed) this.writeRegistry();
-        // Both credential classes die with the agent — the PAT AND the Bridge token. Leaving a live
-        // Bridge token for a removed agent would let it keep authenticating to the Bridge.
+        // The PAT dies with the agent. The Bridge token is a stateless *signed* credential (no
+        // store), so it can't be revoked at remove-time — it self-expires within bridgeTokenTtlMs
+        // (the accepted ≤1h lag; immediate eviction of a compromised agent is a later additive
+        // Bridge revocation-denylist). WriteGuard's no-clobber invariant denies
+        // an overlapping cross-agent write on the agentId regardless of token age in the interim.
         this.removeCredential(id);
-        this.removeBridgeToken(id);
         return {success: existed, id};
     }
 
@@ -196,77 +198,38 @@ class FleetRegistryService extends Base {
     }
 
     /**
-     * @summary Mint a short-lived, hash-stored Bridge session token for agent↔Neural-Link-Bridge
-     * transport auth. The raw token is returned **once** to the caller and is **never**
-     * persisted — only its SHA-256 hash + expiry land in `bridgeTokens.enc`, a store distinct from
-     * the reversibly-encrypted PAT (the Bridge token can never route through the PAT helpers). A
-     * re-mint for the same id replaces the prior record.
+     * @summary Mint a short-lived, **asymmetrically-signed** Bridge session token for
+     * agent↔Neural-Link-Bridge transport auth. The token is a self-contained, stateless credential:
+     * a compact `<base64url(payload)>.<base64url(signature)>` where `payload` is
+     * `{agentId, expiresAt}` and the signature is Ed25519 over those exact payload bytes
+     * ({@link getSigningKey}). Nothing is persisted — there is no per-token store.
      *
-     * Minting does **not** require `id` to be a registered agent (it only produces + stores a hash) —
-     * the validity boundary is {@link verifyBridgeToken}, which fails closed unless `id` is a current
-     * fleet member. So a token minted for a non-member never authenticates; binding the check at
-     * verify (not mint) keeps the gate in one place and tolerates a register-after-mint ordering.
-     * @param {String}  id          The agent id the token is minted for.
+     * **Why signed, not hash-stored (the recorded ticket decision):** the Bridge runs as a separate,
+     * network-facing process. A store-read verifier would have to hold the registry's master key
+     * (the same `getKey()` that decrypts `credentials.enc` = every PAT), so a Bridge compromise would
+     * leak all PATs. An asymmetric signature lets the Bridge verify statelessly with only the
+     * **public** key ({@link getBridgePublicKey}) — zero secret material + zero store access on the
+     * exposed surface, and it cannot forge tokens. The cost is a ≤`bridgeTokenTtlMs` revocation lag
+     * (a removed agent's token stays valid until expiry); accepted because WriteGuard's no-clobber
+     * invariant denies an overlapping cross-agent write on the `agentId` regardless of token age.
+     * Immediate eviction of a *compromised* agent is a later additive Bridge revocation-denylist.
+     *
+     * The verified `agentId` rides **inside** the signed payload — so the Bridge trusts identity from
+     * the signature, never the connection's `?id=` query claim (the spoofing hole this closes).
+     * @param {String}  id          The agent id the token is minted for (signed into the payload).
      * @param {Object} [opts]
      * @param {Number} [opts.ttlMs] Token lifetime in ms; defaults to {@link bridgeTokenTtlMs}.
-     * @returns {Object} `{token, expiresAt}` — the raw token (caller keeps it; absent from storage) + its epoch-ms expiry.
+     * @returns {Object} `{token, expiresAt}` — the signed token (caller keeps it; nothing persisted) + its epoch-ms expiry.
      */
     mintBridgeToken(id, {ttlMs}={}) {
         const
-            token     = crypto.randomBytes(32).toString('base64url'),
-            hash      = crypto.createHash('sha256').update(token).digest('hex'),
             now       = Date.now(),
             expiresAt = now + (ttlMs ?? this.bridgeTokenTtlMs),
-            tokens    = this.readBridgeTokens();
-
-        tokens[id] = {hash, expiresAt, createdAt: now};
-        this.writeBridgeTokens(tokens);
+            payload   = Buffer.from(JSON.stringify({agentId: id, expiresAt})),
+            signature = crypto.sign(null, payload, this.getSigningKey()),
+            token     = `${payload.toString('base64url')}.${signature.toString('base64url')}`;
 
         return {token, expiresAt};
-    }
-
-    /**
-     * @summary Verify a presented Bridge token against the hash-stored record for `id`. This is the
-     * untrusted-input path: a **constant-time** hash compare ({@link crypto.timingSafeEqual}) that
-     * rejects expired tokens and **fails closed** — returns `false` (never throws) on an id that is
-     * not a currently-registered agent (never registered, or removed via {@link removeAgent}), an
-     * unknown / absent / unreadable / malformed store, a bad hash encoding, or a missing / expired
-     * `expiresAt`. Mirrors {@link resolveCredential}'s fail-closed posture; no secret ever surfaces.
-     *
-     * **The Bridge token authenticates a *current fleet member*** — validity is bound to registry
-     * membership, so a removed agent's token can never authenticate (the security invariant the
-     * `removeAgent` → `removeBridgeToken` cleanup and this gate jointly guarantee).
-     * @param {String} id        The agent id presenting the token.
-     * @param {String} presented The raw token to check.
-     * @returns {Boolean} `true` only for a live, matching token owned by a registered agent; `false` otherwise.
-     */
-    verifyBridgeToken(id, presented) {
-        try {
-            // Bind validity to fleet membership: a never-registered or removed id fails closed even
-            // if a token record lingers (defense-in-depth over the removeAgent cleanup). `Map.has`
-            // is prototype-safe for untrusted ids.
-            this.ensureLoaded();
-            if (!this.agents.has(id)) return false;
-
-            const tokens = this.readBridgeTokens();
-            // own-property only: an untrusted id like `toString` must fail closed, never alias a proto member.
-            if (!Object.hasOwn(tokens, id)) return false;
-
-            const record = tokens[id];
-            if (!record || typeof record.expiresAt !== 'number' || Date.now() >= record.expiresAt) {
-                return false;
-            }
-
-            const
-                presentedHash = crypto.createHash('sha256').update(presented).digest(),
-                storedHash    = Buffer.from(String(record.hash), 'hex');
-
-            // timingSafeEqual throws on a length mismatch; a malformed/short stored hash fails closed.
-            return storedHash.length === presentedHash.length && crypto.timingSafeEqual(presentedHash, storedHash);
-        } catch (error) {
-            console.warn('[FleetRegistryService] Bridge-token verify failed closed.', error.message);
-            return false;
-        }
     }
 
     // ---- internals ----------------------------------------------------------
@@ -371,51 +334,6 @@ class FleetRegistryService extends Base {
         fs.writeFileSync(this.credentialsPath(), this.encrypt(JSON.stringify(map)), {mode: 0o600});
     }
 
-    /**
-     * @returns {Object} The decrypted Bridge-token store as a **null-prototype** map
-     * `{agentId: {hash, expiresAt, createdAt}}` (empty + warned on absent/corrupt — fail-closed).
-     * A distinct file + shape from {@link readCredentials}; the two stores never mix. Null-proto is
-     * the same untrusted-key invariant — an absent id can never alias an `Object.prototype` member.
-     * @private
-     */
-    readBridgeTokens() {
-        const file = this.bridgeTokensPath();
-        if (!fs.existsSync(file)) return Object.create(null);
-        try {
-            return Object.assign(Object.create(null), JSON.parse(this.decrypt(fs.readFileSync(file, 'utf8'))));
-        } catch (error) {
-            console.warn('[FleetRegistryService] Bridge-token store unreadable; failing closed.', error.message);
-            return Object.create(null);
-        }
-    }
-
-    /**
-     * Encrypt + write the full Bridge-token map to `bridgeTokens.enc` (`0600`). Encryption is
-     * defense-in-depth *over* the stored SHA-256 hashes — the records carry no reversible secret;
-     * it is never a license to persist a raw token. Distinct file/method from {@link writeCredentials}.
-     * @param {Object} map
-     * @private
-     */
-    writeBridgeTokens(map) {
-        this.ensureDataDir();
-        fs.writeFileSync(this.bridgeTokensPath(), this.encrypt(JSON.stringify(map)), {mode: 0o600});
-    }
-
-    /**
-     * Remove a single Bridge-token record from the store (no-op if absent). Invoked by
-     * {@link removeAgent} so the Bridge credential dies with the agent — the analog of
-     * {@link removeCredential} for the second credential class.
-     * @param {String} id
-     * @private
-     */
-    removeBridgeToken(id) {
-        const tokens = this.readBridgeTokens();
-        if (Object.hasOwn(tokens, id)) {
-            delete tokens[id];
-            this.writeBridgeTokens(tokens);
-        }
-    }
-
     // ---- crypto (AES-256-GCM) ----------------------------------------------
 
     /**
@@ -471,6 +389,39 @@ class FleetRegistryService extends Base {
         return key;
     }
 
+    /**
+     * Resolve the Ed25519 **private** signing key for Bridge session tokens: `NEO_FLEET_SIGNING_KEY`
+     * (a PKCS8 PEM) if set, else a generated `0600` `signing.key` file under `dataDir`. Distinct from
+     * {@link getKey} (the AES master key) — this private key never decrypts the PAT/token stores, and
+     * only its PUBLIC half ({@link getBridgePublicKey}) is provisioned to the network-facing Bridge.
+     * Production SHOULD set the env key. Returns a {@link crypto.KeyObject}.
+     * @returns {Object}
+     * @private
+     */
+    getSigningKey() {
+        const envKey = process.env.NEO_FLEET_SIGNING_KEY;
+        if (envKey) return crypto.createPrivateKey(envKey);
+
+        const file = this.signingKeyPath();
+        if (fs.existsSync(file)) return crypto.createPrivateKey(fs.readFileSync(file, 'utf8'));
+
+        this.ensureDataDir();
+        const {privateKey} = crypto.generateKeyPairSync('ed25519');
+        fs.writeFileSync(file, privateKey.export({type: 'pkcs8', format: 'pem'}), {mode: 0o600});
+        return privateKey;
+    }
+
+    /**
+     * @returns {String} The Ed25519 **public** verify key (SPKI PEM) matching {@link getSigningKey}.
+     * Non-secret — this is the only key material the network-facing Bridge needs to verify token
+     * signatures statelessly. Provisioned to the Bridge at startup via `NEO_FLEET_BRIDGE_PUBLIC_KEY`,
+     * a trusted harness/operator-set value — **never** supplied by a connecting agent.
+     * @private
+     */
+    getBridgePublicKey() {
+        return crypto.createPublicKey(this.getSigningKey()).export({type: 'spki', format: 'pem'});
+    }
+
     // ---- paths --------------------------------------------------------------
 
     /**
@@ -487,8 +438,9 @@ class FleetRegistryService extends Base {
     /** @returns {String} @private */
     credentialsPath() { return path.join(this.getDataDir(), 'credentials.enc'); }
 
-    /** @returns {String} A store distinct from {@link credentialsPath}; the two never share a file. @private */
-    bridgeTokensPath() { return path.join(this.getDataDir(), 'bridgeTokens.enc'); }
+    /** @returns {String} The Ed25519 signing-key file (PKCS8 PEM) — a generated `0600` dev key when
+     * `NEO_FLEET_SIGNING_KEY` is unset. Distinct from {@link keyPath} (the AES master key). @private */
+    signingKeyPath() { return path.join(this.getDataDir(), 'signing.key'); }
 
     /** @returns {String} @private */
     keyPath() { return path.join(this.getDataDir(), 'fleet.key'); }

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -141,8 +141,13 @@ class ConnectionService extends Base {
      */
     async connectToBridge() {
         return new Promise((resolve, reject) => {
-            const url = `ws://127.0.0.1:${this.port}?role=agent&id=${this.agentId}`;
-            const ws  = new WebSocket(url);
+            // Present the FM-minted, asymmetrically-signed Bridge token (injected at spawn under
+            // NEO_FLEET_BRIDGE_TOKEN) so the Bridge authenticates this agent from the signature, not
+            // the `?id=` claim. Absent in no-FM dev → the Bridge's legacy unauthenticated path.
+            const token = process.env.NEO_FLEET_BRIDGE_TOKEN;
+            const url   = `ws://127.0.0.1:${this.port}?role=agent&id=${this.agentId}` +
+                          (token ? `&token=${encodeURIComponent(token)}` : '');
+            const ws    = new WebSocket(url);
 
             ws.on('open', () => {
                 logger.info(`Connected to Neural Link Bridge as ${this.agentId}`);

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -15,6 +15,7 @@ import {test, expect}  from '@playwright/test';
 import fs              from 'fs';
 import os              from 'os';
 import path            from 'path';
+import crypto          from 'crypto';
 
 import Neo                  from '../../../../src/Neo.mjs';
 import * as core            from '../../../../src/core/_export.mjs';
@@ -165,110 +166,108 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
     });
 
     // ---- Bridge session token credential class -----------------------------
-    // A second, distinct credential class for agent<->Neural-Link-Bridge transport auth:
-    // registry-minted, short-lived, hash-stored, verify-only. A token authenticates a CURRENT fleet
-    // member, so verify is gated on registry membership — tests register the agent first (the real
-    // register -> mint -> verify flow). Inherits the freshDataDir hooks above.
-    test.describe('Bridge session token credential class (#13065)', () => {
-        const register = id => FleetRegistryService.defineAgent({githubUsername: id, harnessType: 'codex'});
+    // The agent<->Neural-Link-Bridge transport credential: registry-minted, short-lived, and
+    // **asymmetrically signed**. The token is a stateless `payload.sig` — an
+    // Ed25519 signature over `{agentId, expiresAt}`. The network-facing Bridge verifies with only the
+    // PUBLIC key (getBridgePublicKey), holding no secret + no store. Inherits the freshDataDir hooks.
+    test.describe('Bridge session token credential class (#13172 — asymmetric-signed)', () => {
+        // Verify a minted token the way the Bridge does: Ed25519 over the exact signed payload bytes
+        // with the public key, then decode the claims. Returns `{agentId, expiresAt}` or null.
+        const verifyWithPublicKey = token => {
+            const pub = crypto.createPublicKey(FleetRegistryService.getBridgePublicKey()),
+                  dot = token.indexOf('.');
+            if (dot < 1) return null;
+            const payload   = Buffer.from(token.slice(0, dot), 'base64url'),
+                  signature = Buffer.from(token.slice(dot + 1), 'base64url');
+            if (!crypto.verify(null, payload, pub, signature)) return null;
+            return JSON.parse(payload.toString('utf8'));
+        };
 
-        test('mint -> verify round-trip; wrong / unknown token fails closed', () => {
-            register('round-trip-agent');
+        test('mint -> verify round-trip: the public key recovers the SIGNED agentId + expiry', () => {
             const {token, expiresAt} = FleetRegistryService.mintBridgeToken('round-trip-agent');
 
             expect(typeof token).toBe('string');
-            expect(token.length).toBeGreaterThan(0);
+            expect(token).toContain('.');
             expect(expiresAt).toBeGreaterThan(Date.now());
 
-            expect(FleetRegistryService.verifyBridgeToken('round-trip-agent', token)).toBe(true);
-            expect(FleetRegistryService.verifyBridgeToken('round-trip-agent', 'wrong-token')).toBe(false);
-            expect(FleetRegistryService.verifyBridgeToken('unknown-agent', token)).toBe(false);
+            const claims = verifyWithPublicKey(token);
+            expect(claims).not.toBeNull();
+            expect(claims.agentId).toBe('round-trip-agent'); // identity rides INSIDE the signature
+            expect(claims.expiresAt).toBe(expiresAt);
         });
 
-        test('a re-mint rotates the token — the prior token no longer verifies', () => {
-            register('rotating-agent');
-            const first = FleetRegistryService.mintBridgeToken('rotating-agent').token;
-            const next  = FleetRegistryService.mintBridgeToken('rotating-agent').token;
+        test('SECURITY: a forged / tampered / foreign-signed token fails verification', () => {
+            const {token}              = FleetRegistryService.mintBridgeToken('victim-agent'),
+                  [payloadB64, sigB64] = token.split('.');
 
-            expect(next).not.toBe(first);
-            expect(FleetRegistryService.verifyBridgeToken('rotating-agent', next)).toBe(true);
-            expect(FleetRegistryService.verifyBridgeToken('rotating-agent', first)).toBe(false);
+            // (a) tamper the payload to claim a different agentId — the signature no longer matches
+            const forged = Buffer.from(JSON.stringify({agentId: 'attacker', expiresAt: Date.now() + 1e6})).toString('base64url');
+            expect(verifyWithPublicKey(`${forged}.${sigB64}`)).toBeNull();
+
+            // (b) tamper the signature bytes
+            expect(verifyWithPublicKey(`${payloadB64}.${sigB64.slice(0, -4)}AAAA`)).toBeNull();
+
+            // (c) a token signed by a DIFFERENT key never verifies against ours (can't forge w/o the private key)
+            const other   = crypto.generateKeyPairSync('ed25519'),
+                  p       = Buffer.from(JSON.stringify({agentId: 'victim-agent', expiresAt: Date.now() + 1e6})),
+                  foreign = `${p.toString('base64url')}.${crypto.sign(null, p, other.privateKey).toString('base64url')}`;
+            expect(verifyWithPublicKey(foreign)).toBeNull();
         });
 
-        test('verifyBridgeToken rejects an expired token', () => {
-            register('expiring-agent');
-            const {token} = FleetRegistryService.mintBridgeToken('expiring-agent', {ttlMs: -1});
-            expect(FleetRegistryService.verifyBridgeToken('expiring-agent', token)).toBe(false);
+        test('an expired token is signed with a past expiry (the verifier rejects on expiresAt separately)', () => {
+            const {token, expiresAt} = FleetRegistryService.mintBridgeToken('expiring-agent', {ttlMs: -1});
+            expect(expiresAt).toBeLessThanOrEqual(Date.now());
+            // the signature is still valid — expiry is a SEPARATE check the Bridge enforces on the claims
+            expect(verifyWithPublicKey(token).expiresAt).toBe(expiresAt);
         });
 
-        test('SECURITY: removeAgent invalidates the Bridge token (#13108 cross-family review)', () => {
-            register('edge-agent');
-            const {token} = FleetRegistryService.mintBridgeToken('edge-agent');
-            expect(FleetRegistryService.verifyBridgeToken('edge-agent', token)).toBe(true);
-
-            FleetRegistryService.removeAgent('edge-agent');
-
-            // a removed agent's transport credential must no longer authenticate ...
-            expect(FleetRegistryService.verifyBridgeToken('edge-agent', token)).toBe(false);
-            // ... and its record is cleared from the store, not merely gated at verify
-            expect(FleetRegistryService.readBridgeTokens()['edge-agent']).toBeUndefined();
+        test('the public verify key carries no private material + is stable across calls', () => {
+            const pub = FleetRegistryService.getBridgePublicKey();
+            expect(pub).toContain('BEGIN PUBLIC KEY');
+            expect(pub).not.toContain('PRIVATE');
+            expect(FleetRegistryService.getBridgePublicKey()).toBe(pub); // same generated keypair
         });
 
-        test('SECURITY: a token minted for an unregistered id never verifies (verify gates on membership)', () => {
-            // mint is permissive (it only produces + stores a hash); the boundary is verify, which
-            // fails closed until the id is a registered fleet member.
-            const {token} = FleetRegistryService.mintBridgeToken('ghost-agent');
-            expect(FleetRegistryService.verifyBridgeToken('ghost-agent', token)).toBe(false);
+        test('SECURITY: stateless — the signing key is 0600, no per-token store, no raw secret in the token', () => {
+            const {token} = FleetRegistryService.mintBridgeToken('at-rest-agent'),
+                  dir     = FleetRegistryService.dataDir;
 
-            // registering the agent flips verify to true with the SAME token — proving membership is the gate
-            register('ghost-agent');
-            expect(FleetRegistryService.verifyBridgeToken('ghost-agent', token)).toBe(true);
+            // stateless: the prior hash-store file is gone
+            expect(fs.existsSync(path.join(dir, 'bridgeTokens.enc'))).toBe(false);
+
+            // the generated signing key is a 0600 PKCS8 PEM private key, distinct from the AES master
+            const keyFile = path.join(dir, 'signing.key');
+            expect(fs.existsSync(keyFile)).toBe(true);
+            expect(fs.statSync(keyFile).mode & 0o777).toBe(0o600);
+            // the token itself carries no private key material
+            expect(token).not.toContain('PRIVATE');
         });
 
-        test('SECURITY: mint returns the token once; only its hash persists (no raw token at rest)', () => {
-            register('bridge-agent');
-            const {token} = FleetRegistryService.mintBridgeToken('bridge-agent');
-
-            // (a) the at-rest file is ciphertext — the raw token must not appear
-            const raw = fs.readFileSync(path.join(FleetRegistryService.dataDir, 'bridgeTokens.enc'), 'utf8');
-            expect(raw).not.toContain(token);
-
-            // (b) inspect the decrypted store payload — only {hash, expiresAt, createdAt}, never the raw token
-            const record = FleetRegistryService.readBridgeTokens()['bridge-agent'];
-            expect(record.hash).toMatch(/^[0-9a-f]{64}$/);
-            expect(record.token).toBeUndefined();
-            expect(JSON.stringify(record)).not.toContain(token);
-        });
-
-        test('SECURITY: the Bridge store is separate from the PAT store; the PAT class is unaffected', () => {
+        test('SECURITY: the PAT class is unaffected; a Bridge token never decodes a PAT', () => {
             const pat = 'ghp_CoexistToken_99887766';
             FleetRegistryService.defineAgent({githubUsername: 'dual-agent', harnessType: 'codex', credential: pat});
-            const {token} = FleetRegistryService.mintBridgeToken('dual-agent');
+            const {token} = FleetRegistryService.mintBridgeToken('dual-agent'),
+                  dir     = FleetRegistryService.dataDir;
 
-            const dir = FleetRegistryService.dataDir;
-            // two distinct files; the Bridge token never routes through credentials.enc
-            expect(fs.existsSync(path.join(dir, 'credentials.enc'))).toBe(true);
-            expect(fs.existsSync(path.join(dir, 'bridgeTokens.enc'))).toBe(true);
+            // distinct key files: the AES master (fleet.key, encrypts the PAT store) + the Ed25519 signer (signing.key)
+            expect(fs.existsSync(path.join(dir, 'fleet.key'))).toBe(true);
+            expect(fs.existsSync(path.join(dir, 'signing.key'))).toBe(true);
 
-            // the PAT still round-trips through its own accessor, unchanged by the Bridge token
-            expect(FleetRegistryService.resolveCredential('dual-agent')).toBe(pat);
-            // the Bridge token verifies through its own path; the two classes never cross-validate
-            expect(FleetRegistryService.verifyBridgeToken('dual-agent', token)).toBe(true);
-            expect(FleetRegistryService.verifyBridgeToken('dual-agent', pat)).toBe(false);
+            expect(FleetRegistryService.resolveCredential('dual-agent')).toBe(pat);     // PAT round-trips, unchanged
+            expect(verifyWithPublicKey(token).agentId).toBe('dual-agent');              // token decodes an agentId, not a PAT
         });
 
-        test('FAIL-CLOSED: a corrupt Bridge store yields false, never throws', () => {
-            register('corrupt-agent');
-            const {token} = FleetRegistryService.mintBridgeToken('corrupt-agent');
-            fs.writeFileSync(path.join(FleetRegistryService.dataDir, 'bridgeTokens.enc'), 'not-valid-ciphertext', 'utf8');
-            expect(FleetRegistryService.verifyBridgeToken('corrupt-agent', token)).toBe(false);
-        });
+        test('removeAgent does NOT revoke the stateless signed token (≤TTL lag, accepted — #13172)', () => {
+            FleetRegistryService.defineAgent({githubUsername: 'gone-agent', harnessType: 'codex'});
+            const {token} = FleetRegistryService.mintBridgeToken('gone-agent');
+            expect(verifyWithPublicKey(token).agentId).toBe('gone-agent');
 
-        test('FAIL-CLOSED: unregistered / prototype-chain ids never verify', () => {
-            // none of these are registered agents — the membership gate fails them closed
-            for (const key of ['toString', 'constructor', 'hasOwnProperty', 'valueOf', '__proto__']) {
-                expect(FleetRegistryService.verifyBridgeToken(key, 'anything')).toBe(false);
-            }
+            FleetRegistryService.removeAgent('gone-agent');
+
+            // the signature stays valid post-removal — the token self-expires within bridgeTokenTtlMs.
+            // Immediate eviction of a compromised agent is a later additive Bridge revocation-denylist;
+            // WriteGuard's no-clobber invariant denies an overlapping cross-agent write in the interim.
+            expect(verifyWithPublicKey(token).agentId).toBe('gone-agent');
         });
     });
 });

--- a/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
@@ -1,0 +1,80 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'BridgeHandshakeAuthTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import crypto         from 'crypto';
+
+import Neo       from '../../../../../../../src/Neo.mjs';
+import * as core from '../../../../../../../src/core/_export.mjs';
+import Bridge    from '../../../../../../../ai/mcp/server/neural-link/Bridge.mjs';
+
+const {privateKey, publicKey} = crypto.generateKeyPairSync('ed25519');
+
+// Sign a token the way FleetRegistryService.mintBridgeToken does (Ed25519 over the payload bytes).
+const sign = (agentId, expiresAt = Date.now() + 3_600_000) => {
+    const p = Buffer.from(JSON.stringify({agentId, expiresAt}));
+    return `${p.toString('base64url')}.${crypto.sign(null, p, privateKey).toString('base64url')}`;
+};
+
+// A minimal WebSocket stand-in — handleConnection / registerAgent only touch close / on / send / readyState.
+const makeWs  = () => ({readyState: 1, closed: null, sent: [], on() {}, send(d) {this.sent.push(d)}, close(code, reason) {this.closed = {code, reason}}, terminate() {}});
+const makeReq = query => ({url: `/?${query}`, headers: {host: '127.0.0.1:8081'}});
+
+test.describe('Bridge.handleConnection — agent handshake auth (#13172)', () => {
+    test.beforeEach(() => {
+        // isolate the singleton's connection maps + configure fleet mode (a verify key is present)
+        Bridge.agents          = new Map();
+        Bridge.apps            = new Map();
+        Bridge.bridgePublicKey = publicKey;
+    });
+
+    test('SECURITY: a valid token binds the SIGNED agentId, ignoring a spoofed ?id=', () => {
+        const ws = makeWs();
+        Bridge.handleConnection(ws, makeReq(`role=agent&id=agent-b&token=${sign('agent-a')}`));
+
+        expect(Bridge.agents.has('agent-a')).toBe(true);  // the signature decides identity
+        expect(Bridge.agents.has('agent-b')).toBe(false); // the spoofed ?id= claim is ignored
+        expect(ws.closed).toBe(null);
+    });
+
+    test('SECURITY: a missing / malformed / expired token closes 1008 and registers nothing', () => {
+        const bad = [
+            'role=agent&id=agent-a',                                          // missing token
+            'role=agent&id=agent-a&token=not-a-token',                        // malformed
+            `role=agent&id=agent-a&token=${sign('agent-a', Date.now() - 1)}`, // expired
+            `role=agent&id=agent-a&token=${sign('agent-a').slice(0, -4)}AAAA` // tampered signature
+        ];
+        for (const q of bad) {
+            Bridge.agents = new Map();
+            const ws = makeWs();
+            Bridge.handleConnection(ws, makeReq(q));
+            expect(ws.closed?.code).toBe(1008);
+            expect(Bridge.agents.size).toBe(0);
+        }
+    });
+
+    test('the app / default connection path is unaffected by agent auth', () => {
+        const ws = makeWs();
+        Bridge.handleConnection(ws, makeReq('id=app-1&appName=Colors')); // no role → app
+        expect(Bridge.apps.has('app-1')).toBe(true);
+        expect(ws.closed).toBe(null);
+    });
+
+    test('no configured key → legacy unauthenticated path registers the ?id= claim (no-FM dev)', () => {
+        Bridge.bridgePublicKey = null;
+        const ws = makeWs();
+        Bridge.handleConnection(ws, makeReq('role=agent&id=legacy-agent'));
+        expect(Bridge.agents.has('legacy-agent')).toBe(true);
+        expect(ws.closed).toBe(null);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/neural-link/verifyBridgeToken.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/neural-link/verifyBridgeToken.spec.mjs
@@ -1,0 +1,63 @@
+import {test, expect}      from '@playwright/test';
+import crypto              from 'crypto';
+import {verifyBridgeToken} from '../../../../../../../ai/mcp/server/neural-link/verifyBridgeToken.mjs';
+
+// The Bridge's stateless security gate. Pure — imported directly (no WebSocket singleton),
+// mirroring src/ai/parseAgentEnvelope.spec. A keypair stands in for the FM signer / Bridge verifier.
+const {privateKey, publicKey} = crypto.generateKeyPairSync('ed25519');
+
+// Mint a token the way FleetRegistryService.mintBridgeToken does: Ed25519 over the payload bytes.
+const mint = (agentId, expiresAt = Date.now() + 3_600_000) => {
+    const payload = Buffer.from(JSON.stringify({agentId, expiresAt}));
+    return `${payload.toString('base64url')}.${crypto.sign(null, payload, privateKey).toString('base64url')}`;
+};
+
+test.describe('verifyBridgeToken (Neural Link Bridge auth gate)', () => {
+    test('a valid token returns the SIGNED agentId', () => {
+        expect(verifyBridgeToken(mint('agent-x'), publicKey)).toBe('agent-x');
+    });
+
+    test('fail-closed: no public key (legacy / unauth mode) → null', () => {
+        expect(verifyBridgeToken(mint('agent-x'), null)).toBe(null);
+        expect(verifyBridgeToken(mint('agent-x'), undefined)).toBe(null);
+    });
+
+    test('fail-closed: a non-string or malformed token → null', () => {
+        for (const bad of [undefined, null, 42, {}, '', 'no-dot', '.onlysig']) {
+            expect(verifyBridgeToken(bad, publicKey)).toBe(null);
+        }
+    });
+
+    test('SECURITY: a tampered payload (claim a different agentId) → null', () => {
+        const [, sigB64] = mint('victim').split('.');
+        const forged = Buffer.from(JSON.stringify({agentId: 'attacker', expiresAt: Date.now() + 1e6})).toString('base64url');
+        expect(verifyBridgeToken(`${forged}.${sigB64}`, publicKey)).toBe(null);
+    });
+
+    test('SECURITY: a tampered signature → null', () => {
+        const [payloadB64, sigB64] = mint('agent-x').split('.');
+        expect(verifyBridgeToken(`${payloadB64}.${sigB64.slice(0, -4)}AAAA`, publicKey)).toBe(null);
+    });
+
+    test('SECURITY: a token signed by a DIFFERENT key → null (cannot forge without the private key)', () => {
+        const other   = crypto.generateKeyPairSync('ed25519'),
+              p       = Buffer.from(JSON.stringify({agentId: 'agent-x', expiresAt: Date.now() + 1e6})),
+              foreign = `${p.toString('base64url')}.${crypto.sign(null, p, other.privateKey).toString('base64url')}`;
+        expect(verifyBridgeToken(foreign, publicKey)).toBe(null);
+    });
+
+    test('fail-closed: an expired token → null', () => {
+        expect(verifyBridgeToken(mint('agent-x', Date.now() - 1), publicKey)).toBe(null);
+    });
+
+    test('fail-closed: a malformed payload (missing / wrong-typed agentId or expiresAt) → null', () => {
+        const sign = obj => {
+            const p = Buffer.from(JSON.stringify(obj));
+            return `${p.toString('base64url')}.${crypto.sign(null, p, privateKey).toString('base64url')}`;
+        };
+        expect(verifyBridgeToken(sign({expiresAt: Date.now() + 1e6}),             publicKey)).toBe(null); // no agentId
+        expect(verifyBridgeToken(sign({agentId: '',  expiresAt: Date.now() + 1e6}), publicKey)).toBe(null); // empty agentId
+        expect(verifyBridgeToken(sign({agentId: 'x'}),                            publicKey)).toBe(null); // no expiresAt
+        expect(verifyBridgeToken(sign({agentId: 'x', expiresAt: 'soon'}),         publicKey)).toBe(null); // non-number expiry
+    });
+});


### PR DESCRIPTION
Resolves #13172
Related: #13167
Related: #13056

Authored by Claude Opus 4.8 (Claude Code). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.

Authenticates Neural-Link Bridge agent connections so the network-facing Bridge trusts an agent's identity from a verifiable **signature**, not the raw `?id=` query claim it accepts today (the spoofing path that #13167's WriteGuard enforcement would otherwise be keyed on). The credential is an Ed25519 asymmetric-signed token: `FleetRegistryService.mintBridgeToken` signs `{agentId, expiresAt}` with a private key; the Bridge verifies statelessly with only the **public** key — so a Bridge compromise can neither read the master-key/PAT store nor forge a token, and the design is topology-independent (no-FM dev + cloud). This is **Leaf A** of #13167; Leaf B (the Client unwrap, #13174) shipped, Leaf C (WriteGuard) consumes the verified `agentId` next.

Evidence: L1 (`node --check` on the 4 sources + 2 specs; 25 focused Playwright unit specs green — 17 `FleetRegistryService` + 8 `verifyBridgeToken` gate; plus 17 `FleetLifecycleService` regression green) → L1 required (pure crypto + helper-contract ACs). Residual: live fleet-mode auth engaging end-to-end at Bridge startup is L3, gated on `NEO_FLEET_BRIDGE_PUBLIC_KEY` provisioning [#13172].

## Deltas from ticket

- **Approach evolved (paired decision, recorded across #13172's comments).** The ticket scoped a store-read verifier; the key-isolation pairing with @neo-opus-ada falsified it — `bridgeTokens.enc` shares its key with `credentials.enc` (the AES master key that decrypts every agent's PAT), so a store-read Bridge would leak all PATs on compromise. Decided **(2)-asymmetric signed token** (Bridge holds only the public key). The HMAC-symmetric variant was rejected (a compromised Bridge could forge); the FM-IPC variant was rejected (the Bridge runs independent of the FM → breaks no-FM/cloud).
- **Replaced, not added.** `mintBridgeToken` now signs; the orphaned hash-store machinery (`verifyBridgeToken` / `readBridgeTokens` / `writeBridgeTokens` / `removeBridgeToken` / `bridgeTokens.enc`) is removed — dead with signing, with no callers besides the FM spawn-inject of `.token` (unchanged shape).
- **Revocation.** `removeAgent` no longer revokes the (now stateless) token — it self-expires within `bridgeTokenTtlMs`. The ≤TTL lag was accepted by @neo-opus-ada as enforcement owner: WriteGuard's no-clobber invariant denies an overlapping cross-agent write on the `agentId` regardless of token age. Immediate eviction of a *compromised* agent is a later additive Bridge revocation-denylist.
- **Verify extracted** to a pure, Bridge-free `verifyBridgeToken.mjs` (mirrors `src/ai/parseAgentEnvelope.mjs`) so the security gate is unit-testable without the WebSocket singleton.
- **Scope boundary.** The `{type:'agent_message', agentId, message}` sidecar emit (ledger row 2) is a separate final-flip leaf, sequenced after Leaf B's backward-compat unwrap (already shipped) to avoid breaking the live Agent→App channel.
- **Provisioning trust-root.** The Bridge reads its verify key from `NEO_FLEET_BRIDGE_PUBLIC_KEY` (a trusted harness/operator-set value, never agent-supplied). With no key set (no-FM dev) it falls back to the legacy unauthenticated path — auth and multi-writer enforcement are a matched pair (both on in fleet mode, both off in single-agent dev).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/verifyBridgeToken.spec.mjs test/playwright/unit/ai/FleetRegistryService.spec.mjs` → **25 passed** (8 gate + 17 FM).
- `npm run test-unit -- test/playwright/unit/ai/FleetLifecycleService.spec.mjs` → **17 passed** (no regression on the `.token` spawn-inject).
- `node --check` on all 4 changed sources + both specs.
- Gate coverage (`verifyBridgeToken`): valid → signed `agentId`; tampered payload (claim another agentId) / tampered sig / **foreign-key-signed** → null; expired → null; malformed token + malformed payload (missing/wrong-typed `agentId`/`expiresAt`) → null; no public key → null (legacy fallback).

## Post-Merge Validation

- [ ] Provision `NEO_FLEET_BRIDGE_PUBLIC_KEY` (from `FleetRegistryService.getBridgePublicKey()`) at Bridge startup so fleet-mode auth engages end-to-end (the L3 live-verify residual). Until then the Bridge runs the legacy unauthenticated path.
- [ ] Leaf C (WriteGuard enforcement) consumes the verified `agentId` threaded through Leaf B's Client context.

## Commits

- `e181eb76b` — feat(ai): authenticate Bridge agent connections via asymmetric-signed tokens (#13172)

## Evolution

Store-read verifier (original ticket) → @neo-opus-ada's key-isolation catch (the bridge-token key IS the master/PAT key) → my asymmetric refinement (HMAC-symmetric would let a compromised Bridge forge) → enforcement-owner decision: (2)-asymmetric, with ≤TTL revocation sufficient because the use-case is cooperative multi-writer conflict-prevention, not adversarial eviction. Each step is recorded on #13172.
