### PR TITLE
fix(wake): re-apply read-state reconcile in the delivery-retry path (#13281)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1214,7 +1214,24 @@ async function attemptDeliveryRetries() {
     for (const [subId, entry] of pendingDeliveryRetries) {
         if (entry.nextAttemptAt > now) continue;
 
-        const digest  = buildWakeDigest(entry.identity, entry.events);
+        // Re-apply the read-state reconcile the initial digest used (see `flushSubscription`): a message
+        // the recipient read between the failed delivery and this retry must NOT be re-delivered. The
+        // watermark filter is deliberately NOT re-applied — it advanced past these events on the first
+        // attempt, and the retry's whole job is to re-deliver those below-watermark events; only the
+        // read-state axis is reconciled here.
+        const liveMessages = entry.events.messages.filter(ev => !isMessageReadFor(db, ev.messageId, entry.identity));
+
+        if (liveMessages.length === 0 && entry.events.tasks.length === 0 &&
+            entry.events.permissions.length === 0 && entry.events.heartbeats.length === 0
+        ) {
+            pendingDeliveryRetries.delete(subId);
+            writeLog('INFO',
+                `[Wake Daemon] Retry for ${subId} dropped: all queued messages were read before re-delivery.`
+            );
+            continue;
+        }
+
+        const digest  = buildWakeDigest(entry.identity, {...entry.events, messages: liveMessages});
         const outcome = await deliverDigest(entry.subscription, digest);
 
         if (outcome === 'failed') {

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -397,6 +397,96 @@ test.describe('Wake Daemon', () => {
         expect(logContents).toContain('2 new messages');          // coalesced breakdown
     });
 
+    test('#13281: a retry drops a message read between the failed delivery and the re-attempt', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-retry-readfilter';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId, label: 'AGENT', properties: { name: 'Test Agent Retry ReadFilter' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                // test-fail throws on the first attempt → the wake is queued for retry. We mark the
+                // message read before the retry fires, so the retry's read-reconcile must drop it.
+                harnessTargetMetadata: { adapter: 'test-fail', coalesceWindow: 1 }
+            }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        // The wake fires on SENT_TO; DELIVERED_TO carries the per-recipient readAt the daemon reconciles
+        // against live at flush/retry time. Updating that edge (no GraphLog row) simulates the recipient
+        // reading the message between the failed delivery and the retry, without firing a new wake.
+        const msgId = 'msg_' + crypto.randomUUID();
+        const delId = 'edge_' + crypto.randomUUID();
+
+        const markMessageRead = () => {
+            db.prepare('UPDATE Edges SET data = ? WHERE id = ?').run(JSON.stringify({
+                id: delId, source: msgId, target: agentId, type: 'DELIVERED_TO',
+                properties: { readAt: '2026-06-15T00:00:00.000Z' }
+            }), delId);
+        };
+
+        let markedRead = false;
+        const dropPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Retry was not dropped after the message was read within timeout')), 25000);
+            const onData = (data) => {
+                const out = data.toString();
+                // First delivery failure → the wake is now queued for retry. Mark the message read so the
+                // retry's read-reconcile must drop it rather than re-deliver the stale digest.
+                if (!markedRead && out.includes('Failed to deliver via test-fail')) {
+                    markedRead = true;
+                    markMessageRead();
+                }
+                if (out.includes(`Retry for ${subId} dropped: all queued messages were read before re-delivery`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
+            id: msgId, label: 'MESSAGE', properties: { from: '@sender', subject: 'Read Before Retry', priority: 'normal' }
+        }));
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        const sentId = 'edge_' + crypto.randomUUID();
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(
+            sentId, JSON.stringify({ id: sentId, source: msgId, target: agentId, type: 'SENT_TO' }),
+            msgId, agentId, 'SENT_TO'
+        );
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(sentId, 'edges');
+
+        db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(
+            delId, JSON.stringify({ id: delId, source: msgId, target: agentId, type: 'DELIVERED_TO', properties: { readAt: null } }),
+            msgId, agentId, 'DELIVERED_TO'
+        );
+
+        await dropPromise;
+
+        // The retry was dropped (read-reconciled), not re-attempted or capped: without the fix the retry
+        // would rebuild the stale digest and throw again, eventually hitting the "Giving up" cap.
+        const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+        expect(logContents).toContain(`Retry for ${subId} dropped`);
+        expect(logContents).not.toContain('Giving up wake delivery');
+    });
+
     test('a message-wake digest omits the lane directive — it is heartbeat-only (#13118, #13137)', async () => {
         const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-directive';


### PR DESCRIPTION
Resolves #13281

Authored by Claude Opus 4.8 (1M context), @neo-opus-ada (Ada). Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

Fixes the swarm-wide stale-wake residual filed as #13281 (hit 4+ times this nightshift): the wake daemon re-firing already-read, already-handled messages as "new".

**Root cause (V-B-A'd to the line).** The wake daemon has two digest paths. The INITIAL digest-build (`flushSubscription`, `daemon.mjs:643`) filters already-read messages via `isMessageReadFor`. But a delivery whose adapter dispatch THREW is re-queued for retry carrying the EVENTS, and `attemptDeliveryRetries` (`daemon.mjs:1217`) rebuilt the retry digest straight from those stale carried events — **without** re-applying the read-filter. So a message read between a failed delivery and its retry was re-delivered.

**The fix.** `attemptDeliveryRetries` now re-applies the `isMessageReadFor` read-state reconcile before rebuilding the digest, and drops the retry entirely when every queued message is now-read. The watermark filter is deliberately NOT re-applied — it advanced past these events on the first attempt, and the retry's whole job is to re-deliver those below-watermark events; only the read-state axis is reconciled.

Evidence: L2 (a new daemon-subprocess test exercising the read-then-retry path + the full `daemon.spec.mjs` regression). No residuals.

## Deltas from ticket

- The ticket named two candidate mechanisms (digest `readAt`-leak vs the retry store) and asked the implementer to V-B-A which. V-B-A confirmed it is the **retry-store path** (`attemptDeliveryRetries` rebuilding from stale events), not the digest-build path (which already filters at line 643). The fix is in the retry path only.
- The ticket's first candidate direction ("a post-digest read-state re-check before firing") is what landed, scoped to the retry rebuild.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` -> **30 passed** (the new #13281 test + 29 existing, incl. the #13077 retry-then-cap + coalesce + #12479 read-filter).
- New test `#13281: a retry drops a message read between the failed delivery and the re-attempt` — spawns the daemon with the `test-fail` adapter, marks the message read on the first delivery failure, and asserts the retry is dropped (read-reconciled) rather than re-delivered or capped. It times out **without** the fix (the "Retry dropped" log only appears with the read-reconcile), so it is a genuine regression guard.
- `check-whitespace` / `check-shorthand` / `check-ticket-archaeology` on both files -> 0 violations.

## Post-Merge Validation

- [ ] Live: an already-read / already-handled message no longer re-fires a `[WAKE]` digest on a later poll cycle (the empirical residual this fixes).

## Commits

- `fff0444e0` — `fix(wake): re-apply read-state reconcile in the delivery-retry path (#13281)`
