### PR TITLE
feat(ai): wire neural-link HealthService to RuntimeFreshnessService (#13297)

### DIFF
--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -84,7 +84,10 @@ class ConnectionService extends Base {
      * @returns {Promise<void>}
      */
     async initAsync() {
-        if (aiConfig.autoConnect) {
+        // Skip the Bridge auto-connect under unitTestMode: unit specs that import this singleton (e.g. via
+        // HealthService) must stay hermetic and must not reach or spawn the live Bridge. The e2e harness
+        // connects explicitly via manageConnection(); production (non-unitTestMode) auto-connects as before.
+        if (aiConfig.autoConnect && !Neo.config.unitTestMode) {
             await this.ensureBridgeAndConnect();
         }
     }

--- a/ai/services/neural-link/HealthService.mjs
+++ b/ai/services/neural-link/HealthService.mjs
@@ -1,6 +1,31 @@
-import Base              from '../../../src/core/Base.mjs';
-import ConnectionService from './ConnectionService.mjs';
-import logger            from '../../mcp/server/neural-link/logger.mjs';
+import path                     from 'path';
+import {fileURLToPath}          from 'url';
+import Base                     from '../../../src/core/Base.mjs';
+import ConnectionService        from './ConnectionService.mjs';
+import logger                   from '../../mcp/server/neural-link/logger.mjs';
+import RuntimeFreshnessService  from '../../mcp/server/shared/services/RuntimeFreshnessService.mjs';
+
+const
+    serviceDir              = path.dirname(fileURLToPath(import.meta.url)),
+    configPath              = path.resolve(serviceDir, '../../config.mjs'),
+    openApiPath             = path.resolve(serviceDir, '../../mcp/server/neural-link/openapi.yaml'),
+    runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
+        files  : [{
+            key       : 'configDigest',
+            path      : configPath,
+            errorLabel: 'config digest'
+        }, {
+            key       : 'openApiDigest',
+            path      : openApiPath,
+            errorLabel: 'OpenAPI digest'
+        }],
+        serviceName       : 'Neural Link MCP server',
+        identityLabel     : 'source/config identity',
+        assertionFacts    : 'tool-schema/source facts',
+        restartScope      : 'cached source, config, and tool definitions',
+        statusFields      : ['configDigest', 'openApiDigest'],
+        unavailableSummary: 'config digest and OpenAPI digest'
+    });
 
 /**
  * @summary Monitors the health of the Neural Link MCP Server.
@@ -8,6 +33,13 @@ import logger            from '../../mcp/server/neural-link/logger.mjs';
  * This service checks the status of the WebSocket server and the active connections
  * to the App Worker(s). It provides a `healthcheck` tool that agents can use
  * to verify if the runtime bridge is operational.
+ *
+ * A long-lived Neural Link MCP process can stay bridge-healthy while its checkout, config, or
+ * OpenAPI schema has moved underneath it — the gap that lets a stale bridge process keep forwarding
+ * pre-merge frames undetected. The `runtimeFreshness` block in the healthcheck payload surfaces that
+ * drift via the shared, digest-based {@link Neo.ai.mcp.server.shared.services.RuntimeFreshnessService}
+ * (cloud-safe — no `gitHead` coupling), bringing the bridge to parity with the Memory Core, Knowledge
+ * Base, and GitHub Workflow MCP servers.
  *
  * @class Neo.ai.services.neural-link.HealthService
  * @extends Neo.core.Base
@@ -25,6 +57,61 @@ class HealthService extends Base {
          * @protected
          */
         singleton: true
+    }
+
+    /**
+     * Shared runtime freshness tracker.
+     * @member {RuntimeFreshnessTracker} #runtimeFreshnessTracker
+     * @private
+     */
+    #runtimeFreshnessTracker = runtimeFreshnessTracker;
+
+    /**
+     * Optional unit-test seam for injecting boot/current runtime identity reads.
+     * @member {Function|null} runtimeFreshnessReader
+     */
+    runtimeFreshnessReader = null;
+
+    /**
+     * Duration (in milliseconds) for which runtime freshness remains cached.
+     * @member {Number} runtimeFreshnessCacheDuration
+     */
+    runtimeFreshnessCacheDuration = 30 * 1000;
+
+    /**
+     * Boot-time runtime identity captured before long-lived MCP clients can go stale.
+     * @member {Object} bootRuntimeIdentity
+     */
+    get bootRuntimeIdentity() {
+        return this.#runtimeFreshnessTracker.bootRuntimeIdentity;
+    }
+
+    set bootRuntimeIdentity(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeIdentity = value || {};
+    }
+
+    /**
+     * Boot-time runtime identity read errors.
+     * @member {String[]} bootRuntimeFreshnessErrors
+     */
+    get bootRuntimeFreshnessErrors() {
+        return this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors;
+    }
+
+    set bootRuntimeFreshnessErrors(value) {
+        this.#runtimeFreshnessTracker.bootRuntimeFreshnessErrors = Array.isArray(value) ? value : [];
+    }
+
+    /**
+     * ISO timestamp captured when this server module was loaded.
+     * @member {String} runtimeStartedAt
+     */
+    get runtimeStartedAt() {
+        return this.#runtimeFreshnessTracker.startedAt;
+    }
+
+    set runtimeStartedAt(value) {
+        this.#runtimeFreshnessTracker.startedAt = value;
     }
 
     /**
@@ -52,7 +139,8 @@ class HealthService extends Base {
                 windows  : status.windows,
                 agents   : status.agents,
                 version  : process.env.npm_package_version || '1.0.0',
-                uptime   : process.uptime()
+                uptime   : process.uptime(),
+                runtimeFreshness: await this.resolveRuntimeFreshness()
             };
         } catch (error) {
             logger.error('[HealthService] Unexpected error during health check:', error);
@@ -63,6 +151,29 @@ class HealthService extends Base {
                 code   : 'HEALTH_CHECK_ERROR'
             };
         }
+    }
+
+    /**
+     * Resolves the live runtime freshness diagnostic for the attached Neural Link MCP process.
+     *
+     * A process can be bridge-healthy while stale relative to the checkout/config an agent is
+     * inspecting. Surfacing this lightweight warning in the healthcheck avoids duplicate source
+     * tickets when the right action is restart/reconnect.
+     *
+     * @returns {Promise<Object>} Runtime freshness diagnostic payload.
+     */
+    async resolveRuntimeFreshness() {
+        return this.#runtimeFreshnessTracker.resolve({
+            reader       : this.runtimeFreshnessReader,
+            cacheDuration: this.runtimeFreshnessCacheDuration
+        });
+    }
+
+    /**
+     * Clears the short runtime-freshness cache, forcing the next resolve to re-read identity.
+     */
+    clearCache() {
+        this.#runtimeFreshnessTracker.clearCache();
     }
 }
 

