### PR TITLE
feat(ai): enforce multi-writer write-locks on the InstanceService write path

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -7,6 +7,7 @@ import InteractionService from './client/InteractionService.mjs';
 import RuntimeService     from './client/RuntimeService.mjs';
 import Socket             from '../data/connection/WebSocket.mjs';
 import WindowManager      from '../manager/Window.mjs';
+import WriteGuard         from './WriteGuard.mjs';
 import {parseAgentEnvelope} from './parseAgentEnvelope.mjs';
 
 /**
@@ -68,6 +69,14 @@ class Client extends Base {
      * @protected
      */
     socket = null
+    /**
+     * The per-heap multi-writer write-lock authority — owns the live held-lock table for this App-Worker heap.
+     * One {@link Neo.ai.Client} (a singleton) ⇒ one {@link Neo.ai.WriteGuard} ⇒ the heap's shared write truth, so a
+     * write-class service can deny a *different* writer's overlapping subtree write. See {@link Neo.ai.admitWrite}.
+     * @member {Neo.ai.WriteGuard|null} writeGuard=null
+     * @protected
+     */
+    writeGuard = null
 
     /**
      * @param {Object} config
@@ -76,6 +85,8 @@ class Client extends Base {
         super.construct(config);
 
         let me = this;
+
+        me.writeGuard = Neo.create(WriteGuard);
 
         me.services = {
             component  : Neo.create(ComponentService,   {client: me}),

--- a/src/ai/admitWrite.mjs
+++ b/src/ai/admitWrite.mjs
@@ -1,0 +1,59 @@
+import {resolveWriteLock} from './resolveWriteLock.mjs';
+
+/**
+ * @summary Admit or deny a Neural Link write — the seam that joins the write-lock *decision* to the heap *authority*.
+ *
+ * The single enforcement step a write-class service runs before it mutates. It composes the two halves of the
+ * multi-writer regime: {@link Neo.ai.resolveWriteLock} decides *what lock* a request needs (or that it is legacy /
+ * undecidable), and the injected `writeGuard` ({@link Neo.ai.WriteGuard}) *acquires and holds* that lock — denying a
+ * cross-writer overlap. The result is a plain verdict (`admitted` / `reason` / `conflict`); acting on it — mutate vs
+ * throw — stays in the caller, so this stays a pure function over its inputs and is unit-provable with a stub guard.
+ *
+ * Fail-closed by construction — only a fully-valid, non-conflicting agent request (or a genuinely legacy one) admits:
+ * - **decision not enforced** (`context` absent → legacy / non-agent frame): `{admitted: true}` — write unguarded.
+ * - **enforced, no lock** (incomplete identity / unresolvable target): `{admitted: false, reason}` — deny, no mutate;
+ *   `reason` is `resolveWriteLock`'s (`'incomplete-identity'` | `'unresolvable-target'`).
+ * - **enforced, lock, but no `writeGuard`**: `{admitted: false, reason: 'no-write-guard'}` — a misconfiguration where
+ *   enforcement is required but no heap authority exists denies rather than silently mutating (never fail open).
+ * - **enforced, lock, guard grants** (no overlap, or same-writer re-entrant): `{admitted: true}` — the lock is now
+ *   **held** in the guard's table until release (disconnect sweep).
+ * - **enforced, lock, guard denies** (a *different* writer holds an overlapping subtree): `{admitted: false,
+ *   reason: 'conflict', conflict}` — deny, no mutate; `conflict` is the guard's defensive copy of the holder.
+ *
+ * @param {Object}        params
+ * @param {Object|null}   params.context     The Bridge-stamped `{agentId, sessionId}` writer pair, or `null` /
+ *                                            `undefined` for a bare / legacy frame (see {@link Neo.ai.parseAgentEnvelope}).
+ * @param {String}        params.componentId The target component id (the write's subtree node).
+ * @param {Function}      params.parentOf    `(id: String) => String|null|undefined` — injected parent lookup, exactly
+ *                                            as {@link Neo.ai.deriveSubtreePath} consumes it (`id => Neo.getComponent(id)?.parentId`).
+ * @param {Object}        params.writeGuard  The heap's {@link Neo.ai.WriteGuard} instance (`requestWrite(lock) →
+ *                                            {granted, conflict}`). Required only when the decision is enforced with a lock.
+ * @returns {{admitted: Boolean, reason: (String|null), conflict: (Object|null)}}
+ *   `admitted:true` ⇒ the caller may mutate (the lock, if any, is held). `admitted:false` ⇒ the caller must NOT mutate;
+ *   `reason` names why and `conflict` (when present) is the overlapping holder.
+ */
+export function admitWrite({context, componentId, parentOf, writeGuard}) {
+    const decision = resolveWriteLock(context, componentId, parentOf);
+
+    // Legacy / non-agent frame — the multi-writer regime does not apply; write unguarded.
+    if (!decision.enforced) {
+        return {admitted: true, reason: null, conflict: null}
+    }
+
+    // Enforced, but identity / target is undecidable — fail closed (deny, no mutate).
+    if (!decision.lock) {
+        return {admitted: false, reason: decision.reason, conflict: null}
+    }
+
+    // Enforced with a valid lock, but no heap authority to hold it — fail closed rather than mutate unguarded.
+    if (!writeGuard) {
+        return {admitted: false, reason: 'no-write-guard', conflict: null}
+    }
+
+    // Acquire-and-hold; a cross-writer overlap is denied with a copy of the conflicting holder.
+    const {granted, conflict} = writeGuard.requestWrite(decision.lock);
+
+    return granted
+        ? {admitted: true,  reason: null,       conflict: null}
+        : {admitted: false, reason: 'conflict', conflict}
+}

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -1,4 +1,5 @@
-import Service from './Service.mjs';
+import Service      from './Service.mjs';
+import {admitWrite} from '../admitWrite.mjs';
 
 /**
  * Handles generic instance-related Neural Link requests.
@@ -66,18 +67,43 @@ class InstanceService extends Service {
     }
 
     /**
+     * Enforces the multi-writer write-lock before a write-class op mutates: composes the {@link Neo.ai.admitWrite}
+     * decision with this heap's {@link Neo.ai.Client#writeGuard} and **throws** a deny (no mutation) when the write is
+     * not admitted. A bare / legacy frame (no `context`) is unguarded — backward-compatible with non-agent callers.
+     * @param {Object|null} context The Bridge-stamped `{agentId, sessionId}` writer pair, or null/undefined (legacy).
+     * @param {String} id The target component id whose subtree the write locks.
+     * @protected
+     */
+    assertWritable(context, id) {
+        const {admitted, reason, conflict} = admitWrite({
+            context,
+            componentId: id,
+            parentOf   : cid => Neo.getComponent(cid)?.parentId,
+            writeGuard : this.client?.writeGuard
+        });
+
+        if (!admitted) {
+            const heldBy = conflict ? ` (held by ${conflict.agentId} / ${conflict.sessionId})` : '';
+            throw new Error(`Write denied for ${id}: ${reason}${heldBy}`)
+        }
+    }
+
+    /**
      * Sets properties on a specific instance by its ID.
      * @param {Object} params
      * @param {String} params.id
      * @param {Object} params.properties
+     * @param {Object|null} [context] The Bridge-stamped agent writer pair (2nd dispatch arg); null/undefined = legacy.
      * @returns {Object}
      */
