### PR TITLE
feat(dashboard): render dock splitter resize affordances (#13206)

### DIFF
--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -44,6 +44,14 @@ class DockLayoutAdapter extends Base {
     ])
 
     /**
+     * Default visual extent for projected splitter affordances.
+     * @member {Number} splitterSize=6
+     * @protected
+     * @static
+     */
+    static splitterSize = 6
+
+    /**
      * Builds a recoverable placeholder config for a dock item whose live component and blueprint cannot be resolved.
      * @param {String} itemId
      * @param {Object|null} item
@@ -178,6 +186,57 @@ class DockLayoutAdapter extends Base {
         }
 
         return values
+    }
+
+    /**
+     * @summary Creates the semantic operation descriptor emitted after a splitter drag resolves.
+     *
+     * Pointer handlers own pixel math. This helper keeps the adapter/model seam semantic by converting
+     * projected splitter metadata plus resolved child sizes into the existing `resizeSplit` descriptor.
+     * @param {Object} splitter Projected splitter config, or its `data` payload.
+     * @param {Number[]} sizes Positive values mapped to the split node's child order.
+     * @returns {Object}
+     * @static
+     */
+    static createResizeSplitOperation(splitter, sizes) {
+        let metadata = splitter?.data || splitter || {};
+
+        return {
+            operation  : 'resizeSplit',
+            sizes      : Array.isArray(sizes) ? sizes.slice() : sizes,
+            splitNodeId: metadata.splitNodeId || metadata.dockNodeId || splitter?.dockNodeId
+        }
+    }
+
+    /**
+     * @summary Projects the stable resize affordance between two adjacent split children.
+     * @param {String} splitNodeId
+     * @param {String} orientation
+     * @param {Number} boundaryIndex
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static createSplitterAffordance(splitNodeId, orientation, boundaryIndex) {
+        let isVertical = orientation === 'vertical';
+
+        return {
+            cls                   : ['neo-dashboard-dock-splitter', `neo-dashboard-dock-splitter-${orientation}`],
+            data                  : {
+                boundaryIndex,
+                dockNodeId : splitNodeId,
+                dockSplitter: true,
+                operation   : 'resizeSplit',
+                orientation,
+                splitNodeId
+            },
+            dockNodeId            : splitNodeId,
+            dockNodeType          : 'splitter',
+            dockSplitBoundaryIndex: boundaryIndex,
+            dockSplitOrientation  : orientation,
+            [isVertical ? 'height' : 'width']: this.splitterSize,
+            ntype                 : 'component'
+        }
     }
 
     /**
@@ -316,17 +375,26 @@ class DockLayoutAdapter extends Base {
     static projectSplitNode(nodeId, node, context) {
         let children    = Array.isArray(node.children) ? node.children : [],
             flexValues  = this.getFlexValues(node.sizes, children.length),
+            items       = [],
             orientation = node.orientation === 'vertical' ? 'vertical' : 'horizontal',
             layoutNtype = orientation === 'vertical' ? 'vbox' : 'hbox';
+
+        children.forEach((childId, index) => {
+            items.push({
+                ...this.projectNode(childId, context),
+                flex: flexValues[index]
+            });
+
+            if (index < children.length - 1) {
+                items.push(this.createSplitterAffordance(nodeId, orientation, index))
+            }
+        });
 
         return {
             cls         : ['neo-dashboard-dock-split', `neo-dashboard-dock-split-${orientation}`],
             dockNodeId  : nodeId,
             dockNodeType: 'split',
-            items       : children.map((childId, index) => ({
-                ...this.projectNode(childId, context),
-                flex: flexValues[index]
-            })),
+            items,
             layout      : {ntype: layoutNtype, align: 'stretch'},
             ntype       : 'container'
         }

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect}    from '@playwright/test';
 import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
 import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockZoneModel     from '../../../../src/dashboard/DockZoneModel.mjs';
 
 const createModel = () => ({
     schema: 'neo.harness.dockZone.v1',
@@ -124,6 +125,10 @@ const createEdgeZoneModel = () => ({
     }
 });
 
+const getProjectedChildren = splitConfig => splitConfig.items.filter(item => item.dockNodeType !== 'splitter');
+
+const getProjectedSplitters = splitConfig => splitConfig.items.filter(item => item.dockNodeType === 'splitter');
+
 test.describe('Neo.dashboard.DockLayoutAdapter', () => {
     test('projects split nodes to existing hbox and vbox layout primitives', () => {
         let model  = createModel(),
@@ -132,14 +137,87 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
                     ntype    : 'dashboard-panel',
                     reference: componentRef
                 }
-            });
+            }),
+            rootChildren = getProjectedChildren(result),
+            sideSplit    = rootChildren[1],
+            sideChildren = getProjectedChildren(sideSplit);
 
         expect(result.ntype).toBe('container');
         expect(result.layout).toEqual({ntype: 'hbox', align: 'stretch'});
-        expect(result.items.map(item => item.flex)).toEqual([0.7, 0.3]);
+        expect(rootChildren.map(item => item.flex)).toEqual([0.7, 0.3]);
 
-        expect(result.items[1].layout).toEqual({ntype: 'vbox', align: 'stretch'});
-        expect(result.items[1].items.map(item => item.flex)).toEqual([0.55, 0.45]);
+        expect(sideSplit.layout).toEqual({ntype: 'vbox', align: 'stretch'});
+        expect(sideChildren.map(item => item.flex)).toEqual([0.55, 0.45]);
+    });
+
+    test('projects resize splitter affordances between adjacent split children', () => {
+        let result = DockLayoutAdapter.project(createModel(), {
+                resolveComponentRef: componentRef => ({
+                    ntype    : 'dashboard-panel',
+                    reference: componentRef
+                })
+            }),
+            rootSplitter = getProjectedSplitters(result)[0],
+            sideSplit    = getProjectedChildren(result)[1],
+            sideSplitter = getProjectedSplitters(sideSplit)[0];
+
+        expect(result.items.map(item => item.dockNodeType)).toEqual(['tabs', 'splitter', 'split']);
+        expect(rootSplitter).toMatchObject({
+            dockNodeId            : 'root',
+            dockNodeType          : 'splitter',
+            dockSplitBoundaryIndex: 0,
+            dockSplitOrientation  : 'horizontal',
+            ntype                 : 'component',
+            width                 : DockLayoutAdapter.splitterSize
+        });
+        expect(rootSplitter.height).toBeUndefined();
+        expect(rootSplitter.data).toMatchObject({
+            boundaryIndex: 0,
+            dockSplitter: true,
+            operation   : 'resizeSplit',
+            orientation : 'horizontal',
+            splitNodeId : 'root'
+        });
+
+        expect(sideSplit.items.map(item => item.dockNodeType)).toEqual(['tabs', 'splitter', 'tabs']);
+        expect(sideSplitter).toMatchObject({
+            dockNodeId            : 'side-split',
+            dockNodeType          : 'splitter',
+            dockSplitBoundaryIndex: 0,
+            dockSplitOrientation  : 'vertical',
+            height                : DockLayoutAdapter.splitterSize,
+            ntype                 : 'component'
+        });
+        expect(sideSplitter.width).toBeUndefined();
+    });
+
+    test('creates resizeSplit operation descriptors from splitter affordance metadata', () => {
+        let model    = createModel(),
+            result   = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => ({
+                    ntype    : 'dashboard-panel',
+                    reference: componentRef
+                })
+            }),
+            sizes    = [3, 1],
+            splitter = getProjectedSplitters(result)[0],
+            descriptor,
+            resized;
+
+        descriptor = DockLayoutAdapter.createResizeSplitOperation(splitter, sizes);
+        sizes[0]   = 1;
+
+        expect(descriptor).toEqual({
+            operation  : 'resizeSplit',
+            sizes      : [3, 1],
+            splitNodeId: 'root'
+        });
+
+        resized = DockZoneModel.applyOperation(model, descriptor);
+
+        expect(resized.errors).toEqual([]);
+        expect(resized.document.nodes.root.sizes).toEqual([0.75, 0.25]);
+        expect(model.nodes.root.sizes).toEqual([0.7, 0.3]);
     });
 
     test('projects tab nodes to tab.Container-compatible configs', () => {
@@ -165,7 +243,8 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             }),
             row    = result.items[0],
             center = row.items[0],
-            right  = row.items[1];
+            right  = row.items[1],
+            rightChildren = getProjectedChildren(right);
 
         expect(result.dockNodeType).toBe('edge-zone');
         expect(result.layout).toEqual({ntype: 'vbox', align: 'stretch'});
@@ -177,8 +256,8 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(center.items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
 
         expect(right.layout).toEqual({ntype: 'vbox', align: 'stretch'});
-        expect(right.items.map(item => item.flex)).toEqual([0.55, 0.45]);
-        expect(right.items.map(item => item.items[0].data.dockItemId)).toEqual(['terminal', 'inspector']);
+        expect(rightChildren.map(item => item.flex)).toEqual([0.55, 0.45]);
+        expect(rightChildren.map(item => item.items[0].data.dockItemId)).toEqual(['terminal', 'inspector']);
     });
 
     test('falls back to recoverable placeholders without mutating the source model', () => {
@@ -190,7 +269,7 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
                     reference: componentRef
                 }
             }),
-            placeholder = result.items[1].items[1].items[0];
+            placeholder = getProjectedChildren(getProjectedChildren(result)[1])[1].items[0];
 
         expect(placeholder.ntype).toBe('dashboard-panel');
         expect(placeholder.data).toEqual({
@@ -214,7 +293,7 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             })
         });
 
-        expect(result.items.map(item => item.flex)).toEqual([1, 1]);
+        expect(getProjectedChildren(result).map(item => item.flex)).toEqual([1, 1]);
         expect(model.nodes.root.sizes.length).toBe(2);
     });
 


### PR DESCRIPTION
Resolves #13206

Authored by GPT-5 (Codex Desktop). Session 019ec50d-5a01-7b11-9490-50f3241e8cfc.

## Follow-ups

- #13213 - Harness-view pointer/drag wiring for dock splitter affordances; linked as parent_child to #13158.

Close-target note: #13206 was re-scoped after cross-family review to the delivered splitter affordance, semantic descriptor helper, and descriptor-to-model commit proof. #13213 owns the live Harness-view pointer/drag interaction.

Renders stable dashboard dock splitter affordances between projected split children and adds a pure adapter helper that turns resolved splitter resize sizes into the existing `resizeSplit` operation descriptor. The model remains the persistence authority: projected splitter metadata identifies the owning split, boundary, and orientation, while committed size changes still flow through `DockZoneModel.applyOperation()`.

Evidence: L2 (focused unit projection + descriptor-to-model commit path) -> L2 required (unit-first adapter/affordance metadata plus narrow interaction path). No residuals.

Related: #13158, #13012.

## Deltas from ticket

- The source already had `DockZoneModel.resizeSplit()` and `applyOperation({operation: 'resizeSplit', ...})`, so this PR does not add another model operation.
- The implementation keeps pointer math out of the adapter. Event handlers can compute positive `sizes`, but only the semantic descriptor crosses into the model.

## Test Evidence

- `node --check src/dashboard/DockLayoutAdapter.mjs`
- `node --check test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs`
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` -> 9 passed
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/dashboard/DockZoneModel.spec.mjs` -> 53 passed
- `git diff --check`
- `npm run test-unit` -> not a clean gate in this workspace: 3754 passed, 35 unrelated failures, 1 interrupted after the process stopped producing useful output, 39 did not run

## Post-Merge Validation

- [ ] When the Harness view wires pointer handling, drag a projected splitter and confirm the handler feeds computed ratios into `DockLayoutAdapter.createResizeSplitOperation()` rather than mutating persisted `node.sizes` directly.

## Commits

- `b2f7190dc` - `feat(dashboard): render dock splitter resize affordances (#13206)`
