### PR TITLE
feat(ai): Bridge agent-message sidecar emit + per-connection sessionId

### DIFF
--- a/ai/mcp/server/neural-link/Bridge.mjs
+++ b/ai/mcp/server/neural-link/Bridge.mjs
@@ -214,6 +214,11 @@ class Bridge extends Base {
         logger.info(`Bridge: Agent connected [${id}]`);
         this.agents.set(id, ws);
 
+        // A stable, Bridge-authoritative per-connection id (minted here, lives for the connection's
+        // lifetime) stamped into the agent_message sidecar + the disconnect notice, so the app-side
+        // write-guard can key locks on the (agentId, sessionId) pair.
+        ws.sessionId = crypto.randomUUID();
+
         ws.on('message', (data) => this.handleAgentMessage(id, data));
         ws.on('close',   ()     => {
             logger.info(`Bridge: Agent disconnected [${id}]`);
@@ -221,6 +226,13 @@ class Bridge extends Base {
             this.broadcastToAgents({
                 type   : 'agent_disconnected',
                 agentId: id
+            });
+            // Lets the app-side write-guard release locks held by the now-dead writer; idempotent so a
+            // blanket app broadcast is safe.
+            this.broadcastToApps({
+                type     : 'agent_disconnected',
+                agentId  : id,
+                sessionId: ws.sessionId
             });
         });
         ws.on('error', (err) => logger.error(`Bridge: Agent error [${id}]`, err));
@@ -294,11 +306,17 @@ class Bridge extends Base {
                 return;
             }
 
-            const appWs = this.apps.get(payload.target);
+            const agentWs = this.agents.get(agentId);
+            const appWs   = this.apps.get(payload.target);
 
             if (appWs) {
-                // Forward transparently
-                appWs.send(JSON.stringify(payload.message));
+                // Forward, wrapping the message in the Bridge-stamped sidecar (the app-side Client unwraps it)
+                appWs.send(JSON.stringify({
+                    type     : 'agent_message',
+                    agentId,
+                    sessionId: agentWs?.sessionId,
+                    message  : payload.message
+                }));
             } else {
                 logger.warn(`Bridge: Target App [${payload.target}] not found for Agent [${agentId}]`);
 
@@ -352,6 +370,17 @@ class Bridge extends Base {
     broadcastToAgents(payload) {
         const data = JSON.stringify(payload);
         for (const ws of this.agents.values()) {
+            ws.send(data);
+        }
+    }
+
+    /**
+     * Sends a message to all connected Apps.
+     * @param {Object} payload
+     */
+    broadcastToApps(payload) {
+        const data = JSON.stringify(payload);
+        for (const ws of this.apps.values()) {
             ws.send(data);
         }
     }

--- a/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
@@ -27,7 +27,8 @@ const sign = (agentId, expiresAt = Date.now() + 3_600_000) => {
 };
 
 // A minimal WebSocket stand-in — handleConnection / registerAgent only touch close / on / send / readyState.
-const makeWs  = () => ({readyState: 1, closed: null, sent: [], on() {}, send(d) {this.sent.push(d)}, close(code, reason) {this.closed = {code, reason}}, terminate() {}});
+// `on` records each handler under `this.handlers` so a test can synthetically fire e.g. the 'close' handler.
+const makeWs  = () => ({readyState: 1, closed: null, sent: [], handlers: {}, on(event, handler) {this.handlers[event] = handler}, send(d) {this.sent.push(d)}, close(code, reason) {this.closed = {code, reason}}, terminate() {}});
 const makeReq = query => ({url: `/?${query}`, headers: {host: '127.0.0.1:8081'}});
 
 test.describe('Bridge.handleConnection — agent handshake auth (#13172)', () => {
@@ -76,5 +77,58 @@ test.describe('Bridge.handleConnection — agent handshake auth (#13172)', () =>
         Bridge.handleConnection(ws, makeReq('role=agent&id=legacy-agent'));
         expect(Bridge.agents.has('legacy-agent')).toBe(true);
         expect(ws.closed).toBe(null);
+    });
+});
+
+test.describe('Bridge.handleAgentMessage — agent-message sidecar emit', () => {
+    test.beforeEach(() => {
+        Bridge.agents = new Map();
+        Bridge.apps   = new Map();
+    });
+
+    test('registerAgent stamps a non-empty string sessionId on the agent socket', () => {
+        const ws = makeWs();
+        Bridge.registerAgent('agent-a', ws);
+
+        expect(typeof ws.sessionId).toBe('string');
+        expect(ws.sessionId.length).toBeGreaterThan(0);
+    });
+
+    test('handleAgentMessage forwards the message wrapped in the Bridge-stamped sidecar', () => {
+        const appWs   = makeWs();
+        const agentWs = makeWs();
+
+        Bridge.apps.set('app-1', appWs);
+        Bridge.registerAgent('agent-a', agentWs); // stamps agentWs.sessionId
+
+        Bridge.handleAgentMessage('agent-a', Buffer.from(JSON.stringify({
+            target : 'app-1',
+            message: {id: 1, method: 'x'}
+        })));
+
+        const frame = JSON.parse(appWs.sent.at(-1));
+
+        expect(frame.type).toBe('agent_message');
+        expect(frame.agentId).toBe('agent-a');
+        expect(frame.sessionId).toBe(agentWs.sessionId);
+        expect(frame.message).toEqual({id: 1, method: 'x'});
+    });
+
+    test('agent disconnect broadcasts an agent_disconnected frame (with sessionId) to apps', () => {
+        const appWs   = makeWs();
+        const agentWs = makeWs();
+
+        Bridge.apps.set('app-1', appWs);
+        Bridge.registerAgent('agent-a', agentWs);
+
+        const sessionId = agentWs.sessionId;
+
+        agentWs.handlers.close(); // synthetically fire the recorded 'close' handler
+
+        const frame = appWs.sent.map(JSON.parse).find(f => f.type === 'agent_disconnected');
+
+        expect(frame).toBeTruthy();
+        expect(frame.agentId).toBe('agent-a');
+        expect(frame.sessionId).toBe(sessionId);
     });
 });


### PR DESCRIPTION
Resolves #13196

Completes the **sidecar-emit half of Leaf A** (#13167's Contract Ledger row 2): the Bridge now stamps its authoritative agent identity into the message it forwards to the target app, so the app-side Client threads `{agentId, sessionId}` to the topological-lock enforcement. Sequenced **after** the merged auth (#13181 — which makes the stamped `agentId` trustworthy) and the merged Client unwrap (#13174 / Leaf B — which taught the Client to unwrap `agent_message` *before* the Bridge emits it, so the flip never breaks the live channel).

Evidence: L2 (`Bridge.spec` executes `registerAgent` / `handleAgentMessage` against a mock WebSocket — asserts the `agent_message` sidecar frame shape, the per-connection `sessionId` mint, and the app-bound `agent_disconnected` broadcast; `parseAgentEnvelope` consumer regression green) → L2 required (#13196's ACs scope unit proof on the `Bridge.spec` scaffolding). No residuals — the live Bridge↔app denied-cross-agent-write proof is the umbrella #13167 Leaf C integration test, downstream of this leaf.

## What changed

- **`registerAgent`** mints a stable, Bridge-authoritative per-connection `ws.sessionId = crypto.randomUUID()` — unspoofable (same trust model as the verified `agentId`), re-entrant for one connection. This is the opaque, harness-native per-writer discriminator that `WriteGuard` / `LockRegistry` need for the `(agentId, sessionId)` lock pair — no #12984 cross-harness canonicalization required.
- **`handleAgentMessage`** forwards `{type:'agent_message', agentId, sessionId, message}` instead of the bare `payload.message` — mirroring `handleAppMessage`'s existing `{type:'app_message', ...}` envelope. The merged `parseAgentEnvelope` reads `{type, agentId, message}` and ignores the extra `sessionId` harmlessly (forward-compat; Leaf C extends the extract).
- **Agent disconnect** now also broadcasts `{type:'agent_disconnected', agentId, sessionId}` to apps via a new `broadcastToApps` (a verbatim mirror of `broadcastToAgents`), so the app-side `WriteGuard.releaseAll({agentId, sessionId})` sweeps the dead writer's held locks (connection-lifetime lease GC; idempotent, so a blanket app broadcast is safe).
- **Incidental bugfix:** `handleAgentMessage` now captures `const agentWs = this.agents.get(agentId)` — which both supplies the sidecar `sessionId` **and** fixes a pre-existing reference to an undefined `agentWs` in the target-not-found error branch (that error response never fired before).

## Deltas from ticket

None on the contract. The `sessionId` half was added to #13196's ACs via the convergence with @neo-opus-ada (the `(agentId, sessionId)` pair is `WriteGuard`'s writer identity, per `LockRegistry`); this PR implements exactly that. The `agentWs`-undefined bugfix is in-scope — the same `this.agents.get(agentId)` capture that supplies the `sessionId` is what fixes it.

## Test Evidence

- `Bridge.spec.mjs`: **7 passed** (4 existing handshake-auth + 3 new) — `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs`. New tests: per-connection `sessionId` mint; sidecar forward shape (`type` / `agentId` / `sessionId` / `message` deep-equal); disconnect-to-apps frame carrying `sessionId`.
- `parseAgentEnvelope.spec.mjs`: **6 passed** (the app-side consumer, unchanged) — confirms the producer↔consumer contract holds end-to-end with **no regression**.
- The `makeWs` test mock was extended to record handlers (so the disconnect test can synthetically fire the `'close'` handler); the existing auth tests never fire handlers and still pass.

## Post-Merge Validation

@neo-opus-ada's Leaf C then extends `parseAgentEnvelope` to extract `sessionId` + wires `WriteGuard.requestWrite({agentId, sessionId, subtreePath})` on write and `releaseAll({agentId, sessionId})` on the `agent_disconnected` frame — completing the end-to-end enforcement chain. The umbrella #13167 closes on Leaf C plus a live denied-cross-agent-write integration proof (two agents issuing conflicting subtree writes confirm deny-no-mutate once Leaf C lands).

Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.
