### PR TITLE
test(neural-link): e2e proof for create_component — live create + get_component_tree visibility (#13157)

### DIFF
--- a/test/playwright/e2e/NeuralLinkCreateComponent.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkCreateComponent.spec.mjs
@@ -1,0 +1,52 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * @summary E2E proof for the `create_component` Neural Link tool — the live-app counterpart to the
+ * unit specs (which mock the transport). Drives a live Neo app over the Neural Link, creates a
+ * component into a real container via `create_component`, and verifies end-to-end that the new
+ * component is registered (queryable + present in `get_component_tree`) AND actually rendered into
+ * the live DOM — the full App-Worker round-trip the unit coverage cannot exercise.
+ *
+ * Multi-window note: a create targeting a globally-unique `parentId` lands in that container's
+ * window by construction — component ids are unique across the (single, shared) App Worker, so no
+ * windowId param is needed to target a specific window's container.
+ */
+test.describe('Neural Link — create_component (e2e)', () => {
+    test.setTimeout(90000);
+
+    test('creates a component into a live container; it renders + appears in the component tree', async ({ page, neuralLink }) => {
+        await page.goto('/examples/button/base/index.html');
+        await expect(page.locator('.neo-button').first()).toBeVisible({ timeout: 30000 });
+
+        const app = await neuralLink.connectToApp('Neo.examples.button.base');
+
+        // Resolve a target container (the example's root viewport, else any container). The NL query
+        // return shape is normalized defensively so this proof does not couple to one envelope shape.
+        const pick = res => res?.[0]?.id ?? res?.components?.[0]?.id ?? res?.instances?.[0]?.id ?? res?.id ?? null;
+
+        let containerId = pick(await app.findInstances({ ntype: 'viewport' }, ['id']));
+
+        if (!containerId) {
+            containerId = pick(await app.findInstances({ ntype: 'container' }, ['id']));
+        }
+
+        expect(containerId, 'could not resolve a target container id for the create').toBeTruthy();
+
+        const text = 'NL-Created-' + Date.now();
+
+        await app.createComponent(containerId, { ntype: 'button', text });
+
+        // 1) get_component_tree visibility — the created component shows up in the live tree (async render).
+        await expect.poll(async () => JSON.stringify(await app.getComponentTree()).includes(text), {
+            message: 'the created component should appear in get_component_tree',
+            timeout: 15000
+        }).toBe(true);
+
+        // 2) registered + queryable by selector.
+        const found = await app.queryComponent({ ntype: 'button', text });
+        expect(JSON.stringify(found), 'the created component should be queryable').toContain(text);
+
+        // 3) actually rendered into the live DOM.
+        await expect(page.locator(`.neo-button:has-text("${text}")`)).toBeVisible({ timeout: 10000 });
+    });
+});

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -293,6 +293,17 @@ export const test = base.extend({
                         return NeuralLink_ComponentService.getComponentTree({ sessionId, rootId, depth, lean });
                     },
 
+                    /**
+                     * Creates a component inside a target container at runtime (the `create_component`
+                     * write-locked tool). Validates the config server-side, then delegates to `container.add()`.
+                     * @param {String} parentId The target container's component id.
+                     * @param {Object} config   A component config declaring `module`, `ntype`, or `className`.
+                     * @returns {Promise<Object>}
+                     */
+                    async createComponent(parentId, config) {
+                        return NeuralLink_ComponentService.createComponent({ sessionId, parentId, config });
+                    },
+
 
                     // --- Interaction Methods ---
 


### PR DESCRIPTION
Resolves #13157
Refs #13185, #9846

The live-app e2e proof for `create_component` — #13157 re-scoped to AC2 + AC3 per @neo-gpt's review; AC1's direct multi-window proof split to #13185.

Evidence: L3 (e2e: `NeuralLinkCreateComponent.spec` drives a live App Worker over the Neural Link, creates a component, asserts `get_component_tree` visibility + queryable + DOM render; 2 runs green) → L3 required. **Residual: AC1 (multi-window shared-worker targeting) → #13185 [split].**

## What it proves (AC2 + AC3)
Drives `examples/button/base` over the Neural Link, creates a button into a real container via `create_component`, and asserts the full App-Worker round-trip:
1. the new component appears in `get_component_tree`;
2. it's queryable by selector (`query_component`);
3. it renders into the live DOM.

Adds a `createComponent` method to the `neuralLink` fixture (mirrors `getComponentTree`).

## Close-target (re-scoped per @neo-gpt's #13183 review)
- **AC2 (get_component_tree visibility) + AC3 (E2E)** — directly proven; #13157 re-scoped to these.
- **AC1 (multi-window, shared-worker)** — **split to #13185.** The run here is single-window (`isSharedWorker:false`), so this PR no longer claims AC1. The mechanism is sound by composition (`create_component` → window-agnostic id-based `call_method` → globally-unique ids → the App Worker's existing per-window routing), so #13185 is belt-and-suspenders — but the close-target is now honest.

## Decision Record impact
`none` — reuses the existing NL transport + `create_component` (#13154, merged).

## Deltas
- AC1 (multi-window) split to #13185 (truth-synced per the review); this PR Resolves the re-scoped #13157 (AC2 + AC3 only).

## Test Evidence
- `npm run test-e2e -- test/playwright/e2e/NeuralLinkCreateComponent.spec.mjs` → **1 passed**, reproduced across 2 runs (4.6–5.3s). `node --check` + `check-ticket-archaeology` clean.

## Post-Merge Validation
- [ ] AC1 direct multi-window (shared-worker) proof tracked in #13185.

Authored by Claude Opus 4.8 (Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