-    setInstanceProperties({id, properties}) {
+    setInstanceProperties({id, properties}, context) {
         const instance = Neo.get(id);
 
         if (!instance) {
             throw new Error(`Instance not found: ${id}`)
         }
+
+        this.assertWritable(context, id);
 
         instance.set(properties);
 
@@ -90,9 +116,10 @@ class InstanceService extends Service {
      * @param {String} params.id
      * @param {String} params.method
      * @param {Array}  [params.args]
+     * @param {Object|null} [context] The Bridge-stamped agent writer pair (2nd dispatch arg); null/undefined = legacy.
      * @returns {Object}
      */
-    async callMethod({id, method, args=[]}) {
+    async callMethod({id, method, args=[]}, context) {
         const instance = Neo.get(id);
 
         if (!instance) {
@@ -107,6 +134,8 @@ class InstanceService extends Service {
         if (!scope || typeof scope[methodName] !== 'function') {
             throw new Error(`Method not found: ${method} on instance ${id}`)
         }
+
+        this.assertWritable(context, id);
 
         const result = await scope[methodName].call(scope, ...args);
 

--- a/test/playwright/unit/ai/admitWrite.spec.mjs
+++ b/test/playwright/unit/ai/admitWrite.spec.mjs
@@ -1,0 +1,155 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'AdmitWriteTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../src/Neo.mjs';
+import * as core       from '../../../../src/core/_export.mjs';
+import InstanceService from '../../../../src/ai/client/InstanceService.mjs';
+import WriteGuard      from '../../../../src/ai/WriteGuard.mjs';
+import {admitWrite}    from '../../../../src/ai/admitWrite.mjs';
+
+// admitWrite is the pure seam joining resolveWriteLock (the decision) to a WriteGuard (the held-lock authority).
+// The decision branches are isolated with a STUB guard — so we can assert *whether* the authority is consulted and
+// *with exactly which lock*. The grant / deny + held-lock semantics use a REAL Neo.ai.WriteGuard, so the cross-writer
+// denial is the genuine LockRegistry conflict math end-to-end, not a mock of the very thing under test.
+//
+// Linear component tree  root → mid → leaf  (parentOf returns the parent id; falsy at the root).
+const
+    PARENTS  = {leaf: 'mid', mid: 'root', root: null},
+    parentOf = id => PARENTS[id],
+    CTX_A    = {agentId: 'agent-a', sessionId: 'sess-a'},
+    CTX_B    = {agentId: 'agent-b', sessionId: 'sess-b'};
+
+// A guard stub that records every lock it is asked to hold and returns a scripted verdict.
+const stubGuard = verdict => {
+    const calls = [];
+    return {calls, requestWrite(lock) {calls.push(lock); return verdict}}
+};
+
+test.describe('admitWrite (NL write-enforcement orchestration)', () => {
+    test('legacy / non-agent frame (absent context) → admitted; the authority is never consulted', () => {
+        const guard = stubGuard({granted: false}); // would DENY if consulted — proves the unguarded path skips it
+        for (const absent of [null, undefined, 'x', 42, true]) {
+            expect(admitWrite({context: absent, componentId: 'leaf', parentOf, writeGuard: guard}))
+                .toEqual({admitted: true, reason: null, conflict: null})
+        }
+        expect(guard.calls).toHaveLength(0)
+    });
+
+    test('enforced + incomplete identity → denied, no mutate; the authority is never consulted', () => {
+        const guard = stubGuard({granted: true}); // would GRANT if consulted
+        for (const bad of [{agentId: '', sessionId: 'sess-a'}, {agentId: 'agent-a', sessionId: ''}, {}, {foo: 1}]) {
+            expect(admitWrite({context: bad, componentId: 'leaf', parentOf, writeGuard: guard}))
+                .toEqual({admitted: false, reason: 'incomplete-identity', conflict: null})
+        }
+        expect(guard.calls).toHaveLength(0)
+    });
+
+    test('enforced + unresolvable target → denied, no mutate; the authority is never consulted', () => {
+        const guard = stubGuard({granted: true});
+        for (const badId of ['', 'document.body']) {
+            expect(admitWrite({context: CTX_A, componentId: badId, parentOf, writeGuard: guard}))
+                .toEqual({admitted: false, reason: 'unresolvable-target', conflict: null})
+        }
+        expect(guard.calls).toHaveLength(0)
+    });
+
+    test('enforced + valid lock but NO writeGuard → denied (no-write-guard); never fails open on a misconfig', () => {
+        for (const noGuard of [undefined, null]) {
+            expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: noGuard}))
+                .toEqual({admitted: false, reason: 'no-write-guard', conflict: null})
+        }
+    });
+
+    test('enforced + guard grants → admitted; the EXACT resolved absolute lock is what gets held', () => {
+        const guard = stubGuard({granted: true, conflict: null});
+        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
+            .toEqual({admitted: true, reason: null, conflict: null});
+        // the descriptor handed to the authority is resolveWriteLock's absolute root→node lock, verbatim
+        expect(guard.calls).toEqual([{agentId: 'agent-a', sessionId: 'sess-a', subtreePath: ['root', 'mid', 'leaf']}])
+    });
+
+    test('enforced + guard denies → denied with reason:conflict and the conflicting holder surfaced', () => {
+        const holder = {agentId: 'agent-b', sessionId: 'sess-b', subtreePath: ['root']},
+              guard  = stubGuard({granted: false, conflict: holder});
+        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}))
+            .toEqual({admitted: false, reason: 'conflict', conflict: holder})
+    });
+
+    // ── integration: the REAL WriteGuard + LockRegistry conflict math (the actual enforcement, not a mock) ──
+    test('REAL WriteGuard — overlapping subtree: first writer holds, second denied, same-writer re-entrant', () => {
+        const guard = Neo.create('Neo.ai.WriteGuard');
+
+        // writer A acquires (and holds) the 'mid' subtree
+        expect(admitWrite({context: CTX_A, componentId: 'mid', parentOf, writeGuard: guard}).admitted).toBe(true);
+        expect(guard.heldLocks()).toHaveLength(1);
+
+        // writer B writes 'leaf' — a descendant of A's held 'mid' → genuine overlap → denied, nothing held for B
+        const b = admitWrite({context: CTX_B, componentId: 'leaf', parentOf, writeGuard: guard});
+        expect(b.admitted).toBe(false);
+        expect(b.reason).toBe('conflict');
+        expect(b.conflict).toMatchObject({agentId: 'agent-a', sessionId: 'sess-a'});
+        expect(guard.heldLocks()).toHaveLength(1);
+
+        // the SAME writer A re-acquiring an overlapping subtree is re-entrant → still admitted
+        expect(admitWrite({context: CTX_A, componentId: 'leaf', parentOf, writeGuard: guard}).admitted).toBe(true)
+    });
+
+    test('REAL WriteGuard — disjoint subtrees: two writers both admitted (no false-positive conflict)', () => {
+        const
+            guard   = Neo.create('Neo.ai.WriteGuard'),
+            // two disjoint linear trees:  root → mid → leaf   and   other → branch
+            parents = {leaf: 'mid', mid: 'root', root: null, branch: 'other', other: null},
+            pOf     = id => parents[id];
+
+        expect(admitWrite({context: CTX_A, componentId: 'leaf',   parentOf: pOf, writeGuard: guard}).admitted).toBe(true);
+        expect(admitWrite({context: CTX_B, componentId: 'branch', parentOf: pOf, writeGuard: guard}).admitted).toBe(true);
+        expect(guard.heldLocks()).toHaveLength(2)
+    });
+});
+
+// The service-boundary wiring: a denied write must THROW and NOT mutate the target. Uses a real WriteGuard + a real
+// InstanceService; Neo.get / Neo.getComponent are the only live-heap couplings, stubbed for the call window and
+// restored — the live two-agent run over a mounted tree is the umbrella whitebox-e2e follow-up.
+test.describe('InstanceService write enforcement (wiring)', () => {
+    test('setInstanceProperties denies a cross-writer write — throws and never calls instance.set', () => {
+        const
+            guard   = Neo.create('Neo.ai.WriteGuard'),
+            service = Neo.create('Neo.ai.client.InstanceService', {client: {writeGuard: guard}}),
+            tree    = {leaf: {parentId: 'mid'}, mid: {parentId: 'root'}, root: {parentId: null}};
+
+        let setCalls = 0;
+        const fakeInstance = {set() {setCalls++}};
+
+        const origGet = Neo.get, origGetComponent = Neo.getComponent;
+        Neo.get          = () => fakeInstance;       // every target id resolves to the observable fake
+        Neo.getComponent = id => tree[id];           // parentOf walks the synthetic tree
+
+        try {
+            // writer A writes 'mid' → admitted + mutates + holds the subtree
+            service.setInstanceProperties({id: 'mid', properties: {x: 1}}, CTX_A);
+            expect(setCalls).toBe(1);
+
+            // writer B writes 'leaf' (descendant of A's held 'mid') → denied: throws, and instance.set is NOT called
+            expect(() => service.setInstanceProperties({id: 'leaf', properties: {x: 2}}, CTX_B))
+                .toThrow(/Write denied/);
+            expect(setCalls).toBe(1); // unchanged — the denied write did not mutate
+
+            // a bare / legacy frame (no context) is unguarded — still mutates (backward-compatible)
+            service.setInstanceProperties({id: 'leaf', properties: {x: 3}});
+            expect(setCalls).toBe(2)
+        } finally {
+            Neo.get = origGet; Neo.getComponent = origGetComponent
+        }
+    })
+});


### PR DESCRIPTION
Resolves #13224

## Summary

Wires the merged multi-writer enforcement primitives onto the actual mutation path — the **write half of #13167 Leaf B/C**. Until now `resolveWriteLock` / `WriteGuard` / `LockRegistry` / `deriveSubtreePath` were all merged but **unconsumed**: `InstanceService` mutated unconditionally, so two agents sharing one App-Worker heap could clobber each other's component writes. This makes the enforcement actually enforce.

**Three pieces:**

- **`src/ai/admitWrite.mjs` (new, pure):** `admitWrite({context, componentId, parentOf, writeGuard}) → {admitted, reason, conflict}` — the seam that joins `resolveWriteLock` (the *decision*) to a `WriteGuard` (the *held-lock authority*). Fail-closed: legacy / no-context → admit (unguarded); incomplete-identity / unresolvable-target → deny; missing guard while enforcing → deny (`no-write-guard`, never fail-open on a misconfig); cross-writer overlap → deny with the conflicting holder. Deps injected → unit-provable against a stub guard.
- **`src/ai/Client.mjs`:** the Client (a per-heap connect-on-init singleton) now owns a per-heap `WriteGuard` instance — the heap's shared write truth. `WriteGuard` stays **non-singleton** (its spec constructs per-test for isolation; that is unchanged).
- **`src/ai/client/InstanceService.mjs`:** `setInstanceProperties` / `callMethod` take the `context` already threaded by `Client.handleRequest` (#13174) and call `admitWrite` (via a small `assertWritable` guard) **before** mutating. A denied write throws and does not mutate; a bare / legacy frame (no context) is unguarded — backward-compatible.

Evidence: 34 unit tests green (9 new + 25 regression); `node --check` clean; `git diff --check` clean. No source file outside `src/ai/` touched.

## Deltas from ticket (if any)

None — the slice matches #13224's ACs. Two design points worth a reviewer's eye:

- **`call_method` is enforced too** (not only `set_instance_properties`), per the #13167 contract-of-record that classifies both as write-class. Deliberately conservative: a read-only method call still acquires a held lock on its subtree (purity can't be proven statically). A future allowlist of known-pure methods could narrow this — flagged, not built.
- **No release in this slice.** `requestWrite` acquires-and-holds; the `agent_disconnected → WriteGuard.releaseAgent` sweep that frees a dropped writer's locks is the **immediate follow-up** (it needs a Bridge disconnect frame not yet on `dev`). Within a session, same-writer re-acquire is re-entrant, so one agent is never self-blocked; a *different* writer is correctly denied.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/admitWrite.spec.mjs` → **9 passed**. Regression sweep (`ClientDispatcher`, `ClientWindowRegistration`, `WriteGuard`, `resolveWriteLock`) → **25 passed**.

`admitWrite.spec.mjs` (9):
- **6 orchestration cases** over a *stub guard* — asserts *whether* the authority is consulted and *with exactly which lock*: legacy-skip (guard never touched), incomplete-identity deny, unresolvable-target deny, no-write-guard deny, grant → admit (exact absolute lock held), deny → conflict surfaced.
- **2 real `Neo.ai.WriteGuard` integration cases** — the genuine `LockRegistry` conflict math, *not* a mock: overlapping subtree → first holds / second denied / same-writer re-entrant; disjoint subtrees → both admitted (no false-positive).
- **1 service-boundary wiring case** — a real `InstanceService` + real `WriteGuard`: a cross-writer `setInstanceProperties` **throws and never calls `instance.set`**; a legacy (no-context) frame still mutates.

## Post-Merge Validation

The `learn/agentos/MultiWriterEnforcement.md` "PENDING wiring" row (#13218) becomes live for `set_instance_properties` / `call_method`: a second agent's overlapping write is denied at the service boundary. The umbrella #13167 stays open for the disconnect-release sweep + the live two-agent whitebox-e2e proof.

---

Refs #13167 (Leaf B/C contract-of-record), #13056 (Extended-NL epic). Consumes #13207 (`resolveWriteLock`), #13134 (`WriteGuard`), #13138 (`deriveSubtreePath`), #13205 (`parseAgentEnvelope` sessionId thread).

Authored by @neo-opus-ada (Ada, Claude Opus 4.8 [1M context]) — origin session 4c598c8f-d8a7-4288-9420-e825a45d310e.
