### PR TITLE
feat(ai): TransactionService in-heap undo-stack core (#13230)

### DIFF
--- a/src/ai/TransactionService.mjs
+++ b/src/ai/TransactionService.mjs
@@ -1,0 +1,308 @@
+import Base from '../core/Base.mjs';
+
+/**
+ * JSON deep-clone of a transaction op's data-only descriptors. The in-heap stack never hands a caller a live
+ * reference into its held undo state, and every captured reverse-op is **data-not-code** (a JSON tool-descriptor
+ * per the Neural Link capability boundary), so a structural JSON clone is both sufficient *and* the contract
+ * guard — a function / class reference smuggled into `forward` / `reverse` would throw here rather than enter the
+ * stack.
+ * @param {Object} op
+ * @returns {Object}
+ */
+const cloneOp = op => ({
+    sequenceId       : op.sequenceId,
+    originWriter     : {agentId: op.originWriter.agentId, sessionId: op.originWriter.sessionId},
+    targetSubtreePath: [...op.targetSubtreePath],
+    forward          : JSON.parse(JSON.stringify(op.forward)),
+    reverse          : JSON.parse(JSON.stringify(op.reverse)),
+    label            : op.label
+});
+
+/**
+ * Deep-copy a transaction (id + status + a clone of every op), for introspection / undo return values.
+ * @param {Object} tx
+ * @returns {Object}
+ */
+const cloneTx = tx => ({txId: tx.txId, status: tx.status, ops: tx.ops.map(cloneOp)});
+
+/**
+ * The stable string key for a writer's undo stack — the **full session identity**, so two Neural Link sessions
+ * or two writers never share a stack. Fails closed (`null`) when any field is missing: no shared / wildcard stack.
+ * @param {Object} [id={}] `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+ * @returns {String|null}
+ */
+const stackKey = ({neuralLinkSessionId, requesterAgentId, requesterSessionId} = {}) => {
+    if (!neuralLinkSessionId || !requesterAgentId || !requesterSessionId) {
+        return null
+    }
+    return JSON.stringify([neuralLinkSessionId, requesterAgentId, requesterSessionId])
+};
+
+/**
+ * @summary In-heap, per-session transaction stack — the **active undo authority** for one App-Worker heap.
+ *
+ * The stateful counterpart to the Neural Link mutation primitives: where each write-class op mutates the live
+ * component tree, this records that op's **reverse** so an agent can say *"undo that"* and revert cleanly. It is
+ * the heap's active undo state, distinct by design from `Neo.ai.RecorderService` / `nl_action_log` — that ledger
+ * stays a **forward-only audit** trail; this is the live reversible stack (in-memory now by the converged design,
+ * persistence a later slice — the active-vs-archive split).
+ *
+ * Like `Neo.ai.WriteGuard`, it is a per-heap authority owned by the in-app `Neo.ai.Client` and is **pure over its
+ * inputs** — reverse-capture, the enforcement grant, and the live tree all live in the caller; this class only
+ * owns the stack lifecycle, so it is unit-testable via event sequences with no live-heap or socket dependency.
+ *
+ * **Lifecycle / state machine**: `open → committed → undone`, with `aborted` / `timedOut`
+ * as failure / teardown terminals. A reverse-op is captured ({@link record}) only after the forward write is
+ * enforcement-granted — the caller (the `InstanceService` write-path, behind `Neo.ai.admitWrite`) guarantees that
+ * ordering, so a denied write never reaches {@link record} and leaves no reverse record. Slice-1 is **single-level**
+ * undo: {@link undo} reverts the most-recent committed transaction for the writer.
+ *
+ * **Identity / provenance**: each op stores `originWriter:{agentId, sessionId}` as
+ * provenance / authorization evidence **only**; the stack never enforces with it — undo is re-dispatched and
+ * re-enforced as the *current* requester by the caller, and the enforcement `subtreePath` is re-derived at undo
+ * time on the live tree (the stored `targetSubtreePath` is audit metadata, never the enforcement path).
+ *
+ * Scope boundary (Slice-1): this is the stack authority + its lifecycle API. The `InstanceService`
+ * capture-hook, the `undo` Neural Link tool, `redo` + named batching (Slice-2), Memory-Core persistence (Slice-3),
+ * and any privileged `systemRollback` are named follow-up slices, not this module.
+ * @class Neo.ai.TransactionService
+ * @extends Neo.core.Base
+ */
+class TransactionService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.TransactionService'
+         * @protected
+         */
+        className: 'Neo.ai.TransactionService',
+        /**
+         * Max committed transactions retained per session; the oldest is evicted (and no longer undoable) past
+         * this depth — a bound on heap growth (the converged density cap).
+         * @member {Number} maxStackDepth=50
+         */
+        maxStackDepth: 50,
+        /**
+         * Max reverse-ops a single transaction may hold (a bound on a runaway batch; Slice-1 is typically 1).
+         * @member {Number} maxOpsPerTransaction=100
+         */
+        maxOpsPerTransaction: 100,
+        /**
+         * Max serialized byte size of a single reverse-op descriptor — a captured reverse larger than this is
+         * rejected (fail-closed: better to drop reversibility for one giant op than blow the heap budget).
+         * @member {Number} maxReversePayloadBytes=65536
+         */
+        maxReversePayloadBytes: 65536
+    }
+
+    /**
+     * Per-session undo state, keyed by {@link stackKey}. Each value is `{open: Object|null, committed: Object[]}`:
+     * at most one `open` transaction at a time, plus the depth-capped `committed` stack (newest last). In-memory
+     * + same-live-session only (the converged design); a disconnect {@link sweep}s the session away.
+     * @member {Map<String,Object>} sessions
+     * @protected
+     */
+    sessions = new Map()
+
+    /**
+     * @summary Open a new transaction for a writer's session (`status: 'open'`).
+     * Slice-1 holds at most one open transaction per session: opening a new one while a prior is still open
+     * marks the stale one `aborted` (a write that never committed / a teardown gap) so a leaked open transaction
+     * can't accumulate ops forever. Fails closed on an incomplete session identity or missing `txId`.
+     * @param {Object} params
+     * @param {Object} params.id   `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {String} params.txId
+     * @returns {{ok: Boolean, reason: (String|null)}}
+     */
+    begin({id, txId}) {
+        const key = stackKey(id);
+
+        if (!key || typeof txId !== 'string' || txId === '') {
+            return {ok: false, reason: 'invalid-session-or-tx'}
+        }
+
+        let entry = this.sessions.get(key);
+
+        if (!entry) {
+            entry = {open: null, committed: []};
+            this.sessions.set(key, entry)
+        }
+
+        if (entry.open) {
+            entry.open.status = 'aborted' // a prior open tx never committed — fail-safe abort, don't leak it
+        }
+
+        entry.open = {txId, status: 'open', ops: []};
+
+        return {ok: true, reason: null}
+    }
+
+    /**
+     * @summary Record a reverse-op into the session's open transaction — the capture step.
+     * The caller invokes this only **after** the forward write is enforcement-granted (so a denied write leaves no
+     * reverse record). Fails closed on: no open transaction, a `txId` mismatch, a malformed op (missing
+     * `originWriter` / `targetSubtreePath` / `reverse`), the per-transaction op cap, or an oversized reverse payload.
+     * @param {Object} params
+     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {String} params.txId
+     * @param {Object} params.op  `{sequenceId, originWriter:{agentId,sessionId}, targetSubtreePath:String[], forward, reverse, label}`
+     * @returns {{ok: Boolean, reason: (String|null)}}
+     */
+    record({id, txId, op}) {
+        const entry = this.sessions.get(stackKey(id) ?? '');
+
+        if (!entry?.open || entry.open.txId !== txId) {
+            return {ok: false, reason: 'no-open-transaction'}
+        }
+
+        if (!op || typeof op !== 'object' ||
+            !op.originWriter?.agentId || !op.originWriter?.sessionId ||
+            !Array.isArray(op.targetSubtreePath) || op.reverse === undefined) {
+            return {ok: false, reason: 'malformed-op'}
+        }
+
+        if (entry.open.ops.length >= this.maxOpsPerTransaction) {
+            return {ok: false, reason: 'max-ops-per-transaction'}
+        }
+
+        let serialized;
+
+        try {
+            serialized = JSON.stringify(op.reverse)
+        } catch (e) {
+            return {ok: false, reason: 'reverse-not-serializable'} // a non-JSON reverse (function/cycle) — data-not-code guard
+        }
+
+        if (serialized.length > this.maxReversePayloadBytes) {
+            return {ok: false, reason: 'max-reverse-payload-bytes'}
+        }
+
+        entry.open.ops.push(cloneOp(op));
+
+        return {ok: true, reason: null}
+    }
+
+    /**
+     * @summary Commit the session's open transaction — `open → committed`.
+     * The committed transaction joins the undo stack (newest last); if that pushes the stack past
+     * {@link maxStackDepth}, the **oldest** committed transaction is evicted (no longer undoable). A commit with no
+     * ops is dropped rather than committed (nothing to undo). Fails closed on no-open / `txId` mismatch.
+     * @param {Object} params
+     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {String} params.txId
+     * @returns {{ok: Boolean, reason: (String|null)}}
+     */
+    commit({id, txId}) {
+        const entry = this.sessions.get(stackKey(id) ?? '');
+
+        if (!entry?.open || entry.open.txId !== txId) {
+            return {ok: false, reason: 'no-open-transaction'}
+        }
+
+        const tx = entry.open;
+
+        entry.open = null;
+
+        if (tx.ops.length === 0) {
+            tx.status = 'aborted';
+            return {ok: false, reason: 'empty-transaction'} // nothing captured — not undoable
+        }
+
+        tx.status = 'committed';
+        entry.committed.push(tx);
+
+        if (entry.committed.length > this.maxStackDepth) {
+            entry.committed.shift() // evict the oldest — past the depth bound it is no longer undoable
+        }
+
+        return {ok: true, reason: null}
+    }
+
+    /**
+     * @summary Undo the most-recent committed transaction for the writer — `committed → undone` (single-level).
+     * Marks the transaction `undone` and returns its reverse-ops **in reverse capture order** (last-in mutation
+     * undone first), for the caller to re-dispatch as validated tool calls — re-enforced as the *current*
+     * requester, with the enforcement `subtreePath` re-derived on the live tree (NOT the stored audit path). Does
+     * not itself mutate the tree or the lock table. Returns `reverseOps: null` when there is nothing to undo.
+     * @param {Object} params
+     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @returns {{txId: (String|null), reverseOps: (Object[]|null)}}
+     */
+    undo({id}) {
+        const entry = this.sessions.get(stackKey(id) ?? '');
+
+        if (!entry || entry.committed.length === 0) {
+            return {txId: null, reverseOps: null}
+        }
+
+        const tx = entry.committed.pop();
+
+        tx.status = 'undone';
+
+        return {txId: tx.txId, reverseOps: tx.ops.map(cloneOp).reverse()}
+    }
+
+    /**
+     * @summary Abort the session's open transaction (`open → aborted`) — the failure / teardown path.
+     * A no-op when no transaction is open or the `txId` does not match (idempotent). An aborted transaction is
+     * dropped, never undoable, and leaves no reverse record.
+     * @param {Object} params
+     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {String} params.txId
+     * @returns {{aborted: Boolean}}
+     */
+    abort({id, txId}) {
+        const entry = this.sessions.get(stackKey(id) ?? '');
+
+        if (!entry?.open || entry.open.txId !== txId) {
+            return {aborted: false}
+        }
+
+        entry.open.status = 'aborted';
+        entry.open        = null;
+
+        return {aborted: true}
+    }
+
+    /**
+     * @summary Sweep a writer's entire undo state on disconnect / worker-restart — aborts any open transaction and
+     * retires the session's stack. The transaction-side counterpart to `WriteGuard.releaseAgent` (the caller runs
+     * both on an `agent_disconnected` frame, so the lock + transaction lifecycles cannot diverge silently). Fails
+     * closed on an incomplete identity (sweeps nothing — never clears the whole table).
+     * @param {Object} params
+     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @returns {{swept: Boolean}}
+     */
+    sweep({id}) {
+        const key = stackKey(id);
+
+        if (!key || !this.sessions.has(key)) {
+            return {swept: false}
+        }
+
+        this.sessions.delete(key);
+
+        return {swept: true}
+    }
+
+    /**
+     * @summary A deep snapshot of a session's undo state (introspection / testing).
+     * Every returned transaction + op is a copy, so a caller cannot mutate the live stack through the result.
+     * @param {Object} params
+     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @returns {{open: (Object|null), committed: Object[]}}
+     */
+    stackOf({id}) {
+        const entry = this.sessions.get(stackKey(id) ?? '');
+
+        if (!entry) {
+            return {open: null, committed: []}
+        }
+
+        return {
+            open     : entry.open ? cloneTx(entry.open) : null,
+            committed: entry.committed.map(cloneTx)
+        }
+    }
+}
+
+export default Neo.setupClass(TransactionService);

