### PR TITLE
fix(ai): wire tx-sweep into agent-disconnect (lock/tx coherence) (#13282)

### DIFF
--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -272,27 +272,36 @@ class Client extends Base {
     }
 
     /**
-     * @summary Release held write locks for one Bridge-stamped disconnected agent session.
+     * @summary Release held write locks AND sweep the open transaction for one Bridge-stamped disconnected
+     * agent session — both on the same frame, so the lock and transaction lifecycles cannot diverge silently.
      * App-side `agent_disconnected` frames are lifecycle notifications, not JSON-RPC. Require the full
-     * `(agentId, sessionId)` writer key before calling {@link Neo.ai.WriteGuard#releaseAgent}; a half-stamped
-     * frame is dropped so it cannot sweep every session for an agent or every agent sharing a session id.
+     * `(agentId, sessionId)` writer key before calling {@link Neo.ai.WriteGuard#releaseAgent} +
+     * {@link Neo.ai.TransactionService#sweep}; a half-stamped frame is dropped so it can neither release a
+     * whole agent (or every agent sharing a session id) nor sweep a transaction stack it cannot key.
      * @param {Object} [frame={}]
      * @param {String} [frame.agentId]
      * @param {String} [frame.sessionId]
-     * @returns {{released: Number}}
+     * @returns {{released: Number, swept: Boolean}}
      */
     handleAgentDisconnected(frame = {}) {
         const
-            {agentId, sessionId} = frame,
-            {writeGuard}         = this;
+            {agentId, sessionId}             = frame,
+            {transactionService, writeGuard} = this;
 
         if (typeof agentId !== 'string' || agentId === '' ||
             typeof sessionId !== 'string' || sessionId === '' ||
             !writeGuard) {
-            return {released: 0}
+            return {released: 0, swept: false}
         }
 
-        return writeGuard.releaseAgent({agentId, sessionId})
+        // The transaction lifecycle must not outlive the lock lifecycle: release the agent's held write-locks
+        // AND sweep its open transaction + undo stack on the same `agent_disconnected` frame — otherwise a
+        // disconnect (or worker restart) leaks an open transaction. `sweep` is the transaction-side counterpart
+        // to `releaseAgent`; both key on the same `(agentId, sessionId)` pair validated above.
+        const {released}      = writeGuard.releaseAgent({agentId, sessionId}),
+              {swept = false} = transactionService?.sweep({id: {agentId, sessionId}}) ?? {};
+
+        return {released, swept}
     }
 
     /**

--- a/test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs
+++ b/test/playwright/unit/ai/ClientAgentDisconnect.spec.mjs
@@ -122,4 +122,47 @@ test.describe('Neo.ai.Client - agent disconnect lock release', () => {
             lock('neo-opus-vega', 'sess-1', ['root', 'c'])
         ])
     });
+
+    // The lock + transaction lifecycles must not diverge: a disconnect frame that releases locks must ALSO
+    // sweep the writer's open transaction. (sweep's own behavior is covered by TransactionService.spec; these
+    // assert the Client WIRING — that handleAgentDisconnected calls it with the same validated writer pair.)
+    test('handleAgentDisconnected sweeps the disconnected writer\'s transaction stack alongside releasing locks', () => {
+        client.writeGuard.requestWrite(lock('neo-opus-ada', 'sess-1', ['root', 'panel']));
+
+        const sweptIds      = [],
+              realTxService = client.transactionService;
+
+        client.transactionService = {sweep: ({id}) => { sweptIds.push(id); return {swept: true} }};
+
+        try {
+            const result = client.handleAgentDisconnected({agentId: 'neo-opus-ada', sessionId: 'sess-1'});
+
+            expect(result.released).toBe(1);                                            // lock released
+            expect(result.swept).toBe(true);                                            // tx stack swept (the wiring)
+            expect(sweptIds).toEqual([{agentId: 'neo-opus-ada', sessionId: 'sess-1'}]); // keyed on the same writer pair
+            expect(client.writeGuard.heldLocks()).toHaveLength(0)
+        } finally {
+            client.transactionService = realTxService
+        }
+    });
+
+    test('a half-stamped disconnect frame never sweeps the transaction stack (fail-closed)', () => {
+        const sweptIds      = [],
+              realTxService = client.transactionService;
+
+        client.transactionService = {sweep: ({id}) => { sweptIds.push(id); return {swept: true} }};
+
+        try {
+            for (const frame of [{agentId: 'neo-opus-ada'}, {sessionId: 'sess-1'}, {agentId: 'neo-opus-ada', sessionId: ''}]) {
+                const result = client.handleAgentDisconnected(frame);
+
+                expect(result.released).toBe(0);
+                expect(result.swept).toBe(false)
+            }
+
+            expect(sweptIds).toHaveLength(0) // incomplete identity → neither release nor sweep
+        } finally {
+            client.transactionService = realTxService
+        }
+    });
 });


### PR DESCRIPTION
## Summary

`Neo.ai.TransactionService.sweep` — abort the open transaction + retire the session's undo stack on disconnect — was **defined but never called** (`grep '\.sweep(' src/ ai/` → empty). `Client.handleAgentDisconnected` ran only `WriteGuard.releaseAgent`, so an `agent_disconnected` frame released the agent's write-locks but **leaked its open transaction** — the exact lock/transaction lifecycle divergence the sweep's own JSDoc says it exists to prevent (*"the caller runs both on an `agent_disconnected` frame, so the lock + transaction lifecycles cannot diverge silently"*). Found while auditing #13221's completeness.

Fix: `handleAgentDisconnected` now calls `transactionService.sweep({id: {agentId, sessionId}})` alongside `releaseAgent`, after the same identity validation, and returns `{released, swept}`. Both fail closed on the incomplete identity already rejected; the sole caller (`onSocketMessage`) ignores the return; `WriteGuard.releaseAgent` is unchanged.

Resolves #13282

Refs #13221 (NL undo Slice-1 — this completes its AC7), #13230 (TransactionService core), #13236 (stack key), #13012 (Agent Harness, Pillar-2)

Evidence: L2 (24 unit tests green — `ClientAgentDisconnect` 6 incl. 2 new wiring tests + `TransactionService` 18; the sweep's own behavior is covered by `TransactionService.spec`; the return-shape blast radius was verified isolated) → L2 required (#13282's ACs are the wiring + the fail-closed symmetry, both unit-asserted; a live-bridge disconnect e2e is broader, not a #13282 AC).

## Test Evidence

`UNIT_TEST_MODE=true playwright -c …unit.mjs` at head `4208dbdcd`:

- **`ClientAgentDisconnect.spec.mjs` (2 new, 6 total green)** — the Client *wiring* (sweep's behavior is `TransactionService.spec`'s job):
  - a complete frame sweeps the disconnected writer's transaction stack via `TransactionService.sweep`, keyed on the **same** `(agentId, sessionId)` pair it releases locks for (`{released: 1, swept: true}`);
  - a half-stamped frame (`{agentId}` / `{sessionId}` / empty-string) **never** sweeps and never releases — `{released: 0, swept: false}`, fail-closed symmetry with `releaseAgent`.
  - the 4 existing release-only tests stay green under the new return shape.
- **`TransactionService.spec.mjs` (18 green)** — `sweep`, `abort`, `timeout`, caps, `stackOf` — unchanged.

`node --check` clean on `src/ai/Client.mjs`.

## Post-Merge Validation

- A connected agent opens a transaction (any captured mutation), then disconnects → its open transaction + undo stack are swept; a reconnect on the same `(agentId, sessionId)` key starts clean (no leaked open tx). Observable on the now-NL-drivable example (#13279) via a `manage_connection` disconnect or a bridge teardown.

## Deltas

- **Return shape** `{released}` → `{released, swept}`. Blast radius verified isolated: the sole src caller (`Client.onSocketMessage`) ignores the return; only `ClientAgentDisconnect.spec` asserted it (updated); `WriteGuard.releaseAgent` (asserted by `WriteGuard`/`LockRegistry` specs) is unchanged.
- **Scope: the disconnect path only.** Lease/timeout-driven sweep (wiring `TransactionService.timeout` to a daemon) is a separate concern, out of scope (noted on #13282).
- **#13221 AC10 (live-tree e2e undo round-trip) remains** its other open sub-lane — now enabled by the NL-drivable example (#13279). #13221 stays open until it lands; this PR closes only the AC7 wiring (its own ticket #13282).

Authored by @neo-opus-vega (Claude Opus 4.8, Claude Code). Origin Session ID: a0bc6b23-78c5-4bd7-b944-9db5e236f42d.
