### PR TITLE
feat(dashboard): wire dock splitter drag (#13213)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -1,3 +1,16 @@
 .neo-dashboard {
 
 }
+
+.neo-dashboard-dock-splitter {
+    flex-shrink: 0;
+    touch-action: none;
+
+    &-horizontal {
+        cursor: ew-resize;
+    }
+
+    &-vertical {
+        cursor: ns-resize;
+    }
+}

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -1,4 +1,5 @@
-import Base from '../core/Base.mjs';
+import Base         from '../core/Base.mjs';
+import DockSplitter from './DockSplitter.mjs';
 
 /**
  * @summary Projects Agent Harness dock-zone model nodes into existing Neo layout and tab configs.
@@ -217,12 +218,14 @@ class DockLayoutAdapter extends Base {
      * @protected
      * @static
      */
-    static createSplitterAffordance(splitNodeId, orientation, boundaryIndex) {
+    static createSplitterAffordance(splitNodeId, orientation, boundaryIndex, context={}) {
         let isVertical = orientation === 'vertical';
 
         return {
-            cls                   : ['neo-dashboard-dock-splitter', `neo-dashboard-dock-splitter-${orientation}`],
-            data                  : {
+            applyDockZoneOperation    : context.applyDockZoneOperation,
+            boundaryIndex,
+            cls                       : ['neo-dashboard-dock-splitter', `neo-dashboard-dock-splitter-${orientation}`],
+            data                      : {
                 boundaryIndex,
                 dockNodeId : splitNodeId,
                 dockSplitter: true,
@@ -230,12 +233,18 @@ class DockLayoutAdapter extends Base {
                 orientation,
                 splitNodeId
             },
-            dockNodeId            : splitNodeId,
-            dockNodeType          : 'splitter',
-            dockSplitBoundaryIndex: boundaryIndex,
-            dockSplitOrientation  : orientation,
-            [isVertical ? 'height' : 'width']: this.splitterSize,
-            ntype                 : 'component'
+            dockNodeId                : splitNodeId,
+            dockZoneDocument          : context.dockZoneDocument,
+            dockNodeType              : 'splitter',
+            dockSplitBoundaryIndex    : boundaryIndex,
+            dockSplitOrientation      : orientation,
+            module                    : DockSplitter,
+            ntype                     : 'dashboard-dock-splitter',
+            onDockZoneDocumentChange  : context.onDockZoneDocumentChange,
+            orientation,
+            size                      : this.splitterSize,
+            splitNodeId,
+            [isVertical ? 'height' : 'width']: this.splitterSize
         }
     }
 
@@ -259,9 +268,12 @@ class DockLayoutAdapter extends Base {
         }
 
         return this.projectNode(model.root, {
-            items              : model.items || {},
-            nodes              : model.nodes,
-            resolveComponentRef: options.resolveComponentRef || (() => null)
+            applyDockZoneOperation    : options.applyDockZoneOperation,
+            dockZoneDocument          : options.dockZoneDocument || model,
+            items                     : model.items || {},
+            nodes                     : model.nodes,
+            onDockZoneDocumentChange  : options.onDockZoneDocumentChange,
+            resolveComponentRef       : options.resolveComponentRef || (() => null)
         })
     }
 
@@ -386,7 +398,7 @@ class DockLayoutAdapter extends Base {
             });
 
             if (index < children.length - 1) {
-                items.push(this.createSplitterAffordance(nodeId, orientation, index))
+                items.push(this.createSplitterAffordance(nodeId, orientation, index, context))
             }
         });
 

