### PR TITLE
fix(github-workflow): archive marooned merged PRs via the missing pull reconcile (#13001)

### DIFF
--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -114,6 +114,12 @@ class SyncService extends Base {
         // 2. Reconcile closed issue locations - archive stale closed issues before pull
         const reconcileStats = await IssueSyncer.reconcileClosedIssueLocations(metadata);
 
+        // 2b. Reconcile closed PULL locations — the sibling reconcile that was missing. The
+        //     delta-only pull sync skips PRs untouched since the last cutoff, so old merged PRs marooned
+        //     in active pulls/ are never re-bucketed; this per-sync reconcile (mirroring the issue one)
+        //     archives them and keeps pulls archived going forward.
+        const pullReconcileStats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
+
         // 3. Push local changes
         const pushStats = await IssueSyncer.pushToGitHub(metadata);
 
@@ -218,8 +224,9 @@ class SyncService extends Base {
         const durationMs = endTime - startTime;
 
         const finalStats = {
-            reconciled  : reconcileStats,
-            pushed      : pushStats,
+            reconciled     : reconcileStats,
+            reconciledPulls: pullReconcileStats,
+            pushed         : pushStats,
             pulled      : pullStats.pulled,
             dropped     : pullStats.dropped,
             releases    : releaseStats,
@@ -235,6 +242,7 @@ class SyncService extends Base {
 
         logger.info('✨ Sync Complete');
         logger.info(`   Reconciled:  ${finalStats.reconciled.count} issues archived`);
+        logger.info(`   Reconciled:  ${finalStats.reconciledPulls.count} pull requests archived`);
         logger.info(`   Pushed:      ${finalStats.pushed.count} issues`);
         logger.info(`   Pulled:      ${finalStats.pulled.count} issues (${finalStats.pulled.created} new, ${finalStats.pulled.updated} updated, ${finalStats.pulled.moved} moved)`);
         logger.info(`   Dropped:     ${finalStats.dropped.count} issues`);
@@ -284,7 +292,7 @@ class SyncService extends Base {
     }
 
     /**
-     * Facade for the one-time archive re-bucket migration (#12194). Loads metadata, delegates to
+     * Facade for the one-time archive re-bucket migration. Loads metadata, delegates to
      * `IssueSyncer.migrateArchiveBuckets`, then persists the updated metadata (unless `dryRun`).
      * Invoked out-of-band by `ai/scripts/migrations/rebucketArchive.mjs` — never the regular sync loop.
      * @param {object} [opts]

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -232,13 +232,15 @@ class PullRequestSyncer extends Base {
      * syncers." Run every sync, it both archives the existing backlog and keeps pulls archived going
      * forward; it mirrors the issue reconcile's relocate-only, archive-only, never-fetch contract.
      *
-     * For each cached PR still in the active dir whose terminal state buckets it to a release version, it
-     * computes the correct archive path (via the same `#planBuckets` / `#getPullRequestPath` the live sync
-     * uses) and `fs.rename`s the file there, updating the metadata path. It NEVER moves a file back to
-     * active (an archive→active relocation would violate sealed-chunk semantics), NEVER deletes, and NEVER
-     * re-fetches from GitHub.
+     * It scans the active **corpus** (the `pr-*.md` files on disk), NOT the sync metadata: the delta-sync
+     * rebuilds `metadata.pulls` from each run's delta fetch, so it is not a full index — the marooned
+     * backlog exists only as files. For each terminal (`CLOSED`/`MERGED`) PR file it reads the frontmatter
+     * bucketing inputs (`state` / `closedAt` / `mergedAt`), buckets via the same `#planBuckets` the live
+     * sync uses, and `fs.rename`s a mis-located file to its archive path (updating the metadata path when
+     * an entry exists). It NEVER moves a file back to active (sealed-chunk semantics), NEVER deletes, and
+     * NEVER re-fetches from GitHub.
      *
-     * @param {object} metadata Sync metadata; pull `path`s are updated in place (the caller persists).
+     * @param {object} metadata Sync metadata; a moved PR's `path` is updated in place when cached.
      * @returns {Promise<{count: number, pullRequests: number[]}>} Archived count + the PR numbers moved.
      */
     async reconcileClosedPullRequestLocations(metadata) {
@@ -252,51 +254,75 @@ class PullRequestSyncer extends Base {
             return stats;
         }
 
-        const planBuckets = this.#planBuckets(metadata);
+        const pullsDir = issueSyncConfig.pullsDir;
 
-        for (const prNumber in metadata.pulls) {
-            const prData              = metadata.pulls[prNumber];
-            const currentAbsolutePath = this.#resolvePath(prData.path);
+        // Nothing to reconcile if the active pulls dir does not exist yet.
+        if (!existsSync(pullsDir)) {
+            return stats;
+        }
 
-            // Only process PRs still in the ACTIVE directory — already-archived ones are sealed.
-            if (!currentAbsolutePath || !currentAbsolutePath.startsWith(issueSyncConfig.pullsDir)) {
-                continue;
-            }
+        // Scan the active CORPUS (files on disk), NOT metadata.pulls — the delta-sync rebuilds that cache
+        // from each run's delta fetch, so it is not a full index; the marooned backlog lives only as
+        // files. Read each file's frontmatter for the bucketing inputs.
+        const relFiles = (await fs.readdir(pullsDir, {recursive: true}))
+            .filter(rel => /(?:^|[\\/])pr-\d+\.md$/.test(rel));
 
-            // Only terminal PRs (CLOSED or MERGED) are archive candidates; an open PR belongs in active.
-            if (prData.state !== 'CLOSED' && prData.state !== 'MERGED') {
-                continue;
-            }
-
-            // Where this terminal PR SHOULD live (archive tier iff its bucket carries a release version).
-            const correctPath = this.#getPullRequestPath({number: parseInt(prNumber, 10)}, planBuckets);
-
-            if (!correctPath) {
-                logger.warn(`PR #${prNumber} has null target path during reconciliation, skipping.`);
-                continue;
-            }
-
-            // Already correctly located, or the correct path is still active (no archive applies) → skip.
-            if (currentAbsolutePath === correctPath || correctPath.startsWith(issueSyncConfig.pullsDir)) {
-                continue;
-            }
-
-            logger.debug(`📦 Archiving closed PR #${prNumber}: ${currentAbsolutePath} → ${correctPath}`);
-
+        const scanned = [];
+        for (const rel of relFiles) {
+            const absPath = path.join(pullsDir, rel);
             try {
-                await fs.mkdir(path.dirname(correctPath), { recursive: true });
-                await fs.rename(currentAbsolutePath, correctPath);
-
-                metadata.pulls[prNumber].path = this.#relativePath(correctPath);
-
-                stats.count++;
-                stats.pullRequests.push(parseInt(prNumber, 10));
+                const {data} = matter(await fs.readFile(absPath, 'utf-8'));
+                if (data?.number == null) continue;
+                scanned.push({
+                    absPath,
+                    number   : data.number,
+                    state    : data.state,
+                    closedAt : data.closedAt,
+                    mergedAt : data.mergedAt,
+                    milestone: data.milestone ? {title: data.milestone} : null
+                });
             } catch (e) {
-                logger.error(`❌ Failed to archive PR #${prNumber}: ${e.message}`);
+                logger.warn(`Skipping unreadable pull file ${rel}: ${e.message}`);
             }
         }
 
-        await pruneEmptyDirs(issueSyncConfig.pullsDir);
+        // Bucket the scanned corpus (+ any cached metadata) by release date, exactly as the live sync does.
+        const planBuckets = this.#planBuckets(metadata, scanned);
+
+        for (const pr of scanned) {
+            // Only terminal PRs (CLOSED or MERGED) are archive candidates; an open PR belongs in active.
+            if (pr.state !== 'CLOSED' && pr.state !== 'MERGED') {
+                continue;
+            }
+
+            const correctPath = this.#getPullRequestPath({number: pr.number}, planBuckets);
+
+            // No target, already correctly located, or the correct path is still active (no archive
+            // applies) → skip. Never relocate INTO active.
+            if (!correctPath || pr.absPath === correctPath || correctPath.startsWith(pullsDir)) {
+                continue;
+            }
+
+            logger.debug(`📦 Archiving closed PR #${pr.number}: ${pr.absPath} → ${correctPath}`);
+
+            try {
+                await fs.mkdir(path.dirname(correctPath), { recursive: true });
+                await fs.rename(pr.absPath, correctPath);
+
+                // Update the metadata path when this PR is tracked; marooned files outside the delta-only
+                // cache simply move (the next sync rebuilds metadata against the new location).
+                if (metadata.pulls?.[pr.number]) {
+                    metadata.pulls[pr.number].path = this.#relativePath(correctPath);
+                }
+
+                stats.count++;
+                stats.pullRequests.push(pr.number);
+            } catch (e) {
+                logger.error(`❌ Failed to archive PR #${pr.number}: ${e.message}`);
+            }
+        }
+
+        await pruneEmptyDirs(pullsDir);
 
         logger.info(stats.count > 0
             ? `📦 Archived ${stats.count} closed pull request(s)`

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -224,6 +224,88 @@ class PullRequestSyncer extends Base {
     }
 
     /**
+     * @summary Reconcile closed/merged pull-request locations — archive any terminal PR still sitting in
+     * the active `pulls/` directory. The sibling of `IssueSyncer.reconcileClosedIssueLocations` that was
+     * missing: `SyncService` ran the issue reconcile every sync but had no pull equivalent, so
+     * closed/merged PRs accumulated in active `resources/content/pulls/` — the marooning this reconciles.
+     * `migrateArchiveBuckets`' own JSDoc named it — "pulls … are a sibling follow-up on their own
+     * syncers." Run every sync, it both archives the existing backlog and keeps pulls archived going
+     * forward; it mirrors the issue reconcile's relocate-only, archive-only, never-fetch contract.
+     *
+     * For each cached PR still in the active dir whose terminal state buckets it to a release version, it
+     * computes the correct archive path (via the same `#planBuckets` / `#getPullRequestPath` the live sync
+     * uses) and `fs.rename`s the file there, updating the metadata path. It NEVER moves a file back to
+     * active (an archive→active relocation would violate sealed-chunk semantics), NEVER deletes, and NEVER
+     * re-fetches from GitHub.
+     *
+     * @param {object} metadata Sync metadata; pull `path`s are updated in place (the caller persists).
+     * @returns {Promise<{count: number, pullRequests: number[]}>} Archived count + the PR numbers moved.
+     */
+    async reconcileClosedPullRequestLocations(metadata) {
+        logger.info('🔄 Reconciling closed pull request locations...');
+
+        const stats = { count: 0, pullRequests: [] };
+
+        // Buckets are derived from release history; without it the correct archive version is unknown.
+        if (!ReleaseNotesSyncer.sortedReleases || ReleaseNotesSyncer.sortedReleases.length === 0) {
+            logger.warn('No releases available for pull-request reconciliation, skipping.');
+            return stats;
+        }
+
+        const planBuckets = this.#planBuckets(metadata);
+
+        for (const prNumber in metadata.pulls) {
+            const prData              = metadata.pulls[prNumber];
+            const currentAbsolutePath = this.#resolvePath(prData.path);
+
+            // Only process PRs still in the ACTIVE directory — already-archived ones are sealed.
+            if (!currentAbsolutePath || !currentAbsolutePath.startsWith(issueSyncConfig.pullsDir)) {
+                continue;
+            }
+
+            // Only terminal PRs (CLOSED or MERGED) are archive candidates; an open PR belongs in active.
+            if (prData.state !== 'CLOSED' && prData.state !== 'MERGED') {
+                continue;
+            }
+
+            // Where this terminal PR SHOULD live (archive tier iff its bucket carries a release version).
+            const correctPath = this.#getPullRequestPath({number: parseInt(prNumber, 10)}, planBuckets);
+
+            if (!correctPath) {
+                logger.warn(`PR #${prNumber} has null target path during reconciliation, skipping.`);
+                continue;
+            }
+
+            // Already correctly located, or the correct path is still active (no archive applies) → skip.
+            if (currentAbsolutePath === correctPath || correctPath.startsWith(issueSyncConfig.pullsDir)) {
+                continue;
+            }
+
+            logger.debug(`📦 Archiving closed PR #${prNumber}: ${currentAbsolutePath} → ${correctPath}`);
+
+            try {
+                await fs.mkdir(path.dirname(correctPath), { recursive: true });
+                await fs.rename(currentAbsolutePath, correctPath);
+
+                metadata.pulls[prNumber].path = this.#relativePath(correctPath);
+
+                stats.count++;
+                stats.pullRequests.push(parseInt(prNumber, 10));
+            } catch (e) {
+                logger.error(`❌ Failed to archive PR #${prNumber}: ${e.message}`);
+            }
+        }
+
+        await pruneEmptyDirs(issueSyncConfig.pullsDir);
+
+        logger.info(stats.count > 0
+            ? `📦 Archived ${stats.count} closed pull request(s)`
+            : '✓ No closed pull requests need archiving');
+
+        return stats;
+    }
+
+    /**
      * Fetches pull requests from GitHub and syncs them to local markdown.
      * @param {object} metadata The sync metadata containing cached records.
      * @returns {Promise<object>} Statistics about the operation.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -275,6 +275,80 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         // Pre-fix (full-corpus scan) this would be 3.
         expect(queryCalls).toBe(2);
     });
+
+    // --- the missing pull reconcile (IssueSyncer had reconcileClosedIssueLocations; pulls had none,
+    //     so the delta-only sync left merged PRs marooned in active pulls/). ---
+
+    test('reconcileClosedPullRequestLocations archives a merged PR marooned in active pulls/ (#13001)', async () => {
+        const prNumber   = 11530,
+              activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: MERGED\n---\nbody`, 'utf-8');
+
+        const metadata = {pulls: {[prNumber]: {
+            number: prNumber, state: 'MERGED', closedAt: '2026-05-01T00:00:00Z',
+            path  : path.relative(aiConfig.projectRoot, activePath)
+        }}};
+        // A release published AFTER the merge → the closedAt→release resolution buckets it to v13.0.0.
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats       = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata),
+              archivePath = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`);
+
+        expect(stats.count).toBe(1);
+        expect(stats.pullRequests).toEqual([prNumber]);
+        await expect(fs.pathExists(activePath)).resolves.toBe(false);   // moved out of active
+        await expect(fs.pathExists(archivePath)).resolves.toBe(true);   // archived under v13.0.0
+        expect(metadata.pulls[prNumber].path).toBe(path.relative(aiConfig.projectRoot, archivePath));
+    });
+
+    test('reconcileClosedPullRequestLocations leaves an OPEN PR in active (never archives a non-terminal PR)', async () => {
+        const prNumber   = 22222,
+              activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\n---\n`, 'utf-8');
+
+        const metadata = {pulls: {[prNumber]: {number: prNumber, state: 'OPEN', path: path.relative(aiConfig.projectRoot, activePath)}}};
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
+
+        expect(stats.count).toBe(0);
+        await expect(fs.pathExists(activePath)).resolves.toBe(true);    // untouched
+    });
+
+    test('reconcileClosedPullRequestLocations skips an already-archived PR (never relocates back to active)', async () => {
+        const prNumber    = 33333,
+              archivePath = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`);
+        await fs.ensureDir(path.dirname(archivePath));
+        await fs.writeFile(archivePath, `---\nnumber: ${prNumber}\n---\n`, 'utf-8');
+
+        const metadata = {pulls: {[prNumber]: {
+            number: prNumber, state: 'MERGED', closedAt: '2026-05-01T00:00:00Z',
+            path  : path.relative(aiConfig.projectRoot, archivePath)
+        }}};
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
+
+        expect(stats.count).toBe(0);                                    // already sealed → skipped
+        await expect(fs.pathExists(archivePath)).resolves.toBe(true);
+    });
+
+    test('reconcileClosedPullRequestLocations is a no-op when no releases are loaded (fail-safe)', async () => {
+        const prNumber   = 44444,
+              activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, '---\n---\n', 'utf-8');
+
+        const metadata = {pulls: {[prNumber]: {number: prNumber, state: 'MERGED', closedAt: '2026-05-01T00:00:00Z', path: path.relative(aiConfig.projectRoot, activePath)}}};
+        ReleaseNotesSyncer.sortedReleases = [];                          // no releases → cannot resolve buckets
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
+
+        expect(stats.count).toBe(0);
+        await expect(fs.pathExists(activePath)).resolves.toBe(true);    // untouched (fail-safe skip)
+    });
 });
 
 function buildPullRequest(number) {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -279,16 +279,15 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
     // --- the missing pull reconcile (IssueSyncer had reconcileClosedIssueLocations; pulls had none,
     //     so the delta-only sync left merged PRs marooned in active pulls/). ---
 
-    test('reconcileClosedPullRequestLocations archives a merged PR marooned in active pulls/ (#13001)', async () => {
+    test('archives a marooned merged PR FILE with NO metadata entry — the production corpus case (#13001)', async () => {
         const prNumber   = 11530,
               activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
         await fs.ensureDir(path.dirname(activePath));
-        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: MERGED\n---\nbody`, 'utf-8');
+        // The reconcile reads the FILE's frontmatter (number/state/closedAt), not metadata.
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: MERGED\nclosedAt: '2026-05-01T00:00:00Z'\n---\nbody`, 'utf-8');
 
-        const metadata = {pulls: {[prNumber]: {
-            number: prNumber, state: 'MERGED', closedAt: '2026-05-01T00:00:00Z',
-            path  : path.relative(aiConfig.projectRoot, activePath)
-        }}};
+        // NO metadata entry for this PR — exactly the marooned corpus the delta-only cache misses.
+        const metadata = {pulls: {}};
         // A release published AFTER the merge → the closedAt→release resolution buckets it to v13.0.0.
         ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
 
@@ -299,52 +298,46 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         expect(stats.pullRequests).toEqual([prNumber]);
         await expect(fs.pathExists(activePath)).resolves.toBe(false);   // moved out of active
         await expect(fs.pathExists(archivePath)).resolves.toBe(true);   // archived under v13.0.0
+    });
+
+    test('also updates metadata.path when the moved PR IS tracked in the delta cache', async () => {
+        const prNumber   = 12000,
+              activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: MERGED\nclosedAt: '2026-05-01T00:00:00Z'\n---\n`, 'utf-8');
+
+        const metadata = {pulls: {[prNumber]: {number: prNumber, state: 'MERGED', closedAt: '2026-05-01T00:00:00Z', path: path.relative(aiConfig.projectRoot, activePath)}}};
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats       = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata),
+              archivePath = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`);
+
+        expect(stats.count).toBe(1);
+        await expect(fs.pathExists(archivePath)).resolves.toBe(true);
         expect(metadata.pulls[prNumber].path).toBe(path.relative(aiConfig.projectRoot, archivePath));
     });
 
-    test('reconcileClosedPullRequestLocations leaves an OPEN PR in active (never archives a non-terminal PR)', async () => {
+    test('leaves an OPEN PR file in active (never archives a non-terminal PR)', async () => {
         const prNumber   = 22222,
               activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
         await fs.ensureDir(path.dirname(activePath));
-        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\n---\n`, 'utf-8');
-
-        const metadata = {pulls: {[prNumber]: {number: prNumber, state: 'OPEN', path: path.relative(aiConfig.projectRoot, activePath)}}};
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: OPEN\n---\n`, 'utf-8');
         ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
 
-        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations({pulls: {}});
 
         expect(stats.count).toBe(0);
         await expect(fs.pathExists(activePath)).resolves.toBe(true);    // untouched
     });
 
-    test('reconcileClosedPullRequestLocations skips an already-archived PR (never relocates back to active)', async () => {
-        const prNumber    = 33333,
-              archivePath = path.join(aiConfig.issueSync.contentRoot, 'archive', 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`);
-        await fs.ensureDir(path.dirname(archivePath));
-        await fs.writeFile(archivePath, `---\nnumber: ${prNumber}\n---\n`, 'utf-8');
-
-        const metadata = {pulls: {[prNumber]: {
-            number: prNumber, state: 'MERGED', closedAt: '2026-05-01T00:00:00Z',
-            path  : path.relative(aiConfig.projectRoot, archivePath)
-        }}};
-        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
-
-        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
-
-        expect(stats.count).toBe(0);                                    // already sealed → skipped
-        await expect(fs.pathExists(archivePath)).resolves.toBe(true);
-    });
-
-    test('reconcileClosedPullRequestLocations is a no-op when no releases are loaded (fail-safe)', async () => {
+    test('is a no-op when no releases are loaded (fail-safe)', async () => {
         const prNumber   = 44444,
               activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
         await fs.ensureDir(path.dirname(activePath));
-        await fs.writeFile(activePath, '---\n---\n', 'utf-8');
-
-        const metadata = {pulls: {[prNumber]: {number: prNumber, state: 'MERGED', closedAt: '2026-05-01T00:00:00Z', path: path.relative(aiConfig.projectRoot, activePath)}}};
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: MERGED\nclosedAt: '2026-05-01T00:00:00Z'\n---\n`, 'utf-8');
         ReleaseNotesSyncer.sortedReleases = [];                          // no releases → cannot resolve buckets
 
-        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations(metadata);
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations({pulls: {}});
 
         expect(stats.count).toBe(0);
         await expect(fs.pathExists(activePath)).resolves.toBe(true);    // untouched (fail-safe skip)


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada. Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Resolves #13001

The v13 archival left **1,325 merged PRs marooned** in active `resources/content/pulls/` (only 120 archived). Root cause (V-B-A'd against `origin/dev`): `SyncService` runs `IssueSyncer.reconcileClosedIssueLocations` **every sync** to archive stale closed issues — but there was **no pull equivalent**, and the delta-only pull sync skips PRs untouched since the last cutoff, so old merged PRs were never re-bucketed. `migrateArchiveBuckets`' own JSDoc named the gap: *"pulls … are a sibling follow-up on their own syncers."*

- **`PullRequestSyncer.reconcileClosedPullRequestLocations`** (new): **scans the active `resources/content/pulls/` corpus** — `fs.readdir(pullsDir, {recursive:true})` for `pr-*.md`, parses each file's frontmatter with `gray-matter`, and buckets via the existing `#planBuckets`. For every **terminal** (`CLOSED`/`MERGED`) file whose computed `#getPullRequestPath` differs from its current location, it `fs.rename`s the file into `archive/pulls/v*/` — **even when that PR has no `metadata.pulls` entry**. This is the crux of the fix: the delta-only `metadata.pulls` cache (~30 entries) is **not** the corpus, so iterating it (the prior approach the first review rightly rejected) could never see the 1,325 marooned files. Already-archived files sit outside the active scan root, so they are never revisited. The `metadata.pulls` path is updated **only when that PR is tracked**; empty active dirs are pruned afterward, and `_index.json` is rebuilt by the next sync. **Relocate-only** (never back to active = sealed-chunk-safe), **archive-only**, **never re-fetches** GitHub; fail-safe skip when no releases are loaded.
- **`SyncService`**: wires it as step **2b** after the issue reconcile + reports the count. The per-sync reconcile both **archives the existing 1,325 backlog** (the next sync moves them) and **keeps pulls archived going forward**.

Also incidentally removed a stale `#12194` archaeology ref in an existing `SyncService` JSDoc (flagged by `check-ticket-archaeology` once my edit re-staged the file) — behavior-neutral.

Evidence: L2 (real-fs unit spec — an actual corpus scan + `fs.rename` of a marooned `pr-*.md` between temp active/archive trees, asserting the file moved even with no metadata entry + the metadata path updated when tracked) → L2 sufficient (the reconcile's corpus-scan / terminal-filter / relocate / fail-safe contract). No residuals.

## Deltas from ticket (if any)
The ticket title leans on "milestone-gated"; the V-B-A'd root cause is the **missing pull reconcile** (the live bucketing is `closedAt`→release, not milestone-gated). The fix targets the verified cause — same outcome (the 1,325 get archived), narrower mechanism.

## Test Evidence
```
UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs \
  test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
→ 10 passed (900ms)

node --check ai/services/github-workflow/sync/PullRequestSyncer.mjs → OK
node --check ai/services/github-workflow/SyncService.mjs            → OK
```
4 new cases (the 6 existing stay green), mirroring the implemented corpus scan:
- **archives a marooned merged PR FILE with NO metadata entry** — the production corpus case: the file moves to `archive/pulls/v13.0.0/` purely from its on-disk frontmatter, no `metadata.pulls` entry required.
- **also updates `metadata.path` when the moved PR IS tracked** in the delta cache.
- **leaves an OPEN PR file in active** — never archives a non-terminal PR.
- **is a no-op when no releases are loaded** (fail-safe).

## Post-Merge Validation
- [ ] On the next data-sync-pipeline run (operator/CI-controlled), the reconcile archives the existing ~1,325 marooned merged PRs out of active `resources/content/pulls/` into `archive/pulls/v*/` — verifiable by the post-sync `Reconciled: N pull requests archived` log + a `pulls/` file count drop.
- [ ] Going forward, newly-terminal PRs move to archive at sync, not active.

Related: the pull sibling of `IssueSyncer.reconcileClosedIssueLocations`; the data-sync pipeline (§critical_gates rule 3 exception).
