### PR TITLE
docs(grid): add pooled animation contract (#13219)

### DIFF
--- a/apps/portal/llms.txt
+++ b/apps/portal/llms.txt
@@ -483,6 +483,7 @@ Here you find the full history of Neo.mjs updates.
 - [Records](https://neomjs.com/raw/learn/guides/datahandling/Records.md)
 - [Grids](https://neomjs.com/raw/learn/guides/datahandling/Grids.md)
 - [Dynamic Grids & Virtualization](https://neomjs.com/raw/learn/guides/datahandling/DynamicGrids.md)
+- [Pooled Grid Animation Contract](https://neomjs.com/raw/learn/guides/datahandling/PooledGridAnimation.md)
 - [Streaming Data & Progressive Rendering](https://neomjs.com/raw/learn/guides/datahandling/Streaming.md)
 - [Tables (Stores)](https://neomjs.com/raw/learn/guides/datahandling/Tables.md)
 - [TreeStore & Hierarchical Data](https://neomjs.com/raw/learn/guides/datahandling/TreeStore.md)

--- a/apps/portal/sitemap.xml
+++ b/apps/portal/sitemap.xml
@@ -528,6 +528,10 @@
     <lastmod>2026-02-17T16:26:17+01:00</lastmod>
   </url>
   <url>
+    <loc>https://neomjs.com/learn/guides/datahandling/PooledGridAnimation</loc>
+    <lastmod>2026-06-14T16:30:16+02:00</lastmod>
+  </url>
+  <url>
     <loc>https://neomjs.com/learn/guides/datahandling/Streaming</loc>
     <lastmod>2026-02-10T20:46:29+01:00</lastmod>
   </url>
@@ -828,7 +832,7 @@
   </url>
   <url>
     <loc>https://neomjs.com/apps/portal/index.html</loc>
-    <lastmod>2026-06-14T15:26:30Z</lastmod>
+    <lastmod>2026-06-14T15:36:02Z</lastmod>
   </url>
   <url>
     <loc>https://neomjs.com/apps/realworld/index.html</loc>

--- a/learn/guides/datahandling/Grids.md
+++ b/learn/guides/datahandling/Grids.md
@@ -557,6 +557,9 @@ const myGrid = Neo.create(GridContainer, {
 ### Animated Row Sorting
 
 To animate row sorting, set the `animatedRowSorting` config to `true` on the `Neo.grid.Body` (via `body`).
+The current `AnimateRows` plugin is a flat-store row sorting/filtering affordance. Do not use it as a
+TreeGrid expand/collapse animation path; TreeGrid structural animation must follow the
+[pooled row contract](./PooledGridAnimation.md).
 
 ```javascript readonly
 const myGrid = Neo.create(GridContainer, {

--- a/learn/guides/datahandling/PooledGridAnimation.md
+++ b/learn/guides/datahandling/PooledGridAnimation.md
@@ -1,0 +1,133 @@
+# Pooled Grid Animation Contract
+
+Neo grids virtualize rows by recycling a fixed DOM pool. That is the right default for
+scrolling, but it changes the animation contract: row transitions must not assume that
+logical records own stable DOM rows.
+
+This guide records the design contract for animating TreeGrid structural changes under
+pooled rows. It is intentionally a contract first, not visual tuning. Easing, duration,
+and stagger only matter after the renderer and data-layer invariants are preserved.
+
+## Decision
+
+Use a snapshot overlay for TreeGrid expand and collapse animation.
+
+The `TreeStore` keeps its current synchronous projection semantics. `expand()` and
+`collapse()` continue to mutate the visible flat projection immediately, and bulk
+operations continue to rebuild the projection and fire one `load` event. The grid body
+then renders the final state through the normal pooled row layer, while a temporary
+overlay owns the visual transition for the affected viewport rows.
+
+The overlay is a visual artifact, not a second data source. It captures before and after
+row geometry, paints only during the transition window, and is removed once the animation
+finishes or is cancelled.
+
+Snapshot overlay is accepted because it keeps data truth and visual continuity separate:
+the store remains immediately correct, the pooled row layer remains the only live
+interactive layer, and animation cancellation can discard a stale overlay without
+rolling back data or replaying queued mutations.
+
+## Source Contracts
+
+| Contract | Source | Required behavior |
+| --- | --- | --- |
+| Fixed row pool | `src/grid/Body.mjs#createRowPool()` | VDOM children remain aligned to the full row pool. Animation must not remove, append, or reorder pooled row VDOM nodes. |
+| Modulo row identity | `src/grid/Body.mjs#getRowId()` | Physical row ids are slot ids, not record ids. Tree structural animation must not key movement by pooled row ids. |
+| View projection | `src/data/TreeStore.mjs#expand()` and `src/data/TreeStore.mjs#collapse()` | Projection mutation stays immediate for ordinary TreeStore use. No async-only TreeStore path is introduced. |
+| Bulk projection | `src/data/TreeStore.mjs#expandAll()` and `src/data/TreeStore.mjs#collapseAll()` | Large projection rebuilds may fall back to no animation or a bounded viewport overlay. They must not emit per-node splice storms. |
+| Existing plugin | `src/grid/plugin/AnimateRows.mjs` | `AnimateRows` remains a flat-store row sorting/filtering plugin until it is repaired behind the shared pooled-grid contract. |
+
+## Rejected Alternatives
+
+### Delayed permutation
+
+Rejected for the first TreeGrid substrate.
+
+Delayed permutation would expose structural mutation intent, animate the visual gap, and
+commit the TreeStore splice after the transition. That makes an ordinary data operation
+depend on animation lifecycle timing. It also adds queueing questions for selection,
+filters, sorting, async child loading, `singleExpand`, rapid toggles, and bulk
+`expandAll()` / `collapseAll()`. The existing TreeStore contract is cleaner: the data
+layer commits the truth immediately, and the view decides how much of that change can be
+animated.
+
+### Current `AnimateRows` enablement
+
+Rejected for TreeGrid structural changes.
+
+`AnimateRows` maps VDOM rows by `row.id`, pushes inserted VDOM rows, fades leftovers, and
+later forces `owner.createViewData()`. That can work for flat row sorting, but it fights
+the current grid body contract where `row.id` is a modulo pool slot. Enabling it for
+TreeGrid expand/collapse would create a second row lifecycle over a renderer that
+intentionally keeps the pool stable.
+
+### Global transform transitions
+
+Rejected.
+
+Normal virtual scrolling updates pooled rows with transforms. A global
+`transition: transform` on grid rows would animate ordinary scroll recycling, making
+scrolling lag behind the user's input. Structural animation must be explicitly scoped to
+the overlay or to a future animation layer that can distinguish scroll movement from
+TreeStore projection changes.
+
+## Snapshot Overlay Requirements
+
+1. Capture the visible viewport before the TreeStore mutation. The capture keys logical
+   records through record identity, not pooled row ids.
+2. Let the TreeStore mutation commit immediately.
+3. Render the grid body in its final state through `createViewData()`.
+4. Capture the post-mutation viewport geometry.
+5. Animate an overlay for rows that entered, exited, or moved within the affected
+   viewport.
+6. Remove the overlay on transition end, scroll, store load/filter/sort, resize, or any
+   subsequent structural mutation that would make the snapshot stale.
+
+The overlay must not intercept selection, focus, or row toggle interaction. During an
+active transition, user input continues to target the live pooled row layer.
+
+## Guardrails
+
+- TreeGrid must not add `.neo-tree-row-entering` / `.neo-tree-row-leaving` as a parallel
+  row lifecycle over pooled rows.
+- `animatedRowSorting` remains off by default for TreeGrid.
+- Bulk expand/collapse may use a bounded viewport overlay or skip animation entirely.
+  The fallback must be explicit and deterministic.
+- Rapid toggle, scroll, resize, load, filter, and sort cancel the current overlay before
+  the next render decision.
+- Async child loading animates only after children are available and the projection
+  changes. Loading state itself is outside this contract.
+- Selection is validated by record identity after the structural change, not by physical
+  row slot.
+
+## Verification Contract
+
+The first runtime PR that implements this contract must verify the following paths with
+the chosen animation config enabled:
+
+- `test/playwright/e2e/GridTree.spec.mjs`
+- `test/playwright/e2e/GridTreeBigData.spec.mjs`
+
+The verification must cover:
+
+- single expand and collapse
+- mixed expand, collapse, and sort sequences
+- bulk expand all followed by individual collapse
+- bulk collapse all
+- selection persistence after structural changes
+- rapid toggle or explicit cancellation behavior
+- scroll during an active transition or explicit cancellation behavior
+
+If a behavior is intentionally non-animated, the test should assert the fallback contract
+rather than only asserting the final visual state.
+
+## Implementation Notes
+
+Future data-layer hooks for mutation intent or commit timing must include JSDoc and
+`@summary` coverage. The preferred path does not require such hooks for the first slice:
+the grid can treat TreeStore projection changes as immediately committed data and keep
+animation lifecycle inside the view layer.
+
+The implementation should also narrow or repair `AnimateRows` before exposing it to
+TreeGrid. A safe narrow path is to keep it documented as a flat-store row sorting plugin
+until the shared overlay layer exists.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -120,6 +120,7 @@
             {"name": "Records",                                        "parentId": "guides/datahandling",                                 "id": "guides/datahandling/Records"},
             {"name": "Grids",                                          "parentId": "guides/datahandling",                                 "id": "guides/datahandling/Grids"},
             {"name": "Dynamic Grids & Virtualization",                 "parentId": "guides/datahandling",                                 "id": "guides/datahandling/DynamicGrids"},
+            {"name": "Pooled Grid Animation Contract",                  "parentId": "guides/datahandling",                                 "id": "guides/datahandling/PooledGridAnimation"},
             {"name": "Streaming Data & Progressive Rendering",         "parentId": "guides/datahandling",                                 "id": "guides/datahandling/Streaming"},
             {"name": "Tables (Stores)",                                "parentId": "guides/datahandling",                                 "id": "guides/datahandling/Tables", "hidden": true},
             {"name": "TreeStore & Hierarchical Data",                  "parentId": "guides/datahandling",                                 "id": "guides/datahandling/TreeStore"},


### PR DESCRIPTION
Resolves #13219

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec50d-5a01-7b11-9490-50f3241e8cfc.

Adds a Data Handling guide that selects snapshot overlay as the pooled-grid TreeGrid animation contract, rejects delayed permutation/current `AnimateRows` enablement/global transform transitions, and registers the guide in `learn/tree.json`. It narrows the existing `animatedRowSorting` docs away from TreeGrid expand/collapse and regenerates the portal SEO outputs for the new published route.

Evidence: L1 (static docs/source-contract audit + Tree JSON Lint) -> L1 required (design-document close target; no runtime behavior changed). No residuals.

## Deltas from ticket
- Delivered the design-document path for #13219; no runtime animation code changed.
- Added a public docs guard that keeps `animatedRowSorting` scoped to flat-store row sorting/filtering until the shared pooled-grid substrate exists.
- Regenerated `apps/portal/llms.txt` and `apps/portal/sitemap.xml` after Tree JSON Lint caught the missing SEO route.
- Rebased onto current `origin/dev` after #13220/#13233 landed and refreshed the SEO conflict resolution.

## Test Evidence
- `npm run ai:lint-tree-json` passed locally on rebased head `c4d116337` (199 nodes).
- `git diff --check origin/dev..HEAD` passed after the final rebase.
- `merge-base HEAD origin/dev == origin/dev` after rebasing onto current `origin/dev`.
- No conflict markers remain in `apps/portal/sitemap.xml` or `apps/portal/llms.txt`.
- Source audit covered `src/grid/Body.mjs#createRowPool()`, `src/grid/Body.mjs#getRowId()`, `src/grid/plugin/AnimateRows.mjs`, and `src/data/TreeStore.mjs#expand()` / `collapse()` / bulk projection paths.

## Post-Merge Validation
- [ ] Docs navigation exposes `learn/guides/datahandling/PooledGridAnimation.md` in the Data Handling guide tree.

## Review Routing
Pure documentation/navigation change with no runtime impact; cross-family mandate micro-change exemption applies.

## Commits
- `c0548ace1` — `docs(grid): add pooled animation contract (#13219)`
- `c4d116337` — `docs(grid): regenerate pooled animation SEO (#13219)`
