### PR TITLE
feat(examples): wire interactive dock-splitter resize + enable NL (#13278)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -1,14 +1,16 @@
 import DockLayoutAdapter from '../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockZoneModel     from '../../../src/dashboard/DockZoneModel.mjs';
 import Viewport          from '../../../src/container/Viewport.mjs';
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits for tab zones
 
 /**
  * A representative dock-zone document (`neo.harness.dockZone.v1`): a horizontal split of a two-tab main zone and a
  * vertical side-split of two single-tab zones, over four items. The shape `Neo.dashboard.DockLayoutAdapter.project`
- * consumes — see its spec for the full contract.
+ * consumes — see its spec for the full contract. Used as the example's INITIAL committed document; the live document
+ * advances on each splitter resize (see `MainContainer#dockModel`).
  * @type {Object}
  */
-const dockModel = {
+const initialDockModel = {
     schema: 'neo.harness.dockZone.v1',
     root  : 'root',
     items : {
@@ -39,13 +41,20 @@ const resolveComponentRef = componentRef => ({
 });
 
 /**
- * @summary Standalone example for the dashboard dock-zone layout system.
+ * @summary Standalone, interactive example for the dashboard dock-zone layout system.
  *
- * Builds a representative {@link Neo.dashboard.DockZoneModel} document, then projects it through
- * {@link Neo.dashboard.DockLayoutAdapter} into a live container of split / tab zones with splitter affordances — the
- * missing standalone showcase + first *runtime* exercise of `DockLayoutAdapter.project`, which until now was only
- * unit-tested and never run in a live app's render path. This is the **static** render slice: the splitters render, but
- * the resize commit loop is not wired here (see the items config below); that stays in the interactive slice.
+ * Builds a representative {@link Neo.dashboard.DockZoneModel} document, projects it through
+ * {@link Neo.dashboard.DockLayoutAdapter} into a live container of split / tab zones with splitter affordances, and
+ * wires the **resize commit loop** end-to-end: dragging a splitter commits a `resizeSplit` operation through
+ * `DockZoneModel`, and the layout re-projects from the new committed document.
+ *
+ * The example owns the committed document ({@link #dockModel}) as the single source of truth and drives the loop with
+ * the two callbacks `DockSplitter` calls — a clean reducer / view-sync split:
+ * - {@link #applyDockZoneOperation} is the **reducer**: a pure `DockZoneModel.applyOperation` over the current document.
+ * - {@link #onDockZoneDocumentChange} is the **view-sync**: it stores the committed document and re-projects from it.
+ *
+ * This is the first *runtime* exercise of the full model → operation → re-projection cycle in a standalone app; Slice 1
+ * delivered the static render. See `learn/agentos/HarnessDockZoneModel.md` for the model/projection contract.
  * @class Neo.examples.dashboard.dock.MainContainer
  * @extends Neo.container.Viewport
  */
@@ -59,16 +68,76 @@ class MainContainer extends Viewport {
         /**
          * @member {Object} layout={ntype:'fit'}
          */
-        layout: {ntype: 'fit'},
-        /**
-         * The dock layout: the model projected once into a live container — split + tab zones + splitter affordances.
-         * The splitters render, but the resize commit loop (`dockZoneDocument` / `applyDockZoneOperation` +
-         * `onDockZoneDocumentChange`) is not wired here — that stays in the interactive slice; this is the static render.
-         * @member {Object[]} items
-         */
-        items: [
-            DockLayoutAdapter.project(dockModel, {resolveComponentRef})
-        ]
+        layout: {ntype: 'fit'}
+        // `items` is built in construct() — not here — so each projection can carry the instance-bound
+        // applyDockZoneOperation + onDockZoneDocumentChange callbacks the resize commit loop needs.
+    }
+
+    /**
+     * The live committed dock-zone document — the single source of truth the view projects from. Initialized to
+     * `initialDockModel`; advanced by {@link #onDockZoneDocumentChange} on each committed splitter resize.
+     * @member {Object|null} dockModel=null
+     */
+    dockModel = null
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.dockModel = initialDockModel;
+        me.add(me.projectDockModel())
+    }
+
+    /**
+     * The owning reducer `DockSplitter.commitResizeSplit` calls: applies a splitter-emitted operation descriptor
+     * against the live committed document and returns `DockZoneModel`'s fail-closed `{document, errors}` result.
+     * Pure — the view sync happens in {@link #onDockZoneDocumentChange}, which the splitter calls on success.
+     * @param {Object} descriptor The `resizeSplit` operation descriptor.
+     * @returns {{document: Object, errors: String[]}}
+     */
+    applyDockZoneOperation(descriptor) {
+        return DockZoneModel.applyOperation(this.dockModel, descriptor)
+    }
+
+    /**
+     * The view-sync `DockSplitter` calls after a successful commit: stores the new committed document and re-projects
+     * the layout from it.
+     *
+     * Deferred one tick: this fires synchronously from inside the committing splitter's `onDragEnd` (via
+     * `commitResizeSplit`). Re-projecting immediately would `removeAll()` — destroying that splitter mid-handler, a
+     * use-after-destroy on the rest of `onDragEnd`. The `isDestroyed` guard covers teardown before the tick fires.
+     * @param {Object} document The committed dock-zone document.
+     */
+    onDockZoneDocumentChange(document) {
+        let me = this;
+
+        me.dockModel = document;
+
+        me.timeout(0).then(() => {
+            if (!me.isDestroyed) {
+                me.removeAll();
+                me.add(me.projectDockModel())
+            }
+        })
+    }
+
+    /**
+     * Projects the live committed {@link #dockModel} into a dock-zone container config, threading the instance-bound
+     * resize-commit-loop callbacks onto every projected splitter affordance.
+     * @returns {Object}
+     */
+    projectDockModel() {
+        let me = this;
+
+        return DockLayoutAdapter.project(me.dockModel, {
+            applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
+            onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
+            resolveComponentRef
+        })
     }
 }
 

--- a/examples/dashboard/dock/neo-config.json
+++ b/examples/dashboard/dock/neo-config.json
@@ -2,5 +2,6 @@
     "appPath"    : "examples/dashboard/dock/app.mjs",
     "basePath"   : "../../../",
     "environment": "development",
-    "mainPath"   : "./Main.mjs"
+    "mainPath"   : "./Main.mjs",
+    "useAiClient": true
 }

--- a/test/playwright/unit/dashboard/DockSplitter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockSplitter.spec.mjs
@@ -151,4 +151,85 @@ test.describe('Neo.dashboard.DockSplitter', () => {
         expect(rejected).toHaveLength(1);
         expect(rejected[0].descriptor.sizes).toEqual([1500, -500])
     });
+
+    test('commits through an owning applyDockZoneOperation reducer and notifies onDockZoneDocumentChange', async () => {
+        let parent       = createParent(),
+            committedDoc = {marker: 'from-reducer'},
+            reducerCalls = [],
+            notifyCalls  = [];
+
+        // No dockZoneDocument supplied: the reducer path must be preferred over the local-document fallback.
+        splitter = Neo.create(DockSplitter, {
+            applyDockZoneOperation(descriptor, instance) {
+                reducerCalls.push({descriptor, instance});
+                return {document: committedDoc, errors: []}
+            },
+            boundaryIndex  : 0,
+            id             : 'dock-splitter-reducer',
+            onDockZoneDocumentChange(document, descriptor, instance) {
+                notifyCalls.push({document, descriptor, instance})
+            },
+            orientation    : 'horizontal',
+            parentComponent: parent,
+            splitNodeId    : 'root'
+        });
+
+        splitter.dragZone = {
+            dragEnd: () => {}
+        };
+
+        await splitter.captureDragStart({clientX: 100, clientY: 0});
+        const result = splitter.onDragEnd({clientX: 0, clientY: 0});
+
+        // the owning reducer is consulted with the resize descriptor + the splitter instance
+        expect(reducerCalls).toHaveLength(1);
+        expect(reducerCalls[0].instance).toBe(splitter);
+        expect(reducerCalls[0].descriptor).toEqual({operation: 'resizeSplit', sizes: [600, 400], splitNodeId: 'root'});
+
+        // the reducer's returned document is adopted as the splitter's doc + handed to the notify callback
+        expect(result.errors).toEqual([]);
+        expect(result.document).toBe(committedDoc);
+        expect(splitter.dockZoneDocument).toEqual(committedDoc); // adopted (the dockZoneDocument_ config clones on set)
+        expect(notifyCalls).toHaveLength(1);
+        expect(notifyCalls[0].document).toBe(committedDoc);
+        expect(notifyCalls[0].descriptor).toEqual({operation: 'resizeSplit', sizes: [600, 400], splitNodeId: 'root'});
+        expect(notifyCalls[0].instance).toBe(splitter)
+    });
+
+    test('does not adopt or notify when the owning reducer rejects the resize', async () => {
+        let parent       = createParent(),
+            reducerCalls = [],
+            notified     = false,
+            rejected     = [];
+
+        splitter = Neo.create(DockSplitter, {
+            applyDockZoneOperation(descriptor) {
+                reducerCalls.push(descriptor);
+                return {document: createDocument(), errors: ['rejected by reducer']}
+            },
+            boundaryIndex   : 0,
+            dockZoneDocument: createDocument(),
+            id              : 'dock-splitter-reducer-reject',
+            onDockZoneDocumentChange() {
+                notified = true
+            },
+            orientation     : 'horizontal',
+            parentComponent : parent,
+            splitNodeId     : 'root'
+        });
+
+        splitter.dragZone = {
+            dragEnd: () => {}
+        };
+        splitter.on('dockSplitterResizeRejected', data => rejected.push(data));
+
+        await splitter.captureDragStart({clientX: 100, clientY: 0});
+        const result = splitter.onDragEnd({clientX: 0, clientY: 0});
+
+        expect(reducerCalls).toHaveLength(1);                                    // the reducer WAS consulted
+        expect(result.errors).toEqual(['rejected by reducer']);
+        expect(notified).toBe(false);                                            // notify is gated on success — NOT fired
+        expect(splitter.dockZoneDocument.nodes.root.sizes).toEqual([0.7, 0.3]);  // the local doc is left untouched
+        expect(rejected).toHaveLength(1)                                         // the rejection event fired instead
+    });
 });


