### PR TITLE
feat(ai): the undo Neural Link tool — peek, re-dispatch reverse, consume (#13257)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -1240,6 +1240,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /instance/undo:
+    post:
+      summary: Undo Last Mutation
+      operationId: undo
+      x-neo-tool-tier: write-locked
+      x-pass-as-object: true
+      description: |
+        Reverts the requester's most-recent committed Neural Link mutation (single-level undo).
+
+        **When to Use:**
+        After a `set_instance_properties` (or other write-class) mutation, to cleanly revert it. The captured
+        reverse-op is re-dispatched under live enforcement as the current caller. No-op + recoverable error when
+        there is nothing to undo or the revert is denied.
+      tags: [Instance]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UndoRequest'
+      responses:
+        '200':
+          description: Undo result
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /instance/method/call:
     post:
       summary: Call Instance Method
@@ -1740,6 +1775,13 @@ components:
           description: Optional filter by log type.
 
     ReloadPageRequest:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          description: The target App Worker Session ID
+
+    UndoRequest:
       type: object
       properties:
         sessionId:

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -1246,13 +1246,7 @@ paths:
       operationId: undo
       x-neo-tool-tier: write-locked
       x-pass-as-object: true
-      description: |
-        Reverts the requester's most-recent committed Neural Link mutation (single-level undo).
-
-        **When to Use:**
-        After a `set_instance_properties` (or other write-class) mutation, to cleanly revert it. The captured
-        reverse-op is re-dispatched under live enforcement as the current caller. No-op + recoverable error when
-        there is nothing to undo or the revert is denied.
+      description: Reverts the requester's most-recent committed mutation (single-level undo); no-op + recoverable error when there is nothing to undo or the revert is denied.
       tags: [Instance]
       requestBody:
         content:

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -55,6 +55,7 @@ const serviceMapping = {
     set_instance_properties      : InstanceService   .setInstanceProperties     .bind(InstanceService),
     set_route                    : RuntimeService    .setRoute                  .bind(RuntimeService),
     simulate_event               : InteractionService.simulateEvent             .bind(InteractionService),
+    undo                         : InstanceService   .undo                      .bind(InstanceService),
     verify_component_consistency : InteractionService.verifyComponentConsistency.bind(InteractionService)
 };
 

--- a/ai/services/neural-link/InstanceService.mjs
+++ b/ai/services/neural-link/InstanceService.mjs
@@ -79,6 +79,18 @@ class InstanceService extends Base {
     }
 
     /**
+     * Reverts the requester's most-recent committed Neural Link mutation transaction — forwards the `undo` tool to
+     * the connected App Worker, which pops the requester's last committed transaction and re-dispatches its captured
+     * reverse-op(s) under live enforcement. See {@link Neo.ai.client.InstanceService#undo}.
+     * @param {Object} opts
+     * @param {String} opts.sessionId
+     * @returns {Promise<Object>}
+     */
+    async undo({sessionId}) {
+        return await ConnectionService.call(sessionId, 'undo', {})
+    }
+
+    /**
      * Calls a method on a specific instance.
      * @param {Object} opts
      * @param {String} opts.sessionId

--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -126,6 +126,7 @@ class Client extends Base {
             find_instances         : instance,
             get_instance_properties: instance,
             set_instance_properties: instance,
+            undo                   : instance,
 
             get_record            : data,
             inspect_state_provider: data,

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -115,8 +115,10 @@ class InstanceService extends Service {
 
         // Capture the reverse (the pre-set values) BEFORE mutating, so an agent can undo this write. Best-effort +
         // fail-closed: only an enforcement-granted *agent* write (a writer identity in `context`) is captured, and a
-        // malformed / unserializable reverse is dropped, never thrown into the write path.
-        const undoOp = this.buildSetReverse({context, id, instance, properties});
+        // malformed / unserializable reverse is dropped, never thrown into the write path. An undo-replay
+        // (`context.undoReplay`, set by {@link #undo}) is NOT captured — re-applying a reverse must never enqueue a
+        // new undoable transaction (single-level undo; redo is a later slice).
+        const undoOp = context?.undoReplay ? null : this.buildSetReverse({context, id, instance, properties});
 
         instance.set(properties);
 
@@ -193,6 +195,66 @@ class InstanceService extends Service {
         } else {
             transactionService.abort({id: stackId, txId})
         }
+    }
+
+    /**
+     * Reverts the requester's most-recent committed transaction — the `undo` Neural Link tool.
+     *
+     * Peeks the writer's last committed transaction (non-consuming, via {@link Neo.ai.TransactionService#stackOf}) and
+     * re-dispatches each captured reverse-op through the **enforced** dispatch path
+     * ({@link Neo.ai.Client#handleRequest}), so the revert re-enters {@link Neo.ai.admitWrite} as the **current**
+     * caller with its `subtreePath` re-derived on the live tree (provenance ≠ enforcement identity). The transaction
+     * is consumed ({@link Neo.ai.TransactionService#undo}, `committed → undone`) **only on full success**. Each
+     * re-dispatch carries an `undoReplay` marker so the replayed writes are not themselves captured — undo never
+     * enqueues a new undoable transaction (single-level; redo is a later slice).
+     *
+     * Recoverable + fail-closed (never throws for an expected outcome): no writer identity, no stack authority,
+     * nothing to undo, or a denied / unresolvable-target re-dispatch → `{undone: false, reason}` with the transaction
+     * **preserved** (no-op). Capture is suppressed during replay and the App Worker is single-threaded, so the peeked
+     * last-committed transaction is stable through the consume.
+     * @param {Object} [params] No parameters — undo targets the requester's own stack.
+     * @param {Object|null} [context] The Bridge-stamped `{agentId, sessionId}` writer pair (2nd dispatch arg).
+     * @returns {Promise<Object>} `{undone: Boolean, txId?: String, reverted?: Number, reason?: String}`
+     */
+    async undo(params, context) {
+        const transactionService = this.client?.transactionService;
+
+        if (!context?.agentId || !context?.sessionId) {
+            return {undone: false, reason: 'no-writer-identity'}
+        }
+
+        if (!transactionService) {
+            return {undone: false, reason: 'no-transaction-service'}
+        }
+
+        const
+            stackId     = {agentId: context.agentId, sessionId: context.sessionId},
+            {committed} = transactionService.stackOf({id: stackId});
+
+        if (committed.length === 0) {
+            return {undone: false, reason: 'nothing-to-undo'}
+        }
+
+        const
+            tx         = committed[committed.length - 1],
+            reverseOps = tx.ops.slice().reverse(), // last mutation undone first
+            replayCtx  = {...context, undoReplay: true};
+
+        // Re-dispatch each reverse as a validated tool, enforced as the CURRENT caller. Capture is suppressed
+        // (replayCtx.undoReplay), so a successful replay enqueues no new undoable transaction.
+        try {
+            for (const op of reverseOps) {
+                await this.client.handleRequest(op.reverse.tool, op.reverse.args, replayCtx)
+            }
+        } catch (error) {
+            // Preserve-on-fail: a denied / unresolvable re-dispatch leaves the transaction committed (no-op).
+            return {undone: false, reason: `undo-denied: ${error.message}`}
+        }
+
+        // All reverses applied — consume the transaction (committed → undone).
+        const {txId} = transactionService.undo({id: stackId});
+
+        return {undone: true, txId, reverted: reverseOps.length}
     }
 
     /**

--- a/test/playwright/unit/ai/InstanceServiceUndo.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceUndo.spec.mjs
@@ -1,0 +1,109 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'InstanceServiceUndoTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import ComponentManager   from '../../../../src/manager/Component.mjs'; // binds Neo.getComponent + registers components
+import InstanceManager    from '../../../../src/manager/Instance.mjs';  // binds Neo.get + registers instances
+import InstanceService    from '../../../../src/ai/client/InstanceService.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+import WriteGuard         from '../../../../src/ai/WriteGuard.mjs';
+
+// Neo.ai.client.InstanceService.undo is the app-side `undo` Neural Link tool. It peeks the requester's last committed
+// transaction (non-consuming), re-dispatches each captured reverse through the enforced dispatch path (re-entering
+// admitWrite as the CURRENT caller, with an `undoReplay` marker that suppresses re-capture), and consumes the
+// transaction only on full success. These tests drive a real component through capture → undo with a real
+// TransactionService + WriteGuard, plus a `handleRequest` stub that routes the replay back to the service (the role
+// Neo.ai.Client plays in the live heap), and assert the revert, the single-level suppression, and preserve-on-fail.
+
+const ID = {agentId: 'agent-a', sessionId: 'sess-a'};
+
+test.describe('Neo.ai.client.InstanceService — the `undo` tool', () => {
+    let component, service, transactionService;
+
+    test.beforeEach(() => {
+        transactionService = Neo.create(TransactionService);
+
+        const client = {
+            transactionService,
+            writeGuard   : Neo.create(WriteGuard),
+            // mirrors Neo.ai.Client#handleRequest: snake_case tool -> camelCase service method, threading the context
+            handleRequest: (method, params, ctx) => service[Neo.snakeToCamel(method)](params, ctx)
+        };
+
+        service   = Neo.create(InstanceService, {client});
+        component = Neo.create(Component, {appName, id: 'undo-cmp', width: 100})
+    });
+
+    test.afterEach(() => {
+        !component.isDestroyed && component.destroy()
+    });
+
+    test('reverts the last committed set on the live tree and consumes the transaction', async () => {
+        service.setInstanceProperties({id: 'undo-cmp', properties: {width: 200}}, ID);
+        expect(component.width).toBe(200);                                       // forward write applied
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(1);
+
+        const result = await service.undo({}, ID);
+
+        expect(result.undone).toBe(true);
+        expect(result.reverted).toBe(1);
+        expect(component.width).toBe(100);                                       // reverted to the pre-set value
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0)   // transaction consumed (committed -> undone)
+    });
+
+    test('the undo-replay is NOT itself captured — a second undo finds nothing (single-level, no redo enqueued)', async () => {
+        service.setInstanceProperties({id: 'undo-cmp', properties: {width: 200}}, ID);
+
+        const first = await service.undo({}, ID);
+        expect(first.undone).toBe(true);
+
+        // The replayed set(width:100) carried the `undoReplay` marker, so it was not captured. Had it been captured,
+        // the stack would now hold a redoable transaction — single-level Slice-1 forbids that.
+        const second = await service.undo({}, ID);
+        expect(second).toEqual({undone: false, reason: 'nothing-to-undo'})
+    });
+
+    test('nothing to undo → recoverable no-op error', async () => {
+        expect(await service.undo({}, ID)).toEqual({undone: false, reason: 'nothing-to-undo'})
+    });
+
+    test('a legacy call with no writer identity → recoverable no-op error', async () => {
+        service.setInstanceProperties({id: 'undo-cmp', properties: {width: 200}}, ID); // an agent write exists on the stack
+        expect(await service.undo({}, null)).toEqual({undone: false, reason: 'no-writer-identity'})
+    });
+
+    test('an absent transactionService → recoverable no-op error', async () => {
+        const service2 = Neo.create(InstanceService, {client: {writeGuard: Neo.create(WriteGuard)}});
+        expect(await service2.undo({}, ID)).toEqual({undone: false, reason: 'no-transaction-service'})
+    });
+
+    test('a denied / unresolvable re-dispatch → no-op + recoverable error, transaction PRESERVED (fail-closed)', async () => {
+        service.setInstanceProperties({id: 'undo-cmp', properties: {width: 200}}, ID);
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(1);
+
+        // simulate a denied enforcement / unresolvable target on the revert re-dispatch
+        service.client.handleRequest = () => { throw new Error('Write denied for undo-cmp: subtree-locked') };
+
+        const result = await service.undo({}, ID);
+
+        expect(result.undone).toBe(false);
+        expect(result.reason).toMatch(/^undo-denied:/);
+        // preserve-on-fail: the transaction is NOT consumed — it stays committed for a later retry
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(1)
+    })
+});

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -127,6 +127,7 @@ const expectedNeuralLinkToolTiers = {
     set_instance_properties      : 'write-locked',
     set_route                    : 'write-locked',
     simulate_event               : 'write-locked',
+    undo                         : 'write-locked',
     verify_component_consistency : 'read'
 };
 
@@ -142,7 +143,8 @@ const neuralLinkDangerousReadForbidden = [
     'remove_component',
     'set_instance_properties',
     'set_route',
-    'simulate_event'
+    'simulate_event',
+    'undo'
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds the **`undo` Neural Link tool** — the layer that makes the captured undo stack invocable, so an agent can say *"undo that"* and the live app reverts. Sub-A2 of #13221 (NL mutation undo — Slice-1); the TransactionService core (#13231) and the `set_instance_properties` reverse-capture hook (#13249) have already merged.

**Flow (tool layer — no core change):** `undo` peeks the requester's last committed transaction (`TransactionService.stackOf`, non-consuming) → re-dispatches each captured reverse through the **enforced** `Client.handleRequest` path, so the revert re-enters `admitWrite` as the **current** caller with its `subtreePath` re-derived on the live tree (provenance ≠ enforcement identity) → consumes the transaction (`undo()`, `committed → undone`) **only on full success**.

- **Capture-suppression during replay:** each re-dispatch carries an `undoReplay` marker; the capture-hook skips recording, so undo never enqueues a new undoable transaction (single-level; redo is Slice-2).
- **Preserve-on-fail:** a denied / unresolvable-target re-dispatch → no-op (the transaction stays `committed`) + a recoverable error.

Resolves #13257

Refs #13221 (Slice-1 parent), #13012 (Pillar-2), #9848 (Slice-tracking parent)

Evidence: L2 (66 in-process unit + integration tests green — incl. the real-`component.Base` `set` → `undo` → revert + stack-consume round-trip, the live-tree revert #13257's e2e AC requires) → L2 required (#13257 unit + e2e ACs; a live-bridge multi-agent e2e is broader, not a #13257 AC, and rides with Sub-B's full agent loop). No residuals.

## Test Evidence

`UNIT_TEST_MODE=true playwright -c …unit.mjs` — 66 green; head `364ef0d30` (the latest commit only tightens the openapi description per review — no behavior/test change; the 66 below ran on the code path):

- **`InstanceServiceUndo.spec.mjs` (new, 6 tests)** — reverts the last committed set on a **real component tree** + consumes the tx (the round-trip = #13257's live-tree e2e AC); undo-replay not re-captured (a second undo → `nothing-to-undo`, no redo enqueued); nothing-to-undo / no-writer-identity / absent-transactionService recoverable no-ops; **preserve-on-fail** (denied re-dispatch → tx preserved + recoverable error).
- **`InstanceServiceUndoCapture.spec.mjs` (6, regression)** — the #13249 capture-hook stays green after the `undoReplay` suppression edit.
- **`OpenApiValidatorCompliance.spec.mjs` (30)** — incl. #13064 tier classification + "OpenAPI operations stay aligned with serviceMapping keys" (the openapi `/instance/undo` op, the toolService binding, and the client serviceMap are consistent) + "mutation/admin cannot be tiered as read" (undo is `write-locked`).
- **`TransactionService.spec.mjs` (16) + `parseAgentEnvelope.spec.mjs` (9)** — core + envelope regression green.

`node --check` clean on all edited `.mjs`; openapi parses (undo tier `write-locked`, single-line description, `UndoRequest` schema present).

## Post-Merge Validation

- Optional real-bridge smoke (not a #13257 AC): a connected agent does `set_instance_properties` → `undo` → confirms the property reverts in the running app; a second `undo` reports `nothing-to-undo`.

## Deltas

- **#13257 (the `undo` tool) is fully delivered, no residual.** The tool reverts any captured reverse; `set` is captured today (#13249), so the round-trip proves undo-of-set on a real component tree (#13257's e2e AC, at L2 — in-process integration, the achievable level for an `examples/`-free service slice). `create_component` / `remove_component` reverse-capture is **Sub-B** — a *separate* ticket, **not** a #13257 residual: the tool already re-dispatches their reverses the moment Sub-B captures them. A live-bridge multi-agent e2e is a broader future validation, not a #13257 AC.
- **`undo` lives in `client/InstanceService`** for Slice-1 (co-located with the capture-hook; all Slice-1 reverses are `set` → InstanceService). It re-dispatches via the generic `handleRequest`, so it routes cross-service reverses (create/remove) once Sub-B captures them.
- **Race-freedom** of peek-then-consume holds for Slice-1's synchronous `set` reverse (the `await` resolves on a microtask before any incoming socket macrotask). When async reverses arrive (Sub-B), revisit with a txId-targeted consume.

Authored by @neo-opus-vega (Claude Opus 4.8, Claude Code). Origin Session ID: 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
