### PR TITLE
feat(ai): parseAgentEnvelope threads the Bridge sessionId (#13204)

### DIFF
--- a/src/ai/parseAgentEnvelope.mjs
+++ b/src/ai/parseAgentEnvelope.mjs
@@ -2,15 +2,15 @@
  * @summary Parse an inbound Neural Link frame into its JSON-RPC message + an optional agent context.
  *
  * Backward-compatible envelope handling for the multi-writer enforcement transport. The Bridge
- * forwards either a bare JSON-RPC message (legacy / non-agent) or — once the agent identity-transport
- * lands — a `{type:'agent_message', agentId, message}` sidecar. **This parser does not authenticate**:
- * it routes the frame and surfaces the agent context, but the trustworthiness of `agentId` is
- * established UPSTREAM by the Bridge connection-auth leaf (a token verification that retires the
- * self-claimed connection id) — not here. On current `dev` the Bridge still forwards bare JSON-RPC
- * (no sidecar), so the `agent_message` path is dormant until the auth + emit leaves land. This returns
- * the inner JSON-RPC plus the agent context so `Neo.ai.Client` threads the Bridge-stamped `agentId` to
- * the write services for topological-lock enforcement, while a legacy bare frame is dispatched exactly
- * as before.
+ * forwards either a bare JSON-RPC message (legacy / non-agent) or — now that the agent identity-transport
+ * has landed — a `{type:'agent_message', agentId, sessionId, message}` sidecar. **This parser does not
+ * authenticate**: it routes the frame and surfaces the agent context, but the trustworthiness of
+ * `agentId` is established UPSTREAM by the Bridge connection-auth leaf (a token verification that retires
+ * the self-claimed connection id) — not here. The `sessionId` is likewise Bridge-minted (one per
+ * authenticated connection, stamped at `registerAgent`), not self-claimed. The Bridge auth + sidecar-emit
+ * leaves have landed, so the sidecar is live. This returns the inner JSON-RPC plus the agent context so
+ * `Neo.ai.Client` threads the Bridge-stamped `(agentId, sessionId)` pair to the write services for
+ * topological-lock enforcement, while a legacy bare frame is dispatched exactly as before.
  *
  * It is deliberately pure (no Client, no socket): `Neo.ai.Client` is a connect-on-init singleton, so
  * keeping the parsing logic free of it makes the contract unit-testable — and it lets the Client learn
@@ -18,21 +18,23 @@
  * Client that already understands it never breaks the live agent→app channel.
  *
  * @param {*} frame The parsed inbound WebSocket frame.
- * @returns {{jsonrpc: (Object|null), context: ({agentId: (String|null)}|null)}}
+ * @returns {{jsonrpc: (Object|null), context: ({agentId: (String|null), sessionId: (String|null)}|null)}}
  *   `jsonrpc` is the JSON-RPC message to dispatch, or `null` if the frame carries none.
- *   `context` is `{agentId}` for an `agent_message` — the enforcement keys on it, and a malformed /
- *   absent agentId yields `{agentId: null}` so the write service fails closed rather than mutating —
- *   or `null` for a bare / legacy frame (non-agent, unenforced).
+ *   `context` is `{agentId, sessionId}` for an `agent_message` — the enforcement keys on the
+ *   `(agentId, sessionId)` writer pair, and a malformed / absent id yields `null` for that field so the
+ *   write service fails closed rather than mutating — or `null` for a bare / legacy frame (non-agent,
+ *   unenforced).
  */
 export function parseAgentEnvelope(frame) {
     if (frame && typeof frame === 'object' && frame.type === 'agent_message') {
         const
-            message = frame.message,
-            agentId = (typeof frame.agentId === 'string' && frame.agentId.length > 0) ? frame.agentId : null;
+            message   = frame.message,
+            agentId   = (typeof frame.agentId   === 'string' && frame.agentId.length   > 0) ? frame.agentId   : null,
+            sessionId = (typeof frame.sessionId === 'string' && frame.sessionId.length > 0) ? frame.sessionId : null;
 
         return {
             jsonrpc: (message && typeof message === 'object') ? message : null,
-            context: {agentId}
+            context: {agentId, sessionId}
         }
     }
 

--- a/test/playwright/unit/ai/parseAgentEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/parseAgentEnvelope.spec.mjs
@@ -6,10 +6,10 @@ import {parseAgentEnvelope} from '../../../../src/ai/parseAgentEnvelope.mjs';
 const RPC = {jsonrpc: '2.0', id: 1, method: 'set_instance_properties', params: {id: 'c-1', properties: {}}};
 
 test.describe('parseAgentEnvelope (Neural Link agent-context unwrap)', () => {
-    test('agent_message → inner JSON-RPC + the Bridge-stamped agentId context', () => {
-        const r = parseAgentEnvelope({type: 'agent_message', agentId: 'neo-opus-ada', message: RPC});
+    test('agent_message → inner JSON-RPC + the Bridge-stamped (agentId, sessionId) context', () => {
+        const r = parseAgentEnvelope({type: 'agent_message', agentId: 'neo-opus-ada', sessionId: 'sess-abc', message: RPC});
         expect(r.jsonrpc).toBe(RPC);
-        expect(r.context).toEqual({agentId: 'neo-opus-ada'})
+        expect(r.context).toEqual({agentId: 'neo-opus-ada', sessionId: 'sess-abc'})
     });
 
     test('a bare JSON-RPC frame → the frame itself, no agent context (legacy / non-agent, unenforced)', () => {
@@ -20,17 +20,25 @@ test.describe('parseAgentEnvelope (Neural Link agent-context unwrap)', () => {
 
     test('agent_message with a missing / empty / non-string agentId → fail-closed marker (context.agentId null)', () => {
         for (const bad of [undefined, '', null, 42, {}]) {
-            const r = parseAgentEnvelope({type: 'agent_message', agentId: bad, message: RPC});
-            expect(r.context).toEqual({agentId: null}); // the write service denies on this
-            expect(r.jsonrpc).toBe(RPC)                  // still dispatched, so it is denied — not silently dropped
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: bad, sessionId: 'sess-1', message: RPC});
+            expect(r.context).toEqual({agentId: null, sessionId: 'sess-1'}); // the write service denies on a null agentId
+            expect(r.jsonrpc).toBe(RPC)                                       // still dispatched, so it is denied — not silently dropped
+        }
+    });
+
+    test('agent_message with a missing / empty / non-string sessionId → fail-closed marker (context.sessionId null)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: 'neo-opus-ada', sessionId: bad, message: RPC});
+            expect(r.context).toEqual({agentId: 'neo-opus-ada', sessionId: null}); // the (agentId, sessionId) pair is incomplete → write service denies
+            expect(r.jsonrpc).toBe(RPC)                                            // still dispatched, so it is denied — not silently dropped
         }
     });
 
     test('agent_message with no / non-object message → nothing to dispatch, context preserved', () => {
         for (const bad of [undefined, null, 'x', 42]) {
-            const r = parseAgentEnvelope({type: 'agent_message', agentId: 'a', message: bad});
+            const r = parseAgentEnvelope({type: 'agent_message', agentId: 'a', sessionId: 's', message: bad});
             expect(r.jsonrpc).toBe(null);
-            expect(r.context).toEqual({agentId: 'a'})
+            expect(r.context).toEqual({agentId: 'a', sessionId: 's'})
         }
     });
 


### PR DESCRIPTION
Resolves #13204

## Summary

Extended-NL **Leaf C, part 1** — the safe mechanical first slice of the multi-writer enforcement, now that the identity transport has merged.

The Bridge connection-auth leaf (#13181) and the sidecar-emit leaf (#13196 / #13199) landed: the Bridge mints `ws.sessionId = crypto.randomUUID()` at `registerAgent` and stamps it onto every `agent_message` frame as `{type:'agent_message', agentId, sessionId, message}`. The merged `parseAgentEnvelope` dropped that `sessionId` on the floor — it surfaced `context: {agentId}` only.

This threads `sessionId` through with the **same fail-closed guard** as `agentId` (non-empty-string → value, else `null`) and surfaces `context: {agentId, sessionId}`, so the downstream write services (`WriteGuard` / `LockRegistry`) can key topological-lock enforcement on the **(agentId, sessionId) writer pair** — the canonical writer identity for this transport. A malformed / absent id yields `null` for that field, so the write service fails closed rather than mutating. Bare / legacy frames are untouched (`context: null`).

This is parse-only: no write-service wiring yet (that is the next Leaf C slice — `InstanceService` → `WriteGuard.requestWrite` + `releaseAll`-on-disconnect + whitebox-e2e). Keeping the parser pure keeps the contract unit-provable without standing up a socket or the connect-on-init `Neo.ai.Client` singleton.

Evidence: 7/7 unit tests green via the custom unit config (`playwright.config.unit.mjs`), including a new dedicated `sessionId` fail-closed case mirroring the `agentId` one. `node --check` clean.

## Deltas from ticket (if any)

None — the change is exactly the ticket's part-1 scope (parse + thread + fail-closed guard, JSDoc refresh off the now-stale "dormant on dev" wording, spec). No write-service wiring (deferred to the next Leaf C slice, by design).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/parseAgentEnvelope.spec.mjs`

```
Running 7 tests using 7 workers
  7 passed (763ms)
```

New / changed cases:
- `agent_message → inner JSON-RPC + the Bridge-stamped (agentId, sessionId) context` — happy path, sessionId threaded through.
- **NEW** `agent_message with a missing / empty / non-string sessionId → fail-closed marker (context.sessionId null)` — `[undefined, '', null, 42, {}]` each → `{agentId, sessionId: null}`; the inner message is still dispatched (denied downstream, not silently dropped).
- `…missing / empty / non-string agentId…` — now asserts `{agentId: null, sessionId: 'sess-1'}` (the other half of the pair is preserved; LockRegistry.normalizeLock denies on the incomplete pair).
- `…no / non-object message…` — `context: {agentId, sessionId}` preserved.
- Bare-frame / foreign-`type` / non-object cases unchanged (`context: null`).

## Post-Merge Validation

The next Leaf C slice consumes `context.sessionId`: `InstanceService.setInstanceProperties` / `callMethod` → `WriteGuard.requestWrite({agentId, sessionId, subtreePath})`, deny-no-mutate on conflict; the `agent_disconnected` frame → `WriteGuard.releaseAgent({agentId, sessionId})`. When that wiring lands and a live two-agent whitebox-e2e shows cross-agent denial keyed on the pair, this leaf is validated end-to-end.

---

Refs #13167 (Leaf C parent), #13012 (Extended-NL enforcement epic).

Authored by @neo-opus-ada (Ada, Claude Opus 4.8) — origin session `4c598c8f-d8a7-4288-9420-e825a45d310e`.
