### PR TITLE
test(neural-link): direct multi-window create_component e2e + NL-enable shareddialog (#13185)

### DIFF
--- a/apps/shareddialog/neo-config.json
+++ b/apps/shareddialog/neo-config.json
@@ -4,5 +4,6 @@
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
     "mainThreadAddons": ["DragDrop", "Stylesheet", "WindowPosition"],
+    "useAiClient"     : true,
     "useSharedWorkers": true
 }

--- a/test/playwright/e2e/NeuralLinkCreateComponentMultiWindow.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkCreateComponentMultiWindow.spec.mjs
@@ -1,0 +1,65 @@
+import { test, expect }                from '../fixtures.mjs';
+import { NeuralLink_ComponentService } from '../../../ai/services.mjs';
+
+/**
+ * @summary Direct multi-window proof for the `create_component` Neural Link tool.
+ *
+ * The single-window create + inspection path is covered by a sibling spec; this one carries the
+ * multi-window axis: that `create_component` lands in the CORRECT window under a shared App Worker.
+ * The mechanism is sound by composition (create_component → window-agnostic id-based `call_method` →
+ * globally-unique ids → the App Worker's existing per-window delta routing), and this is the DIRECT
+ * L3 evidence.
+ *
+ * Subject app: `apps/shareddialog` (`useSharedWorkers:true`, `useAiClient:true`). Its "Open docked
+ * Window" button opens a second window (the `shareddialog2` childapp) sharing the SAME App Worker heap.
+ * The window-2 target container is read FROM the popup's own DOM (so it is window-2 by construction, no
+ * windowId heuristics), created into via NL with the shared `sessionId`, then asserted to render in
+ * window 2 and NOT in window 1 — the negative half is what proves per-window targeting vs a broadcast.
+ */
+test.describe('Neural Link create_component — multi-window shared-worker targeting (AC1)', () => {
+    test.setTimeout(90000);
+
+    test('create_component into a window-2 container renders in window 2, not window 1', async ({ page, neuralLink }) => {
+        await page.goto('/apps/shareddialog/index.html');
+
+        // One shared App Worker → a single sessionId covers EVERY window's component tree.
+        const app = await neuralLink.connectToApp('SharedDialog');
+        expect(app.sessionId).toBeTruthy();
+
+        // AC1 is specifically about the shared-worker topology — assert we are actually in it.
+        const isShared = await page.evaluate(() => window.Neo?.config?.useSharedWorkers === true);
+        expect(isShared).toBe(true);
+
+        // Open window 2 (the shareddialog2 childapp) in the same SharedWorker via the docked-window button.
+        const [popup] = await Promise.all([
+            page.waitForEvent('popup'),
+            page.getByRole('button', { name: 'Open docked Window' }).click()
+        ]);
+        await popup.waitForLoadState('domcontentloaded');
+
+        // Window 2's own viewport — its id is, by construction, a window-2 container.
+        const popupViewport = popup.locator('.neo-viewport').first();
+        await expect(popupViewport).toBeAttached({ timeout: 30000 });
+
+        const window2ContainerId = await popupViewport.getAttribute('id');
+        expect(window2ContainerId).toBeTruthy();
+
+        // The tool under test: create_component into the window-2 container, over the shared sessionId.
+        const probeId = 'nl-multiwin-create-probe';
+        await NeuralLink_ComponentService.createComponent({
+            sessionId: app.sessionId,
+            parentId : window2ContainerId,
+            config   : { ntype: 'button', id: probeId, text: 'NL Multi-Window Probe' }
+        });
+
+        // It renders in window 2 (its parent's window) ...
+        const probeInWindow2 = popup.locator(`#${probeId}`);
+        await expect(probeInWindow2).toBeVisible({ timeout: 15000 });
+        await expect(probeInWindow2).toContainText('NL Multi-Window Probe');
+
+        // ... and NOT in window 1 — the per-window-targeting assertion.
+        expect(await page.locator(`#${probeId}`).count()).toBe(0);
+
+        await popup.close();
+    });
+});


### PR DESCRIPTION
## Summary

The **direct multi-window proof** for `create_component` (#13157 AC1) — the L3 evidence @neo-gpt's #13183 review asked for ("direct L3 proof OR close-target truth-sync"; #13183 took the truth-sync split, this delivers the direct proof, the stronger option).

A shared-worker e2e: `apps/shareddialog` (now NL-enabled) opens a 2nd window (the `shareddialog2` childapp, same App Worker), then `create_component` targets a **window-2** container — resolved from the popup's own DOM, so it's window-2 by construction — over the shared `sessionId`, and asserts the component renders in window 2 and **NOT** window 1. That proves per-window targeting under `useSharedWorkers:true`, not a broadcast.

Resolves #13185.
Refs #13157, #13183, #9846.

Evidence: L3 (e2e) — 3 consecutive green local runs; the create_component result lands with `appName:"SharedDialog2"` + the window-2 `windowId`. → L3 required (multi-window runtime behavior can only be proven end-to-end).

## Changes

- **`test/playwright/e2e/NeuralLinkCreateComponentMultiWindow.spec.mjs`** (new) — the multi-window `create_component` e2e.
- **`apps/shareddialog/neo-config.json`** — `"useAiClient": true`, so the shared-worker demo connects to the NL Bridge. This is the foundation that was missing: **no app had both `useSharedWorkers` and `useAiClient`**, which is why no shared-worker NL e2e existed. NL-enabling a demo is vision-aligned (NL-introspectable apps = the harness Pillar-2 thesis) and degrades gracefully when no Bridge is running.

## Test Evidence

`npm run test-e2e -- test/playwright/e2e/NeuralLinkCreateComponentMultiWindow.spec.mjs` — **3/3 green** (5.4–5.6s). The NL `register` confirms `isSharedWorker:true`; the `create_component` result confirms `appName:"SharedDialog2"`, `parentId:"neo-viewport-2"`, `windowId` = window 2's (distinct from window 1's `windowId`) — the component was routed to the correct window. No existing `shareddialog` test exists to regress (verified).

## Post-Merge Validation

- CI `e2e` green on the PR.
- The shared-worker NL e2e path is now **established** — future multi-window NL e2es (harness Pillar-2 co-habitation) can build on this pattern: an NL-enabled shared-worker app + the popup-DOM window-2 discriminator.

## Deltas

- **create_component footgun discovered (follow-up worthy):** the tool's config validation accepts `module`, but a STRING `module` breaks `container.add` downstream at `createItem` (`src/container/Base.mjs:445` — `module.prototype.className` on a string is undefined). Over the NL wire only `ntype`/`className` are usable (a class object isn't serializable). The tool should reject/guide away from `module`-as-string. I'll file a create_component hardening follow-up.
- NL-enabling `shareddialog` is the minimal foundation; a dedicated shared-worker NL test app could replace it later, but enabling NL on a demo is lower-footprint and vision-aligned.

Authored by @neo-opus-vega (Vega, Claude Opus 4.8 [1M context]) — origin session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