--- a/test/playwright/unit/ai/services/neural-link/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/HealthService.spec.mjs
@@ -1,0 +1,112 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'NeuralLinkHealthServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Unit coverage for the Neural Link HealthService runtime-freshness diagnostic.
+ *
+ * The Neural Link bridge runs as a long-lived MCP process that can stay bridge-healthy while its
+ * checkout/config/schema has moved underneath it — a stale process keeps forwarding pre-merge frames
+ * undetected. This wires the bridge to the shared digest-based RuntimeFreshnessService for parity with
+ * the Memory Core, Knowledge Base, and GitHub Workflow servers. These specs verify the wiring via the
+ * injected reader seam: matching identity reports `current`, a changed config/OpenAPI digest reports
+ * `stale` with Neural-Link restart guidance, gitHead drift is ignored (no rootDir → digest-only,
+ * cloud-safe), and an unreadable identity degrades to `unknown` without throwing.
+ */
+test.describe.serial('Neo.ai.services.neural-link.HealthService runtimeFreshness', () => {
+    let HealthService, bootRuntimeIdentity, bootRuntimeFreshnessErrors;
+
+    test.beforeAll(async () => {
+        HealthService              = (await import('../../../../../../ai/services/neural-link/HealthService.mjs')).default;
+        bootRuntimeIdentity        = HealthService.bootRuntimeIdentity;
+        bootRuntimeFreshnessErrors = HealthService.bootRuntimeFreshnessErrors;
+    });
+
+    test.afterEach(() => {
+        HealthService.runtimeFreshnessReader        = null;
+        HealthService.runtimeFreshnessCacheDuration = 30 * 1000;
+        HealthService.bootRuntimeIdentity           = bootRuntimeIdentity;
+        HealthService.bootRuntimeFreshnessErrors    = bootRuntimeFreshnessErrors;
+        HealthService.clearCache();
+    });
+
+    test('classifies matching boot/current identity as current', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot   : {configDigest: 'sha256:same-config', openApiDigest: 'sha256:same-openapi'},
+            current: {configDigest: 'sha256:same-config', openApiDigest: 'sha256:same-openapi'}
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'current',
+            stale : {configDigest: false, openApiDigest: false},
+            hint  : null
+        });
+        expect(result.details).toContain('Runtime source/config identity matches the current checkout.');
+        expect(result.boot).toBeUndefined();
+        expect(result.current).toBeUndefined();
+    });
+
+    test('classifies stale config + OpenAPI identity with Neural Link restart guidance', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot   : {configDigest: 'sha256:old-config', openApiDigest: 'sha256:old-openapi'},
+            current: {configDigest: 'sha256:new-config', openApiDigest: 'sha256:new-openapi'}
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'stale',
+            stale : {configDigest: true, openApiDigest: true},
+            hint  : 'Restart or reconnect the Neural Link MCP server to refresh cached source, config, and tool definitions.'
+        });
+        expect(result.details[0]).toContain('Neural Link MCP server');
+        expect(result.details[0]).toContain('configDigest');
+    });
+
+    test('ignores gitHead drift entirely — digest-only, cloud-safe (no rootDir)', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot   : {gitHead: 'old-head', configDigest: 'sha256:same-config', openApiDigest: 'sha256:same-openapi'},
+            current: {gitHead: 'new-head', configDigest: 'sha256:same-config', openApiDigest: 'sha256:same-openapi'}
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result.status).toBe('current');
+        expect(result.stale).not.toHaveProperty('gitHead');
+        expect(result.stale).toEqual({configDigest: false, openApiDigest: false});
+    });
+
+    test('classifies missing identity as unknown without throwing', async () => {
+        HealthService.runtimeFreshnessReader = async () => ({
+            boot   : {},
+            current: {},
+            errors : ['current config digest unavailable: fixture']
+        });
+
+        const result = await HealthService.resolveRuntimeFreshness();
+
+        expect(result).toMatchObject({
+            status: 'unknown',
+            stale : {configDigest: null, openApiDigest: null},
+            hint  : null
+        });
+        expect(result.details).toContain('current config digest unavailable: fixture');
+    });
+});


