### PR TITLE
feat(ai): ingest ADRs into graph (#11377)

### DIFF
--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -10,6 +10,7 @@ import { Memory_TextEmbeddingService as TextEmbeddingService } from '../../../se
 import { Memory_GraphService as GraphService } from '../../../services.mjs';
 import Json from '../../../../src/util/Json.mjs';
 import logger from '../../../mcp/server/memory-core/logger.mjs';
+import AdrIngestor from '../../../services/ingestion/AdrIngestor.mjs';
 import ConceptDiscoveryService from '../../../services/ingestion/ConceptDiscoveryService.mjs';
 import ConceptIngestor from '../../../services/ingestion/ConceptIngestor.mjs';
 import FileSystemIngestor from '../../../services/memory-core/FileSystemIngestor.mjs';
@@ -238,7 +239,20 @@ class DreamService extends Base {
             } else {
                 logger.info(`[DreamService] Found ${sessions.length} undigested session(s). Beginning REM pipeline...`);
 
-                // Phase 0: Ingest the version-controlled Concept Ontology (.neo-ai-data/concepts/*.jsonl)
+                // Phase 0a: Ingest local ADRs as deterministic graph nodes before any LLM
+                // extraction while keeping ADRs out of the Tri-Vector VALID_TYPES enum.
+                const adrIngestStart = Date.now();
+                try {
+                    await AdrIngestor.syncAdrsToGraph();
+                    perPhaseStates.push(finishPhase('adrIngest', adrIngestStart, 'completed'));
+                } catch (e) {
+                    perPhaseStates.push(finishPhase('adrIngest', adrIngestStart, 'failed', {
+                        error: toErrorMessage(e)
+                    }));
+                    throw e;
+                }
+
+                // Phase 0b: Ingest the version-controlled Concept Ontology (.neo-ai-data/concepts/*.jsonl)
                 // into the Native Edge Graph as first-class CONCEPT nodes + typed edges. Runs BEFORE
                 // FileSystemIngestor so downstream gap inference can traverse concept-graph relationships
                 // deterministically instead of regex-matching token lists against file paths.

--- a/ai/services/ingestion/AdrIngestor.mjs
+++ b/ai/services/ingestion/AdrIngestor.mjs
@@ -1,0 +1,342 @@
+import crypto                                from 'crypto';
+import fs                                    from 'fs';
+import path                                  from 'path';
+import Base                                  from '../../../src/core/Base.mjs';
+import {Memory_GraphService as GraphService} from '../../services.mjs';
+import logger                                from '../../mcp/server/memory-core/logger.mjs';
+
+const
+    ADR_EDGE_TYPES = Object.freeze({
+        CITES_AUTHORITY    : 'CITES_AUTHORITY',
+        CODIFIES_CONCEPT   : 'CODIFIES_CONCEPT',
+        GOVERNS            : 'GOVERNS',
+        GRADUATED_FROM     : 'GRADUATED_FROM',
+        IMPLEMENTS_DECISION: 'IMPLEMENTS_DECISION'
+    }),
+    ADR_FILE_REGEX     = /^(\d{4})-.*\.md$/,
+    ISSUE_REF_REGEX    = /\b(?:Epic|Issue|Ticket)\s+#(\d+)\b/gi,
+    PR_REF_REGEX       = /\bPR\s+#(\d+)\b/gi,
+    CONCEPT_REF_REGEX  = /\bCONCEPT:([A-Za-z0-9_.:-]+)\b/g,
+    SESSION_REF_REGEX  = /\bOrigin Session ID:\s*`?([A-Za-z0-9_.:-]+)`?/gi,
+    STATUS_ROW_REGEX   = /^\|\s*\*\*Status\*\*\s*\|\s*([^|]+?)\s*\|/mi,
+    STATUS_BOLD_REGEX  = /^\s*\*\*Status\*\*:\s*(.+)$/mi,
+    SUPERSEDES_ROW_REGEX = /^\|\s*\*\*Supersedes\*\*\s*\|\s*([^|]+?)\s*\|/mi;
+
+/**
+ * Stable deep-stringify for ADR payload hashing. Sorts object keys recursively so
+ * logically-identical metadata emits the same hash regardless of parser order.
+ * @param {*} value
+ * @returns {String}
+ * @private
+ */
+function stableStringify(value) {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+
+    if (Array.isArray(value)) {
+        return '[' + value.map(stableStringify).join(',') + ']';
+    }
+
+    const keys = Object.keys(value).sort();
+
+    return '{' + keys.map(k => JSON.stringify(k) + ':' + stableStringify(value[k])).join(',') + '}';
+}
+
+/**
+ * @summary Deterministically ingests Architecture Decision Records into the Native Edge Graph as
+ * first-class `ADR` nodes with consumer-backed relationship edges.
+ *
+ * The ADR-node contract makes decision records graph-queryable without widening the REM LLM
+ * extractor's `VALID_TYPES` enum. This service mirrors the `ConceptIngestor` pattern: scan the
+ * version-controlled ADR corpus, parse stable metadata, upsert `ADR` nodes, and replace only
+ * ADR-owned edge taxonomy rows. It is intentionally deterministic and filesystem-backed; no LLM
+ * inference is involved, and no speculative edges are emitted.
+ *
+ * Non-Accepted ADR status values in the current corpus normalize to `Draft` for the pinned
+ * ADR-node contract while preserving the source value as `rawStatus`.
+ *
+ * @class Neo.ai.daemons.services.AdrIngestor
+ * @extends Neo.core.Base
+ * @see learn/agentos/decisions/0006-adrs-as-graph-queryable-entities.md
+ * @see Neo.ai.daemons.services.ConceptIngestor
+ * @singleton
+ */
+class AdrIngestor extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.daemons.services.AdrIngestor'
+         * @protected
+         */
+        className: 'Neo.ai.daemons.services.AdrIngestor',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Computes the differential-sync hash stored under `properties.payloadHash`.
+     * @param {Object} adr Parsed ADR metadata.
+     * @returns {String}
+     * @protected
+     */
+    computePayloadHash(adr) {
+        const payload = {
+            adrNumber : adr.adrNumber,
+            rawStatus : adr.rawStatus,
+            source    : adr.source,
+            status    : adr.status,
+            supersedes: adr.supersedes,
+            title     : adr.title
+        };
+
+        return crypto.createHash('sha256').update(stableStringify(payload)).digest('hex');
+    }
+
+    /**
+     * @summary Parses a markdown ADR file into graph-node metadata and deterministic edge rows.
+     * @param {String} fileName ADR markdown file name.
+     * @param {String} content ADR markdown body.
+     * @param {String} source Repo-relative source path.
+     * @returns {Object}
+     * @protected
+     */
+    parseAdr(fileName, content, source) {
+        const fileMatch = fileName.match(ADR_FILE_REGEX);
+        if (!fileMatch) {
+            throw new Error(`Invalid ADR file name: ${fileName}`);
+        }
+
+        const
+            adrNumber    = fileMatch[1],
+            id           = `adr-${adrNumber}`,
+            headingMatch = content.match(/^#\s+ADR\s+\d{4}:?\s*(.+)$/mi),
+            title        = headingMatch?.[1]?.trim() || path.basename(fileName, '.md'),
+            statusMatch  = content.match(STATUS_ROW_REGEX) || content.match(STATUS_BOLD_REGEX),
+            rawStatus    = (statusMatch?.[1] || 'Draft').replace(/\s+/g, ' ').trim(),
+            status       = /^Accepted\b/i.test(rawStatus) ? 'Accepted' : 'Draft',
+            supersedes   = this.parseSupersedes(content);
+
+        return {
+            adrNumber,
+            id,
+            rawStatus,
+            source,
+            status,
+            supersedes,
+            title,
+            edges: this.parseEdges(id, content)
+        };
+    }
+
+    /**
+     * Parses the ADR table's Supersedes cell into a reviewable array without attempting to
+     * interpret the prose into richer graph nodes.
+     * @param {String} content ADR markdown body.
+     * @returns {String[]}
+     * @protected
+     */
+    parseSupersedes(content) {
+        const match = content.match(SUPERSEDES_ROW_REGEX);
+        if (!match) {
+            return [];
+        }
+
+        return match[1]
+            .split(/;|\n/)
+            .map(item => item.replace(/^\s*(?:[-*]\s+|\([a-z0-9]+\)\s+|[a-z0-9]+\.\s+)/i, '').trim())
+            .filter(Boolean);
+    }
+
+    /**
+     * Extracts only the consumer-backed ADR edge taxonomy from deterministic textual anchors.
+     * @param {String} adrId Stable ADR node id (`adr-NNNN`).
+     * @param {String} content ADR markdown body.
+     * @returns {Object[]}
+     * @protected
+     */
+    parseEdges(adrId, content) {
+        const edges = new Map();
+
+        const addEdge = (source, target, type, properties = {}) => {
+            edges.set(`${source}|${target}|${type}`, {source, target, type, properties});
+        };
+
+        for (const match of content.matchAll(ISSUE_REF_REGEX)) {
+            const issueId = `issue-${match[1]}`;
+            addEdge(adrId, issueId, ADR_EDGE_TYPES.GOVERNS);
+            addEdge(issueId, adrId, ADR_EDGE_TYPES.CITES_AUTHORITY);
+        }
+
+        for (const match of content.matchAll(PR_REF_REGEX)) {
+            addEdge(`pr-${match[1]}`, adrId, ADR_EDGE_TYPES.IMPLEMENTS_DECISION);
+        }
+
+        for (const match of content.matchAll(SESSION_REF_REGEX)) {
+            addEdge(adrId, `session:${match[1]}`, ADR_EDGE_TYPES.GRADUATED_FROM);
+        }
+
+        for (const match of content.matchAll(CONCEPT_REF_REGEX)) {
+            addEdge(adrId, match[1], ADR_EDGE_TYPES.CODIFIES_CONCEPT);
+        }
+
+        return Array.from(edges.values());
+    }
+
+    /**
+     * Ensures edge endpoints exist before insertion. The graph storage layer enforces foreign
+     * keys for both endpoint columns, so deterministic ADR edges seed only minimal stubs when
+     * the richer issue/PR/session/concept ingestors have not materialized a node yet.
+     * @param {Object[]} edges ADR edge rows to insert.
+     * @protected
+     */
+    ensureEdgeEndpointsExist(edges) {
+        for (const edge of edges) {
+            this.ensureNodeExists(edge.source);
+            this.ensureNodeExists(edge.target);
+        }
+    }
+
+    /**
+     * Creates a minimal node stub for an edge endpoint if no richer node is already present.
+     * @param {String} id Graph node id.
+     * @protected
+     */
+    ensureNodeExists(id) {
+        GraphService.db.getAdjacentNodes(id, 'both');
+
+        if (GraphService.db.nodes.get(id)) {
+            return;
+        }
+
+        let type = 'CONCEPT';
+        if (id.startsWith('adr-')) {
+            type = 'ADR';
+        } else if (id.startsWith('issue-')) {
+            type = 'ISSUE';
+        } else if (id.startsWith('pr-')) {
+            type = 'PULL_REQUEST';
+        } else if (id.startsWith('discussion-')) {
+            type = 'DISCUSSION';
+        } else if (id.startsWith('session:')) {
+            type = 'SESSION';
+        }
+
+        GraphService.upsertNode({
+            id,
+            type,
+            name      : id,
+            properties: {isAdrEdgeStub: true}
+        });
+    }
+
+    /**
+     * Removes and replaces all ADR-taxonomy edges incident to one ADR node.
+     * @param {String} adrId Stable ADR node id.
+     * @param {Object[]} edges Replacement edge rows.
+     * @protected
+     */
+    replaceAdrEdges(adrId, edges) {
+        const
+            db            = GraphService.db,
+            adrEdgeTypes  = new Set(Object.values(ADR_EDGE_TYPES)),
+            existingEdges = db.edges.items.slice(),
+            edgesToRemove = existingEdges.filter(edge =>
+                adrEdgeTypes.has(edge.type) && (edge.source === adrId || edge.target === adrId)
+            );
+
+        if (edgesToRemove.length > 0) {
+            db.edges.remove(edgesToRemove);
+        }
+
+        this.ensureEdgeEndpointsExist(edges);
+
+        for (const edge of edges) {
+            db.addEdge(edge);
+        }
+    }
+
+    /**
+     * Main entry point. Scans local ADR markdown files, upserts `ADR` nodes, and refreshes the
+     * deterministic ADR edge taxonomy.
+     * @param {Object} [options]
+     * @param {String} [options.decisionsDir] Absolute or repo-relative ADR directory override.
+     * @param {String} [options.sourceRoot=process.cwd()] Source-root used for repo-relative paths.
+     * @returns {Promise<Object>} `{adrsProcessed, adrsUpserted, adrsSkipped, edgesReplaced, errors}`
+     */
+    async syncAdrsToGraph({decisionsDir = 'learn/agentos/decisions', sourceRoot = process.cwd()} = {}) {
+        const stats = {
+            adrsProcessed: 0,
+            adrsUpserted : 0,
+            adrsSkipped  : 0,
+            edgesReplaced: 0,
+            errors       : []
+        };
+
+        try {
+            const
+                rootDir = path.resolve(sourceRoot),
+                adrDir  = path.resolve(rootDir, decisionsDir);
+
+            if (!fs.existsSync(adrDir)) {
+                stats.errors.push(`[input] ADR directory not found: ${adrDir}`);
+                return stats;
+            }
+
+            const files = (await fs.promises.readdir(adrDir)).filter(file => ADR_FILE_REGEX.test(file)).sort();
+
+            for (const file of files) {
+                stats.adrsProcessed++;
+
+                try {
+                    const
+                        filePath     = path.join(adrDir, file),
+                        source       = path.relative(rootDir, filePath),
+                        content      = await fs.promises.readFile(filePath, 'utf8'),
+                        adr          = this.parseAdr(file, content, source),
+                        payloadHash  = this.computePayloadHash(adr),
+                        existingNode = GraphService.db.nodes.get(adr.id);
+
+                    if (existingNode?.properties?.payloadHash === payloadHash) {
+                        stats.adrsSkipped++;
+                        continue;
+                    }
+
+                    GraphService.upsertNode({
+                        id        : adr.id,
+                        type      : 'ADR',
+                        name      : adr.title,
+                        properties: {
+                            adrNumber     : adr.adrNumber,
+                            adrNumberValue: Number(adr.adrNumber),
+                            payloadHash,
+                            rawStatus     : adr.rawStatus,
+                            source        : adr.source,
+                            status        : adr.status,
+                            supersedes    : adr.supersedes,
+                            title         : adr.title
+                        }
+                    });
+
+                    stats.adrsUpserted++;
+                    this.replaceAdrEdges(adr.id, adr.edges);
+                    stats.edgesReplaced += adr.edges.length;
+                } catch (e) {
+                    stats.errors.push(`[${file}] ${e.message}`);
+                    logger.warn(`[AdrIngestor] Failed to ingest ADR '${file}': ${e.message}`);
+                }
+            }
+
+            logger.info(`[AdrIngestor] Sync complete: ${stats.adrsUpserted} upserted, ${stats.adrsSkipped} unchanged, ${stats.edgesReplaced} edges${stats.errors.length > 0 ? `, ${stats.errors.length} errors` : ''}.`);
+        } catch (e) {
+            logger.error('[AdrIngestor] Fatal sync error:', e);
+            stats.errors.push(`[fatal] ${e.message}`);
+        }
+
+        return stats;
+    }
+}
+
+export default Neo.setupClass(AdrIngestor);

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -1018,7 +1018,7 @@ class GraphService extends Base {
 
     /**
      * Finds nodes that have lost all structural edges to trigger algorithmic forgetting.
-     * Protects structural-anchor node types (`SYSTEM_ANCHOR`, `System`, `ISSUE`, `DISCUSSION`,
+     * Protects structural-anchor node types (`SYSTEM_ANCHOR`, `System`, `ADR`, `ISSUE`, `DISCUSSION`,
      * `PULL_REQUEST`, `SESSION`, `MEMORY`, `AgentIdentity`, `BroadcastSentinel`, `WAKE_SUBSCRIPTION`) from pruning regardless of edge state. `SESSION` and
      * `MEMORY` are protected because they are load-bearing anchors for future mailbox
      * (`IN_REPLY_TO`), identity (`AUTHORED_BY`), and provenance (`MENTIONED_IN`) edges — they may
@@ -1027,7 +1027,8 @@ class GraphService extends Base {
      * `AgentIdentity` and `BroadcastSentinel` are protected to prevent silent wipes during
      * idle or fresh Memory Core states prior to their first activity edges.
      * `WAKE_SUBSCRIPTION` nodes are protected natively against GC race conditions during background
-     * maintenance sweeps.
+     * maintenance sweeps. `ADR` nodes are durable architectural authority records, so they remain
+     * graph-queryable even before relationship edges are materialized.
      * @returns {String[]} Array of node IDs mapping to orphaned vectors.
      */
     getOrphanedNodes() {
@@ -1048,7 +1049,7 @@ class GraphService extends Base {
                 data = JSON.parse(row.data);
             } catch(e) { continue; }
 
-            if (data.label !== 'SYSTEM_ANCHOR' && data.label !== 'System' && data.label !== 'ISSUE' && data.label !== 'DISCUSSION' && data.label !== 'PULL_REQUEST' && data.label !== 'SESSION' && data.label !== 'MEMORY' && data.label !== 'AgentIdentity' && data.label !== 'BroadcastSentinel' && data.label !== 'WAKE_SUBSCRIPTION') {
+            if (data.label !== 'SYSTEM_ANCHOR' && data.label !== 'System' && data.label !== 'ADR' && data.label !== 'ISSUE' && data.label !== 'DISCUSSION' && data.label !== 'PULL_REQUEST' && data.label !== 'SESSION' && data.label !== 'MEMORY' && data.label !== 'AgentIdentity' && data.label !== 'BroadcastSentinel' && data.label !== 'WAKE_SUBSCRIPTION') {
                 orphaned.push(row.id);
             }
         }

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -719,6 +719,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // into the session loop and silently reintroduces N×M traversal cost at ontology scale.
 
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
         const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
@@ -745,6 +746,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             synthesizeGolden   : DreamService.synthesizeGoldenPath,
             triVector          : SemanticGraphExtractor.executeTriVectorExtraction,
             syncSession        : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs           : AdrIngestor.syncAdrsToGraph,
             syncConcepts       : ConceptIngestor.syncConceptsToGraph,
             syncFs             : FileSystemIngestor.syncWorkspaceToGraph,
             extractTopo        : TopologyInferenceEngine.extractTopology,
@@ -775,6 +777,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
                 memoriesSkipped : 0,
                 memoriesUpserted: 0
             });
+            AdrIngestor.syncAdrsToGraph              = async () => ({});
             ConceptIngestor.syncConceptsToGraph     = async () => ({});
             FileSystemIngestor.syncWorkspaceToGraph = async () => {};
             TopologyInferenceEngine.extractTopology = async () => {};
@@ -794,6 +797,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;
             SemanticGraphExtractor.executeTriVectorExtraction = orig.triVector;
             MemorySessionIngestor.syncSessionToGraph          = orig.syncSession;
+            AdrIngestor.syncAdrsToGraph                       = orig.syncAdrs;
             ConceptIngestor.syncConceptsToGraph               = orig.syncConcepts;
             FileSystemIngestor.syncWorkspaceToGraph           = orig.syncFs;
             TopologyInferenceEngine.extractTopology           = orig.extractTopo;
@@ -808,6 +812,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // rows instead of permanently masking them behind `graphDigested: true`.
 
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
         const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
@@ -834,6 +839,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             synthesizeGolden   : DreamService.synthesizeGoldenPath,
             triVector          : SemanticGraphExtractor.executeTriVectorExtraction,
             syncSession        : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs           : AdrIngestor.syncAdrsToGraph,
             syncConcepts       : ConceptIngestor.syncConceptsToGraph,
             syncFs             : FileSystemIngestor.syncWorkspaceToGraph,
             extractTopo        : TopologyInferenceEngine.extractTopology,
@@ -864,6 +870,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
                 memoriesSkipped : 1,
                 memoriesUpserted: 2
             });
