### PR TITLE
fix(memory-core): local-first provider diagnostics (#13300)

### DIFF
--- a/ai/mcp/client/config.mjs
+++ b/ai/mcp/client/config.mjs
@@ -40,8 +40,7 @@ const defaultConfig = {
         "memory-core": {
             transportType: "stdio",
             command      : "npm",
-            args         : ["run", "ai:mcp-server-memory-core"],
-            requiredEnv  : ["GEMINI_API_KEY"]
+            args         : ["run", "ai:mcp-server-memory-core"]
         },
         "neural-link": {
             transportType: "stdio",

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -295,7 +295,7 @@ function buildSingleEmbeddingProviderBlock(cfg, active, configName) {
  * @returns {{active: String, host: String|null, model: String|null, local: Boolean}}
  */
 export function buildSummaryProviderBlock(cfg) {
-    const active = cfg.modelProvider || 'gemini';
+    const active = cfg.modelProvider || 'openAiCompatible';
 
     if (active === 'openAiCompatible') {
         const host = cfg.openAiCompatible?.host || null;
@@ -308,11 +308,89 @@ export function buildSummaryProviderBlock(cfg) {
         };
     }
 
+    if (active === 'ollama') {
+        const host = cfg.ollama?.host || null;
+
+        return {
+            active,
+            host,
+            model: cfg.ollama?.model || null,
+            local: !!host && /^(https?:\/\/)?(127\.0\.0\.1|localhost|\[::1\])(?::|\/|$)/.test(host)
+        };
+    }
+
     return {
         active,
         host : null,
         model: active === 'gemini' ? cfg.modelName || null : null,
         local: false
+    };
+}
+
+/**
+ * @summary Resolves whether the configured Memory Core model providers have their
+ *          required credentials available.
+ *
+ * Local providers (`openAiCompatible`, `ollama`) are valid without `GEMINI_API_KEY`;
+ * Gemini requires `GEMINI_API_KEY` only for the exact summary or embedding surface that
+ * selects Gemini. This keeps health diagnostics aligned with the provider SSOT instead
+ * of treating a missing Gemini key as a universal Memory Core outage.
+ *
+ * @param {Object} cfg aiConfig-shaped input containing `modelProvider`, `embeddingProvider`,
+ *     and `engine`.
+ * @param {Object} [env=process.env] Environment object used for deterministic tests.
+ * @returns {{ready: Boolean, summary: Object, embedding: Object, details: String[]}}
+ */
+export function buildProviderPrerequisiteBlock(cfg, env = process.env) {
+    const supportedProviders = ['gemini', 'openAiCompatible', 'ollama'],
+          engine             = cfg.engine,
+          summaryProvider    = cfg.modelProvider || 'openAiCompatible',
+          embeddingProvider  = cfg.embeddingProvider || 'openAiCompatible',
+          checkProvider      = (provider, surface, unavailableDetail) => {
+              if (!supportedProviders.includes(provider)) {
+                  return {
+                      ready : false,
+                      detail: `Unsupported ${surface} provider '${provider}'. Expected 'gemini' | 'openAiCompatible' | 'ollama'.`
+                  };
+              }
+
+              if (provider === 'gemini' && !env.GEMINI_API_KEY) {
+                  return {
+                      ready : false,
+                      detail: unavailableDetail
+                  };
+              }
+
+              return {
+                  ready : true,
+                  detail: null
+              };
+          },
+          summary = checkProvider(
+              summaryProvider,
+              'summary',
+              "Summary provider 'gemini' requires GEMINI_API_KEY - summarization features unavailable"
+          ),
+          embedding = (engine === 'chroma' || engine === 'hybrid')
+              ? checkProvider(
+                  embeddingProvider,
+                  'embedding',
+                  "Embedding provider 'gemini' requires GEMINI_API_KEY - semantic memory features unavailable"
+              )
+              : {ready: true, detail: null},
+          details = [summary.detail, embedding.detail].filter(Boolean);
+
+    return {
+        ready: summary.ready && embedding.ready,
+        summary: {
+            provider: summaryProvider,
+            ready   : summary.ready
+        },
+        embedding: {
+            provider: embeddingProvider,
+            ready   : embedding.ready
+        },
+        details
     };
 }
 
@@ -1146,20 +1224,8 @@ class HealthService extends Base {
 
 
 
-    #checkApiKeyConfigured() {
-        const providers = [aiConfig.modelProvider];
-        const engine = aiConfig.engine;
-
-        if (engine === 'chroma' || engine === 'hybrid') {
-            providers.push(aiConfig.embeddingProvider);
-        }
-
-        const needsGemini = providers.some(p => p === 'gemini');
-
-        if (!needsGemini) {
-            return true; // Local generation and embedding does not require Gemini key
-        }
-        return !!process.env.GEMINI_API_KEY;
+    #checkProviderPrerequisites() {
+        return buildProviderPrerequisiteBlock(aiConfig);
     }
 
     /**
@@ -1233,11 +1299,11 @@ class HealthService extends Base {
      * The checks are performed in order of criticality:
      * 1. ChromaDB connectivity (if it's not running, nothing else matters)
      * 2. Collection accessibility (ensures data structures are ready)
-     * 3. API key presence (optional, but needed for summarization)
+     * 3. Provider prerequisites (only the configured provider surfaces require credentials)
      *
      * Status levels:
-     * - healthy: ChromaDB running, collections accessible, API key present
-     * - degraded: ChromaDB running, collections accessible, but API key missing
+     * - healthy: ChromaDB running, collections accessible, configured providers ready
+     * - degraded: ChromaDB running, collections accessible, but a configured provider is missing credentials
      * - unhealthy: ChromaDB not running or collections not accessible
      *
      * @returns {Promise<object>} A comprehensive health status payload
@@ -1305,13 +1371,13 @@ class HealthService extends Base {
 
         await this.#applyEmbeddingWriteCanary(payload);
 
-        // Step 3: Check API key for summarization feature
-        const apiKeyConfigured = this.#checkApiKeyConfigured();
-        payload.features.summarization = apiKeyConfigured;
+        // Step 3: Check configured provider prerequisites.
+        const providerPrerequisites = this.#checkProviderPrerequisites();
+        payload.features.summarization = providerPrerequisites.summary.ready;
 
-        if (!apiKeyConfigured) {
+        if (!providerPrerequisites.ready) {
             payload.status = 'degraded';
-            payload.details.push('GEMINI_API_KEY not set - summarization features unavailable');
+            payload.details.push(...providerPrerequisites.details);
         }
 
         if (payload.identity.warning) {
@@ -1455,16 +1521,17 @@ class HealthService extends Base {
      * with a clear error message if dependencies are not available.
      *
      * By throwing an exception, we ensure that:
-     * 1. The operation doesn't attempt to use ChromaDB/Gemini and get cryptic errors
+     * 1. The operation doesn't attempt to use unavailable storage/provider dependencies and get cryptic errors
      * 2. The agent receives a clear, actionable error message via the MCP protocol
      * 3. Users understand exactly what needs to be fixed
      *
      * This method leverages the cached health check, so calling it frequently
      * (e.g., before each tool invocation) has minimal performance impact.
      *
-     * Note: Both ChromaDB and GEMINI_API_KEY are required for all memory operations,
-     * since adding/querying memories requires text embeddings via the Gemini API.
-     * Only database lifecycle operations (start/stop) can work in degraded state.
+     * Note: Embedding-dependent reads require ChromaDB and the configured embedding
+     * provider to be available. Local providers do not require `GEMINI_API_KEY`, and
+     * the server exempts mailbox, WAL-backed `add_memory`, and non-embedding recency
+     * reads from this gate when a model-provider surface is degraded.
      *
      * @throws {Error} If the Memory Core is not fully healthy, with a detailed message
      * @returns {Promise<void>}

--- a/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
@@ -67,6 +67,18 @@ test.describe('Neo.ai.mcp.client.Client transport config', () => {
         client.destroy();
     });
 
+    test('#13300: memory-core client boot is not hard-gated on GEMINI_API_KEY', () => {
+        const client = Neo.create(TransportConfigClient, {
+            serverName: 'memory-core'
+        });
+
+        client.loadServerConfig('memory-core');
+
+        expect(client.requiredEnv).toEqual([]);
+
+        client.destroy();
+    });
+
     test('creates streamable HTTP transports from remote endpoint config', () => {
         const serverName = addServerConfig({
             transportType   : 'streamable-http',

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -179,7 +179,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         const toolCalls = [];
         const degradedError = new Error([
             'Memory Core is not fully operational:',
-            '  - GEMINI_API_KEY not set - summarization features unavailable'
+            "  - Summary provider 'gemini' requires GEMINI_API_KEY - summarization features unavailable"
         ].join('\n'));
 
         const mcpServer = {
@@ -258,7 +258,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
             expect(queryResult.isError).toBe(true);
             expect(queryResult.content[0].text).toContain('Cannot execute query_raw_memories: Memory Core is not fully operational');
-            expect(queryResult.content[0].text).toContain('GEMINI_API_KEY not set - summarization features unavailable');
+            expect(queryResult.content[0].text).toContain("Summary provider 'gemini' requires GEMINI_API_KEY - summarization features unavailable");
             expect(healthCalls).toEqual(['ensureHealthy']);
             expect(toolCalls).toHaveLength(2);
         } finally {
@@ -273,7 +273,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         const toolCalls = [];
         const degradedError = new Error([
             'Memory Core is not fully operational:',
-            '  - GEMINI_API_KEY not set - summarization features unavailable'
+            "  - Summary provider 'gemini' requires GEMINI_API_KEY - summarization features unavailable"
         ].join('\n'));
 
         const mcpServer = {

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -874,10 +874,11 @@ test.describe('EmbeddingProviderConfig #11596 — resolveEmbeddingProvider', () 
  * @see Neo.ai.services.memory-core.HealthService#buildSummaryProviderBlock
  */
 test.describe('HealthService #10724 — buildSummaryProviderBlock', () => {
-    let buildSummaryProviderBlock;
+    let buildProviderPrerequisiteBlock, buildSummaryProviderBlock;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/HealthService.mjs');
+        buildProviderPrerequisiteBlock = mod.buildProviderPrerequisiteBlock;
         buildSummaryProviderBlock = mod.buildSummaryProviderBlock;
     });
 
@@ -914,6 +915,74 @@ test.describe('HealthService #10724 — buildSummaryProviderBlock', () => {
             model : 'gemini-2.5-flash',
             local : false
         });
+    });
+
+    test('#13300: missing summary provider defaults to local openAiCompatible, not Gemini', () => {
+        const result = buildSummaryProviderBlock({
+            openAiCompatible: {
+                host : 'http://localhost:1234',
+                model: 'local-summary'
+            }
+        });
+
+        expect(result).toEqual({
+            active: 'openAiCompatible',
+            host  : 'http://localhost:1234',
+            model : 'local-summary',
+            local : true
+        });
+    });
+
+    test('#13300: local summary and embedding providers do not require GEMINI_API_KEY', () => {
+        const result = buildProviderPrerequisiteBlock({
+            engine           : 'chroma',
+            modelProvider    : 'openAiCompatible',
+            embeddingProvider: 'openAiCompatible'
+        }, {});
+
+        expect(result).toEqual({
+            ready  : true,
+            summary: {
+                provider: 'openAiCompatible',
+                ready   : true
+            },
+            embedding: {
+                provider: 'openAiCompatible',
+                ready   : true
+            },
+            details: []
+        });
+        expect(JSON.stringify(result)).not.toContain('GEMINI_API_KEY');
+    });
+
+    test('#13300: Gemini summary provider gets a summary-specific missing-key diagnostic', () => {
+        const result = buildProviderPrerequisiteBlock({
+            engine           : 'chroma',
+            modelProvider    : 'gemini',
+            embeddingProvider: 'openAiCompatible'
+        }, {});
+
+        expect(result.ready).toBe(false);
+        expect(result.summary.ready).toBe(false);
+        expect(result.embedding.ready).toBe(true);
+        expect(result.details).toEqual([
+            "Summary provider 'gemini' requires GEMINI_API_KEY - summarization features unavailable"
+        ]);
+    });
+
+    test('#13300: Gemini embedding provider gets an embedding-specific missing-key diagnostic', () => {
+        const result = buildProviderPrerequisiteBlock({
+            engine           : 'chroma',
+            modelProvider    : 'openAiCompatible',
+            embeddingProvider: 'gemini'
+        }, {});
+
+        expect(result.ready).toBe(false);
+        expect(result.summary.ready).toBe(true);
+        expect(result.embedding.ready).toBe(false);
+        expect(result.details).toEqual([
+            "Embedding provider 'gemini' requires GEMINI_API_KEY - semantic memory features unavailable"
+        ]);
     });
 });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session unavailable after Codex compaction; current lane recovered from Memory Core / A2A context.

