### PR TITLE
feat(neural-link): add remove_component tool — validate id + delegate destroy(true) (#9847)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -837,6 +837,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /component/remove:
+    post:
+      summary: Remove Component
+      operationId: remove_component
+      x-neo-tool-tier: write-locked
+      x-pass-as-object: true
+      description: |
+        Removes (destroys) a live component by its id — a schema-validated, CONSTRAINED alternative to
+        the admin-tier `call_method(component.destroy(...))`. The symmetric counterpart to `create_component`.
+
+        **When to Use:**
+        To remove a component from the live tree at runtime (e.g. dispose a transient dialog, or a
+        no-longer-needed toolbar button) without granting admin method-call access. The component is
+        resolved by `componentId`; the removal also detaches the node from the parent's DOM, not just the
+        instance.
+      tags: [Component]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoveComponentRequest'
+      responses:
+        '200':
+          description: Component destroyed and detached from its parent
+        '400':
+          description: Invalid request body (componentId missing)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /component/vdom/query:
     post:
       summary: Query VDOM
@@ -1780,6 +1818,18 @@ components:
         config:
           type: object
           description: The component configuration; must declare a `module`, `ntype`, or `className`
+        sessionId:
+          type: string
+          description: The target App Worker Session ID
+
+    RemoveComponentRequest:
+      type: object
+      required:
+        - componentId
+      properties:
+        componentId:
+          type: string
+          description: The id of the component to destroy (also detached from the parent DOM)
         sessionId:
           type: string
           description: The target App Worker Session ID

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -51,6 +51,7 @@ const serviceMapping = {
     query_component              : ComponentService  .queryComponent            .bind(ComponentService),
     query_vdom                   : ComponentService  .queryVdom                 .bind(ComponentService),
     reload_page                  : RuntimeService    .reloadPage                .bind(RuntimeService),
+    remove_component             : ComponentService  .removeComponent           .bind(ComponentService),
     set_instance_properties      : InstanceService   .setInstanceProperties     .bind(InstanceService),
     set_route                    : RuntimeService    .setRoute                  .bind(RuntimeService),
     simulate_event               : InteractionService.simulateEvent             .bind(InteractionService),

--- a/ai/services/neural-link/ComponentService.mjs
+++ b/ai/services/neural-link/ComponentService.mjs
@@ -175,6 +175,32 @@ class ComponentService extends Base {
 
         return await ConnectionService.call(sessionId, 'call_method', {id: parentId, method: 'add', args: [config]});
     }
+
+    /**
+     * Removes (destroys) a live component by its ID — a first-class, `write-locked` alternative to the
+     * generic `admin`-tier `call_method(component.destroy(...))`. The symmetric counterpart to
+     * {@link #createComponent}.
+     *
+     * Validates `componentId` server-side (fail-fast with a semantic message, no dispatch on bad input),
+     * then delegates to the existing `call_method` dispatch — `component.destroy(true)` — reusing the
+     * worker-side handler (no new worker op). The pinned `true` is `destroy`'s `updateParentVdom` flag:
+     * it detaches the node from the parent's DOM so the component actually disappears from the live tree.
+     * The framework default `destroy(false)` unregisters the instance but ORPHANS its DOM node, so the
+     * flag is required for a correct removal. Pinning the method to `destroy` is exactly what keeps this
+     * a CONSTRAINED write tool (`write-locked`) rather than the arbitrary-method `admin` `call_method`:
+     * an agent can remove components without being granted admin method-call access.
+     * @param {Object} opts             The options object.
+     * @param {String} opts.componentId The id of the component to destroy.
+     * @param {String} [opts.sessionId] The target session ID.
+     * @returns {Promise<Object>} The result of destroying the component.
+     */
+    async removeComponent({componentId, sessionId}) {
+        if (!componentId) {
+            throw new Error('remove_component: `componentId` (the component to destroy) is required.');
+        }
+
+        return await ConnectionService.call(sessionId, 'call_method', {id: componentId, method: 'destroy', args: [true]});
+    }
 }
 
 export default Neo.setupClass(ComponentService);

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -123,6 +123,7 @@ const expectedNeuralLinkToolTiers = {
     query_component              : 'read',
     query_vdom                   : 'read',
     reload_page                  : 'admin',
+    remove_component             : 'write-locked',
     set_instance_properties      : 'write-locked',
     set_route                    : 'write-locked',
     simulate_event               : 'write-locked',
@@ -138,6 +139,7 @@ const neuralLinkDangerousReadForbidden = [
     'modify_state_provider',
     'patch_code',
     'reload_page',
+    'remove_component',
     'set_instance_properties',
     'set_route',
     'simulate_event'

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -18,14 +18,16 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Coverage for `ComponentService.createComponent` — the `create_component` Neural Link tool.
+ * @summary Coverage for `ComponentService.createComponent` + `removeComponent` — the `create_component`
+ * and `remove_component` Neural Link tools.
  *
- * The tool is a `write-locked`, schema-validated alternative to the admin-tier `call_method(container.add())`:
- * it validates the config server-side (fail-fast, no dispatch on bad input) and delegates a valid create to
- * the existing `call_method` transport op as `parent.add(config)`. These tests mock `ConnectionService.call`
- * so they assert the server-side validation + the exact delegated dispatch, without a live App Worker.
+ * Both are `write-locked`, schema-validated alternatives to the admin-tier `call_method(...)`: they validate
+ * server-side (fail-fast, no dispatch on bad input) and delegate to the existing `call_method` transport op —
+ * create as `parent.add(config)`, remove as `component.destroy(true)` (the pinned `true` = `updateParentVdom`,
+ * so the DOM node is detached, not orphaned). These tests mock `ConnectionService.call` so they assert the
+ * server-side validation + the exact delegated dispatch, without a live App Worker.
  */
-test.describe('Neo.ai.services.neural-link.ComponentService — createComponent', () => {
+test.describe('Neo.ai.services.neural-link.ComponentService — createComponent + removeComponent', () => {
     let ComponentService, ConnectionService, calls, originalCall, originalReady;
 
     test.beforeAll(async () => {
@@ -99,5 +101,24 @@ test.describe('Neo.ai.services.neural-link.ComponentService — createComponent'
         await ComponentService.createComponent({parentId: 'p1', config: {className: 'Neo.x.Y'}, sessionId: 's1'});
         expect(calls.length).toBe(2);
         expect(calls.every(c => c.op === 'call_method' && c.payload.method === 'add')).toBe(true);
+    });
+
+    test('removeComponent rejects a missing componentId without dispatching', async () => {
+        await expect(ComponentService.removeComponent({sessionId: 's1'}))
+            .rejects.toThrow(/componentId/);
+        expect(calls.length).toBe(0);
+    });
+
+    test('removeComponent delegates a valid id to call_method as component.destroy(true)', async () => {
+        await ComponentService.removeComponent({componentId: 'dialog-1', sessionId: 's1'});
+
+        expect(calls.length).toBe(1);
+        // The pinned `true` is destroy's `updateParentVdom` flag — it detaches the DOM node, not just the
+        // instance (the framework default `destroy(false)` would orphan the node in the live DOM).
+        expect(calls[0]).toEqual({
+            sessionId: 's1',
+            op       : 'call_method',
+            payload  : {id: 'dialog-1', method: 'destroy', args: [true]}
+        });
     });
 });


### PR DESCRIPTION
## Summary

Slice 1 of `remove_component` — the symmetric counterpart to `create_component`. A thin `write-locked` Neural Link tool that validates `componentId` presence server-side, then delegates to `call_method` as `component.destroy(true)`. The pinned `true` is `destroy`'s `updateParentVdom` flag — it detaches the DOM node, not just the instance (the framework default `destroy(false)` would orphan the node in the live tree). Pinning the method to `destroy` is what keeps this a CONSTRAINED write tool rather than the arbitrary-method admin `call_method`: an agent can remove components without being granted admin method-call access.

Resolves #9847 (re-scoped to Slice 1 — see the ticket's "Deferred to Slice 2" section).
Refs #13186 (Slice 2: existence-probe + snapshot-for-undo + e2e proof), #9848 (Transaction/Undo stack).

Evidence: built across the 6 NL-tool wiring sites; unit + governance + smoke specs green (see Test Evidence below).

## Changes

Wired `remove_component` across the standard NL-tool sites:

- `ai/services/neural-link/ComponentService.mjs` — `removeComponent({componentId, sessionId})`: presence-validates the id (fail-fast, no dispatch on a missing id), delegates `call_method(id, 'destroy', [true])`.
- `ai/mcp/server/neural-link/openapi.yaml` — `/component/remove` path (`x-neo-tool-tier: write-locked`) + `RemoveComponentRequest` schema.
- `ai/mcp/server/neural-link/toolService.mjs` — `remove_component` serviceMapping entry.
- `test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — governance fixtures: tier map (`write-locked`) + dangerous-read-forbidden list.
- `test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs` — unit coverage (validation + the exact `destroy(true)` dispatch).

## Test Evidence

Local (opus-vega clone, on `feat/9847-remove-component`):

- `ComponentService.spec.mjs` — **7 passed** (5 createComponent + 2 removeComponent; the happy-path asserts the exact `{id, method:'destroy', args:[true]}` dispatch).
- `OpenApiValidatorCompliance.spec.mjs` — **30 passed** (tier map ↔ openapi ↔ dangerous-read consistency; strict-client schema compliance).
- `McpServerListToolsSmoke.spec.mjs` — **19 passed** (serviceMapping ↔ openapi tool-list cross-check).
- `node --check` on all 4 edited `.mjs` files — clean; `openapi.yaml` parses (39 operations; `remove_component` = `write-locked`; `RemoveComponentRequest` present).

Note: 2 failures in `test/playwright/unit/ai/mcp/server/shared/services/` (`BootEnvelopeResolver` #12418, `DestructiveOperationGuard` #10845) reproduce on **clean dev** (stash → re-run → same 2 fail → restore) — pre-existing local-environment artifacts (this clone's NEO env state + DB-path "production-like" detection), unrelated to this additive change.

## Post-Merge Validation

- CI `unit` + `ai/mcp/validation` scopes green on the PR.
- `remove_component` appears in the NL MCP tool list at `write-locked` tier (verify via `listTools` / the harness projection).
- Slice 2 (#13186) adds the e2e proof that the removed component is gone from `get_component_tree`, plus the snapshot round-trip.

## Deltas

- **No e2e in this PR** — deferred to Slice 2 (#13186), explicitly scoped on the ticket. Slice 1's `destroy(true)` delivers the removal *behavior*; #13186 *proves* it (mirroring `NeuralLinkCreateComponent.spec.mjs`).
- **No snapshot / undo-stack integration** — Slice 2 (#13186) / #9848.
- **No explicit existence-probe** — Slice 1 presence-validates `componentId`; a non-existent id surfaces as a worker-side `call_method` error. Explicit pre-probe → #13186.

Authored by @neo-opus-vega (Vega, Claude Opus 4.8 [1M context]) — origin session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
