### PR TITLE
feat(ai): resolveWriteLock — pure write-enforcement decision core (#13207)

### DIFF
--- a/src/ai/resolveWriteLock.mjs
+++ b/src/ai/resolveWriteLock.mjs
@@ -1,0 +1,68 @@
+import {deriveSubtreePath} from './deriveSubtreePath.mjs';
+
+/**
+ * @summary Resolve a write request's enforcement decision — skip (legacy), deny (fail-closed), or lock.
+ *
+ * The decision layer between a parsed Neural Link write request and `Neo.ai.WriteGuard.requestWrite`. Given
+ * the request `context` (the Bridge-stamped `{agentId, sessionId}` writer pair, or `null` for a bare /
+ * legacy frame — see {@link Neo.ai.parseAgentEnvelope}), the target component id, and an injected `parentOf`
+ * lookup, it returns a **decision**, never a side effect — so the four security-critical outcomes are
+ * unit-provable in isolation, with no live heap, socket, or `WriteGuard`.
+ *
+ * Outcomes — fail-closed by construction; **only a fully-valid agent request produces a lock**:
+ * - **`context` absent** (`null` / `undefined` / non-object): `{enforced: false}` — a legacy / non-agent
+ *   request writes unguarded. The multi-writer regime only governs identified agent writes, and an absent
+ *   context is not an agent-controllable bypass: the Bridge stamps the `agent_message` envelope on every
+ *   authenticated-agent frame, so a frame that reaches the Client *without* a context is one the Bridge did
+ *   not attribute to an agent (genuinely non-agent / legacy).
+ * - **`context` present, identity incomplete** (`agentId` or `sessionId` missing / non-string / empty):
+ *   `{enforced: true, lock: null, reason: 'incomplete-identity'}` — the caller denies without mutating. A
+ *   half-stamped writer pair must never acquire a lock (`LockRegistry` keys on the full pair), so it fails
+ *   closed. A present-but-malformed object context (missing both fields, wrong shape) lands here too —
+ *   denied, not silently treated as legacy.
+ * - **`context` present, target unresolvable** (`deriveSubtreePath` → `null`: malformed / cyclic id):
+ *   `{enforced: true, lock: null, reason: 'unresolvable-target'}` — deny without mutating; never lock on a
+ *   path that is not a sound absolute root→node path (a relative / corrupt path would mis-compute overlap).
+ * - **`context` present, identity + target valid**: `{enforced: true, lock: {agentId, sessionId,
+ *   subtreePath}}` — the exact descriptor `WriteGuard.requestWrite` consumes.
+ *
+ * Pure: `parentOf` is injected exactly as {@link Neo.ai.deriveSubtreePath} takes it, so the derivation and
+ * every decision branch are testable against a mock tree. It decides *what lock* (or *deny* / *skip*);
+ * holding the lock + conflict detection stay in `WriteGuard` / `LockRegistry`, and acting on the decision
+ * (mutate vs deny) stays in the write service that calls this.
+ *
+ * @param {Object|null} context   The request context: `{agentId, sessionId}` for an agent request, or
+ *                                `null` / `undefined` for a bare / legacy frame.
+ * @param {String} componentId    The target component id (the write's subtree node).
+ * @param {Function} parentOf     `(id: String) => String|null|undefined` — the parent id of `id`, injected
+ *                                (the wiring supplies `id => Neo.getComponent(id)?.parentId`).
+ * @returns {{enforced: Boolean, lock: (Object|null), reason: (String|undefined)}}
+ *   `enforced:false` ⇒ write unguarded (legacy). `enforced:true` with `lock` ⇒ pass `lock` to
+ *   `WriteGuard.requestWrite`. `enforced:true` with `lock:null` ⇒ deny without mutating; `reason` names why
+ *   (`'incomplete-identity'` | `'unresolvable-target'`).
+ */
+export function resolveWriteLock(context, componentId, parentOf) {
+    // Bare / legacy frame (no Bridge-attributed agent) — the multi-writer regime does not apply: write unguarded.
+    if (context === null || typeof context !== 'object') {
+        return {enforced: false, lock: null}
+    }
+
+    const
+        {agentId, sessionId} = context,
+        validAgentId   = typeof agentId   === 'string' && agentId.length   > 0,
+        validSessionId = typeof sessionId === 'string' && sessionId.length > 0;
+
+    // An identified write is enforced; a malformed / half-stamped writer pair fails closed (never locks).
+    if (!validAgentId || !validSessionId) {
+        return {enforced: true, lock: null, reason: 'incomplete-identity'}
+    }
+
+    const subtreePath = deriveSubtreePath(componentId, parentOf);
+
+    // A target that does not resolve to a sound absolute path fails closed rather than locking a corrupt path.
+    if (subtreePath === null) {
+        return {enforced: true, lock: null, reason: 'unresolvable-target'}
+    }
+
+    return {enforced: true, lock: {agentId, sessionId, subtreePath}}
+}

--- a/test/playwright/unit/ai/resolveWriteLock.spec.mjs
+++ b/test/playwright/unit/ai/resolveWriteLock.spec.mjs
@@ -1,0 +1,74 @@
+import {test, expect}      from '@playwright/test';
+import {resolveWriteLock} from '../../../../src/ai/resolveWriteLock.mjs';
+
+// Pure decision core — imported directly (no live heap, no WriteGuard, no socket), so the four enforcement
+// outcomes are provable in isolation. Mirrors deriveSubtreePath.spec / parseAgentEnvelope.spec.
+//
+// A linear component tree  root → mid → leaf  (parentOf returns the parent id, falsy at the root).
+const
+    PARENTS  = {leaf: 'mid', mid: 'root', root: null},
+    parentOf = id => PARENTS[id],
+    CTX      = {agentId: 'neo-opus-ada', sessionId: 'sess-abc'};
+
+test.describe('resolveWriteLock (NL write-enforcement decision core)', () => {
+    test('absent context (null / undefined / non-object) → not enforced, write unguarded (legacy)', () => {
+        for (const absent of [null, undefined, 'x', 42, true]) {
+            expect(resolveWriteLock(absent, 'leaf', parentOf)).toEqual({enforced: false, lock: null})
+        }
+    });
+
+    test('valid identity + resolvable target → enforced with the exact WriteGuard lock descriptor', () => {
+        const r = resolveWriteLock(CTX, 'leaf', parentOf);
+        expect(r).toEqual({
+            enforced: true,
+            lock    : {agentId: 'neo-opus-ada', sessionId: 'sess-abc', subtreePath: ['root', 'mid', 'leaf']}
+        });
+        // the path IS the deriveSubtreePath output (absolute root→node), and the lock carries no extra keys
+        expect(Object.keys(r.lock).sort()).toEqual(['agentId', 'sessionId', 'subtreePath'])
+    });
+
+    test('a root-level target resolves to its single-element path', () => {
+        const r = resolveWriteLock(CTX, 'root', parentOf);
+        expect(r.enforced).toBe(true);
+        expect(r.lock.subtreePath).toEqual(['root'])
+    });
+
+    test('incomplete identity — a missing / empty / non-string agentId fails closed (deny, no lock)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = resolveWriteLock({agentId: bad, sessionId: 'sess-abc'}, 'leaf', parentOf);
+            expect(r).toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+        }
+    });
+
+    test('incomplete identity — a missing / empty / non-string sessionId fails closed (deny, no lock)', () => {
+        for (const bad of [undefined, '', null, 42, {}]) {
+            const r = resolveWriteLock({agentId: 'neo-opus-ada', sessionId: bad}, 'leaf', parentOf);
+            expect(r).toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+        }
+    });
+
+    test('a present-but-malformed object context (missing both fields / array) denies — NOT treated as legacy', () => {
+        for (const malformed of [{}, {foo: 'bar'}, []]) {
+            const r = resolveWriteLock(malformed, 'leaf', parentOf);
+            expect(r).toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+        }
+    });
+
+    test('valid identity + unresolvable target (malformed / cyclic id) fails closed (deny, no lock)', () => {
+        // empty-string + the document.body sentinel + a cyclic chain all make deriveSubtreePath return null
+        for (const badId of ['', 'document.body']) {
+            expect(resolveWriteLock(CTX, badId, parentOf))
+                .toEqual({enforced: true, lock: null, reason: 'unresolvable-target'})
+        }
+        const cyclic = {a: 'b', b: 'a'};
+        expect(resolveWriteLock(CTX, 'a', id => cyclic[id]))
+            .toEqual({enforced: true, lock: null, reason: 'unresolvable-target'})
+    });
+
+    test('an unidentified write never touches the component tree (deny short-circuits before deriveSubtreePath)', () => {
+        // parentOf throws — if the tree were consulted for an incomplete-identity request, this would throw.
+        const exploding = () => { throw new Error('tree must not be walked for an unidentified write') };
+        expect(resolveWriteLock({agentId: '', sessionId: 'sess-abc'}, 'leaf', exploding))
+            .toEqual({enforced: true, lock: null, reason: 'incomplete-identity'})
+    });
+});


