### PR TITLE
fix(ai): resolve PR author family from canonical @identity, not the drift-prone GitHub login (#13234)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -141,12 +141,12 @@ gh pr create --title "feat/fix/chore: Your Title (#TICKET_ID)" --body "Comprehen
 
 To ensure symmetric discipline across the PR lifecycle and enable accurate cross-model convergence tracking, you MUST explicitly self-identify within the PR body you generate. This mirrors the authorship requirements in the `pr-review` skill.
 
-Your PR body MUST include a self-identification block near the top, formatted exactly as follows:
-`Authored by [Model Name] ([Agent Wrapper]). Session <Origin Session ID>.`
+Your PR body MUST include a self-identification block near the top, formatted exactly as follows (`@<identity>` is canonical — the cross-family gate keys off it; §6.1):
+`Authored by [Model Name] ([Agent Wrapper]), @<identity> ([Social Name]). Session <Origin Session ID>.`
 
 **Cross-Harness Authorship Convention:**
 When you author a PR based on a handoff, ticket, or artifact synthesized by a *different* model in a *different* session (e.g., executing an implementation plan created by another agent), you MUST attribute the full provenance:
-`Authored by [Model-B] ([Harness-B]) consuming [Model-A]'s handoff — session A <id>, session B <id>.`
+`Authored by [Model-B] ([Harness-B]), @<identity-B> consuming [Model-A]'s handoff — session A <id>, session B <id>.`
 
 This ensures A2A provenance remains graph-extractable even if you do not have a dedicated GitHub service account.
 
@@ -170,7 +170,7 @@ You MUST follow this exact handoff protocol:
 
 ### 6.1 The Cross-Family Mandate
 
-**No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `manage_pr_review` (state `APPROVED`) per `pr-review-guide.md §2`. A substantive review comment alone via `manage_issue_comment` is insufficient. **Author family** is resolved from the body's `@identity` self-id, not the drift-prone GitHub login (advisory only); agent PR bodies MUST carry `@identity` in the `Authored by` line.
+**No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `manage_pr_review` (state `APPROVED`) per `pr-review-guide.md §2`. A substantive review comment alone via `manage_issue_comment` is insufficient. **Author family** is resolved from the §5 `@identity` self-id, not the drift-prone GitHub login (advisory only).
 
 **Exceptions Matrix:**
 - **Micro-change exemption**: Commit type `chore` AND `< 20 lines` changed, OR pure documentation with no runtime impact.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -170,7 +170,7 @@ You MUST follow this exact handoff protocol:
 
 ### 6.1 The Cross-Family Mandate
 
-**No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `manage_pr_review` (state `APPROVED`) per `pr-review-guide.md §2`. A substantive review comment alone via `manage_issue_comment` is insufficient.
+**No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `manage_pr_review` (state `APPROVED`) per `pr-review-guide.md §2`. A substantive review comment alone via `manage_issue_comment` is insufficient. **Author family** is resolved from the body's `@identity` self-id, not the drift-prone GitHub login (advisory only); agent PR bodies MUST carry `@identity` in the `Authored by` line.
 
 **Exceptions Matrix:**
 - **Micro-change exemption**: Commit type `chore` AND `< 20 lines` changed, OR pure documentation with no runtime impact.

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -652,6 +652,54 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Extracts the canonical `@identity` (login, `@`-stripped) from a PR body's
+     * `Authored by … @identity` self-id line.
+     *
+     * The body self-id is the drift-free author source: the GitHub PR opener can mis-resolve (an MCP
+     * `@me` identity-resolution drift stamps a different agent's login on the opener), but the body
+     * declares its own canonical `@identity`. Returns null when no self-id is present (legacy / external
+     * bodies), so the caller falls back to the advisory login. Matches only an `@handle` on the
+     * `Authored by` line itself, so an unrelated mention elsewhere in the body cannot be mistaken for it.
+     * @param {String} body
+     * @returns {(String|null)} The `@`-stripped identity login, or null.
+     */
+    static parseSelfIdLogin(body) {
+        if (typeof body !== 'string') return null;
+
+        const match = body.match(/Authored by[^\n]*?@([A-Za-z0-9-]+)/);
+
+        return match ? match[1] : null
+    }
+
+    /**
+     * @summary Resolves a PR author's model family from the canonical body `@identity`, falling back
+     * to the drift-prone GitHub login as an advisory source.
+     *
+     * The body's self-declared `@identity` wins; the GitHub author login is advisory-only (used when the
+     * body carries no self-id), and a body-vs-login family disagreement is logged as drift rather than
+     * silently trusted. Model-name substring inference is deliberately NOT used — the self-id is the
+     * canonical source, the login is the legacy bridge until every agent PR body carries `@identity`.
+     * @param {Object} pr GitHub PR payload (`author`, `body`, `number`).
+     * @param {Object} agentFamilies Login-to-family map (`@`-stripped logins).
+     * @returns {(String|undefined)} The model family, or undefined when neither source resolves.
+     */
+    static resolveAuthorFamily(pr, agentFamilies) {
+        const selfIdLogin  = this.parseSelfIdLogin(pr?.body),
+              selfIdFamily = selfIdLogin ? agentFamilies[selfIdLogin] : undefined,
+              loginFamily  = agentFamilies[pr?.author?.login];
+
+        if (selfIdFamily) {
+            if (loginFamily && loginFamily !== selfIdFamily) {
+                logger.warn(`[GoldenPathSynthesizer] PR #${pr.number}: author identity drift — body self-id @${selfIdLogin} (${selfIdFamily}) != GitHub login @${pr.author?.login} (${loginFamily}); using the canonical self-id.`);
+            }
+
+            return selfIdFamily
+        }
+
+        return loginFamily
+    }
+
+    /**
      * @summary Determines whether a PR has cross-family review coverage.
      *
      * @param {Object} pr GitHub PR payload from `gh pr list`.
@@ -659,8 +707,7 @@ class GoldenPathSynthesizer extends Base {
      * @returns {Boolean}
      */
     static hasCrossFamilyReview(pr, agentFamilies = this.getCoreSwarmAgentFamilies()) {
-        const authorLogin  = pr.author?.login;
-        const authorFamily = agentFamilies[authorLogin];
+        const authorFamily = this.resolveAuthorFamily(pr, agentFamilies);
         const reviews      = Array.isArray(pr.reviews) ? pr.reviews : [];
 
         return reviews.some(review => {

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -658,15 +658,16 @@ class GoldenPathSynthesizer extends Base {
      * The body self-id is the drift-free author source: the GitHub PR opener can mis-resolve (an MCP
      * `@me` identity-resolution drift stamps a different agent's login on the opener), but the body
      * declares its own canonical `@identity`. Returns null when no self-id is present (legacy / external
-     * bodies), so the caller falls back to the advisory login. Matches only an `@handle` on the
-     * `Authored by` line itself, so an unrelated mention elsewhere in the body cannot be mistaken for it.
+     * bodies), so the caller falls back to the advisory login. The pattern is **line-anchored** (`^…/m`)
+     * to the canonical self-id line, so a `Co-Authored by` trailer or descriptive prose that merely
+     * contains `Authored by` mid-line does not match.
      * @param {String} body
      * @returns {(String|null)} The `@`-stripped identity login, or null.
      */
     static parseSelfIdLogin(body) {
         if (typeof body !== 'string') return null;
 
-        const match = body.match(/Authored by[^\n]*?@([A-Za-z0-9-]+)/);
+        const match = body.match(/^Authored by[^\n]*?@([A-Za-z0-9-]+)/m);
 
         return match ? match[1] : null
     }

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -851,10 +851,16 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         Synthesizer = mod.default.constructor;
     });
 
-    test('parseSelfIdLogin extracts the @identity from the Authored-by line, or null when absent', () => {
+    test('parseSelfIdLogin extracts the @identity only from the canonical line-start self-id', () => {
         expect(Synthesizer.parseSelfIdLogin('Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session x.')).toBe('neo-gpt');
         expect(Synthesizer.parseSelfIdLogin('Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace).')).toBe('neo-claude-opus');
+        // Real PR bodies open with `Resolves #N`, so the self-id is mid-body — the /m anchor must still match it.
+        expect(Synthesizer.parseSelfIdLogin('Resolves #1\n\nAuthored by GPT-5 (Codex Desktop), @neo-gpt (Euclid).')).toBe('neo-gpt');
         expect(Synthesizer.parseSelfIdLogin('Authored by GPT-5 (Codex Desktop). Session x.')).toBe(null); // legacy, no @identity
+        // Overmatch guards: a `Co-Authored by` trailer or prose merely containing `Authored by` mid-line must NOT match.
+        expect(Synthesizer.parseSelfIdLogin('Co-Authored by Claude Opus, @neo-claude-opus.')).toBe(null);
+        expect(Synthesizer.parseSelfIdLogin('Note: Authored by old session @neo-gpt in context.')).toBe(null);
+        expect(Synthesizer.parseSelfIdLogin('Body text\nCo-Authored by X, @neo-gpt\nmore')).toBe(null);
         expect(Synthesizer.parseSelfIdLogin(null)).toBe(null)
     });
 

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -834,3 +834,59 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).not.toContain(closedId);
     });
 });
+
+test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from canonical @identity', () => {
+    let Synthesizer;
+
+    // `@`-stripped login → modelFamily, matching getCoreSwarmAgentFamilies().
+    const agentFamilies = {
+        'neo-gpt'        : 'openai',
+        'neo-claude-opus': 'claude',
+        'neo-opus-ada'   : 'claude',
+        'neo-opus-vega'  : 'claude'
+    };
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/GoldenPathSynthesizer.mjs');
+        Synthesizer = mod.default.constructor;
+    });
+
+    test('parseSelfIdLogin extracts the @identity from the Authored-by line, or null when absent', () => {
+        expect(Synthesizer.parseSelfIdLogin('Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session x.')).toBe('neo-gpt');
+        expect(Synthesizer.parseSelfIdLogin('Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace).')).toBe('neo-claude-opus');
+        expect(Synthesizer.parseSelfIdLogin('Authored by GPT-5 (Codex Desktop). Session x.')).toBe(null); // legacy, no @identity
+        expect(Synthesizer.parseSelfIdLogin(null)).toBe(null)
+    });
+
+    test('resolves author family from the body @identity, overriding a drifted GitHub login', () => {
+        // The drift shape: the GitHub opener mis-resolved to a Claude login, but the body self-id is GPT.
+        const pr = {
+            number : 13233,
+            author : {login: 'neo-opus-ada'}, // drifted (mis-resolved opener)
+            body   : 'Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session x.',
+            reviews: [{author: {login: 'neo-claude-opus'}, state: 'APPROVED'}]
+        };
+        // Login-only reads author=claude, reviewer=claude -> false (the bug). The self-id reads author=openai -> cross-family true.
+        expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(true)
+    });
+
+    test('falls back to the GitHub login when the body carries no @identity self-id (legacy)', () => {
+        const pr = {
+            number : 1,
+            author : {login: 'neo-gpt'},
+            body   : 'Authored by GPT-5 (Codex Desktop). Session x.', // no @identity → advisory login path
+            reviews: [{author: {login: 'neo-claude-opus'}, state: 'APPROVED'}]
+        };
+        expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(true)
+    });
+
+    test('same-family author + reviewer (both Claude) is correctly NOT cross-family', () => {
+        const pr = {
+            number : 2,
+            author : {login: 'someone-unmapped'},
+            body   : 'Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace).',
+            reviews: [{author: {login: 'neo-opus-ada'}, state: 'APPROVED'}] // both claude
+        };
+        expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(false)
+    });
+});

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -840,7 +840,7 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
 
     // `@`-stripped login → modelFamily, matching getCoreSwarmAgentFamilies().
     const agentFamilies = {
-        'neo-gpt'        : 'openai',
+        'neo-gpt'        : 'gpt',
         'neo-claude-opus': 'claude',
         'neo-opus-ada'   : 'claude',
         'neo-opus-vega'  : 'claude'
@@ -866,7 +866,7 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
             body   : 'Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session x.',
             reviews: [{author: {login: 'neo-claude-opus'}, state: 'APPROVED'}]
         };
