### PR TITLE
docs(adr): define 'semantic anchor' for our use in ADR 0011 §2.1 (#11591)

### DIFF
--- a/learn/agentos/decisions/0011-substrate-numbering-convention.md
+++ b/learn/agentos/decisions/0011-substrate-numbering-convention.md
@@ -52,6 +52,8 @@ AGENTS.md §mailbox_check_protocol
 
 Use the semantic underscore-separated form when it reduces drift across heading movement or compaction. Preserve positional `§N` where it is historical, already source-readable, or cheaper than introducing a new semantic token. Do not add manual HTML anchor tags or markdown links merely to make the reference clickable in rendered Markdown.
 
+The semantic underscore-separated form is a **semantic anchor**: its reference identity is the named *concept*, not the source position, so it survives heading movement and compaction where a positional `§N` (anchored to position) drifts. The term names the concept, never the rejected `<a id>` markup — it is load-bearing across the substrate (e.g. `AGENTS.md`'s *"semantic anchor per … core value"*) and was inadvertently dropped by PR #11589 when it correctly removed the manual-HTML-anchor implementation.
+
 ### 2.2 Reference stability and rendered aliases
 
 Once a semantic `§<ref>` token is introduced, the token is treated as the live reference identity until explicitly retired or updated in the same PR as the referenced heading/content change.

--- a/learn/agentos/decisions/0011-substrate-numbering-convention.md
+++ b/learn/agentos/decisions/0011-substrate-numbering-convention.md
@@ -52,7 +52,7 @@ AGENTS.md §mailbox_check_protocol
 
 Use the semantic underscore-separated form when it reduces drift across heading movement or compaction. Preserve positional `§N` where it is historical, already source-readable, or cheaper than introducing a new semantic token. Do not add manual HTML anchor tags or markdown links merely to make the reference clickable in rendered Markdown.
 
-The semantic underscore-separated form is a **semantic anchor**: its reference identity is the named *concept*, not the source position, so it survives heading movement and compaction where a positional `§N` (anchored to position) drifts. The term names the concept, never the rejected `<a id>` markup — it is load-bearing across the substrate (e.g. `AGENTS.md`'s *"semantic anchor per … core value"*) and was inadvertently dropped by PR #11589 when it correctly removed the manual-HTML-anchor implementation.
+In this substrate we call the semantic underscore-separated form a **semantic anchor** (the phrase has other meanings elsewhere; this records ours): its reference identity is the named *concept*, not the source position, so it survives heading movement and compaction where a positional `§N` (anchored to position) drifts. The term names the concept, never the rejected `<a id>` markup — it is load-bearing across the substrate (e.g. `AGENTS.md`'s *"semantic anchor per … core value"*) and was inadvertently dropped by PR #11589 when it correctly removed the manual-HTML-anchor implementation.
 
 ### 2.2 Reference stability and rendered aliases
 


### PR DESCRIPTION
Resolves #11591

Defines what **"semantic anchor"** means in our substrate — a one-line local definition in ADR 0011 §2.1. Per @tobiu (2026-06-14): the phrase has many existing external meanings, so this records *our* usage rather than implying a novel coinage; he green-lit the one-liner (*"for this you really don't need my approval"*).

## Summary

ADR 0011 §2.1 already distinguishes semantic vs positional `§<ref>` tokens but never named the concept. This adds one clause: *in this substrate* the semantic underscore-separated form is a **semantic anchor** — its identity is the named concept, not the source position, so it survives heading movement / compaction where a positional `§N` drifts. The term is load-bearing elsewhere (`AGENTS.md` §swarm_topology_anchor: *"semantic anchor per … core value"*) and was inadvertently dropped by PR #11589 when it correctly removed the rejected manual-HTML-`<a id>` implementation.

Evidence: docs-only ADR amendment; `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → `OK` (no byte-budget regression); `git diff --check` clean; no `*.mjs` touched.

## Deltas from ticket (if any)

**Scope reduced + reframed, by V-B-A + operator feedback.** #11591 scoped a +20–30 line restoration across §2.1/§2.2/§2.3/§5/§7, but current `dev` already carries the distinguishing language (§2.1–§2.3 distinguish semantic vs positional; §2.5 states *"the heading IS the anchor"*) — only the explicit *named term* was missing. Re-adding 20–30 lines would be redundant bloat (Accretion Defense). And per @tobiu the framing is **"define for our use"**, not "coin" — so this delivers the genuine residual: one clause that names + locally-defines the concept (the clause now reads *"In this substrate we call … a semantic anchor (the phrase has other meanings elsewhere; this records ours)"*).

**Substrate Accretion Defense:** net-additive (~2 lines) but decay-mitigating — restores an operator-flagged term still live across the substrate.

## Test Evidence

Docs-only `.md` ADR change — no unit tests apply. `lint-skill-manifest` OK; `git diff --check` clean; no `*.mjs` touched.

## Post-Merge Validation

A reviewer/author citing a `§<ref>` can name *why* the kebab form is preferred for durable references ("it's a semantic anchor — concept-anchored, compaction-stable") directly from ADR 0011 §2.1.

---

Refs #11589 (the over-removal this corrects), #11558 (the substrate-numbering epic). Green-lit by @tobiu 2026-06-14; un-drafted.

Authored by @neo-opus-ada (Ada, Claude Opus 4.8 [1M context]) — origin session 4c598c8f-d8a7-4288-9420-e825a45d310e.
