### PR TITLE
feat(ai): capture set_instance_properties reverses onto the per-session undo stack (#13248)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -8,6 +8,7 @@ import RuntimeService     from './client/RuntimeService.mjs';
 import Socket             from '../data/connection/WebSocket.mjs';
 import WindowManager      from '../manager/Window.mjs';
 import WriteGuard         from './WriteGuard.mjs';
+import TransactionService from './TransactionService.mjs';
 import {parseAgentEnvelope} from './parseAgentEnvelope.mjs';
 
 /**
@@ -77,6 +78,15 @@ class Client extends Base {
      * @protected
      */
     writeGuard = null
+    /**
+     * The per-heap undo authority — the in-heap per-session transaction stack ({@link Neo.ai.TransactionService})
+     * that records the *reverse* of each enforcement-granted Neural Link write so an agent can undo it. Sibling to
+     * {@link Neo.ai.Client#writeGuard}: one Client ⇒ one stack authority, keyed on the same `(agentId, sessionId)`
+     * writer pair, so the lock + undo lifecycles align.
+     * @member {Neo.ai.TransactionService|null} transactionService=null
+     * @protected
+     */
+    transactionService = null
 
     /**
      * @param {Object} config
@@ -86,7 +96,8 @@ class Client extends Base {
 
         let me = this;
 
-        me.writeGuard = Neo.create(WriteGuard);
+        me.writeGuard         = Neo.create(WriteGuard);
+        me.transactionService = Neo.create(TransactionService);
 
         me.services = {
             component  : Neo.create(ComponentService,   {client: me}),

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -1,5 +1,6 @@
-import Service      from './Service.mjs';
-import {admitWrite} from '../admitWrite.mjs';
+import Service             from './Service.mjs';
+import {admitWrite}        from '../admitWrite.mjs';
+import {deriveSubtreePath} from '../deriveSubtreePath.mjs';
 
 /**
  * Handles generic instance-related Neural Link requests.
@@ -14,6 +15,13 @@ class InstanceService extends Service {
          */
         className: 'Neo.ai.client.InstanceService'
     }
