### PR TITLE
feat(dashboard): persist dock auto-hide state (#13254)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -131,6 +131,7 @@ Optional item fields:
 - `blueprint`: a serializable Neo component config when the item is created from saved state rather than a live instance.
 - `closable`, `pinnable`, `movable`: UI policy hints. Defaults are adapter-defined.
 - `pinned`: semantic pin state. `true` means pinned open; `false` means auto-hide eligible when an adapter supports that affordance. Omitted preserves the adapter-defined default. `pinnable === false` means `setItemPinned` must reject pin-state changes.
+- `autoHidden`: semantic collapsed/auto-hide state. `true` means the item is committed as collapsed into an auto-hide affordance; `false` means the item is visible when the owning layout renders it. A pinned-open item must not be serialized with `autoHidden: true`; `setItemPinned(..., true)` clears `autoHidden`.
 - `metadata`: JSON-only descriptive data. It must not contain DOM nodes, functions, secrets, PATs, or live component objects.
 
 ### Stale Component References
@@ -150,11 +151,13 @@ Persist:
 - node ids, types, zone mapping, split orientation, split child order, normalized split sizes
 - tab item order and `activeItemId`
 - stable item ids, item pin state, and JSON-only item metadata
+- committed item auto-hide/collapsed state
 
 Do not persist:
 
 - `DOMRect`, screen coordinates, hover rectangles, and preview overlays
 - `dockPreview` payloads, preview ids, rejection reasons, and placement hints
+- runtime hover/open state for auto-hidden panes
 - `windowId`, `appName`, `sourceSortZone`, `targetSortZone`, `currentIndex`, `draggedItem`
 - live `Neo.component.Base` instances
 - functions, controllers, event listeners, PATs, or harness credentials
@@ -206,6 +209,7 @@ Future implementations should mutate the model through semantic operations inste
 | `detachItem` | `itemId` | Removes an item from the dock tree while preserving its item record for popup/window ownership. |
 | `closeItem` | `itemId` | Removes an item from both tree and catalog when policy permits. |
 | `setItemPinned` | `itemId`, `pinned` | Updates an item's semantic pin state when `pinnable` policy permits it. |
+| `setItemAutoHidden` | `itemId`, `autoHidden` | Updates an item's committed collapsed/auto-hide state when `pinnable` policy permits it. |
 | `normalizeTree` | full model | Removes empty tabs/splits and validates references after any operation. |
 | `createSavedLayoutCollection` | saved-layout wrappers, metadata | Creates a named perspective collection from valid saved-layout wrappers. |
 | `upsertSavedLayout` | collection, saved-layout wrapper, `activate` | Adds or replaces a named saved layout and optionally selects it. |
@@ -221,6 +225,7 @@ Every operation must maintain:
 - `tabs.activeItemId` is either null for empty tabs or one of `tabs.items`
 - empty structural nodes are collapsed before serialization
 - pin-state changes require a boolean `pinned` payload and must reject items with `pinnable === false`
+- auto-hide state changes require a boolean `autoHidden` payload, must reject items with `pinnable === false`, and must not leave a pinned-open item serialized as collapsed
 
 ## Drag Integration Boundary
 
@@ -358,7 +363,7 @@ Optional wrapper fields:
 - `revision`: monotonic revision, content version, or adapter-owned equivalent used for conflict/recovery messaging.
 - `metadata`: JSON-only descriptive data. It must not contain DOM nodes, functions, live component instances, credentials, PATs, access tokens, or harness bridge tokens.
 
-Persistence consumes only committed dock-zone state. It must not serialize `dockPreview`, hover rectangles, screen coordinates, `windowId`, `sourceSortZone`, `targetSortZone`, live components, event listeners, controllers, functions, or credential material. If a future detached-window slice needs restore hints, those hints must be separate semantic placement metadata; they must not turn the dock layout into an OS-window session dump.
+Persistence consumes only committed dock-zone state. It must not serialize `dockPreview`, hover rectangles, screen coordinates, `windowId`, `sourceSortZone`, `targetSortZone`, runtime hover/open state for auto-hidden panes, live components, event listeners, controllers, functions, or credential material. If a future detached-window slice needs restore hints, those hints must be separate semantic placement metadata; they must not turn the dock layout into an OS-window session dump.
 
 Restore must validate the wrapper schema, the inner dock-zone schema, and the normalized model invariants before replacing an active layout. Unsupported wrapper versions, unsupported dock-zone versions, invalid references, or invalid split/tab invariants fail closed: keep the last-good active layout and surface validation or recovery state to the caller.
 

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -78,7 +78,7 @@ class DockZoneModel extends Base {
      * @protected
      * @static
      */
-    static dockZoneItemKeys = new Set(['componentRef', 'title', 'kind', 'blueprint', 'closable', 'pinnable', 'pinned', 'movable', 'metadata'])
+    static dockZoneItemKeys = new Set(['componentRef', 'title', 'kind', 'blueprint', 'closable', 'pinnable', 'pinned', 'autoHidden', 'movable', 'metadata'])
 
     /**
      * Fields allowed on persisted dock-zone nodes, keyed by node type.
@@ -473,6 +473,14 @@ class DockZoneModel extends Base {
         for (const [itemId, item] of Object.entries(items)) {
             if (DockZoneModel.isJsonRecord(item) && Object.hasOwn(item, 'pinned') && typeof item.pinned !== 'boolean') {
                 errors.push(`item "${itemId}" pinned must be a boolean`)
+            }
+
+            if (DockZoneModel.isJsonRecord(item) && Object.hasOwn(item, 'autoHidden') && typeof item.autoHidden !== 'boolean') {
+                errors.push(`item "${itemId}" autoHidden must be a boolean`)
+            }
+
+            if (DockZoneModel.isJsonRecord(item) && item.pinned === true && item.autoHidden === true) {
+                errors.push(`item "${itemId}" cannot be pinned and autoHidden at the same time`)
             }
         }
 
@@ -1252,6 +1260,32 @@ class DockZoneModel extends Base {
 
         doc.items[itemId].pinned = pinned;
 
+        if (pinned) {
+            doc.items[itemId].autoHidden = false
+        }
+
+        return DockZoneModel.commit(document, doc)
+    }
+
+    /**
+     * @summary Updates an item's persisted auto-hide/collapsed state when its policy permits it.
+     * @param {Object} document
+     * @param {Object} args {itemId, autoHidden}
+     * @returns {{document:Object, errors:String[]}}
+     * @static
+     */
+    static setItemAutoHidden(document, {itemId, autoHidden} = {}) {
+        let item = document.items?.[itemId];
+
+        if (!item) return {document, errors: [`unknown item "${itemId}"`]};
+        if (typeof autoHidden !== 'boolean') return {document, errors: ['autoHidden must be a boolean']};
+        if (item.pinnable === false) return {document, errors: [`item "${itemId}" is not pinnable`]};
+        if (autoHidden && item.pinned === true) return {document, errors: [`item "${itemId}" is pinned and cannot be autoHidden`]};
+
+        let doc = DockZoneModel.clone(document);
+
+        doc.items[itemId].autoHidden = autoHidden;
+
         return DockZoneModel.commit(document, doc)
     }
 
@@ -1284,6 +1318,8 @@ class DockZoneModel extends Base {
                 return DockZoneModel.closeItem(document, descriptor);
             case 'setItemPinned':
                 return DockZoneModel.setItemPinned(document, descriptor);
+            case 'setItemAutoHidden':
+                return DockZoneModel.setItemAutoHidden(document, descriptor);
             default:
                 return {document, errors: [`unknown operation "${descriptor.operation}"`]}
         }

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -316,10 +316,11 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(restored.errors.join(' ')).toContain('authKey')
         });
 
