### PR TITLE
feat(ai): fail-build lint banning Class-A DB-path AiConfig mutation in tests (#13227)

### DIFF
--- a/.github/workflows/aiconfig-test-mutation-lint.yml
+++ b/.github/workflows/aiconfig-test-mutation-lint.yml
@@ -1,0 +1,34 @@
+name: AiConfig Test-Mutation Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'test/**/*.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
+      - '.github/workflows/aiconfig-test-mutation-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'test/**/*.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
+      - '.github/workflows/aiconfig-test-mutation-lint.yml'
+
+concurrency:
+  group: aiconfig-test-mutation-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Ban Class-A DB-path AiConfig mutations in tests
+        run: node ./buildScripts/util/check-aiconfig-test-mutation.mjs

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -1,4 +1,3 @@
-import {program}      from 'commander';
 import {execSync, spawnSync} from 'node:child_process';
 import {readFileSync}  from 'node:fs';
 import path            from 'node:path';
@@ -196,17 +195,12 @@ function main() {
         process.exit(1);
     }
 
-    program
-        .name('check-aiconfig-test-mutation')
-        .description('Fail-build gate: bans Class-A DB-path AiConfig mutations in tests (ADR-0019 §4 B4, #12335 orphan-bleed).')
-        .argument('[files...]', 'Specific files to scan (lint-staged passes staged paths). When omitted, scans test/.')
-        .option('-q, --quiet', 'Suppress the per-violation listing; print summary only.', false)
-        .showHelpAfterError();
-
-    program.parse(process.argv);
-
-    const argvFiles = program.args,
-          options   = program.opts();
+    // Minimal argv parse — no external deps, so the standalone CI workflow runs without `npm install`
+    // (the dependency-free pattern the other lint workflows follow). lint-staged passes staged paths as
+    // positional args; `--quiet` suppresses the per-violation listing.
+    const rawArgv   = process.argv.slice(2),
+          quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+          argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
 
     function collectDefaultFiles() {
         const result = spawnSync('find', ['test', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
@@ -248,7 +242,7 @@ function main() {
 
     if (violations.length > 0) {
         console.error(`\x1b[31mcheck-aiconfig-test-mutation: ${violations.length} DB-path AiConfig mutation(s) in tests:\x1b[0m`);
-        if (!options.quiet) {
+        if (!quiet) {
             violations.forEach(v => console.error('  ' + v));
             console.error('\nA test must NEVER mutate the shared AiConfig DB paths — test data bleeds into live DBs (the');
             console.error('#12335 orphan incident; ADR-0019 §4 B4). Isolate by construction (UNIT_TEST_MODE resolves the');

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -1,0 +1,248 @@
+import {program}      from 'commander';
+import {execSync, spawnSync} from 'node:child_process';
+import {readFileSync}  from 'node:fs';
+import path            from 'node:path';
+import process         from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
+
+// Inline relief valve for a genuinely unavoidable test-config mutation (judgment-call escape, not a
+// blanket bypass). A line carrying this marker is skipped.
+export const ESCAPE_MARKER = 'aiconfig-mutation-ok';
+
+/*
+ * Class-A safety-critical DB-path leaves. A test that writes one of these to the shared `AiConfig`
+ * singleton is the orphan-bleed mechanism: the reactive set-trap routes the assignment to the shared
+ * provider, so failed cleanup / a shared process / test-ordering means the next consumer reads the
+ * test DB — or a live read lands on test state (the B4 safety-critical class). A test must isolate by
+ * construction (`UNIT_TEST_MODE` resolves the test DB), never mutate the singleton.
+ *
+ * The pattern requires an `aiConfig` / `Memory_Config` root before a dangerous leaf, so a non-config
+ * `x.database = y` does not trip it; the trailing `=(?![=>])` excludes comparisons (`==` / `===`) and
+ * arrows (`=>`), and a capture-read (`const x = aiConfig.storagePaths.graph`) has no `=` after the
+ * leaf, so only true assignments match. Config-VARYING leaves (retry / transport) are deliberately
+ * out of scope here — that class has no by-construction story yet.
+ */
+export const DB_PATH_MUTATION = /\b(?:aiConfig|Memory_Config)\b[\w.$[\]'"`-]*\.(?:storagePaths|database|collections|logPath)\b[\w.$[\]'"`]*\s*=(?![=>])/;
+
+/*
+ * Files that already mutate Class-A DB paths, grandfathered while the cleanup migrates them to
+ * by-construction isolation. The ratchet bites only NEW offenders; this set shrinks as the cleanup
+ * lands. Paths are repo-relative POSIX.
+ */
+export const ALLOWLIST = new Set([
+    'test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs',
+    'test/playwright/unit/ai/daemons/orchestrator/services/DreamServiceGoldenPath.spec.mjs',
+    'test/playwright/unit/ai/mcp/server/knowledge-base/logger.spec.mjs',
+    'test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs',
+    'test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs',
+    'test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs',
+    'test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs',
+    'test/playwright/unit/ai/scripts/runners/runSandman.spec.mjs',
+    'test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs',
+    'test/playwright/unit/ai/services/graph/LazyEdgeDrainer.spec.mjs',
+    'test/playwright/unit/ai/services/graph/SemanticGraphExtractor.spec.mjs',
+    'test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs',
+    'test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/CoalescingEngineService.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/DatabaseService.graphBackup.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/DatabaseService.importMergeChroma.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/FileSystemIngestor.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/SessionSummarization.spec.mjs',
+    'test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs'
+]);
+
+/**
+ * @summary Returns the code portion of a line with string contents and comments removed.
+ *
+ * A string-aware scan: string literals collapse to a single space (so a config path inside a string —
+ * a log message, a `describe(...)` title — never reads as a mutation), and line/block comments are
+ * dropped. Block-comment state is carried across lines via `state.inBlock`. The dual of
+ * `check-ticket-archaeology.mjs`'s `extractComment`, which keeps the comment and drops the code.
+ * @param {String} line
+ * @param {{inBlock: Boolean}} state Mutated in place as block comments open and close across lines.
+ * @returns {String} The code text on this line (comments + string contents stripped).
+ */
+export function stripStringsAndComments(line, state) {
+    let code = '',
+        i    = 0;
+
+    const n = line.length;
+
+    if (state.inBlock) {
+        const end = line.indexOf('*/');
+
+        if (end === -1) {
+            return ''
+        }
+
+        i             = end + 2;
+        state.inBlock = false
+    }
+
+    let inString = null;
+
+    while (i < n) {
+        const ch   = line[i],
+              next = line[i + 1];
+
+        if (inString) {
+            if (ch === '\\') {
+                i += 2;
+                continue
+            }
+            if (ch === inString) {
+                inString = null
+            }
+            i++;
+            continue
+        }
+
+        if (ch === '"' || ch === "'" || ch === '`') {
+            inString = ch;
+            code    += ' ';
+            i++;
+            continue
+        }
+
+        if (ch === '/' && next === '/') {
+            break
+        }
+
+        if (ch === '/' && next === '*') {
+            const end = line.indexOf('*/', i + 2);
+
+            if (end === -1) {
+                state.inBlock = true;
+                break
+            }
+
+            i = end + 2;
+            continue
+        }
+
+        code += ch;
+        i++
+    }
+
+    return code
+}
+
+/**
+ * @summary Scans file content for Class-A DB-path `AiConfig` mutations in executable code.
+ * @param {String} content
+ * @returns {Object[]} `[{line, text}]` — one entry per offending line (1-based line numbers).
+ */
+export function findDbPathMutations(content) {
+    const lines = content.split('\n'),
+          state = {inBlock: false},
+          hits  = [];
+
+    lines.forEach((line, index) => {
+        if (line.includes(ESCAPE_MARKER)) {
+            return
+        }
+
+        const code = stripStringsAndComments(line, state);
+
+        if (DB_PATH_MUTATION.test(code)) {
+            hits.push({line: index + 1, text: line.trim()})
+        }
+    });
+
+    return hits
+}
+
+/**
+ * @summary Normalizes an input path (absolute from lint-staged, or relative) to a repo-relative POSIX path.
+ * @param {String} file
+ * @param {String} gitRoot
+ * @returns {String}
+ */
+export function toRepoRelative(file, gitRoot) {
+    return path.relative(gitRoot, path.resolve(gitRoot, file)).split(path.sep).join('/')
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+    } catch (e) {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1);
+    }
+
+    program
+        .name('check-aiconfig-test-mutation')
+        .description('Fail-build gate: bans Class-A DB-path AiConfig mutations in tests (ADR-0019 §4 B4, #12335 orphan-bleed).')
+        .argument('[files...]', 'Specific files to scan (lint-staged passes staged paths). When omitted, scans test/.')
+        .option('-q, --quiet', 'Suppress the per-violation listing; print summary only.', false)
+        .showHelpAfterError();
+
+    program.parse(process.argv);
+
+    const argvFiles = program.args,
+          options   = program.opts();
+
+    function collectDefaultFiles() {
+        const result = spawnSync('find', ['test', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
+        if (result.status !== 0) {
+            console.error('\x1b[31mError: find command failed.\x1b[0m');
+            console.error(result.stderr);
+            process.exit(1);
+        }
+        return result.stdout.trim().split('\n').filter(Boolean);
+    }
+
+    const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles();
+    const files    = rawFiles
+        .filter(f => f.endsWith('.mjs'))
+        .map(f => toRepoRelative(f, gitRoot))
+        .filter(f => f.startsWith('test/'));
+
+    if (files.length === 0) {
+        console.log('check-aiconfig-test-mutation: 0 test .mjs files in scope, nothing to check.');
+        process.exit(0);
+    }
+
+    const violations = [];
+    for (const file of files) {
+        if (ALLOWLIST.has(file)) {
+            continue
+        }
+
+        let content;
+        try {
+            content = readFileSync(path.resolve(gitRoot, file), 'utf-8');
+        } catch (e) {
+            console.error(`check-aiconfig-test-mutation: could not read ${file}: ${e.message}`);
+            continue
+        }
+
+        findDbPathMutations(content).forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
+    }
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-aiconfig-test-mutation: ${violations.length} DB-path AiConfig mutation(s) in tests:\x1b[0m`);
+        if (!options.quiet) {
+            violations.forEach(v => console.error('  ' + v));
+            console.error('\nA test must NEVER mutate the shared AiConfig DB paths — test data bleeds into live DBs (the');
+            console.error('#12335 orphan incident; ADR-0019 §4 B4). Isolate by construction (UNIT_TEST_MODE resolves the');
+            console.error(`test DB), or — only if genuinely unavoidable — add an "${ESCAPE_MARKER}: <reason>" marker on the line.`);
+        }
+        process.exit(1);
+    }
+
+    console.log(`check-aiconfig-test-mutation: ${files.length} test file(s) scanned, 0 new violations.`);
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -23,10 +23,18 @@ export const ESCAPE_MARKER = 'aiconfig-mutation-ok';
  * The pattern requires an `aiConfig` / `Memory_Config` root before a dangerous leaf, so a non-config
  * `x.database = y` does not trip it; the trailing `=(?![=>])` excludes comparisons (`==` / `===`) and
  * arrows (`=>`), and a capture-read (`const x = aiConfig.storagePaths.graph`) has no `=` after the
- * leaf, so only true assignments match. Config-VARYING leaves (retry / transport) are deliberately
- * out of scope here — that class has no by-construction story yet.
+ * leaf, so only true assignments match. A dangerous leaf is caught whether dot-accessed
+ * (`.storagePaths`) or string-literal-bracket-accessed (`['storagePaths']`); a computed key
+ * (`aiConfig[varName]`) is out of a static lint's reach — the escape marker + the by-construction
+ * migration cover that residue. Config-VARYING leaves (retry / transport) are deliberately out of
+ * scope here — that class has no by-construction story yet.
  */
-export const DB_PATH_MUTATION = /\b(?:aiConfig|Memory_Config)\b[\w.$[\]'"`-]*\.(?:storagePaths|database|collections|logPath)\b[\w.$[\]'"`]*\s*=(?![=>])/;
+const DB_PATH_LEAVES = '(?:storagePaths|database|collections|logPath)';
+export const DB_PATH_MUTATION = new RegExp(
+    `\\b(?:aiConfig|Memory_Config)\\b[\\w.$[\\]'"\`-]*` +                       // a config root, then any path chars
+    `(?:\\.${DB_PATH_LEAVES}\\b|\\[\\s*['"\`]${DB_PATH_LEAVES}['"\`]\\s*\\])` + // a dangerous leaf: dot OR string-literal bracket
+    `[\\w.$[\\]'"\`]*\\s*=(?![=>])`                                             // optional trailing path, then assignment (not == / =>)
+);
 
 /*
  * Files that already mutate Class-A DB paths, grandfathered while the cleanup migrates them to
@@ -59,27 +67,30 @@ export const ALLOWLIST = new Set([
 ]);
 
 /**
- * @summary Returns the code portion of a line with string contents and comments removed.
+ * @summary Builds a per-character "is this code?" mask for a line — false inside string literals and
+ * comments, true in executable code.
  *
- * A string-aware scan: string literals collapse to a single space (so a config path inside a string —
- * a log message, a `describe(...)` title — never reads as a mutation), and line/block comments are
- * dropped. Block-comment state is carried across lines via `state.inBlock`. The dual of
- * `check-ticket-archaeology.mjs`'s `extractComment`, which keeps the comment and drops the code.
+ * Block-comment state is carried across lines via `state.inBlock`. Unlike a strip-to-text pass the mask
+ * preserves positions, so a regex match found on the RAW line can be classified by whether its root
+ * token sits in code. That is what lets a string-literal *bracket key* (`['storagePaths']` — real code
+ * that merely contains a string) be detected, while a mutation pattern living entirely inside a string
+ * (a log message, a `describe(...)` title) is excluded. The structural complement of
+ * `check-ticket-archaeology.mjs`'s `extractComment`.
  * @param {String} line
  * @param {{inBlock: Boolean}} state Mutated in place as block comments open and close across lines.
- * @returns {String} The code text on this line (comments + string contents stripped).
+ * @returns {Boolean[]} `mask[i]` is true when raw character `i` is executable code.
  */
-export function stripStringsAndComments(line, state) {
-    let code = '',
-        i    = 0;
+export function codeMask(line, state) {
+    const n    = line.length,
+          mask = new Array(n).fill(false);
 
-    const n = line.length;
+    let i = 0;
 
     if (state.inBlock) {
         const end = line.indexOf('*/');
 
         if (end === -1) {
-            return ''
+            return mask
         }
 
         i             = end + 2;
@@ -106,7 +117,6 @@ export function stripStringsAndComments(line, state) {
 
         if (ch === '"' || ch === "'" || ch === '`') {
             inString = ch;
-            code    += ' ';
             i++;
             continue
         }
@@ -127,15 +137,17 @@ export function stripStringsAndComments(line, state) {
             continue
         }
 
-        code += ch;
+        mask[i] = true;
         i++
     }
 
-    return code
+    return mask
 }
 
+const DB_PATH_MUTATION_GLOBAL = new RegExp(DB_PATH_MUTATION.source, 'g');
+
 /**
- * @summary Scans file content for Class-A DB-path `AiConfig` mutations in executable code.
+ * @summary Scans file content for Class-A DB-path `AiConfig` mutations whose root token sits in code.
  * @param {String} content
  * @returns {Object[]} `[{line, text}]` — one entry per offending line (1-based line numbers).
  */
@@ -149,10 +161,16 @@ export function findDbPathMutations(content) {
             return
         }
 
-        const code = stripStringsAndComments(line, state);
+        const mask = codeMask(line, state);
 
-        if (DB_PATH_MUTATION.test(code)) {
-            hits.push({line: index + 1, text: line.trim()})
+        for (const match of line.matchAll(DB_PATH_MUTATION_GLOBAL)) {
+            // The match starts at the aiConfig / Memory_Config root; flag it only when that root is real
+            // code, not a string that merely quotes a mutation-looking pattern (a bracket key like
+            // `['storagePaths']` is fine — its root token is still in code).
+            if (mask[match.index]) {
+                hits.push({line: index + 1, text: line.trim()});
+                break
+            }
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -231,6 +231,9 @@
         "*.mjs": [
             "node ./buildScripts/util/check-shorthand.mjs",
             "node ./buildScripts/util/check-ticket-archaeology.mjs"
+        ],
+        "test/**/*.mjs": [
+            "node ./buildScripts/util/check-aiconfig-test-mutation.mjs"
         ]
     }
 }

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -25,6 +25,20 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         expect(findDbPathMutations('aiConfig.storagePaths.graph = originalGraphPath;').map(h => h.line)).toEqual([1])
     });
 
+    test('flags string-literal bracket access to a dangerous leaf (closes the bypass)', () => {
+        expect(findDbPathMutations('aiConfig["storagePaths"].graph = testPath;').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations("aiConfig['engines']['chroma']['database'] = name;").map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('Memory_Config.data["collections"] = {};').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('aiConfig.storagePaths["graph"] = testPath;').map(h => h.line)).toEqual([1])
+    });
+
+    test('does NOT flag a computed (non-literal) key — out of a static lint reach, by design', () => {
+        expect(findDbPathMutations('aiConfig[dbKey] = fakeDb;')).toEqual([]);
+        expect(findDbPathMutations('aiConfig[leafName].graph = p;')).toEqual([]);
+        // a Class-B leaf via bracket stays out of scope too (transport is not a DB-path leaf)
+        expect(findDbPathMutations('aiConfig["transport"] = "sse";')).toEqual([])
+    });
+
     test('does NOT flag a comparison (=== / ==)', () => {
         expect(findDbPathMutations('if (aiConfig.storagePaths.graph === testPath) doThing();')).toEqual([]);
         expect(findDbPathMutations('expect(aiConfig.collections.memory == name).toBe(true);')).toEqual([])

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -1,0 +1,77 @@
+import {test, expect}                                           from '@playwright/test';
+import {findDbPathMutations, ALLOWLIST, ESCAPE_MARKER}          from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
+
+/**
+ * Self-test for the Class-A DB-path AiConfig test-mutation guard: the mechanical enforcement of the
+ * B4 safety-critical rule — a test must never mutate the shared AiConfig DB paths (the orphan-bleed
+ * class). Verifies it flags true DB-path assignments, exempts comparisons / capture-reads /
+ * config-varying (Class B) leaves / non-config roots / string + comment context, and honors the
+ * inline escape marker.
+ */
+test.describe('check-aiconfig-test-mutation guard', () => {
+    test('flags storagePaths / database / collections / logPath assignments', () => {
+        expect(findDbPathMutations('aiConfig.storagePaths.graph = testPath;').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations("aiConfig.engines.chroma.database = `graph-${process.pid}`;").map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('aiConfig.collections.memory = name;').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('aiConfig.data.logPath = tmpLogDir;').map(h => h.line)).toEqual([1])
+    });
+
+    test('flags the Memory_Config root and an SDK-prefixed root', () => {
+        expect(findDbPathMutations('Memory_Config.data.collections = {};').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('SDK.Memory_Config.data.storagePaths.graph = p;').map(h => h.line)).toEqual([1])
+    });
+
+    test('flags a restore-write (restore is itself a B4 mutation)', () => {
+        expect(findDbPathMutations('aiConfig.storagePaths.graph = originalGraphPath;').map(h => h.line)).toEqual([1])
+    });
+
+    test('does NOT flag a comparison (=== / ==)', () => {
+        expect(findDbPathMutations('if (aiConfig.storagePaths.graph === testPath) doThing();')).toEqual([]);
+        expect(findDbPathMutations('expect(aiConfig.collections.memory == name).toBe(true);')).toEqual([])
+    });
+
+    test('does NOT flag a capture-read (DB path on the RHS)', () => {
+        expect(findDbPathMutations('const originalGraphPath = aiConfig.storagePaths.graph;')).toEqual([]);
+        expect(findDbPathMutations('const db = aiConfig.engines.chroma.database;')).toEqual([])
+    });
+
+    test('does NOT flag a config-VARYING (Class B) leaf — out of scope', () => {
+        expect(findDbPathMutations('aiConfig.openAiCompatible.unloadRetryCount = 3;')).toEqual([]);
+        expect(findDbPathMutations('aiConfig.transport = "sse";')).toEqual([]);
+        expect(findDbPathMutations('SDK.Memory_Config.data.embeddingProvider = "openAiCompatible";')).toEqual([])
+    });
+
+    test('does NOT flag a non-config root with a same-named leaf', () => {
+        expect(findDbPathMutations('myService.database = fakeDb;')).toEqual([]);
+        expect(findDbPathMutations('record.collections = [];')).toEqual([])
+    });
+
+    test('does NOT flag a leaf whose name merely starts with a dangerous token', () => {
+        expect(findDbPathMutations('aiConfig.collectionsCount = 5;')).toEqual([]);
+        expect(findDbPathMutations('aiConfig.databaseUrl = url;')).toEqual([])
+    });
+
+    test('does NOT flag a mutation that lives inside a string literal', () => {
+        expect(findDbPathMutations("const sample = 'aiConfig.storagePaths.graph = x';")).toEqual([]);
+        expect(findDbPathMutations('log(`set aiConfig.collections.memory = ${name}`);')).toEqual([])
+    });
+
+    test('does NOT flag a mutation inside a // line or /* block */ comment', () => {
+        expect(findDbPathMutations('// aiConfig.storagePaths.graph = x (legacy note)')).toEqual([]);
+        expect(findDbPathMutations([
+            '/**',
+            ' * aiConfig.engines.chroma.database = foo — described, not executed.',
+            ' */',
+            'const x = 1;'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('honors the inline escape marker on a genuinely unavoidable line', () => {
+        expect(findDbPathMutations(`aiConfig.storagePaths.graph = p; // ${ESCAPE_MARKER}: legacy shim, migrates in #12435`)).toEqual([])
+    });
+
+    test('the grandfather allowlist is populated (the ratchet bites only new offenders)', () => {
+        expect(ALLOWLIST.size).toBeGreaterThan(0);
+        expect(ALLOWLIST.has('test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs')).toBe(true)
+    })
+});


### PR DESCRIPTION
Resolves #13227

A test that writes `aiConfig.{storagePaths | engines.chroma.database | collections | logPath}` to the shared `AiConfig` singleton is the orphan-bleed mechanism — the reactive set-trap routes the assignment to the shared provider, so failed cleanup / a shared process / test-ordering means the next consumer reads the test DB (the #12335 orphan incident; ADR-0019 §4 B4). The B4 lint was unshipped (#12451 shipped only the *A4 inline-`process.env`* guard via PR #12472). Scoped per the [#12435 decomposition](https://github.com/neomjs/neo/issues/12435#issuecomment-4701771729) to **Class A** (the safety-critical DB-path subset).

Evidence: L2 (12/12 focused unit tests over the detection regex + string/comment exclusion + escape marker + allowlist; repo self-scan = 0 new violations; a synthetic new violation exits 1) → L2 required (a lint primitive + its self-test). No residuals.

## What it does

`buildScripts/util/check-aiconfig-test-mutation.mjs` flags `(aiConfig | Memory_Config.data).{storagePaths | engines.chroma.database | collections | logPath} = …` assignments in `test/**` — **code only** (string + comment context stripped via the same scanner shape as `check-ticket-archaeology.mjs`). The trailing `=(?![=>])` excludes comparisons (`==` / `===`) and arrows; a capture-read (`const x = aiConfig.storagePaths.graph`) has no `=` after the leaf, so only true assignments match.

- **Grandfather allowlist** — the current 22 Class-A offenders are listed + skipped, so the ratchet bites only NEW offenders and CI stays green. The set shrinks as #12435 migrates them.
- **Escape marker** — `aiconfig-mutation-ok: <reason>` for a genuinely unavoidable line.
- Wired into `lint-staged` under a `test/**/*.mjs` glob.

## Deltas from ticket

- **Scope = Class A only (DB-path), not the broad `any aiConfig.<path> =`.** The #12435 decomposition found the surface is ~45 files in two classes: Class A (DB-path, the orphan-bleed safety-critical subset — *this PR*) and Class B (config-varying: retry / transport — which have **no by-construction isolation story yet**, an open design question). Flagging Class B now would block legitimate tests with no sanctioned alternative, so it's deferred; the broad lint follows once Class B's override mechanism is designed.

## Test Evidence

- `check-aiconfig-test-mutation.spec.mjs`: **12 passed** — `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs`. Covers DB-path assignments (storagePaths / database / collections / logPath), `Memory_Config` + `SDK`-prefixed roots, restore-writes, and the negatives: comparisons, capture-reads, Class-B leaves, non-config roots, prefix-collisions (`collectionsCount` / `databaseUrl`), string + comment context, and the escape marker.
- Repo self-scan: `node ./buildScripts/util/check-aiconfig-test-mutation.mjs` → **508 test files scanned, 0 new violations** (allowlist grandfathers the 22).
- Ratchet check: a synthetic non-allowlisted DB-path mutation → **exit 1** with the violation reported.
- Pre-commit: the lint ran on its own commit via `lint-staged`; whitespace / shorthand / ticket-archaeology green.

## Post-Merge Validation

- Confirm CI's `lint-staged` / pre-commit path invokes the new check on a `test/**` change.
- As #12435 migrates a Class-A file to by-construction isolation, removing it from the allowlist should keep the lint green (the mutation is gone).

Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.
