### PR TITLE
fix(github-workflow): resolve issue-only label targets (#13262)

### DIFF
--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -7,7 +7,7 @@ import {projectConversationTrust} from './shared/conversationTrust.mjs';
 import {exec}            from 'child_process';
 import {promisify}       from 'util';
 import {spawn}           from 'child_process';
-import {GET_ISSUE_AND_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST} from './queries/issueQueries.mjs';
+import {GET_ISSUE_LABEL_IDS, GET_PULL_REQUEST_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST} from './queries/issueQueries.mjs';
 import {GET_PULL_REQUEST_ID} from './queries/pullRequestQueries.mjs';
 import {
     ADD_LABELS,
@@ -1148,13 +1148,26 @@ class IssueService extends Base {
     }
 
     /**
-     * Fetches the GraphQL node IDs for an issue or pull request and a set of labels.
-     * @param {number}   issueNumber The number of the issue or PR.
-     * @param {string[]} labelNames  An array of label names.
-     * @returns {Promise<{labelableId: string, labelIds: string[]}>} The node IDs.
+     * @summary Detects GitHub's missing-number GraphQL error for one labelable branch.
+     * @param {Error}  error       GraphQL failure.
+     * @param {String} type        GitHub type name (`Issue` or `PullRequest`).
+     * @param {Number} issueNumber Repository issue/PR number.
+     * @returns {Boolean}
      * @private
      */
-    async #getIds(issueNumber, labelNames) {
+    #isMissingLabelableError(error, type, issueNumber) {
+        return new RegExp(`Could not resolve to an? ${type} with the number of ${issueNumber}`).test(error?.message || '');
+    }
+
+    /**
+     * @summary Fetches one labelable branch while converting "missing target" to null.
+     * @param {String} query       GraphQL query to execute.
+     * @param {Number} issueNumber Repository issue/PR number.
+     * @param {String} type        GitHub type name (`Issue` or `PullRequest`).
+     * @returns {Promise<Object|null>}
+     * @private
+     */
+    async #queryLabelableIds(query, issueNumber, type) {
         const variables = {
             owner      : aiConfig.owner,
             repo       : aiConfig.repo,
@@ -1162,19 +1175,61 @@ class IssueService extends Base {
             maxLabels  : aiConfig.issueSync.maxRepoLabels
         };
 
-        const data = await GraphqlService.query(GET_ISSUE_AND_LABEL_IDS, variables);
+        try {
+            return await GraphqlService.query(query, variables);
+        } catch (error) {
+            if (this.#isMissingLabelableError(error, type, issueNumber)) {
+                return null;
+            }
+            throw error;
+        }
+    }
 
+    /**
+     * @summary Resolves repository label names into GraphQL IDs.
+     * @param {Object}   data        GraphQL repository payload.
+     * @param {String[]} labelNames  Requested labels.
+     * @param {Number}   issueNumber Repository issue/PR number.
+     * @returns {String[]}
+     * @private
+     */
+    #resolveLabelIds(data, labelNames, issueNumber) {
         const
-            labelableId = data.repository.issue?.id || data.repository.pullRequest?.id,
-            repoLabels   = data.repository.labels.nodes,
-            labelIds     = labelNames.map(name => {
+            repoLabels = data?.repository?.labels?.nodes || [],
+            labelIds   = labelNames.map(name => {
                 const label = repoLabels.find(l => l.name === name);
                 return label ? label.id : null;
             }).filter(Boolean);
 
-        if (!labelableId || labelIds.length !== labelNames.length) {
+        if (labelIds.length !== labelNames.length) {
             throw new Error(`Could not find issue or pull request #${issueNumber} or one of the labels: ${labelNames.join(', ')}`);
         }
+
+        return labelIds;
+    }
+
+    /**
+     * Fetches the GraphQL node IDs for an issue or pull request and a set of labels.
+     * @param {number}   issueNumber The number of the issue or PR.
+     * @param {string[]} labelNames  An array of label names.
+     * @returns {Promise<{labelableId: string, labelIds: string[]}>} The node IDs.
+     * @private
+     */
+    async #getIds(issueNumber, labelNames) {
+        let
+            data        = await this.#queryLabelableIds(GET_ISSUE_LABEL_IDS, issueNumber, 'Issue'),
+            labelableId = data?.repository?.issue?.id;
+
+        if (!labelableId) {
+            data        = await this.#queryLabelableIds(GET_PULL_REQUEST_LABEL_IDS, issueNumber, 'PullRequest');
+            labelableId = data?.repository?.pullRequest?.id;
+        }
+
+        if (!labelableId) {
+            throw new Error(`Could not find issue or pull request #${issueNumber} or one of the labels: ${labelNames.join(', ')}`);
+        }
+
+        const labelIds = this.#resolveLabelIds(data, labelNames, issueNumber);
 
         return { labelableId, labelIds };
     }

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -787,7 +787,7 @@ export const GET_BLOCKED_BY = `
 `;
 
 /**
- * Fetches the GraphQL Labelable node ID for an issue or pull request and all labels in the repository.
+ * Fetches the GraphQL Labelable node ID for an issue and all labels in the repository.
  * This is a utility query used by mutations that add/remove labels.
  *
  * Variables required:
@@ -796,12 +796,35 @@ export const GET_BLOCKED_BY = `
  * - $issueNumber: Int!
  * - $maxLabels: Int!
  */
-export const GET_ISSUE_AND_LABEL_IDS = `
-    query GetIssueAndLabelIds($owner: String!, $repo: String!, $issueNumber: Int!, $maxLabels: Int!) {
+export const GET_ISSUE_LABEL_IDS = `
+    query GetIssueLabelIds($owner: String!, $repo: String!, $issueNumber: Int!, $maxLabels: Int!) {
         repository(owner: $owner, name: $repo) {
             issue(number: $issueNumber) {
                 id
             }
+            labels(first: $maxLabels) {
+                nodes {
+                    id
+                    name
+                }
+            }
+        }
+    }
+`;
+
+/**
+ * Fetches the GraphQL Labelable node ID for a pull request and all labels in the repository.
+ * This is a utility query used by mutations that add/remove labels.
+ *
+ * Variables required:
+ * - $owner: String!
+ * - $repo: String!
+ * - $issueNumber: Int!
+ * - $maxLabels: Int!
+ */
+export const GET_PULL_REQUEST_LABEL_IDS = `
+    query GetPullRequestLabelIds($owner: String!, $repo: String!, $issueNumber: Int!, $maxLabels: Int!) {
+        repository(owner: $owner, name: $repo) {
             pullRequest(number: $issueNumber) {
                 id
             }

--- a/ai/services/gitlab-workflow/queries/issueQueries.mjs
+++ b/ai/services/gitlab-workflow/queries/issueQueries.mjs
@@ -11,7 +11,7 @@
  * Lookup queries (`GET_ISSUE_GID`, `GET_PROJECT_LABEL_IDS`) resolve the opaque global ids
  * (`gid://gitlab/Issue/...`, `gid://gitlab/ProjectLabel/...`) that GitLab mutations require but
  * the MCP tool contract only carries as `iid` / label-name — the GitLab twin of the
- * github-workflow `GET_ISSUE_ID` / `GET_ISSUE_AND_LABEL_IDS` two-step pattern.
+ * github-workflow `GET_ISSUE_ID` / `GET_ISSUE_LABEL_IDS` two-step pattern.
  */
 
 /**

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -437,11 +437,12 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
             callCount++;
             if (callCount === 1) {
                 expect(variables.issueNumber).toBe(10077);
+                expect(query).toContain('issue(number: $issueNumber)');
+                expect(query).not.toContain('pullRequest(number: $issueNumber)');
                 return {
                     repository: {
-                        issue      : {id: ISSUE_NODE_ID},
-                        pullRequest: null,
-                        labels     : {nodes: repoLabels}
+                        issue : {id: ISSUE_NODE_ID},
+                        labels: {nodes: repoLabels}
                     }
                 };
             }
@@ -473,15 +474,21 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
             callCount++;
             if (callCount === 1) {
                 expect(variables.issueNumber).toBe(11695);
+                expect(query).toContain('issue(number: $issueNumber)');
+                expect(query).not.toContain('pullRequest(number: $issueNumber)');
+                throw new Error('GitHub API error: Could not resolve to an Issue with the number of 11695.');
+            }
+            if (callCount === 2) {
+                expect(query).toContain('pullRequest(number: $issueNumber)');
+                expect(query).not.toContain('issue(number: $issueNumber)');
                 return {
                     repository: {
-                        issue      : null,
                         pullRequest: {id: PR_NODE_ID},
                         labels     : {nodes: repoLabels}
                     }
                 };
             }
-            if (callCount === 2) {
+            if (callCount === 3) {
                 expect(variables).toEqual({
                     labelableId: PR_NODE_ID,
                     labelIds   : ['LA_ai']
@@ -498,7 +505,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
         });
 
         expect(result.message).toContain('Successfully added labels');
-        expect(callCount).toBe(2);
+        expect(callCount).toBe(3);
     });
 
     test('removes labels from a Pull Request using the pullRequest Labelable id', async () => {
@@ -508,15 +515,19 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
         GraphqlService.query = async (query, variables) => {
             callCount++;
             if (callCount === 1) {
+                expect(query).toContain('issue(number: $issueNumber)');
+                throw new Error('GitHub API error: Could not resolve to an Issue with the number of 11695.');
+            }
+            if (callCount === 2) {
+                expect(query).toContain('pullRequest(number: $issueNumber)');
                 return {
                     repository: {
-                        issue      : null,
                         pullRequest: {id: PR_NODE_ID},
                         labels     : {nodes: repoLabels}
                     }
                 };
             }
-            if (callCount === 2) {
+            if (callCount === 3) {
                 expect(variables).toEqual({
                     labelableId: PR_NODE_ID,
                     labelIds   : ['LA_bug']
@@ -533,21 +544,21 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
         });
 
         expect(result.message).toContain('Successfully removed labels');
-        expect(callCount).toBe(2);
+        expect(callCount).toBe(3);
     });
 
     test('returns a structured GraphQL error when neither issue nor Pull Request exists', async () => {
         let callCount = 0;
 
-        GraphqlService.query = async () => {
+        GraphqlService.query = async query => {
             callCount++;
-            return {
-                repository: {
-                    issue      : null,
-                    pullRequest: null,
-                    labels     : {nodes: repoLabels}
-                }
-            };
+            if (query.includes('issue(number: $issueNumber)')) {
+                throw new Error('GitHub API error: Could not resolve to an Issue with the number of 999999.');
+            }
+            if (query.includes('pullRequest(number: $issueNumber)')) {
+                throw new Error('GitHub API error: Could not resolve to a PullRequest with the number of 999999.');
+            }
+            throw new Error(`Unexpected query: ${query}`);
         };
 
         const result = await IssueService.manageIssueLabels({
@@ -559,7 +570,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
         expect(result.error).toBe('GraphQL API request failed');
         expect(result.code).toBe('GRAPHQL_API_ERROR');
         expect(result.message).toContain('issue or pull request #999999');
-        expect(callCount).toBe(1);
+        expect(callCount).toBe(2);
     });
 
     test('returns a structured GraphQL error when a requested label is missing', async () => {
@@ -569,9 +580,8 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
             callCount++;
             return {
                 repository: {
-                    issue      : {id: 'I_kwDOABcD_issue10077'},
-                    pullRequest: null,
-                    labels     : {nodes: repoLabels}
+                    issue : {id: 'I_kwDOABcD_issue10077'},
+                    labels: {nodes: repoLabels}
                 }
             };
         };
@@ -585,6 +595,27 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueLabel
         expect(result.error).toBe('GraphQL API request failed');
         expect(result.code).toBe('GRAPHQL_API_ERROR');
         expect(result.message).toContain('missing-label');
+        expect(callCount).toBe(1);
+    });
+
+    test('does not fall through to PR lookup on unrelated issue lookup errors', async () => {
+        let callCount = 0;
+
+        GraphqlService.query = async query => {
+            callCount++;
+            expect(query).toContain('issue(number: $issueNumber)');
+            throw new Error('GitHub API error: rate limit exceeded');
+        };
+
+        const result = await IssueService.manageIssueLabels({
+            issue_number: 10077,
+            action      : 'add',
+            labels      : ['bug']
+        });
+
+        expect(result.error).toBe('GraphQL API request failed');
+        expect(result.code).toBe('GRAPHQL_API_ERROR');
+        expect(result.message).toContain('rate limit exceeded');
         expect(callCount).toBe(1);
     });
 });


### PR DESCRIPTION
Resolves #13262

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec50d-5a01-7b11-9490-50f3241e8cfc.

`manage_issue_labels` now resolves GitHub Issues and Pull Requests through separate labelable lookups instead of one combined `issue + pullRequest` GraphQL query. That avoids GitHub rejecting an issue-label operation just because no PR with the same number exists, while preserving PR-label support from the earlier #10077 fix and keeping the MCP schema unchanged.

Evidence: L2 (focused unit coverage of IssueService label resolution + live-style missing-side GraphQL errors) -> L2 required. No residuals.

## Deltas from Ticket

- Added a stale-reference cleanup in the GitLab workflow query comments so it points at the new GitHub query constant name.
- Kept the existing `manage_issue_labels` request/response contract intact; only the internal lookup path changed.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs` -> 41/41 passed.
- `git diff --check` passed.
- `rg "GET_ISSUE_AND_LABEL_IDS|GetIssueAndLabelIds" ai test buildScripts src` returned no matches.

## Post-Merge Validation

- [ ] After the GitHub Workflow MCP server is running on the merged `dev`, call `manage_issue_labels` on an issue-only number and confirm it no longer falls back to REST because of a missing PR-side lookup.

## Commits

- `7e87860c8` - `fix(github-workflow): resolve issue-only label targets (#13262)`
