### PR TITLE
fix(memory-core): decouple add_memory graph projection (#13283)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -5,7 +5,7 @@ import GraphService          from './GraphService.mjs';
 import logger                from '../../mcp/server/memory-core/logger.mjs';
 import SessionService        from './SessionService.mjs';
 import {withTimeout}         from './helpers/withTimeout.mjs';
-import {appendWalMemory, getMissingMemoryWalLeaves, pruneReconciledWalSegments, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
+import {appendWalGraphProjectionMarker, appendWalMemory, getMissingMemoryWalLeaves, pruneReconciledWalSegments, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
 import {buildChatModel}      from '../../provider/buildChatModel.mjs';
 import aiConfig              from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId} from '../../mcp/server/shared/services/RequestContextService.mjs';
@@ -34,6 +34,26 @@ const MINI_SUMMARY_BACKFILL_MAX_RUN_MS = 600000;
  * @type {Number}
  */
 const CHROMA_FETCH_TIMEOUT_MS = 10000;
+
+/**
+ * Bounded in-process graph-projection retry for WAL-accepted memories. This is the cloud-safe host:
+ * it does not require a local orchestrator daemon, and a persistent MCP server keeps retrying
+ * transient graph contention without making `add_memory` wait.
+ * @type {Number}
+ */
+const GRAPH_PROJECTION_MAX_ATTEMPTS = 5;
+
+/**
+ * Base delay for graph projection retries.
+ * @type {Number}
+ */
+const GRAPH_PROJECTION_RETRY_BASE_MS = 250;
+
+/**
+ * Maximum delay for graph projection retries.
+ * @type {Number}
+ */
+const GRAPH_PROJECTION_RETRY_MAX_MS = 5000;
 
 /**
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
@@ -300,8 +320,10 @@ class MemoryService extends Base {
      *    only deliberate error envelopes; everything after them is never-fail.
      * 2. **Durable JSONL write-ahead append** — the full payload lands on local disk first, so a
      *    crash or embed failure never loses the turn.
-     * 3. **Synchronous graph writes** — the `AGENT_MEMORY` node + edges keep the read-after-write
-     *    recency contract (`queryRecentTurns` reads these rows "fresh the instant the write returns").
+     * 3. **Asynchronous graph projection** — the `AGENT_MEMORY` node + edges are derived from the
+     *    accepted WAL record and must never veto the turn save. `queryRecentTurns` overlays pending
+     *    WAL records until projection catches up, preserving read-after-write recency without making
+     *    SQLite graph availability part of the acceptance gate.
      * 4. **No embed on this path.** The model-dependent Chroma `collection.add` is owned entirely
      *    by the orchestrator-managed embed daemon (`ai/daemons/embed/daemon.mjs`), which drains the
      *    WAL with retry/backoff and marks records reconciled. Until a record is drained, the WAL
@@ -402,11 +424,14 @@ class MemoryService extends Base {
             //    awaited here, which also lost the graph node below whenever it threw.
             const walDir       = aiConfig.memoryWal.dir;
             const {segmentKey} = await appendWalMemory(
-                {id: memoryId, timestamp: now, metadata, document: combinedText},
+                {id: memoryId, timestamp: now, metadata, document: combinedText, graphProjectionVersion: 1},
                 {dir: walDir}
             );
 
-            // 2. Topologically inject the new memory into the Native Edge Graph
+            // 2. Schedule the Native Edge Graph projection from the accepted WAL record. This is
+            //    derived work: graph contention/unavailability must not reject the mandatory
+            //    add_memory save once the WAL append has succeeded. Recency reads merge pending WAL
+            //    rows until the graph projection catches up.
             const memoryProperties = {
                 ...(canonicalIdentity ? { agentIdentity: canonicalIdentity } : {}),
                 ...(userId ? { userId } : {}),
@@ -414,30 +439,17 @@ class MemoryService extends Base {
                 timestamp
             };
 
-            GraphService.upsertNode({
-                id: memoryId,
-                type: 'AGENT_MEMORY',
-                name: `Memory: ${timestamp}`,
-                description: `Agent thought flow inside session ${sessionId}.`,
-                semanticVectorId: memoryId,
-                properties: memoryProperties
+            this._scheduleMemoryGraphProjection({
+                memoryId,
+                timestamp,
+                sessionId,
+                segmentKey,
+                walDir,
+                requestIdentity,
+                memoryProperties
             });
 
-            // 3. Stamp write-time provenance when the transport resolved a real AgentIdentity.
-            // Fallback-only identities remain scalar metadata so single-tenant/unseeded callers
-            // keep working without hallucinated graph edges to nodes that do not exist.
-            if (requestIdentity) {
-                GraphService.linkNodes(memoryId, requestIdentity, 'AUTHORED_BY', 1.0, {
-                    timestamp,
-                    userId      : requestIdentity,
-                    sharedEntity: true
-                });
-            }
-
-            // 4. Link this memory dynamically to the active context frontier
-            GraphService.linkNodes('frontier', memoryId, 'SPAWNED_MEMORY', 0.8);
-
-            // 5. WAL retention (write-side, best-effort): bound the reconciled-segment count on
+            // 3. WAL retention (write-side, best-effort): bound the reconciled-segment count on
             //    each append. Never prunes a segment holding a pending record, never fails the save.
             //    The embed itself no longer runs here — the orchestrator-managed embed daemon
             //    (`ai/daemons/embed/daemon.mjs`) drains pending records with retry/backoff; the
@@ -448,10 +460,11 @@ class MemoryService extends Base {
                 activeSegmentKey: segmentKey
             }).catch(() => {});
 
-            // 6. Best-effort inline tweet-summary via the configured chat model (the modelProvider
+            // 4. Best-effort inline tweet-summary via the configured chat model (the modelProvider
             //    SSOT — reads the resolved leaf at the use site, never aliases it). Fire-and-forget
-            //    so the per-turn write stays fast: the memory node above is already written (fresh
-            //    for recency recall); this only enriches it asynchronously. Fully self-contained —
+            //    so the per-turn write stays fast: the memory is already WAL-accepted and visible
+            //    through the pending recency overlay; this only enriches graph projection
+            //    asynchronously. Fully self-contained —
             //    errors/timeouts never touch the write path, and a null summary never hides the turn
             //    (recency recall falls back to raw content). The summarizer choice (local gemma4 OR
             //    remote gemini-flash) is the user's deployment-agnostic provider setting → cloud-ready.
@@ -468,15 +481,15 @@ class MemoryService extends Base {
                 }
             }).catch(() => {});
 
-            // 7. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
+            // 5. Mailbox delta signal: per-turn piggyback of inbox unread-count + latest preview.
             //    Non-fatal — buildMailboxDelta swallows its own errors and returns null on failure,
             //    so a degraded mailbox query never blocks a successful memory write.
             const mailbox = buildMailboxDelta();
 
             return {id: memoryId, sessionId, timestamp, message: "Memory successfully added", mailbox};
         } catch (error) {
-            // Reaches here only for LOCAL write failures (WAL filesystem / SQLite graph) — the
-            // embed and every other model-dependent step are off this path by construction.
+            // Reaches here only for WAL acceptance or validation-adjacent failures. Graph
+            // projection, embed, and every model-dependent step are off this path by construction.
             logger.error('[MemoryService] Error adding memory:', error);
             return {
                 error  : 'Failed to add memory',
@@ -484,6 +497,86 @@ class MemoryService extends Base {
                 code   : 'MEMORY_ADD_ERROR'
             };
         }
+    }
+
+    /**
+     * @summary Schedules best-effort graph projection for a WAL-accepted memory.
+     *
+     * The mandatory durability contract ends at the WAL append. Graph rows and provenance edges are
+     * derived projection work, so they are deliberately moved behind the acceptance boundary; any
+     * graph failure is logged while the WAL row remains visible as projection-pending rather than
+     * surfacing as an `add_memory` error envelope.
+     *
+     * @param {Object} options
+     * @param {String} options.memoryId
+     * @param {String} options.timestamp ISO timestamp.
+     * @param {String} options.sessionId
+     * @param {String} options.segmentKey WAL segment key.
+     * @param {String} options.walDir WAL directory.
+     * @param {String|undefined} options.requestIdentity Bound AgentIdentity, when present.
+     * @param {Object} options.memoryProperties Graph properties derived from the WAL metadata.
+     * @param {Number} [attempt=1] Current bounded retry attempt.
+     * @returns {void}
+     * @private
+     */
+    _scheduleMemoryGraphProjection(options, attempt = 1) {
+        const delayMs = attempt === 1
+            ? 0
+            : Math.min(GRAPH_PROJECTION_RETRY_BASE_MS * 2 ** (attempt - 2), GRAPH_PROJECTION_RETRY_MAX_MS);
+
+        setTimeout(async () => {
+            try {
+                await this._projectMemoryToGraph(options);
+            } catch (error) {
+                if (attempt < GRAPH_PROJECTION_MAX_ATTEMPTS) {
+                    logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} (attempt ${attempt}/${GRAPH_PROJECTION_MAX_ATTEMPTS}); retrying: ${error.message}`);
+                    this._scheduleMemoryGraphProjection(options, attempt + 1);
+                    return;
+                }
+
+                logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} after ${GRAPH_PROJECTION_MAX_ATTEMPTS} attempts; WAL row remains projection-pending: ${error.message}`);
+            }
+        }, delayMs);
+    }
+
+    /**
+     * @summary Projects one WAL-accepted memory into the Native Edge Graph.
+     * @param {Object} options
+     * @param {String} options.memoryId
+     * @param {String} options.timestamp ISO timestamp.
+     * @param {String} options.sessionId
+     * @param {String} options.segmentKey WAL segment key.
+     * @param {String} options.walDir WAL directory.
+     * @param {String|undefined} options.requestIdentity Bound AgentIdentity, when present.
+     * @param {Object} options.memoryProperties Graph properties derived from the WAL metadata.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async _projectMemoryToGraph({memoryId, timestamp, sessionId, segmentKey, walDir, requestIdentity, memoryProperties}) {
+        GraphService.upsertNode({
+            id: memoryId,
+            type: 'AGENT_MEMORY',
+            name: `Memory: ${timestamp}`,
+            description: `Agent thought flow inside session ${sessionId}.`,
+            semanticVectorId: memoryId,
+            properties: memoryProperties
+        });
+
+        // Stamp write-time provenance when the transport resolved a real AgentIdentity.
+        // Fallback-only identities remain scalar metadata so single-tenant/unseeded callers
+        // keep working without hallucinated graph edges to nodes that do not exist.
+        if (requestIdentity) {
+            GraphService.linkNodes(memoryId, requestIdentity, 'AUTHORED_BY', 1.0, {
+                timestamp,
+                userId      : requestIdentity,
+                sharedEntity: true
+            });
+        }
+
+        // Link this memory dynamically to the active context frontier.
+        GraphService.linkNodes('frontier', memoryId, 'SPAWNED_MEMORY', 0.8);
+
+        await appendWalGraphProjectionMarker({id: memoryId, segmentKey}, {dir: walDir});
     }
 
     /**
@@ -527,6 +620,60 @@ class MemoryService extends Base {
             return new Map(records.map(record => [record.id, record.metadata || {}]));
         } catch {
             return new Map();
+        }
+    }
+
+    /**
+     * @summary Reads pending WAL records as recency rows for graph-projection lag/failure windows.
+     *
+     * Graph projection is derived work after WAL acceptance. Until it catches up, the WAL itself is
+     * the read-after-write source of truth for the caller's own recency feed. This overlay is
+     * tenant-scoped with the same fail-closed `userId` + `agentIdentity` filter as the graph query.
+     *
+     * @param {Object} options
+     * @param {String} options.identity Canonical AgentIdentity to recall.
+     * @param {String} options.userId Normalized tenant id.
+     * @param {Object} [options.before] Optional compound pagination cursor.
+     * @param {Set<String>} [options.excludeIds] Graph rows already present in this page query.
+     * @returns {Promise<Object[]>} Row-shaped pending turns.
+     * @private
+     */
+    async _readPendingWalRecencyRows({identity, userId, before, excludeIds = new Set()} = {}) {
+        try {
+            const records = await readPendingWalRecords({dir: aiConfig.memoryWal.dir, markerType: 'graph'});
+            const rows    = [];
+
+            for (const record of records) {
+                if (!record?.id || excludeIds.has(record.id)) continue;
+                if (record.graphProjectionVersion !== 1) continue;
+
+                const meta = record.metadata || {};
+                if (meta.agentIdentity !== identity || normalizeUserId(meta.userId) !== userId) continue;
+
+                const timestampMs = Number(meta.timestamp ?? record.timestamp);
+                if (!Number.isFinite(timestampMs)) continue;
+
+                const timestamp = new Date(timestampMs).toISOString();
+                if (before?.timestamp) {
+                    const beforeTimestamp = String(before.timestamp),
+                          beforeId        = String(before.id ?? '');
+                    if (timestamp > beforeTimestamp || (timestamp === beforeTimestamp && record.id >= beforeId)) {
+                        continue;
+                    }
+                }
+
+                rows.push({
+                    id               : record.id,
+                    sessionId        : meta.sessionId,
+                    timestamp,
+                    miniSummary      : meta.miniSummary ?? null,
+                    projectionPending: true
+                });
+            }
+
+            return rows;
+        } catch {
+            return [];
         }
     }
 
@@ -644,9 +791,9 @@ class MemoryService extends Base {
      *
      * The recency retrieval axis — the complement to {@link queryMemories}' *relevance* (semantic)
      * axis. Built for post-compaction context recovery ("what just happened, in order"), which
-     * semantic search cannot reconstruct. Reads the `AGENT_MEMORY` graph rows that
-     * {@link addMemory} writes *synchronously* (fresh the instant the write returns — never the
-     * lagged REM-projection nodes), tenant-scoped and fail-closed for multi-tenant cloud.
+     * semantic search cannot reconstruct. Reads graph-projected `AGENT_MEMORY` rows plus WAL-pending
+     * rows whose graph projection has not caught up yet, tenant-scoped and fail-closed for
+     * multi-tenant cloud.
      *
      * Graduated from a cross-family Ideation Sandbox; see the originating issue for the full
      * acceptance-criteria + signal ledger.
@@ -698,8 +845,9 @@ class MemoryService extends Base {
 
             const boundedLimit = Math.max(1, Math.min(Number(limit) || 20, 100));
 
-            // AC2/AC3 — recency read over the synchronously-written AGENT_MEMORY rows. ORDER BY
-            // (timestamp, id) DESC for a stable reverse-chronological page even at equal timestamps.
+            // AC2/AC3 — recency read over graph-projected AGENT_MEMORY rows plus pending WAL rows.
+            // ORDER BY (timestamp, id) DESC for a stable reverse-chronological page even at equal
+            // timestamps.
             const params = [identity, userId];
             let cursorClause = '';
             if (before && before.timestamp) {
@@ -710,7 +858,13 @@ class MemoryService extends Base {
             }
             params.push(boundedLimit);
 
-            const rows = sqlite.prepare(`
+            // Read graph-pending WAL rows BEFORE the graph query. If projection completes during
+            // this method, the row is either present in this pending snapshot or visible in the
+            // graph query below; querying graph first creates a race where the graph marker can
+            // land between the two reads and hide the row from both surfaces.
+            const pendingRows = await this._readPendingWalRecencyRows({identity, userId, before});
+
+            const graphRows = sqlite.prepare(`
                 SELECT memory.id                                            AS id,
                        json_extract(memory.data, '$.properties.sessionId')   AS sessionId,
                        json_extract(memory.data, '$.properties.timestamp')   AS timestamp,
@@ -723,6 +877,15 @@ class MemoryService extends Base {
                 ORDER BY json_extract(memory.data, '$.properties.timestamp') DESC, memory.id DESC
                 LIMIT ?
             `).all(...params);
+
+            const graphIds = new Set(graphRows.map(row => row.id));
+
+            const rows = [...graphRows, ...pendingRows.filter(row => !graphIds.has(row.id))]
+                .sort((a, b) => {
+                    const timestampOrder = String(b.timestamp).localeCompare(String(a.timestamp));
+                    return timestampOrder || String(b.id).localeCompare(String(a.id));
+                })
+                .slice(0, boundedLimit);
 
             // 'summary' = compact graph-only projection (with a raw fallback for not-yet-summarized
             // turns); 'full' joins Chroma for content.
@@ -789,12 +952,13 @@ class MemoryService extends Base {
         return rows.map(row => {
             const meta = byId.get(row.id) || {};
             const turn = {
-                id         : row.id,
-                sessionId  : row.sessionId,
-                timestamp  : row.timestamp,
-                miniSummary: row.miniSummary ?? null,
-                prompt     : meta.prompt   ?? null,
-                response   : meta.response ?? null
+                id               : row.id,
+                sessionId        : row.sessionId,
+                timestamp        : row.timestamp,
+                miniSummary      : row.miniSummary ?? null,
+                projectionPending: row.projectionPending === true,
+                prompt           : meta.prompt   ?? null,
+                response         : meta.response ?? null
             };
             // Privacy: the private `thought` field is included only when the caller passed the
             // already-authorized 'private' projection (own-agent recall — gated in queryRecentTurns).
@@ -819,11 +983,12 @@ class MemoryService extends Base {
      */
     async _hydrateRecentTurnSummaries(rows) {
         const turns = rows.map(row => ({
-            id             : row.id,
-            sessionId      : row.sessionId,
-            timestamp      : row.timestamp,
-            summary        : row.miniSummary ?? null,
-            summaryFallback: false
+            id               : row.id,
+            sessionId        : row.sessionId,
+            timestamp        : row.timestamp,
+            projectionPending: row.projectionPending === true,
+            summary          : row.miniSummary ?? null,
+            summaryFallback  : false
         }));
 
         const unsummarized = turns.filter(turn => !turn.summary);

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -56,6 +56,13 @@ const GRAPH_PROJECTION_RETRY_BASE_MS = 250;
 const GRAPH_PROJECTION_RETRY_MAX_MS = 5000;
 
 /**
+ * Hosted graph-projection drain cadence. This is intentionally independent of the Chroma embed
+ * daemon: graph projection and embedding are separate derived states.
+ * @type {Number}
+ */
+const GRAPH_PROJECTION_DRAIN_INTERVAL_MS = 60000;
+
+/**
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
  * a `MemoryService` ⇄ `SessionService` import cycle). Kept exported here for back-compat with
  * existing importers.
@@ -307,6 +314,7 @@ class MemoryService extends Base {
     async initAsync() {
         await super.initAsync();
         await StorageRouter.ready();
+        this._startGraphProjectionDrainLoop();
     }
 
     /**
@@ -422,11 +430,7 @@ class MemoryService extends Base {
             //    model-dependent work. This is the never-fail anchor — once this returns, the turn
             //    survives a crash, an embed failure, or a Chroma outage. The embed used to be
             //    awaited here, which also lost the graph node below whenever it threw.
-            const walDir       = aiConfig.memoryWal.dir;
-            const {segmentKey} = await appendWalMemory(
-                {id: memoryId, timestamp: now, metadata, document: combinedText, graphProjectionVersion: 1},
-                {dir: walDir}
-            );
+            const walDir = aiConfig.memoryWal.dir;
 
             // 2. Schedule the Native Edge Graph projection from the accepted WAL record. This is
             //    derived work: graph contention/unavailability must not reject the mandatory
@@ -438,6 +442,20 @@ class MemoryService extends Base {
                 sessionId,
                 timestamp
             };
+            const {segmentKey} = await appendWalMemory(
+                {
+                    id: memoryId,
+                    timestamp: now,
+                    metadata,
+                    document: combinedText,
+                    graphProjectionVersion: 1,
+                    graphProjection: {
+                        requestIdentity,
+                        memoryProperties
+                    }
+                },
+                {dir: walDir}
+            );
 
             this._scheduleMemoryGraphProjection({
                 memoryId,
@@ -577,6 +595,90 @@ class MemoryService extends Base {
         GraphService.linkNodes('frontier', memoryId, 'SPAWNED_MEMORY', 0.8);
 
         await appendWalGraphProjectionMarker({id: memoryId, segmentKey}, {dir: walDir});
+    }
+
+    /**
+     * @summary Starts the hosted graph-projection drain loop.
+     *
+     * This is the cloud-safe backstop for WAL-accepted rows whose immediate bounded retry exhausted
+     * or whose process restarted before projection completed. It mirrors the embed daemon's durable
+     * WAL-reconcile shape without requiring a separate local orchestrator process.
+     *
+     * @returns {void}
+     * @private
+     */
+    _startGraphProjectionDrainLoop() {
+        if (this.graphProjectionDrainTimer) return;
+
+        this.drainPendingGraphProjections().catch(error => {
+            logger.warn(`[MemoryService] graph projection startup drain failed: ${error.message}`);
+        });
+
+        this.graphProjectionDrainTimer = setInterval(() => {
+            this.drainPendingGraphProjections().catch(error => {
+                logger.warn(`[MemoryService] graph projection drain failed: ${error.message}`);
+            });
+        }, GRAPH_PROJECTION_DRAIN_INTERVAL_MS);
+        this.graphProjectionDrainTimer.unref?.();
+    }
+
+    /**
+     * @summary Reconciles graph-pending WAL records into the Native Edge Graph.
+     * @param {Object} [options]
+     * @param {String[]} [options.ids] Optional targeted records.
+     * @param {Number} [options.limit] Maximum pending records to process.
+     * @returns {Promise<{pending: Number, projected: Number, failed: Number}>}
+     */
+    async drainPendingGraphProjections({ids, limit = aiConfig.memoryWal.batchSize} = {}) {
+        const records = await readPendingWalRecords({
+            dir       : aiConfig.memoryWal.dir,
+            ids,
+            limit,
+            markerType: 'graph'
+        });
+        const summary = {pending: records.length, projected: 0, failed: 0};
+
+        for (const record of records) {
+            if (record.graphProjectionVersion !== 1) continue;
+
+            try {
+                await this._projectMemoryToGraph(this._graphProjectionOptionsFromWalRecord(record));
+                summary.projected++;
+            } catch (error) {
+                summary.failed++;
+                logger.warn(`[MemoryService] graph projection drain failed for ${record.id}: ${error.message}`);
+            }
+        }
+
+        return summary;
+    }
+
+    /**
+     * @summary Rebuilds graph-projection inputs from a WAL record.
+     * @param {Object} record WAL memory record.
+     * @returns {Object} Options for {@link _projectMemoryToGraph}.
+     * @private
+     */
+    _graphProjectionOptionsFromWalRecord(record) {
+        const meta          = record.metadata || {},
+              timestampMs   = Number(meta.timestamp ?? record.timestamp),
+              timestamp     = Number.isFinite(timestampMs) ? new Date(timestampMs).toISOString() : new Date().toISOString(),
+              storedOptions = record.graphProjection || {};
+
+        return {
+            memoryId        : record.id,
+            timestamp,
+            sessionId       : meta.sessionId,
+            segmentKey      : record.segmentKey,
+            walDir          : aiConfig.memoryWal.dir,
+            requestIdentity : storedOptions.requestIdentity,
+            memoryProperties: storedOptions.memoryProperties || {
+                ...(meta.agentIdentity ? { agentIdentity: meta.agentIdentity } : {}),
+                ...(meta.userId ? { userId: normalizeUserId(meta.userId) } : {}),
+                sessionId: meta.sessionId,
+                timestamp
+            }
+        };
     }
 
     /**

--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -87,6 +87,15 @@ export function getWalMarkersFileName(segmentKey) {
 }
 
 /**
+ * @summary Builds the graph-projection markers file name for a segment key.
+ * @param {String} segmentKey `YYYY-MM-DD` day key.
+ * @returns {String} JSONL graph-projection markers file name.
+ */
+export function getWalGraphMarkersFileName(segmentKey) {
+    return `wal-${segmentKey}.graph.jsonl`;
+}
+
+/**
  * @summary Appends one memory record to its UTC-day WAL segment. The durable write `addMemory`
  * awaits BEFORE any model-dependent work — this returning is what makes the turn save crash-safe.
  *
@@ -143,6 +152,38 @@ export async function appendWalEmbedMarker({id, segmentKey, embeddedAt}, {dir} =
     const filePath = path.join(dir, getWalMarkersFileName(segmentKey));
 
     await fs.appendFile(filePath, `${JSON.stringify({id, embeddedAt: embeddedAt ?? Date.now()})}\n`, 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Appends a graph-projection success marker for one WAL record.
+ *
+ * Separate from the embed marker by design: Chroma reconciliation and graph projection are two
+ * different derived states. A record may be embedded while graph projection is still pending, so
+ * recency overlays and retention must not rely on the embed marker as graph evidence.
+ *
+ * @param {Object} marker
+ * @param {String} marker.id          Memory UUID the graph projection succeeded for.
+ * @param {String} marker.segmentKey  Segment key the record was written under.
+ * @param {Number} [marker.projectedAt] Epoch-ms projection completion time.
+ * @param {Object} options
+ * @param {String} options.dir Directory for WAL segment files.
+ * @returns {Promise<String>} Written markers file path.
+ */
+export async function appendWalGraphProjectionMarker({id, segmentKey, projectedAt}, {dir} = {}) {
+    if (!dir) {
+        throw new TypeError('appendWalGraphProjectionMarker: dir is required');
+    }
+    if (typeof id !== 'string' || id.length === 0 || typeof segmentKey !== 'string' || segmentKey.length === 0) {
+        throw new TypeError('appendWalGraphProjectionMarker: id and segmentKey are required');
+    }
+
+    await fs.mkdir(dir, {recursive: true});
+
+    const filePath = path.join(dir, getWalGraphMarkersFileName(segmentKey));
+
+    await fs.appendFile(filePath, `${JSON.stringify({id, projectedAt: projectedAt ?? Date.now()})}\n`, 'utf8');
 
     return filePath;
 }
@@ -212,14 +253,16 @@ async function listWalSegmentKeys(dir) {
  * @param {String} options.dir Directory for WAL segment files.
  * @param {String[]} [options.ids] When given, only records with these ids are returned.
  * @param {Number} [options.limit] Maximum records to return (applied after the ids filter).
+ * @param {String} [options.markerType='embed'] Reconciliation marker stream: `'embed'` or `'graph'`.
  * @returns {Promise<Object[]>} Pending records (each carries its `segmentKey`), newest segment first.
  */
-export async function readPendingWalRecords({dir, ids, limit} = {}) {
+export async function readPendingWalRecords({dir, ids, limit, markerType = 'embed'} = {}) {
     if (!dir) return [];
 
     const idFilter = Array.isArray(ids) ? new Set(ids) : null;
     const bounded  = Number.isFinite(limit) && limit > 0 ? limit : Infinity;
     const pending  = [];
+    const markerFileName = markerType === 'graph' ? getWalGraphMarkersFileName : getWalMarkersFileName;
 
     for (const segmentKey of await listWalSegmentKeys(dir)) {
         if (pending.length >= bounded) break;
@@ -228,7 +271,7 @@ export async function readPendingWalRecords({dir, ids, limit} = {}) {
         if (records.length === 0) continue;
 
         const markedIds = new Set(
-            (await readJsonlEntries(path.join(dir, getWalMarkersFileName(segmentKey)))).map(entry => entry.id)
+            (await readJsonlEntries(path.join(dir, markerFileName(segmentKey)))).map(entry => entry.id)
         );
 
         for (const record of records) {
@@ -272,8 +315,15 @@ export async function pruneReconciledWalSegments({dir, retentionLimit, activeSeg
         const marked  = new Set(
             (await readJsonlEntries(path.join(dir, getWalMarkersFileName(segmentKey)))).map(entry => entry.id)
         );
+        const graphMarked = new Set(
+            (await readJsonlEntries(path.join(dir, getWalGraphMarkersFileName(segmentKey)))).map(entry => entry.id)
+        );
 
-        if (records.every(record => record?.id && marked.has(record.id))) {
+        if (records.every(record =>
+            record?.id &&
+            marked.has(record.id) &&
+            (record.graphProjectionVersion !== 1 || graphMarked.has(record.id))
+        )) {
             reconciled.push(segmentKey);
         }
     }

--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -253,7 +253,8 @@ async function listWalSegmentKeys(dir) {
  * @param {String} options.dir Directory for WAL segment files.
  * @param {String[]} [options.ids] When given, only records with these ids are returned.
  * @param {Number} [options.limit] Maximum records to return (applied after the ids filter).
- * @param {String} [options.markerType='embed'] Reconciliation marker stream: `'embed'` or `'graph'`.
+ * @param {String} [options.markerType='embed'] Reconciliation marker stream: `'embed'` or `'graph'`;
+ *   graph-marker reads only treat versioned graph-projection records as pending work.
  * @returns {Promise<Object[]>} Pending records (each carries its `segmentKey`), newest segment first.
  */
 export async function readPendingWalRecords({dir, ids, limit, markerType = 'embed'} = {}) {
@@ -277,6 +278,7 @@ export async function readPendingWalRecords({dir, ids, limit, markerType = 'embe
         for (const record of records) {
             if (pending.length >= bounded) break;
             if (!record?.id || markedIds.has(record.id)) continue;
+            if (markerType === 'graph' && record.graphProjectionVersion !== 1) continue;
             if (idFilter && !idFilter.has(record.id)) continue;
             pending.push(record);
         }
@@ -333,7 +335,8 @@ export async function pruneReconciledWalSegments({dir, retentionLimit, activeSeg
 
     await Promise.all(toRemove.flatMap(segmentKey => [
         fs.rm(path.join(dir, getWalRecordsFileName(segmentKey)), {force: true}),
-        fs.rm(path.join(dir, getWalMarkersFileName(segmentKey)), {force: true})
+        fs.rm(path.join(dir, getWalMarkersFileName(segmentKey)), {force: true}),
+        fs.rm(path.join(dir, getWalGraphMarkersFileName(segmentKey)), {force: true})
     ]));
 
     return toRemove.length;

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs
@@ -70,6 +70,8 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
         GraphService.linkNodes            = originalLinkNodes;
     });
 
+    const flushGraphProjection = () => new Promise(resolve => setTimeout(resolve, 10));
+
     test('addMemory canonicalizes profile-string agent to node-id graph identity', async () => {
         await MemoryService.addMemory({
             agent    : 'neo-gemini-pro',
@@ -78,6 +80,8 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
             thought  : 'thinking',
             response : 'hi'
         });
+
+        await flushGraphProjection();
 
         expect(upsertNodeCalls).toHaveLength(1);
         const node = upsertNodeCalls[0];
@@ -100,6 +104,8 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
             thought  : 'thinking',
             response : 'hi'
         });
+
+        await flushGraphProjection();
 
         expect(upsertNodeCalls).toHaveLength(1);
         const node = upsertNodeCalls[0];
@@ -147,6 +153,7 @@ test.describe('MemoryService — AGENT_MEMORY Schema (#10620)', () => {
 
         // addMemory leaves the record WAL-pending — flush it through the daemon drain path.
         await drainMemoryWal({ids: [result.id]});
+        await flushGraphProjection();
 
         expect(collectionAddCalls).toHaveLength(1);
         expect(collectionAddCalls[0].metadatas[0].userId).toBe('neo-gpt');

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -26,9 +26,10 @@ import {drainMemoryWal}      from './util.mjs';
  *   AC2 never-fail      — the write path never touches the content store at all (the embed
  *                         daemon owns the drain), so a down OR hung store can neither fail nor
  *                         stall the tool; the payload is durable in the WAL (pending) either way.
- *   AC3 recency         — the AGENT_MEMORY graph row stays synchronous: a just-written turn is
- *                         immediately visible to query_recent_turns even with the embed down,
- *                         and the WAL pending-overlay serves its content for BOTH detail levels.
+ *   AC3 recency         — graph projection is derived/fail-soft: a just-written turn is immediately
+ *                         visible to query_recent_turns through the WAL pending-overlay even when
+ *                         graph projection has not caught up, and that overlay serves content for
+ *                         BOTH detail levels.
  *   Drain reconcile     — the daemon drain path (`drainWalOnce` via the `drainMemoryWal` spec
  *                         helper) embeds pending records and marks them reconciled, and never
  *                         re-embeds a purge-tombstoned record.
@@ -155,30 +156,72 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         collectionMode = 'ok';
     });
 
+    test('AC3: graph projection failure cannot fail the save and recency uses the pending WAL overlay', async () => {
+        const originalUpsertNode   = GraphService.upsertNode;
+        const originalBuildSummary = MemoryService.buildMiniSummary;
+
+        GraphService.upsertNode       = () => { throw new Error('graph down (spec)'); };
+        MemoryService.buildMiniSummary = async () => null;
+
+        try {
+            const result = await asTenant(() => MemoryService.addMemory({
+                prompt: 'graph-down prompt', thought: 'graph-down thought', response: 'graph-down response'
+            }));
+
+            expect(result.code).toBeUndefined();
+            expect(result.error).toBeUndefined();
+            expect(result.id).toBeTruthy();
+            expect(result.message).toBe('Memory successfully added');
+
+            // Let the scheduled projection attempt run and fail under the stub. The failure must
+            // stay logged/fail-soft, not turn into a rejected add_memory result or unhandled throw.
+            await new Promise(resolve => setImmediate(resolve));
+
+            const pending = await readPendingWalRecords({dir: testWalDir, ids: [result.id]});
+            expect(pending).toHaveLength(1);
+
+            const recent = await asTenant(() => MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 1, detail: 'full', projection: 'private'}));
+
+            expect(recent.count).toBe(1);
+            expect(recent.turns[0].id).toBe(result.id);
+            expect(recent.turns[0].projectionPending).toBe(true);
+            expect(recent.turns[0].prompt).toBe('graph-down prompt');
+            expect(recent.turns[0].response).toBe('graph-down response');
+            expect(recent.turns[0].thought).toBe('graph-down thought');
+        } finally {
+            GraphService.upsertNode        = originalUpsertNode;
+            MemoryService.buildMiniSummary = originalBuildSummary;
+        }
+    });
+
     test('AC3: with the embed down, a just-written turn is immediately recency-visible and the WAL overlay serves BOTH detail levels', async () => {
         collectionMode = 'throw';
 
-        const {summaryResult, fullResult} = await asTenant(async () => {
-            await MemoryService.addMemory({
+        const {write, summaryResult, fullResult} = await asTenant(async () => {
+            const write = await MemoryService.addMemory({
                 prompt: 'overlay prompt', thought: 'overlay thought', response: 'overlay response'
             });
             return {
-                summaryResult: await MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 1}),
-                fullResult   : await MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 1, detail: 'full', projection: 'private'})
+                write,
+                summaryResult: await MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 20}),
+                fullResult   : await MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 20, detail: 'full', projection: 'private'})
             };
         });
 
-        // Graph row synchronous → immediately visible (read-after-write recency preserved).
-        expect(summaryResult.count).toBe(1);
+        // The row is immediately visible even if graph projection has not caught up yet.
+        expect(summaryResult.count).toBeGreaterThan(0);
         // No Chroma content exists yet — the summary fallback comes from the WAL pending-overlay.
-        expect(summaryResult.turns[0].summary).toContain('overlay prompt');
-        expect(summaryResult.turns[0].summaryFallback).toBe(true);
+        const summaryTurn = summaryResult.turns.find(turn => turn.id === write.id);
+        expect(summaryTurn).toBeTruthy();
+        expect(summaryTurn.summary).toContain('overlay prompt');
+        expect(summaryTurn.summaryFallback).toBe(true);
 
         // detail:'full' hydration equally falls back to the WAL payload.
-        expect(fullResult.count).toBe(1);
-        expect(fullResult.turns[0].prompt).toBe('overlay prompt');
-        expect(fullResult.turns[0].response).toBe('overlay response');
-        expect(fullResult.turns[0].thought).toBe('overlay thought');
+        const fullTurn = fullResult.turns.find(turn => turn.id === write.id);
+        expect(fullTurn).toBeTruthy();
+        expect(fullTurn.prompt).toBe('overlay prompt');
+        expect(fullTurn.response).toBe('overlay response');
+        expect(fullTurn.thought).toBe('overlay thought');
 
         collectionMode = 'ok';
     });

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -30,6 +30,9 @@ import {drainMemoryWal}      from './util.mjs';
  *                         visible to query_recent_turns through the WAL pending-overlay even when
  *                         graph projection has not caught up, and that overlay serves content for
  *                         BOTH detail levels.
+ *   Graph backstop      — graph-pending WAL records have a hosted re-drive path after process
+ *                         restart or exhausted in-process retries; embed reconciliation alone does
+ *                         not hide graph-pending work.
  *   Drain reconcile     — the daemon drain path (`drainWalOnce` via the `drainMemoryWal` spec
  *                         helper) embeds pending records and marks them reconciled, and never
  *                         re-embeds a purge-tombstoned record.
@@ -191,6 +194,67 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         } finally {
             GraphService.upsertNode        = originalUpsertNode;
             MemoryService.buildMiniSummary = originalBuildSummary;
+        }
+    });
+
+    test('graph-pending WAL records are re-driven by the hosted graph projection drain', async () => {
+        const originalSchedule     = MemoryService._scheduleMemoryGraphProjection;
+        const originalBuildSummary = MemoryService.buildMiniSummary;
+
+        MemoryService._scheduleMemoryGraphProjection = () => {};
+        MemoryService.buildMiniSummary               = async () => null;
+
+        try {
+            const result = await asTenant(() => MemoryService.addMemory({
+                prompt: 'graph-drain prompt', thought: 'graph-drain thought', response: 'graph-drain response'
+            }));
+
+            expect(result.id).toBeTruthy();
+
+            const graphPendingBefore = await readPendingWalRecords({
+                dir       : testWalDir,
+                ids       : [result.id],
+                markerType: 'graph'
+            });
+            expect(graphPendingBefore).toHaveLength(1);
+
+            const embedSummary = await drainMemoryWal({ids: [result.id]});
+            expect(embedSummary.embedded).toBe(1);
+            expect((await readPendingWalRecords({dir: testWalDir, ids: [result.id]}))).toHaveLength(0);
+
+            // Embed reconciliation is deliberately separate from graph reconciliation: an
+            // embedded-but-unprojected record must stay visible to the graph drain.
+            expect((await readPendingWalRecords({
+                dir       : testWalDir,
+                ids       : [result.id],
+                markerType: 'graph'
+            }))).toHaveLength(1);
+
+            const graphSummary = await MemoryService.drainPendingGraphProjections({ids: [result.id]});
+
+            expect(graphSummary).toEqual({pending: 1, projected: 1, failed: 0});
+            expect((await readPendingWalRecords({
+                dir       : testWalDir,
+                ids       : [result.id],
+                markerType: 'graph'
+            }))).toHaveLength(0);
+
+            const recent = await asTenant(() => MemoryService.queryRecentTurns({
+                agentIdentity: '@me',
+                limit        : 20,
+                detail       : 'full',
+                projection   : 'private'
+            }));
+            const turn = recent.turns.find(item => item.id === result.id);
+
+            expect(turn).toBeTruthy();
+            expect(turn.projectionPending).toBe(false);
+            expect(turn.prompt).toBe('graph-drain prompt');
+            expect(turn.response).toBe('graph-drain response');
+            expect(turn.thought).toBe('graph-drain thought');
+        } finally {
+            MemoryService._scheduleMemoryGraphProjection = originalSchedule;
+            MemoryService.buildMiniSummary               = originalBuildSummary;
         }
     });
 

--- a/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs
@@ -41,12 +41,12 @@ test.describe('Neo.ai.services.memory-core.queryRecentTurns', () => {
         TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
         StorageRouter        = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
 
-        // CI unit has no ChromaDB server. The Chroma embed is DEFERRED (fire-and-
-        // forget after the durable WAL append + synchronous graph writes), so a missing Chroma no
-        // longer fails addMemory — but the deferred embed and the detail:'full' join still hit the
-        // content store. Back it with an in-memory fake so the spec exercises the real
-        // addMemory→queryRecentTurns flow without a live Chroma. The recency query reads the GRAPH;
-        // content comes from the fake store or, for not-yet-embedded turns, the WAL pending-overlay.
+        // CI unit has no ChromaDB server. The Chroma embed is DEFERRED after the durable WAL append,
+        // so a missing Chroma no longer fails addMemory — but the deferred embed and the detail:'full'
+        // join still hit the content store. Back it with an in-memory fake so the spec exercises the
+        // real addMemory→queryRecentTurns flow without a live Chroma. The recency query reads graph-
+        // projected rows plus WAL-pending rows whose graph projection has not caught up yet; content
+        // comes from the fake store or, for not-yet-embedded turns, the WAL pending-overlay.
         memStore = new Map();
         originalGetMemoryCollection = StorageRouter.getMemoryCollection;
         StorageRouter.getMemoryCollection = async () => ({

--- a/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
@@ -93,11 +93,12 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     });
 
     test('graph-projection pending state is tracked independently from embed reconciliation', async () => {
+        await appendWalMemory(record('legacy', DAY1), {dir: tmpDir});
         await appendWalMemory({...record('m1', DAY1), graphProjectionVersion: 1}, {dir: tmpDir});
 
         await appendWalEmbedMarker({id: 'm1', segmentKey: '2026-06-01'}, {dir: tmpDir});
 
-        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual([]);
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['legacy']);
         expect((await readPendingWalRecords({dir: tmpDir, markerType: 'graph'})).map(r => r.id)).toEqual(['m1']);
 
         await appendWalGraphProjectionMarker({id: 'm1', segmentKey: '2026-06-01'}, {dir: tmpDir});

--- a/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs
@@ -8,8 +8,10 @@ import path            from 'path';
 
 import {
     appendWalEmbedMarker,
+    appendWalGraphProjectionMarker,
     appendWalMemory,
     getMissingMemoryWalLeaves,
+    getWalGraphMarkersFileName,
     getWalMarkersFileName,
     getWalRecordsFileName,
     getWalSegmentKey,
@@ -22,6 +24,7 @@ import {
  * `add_memory` write path. Falsifier coverage for the store contract:
  *
  *   - append → pending; embed-marker → reconciled (no longer pending)
+ *   - graph-projection marker is separate from embed reconciliation
  *   - reads tolerate corrupt/torn lines and a missing directory
  *   - pruning removes ONLY fully-reconciled, non-active segments beyond the retention bound —
  *     a pending payload is never lost to retention
@@ -52,6 +55,7 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
         expect(getWalSegmentKey(DAY1)).toBe('2026-06-01');
         expect(getWalRecordsFileName('2026-06-01')).toBe('wal-2026-06-01.jsonl');
         expect(getWalMarkersFileName('2026-06-01')).toBe('wal-2026-06-01.embedded.jsonl');
+        expect(getWalGraphMarkersFileName('2026-06-01')).toBe('wal-2026-06-01.graph.jsonl');
     });
 
     test('appendWalMemory writes the full payload into its day segment and reports the key', async () => {
@@ -74,6 +78,7 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
         await expect(appendWalMemory(record('m1', DAY1), {})).rejects.toThrow('dir is required');
         await expect(appendWalMemory({timestamp: DAY1}, {dir: tmpDir})).rejects.toThrow('record.id is required');
         await expect(appendWalEmbedMarker({id: 'm1'}, {dir: tmpDir})).rejects.toThrow('id and segmentKey are required');
+        await expect(appendWalGraphProjectionMarker({id: 'm1'}, {dir: tmpDir})).rejects.toThrow('id and segmentKey are required');
     });
 
     test('readPendingWalRecords returns appended records until their embed marker lands', async () => {
@@ -85,6 +90,19 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
         await appendWalEmbedMarker({id: 'm1', segmentKey: '2026-06-01'}, {dir: tmpDir});
 
         expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['m2']);
+    });
+
+    test('graph-projection pending state is tracked independently from embed reconciliation', async () => {
+        await appendWalMemory({...record('m1', DAY1), graphProjectionVersion: 1}, {dir: tmpDir});
+
+        await appendWalEmbedMarker({id: 'm1', segmentKey: '2026-06-01'}, {dir: tmpDir});
+
+        expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual([]);
+        expect((await readPendingWalRecords({dir: tmpDir, markerType: 'graph'})).map(r => r.id)).toEqual(['m1']);
+
+        await appendWalGraphProjectionMarker({id: 'm1', segmentKey: '2026-06-01'}, {dir: tmpDir});
+
+        expect((await readPendingWalRecords({dir: tmpDir, markerType: 'graph'})).map(r => r.id)).toEqual([]);
     });
 
     test('readPendingWalRecords filters by ids, bounds by limit, and reads newest segments first', async () => {
@@ -109,8 +127,9 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
     test('pruning removes only fully-reconciled, non-active segments beyond the retention bound', async () => {
         // Three reconciled segments + one with a pending record.
         for (const [id, ms, key] of [['a', DAY1, '2026-06-01'], ['b', DAY2, '2026-06-02'], ['c', DAY3, '2026-06-03']]) {
-            await appendWalMemory(record(id, ms), {dir: tmpDir});
+            await appendWalMemory({...record(id, ms), graphProjectionVersion: 1}, {dir: tmpDir});
             await appendWalEmbedMarker({id, segmentKey: key}, {dir: tmpDir});
+            await appendWalGraphProjectionMarker({id, segmentKey: key}, {dir: tmpDir});
         }
         await appendWalMemory(record('pending', Date.UTC(2026, 4, 30, 12)), {dir: tmpDir}); // 2026-05-30
 
@@ -127,6 +146,24 @@ test.describe('Neo.ai.services.memory-core.helpers.memoryWalStore', () => {
 
         // A pending record survives any retention pressure.
         expect((await readPendingWalRecords({dir: tmpDir})).map(r => r.id)).toEqual(['pending']);
+    });
+
+    test('pruning preserves graph-projection-pending records even after embed reconciliation', async () => {
+        await appendWalMemory({...record('graph-pending', DAY1), graphProjectionVersion: 1}, {dir: tmpDir});
+        await appendWalEmbedMarker({id: 'graph-pending', segmentKey: '2026-06-01'}, {dir: tmpDir});
+
+        await appendWalMemory(record('old-style-reconciled-a', DAY2), {dir: tmpDir});
+        await appendWalEmbedMarker({id: 'old-style-reconciled-a', segmentKey: '2026-06-02'}, {dir: tmpDir});
+        await appendWalMemory(record('old-style-reconciled-b', DAY3), {dir: tmpDir});
+        await appendWalEmbedMarker({id: 'old-style-reconciled-b', segmentKey: '2026-06-03'}, {dir: tmpDir});
+
+        const removed = await pruneReconciledWalSegments({dir: tmpDir, retentionLimit: 1, activeSegmentKey: '2026-06-04'});
+        expect(removed).toBe(1);
+
+        const names = await fs.readdir(tmpDir);
+        expect(names).toContain('wal-2026-06-01.jsonl');
+        expect(names).not.toContain('wal-2026-06-02.jsonl');
+        expect(names).toContain('wal-2026-06-03.jsonl');
     });
 
     test('pruning is a no-op without a positive retention bound or with a missing directory', async () => {


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Resolves #13283

`add_memory` now treats the WAL append as the acceptance boundary: graph projection is derived work scheduled after durable acceptance, retried with bounded in-process backoff, and tracked with a graph-projection marker separate from Chroma embed reconciliation. `query_recent_turns` overlays graph-pending WAL rows with `projectionPending: true`, so accepted turns remain visible even when graph projection is contended, failing, or racing with the read path.

The graph-pending path also has a hosted recovery backstop: the persistent Memory Core process drains graph-pending WAL rows on startup and every 60s, re-driving rows that missed the immediate retry window because the process restarted or the bounded retry sequence exhausted. This keeps the cloud deployment path inside the MCP host and avoids requiring a local-only orchestrator daemon.

Evidence: L2 (unit-level Memory Core service, WAL filesystem, in-memory graph, MCP server exemption, query-recent-turns, and embed-drain coverage) -> L2 required (Memory Core write/read contract; no GUI or external-host-only ACs). No residuals.

## Deltas from Ticket

The ticket allowed a daemon or cloud-safe hosted loop. This PR uses the cloud-safe hosted path first: the persistent Memory Core process schedules bounded retries itself and also hosts the durable graph-pending drain. No local orchestrator daemon is required for correctness.

The PR adds a distinct graph marker stream because the existing WAL marker only represented Chroma embedding; using the embed marker for graph state would allow an embedded-but-unprojected turn to disappear from recency. The graph marker reader ignores legacy pre-version WAL records so old rows cannot consume the graph-drain batch limit.

The recency overlay intentionally reads graph-pending WAL rows before graph rows, then de-dupes by id. This closes the race where graph projection could complete between the graph query and WAL-pending read.

## Test Evidence

- `node --check ai/services/memory-core/MemoryService.mjs`
- `node --check ai/services/memory-core/helpers/memoryWalStore.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs`
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs` -> 19 passed
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs` -> 93 passed
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/WriteSideInvariant.spec.mjs test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs test/playwright/unit/ai/daemons/embed/drainCycle.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` -> 124 passed
- `git diff --check`
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev` on `8c11ab95bb6ae9abb7ca6402c88fb651cae8bfd6`

## Post-Merge Validation

- [ ] During a heavy-maintenance window, confirm a mandatory end-of-turn `add_memory` returns after WAL acceptance even if graph projection is delayed.
- [ ] Inspect recent-turn output for `projectionPending: true` only while graph projection is genuinely pending.
- [ ] Confirm the hosted graph-pending drain clears a deliberately stranded WAL row in a live MCP process without a local orchestrator daemon.

## Commits

- `b32565cb0` - `fix(memory-core): decouple add_memory graph projection (#13283)`
- `b9dcf3e16` - `test(memory-core): await deferred graph projection (#13283)`
- `a78ad133a` - `fix(memory-core): drain graph-pending WAL projections (#13283)`
