### PR TITLE
fix(memory-core): include 'distances' in query — restore re-ranker semantic score (#13222)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1102,7 +1102,8 @@ class MemoryService extends Base {
             const queryArgs = {
                 queryTexts: [query],
                 nResults,
-                include   : ['metadatas']
+                // 'distances' is load-bearing — the Dual-Pass re-ranker's semantic score needs it (else topology-only).
+                include   : ['metadatas', 'distances']
             };
 
             // Tenant-scoped where clause with additive shared-commons access.

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -371,7 +371,8 @@ class SummaryService extends Base {
             const queryArgs = {
                 queryTexts: [query],
                 nResults,
-                include   : ['metadatas', 'documents']
+                // 'distances' is load-bearing — the Dual-Pass re-ranker's semantic score needs it (else topology-only).
+                include   : ['metadatas', 'documents', 'distances']
             };
 
             // Tenant-scoped where clause with additive shared-commons access.

--- a/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryReRanker.spec.mjs
@@ -148,6 +148,58 @@ test.describe('StorageRouter Query Re-Ranker Defensive Handling', () => {
         expect(result.results[0].relevanceScore).toBeGreaterThan(0);
     });
 
+    test('#13222: queryMemories requests distances in the chroma include (re-ranker semantic-score input)', async () => {
+        // Regression guard for the include that omitted 'distances'. The Dual-Pass re-ranker reads the
+        // vector distance as its Pass-1 semantic score; without 'distances' in the include, chroma
+        // returns none, the score collapses to a constant 1, and ranking silently degrades to
+        // topology-only (the pre-existing `relevanceScore > 0` assertion cannot catch a constant 1).
+        // Substrate-free: stub the collection to capture the include the service actually sends, so the
+        // guard runs without the seeded chroma data the behavioral path needs.
+        const StorageRouter = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+        await StorageRouter.ready();
+
+        const originalGetCollection = StorageRouter.getMemoryCollection;
+        let capturedInclude;
+
+        StorageRouter.getMemoryCollection = async () => ({
+            query: async (args) => {
+                capturedInclude = args.include;
+                return {ids: [[]], distances: [[]], metadatas: [[]]};
+            }
+        });
+
+        try {
+            await SDK.Memory_Service.queryMemories({query: 'include probe', nResults: 3, sessionId: 'include-probe'});
+            expect(capturedInclude).toContain('distances');
+        } finally {
+            StorageRouter.getMemoryCollection = originalGetCollection;
+        }
+    });
+
+    test('#13222: querySummaries requests distances in the chroma include (summary-path parity)', async () => {
+        const SummaryService = (await import('../../../../../../ai/services/memory-core/SummaryService.mjs')).default;
+        await SummaryService.ready();
+        const StorageRouter = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+        await StorageRouter.ready();
+
+        const originalGetCollection = StorageRouter.getSummaryCollection;
+        let capturedInclude;
+
+        StorageRouter.getSummaryCollection = async () => ({
+            query: async (args) => {
+                capturedInclude = args.include;
+                return {ids: [[]], distances: [[]], metadatas: [[]], documents: [[]]};
+            }
+        });
+
+        try {
+            await SummaryService.querySummaries({query: 'include probe', nResults: 3});
+            expect(capturedInclude).toContain('distances');
+        } finally {
+            StorageRouter.getSummaryCollection = originalGetCollection;
+        }
+    });
+
     test('SummaryService.querySummaries should not crash on empty collections', async () => {
         // The summary collection is empty (no summarization run)
         // This should return gracefully, not crash


### PR DESCRIPTION
Resolves #13222

`query_summaries` and `query_raw_memories` passed a chroma `include` that omitted `'distances'`, so the response carried no distance values. The Dual-Pass re-ranker (`StorageRouter.injectQueryReRanker`) reads those distances as its Pass-1 semantic score — with none returned, `vectorDist` defaulted to `0` → `semanticScore` a constant `1`, **silently degrading ranking to topology-only** and reporting `distance:0 / relevanceScore:1` on every result. Split from #12450 (the bug-b score-reporting half, independent of the summary-vector corruption tracked in #12828 / #12830).

Evidence: L2 (substrate-free unit guards capture the `include` each service sends and assert `'distances'` is present — 2/2 green) → L2 required (a 2-line include fix plus a regression guard the prior `relevanceScore > 0` assertion could not provide). No residuals.

## The fix

- `MemoryService.mjs:1105`: `include: ['metadatas']` → `['metadatas', 'distances']`
- `SummaryService.mjs:374`: `include: ['metadatas', 'documents']` → `['metadatas', 'documents', 'distances']`

Restores real vector distances end-to-end: Pass-1 distances → real `semanticScore` → composite rank → `relevanceScore` (`MemoryService.mjs:1186` / `SummaryService.mjs:452`). A load-bearing inline comment documents why `'distances'` must stay in the include, so a future tidy does not strip it.

## Deltas from ticket

- **Test shape:** the ticket's AC sketched a behavioral assertion (distinct embeddings → `distance > 0` / `relevanceScore < 1`). Switched to **substrate-free include-assertion** guards: the behavioral path needs seeded, queryable chroma data that only runs in CI's Docker MC `integration-unified` — verified, the 3 pre-existing `count > 0` tests in this same spec (lines 116 / 134 / 400) fail **identically on the base branch with my changes stashed**, so it is an environment limitation, not the fix. The include-assertion runs everywhere and deterministically guards the exact regression (`'distances'` present in the include), so it is the stronger guard. Both query paths covered.
- **Scope:** bug-(a) summary-vector corruption / `query_summaries` recency-fallback stays out of scope (couples to #12828 / #12830); this leaf fixes the score-reporting plus the re-ranker semantic-signal collapse.

## Test Evidence

- `QueryReRanker.spec.mjs -g "#13222"`: **2 passed** (971ms) — `queryMemories` and `querySummaries` each assert `'distances'` is in the chroma `include`.
- Base-branch control (my changes `git stash`ed): the 3 pre-existing env-gated `count > 0` tests fail **identically** with and without my change → my change introduces no regression; those execute in CI `integration-unified` (Docker MC seeded substrate).
- Pre-commit hooks (whitespace / shorthand / ticket-archaeology): green.

## Post-Merge Validation

- Re-run `query_raw_memories` against the live MC and confirm `relevanceScore` now **varies** (real distances) rather than a constant `1`.
- Confirm the Dual-Pass re-ranker's composite scores reflect the semantic component again (not topology-only).
- For `query_summaries`: if results still recency-fall-back after this fix, the residual is bug-(a) summary-vector corruption (#12828 / #12830), not the include.

Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.
