### PR TITLE
fix(github-workflow): enforce write guard classification (#13252)

### DIFF
--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -21,20 +21,101 @@ const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, 'openapi.yaml');
 
-const PUBLIC_GITHUB_WRITE_TOOLS = Object.freeze(new Set([
-    'create_discussion',
-    'create_issue',
-    'manage_discussion',
-    'manage_discussion_comment',
-    'manage_issue_assignees',
-    'manage_issue_comment',
-    'manage_issue_labels',
-    'manage_issue_projects',
-    'manage_pr_review',
-    'manage_pr_reviewers',
-    'signal_state_transition',
-    'update_issue_relationship'
+const PUBLIC_GITHUB_WRITE_ACCESS     = 'public-write';
+const NON_PUBLIC_GITHUB_WRITE_ACCESS = 'non-public-write';
+const GITHUB_TOOL_ACCESS_TYPES       = Object.freeze(new Set([
+    PUBLIC_GITHUB_WRITE_ACCESS,
+    NON_PUBLIC_GITHUB_WRITE_ACCESS
 ]));
+
+/**
+ * @summary Canonical access classification for every GitHub Workflow MCP tool.
+ *
+ * `public-write` tools can mutate github.com state and therefore must pass the
+ * GitHub write identity guard. `non-public-write` tools may read remote state or
+ * mutate only the caller-local workspace. Keeping every `serviceMapping` key in
+ * this policy turns future tool additions into an explicit classification step.
+ */
+const GITHUB_TOOL_ACCESS = Object.freeze({
+    checkout_pull_request      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    create_discussion          : PUBLIC_GITHUB_WRITE_ACCESS,
+    create_issue               : PUBLIC_GITHUB_WRITE_ACCESS,
+    get_conversation           : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    get_discussion_conversation: NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    get_local_issue_by_id      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    get_pull_request_diff      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    get_viewer_permission      : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    healthcheck                : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    list_issues                : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    list_labels                : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    list_pull_requests         : NON_PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_discussion          : PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_discussion_comment  : PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_issue_assignees     : PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_issue_comment       : PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_issue_labels        : PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_issue_projects      : PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_pr_review           : PUBLIC_GITHUB_WRITE_ACCESS,
+    manage_pr_reviewers        : PUBLIC_GITHUB_WRITE_ACCESS,
+    signal_state_transition    : PUBLIC_GITHUB_WRITE_ACCESS,
+    sync_all                   : PUBLIC_GITHUB_WRITE_ACCESS,
+    update_issue_relationship  : PUBLIC_GITHUB_WRITE_ACCESS
+});
+
+const PUBLIC_GITHUB_WRITE_TOOLS = Object.freeze(new Set(
+    Object.entries(GITHUB_TOOL_ACCESS)
+        .filter(([, access]) => access === PUBLIC_GITHUB_WRITE_ACCESS)
+        .map(([toolName]) => toolName)
+));
+
+function getMissingGitHubToolAccessClassifications(mapping, accessPolicy = GITHUB_TOOL_ACCESS) {
+    return Object.keys(mapping).filter(toolName => !Object.hasOwn(accessPolicy, toolName));
+}
+
+function getInvalidGitHubToolAccessClassifications(accessPolicy = GITHUB_TOOL_ACCESS) {
+    return Object.entries(accessPolicy)
+        .filter(([, access]) => !GITHUB_TOOL_ACCESS_TYPES.has(access))
+        .map(([toolName]) => toolName);
+}
+
+/**
+ * @summary Fails closed when a service-mapped tool lacks an access classification.
+ * @param {Object} mapping Operation id to handler function.
+ * @param {Object} [accessPolicy] Tool access policy keyed by operation id.
+ * @returns {Boolean} True when every mapped tool is classified.
+ */
+function assertNoUnclassifiedGitHubTools(mapping, accessPolicy = GITHUB_TOOL_ACCESS) {
+    const missing = getMissingGitHubToolAccessClassifications(mapping, accessPolicy);
+    const invalid = getInvalidGitHubToolAccessClassifications(accessPolicy);
+
+    if (missing.length || invalid.length) {
+        throw new Error([
+            'GitHub tool access policy incomplete.',
+            missing.length ? `Missing classification: ${missing.sort().join(', ')}` : null,
+            invalid.length ? `Invalid classification: ${invalid.sort().join(', ')}` : null
+        ].filter(Boolean).join(' '));
+    }
+
+    return true;
+}
+
+/**
+ * @summary Verifies the canonical policy and runtime service mapping stay in lockstep.
+ * @param {Object} mapping Operation id to handler function.
+ * @param {Object} [accessPolicy] Tool access policy keyed by operation id.
+ * @returns {Boolean} True when mapping and policy cover the same operation ids.
+ */
+function assertCompleteGitHubToolAccessPolicy(mapping, accessPolicy = GITHUB_TOOL_ACCESS) {
+    assertNoUnclassifiedGitHubTools(mapping, accessPolicy);
+
+    const stale = Object.keys(accessPolicy).filter(toolName => !Object.hasOwn(mapping, toolName));
+
+    if (stale.length) {
+        throw new Error(`GitHub tool access policy has stale classification: ${stale.sort().join(', ')}`);
+    }
+
+    return true;
+}
 
 /**
  * @summary Normalizes AgentIdentity-style and GitHub-login-style strings to a GitHub login.
@@ -177,6 +258,8 @@ function isPublicGitHubWriteTool(toolName) {
  * @returns {Object} A mapping where public write handlers are guarded.
  */
 function guardGitHubWriteTools(mapping, guardOptions) {
+    assertNoUnclassifiedGitHubTools(mapping);
+
     return Object.fromEntries(
         Object.entries(mapping).map(([toolName, handler]) => [
             toolName,
@@ -329,11 +412,16 @@ const serviceMapping = {
     update_issue_relationship  : IssueService      .updateIssueRelationship.bind(IssueService)
 };
 
+assertCompleteGitHubToolAccessPolicy(serviceMapping);
+
 const guardedServiceMapping = guardGitHubWriteTools(serviceMapping);
 
 // Exported for unit-test access. `buildDevBranchGuard` accepts injected
 // `delegate` + `getBranch` for fixture-driven testing without spawning real `git`.
 export {
+    GITHUB_TOOL_ACCESS,
+    assertCompleteGitHubToolAccessPolicy,
+    assertNoUnclassifiedGitHubTools,
     buildDevBranchGuard,
     buildGitHubWriteIdentityGuard,
     getConversationRouter,

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -206,12 +206,14 @@ test.describe('Neo.ai.services.github-workflow.toolService — getConversationRo
 /**
  * Public GitHub write-boundary identity guard.
  *
- * #13243 protects agent-authored public GitHub mutations from the GH_TOKEN drift
+ * Protects agent-authored public GitHub mutations from the GH_TOKEN drift
  * class demonstrated on 2026-06-14: the harness can believe it is one agent while
  * GitHub's effective viewer login is another account. The guard is injected at the
  * GitHub Workflow MCP tool boundary, before service delegates mutate GitHub state.
  */
 test.describe('Neo.ai.services.github-workflow.toolService — write identity guard (#13243)', () => {
+    let GITHUB_TOOL_ACCESS;
+    let assertCompleteGitHubToolAccessPolicy;
     let buildGitHubWriteIdentityGuard;
     let guardGitHubWriteTools;
     let isPublicGitHubWriteTool;
@@ -219,10 +221,12 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
-        buildGitHubWriteIdentityGuard = mod.buildGitHubWriteIdentityGuard;
-        guardGitHubWriteTools         = mod.guardGitHubWriteTools;
-        isPublicGitHubWriteTool       = mod.isPublicGitHubWriteTool;
-        normalizeGitHubIdentityLogin  = mod.normalizeGitHubIdentityLogin;
+        GITHUB_TOOL_ACCESS                    = mod.GITHUB_TOOL_ACCESS;
+        assertCompleteGitHubToolAccessPolicy = mod.assertCompleteGitHubToolAccessPolicy;
+        buildGitHubWriteIdentityGuard         = mod.buildGitHubWriteIdentityGuard;
+        guardGitHubWriteTools                 = mod.guardGitHubWriteTools;
+        isPublicGitHubWriteTool               = mod.isPublicGitHubWriteTool;
+        normalizeGitHubIdentityLogin          = mod.normalizeGitHubIdentityLogin;
     });
 
     test('normalizes AgentIdentity node ids to GitHub logins', () => {
@@ -309,7 +313,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         const mapping = guardGitHubWriteTools({
             get_conversation    : readHandler,
             healthcheck         : readHandler,
-            manage_issue_comment: writeHandler
+            manage_issue_comment: writeHandler,
+            sync_all            : writeHandler
         }, {
             assertExpectedIdentity: async () => ({
                 ok    : false,
@@ -318,6 +323,7 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         });
 
         expect(isPublicGitHubWriteTool('manage_issue_comment')).toBe(true);
+        expect(isPublicGitHubWriteTool('sync_all')).toBe(true);
         expect(isPublicGitHubWriteTool('get_conversation')).toBe(false);
         expect(isPublicGitHubWriteTool('healthcheck')).toBe(false);
         expect(mapping.get_conversation).toBe(readHandler);
@@ -328,6 +334,28 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         await expect(mapping.manage_issue_comment()).rejects.toMatchObject({
             code: 'GITHUB_IDENTITY_MISMATCH'
         });
+        await expect(mapping.sync_all()).rejects.toMatchObject({
+            code: 'GITHUB_IDENTITY_MISMATCH'
+        });
+    });
+
+    test('rejects service mappings with unclassified future tools (#13252)', () => {
+        expect(() => guardGitHubWriteTools({
+            get_conversation       : async () => {},
+            future_public_mutation : async () => {}
+        })).toThrow(/Missing classification: future_public_mutation/);
+    });
+
+    test('canonical access policy covers every registered GitHub Workflow tool (#13252)', async () => {
+        const {listTools} = await import('../../../../../../ai/mcp/server/github-workflow/toolService.mjs');
+
+        const registeredTools = listTools().tools.map(tool => tool.name).sort();
+        const policyTools     = Object.keys(GITHUB_TOOL_ACCESS).sort();
+
+        expect(policyTools).toEqual(registeredTools);
+        expect(assertCompleteGitHubToolAccessPolicy(
+            Object.fromEntries(registeredTools.map(toolName => [toolName, async () => {}]))
+        )).toBe(true);
     });
 
     test('classifies the public GitHub write boundary explicitly', () => {
@@ -343,6 +371,7 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
             'manage_pr_review',
             'manage_pr_reviewers',
             'signal_state_transition',
+            'sync_all',
             'update_issue_relationship'
         ].forEach(toolName => {
             expect(isPublicGitHubWriteTool(toolName), `${toolName} is a public write`).toBe(true);
@@ -358,8 +387,7 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
             'healthcheck',
             'list_issues',
             'list_labels',
-            'list_pull_requests',
-            'sync_all'
+            'list_pull_requests'
         ].forEach(toolName => {
             expect(isPublicGitHubWriteTool(toolName), `${toolName} is not a public write`).toBe(false);
         });


### PR DESCRIPTION
Resolves #13252

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 4ed21ddf-b92f-45ce-8689-bb3ebb563dd9.

Adds a canonical access policy for every GitHub Workflow MCP `serviceMapping` operation and fails closed when a mapped tool is missing a classification. The public-write set is now derived from that policy, so future tool additions must be classified before they can be guarded or exposed without tripping module/test startup. The implementation also classifies `sync_all` as a guarded public GitHub write boundary because the tool reaches `SyncService.runFullSync()` -> `IssueSyncer.pushToGitHub()` -> GitHub `UPDATE_ISSUE`.

Evidence: L2 (focused unit coverage over runtime mapping, synthetic future-tool falsifier, and existing guard behavior) -> L2 required (write-boundary completeness invariant). No residuals.

## Deltas from ticket

The intake source check found that `sync_all` was previously listed in the non-write classifier test even though its sync path can push local content changes to GitHub. This PR corrects that classification and keeps daemon/build-script direct `SyncService.runFullSync()` callers unaffected because the identity guard remains at the MCP tool boundary.

Implementation strategy chosen: completeness-test enforcement plus fail-closed module/guard construction. The policy remains explicit, but every runtime-mapped tool must have a valid access classification and stale policy entries are rejected against the canonical mapping.

## Test Evidence

- `node --check ai/mcp/server/github-workflow/toolService.mjs`
- `node --check test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs` — 22 passed
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, and `check-ticket-archaeology`

## Post-Merge Validation

- [ ] When adding the next GitHub Workflow MCP tool, confirm CI rejects the branch until the operation is classified in `GITHUB_TOOL_ACCESS`.

## Commits

- `7c3ce67c0` — `fix(github-workflow): enforce write guard classification (#13252)`

## Evolution

The ticket started as a future-completeness hardening follow-up. Source V-B-A surfaced one existing classification gap: `sync_all` can mutate GitHub state indirectly through the sync push path. Treating that as a public write makes the guard boundary match current behavior instead of preserving a stale read/non-write assumption.