-        // Login-only reads author=claude, reviewer=claude -> false (the bug). The self-id reads author=openai -> cross-family true.
+        // Login-only reads author=claude, reviewer=claude -> false (the bug). The self-id reads author=gpt -> cross-family true.
         expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(true)
     });
 


### PR DESCRIPTION
Resolves #13234

`GoldenPathSynthesizer.hasCrossFamilyReview` keyed `authorFamily` off `pr.author.login` — so when the GitHub opener attribution drifts (the MCP `@me` identity-resolution mis-maps; e.g. #13233's true GPT author resolved to `neo-opus-ada`), a cross-family-reviewed PR reported "cross-family reviewed: **no**" — a false-negative. **Severity is bounded:** this feeds the Golden-Path *report*, not the merge-gate enforcement (the gate is @tobiu reading the review) — a reporting inaccuracy, not a merge-safety bypass.

Evidence: L2 (4 substrate-free unit tests over the resolver + the drift / legacy / same-family paths — 4/4 green; `node --check` clean) → L2 required (a pure resolver fix, fully unit-verifiable). No residuals.

## The fix (per the #13234 design decision — B, cross-family-validated by @neo-gpt)

- New `resolveAuthorFamily(pr, agentFamilies)` resolves the author family from the PR body's canonical `Authored by … @identity` self-id → `agentFamilies[identity]` (= `AgentIdentity.modelFamily`). `parseSelfIdLogin` extracts the `@`-stripped identity from the `Authored by` line only (an unrelated `@mention` elsewhere can't be mistaken for it).
- The GitHub `pr.author.login` is an **advisory fallback** used when the body carries no self-id; a body-vs-login family disagreement is **logged as drift** (`logger.warn`), not silently trusted.
- **No model-name substring inference** (per gpt's explicit constraint).
- `hasCrossFamilyReview` now uses the resolver for the author family; `pull-request-workflow.md §6.1` documents the verified-identity source (agent bodies MUST carry `@identity` in the Authored-by line).

## Deltas from ticket

- **Scope = author-side (the demonstrated drift).** #13234's three ACs are met (resolver keys off body self-id; drift surfaced; §6.1 documented). The **reviewer-side** canonical-identity resolution (gpt's §6.1 ask — `reviewerFamily` still keys off `review.author.login`) is deferred: it needs a canonical-reviewer-identity surface that doesn't cleanly exist yet (reviews carry no `@identity` body self-id) — a follow-up.
- **Two more follow-ups** (the "standardize + enforce" half of B): (1) a lint requiring `@identity` in agent PR bodies' Authored-by line; (2) @neo-gpt's Codex-Desktop template emitting `@neo-gpt` (his current bodies name only "GPT-5" — exactly why the drift bites his PRs until then).

## Test Evidence

- `GoldenPathSynthesizer.spec.mjs -g "author family from canonical"`: **4 passed** (1.1s) — the drift case (body `@neo-gpt` overrides a drifted `neo-opus-ada` login → cross-family TRUE), the legacy no-`@identity` login fallback, same-family correctly NOT cross-family, and `parseSelfIdLogin` extraction.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`: OK (the §6.1 note fits the 250-byte workflow-map budget).
- Pre-commit (whitespace / shorthand / ticket-archaeology / aiconfig-test-mutation): green.

## Post-Merge Validation

- Confirm the Golden Path "Recent Open PRs … cross-family reviewed" line reports correctly for a drifted-author PR once a body carries `@identity`.
- Confirm the drift `logger.warn` fires when a body self-id and GitHub login disagree on family.

Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.
