### PR TITLE
fix(sync): rebuild content indexes after sync (#13260)

### DIFF
--- a/.github/workflows/data-sync-pipeline.yml
+++ b/.github/workflows/data-sync-pipeline.yml
@@ -51,14 +51,7 @@ jobs:
       - name: Rebuild Indexes & SEO
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          node ./buildScripts/docs/index/labels.mjs
-          node ./buildScripts/docs/index/release.mjs
-          node ./buildScripts/docs/index/pulls.mjs
-          node ./buildScripts/docs/index/discussions.mjs
-          node ./buildScripts/docs/index/tickets.mjs
-          node ./buildScripts/docs/seo/generate.mjs --format xml --base-url https://neomjs.com -o apps/portal/sitemap.xml
-          node ./buildScripts/docs/seo/generate.mjs --format llms --base-url https://neomjs.com -o apps/portal/llms.txt
+        run: node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs --include-labels
 
       - name: Commit, Rebase and Push
         run: |
@@ -99,18 +92,18 @@ jobs:
 
           echo "Cloning pages repository..."
           git clone https://x-access-token:${PAGES_DEPLOY_PAT}@github.com/neomjs/pages.git temp_pages
-          
+
           # Ensure target directories exist
           mkdir -p temp_pages/node_modules/neo.mjs/apps/devindex/resources/data
           mkdir -p temp_pages/node_modules/neo.mjs/apps/portal/resources/data
           mkdir -p temp_pages/node_modules/neo.mjs/resources/content
-          
+
           # Copy the data files
           cp apps/devindex/resources/data/users.jsonl temp_pages/node_modules/neo.mjs/apps/devindex/resources/data/
           cp -f apps/portal/resources/data/*.json temp_pages/node_modules/neo.mjs/apps/portal/resources/data/ 2>/dev/null || true
           cp -f apps/portal/sitemap.xml temp_pages/ 2>/dev/null || true
           cp -f apps/portal/llms.txt temp_pages/ 2>/dev/null || true
-          
+
           # Copy resources content (syncing deletions natively via git).
           # Per Epic #11187 7-bucket fan-out: support both legacy paths (issue-archive/,
           # pr-archive/) and the new single-root archive/ umbrella during the migration
@@ -124,20 +117,20 @@ jobs:
               cp -r "resources/content/$dir" temp_pages/node_modules/neo.mjs/resources/content/
             fi
           done
-          
+
           cd temp_pages
-          
+
           # Check for changes and push
           if [[ -n $(git status -s node_modules/neo.mjs/apps/devindex/resources/data/users.jsonl node_modules/neo.mjs/apps/portal/resources/data/*.json sitemap.xml llms.txt node_modules/neo.mjs/resources/content/) ]]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            
+
             git add node_modules/neo.mjs/apps/devindex/resources/data/users.jsonl
             git add node_modules/neo.mjs/apps/portal/resources/data/*.json 2>/dev/null || true
             git add sitemap.xml 2>/dev/null || true
             git add llms.txt 2>/dev/null || true
             git add -A node_modules/neo.mjs/resources/content/
-            
+
             git commit --no-verify -m "chore(data): Sync data and content from neo repo [skip ci]"
             git push origin main
           else

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1542,7 +1542,7 @@ paths:
         - DON'T: after `create_issue` or `create_comment` (already in context).
         - DON'T: for code changes (syncs only ticket metadata).
 
-        **How it works:** pulls remote data, creates `.md` files for new issues, pushes modified `.md` files to GitHub. Cached for fast no-ops.
+        **How it works:** pulls remote data, creates `.md` files for new issues, pushes modified `.md` files to GitHub, then rebuilds the derived Portal indexes, `sitemap.xml`, and `llms.txt`. Cached for fast no-ops; derive failures reject the sync instead of returning success with stale generated artifacts.
 
         **Rejection:** throws `sync_all REJECTED: working-tree is on branch '<name>', not 'dev'.` with remediation guidance pointing to switch-to-dev or daemon-driven sync.
       tags: [Issues]

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -20,12 +20,17 @@ const generatedSyncPaths = [
     'resources/content/release-notes/',
     'resources/content/archive/',
     'resources/content/_index.json',
-    'resources/content/.sync-metadata.json'
+    'resources/content/.sync-metadata.json',
+    'apps/portal/resources/data/',
+    'apps/portal/sitemap.xml',
+    'apps/portal/llms.txt'
 ];
 
 const isGeneratedSyncFile = file => generatedSyncPaths.some(item =>
     item.endsWith('/') ? file.startsWith(item) : file === item
 );
+
+const generatedSyncStatusPaths = generatedSyncPaths.join(' ');
 
 /**
  * @summary Orchestrates the bi-directional synchronization of GitHub issues and releases with local Markdown files.
@@ -81,6 +86,16 @@ class SyncService extends Base {
                 logger.error('[SyncService] Startup sync failed:', error.message);
             }
         }
+    }
+
+    /**
+     * @summary Rebuilds Portal indexes and SEO artifacts after GitHub Workflow content emission.
+     * @returns {Promise<Object>} Generated artifact paths.
+     */
+    async rebuildContentIndexesAndSeo() {
+        const {rebuildContentIndexesAndSeo} = await import('../../../buildScripts/docs/rebuildContentIndexesAndSeo.mjs');
+
+        return rebuildContentIndexesAndSeo({root: aiConfig.projectRoot});
     }
 
     /**
@@ -162,6 +177,8 @@ class SyncService extends Base {
         // 11. Save metadata.
         await MetadataManager.save(newMetadata);
 
+        await this.rebuildContentIndexesAndSeo();
+
         if (aiConfig.pushToRepoAfterSync) {
             const {permission} = await RepositoryService.getViewerPermission();
             const writePermissions = ['ADMIN', 'MAINTAIN', 'WRITE'];
@@ -169,7 +186,7 @@ class SyncService extends Base {
             if (writePermissions.includes(permission)) {
                 try {
                     const cwd = aiConfig.projectRoot;
-                    const {stdout} = await execAsync('git status --porcelain resources/content', {cwd});
+                    const {stdout} = await execAsync(`git status --porcelain ${generatedSyncStatusPaths}`, {cwd});
                     const lines = stdout.trim().split('\n').filter(Boolean);
 
                     if (lines.length > 0) {
@@ -180,7 +197,7 @@ class SyncService extends Base {
                             await execAsync('git restore resources/content/.sync-metadata.json', {cwd});
                         } else {
                             logger.info('[SyncService] Detected real content changes. Committing and pushing.');
-                            await execAsync('git add resources/content', {cwd});
+                            await execAsync(`git add ${generatedSyncStatusPaths}`, {cwd});
                             const {stdout: stagedStdout} = await execAsync('git diff --cached --name-only', {cwd});
                             const nonSyncFiles = stagedStdout.trim().split('\n').filter(Boolean).filter(file =>
                                 !isGeneratedSyncFile(file)

--- a/buildScripts/docs/rebuildContentIndexesAndSeo.mjs
+++ b/buildScripts/docs/rebuildContentIndexesAndSeo.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import fs                          from 'fs-extra';
+import path                        from 'path';
+import {fileURLToPath}             from 'url';
+import createReleaseIndex          from './index/release.mjs';
+import createDiscussionIndex       from './index/discussions.mjs';
+import createPullRequestIndex      from './index/pulls.mjs';
+import createTicketIndex           from './index/tickets.mjs';
+import {getLlmsTxt, getSitemapXml} from './seo/generate.mjs';
+
+const DEFAULT_BASE_URL = 'https://neomjs.com';
+
+/**
+ * @module buildScripts.docs.rebuildContentIndexesAndSeo
+ * @summary Rebuilds the Portal's content-derived indexes and SEO artifacts from
+ * `resources/content/` as one fail-fast bundle.
+ *
+ * The GitHub Workflow sync uses the local-only default so a successful content
+ * sync cannot leave
+ * `apps/portal/resources/data`, `apps/portal/sitemap.xml`, or
+ * `apps/portal/llms.txt` stale relative to the emitted markdown corpus. Release
+ * and CI callers can opt into the remote GitHub label index via
+ * `includeLabelIndex`; the label builder is intentionally loaded lazily so
+ * `sync_all` does not import the GitHub Workflow SDK label path.
+ */
+
+/**
+ * Rebuilds all content-derived Portal indexes and SEO outputs.
+ * @param {Object} [options]
+ * @param {String} [options.root=process.cwd()] Repository root.
+ * @param {String} [options.baseUrl='https://neomjs.com'] Canonical site URL for SEO outputs.
+ * @param {String} [options.sitemapPath] Target sitemap path.
+ * @param {String} [options.llmsPath] Target llms.txt path.
+ * @param {Boolean} [options.includeLabelIndex=false] Also rebuild the remote GitHub label index.
+ * @param {Function} [options.createLabelIndexFn] Test seam for the label index builder.
+ * @param {Function} [options.createReleaseIndexFn] Test seam for the release index builder.
+ * @param {Function} [options.createDiscussionIndexFn] Test seam for the discussion index builder.
+ * @param {Function} [options.createPullRequestIndexFn] Test seam for the pull-request index builder.
+ * @param {Function} [options.createTicketIndexFn] Test seam for the ticket index builder.
+ * @param {Function} [options.getSitemapXmlFn] Test seam for sitemap generation.
+ * @param {Function} [options.getLlmsTxtFn] Test seam for llms.txt generation.
+ * @param {Function} [options.writeFileSync] Test seam for filesystem writes.
+ * @param {Function} [options.log] Test seam for logging.
+ * @returns {Promise<Object>} Generated artifact paths.
+ */
+async function rebuildContentIndexesAndSeo({
+    root                     = process.cwd(),
+    baseUrl                  = DEFAULT_BASE_URL,
+    sitemapPath              = path.join(root, 'apps/portal/sitemap.xml'),
+    llmsPath                 = path.join(root, 'apps/portal/llms.txt'),
+    includeLabelIndex        = false,
+    createLabelIndexFn       = null,
+    createReleaseIndexFn     = createReleaseIndex,
+    createDiscussionIndexFn  = createDiscussionIndex,
+    createPullRequestIndexFn = createPullRequestIndex,
+    createTicketIndexFn      = createTicketIndex,
+    getSitemapXmlFn          = getSitemapXml,
+    getLlmsTxtFn             = getLlmsTxt,
+    writeFileSync            = fs.writeFileSync,
+    log                      = console.log
+} = {}) {
+    if (includeLabelIndex) {
+        const labelIndexFn = createLabelIndexFn || (await import('./index/labels.mjs')).default;
+        await labelIndexFn();
+    }
+
+    await createReleaseIndexFn();
+    await createPullRequestIndexFn();
+    await createDiscussionIndexFn();
+    await createTicketIndexFn();
+
+    const sitemapXml = await getSitemapXmlFn({baseUrl, existingSitemapPath: sitemapPath});
+    writeFileSync(sitemapPath, sitemapXml);
+    log(`Generated ${path.relative(root, sitemapPath)}`);
+
+    const llmsTxt = await getLlmsTxtFn({baseUrl});
+    writeFileSync(llmsPath, llmsTxt);
+    log(`Generated ${path.relative(root, llmsPath)}`);
+
+    return {
+        baseUrl,
+        llmsPath,
+        sitemapPath
+    }
+}
+
+async function runCli() {
+    await rebuildContentIndexesAndSeo({
+        includeLabelIndex: process.argv.includes('--include-labels')
+    })
+}
+
+const cliEntryPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const modulePath   = fileURLToPath(import.meta.url);
+
+if (cliEntryPath && cliEntryPath === modulePath) {
+    runCli().catch(error => {
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+export {rebuildContentIndexesAndSeo};
+export default rebuildContentIndexesAndSeo;

--- a/buildScripts/release/prepare.mjs
+++ b/buildScripts/release/prepare.mjs
@@ -10,12 +10,7 @@
 import fs                          from 'fs-extra';
 import os                          from 'os';
 import path                        from 'path';
-import createLabelIndex            from '../docs/index/labels.mjs';
-import createReleaseIndex          from '../docs/index/release.mjs';
-import createDiscussionIndex       from '../docs/index/discussions.mjs';
-import createPullRequestIndex      from '../docs/index/pulls.mjs';
-import createTicketIndex           from '../docs/index/tickets.mjs';
-import {getLlmsTxt, getSitemapXml} from '../docs/seo/generate.mjs';
+import rebuildContentIndexesAndSeo from '../docs/rebuildContentIndexesAndSeo.mjs';
 
 const
     root        = path.resolve(),
@@ -134,25 +129,8 @@ if (insideNeo) {
     }
 }
 
-// Generate the release content JSON before SEO files
-await createLabelIndex();
-await createReleaseIndex();
-await createPullRequestIndex();
-await createDiscussionIndex();
-await createTicketIndex();
-
-// Generate sitemap.xml and llms.txt to ensure SEO files are up-to-date with the latest content and routes.
-// This is crucial for search engine discoverability and AI model consumption.
-const baseUrl = 'https://neomjs.com'; // Hardcode canonical base URL
-const sitemapPath = path.join(root, 'apps/portal/sitemap.xml');
-
-const sitemapXml = await getSitemapXml({baseUrl, existingSitemapPath: sitemapPath});
-fs.writeFileSync(sitemapPath, sitemapXml);
-console.log('Generated apps/portal/sitemap.xml');
-
-const llmsTxt = await getLlmsTxt({baseUrl});
-fs.writeFileSync(path.join(root, 'apps/portal/llms.txt'), llmsTxt);
-console.log('Generated apps/portal/llms.txt');
+// Generate the Portal indexes and SEO files from the shared bundle used by sync paths.
+await rebuildContentIndexesAndSeo({root, includeLabelIndex: true});
 
 const processTime = (Math.round((new Date - startDate) * 100) / 100000).toFixed(2);
 console.log(`\nTotal time for ${programName}: ${processTime}s`);

--- a/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
@@ -1,0 +1,113 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs/promises';
+import path           from 'path';
+
+import {
+    rebuildContentIndexesAndSeo
+} from '../../../../../../buildScripts/docs/rebuildContentIndexesAndSeo.mjs';
+
+test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
+    test('runs local content index builders before SEO generation and writes both SEO artifacts', async () => {
+        const
+            calls  = [],
+            writes = [];
+
+        const record = name => async (...args) => {
+            calls.push({name, args});
+            return `${name}-result`;
+        };
+
+        const result = await rebuildContentIndexesAndSeo({
+            root                    : '/repo',
+            baseUrl                 : 'https://example.test',
+            sitemapPath             : '/repo/apps/portal/sitemap.xml',
+            llmsPath                : '/repo/apps/portal/llms.txt',
+            createReleaseIndexFn    : record('releases'),
+            createPullRequestIndexFn: record('pulls'),
+            createDiscussionIndexFn : record('discussions'),
+            createTicketIndexFn     : record('tickets'),
+            getSitemapXmlFn         : record('sitemap'),
+            getLlmsTxtFn            : record('llms'),
+            writeFileSync           : (filePath, content) => writes.push({filePath, content}),
+            log                     : () => {}
+        });
+
+        expect(calls.map(call => call.name)).toEqual([
+            'releases',
+            'pulls',
+            'discussions',
+            'tickets',
+            'sitemap',
+            'llms'
+        ]);
+        expect(calls.find(call => call.name === 'sitemap').args[0]).toEqual({
+            baseUrl            : 'https://example.test',
+            existingSitemapPath: '/repo/apps/portal/sitemap.xml'
+        });
+        expect(calls.find(call => call.name === 'llms').args[0]).toEqual({
+            baseUrl: 'https://example.test'
+        });
+        expect(writes).toEqual([
+            {filePath: '/repo/apps/portal/sitemap.xml', content: 'sitemap-result'},
+            {filePath: '/repo/apps/portal/llms.txt', content: 'llms-result'}
+        ]);
+        expect(result).toEqual({
+            baseUrl    : 'https://example.test',
+            llmsPath   : '/repo/apps/portal/llms.txt',
+            sitemapPath: '/repo/apps/portal/sitemap.xml'
+        });
+    });
+
+    test('can explicitly include the remote GitHub label index for release and CI callers', async () => {
+        const calls = [];
+
+        const record = name => async () => {
+            calls.push(name);
+        };
+
+        await rebuildContentIndexesAndSeo({
+            includeLabelIndex       : true,
+            createLabelIndexFn      : record('labels'),
+            createReleaseIndexFn    : record('releases'),
+            createPullRequestIndexFn: record('pulls'),
+            createDiscussionIndexFn : record('discussions'),
+            createTicketIndexFn     : record('tickets'),
+            getSitemapXmlFn         : async () => '<xml />',
+            getLlmsTxtFn            : async () => 'llms',
+            writeFileSync           : () => {},
+            log                     : () => {}
+        });
+
+        expect(calls).toEqual(['labels', 'releases', 'pulls', 'discussions', 'tickets']);
+    });
+
+    test('fails closed when a derive step rejects before generated artifacts are written', async () => {
+        const writes = [];
+
+        await expect(rebuildContentIndexesAndSeo({
+            createLabelIndexFn      : async () => {},
+            createReleaseIndexFn    : async () => {},
+            createPullRequestIndexFn: async () => { throw new Error('pull index failed'); },
+            createDiscussionIndexFn : async () => { throw new Error('must not run'); },
+            createTicketIndexFn     : async () => { throw new Error('must not run'); },
+            getSitemapXmlFn         : async () => '<xml />',
+            getLlmsTxtFn            : async () => 'llms',
+            writeFileSync           : (filePath, content) => writes.push({filePath, content}),
+            log                     : () => {}
+        })).rejects.toThrow('pull index failed');
+
+        expect(writes).toEqual([]);
+    });
+
+    test('data-sync pipeline delegates to the shared helper instead of duplicating the seven derive commands', async () => {
+        const workflow = await fs.readFile(path.resolve(process.cwd(), '.github/workflows/data-sync-pipeline.yml'), 'utf8');
+
+        expect(workflow).toContain('node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs --include-labels');
+        expect(workflow).not.toContain('node ./buildScripts/docs/index/labels.mjs');
+        expect(workflow).not.toContain('node ./buildScripts/docs/index/release.mjs');
+        expect(workflow).not.toContain('node ./buildScripts/docs/index/pulls.mjs');
+        expect(workflow).not.toContain('node ./buildScripts/docs/index/discussions.mjs');
+        expect(workflow).not.toContain('node ./buildScripts/docs/index/tickets.mjs');
+        expect(workflow).toContain('GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n        run: node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs --include-labels');
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -14,6 +14,8 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
+import fs             from 'fs/promises';
+import path           from 'path';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
@@ -36,6 +38,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalSyncDiscussions;
     let originalSyncPullRequests;
     let originalGetViewerPermission;
+    let originalRebuildContentIndexesAndSeo;
 
     let originalIngestIssueStates;
     let originalIngestDiscussionStates;
@@ -76,6 +79,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         originalSyncDiscussions = DiscussionSyncer.syncDiscussions;
         originalSyncPullRequests = PullRequestSyncer.syncPullRequests;
         originalGetViewerPermission = RepositoryService.getViewerPermission;
+        originalRebuildContentIndexesAndSeo = SyncService.rebuildContentIndexesAndSeo;
         originalLoadMetadata = MetadataManager.load;
         originalSaveMetadata = MetadataManager.save;
 
@@ -87,6 +91,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         DiscussionSyncer.syncDiscussions = async () => ({ count: 0 });
         PullRequestSyncer.syncPullRequests = async () => ({ count: 0 });
         RepositoryService.getViewerPermission = async () => ({ permission: 'READ' }); // Skip git commands
+        SyncService.rebuildContentIndexesAndSeo = async () => ({});
         MetadataManager.load = async () => ({ issues: {}, releases: {}, discussions: {}, pullRequests: {} });
         MetadataManager.save = async () => {};
 
@@ -108,6 +113,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         DiscussionSyncer.syncDiscussions = originalSyncDiscussions;
         PullRequestSyncer.syncPullRequests = originalSyncPullRequests;
         RepositoryService.getViewerPermission = originalGetViewerPermission;
+        SyncService.rebuildContentIndexesAndSeo = originalRebuildContentIndexesAndSeo;
         MetadataManager.load = originalLoadMetadata;
         MetadataManager.save = originalSaveMetadata;
 
@@ -125,8 +131,55 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         expect(stage2Calls.pullRequestFeedback).toBe(1);
     });
 
+    test('runFullSync rebuilds content indexes and SEO before the auto-push status check (#13260)', async () => {
+        const order = [];
+
+        MetadataManager.save = async () => { order.push('metadata-save'); };
+        SyncService.rebuildContentIndexesAndSeo = async () => { order.push('derive'); };
+        RepositoryService.getViewerPermission = async () => {
+            order.push('permission-check');
+            return {permission: 'READ'};
+        };
+
+        const result = await SyncService.runFullSync();
+
+        expect(result.success).toBe(true);
+        expect(order).toEqual(['metadata-save', 'derive', 'permission-check']);
+    });
+
+    test('runFullSync rejects before auto-push and Stage 2 when the post-sync derive fails (#13260)', async () => {
+        let permissionChecks = 0;
+
+        SyncService.rebuildContentIndexesAndSeo = async () => {
+            throw new Error('derive failed');
+        };
+        RepositoryService.getViewerPermission = async () => {
+            permissionChecks++;
+            return {permission: 'WRITE'};
+        };
+
+        await expect(SyncService.runFullSync()).rejects.toThrow('derive failed');
+
+        expect(permissionChecks).toBe(0);
+        expect(stage2Calls).toEqual({
+            issueStates        : 0,
+            discussionStates   : 0,
+            pullRequestFeedback: 0
+        });
+    });
+
+    test('auto-commit allowlist includes content-derived Portal index and SEO artifacts (#13260)', async () => {
+        const source = await fs.readFile(path.resolve(process.cwd(), 'ai/services/github-workflow/SyncService.mjs'), 'utf8');
+
+        expect(source).toContain("'apps/portal/resources/data/'");
+        expect(source).toContain("'apps/portal/sitemap.xml'");
+        expect(source).toContain("'apps/portal/llms.txt'");
+        expect(source).toContain('git status --porcelain ${generatedSyncStatusPaths}');
+        expect(source).toContain('git add ${generatedSyncStatusPaths}');
+    });
+
     /**
-     * #11573 regression coverage — metadata persistence carry-over.
+     * Regression coverage for metadata persistence carry-over.
      *
      * Empirical bug: `IssueSyncer.pullFromGitHub` returns a FRESH `newMetadata` object
      * carrying only `{issues, pushFailures, lastSync}`. Subsequent calls to
@@ -205,7 +258,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     });
 
     /**
-     * #11573 regression coverage — explicit empty-input safety.
+     * Regression coverage for explicit empty-input safety.
      *
      * Verifies that when DiscussionSyncer / PullRequestSyncer leave metadata.discussions
      * or metadata.pulls undefined (e.g., early-exit path), the carry-over still produces


### PR DESCRIPTION
Resolves #13260

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 4ed21ddf-b92f-45ce-8689-bb3ebb563dd9.

Adds a shared fail-fast derive bundle for the Portal's content indexes and SEO artifacts, then wires it into the three paths that can emit or publish the content corpus: `prepare.mjs`, the data-sync workflow, and `SyncService.runFullSync()`. The sync path now rebuilds `apps/portal/resources/data/`, `apps/portal/sitemap.xml`, and `apps/portal/llms.txt` after metadata save and before auto-push / Stage 2 ingestion, so `sync_all` cannot return success with stale derived artifacts.

Evidence: L2 (focused unit coverage + local-only real helper smoke) -> L2 required (deterministic local derive and workflow contract). No residuals.

## Deltas from ticket

The label index is deliberately not part of the default `sync_all` post-hook. Live smoke testing showed `labels.mjs` imports the GitHub Workflow SDK label path and fetches remote GitHub labels, so the shared helper keeps label generation behind `--include-labels` / `includeLabelIndex: true` for release and CI callers while the sync hook stays local-corpus-only.

## Test Evidence

- `node --check buildScripts/docs/rebuildContentIndexesAndSeo.mjs`
- `node --check buildScripts/release/prepare.mjs`
- `node --check ai/services/github-workflow/SyncService.mjs`
- `node --check test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs`
- `node --check test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs`
- `git diff --check origin/dev..HEAD`
- `node ./buildScripts/util/check-whitespace.mjs`
- `node ./buildScripts/util/check-shorthand.mjs`
- `node ./buildScripts/util/check-aiconfig-test-mutation.mjs`
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs` — 10 passed
- `node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs` — local-only smoke passed; generated artifact churn restored before commit

## Post-Merge Validation

- [ ] Trigger or observe the next data-sync cycle and confirm derived Portal artifacts are included whenever the content corpus changes.

## Commits

- `143a100ed` — `fix(sync): rebuild content indexes after sync (#13260)`

## Evolution

The first helper shape included labels by default because the data-sync workflow had seven inline derive commands. The local smoke falsified that as a safe sync hook: label generation is remote/SDK-backed, while the `sync_all` hook needs a local-corpus-only derive. The final helper makes the split explicit and keeps CI/release behavior byte-equivalent through `--include-labels`.
