### PR TITLE
fix(neural-link): reject stale bridge handshakes (#13299)

### DIFF
--- a/ai/mcp/server/neural-link/Bridge.mjs
+++ b/ai/mcp/server/neural-link/Bridge.mjs
@@ -2,6 +2,7 @@ import {WebSocketServer}  from 'ws';
 import crypto             from 'crypto';
 import Base               from '../../../../src/core/Base.mjs';
 import logger             from './logger.mjs';
+import {createBridgeInfoPayload} from './BridgeProtocol.mjs';
 import {verifyBridgeToken} from './verifyBridgeToken.mjs';
 
 /**
@@ -237,6 +238,8 @@ class Bridge extends Base {
         });
         ws.on('error', (err) => logger.error(`Bridge: Agent error [${id}]`, err));
 
+        this.sendBridgeInfo(ws);
+
         // Notify other agents
         this.broadcastToAgents({
             type   : 'agent_connected',
@@ -252,6 +255,16 @@ class Bridge extends Base {
                     appName    : appWs.appName || 'Unknown'
                 }));
             }
+        }
+    }
+
+    /**
+     * @summary Sends the freshness/protocol stamp expected by current agent clients.
+     * @param {WebSocket} ws
+     */
+    sendBridgeInfo(ws) {
+        if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify(createBridgeInfoPayload()))
         }
     }
 

--- a/ai/mcp/server/neural-link/BridgeProtocol.mjs
+++ b/ai/mcp/server/neural-link/BridgeProtocol.mjs
@@ -1,0 +1,65 @@
+/**
+ * @summary Protocol contract shared by the Neural Link Bridge and agent-side
+ * ConnectionService.
+ *
+ * A running Bridge must emit this stamp during agent registration before the
+ * agent-side service treats the connection as fresh. Older Bridge processes do
+ * not know this frame, which lets local e2e runs fail loudly instead of binding
+ * stale behavior from a long-lived `:8081` process.
+ */
+export const BRIDGE_INFO_TYPE = 'bridge_info';
+
+/**
+ * @summary Monotonic Bridge protocol version for agent-side freshness checks.
+ * @type {Number}
+ */
+export const BRIDGE_PROTOCOL_VERSION = 1;
+
+/**
+ * @summary Current protocol capabilities that stale local bridges must prove.
+ * @type {String[]}
+ */
+export const BRIDGE_PROTOCOL_FEATURES = Object.freeze([
+    'agent-message-sidecar'
+]);
+
+/**
+ * @summary Error code used when a running Bridge is reachable but not fresh.
+ * @type {String}
+ */
+export const STALE_BRIDGE_ERROR_CODE = 'NEURAL_LINK_STALE_BRIDGE';
+
+/**
+ * @summary Creates the Bridge freshness payload emitted to newly-connected agents.
+ * @returns {Object}
+ */
+export function createBridgeInfoPayload() {
+    return {
+        type           : BRIDGE_INFO_TYPE,
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        features       : [...BRIDGE_PROTOCOL_FEATURES]
+    };
+}
+
+/**
+ * @summary Returns true when a Bridge freshness payload matches the current protocol.
+ * @param {Object} payload
+ * @returns {Boolean}
+ */
+export function isBridgeInfoPayloadFresh(payload) {
+    return payload?.type === BRIDGE_INFO_TYPE &&
+           payload.protocolVersion === BRIDGE_PROTOCOL_VERSION &&
+           Array.isArray(payload.features) &&
+           BRIDGE_PROTOCOL_FEATURES.every(feature => payload.features.includes(feature))
+}
+
+/**
+ * @summary Creates a typed stale-Bridge error for ConnectionService control flow.
+ * @param {String} message
+ * @returns {Error}
+ */
+export function createStaleBridgeError(message) {
+    const error = new Error(message);
+    error.code  = STALE_BRIDGE_ERROR_CODE;
+    return error
+}