+            AdrIngestor.syncAdrsToGraph              = async () => ({});
             ConceptIngestor.syncConceptsToGraph     = async () => ({});
             FileSystemIngestor.syncWorkspaceToGraph = async () => {};
             TopologyInferenceEngine.extractTopology = async () => {};
@@ -889,6 +896,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.synthesizeGoldenPath                 = orig.synthesizeGolden;
             SemanticGraphExtractor.executeTriVectorExtraction = orig.triVector;
             MemorySessionIngestor.syncSessionToGraph          = orig.syncSession;
+            AdrIngestor.syncAdrsToGraph                       = orig.syncAdrs;
             ConceptIngestor.syncConceptsToGraph               = orig.syncConcepts;
             FileSystemIngestor.syncWorkspaceToGraph           = orig.syncFs;
             TopologyInferenceEngine.extractTopology           = orig.extractTopo;
@@ -910,6 +918,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // SemanticGraphExtractor choreography under test runs real. Hypothesis 9 (PRIMARY),
         // Discussion silent-failure enumeration §2.4.
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
         const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
@@ -933,6 +942,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             runGarbageCol     : DreamService.runGarbageCollection,
             synthesizeGolden  : DreamService.synthesizeGoldenPath,
             syncSession       : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs          : AdrIngestor.syncAdrsToGraph,
             syncConcepts      : ConceptIngestor.syncConceptsToGraph,
             syncFs            : FileSystemIngestor.syncWorkspaceToGraph,
             extractTopo       : TopologyInferenceEngine.extractTopology,
