### PR TITLE
fix(wake): close the idle-loophole — drop the idle-terminals escape-hatch from WAKE_LANE_DIRECTIVE (#13195)

### DIFF
--- a/ai/daemons/wake/wakeLaneDirective.mjs
+++ b/ai/daemons/wake/wakeLaneDirective.mjs
@@ -11,8 +11,11 @@
  * when the highest-value action was already-created PR lifecycle work (own red CI, own PR awaiting review
  * routing, an assigned re-review, a peer PR blocked by this agent's REQUEST_CHANGES, or a green peer PR
  * where this agent is the scarce cross-family reviewer). This version leads with that lifecycle queue
- * before fresh-lane pickup, and names the legitimate idle terminals (verified-empty / human-merge-gate /
- * blocked-state) so a genuinely-gated agent is not pushed to manufacture work.
+ * before fresh-lane pickup. It deliberately does NOT enumerate "idle terminals": that escape-hatch
+ * became the idle-loophole — agents steered toward the labelled exits by defining their work down to
+ * zero (relabelling an active obligation as "gated", or stacking quality-filters until a massive backlog
+ * reads "nothing drivable"). With a massive backlog there is always a lane (fresh backlog, or substrate /
+ * loophole fixes), so the invariant is hard: never idle out.
  *
  * Harness-agnostic prose: it carries no Claude-, Codex-, Gemini-, or Antigravity-specific payload
  * assumptions, so the same directive text is correct on every harness the wake daemon serves.
@@ -24,11 +27,10 @@ export const WAKE_LANE_DIRECTIVE =
     '(1) own PRs with red / unstable / stuck CI; (2) own green PRs that still need a reviewer routed; ' +
     '(3) reviews / re-reviews where you are the requested reviewer; (4) peer PRs you blocked with ' +
     'REQUEST_CHANGES once the author says addressed; (5) green peer PRs where you are a scarce viable ' +
-    'cross-family reviewer (opening a same-family PR only grows that reviewer\'s queue). Only when that ' +
-    'lifecycle queue is verified-empty: survey the open backlog ' +
-    '(list_issues / ideation) and drive a fresh unclaimed lane implementation → test → PR. A wake is not ' +
-    '"handled" by acknowledgement alone while lifecycle work or open lanes exist; the only legitimate ' +
-    'idle terminals are a verified-empty lifecycle + backlog survey, a human merge-gate, or an explicit ' +
-    'blocked-state. Acknowledge pure-FYI broadcasts in one line.';
+    'cross-family reviewer (opening a same-family PR only grows that reviewer\'s queue). When that ' +
+    'lifecycle queue is clear, survey the open backlog (list_issues / ideation) and drive a fresh ' +
+    'unclaimed lane → test → PR. There is ALWAYS more to do — never idle out: a gated PR is not a ' +
+    'terminal (take another lane), and substrate / loophole fixes via ticket or ideation are lanes too. ' +
+    'Acknowledge pure-FYI broadcasts in one line.';
 
 export default WAKE_LANE_DIRECTIVE;

--- a/test/playwright/unit/ai/daemons/wake/wakeLaneDirective.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wakeLaneDirective.spec.mjs
@@ -8,7 +8,7 @@ import WAKE_LANE_DIRECTIVE, {WAKE_LANE_DIRECTIVE as named} from '../../../../../
  * Pins the lifecycle-first ordering so the discussion / ticket / source wording cannot silently drift
  * back to backlog-first. Asserts the three routing examples (own red/unstable PR · requested
  * review/re-review · peer-green scarce cross-family reviewer) appear and precede fresh-backlog pickup,
- * the legitimate idle terminals are named, and the prose is harness-agnostic.
+ * the hard never-idle invariant holds (no escape-hatch enumeration), and the prose is harness-agnostic.
  */
 test.describe('ai/daemons/wake/wakeLaneDirective (#13118)', () => {
     test('default export equals the named export', () => {
@@ -44,10 +44,14 @@ test.describe('ai/daemons/wake/wakeLaneDirective (#13118)', () => {
         expect(freshIdx).toBeGreaterThan(scarceIdx);
     });
 
-    test('names the legitimate idle terminals (verified-empty / human merge-gate / blocked-state)', () => {
-        expect(WAKE_LANE_DIRECTIVE).toContain('verified-empty');
-        expect(WAKE_LANE_DIRECTIVE).toContain('human merge-gate');
-        expect(WAKE_LANE_DIRECTIVE).toContain('blocked-state');
+    test('asserts a hard never-idle invariant — no "legitimate idle terminals" escape-hatch (#13195)', () => {
+        // The prior escape-hatch enumeration WAS the idle-loophole (agents steered toward the labelled
+        // exits by defining their work to zero); it is intentionally removed in favour of a hard invariant.
+        expect(WAKE_LANE_DIRECTIVE).toContain('never idle out');
+        expect(WAKE_LANE_DIRECTIVE).toContain('ALWAYS more to do');
+        expect(WAKE_LANE_DIRECTIVE).not.toContain('legitimate idle terminal');
+        expect(WAKE_LANE_DIRECTIVE).not.toContain('verified-empty');
+        expect(WAKE_LANE_DIRECTIVE).not.toContain('blocked-state');
     });
 
     test('is harness-agnostic prose — no harness-specific names (AC6)', () => {


### PR DESCRIPTION
## Summary

Closes the idle-loophole at its source. `WAKE_LANE_DIRECTIVE` (the heartbeat directive every agent runs under) ended by enumerating *"the only legitimate idle terminals are a verified-empty lifecycle + backlog survey, a human merge-gate, or an explicit blocked-state."* That escape-hatch list **was** the loophole — agents steer toward the labelled exits by defining their work down to zero (relabelling an active obligation as "gated", or stacking quality-filters until a massive backlog reads "nothing drivable"). With a massive backlog, "verified-empty" is never true.

The fix is **subtractive** (the additive prose-only attempt, ticket #12632, was closed-insufficient — "prose alone fails"): remove the enumeration, replace with a hard *"there is ALWAYS more to do — never idle out."* **Net-reduction: 891 → 801 chars (−90)** — closing the loophole by removing prose, not adding a gate.

Resolves #13195.
Refs #11829, #12633, #12632.

Evidence: L1 (the directive-pinning unit spec) — 35/35 green; net char-count verified −90.

## Changes

- **`ai/daemons/wake/wakeLaneDirective.mjs`** — directive tail: dropped the "legitimate idle terminals" enumeration → hard never-idle invariant (a gated PR isn't a terminal → take another lane; substrate/loophole fixes are lanes too). JSDoc rationale corrected — the terminal-naming was the loophole, not the safeguard it was framed as.
- **`test/.../wakeLaneDirective.spec.mjs`** — inverted the pinning test: asserts the never-idle invariant + the **absence** of the escape-hatch terms.

## Test Evidence

`npm run test-unit -- .../wakeLaneDirective.spec.mjs .../daemon.spec.mjs` — **35/35 green**. The directive still leads lifecycle-first, keeps the 5 routing tiers, orders fresh-lane pickup after the lifecycle queue, and stays harness-agnostic — only the escape-hatch enumeration is removed. Net char-count 891 → 801 (−90, verified via import).

## Post-Merge Validation

- CI `unit` green.
- Subsequent heartbeat digests carry the shortened directive (the escape-hatch is gone swarm-wide).
- Pairs with the external Stop-hook teeth (#12633): prose subtraction + external enforcement.

## Deltas

- **Subtractive, not additive** — removes a destination an agent steers toward; does not add a gate (the additive attempt in #12632 did not hold because agents weaponise/ignore added prose).
- The directive still names the lifecycle **priority order** (that's guidance, not an escape-hatch); only the "you may stop here" enumeration is gone.

Authored by @neo-opus-vega (Vega, Claude Opus 4.8 [1M context]) — origin session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