### PR DESCRIPTION
Resolves #13297
Refs #13289

Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.

Wires the neural-link MCP bridge's `HealthService` to the shared `RuntimeFreshnessService`, bringing it to freshness parity with the Memory Core / Knowledge Base / GitHub Workflow servers. neural-link was the only MCP server with **zero** runtime-freshness tracking — the gap that let a stale bridge process forward pre-merge frames undetected (#13286). The healthcheck payload now carries a `runtimeFreshness` block (`status: current/stale/unknown` + a restart `hint`), digest-based and cloud-safe (no `gitHead` coupling).

Evidence: L2 (4 focused unit specs on the freshness classification via the injected reader seam) -> L2 required (deterministic in-process digest comparison). No residuals.

## Implementation

- `ai/services/neural-link/HealthService.mjs`: a module-level `RuntimeFreshnessService.createTracker(...)` (digests `ai/config.mjs` + `ai/mcp/server/neural-link/openapi.yaml`, `serviceName: 'Neural Link MCP server'`); the `#runtimeFreshnessTracker` field + boot-identity / reader / cache accessors; `resolveRuntimeFreshness()` + `clearCache()`; and `runtimeFreshness: await this.resolveRuntimeFreshness()` in the healthcheck payload. Mirrors the KB consumer exactly.
- `test/playwright/unit/ai/services/neural-link/HealthService.spec.mjs` (new): 4 specs — matching identity -> `current`; changed config/OpenAPI digest -> `stale` with Neural-Link restart guidance; gitHead drift ignored (digest-only, no rootDir); unreadable identity -> `unknown` without throwing.

## Deltas from Ticket

- Close-target is the leaf #13297 (this PR fully delivers the wiring), with `Refs #13289` — the umbrella stays open for the harder source-**code** staleness detection (an Ideation Sandbox candidate). Mirrors the #13290->#13291 close-target split.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/neural-link/HealthService.spec.mjs` -> **4 passed**.
- Husky pre-commit gates passed: whitespace, shorthand, AiConfig test-mutation, ticket-archaeology.

## Post-Merge Validation

- [ ] A `healthcheck` call on a running neural-link MCP server returns a `runtimeFreshness` block, and reports `stale` after the config/OpenAPI changes underneath a long-lived process.

## Commit

- `fb45eec70` - `feat(ai): wire neural-link HealthService to RuntimeFreshnessService (#13297)`
