### PR TITLE
fix(ai): release WriteGuard locks on agent disconnect (#13229)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -260,11 +260,40 @@ class Client extends Base {
     }
 
     /**
+     * @summary Release held write locks for one Bridge-stamped disconnected agent session.
+     * App-side `agent_disconnected` frames are lifecycle notifications, not JSON-RPC. Require the full
+     * `(agentId, sessionId)` writer key before calling {@link Neo.ai.WriteGuard#releaseAgent}; a half-stamped
+     * frame is dropped so it cannot sweep every session for an agent or every agent sharing a session id.
+     * @param {Object} [frame={}]
+     * @param {String} [frame.agentId]
+     * @param {String} [frame.sessionId]
+     * @returns {{released: Number}}
+     */
+    handleAgentDisconnected(frame = {}) {
+        const
+            {agentId, sessionId} = frame,
+            {writeGuard}         = this;
+
+        if (typeof agentId !== 'string' || agentId === '' ||
+            typeof sessionId !== 'string' || sessionId === '' ||
+            !writeGuard) {
+            return {released: 0}
+        }
+
+        return writeGuard.releaseAgent({agentId, sessionId})
+    }
+
+    /**
      * Handles incoming messages from the WebSocket.
      * Parses the JSON-RPC payload and delegates valid requests to `handleRequest`.
      * @param {Object} data
      */
     async onSocketMessage({data}) {
+        if (data?.type === 'agent_disconnected') {
+            this.handleAgentDisconnected(data);
+            return
+        }
+
         const {jsonrpc, context} = parseAgentEnvelope(data);
 
         if (jsonrpc?.method) {

--- a/test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs
+++ b/test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs
@@ -1,0 +1,125 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'AiClientAgentDisconnectTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+
+const lock = (agentId, sessionId, subtreePath) => ({agentId, sessionId, subtreePath});
+
+test.describe('Neo.ai.Client - agent disconnect lock release', () => {
+    let client, originalWebSocket;
+
+    test.beforeAll(() => {
+        originalWebSocket = globalThis.WebSocket;
+
+        globalThis.WebSocket = class UnitTestWebSocket {
+            static CLOSED     = 3
+            static CLOSING    = 2
+            static CONNECTING = 0
+            static OPEN       = 1
+
+            readyState = UnitTestWebSocket.OPEN
+
+            constructor(serverAddress) {
+                this.serverAddress = serverAddress
+            }
+
+            close() {
+                this.readyState = UnitTestWebSocket.CLOSED
+            }
+
+            send() {}
+        };
+
+        Neo.currentWorker = {
+            on: () => {}
+        };
+        Neo.worker = {
+            App: {
+                id            : 'test-worker',
+                isSharedWorker: false
+            }
+        }
+    });
+
+    test.afterAll(() => {
+        globalThis.WebSocket = originalWebSocket
+    });
+
+    test.beforeEach(async () => {
+        const {default: Client} = await import('../../../../src/ai/Client.mjs');
+
+        client             = Neo.ai.Client || Neo.create(Client, {appName});
+        client.writeGuard  = Neo.create('Neo.ai.WriteGuard');
+        client.isConnected = false
+    });
+
+    test('onSocketMessage releases the disconnected writer and frees the held subtree', async () => {
+        client.writeGuard.requestWrite(lock('neo-opus-ada', 'sess-1', ['root', 'panel']));
+
+        expect(client.writeGuard.requestWrite(lock('neo-opus-vega', 'sess-2', ['root', 'panel'])).granted).toBe(false);
+
+        await client.onSocketMessage({
+            data: {
+                type     : 'agent_disconnected',
+                agentId  : 'neo-opus-ada',
+                sessionId: 'sess-1'
+            }
+        });
+
+        expect(client.writeGuard.heldLocks()).toHaveLength(0);
+        expect(client.writeGuard.requestWrite(lock('neo-opus-vega', 'sess-2', ['root', 'panel'])).granted).toBe(true)
+    });
+
+    test('handleAgentDisconnected only releases the exact disconnected writer session', () => {
+        client.writeGuard.requestWrite(lock('neo-opus-ada', 'sess-1', ['root', 'a']));
+        client.writeGuard.requestWrite(lock('neo-opus-ada', 'sess-2', ['root', 'b']));
+
+        const result = client.handleAgentDisconnected({agentId: 'neo-opus-ada', sessionId: 'sess-1'});
+
+        expect(result.released).toBe(1);
+        expect(client.writeGuard.heldLocks()).toEqual([lock('neo-opus-ada', 'sess-2', ['root', 'b'])])
+    });
+
+    test('an unknown disconnected writer is a no-op', () => {
+        client.writeGuard.requestWrite(lock('neo-opus-ada', 'sess-1', ['root', 'panel']));
+
+        const result = client.handleAgentDisconnected({agentId: 'neo-opus-vega', sessionId: 'sess-2'});
+
+        expect(result.released).toBe(0);
+        expect(client.writeGuard.heldLocks()).toEqual([lock('neo-opus-ada', 'sess-1', ['root', 'panel'])])
+    });
+
+    test('half-stamped disconnect frames fail closed and do not sweep broad selectors', () => {
+        client.writeGuard.requestWrite(lock('neo-opus-ada',  'sess-1', ['root', 'a']));
+        client.writeGuard.requestWrite(lock('neo-opus-ada',  'sess-2', ['root', 'b']));
+        client.writeGuard.requestWrite(lock('neo-opus-vega', 'sess-1', ['root', 'c']));
+
+        for (const frame of [
+            {agentId: 'neo-opus-ada'},
+            {sessionId: 'sess-1'},
+            {agentId: '', sessionId: 'sess-1'},
+            {agentId: 'neo-opus-ada', sessionId: ''},
+            {agentId: null, sessionId: 'sess-1'},
+            {agentId: 'neo-opus-ada', sessionId: null}
+        ]) {
+            expect(client.handleAgentDisconnected(frame).released).toBe(0)
+        }
+
+        expect(client.writeGuard.heldLocks()).toEqual([
+            lock('neo-opus-ada',  'sess-1', ['root', 'a']),
+            lock('neo-opus-ada',  'sess-2', ['root', 'b']),
+            lock('neo-opus-vega', 'sess-1', ['root', 'c'])
+        ])
+    });
+});


### PR DESCRIPTION
Resolves #13229

Authored by GPT-5 (Codex Desktop). Session 019ec50d-5a01-7b11-9490-50f3241e8cfc.

The Client now treats Bridge app-side `{type:'agent_disconnected', agentId, sessionId}` frames as lifecycle notifications before JSON-RPC dispatch and releases only the matching `(agentId, sessionId)` held locks via `WriteGuard.releaseAgent`. The handler fails closed on half-stamped frames so a missing `sessionId` cannot release every session for one agent, and an unknown disconnected writer remains a no-op.

Evidence: L2 (focused Playwright unit coverage around the Client lifecycle frame + real WriteGuard lock table) -> L2 required (Client-side release behavior is unit-verifiable; Bridge app-frame emission is already covered in current `dev`). No residuals.

## Deltas from ticket
Current `dev` already includes the Bridge app broadcast from `#13226`: agent close emits an app-side `agent_disconnected` frame with `sessionId`, and `Bridge.spec.mjs` covers that contract. This PR therefore implements the remaining Client consumer half and documents the fail-closed half-stamp boundary at the Client.

## Test Evidence
- `git diff --check`
- `node --check src/ai/Client.mjs`
- `node --check test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs test/playwright/unit/ai/ClientDispatcher.spec.mjs test/playwright/unit/ai/ClientWindowRegistration.spec.mjs test/playwright/unit/ai/WriteGuard.spec.mjs test/playwright/unit/ai/parseAgentEnvelope.spec.mjs` - 28/28 passed on head `338cba694`

## Post-Merge Validation
- [ ] With two live agents sharing one app heap, disconnecting the Bridge session that holds a WriteGuard lock frees the subtree for another writer without releasing other sessions.

## Commit
- `338cba694` - `fix(ai): release WriteGuard locks on agent disconnect (#13229)`
