### PR TITLE
fix(memory-core): guard actionable wake suppression (#13295)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1036,7 +1036,7 @@ paths:
                 wakeSuppressed:
                   type: boolean
                   default: false
-                  description: "Persist + deliver the message but emit NO wake event — the recipient sees it on their next list_messages rather than via an interrupt. Use for awareness/FYI (e.g. PR-opened-you're-not-the-reviewer, lane-progress, acks) or session-sunset self-DM handovers. Do NOT suppress actionable messages (you're the reviewer, a lane was claimed on you, REQUEST_CHANGES) — those must wake. In autonomous mode a suppressed message stays unseen until the recipient next lists/boots. Default: omit (= false)."
+                  description: "Persist + deliver the message but emit NO wake event — the recipient sees it on their next list_messages rather than via an interrupt. Use for awareness/FYI (e.g. PR-opened-you're-not-the-reviewer, lane-progress, acks) or session-sunset self-DM handovers. Do NOT suppress actionable messages (you're the reviewer, a lane was claimed on you, REQUEST_CHANGES) — those must wake. Known-actionable direct lifecycle messages are rejected when wakeSuppressed is true. In autonomous mode a suppressed message stays unseen until the recipient next lists/boots. Default: omit (= false)."
                 task:
                   type: object
                   description: "Optional A2A Task envelope (https://a2a-protocol.org/latest/specification/) for structured agent coordination. Omit for free-form markdown messages."

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -7,6 +7,19 @@ import WakeSubscriptionService from './WakeSubscriptionService.mjs';
 import crypto from 'crypto';
 import SemanticGraphExtractor from '../../services/graph/SemanticGraphExtractor.mjs';
 
+const
+    WAKE_SUPPRESSION_ALLOWED_TAGS = new Set(['sunset-protocol-handover', 'lead-role-baton']),
+    WAKE_SUPPRESSION_ACTIONABLE_SUBJECTS = [
+        /^\[re-review/i,
+        /^\[review/i,
+        /^\[review-response/i,
+        /\bre-?review\b/i,
+        /\breview-?request\b/i,
+        /\bREQUEST_CHANGES\b/i,
+        /\bCHANGES_REQUESTED\b/i,
+        /\blane-override\b/i
+    ];
+
 /**
  * Normalizes a raw addressing target into its canonical Graph Node ID format.
  * Enforces the unified identity substrate where `@<login>` is canonical for all identities.
@@ -122,6 +135,63 @@ function setRecordProperties(record, properties) {
     } else if (record) {
         record.properties = properties;
     }
+}
+
+/**
+ * @summary True for intentionally mailbox-only wake suppression cases whose recipients should
+ * pick the message up through `list_messages`, not through an interrupt wake.
+ * @param {Object} args
+ * @param {String} args.subject
+ * @param {String[]} args.taggedConcepts
+ * @param {String} args.to
+ * @returns {Boolean}
+ * @private
+ */
+function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
+    if (to === 'AGENT:*') return true;
+
+    if (taggedConcepts.some(tag => WAKE_SUPPRESSION_ALLOWED_TAGS.has(tag))) {
+        return true;
+    }
+
+    return /^\[alert\]/i.test(subject);
+}
+
+/**
+ * @summary Returns the actionable-suppression reason for a direct A2A message, or `null` when
+ * `wakeSuppressed` is safe. `wakeSuppressed` is honored downstream by the wake substrate; this
+ * guard sits at message acceptance so known-actionable direct lifecycle messages cannot silently
+ * become mailbox-only.
+ * @param {Object} args
+ * @param {Boolean} args.wakeSuppressed
+ * @param {String} args.to
+ * @param {String} args.subject
+ * @param {String} args.priority
+ * @param {String[]} args.taggedConcepts
+ * @param {Object} [args.task]
+ * @returns {String|null}
+ * @private
+ */
+function getWakeSuppressionRisk({wakeSuppressed, to, subject = '', priority = 'normal', taggedConcepts = [], task}) {
+    if (!wakeSuppressed || isAllowedWakeSuppression({subject, taggedConcepts, to})) {
+        return null;
+    }
+
+    if (!to?.startsWith('@')) {
+        return null;
+    }
+
+    if (priority === 'high') {
+        return 'high-priority direct message';
+    }
+
+    if (task) {
+        return 'direct task message';
+    }
+
+    const pattern = WAKE_SUPPRESSION_ACTIONABLE_SUBJECTS.find(item => item.test(subject));
+
+    return pattern ? 'actionable direct lifecycle subject' : null;
 }
 
 /**
@@ -371,7 +441,8 @@ class MailboxService extends Base {
      * @param {String[]} [args.taggedConcepts] Array of concept IDs tagged
      * @param {Boolean} [args.wakeSuppressed=false] Persist the message without emitting `SENT_TO_ME`
      *   wake events. Intended for mailbox-only handovers such as session-sunset self-DMs that must be
-     *   consumed by the next boot, not injected back into the active sender harness.
+     *   consumed by the next boot, not injected back into the active sender harness. Known-actionable
+     *   direct lifecycle messages reject wake suppression before persistence.
      * @param {Object} [args.task] Optional A2A Task envelope payload. When present,
      *   stored verbatim as a property on the MESSAGE node and surfaced by get_message + list_messages
      *   for programmatic agent coordination. This write primitive treats `task` as opaque JSON;
@@ -483,6 +554,16 @@ class MailboxService extends Base {
             }
         }
 
+        if (task?.state && !MailboxService.VALID_TASK_STATES.includes(task.state)) {
+            throw new Error(`Invalid task state: ${task.state}. Must be one of: ${MailboxService.VALID_TASK_STATES.join(', ')}`);
+        }
+
+        const wakeSuppressionRisk = getWakeSuppressionRisk({wakeSuppressed, to, subject, priority, taggedConcepts, task});
+
+        if (wakeSuppressionRisk) {
+            throw new Error(`Cannot suppress wake for ${wakeSuppressionRisk}. Omit wakeSuppressed or set it to false; mailbox-only suppression is reserved for awareness/FYI, session-sunset handover, lead-role baton, and audit-alert messages.`);
+        }
+
         // 1. Create the Message Node
         // The optional `task` property carries an A2A-Task-object-shaped JSON payload. When
         // present, downstream consumers surface it for programmatic agent coordination. The
@@ -506,9 +587,6 @@ class MailboxService extends Base {
         };
 
         if (task !== undefined) {
-            if (task.state && !MailboxService.VALID_TASK_STATES.includes(task.state)) {
-                throw new Error(`Invalid task state: ${task.state}. Must be one of: ${MailboxService.VALID_TASK_STATES.join(', ')}`);
-            }
             messageProperties.task = task;
         }
 

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -443,6 +443,69 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(node.properties.readAt).toBeNull();
     });
 
+    test('addMessage rejects wakeSuppressed known-actionable direct lifecycle messages', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await expect(MailboxService.addMessage({
+                to             : '@bob',
+                subject        : '[review][REQUEST_CHANGES] #13290 — close-target gate',
+                body           : 'This must wake the PR author.',
+                wakeSuppressed : true
+            })).rejects.toThrow(/Cannot suppress wake for actionable direct lifecycle subject/);
+
+            await expect(MailboxService.addMessage({
+                to             : '@bob',
+                subject        : 'urgent direct escalation',
+                body           : 'High-priority direct messages must wake.',
+                priority       : 'high',
+                wakeSuppressed : true
+            })).rejects.toThrow(/Cannot suppress wake for high-priority direct message/);
+        });
+
+        expect(GraphService.db.nodes.items.filter(node =>
+            node.label === 'MESSAGE' &&
+            node.properties?.wakeSuppressed === true
+        )).toHaveLength(0);
+    });
+
+    test('addMessage preserves explicit mailbox-only wakeSuppressed exceptions', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const baton = await MailboxService.addMessage({
+                to             : '@bob',
+                subject        : '[handoff] Lead Role Baton',
+                body           : 'fromLead: @alice\ntoLead: @bob',
+                taggedConcepts : ['lead-role-baton'],
+                wakeSuppressed : true
+            });
+
+            const audit = await MailboxService.addMessage({
+                to             : '@bob',
+                subject        : '[alert] critical: errorRate 0.9 over threshold 0.1 (tenant tenant-x)',
+                body           : 'KB audit alert.',
+                priority       : 'high',
+                wakeSuppressed : true
+            });
+
+            const awareness = await MailboxService.addMessage({
+                to             : 'AGENT:*',
+                subject        : '[lane-claim] #13295 — non-overlapping awareness',
+                body           : 'Broadcast awareness only.',
+                wakeSuppressed : true
+            });
+
+            expect((await MailboxService.getMessage({ messageId: baton.messageId })).wakeSuppressed).toBe(true);
+            expect((await MailboxService.getMessage({ messageId: audit.messageId })).wakeSuppressed).toBe(true);
+            expect((await MailboxService.getMessage({ messageId: awareness.messageId })).wakeSuppressed).toBe(true);
+        });
+    });
+
     test('Reachable Counterparty exception permits replies without explicit grant', async () => {
         // Alice sends to Bob (alice can send to broadcast or we need to ensure alice can send)
         // Actually, to send initially, we need permission unless it is broadcast.


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 9c41c4c0-e14b-4e86-bd59-62f7fe64491a.

Resolves #13295
Related: #13287
Related: #13012

Adds an acceptance-time guard in `MailboxService.addMessage()` so known-actionable direct A2A lifecycle messages cannot silently set `wakeSuppressed:true` and become mailbox-only. The downstream wake honor-sites stay unchanged: suppressed mailbox-only messages still do not wake, but review/REQUEST_CHANGES-style direct messages, high-priority direct messages, and direct task messages now fail closed before persistence.

Evidence: L2 (Memory Core service unit coverage + adjacent OpenAPI/KB-alert/wake honor-site unit coverage) -> L2 required (#13295 changes the add_message acceptance contract and can be proven at service/schema level). No residuals.

## Deltas from ticket

- Chose fail-closed rejection rather than audit-only for known-actionable direct suppression. The error tells callers to omit `wakeSuppressed` or set it false.
- Preserved the intended mailbox-only exceptions: `AGENT:*` awareness broadcasts, `sunset-protocol-handover`, `lead-role-baton`, and `[alert]` KB audit messages.
- Posted the required #13287 evidence note clarifying that suppressed direct messages are upstream-invalid evidence for Codex submit/start-turn failure: `IC_kwDODSospM8AAAABGGbLQw`.

## Test Evidence

- `node --check ai/services/memory-core/MailboxService.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` -> 68 passed
- `npm run test-unit -- test/playwright/unit/ai/daemons/kb-alerting/KbAlertingService.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` -> 48 passed
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs -g "wakeSuppressed"` -> 2 passed
- `git diff --check`
- Pre-commit hook ran `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, and `check-ticket-archaeology`.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `6e692337c fix(memory-core): guard actionable wake suppression (#13295)`.

## Post-Merge Validation

- [ ] Attempting to send a direct `[review][REQUEST_CHANGES]` A2A message with `wakeSuppressed:true` from a live MCP client rejects before persistence.
- [ ] Session-sunset self-DM, lead-role baton, awareness broadcast, and KB audit alert mailbox-only sends still remain accepted.

## Commit

- `6e692337c` — `fix(memory-core): guard actionable wake suppression (#13295)`