### PR TITLE
test(neural-link): e2e proof for remove_component — create → remove → assert gone (tree + DOM) (#13186)

### DIFF
--- a/test/playwright/e2e/NeuralLinkRemoveComponent.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkRemoveComponent.spec.mjs
@@ -1,0 +1,51 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * @summary E2E proof for the `remove_component` Neural Link tool — the live-app counterpart to the unit
+ * spec (which mocks the transport). Creates a probe via `create_component`, verifies it is registered +
+ * rendered, then removes it via `remove_component` and verifies it is GONE from both `get_component_tree`
+ * AND the live DOM — the full destroy round-trip (instance deregistration + parent-vdom detach via the
+ * pinned `destroy(true)`) that the unit coverage cannot exercise. The create→remove pairing also proves
+ * the two write-locked tools compose over one live session.
+ */
+test.describe('Neural Link — remove_component (e2e)', () => {
+    test.setTimeout(90000);
+
+    test('removes a live component; it disappears from the component tree + the DOM', async ({ page, neuralLink }) => {
+        await page.goto('/examples/button/base/index.html');
+        await expect(page.locator('.neo-button').first()).toBeVisible({ timeout: 30000 });
+
+        const app = await neuralLink.connectToApp('Neo.examples.button.base');
+
+        // Resolve a target container (root viewport, else any container) — normalized defensively so the
+        // proof does not couple to one NL return-envelope shape (mirrors NeuralLinkCreateComponent.spec).
+        const pick = res => res?.[0]?.id ?? res?.components?.[0]?.id ?? res?.instances?.[0]?.id ?? res?.id ?? null;
+
+        let containerId = pick(await app.findInstances({ ntype: 'viewport' }, ['id']));
+        if (!containerId) {
+            containerId = pick(await app.findInstances({ ntype: 'container' }, ['id']));
+        }
+        expect(containerId, 'could not resolve a target container id for the create').toBeTruthy();
+
+        // Create a probe to remove (a fixed id lets the assertions target it precisely).
+        const probeId = 'nl-remove-probe-' + Date.now();
+        await app.createComponent(containerId, { ntype: 'button', id: probeId, text: 'remove-me' });
+
+        // Present first — registered in the tree AND rendered in the live DOM.
+        await expect.poll(async () => JSON.stringify(await app.getComponentTree()).includes(probeId), {
+            message: 'the probe should appear in get_component_tree before removal',
+            timeout: 15000
+        }).toBe(true);
+        await expect(page.locator(`#${probeId}`)).toBeVisible({ timeout: 10000 });
+
+        // The tool under test: remove it.
+        await app.removeComponent(probeId);
+
+        // GONE — absent from the tree (instance deregistered) AND detached from the DOM (`destroy(true)`).
+        await expect.poll(async () => JSON.stringify(await app.getComponentTree()).includes(probeId), {
+            message: 'the probe should be absent from get_component_tree after removal',
+            timeout: 15000
+        }).toBe(false);
+        await expect(page.locator(`#${probeId}`)).toHaveCount(0);
+    });
+});

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -304,6 +304,16 @@ export const test = base.extend({
                         return NeuralLink_ComponentService.createComponent({ sessionId, parentId, config });
                     },
 
+                    /**
+                     * Removes (destroys) a live component by id (the `remove_component` write-locked tool).
+                     * Delegates to `component.destroy(true)` — detaches the DOM node, not just the instance.
+                     * @param {String} componentId The id of the component to destroy.
+                     * @returns {Promise<Object>}
+                     */
+                    async removeComponent(componentId) {
+                        return NeuralLink_ComponentService.removeComponent({ sessionId, componentId });
+                    },
+
 
                     // --- Interaction Methods ---
 


### PR DESCRIPTION
## Summary

The **e2e proof for `remove_component`** (#13186, re-scoped to this now-unblocked slice). Creates a probe via `create_component`, verifies it is registered + rendered, then `remove_component`s it and verifies it is **GONE** from both `get_component_tree` AND the live DOM — the full destroy round-trip (instance deregistration + parent-vdom detach via the pinned `destroy(true)`) the unit spec can't exercise. The create→remove pairing also proves the two `write-locked` tools compose over one live session.

Resolves #13186.
Refs #9847, #9848 (snapshot-for-undo deferred there).

Evidence: L3 (e2e) — 2 consecutive green local runs; the probe disappears from the tree + DOM after `remove_component`. → L3 required (live destroy round-trip can only be proven end-to-end).

## Changes

- **`test/playwright/e2e/NeuralLinkRemoveComponent.spec.mjs`** (new) — the create → assert-present → remove → assert-gone e2e.
- **`test/playwright/fixtures.mjs`** — `neuralLink.removeComponent(componentId)` fixture method (mirrors the merged `createComponent` fixture method).

## Test Evidence

`npm run test-e2e -- test/playwright/e2e/NeuralLinkRemoveComponent.spec.mjs` — **2/2 green** (2.0s, 4.7s). The `create_component` result confirms the probe (a `Neo.button.Base` at the resolved container); after `remove_component`, both the `get_component_tree` poll AND `page.locator('#<probeId>').toHaveCount(0)` confirm it is gone.

## Post-Merge Validation

- CI `e2e` green on the PR.
- `remove_component` is now proven end-to-end (Slice 1 tool #13188 + this Slice 2 e2e). The full `create_component` + `remove_component` lifecycle is e2e-validated.

## Deltas

- **Re-scoped #13186** to the e2e proof (the now-unblocked, high-value part). Snapshot-for-undo + the snapshot-integrity e2e are deferred to the undo-stack #9848 (no standalone value until it exists). The existence-probe is deferred as a marginal hardening (Slice 1 presence-validates; a non-existent id already errors worker-side).
- Single-window app (`examples/button/base`) — the destroy behavior isn't window-specific; multi-window targeting is already proven by #13191.

Authored by @neo-opus-vega (Vega, Claude Opus 4.8 [1M context]) — origin session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
