### PR TITLE
feat(ai): capture create_component's reverse for undo — server-stamped marker (#13261)

### DIFF
--- a/ai/services/neural-link/ComponentService.mjs
+++ b/ai/services/neural-link/ComponentService.mjs
@@ -180,7 +180,11 @@ class ComponentService extends Base {
             throw new Error('create_component: `config` must declare a `module`, `ntype`, or `className` to instantiate.');
         }
 
-        return await ConnectionService.call(sessionId, 'call_method', {id: parentId, method: 'add', args: [config]});
+        // `undoKind` is a server-only capture marker (deliberately NOT in CallMethodRequest's schema): the app-side
+        // write-path records create's inverse (destroy the new child) so the `undo` tool can revert a creation. The
+        // generic `call_method` service forwards only {id, method, args}, so this marker cannot be injected by a
+        // public caller — generic call_method stays non-undoable.
+        return await ConnectionService.call(sessionId, 'call_method', {id: parentId, method: 'add', args: [config], undoKind: 'create_component'});
     }
 
     /**

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -168,6 +168,59 @@ class InstanceService extends Service {
     }
 
     /**
+     * Builds the reverse-op for a `create_component` write — `create⁻¹ = destroy(newId)`, capturing the id of the
+     * just-added child. **Server-stamped only:** the inverse is recorded ONLY when `undoKind === 'create_component'`
+     * (the server-side generic `call_method` strips any public-injected marker), the dispatch is the canonical
+     * `add(config)` shape, a writer identity is present, and it is not an undo replay. Returns `null` otherwise so
+     * {@link #recordUndo} no-ops — a generic `call_method` stays non-undoable. Data-not-code: the reverse is a
+     * re-dispatchable validated tool descriptor (the app-side `destroy(true)` form `remove_component` maps to).
+     * @param {Object} params
+     * @param {Object|null} params.context  The Bridge-stamped `{agentId, sessionId}` writer pair.
+     * @param {String} params.id  The parent container id (the `add` target).
+     * @param {String} params.method
+     * @param {Array} params.args
+     * @param {String} [params.undoKind]  The server-stamped capture marker.
+     * @param {*} params.result  The `add` return — the created component instance.
+     * @returns {Object|null} A reverse-record op, or `null` when the call is not a capturable create.
+     * @protected
+     */
+    buildCreateReverse({context, id, method, args, undoKind, result}) {
+        if (undoKind !== 'create_component' || context?.undoReplay) {
+            return null
+        }
+
+        if (!context?.agentId || !context?.sessionId) {
+            return null
+        }
+
+        // canonical create shape only — a marker on any other call_method shape is dropped (fail-closed)
+        if (method !== 'add' || args.length !== 1 || !args[0] || typeof args[0] !== 'object') {
+            return null
+        }
+
+        const newId = result?.id;
+
+        if (typeof newId !== 'string' || newId === '') {
+            return null
+        }
+
+        const targetSubtreePath = deriveSubtreePath(newId, cid => Neo.getComponent(cid)?.parentId);
+
+        if (!targetSubtreePath) {
+            return null
+        }
+
+        return {
+            sequenceId       : `${newId}:${++this.undoSequence}`,
+            originWriter     : {agentId: context.agentId, sessionId: context.sessionId},
+            targetSubtreePath,
+            forward          : {tool: 'create_component', args: {parentId: id, config: args[0]}},
+            reverse          : {tool: 'call_method', args: {id: newId, method: 'destroy', args: [true]}},
+            label            : `create ${args[0].ntype || args[0].className || 'component'} in ${id}`
+        }
+    }
+
+    /**
      * Records a captured reverse-op as a single-op committed transaction on this heap's undo stack
      * ({@link Neo.ai.Client#transactionService}) — `begin` → `record` → `commit`, keyed on the writer's
      * `(agentId, sessionId)`. Best-effort: a `null` op, an absent stack authority, or a stack rejection (a malformed /
@@ -266,7 +319,7 @@ class InstanceService extends Service {
      * @param {Object|null} [context] The Bridge-stamped agent writer pair (2nd dispatch arg); null/undefined = legacy.
      * @returns {Object}
      */
