### PR TITLE
docs(harness): clarify Electron lane routing (#13302)

### DIFF
--- a/.agents/workflows/agent-harness.md
+++ b/.agents/workflows/agent-harness.md
@@ -6,7 +6,7 @@ The fastest correct path into the Agent Harness line (Epic #13012). No 20-page r
 
 1. **Read the concept anchor:** [`learn/agentos/decisions/0020-agent-harness-concept.md`](../../learn/agentos/decisions/0020-agent-harness-concept.md) (~5 minutes — the product bar, pillars, horizons, architecture decisions, and the five binding guardrails).
 2. **Glance the live state:** [Project board 13](https://github.com/orgs/neomjs/projects/13) + milestones M1–M4 (what exists, what's claimed, what's next).
-3. **Open your target work item only.** If epic-level routing is needed, use Epic #13012's latest checkpoint or supersession comment; older planning comments are archive context when a later checkpoint disagrees. Discussion #10119 is archaeology — never required reading.
+3. **Open your target work item only.** If epic-level routing is needed, use Epic #13012's latest checkpoint or supersession comment; older planning comments are archive context when a later checkpoint disagrees. Discussion #10119 is archaeology — never required reading. Electron shell/build-root work routes through #13033; do not file duplicate Electron-support tickets unless live state shows disjoint scope, supersession, or explicit handoff.
 4. **Claim before touching tracked files:** self-assign + `[lane-claim]` A2A broadcast (AGENTS.md critical gate). Lanes are self-selected; affinity notes in epic comments are observations, not assignments.
 5. **Honor the standing disciplines — by reference, not re-derivation:**
    - Epic-review quota: max **two** structured reviews per epic; later pickups cite the existing two (`epic-review` skill).


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session unavailable in current Codex Desktop surface after compaction.

Resolves #13302

Adds one compact routing note to the Agent Harness entry workflow: Electron shell/build-root work routes through #13033, and new Electron-support tickets should not be filed unless live state shows disjoint scope, supersession, or explicit handoff.

Evidence: L1 (static workflow diff + whitespace check + targeted rendered read) -> L1 required (documentation-only routing note). No residuals.

## Deltas from ticket

No scope additions. The implementation keeps the note inside `.agents/workflows/agent-harness.md` and does not modify AGENTS.md, skills, ADRs, #13033 ownership, or Electron runtime code.

## Substrate Slot Rationale

Modified surface: `.agents/workflows/agent-harness.md`, an on-demand mission-entry workflow. Disposition delta: rewrite/clarify one existing step. Trigger-frequency: harness-entry only. Failure-severity: duplicate-lane coordination friction. Enforceability: discipline-only via workflow read. Decay mitigation: the note includes live-state escape hatches for disjoint scope, supersession, and explicit handoff, so it can be removed or updated when #13033 changes.

## Test Evidence

- `git diff --check` -> passed.
- `nl -ba .agents/workflows/agent-harness.md` -> verified the workflow remains a compact 17-line entry document.
- Pre-create duplicate sweep found #13033 as the existing Electron implementation lane and no open workflow-routing equivalent.

## Post-Merge Validation

- [ ] Fresh Agent Harness entrant sees #13033 before filing or claiming Electron-support work.

## Commits

- `7bf429c55` — `docs(harness): clarify Electron lane routing (#13302)`