### PR DESCRIPTION
## Summary

Slice 2 of #13247 — wires the **interactive resize commit loop** into the standalone `examples/dashboard/dock/` example, atop Slice 1 (static render, #13255). Dragging a splitter now commits a `resizeSplit` through `DockZoneModel` and the layout re-projects from the new committed document — the first **runtime** exercise of the full model → operation → re-projection cycle in a standalone app.

`MainContainer` owns the committed dock-zone document (`this.dockModel`) as the single source of truth and drives `DockSplitter`'s two callbacks as a clean **reducer / view-sync split**:
- `applyDockZoneOperation` — the **reducer**: a pure `DockZoneModel.applyOperation` over the current document.
- `onDockZoneDocumentChange` — the **view-sync**: stores the committed document and re-projects, **deferred one tick**.

`items` is built in `construct()` (not static config) so each projection can carry the instance-bound callbacks. The deferral is load-bearing: the notify fires synchronously from the committing splitter's `onDragEnd`, so an immediate `removeAll()` would destroy that splitter mid-handler (a use-after-destroy on the rest of `onDragEnd`); `me.timeout(0)` + an `isDestroyed` guard push the re-projection past `onDragEnd`.

**NL support (operator-directed):** `neo-config.json` gains `useAiClient: true`, so the App-Worker AI Client (`src/ai/Client.mjs`) boots and an agent can connect via the Neural Link bridge to inspect + drive the live dock layout (`set_instance_properties` / `call_method` on the splitters / `undo`). The example becomes a real dogfooding + verification surface for the resize loop.

