### PR TITLE
feat(ai): HealthService degrades on GitHub identity drift (#13244)

### DIFF
--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -303,6 +303,13 @@ async function getConversationRouter(options) {
     };
 }
 
+// The github-workflow healthcheck degrades on identity drift, including the Memory-Core self-identity
+// leg. That identity resolves from this MCP request context, which sits above HealthService's service
+// layer — so inject the reader here rather than have the service import the context upward. Mirrors the
+// write-guard's defaultGitHubIdentityAssertion sourcing.
+HealthService.memoryCoreIdentityReader = () =>
+    RequestContextService.getAgentIdentityNodeId() || RequestContextService.getUserId();
+
 const serviceMapping = {
     checkout_pull_request      : PullRequestService.checkoutPullRequest    .bind(PullRequestService),
     create_discussion          : DiscussionService .createDiscussion       .bind(DiscussionService),

--- a/ai/services/github-workflow/HealthService.mjs
+++ b/ai/services/github-workflow/HealthService.mjs
@@ -196,6 +196,16 @@ class HealthService extends Base {
     agentLoginReader = null;
 
     /**
+     * Injectable reader for the Memory-Core self-identity — the second surface that shares the
+     * agent's token. Its source (the MCP request context) lives above this service layer, so the
+     * github-workflow server injects it at wire-up; left null elsewhere, where the GitHub-login leg
+     * still asserts. A null or unresolvable read skips the Memory-Core leg rather than failing the
+     * healthcheck on a missing supplementary signal. Mirrors {@link agentLoginReader}.
+     * @member {Function|null} memoryCoreIdentityReader
+     */
+    memoryCoreIdentityReader = null;
+
+    /**
      * ISO timestamp captured when this server module was loaded.
      * @member {String} runtimeStartedAt
      */
@@ -451,13 +461,16 @@ class HealthService extends Base {
     }
 
     /**
-     * @summary Asserts the live authenticated GitHub identity is the EXPECTED agent (`NEO_AGENT_IDENTITY`).
+     * @summary Asserts the live authenticated identity is the EXPECTED agent (`NEO_AGENT_IDENTITY`).
      *
      * A drifted `GH_TOKEN` authenticates cleanly yet acts as the wrong identity — the silent failure
      * class that mis-attributes PRs and reviews. This resolves the live login (via {@link agentLoginReader},
-     * defaulting to `gh api user --jq .login`) and delegates the fail-closed comparison to the pure
-     * `assertExpectedIdentity` core. Returns `{ok:true}` (a no-op) when no expected identity is
-     * configured, and fails closed when the login cannot be resolved.
+     * defaulting to `gh api user --jq .login`) and, when a {@link memoryCoreIdentityReader} is injected,
+     * the Memory-Core self-identity (the second surface sharing the token), then delegates the
+     * fail-closed comparison to the pure `assertExpectedIdentity` core — so a drift on EITHER surface
+     * degrades the healthcheck. Returns `{ok:true}` (a no-op) when no expected identity is configured,
+     * fails closed when the login cannot be resolved, and skips the Memory-Core leg when its reader is
+     * absent or yields nothing.
      *
      * @returns {Promise<{ok: Boolean, reason: (String|null)}>}
      */
@@ -479,7 +492,21 @@ class HealthService extends Base {
             return {ok: false, reason: `identity drift: could not resolve the authed GitHub login (${e.message})`};
         }
 
-        return assertExpectedIdentity({expected: expectedIdentity, actualLogin});
+        // Second surface that shares the drifted token: the Memory-Core self-identity. Sourced via the
+        // injected reader (its MCP request context lives above this layer); absent or unresolvable ->
+        // left null so the core asserts the GitHub surface alone rather than failing the healthcheck on
+        // a missing supplementary signal.
+        let memoryCoreIdentity = null;
+
+        if (this.memoryCoreIdentityReader) {
+            try {
+                memoryCoreIdentity = await this.memoryCoreIdentityReader();
+            } catch (e) {
+                memoryCoreIdentity = null;
+            }
+        }
+
+        return assertExpectedIdentity({expected: expectedIdentity, actualLogin, memoryCoreIdentity});
     }
 
     /**

--- a/ai/services/github-workflow/HealthService.mjs
+++ b/ai/services/github-workflow/HealthService.mjs
@@ -5,6 +5,7 @@ import RuntimeFreshnessService from '../../mcp/server/shared/services/RuntimeFre
 import Base                    from '../../../src/core/Base.mjs';
 import logger                  from '../../mcp/server/github-workflow/logger.mjs';
 import semver                  from 'semver';
+import {assertExpectedIdentity} from '../../graph/assertExpectedIdentity.mjs';
 
 const
     execAsync               = promisify(exec),
@@ -187,6 +188,14 @@ class HealthService extends Base {
     runtimeFreshnessReader = null;
 
     /**
+     * Optional unit-test seam for injecting the authenticated GitHub login read. Defaults to
+     * resolving it via `gh api user --jq .login`; tests inject a drifted login to exercise the
+     * degraded path without a live `gh`.
+     * @member {Function|null} agentLoginReader
+     */
+    agentLoginReader = null;
+
+    /**
      * ISO timestamp captured when this server module was loaded.
      * @member {String} runtimeStartedAt
      */
@@ -341,7 +350,7 @@ class HealthService extends Base {
      * to 'healthy'), we log a clear message so users know their fix worked.
      * @returns {Promise<object>} A health status payload with structure:
      *   {
-     *     status: 'healthy' | 'unhealthy',
+     *     status: 'healthy' | 'degraded' | 'unhealthy',
      *     timestamp: ISO string,
      *     githubCli: {
      *       installed: boolean,
@@ -442,6 +451,38 @@ class HealthService extends Base {
     }
 
     /**
+     * @summary Asserts the live authenticated GitHub identity is the EXPECTED agent (`NEO_AGENT_IDENTITY`).
+     *
+     * A drifted `GH_TOKEN` authenticates cleanly yet acts as the wrong identity — the silent failure
+     * class that mis-attributes PRs and reviews. This resolves the live login (via {@link agentLoginReader},
+     * defaulting to `gh api user --jq .login`) and delegates the fail-closed comparison to the pure
+     * `assertExpectedIdentity` core. Returns `{ok:true}` (a no-op) when no expected identity is
+     * configured, and fails closed when the login cannot be resolved.
+     *
+     * @returns {Promise<{ok: Boolean, reason: (String|null)}>}
+     */
+    async checkAgentIdentity() {
+        const expectedIdentity = process.env.NEO_AGENT_IDENTITY;
+
+        // No expected identity declared (non-harness / unconfigured) — nothing to assert against.
+        if (!expectedIdentity) {
+            return {ok: true, reason: null};
+        }
+
+        let actualLogin;
+
+        try {
+            const readLogin = this.agentLoginReader || (async () => (await execAsync('gh api user --jq .login')).stdout.trim());
+            actualLogin = await readLogin();
+        } catch (e) {
+            // The authed login could not be resolved — fail closed; a drift cannot be ruled out.
+            return {ok: false, reason: `identity drift: could not resolve the authed GitHub login (${e.message})`};
+        }
+
+        return assertExpectedIdentity({expected: expectedIdentity, actualLogin});
+    }
+
+    /**
      * Performs a comprehensive health check without using the cache.
      *
      * Intent: This is the core health check logic, separated from the caching layer
@@ -512,7 +553,20 @@ class HealthService extends Base {
             payload.githubCli.details.push(authCheck.error);
             logger.info('[HealthService] gh-status: unauthenticated');
         } else {
-            // Step 3: Enrich with Notifications (Passive Inbox) if authenticated
+            // Step 3: Identity-drift assertion. The agent IS authenticated — but is it the EXPECTED
+            // agent? A drifted GH_TOKEN authenticates cleanly yet acts as the wrong identity — the
+            // silent failure that mis-attributes PRs and reviews. Degrade (not unhealthy: auth is
+            // valid) so a drifted token is surfaced loudly here, before any state-changing write.
+            const identityResult = await this.checkAgentIdentity();
+
+            if (!identityResult.ok) {
+                payload.status                  = 'degraded';
+                payload.githubCli.identityDrift = identityResult.reason;
+                payload.githubCli.details.push(identityResult.reason);
+                logger.warn(`[HealthService] gh-status: degraded; ${identityResult.reason}`);
+            }
+
+            // Step 4: Enrich with Notifications (Passive Inbox) if authenticated
             try {
                 const { stdout } = await execAsync("gh api 'notifications?participating=true'");
                 const notifications = JSON.parse(stdout);

--- a/test/playwright/unit/ai/services/github-workflow/HealthService.identity.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/HealthService.identity.spec.mjs
@@ -1,0 +1,75 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GithubWorkflowHealthServiceIdentityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+// Exercises HealthService.checkAgentIdentity() in isolation — the GH_TOKEN identity-drift detection
+// that degrades the healthcheck BEFORE any write. The authed login is injected via agentLoginReader
+// so no live `gh` is needed; the comparison delegates to the pure ai/graph/assertExpectedIdentity core.
+test.describe.serial('Neo.ai.services.github-workflow.HealthService - agent identity drift', () => {
+    let HealthService;
+    const originalIdentity = process.env.NEO_AGENT_IDENTITY;
+
+    test.beforeAll(async () => {
+        HealthService = (await import('../../../../../../ai/services/github-workflow/HealthService.mjs')).default;
+    });
+
+    test.afterEach(() => {
+        HealthService.agentLoginReader = null;
+
+        if (originalIdentity === undefined) {
+            delete process.env.NEO_AGENT_IDENTITY;
+        } else {
+            process.env.NEO_AGENT_IDENTITY = originalIdentity;
+        }
+    });
+
+    test('flags drift: the authed login is not the expected agent', async () => {
+        process.env.NEO_AGENT_IDENTITY = '@neo-gpt';
+        HealthService.agentLoginReader = async () => 'neo-opus-ada';
+
+        const result = await HealthService.checkAgentIdentity();
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('authed as neo-opus-ada');
+        expect(result.reason).toContain('expected neo-gpt');
+    });
+
+    test('passes when the authed login matches the expected agent', async () => {
+        process.env.NEO_AGENT_IDENTITY = '@neo-gpt';
+        HealthService.agentLoginReader = async () => 'neo-gpt';
+
+        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null});
+    });
+
+    test('is a no-op when no expected identity is configured', async () => {
+        delete process.env.NEO_AGENT_IDENTITY;
+        HealthService.agentLoginReader = async () => 'whoever';
+
+        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null});
+    });
+
+    test('fails closed when the authed login cannot be resolved', async () => {
+        process.env.NEO_AGENT_IDENTITY = '@neo-gpt';
+        HealthService.agentLoginReader = async () => { throw new Error('gh exploded'); };
+
+        const result = await HealthService.checkAgentIdentity();
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('could not resolve the authed GitHub login');
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/HealthService.identity.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/HealthService.identity.spec.mjs
@@ -29,7 +29,8 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - agent iden
     });
 
     test.afterEach(() => {
-        HealthService.agentLoginReader = null;
+        HealthService.agentLoginReader         = null;
+        HealthService.memoryCoreIdentityReader = null;
 
         if (originalIdentity === undefined) {
             delete process.env.NEO_AGENT_IDENTITY;
@@ -71,5 +72,39 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - agent iden
 
         expect(result.ok).toBe(false);
         expect(result.reason).toContain('could not resolve the authed GitHub login');
+    });
+
+    test('flags Memory-Core drift even when the GitHub login matches', async () => {
+        process.env.NEO_AGENT_IDENTITY = '@neo-gpt';
+        HealthService.agentLoginReader         = async () => 'neo-gpt';
+        HealthService.memoryCoreIdentityReader = async () => '@neo-opus-ada';
+
+        const result = await HealthService.checkAgentIdentity();
+
+        expect(result.ok).toBe(false);
+        expect(result.reason).toContain('Memory-Core identity');
+    });
+
+    test('passes when both the GitHub login and the Memory-Core identity match', async () => {
+        process.env.NEO_AGENT_IDENTITY = '@neo-gpt';
+        HealthService.agentLoginReader         = async () => 'neo-gpt';
+        HealthService.memoryCoreIdentityReader = async () => '@neo-gpt';
+
+        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null});
+    });
+
+    test('skips the Memory-Core leg when its reader yields null — the GitHub-login leg still asserts', async () => {
+        process.env.NEO_AGENT_IDENTITY = '@neo-gpt';
+        HealthService.memoryCoreIdentityReader = async () => null;
+
+        HealthService.agentLoginReader = async () => 'neo-gpt';
+        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null});
+
+        // A null Memory-Core read must not mask a GitHub-login drift.
+        HealthService.agentLoginReader = async () => 'neo-opus-ada';
+        const drift = await HealthService.checkAgentIdentity();
+
+        expect(drift.ok).toBe(false);
+        expect(drift.reason).toContain('authed as neo-opus-ada');
     });
 });


### PR DESCRIPTION
Resolves #13244

Authored by Claude Opus 4.8 (1M context), @neo-opus-ada (Ada). Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Wires the GitHub Workflow healthcheck to the identity-drift detection core, so a drifted `GH_TOKEN` **or** a drifted Memory-Core session identity is surfaced as a `degraded` healthcheck status **before** any state-changing write. This is the healthcheck half (part a) of the detection-seam for the 2026-06-14 agent identity-drift incident (#13239, forensic record merged via #13240); the write-boundary guard (part b) is @neo-gpt's #13243, which landed the shared core on dev via #13246.

`HealthService.checkAgentIdentity()` reads the harness `NEO_AGENT_IDENTITY`, resolves the live authed login (`gh api user --jq .login`, behind an injectable `agentLoginReader`) **and** the Memory-Core self-identity (behind an injectable `memoryCoreIdentityReader`), then delegates the comparison to the pure `assertExpectedIdentity` core already on dev. A drift on **either** surface degrades the authenticated healthcheck (`status: 'degraded'`, `githubCli.identityDrift: "identity drift: ..."`) and logs a warning. With no expected identity configured it is a no-op; it fails closed when the authed login cannot be resolved; a null/unresolvable Memory-Core read skips that leg while the GitHub-login leg still asserts. Same failure class as #12450 — a silent failure that would otherwise be erased into a clean result.

Evidence: L2 (HealthService.checkAgentIdentity unit coverage across the degrade / no-op / fail-closed / both-legs branches, plus the shared-core spec already on dev) -> L2 required (the logic is fully unit-coverable; the degrade surface has no runtime-only AC). No residuals.

Related: #13239
Related: #13243

## Deltas from ticket

- The pure shared core (`assertExpectedIdentity` + its 8-test spec) was split out and landed FIRST via #13246 — it is consumed by BOTH this healthcheck and the write-boundary guard, so it belongs on dev independently. This PR is the healthcheck integration: `HealthService` + a one-line reader injection in the github-workflow `toolService` + the spec. The ticket's "deliver a pure, unit-testable shared core" AC is satisfied on dev, not re-shipped here.
- Both legs of AC #2 are now wired: the healthcheck degrades on a GitHub-login **OR** a Memory-Core identity drift. The Memory-Core leg was added after @neo-gpt's pre-review caught that the first cut passed only `{expected, actualLogin}`. The Memory-Core identity resolves from the MCP request context, which sits above HealthService's service layer — so the github-workflow server injects `RequestContextService.getAgentIdentityNodeId() || getUserId()` at wire-up rather than HealthService importing upward, mirroring the write-guard's `defaultGitHubIdentityAssertion` sourcing.
- `agentLoginReader` / `memoryCoreIdentityReader` are nullable injectable members mirroring the existing `runtimeFreshnessReader` seam, so the drift check is unit-provable with no live `gh` / Memory-Core.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/graph/assertExpectedIdentity.spec.mjs test/playwright/unit/ai/services/github-workflow/HealthService.identity.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 34 passed, run against current dev. (8 core on dev + 7 HealthService identity incl. 3 Memory-Core-leg cases + 21 cross-server smoke, which loads the github-workflow `toolService` with the new injection.)
- `node ./buildScripts/util/check-whitespace.mjs` / `check-shorthand.mjs` / `check-ticket-archaeology.mjs` on the 3 changed files -> 0 violations.
- New tests in `HealthService.identity.spec.mjs`: flags Memory-Core drift even when the GitHub login matches; passes when both legs match; skips the Memory-Core leg when its reader yields null (GitHub-login leg still asserts).

## Post-Merge Validation

- [ ] A live drifted `GH_TOKEN` (or Memory-Core session identity) surfaces `status: 'degraded'` + `githubCli.identityDrift` from the github-workflow healthcheck before any write is attempted.

## Commits

- `9bf1c9ab2` — `feat(ai): HealthService degrades on GitHub identity drift (#13244)`
- `f9a4ef196` — `feat(ai): wire HealthService Memory-Core identity leg (#13244)`
