### PR TITLE
feat(ai): Fleet Manager control-plane facade — FleetManager (#13192)

### DIFF
--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -1,0 +1,139 @@
+import path                    from 'path';
+import {fileURLToPath}         from 'url';
+import Base                    from '../../../src/core/Base.mjs';
+import FleetLifecycleService   from './FleetLifecycleService.mjs';
+import {inspectFleetRepos}     from './inspectFleetRepos.mjs';
+import {startAgentProvisioned} from './startAgentProvisioned.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename);
+
+/**
+ * @class Neo.ai.services.fleet.FleetManager
+ * @extends Neo.core.Base
+ * @singleton
+ *
+ * @summary
+ * The Brain-side (Node-only) Fleet Manager control-plane facade — the surface-independent service
+ * layer that resolves the managed checkout root ONCE and exposes the operator operations turnkey, so
+ * any surface (an MCP control-plane, the settings pane) sits *thinly* on top rather than re-resolving
+ * `managedRoot` or re-wiring the registry / lifecycle singletons at each call site.
+ *
+ * It **composes** the merged Fleet Manager primitives without modifying them:
+ * - `startAgent(id)` → {@link Neo.ai.services.fleet.startAgentProvisioned} (provision-then-start);
+ * - `fleetRepoStatus()` → {@link Neo.ai.services.fleet.inspectFleetRepos} (fleet repo observability),
+ *
+ * each fed the resolved `managedRoot` + the lifecycle service — the registry is derived from the
+ * lifecycle service (`getRegistry`), so there is one source of truth. `getManagedRoot` follows the
+ * registry's `getDataDir` precedent: a config field, then the `NEO_FLEET_MANAGED_ROOT` env, then a
+ * `__dirname`-relative default — no hidden fallback.
+ *
+ * The injectable seams (`lifecycleService`, `provisionAndStartFn`, `repoStatusFn` — default-real,
+ * mirroring `FleetLifecycleService`'s `spawnFn` / `registry`) let the resolution + wiring be unit-proven
+ * without standing up real fs / git / process spawn. The operator-facing **surface** (MCP control-plane
+ * vs settings-pane wiring) is a separate leaf that consumes this facade — it is not part of it.
+ */
+class FleetManager extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.fleet.FleetManager'
+         * @protected
+         */
+        className: 'Neo.ai.services.fleet.FleetManager',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * The absolute fleet-managed checkout root. `null` ⇒ resolved (env, then a `__dirname`-relative
+         * default) via {@link getManagedRoot}. Set a per-tenant / temp path to override.
+         * @member {String|null} managedRoot=null
+         */
+        managedRoot: null,
+        /**
+         * Lifecycle collaborator. Defaults (via {@link getLifecycleService}) to the
+         * `FleetLifecycleService` singleton; inject a stub for tests.
+         * @member {Object|null} lifecycleService=null
+         */
+        lifecycleService: null,
+        /**
+         * Provision-then-start composer. Defaults (via {@link getProvisionAndStartFn}) to
+         * `startAgentProvisioned`; inject a recording stub for tests.
+         * @member {Function|null} provisionAndStartFn=null
+         */
+        provisionAndStartFn: null,
+        /**
+         * Fleet repo-status aggregator. Defaults (via {@link getRepoStatusFn}) to `inspectFleetRepos`;
+         * inject a recording stub for tests.
+         * @member {Function|null} repoStatusFn=null
+         */
+        repoStatusFn: null
+    }
+
+    /**
+     * @summary Resolve (config > env > default) the absolute fleet-managed checkout root.
+     * Mirrors `FleetRegistryService.getDataDir`: the `managedRoot` config field, then the
+     * `NEO_FLEET_MANAGED_ROOT` env, then a `__dirname`-relative `<repoRoot>/.neo-ai-data/fleet/repos`
+     * default. No hidden fallback — an unset config + unset env yields exactly the default.
+     * @returns {String}
+     */
+    getManagedRoot() {
+        return this.managedRoot || process.env.NEO_FLEET_MANAGED_ROOT || path.resolve(__dirname, '../../../.neo-ai-data/fleet/repos');
+    }
+
+    /**
+     * @returns {Object} the lifecycle collaborator (injected stub or the default singleton).
+     * @protected
+     */
+    getLifecycleService() {
+        return this.lifecycleService || FleetLifecycleService;
+    }
+
+    /**
+     * @returns {Function} the provision-then-start composer (injected stub or `startAgentProvisioned`).
+     * @protected
+     */
+    getProvisionAndStartFn() {
+        return this.provisionAndStartFn || startAgentProvisioned;
+    }
+
+    /**
+     * @returns {Function} the repo-status aggregator (injected stub or `inspectFleetRepos`).
+     * @protected
+     */
+    getRepoStatusFn() {
+        return this.repoStatusFn || inspectFleetRepos;
+    }
+
+    /**
+     * @summary Turnkey provision-then-start: ensure the agent's repo (at the resolved managed root)
+     * exists, then start its harness inside it. Delegates to `startAgentProvisioned` — fail-closed on a
+     * provisioning failure (the harness is not spawned).
+     * @param {String} agentId Registry agent id.
+     * @returns {Promise<Object>} the agent's lifecycle status.
+     */
+    async startAgent(agentId) {
+        return this.getProvisionAndStartFn()({
+            lifecycleService: this.getLifecycleService(),
+            managedRoot     : this.getManagedRoot(),
+            agentId
+        });
+    }
+
+    /**
+     * @summary Turnkey fleet repo observability: the per-agent repo-provisioning state across the whole
+     * fleet, at the resolved managed root. Delegates to `inspectFleetRepos` (read-only); the registry is
+     * the lifecycle service's, so process + repo views key off one agent set.
+     * @returns {Object[]} one status entry per registered agent (see `inspectFleetRepos`).
+     */
+    fleetRepoStatus() {
+        return this.getRepoStatusFn()({
+            registry   : this.getLifecycleService().getRegistry(),
+            managedRoot: this.getManagedRoot()
+        });
+    }
+}
+
+export default Neo.setupClass(FleetManager);