### PR DESCRIPTION
Resolves #13207

## Summary

Extended-NL **Leaf C (part 2a)** — the pure write-enforcement **decision core**, advancing #13167's Contract Ledger rows 4–6 (write-service enforcement / subtree-path source / no-agent fail-closed).

The in-heap primitives are merged on `dev` (`LockRegistry` #13125, `WriteGuard` #13134, `deriveSubtreePath` #13138) but nothing decides **whether** a given write is enforced and **with what lock — or denied fail-closed**. New `src/ai/resolveWriteLock.mjs` — `resolveWriteLock(context, componentId, parentOf)` — is that decision, returned as a value (never a side effect), so the four security-critical outcomes are unit-provable with no live heap, socket, or `WriteGuard`:

| Input | Decision |
|---|---|
| `context` absent (`null` / `undefined` / non-object) | `{enforced: false, lock: null}` — legacy / non-agent, write unguarded |
| `context` present, `agentId` **or** `sessionId` missing / non-string / empty (incl. a malformed object context) | `{enforced: true, lock: null, reason: 'incomplete-identity'}` — deny, no mutate |
| valid identity, `deriveSubtreePath` → `null` (malformed / cyclic target) | `{enforced: true, lock: null, reason: 'unresolvable-target'}` — deny, no mutate |
| valid identity + target | `{enforced: true, lock: {agentId, sessionId, subtreePath}}` — the exact `WriteGuard.requestWrite` descriptor |

**Fail-closed by construction:** only a fully-valid agent request produces a lock. The one fail-open path — absent context → legacy — is not an agent-controllable bypass: the Bridge stamps the `agent_message` envelope on every authenticated-agent frame (#13181/#13196), so a frame reaching the Client *without* a context is one the Bridge did not attribute to an agent. A present-but-malformed object context denies (fail-closed), it is not silently treated as legacy.

Pure (`parentOf` injected exactly as `deriveSubtreePath` takes it; composes it). This is the same pure-core-ahead-of-wiring decomposition @neo-gpt endorsed on #13205 (`parseAgentEnvelope`). It deliberately does **not** mutate or wire anything yet, so it is dev-safe and merges independently of #13205.

Evidence: L1 (the focused unit spec) — 8/8 green via the custom unit config; `node --check` clean.

## Deltas from ticket (if any)

None — exactly the ticket's scope (the pure decision function + exhaustive spec + Anchor & Echo JSDoc). The `InstanceService` wiring that consumes the decision and calls `WriteGuard` is explicitly the next slice (it reads `context.sessionId` at runtime → gated on #13205 merging; landing it before would deny every agent write on current `dev`).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/resolveWriteLock.spec.mjs`

```
Running 8 tests using 8 workers
  8 passed (586ms)
```

Cases: absent context (`null`/`undefined`/string/number/boolean) → `enforced:false`; valid identity + resolvable target → the exact `{agentId, sessionId, subtreePath}` lock (asserted key-set, no extra fields); a root-level target → single-element path; the incomplete-identity matrix (`undefined`/`''`/`null`/`42`/`{}` for **each** of `agentId`/`sessionId`) → deny; a malformed object context (`{}` / wrong-shape / `[]`) → deny (not legacy); unresolvable target (`''`, `'document.body'`, cyclic chain) → deny; and a short-circuit guard proving an unidentified write **never walks the tree** (a throwing `parentOf` is never called).

## Post-Merge Validation

The next slice (the `InstanceService.setInstanceProperties` / `callMethod` wiring) consumes this: `const d = resolveWriteLock(context, id, parentOf); if (d.enforced) { if (!d.lock) deny; else if (!WriteGuard.requestWrite(d.lock).granted) deny; } mutate;`. When that wiring lands (post-#13205) and a live two-agent whitebox-e2e shows a cross-agent write denied while the holder keeps its lock, the decision core is validated end-to-end.

---

Refs #13167 (Leaf B/C contract-of-record), #13056 (Extended-NL epic).

Authored by @neo-opus-ada (Ada, Claude Opus 4.8 [1M context]) — origin session 4c598c8f-d8a7-4288-9420-e825a45d310e.
