### PR TITLE
feat(mcp): add file-system tool handbook slice (#13268)

### DIFF
--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -22,7 +22,18 @@ class ToolService_tmp extends Base {
          * Path to the OpenAPI specification file.
          * @member {String|null} openApiFilePath=null
          */
-        openApiFilePath: null
+        openApiFilePath: null,
+        /**
+         * Enables compact `tools/list` descriptions while preserving full
+         * detail for `getToolHandbook()`.
+         * @member {Boolean} compactToolDescriptions=false
+         */
+        compactToolDescriptions: false,
+        /**
+         * Maximum description length emitted through compact `tools/list`.
+         * @member {Number} toolListDescriptionMaxLength=160
+         */
+        toolListDescriptionMaxLength: 160
     }
 
     /**
@@ -55,6 +66,12 @@ class ToolService_tmp extends Base {
      * @protected
      */
     toolMapping = null
+    /**
+     * Internal cache for lazy-loaded tool handbook entries.
+     * @member {Object|null} toolHandbookMapping=null
+     * @protected
+     */
+    toolHandbookMapping = null
 
     /**
      * Executes a specific tool with the given arguments.
@@ -65,10 +82,7 @@ class ToolService_tmp extends Base {
     async callTool(toolName, args, options={}) {
         this.initializeToolMapping();
 
-        const lastDoubleUnderscoreIndex = toolName.lastIndexOf('__');
-        const effectiveToolName = lastDoubleUnderscoreIndex !== -1
-            ? toolName.substring(lastDoubleUnderscoreIndex + 2)
-            : toolName;
+        const effectiveToolName = this.resolveEffectiveToolName(toolName);
 
         const tool = this.toolMapping[effectiveToolName];
 
@@ -106,8 +120,9 @@ class ToolService_tmp extends Base {
             return;
         }
 
-        me.toolMapping        = {};
-        me.allToolsForListing = [];
+        me.toolMapping         = {};
+        me.allToolsForListing  = [];
+        me.toolHandbookMapping = {};
         me.toolProjectionTiers = {};
 
         const openApiDocument = yaml.load(fs.readFileSync(me.openApiFilePath, 'utf8'));
@@ -142,10 +157,15 @@ class ToolService_tmp extends Base {
                         }
                     }
 
+                    const fullDescription = operation.description || operation.summary || toolName;
+                    const listDescription = me.compactToolDescriptions
+                        ? me.buildToolListDescription(operation, fullDescription)
+                        : fullDescription;
+
                     const tool = {
                         name        : toolName,
                         title       : operation.summary || toolName,
-                        description : operation.description || operation.summary,
+                        description : listDescription,
                         zodSchema   : inputZodSchema,
                         toolTier,
                         argNames,
@@ -154,6 +174,7 @@ class ToolService_tmp extends Base {
                     };
                     me.toolMapping[toolName] = tool;
                     me.toolProjectionTiers[toolName] = toolTier;
+                    me.toolHandbookMapping[toolName] = me.buildToolHandbookEntry(toolName, operation, fullDescription);
 
                     const toolForListing = {
                         name       : tool.name,
@@ -171,6 +192,74 @@ class ToolService_tmp extends Base {
                 }
             }
         }
+    }
+
+    /**
+     * @summary Builds the compact description emitted through `tools/list`.
+     * @param {Object} operation       Parsed OpenAPI operation.
+     * @param {String} fullDescription Full operation description fallback.
+     * @returns {String}
+     * @protected
+     */
+    buildToolListDescription(operation, fullDescription) {
+        const
+            source = operation['x-neo-tool-summary'] || operation.summary || fullDescription || '',
+            singleLine = String(source).replace(/\s+/g, ' ').trim(),
+            maxLength  = this.toolListDescriptionMaxLength;
+
+        if (!maxLength || singleLine.length <= maxLength) {
+            return singleLine;
+        }
+
+        return `${singleLine.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+    }
+
+    /**
+     * @summary Builds one lazy-loaded handbook entry from OpenAPI metadata.
+     * @param {String} toolName        The operation id.
+     * @param {Object} operation       Parsed OpenAPI operation.
+     * @param {String} fullDescription Full operation description fallback.
+     * @returns {Object}
+     * @protected
+     */
+    buildToolHandbookEntry(toolName, operation, fullDescription) {
+        const
+            dedicated = operation['x-neo-tool-handbook'],
+            handbook  = dedicated || fullDescription || operation.summary || toolName;
+
+        return {
+            toolId     : toolName,
+            found      : true,
+            title      : operation.summary || toolName,
+            description: operation.description || operation.summary || '',
+            handbook,
+            source     : dedicated ? 'x-neo-tool-handbook' : (operation.description ? 'description' : 'summary')
+        };
+    }
+
+    /**
+     * @summary Returns the lazy-loaded handbook entry for one tool id/name.
+     * @param {String} toolId The OpenAPI operation id or namespaced MCP tool id.
+     * @returns {Object}
+     */
+    getToolHandbook(toolId) {
+        this.initializeToolMapping();
+
+        const
+            requestedToolId = String(toolId || ''),
+            effectiveToolId = this.resolveEffectiveToolName(requestedToolId),
+            entry           = this.toolHandbookMapping[effectiveToolId];
+
+        if (!entry) {
+            return {
+                toolId: requestedToolId,
+                found : false,
+                code  : 'TOOL_NOT_FOUND',
+                message: `Tool "${requestedToolId}" does not exist in this MCP server.`
+            };
+        }
+
+        return entry;
     }
 
     /**
@@ -375,10 +464,7 @@ class ToolService_tmp extends Base {
 
         // 1. Try Server-side validation using internal Zod schemas
         if (me.toolMapping) {
-            const lastDoubleUnderscoreIndex = toolName.lastIndexOf('__');
-            const effectiveToolName = lastDoubleUnderscoreIndex !== -1
-                ? toolName.substring(lastDoubleUnderscoreIndex + 2)
-                : toolName;
+            const effectiveToolName = this.resolveEffectiveToolName(toolName);
 
             const tool = me.toolMapping[effectiveToolName];
             if (tool) {
@@ -393,6 +479,20 @@ class ToolService_tmp extends Base {
         }
 
         return true;
+    }
+
+    /**
+     * @summary Resolves namespaced MCP tool ids back to OpenAPI operation ids.
+     * @param {String} toolName
+     * @returns {String}
+     * @protected
+     */
+    resolveEffectiveToolName(toolName) {
+        const lastDoubleUnderscoreIndex = toolName.lastIndexOf('__');
+
+        return lastDoubleUnderscoreIndex !== -1
+            ? toolName.substring(lastDoubleUnderscoreIndex + 2)
+            : toolName;
     }
 }
 

--- a/ai/mcp/server/file-system/openapi.yaml
+++ b/ai/mcp/server/file-system/openapi.yaml
@@ -47,11 +47,59 @@ paths:
                     type: string
                     example: "OK"
 
+  /tool/handbook:
+    post:
+      summary: Tool Handbook
+      operationId: get_mcp_tool_handbook
+      description: Returns lazy-loaded usage detail for one file-system MCP tool.
+      tags: [Health]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [toolId]
+              properties:
+                toolId:
+                  type: string
+                  description: Tool operation id to inspect.
+      responses:
+        '200':
+          description: Tool handbook lookup result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  toolId:
+                    type: string
+                  found:
+                    type: boolean
+                  title:
+                    type: string
+                  description:
+                    type: string
+                  handbook:
+                    type: string
+                  source:
+                    type: string
+                  code:
+                    type: string
+                  message:
+                    type: string
+
   /read_file:
     post:
       summary: Read a specific file safely.
       operationId: read_file
       description: Reads the complete text of a file from the workspace. Throws a 403 on directory escape attempts.
+      x-neo-tool-summary: Read a workspace file by absolute path.
+      x-neo-tool-handbook: |
+        Reads the complete text of a file from the workspace sandbox. Use this for source
+        inspection before editing or review. Pass an absolute path; directory traversal outside
+        the permitted workspace is rejected by the file-system service rather than silently
+        rewritten.
       tags: [IO]
       requestBody:
         required: true

--- a/ai/mcp/server/file-system/services/toolService.mjs
+++ b/ai/mcp/server/file-system/services/toolService.mjs
@@ -8,17 +8,20 @@ const __dirname       = path.dirname(__filename);
 const openApiFilePath = path.join(__dirname, '../openapi.yaml');
 
 const serviceMapping = {
-    healthcheck        : FileSystemService.healthcheck.bind(FileSystemService),
-    read_file          : FileSystemService.readFile.bind(FileSystemService),
-    write_file         : FileSystemService.writeFile.bind(FileSystemService),
-    list_directory     : FileSystemService.listDirectory.bind(FileSystemService),
-    check_syntax       : FileSystemService.checkSyntax.bind(FileSystemService),
-    run_playwright_test: FileSystemService.runPlaywrightTest.bind(FileSystemService)
+    healthcheck          : FileSystemService.healthcheck.bind(FileSystemService),
+    get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
+    read_file            : FileSystemService.readFile.bind(FileSystemService),
+    write_file           : FileSystemService.writeFile.bind(FileSystemService),
+    list_directory       : FileSystemService.listDirectory.bind(FileSystemService),
+    check_syntax         : FileSystemService.checkSyntax.bind(FileSystemService),
+    run_playwright_test  : FileSystemService.runPlaywrightTest.bind(FileSystemService)
 };
 
 const toolService = Neo.create(ToolService, {
+    compactToolDescriptions    : true,
     openApiFilePath,
-    serviceMapping
+    serviceMapping,
+    toolListDescriptionMaxLength: 120
 });
 
 const callTool  = toolService.callTool.bind(toolService);

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -245,6 +245,55 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         });
     }
 
+    test('file-system exposes compact list descriptions plus lazy-loaded handbook detail (#13268)', async () => {
+        const
+            server        = servers.find(item => item.name === 'file-system'),
+            {tools}       = await listTools(server),
+            byName        = Object.fromEntries(tools.map(tool => [tool.name, tool])),
+            moduleUrl     = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {callTool}    = await import(moduleUrl),
+            handbook      = await callTool('get_mcp_tool_handbook', {toolId: 'read_file'}),
+            missing       = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
+            healthcheck   = byName.healthcheck,
+            readFile      = byName.read_file,
+            handbookTool  = byName.get_mcp_tool_handbook;
+
+        expect(handbookTool.description.length).toBeLessThanOrEqual(120);
+        expect(readFile.description).toBe('Read a workspace file by absolute path.');
+        expect(readFile.description).not.toContain('directory traversal outside');
+        expect(readFile.inputSchema.properties.absolutePath.type).toBe('string');
+        expect(healthcheck.annotations.readOnlyHint).toBe(true);
+
+        for (const tool of tools) {
+            expect(tool.description.length, `file-system.${tool.name} description is not compact`).toBeLessThanOrEqual(120);
+        }
+
+        expect(handbook).toMatchObject({
+            toolId: 'read_file',
+            found : true,
+            source: 'x-neo-tool-handbook'
+        });
+        expect(handbook.handbook.replace(/\s+/g, ' ')).toContain('directory traversal outside the permitted workspace');
+
+        expect(missing).toEqual({
+            toolId: 'missing_tool',
+            found : false,
+            code  : 'TOOL_NOT_FOUND',
+            message: 'Tool "missing_tool" does not exist in this MCP server.'
+        });
+    });
+
+    test('unmigrated servers keep their existing list description behavior (#13268)', async () => {
+        const
+            server     = servers.find(item => item.name === 'github-workflow'),
+            {tools}    = await listTools(server),
+            tool       = tools.find(item => item.name === 'update_issue_relationship'),
+            operations = getOperationsById(server);
+
+        expect(tool.description).toBe(operations.update_issue_relationship.description);
+        expect(tool.description.length).toBeGreaterThan(120);
+    });
+
     test('neural-link embedded-harness projection lists only default-visible tier tools (#13084)', async () => {
         const
             server           = servers.find(item => item.name === 'neural-link'),


### PR DESCRIPTION
Resolves #13268

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 4ed21ddf-b92f-45ce-8689-bb3ebb563dd9.

Adds the first V4.1 MCP tool-handbook slice on the file-system server. `ToolService` now has an opt-in compact `tools/list` projection and a lazy-loaded `getToolHandbook()` lookup; the file-system server exposes `get_mcp_tool_handbook`, uses compact list descriptions, and keeps detailed guidance in `x-neo-tool-handbook`. Unmigrated servers keep their current list-description behavior.

Evidence: L2 (ToolService list/call unit coverage plus cross-server OpenAPI/schema validation) -> L2 required (first representative server slice with focused unit coverage). No residuals.

Related: #10757
Related: #9953

## Deltas from ticket

- Representative server is `file-system`, chosen because it has a small MCP surface and no external singleton startup dependencies.
- Detailed handbook text uses OpenAPI vendor metadata (`x-neo-tool-handbook`) instead of bloating the runtime operation description.
- `#9953` remains prior art; this PR does not attempt repo-wide manifest truncation.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 21 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 30 passed
- `npm run ai:lint-mcp-test-locations` -> OK
- `node ./buildScripts/util/check-whitespace.mjs ai/mcp/ToolService.mjs ai/mcp/server/file-system/openapi.yaml ai/mcp/server/file-system/services/toolService.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> passed
- `node ./buildScripts/util/check-shorthand.mjs ai/mcp/ToolService.mjs ai/mcp/server/file-system/services/toolService.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 0 violations
- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/mcp/ToolService.mjs ai/mcp/server/file-system/services/toolService.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 0 violations
- `node ./buildScripts/util/check-aiconfig-test-mutation.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 0 new violations
- `git diff --check` and `git diff --cached --check` -> passed

## Post-Merge Validation

- [ ] Later V4.1 slices can opt additional MCP servers into compact descriptions plus handbook metadata.

## Commits

- `264909193` — `feat(mcp): add file-system tool handbook slice (#13268)`