### PR TITLE
fix(neural-link): reject non-class `module` in create_component — clear error over the createItem crash (#13193)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -812,8 +812,9 @@ paths:
 
         **When to Use:**
         To add a new component to a live container (e.g. add a `Button` to a `Toolbar`) without granting
-        admin method-call access. The `config` must declare a `module`, `ntype`, or `className`; the
-        target container is resolved by `parentId`.
+        admin method-call access. The `config` must declare an `ntype` (e.g. `button`) or `className`
+        (e.g. `Neo.button.Base`) — a `module` is a class reference and cannot cross the wire. The target
+        container is resolved by `parentId`.
       tags: [Component]
       requestBody:
         required: true
@@ -1779,7 +1780,7 @@ components:
           description: The target container's component ID (the parent to add into)
         config:
           type: object
-          description: The component configuration; must declare a `module`, `ntype`, or `className`
+          description: The component configuration; declare an `ntype` (e.g. `button`) or `className` (e.g. `Neo.button.Base`). A `module` (class reference) cannot cross the wire — use `ntype`/`className`.
         sessionId:
           type: string
           description: The target App Worker Session ID

--- a/ai/services/neural-link/ComponentService.mjs
+++ b/ai/services/neural-link/ComponentService.mjs
@@ -158,7 +158,7 @@ class ComponentService extends Base {
      * an agent can create components without being granted admin method-call access.
      * @param {Object} opts             The options object.
      * @param {String} opts.parentId    The target container's component ID.
-     * @param {Object} opts.config      The component configuration; must declare a `module`, `ntype`, or `className`.
+     * @param {Object} opts.config      The component configuration; declare an `ntype` (e.g. `button`) or `className` (e.g. `Neo.button.Base`). A `module` is a class reference that cannot cross the wire — use `ntype`/`className`.
      * @param {String} [opts.sessionId] The target session ID.
      * @returns {Promise<Object>} The result of adding the component to the container.
      */
@@ -168,6 +168,13 @@ class ComponentService extends Base {
         }
         if (!config || typeof config !== 'object' || Array.isArray(config)) {
             throw new Error('create_component: `config` must be a component configuration object.');
+        }
+        // A `module` is a CLASS reference (the imported class, not its name-string). It cannot cross the
+        // Neural Link wire (JSON carries no class), and a string/non-class `module` would crash the
+        // worker-side `container.add` at `createItem` (`module.prototype.className` on a non-class). Fail
+        // fast with a pointer to the wire-usable forms instead of surfacing that cryptic downstream error.
+        if (config.module && typeof config.module !== 'function') {
+            throw new Error('create_component: `module` must be a class reference, which cannot cross the Neural Link wire — declare `ntype` (e.g. "button") or `className` (e.g. "Neo.button.Base") instead.');
         }
         if (!config.module && !config.ntype && !config.className) {
             throw new Error('create_component: `config` must declare a `module`, `ntype`, or `className` to instantiate.');

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -81,8 +81,16 @@ test.describe('Neo.ai.services.neural-link.ComponentService — createComponent'
         expect(calls.length).toBe(0);
     });
 
+    test('rejects a non-class `module` (a class reference cannot cross the wire) — guides to ntype/className', async () => {
+        // The footgun: an agent naturally tries `module: 'Neo.button.Base'` (a string); over the wire a
+        // class can't serialize, and the string would crash the worker-side container.add at createItem.
+        await expect(ComponentService.createComponent({parentId: 'p1', config: {module: 'Neo.button.Base'}, sessionId: 's1'}))
+            .rejects.toThrow(/class reference|ntype/);
+        expect(calls.length).toBe(0);
+    });
+
     test('delegates a valid config to call_method as parent.add(config)', async () => {
-        const config = {module: 'Neo.button.Base', text: 'Save'};
+        const config = {className: 'Neo.button.Base', text: 'Save'};
         const result = await ComponentService.createComponent({parentId: 'toolbar-1', config, sessionId: 's1'});
 
         expect(calls.length).toBe(1);


### PR DESCRIPTION
## Summary

Fixes a `create_component` footgun (surfaced while building #13191's e2e): the config validation accepts `module`, but a non-class `module` — always a string over the Neural Link wire, since a class reference can't serialize — crashed the worker-side `container.add` at `createItem` (`module.prototype.className` on a non-class → `Cannot read properties of undefined`). Now it **fails fast with a clear error** guiding to `ntype`/`className`, and the agent-facing openapi descriptions say so up front so agents don't reach for `module` at all.

Resolves #13193.
Refs #9846 (create_component), #13191 (where the footgun surfaced).

Evidence: L1 (unit) — the guard + the updated/added validation tests; `ComponentService.spec` 6/6 + `OpenApiValidatorCompliance` 30/30 green. → L1 required (pure server-side validation).

## Changes

- **`ai/services/neural-link/ComponentService.mjs`** — fail-fast guard: a non-class `module` (`typeof !== 'function'`) throws a semantic error ("declare `ntype`/`className`") before dispatch, instead of the cryptic downstream `createItem` crash. JSDoc updated.
- **`test/.../ComponentService.spec.mjs`** — new test (a non-class `module` is rejected, no dispatch); the happy-path test switched from the now-rejected `module` to `className`.
- **`ai/mcp/server/neural-link/openapi.yaml`** — the `/component/create` description + `CreateComponentRequest.config` description now guide agents to `ntype`/`className` (a `module` is a class reference, not wire-usable).

## Test Evidence

`npm run test-unit -- .../ComponentService.spec.mjs` — **6/6 green** (incl. the new non-class-`module` rejection + the `className` happy-path). `OpenApiValidatorCompliance.spec` — **30/30** (the description changes don't break tier/schema compliance). `node --check` clean; openapi parses.

## Post-Merge Validation

- CI `unit` + `ai/mcp/validation` green.
- An agent calling `create_component` with `module: 'Neo.button.Base'` now gets a clear pointer to `ntype`/`className` instead of `Cannot read properties of undefined (reading 'className')`.

## Deltas

- `module` is still accepted IF it's an actual class (`typeof === 'function'`) — a never-over-the-wire case kept for in-process callers; only the non-class (string) form is rejected. The declares-check (`module || ntype || className`) is unchanged.
- Scoped minimal: the runtime guard + the agent-facing descriptions. No schema-structure change (the `config` stays an open object).

Authored by @neo-opus-vega (Vega, Claude Opus 4.8 [1M context]) — origin session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
