### PR TITLE
test(ai): live two-writer WriteGuard whitebox-e2e (#13167)

### DIFF
--- a/test/playwright/e2e/WriteGuardMultiWriterNL.spec.mjs
+++ b/test/playwright/e2e/WriteGuardMultiWriterNL.spec.mjs
@@ -1,0 +1,156 @@
+import { test, expect } from '../fixtures.mjs';
+import WebSocket        from 'ws';
+
+/**
+ * @summary LIVE two-writer proof for the multi-writer WriteGuard enforcement (the umbrella-closure proof) —
+ * the live-app counterpart to the unit specs (which inject the writer context past the transport).
+ *
+ * Two DISTINCT agent writers connect to the live Neural Link Bridge:
+ *  - writer-1 = the fixture's `ConnectionService` (one `(agentId, sessionId)` pair),
+ *  - writer-2 = a RAW second `ws` (`?role=agent&id=…`) — the Bridge mints a distinct `sessionId` per
+ *    connection, so the two are distinct writers. Per the Bridge-auth read (@neo-claude-opus): the Bridge
+ *    stamps the `agent_message` sidecar for EVERY agent connection unconditionally (dev / no-token
+ *    included), and `WriteGuard` keys on `(agentId, sessionId)` regardless of token-verification — so a
+ *    no-token dev connection IS enforced.
+ *
+ * It exercises the full transport→enforcement path the unit coverage cannot reach: Bridge `agent_message`
+ * sidecar → `parseAgentEnvelope` → `InstanceService.assertWritable` → `admitWrite` → `WriteGuard`.
+ *
+ * Scenario: writer-1 writes component A (acquires + HOLDS the lock on A's subtree — held-on-grant until
+ * disconnect). Then writer-2 writes the SAME component A → DENIED (overlapping subtree, different writer).
+ * A control write by writer-2 to a sibling B → ADMITTED (no overlap) — proving writer-2's writes succeed
+ * absent a conflict, so the deny on A is a genuine cross-writer conflict, not a broken writer-2.
+ *
+ * ⚠️ REQUIRES A FRESH BRIDGE. A long-running bridge predating the `agent_message` sidecar-emit merge
+ * forwards BARE frames → enforcement silently no-ops → writer-2's A write would wrongly ADMIT. CI (clean
+ * port) spawns a fresh bridge from source via `ConnectionService.spawnBridge`. LOCALLY, kill any
+ * neural-link bridge on :8081 first. A step-2 ADMIT (instead of deny) most likely means a stale bridge,
+ * not a logic regression — a stale bridge fails the conflict assertion for an environment reason.
+ *
+ * LIVE-VERIFIED (fresh bridge, headless chromium): the full path fires end-to-end — writer-1's
+ * `set_instance_properties` on `neo-button-1` holds the lock; writer-2's overlapping write returns the
+ * jsonrpc error `-32603 "Write denied for <id>: conflict (held by <agentId> / <sessionId>)"` from
+ * `InstanceService.assertWritable`; writer-2's sibling write returns `{result:{success:true}}`. The raw-`ws`
+ * response arrives as a `{type:'app_message', message:<jsonrpc>}` frame, matched by request id below.
+ */
+test.describe('WriteGuard multi-writer enforcement (live two-writer e2e)', () => {
+    test.setTimeout(90000);
+
+    test('a second writer is DENIED an overlapping write but ADMITTED a non-overlapping one', async ({ page, neuralLink }) => {
+        await page.goto('/examples/button/base/index.html');
+        await expect(page.locator('.neo-button').first()).toBeVisible({ timeout: 30000 });
+
+        const app = await neuralLink.connectToApp('Neo.examples.button.base');
+        expect(app.sessionId, 'app worker session id').toBeTruthy();
+
+        // Normalize the NL query envelope defensively so this proof does not couple to one shape.
+        const idsOf = res => (Array.isArray(res) ? res : res?.components ?? res?.instances ?? [])
+            .map(c => c?.id).filter(Boolean);
+        const pickId = res => idsOf(res)[0] ?? res?.id ?? null;
+
+        // A container to host the two sibling write targets.
+        const containerId = pickId(await app.findInstances({ ntype: 'viewport' }, ['id']))
+                         ?? pickId(await app.findInstances({ ntype: 'container' }, ['id']));
+        expect(containerId, 'a container to host the two writers').toBeTruthy();
+
+        // Two sibling targets A, B. Create buttons until the example exposes at least two.
+        let buttonIds = idsOf(await app.findInstances({ ntype: 'button' }, ['id']));
+        while (buttonIds.length < 2) {
+            const seen = buttonIds.length;
+            await app.createComponent(containerId, { ntype: 'button', text: 'wg-target-' + seen });
+            await expect.poll(
+                async () => idsOf(await app.findInstances({ ntype: 'button' }, ['id'])).length,
+                { message: 'created button should register', timeout: 10000 }
+            ).toBeGreaterThan(seen);
+            buttonIds = idsOf(await app.findInstances({ ntype: 'button' }, ['id']));
+        }
+        const [componentA, componentB] = buttonIds;
+        expect(componentA).not.toBe(componentB);
+
+        // writer-1 (the fixture ConnectionService, identity #1) acquires + HOLDS the lock on A's subtree.
+        await app.setProperties(componentA, { text: 'writer-1-holds-A' });
+
+        // writer-2 — a RAW second agent ws with a DISTINCT identity (the bridge mints its own sessionId).
+        const writer2 = await openRawAgent(BRIDGE_PORT, 'neo-writer-2');
+
+        try {
+            // (1) Overlapping write — same component A, different writer → DENIED (conflict).
+            const denied = await writer2.call(app.sessionId, 'set_instance_properties',
+                { id: componentA, properties: { text: 'writer-2-tries-A' } });
+            expect(denied.error,
+                'writer-2 overlapping write must be denied (conflict); an ADMIT here most likely means a STALE bridge'
+            ).toBeTruthy();
+
+            // (2) Non-overlapping control — sibling B → ADMITTED (proves writer-2 writes work absent a conflict).
+            const admitted = await writer2.call(app.sessionId, 'set_instance_properties',
+                { id: componentB, properties: { text: 'writer-2-writes-B' } });
+            expect(admitted.error,
+                'writer-2 non-overlapping write must be admitted'
+            ).toBeFalsy();
+        } finally {
+            writer2.close();
+        }
+    });
+});
+
+/** Bridge default port — see `ai/mcp/server/neural-link/Bridge.mjs` (`port: 8081`). */
+const BRIDGE_PORT = 8081;
+
+/**
+ * Opens a raw second agent connection to the live Neural Link Bridge — a writer identity DISTINCT from
+ * the fixture's writer-1. The Bridge accepts a `role=agent&id=` connection (no token = dev path), mints a
+ * per-connection `sessionId`, and stamps the `agent_message` sidecar on every forward, so writes from
+ * this socket carry a `(agentId, sessionId)` the WriteGuard sees as a separate writer.
+ *
+ * @param {Number} port
+ * @param {String} agentId A distinct agent id for this writer.
+ * @returns {Promise<{call: Function, close: Function}>}
+ */
+async function openRawAgent(port, agentId) {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}?role=agent&id=${encodeURIComponent(agentId)}`);
+
+    await new Promise((resolve, reject) => {
+        ws.on('open',  resolve);
+        ws.on('error', reject);
+    });
+
+    let nextId = 1;
+
+    return {
+        /**
+         * Sends a JSON-RPC method to the target App Worker over this raw agent socket and resolves with the
+         * App Worker's response (success or jsonrpc error). The Bridge routes the response back to this
+         * socket; we match by request id, tolerating a bare response or a `{message: <response>}` envelope.
+         */
+        call(targetSessionId, method, params) {
+            const id = nextId++;
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    ws.off('message', onMessage);
+                    reject(new Error(`raw-agent call ${method} (#${id}) timed out`));
+                }, 15000);
+
+                const onMessage = data => {
+                    let frame;
+                    try { frame = JSON.parse(data.toString()); } catch { return; }
+                    const msg = frame?.message ?? frame;
+                    if (msg && msg.id === id) {
+                        clearTimeout(timer);
+                        ws.off('message', onMessage);
+                        resolve(msg);
+                    }
+                };
+
+                ws.on('message', onMessage);
+                ws.send(JSON.stringify({
+                    target : targetSessionId,
+                    message: { jsonrpc: '2.0', method, params, id }
+                }));
+            });
+        },
+
+        close() {
+            ws.close();
+        }
+    };
+}


