### PR TITLE
fix(ai): align TransactionService stack key to the (agentId, sessionId) writer pair (#13236)

### DIFF
--- a/src/ai/TransactionService.mjs
+++ b/src/ai/TransactionService.mjs
@@ -26,16 +26,19 @@ const cloneOp = op => ({
 const cloneTx = tx => ({txId: tx.txId, status: tx.status, ops: tx.ops.map(cloneOp)});
 
 /**
- * The stable string key for a writer's undo stack — the **full session identity**, so two Neural Link sessions
- * or two writers never share a stack. Fails closed (`null`) when any field is missing: no shared / wildcard stack.
- * @param {Object} [id={}] `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+ * The stable string key for a writer's undo stack — the `(agentId, sessionId)` writer pair, so two writers never
+ * share a stack. This is the **same writer identity `Neo.ai.WriteGuard` keys locks on** — the Bridge stamps the
+ * pair per agent connection (the `agent_message` sidecar) — so the lock + undo lifecycles key identically and a
+ * disconnect sweep maps straight from the `agent_disconnected` frame. Fails closed (`null`) when either field is
+ * missing: no shared / wildcard stack.
+ * @param {Object} [id={}] `{agentId, sessionId}` — the Bridge-stamped writer pair
  * @returns {String|null}
  */
-const stackKey = ({neuralLinkSessionId, requesterAgentId, requesterSessionId} = {}) => {
-    if (!neuralLinkSessionId || !requesterAgentId || !requesterSessionId) {
+const stackKey = ({agentId, sessionId} = {}) => {
+    if (!agentId || !sessionId) {
         return null
     }
-    return JSON.stringify([neuralLinkSessionId, requesterAgentId, requesterSessionId])
+    return JSON.stringify([agentId, sessionId])
 };
 
 /**
@@ -114,7 +117,7 @@ class TransactionService extends Base {
      * marks the stale one `aborted` (a write that never committed / a teardown gap) so a leaked open transaction
      * can't accumulate ops forever. Fails closed on an incomplete session identity or missing `txId`.
      * @param {Object} params
-     * @param {Object} params.id   `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id   `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @param {String} params.txId
      * @returns {{ok: Boolean, reason: (String|null)}}
      */
@@ -149,7 +152,7 @@ class TransactionService extends Base {
      * `reverse` / `label` missing or mistyped); a non-serializable `forward` or `reverse` (the data-not-code guard);
      * the per-transaction op cap; an over-long `label`; or an oversized op payload.
      * @param {Object} params
-     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @param {String} params.txId
      * @param {Object} params.op  `{sequenceId, originWriter:{agentId,sessionId}, targetSubtreePath:String[], forward, reverse, label}`
      * @returns {{ok: Boolean, reason: (String|null)}}
@@ -215,7 +218,7 @@ class TransactionService extends Base {
      * {@link maxStackDepth}, the **oldest** committed transaction is evicted (no longer undoable). A commit with no
      * ops is dropped rather than committed (nothing to undo). Fails closed on no-open / `txId` mismatch.
      * @param {Object} params
-     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @param {String} params.txId
      * @returns {{ok: Boolean, reason: (String|null)}}
      */
@@ -252,7 +255,7 @@ class TransactionService extends Base {
      * requester, with the enforcement `subtreePath` re-derived on the live tree (NOT the stored audit path). Does
      * not itself mutate the tree or the lock table. Returns `reverseOps: null` when there is nothing to undo.
      * @param {Object} params
-     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @returns {{txId: (String|null), reverseOps: (Object[]|null)}}
      */
     undo({id}) {
@@ -274,7 +277,7 @@ class TransactionService extends Base {
      * A no-op when no transaction is open or the `txId` does not match (idempotent). An aborted transaction is
      * dropped, never undoable, and leaves no reverse record.
      * @param {Object} params
-     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @param {String} params.txId
      * @returns {{aborted: Boolean}}
      */
@@ -298,7 +301,7 @@ class TransactionService extends Base {
      * coherent undo unit). The terminal is recorded separately from `aborted` so a lease expiry stays auditable as
      * its own cause rather than masquerading as a deliberate abort.
      * @param {Object} params
-     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @param {String} params.txId
      * @returns {{timedOut: Boolean}}
      */
@@ -321,7 +324,7 @@ class TransactionService extends Base {
      * both on an `agent_disconnected` frame, so the lock + transaction lifecycles cannot diverge silently). Fails
      * closed on an incomplete identity (sweeps nothing — never clears the whole table).
      * @param {Object} params
-     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @returns {{swept: Boolean}}
      */
     sweep({id}) {
@@ -340,7 +343,7 @@ class TransactionService extends Base {
      * @summary A deep snapshot of a session's undo state (introspection / testing).
      * Every returned transaction + op is a copy, so a caller cannot mutate the live stack through the result.
      * @param {Object} params
-     * @param {Object} params.id  `{neuralLinkSessionId, requesterAgentId, requesterSessionId}`
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
      * @returns {{open: (Object|null), committed: Object[]}}
      */
     stackOf({id}) {

--- a/src/ai/TransactionService.mjs
+++ b/src/ai/TransactionService.mjs
@@ -35,7 +35,9 @@ const cloneTx = tx => ({txId: tx.txId, status: tx.status, ops: tx.ops.map(cloneO
  * @returns {String|null}
  */
 const stackKey = ({agentId, sessionId} = {}) => {
-    if (!agentId || !sessionId) {
+    // Stricter than a truthy check, mirroring `LockRegistry.normalizeLock` — a non-string id fails closed too, so
+    // the undo-stack key and the write-lock key reject exactly the same way (fail-closed symmetry across both sides).
+    if (typeof agentId !== 'string' || agentId === '' || typeof sessionId !== 'string' || sessionId === '') {
         return null
     }
     return JSON.stringify([agentId, sessionId])

--- a/test/playwright/unit/ai/TransactionService.spec.mjs
+++ b/test/playwright/unit/ai/TransactionService.spec.mjs
@@ -23,8 +23,8 @@ import TransactionService from '../../../../src/ai/TransactionService.mjs';
 // (every required reverse-record field + both-descriptor serializability), and the caps.
 
 const
-    ID  = {neuralLinkSessionId: 'nl-1', requesterAgentId: 'agent-a', requesterSessionId: 'sess-a'},
-    ID2 = {neuralLinkSessionId: 'nl-1', requesterAgentId: 'agent-b', requesterSessionId: 'sess-b'},
+    ID  = {agentId: 'agent-a', sessionId: 'sess-a'},
+    ID2 = {agentId: 'agent-b', sessionId: 'sess-b'},
 
     // a minimal valid reverse-op (WHO + WHAT + audit path); set⁻¹ is set(old values)
     op = (n = 1, seq = `seq-${n}`) => ({
@@ -111,7 +111,7 @@ test.describe('Neo.ai.TransactionService — in-heap per-session undo stack', ()
     test('begin fails closed on an incomplete session identity or empty txId', () => {
         const s = svc();
 
-        for (const badId of [{}, {requesterAgentId: 'a', requesterSessionId: 's'}, {neuralLinkSessionId: 'nl-1'}]) {
+        for (const badId of [{}, {agentId: 'a'}, {sessionId: 's'}]) {
             expect(s.begin({id: badId, txId: 'tx-1'}).ok).toBe(false)
         }
         expect(s.begin({id: ID, txId: ''}).ok).toBe(false);

--- a/test/playwright/unit/ai/TransactionService.spec.mjs
+++ b/test/playwright/unit/ai/TransactionService.spec.mjs
@@ -108,10 +108,11 @@ test.describe('Neo.ai.TransactionService — in-heap per-session undo stack', ()
     });
 
     // ── fail-closed branches ──────────────────────────────────────────────────────────────────────
-    test('begin fails closed on an incomplete session identity or empty txId', () => {
+    test('begin fails closed on an invalid/incomplete writer identity or empty txId', () => {
         const s = svc();
 
-        for (const badId of [{}, {agentId: 'a'}, {sessionId: 's'}]) {
+        // missing fields + non-string ids — the stricter typeof guard mirrors LockRegistry.normalizeLock
+        for (const badId of [{}, {agentId: 'a'}, {sessionId: 's'}, {agentId: 123, sessionId: 's'}, {agentId: 'a', sessionId: {}}]) {
             expect(s.begin({id: badId, txId: 'tx-1'}).ok).toBe(false)
         }
         expect(s.begin({id: ID, txId: ''}).ok).toBe(false);


### PR DESCRIPTION
Authored by Vega (Claude Opus 4.8, Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.

Resolves #13236
Refs #13221 · Refs #13230 · Refs #13231

Wiring the #13221 Slice-1 capture-hook onto the merged #13231 `TransactionService` core surfaced that its per-session stack key — the 3-tuple `{neuralLinkSessionId, requesterAgentId, requesterSessionId}` — had **no source for `neuralLinkSessionId`** in the live Neural Link flow. The pure-core-then-wiring pattern validated the core against reality and caught the over-spec.

**The live writer identity is the `(agentId, sessionId)` 2-tuple** (V-B-A'd from source on `dev`):
- `Bridge.mjs:217-220` mints `ws.sessionId` per agent connection *"so the app-side write-guard can key locks on the `(agentId, sessionId)` pair."*
- `parseAgentEnvelope` yields `context: {agentId, sessionId}`; `WriteGuard.sameWriter` keys on exactly that pair.
- The `agent_disconnected` frame carries only `{agentId, sessionId}` — so `TransactionService.sweep` (the tx-side counterpart to `WriteGuard.releaseAgent`) only has the 2-tuple to reconcile on.

This PR aligns the stack key to that same `(agentId, sessionId)` writer pair, so the lock + undo lifecycles key identically (the disconnect sweep maps straight from the frame) and the key matches the op's `originWriter` provenance shape. `neuralLinkSessionId` was over-design — the per-heap `TransactionService` instance already scopes the NL session; a multi-NL-session slice can add a scoping field with real semantics if it ever needs one.

Evidence: L2 (the 18-test unit spec passes on the 2-tuple key, per-writer isolation asserted on `(agentId, sessionId)`) → L2 sufficient (a pure in-heap core change; no runtime-effect-on-an-unreachable-surface AC — the live capture + undo is the #13221 wiring this unblocks).

## Deltas from ticket
None — delivers #13236's ACs exactly: `stackKey` keys on `{agentId, sessionId}` + fails closed on either field missing; all lifecycle-method `id` params + JSDoc reflect the 2-tuple; the unit fixtures key on it. The #13221 Contract Ledger row is reconciled via a parent-ticket comment (the ledger lives in #13221's body).

## Test Evidence
`UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/TransactionService.spec.mjs` → **18 passed** on the current head (`fddd122ff`, which includes @neo-opus-ada's guard-symmetry follow-up). The fixtures (`ID` / `ID2`) + the begin-fail-closed cases (now incl. non-string-id rejection) key on `{agentId, sessionId}`; per-writer isolation, the caps, abort / timeout / sweep, and deep-copy introspection all pass unchanged.

## Post-Merge Validation
- [ ] The #13221 capture-hook wires `TransactionService` into the `InstanceService` write-path keyed on the live `(agentId, sessionId)` context (the next slice, building on this corrected core).
- [ ] `sweep` is driven by the `agent_disconnected` frame's `{agentId, sessionId}` (paired with `WriteGuard.releaseAgent`) — exercised by the #13221 wiring + its e2e.

Origin Session ID: 4cc428e3-cf36-4324-8646-1b96cb23fa4a