--- a/ai/mcp/server/neural-link/BridgeProtocol.mjs
+++ b/ai/mcp/server/neural-link/BridgeProtocol.mjs
@@ -11,6 +11,8 @@ export const BRIDGE_INFO_TYPE = 'bridge_info';
 
 /**
  * @summary Monotonic Bridge protocol version for agent-side freshness checks.
+ * Bump this or `BRIDGE_PROTOCOL_FEATURES` whenever the Bridge's agent-facing
+ * behavior changes in a way clients must not accept from stale long-lived processes.
  * @type {Number}
  */
 export const BRIDGE_PROTOCOL_VERSION = 1;

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -5,6 +5,12 @@ import fs        from 'fs';
 import WebSocket from 'ws';
 import Base              from '../../../src/core/Base.mjs';
 import logger            from '../../mcp/server/neural-link/logger.mjs';
+import {
+    BRIDGE_INFO_TYPE,
+    STALE_BRIDGE_ERROR_CODE,
+    createStaleBridgeError,
+    isBridgeInfoPayloadFresh
+} from '../../mcp/server/neural-link/BridgeProtocol.mjs';
 import {resolveCallTarget} from './resolveCallTarget.mjs';
 
 /**
@@ -37,9 +43,15 @@ class ConnectionService extends Base {
         cwd: null,
         /**
          * @member {Number} port=8081
+         * Legacy prototype default; connection/spawn reads `aiConfig.port` at the use site.
          * @protected
          */
         port: 8081,
