### PR TITLE
fix(wake): pin Codex wake submission boundary (#13287)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -713,12 +713,17 @@ function resolveCodexCliPath() {
 }
 
 /**
- * @summary Delivers a Codex wake digest through the native Codex app-server control plane.
+ * @summary Dispatches a Codex wake digest through the native Codex app-server control plane.
  *
  * This is the normal wake-daemon equivalent of the existing resume-harness
  * `codex debug app-server send-message-v2 <payload>` route. It intentionally does
  * not fall back to `osascript`; a route explicitly configured as `codex-app-server`
  * must fail visibly instead of recreating the GUI-focus delivery path.
+ *
+ * `send-message-v2` command success proves app-server acceptance/injection only.
+ * The Codex prompt-submission / turn-start boundary remains a wake-prompt landing
+ * matrix requirement and needs live app evidence until a submit-capable app-server
+ * command is available.
  *
  * @param {Object} subscription WAKE_SUBSCRIPTION node.
  * @param {String} digest Wake digest body.
@@ -733,7 +738,7 @@ async function deliverViaCodexAppServer(subscription, digest) {
     }
 
     await spawnAsync(resolveCodexCliPath(), ['debug', 'app-server', 'send-message-v2', digest]);
-    writeLog('INFO', `[Wake Daemon] Delivered ${subscription.id} via codex-app-server`);
+    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via codex-app-server send-message-v2`);
 }
 
 /**

--- a/ai/docs/wake-prompt-landing-matrix.md
+++ b/ai/docs/wake-prompt-landing-matrix.md
@@ -29,11 +29,12 @@ The following criteria must be satisfied for each supported harness.
 | **6. Prompt Payload Lands** | Payload lands natively in Claude's prompt field. | Payload lands directly in the Antigravity Agent Composer. | Payload lands in Codex Desktop's prompt surface. |
 | **7. No File Modification (Negative Assertion)** | N/A (or no stray pasting in other apps). | **MUST NOT** land in any active editor/file content (`git status` remains clean). | N/A (or no stray pasting). |
 | **8. No Fresh Session Spawns (Negative Assertion)** | Must resume existing session unless explicit sunset state authorizes spawn. | Must resume existing session unless explicit sunset state authorizes spawn. | Must resume existing session unless explicit sunset state authorizes spawn. |
-| **9. Actionable Receipt** | Recipient can act on prompt or emit clear blocked signal. | Recipient can act on prompt or emit clear blocked signal. | Recipient can act on prompt or emit clear blocked signal. |
-| **10. Evidence Artifact** | Manual or test log evidence captured in PR/comment. | Manual or test log evidence captured in PR/comment. | Manual or test log evidence captured in PR/comment. |
+| **9. Prompt Submitted / Turn Starts** | Wake payload is submitted and starts/steers the agent turn without a human pressing Enter. | Wake payload is submitted and starts/steers the agent turn without a human pressing Enter. | Wake payload is submitted and starts/steers the agent turn without a human pressing Enter. |
+| **10. Actionable Receipt** | Recipient can act on prompt or emit clear blocked signal. | Recipient can act on prompt or emit clear blocked signal. | Recipient can act on prompt or emit clear blocked signal. |
+| **11. Evidence Artifact** | Manual or test log evidence captured in PR/comment. | Manual or test log evidence captured in PR/comment. | Manual or test log evidence captured in PR/comment. |
 
 ## Evidence Requirements
 
-Due to the brittle nature of native UI automation across multiple different IDEs and proprietary desktop apps, **live/manual evidence is acceptable** for UI-only assertions (requirements 6-9).
+Due to the brittle nature of native UI automation across multiple different IDEs and proprietary desktop apps, **live/manual evidence is acceptable** for UI-only assertions (requirements 6-10).
 
 However, deterministic headless unit/integration tests **MUST** be used to validate the backend and wake-daemon adapter intent (requirements 1-5).

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1024,7 +1024,7 @@ test.describe('Wake Daemon', () => {
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
-                if (out.includes(`[Wake Daemon] Delivered ${subId} via codex-app-server`)) {
+                if (out.includes(`[Wake Daemon] Dispatched ${subId} via codex-app-server send-message-v2`)) {
                     clearTimeout(timeout);
                     resolve();
                 }
@@ -1994,12 +1994,95 @@ test.describe('Wake Daemon', () => {
         const aIndex = scriptContent.indexOf('keystroke "a" using command down');
         const xIndex = scriptContent.indexOf('keystroke "x" using command down');
         const pasteIndex = scriptContent.indexOf('keystroke "v" using command down');
+        const enterIndex = scriptContent.indexOf('key code 36');
 
         expect(rIndex).toBeGreaterThan(-1);
         expect(zIndex).toBeGreaterThan(rIndex);
         expect(aIndex).toBeGreaterThan(zIndex);
         expect(xIndex).toBeGreaterThan(aIndex);
         expect(pasteIndex).toBeGreaterThan(xIndex);
+        expect(enterIndex).toBeGreaterThan(pasteIndex);
+        expect(rawArgs.at(-1)).toContain('[WAKE][priority:normal]');
+        expect(rawArgs.at(-1)).toContain('Test Codex Cleanup');
+        expect(rawArgs.at(-1)).not.toContain('lifecycle-first');
+    });
+
+    test('Codex UI wake submits a mixed message + heartbeat digest with Enter and omits the heartbeat-only directive (#13287)', async () => {
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-mixed-submit';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Codex Mixed Submit' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'osascript',
+                    appName: 'Codex',
+                    coalesceWindow: 1,
+                    focusSeedKey: 'r'
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_mixed_submit_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver mixed Codex wake within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes(`Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        insertMessageWake(db, {agentId, subject: 'Codex Mixed Submit'});
+        const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
+
+        await deliveryPromise;
+
+        const rawArgs       = JSON.parse(fs.readFileSync(mockOutPath, 'utf-8'));
+        const scriptContent = rawArgs.filter((_, i) => rawArgs[i - 1] === '-e').join('\n');
+        const pasteIndex    = scriptContent.indexOf('keystroke "v" using command down');
+        const enterIndex    = scriptContent.indexOf('key code 36');
+        const digest        = rawArgs.at(-1);
+
+        expect(pasteIndex).toBeGreaterThan(-1);
+        expect(enterIndex).toBeGreaterThan(pasteIndex);
+        expect(digest).toContain('Codex Mixed Submit');
+        expect(digest).toContain('new messages');
+        expect(digest).toContain('heartbeat pulses');
+        expect(digest).not.toContain('lifecycle-first');
     });
 
     test('getNodesData and getEdgesData deterministically chunk queries by SQLITE_IN_CLAUSE_BATCH_SIZE', () => {


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Resolves #13291
Related: #13287
Related: #13012

Pins the Codex wake boundary that the operator surfaced: prompt landing is not the same as prompt submission. The wake matrix now has an explicit submitted/turn-start criterion, the Codex UI bridge tests prove direct message and mixed message+heartbeat digests still include the Enter submit step, and the app-server route is documented/logged as `send-message-v2` dispatch rather than full submission proof.

Evidence: L2 (mock-bin wake-daemon unit coverage for Codex `osascript` Enter intent, mixed digest shape, and `codex-app-server` command dispatch classification) -> L4 required (#13287 live Codex Desktop prompt submits and starts a turn without operator Enter). Residual: AC2 [#13287].

## Deltas from ticket

Live V-B-A found the active `@neo-gpt` wake subscription has no explicit `codex-app-server` adapter; the current bridge path defaults to `osascript` on macOS. This PR therefore avoids an adapter switch and instead separates the two contracts:

- `osascript` UI bridge: backend intent includes paste + `key code 36` for direct message and mixed message+heartbeat digests.
- `codex-app-server`: current local CLI help exposes only `send-message-v2`, so command success is treated as app-server dispatch/injection proof, not turn-start proof.

#13291 is the close-target leaf for this L2 boundary pin. #13287 remains open for the L4 live Codex behavioral proof and root-cause work.

## Test Evidence

- `node --check ai/daemons/wake/daemon.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs -g "Codex|app-server"` -> 4 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` -> 31 passed
- `git diff --check`

## Post-Merge Validation

- [ ] Continue the controlled Codex wake matrix on #13287 with pure heartbeat, direct A2A message, and mixed message+heartbeat payloads; capture L4 evidence that prompt lands, submits, and starts a turn without operator Enter.
- [ ] If `send-message-v2` still only injects without submit/turn-start, keep normal A2A wake delivery on the UI bridge route until a submit-capable app-server command exists.

## Commits

- `8e0655924` — `fix(wake): pin Codex wake submission boundary (#13287)`
