### PR TITLE
feat(ai): emit a stable code from assertExpectedIdentity (#13275)

### DIFF
--- a/ai/graph/assertExpectedIdentity.mjs
+++ b/ai/graph/assertExpectedIdentity.mjs
@@ -22,6 +22,21 @@ import {IDENTITIES} from './identityRoots.mjs';
  */
 
 /**
+ * @summary Stable machine codes naming each `assertExpectedIdentity` outcome — a structured contract
+ * so consumers branch on a code, not on the human-readable `reason` prose (which is free to reword).
+ * Generic by design (not GitHub-specific): a consumer like the write-boundary guard maps these to its
+ * own domain codes. `OK` is the pass; each other value names one distinct fail-closed kind.
+ * @enum {String}
+ */
+export const IdentityAssertionCode = Object.freeze({
+    OK                  : 'OK',
+    EXPECTED_UNMAPPABLE : 'EXPECTED_UNMAPPABLE',
+    NO_AUTHED_LOGIN     : 'NO_AUTHED_LOGIN',
+    LOGIN_MISMATCH      : 'LOGIN_MISMATCH',
+    MEMORY_CORE_MISMATCH: 'MEMORY_CORE_MISMATCH'
+});
+
+/**
  * @summary Strips a single leading `@` so the id form (`@neo-gpt`) and the `gh api user` login form
  * (`neo-gpt`) compare equal. Non-string input passes through unchanged for the caller to reject.
  * @param {*} value
@@ -52,11 +67,13 @@ const resolveExpectedLogin = expected => {
 /**
  * @summary Fail-closed assertion that the live authed identity matches the expected agent.
  *
- * Returns `{ok:true, reason:null}` only when the expected agent resolves to a canonical login AND
- * the authed login matches it AND (when supplied) the Memory-Core self-identity matches it too. Any
- * gap — unmappable expected id, absent authed login, login mismatch, or Memory-Core mismatch —
- * returns `{ok:false, reason}` with an explicit `"authed as X, expected Y"`-style message suitable
- * for a `degraded` healthcheck status or a write-boundary denial.
+ * Returns `{ok:true, reason:null, code:'OK'}` only when the expected agent resolves to a canonical
+ * login AND the authed login matches it AND (when supplied) the Memory-Core self-identity matches it
+ * too. Any gap — unmappable expected id, absent authed login, login mismatch, or Memory-Core mismatch
+ * — returns `{ok:false, reason, code}` with an explicit `"authed as X, expected Y"`-style message
+ * suitable for a `degraded` healthcheck status or a write-boundary denial. The `code` is a stable
+ * {@link IdentityAssertionCode} naming the outcome kind, so consumers branch on it rather than
+ * string-matching the human-readable `reason`.
  *
  * `memoryCoreIdentity` is optional: omit it (or pass `null`/`undefined`) to assert the GitHub surface
  * alone; pass it to also cover the second surface that shares the drifted token.
@@ -66,32 +83,32 @@ const resolveExpectedLogin = expected => {
  * (an `IDENTITIES` id / login, `@`-prefixed or bare).
  * @param {String} params.actualLogin The live authed login from `gh api user --jq .login` (bare).
  * @param {String} [params.memoryCoreIdentity] The Memory-Core self-identity, when available.
- * @returns {{ok: Boolean, reason: (String|null)}}
+ * @returns {{ok: Boolean, reason: (String|null), code: String}} `code` is an {@link IdentityAssertionCode} value.
  */
 export function assertExpectedIdentity({expected, actualLogin, memoryCoreIdentity} = {}) {
     const expectedLogin = resolveExpectedLogin(expected);
 
     if (!expectedLogin) {
-        return {ok: false, reason: `identity drift: expected identity '${expected}' is missing or unmappable in identityRoots`};
+        return {ok: false, reason: `identity drift: expected identity '${expected}' is missing or unmappable in identityRoots`, code: IdentityAssertionCode.EXPECTED_UNMAPPABLE};
     }
 
     const authedLogin = bare(actualLogin);
 
     if (!authedLogin) {
-        return {ok: false, reason: `identity drift: no authed login resolved, expected ${expectedLogin}`};
+        return {ok: false, reason: `identity drift: no authed login resolved, expected ${expectedLogin}`, code: IdentityAssertionCode.NO_AUTHED_LOGIN};
     }
 
     if (authedLogin !== expectedLogin) {
-        return {ok: false, reason: `identity drift: authed as ${authedLogin}, expected ${expectedLogin}`};
+        return {ok: false, reason: `identity drift: authed as ${authedLogin}, expected ${expectedLogin}`, code: IdentityAssertionCode.LOGIN_MISMATCH};
     }
 
     if (memoryCoreIdentity != null) {
         const memoryLogin = bare(memoryCoreIdentity);
 
         if (memoryLogin !== expectedLogin) {
-            return {ok: false, reason: `identity drift: Memory-Core identity ${memoryLogin}, expected ${expectedLogin}`};
+            return {ok: false, reason: `identity drift: Memory-Core identity ${memoryLogin}, expected ${expectedLogin}`, code: IdentityAssertionCode.MEMORY_CORE_MISMATCH};
         }
     }
 
-    return {ok: true, reason: null};
+    return {ok: true, reason: null, code: IdentityAssertionCode.OK};
 }

--- a/ai/mcp/server/github-workflow/toolService.mjs
+++ b/ai/mcp/server/github-workflow/toolService.mjs
@@ -12,7 +12,7 @@ import PullRequestService from '../../../services/github-workflow/PullRequestSer
 import RepositoryService  from '../../../services/github-workflow/RepositoryService.mjs';
 import ToolService        from '../../ToolService.mjs';
 import SyncService        from '../../../services/github-workflow/SyncService.mjs';
-import {assertExpectedIdentity as assertExpectedGitHubIdentity} from '../../../graph/assertExpectedIdentity.mjs';
+import {assertExpectedIdentity as assertExpectedGitHubIdentity, IdentityAssertionCode} from '../../../graph/assertExpectedIdentity.mjs';
 import RequestContextService from '../shared/services/RequestContextService.mjs';
 import config             from './config.mjs';
 
@@ -137,32 +137,25 @@ function normalizeGitHubIdentityLogin(identity) {
 }
 
 /**
- * @summary Maps the shared assertion reason into a stable write-boundary error code.
- * @param {String|null} reason Shared assertion reason.
+ * @summary Maps the shared assertion's stable {@link IdentityAssertionCode} into a write-boundary
+ * error code. Keys on the machine `code`, not the human-readable `reason` prose (which is free to
+ * reword); an unknown or absent code falls back to the generic assertion-failed code.
+ * @param {String} code The shared assertion's `code`.
  * @returns {String}
  */
-function getGitHubIdentityErrorCode(reason) {
-    if (!reason) {
-        return 'GITHUB_IDENTITY_ASSERTION_FAILED';
+function getGitHubIdentityErrorCode(code) {
+    switch (code) {
+        case IdentityAssertionCode.EXPECTED_UNMAPPABLE:
+            return 'GITHUB_IDENTITY_UNRESOLVED';
+        case IdentityAssertionCode.NO_AUTHED_LOGIN:
+            return 'GITHUB_VIEWER_UNRESOLVED';
+        case IdentityAssertionCode.MEMORY_CORE_MISMATCH:
+            return 'GITHUB_MEMORY_CORE_IDENTITY_MISMATCH';
+        case IdentityAssertionCode.LOGIN_MISMATCH:
+            return 'GITHUB_IDENTITY_MISMATCH';
+        default:
+            return 'GITHUB_IDENTITY_ASSERTION_FAILED';
     }
-
-    if (reason.includes('missing or unmappable')) {
-        return 'GITHUB_IDENTITY_UNRESOLVED';
-    }
-
-    if (reason.includes('no authed login')) {
-        return 'GITHUB_VIEWER_UNRESOLVED';
-    }
-
-    if (reason.includes('Memory-Core identity')) {
-        return 'GITHUB_MEMORY_CORE_IDENTITY_MISMATCH';
-    }
-
-    if (reason.includes('authed as')) {
-        return 'GITHUB_IDENTITY_MISMATCH';
-    }
-
-    return 'GITHUB_IDENTITY_ASSERTION_FAILED';
 }
 
 /**
@@ -176,7 +169,7 @@ function createGitHubIdentityError(assertion) {
 
     Object.assign(error, {
         ...assertion,
-        code: getGitHubIdentityErrorCode(assertion.reason)
+        code: getGitHubIdentityErrorCode(assertion.code)
     });
 
     return error;

--- a/test/playwright/unit/ai/graph/assertExpectedIdentity.spec.mjs
+++ b/test/playwright/unit/ai/graph/assertExpectedIdentity.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}          from '@playwright/test';
-import {assertExpectedIdentity} from '../../../../../ai/graph/assertExpectedIdentity.mjs';
+import {test, expect}                                  from '@playwright/test';
+import {assertExpectedIdentity, IdentityAssertionCode} from '../../../../../ai/graph/assertExpectedIdentity.mjs';
 
 // Pure function over the static IDENTITIES table — imported directly; no Neo globals, no setup, no I/O.
 // Uses REAL identityRoots entries (@neo-gpt, @neo-opus-ada, @system) so the test exercises the live
@@ -8,12 +8,12 @@ import {assertExpectedIdentity} from '../../../../../ai/graph/assertExpectedIden
 test.describe('assertExpectedIdentity (fail-closed GitHub identity-drift detection core)', () => {
     test('ok when the authed login matches the expected agent (GitHub surface only)', () => {
         expect(assertExpectedIdentity({expected: '@neo-gpt', actualLogin: 'neo-gpt'}))
-            .toEqual({ok: true, reason: null});
+            .toEqual({ok: true, reason: null, code: IdentityAssertionCode.OK});
     });
 
     test('ok when the Memory-Core identity also matches', () => {
         expect(assertExpectedIdentity({expected: '@neo-gpt', actualLogin: 'neo-gpt', memoryCoreIdentity: '@neo-gpt'}))
-            .toEqual({ok: true, reason: null});
+            .toEqual({ok: true, reason: null, code: IdentityAssertionCode.OK});
     });
 
     test('normalizes the @ prefix on both the expected and the authed forms', () => {
@@ -27,6 +27,7 @@ test.describe('assertExpectedIdentity (fail-closed GitHub identity-drift detecti
         expect(result.ok).toBe(false);
         expect(result.reason).toContain('authed as neo-opus-ada');
         expect(result.reason).toContain('expected neo-gpt');
+        expect(result.code).toBe(IdentityAssertionCode.LOGIN_MISMATCH);
     });
 
     test('fail-closed when the Memory-Core identity drifts even though the GitHub login matches', () => {
@@ -34,6 +35,7 @@ test.describe('assertExpectedIdentity (fail-closed GitHub identity-drift detecti
 
         expect(result.ok).toBe(false);
         expect(result.reason).toContain('Memory-Core identity neo-opus-ada');
+        expect(result.code).toBe(IdentityAssertionCode.MEMORY_CORE_MISMATCH);
     });
 
     test('fail-closed when the expected identity is missing or unmappable', () => {
@@ -50,5 +52,31 @@ test.describe('assertExpectedIdentity (fail-closed GitHub identity-drift detecti
 
     test('fail-closed for an identity that has no githubLogin (e.g. the @system sender)', () => {
         expect(assertExpectedIdentity({expected: '@system', actualLogin: 'neo-gpt'}).ok).toBe(false);
+    });
+
+    // Every outcome carries a stable machine `code` so consumers branch on it, not on the
+    // human-readable `reason` prose. Each branch maps to exactly one IdentityAssertionCode.
+    test('emits a stable code for every outcome branch', () => {
+        expect(assertExpectedIdentity({expected: '@neo-gpt', actualLogin: 'neo-gpt'}).code)
+            .toBe(IdentityAssertionCode.OK);
+        expect(assertExpectedIdentity({expected: 'nonexistent-agent', actualLogin: 'neo-gpt'}).code)
+            .toBe(IdentityAssertionCode.EXPECTED_UNMAPPABLE);
+        expect(assertExpectedIdentity({expected: '@neo-gpt', actualLogin: null}).code)
+            .toBe(IdentityAssertionCode.NO_AUTHED_LOGIN);
+        expect(assertExpectedIdentity({expected: '@neo-gpt', actualLogin: 'neo-opus-ada'}).code)
+            .toBe(IdentityAssertionCode.LOGIN_MISMATCH);
+        expect(assertExpectedIdentity({expected: '@neo-gpt', actualLogin: 'neo-gpt', memoryCoreIdentity: 'neo-opus-ada'}).code)
+            .toBe(IdentityAssertionCode.MEMORY_CORE_MISMATCH);
+    });
+
+    test('IdentityAssertionCode is a frozen enum of the stable code values', () => {
+        expect(Object.isFrozen(IdentityAssertionCode)).toBe(true);
+        expect(IdentityAssertionCode).toEqual({
+            OK                  : 'OK',
+            EXPECTED_UNMAPPABLE : 'EXPECTED_UNMAPPABLE',
+            NO_AUTHED_LOGIN     : 'NO_AUTHED_LOGIN',
+            LOGIN_MISMATCH      : 'LOGIN_MISMATCH',
+            MEMORY_CORE_MISMATCH: 'MEMORY_CORE_MISMATCH'
+        });
     });
 });

--- a/test/playwright/unit/ai/services/github-workflow/HealthService.identity.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/HealthService.identity.spec.mjs
@@ -54,7 +54,7 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - agent iden
         process.env.NEO_AGENT_IDENTITY = '@neo-gpt';
         HealthService.agentLoginReader = async () => 'neo-gpt';
 
-        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null});
+        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null, code: 'OK'});
     });
 
     test('is a no-op when no expected identity is configured', async () => {
@@ -90,7 +90,7 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - agent iden
         HealthService.agentLoginReader         = async () => 'neo-gpt';
         HealthService.memoryCoreIdentityReader = async () => '@neo-gpt';
 
-        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null});
+        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null, code: 'OK'});
     });
 
     test('skips the Memory-Core leg when its reader yields null — the GitHub-login leg still asserts', async () => {
@@ -98,7 +98,7 @@ test.describe.serial('Neo.ai.services.github-workflow.HealthService - agent iden
         HealthService.memoryCoreIdentityReader = async () => null;
 
         HealthService.agentLoginReader = async () => 'neo-gpt';
-        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null});
+        expect(await HealthService.checkAgentIdentity()).toEqual({ok: true, reason: null, code: 'OK'});
 
         // A null Memory-Core read must not mask a GitHub-login drift.
         HealthService.agentLoginReader = async () => 'neo-opus-ada';

--- a/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/toolService.spec.mjs
@@ -244,7 +244,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         }, {
             assertExpectedIdentity: async () => ({
                 ok    : true,
-                reason: null
+                reason: null,
+                code  : 'OK'
             })
         });
 
@@ -262,7 +263,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         }, {
             assertExpectedIdentity: async () => ({
                 ok    : false,
-                reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt'
+                reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt',
+                code  : 'LOGIN_MISMATCH'
             })
         });
 
@@ -280,7 +282,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         }, {
             assertExpectedIdentity: async () => ({
                 ok    : false,
-                reason: "identity drift: expected identity 'missing-agent' is missing or unmappable in identityRoots"
+                reason: "identity drift: expected identity 'missing-agent' is missing or unmappable in identityRoots",
+                code  : 'EXPECTED_UNMAPPABLE'
             })
         });
 
@@ -297,7 +300,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         }, {
             assertExpectedIdentity: async () => ({
                 ok    : false,
-                reason: 'identity drift: no authed login resolved, expected neo-gpt'
+                reason: 'identity drift: no authed login resolved, expected neo-gpt',
+                code  : 'NO_AUTHED_LOGIN'
             })
         });
 
@@ -318,7 +322,8 @@ test.describe('Neo.ai.services.github-workflow.toolService — write identity gu
         }, {
             assertExpectedIdentity: async () => ({
                 ok    : false,
-                reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt'
+                reason: 'identity drift: authed as neo-opus-ada, expected neo-gpt',
+                code  : 'LOGIN_MISMATCH'
             })
         });
 


### PR DESCRIPTION
Resolves #13275

Authored by Claude Opus 4.8 (1M context), @neo-opus-ada (Ada). Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Finding B from the identity-drift detection-seam: emit a stable machine `code` from the shared `assertExpectedIdentity` core so consumers branch on a code, not on the human-readable `reason` prose — **and adopt it in the GitHub write-guard**.

`assertExpectedIdentity` returned only `{ok, reason}`, where `reason` is human-readable prose. The write-boundary guard (`ai/mcp/server/github-workflow/toolService.mjs` `getGitHubIdentityErrorCode`) derived its `GITHUB_*` codes by string-matching that prose (`reason.includes('Memory-Core identity')` etc.) — a fragile implicit contract that silently breaks on any rewording.

This PR:
1. Adds a stable generic `code` (a frozen `IdentityAssertionCode` enum: `OK` / `EXPECTED_UNMAPPABLE` / `NO_AUTHED_LOGIN` / `LOGIN_MISMATCH` / `MEMORY_CORE_MISMATCH`) to every `assertExpectedIdentity` return.
2. Refactors the write-guard's `getGitHubIdentityErrorCode` to map the generic `code` → its `GITHUB_*` code (a `switch`), **retiring the `reason.includes(...)` string-matching**. The exact `GITHUB_*` output taxonomy is preserved.

`reason` stays for human-readable detail. Additive on the core side — any `.ok` / `.reason` consumer is unaffected.

Evidence: L2 (pure-function unit coverage of the `code` per branch + the frozen enum + the write-guard's identity-guard spec re-keyed on `code` + the HealthService consumer spec) -> L2 required (fully unit-coverable; no runtime AC). No residuals.

Related: #13244
Related: #13243
Related: #13252

## Deltas from ticket

- The ticket proposed bare string codes; this ships them as a frozen exported `IdentityAssertionCode` enum so consumers reference named constants, not magic strings.
- `code` is present on EVERY return (including `OK`), not only failures — a sometimes-present field is a footgun. This required updating `HealthService.identity.spec`'s exact-match (`toEqual`) success assertions to include `code: 'OK'` (the additive field's honest blast radius; real consumers read fields individually and are unaffected).
- Per @neo-gpt's #13277 review (the close-target must not overclaim the write-guard adoption): the write-guard now actually consumes the `code`, so this PR **fully delivers** #13275 rather than leaving the adoption as a post-merge residual. The write-guard's spec fakes were updated to faithfully return the core's `code`.
- HealthService's own wrapper early-returns (the no-op + the reader-throw failure) intentionally stay `{ok, reason}` — no consumer reads their `code` yet; full `code`-propagation through HealthService is a follow-up if a consumer needs it.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs` over the core spec + `HealthService.identity.spec` + `toolService.spec` + `McpServerListToolsSmoke.spec` -> **58 passed**. Covers: the core `code` per branch + frozen enum; the write-guard's identity-guard tests re-keyed on `code` (exact `GITHUB_*` outputs preserved); the cross-server smoke loading the github-workflow `toolService` with the new import.
- `check-whitespace` / `check-shorthand` / `check-ticket-archaeology` on all changed files -> 0 violations.

## Post-Merge Validation

No residuals — both the core `code` and the write-guard adoption land in this PR.

## Commits

- `c2ba1ef82` — `feat(ai): emit a stable code from assertExpectedIdentity (#13275)`
- `29fbbad8c` — `feat(ai): consume the identity code in the GitHub write-guard (#13275)`