+        /**
+         * @member {Number} bridgeInfoTimeout=1000
+         * @protected
+         */
+        bridgeInfoTimeout: 1000,
         /**
          * @member {Boolean} singleton=true
          * @protected
@@ -87,9 +99,30 @@ class ConnectionService extends Base {
         // Skip the Bridge auto-connect under unitTestMode: unit specs that import this singleton (e.g. via
         // HealthService) must stay hermetic and must not reach or spawn the live Bridge. The e2e harness
         // connects explicitly via manageConnection(); production (non-unitTestMode) auto-connects as before.
-        if (aiConfig.autoConnect && !Neo.config.unitTestMode) {
+        if (!Neo.config.unitTestMode && aiConfig.autoConnect) {
             await this.ensureBridgeAndConnect();
         }
+    }
+
+    /**
+     * @summary Builds the agent-side Bridge WebSocket URL from the resolved config leaf.
+     * @param {Object} [options={}]
+     * @param {String} [options.agentId=this.agentId]
+     * @param {Number} [options.port=aiConfig.port]
+     * @param {String} [options.token=process.env.NEO_FLEET_BRIDGE_TOKEN]
+     * @returns {String}
+     */
+    createBridgeUrl({agentId = this.agentId, port = aiConfig.port, token = process.env.NEO_FLEET_BRIDGE_TOKEN} = {}) {
+        const url = new URL(`ws://127.0.0.1:${port}`);
+
+        url.searchParams.set('role', 'agent');
+        url.searchParams.set('id', agentId);
+
+        if (token) {
+            url.searchParams.set('token', token)
+        }
+
+        return url.toString()
     }
 
     /**
@@ -147,28 +180,86 @@ class ConnectionService extends Base {
             // Present the FM-minted, asymmetrically-signed Bridge token (injected at spawn under
             // NEO_FLEET_BRIDGE_TOKEN) so the Bridge authenticates this agent from the signature, not
             // the `?id=` claim. Absent in no-FM dev → the Bridge's legacy unauthenticated path.
-            const token = process.env.NEO_FLEET_BRIDGE_TOKEN;
-            const url   = `ws://127.0.0.1:${this.port}?role=agent&id=${this.agentId}` +
-                          (token ? `&token=${encodeURIComponent(token)}` : '');
-            const ws    = new WebSocket(url);
+            const port = aiConfig.port,
+                  url  = this.createBridgeUrl({port}),
+                  ws   = new WebSocket(url);
 
-            ws.on('open', () => {
-                logger.info(`Connected to Neural Link Bridge as ${this.agentId}`);
+            let settled = false;
+
+            const rejectOnce = (error, closeSocket = true) => {
+                if (settled) return;
+
+                settled = true;
+                clearTimeout(handshakeTimeout);
+
+                if (closeSocket && ws.readyState === WebSocket.OPEN) {
+                    ws.close()
+                }
+
+                reject(error);
+            };
+
+            const resolveOnce = () => {
+                if (settled) return;
+
+                settled = true;
+                clearTimeout(handshakeTimeout);
+
                 this.bridgeSocket = ws;
                 resolve();
+            };
+
+            const handshakeTimeout = setTimeout(() => {
+                rejectOnce(createStaleBridgeError(
+                    `Stale Neural Link Bridge on port ${port}: missing ${BRIDGE_INFO_TYPE} freshness handshake. ` +
+                    'Stop or refresh the existing bridge, or run against a dedicated fresh Bridge port.'
+                ));
+            }, this.bridgeInfoTimeout);
+
+            ws.on('open', () => {
+                logger.info(`Connected to Neural Link Bridge as ${this.agentId}; awaiting ${BRIDGE_INFO_TYPE}`);
             });
 
-            ws.on('message', (data) => this.handleBridgeMessage(data));
+            ws.on('message', (data) => {
+                if (!settled) {
+                    let payload;
+
+                    try {
+                        payload = JSON.parse(data.toString())
+                    } catch {
+                        return
+                    }
+
+                    if (payload?.type !== BRIDGE_INFO_TYPE) {
+                        return
+                    }
+
+                    if (!isBridgeInfoPayloadFresh(payload)) {
+                        rejectOnce(createStaleBridgeError(
+                            `Stale Neural Link Bridge on port ${port}: incompatible ${BRIDGE_INFO_TYPE} ` +
+                            `payload ${JSON.stringify(payload)}.`
+                        ));
+                        return
+                    }
+
+                    logger.info(`Verified Neural Link Bridge freshness on port ${port}`);
+                    resolveOnce();
+                    return
+                }
+
+                this.handleBridgeMessage(data)
+            });
 
             ws.on('close', () => {
                 logger.warn('Disconnected from Neural Link Bridge');
                 this.bridgeSocket = null;
+                rejectOnce(new Error('Neural Link Bridge closed before freshness handshake completed.'), false);
                 // Optional: Auto-reconnect logic could go here
             });
 
             ws.on('error', (err) => {
-                if (!this.bridgeSocket) {
-                    reject(err); // Reject if error happens during initial connect
+                if (!settled) {
+                    rejectOnce(err, false); // Reject if error happens during initial connect
                 } else {
                     logger.error('Bridge Socket Error:', err);
                 }
@@ -187,6 +278,11 @@ class ConnectionService extends Base {
             await this.connectToBridge();
             connected = true;
         } catch (e) {
+            if (e.code === STALE_BRIDGE_ERROR_CODE) {
+                logger.error(e.message);
+                throw e
+            }
+
             logger.info('Failed to connect to existing bridge:', e.message);
             logger.info('Assuming Bridge not running. Spawning new Bridge process...');
         }
@@ -498,10 +594,12 @@ class ConnectionService extends Base {
         return new Promise((resolve, reject) => {
             const args    = ['run', 'ai:server-neural-link'];
             const logFile = fs.openSync('./bridge.log', 'a');
+            const port    = aiConfig.port;
 
             this.bridgeProcess = spawn('npm', args, {
                 cwd     : this.cwd || process.cwd(),
                 detached: true,
+                env     : {...process.env, NEO_NL_PORT: String(port)},
                 stdio   : ['ignore', logFile, logFile]
             });
 

--- a/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
@@ -17,6 +17,13 @@ import crypto         from 'crypto';
 import Neo       from '../../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../../src/core/_export.mjs';
 import Bridge    from '../../../../../../../ai/mcp/server/neural-link/Bridge.mjs';
+import {
+    BRIDGE_INFO_TYPE,
+    BRIDGE_PROTOCOL_FEATURES,
+    BRIDGE_PROTOCOL_VERSION,
+    createBridgeInfoPayload,
+    isBridgeInfoPayloadFresh
+} from '../../../../../../../ai/mcp/server/neural-link/BridgeProtocol.mjs';
 
 const {privateKey, publicKey} = crypto.generateKeyPairSync('ed25519');
 
@@ -77,6 +84,36 @@ test.describe('Bridge.handleConnection — agent handshake auth (#13172)', () =>
         Bridge.handleConnection(ws, makeReq('role=agent&id=legacy-agent'));
         expect(Bridge.agents.has('legacy-agent')).toBe(true);
         expect(ws.closed).toBe(null);
+    });
+});
+
+test.describe('Bridge protocol freshness stamp (#13299)', () => {
+    test.beforeEach(() => {
+        Bridge.agents = new Map();
+        Bridge.apps   = new Map();
+    });
+
+    test('createBridgeInfoPayload exposes the current Bridge protocol contract', () => {
+        const payload = createBridgeInfoPayload();
+
+        expect(payload).toEqual({
+            type           : BRIDGE_INFO_TYPE,
+            protocolVersion: BRIDGE_PROTOCOL_VERSION,
+            features       : [...BRIDGE_PROTOCOL_FEATURES]
+        });
+        expect(isBridgeInfoPayloadFresh(payload)).toBe(true);
+        expect(isBridgeInfoPayloadFresh({...payload, protocolVersion: 0})).toBe(false);
+        expect(isBridgeInfoPayloadFresh({...payload, features: []})).toBe(false);
+    });
+
+    test('registerAgent sends bridge_info before ordinary agent notifications', () => {
+        const ws = makeWs();
+        Bridge.registerAgent('agent-a', ws);
+
+        const firstFrame = JSON.parse(ws.sent[0]);
+
+        expect(isBridgeInfoPayloadFresh(firstFrame)).toBe(true);
+        expect(JSON.parse(ws.sent[1]).type).toBe('agent_connected');
     });
 });
 

--- a/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
@@ -1,0 +1,92 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'ConnectionServiceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {STALE_BRIDGE_ERROR_CODE} from '../../../../../../ai/mcp/server/neural-link/BridgeProtocol.mjs';
+
+/**
+ * @summary Unit coverage for the Neural Link ConnectionService freshness gate.
+ *
+ * These tests deliberately stub `connectToBridge` / `spawnBridge` rather than opening a WebSocket:
+ * importing the singleton is safe because `unitTestMode` suppresses auto-connect, and the branch logic
+ * is what decides whether a stale shared Bridge is reused, spawned over, or failed loudly.
+ */
+test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshness gate (#13299)', () => {
+    let ConnectionService, originalConnectToBridge, originalSpawnBridge;
+
+    test.beforeAll(async () => {
+        ConnectionService = (await import('../../../../../../ai/services/neural-link/ConnectionService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalConnectToBridge = ConnectionService.connectToBridge;
+        originalSpawnBridge     = ConnectionService.spawnBridge;
+        ConnectionService.bridgeSocket = null;
+    });
+
+    test.afterEach(() => {
+        ConnectionService.connectToBridge = originalConnectToBridge;
+        ConnectionService.spawnBridge     = originalSpawnBridge;
+        ConnectionService.bridgeSocket    = null;
+    });
+
+    test('builds the Bridge URL from an explicit port and encoded fleet token', () => {
+        const url = ConnectionService.createBridgeUrl({
+            agentId: 'agent-test',
+            port   : 19081,
+            token  : 'token with spaces'
+        });
+
+        expect(url).toBe('ws://127.0.0.1:19081/?role=agent&id=agent-test&token=token+with+spaces');
+    });
+
+    test('spawns a Bridge only when the first connection attempt is a missing listener', async () => {
+        let attempts = 0,
+            spawned  = false;
+
+        ConnectionService.connectToBridge = async () => {
+            attempts++;
+
+            if (attempts === 1) {
+                throw new Error('connect ECONNREFUSED 127.0.0.1:8081')
+            }
+        };
+        ConnectionService.spawnBridge = async () => {
+            spawned = true;
+        };
+
+        await ConnectionService.ensureBridgeAndConnect();
+
+        expect(attempts).toBe(2);
+        expect(spawned).toBe(true);
+    });
+
+    test('fails loudly instead of spawning over a reachable stale Bridge', async () => {
+        let spawned = false;
+        const staleError = new Error('Stale Neural Link Bridge on port 8081: missing bridge_info freshness handshake.');
+        staleError.code  = STALE_BRIDGE_ERROR_CODE;
+
+        ConnectionService.connectToBridge = async () => {
+            throw staleError
+        };
+        ConnectionService.spawnBridge = async () => {
+            spawned = true;
+        };
+
+        await expect(ConnectionService.ensureBridgeAndConnect()).rejects.toThrow(/Stale Neural Link Bridge/);
+
+        expect(spawned).toBe(false);
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 4f544e1c-70b1-46f5-8994-15a177e6a85d.

Resolves #13299

Adds a Neural Link Bridge freshness handshake so local e2e connects no longer silently bind a stale `:8081` bridge from an older checkout. Current bridges emit a `bridge_info` protocol stamp when an agent registers; `ConnectionService` waits for that stamp before treating the socket as connected, reads the resolved Neural Link `aiConfig.port` at connect/spawn time, and fails loudly on a reachable stale bridge instead of trying to spawn over an operator-owned shared port.

Evidence: L2 (unit protocol + ConnectionService branch coverage; import-side-effect guard) -> L2 required (local stale bridge must fail loudly or current bridge handshakes without extra spawn). No residuals.

## Deltas from ticket

- Chose the ticket fail-loud option for unmanaged stale shared bridges. Agents must not kill the operator/shared `:8081` process.
- Added the server-side port propagation needed for dedicated-port bridge runs: spawned bridges inherit `NEO_NL_PORT` from the resolved Neural Link config leaf. Browser-side `neuralLinkUrl` injection remains separate from this close target.
- Added the reviewer-requested protocol bump-discipline note so future Bridge agent-facing behavior changes keep the freshness contract load-bearing.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs` — 12 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link test/playwright/unit/ai/services/neural-link` — 35 passed.
- Follow-up after review: `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs` — 12 passed.
- Pre-commit hooks passed: whitespace, shorthand, AiConfig test-mutation, and ticket archaeology.
- `git diff --check` passed before commit.

## Post-Merge Validation

- [ ] Local e2e connect against a pre-PR Bridge reports the stale-bridge freshness error rather than false `no-writer-identity` / `no-conflict`.
- [ ] Local e2e connect against a fresh Bridge handshakes normally without an extra spawn.
- [ ] Refresh the shared `:8081` Bridge (`run-bridge.mjs`) before or alongside any Neural Link MCP-server restart after this merges; a reachable pre-PR bridge is intentionally rejected, and the client will not spawn over it.
- [ ] Verify the Neural Link MCP server reports degraded/unhealthy rather than crashing when startup hits a stale-bridge handshake rejection; current `Server.boot()` connects stdio early, catches `ConnectionService.ready()` errors, and keeps `healthcheck` / `manage_connection` reachable for recovery.

## Commit

- `204ead894` — `fix(neural-link): reject stale bridge handshakes (#13299)`
- `b03d1f900` — `docs(neural-link): note bridge protocol bump discipline (#13299)`