### PR TITLE
fix(agent-harness): refresh stale intake pointer (#13250)

### DIFF
--- a/.agents/workflows/agent-harness.md
+++ b/.agents/workflows/agent-harness.md
@@ -6,8 +6,8 @@ The fastest correct path into the Agent Harness line (Epic #13012). No 20-page r
 
 1. **Read the concept anchor:** [`learn/agentos/decisions/0020-agent-harness-concept.md`](../../learn/agentos/decisions/0020-agent-harness-concept.md) (~5 minutes — the product bar, pillars, horizons, architecture decisions, and the five binding guardrails).
 2. **Glance the live state:** [Project board 13](https://github.com/orgs/neomjs/projects/13) + milestones M1–M4 (what exists, what's claimed, what's next).
-3. **Open your target work item only.** Epic #13012's maintained plan-of-record comment is the per-epic index; Discussion #10119 is archaeology — never required reading.
-4. **Claim before touching tracked files:** self-assign + `[lane-claim]` A2A broadcast (AGENTS.md critical gate). Lanes are self-selected; affinity notes on the plan-of-record are observations, not assignments.
+3. **Open your target work item only.** If epic-level routing is needed, use Epic #13012's latest checkpoint or supersession comment; older planning comments are archive context when a later checkpoint disagrees. Discussion #10119 is archaeology — never required reading.
+4. **Claim before touching tracked files:** self-assign + `[lane-claim]` A2A broadcast (AGENTS.md critical gate). Lanes are self-selected; affinity notes in epic comments are observations, not assignments.
 5. **Honor the standing disciplines — by reference, not re-derivation:**
    - Epic-review quota: max **two** structured reviews per epic; later pickups cite the existing two (`epic-review` skill).
    - Venue rules: work items carry records and status; dialogue lives in A2A; divergence lives in Discussions.

--- a/learn/agentos/decisions/0020-agent-harness-concept.md
+++ b/learn/agentos/decisions/0020-agent-harness-concept.md
@@ -62,6 +62,6 @@ A future session — any maintainer, any family, post-compaction — picks the h
 
 1. **Read this ADR** (the concept: bar, pillars, horizons, architecture decisions, guardrails — ~5 minutes).
 2. **Glance [Project board 13](https://github.com/orgs/neomjs/projects/13)** (live state: what exists, what's claimed, what's next) + the milestone ladder (M1–M4).
-3. **Open the target work item only.** The maintained plan-of-record comment on Epic #13012 is the per-epic index; Discussion #10119 is archaeology.
+3. **Open the target work item only.** If epic-level routing is needed, use Epic #13012's latest checkpoint or supersession comment; older planning comments are archive context when a later checkpoint disagrees. Discussion #10119 is archaeology.
 
 **Cold-read contract:** if a fresh session cannot state the product bar, the current pillar, and the next actionable leaves from steps 1–2 alone, this ADR has failed and gets amended — file the friction.


### PR DESCRIPTION
Resolves #13250
Related: #13012

Authored by GPT-5 (Codex Desktop). Session 019ec50d-5a01-7b11-9490-50f3241e8cfc.

Refreshes the Agent Harness session-entry pointer so fresh maintainers do not treat the older #13012 planning comment as the current routing source after newer checkpoint / supersession comments exist.

Evidence: L1 (static workflow/ADR diff + stale-phrase grep + cold-read source check) -> L1 required (docs/workflow pointer correction). No residuals.

## Deltas from ticket

- Kept the fix pointer-based: no copied #13012 roster, no new workflow, no skill or always-loaded substrate mutation.
- Removed the stale `plan-of-record` wording from both target files, including the Step 4 affinity-note phrasing.

## Decision Record impact

Amends ADR 0020 §7 session-intake wording only. The Agent Harness concept decision, pillars, horizons, shell decision, and guardrails are unchanged.

## Test Evidence

- `gh issue view 13250 --json number,title,state,body,labels,assignees,url` -> open, assigned to `neo-gpt`, Contract Ledger present.
- Parent epic gate: #13012 is open with labels `epic`, `ai`, `architecture`; existing @neo-gpt epic-review anchor found at https://github.com/neomjs/neo/issues/13012#issuecomment-4695275046.
- `rg -n "maintained plan-of-record comment|plan-of-record" .agents/workflows/agent-harness.md learn/agentos/decisions/0020-agent-harness-concept.md` -> no matches after patch.
- `git diff --check` -> clean.
- `git diff --cached --check` -> clean before commit.
- Branch freshness before push: `merge-base HEAD origin/dev == origin/dev` at `071dbba7f7a25f6a77a67dd140294e3c2bcb62a8`.
- Branch close-keyword hygiene: `git log origin/dev..HEAD --format='%h%x09%s%n%b'` contains only `529be8c29 fix(agent-harness): refresh stale intake pointer (#13250)`.

## Post-Merge Validation

- [ ] Fresh Agent Harness session entry leads through ADR 0020, Project board 13 / milestones, the target work item, and the latest #13012 checkpoint/supersession context without reading Discussion #10119 or old planning history.

## Commit

- `529be8c29` — `fix(agent-harness): refresh stale intake pointer (#13250)`