--- a/src/dashboard/DockSplitter.mjs
+++ b/src/dashboard/DockSplitter.mjs
@@ -249,11 +249,7 @@ class DockSplitter extends Component {
      * @protected
      */
     createResizeSplitDescriptor(data={}) {
-        return {
-            operation  : 'resizeSplit',
-            sizes      : this.resolveSizeVector(data),
-            splitNodeId: this.splitNodeId || this.data?.splitNodeId || this.data?.dockNodeId
-        }
+        return Neo.dashboard.DockLayoutAdapter.createResizeSplitOperation(this, this.resolveSizeVector(data))
     }
 
     /**

--- a/src/dashboard/DockSplitter.mjs
+++ b/src/dashboard/DockSplitter.mjs
@@ -1,0 +1,403 @@
+import Component     from '../component/Base.mjs';
+import DragZone      from '../draggable/DragZone.mjs';
+import DockZoneModel from './DockZoneModel.mjs';
+import NeoArray      from '../util/Array.mjs';
+
+/**
+ * @summary Runtime splitter affordance that converts drag completion into a `resizeSplit` operation.
+ *
+ * `Neo.component.Splitter` resizes sibling styles directly. The dock-zone model is persisted JSON, so
+ * this component keeps pointer geometry runtime-only and commits through `DockZoneModel.applyOperation()`
+ * or a supplied owning reducer callback.
+ *
+ * @class Neo.dashboard.DockSplitter
+ * @extends Neo.component.Base
+ * @see Neo.dashboard.DockLayoutAdapter
+ * @see Neo.dashboard.DockZoneModel
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockSplitter extends Component {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockSplitter'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockSplitter',
+        /**
+         * @member {String} ntype='dashboard-dock-splitter'
+         * @protected
+         */
+        ntype: 'dashboard-dock-splitter',
+        /**
+         * @member {String[]} baseCls=['neo-dashboard-dock-splitter','neo-draggable']
+         */
+        baseCls: ['neo-dashboard-dock-splitter', 'neo-draggable'],
+        /**
+         * Callback for an owning Harness/dashboard reducer. Receives `(descriptor, splitter)`.
+         * @member {Function|null} applyDockZoneOperation=null
+         */
+        applyDockZoneOperation: null,
+        /**
+         * Index of the split boundary between adjacent model children.
+         * @member {Number|null} boundaryIndex_=null
+         * @reactive
+         */
+        boundaryIndex_: null,
+        /**
+         * @member {Neo.draggable.DragZone|null} dragZone=null
+         * @protected
+         */
+        dragZone: null,
+        /**
+         * @member {Object|null} dragZoneConfig=null
+         */
+        dragZoneConfig: null,
+        /**
+         * Current committed dock-zone document. Used when no reducer callback is supplied.
+         * @member {Object|null} dockZoneDocument_=null
+         * @reactive
+         */
+        dockZoneDocument_: null,
+        /**
+         * Notified after a successful local document commit.
+         * @member {Function|null} onDockZoneDocumentChange=null
+         */
+        onDockZoneDocumentChange: null,
+        /**
+         * Split orientation from the dock-zone model (`horizontal` means side-by-side children).
+         * @member {String} orientation_='horizontal'
+         * @reactive
+         */
+        orientation_: 'horizontal',
+        /**
+         * Visual splitter extent in px.
+         * @member {Number} size_=6
+         * @reactive
+         */
+        size_: 6,
+        /**
+         * Dock-zone split node id.
+         * @member {String|null} splitNodeId_=null
+         * @reactive
+         */
+        splitNodeId_: null
+    }
+
+    /**
+     * @member {Object|null} dragStartState=null
+     * @protected
+     */
+    dragStartState = null
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.addDomListeners([
+            {'drag:end'  : me.onDragEnd,   scope: me},
+            {'drag:start': me.onDragStart, scope: me}
+        ])
+    }
+
+    /**
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetBoundaryIndex(value, oldValue) {
+        this.data = {
+            ...(this.data || {}),
+            boundaryIndex: value
+        }
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetOrientation(value, oldValue) {
+        let me          = this,
+            orientation = me.getValidatedOrientation(value),
+            cls         = me.cls || [],
+            height      = orientation === 'vertical' ? me.size : null,
+            width       = orientation === 'vertical' ? null    : me.size;
+
+        if (oldValue) {
+            NeoArray.remove(cls, `neo-dashboard-dock-splitter-${oldValue}`)
+        }
+
+        NeoArray.add(cls, `neo-dashboard-dock-splitter-${orientation}`);
+
+        me.set({
+            cls,
+            height,
+            minHeight: height,
+            minWidth : width,
+            width
+        })
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetSize(value, oldValue) {
+        let me     = this,
+            height = me.getValidatedOrientation(me.orientation) === 'vertical' ? value : null,
+            width  = height === null ? value : null;
+
+        me.set({
+            height,
+            minHeight: height,
+            minWidth : width,
+            width
+        })
+    }
+
+    /**
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetSplitNodeId(value, oldValue) {
+        this.data = {
+            ...(this.data || {}),
+            dockNodeId : value,
+            splitNodeId: value
+        }
+    }
+
+    /**
+     * Captures child sizes at drag start so drag completion can stay model-order based.
+     * @param {Object} data
+     * @returns {Promise<Object>}
+     */
+    async captureDragStart(data={}) {
+        let me       = this,
+            children = me.getSplitChildItems(),
+            ids      = [me.parent?.id, ...children.map(item => item.id)].filter(Boolean),
+            rects    = [],
+            axis     = me.getSizeAxis(),
+            sizes;
+
+        if (ids.length && me.parent?.getDomRect) {
+            try {
+                rects = await me.parent.getDomRect(ids)
+            } catch (error) {
+                rects = []
+            }
+        }
+
+        sizes = children.map((item, index) => {
+            let rect  = rects[index + 1],
+                value = rect?.[axis];
+
+            return Number.isFinite(value) && value > 0 ? value : Number(item.flex) || 1
+        });
+
+        me.dragStartState = {
+            clientX: data.clientX,
+            clientY: data.clientY,
+            sizes
+        };
+
+        return me.dragStartState
+    }
+
+    /**
+     * @param {Object} descriptor
+     * @returns {{document:Object|null, errors:String[]}}
+     * @protected
+     */
+    commitResizeSplit(descriptor) {
+        let me     = this,
+            result = null;
+
+        if (typeof me.applyDockZoneOperation === 'function') {
+            result = me.applyDockZoneOperation(descriptor, me) || null
+        } else if (me.dockZoneDocument) {
+            result = DockZoneModel.applyOperation(me.dockZoneDocument, descriptor)
+        }
+
+        if (!result) {
+            result = {
+                document: me.dockZoneDocument,
+                errors  : ['DockSplitter requires `dockZoneDocument` or `applyDockZoneOperation` to commit resizeSplit.']
+            }
+        }
+
+        if (!result.errors?.length && result.document) {
+            me.dockZoneDocument = result.document;
+
+            if (typeof me.onDockZoneDocumentChange === 'function') {
+                me.onDockZoneDocumentChange(result.document, descriptor, me)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * @param {Object} data
+     * @returns {Object}
+     * @protected
+     */
+    createResizeSplitDescriptor(data={}) {
+        return {
+            operation  : 'resizeSplit',
+            sizes      : this.resolveSizeVector(data),
+            splitNodeId: this.splitNodeId || this.data?.splitNodeId || this.data?.dockNodeId
+        }
+    }
+
+    /**
+     * @returns {String}
+     * @protected
+     */
+    getCursorStyle() {
+        return this.getValidatedOrientation(this.orientation) === 'vertical'
+            ? 'ns-resize !important'
+            : 'ew-resize !important'
+    }
+
+    /**
+     * @returns {String}
+     * @protected
+     */
+    getSizeAxis() {
+        return this.getValidatedOrientation(this.orientation) === 'vertical' ? 'height' : 'width'
+    }
+
+    /**
+     * @returns {Object[]}
+     * @protected
+     */
+    getSplitChildItems() {
+        return (this.parent?.items || []).filter(item => item && item.dockNodeType !== 'splitter')
+    }
+
+    /**
+     * @param {String} orientation
+     * @returns {String}
+     * @protected
+     */
+    getValidatedOrientation(orientation) {
+        return orientation === 'vertical' ? 'vertical' : 'horizontal'
+    }
+
+    /**
+     * @param {Object} data
+     * @returns {Object}
+     */
+    onDragEnd(data={}) {
+        let me         = this,
+            descriptor = me.createResizeSplitDescriptor(data),
+            result;
+
+        if (me.parent) {
+            me.parent.disabled = false
+        }
+
+        if (me.dragZone) {
+            me.dragZone.dragEnd(data)
+        }
+
+        me.style = {
+            ...(me.style || {}),
+            opacity: 1
+        };
+
+        result = me.commitResizeSplit(descriptor);
+
+        me.fire(result.errors?.length ? 'dockSplitterResizeRejected' : 'dockSplitterResize', {
+            descriptor,
+            result,
+            splitter: me
+        });
+
+        me.dragStartState = null;
+
+        return result
+    }
+
+    /**
+     * @param {Object} data
+     */
+    async onDragStart(data={}) {
+        let me         = this,
+            orientation = me.getValidatedOrientation(me.orientation),
+            vertical    = orientation === 'vertical';
+
+        if (me.parent) {
+            me.parent.disabled = true
+        }
+
+        if (!me.dragZone) {
+            me.dragZone = Neo.create({
+                module             : DragZone,
+                appName            : me.appName,
+                bodyCursorStyle    : me.getCursorStyle(),
+                boundaryContainerId: me.parent?.id,
+                dragElement        : me.vdom,
+                moveHorizontal     : !vertical,
+                moveVertical       : vertical,
+                owner              : me,
+                useProxyWrapper    : false,
+                windowId           : me.windowId,
+                ...me.dragZoneConfig
+            })
+        } else {
+            me.dragZone.set({
+                bodyCursorStyle: me.getCursorStyle(),
+                moveHorizontal : !vertical,
+                moveVertical   : vertical
+            })
+        }
+
+        await me.captureDragStart(data);
+        await me.dragZone.dragStart(data);
+
+        me.style = {
+            ...(me.style || {}),
+            opacity: 0.5
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @returns {Number[]|null}
+     * @protected
+     */
+    resolveSizeVector(data={}) {
+        if (Array.isArray(data.sizes)) {
+            return data.sizes.slice()
+        }
+
+        let me             = this,
+            boundaryIndex  = Number(me.boundaryIndex ?? me.data?.boundaryIndex),
+            dragStartState = me.dragStartState,
+            sizes          = dragStartState?.sizes?.map(Number) || me.getSplitChildItems().map(item => Number(item.flex) || 1),
+            coordinate     = me.getValidatedOrientation(me.orientation) === 'vertical' ? 'clientY' : 'clientX',
+            start          = Number(dragStartState?.[coordinate]),
+            end            = Number(data[coordinate]),
+            delta          = Number.isFinite(start) && Number.isFinite(end) ? end - start : 0,
+            output         = sizes.slice();
+
+        if (!Number.isInteger(boundaryIndex) || boundaryIndex < 0 || boundaryIndex + 1 >= output.length) {
+            return null
+        }
+
+        output[boundaryIndex]     += delta;
+        output[boundaryIndex + 1] -= delta;
+
+        return output
+    }
+}
+
+export default Neo.setupClass(DockSplitter);

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect}    from '@playwright/test';
 import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
 import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockSplitter      from '../../../../src/dashboard/DockSplitter.mjs';
 import DockZoneModel     from '../../../../src/dashboard/DockZoneModel.mjs';
 
 const createModel = () => ({
@@ -167,7 +168,11 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             dockNodeType          : 'splitter',
             dockSplitBoundaryIndex: 0,
             dockSplitOrientation  : 'horizontal',
-            ntype                 : 'component',
+            module                : DockSplitter,
+            ntype                 : 'dashboard-dock-splitter',
+            orientation           : 'horizontal',
+            size                  : DockLayoutAdapter.splitterSize,
+            splitNodeId           : 'root',
             width                 : DockLayoutAdapter.splitterSize
         });
         expect(rootSplitter.height).toBeUndefined();
@@ -186,7 +191,11 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             dockSplitBoundaryIndex: 0,
             dockSplitOrientation  : 'vertical',
             height                : DockLayoutAdapter.splitterSize,
-            ntype                 : 'component'
+            module                : DockSplitter,
+            ntype                 : 'dashboard-dock-splitter',
+            orientation           : 'vertical',
+            size                  : DockLayoutAdapter.splitterSize,
+            splitNodeId           : 'side-split'
         });
         expect(sideSplitter.width).toBeUndefined();
     });

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -1,0 +1,138 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockSplitterTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import DockSplitter   from '../../../../src/dashboard/DockSplitter.mjs';
+
+const createDocument = () => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        left : {componentRef: 'left', title: 'Left'},
+        right: {componentRef: 'right', title: 'Right'}
+    },
+    nodes: {
+        root: {
+            type       : 'split',
+            orientation: 'horizontal',
+            children   : ['left-tabs', 'right-tabs'],
+            sizes      : [0.7, 0.3]
+        },
+        'left-tabs': {
+            type        : 'tabs',
+            items       : ['left'],
+            activeItemId: 'left'
+        },
+        'right-tabs': {
+            type        : 'tabs',
+            items       : ['right'],
+            activeItemId: 'right'
+        }
+    }
+});
+
+const createParent = () => ({
+    disabled: false,
+    id      : 'dock-parent',
+    items   : [
+        {dockNodeType: 'tabs', flex: 0.7, id: 'left-component'},
+        {dockNodeType: 'splitter', id: 'dock-splitter-placeholder'},
+        {dockNodeType: 'tabs', flex: 0.3, id: 'right-component'}
+    ],
+    getDomRect(ids) {
+        return Promise.resolve(ids.map(id => {
+            if (id === 'dock-parent') {
+                return {height: 500, width: 1000, x: 0, y: 0}
+            }
+
+            if (id === 'left-component') {
+                return {height: 500, width: 700, x: 0, y: 0}
+            }
+
+            return {height: 500, width: 300, x: 700, y: 0}
+        }))
+    }
+});
+
+test.describe('Neo.dashboard.DockSplitter', () => {
+    let splitter;
+
+    test.afterEach(() => {
+        splitter?.destroy();
+        splitter = null
+    });
+
+    test('commits drag completion through resizeSplit without mutating sibling styles', async () => {
+        let parent   = createParent(),
+            document = createDocument(),
+            events   = [];
+
+        splitter = Neo.create(DockSplitter, {
+            boundaryIndex   : 0,
+            dockZoneDocument: document,
+            id              : 'dock-splitter-commit',
+            orientation     : 'horizontal',
+            parentComponent : parent,
+            splitNodeId     : 'root'
+        });
+
+        splitter.dragZone = {
+            dragEnd: () => {}
+        };
+        splitter.on('dockSplitterResize', data => events.push(data));
+
+        await splitter.captureDragStart({clientX: 100, clientY: 0});
+        const result = splitter.onDragEnd({clientX: 0, clientY: 0});
+
+        expect(result.errors).toEqual([]);
+        expect(result.document.nodes.root.sizes).toEqual([0.6, 0.4]);
+        expect(splitter.dockZoneDocument.nodes.root.sizes).toEqual([0.6, 0.4]);
+        expect(document.nodes.root.sizes).toEqual([0.7, 0.3]);
+        expect(splitter.parent.items[0].style).toBeUndefined();
+        expect(splitter.parent.items[2].style).toBeUndefined();
+        expect(splitter.parent.disabled).toBe(false);
+        expect(events).toHaveLength(1);
+        expect(events[0].descriptor).toEqual({
+            operation  : 'resizeSplit',
+            sizes      : [600, 400],
+            splitNodeId: 'root'
+        })
+    });
+
+    test('leaves the document unchanged when the resolved size vector is rejected', async () => {
+        let parent   = createParent(),
+            document = createDocument(),
+            rejected = [];
+
+        splitter = Neo.create(DockSplitter, {
+            boundaryIndex   : 0,
+            dockZoneDocument: document,
+            id              : 'dock-splitter-reject',
+            orientation     : 'horizontal',
+            parentComponent : parent,
+            splitNodeId     : 'root'
+        });
+
+        splitter.dragZone = {
+            dragEnd: () => {}
+        };
+        splitter.on('dockSplitterResizeRejected', data => rejected.push(data));
+
+        await splitter.captureDragStart({clientX: 100, clientY: 0});
+        const result = splitter.onDragEnd({clientX: 900, clientY: 0});
+
+        expect(result.errors.join(' ')).toContain('must be greater than 0');
+        expect(result.document.nodes.root.sizes).toEqual([0.7, 0.3]);
+        expect(splitter.dockZoneDocument.nodes.root.sizes).toEqual([0.7, 0.3]);
+        expect(document.nodes.root.sizes).toEqual([0.7, 0.3]);
+        expect(rejected).toHaveLength(1);
+        expect(rejected[0].descriptor.sizes).toEqual([1500, -500])
+    });
+});

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -6,10 +6,11 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../src/Neo.mjs';
-import * as core      from '../../../../src/core/_export.mjs';
-import DockSplitter   from '../../../../src/dashboard/DockSplitter.mjs';
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../src/Neo.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
+import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockSplitter      from '../../../../src/dashboard/DockSplitter.mjs';
 
 const createDocument = () => ({
     schema: 'neo.harness.dockZone.v1',
@@ -70,40 +71,55 @@ test.describe('Neo.dashboard.DockSplitter', () => {
     });
 
     test('commits drag completion through resizeSplit without mutating sibling styles', async () => {
-        let parent   = createParent(),
-            document = createDocument(),
-            events   = [];
+        let parent     = createParent(),
+            document   = createDocument(),
+            events     = [],
+            original   = DockLayoutAdapter.createResizeSplitOperation,
+            operations = [];
 
-        splitter = Neo.create(DockSplitter, {
-            boundaryIndex   : 0,
-            dockZoneDocument: document,
-            id              : 'dock-splitter-commit',
-            orientation     : 'horizontal',
-            parentComponent : parent,
-            splitNodeId     : 'root'
-        });
+        DockLayoutAdapter.createResizeSplitOperation = function(splitterInstance, sizes) {
+            operations.push({sizes: sizes?.slice?.() || sizes, splitter: splitterInstance});
 
-        splitter.dragZone = {
-            dragEnd: () => {}
+            return original.call(this, splitterInstance, sizes)
         };
-        splitter.on('dockSplitterResize', data => events.push(data));
 
-        await splitter.captureDragStart({clientX: 100, clientY: 0});
-        const result = splitter.onDragEnd({clientX: 0, clientY: 0});
+        try {
+            splitter = Neo.create(DockSplitter, {
+                boundaryIndex   : 0,
+                dockZoneDocument: document,
+                id              : 'dock-splitter-commit',
+                orientation     : 'horizontal',
+                parentComponent : parent,
+                splitNodeId     : 'root'
+            });
 
-        expect(result.errors).toEqual([]);
-        expect(result.document.nodes.root.sizes).toEqual([0.6, 0.4]);
-        expect(splitter.dockZoneDocument.nodes.root.sizes).toEqual([0.6, 0.4]);
-        expect(document.nodes.root.sizes).toEqual([0.7, 0.3]);
-        expect(splitter.parent.items[0].style).toBeUndefined();
-        expect(splitter.parent.items[2].style).toBeUndefined();
-        expect(splitter.parent.disabled).toBe(false);
-        expect(events).toHaveLength(1);
-        expect(events[0].descriptor).toEqual({
-            operation  : 'resizeSplit',
-            sizes      : [600, 400],
-            splitNodeId: 'root'
-        })
+            splitter.dragZone = {
+                dragEnd: () => {}
+            };
+            splitter.on('dockSplitterResize', data => events.push(data));
+
+            await splitter.captureDragStart({clientX: 100, clientY: 0});
+            const result = splitter.onDragEnd({clientX: 0, clientY: 0});
+
+            expect(operations).toHaveLength(1);
+            expect(operations[0].splitter).toBe(splitter);
+            expect(operations[0].sizes).toEqual([600, 400]);
+            expect(result.errors).toEqual([]);
+            expect(result.document.nodes.root.sizes).toEqual([0.6, 0.4]);
+            expect(splitter.dockZoneDocument.nodes.root.sizes).toEqual([0.6, 0.4]);
+            expect(document.nodes.root.sizes).toEqual([0.7, 0.3]);
+            expect(splitter.parent.items[0].style).toBeUndefined();
+            expect(splitter.parent.items[2].style).toBeUndefined();
+            expect(splitter.parent.disabled).toBe(false);
+            expect(events).toHaveLength(1);
+            expect(events[0].descriptor).toEqual({
+                operation  : 'resizeSplit',
+                sizes      : [600, 400],
+                splitNodeId: 'root'
+            })
+        } finally {
+            DockLayoutAdapter.createResizeSplitOperation = original
+        }
     });
 
     test('leaves the document unchanged when the resolved size vector is rejected', async () => {


### PR DESCRIPTION
Resolves #13213

Authored by GPT-5 (Codex Desktop). Session 019ec50d-5a01-7b11-9490-50f3241e8cfc.

Adds `Neo.dashboard.DockSplitter` and wires `DockLayoutAdapter` splitter affordances to instantiate it. Drag completion now resolves adjacent split-child sizes in model order and commits through `DockZoneModel.applyOperation()` or an owning reducer callback, keeping pointer geometry runtime-only and preventing generic splitter sibling-style mutation from becoming the persistence authority.

Evidence: L2 (Playwright unit coverage of the component drag lifecycle plus model/adapter operation seam) → L2 required (handler-level commit/rejection tests named in #13213). No residuals.

Related: #13158
Related: #13206
Related: #13209

## Deltas from ticket

- Uses a dashboard-specific `DockSplitter` instead of wrapping `Neo.component.Splitter`, because the generic splitter directly mutates sibling inline styles.
- Threads optional `applyDockZoneOperation`, `dockZoneDocument`, and `onDockZoneDocumentChange` props through projected splitter configs so Harness state can own committed document replacement.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs test/playwright/unit/dashboard/DockSplitter.spec.mjs` — 11 passed.
- `npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs test/playwright/unit/dashboard/DockSplitter.spec.mjs` — 64 passed.
- `git diff --check` and `git diff --cached --check` passed.
- Pre-push freshness passed: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `8a2c397e5 feat(dashboard): wire dock splitter drag (#13213)`.

## Post-Merge Validation

- [ ] Smoke drag a rendered Agent Harness dock splitter against the owning Harness state reducer once the Harness app consumes the projected `DockSplitter`.

## Commit

- `8a2c397e5` — `feat(dashboard): wire dock splitter drag (#13213)`