### PR TITLE
feat(ai): safe agent-repo removal primitive — removeAgentRepo (#13187)

### DIFF
--- a/ai/services/fleet/removeAgentRepo.mjs
+++ b/ai/services/fleet/removeAgentRepo.mjs
@@ -1,0 +1,71 @@
+import fs                    from 'node:fs';
+import {deriveAgentRepoPath} from './deriveAgentRepoPath.mjs';
+import {inspectAgentRepo}    from './inspectAgentRepo.mjs';
+
+/**
+ * Default destructive remove: a recursive directory removal. `force: true` makes an already-absent
+ * path a no-op (defensive — the caller already gates on existence). Injectable via the `removeDir`
+ * seam so the contract is unit-testable without deleting beyond a test's own temp fixtures.
+ * @param {String} repoPath
+ * @private
+ */
+function defaultRemoveDir(repoPath) {
+    fs.rmSync(repoPath, {recursive: true, force: true});
+}
+
+/**
+ * @summary Safely remove an agent's managed repo checkout — the cleanup counterpart to
+ * {@link Neo.ai.services.fleet.ensureAgentRepo} (provision ↔ remove).
+ *
+ * Derives the agent's stable, contained checkout path, classifies what is on disk (via
+ * {@link Neo.ai.services.fleet.inspectAgentRepo}), and removes **only what the Fleet Manager
+ * provisioned** — a managed checkout, or an empty managed dir (a pre-clone shell). A **foreign
+ * occupant** (a non-checkout directory, a file, a symlink → `'occupied-non-checkout'`) is **refused**,
+ * never clobbered — the exact mirror of provisioning's never-clobber guarantee. An absent path is an
+ * idempotent no-op.
+ *
+ * **Destructive + caller-driven.** Removing a checkout deletes the agent's working tree *including any
+ * uncommitted work*, and the Fleet Manager's auto-memory is checkout-path-keyed — so deleting a path
+ * orphans memory keyed on it. The *policy* of **when** to remove (and whether to preserve that memory)
+ * is the **caller's** concern, NOT this mechanism's: this primitive is a safe, on-demand removal
+ * mechanism and is deliberately **never auto-wired** into `removeAgent`. It only ever decides *what is
+ * safe to remove*, never *whether removal is wanted*.
+ *
+ * Pure composition over injectable seams: `inspect` (default
+ * {@link Neo.ai.services.fleet.inspectAgentRepo}) + `removeDir` (default a real recursive remove) make
+ * the safe/refuse/no-op contract unit-testable, mirroring the fleet services' default-real + seam idiom.
+ *
+ * @param {Object}    options
+ * @param {String}    options.managedRoot The absolute, trusted fleet-managed checkout root.
+ * @param {String}    options.agentId     The Fleet Manager agent id.
+ * @param {String}    options.repoSlug    The repo identifier, e.g. `'neomjs/neo'`.
+ * @param {Function} [options.inspect]    `({repoPath}) => {exists, isCheckout, state, …}` classifier;
+ *                                        defaults to {@link Neo.ai.services.fleet.inspectAgentRepo}.
+ * @param {Function} [options.removeDir]  `(repoPath) => void` destructive remove; defaults to a real
+ *                                        recursive directory removal, injectable for tests.
+ * @returns {{removed: Boolean, repoPath: String, state: (String|undefined), reason: (String|undefined)}}
+ *   `removed` is `true` only when a managed checkout / empty dir was actually removed; an absent path is
+ *   `{removed: false, reason: 'absent'}`.
+ * @throws {Error} On invalid `managedRoot` / `agentId` / `repoSlug` (from derivation), or when the path
+ *   holds a non-managed occupant (fail-closed — never remove what the Fleet Manager did not provision).
+ */
+export function removeAgentRepo({managedRoot, agentId, repoSlug, inspect = inspectAgentRepo, removeDir = defaultRemoveDir} = {}) {
+    const
+        repoPath   = deriveAgentRepoPath({managedRoot, agentId, repoSlug}),
+        inspection = inspect({repoPath});
+
+    // Idempotent: nothing on disk → nothing to remove.
+    if (!inspection.exists) {
+        return {removed: false, reason: 'absent', repoPath};
+    }
+
+    // Remove ONLY what the Fleet Manager provisioned: our managed checkout (`isCheckout`) or an empty
+    // managed dir (`state === 'empty'`, a pre-clone shell). Everything else on an existing path is a
+    // non-managed occupant — refuse, never remove.
+    if (inspection.isCheckout || inspection.state === 'empty') {
+        removeDir(repoPath);
+        return {removed: true, state: inspection.state, repoPath};
+    }
+
+    throw new Error(`removeAgentRepo: refusing to remove a non-managed occupant at '${repoPath}' (state: '${inspection.state}'). Only a Fleet-Manager-provisioned checkout or empty dir is removable.`);
+}

--- a/test/playwright/unit/ai/removeAgentRepo.spec.mjs
+++ b/test/playwright/unit/ai/removeAgentRepo.spec.mjs
@@ -1,0 +1,100 @@
+import {test, expect}        from '@playwright/test';
+import fs                    from 'node:fs';
+import os                    from 'node:os';
+import path                  from 'node:path';
+import {removeAgentRepo}     from '../../../../ai/services/fleet/removeAgentRepo.mjs';
+import {deriveAgentRepoPath} from '../../../../ai/services/fleet/deriveAgentRepoPath.mjs';
+
+// Real-fs contract for the safe-removal mechanism (mirrors inspectAgentRepo.spec's temp-dir idiom):
+// remove ONLY a managed checkout / empty dir, REFUSE a foreign occupant or symlink, no-op on absent.
+// Each case uses a fresh managed root under one suite root removed in afterAll.
+
+let suiteRoot, caseRoot;
+
+test.beforeAll(() => { suiteRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-remove-')); });
+test.afterAll(()  => { fs.rmSync(suiteRoot, {recursive: true, force: true}); });
+test.beforeEach(() => { caseRoot = fs.mkdtempSync(path.join(suiteRoot, 'case-')); });
+
+const ARGS = root => ({managedRoot: root, agentId: 'agent-a', repoSlug: 'neomjs/neo'});
+
+/** Create the derived checkout path (+ leading dirs) under `root` and return it. */
+function derivedPath(root) {
+    const p = deriveAgentRepoPath(ARGS(root));
+    fs.mkdirSync(p, {recursive: true});
+    return p;
+}
+
+test.describe('removeAgentRepo (Fleet Manager safe repo removal)', () => {
+    test('removes a managed checkout (.git present) → removed, path gone', () => {
+        const repoPath = derivedPath(caseRoot);
+        fs.mkdirSync(path.join(repoPath, '.git'));                 // inspectAgentRepo → 'checkout'
+        fs.writeFileSync(path.join(repoPath, 'file.txt'), 'work');
+
+        const result = removeAgentRepo(ARGS(caseRoot));
+
+        expect(result.removed).toBe(true);
+        expect(result.state).toBe('checkout');
+        expect(fs.existsSync(repoPath)).toBe(false);              // actually gone
+    });
+
+    test('removes an empty managed dir → removed, path gone', () => {
+        const repoPath = derivedPath(caseRoot);                  // empty
+
+        const result = removeAgentRepo(ARGS(caseRoot));
+
+        expect(result.removed).toBe(true);
+        expect(result.state).toBe('empty');
+        expect(fs.existsSync(repoPath)).toBe(false);
+    });
+
+    test('REFUSES a foreign occupant (non-checkout content) → throws, survives untouched', () => {
+        const repoPath = derivedPath(caseRoot);
+        fs.writeFileSync(path.join(repoPath, 'foreign.txt'), 'not ours');  // no .git → occupied-non-checkout
+
+        expect(() => removeAgentRepo(ARGS(caseRoot))).toThrow(/non-managed occupant/);
+        expect(fs.readFileSync(path.join(repoPath, 'foreign.txt'), 'utf8')).toBe('not ours');  // survived
+    });
+
+    test('REFUSES a symlink occupant → throws, survives (containment defense)', () => {
+        const repoPath = deriveAgentRepoPath(ARGS(caseRoot));
+        fs.mkdirSync(path.dirname(repoPath), {recursive: true});
+        const target = fs.mkdtempSync(path.join(suiteRoot, 'symlink-target-'));
+        fs.symlinkSync(target, repoPath);                        // symlink at the derived path
+
+        expect(() => removeAgentRepo(ARGS(caseRoot))).toThrow(/non-managed occupant/);
+        expect(fs.lstatSync(repoPath).isSymbolicLink()).toBe(true);  // symlink itself survived
+    });
+
+    test('an absent path is an idempotent no-op → {removed:false, reason:absent}', () => {
+        const result = removeAgentRepo(ARGS(caseRoot));          // nothing created
+        expect(result).toMatchObject({removed: false, reason: 'absent'});
+    });
+
+    test('removeDir seam is honored: called for a managed checkout, NOT for foreign / absent', () => {
+        // managed → called with the derived path
+        const repoPath = derivedPath(caseRoot);
+        fs.mkdirSync(path.join(repoPath, '.git'));
+        const calls = [];
+        removeAgentRepo({...ARGS(caseRoot), removeDir: p => calls.push(p)});
+        expect(calls).toEqual([repoPath]);
+
+        // foreign → never called (refused first)
+        const root2    = fs.mkdtempSync(path.join(suiteRoot, 'case2-'));
+        const foreign  = derivedPath(root2);
+        fs.writeFileSync(path.join(foreign, 'x.txt'), 'x');
+        const calls2 = [];
+        expect(() => removeAgentRepo({...ARGS(root2), removeDir: p => calls2.push(p)})).toThrow();
+        expect(calls2).toHaveLength(0);
+
+        // absent → never called
+        const root3  = fs.mkdtempSync(path.join(suiteRoot, 'case3-'));
+        const calls3 = [];
+        removeAgentRepo({...ARGS(root3), removeDir: p => calls3.push(p)});
+        expect(calls3).toHaveLength(0);
+    });
+
+    test('invalid inputs throw (inherited from deriveAgentRepoPath)', () => {
+        expect(() => removeAgentRepo({agentId: 'a', repoSlug: 'x/y'})).toThrow();          // missing managedRoot
+        expect(() => removeAgentRepo({managedRoot: caseRoot, repoSlug: 'x/y'})).toThrow(); // missing agentId
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13187

**The cleanup counterpart to the FM provisioning chain (provision ↔ remove).** `ensureAgentRepo` lands an agent's managed checkout; nothing removed it on agent removal, so managed checkouts accumulate and a stale leftover at a derived path can confuse a later re-provision. `removeAgentRepo` is the safe, caller-driven removal mechanism.

- **`ai/services/fleet/removeAgentRepo.mjs`** (new, standalone — sibling to `ensureAgentRepo`): derive the contained path → `inspectAgentRepo` → remove **only** what the FM provisioned (a managed `checkout`, or an `empty` managed dir); **refuse** a foreign occupant / symlink (`occupied-non-checkout` → throw, never clobber — the mirror of provisioning's never-clobber); `absent` → idempotent no-op. `removeDir` is an injectable seam (default a real recursive remove) so the safe/refuse/no-op contract tests without deleting beyond a test's own temp fixtures.
- **Destructive + caller-driven by design:** removal deletes the working tree *including uncommitted work*, and FM auto-memory is checkout-path-keyed — so the *policy* of **when** to remove (and whether to preserve that memory) is the **caller's**, not this mechanism's. It is deliberately **never auto-wired** into `removeAgent`; it only decides what is *safe* to remove, never whether removal is *wanted*.

This uses only **merged** primitives (`deriveAgentRepoPath` #13145, `inspectAgentRepo` #13148), so it is independent of my in-flight FM PRs (#13174/#13178/#13180/#13184) — no stacking, no conflict.

Evidence: L2 (real-fs contract — actual managed checkout / empty / foreign / symlink / absent fixtures in temp dirs, real removal verified by path-gone assertions) → L2 sufficient (every AC is the removal mechanism's safety contract; auto-memory preservation policy is the caller's, out of scope). No residuals.

## Deltas from ticket (if any)
None. Delivers #13187's Contract Ledger exactly: remove-managed, refuse-foreign (incl. symlink), no-op-absent, injectable `removeDir` seam.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/removeAgentRepo.spec.mjs
→ 7 passed (657ms)

node --check ai/services/fleet/removeAgentRepo.mjs → OK
```
7 cases: managed checkout → removed (path gone); empty → removed; foreign occupant → refused (survives); symlink → refused (survives, containment defense); absent → no-op `{removed:false, reason:'absent'}`; `removeDir` seam honored (called for managed, NOT for foreign/absent); invalid inputs throw (from `deriveAgentRepoPath`).

## Post-Merge Validation
- [ ] When a caller / control-plane surface invokes `removeAgentRepo` on a deliberate agent removal, the agent's managed checkout is removed and the auto-memory-preservation policy (caller's) is honored (whitebox-e2e once a caller exists).

Related: parent epic #13015 (FM MVP); the removal counterpart to `ensureAgentRepo` (#13162); consumes `deriveAgentRepoPath` (#13145) + `inspectAgentRepo` (#13148).
