### PR TITLE
feat(examples): standalone dock-zone layout example (Slice 1: static render) (#13253)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -42,9 +42,10 @@ const resolveComponentRef = componentRef => ({
  * @summary Standalone example for the dashboard dock-zone layout system.
  *
  * Builds a representative {@link Neo.dashboard.DockZoneModel} document, then projects it through
- * {@link Neo.dashboard.DockLayoutAdapter} into a live container of split / tab zones with interactive resize
- * splitters — the missing standalone showcase + first *runtime* exercise of `DockLayoutAdapter.project`, which until
- * now was only unit-tested and never run in a live app's render path.
+ * {@link Neo.dashboard.DockLayoutAdapter} into a live container of split / tab zones with splitter affordances — the
+ * missing standalone showcase + first *runtime* exercise of `DockLayoutAdapter.project`, which until now was only
+ * unit-tested and never run in a live app's render path. This is the **static** render slice: the splitters render, but
+ * the resize commit loop is not wired here (see the items config below); that stays in the interactive slice.
  * @class Neo.examples.dashboard.dock.MainContainer
  * @extends Neo.container.Viewport
  */
@@ -60,8 +61,9 @@ class MainContainer extends Viewport {
          */
         layout: {ntype: 'fit'},
         /**
-         * The dock layout: the model projected once into a live container — split + tab zones + interactive resize
-         * splitters (the splitter affordances the projection emits drive `DockZoneModel.applyOperation('resizeSplit')`).
+         * The dock layout: the model projected once into a live container — split + tab zones + splitter affordances.
+         * The splitters render, but the resize commit loop (`dockZoneDocument` / `applyDockZoneOperation` +
+         * `onDockZoneDocumentChange`) is not wired here — that stays in the interactive slice; this is the static render.
          * @member {Object[]} items
          */
         items: [

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -1,0 +1,73 @@
+import DockLayoutAdapter from '../../../src/dashboard/DockLayoutAdapter.mjs';
+import Viewport          from '../../../src/container/Viewport.mjs';
+import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits for tab zones
+
+/**
+ * A representative dock-zone document (`neo.harness.dockZone.v1`): a horizontal split of a two-tab main zone and a
+ * vertical side-split of two single-tab zones, over four items. The shape `Neo.dashboard.DockLayoutAdapter.project`
+ * consumes — see its spec for the full contract.
+ * @type {Object}
+ */
+const dockModel = {
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        strategy: {componentRef: 'Strategy', title: 'Strategy', kind: 'panel'},
+        swarm   : {componentRef: 'Swarm',    title: 'Swarm',    kind: 'panel'},
+        terminal: {componentRef: 'Terminal', title: 'Terminal', kind: 'terminal'},
+        logs    : {componentRef: 'Logs',     title: 'Logs',     kind: 'panel'}
+    },
+    nodes: {
+        root           : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
+        'main-tabs'    : {type: 'tabs',  items: ['strategy', 'swarm'], activeItemId: 'strategy'},
+        'side-split'   : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},
+        'terminal-tabs': {type: 'tabs',  items: ['terminal'], activeItemId: 'terminal'},
+        'logs-tabs'    : {type: 'tabs',  items: ['logs'],     activeItemId: 'logs'}
+    }
+};
+
+/**
+ * Resolves a model `componentRef` to the component config rendered inside its dock zone. For this example, a simple
+ * centered label per panel; a real app resolves each ref to its feature view.
+ * @param {String} componentRef
+ * @returns {Object}
+ */
+const resolveComponentRef = componentRef => ({
+    ntype: 'component',
+    style: {alignItems: 'center', color: '#888', display: 'flex', fontSize: '20px', justifyContent: 'center'},
+    html : componentRef
+});
+
+/**
+ * @summary Standalone example for the dashboard dock-zone layout system.
+ *
+ * Builds a representative {@link Neo.dashboard.DockZoneModel} document, then projects it through
+ * {@link Neo.dashboard.DockLayoutAdapter} into a live container of split / tab zones with interactive resize
+ * splitters — the missing standalone showcase + first *runtime* exercise of `DockLayoutAdapter.project`, which until
+ * now was only unit-tested and never run in a live app's render path.
+ * @class Neo.examples.dashboard.dock.MainContainer
+ * @extends Neo.container.Viewport
+ */
+class MainContainer extends Viewport {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.dashboard.dock.MainContainer'
+         * @protected
+         */
+        className: 'Neo.examples.dashboard.dock.MainContainer',
+        /**
+         * @member {Object} layout={ntype:'fit'}
+         */
+        layout: {ntype: 'fit'},
+        /**
+         * The dock layout: the model projected once into a live container — split + tab zones + interactive resize
+         * splitters (the splitter affordances the projection emits drive `DockZoneModel.applyOperation('resizeSplit')`).
+         * @member {Object[]} items
+         */
+        items: [
+            DockLayoutAdapter.project(dockModel, {resolveComponentRef})
+        ]
+    }
+}
+
+export default Neo.setupClass(MainContainer);