-    async callMethod({id, method, args=[]}, context) {
+    async callMethod({id, method, args=[], undoKind}, context) {
         const instance = Neo.get(id);
 
         if (!instance) {
@@ -285,6 +338,12 @@ class InstanceService extends Service {
         this.assertWritable(context, id);
 
         const result = await scope[methodName].call(scope, ...args);
+
+        // create_component reverse-capture: a server-stamped create (the canonical `add(config)` dispatch) records
+        // its inverse — destroy the new child — so an agent can undo a creation. The marker is server-only (the
+        // server-side generic call_method forwards just {id, method, args}, so a public-injected `undoKind` is
+        // stripped); a generic call_method + an undo replay are NOT captured. See {@link #buildCreateReverse}.
+        this.recordUndo(context, this.buildCreateReverse({context, id, method, args, undoKind, result}));
 
         return {result: this.safeSerialize(result)}
     }

--- a/test/playwright/unit/ai/InstanceServiceCreateUndoCapture.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceCreateUndoCapture.spec.mjs
@@ -1,0 +1,115 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'InstanceServiceCreateUndoCaptureTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import Container          from '../../../../src/container/Base.mjs';
+import ComponentManager   from '../../../../src/manager/Component.mjs'; // binds Neo.getComponent + registers components
+import InstanceManager    from '../../../../src/manager/Instance.mjs';  // binds Neo.get + registers instances
+import InstanceService    from '../../../../src/ai/client/InstanceService.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+import WriteGuard         from '../../../../src/ai/WriteGuard.mjs';
+
+// `create_component` is forwarded server-side as a server-stamped `call_method` `parent.add(config)`; the
+// app-side Neo.ai.client.InstanceService.callMethod records its inverse (destroy the new child) onto the writer's undo
+// stack — but ONLY with the server-stamped `undoKind` marker + the canonical `add(config)` shape. These tests isolate
+// the capture wiring: `container.add` is stubbed (its vdom path is Neo's, exercised elsewhere; here it returns a
+// controlled instance) so the assertions are on MY capture logic — the marker gate, the reverse descriptor, the
+// round-trip revert via the merged `undo` tool, the generic-call_method non-capture (gpt guardrail 1), and fail-closed.
+
+const ID = {agentId: 'agent-a', sessionId: 'sess-a'};
+
+test.describe('Neo.ai.client.InstanceService — create_component undo capture', () => {
+    let container, service, transactionService;
+
+    test.beforeEach(() => {
+        transactionService = Neo.create(TransactionService);
+
+        const client = {
+            transactionService,
+            writeGuard   : Neo.create(WriteGuard),
+            // mirrors Neo.ai.Client#handleRequest: snake_case tool -> camelCase service method, threading the context
+            handleRequest: (method, params, ctx) => service[Neo.snakeToCamel(method)](params, ctx)
+        };
+
+        service   = Neo.create(InstanceService, {client});
+        container = Neo.create(Container, {appName, id: 'undo-create-container', items: []})
+    });
+
+    test.afterEach(() => {
+        !container.isDestroyed && container.destroy()
+    });
+
+    test('a server-stamped create captures its inverse (destroy the new child) on the writer stack', async () => {
+        container.add = () => ({id: 'created-child'}); // stub: the new child the create produced (isolate the capture)
+
+        await service.callMethod({
+            id: 'undo-create-container', method: 'add', args: [{ntype: 'component'}], undoKind: 'create_component'
+        }, ID);
+
+        const stack = transactionService.stackOf({id: ID});
+        expect(stack.committed).toHaveLength(1);
+
+        const op = stack.committed[0].ops[0];
+        // the captured reverse re-dispatches as a validated call_method destroy(newId, true)
+        expect(op.reverse).toEqual({tool: 'call_method', args: {id: 'created-child', method: 'destroy', args: [true]}});
+        expect(op.forward.tool).toBe('create_component');
+        expect(op.originWriter).toEqual(ID)
+    });
+
+    test('round-trip: a captured create → undo → the new child is destroyed + the transaction consumed', async () => {
+        const child = Neo.create(Component, {appName, id: 'rt-child'}); // a real, destroyable child
+        container.add = () => child;
+
+        await service.callMethod({
+            id: 'undo-create-container', method: 'add', args: [{ntype: 'component', id: 'rt-child'}],
+            undoKind: 'create_component'
+        }, ID);
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(1);
+
+        const result = await service.undo({}, ID);
+
+        expect(result.undone).toBe(true);
+        expect(Neo.getComponent('rt-child')?.isDestroyed ?? true).toBe(true);     // reverse destroyed the new child
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0)    // transaction consumed
+    });
+
+    test('a generic call_method add (NO server-stamped marker) is NOT captured — generic call_method stays non-undoable', async () => {
+        container.add = () => ({id: 'unmarked-child'});
+
+        await service.callMethod({
+            id: 'undo-create-container', method: 'add', args: [{ntype: 'component'}]
+        }, ID); // no undoKind — a plain call_method, exactly what a public caller can reach
+
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0) // nothing captured
+    });
+
+    test('buildCreateReverse is fail-closed — only a marked, canonical, attributed, non-replay create captures', () => {
+        const base = {
+            context: ID, id: 'undo-create-container', method: 'add', args: [{ntype: 'component'}],
+            undoKind: 'create_component', result: {id: 'new-x'}
+        };
+
+        expect(service.buildCreateReverse(base)).not.toBeNull();                                       // happy path
+        expect(service.buildCreateReverse({...base, undoKind: undefined})).toBeNull();                 // no marker (generic call_method)
+        expect(service.buildCreateReverse({...base, context: {...ID, undoReplay: true}})).toBeNull();  // undo replay
+        expect(service.buildCreateReverse({...base, context: null})).toBeNull();                       // no writer identity
+        expect(service.buildCreateReverse({...base, method: 'insert'})).toBeNull();                    // non-canonical method
+        expect(service.buildCreateReverse({...base, args: []})).toBeNull();                            // non-canonical args
+        expect(service.buildCreateReverse({...base, result: null})).toBeNull()                         // unresolvable new id
+    })
+});

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -99,7 +99,7 @@ test.describe('Neo.ai.services.neural-link.ComponentService — createComponent 
         expect(calls[0]).toEqual({
             sessionId: 's1',
             op       : 'call_method',
-            payload  : {id: 'toolbar-1', method: 'add', args: [config]}
+            payload  : {id: 'toolbar-1', method: 'add', args: [config], undoKind: 'create_component'} // server-stamped undo-capture marker
         });
         expect(result).toEqual({success: true, id: 'neo-created-1'});
     });