--- a/test/playwright/unit/ai/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/FleetManager.spec.mjs
@@ -1,0 +1,96 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'FleetManagerTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}          from '@playwright/test';
+
+import Neo                     from '../../../../src/Neo.mjs';
+import * as core               from '../../../../src/core/_export.mjs';
+import FleetManager            from '../../../../ai/services/fleet/FleetManager.mjs';
+import {inspectFleetRepos}     from '../../../../ai/services/fleet/inspectFleetRepos.mjs';
+import {startAgentProvisioned} from '../../../../ai/services/fleet/startAgentProvisioned.mjs';
+import path                    from 'path';
+
+const ENV_KEY = 'NEO_FLEET_MANAGED_ROOT';
+let savedEnv;
+
+/** Reset the singleton's injectable config between serial cases. */
+function reset() {
+    FleetManager.managedRoot         = null;
+    FleetManager.lifecycleService    = null;
+    FleetManager.provisionAndStartFn = null;
+    FleetManager.repoStatusFn        = null;
+}
+
+// Singleton-stateful service → serial, with env + injected-config reset per case.
+test.describe.configure({mode: 'serial'});
+
+test.describe('Neo.ai.services.fleet.FleetManager', () => {
+    test.beforeEach(() => { savedEnv = process.env[ENV_KEY]; delete process.env[ENV_KEY]; reset(); });
+    test.afterEach(()  => {
+        if (savedEnv === undefined) delete process.env[ENV_KEY]; else process.env[ENV_KEY] = savedEnv;
+        reset();
+    });
+
+    test('getManagedRoot: the config field wins over env + default', () => {
+        FleetManager.managedRoot = '/explicit/root';
+        process.env[ENV_KEY]     = '/env/root';
+        expect(FleetManager.getManagedRoot()).toBe('/explicit/root');
+    });
+
+    test('getManagedRoot: env wins when no config field is set', () => {
+        process.env[ENV_KEY] = '/env/root';
+        expect(FleetManager.getManagedRoot()).toBe('/env/root');
+    });
+
+    test('getManagedRoot: a __dirname-relative default when neither config nor env is set (no hidden fallback)', () => {
+        const root = FleetManager.getManagedRoot();
+        expect(path.isAbsolute(root)).toBe(true);
+        expect(root.endsWith(path.join('.neo-ai-data', 'fleet', 'repos'))).toBe(true);
+    });
+
+    test('startAgent provisions+starts via the composer with the resolved root + lifecycle service', async () => {
+        const lifecycle = {getRegistry: () => ({}), isRunning: () => false, status: () => ({}), start: () => ({})},
+              calls     = [];
+
+        FleetManager.managedRoot         = '/managed/root';
+        FleetManager.lifecycleService    = lifecycle;
+        FleetManager.provisionAndStartFn = async args => { calls.push(args); return {state: 'running'}; };
+
+        const status = await FleetManager.startAgent('agent-a');
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({lifecycleService: lifecycle, managedRoot: '/managed/root', agentId: 'agent-a'});
+        expect(status.state).toBe('running');
+    });
+
+    test('fleetRepoStatus inspects via the aggregator with the resolved root + the lifecycle registry', () => {
+        const registry  = {marker: 'reg'},
+              lifecycle = {getRegistry: () => registry},
+              calls     = [];
+
+        FleetManager.managedRoot      = '/managed/root';
+        FleetManager.lifecycleService = lifecycle;
+        FleetManager.repoStatusFn     = args => { calls.push(args); return [{agentId: 'a'}]; };
+
+        const result = FleetManager.fleetRepoStatus();
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({registry, managedRoot: '/managed/root'});
+        expect(result).toEqual([{agentId: 'a'}]);
+    });
+
+    test('seams default to the real composers (a no-injection construction wires them)', () => {
+        expect(FleetManager.getProvisionAndStartFn()).toBe(startAgentProvisioned);
+        expect(FleetManager.getRepoStatusFn()).toBe(inspectFleetRepos);
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13192

**The surface-independent service layer of the FM control-plane keystone** — now buildable since the operator merged `startAgentProvisioned` (#13178) + `inspectFleetRepos` (#13180). A single service that resolves `managedRoot` once and offers the operator operations turnkey, so any surface (an MCP control-plane, the settings pane — **piece 3, separate, @neo-gpt's call**) sits *thinly* on top instead of re-resolving `managedRoot` or re-wiring the registry/lifecycle singletons at each call site.

- **`ai/services/fleet/FleetManager.mjs`** (new singleton, `Neo.core.Base` — sibling to `FleetLifecycleService`/`FleetRegistryService`): **composes the merged primitives without modifying them**:
  - `getManagedRoot()` = `managedRoot` config > `NEO_FLEET_MANAGED_ROOT` env > `<repoRoot>/.neo-ai-data/fleet/repos` — the `FleetRegistryService.getDataDir` precedent (`import.meta.url`-derived `__dirname`), **no hidden fallback**;
  - `async startAgent(id)` → `startAgentProvisioned` (provision-then-start) with the resolved root + the lifecycle service;
  - `fleetRepoStatus()` → `inspectFleetRepos` (observe) with the resolved root + the **lifecycle's** registry (one source of truth — process + repo views key off one agent set);
  - injectable seams (`lifecycleService`, `provisionAndStartFn`, `repoStatusFn` — default-real, mirroring `FleetLifecycleService.spawnFn`/`registry`) so the resolution + wiring is unit-provable without real fs / git / process spawn.

This composes only **merged** primitives and modifies **no** peer service.

Evidence: L1 (pure-composition unit spec with injected lifecycle + composer seams + env manipulation for the resolution precedence) → L1 required (every AC is the facade's resolution/wiring decision-logic; the live provision-and-start path is covered by `startAgentProvisioned`'s own spec + is whitebox-e2e once a surface drives it). No residuals.

## Deltas from ticket (if any)
None. Delivers #13192's Contract Ledger exactly: `getManagedRoot` (config>env>default), `startAgent`, `fleetRepoStatus`, injectable seams.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/FleetManager.spec.mjs
→ 6 passed (614ms)

node --check ai/services/fleet/FleetManager.mjs → OK
```
6 cases: `getManagedRoot` config>env>default precedence (no hidden fallback — unset config + unset env → the `__dirname`-relative default; set env overrides; set config overrides both); `startAgent` wires the resolved root + lifecycle into the composer; `fleetRepoStatus` wires the resolved root + the lifecycle's registry into the aggregator; the seams default to the real `startAgentProvisioned` / `inspectFleetRepos`.

## Post-Merge Validation
- [ ] When the operator-facing surface (MCP control-plane / settings pane, piece 3) consumes `FleetManager.startAgent` / `.fleetRepoStatus`, a live agent provisions+starts in its resolved managed repo and fleet repo health renders — without the surface re-resolving `managedRoot` (whitebox-e2e once the surface exists).

Related: parent epic #13015 (FM MVP); the control-plane service layer over #13178 (`startAgentProvisioned`) + #13180 (`inspectFleetRepos`); #13167 control-plane framing; the surface (piece 3) is routed to @neo-gpt.
