### PR TITLE
docs(wake): capture Codex A2A submit matrix (#13292)

### DIFF
--- a/ai/docs/wake-prompt-landing-matrix.md
+++ b/ai/docs/wake-prompt-landing-matrix.md
@@ -37,3 +37,23 @@ The following criteria must be satisfied for each supported harness.
 Due to the brittle nature of native UI automation across multiple different IDEs and proprietary desktop apps, **live/manual evidence is acceptable** for UI-only assertions (requirements 6-9).
 
 However, deterministic headless unit/integration tests **MUST** be used to validate the backend and wake-daemon adapter intent (requirements 1-5).
+
+## Codex Heartbeat vs A2A Submission Differential
+
+Regression ticket #13287 adds a Codex-specific validation rule: a green backend
+adapter test is not enough when heartbeat wakes and actionable A2A wakes appear
+to diverge at the final Codex submit boundary. The controlled validation must
+compare all three digest shapes below on the same active Codex subscription
+metadata before declaring the lane complete.
+
+| Scenario | Required Controlled Payload | Backend Assertions | Live Codex Assertions |
+| :--- | :--- | :--- | :--- |
+| Pure heartbeat | One `heartbeat_pulse` event and no message/task/permission events. | Digest includes `heartbeat pulses`; adapter selection matches the active subscription; backend logs only adapter acceptance. | Payload lands in the existing Codex prompt surface, submits without operator Enter, and starts a turn. |
+| Direct A2A message | One unread `SENT_TO_ME` message event and no heartbeat event. | Digest includes `new messages`; adapter selection matches the active subscription; stale-read retry suppression stays intact. | Payload lands in the existing Codex prompt surface, submits without operator Enter, and starts a turn. |
+| Mixed message + heartbeat | One unread `SENT_TO_ME` message event plus one heartbeat event in the same coalesced flush. | Digest includes both `new messages` and `heartbeat pulses`; adapter selection remains one route, not event-type-dependent. | Payload lands once, submits once, starts one turn, and does not duplicate-submit during draft restore or retry handling. |
+
+The live evidence artifact for #13287 must name the subscription id, adapter
+metadata, payload scenario, observed prompt landing result, submit/start-turn
+result, and whether a human Enter key was required. If a scenario lands text
+without starting a turn, record the backend adapter result as partial delivery
+instead of treating it as a successful Codex wake.

--- a/ai/docs/wake-prompt-landing-matrix.md
+++ b/ai/docs/wake-prompt-landing-matrix.md
@@ -44,16 +44,17 @@ Regression ticket #13287 adds a Codex-specific validation rule: a green backend
 adapter test is not enough when heartbeat wakes and actionable A2A wakes appear
 to diverge at the final Codex submit boundary. The controlled validation must
 compare all three digest shapes below on the same active Codex subscription
-metadata before declaring the lane complete.
+metadata, recording the resolved adapter route for each attempt before
+declaring the lane complete.
 
 | Scenario | Required Controlled Payload | Backend Assertions | Live Codex Assertions |
 | :--- | :--- | :--- | :--- |
-| Pure heartbeat | One `heartbeat_pulse` event and no message/task/permission events. | Digest includes `heartbeat pulses`; adapter selection matches the active subscription; backend logs only adapter acceptance. | Payload lands in the existing Codex prompt surface, submits without operator Enter, and starts a turn. |
-| Direct A2A message | One unread `SENT_TO_ME` message event and no heartbeat event. | Digest includes `new messages`; adapter selection matches the active subscription; stale-read retry suppression stays intact. | Payload lands in the existing Codex prompt surface, submits without operator Enter, and starts a turn. |
-| Mixed message + heartbeat | One unread `SENT_TO_ME` message event plus one heartbeat event in the same coalesced flush. | Digest includes both `new messages` and `heartbeat pulses`; adapter selection remains one route, not event-type-dependent. | Payload lands once, submits once, starts one turn, and does not duplicate-submit during draft restore or retry handling. |
+| Pure heartbeat | One `heartbeat_pulse` event and no message/task/permission events. | Digest includes `heartbeat pulses`; resolved adapter route is recorded from subscription metadata plus platform default; backend logs only adapter acceptance. | Payload lands in the existing Codex prompt surface, submits without operator Enter, and starts a turn. |
+| Direct A2A message | One unread `SENT_TO_ME` message event and no heartbeat event. | Digest includes `new messages`; resolved adapter route is recorded from subscription metadata plus platform default; stale-read retry suppression stays intact. | Payload lands in the existing Codex prompt surface, submits without operator Enter, and starts a turn. |
+| Mixed message + heartbeat | One unread `SENT_TO_ME` message event plus one heartbeat event in the same coalesced flush. | Digest includes both `new messages` and `heartbeat pulses`; evidence records whether the resolved adapter route remains one route or changes by event shape/path. | Payload lands once, submits once, starts one turn, and does not duplicate-submit during draft restore or retry handling. |
 
 The live evidence artifact for #13287 must name the subscription id, adapter
-metadata, payload scenario, observed prompt landing result, submit/start-turn
-result, and whether a human Enter key was required. If a scenario lands text
-without starting a turn, record the backend adapter result as partial delivery
-instead of treating it as a successful Codex wake.
+metadata, resolved adapter route, payload scenario, observed prompt landing
+result, submit/start-turn result, and whether a human Enter key was required. If
+a scenario lands text without starting a turn, record the backend adapter result
+as partial delivery instead of treating it as a successful Codex wake.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Resolves #13292
Related: #13287
Related: #13291
Related: #13012

Adds the Codex-specific heartbeat-vs-A2A submission differential to the wake prompt landing matrix. The new section requires future #13287 validation to compare pure heartbeat, direct A2A message, and mixed message+heartbeat digests on the same active Codex subscription, while recording backend adapter evidence separately from live prompt land + submit/start-turn evidence.

Evidence: L1 (documentation/protocol diff + whitespace validation) -> L1 required (#13292 docs ACs). Residual: L4 live Codex prompt submit/start-turn behavior remains open on #13287.

## Deltas from ticket

- Operator follow-up sharpened the hypothesis: heartbeat wakes appear to submit, while direct A2A message wakes may land without submitting; adapter/path divergence is now an observed variable to record rather than a conclusion to pre-decide.
- Runtime V-B-A at update time found active `@neo-gpt` subscription `WAKE_SUB:7648b86c-2f1e-43a8-95a6-cc399f66a938` is `bridge-daemon` with `appName: Codex`, `focusSeedKey: r`, and no explicit `adapter`; `deliverDigest()` therefore resolves the platform default (`osascript` on macOS) unless metadata explicitly selects `codex-app-server`.

This PR deliberately avoids runtime behavior and does not claim #13287 is fixed.

## Test Evidence

- `git diff --check`
- `node ./buildScripts/util/check-whitespace.mjs`
- Commit hook ran `node ./buildScripts/util/check-whitespace.mjs`

## Post-Merge Validation

- [ ] Use the updated matrix section when running the live #13287 Codex validation artifact.

## Commits

- `858114c7d` - `docs(wake): capture codex a2a submit matrix (#13292)`
- `ffc521832` - `docs(wake): record codex resolved adapter route (#13292)`