No `src/dashboard/` behavior change — this wires the already-shipped capability (#13225 drag-wiring, #13160 `resizeSplit` op).

Resolves #13278

Refs #13247 (parent), #13253 (Slice 1), #13255 (Slice 1 PR), #13225 / #13160 (capability — merged), #13158 (QT-parity docking-polish epic — its "interactive splitter resize" gap is delivered by #13225 / #13160; scope refresh confirmed by @neo-claude-opus)

Evidence: L2 (70 dashboard unit tests green incl. 2 new `DockSplitter` reducer + notify tests and the resize round-trip; example render browser-verified via the dev-server preview, console clean) → L2 required (#13278 ACs are the wiring + the owning-reducer pattern + the previously-uncovered callback paths + a visual render; an NL-driven end-to-end drag is broader than this slice's ACs — it is the post-merge validation the new `useAiClient` flag enables).

## Test Evidence

`UNIT_TEST_MODE=true playwright -c …unit.mjs test/playwright/unit/dashboard/` at head `513bf0d84` — **70 green**:

- **`DockSplitter.spec.mjs` (2 new)** — covers the two callbacks the example relies on, previously untested (only the local-document path was):
  - the owning `applyDockZoneOperation` **reducer** path is preferred over the local-document fallback (no `dockZoneDocument` supplied); the descriptor reaches the reducer with the splitter instance, and the reducer's returned document is adopted as the splitter's doc + threaded to the notify;
  - `onDockZoneDocumentChange` fires once on a successful commit with the committed document; it does **not** fire (and the local doc is left untouched) when the reducer rejects the resize.
- **Regression** — the existing `DockSplitter` (local-document path + size-vector rejection), `DockLayoutAdapter`, and `DockZoneModel` suites stay green.

**Render verified in-browser** (dev-server preview at `examples/dashboard/dock/`): the `construct()`-built projection mounts the full tree — 2 splits (root horizontal + side vertical), 2 splitter affordances, 3 tab zones, 4 panels (Strategy / Swarm / Terminal / Logs) — at the model's proportions (measured child widths 314 : 6 : 169 ≈ 0.65 : 0.35; side-split 0.6 : 0.4). **Console clean**, including with `useAiClient: true` enabled (the AI Client boots without a bridge present and does not error).

`node --check` clean on the edited `.mjs`.

## Post-Merge Validation

- Run the example, connect the Neural Link bridge, and drive a `resizeSplit` (e.g. `call_method` on a splitter, or mutate the model) → the layout re-projects with the new sizes; `undo` reverts it. This is the NL-driven end-to-end path the `useAiClient` one-liner enables.
- Manually drag a splitter in a browser → the adjacent zones resize and persist through the committed model.

## Deltas

- **NL support is operator-directed** (mid-flight) — `useAiClient: true` makes the example Neural-Link-drivable, which is both the dogfooding payoff and the end-to-end verification path that headless synthetic events can't reach. Verified the example still renders cleanly (no console errors) with the AI Client booting absent a bridge.
- **Synthetic pointer-drag does not drive Neo's `DockSplitter`** in the headless preview: it listens to Neo's synthesized `drag:start`/`drag:end`, which the main-thread DragZone produces from **trusted** pointer events — `isTrusted: false` synthetic events don't engage it. So the end-to-end drag is unit-covered (the loop callbacks) + compositionally sound (the deferred re-projection re-uses the same `project()` + `add()` path the verified `construct()` render uses), and NL-drivable post-merge — not preview-scripted.
- **Advanced QT-parity demos** (auto-hide/pin, perspectives, grouped tab-drag) are #13158's *capability* layer, not yet built in `src/dashboard/` — out of scope here; the example grows to demonstrate them as those land (coordinated with @neo-claude-opus; Slice 3 = the auto-hide demo, teed up once the #13256 model seam gets its UI).

Authored by @neo-opus-vega (Claude Opus 4.8, Claude Code). Origin Session ID: a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
