### PR TITLE
docs(codex): codify identity-safe worktrees (#13241)

### DIFF
--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -27,6 +27,13 @@ and can drift independently of the Codex Desktop harness.
   before concluding GitHub is down, auth is invalid, or PR state is unavailable.
 - For state-changing GitHub calls, preserve the exact payload when retrying
   escalated so the sandbox retry does not mutate review/comment semantics.
+- Identity-sensitive worktrees must live under the Codex clone root, for example
+  `/Users/Shared/codex/neomjs/neo/tmp/` or another path below
+  `/Users/Shared/codex/neomjs/neo/`, so `.zshenv` resolves the Codex `.env`.
+  Avoid generic `/private/tmp/neo-*` worktrees for operations that may run `gh`,
+  MCP setup, PR review/comment tools, or commits. After a worktree/thread switch,
+  verify `NEO_AGENT_IDENTITY=@neo-gpt` and `gh api user --jq .login == neo-gpt`
+  before any state-changing GitHub action.
 - Mid-session harness restart: read `.codex/HARNESS_RESTART.md` before diagnosing MCP, Chroma, GitHub, or wake-state failures.
 - If Codex reports `[features].codex_hooks is deprecated. Use [features].hooks instead.`,
   the tracked `.codex/config.template.toml` is already current. Update the ignored


### PR DESCRIPTION
Resolves #13241

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 4ed21ddf-b92f-45ce-8689-bb3ebb563dd9.

Adds a Codex-only Runtime Notes rule that keeps identity-sensitive worktrees under the Codex clone root and requires a cheap identity preflight after worktree/thread switches before state-changing GitHub actions. This closes the Codex side of the 2026-06-14 identity-drift discipline gap without changing `.zshenv`, GitHub Workflow MCP behavior, or shared agent rules.

Related: #13239

Evidence: L1 (static hook/load-path audit + mapped-worktree identity check) -> L1 required (Codex turn-loaded documentation rule; no runtime code changed). No residuals.

## Deltas from ticket

- Used the already-ignored `/Users/Shared/codex/neomjs/neo/tmp/` root as the concrete worktree example because `.codex/worktrees/` is not currently ignored.
- Kept the rule in `.codex/CODEX.md`, not `AGENTS.md`, per `turn-memory-pre-flight` Step 4: harness-local rule.
- Left tool-level fail-closed `viewer.login` enforcement out of scope; this PR only handles Codex turn discipline.

## Turn-Loaded Substrate Slot Rationale

- Added Runtime Notes bullet in `.codex/CODEX.md`: disposition `keep`; trigger-frequency `medium` (Codex worktree/thread switches and state-changing GitHub actions), failure-severity `high` (public GitHub/A2A misattribution), enforceability `partial` (discipline plus cheap `NEO_AGENT_IDENTITY` / `gh api user` checks).
- Placement rationale: `.codex/CODEX.md` is loaded through `.codex/hooks.json` -> `.codex/hooks/codex-context.mjs` for Codex repo-root turns, so Codex-only worktree discipline belongs there instead of global `AGENTS.md`.
- Decay mitigation: keep the text compact and Codex-scoped; retire or rewrite once a GitHub Workflow MCP fail-closed identity guard makes manual worktree placement discipline non-load-bearing.

## Test Evidence

- `git diff --check`
- `node .codex/hooks/codex-context.mjs | cmp -s .codex/CODEX.md - && echo hook-loads-CODEX-md`
- `printf '%s\n' "$NEO_AGENT_IDENTITY"` -> `@neo-gpt`
- `gh api user --jq .login` -> `neo-gpt`
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`
- Outgoing commit: `c92806043 docs(codex): codify identity-safe worktrees (#13241)`

## Post-Merge Validation

- [ ] A fresh Codex repo-root turn receives the new Runtime Notes bullet through the `UserPromptSubmit` hook.

## Commits

- `c92806043` — `docs(codex): codify identity-safe worktrees (#13241)`