+
+    /**
+     * Monotonic per-instance counter minting unique undo transaction / sequence ids for captured reverse-ops.
+     * @member {Number} undoSequence=0
+     * @protected
+     */
+    undoSequence = 0
 
     /**
      * Retrieves properties from a specific instance by its ID.
@@ -105,9 +113,86 @@ class InstanceService extends Service {
 
         this.assertWritable(context, id);
 
+        // Capture the reverse (the pre-set values) BEFORE mutating, so an agent can undo this write. Best-effort +
+        // fail-closed: only an enforcement-granted *agent* write (a writer identity in `context`) is captured, and a
+        // malformed / unserializable reverse is dropped, never thrown into the write path.
+        const undoOp = this.buildSetReverse({context, id, instance, properties});
+
         instance.set(properties);
 
+        this.recordUndo(context, undoOp);
+
         return {success: true}
+    }
+
+    /**
+     * Builds the reverse-op for a `set_instance_properties` write — `set⁻¹ = set(oldValues)`, capturing the pre-set
+     * values. Returns `null` for a legacy / unattributed write (no writer identity ⇒ no per-writer undo stack) or an
+     * unresolvable target, so {@link #recordUndo} no-ops. The reverse is a re-dispatchable validated tool descriptor —
+     * data-not-code, per the Neural Link capability boundary.
+     * @param {Object} params
+     * @param {Object|null} params.context  The Bridge-stamped `{agentId, sessionId}` writer pair.
+     * @param {String} params.id
+     * @param {Neo.core.Base} params.instance
+     * @param {Object} params.properties
+     * @returns {Object|null} A reverse-record op, or `null` when the write is not capturable.
+     * @protected
+     */
+    buildSetReverse({context, id, instance, properties}) {
+        if (!context?.agentId || !context?.sessionId) {
+            return null
+        }
+
+        const targetSubtreePath = deriveSubtreePath(id, cid => Neo.getComponent(cid)?.parentId);
+
+        if (!targetSubtreePath) {
+            return null
+        }
+
+        const oldValues = {};
+
+        Object.keys(properties).forEach(key => {
+            oldValues[key] = this.safeSerialize(Neo.ns(key, false, instance))
+        });
+
+        return {
+            sequenceId       : `${id}:${++this.undoSequence}`,
+            originWriter     : {agentId: context.agentId, sessionId: context.sessionId},
+            targetSubtreePath,
+            forward          : {tool: 'set_instance_properties', args: {id, properties}},
+            reverse          : {tool: 'set_instance_properties', args: {id, properties: oldValues}},
+            label            : `set ${Object.keys(properties).join(', ')} on ${id}`
+        }
+    }
+
+    /**
+     * Records a captured reverse-op as a single-op committed transaction on this heap's undo stack
+     * ({@link Neo.ai.Client#transactionService}) — `begin` → `record` → `commit`, keyed on the writer's
+     * `(agentId, sessionId)`. Best-effort: a `null` op, an absent stack authority, or a stack rejection (a malformed /
+     * unserializable reverse) is dropped cleanly (`abort`), never thrown — capturing an undo must never break the
+     * forward write it shadows.
+     * @param {Object|null} context
+     * @param {Object|null} op
+     * @protected
+     */
+    recordUndo(context, op) {
+        const transactionService = this.client?.transactionService;
+
+        if (!op || !transactionService) {
+            return
+        }
+
+        const
+            stackId = {agentId: context.agentId, sessionId: context.sessionId},
+            txId    = `tx:${op.sequenceId}`;
+
+        transactionService.begin({id: stackId, txId});
+
+        if (transactionService.record({id: stackId, txId, op}).ok) {
+            transactionService.commit({id: stackId, txId})
+        } else {
+            transactionService.abort({id: stackId, txId})
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/InstanceServiceUndoCapture.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceUndoCapture.spec.mjs
@@ -1,0 +1,86 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'InstanceServiceUndoCaptureTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import ComponentManager   from '../../../../src/manager/Component.mjs'; // binds Neo.getComponent + registers components
+import InstanceManager    from '../../../../src/manager/Instance.mjs';  // binds Neo.get + registers instances
+import InstanceService    from '../../../../src/ai/client/InstanceService.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+import WriteGuard         from '../../../../src/ai/WriteGuard.mjs';
+
+// Neo.ai.client.InstanceService.setInstanceProperties is the app-side write-path for the `set_instance_properties`
+// Neural Link tool. After the multi-writer enforcement grant, it captures the reverse-op (set⁻¹ = set(oldValues))
+// onto the heap's TransactionService undo stack, keyed on the live (agentId, sessionId) writer pair — so an agent
+// can undo the write. These tests drive a real component through the write-path with a real TransactionService +
+// WriteGuard (the in-heap authorities a Client owns), and assert the captured reverse + the legacy-skip.
+
+const ID = {agentId: 'agent-a', sessionId: 'sess-a'};
+
+test.describe('Neo.ai.client.InstanceService — set_instance_properties undo capture', () => {
+    let component, service, transactionService;
+
+    test.beforeEach(() => {
+        transactionService = Neo.create(TransactionService);
+        service            = Neo.create(InstanceService, {
+            client: {transactionService, writeGuard: Neo.create(WriteGuard)}
+        });
+        component = Neo.create(Component, {appName, id: 'undo-capture-cmp', width: 100})
+    });
+
+    test.afterEach(() => {
+        component.destroy()
+    });
+
+    test('captures set⁻¹ (the old values) onto the writer stack for an enforcement-granted agent write', () => {
+        const result = service.setInstanceProperties({id: 'undo-capture-cmp', properties: {width: 200}}, ID);
+
+        expect(result).toEqual({success: true});
+        expect(component.width).toBe(200); // the forward write applied
+
+        const stack = transactionService.stackOf({id: ID});
+
+        expect(stack.committed).toHaveLength(1);
+
+        const op = stack.committed[0].ops[0];
+
+        // the captured reverse is set(oldValues) — re-dispatchable as the same validated tool
+        expect(op.reverse).toEqual({tool: 'set_instance_properties', args: {id: 'undo-capture-cmp', properties: {width: 100}}});
+        expect(op.forward).toEqual({tool: 'set_instance_properties', args: {id: 'undo-capture-cmp', properties: {width: 200}}});
+        expect(op.originWriter).toEqual(ID);                  // provenance = the writer
+        expect(op.targetSubtreePath).toEqual(['undo-capture-cmp']) // parentless component → single-element audit path
+    });
+
+    test('multiple agent writes accumulate as separate committed transactions (most-recent undoable first)', () => {
+        service.setInstanceProperties({id: 'undo-capture-cmp', properties: {width: 200}}, ID);
+        service.setInstanceProperties({id: 'undo-capture-cmp', properties: {width: 300}}, ID);
+
+        const stack = transactionService.stackOf({id: ID});
+
+        expect(stack.committed).toHaveLength(2);
+        // the most-recent write's reverse restores the prior value (200), the older restores the original (100)
+        expect(stack.committed[1].ops[0].reverse.args.properties).toEqual({width: 200});
+        expect(stack.committed[0].ops[0].reverse.args.properties).toEqual({width: 100})
+    });
+
+    test('a legacy write (no context) applies but is NOT captured — no writer identity, no per-writer stack', () => {
+        service.setInstanceProperties({id: 'undo-capture-cmp', properties: {width: 300}}, null);
+
+        expect(component.width).toBe(300);                                       // the write still applies
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0)   // but nothing is captured
+    });
+});

--- a/test/playwright/unit/ai/InstanceServiceUndoCapture.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceUndoCapture.spec.mjs
@@ -83,4 +83,21 @@ test.describe('Neo.ai.client.InstanceService — set_instance_properties undo ca
         expect(component.width).toBe(300);                                       // the write still applies
         expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0)   // but nothing is captured
     });
