### PR TITLE
fix(ai): skip dirty worktrees during prune (#13214)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -72,12 +72,14 @@
  *                                                    # independent-clone topology: explicit
  *                                                    # canonical-root override
  * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale
- *                                                    # remove every non-current .claude/worktrees
- *                                                    # checkout via git, then hydrate current
+ *                                                    # remove clean non-current .claude/worktrees
+ *                                                    # checkouts via git, then hydrate current
  * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run
  *                                                    # report the same keep/remove plan
  *                                                    # without mutating disk
- * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --interval-ms 21600000
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --include-dirty
+ *                                                    # also remove dirty non-current checkouts
+ * node ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --include-dirty --interval-ms 21600000
  *                                                    # local operator scheduler (6h example);
  *                                                    # force-removes all non-current worktrees
  *                                                    # on every tick; intentionally not an
@@ -660,14 +662,16 @@ export async function listClaudeWorktrees({
  * @summary Classifies one Claude Code worktree for keep-current/delete-rest pruning.
  *
  * Worktrees are disposable checkouts; committed work lives in branches/remotes. The only
- * local filesystem state protected by this cleaner is the current active checkout. Every
- * other Claude worktree is removable via `git worktree remove --force`, which keeps git's
- * worktree admin records coherent while deleting any dirty or unmerged non-current checkout.
+ * local filesystem state protected by default is the current active checkout plus dirty
+ * sibling worktrees. Clean non-current Claude worktrees remain removable via
+ * `git worktree remove --force`; dirty or indeterminate sibling state is skipped unless
+ * the operator passes the explicit `includeDirty` override.
  *
  * @param {object}   options
  * @param {object}   options.worktree Parsed worktree record.
  * @param {string}   options.currentPath Absolute current checkout path that must be preserved.
  * @param {string}   options.mainCheckout Absolute primary checkout path that must be preserved.
+ * @param {boolean}  [options.includeDirty=false] True removes dirty non-current worktrees.
  * @param {Function} [options.getSize] Optional size resolver.
  * @returns {Promise<object>}
  */
@@ -675,25 +679,48 @@ export async function classifyWorktree({
     worktree,
     currentPath,
     mainCheckout,
-    exec    = execFileAsync,
-    getSize = getPathSizeBytes
+    includeDirty = false,
+    exec         = execFileAsync,
+    getSize      = getPathSizeBytes
 }) {
     const sizeBytes             = await getSize(worktree.path, {exec});
     const current               = isSamePath(worktree.path, currentPath);
     const primaryMainCheckout   = isSamePath(worktree.path, mainCheckout);
     const protectedCheckoutPath = current || primaryMainCheckout;
+    const classification = {
+        remove: !protectedCheckoutPath,
+        status: current ? 'current' : (primaryMainCheckout ? 'main-checkout' : 'remove'),
+        reason: current
+            ? 'current active worktree'
+            : (primaryMainCheckout ? 'primary checkout' : 'clean non-current Claude worktree')
+    };
+
+    if (classification.remove && !includeDirty) {
+        const dirtyState = await getWorktreeDirtyState({worktreePath: worktree.path, exec});
+
+        if (dirtyState.error) {
+            classification.remove = false;
+            classification.status = 'skipped-status-error';
+            classification.reason = `dirty status could not be determined: ${dirtyState.error.message}`;
+        } else if (dirtyState.dirty) {
+            classification.remove = false;
+            classification.status = 'skipped-dirty';
+            classification.reason = 'dirty non-current Claude worktree';
+        }
+
+        classification.dirtyStatus = dirtyState;
+    }
 
     return {
         ...worktree,
         sizeBytes,
         current,
         mainCheckout: primaryMainCheckout,
-        remove      : !protectedCheckoutPath,
+        remove      : classification.remove,
         removeArgs: ['worktree', 'remove', '--force', worktree.path],
-        status    : current ? 'current' : (primaryMainCheckout ? 'main-checkout' : 'remove'),
-        reason    : current
-            ? 'current active worktree'
-            : (primaryMainCheckout ? 'primary checkout' : 'non-current Claude worktree')
+        status    : classification.status,
+        reason    : classification.reason,
+        dirtyStatus: classification.dirtyStatus || null
     };
 }
 
@@ -708,6 +735,7 @@ export async function classifyWorktree({
  * @param {string}   options.projectRoot Primary checkout path.
  * @param {string}   [options.currentPath=projectRoot] Active checkout path that must not be removed.
  * @param {boolean}  [options.dryRun=false] Whether to only report the keep/remove plan.
+ * @param {boolean}  [options.includeDirty=false] True removes dirty non-current worktrees.
  * @param {string}   [options.worktreesRoot] Worktree parent path.
  * @param {Function} [options.exec] Dependency-injected execFile wrapper.
  * @param {Function} [options.getSize] Optional size resolver.
@@ -719,6 +747,7 @@ export async function pruneStaleWorktrees({
     projectRoot,
     currentPath   = projectRoot,
     dryRun        = false,
+    includeDirty  = false,
     worktreesRoot = DEFAULT_CLAUDE_WORKTREES_ROOT,
     exec          = execFileAsync,
     getSize       = getPathSizeBytes,
@@ -729,7 +758,7 @@ export async function pruneStaleWorktrees({
     const classified = [];
 
     for (const worktree of worktrees) {
-        classified.push(await classifyWorktree({worktree, currentPath, mainCheckout: projectRoot, exec, getSize}));
+        classified.push(await classifyWorktree({worktree, currentPath, mainCheckout: projectRoot, includeDirty, exec, getSize}));
     }
 
     const removable = classified.filter(item => item.remove);
@@ -743,7 +772,9 @@ export async function pruneStaleWorktrees({
     log(`Found ${classified.length} worktree(s), ${formatBytes(totalBytes)} total, ${formatBytes(reclaimableBytes)} reclaimable.`);
 
     for (const item of classified) {
-        const marker = item.remove ? (dryRun ? 'would-remove' : 'remove') : 'keep';
+        const marker = item.remove
+            ? (dryRun ? 'would-remove' : 'remove')
+            : (item.status.startsWith('skipped') ? 'skip' : 'keep');
         log(`${marker}: ${item.status} ${formatBytes(item.sizeBytes)} ${item.path}`);
         log(`  ${item.reason}`);
     }
@@ -795,9 +826,9 @@ export async function hydrateCurrentWorktree({mainCheckout, projectRoot, log = c
  *
  * This is intentionally a CLI/local scheduler, not an Orchestrator task. The Orchestrator
  * has cloud-deployable lanes; worktree deletion is a desktop-harness hygiene action.
- * Warning: each tick force-removes all non-current worktrees, including concurrently-active
- * sibling sessions. Use only on operator-managed hosts where that disposable-worktree policy
- * is acceptable.
+ * Warning: with `includeDirty`, each tick force-removes all non-current worktrees, including
+ * concurrently-active sibling sessions. Use only on operator-managed hosts where that
+ * disposable-worktree policy is acceptable.
  *
  * @param {object}   options
  * @param {number}   options.intervalMs Interval between runs.
@@ -808,7 +839,11 @@ export async function runLocalPruneWorktreeSchedule({intervalMs, log = console.l
         throw new Error(`--interval-ms must be a positive number`);
     }
 
-    log(`WARNING: --schedule-local force-removes all non-current worktrees on every tick, including concurrently-active sibling sessions.`);
+    const dirtyPolicy = pruneOptions.includeDirty
+        ? 'including dirty sibling state'
+        : 'skipping dirty or indeterminate sibling state';
+
+    log(`WARNING: --schedule-local repeatedly prunes non-current worktrees on every tick, ${dirtyPolicy}.`);
 
     let running = false;
     const runOnce = async () => {
@@ -845,6 +880,35 @@ async function getPathSizeBytes(targetPath, {exec = execFileAsync} = {}) {
         return Number.isFinite(kb) ? kb * 1024 : 0;
     } catch {
         return 0;
+    }
+}
+
+/**
+ * @summary Detects uncommitted worktree state for destructive prune decisions.
+ *
+ * Fails closed: if `git status --porcelain` cannot be read, the caller receives a dirty
+ * result with the captured error so the worktree can be skipped instead of force-removed.
+ *
+ * @param {object}   options
+ * @param {string}   options.worktreePath Absolute path to the candidate worktree.
+ * @param {Function} [options.exec] Dependency-injected execFile wrapper.
+ * @returns {Promise<{dirty: boolean, stdout: string, error: Error|null}>}
+ */
+async function getWorktreeDirtyState({worktreePath, exec = execFileAsync}) {
+    try {
+        const {stdout} = await exec('git', ['-C', worktreePath, 'status', '--porcelain']);
+
+        return {
+            dirty: stdout.trim().length > 0,
+            stdout,
+            error: null
+        };
+    } catch (error) {
+        return {
+            dirty: true,
+            stdout: '',
+            error
+        };
     }
 }
 
@@ -900,6 +964,7 @@ if (isMain) {
     const pruneStale = args.has('--prune-stale') || argv.includes('--mode=prune-stale') ||
         (argv.includes('--mode') && argv[argv.indexOf('--mode') + 1] === 'prune-stale');
     const dryRun        = args.has('--dry-run');
+    const includeDirty  = args.has('--include-dirty');
     const scheduleLocal = args.has('--schedule-local');
     const intervalMs    = getNumberFlag(argv, '--interval-ms', 6 * 60 * 60 * 1000);
 
@@ -927,11 +992,12 @@ if (isMain) {
                     projectRoot: mainCheckout,
                     currentPath: projectRoot,
                     dryRun,
+                    includeDirty,
                     intervalMs
                 });
                 await new Promise(() => {});
             } else {
-                await pruneStaleWorktrees({projectRoot: mainCheckout, currentPath: projectRoot, dryRun});
+                await pruneStaleWorktrees({projectRoot: mainCheckout, currentPath: projectRoot, dryRun, includeDirty});
                 process.exit(0);
             }
         }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "ai:probe-keep-alive"          : "node ./ai/scripts/benchmark/keep-alive-probe.mjs",
         "ai:prune-worktrees"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:prune-worktrees:dry-run"   : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run",
-        "ai:prune-worktrees:schedule-dangerous": "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --interval-ms 21600000",
+        "ai:prune-worktrees:schedule-dangerous": "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --schedule-local --include-dirty --interval-ms 21600000",
         "ai:purge-test-collections"    : "node ./ai/scripts/maintenance/purgeTestCollections.mjs",
         "ai:lint-agents"               : "node ./ai/scripts/lint/lint-agents.mjs",
         "ai:lint-config-template-ssot" : "node ./ai/scripts/lint/lint-config-template-ssot.mjs",

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -808,13 +808,17 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     test.describe('#12677 pruneStaleWorktrees', () => {
-        function makePruneExec({removed}) {
+        function makePruneExec({removed, dirtyStatus = ' M ai/config.mjs\n', statusByPath} = {}) {
             const worktreesRoot = path.join(fakeMainCheckout, '.claude', 'worktrees');
             const paths = {
                 current : path.join(worktreesRoot, 'current'),
                 stale   : path.join(worktreesRoot, 'stale'),
                 unmerged: path.join(worktreesRoot, 'unmerged'),
                 dirty   : path.join(worktreesRoot, 'dirty')
+            };
+            const statuses = {
+                [paths.dirty]: dirtyStatus,
+                ...statusByPath
             };
 
             const porcelain = [
@@ -848,6 +852,16 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 if (cmd === 'git' && args[0] === 'worktree' && args[1] === 'remove') {
                     removed.push(args);
                     return {stdout: '', stderr: ''};
+                }
+
+                if (cmd === 'git' && args[0] === '-C' && args[2] === 'status' && args[3] === '--porcelain') {
+                    const status = statuses[args[1]] || '';
+
+                    if (status instanceof Error) {
+                        throw status;
+                    }
+
+                    return {stdout: status, stderr: ''};
                 }
 
                 throw new Error(`Unexpected command: ${cmd} ${args.join(' ')}`);
@@ -886,7 +900,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             ]);
         });
 
-        test('dry-runs the keep-current/delete-rest plan only when requested', async () => {
+        test('dry-runs the keep-current/delete-clean-rest plan only when requested', async () => {
             const removed = [];
             const {exec, paths} = makePruneExec({removed});
 
@@ -911,15 +925,16 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(byPath[paths.stale].status).toBe('remove');
             expect(byPath[paths.stale].remove).toBe(true);
             expect(byPath[paths.unmerged].remove).toBe(true);
-            expect(byPath[paths.dirty].remove).toBe(true);
+            expect(byPath[paths.dirty].status).toBe('skipped-dirty');
+            expect(byPath[paths.dirty].remove).toBe(false);
 
-            expect(result.reclaimableBytes).toBe(9216);
+            expect(result.reclaimableBytes).toBe(5120);
             expect(result.reclaimedBytes).toBe(0);
             expect(result.hydrated).toBe(null);
             expect(removed).toHaveLength(0);
         });
 
-        test('deletes all non-current worktrees by default and hydrates the current checkout', async () => {
+        test('deletes clean non-current worktrees by default and hydrates the current checkout', async () => {
             const removed = [];
             const hydrated = [];
             const {exec, paths} = makePruneExec({removed});
@@ -944,18 +959,80 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
 
             expect(byPath[paths.current].remove).toBe(false);
-            expect(result.skipped.map(item => item.path)).toEqual([paths.current]);
+            expect(byPath[paths.dirty].status).toBe('skipped-dirty');
+            expect(result.skipped.map(item => item.path)).toEqual([paths.current, paths.dirty]);
+            expect(removed).toEqual([
+                ['worktree', 'remove', '--force', paths.stale],
+                ['worktree', 'remove', '--force', paths.unmerged]
+            ]);
+            expect(result.removed.map(item => item.path)).toEqual([paths.stale, paths.unmerged]);
+            expect(result.reclaimedBytes).toBe(5120);
+            expect(result.hydrated).toEqual({ok: true});
+            expect(hydrated).toHaveLength(1);
+            expect(hydrated[0].mainCheckout).toBe(fakeMainCheckout);
+            expect(hydrated[0].projectRoot).toBe(paths.current);
+        });
+
+        test('includeDirty removes dirty non-current worktrees explicitly', async () => {
+            const removed = [];
+            const hydrated = [];
+            const {exec, paths} = makePruneExec({removed});
+
+            const result = await pruneStaleWorktrees({
+                projectRoot : fakeMainCheckout,
+                currentPath : paths.current,
+                includeDirty: true,
+                exec,
+                getSize: async p => ({
+                    [paths.current] : 1024,
+                    [paths.stale]   : 2048,
+                    [paths.unmerged]: 3072,
+                    [paths.dirty]   : 4096
+                })[p] || 0,
+                hydrate: async args => {
+                    hydrated.push(args);
+                    return {ok: true};
+                },
+                log: () => {}
+            });
+
             expect(removed).toEqual([
                 ['worktree', 'remove', '--force', paths.stale],
                 ['worktree', 'remove', '--force', paths.unmerged],
                 ['worktree', 'remove', '--force', paths.dirty]
             ]);
             expect(result.removed.map(item => item.path)).toEqual([paths.stale, paths.unmerged, paths.dirty]);
+            expect(result.skipped.map(item => item.path)).toEqual([paths.current]);
             expect(result.reclaimedBytes).toBe(9216);
-            expect(result.hydrated).toEqual({ok: true});
-            expect(hydrated).toHaveLength(1);
-            expect(hydrated[0].mainCheckout).toBe(fakeMainCheckout);
             expect(hydrated[0].projectRoot).toBe(paths.current);
+        });
+
+        test('skips non-current worktrees when dirty status cannot be determined', async () => {
+            const removed = [];
+            const statusError = new Error('status failed');
+            const {exec, paths} = makePruneExec({
+                removed,
+                dirtyStatus: statusError
+            });
+
+            const result = await pruneStaleWorktrees({
+                projectRoot: fakeMainCheckout,
+                currentPath: paths.current,
+                exec,
+                getSize: async () => 1,
+                hydrate: async () => ({ok: true}),
+                log: () => {}
+            });
+
+            const byPath = Object.fromEntries(result.worktrees.map(item => [item.path, item]));
+
+            expect(byPath[paths.dirty].remove).toBe(false);
+            expect(byPath[paths.dirty].status).toBe('skipped-status-error');
+            expect(byPath[paths.dirty].dirtyStatus.error).toBe(statusError);
+            expect(removed).toEqual([
+                ['worktree', 'remove', '--force', paths.stale],
+                ['worktree', 'remove', '--force', paths.unmerged]
+            ]);
         });
 
         test('never removes the primary checkout even when the worktree root includes it', async () => {
@@ -980,12 +1057,11 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(byPath[paths.current].remove).toBe(false);
             expect(removed).toEqual([
                 ['worktree', 'remove', '--force', paths.stale],
-                ['worktree', 'remove', '--force', paths.unmerged],
-                ['worktree', 'remove', '--force', paths.dirty]
+                ['worktree', 'remove', '--force', paths.unmerged]
             ]);
         });
 
-        test('main-checkout invocation removes every Claude worktree and hydrates main checkout', async () => {
+        test('main-checkout invocation removes clean Claude worktrees and hydrates main checkout', async () => {
             const removed = [];
             const {exec, paths} = makePruneExec({removed});
             const hydrated = [];
@@ -1004,8 +1080,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(removed).toEqual([
                 ['worktree', 'remove', '--force', paths.current],
                 ['worktree', 'remove', '--force', paths.stale],
-                ['worktree', 'remove', '--force', paths.unmerged],
-                ['worktree', 'remove', '--force', paths.dirty]
+                ['worktree', 'remove', '--force', paths.unmerged]
             ]);
             expect(hydrated[0].projectRoot).toBe(fakeMainCheckout);
         });


### PR DESCRIPTION
Resolves #13214

Authored by GPT-5 (Codex Desktop). Session 650bf204-359f-41ff-bc35-19c15da38f54.

Makes `ai:prune-worktrees` safe-by-default for dirty or indeterminate non-current `.claude/worktrees/*` checkouts while preserving the #12677 clean-sprawl cleanup model. Clean non-current Claude worktrees still remove by default; dirty or status-error worktrees are reported as skipped unless the operator passes explicit `--include-dirty`. The dangerous scheduled npm script now passes `--include-dirty` so its intentional destructive semantics remain explicit.

Evidence: L2 (mock git status/remove contract coverage plus real non-destructive dry-run CLI smoke) → L2 required (dirty guard is a destructive-path contract covered by focused unit tests). No residuals.

## Deltas from ticket

The original issue body was stale after #12677/#12678. Intake and peer-role convergence narrowed this PR to Leaf 1 only:
- in scope: dirty-skip-by-default, indeterminate-status fail-closed skip, explicit `--include-dirty` override, and updated #12677 unit coverage.
- out of scope: open-PR classification, merged/no-PR taxonomy, and `git worktree prune` tombstone hygiene.

The narrowed Contract Ledger was posted on #13214 before implementation: https://github.com/neomjs/neo/issues/13214#issuecomment-4701544476

## Test Evidence

- `node --check ai/scripts/migrations/bootstrapWorktree.mjs`
- `npm run test-unit -- test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` → 38 passed
- `npm run ai:prune-worktrees:dry-run` → completed, found 0 worktrees in this checkout, no mutation
- `git diff --check`
- pre-commit hooks: `check-whitespace`, `check-shorthand`, `check-ticket-archaeology`

## Post-Merge Validation

None required beyond CI. The destructive removal path is intentionally verified through dependency-injected git mocks rather than live deletion from the shared checkout.

## Commit

- `d57a95503` — `fix(ai): skip dirty worktrees during prune (#13214)`

Related: #12677
Related: #12678
Related: #11654
