### PR TITLE
feat(ai): capture remove_component's reverse for undo — position-preserving insert (#13272)

### DIFF
--- a/ai/services/neural-link/ComponentService.mjs
+++ b/ai/services/neural-link/ComponentService.mjs
@@ -210,7 +210,11 @@ class ComponentService extends Base {
             throw new Error('remove_component: `componentId` (the component to destroy) is required.');
         }
 
-        return await ConnectionService.call(sessionId, 'call_method', {id: componentId, method: 'destroy', args: [true]});
+        // `undoKind` is a server-only capture marker (NOT in CallMethodRequest's schema): the app-side write-path
+        // snapshots the component's parent + index + config BEFORE destroy so the `undo` tool can re-insert it at its
+        // original position. The generic call_method service forwards only {id, method, args}, so a public caller
+        // cannot inject this marker — generic call_method stays non-undoable.
+        return await ConnectionService.call(sessionId, 'call_method', {id: componentId, method: 'destroy', args: [true], undoKind: 'remove_component'});
     }
 }
 

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -221,6 +221,70 @@ class InstanceService extends Service {
     }
 
     /**
+     * Builds the reverse-op for a `remove_component` write — `remove⁻¹ = insert(index, config)` on the parent,
+     * snapshotting the destroyed component's parent + tree index + a JSON-safe config BEFORE the destroy runs.
+     * **Server-stamped only** (`undoKind === 'remove_component'`), canonical `destroy(true)` shape, writer identity
+     * present, not an undo replay — else `null`, so {@link #recordUndo} no-ops (a generic `call_method` stays
+     * non-undoable). Position-preserving: the reverse re-inserts at the original `index` (not an appending re-create),
+     * so undo restores tree order. The config is a documented JSON-safe `toJSON` snapshot (serializable-config bound,
+     * not full live-state fidelity); the data-not-code + payload-cap guards in {@link Neo.ai.TransactionService} bound it.
+     * @param {Object} params
+     * @param {Object|null} params.context  The Bridge-stamped `{agentId, sessionId}` writer pair.
+     * @param {String} params.id  The component id being destroyed.
+     * @param {String} params.method
+     * @param {Array} params.args
+     * @param {String} [params.undoKind]  The server-stamped capture marker.
+     * @param {Neo.component.Base} params.instance  The live component, read BEFORE destroy.
+     * @returns {Object|null} A reverse-record op, or `null` when the call is not a capturable remove.
+     * @protected
+     */
+    buildRemoveReverse({context, id, method, args, undoKind, instance}) {
+        if (undoKind !== 'remove_component' || context?.undoReplay) {
+            return null
+        }
+
+        if (!context?.agentId || !context?.sessionId) {
+            return null
+        }
+
+        // canonical remove shape only — the server stamps destroy(true); any other shape is dropped (fail-closed)
+        if (method !== 'destroy' || args.length !== 1 || args[0] !== true) {
+            return null
+        }
+
+        const
+            parentId = instance.parentId,
+            parent   = parentId ? Neo.getComponent(parentId) : null;
+
+        if (!parent || typeof parent.indexOf !== 'function') {
+            return null // a parentless / unresolvable target cannot be re-inserted — fail-closed
+        }
+
+        const
+            index  = parent.indexOf(id),
+            config = this.safeSerialize(typeof instance.toJSON === 'function' ? instance.toJSON() : null);
+
+        if (index < 0 || !config || typeof config !== 'object') {
+            return null
+        }
+
+        const targetSubtreePath = deriveSubtreePath(parentId, cid => Neo.getComponent(cid)?.parentId);
+
+        if (!targetSubtreePath) {
+            return null
+        }
+
+        return {
+            sequenceId       : `${id}:${++this.undoSequence}`,
+            originWriter     : {agentId: context.agentId, sessionId: context.sessionId},
+            targetSubtreePath,
+            forward          : {tool: 'remove_component', args: {componentId: id}},
+            reverse          : {tool: 'call_method', args: {id: parentId, method: 'insert', args: [index, config]}},
+            label            : `remove ${id} from ${parentId}`
+        }
+    }
+
+    /**
      * Records a captured reverse-op as a single-op committed transaction on this heap's undo stack
      * ({@link Neo.ai.Client#transactionService}) — `begin` → `record` → `commit`, keyed on the writer's
      * `(agentId, sessionId)`. Best-effort: a `null` op, an absent stack authority, or a stack rejection (a malformed /
@@ -337,13 +401,15 @@ class InstanceService extends Service {
 
         this.assertWritable(context, id);
 
+        // remove_component reverse-capture must snapshot the component's re-creatable state BEFORE destroy runs (the
+        // instance is gone afterwards); create_component's capture is post-call (the new child's id is the `add`
+        // return). A server-stamped marker + the canonical shape gate each; a generic call_method + an undo replay
+        // capture nothing. See {@link #buildRemoveReverse} / {@link #buildCreateReverse}.
+        const removeOp = this.buildRemoveReverse({context, id, method, args, undoKind, instance});
+
         const result = await scope[methodName].call(scope, ...args);
 
-        // create_component reverse-capture: a server-stamped create (the canonical `add(config)` dispatch) records
-        // its inverse — destroy the new child — so an agent can undo a creation. The marker is server-only (the
-        // server-side generic call_method forwards just {id, method, args}, so a public-injected `undoKind` is
-        // stripped); a generic call_method + an undo replay are NOT captured. See {@link #buildCreateReverse}.
-        this.recordUndo(context, this.buildCreateReverse({context, id, method, args, undoKind, result}));
+        this.recordUndo(context, removeOp || this.buildCreateReverse({context, id, method, args, undoKind, result}));
 
         return {result: this.safeSerialize(result)}
     }

--- a/test/playwright/unit/ai/InstanceServiceRemoveUndoCapture.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceRemoveUndoCapture.spec.mjs
@@ -1,0 +1,120 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'InstanceServiceRemoveUndoCaptureTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
+import Container          from '../../../../src/container/Base.mjs';
+import ComponentManager   from '../../../../src/manager/Component.mjs'; // binds Neo.getComponent + registers components
+import InstanceManager    from '../../../../src/manager/Instance.mjs';  // binds Neo.get + registers instances
+import InstanceService    from '../../../../src/ai/client/InstanceService.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+import WriteGuard         from '../../../../src/ai/WriteGuard.mjs';
+
+// `remove_component` forwards server-side as a server-stamped `call_method` `destroy(true)`; the app-side
+// InstanceService.callMethod captures the reverse (`insert(index, config)` on the parent) BEFORE destroy runs — the
+// component's parent/index/config must be snapshotted before it is gone. These tests isolate the capture wiring
+// (`indexOf`/`insert`/`destroy` are stubbed — their vdom path is Neo's, exercised elsewhere), asserting the
+// position-preserving reverse, the round-trip re-dispatch, the generic-call_method non-capture (gpt guardrail 1),
+// and the `buildRemoveReverse` fail-closed branches.
+
+const ID = {agentId: 'agent-a', sessionId: 'sess-a'};
+let seq = 0; // unique ids per test (Date/random are unavailable; a stubbed destroy won't unregister)
+
+test.describe('Neo.ai.client.InstanceService — remove_component undo capture', () => {
+    let parent, child, parentId, childId, service, transactionService, dispatched;
+
+    test.beforeEach(() => {
+        seq++;
+        parentId = `rm-parent-${seq}`;
+        childId  = `rm-child-${seq}`;
+
+        transactionService = Neo.create(TransactionService);
+        dispatched         = [];
+
+        const client = {
+            transactionService,
+            writeGuard   : Neo.create(WriteGuard),
+            // mirrors Neo.ai.Client#handleRequest; records the undo re-dispatch + routes it back to the service
+            handleRequest: (method, params, ctx) => {
+                dispatched.push({method, params});
+                return service[Neo.snakeToCamel(method)]?.(params, ctx)
+            }
+        };
+
+        service = Neo.create(InstanceService, {client});
+        parent  = Neo.create(Container, {appName, id: parentId, items: []});
+        child   = Neo.create(Component, {appName, id: childId, width: 120});
+
+        child.parentId = parentId;
+        child.toJSON   = () => ({ntype: 'component', id: childId, width: 120}); // stub: a small JSON-safe config — a real toJSON can exceed record()'s payload cap / carry non-serializable refs (the documented serializable-config bound)
+        parent.indexOf = () => 2;     // stub: the child's tree position (real indexOf needs it mounted in items)
+        parent.insert  = () => child; // stub: the re-insert (its vdom path is Neo's; we assert the re-dispatch args)
+        child.destroy  = () => {}      // stub: skip the unitTestMode vdom teardown (capture happens before destroy)
+    });
+
+    test.afterEach(() => {
+        !parent.isDestroyed && parent.destroy()
+    });
+
+    test('captures remove\'s inverse — insert(index, config) on the parent — snapshotted before destroy', async () => {
+        await service.callMethod({id: childId, method: 'destroy', args: [true], undoKind: 'remove_component'}, ID);
+
+        const stack = transactionService.stackOf({id: ID});
+        expect(stack.committed).toHaveLength(1);
+
+        const op = stack.committed[0].ops[0];
+        expect(op.forward).toEqual({tool: 'remove_component', args: {componentId: childId}});
+        expect(op.reverse.tool).toBe('call_method');
+        expect(op.reverse.args.id).toBe(parentId);
+        expect(op.reverse.args.method).toBe('insert');
+        expect(op.reverse.args.args[0]).toBe(2);                       // the captured index (position-preserving)
+        expect(op.reverse.args.args[1]).toMatchObject({id: childId});  // the captured config (toJSON snapshot)
+        expect(op.originWriter).toEqual(ID)
+    });
+
+    test('round-trip: a captured remove → undo → re-dispatches insert(index, config) + consumes the tx', async () => {
+        await service.callMethod({id: childId, method: 'destroy', args: [true], undoKind: 'remove_component'}, ID);
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(1);
+
+        const result = await service.undo({}, ID);
+
+        expect(result.undone).toBe(true);
+        const insertCall = dispatched.find(d => d.params?.method === 'insert');
+        expect(insertCall).toBeTruthy();
+        expect(insertCall.params.id).toBe(parentId);
+        expect(insertCall.params.args[0]).toBe(2);                     // re-inserted at the original index
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0) // tx consumed
+    });
+
+    test('a generic call_method destroy (NO server-stamped marker) is NOT captured — generic call_method stays non-undoable', async () => {
+        await service.callMethod({id: childId, method: 'destroy', args: [true]}, ID); // no undoKind
+
+        expect(transactionService.stackOf({id: ID}).committed).toHaveLength(0)
+    });
+
+    test('buildRemoveReverse is fail-closed — only a marked, canonical, attributed, non-replay remove captures', () => {
+        const base = {context: ID, id: childId, method: 'destroy', args: [true], undoKind: 'remove_component', instance: child};
+
+        expect(service.buildRemoveReverse(base)).not.toBeNull();                                          // happy path
+        expect(service.buildRemoveReverse({...base, undoKind: undefined})).toBeNull();                    // no marker
+        expect(service.buildRemoveReverse({...base, context: {...ID, undoReplay: true}})).toBeNull();     // undo replay
+        expect(service.buildRemoveReverse({...base, context: null})).toBeNull();                          // no writer identity
+        expect(service.buildRemoveReverse({...base, method: 'hide'})).toBeNull();                         // non-canonical method
+        expect(service.buildRemoveReverse({...base, args: [false]})).toBeNull();                          // non-canonical arg (not destroy(true))
+        expect(service.buildRemoveReverse({...base, instance: {parentId: null, toJSON: () => ({})}})).toBeNull() // unresolvable parent
+    })
+});

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -126,7 +126,7 @@ test.describe('Neo.ai.services.neural-link.ComponentService — createComponent 
         expect(calls[0]).toEqual({
             sessionId: 's1',
             op       : 'call_method',
-            payload  : {id: 'dialog-1', method: 'destroy', args: [true]}
+            payload  : {id: 'dialog-1', method: 'destroy', args: [true], undoKind: 'remove_component'} // server-stamped undo-capture marker
         });
     });
 });


### PR DESCRIPTION
## Summary

Captures `remove_component`'s reverse so the merged `undo` tool (#13259) reverts a removal — **completing the create/remove undo set** (Sub-B1 create-capture #13264 merged). Sub-B2 of #13221 (gpt's cross-family-vetted guardrail 2: position-preservation).

`remove_component` forwards server-side as `call_method` `destroy(true)`; the app-side `InstanceService.callMethod` captures the reverse **before** the destroy (the component is gone after):
- **Server-stamped marker:** `removeComponent` stamps `undoKind: 'remove_component'` on its `call_method` dispatch (NOT in `CallMethodRequest`'s schema; the generic `call_method` forwards only `{id, method, args}`, so a public-injected marker is stripped → generic `call_method` stays non-undoable).
- **Pre-destroy capture:** on marker + canonical `destroy(true)` + writer identity + non-replay, snapshot `parentId` + the child's **index** (`parent.indexOf`) + a JSON-safe `toJSON` config → reverse = `call_method` `insert(index, config)` on the parent. **Position-preserving** — re-insert at the original index, not an appending re-create (guardrail 2: `add()` appends → tree-order drift).

Resolves #13272

Refs #13221 (Slice-1 parent), #13264 (Sub-B1 create-capture, merged), #13259 (undo tool), #13012 (Pillar-2), #9847 (`remove_component`), #9848

Evidence: L2 (75 in-process unit + integration tests green — incl. the remove → undo → re-dispatch-`insert(index, config)` round-trip + the **server-side** `ComponentService` dispatch spec) → L2 required (#13272 unit + round-trip ACs; a live-bridge e2e is broader, not a #13272 AC). No residuals.

## Test Evidence

`UNIT_TEST_MODE=true playwright -c …unit.mjs` at head `a7758f740` — **75 green**:

- **`InstanceServiceRemoveUndoCapture.spec.mjs` (new, 4):** captures `insert(index, config)` snapshotted before destroy; round-trip (marked remove → `undo` → re-dispatches `insert(index, config)` at the original index + tx consumed); generic-`call_method` `destroy` (no marker) NOT captured (guardrail 1); `buildRemoveReverse` fail-closed (no-marker / replay / no-writer / non-`destroy` / non-`[true]` / unresolvable-parent). Container ops (`indexOf`/`insert`/`destroy`) + `toJSON` are stubbed to isolate the capture wiring (their vdom path is Neo's) — `toJSON` to a small JSON-safe config per the documented serializable-config bound.
- **`ComponentService.spec.mjs` (8, server-side — run this time):** the `removeComponent` dispatch now asserts the `undoKind` marker. *(I missed running this server-side spec on Sub-B1 → a CI catch; lesson applied here.)*
- **Regression:** `InstanceServiceCreateUndoCapture` (4), `InstanceServiceUndoCapture` (6), `InstanceServiceUndo` (6), `TransactionService` (16), `OpenApiValidatorCompliance` (29) — all green; the `callMethod` change is additive (generic `call_method` + create-capture unchanged).

`node --check` clean on the edited `.mjs`.

## Post-Merge Validation

- A connected agent: `remove_component` → `undo` → the component is re-created at its original tree position; a generic `call_method` `destroy` is NOT undoable.

## Deltas

- **`toJSON` serializable-config bound (gpt's note):** the captured config is a `toJSON` snapshot, not full live-state fidelity — a complex component whose `toJSON` exceeds `TransactionService`'s payload cap or carries non-serializable refs is fail-closed (not captured), the documented bound. Simple/serializable components round-trip.
- **Reverse shape:** remove's reverse is the app-side `call_method insert(index, config)` (not the `create_component` tool) — `undo` re-dispatches via the client `handleRequest`, which routes `call_method`; this keeps the position-preservation in the reverse descriptor and avoids extending `create_component` with an index.
- **Pre-destroy capture ordering:** `callMethod` builds the remove reverse BEFORE the `destroy` call (the parent/index/config must be read while the instance is live); create-capture stays post-call (the new id is the `add` return).

Authored by @neo-opus-vega (Claude Opus 4.8, Claude Code). Origin Session ID: 4cc428e3-cf36-4324-8646-1b96cb23fa4a.