--- a/examples/dashboard/dock/app.mjs
+++ b/examples/dashboard/dock/app.mjs
@@ -1,0 +1,6 @@
+import MainContainer from './MainContainer.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: MainContainer,
+    name    : 'Neo.examples.dashboard.dock'
+});

--- a/examples/dashboard/dock/index.html
+++ b/examples/dashboard/dock/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>Neo Dashboard — Dock Layout</title>
+</head>
+<body>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/examples/dashboard/dock/neo-config.json
+++ b/examples/dashboard/dock/neo-config.json
@@ -1,0 +1,6 @@
+{
+    "appPath"    : "examples/dashboard/dock/app.mjs",
+    "basePath"   : "../../../",
+    "environment": "development",
+    "mainPath"   : "./Main.mjs"
+}


### PR DESCRIPTION
## Summary

Adds `examples/dashboard/dock/` — the missing standalone showcase for the dashboard dock-zone layout system (~15+ PRs of machinery: `DockZoneModel`, `DockLayoutAdapter`, `DockSplitter`, split-tab layouts, `resizeSplit`, persistence, …) that until now had **no standalone runtime consumer**.

`MainContainer` composes a representative `neo.harness.dockZone.v1` document — a horizontal split of a 2-tab main zone (`Strategy` / `Swarm`) and a vertical side-split of two single-tab zones (`Terminal` / `Logs`) over four panels — and renders it through `Neo.dashboard.DockLayoutAdapter.project(model, {resolveComponentRef})` into a live, mounted Viewport.

This is the **first runtime exercise of `DockLayoutAdapter.project`** — its only prior exercise was unit assertions (`DockLayoutAdapter.spec.mjs`); it had never run in a live app (the AgentOS `DockPreview` view does not drive the full `project()` path). This is the **static render slice** — splitter affordances render, but the resize commit loop is not wired here (that is the interactive slice on the parent).

Resolves #13253

Refs #13247 (parent — the interactive slice follows)
Related: #13158 (docking epic)

Evidence: L3 (local webpack dev server + Chrome/preview render + console probe of the static dock route) → L3 required (#13253 render-verification AC). No residuals.

## Test Evidence

Verified at head `2236ab57e` (the latest commit is a docs-only comment-scope fix per review — no render change; the render probe below ran on the example):

- `node --check` clean on `app.mjs` + `MainContainer.mjs`.
- DOM probe after boot, **no console errors** at the `error` level: `splitterEls: 2` (exactly the model's two split nodes — root horizontal + side-split vertical), `tabEls: 23`, `dockEls: 13`, `allNeoEls: 36`, Neo Viewport booted.
- Screenshot confirms the visual layout: a ~65/35 horizontal split (STRATEGY | SWARM tabs, Strategy active; vertical TERMINAL / LOGS side-split right at ~60/40), all panel labels + active-tab indicators rendering correctly.
- `DockLayoutAdapter.spec.mjs` (9, the `project()` contract the example consumes) green.

`examples/` is not part of the unit/e2e suites, so verification is the render-probe + visual confirmation above. The example carries **no `src/` changes** (#13253 AC).

## Post-Merge Validation

- Open `examples/dashboard/dock/` against a dev server and confirm the dock layout renders (split + tab zones + splitter affordances, correct proportions).
- This is the first end-to-end runtime confirmation of `DockLayoutAdapter.project` outside unit tests.

## Deltas

- **Scope is Slice 1 (static render)** of #13247. The interactive splitter drag-resize (#13247 AC3), edge-zone drop-targets, and named-layout / persistence / pin polish (#13247 AC4) are **out of scope here** and tracked for #13247's interactive slice. The splitters render as affordances, but the `resizeSplit` commit loop (`onDockZoneDocumentChange` re-projection wiring — `DockSplitter` commits resizes to the persisted JSON model, not direct sibling styles, so a consumer-side re-render is required) is **not yet wired**. The source comments were scoped to say exactly this (review fix).
- `resolveComponentRef` renders simple centered labels per panel; a real app resolves each ref to its feature view.

Authored by @neo-opus-vega (Claude Opus 4.8, Claude Code). Origin Session ID: a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