Resolves #13300

Memory Core provider diagnostics now follow the configured AiConfig providers instead of treating `GEMINI_API_KEY` as a universal Memory Core prerequisite. Local OpenAI-compatible / Ollama routes stay healthy without the old key, Gemini-specific missing-key messages remain when Gemini is actually selected, and the generic MCP client no longer blocks `memory-core` boot before exempt tools can run.

Evidence: L2 (focused unit coverage + repo-local MCP client path without `GEMINI_API_KEY`) -> L2 required (provider-diagnostic and client bootstrap contract for #13300 ACs). No residuals.

## Deltas from ticket
- Included the generic MCP client `memory-core.requiredEnv` removal after V-B-A reproduced the same stale Gemini hard gate before `list_messages` could dispatch.
- Kept `knowledge-base` client config out of scope; #13300 is the Memory Core residual.
- Did not change provider defaults or embedding implementation internals.

## Test Evidence
- `node --check ai/services/memory-core/HealthService.mjs`
- `node --check ai/mcp/client/config.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs`
- `node --check test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs`
- `node --check test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs` - 69 passed
- `NEO_AGENT_IDENTITY=@neo-gpt npm run ai:mcp-client -- --server memory-core --call-tool list_messages --args '{"status":"unread","limit":1}'` - succeeded without `GEMINI_API_KEY` after sandbox SQLite access was lifted

## Post-Merge Validation
- [ ] In a local-first harness with no `GEMINI_API_KEY`, `memory-core` can call exempt mailbox / memory tools and health diagnostics do not instruct the operator to set Gemini unless Gemini is selected.

## Commits
- 0509d23da - local-first provider diagnostics and MCP client Memory Core key gate removal