@@ -961,6 +971,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.runGarbageCollection        = async () => {};
             DreamService.synthesizeGoldenPath        = async () => {};
             MemorySessionIngestor.syncSessionToGraph = async () => ({errors: [], memoriesUpserted: 0, memoriesSkipped: 0});
+            AdrIngestor.syncAdrsToGraph              = async () => ({});
             ConceptIngestor.syncConceptsToGraph      = async () => ({});
             FileSystemIngestor.syncWorkspaceToGraph  = async () => {};
             TopologyInferenceEngine.extractTopology  = async () => {};
@@ -997,6 +1008,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.runGarbageCollection                = orig.runGarbageCol;
             DreamService.synthesizeGoldenPath                = orig.synthesizeGolden;
             MemorySessionIngestor.syncSessionToGraph         = orig.syncSession;
+            AdrIngestor.syncAdrsToGraph                      = orig.syncAdrs;
             ConceptIngestor.syncConceptsToGraph              = orig.syncConcepts;
             FileSystemIngestor.syncWorkspaceToGraph          = orig.syncFs;
             TopologyInferenceEngine.extractTopology          = orig.extractTopo;
@@ -1017,6 +1029,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         // Only peripheral phases + storage + the LLM boundary are neutralized. Hypothesis 11,
         // Discussion silent-failure enumeration §2.4.
         const aiConfig                = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        const AdrIngestor             = (await import('../../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
         const ConceptIngestor         = (await import('../../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;
         const FileSystemIngestor      = (await import('../../../../../../../ai/services/memory-core/FileSystemIngestor.mjs')).default;
         const TopologyInferenceEngine = (await import('../../../../../../../ai/services/graph/TopologyInferenceEngine.mjs')).default;
@@ -1039,6 +1052,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             runGarbageCol     : DreamService.runGarbageCollection,
             synthesizeGolden  : DreamService.synthesizeGoldenPath,
             syncSession       : MemorySessionIngestor.syncSessionToGraph,
+            syncAdrs          : AdrIngestor.syncAdrsToGraph,
             syncConcepts      : ConceptIngestor.syncConceptsToGraph,
             syncFs            : FileSystemIngestor.syncWorkspaceToGraph,
             extractTopo       : TopologyInferenceEngine.extractTopology,
@@ -1065,6 +1079,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.runGarbageCollection        = async () => {};
             DreamService.synthesizeGoldenPath        = async () => {};
             MemorySessionIngestor.syncSessionToGraph = async () => ({errors: [], memoriesUpserted: 0, memoriesSkipped: 0});
+            AdrIngestor.syncAdrsToGraph              = async () => ({});
             ConceptIngestor.syncConceptsToGraph      = async () => ({});
             FileSystemIngestor.syncWorkspaceToGraph  = async () => {};
             TopologyInferenceEngine.extractTopology  = async () => {};
@@ -1101,6 +1116,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
             DreamService.runGarbageCollection                = orig.runGarbageCol;
             DreamService.synthesizeGoldenPath                = orig.synthesizeGolden;
             MemorySessionIngestor.syncSessionToGraph         = orig.syncSession;
+            AdrIngestor.syncAdrsToGraph                      = orig.syncAdrs;
             ConceptIngestor.syncConceptsToGraph              = orig.syncConcepts;
             FileSystemIngestor.syncWorkspaceToGraph          = orig.syncFs;
             TopologyInferenceEngine.extractTopology          = orig.extractTopo;

--- a/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs
@@ -1,0 +1,240 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'AdrIngestorTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+import os             from 'os';
+import {TestLifecycleHelper} from '../../services/memory-core/util.mjs';
+
+test.describe('Neo.ai.daemons.services.AdrIngestor', () => {
+    let GraphService;
+    let AdrIngestor;
+    let logger;
+    let SystemLifecycleService;
+
+    let tmpRoot;
+    let decisionsDir;
+
+    let originalWarn;
+    let warnMessages = [];
+
+    test.beforeAll(async () => {
+        const aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+        aiConfig.autoIngestFileSystem = false;
+        aiConfig.handoffFilePath      = path.join(tmpDir, 'mock_sandman_handoff_adr_ingestor.md');
+
+        GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        AdrIngestor            = (await import('../../../../../../ai/services/ingestion/AdrIngestor.mjs')).default;
+        logger                 = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
+        SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+
+        // Reactive provider SSOT: under UNIT_TEST_MODE the Memory Core config resolves
+        // storagePaths.graph to `:memory:` by construction. Do not mutate the shared AiConfig
+        // DB path; just clear singleton lifecycle/cache state before booting this spec.
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, null, 'clear');
+
+        if (!SystemLifecycleService._initPromise) {
+            await SystemLifecycleService.initAsync();
+        } else {
+            await SystemLifecycleService.ready();
+        }
+
+        if (!GraphService.db) {
+            GraphService._initPromise = null;
+            await GraphService.initAsync();
+        }
+    });
+
+    test.beforeEach(() => {
+        tmpRoot      = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-adr-ingestor-test-'));
+        decisionsDir = path.join(tmpRoot, 'learn/agentos/decisions');
+        fs.mkdirSync(decisionsDir, {recursive: true});
+
+        if (GraphService.db) {
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            if (GraphService.db.storage?.db) {
+                GraphService.db.storage.clear();
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+                GraphService.db.lastSyncId = 0;
+            }
+        }
+
+        warnMessages = [];
+        originalWarn = logger.warn;
+        logger.warn  = (...args) => {
+            warnMessages.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
+        };
+    });
+
+    test.afterEach(() => {
+        if (originalWarn) logger.warn = originalWarn;
+
+        if (tmpRoot && fs.existsSync(tmpRoot)) {
+            try { fs.rmSync(tmpRoot, {recursive: true}); } catch (e) {}
+        }
+    });
+
+    test.afterAll(async () => {
+        await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, null, null, 'clear');
+    });
+
+    function writeAdr(fileName, body) {
+        fs.writeFileSync(path.join(decisionsDir, fileName), body.trim() + '\n', 'utf8');
+    }
+
+    function syncOptions() {
+        return {
+            decisionsDir: 'learn/agentos/decisions',
+            sourceRoot  : tmpRoot
+        };
+    }
+
+    test('should upsert ADR nodes with normalized metadata and payload hashes', async () => {
+        writeAdr('0099-test-decision.md', `
+# ADR 0099: Test Decision Shape
+
+| **Status** | Proposed - transitions to Accepted on merge |
+| **Supersedes** | old decision; obsolete note |
+
+Body.
+        `);
+
+        const stats = await AdrIngestor.syncAdrsToGraph(syncOptions());
+
+        expect(stats.adrsProcessed).toBe(1);
+        expect(stats.adrsUpserted).toBe(1);
+        expect(stats.adrsSkipped).toBe(0);
+        expect(stats.errors).toEqual([]);
+
+        const node = GraphService.db.nodes.get('adr-0099');
+        expect(node).toBeDefined();
+        expect(node.label).toBe('ADR');
+        expect(node.properties.title).toBe('Test Decision Shape');
+        expect(node.properties.status).toBe('Draft');
+        expect(node.properties.rawStatus).toBe('Proposed - transitions to Accepted on merge');
+        expect(node.properties.adrNumber).toBe('0099');
+        expect(node.properties.adrNumberValue).toBe(99);
+        expect(node.properties.source).toBe('learn/agentos/decisions/0099-test-decision.md');
+        expect(node.properties.supersedes).toEqual(['old decision', 'obsolete note']);
+        expect(node.properties.payloadHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    test('should emit only deterministic ADR 0006 edge taxonomy rows', async () => {
+        writeAdr('0099-test-decision.md', `
+# ADR 0099: Test Decision Shape
+
+| **Status** | Accepted - 2026-06-14 |
+| **Implementation ticket** | #456 |
+
+## Related
+
+- Ticket #456
+- Issue #789
+- Epic #1000
+- PR #123
+- Origin Session ID: \`agent-session-abc\`
+- CONCEPT:mx-loop
+        `);
+
+        const stats = await AdrIngestor.syncAdrsToGraph(syncOptions());
+
+        expect(stats.edgesReplaced).toBe(9);
+
+        const edgeKeys = GraphService.db.edges.items
+            .map(edge => `${edge.source}|${edge.target}|${edge.type}`)
+            .sort();
+
+        expect(edgeKeys).toEqual([
+            'adr-0099|issue-1000|GOVERNS',
+            'adr-0099|issue-456|GOVERNS',
+            'adr-0099|issue-789|GOVERNS',
+            'adr-0099|mx-loop|CODIFIES_CONCEPT',
+            'adr-0099|session:agent-session-abc|GRADUATED_FROM',
+            'issue-1000|adr-0099|CITES_AUTHORITY',
+            'issue-456|adr-0099|CITES_AUTHORITY',
+            'issue-789|adr-0099|CITES_AUTHORITY',
+            'pr-123|adr-0099|IMPLEMENTS_DECISION'
+        ].sort());
+
+        expect(GraphService.db.nodes.get('issue-456').label).toBe('ISSUE');
+        expect(GraphService.db.nodes.get('pr-123').label).toBe('PULL_REQUEST');
+        expect(GraphService.db.nodes.get('session:agent-session-abc').label).toBe('SESSION');
+        expect(GraphService.db.nodes.get('mx-loop').label).toBe('CONCEPT');
+    });
+
+    test('should skip unchanged ADRs via payload hash match', async () => {
+        writeAdr('0099-test-decision.md', `
+# ADR 0099: Test Decision Shape
+
+| **Status** | Accepted - 2026-06-14 |
+
+Ticket #456
+        `);
+
+        const first = await AdrIngestor.syncAdrsToGraph(syncOptions());
+        const edgesAfterFirst = GraphService.db.edges.items.length;
+        const second = await AdrIngestor.syncAdrsToGraph(syncOptions());
+
+        expect(first.adrsUpserted).toBe(1);
+        expect(second.adrsUpserted).toBe(0);
+        expect(second.adrsSkipped).toBe(1);
+        expect(second.edgesReplaced).toBe(0);
+        expect(GraphService.db.edges.items.length).toBe(edgesAfterFirst);
+    });
+
+    test('should isolate malformed files as errors while ingesting valid ADRs', async () => {
+        writeAdr('0099-valid.md', `
+# ADR 0099: Valid
+
+**Status**: Accepted
+        `);
+        writeAdr('not-an-adr.md', '# Ignored');
+
+        const stats = await AdrIngestor.syncAdrsToGraph(syncOptions());
+
+        expect(stats.adrsProcessed).toBe(1);
+        expect(stats.adrsUpserted).toBe(1);
+        expect(stats.errors).toEqual([]);
+        expect(warnMessages).toEqual([]);
+        expect(GraphService.db.nodes.get('adr-0099')).toBeDefined();
+    });
+
+    test('should ingest the current ADR corpus without parse errors', async () => {
+        const
+            repoRoot     = process.cwd(),
+            repoAdrDir   = path.resolve(repoRoot, 'learn/agentos/decisions'),
+            expectedAdrs = fs.readdirSync(repoAdrDir).filter(file => /^\d{4}-.*\.md$/.test(file)).length;
+
+        const stats = await AdrIngestor.syncAdrsToGraph({
+            decisionsDir: 'learn/agentos/decisions',
+            sourceRoot  : repoRoot
+        });
+
+        expect(stats.adrsProcessed).toBe(expectedAdrs);
+        expect(stats.errors).toEqual([]);
+        expect(GraphService.db.nodes.items.filter(node => node.label === 'ADR').length).toBe(expectedAdrs);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -138,8 +138,9 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(() => GraphService.removeNodes(['ValidNode', undefined])).toThrow(/invalid node id/);
     });
 
-    test('getOrphanedNodes preserves SYSTEM_ANCHOR nodes while returning ordinary orphans (#9945)', async () => {
+    test('getOrphanedNodes preserves SYSTEM_ANCHOR and ADR nodes while returning ordinary orphans (#9945, #11377)', async () => {
         await GraphService.upsertNode({id: 'frontier', type: 'SYSTEM_ANCHOR'});
+        await GraphService.upsertNode({id: 'adr-0006', type: 'ADR'});
         await GraphService.upsertNode({id: 'DisposableConcept', type: 'CONCEPT'});
 
         await new Promise(resolve => setTimeout(resolve, 50));
@@ -148,6 +149,7 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
 
         expect(orphaned).toContain('DisposableConcept');
         expect(orphaned).not.toContain('frontier');
+        expect(orphaned).not.toContain('adr-0006');
     });
 
     test('decayGlobalTopology updates cached _SYSTEM_STATE records without losing the node id (#12070)', async () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 4ed21ddf-b92f-45ce-8689-bb3ebb563dd9.

Resolves #11377

Adds a deterministic ADR ingestion path for the Native Edge Graph. The REM cycle now scans `learn/agentos/decisions/`, upserts first-class `ADR` nodes, emits only the approved consumer-backed ADR edge taxonomy, and protects `ADR` nodes from orphan pruning so decision records remain queryable before relationship edges materialize.

Evidence: L2 (focused Playwright unit slice plus pre-commit lint gates on rebased head) -> L2 required (#11377 graph-ingestion and regression coverage). No residuals.

## Implementation

- Added `ai/services/ingestion/AdrIngestor.mjs`, mirroring the existing deterministic ingestor pattern while avoiding any Tri-Vector LLM extractor enum widening.
- Wired `DreamService.processUndigestedSessions()` to run ADR ingestion before concept ingestion during REM cycles.
- Protected `ADR` nodes in `GraphService.getOrphanedNodes()`.
- Added focused unit coverage for ADR metadata normalization, payload-hash idempotence, deterministic edge replacement, malformed-file isolation, current-corpus parsing, DreamService wiring, and the orphan-preservation regression.

## Deltas from ticket

- Non-Accepted status strings normalize to `Draft` while preserving the original source value in `rawStatus`, because the current ADR corpus uses status prose beyond the pinned `Draft` / `Accepted` node contract.
- Edge endpoints are minimally stubbed only when richer issue, PR, session, or concept nodes are not already present, because SQLite enforces edge endpoint existence.
- Durable comments intentionally avoid numeric decision anchors; the exact decision-source citation lives in this PR body and the implementation JSDoc path reference.

Decision Record impact: implements the existing ADR-node graph-queryability contract; no new or superseding decision record.

Related: #9945

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs` -> 5 passed.
- `node ./buildScripts/util/check-aiconfig-test-mutation.mjs` -> 517 test files scanned, 0 new violations.
- `npm run test-unit -- test/playwright/unit/ai/services/ingestion/AdrIngestor.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs` -> 56 passed on the rebased head.
- `git diff --check origin/dev...HEAD` -> clean.
- Husky pre-commit lint-staged gates passed: whitespace, shorthand, AiConfig test-mutation, ticket archaeology.

The GraphService slice still prints existing Chroma cleanup warnings when no Chroma daemon is available; those warnings were present in the touched suite path and did not fail the run.

## Post-Merge Validation

- [ ] Next REM cycle confirms ADR nodes exist in the Native Edge Graph and remain queryable without LLM-extractor `ADR` enum expansion.

## Commit

- `25f8d18a7` - `feat(ai): ingest ADRs into graph (#11377)`
