### PR TITLE
test(ai): real-git integration coverage for the FM provisioning chain (#13182)

### DIFF
--- a/test/playwright/unit/ai/ensureAgentRepoGit.spec.mjs
+++ b/test/playwright/unit/ai/ensureAgentRepoGit.spec.mjs
@@ -1,0 +1,99 @@
+import {test, expect}        from '@playwright/test';
+import {execFileSync}        from 'node:child_process';
+import fs                    from 'node:fs';
+import os                    from 'node:os';
+import path                  from 'node:path';
+import {ensureAgentRepo}     from '../../../../ai/services/fleet/ensureAgentRepo.mjs';
+import {deriveAgentRepoPath} from '../../../../ai/services/fleet/deriveAgentRepoPath.mjs';
+
+// Integration coverage of the provisioning chain's DEFAULT clone seam — a real `git clone`, the
+// production path the unit specs stub out (they inject `cloneRepo`). Exercises clone → reuse → conflict
+// against actual git in temp dirs, offline (clones a LOCAL fixture repo, no network). Mirrors
+// check-branch-discipline.spec's real-git fixture idiom (mkdtemp + git init + config + commit +
+// execFileSync). Asserts the production behaviors the stub cannot: a real `.git` checkout, git creating
+// the intermediate `<agent>/` leading dir, reuse not clobbering, and a fail-closed conflict.
+
+let suiteRoot, sourceRepo;
+
+/** Run git in a cwd, output discarded (no shell → no interpolation hazard). */
+function git(cwd, ...args) {
+    execFileSync('git', args, {cwd, stdio: 'ignore'});
+}
+
+/** A fresh managed root per case so the cases never alias a checkout. */
+function freshManagedRoot() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-managed-'));
+}
+
+test.beforeAll(() => {
+    suiteRoot  = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-git-int-'));
+    // A real source repo with one commit, to clone FROM — a local path keeps the suite offline + fast.
+    sourceRepo = path.join(suiteRoot, 'source');
+    fs.mkdirSync(sourceRepo);
+    git(sourceRepo, 'init', '-q');
+    git(sourceRepo, 'config', 'user.email', 'test@example.com');
+    git(sourceRepo, 'config', 'user.name', 'Test User');
+    fs.writeFileSync(path.join(sourceRepo, 'README.md'), '# fixture\n');
+    git(sourceRepo, 'add', '.');
+    git(sourceRepo, 'commit', '-q', '-m', 'init');
+});
+
+test.afterAll(() => {
+    fs.rmSync(suiteRoot, {recursive: true, force: true});
+});
+
+test.describe('ensureAgentRepo — real git clone seam (integration, default un-injected cloneRepo)', () => {
+    test('clones an absent repo: real .git checkout + source content, git created the leading dir, cloned:true', async () => {
+        const managedRoot = freshManagedRoot();
+        try {
+            const result = await ensureAgentRepo({managedRoot, agentId: 'agent-a', repoSlug: 'fixture/repo', cloneUrl: sourceRepo});
+
+            expect(result.cloned).toBe(true);
+            expect(result.action).toBe('cloned');
+            expect(result.repoPath.startsWith(managedRoot + path.sep)).toBe(true);
+            // a real checkout: `.git` + the source content. The intermediate `<agent>/` dir (which
+            // deriveAgentRepoPath's <root>/<agent>/<repo> layout implies) was created by `git clone`.
+            expect(fs.existsSync(path.join(result.repoPath, '.git'))).toBe(true);
+            expect(fs.readFileSync(path.join(result.repoPath, 'README.md'), 'utf8')).toContain('# fixture');
+        } finally {
+            fs.rmSync(managedRoot, {recursive: true, force: true});
+        }
+    });
+
+    test('re-running over the cloned checkout reuses it — no re-clone clobber', async () => {
+        const managedRoot = freshManagedRoot();
+        try {
+            const first = await ensureAgentRepo({managedRoot, agentId: 'agent-b', repoSlug: 'fixture/repo', cloneUrl: sourceRepo});
+            expect(first.cloned).toBe(true);
+
+            // a marker that only survives if the SAME checkout is reused (not re-cloned over)
+            const marker = path.join(first.repoPath, '.reuse-marker');
+            fs.writeFileSync(marker, 'x');
+
+            const second = await ensureAgentRepo({managedRoot, agentId: 'agent-b', repoSlug: 'fixture/repo', cloneUrl: sourceRepo});
+            expect(second.cloned).toBe(false);
+            expect(second.action).toBe('reused');
+            expect(second.repoPath).toBe(first.repoPath);
+            expect(fs.existsSync(marker)).toBe(true);
+        } finally {
+            fs.rmSync(managedRoot, {recursive: true, force: true});
+        }
+    });
+
+    test('a foreign occupant at the derived path is a conflict — fail-closed, never clobbered', async () => {
+        const managedRoot = freshManagedRoot();
+        try {
+            const repoPath = deriveAgentRepoPath({managedRoot, agentId: 'agent-c', repoSlug: 'fixture/repo'});
+            fs.mkdirSync(repoPath, {recursive: true});
+            fs.writeFileSync(path.join(repoPath, 'foreign.txt'), 'do not clobber');
+
+            await expect(ensureAgentRepo({managedRoot, agentId: 'agent-c', repoSlug: 'fixture/repo', cloneUrl: sourceRepo}))
+                .rejects.toThrow();
+
+            // the foreign content survived — the chain never clobbered an occupant
+            expect(fs.readFileSync(path.join(repoPath, 'foreign.txt'), 'utf8')).toBe('do not clobber');
+        } finally {
+            fs.rmSync(managedRoot, {recursive: true, force: true});
+        }
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13182

The FM provisioning chain's unit specs inject the `cloneRepo` stub (so they run without a git binary); the **default seam — a real `git clone`** (`provisionAgentRepo.gitClone` → `execFile('git', ['clone', '--', cloneUrl, repoPath])`) — was the **untested production path**. The #13162-flagged follow-up closes it.

- **`test/playwright/unit/ai/ensureAgentRepoGit.spec.mjs`** (new): a real-git fixture (a temp source repo with one commit, cloned **offline** from a local path) + a temp `managedRoot`, exercising `ensureAgentRepo` with the **un-injected default seam** — i.e. real `git clone`:
  - absent path → the derived checkout has a real `.git` + the source content, git created the intermediate `<agent>/` leading dir (the `<root>/<agent>/<repo>` layout's implicit parent), `{cloned: true, action: 'cloned'}`;
  - re-run over the checkout → `{cloned: false, action: 'reused'}`, a written marker survives (no re-clone clobber);
  - a foreign occupant pre-placed at the derived path → conflict throw, the occupant survives.

No production-code change — the real-git path matches the stubbed contract. Mirrors `check-branch-discipline.spec`'s real-git fixture idiom; offline + temp-dirs cleaned in `afterAll`.

Evidence: L2 (real-subprocess integration — an actual `git clone` against a local fixture, not the stub) → L2 sufficient (covers the chain's production clone/reuse/conflict against real git; the operator-reachable end-to-end provision-and-start is a later control-plane leaf). No residuals.

## Deltas from ticket (if any)
Spec named `ensureAgentRepoGit.spec.mjs` (matches the repo's real-git-in-unit convention, e.g. `check-branch-discipline.spec.mjs`) rather than the ticket's tentative `.integration.spec.mjs` infix. No scope change.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/ensureAgentRepoGit.spec.mjs
→ 3 passed (644ms)

node --check test/playwright/unit/ai/ensureAgentRepoGit.spec.mjs → OK
```
3 cases: absent → real clone (real `.git` + source content + created leading dir + `cloned:true`); re-run → reused, marker survives (no clobber); foreign occupant → conflict throw, occupant survives.

## Post-Merge Validation
- [ ] None standalone — the spec IS the validation; it runs in CI's unit job against the runner's git.

Related: parent epic #13015 (FM MVP); the #13162 follow-up; covers `provisionAgentRepo` (#13155) + `ensureAgentRepo` (#13162) production clone paths.