### PR DESCRIPTION
Resolves #13167

Authored by Claude Opus 4.8 (1M context), @neo-opus-ada (Ada). Session 4c598c8f-d8a7-4288-9420-e825a45d310e.

The live two-writer whitebox-e2e that closes the multi-writer WriteGuard enforcement umbrella — the live-app counterpart to the unit coverage (#13226), which injects the writer context past the transport. **Live-verified** against a fresh bridge.

Two distinct agent writers connect to the live Neural Link Bridge with distinct `(agentId, sessionId)` identities (writer-1 = the fixture `ConnectionService`; writer-2 = a raw second `ws`). writer-1 acquires + holds a write-lock on a component subtree; writer-2's write to the **same** component is **DENIED** (overlapping-subtree conflict), and a control write to a sibling is **ADMITTED**. This exercises the full transport→enforcement path — Bridge `agent_message` sidecar → `parseAgentEnvelope` → `InstanceService.assertWritable` → `admitWrite` → `WriteGuard` — that the unit coverage cannot reach.

Evidence: L3 ACHIEVED (live two-writer enforcement; fresh bridge; headless chromium — green). No residual.

## Deltas from ticket

- The umbrella-closure proof is the multi-writer **conflict** e2e (this PR). The undo-round-trip (@neo-opus-vega's #13286) stays a **separate** spec on her lane.
- The live run surfaced + fixed a scaffold bug: the raw-`ws` wire method was camelCase `setInstanceProperties`; the App-Worker Client dispatches the snake_case `set_instance_properties` prefix (`Client.handleRequest` → `serviceMap` prefix-match → `snakeToCamel`). Both code-review and my own code-verification missed it — exactly the class of bug only an L3 live run catches.

## Test Evidence

- **Live run (fresh bridge on :8081, headless chromium): `1 passed (4.8s)`.** The bridge log shows the full path firing:
  - writer-1 (`agent-6e2c4eff… / f83e4a13…`) `set_instance_properties` on `neo-button-1` → `{success:true}` (acquires + holds the lock).
  - writer-2 (`neo-writer-2`, a distinct identity) overlapping write on `neo-button-1` → `-32603 "Write denied for neo-button-1: conflict (held by agent-6e2c4eff… / f83e4a13…)"` at `InstanceService.assertWritable` (**DENIED**).
  - writer-2 sibling write on `neo-button-2` → `{success:true}` (**ADMITTED**).
- `node --check` + the whitespace/archaeology pre-commit hooks clean. The unit coverage for the same enforcement is #13226 (merged).

## Post-Merge Validation

- [x] Manual e2e run on a fresh bridge: writer-1 holds the lock; writer-2's overlapping write DENIED (conflict); the sibling write ADMITTED. ✅ Done 2026-06-15.
- Note: neo CI runs only lint/unit/integration — not the playwright e2e suite — so this is a manual/local L3 proof like every other `test/playwright/e2e/*` spec. Operator-independent runnability (a dedicated-port bridge so no shared `:8081` restart is needed) is tracked separately as the browser-app bridge-URL override, riding #13305 / #13299.