-        test('rejects non-boolean pinned state on save or restore', () => {
+        test('rejects non-boolean pinned or autoHidden state on save or restore', () => {
             const input = doc();
 
             input.items.strategy.pinned = 'yes';
+            input.items.terminal.autoHidden = 'yes';
 
             const saved = DockZoneModel.createSavedLayout(input, {
                 layoutId: 'operator-default',
@@ -328,6 +329,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
             expect(saved.layout).toBe(null);
             expect(saved.errors.join(' ')).toContain('pinned');
+            expect(saved.errors.join(' ')).toContain('autoHidden');
 
             const savedLayout = {
                 schema  : DockZoneModel.LAYOUT_SCHEMA,
@@ -338,11 +340,44 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             };
 
             savedLayout.dockZone.items.strategy.pinned = 'yes';
+            savedLayout.dockZone.items.terminal.autoHidden = 'yes';
 
             const restored = DockZoneModel.restoreSavedLayout(savedLayout);
 
             expect(restored.document).toBe(null);
-            expect(restored.errors.join(' ')).toContain('pinned')
+            expect(restored.errors.join(' ')).toContain('pinned');
+            expect(restored.errors.join(' ')).toContain('autoHidden')
+        });
+
+        test('rejects saved layouts that pin an auto-hidden item open', () => {
+            const input = doc();
+
+            input.items.terminal.pinned = true;
+            input.items.terminal.autoHidden = true;
+
+            const saved = DockZoneModel.createSavedLayout(input, {
+                layoutId: 'operator-default',
+                title   : 'Operator Default'
+            });
+
+            expect(saved.layout).toBe(null);
+            expect(saved.errors.join(' ')).toContain('cannot be pinned and autoHidden');
+
+            const savedLayout = {
+                schema  : DockZoneModel.LAYOUT_SCHEMA,
+                layoutId: 'operator-default',
+                title   : 'Operator Default',
+                dockZone: doc(),
+                metadata: {}
+            };
+
+            savedLayout.dockZone.items.terminal.pinned = true;
+            savedLayout.dockZone.items.terminal.autoHidden = true;
+
+            const restored = DockZoneModel.restoreSavedLayout(savedLayout);
+
+            expect(restored.document).toBe(null);
+            expect(restored.errors.join(' ')).toContain('cannot be pinned and autoHidden')
         });
 
         test('rejects non-JSON values in metadata and item blueprints', () => {
@@ -756,6 +791,19 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(unpinned.document.items.terminal.pinned).toBe(false)
         });
 
+        test('pinning an item open clears persisted auto-hide state', () => {
+            const input = doc();
+
+            input.items.terminal.autoHidden = true;
+
+            const pinned = DockZoneModel.setItemPinned(input, {itemId: 'terminal', pinned: true});
+
+            expect(pinned.errors).toEqual([]);
+            expect(pinned.document.items.terminal.pinned).toBe(true);
+            expect(pinned.document.items.terminal.autoHidden).toBe(false);
+            expect(input.items.terminal.autoHidden).toBe(true)
+        });
+
         test('fails closed for unknown items, non-boolean state, and non-pinnable items', () => {
             const input = doc();
 
@@ -772,6 +820,56 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             const locked = DockZoneModel.setItemPinned(input, {itemId: 'terminal', pinned: true});
             expect(locked.document).toBe(input);
             expect(locked.errors.join(' ')).toContain('not pinnable')
+        })
+    });
+
+    test.describe('setItemAutoHidden', () => {
+        test('updates auto-hide state without mutating caller input', () => {
+            const input = doc();
+
+            input.items.terminal.pinnable = true;
+
+            const snapshot = JSON.stringify(input),
+                  hidden   = DockZoneModel.setItemAutoHidden(input, {itemId: 'terminal', autoHidden: true});
+
+            expect(hidden.errors).toEqual([]);
+            expect(hidden.document.items.terminal.autoHidden).toBe(true);
+            expect(JSON.stringify(input)).toBe(snapshot);
+            expect(input.items.terminal.autoHidden).toBeUndefined();
+
+            const visible = DockZoneModel.applyOperation(hidden.document, {
+                operation : 'setItemAutoHidden',
+                itemId    : 'terminal',
+                autoHidden: false
+            });
+
+            expect(visible.errors).toEqual([]);
+            expect(visible.document.items.terminal.autoHidden).toBe(false)
+        });
+
+        test('fails closed for unknown items, non-boolean state, non-pinnable items, and pinned-open items', () => {
+            const input = doc();
+
+            input.items.terminal.pinnable = false;
+
+            const unknown = DockZoneModel.setItemAutoHidden(input, {itemId: 'ghost', autoHidden: true});
+            expect(unknown.document).toBe(input);
+            expect(unknown.errors.join(' ')).toContain('ghost');
+
+            const invalid = DockZoneModel.setItemAutoHidden(input, {itemId: 'terminal', autoHidden: 'true'});
+            expect(invalid.document).toBe(input);
+            expect(invalid.errors.join(' ')).toContain('boolean');
+
+            const locked = DockZoneModel.setItemAutoHidden(input, {itemId: 'terminal', autoHidden: true});
+            expect(locked.document).toBe(input);
+            expect(locked.errors.join(' ')).toContain('not pinnable');
+
+            const pinnedInput = doc();
+            pinnedInput.items.terminal.pinned = true;
+
+            const pinned = DockZoneModel.setItemAutoHidden(pinnedInput, {itemId: 'terminal', autoHidden: true});
+            expect(pinned.document).toBe(pinnedInput);
+            expect(pinned.errors.join(' ')).toContain('pinned')
         })
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 4ed21ddf-b92f-45ce-8689-bb3ebb563dd9.

Resolves #13254

Adds the model-level auto-hide seam for dock-zone items: `autoHidden` is now an optional JSON-only item field, `setItemAutoHidden` is the semantic operation for toggling it, and pinned-open items cannot remain serialized as collapsed. Pinning an item open clears `autoHidden`, so later UI rails/popouts can consume a coherent committed state without persisting hover/open geometry.

Related: #13158
Related: #13030

Evidence: L2 (focused Playwright unit contract: `DockZoneModel.spec.mjs` 57/57) -> L2 required (model operation, saved-layout validation, and pin/auto-hide coherence). No residuals for #13254.

## Deltas from ticket

- Chose `autoHidden` as the persisted field name to keep the state explicit and avoid overloading `pinned: false`.
- Kept renderer behavior out of scope; no drag, hover, rail, or popout UI code changed.
- Reused the existing `pinnable === false` policy gate so auto-hide state changes follow the same item policy boundary as pin state.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs` -> 57 passed.
- `git diff --check` -> passed.

## Post-Merge Validation

- [ ] Future auto-hide UI leaf consumes `autoHidden` through `DockZoneModel.applyOperation()` rather than persisting runtime hover/open geometry.

## Commit

- `202d162b1` — `feat(dashboard): persist dock auto-hide state (#13254)`