+
+    // ── AC4: capture-drop is best-effort + fail-closed — never breaks the forward write, never commits a bad undo ──
+    test('a stack rejection (an unserializable reverse) is dropped — the write applies, nothing is committed, nothing thrown', () => {
+        // Force the stack to reject the reverse (the malformed / unserializable-reverse path); the capture must drop it.
+        transactionService.record = () => ({ok: false, reason: 'op-not-serializable'});
+
+        expect(() => service.setInstanceProperties({id: 'undo-capture-cmp', properties: {width: 200}}, ID)).not.toThrow();
+        expect(component.width).toBe(200);                                       // the forward write still applied
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0)   // the rejected tx was aborted, not committed
+    });
+
+    test('an absent transactionService is a no-op — the write applies, nothing thrown (no per-heap undo authority)', () => {
+        const service2 = Neo.create(InstanceService, {client: {writeGuard: Neo.create(WriteGuard)}});
+
+        expect(() => service2.setInstanceProperties({id: 'undo-capture-cmp', properties: {width: 250}}, ID)).not.toThrow();
+        expect(component.width).toBe(250) // the forward write still applied — capture is additive, never a precondition
+    });
 });


### PR DESCRIPTION
Authored by Vega (Claude Opus 4.8, Claude Code). Session 4cc428e3-cf36-4324-8646-1b96cb23fa4a.

Resolves #13248
Refs #13221 · Refs #13238 · Refs #13012 · Refs #9848

The first wiring slice of the Neural Link mutation-undo Slice-1 (#13221), on the merged #13238 `(agentId, sessionId)` 2-tuple `TransactionService` core: capture the *reverse* of a `set_instance_properties` write so an agent can undo it.

- **`Neo.ai.Client`** now owns a per-heap `TransactionService` (sibling to `WriteGuard`, same singleton shape) — the in-heap undo authority, keyed on the same `(agentId, sessionId)` writer pair the locks use.
- **`Neo.ai.client.InstanceService.setInstanceProperties`** captures the reverse-op (`set⁻¹ = set(oldValues)`) **post-enforcement-grant** (after `assertWritable`), keyed on the live `{agentId, sessionId}` context, via a `begin`/`record`/`commit` per write:
  - `buildSetReverse` captures the pre-set values (`safeSerialize(Neo.ns(key, instance))`) + derives the audit `targetSubtreePath` (`deriveSubtreePath`; audit-only — undo re-derives at undo-time).
  - `recordUndo` commits the single-op transaction **best-effort + fail-closed**: a legacy frame (no writer identity ⇒ no per-writer stack), an absent stack authority, or a stack rejection (malformed / unserializable reverse) is dropped (`abort`), **never thrown into the forward write path**.

Evidence: L2 (5 unit tests driving a real component through the write-path with a real `TransactionService` + `WriteGuard`, incl. the AC4 capture-drop negative cases) → L2 sufficient (an in-heap capture slice; the live-undo round-trip is the Sub-A2 e2e, which adds the `undo` NL tool that consumes these reverses).

## Deltas from ticket
None — delivers #13248's ACs exactly.

## Test Evidence
`UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/InstanceServiceUndoCapture.spec.mjs` → **5 passed** on the branch head (`3e0afef05`). Covers: capture correctness (the `set⁻¹` reverse + `forward` + `originWriter` provenance + the `['undo-capture-cmp']` audit path); multi-write accumulation (two writes → two committed txs, most-recent undoable first, reverses restoring `200` then `100`); the legacy-write skip (a no-`context` write applies but is not captured); and the **AC4 capture-drop seam** — a stack rejection (the tx is aborted, not committed) + an absent `transactionService` (a no-op), each leaving the forward write intact, committing no undo, and throwing nothing.

## Post-Merge Validation
- [ ] Sub A2 adds the `undo` NL tool (6-site wiring) + the two-agent e2e that *consumes* these captured reverses (the live undo round-trip).
- [ ] Sub B adds `create_component` / `remove_component` capture (via a node-side marker — they arrive app-side as generic `call_method add/destroy`).

Origin Session ID: 4cc428e3-cf36-4324-8646-1b96cb23fa4a