--- a/src/ai/TransactionService.mjs
+++ b/src/ai/TransactionService.mjs
@@ -87,11 +87,16 @@ class TransactionService extends Base {
          */
         maxOpsPerTransaction: 100,
         /**
-         * Max serialized byte size of a single reverse-op descriptor — a captured reverse larger than this is
-         * rejected (fail-closed: better to drop reversibility for one giant op than blow the heap budget).
-         * @member {Number} maxReversePayloadBytes=65536
+         * Max serialized byte size of a single op descriptor (each of `forward` / `reverse`) — a descriptor larger
+         * than this is rejected (fail-closed: better to drop reversibility for one giant op than blow the heap budget).
+         * @member {Number} maxOpPayloadBytes=65536
          */
-        maxReversePayloadBytes: 65536
+        maxOpPayloadBytes: 65536,
+        /**
+         * Max length of an op's user-facing display `label` — a bound on the label/source string.
+         * @member {Number} maxLabelChars=200
+         */
+        maxLabelChars: 200
     }
 
     /**
@@ -139,8 +144,10 @@ class TransactionService extends Base {
     /**
      * @summary Record a reverse-op into the session's open transaction — the capture step.
      * The caller invokes this only **after** the forward write is enforcement-granted (so a denied write leaves no
-     * reverse record). Fails closed on: no open transaction, a `txId` mismatch, a malformed op (missing
-     * `originWriter` / `targetSubtreePath` / `reverse`), the per-transaction op cap, or an oversized reverse payload.
+     * reverse record). Fails closed (returns `{ok:false}`, never throws) on: no open transaction; a `txId` mismatch;
+     * a malformed op (any of `sequenceId` / `originWriter.{agentId,sessionId}` / `targetSubtreePath` / `forward` /
+     * `reverse` / `label` missing or mistyped); a non-serializable `forward` or `reverse` (the data-not-code guard);
+     * the per-transaction op cap; an over-long `label`; or an oversized op payload.
      * @param {Object} params
      * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
      * @param {String} params.txId
@@ -154,9 +161,22 @@ class TransactionService extends Base {
             return {ok: false, reason: 'no-open-transaction'}
         }
 
-        if (!op || typeof op !== 'object' ||
-            !op.originWriter?.agentId || !op.originWriter?.sessionId ||
-            !Array.isArray(op.targetSubtreePath) || op.reverse === undefined) {
+        if (!op || typeof op !== 'object') {
+            return {ok: false, reason: 'malformed-op'}
+        }
+
+        const {sequenceId, originWriter, targetSubtreePath, forward, reverse, label} = op;
+
+        // Every required reverse-record field must be present + well-typed — a malformed descriptor fails closed
+        // here, never stored half-formed and never reached by cloneOp / undo downstream.
+        if (typeof sequenceId !== 'string' || sequenceId === ''                               ||
+            !originWriter ||
+            typeof originWriter.agentId   !== 'string' || originWriter.agentId   === ''        ||
+            typeof originWriter.sessionId !== 'string' || originWriter.sessionId === ''        ||
+            !Array.isArray(targetSubtreePath) || targetSubtreePath.length === 0                ||
+            !targetSubtreePath.every(segment => typeof segment === 'string' && segment !== '') ||
+            forward === undefined || reverse === undefined                                     ||
+            typeof label !== 'string' || label === '') {
             return {ok: false, reason: 'malformed-op'}
         }
 
@@ -164,16 +184,24 @@ class TransactionService extends Base {
             return {ok: false, reason: 'max-ops-per-transaction'}
         }
 
-        let serialized;
-
-        try {
-            serialized = JSON.stringify(op.reverse)
-        } catch (e) {
-            return {ok: false, reason: 'reverse-not-serializable'} // a non-JSON reverse (function/cycle) — data-not-code guard
+        if (label.length > this.maxLabelChars) {
+            return {ok: false, reason: 'max-label-length'}
         }
 
-        if (serialized.length > this.maxReversePayloadBytes) {
-            return {ok: false, reason: 'max-reverse-payload-bytes'}
+        // BOTH `forward` and `reverse` must be JSON-serializable (the data-not-code guard) + within the payload
+        // bound. A function / cycle / oversized descriptor fails closed — it must never enter the stack OR escape as
+        // an uncaught exception from a downstream `cloneOp`.
+        let forwardJson, reverseJson;
+
+        try {
+            forwardJson = JSON.stringify(forward);
+            reverseJson = JSON.stringify(reverse)
+        } catch (e) {
+            return {ok: false, reason: 'op-not-serializable'}
+        }
+
+        if (forwardJson.length > this.maxOpPayloadBytes || reverseJson.length > this.maxOpPayloadBytes) {
+            return {ok: false, reason: 'max-op-payload-bytes'}
         }
 
         entry.open.ops.push(cloneOp(op));
@@ -261,6 +289,30 @@ class TransactionService extends Base {
         entry.open        = null;
 
         return {aborted: true}
+    }
+
+    /**
+     * @summary Time out the session's open transaction (`open → timedOut`) — the lease-expiry path, distinct from a
+     * caller-driven `abort`. A no-op when no transaction is open or the `txId` does not match (idempotent). A
+     * timed-out transaction is dropped, never undoable, and leaves no reverse record (a partial capture is not a
+     * coherent undo unit). The terminal is recorded separately from `aborted` so a lease expiry stays auditable as
+     * its own cause rather than masquerading as a deliberate abort.
+     * @param {Object} params
+     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {String} params.txId
+     * @returns {{timedOut: Boolean}}
+     */
+    timeout({id, txId}) {
+        const entry = this.sessions.get(stackKey(id) ?? '');
+
+        if (!entry?.open || entry.open.txId !== txId) {
+            return {timedOut: false}
+        }
+
+        entry.open.status = 'timedOut';
+        entry.open        = null;
+
+        return {timedOut: true}
     }
 
     /**

--- a/test/playwright/unit/ai/TransactionService.spec.mjs
+++ b/test/playwright/unit/ai/TransactionService.spec.mjs
@@ -1,0 +1,225 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'TransactionServiceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+
+// Neo.ai.TransactionService is the in-heap per-session undo stack. It is pure over its inputs (reverse-capture,
+// the enforcement grant, and the live tree all live in the caller) — so these tests drive event sequences against
+// a real instance with no live-heap or socket dependency, and assert the lifecycle (open→committed→undone +
+// aborted), the single-level undo + reverse ordering, per-session isolation, the fail-closed branches, and the caps.
+
+const
+    ID  = {neuralLinkSessionId: 'nl-1', requesterAgentId: 'agent-a', requesterSessionId: 'sess-a'},
+    ID2 = {neuralLinkSessionId: 'nl-1', requesterAgentId: 'agent-b', requesterSessionId: 'sess-b'},
+
+    // a minimal valid reverse-op (WHO + WHAT + audit path); set⁻¹ is set(old values)
+    op = (n = 1, seq = `seq-${n}`) => ({
+        sequenceId       : seq,
+        originWriter     : {agentId: 'agent-a', sessionId: 'sess-a'},
+        targetSubtreePath: ['root', 'leaf'],
+        forward          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: n}}},
+        reverse          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: n - 1}}},
+        label            : `set x=${n}`
+    }),
+
+    svc = cfg => Neo.create('Neo.ai.TransactionService', cfg),
+
+    // the Slice-1 single-op capture flow: begin → record → commit
+    commitOne = (s, id, txId, o) => {
+        s.begin({id, txId});
+        s.record({id, txId, op: o});
+        return s.commit({id, txId})
+    };
+
+test.describe('Neo.ai.TransactionService — in-heap per-session undo stack', () => {
+    test('begin → record → commit → undo round-trips a single-op transaction', () => {
+        const s = svc();
+
+        expect(s.begin ({id: ID, txId: 'tx-1'})).toEqual({ok: true, reason: null});
+        expect(s.record({id: ID, txId: 'tx-1', op: op(1)})).toEqual({ok: true, reason: null});
+        expect(s.commit({id: ID, txId: 'tx-1'})).toEqual({ok: true, reason: null});
+
+        const u = s.undo({id: ID});
+
+        expect(u.txId).toBe('tx-1');
+        expect(u.reverseOps).toHaveLength(1);
+        expect(u.reverseOps[0].reverse).toEqual({tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 0}}});
+        expect(u.reverseOps[0].originWriter).toEqual({agentId: 'agent-a', sessionId: 'sess-a'}); // provenance preserved
+        expect(s.undo({id: ID})).toEqual({txId: null, reverseOps: null});                        // stack now empty
+    });
+
+    test('single-level undo pops most-recent committed first', () => {
+        const s = svc();
+
+        commitOne(s, ID, 'tx-1', op(1));
+        commitOne(s, ID, 'tx-2', op(2));
+
+        expect(s.undo({id: ID}).txId).toBe('tx-2');
+        expect(s.undo({id: ID}).txId).toBe('tx-1');
+        expect(s.undo({id: ID}).reverseOps).toBeNull();
+    });
+
+    test('a multi-op transaction returns reverses in REVERSE capture order (last mutation undone first)', () => {
+        const s = svc();
+
+        s.begin ({id: ID, txId: 'tx-1'});
+        s.record({id: ID, txId: 'tx-1', op: op(1, 'a')});
+        s.record({id: ID, txId: 'tx-1', op: op(2, 'b')});
+        s.commit({id: ID, txId: 'tx-1'});
+
+        expect(s.undo({id: ID}).reverseOps.map(o => o.sequenceId)).toEqual(['b', 'a']);
+    });
+
+    test('begin aborts a prior still-open transaction — no leaked open tx, no committed record', () => {
+        const s = svc();
+
+        s.begin ({id: ID, txId: 'tx-1'});
+        s.record({id: ID, txId: 'tx-1', op: op(1)});
+        s.begin ({id: ID, txId: 'tx-2'});                 // tx-1 was open → aborted
+
+        expect(s.commit({id: ID, txId: 'tx-1'}).ok).toBe(false); // tx-1 is no longer open
+        expect(s.stackOf({id: ID}).committed).toHaveLength(0);   // tx-1 left nothing committed
+        expect(s.stackOf({id: ID}).open.txId).toBe('tx-2');
+    });
+
+    test('per-session isolation — two writers keep separate stacks', () => {
+        const s = svc();
+
+        commitOne(s, ID,  'a-1', op(1));
+        commitOne(s, ID2, 'b-1', op(1));
+
+        expect(s.undo({id: ID }).txId).toBe('a-1');
+        expect(s.undo({id: ID2}).txId).toBe('b-1');
+        expect(s.undo({id: ID }).reverseOps).toBeNull(); // each writer's stack is independent
+    });
+
+    // ── fail-closed branches ──────────────────────────────────────────────────────────────────────
+    test('begin fails closed on an incomplete session identity or empty txId', () => {
+        const s = svc();
+
+        for (const badId of [{}, {requesterAgentId: 'a', requesterSessionId: 's'}, {neuralLinkSessionId: 'nl-1'}]) {
+            expect(s.begin({id: badId, txId: 'tx-1'}).ok).toBe(false)
+        }
+        expect(s.begin({id: ID, txId: ''}).ok).toBe(false);
+    });
+
+    test('record / commit fail closed with no open transaction or a txId mismatch', () => {
+        const s = svc();
+
+        expect(s.record({id: ID, txId: 'tx-1', op: op(1)})).toEqual({ok: false, reason: 'no-open-transaction'});
+        expect(s.commit({id: ID, txId: 'tx-1'})).toEqual({ok: false, reason: 'no-open-transaction'});
+
+        s.begin({id: ID, txId: 'tx-1'});
+        expect(s.record({id: ID, txId: 'WRONG', op: op(1)}).reason).toBe('no-open-transaction');
+        expect(s.commit({id: ID, txId: 'WRONG'}).reason).toBe('no-open-transaction');
+    });
+
+    test('record fails closed on a malformed op (missing originWriter / path / reverse)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        const base = op(1);
+        for (const bad of [
+            {...base, originWriter: {agentId: 'a'}},          // missing sessionId
+            {...base, targetSubtreePath: 'not-an-array'},
+            {...base, reverse: undefined}
+        ]) {
+            expect(s.record({id: ID, txId: 'tx-1', op: bad}).reason).toBe('malformed-op')
+        }
+    });
+
+    test('record fails closed on a non-serializable (cyclic) reverse — data-not-code guard', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        const cyclic = {}; cyclic.self = cyclic;
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(1), reverse: cyclic}}).reason)
+            .toBe('reverse-not-serializable');
+    });
+
+    test('commit drops an empty transaction (nothing captured → not undoable)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.commit({id: ID, txId: 'tx-1'})).toEqual({ok: false, reason: 'empty-transaction'});
+        expect(s.undo({id: ID}).reverseOps).toBeNull();
+    });
+
+    // ── caps ──────────────────────────────────────────────────────────────────────────────────────
+    test('maxOpsPerTransaction caps a single transaction', () => {
+        const s = svc({maxOpsPerTransaction: 2});
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.record({id: ID, txId: 'tx-1', op: op(1, 'a')}).ok).toBe(true);
+        expect(s.record({id: ID, txId: 'tx-1', op: op(2, 'b')}).ok).toBe(true);
+        expect(s.record({id: ID, txId: 'tx-1', op: op(3, 'c')})).toEqual({ok: false, reason: 'max-ops-per-transaction'});
+    });
+
+    test('maxReversePayloadBytes rejects an oversized reverse', () => {
+        const s   = svc({maxReversePayloadBytes: 40});
+        s.begin({id: ID, txId: 'tx-1'});
+
+        const big = {...op(1), reverse: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 'y'.repeat(200)}}}};
+        expect(s.record({id: ID, txId: 'tx-1', op: big})).toEqual({ok: false, reason: 'max-reverse-payload-bytes'});
+    });
+
+    test('maxStackDepth evicts the oldest committed transaction', () => {
+        const s = svc({maxStackDepth: 2});
+
+        commitOne(s, ID, 'tx-1', op(1));
+        commitOne(s, ID, 'tx-2', op(2));
+        commitOne(s, ID, 'tx-3', op(3)); // pushes past depth 2 → tx-1 evicted
+
+        expect(s.stackOf({id: ID}).committed.map(t => t.txId)).toEqual(['tx-2', 'tx-3']);
+        expect(s.undo({id: ID}).txId).toBe('tx-3');
+        expect(s.undo({id: ID}).txId).toBe('tx-2');
+        expect(s.undo({id: ID}).reverseOps).toBeNull(); // tx-1 was evicted — not undoable
+    });
+
+    // ── abort / sweep ───────────────────────────────────────────────────────────────────────────────
+    test('abort drops the open transaction (idempotent on mismatch)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.abort({id: ID, txId: 'WRONG'})).toEqual({aborted: false});
+        expect(s.abort({id: ID, txId: 'tx-1'})).toEqual({aborted: true});
+        expect(s.stackOf({id: ID}).open).toBeNull();
+        expect(s.abort({id: ID, txId: 'tx-1'})).toEqual({aborted: false}); // already gone
+    });
+
+    test('sweep retires a writer session entirely; fails closed on incomplete identity', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+        s.begin({id: ID, txId: 'tx-2'}); // an open tx too
+
+        expect(s.sweep({id: {}})).toEqual({swept: false});      // incomplete → sweeps nothing
+        expect(s.sweep({id: ID})).toEqual({swept: true});
+        expect(s.stackOf({id: ID})).toEqual({open: null, committed: []});
+        expect(s.undo({id: ID}).reverseOps).toBeNull();
+        expect(s.sweep({id: ID})).toEqual({swept: false});      // already swept
+    });
+
+    test('stackOf returns a deep copy — mutating it never affects the live stack', () => {
+        const s = svc();
+        commitOne(s, ID, 'tx-1', op(1));
+
+        const snap = s.stackOf({id: ID});
+        snap.committed[0].ops[0].reverse.args.properties.x = 999;
+        snap.committed.push({txId: 'injected'});
+
+        expect(s.undo({id: ID}).reverseOps[0].reverse.args.properties.x).toBe(0); // live stack unchanged
+    });
+});

--- a/test/playwright/unit/ai/TransactionService.spec.mjs
+++ b/test/playwright/unit/ai/TransactionService.spec.mjs
@@ -19,7 +19,8 @@ import TransactionService from '../../../../src/ai/TransactionService.mjs';
 // Neo.ai.TransactionService is the in-heap per-session undo stack. It is pure over its inputs (reverse-capture,
 // the enforcement grant, and the live tree all live in the caller) — so these tests drive event sequences against
 // a real instance with no live-heap or socket dependency, and assert the lifecycle (open→committed→undone +
-// aborted), the single-level undo + reverse ordering, per-session isolation, the fail-closed branches, and the caps.
+// aborted / timedOut), the single-level undo + reverse ordering, per-session isolation, the fail-closed branches
+// (every required reverse-record field + both-descriptor serializability), and the caps.
 
 const
     ID  = {neuralLinkSessionId: 'nl-1', requesterAgentId: 'agent-a', requesterSessionId: 'sess-a'},
@@ -127,27 +128,36 @@ test.describe('Neo.ai.TransactionService — in-heap per-session undo stack', ()
         expect(s.commit({id: ID, txId: 'WRONG'}).reason).toBe('no-open-transaction');
     });
 
-    test('record fails closed on a malformed op (missing originWriter / path / reverse)', () => {
+    test('record fails closed on a malformed op (ANY required field missing or mistyped)', () => {
         const s = svc();
         s.begin({id: ID, txId: 'tx-1'});
 
         const base = op(1);
         for (const bad of [
+            {...base, sequenceId: undefined},                 // missing sequenceId
+            {...base, sequenceId: ''},                        // empty sequenceId
+            {...base, originWriter: undefined},               // missing originWriter (no throw on the access)
             {...base, originWriter: {agentId: 'a'}},          // missing sessionId
             {...base, targetSubtreePath: 'not-an-array'},
-            {...base, reverse: undefined}
+            {...base, targetSubtreePath: []},                 // empty path
+            {...base, targetSubtreePath: ['root', '']},       // empty path segment
+            {...base, forward: undefined},                    // missing forward
+            {...base, reverse: undefined},                    // missing reverse
+            {...base, label: undefined},                      // missing label
+            {...base, label: ''}                              // empty label
         ]) {
             expect(s.record({id: ID, txId: 'tx-1', op: bad}).reason).toBe('malformed-op')
         }
     });
 
-    test('record fails closed on a non-serializable (cyclic) reverse — data-not-code guard', () => {
+    test('record fails closed on a non-serializable (cyclic) forward OR reverse — data-not-code guard', () => {
         const s = svc();
         s.begin({id: ID, txId: 'tx-1'});
 
         const cyclic = {}; cyclic.self = cyclic;
-        expect(s.record({id: ID, txId: 'tx-1', op: {...op(1), reverse: cyclic}}).reason)
-            .toBe('reverse-not-serializable');
+        // both descriptors are stored, so both must be JSON-guarded — neither may throw inside cloneOp downstream
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(1),      reverse: cyclic}}).reason).toBe('op-not-serializable');
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(2, 'b'), forward: cyclic}}).reason).toBe('op-not-serializable');
     });
 
     test('commit drops an empty transaction (nothing captured → not undoable)', () => {
@@ -168,12 +178,23 @@ test.describe('Neo.ai.TransactionService — in-heap per-session undo stack', ()
         expect(s.record({id: ID, txId: 'tx-1', op: op(3, 'c')})).toEqual({ok: false, reason: 'max-ops-per-transaction'});
     });
 
-    test('maxReversePayloadBytes rejects an oversized reverse', () => {
-        const s   = svc({maxReversePayloadBytes: 40});
+    test('maxOpPayloadBytes rejects an oversized forward OR reverse', () => {
+        const s = svc({maxOpPayloadBytes: 40});
         s.begin({id: ID, txId: 'tx-1'});
 
-        const big = {...op(1), reverse: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 'y'.repeat(200)}}}};
-        expect(s.record({id: ID, txId: 'tx-1', op: big})).toEqual({ok: false, reason: 'max-reverse-payload-bytes'});
+        const bigReverse = {...op(1),      reverse: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 'y'.repeat(200)}}}};
+        const bigForward = {...op(2, 'b'), forward: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 'y'.repeat(200)}}}};
+        expect(s.record({id: ID, txId: 'tx-1', op: bigReverse})).toEqual({ok: false, reason: 'max-op-payload-bytes'});
+        expect(s.record({id: ID, txId: 'tx-1', op: bigForward})).toEqual({ok: false, reason: 'max-op-payload-bytes'});
+    });
+
+    test('maxLabelChars rejects an over-long label (at the bound is accepted)', () => {
+        const s = svc({maxLabelChars: 8});
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(1), label: 'x'.repeat(9)}}))
+            .toEqual({ok: false, reason: 'max-label-length'});
+        expect(s.record({id: ID, txId: 'tx-1', op: {...op(2, 'b'), label: 'x'.repeat(8)}}).ok).toBe(true);
     });
 
     test('maxStackDepth evicts the oldest committed transaction', () => {
@@ -198,6 +219,17 @@ test.describe('Neo.ai.TransactionService — in-heap per-session undo stack', ()
         expect(s.abort({id: ID, txId: 'tx-1'})).toEqual({aborted: true});
         expect(s.stackOf({id: ID}).open).toBeNull();
         expect(s.abort({id: ID, txId: 'tx-1'})).toEqual({aborted: false}); // already gone
+    });
+
+    test('timeout drops the open transaction as its own terminal (idempotent on mismatch)', () => {
+        const s = svc();
+        s.begin({id: ID, txId: 'tx-1'});
+
+        expect(s.timeout({id: ID, txId: 'WRONG'})).toEqual({timedOut: false}); // mismatch → no-op
+        expect(s.timeout({id: ID, txId: 'tx-1'})).toEqual({timedOut: true});
+        expect(s.stackOf({id: ID}).open).toBeNull();
+        expect(s.timeout({id: ID, txId: 'tx-1'})).toEqual({timedOut: false}); // already gone
+        expect(s.undo({id: ID}).reverseOps).toBeNull();                       // a timed-out tx is never undoable
     });
 
     test('sweep retires a writer session entirely; fails closed on incomplete identity', () => {


### PR DESCRIPTION
Authored by Vega (Claude Opus 4.8, Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.

Resolves #13230
Refs #13221 · Refs #9848 · Refs #13012

The unblocked foundation of the Neural Link mutation-undo Slice-1: `src/ai/TransactionService.mjs`, a per-heap **in-heap transaction-stack authority** (sibling to `Neo.ai.WriteGuard`) that records the *reverse* of each mutation so an agent can say *"undo that"* and revert cleanly. Pure over its inputs (reverse-capture, the enforcement grant, and the live tree all live in the caller), so it is unit-provable in isolation — exactly as `LockRegistry` / `WriteGuard` / `resolveWriteLock` shipped as standalone cores before their wiring. It is the **active** undo stack, kept distinct by design from the forward-only `RecorderService` / `nl_action_log` audit ledger.

Lifecycle: `begin` / `record` / `commit` / `undo` / `abort` / `timeout` / `sweep` / `stackOf`; `open → committed → undone` (+ `aborted` / `timedOut`) state machine; per-session keying on `{neuralLinkSessionId, requesterAgentId, requesterSessionId}` (a `txId` identifies a transaction *within* a session's stack, not a key shard); each op stores `originWriter` (provenance only) + an audit `targetSubtreePath` + `forward`/`reverse` + a bounded `label`; depth / ops / per-descriptor-payload / label caps. **`record()` is fail-closed**: every required reverse-record field is validated and BOTH `forward` and `reverse` are JSON-serialization-guarded before capture, so a malformed / cyclic / over-cap op returns `{ok:false}` and never stores `undefined` nor throws downstream.

Evidence: L2 (18 unit tests covering every lifecycle path, single-level undo + reverse-ordering, per-session isolation, all fail-closed branches incl. every-required-field + both-descriptor serializability, the caps, the `timeout` terminal, and deep-copy introspection) → L2 required (a pure in-heap core; no runtime-effect-on-an-unreachable-surface AC — the live capture + undo integration is the #13221 wiring). No residuals.

## Deltas from ticket
None — delivers #13230's ACs exactly. **Parent #13221 Contract Ledger reconciliation (post-build, [#13221 comment](https://github.com/neomjs/neo/issues/13221#issuecomment-4701939274)):** the as-built corrects two pre-build drifts in #13221's ledger — target path `ai/services/neural-link/` → **`src/ai/`** (a per-heap authority, sibling to `WriteGuard`/`Client`/`InstanceService`, not a Node-side MCP wire service), and the stack key drops `txId` (the 3-tuple session identity keys the stack; `txId` identifies a transaction within it). The `timedOut` terminal + the full reverse-record field-set are now implemented to match the ledger. Context: #13221's capture-hook + `undo` tool are blocked-by #13226 (the `InstanceService` grant-gate, now merged); this in-heap core depends on neither, so it ships now as the unblocked pure-core foundation, per the established `LockRegistry`/`WriteGuard` pattern.

## Test Evidence
`UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/TransactionService.spec.mjs` → **18 passed** on the branch head (e08c761dc). Covers: round-trip; single-level most-recent-first; multi-op reverse-ordering; begin-aborts-prior-open; per-session isolation; fail-closed (invalid identity, no-open / txId-mismatch, **every required reverse-record field missing/mistyped**, **non-serializable cyclic `forward` OR `reverse`**); the caps (ops-per-tx, **per-descriptor op-payload-bytes**, **label-chars**, stack-depth eviction); abort idempotence; **`timeout` terminal**; sweep + fail-closed; deep-copy introspection.

## Post-Merge Validation
- [ ] #13221 wires the `InstanceService` capture-hook (post-enforcement-grant) + the `undo` Neural Link tool onto this core, once #13226 merges.
- [ ] The live two-agent undo e2e is the #13221 umbrella proof (this PR ships the unit-proven core only).

## Signal Ledger
*(Discussion #13216 graduation — §6.2 quorum, family-keyed)*
- **Claude family** (@neo-opus-vega author · @neo-opus-ada): `[GRADUATION_APPROVED by @neo-opus-ada]` — ratified the converged OQ1-OQ5 shape (incl. the in-memory stack + reverse-record schema this core implements).
- **GPT family** (@neo-gpt): `[GRADUATION_APPROVED]` (non-author, version-bound) — authored the §5.2 STEP_BACK + the ratified AC patch.
- **Gemini family** (@neo-gemini-pro): `operator_benched` — excluded from active-family quorum (archived under Unresolved Liveness).
- **Quorum:** MET (Claude + GPT both APPROVED; GPT non-author). Discussion #13216 closed RESOLVED.

## Unresolved Dissent
None — Discussion #13216 converged without dissent.

## Unresolved Liveness
- @neo-gemini-pro — `operator_benched` per `ai/graph/identityRoots.mjs`; not quorum-required (Slice-1 is high-blast, not Tier-2). May retroactively review on reactivation.