### PR DESCRIPTION
## Summary

Captures `create_component`'s reverse so the merged `undo` tool (#13259) can revert a creation — Sub-B1 of #13221 (gpt-vetted marker design). `create_component` forwards server-side as `call_method` `parent.add(config)`; this slice records its inverse (destroy the new child) onto the writer's undo stack.

**Design (gpt-vetted):**
- **Server-stamped marker (guardrail 1):** `ComponentService.createComponent` stamps an `undoKind: 'create_component'` marker on its `call_method` dispatch — deliberately **NOT** in `CallMethodRequest`'s schema. The server-side generic `call_method` forwards only `{id, method, args}`, so a public-injected marker is **stripped** → a generic `call_method` stays non-undoable (per #13257's AC).
- **App-side capture:** `InstanceService.callMethod`, on marker + canonical `add(config)` shape + a writer identity + non-replay, captures the reverse (`call_method` `destroy(newId, true)` — the app-side form `remove_component` maps to) via `buildCreateReverse` + `recordUndo`; fail-closed on any mismatch.

Resolves #13261

Refs #13221 (Slice-1 parent), #13259 (the undo tool, merged), #13012 (Pillar-2), #9846 (`create_component`), #9848

Evidence: L2 (70 in-process unit + integration tests green — incl. the create-capture + the create → undo → child-destroyed round-trip on a real `component.Base` child) → L2 required (#13261 unit + round-trip ACs; a live-bridge e2e is broader, not a #13261 AC). No residuals.

## Test Evidence

`UNIT_TEST_MODE=true playwright -c …unit.mjs` at head `d28118cde` — **78 green** (a follow-up commit fixed the server-side `ComponentService.spec`'s exact-payload assertion to expect the marker — a CI catch; I'd missed running that spec locally):

- **`InstanceServiceCreateUndoCapture.spec.mjs` (new, 4):** create-capture (reverse = `destroy(newId)`); round-trip (marked create → `undo` → the child is destroyed + the tx consumed); generic-`call_method` `add` (no marker) NOT captured (guardrail 1); `buildCreateReverse` fail-closed (no-marker / replay / no-writer / non-`add` / non-single-arg / unresolvable-id all → `null`). `container.add` is stubbed to isolate the capture wiring from Neo's container vdom path.
- **Regression:** `ComponentService` (8, server-side create dispatch — now asserts the `undoKind` marker), `InstanceServiceUndoCapture` (6, set-capture), `InstanceServiceUndo` (6, the undo tool), `TransactionService` (16), `parseAgentEnvelope` (9), `OpenApiValidatorCompliance` (29) — all green; the `callMethod` change is additive (generic `call_method` behavior unchanged).

`node --check` clean on the edited `.mjs`.

## Post-Merge Validation

- A connected agent: `create_component` → `undo` → the created component is removed from the live tree; a generic `call_method` `add` is NOT undoable.

## Deltas

- **Scope = create capture only.** `remove_component` reverse-capture + the `insert(index, config)` position-preservation (`add()` appends → tree-order drift) is **Sub-B2** (gpt guardrail 2) — a separate slice, not a #13261 residual.
- **`container.add` stubbed in tests:** the capture wiring is the unit under test; `container.add`'s real vdom path is Neo's (exercised in the container/dashboard specs) and crashes the unit harness (no main thread), so it's stubbed to return a controlled instance. The round-trip uses a real `component.Base` child so the reverse `destroy` is genuine.
- **Reverse shape:** create's reverse is the app-side `call_method destroy(newId, true)` (what `remove_component` maps to), not the `remove_component` tool — `undo` re-dispatches via the client `handleRequest`, which routes `call_method`.

Authored by @neo-opus-vega (Claude Opus 4.8, Claude Code). Origin Session ID: 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
