### PR TITLE
feat(dashboard): render dock perspective switcher (#13308)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -1,7 +1,9 @@
 import DockLayoutAdapter from '../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockZoneModel     from '../../../src/dashboard/DockZoneModel.mjs';
 import Viewport          from '../../../src/container/Viewport.mjs';
+import '../../../src/button/Base.mjs';    // registers the `button` ntype used by the perspective toolbar
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits for tab zones
+import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype used by the perspective toolbar
 
 /**
  * A representative dock-zone document (`neo.harness.dockZone.v1`): a horizontal split of a two-tab main zone and a
@@ -28,6 +30,27 @@ const initialDockModel = {
     }
 };
 
+const reviewDockModel = DockZoneModel.clone(initialDockModel);
+
+reviewDockModel.nodes.root.sizes = [0.48, 0.52];
+reviewDockModel.nodes['main-tabs'].activeItemId = 'swarm';
+reviewDockModel.nodes['side-split'].sizes = [0.42, 0.58];
+
+/**
+ * Example-local saved perspectives, persisted through the same `DockZoneModel` collection helpers as user-saved
+ * layouts. The documents stay JSON-only and storage-backend agnostic.
+ * @type {Object[]}
+ */
+const seededPerspectives = [{
+    document: initialDockModel,
+    layoutId: 'operator-default',
+    title   : 'Operator'
+}, {
+    document: reviewDockModel,
+    layoutId: 'review-focus',
+    title   : 'Review'
+}];
+
 /**
  * Resolves a model `componentRef` to the component config rendered inside its dock zone. For this example, a simple
  * centered label per panel; a real app resolves each ref to its feature view.
@@ -48,6 +71,12 @@ const resolveComponentRef = componentRef => ({
  * wires the **resize commit loop** end-to-end: dragging a splitter commits a `resizeSplit` operation through
  * `DockZoneModel`, and the layout re-projects from the new committed document.
  *
+ * The rendered perspective toolbar consumes the same saved-layout collection helpers the model exposes: seed
+ * perspectives are stored as `neo.harness.dockLayoutCollection.v1`, selecting a perspective calls
+ * `restoreActiveSavedLayout()`, Save Current upserts the live committed document, and Delete Active keeps a valid
+ * replacement active. Persistence uses the main-thread `LocalStorage` addon so App-Worker code never reaches for
+ * `window.localStorage` directly.
+ *
  * The example owns the committed document ({@link #dockModel}) as the single source of truth and drives the loop with
  * the two callbacks `DockSplitter` calls — a clean reducer / view-sync split:
  * - {@link #applyDockZoneOperation} is the **reducer**: a pure `DockZoneModel.applyOperation` over the current document.
@@ -66,12 +95,18 @@ class MainContainer extends Viewport {
          */
         className: 'Neo.examples.dashboard.dock.MainContainer',
         /**
-         * @member {Object} layout={ntype:'fit'}
+         * @member {Object} layout={ntype:'vbox', align:'stretch'}
          */
-        layout: {ntype: 'fit'}
+        layout: {ntype: 'vbox', align: 'stretch'}
         // `items` is built in construct() — not here — so each projection can carry the instance-bound
         // applyDockZoneOperation + onDockZoneDocumentChange callbacks the resize commit loop needs.
     }
+
+    /**
+     * Browser-local storage key for the example's named-perspective collection.
+     * @member {String} layoutCollectionStorageKey='neo.examples.dashboard.dock.layoutCollection'
+     */
+    layoutCollectionStorageKey = 'neo.examples.dashboard.dock.layoutCollection'
 
     /**
      * The live committed dock-zone document — the single source of truth the view projects from. Initialized to
@@ -81,6 +116,24 @@ class MainContainer extends Viewport {
     dockModel = null
 
     /**
+     * The active named-perspective collection backing the toolbar.
+     * @member {Object|null} layoutCollection=null
+     */
+    layoutCollection = null
+
+    /**
+     * Last asynchronous storage-load promise, exposed for unit tests and smoke probes.
+     * @member {Promise|null} layoutCollectionLoadPromise=null
+     */
+    layoutCollectionLoadPromise = null
+
+    /**
+     * Monotonic suffix for user-saved example perspectives.
+     * @member {Number} savedPerspectiveCount=0
+     */
+    savedPerspectiveCount = 0
+
+    /**
      * @param {Object} config
      */
     construct(config) {
@@ -88,8 +141,11 @@ class MainContainer extends Viewport {
 
         let me = this;
 
-        me.dockModel = initialDockModel;
-        me.add(me.projectDockModel())
+        me.layoutCollection = me.createDefaultLayoutCollection();
+        me.dockModel        = DockZoneModel.restoreActiveSavedLayout(me.layoutCollection).document || DockZoneModel.clone(initialDockModel);
+
+        me.add(me.buildWorkspaceItems());
+        me.layoutCollectionLoadPromise = me.loadLayoutCollectionFromStorage()
     }
 
     /**
@@ -101,6 +157,107 @@ class MainContainer extends Viewport {
      */
     applyDockZoneOperation(descriptor) {
         return DockZoneModel.applyOperation(this.dockModel, descriptor)
+    }
+
+    /**
+     * Builds a valid default collection from the example's seeded perspectives.
+     * @returns {Object}
+     */
+    createDefaultLayoutCollection() {
+        let layouts = seededPerspectives.map(({document, layoutId, title}) => {
+                let {layout, errors} = DockZoneModel.createSavedLayout(document, {
+                    layoutId,
+                    title,
+                    metadata: {
+                        source: 'examples/dashboard/dock'
+                    }
+                });
+
+                if (errors.length) {
+                    throw new Error(`Failed to create seeded dock perspective "${layoutId}": ${errors.join('; ')}`)
+                }
+
+                return layout
+            }),
+            {collection, errors} = DockZoneModel.createSavedLayoutCollection(layouts, {
+                activeLayoutId: 'operator-default',
+                metadata      : {
+                    owner: 'examples/dashboard/dock'
+                }
+            });
+
+        if (errors.length) {
+            throw new Error(`Failed to create dock perspective collection: ${errors.join('; ')}`)
+        }
+
+        return collection
+    }
+
+    /**
+     * Creates the top-level toolbar + dock projection items from current state.
+     * @returns {Object[]}
+     */
+    buildWorkspaceItems() {
+        let dockConfig = this.projectDockModel();
+
+        dockConfig.flex = 1;
+
+        return [
+            this.createPerspectiveToolbar(),
+            dockConfig
+        ]
+    }
+
+    /**
+     * Builds a compact named-perspective toolbar from the current collection.
+     * @returns {Object}
+     */
+    createPerspectiveToolbar() {
+        let me            = this,
+            collection    = me.layoutCollection,
+            activeLayoutId = collection?.activeLayoutId,
+            layoutButtons = Object.values(collection?.layouts || {}).map(layout => ({
+                cls    : layout.layoutId === activeLayoutId ? ['neo-dashboard-dock-perspective-active'] : [],
+                data   : {layoutId: layout.layoutId},
+                handler: () => me.restorePerspective(layout.layoutId),
+                pressed: layout.layoutId === activeLayoutId,
+                text   : layout.title
+            }));
+
+        return {
+            cls         : ['neo-dashboard-dock-perspective-toolbar'],
+            dockNodeType: 'perspective-toolbar',
+            itemDefaults: {
+                ntype: 'button',
+                style: {margin: '0 8px 0 0'}
+            },
+            items: [{
+                ntype: 'component',
+                style: {
+                    alignItems : 'center',
+                    color      : '#777',
+                    display    : 'flex',
+                    fontWeight  : 600,
+                    marginRight : '12px',
+                    whiteSpace  : 'nowrap'
+                },
+                html: 'Perspectives'
+            }, ...layoutButtons, {
+                iconCls: 'fa fa-save',
+                handler: () => me.saveCurrentPerspective(),
+                text   : 'Save Current'
+            }, {
+                iconCls: 'fa fa-trash',
+                handler: () => me.removeActivePerspective(),
+                text   : 'Delete Active'
+            }],
+            layout: {ntype: 'hbox', align: 'center'},
+            ntype : 'toolbar',
+            style : {
+                borderBottom: '1px solid var(--sem-color-border-default, #ddd)',
+                padding     : '8px 10px'
+            }
+        }
     }
 
     /**
@@ -119,10 +276,207 @@ class MainContainer extends Viewport {
 
         me.timeout(0).then(() => {
             if (!me.isDestroyed) {
-                me.removeAll();
-                me.add(me.projectDockModel())
+                me.refreshDockWorkspace()
             }
         })
+    }
+
+    /**
+     * Reads the persisted named-perspective collection and applies it only when both the collection and active restore
+     * validate. Invalid payloads fail closed to the seeded collection/current document.
+     * @returns {Promise<{collection:Object|null, document:Object|null, errors:String[], loaded:Boolean}>}
+     */
+    async loadLayoutCollectionFromStorage() {
+        let me      = this,
+            storage = Neo.main?.addon?.LocalStorage;
+
+        if (!storage?.readLocalStorageItem) {
+            return {collection: null, document: null, errors: ['LocalStorage addon is unavailable'], loaded: false}
+        }
+
+        try {
+            let {value} = await storage.readLocalStorageItem({
+                    key     : me.layoutCollectionStorageKey,
+                    windowId: me.windowId
+                }),
+                parsed, errors, restored;
+
+            if (!value) {
+                return {collection: null, document: null, errors: [], loaded: false}
+            }
+
+            parsed = JSON.parse(value);
+            errors = DockZoneModel.validateSavedLayoutCollection(parsed);
+
+            if (errors.length) {
+                return {collection: null, document: null, errors, loaded: false}
+            }
+
+            restored = DockZoneModel.restoreActiveSavedLayout(parsed);
+
+            if (restored.errors.length) {
+                return {collection: null, document: null, errors: restored.errors, loaded: false}
+            }
+
+            me.layoutCollection = DockZoneModel.clone(parsed);
+            me.dockModel        = restored.document;
+            me.refreshDockWorkspace();
+
+            return {collection: me.layoutCollection, document: me.dockModel, errors: [], loaded: true}
+        } catch (error) {
+            return {collection: null, document: null, errors: [error.message], loaded: false}
+        }
+    }
+
+    /**
+     * Persists the current named-perspective collection via the main-thread LocalStorage addon.
+     * @param {Object} [collection=this.layoutCollection]
+     * @returns {Promise<{persisted:Boolean, error:String|null}>|undefined}
+     */
+    persistLayoutCollection(collection=this.layoutCollection) {
+        let storage = Neo.main?.addon?.LocalStorage;
+
+        if (!storage?.updateLocalStorageItem || !collection) {
+            return undefined
+        }
+
+        return Promise.resolve(storage.updateLocalStorageItem({
+            key     : this.layoutCollectionStorageKey,
+            value   : JSON.stringify(collection),
+            windowId: this.windowId
+        })).then(() => ({
+            error    : null,
+            persisted: true
+        })).catch(error => ({
+            error    : error?.message || 'LocalStorage update rejected',
+            persisted: false
+        }))
+    }
+
+    /**
+     * Rebuilds the toolbar and dock projection from current state.
+     */
+    refreshDockWorkspace() {
+        this.removeAll();
+        this.add(this.buildWorkspaceItems())
+    }
+
+    /**
+     * Selects and restores a named perspective through `DockZoneModel.restoreActiveSavedLayout()`.
+     * @param {String} layoutId
+     * @returns {{collection:Object, document:Object|null, errors:String[]}}
+     */
+    restorePerspective(layoutId) {
+        let me       = this,
+            selected = DockZoneModel.selectSavedLayout(me.layoutCollection, layoutId),
+            restored;
+
+        if (selected.errors.length) {
+            return {collection: me.layoutCollection, document: null, errors: selected.errors}
+        }
+
+        restored = DockZoneModel.restoreActiveSavedLayout(selected.collection);
+
+        if (restored.errors.length) {
+            return {collection: me.layoutCollection, document: null, errors: restored.errors}
+        }
+
+        me.layoutCollection = selected.collection;
+        me.dockModel        = restored.document;
+        me.persistLayoutCollection();
+        me.refreshDockWorkspace();
+
+        return {collection: me.layoutCollection, document: me.dockModel, errors: []}
+    }
+
+    /**
+     * Saves the current committed dock document as a new named perspective and activates it.
+     * @returns {{collection:Object, layout:Object|null, errors:String[]}}
+     */
+    saveCurrentPerspective() {
+        let me       = this,
+            layoutId = me.nextSavedPerspectiveId(),
+            title    = `Saved ${me.savedPerspectiveCount}`,
+            saved    = DockZoneModel.createSavedLayout(me.dockModel, {
+                layoutId,
+                title,
+                metadata: {
+                    source: 'examples/dashboard/dock',
+                    saved : true
+                }
+            }),
+            upserted;
+
+        if (saved.errors.length) {
+            return {collection: me.layoutCollection, layout: null, errors: saved.errors}
+        }
+
+        upserted = DockZoneModel.upsertSavedLayout(me.layoutCollection, saved.layout, {activate: true});
+
+        if (upserted.errors.length) {
+            return {collection: me.layoutCollection, layout: null, errors: upserted.errors}
+        }
+
+        me.layoutCollection = upserted.collection;
+        me.persistLayoutCollection();
+        me.refreshDockWorkspace();
+
+        return {collection: me.layoutCollection, layout: saved.layout, errors: []}
+    }
+
+    /**
+     * Removes the active saved perspective and restores the next available replacement.
+     * @returns {{collection:Object, document:Object|null, errors:String[]}}
+     */
+    removeActivePerspective() {
+        let me             = this,
+            collection     = me.layoutCollection,
+            layoutIds      = Object.keys(collection?.layouts || {}),
+            activeLayoutId = collection?.activeLayoutId,
+            replacementId  = layoutIds.find(layoutId => layoutId !== activeLayoutId),
+            removed, restored;
+
+        if (!activeLayoutId || !replacementId) {
+            return {collection, document: null, errors: ['at least one replacement perspective must remain']}
+        }
+
+        removed = DockZoneModel.removeSavedLayout(collection, {
+            layoutId            : activeLayoutId,
+            replacementLayoutId : replacementId
+        });
+
+        if (removed.errors.length) {
+            return {collection, document: null, errors: removed.errors}
+        }
+
+        restored = DockZoneModel.restoreActiveSavedLayout(removed.collection);
+
+        if (restored.errors.length) {
+            return {collection, document: null, errors: restored.errors}
+        }
+
+        me.layoutCollection = removed.collection;
+        me.dockModel        = restored.document;
+        me.persistLayoutCollection();
+        me.refreshDockWorkspace();
+
+        return {collection: me.layoutCollection, document: me.dockModel, errors: []}
+    }
+
+    /**
+     * Returns the next free example-generated perspective id and updates the visible suffix counter.
+     * @returns {String}
+     */
+    nextSavedPerspectiveId() {
+        let me = this,
+            id;
+
+        do {
+            me.savedPerspectiveCount++;
+            id = `saved-perspective-${me.savedPerspectiveCount}`
+        } while (me.layoutCollection?.layouts?.[id]);
+
+        return id
     }
 
     /**

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
 import DockZoneModel  from '../../../../src/dashboard/DockZoneModel.mjs';
+import MainContainer  from '../../../../examples/dashboard/dock/MainContainer.mjs';
 
 /**
  * @summary Tests for Neo.dashboard.DockZoneModel — the dock-zone semantic operations executor.
@@ -611,6 +612,136 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
 
             expect(rejectedCollection.collection).toBe(null);
             expect(rejectedCollection.errors.join(' ')).toContain('apiToken')
+        })
+    });
+
+    test.describe('standalone dock example perspectives', () => {
+        let originalLocalStorage;
+
+        function createExampleHarness() {
+            const example = {
+                createDefaultLayoutCollection: MainContainer.prototype.createDefaultLayoutCollection,
+                createPerspectiveToolbar    : MainContainer.prototype.createPerspectiveToolbar,
+                loadLayoutCollectionFromStorage: MainContainer.prototype.loadLayoutCollectionFromStorage,
+                nextSavedPerspectiveId      : MainContainer.prototype.nextSavedPerspectiveId,
+                persistLayoutCollection     : MainContainer.prototype.persistLayoutCollection,
+                removeActivePerspective     : MainContainer.prototype.removeActivePerspective,
+                restorePerspective          : MainContainer.prototype.restorePerspective,
+                saveCurrentPerspective      : MainContainer.prototype.saveCurrentPerspective,
+
+                layoutCollectionStorageKey: 'test.dashboard.dock.layoutCollection',
+                refreshCount              : 0,
+                savedPerspectiveCount     : 0,
+                windowId                  : 1,
+
+                refreshDockWorkspace() {
+                    this.refreshCount++
+                }
+            };
+
+            example.layoutCollection = example.createDefaultLayoutCollection();
+            example.dockModel        = DockZoneModel.restoreActiveSavedLayout(example.layoutCollection).document;
+
+            return example
+        }
+
+        test.beforeEach(() => {
+            originalLocalStorage = {...Neo.main.addon.LocalStorage}
+        });
+
+        test.afterEach(() => {
+            Neo.main.addon.LocalStorage = originalLocalStorage
+        });
+
+        test('saves, restores, deletes, and persists named perspectives through collection helpers', async () => {
+            let writes = [];
+
+            Neo.main.addon.LocalStorage.readLocalStorageItem = async ({key}) => ({key, value: null});
+            Neo.main.addon.LocalStorage.updateLocalStorageItem = async payload => {
+                writes.push(payload)
+            };
+
+            const example = createExampleHarness(),
+                toolbar = example.createPerspectiveToolbar();
+
+            expect(Object.keys(example.layoutCollection.layouts)).toEqual(['operator-default', 'review-focus']);
+            expect(example.layoutCollection.activeLayoutId).toBe('operator-default');
+            expect(toolbar.items.map(item => item.text || item.html)).toEqual([
+                'Perspectives',
+                'Operator',
+                'Review',
+                'Save Current',
+                'Delete Active'
+            ]);
+            expect(toolbar.items[1].pressed).toBe(true);
+            expect(toolbar.items[2].pressed).toBe(false);
+
+            const resized = DockZoneModel.applyOperation(example.dockModel, {
+                operation  : 'resizeSplit',
+                sizes      : [0.4, 0.6],
+                splitNodeId: 'root'
+            });
+
+            expect(resized.errors).toEqual([]);
+            example.dockModel = resized.document;
+
+            const saved = example.saveCurrentPerspective();
+
+            expect(saved.errors).toEqual([]);
+            expect(saved.layout.layoutId).toBe('saved-perspective-1');
+            expect(example.layoutCollection.activeLayoutId).toBe('saved-perspective-1');
+            expect(example.layoutCollection.layouts['saved-perspective-1'].dockZone.nodes.root.sizes).toEqual([0.4, 0.6]);
+
+            const restored = example.restorePerspective('review-focus');
+
+            expect(restored.errors).toEqual([]);
+            expect(example.layoutCollection.activeLayoutId).toBe('review-focus');
+            expect(example.dockModel.nodes.root.sizes).toEqual([0.48, 0.52]);
+            expect(example.dockModel.nodes['main-tabs'].activeItemId).toBe('swarm');
+
+            const deleted = example.removeActivePerspective();
+
+            expect(deleted.errors).toEqual([]);
+            expect(example.layoutCollection.layouts['review-focus']).toBeUndefined();
+            expect(example.layoutCollection.activeLayoutId).toBe('operator-default');
+            expect(example.dockModel).toEqual(example.layoutCollection.layouts['operator-default'].dockZone);
+            expect(example.refreshCount).toBe(3);
+            expect(writes.length).toBeGreaterThanOrEqual(3);
+            expect(JSON.parse(writes.at(-1).value).activeLayoutId).toBe('operator-default')
+        });
+
+        test('rehydrates a valid persisted collection and fails closed for invalid storage payloads', async () => {
+            const persistedReview = savedLayout('persisted-review', 'Persisted Review', d => {
+                    d.nodes['main-tabs'].activeItemId = 'strategy'
+                }),
+                persistedDefault = savedLayout('persisted-default', 'Persisted Default'),
+                {collection} = DockZoneModel.createSavedLayoutCollection([persistedDefault, persistedReview], {
+                    activeLayoutId: 'persisted-review'
+                });
+
+            let readValue = JSON.stringify(collection);
+
+            Neo.main.addon.LocalStorage.readLocalStorageItem = async ({key}) => ({key, value: readValue});
+            Neo.main.addon.LocalStorage.updateLocalStorageItem = async () => {};
+
+            const hydrated = createExampleHarness(),
+                loaded = await hydrated.loadLayoutCollectionFromStorage();
+
+            expect(loaded.loaded).toBe(true);
+            expect(hydrated.layoutCollection.activeLayoutId).toBe('persisted-review');
+            expect(hydrated.dockModel).toEqual(persistedReview.dockZone);
+            expect(hydrated.refreshCount).toBe(1);
+
+            readValue = JSON.stringify({schema: 'neo.harness.dockLayoutCollection.v0'});
+
+            const invalid = createExampleHarness(),
+                invalidLoad = await invalid.loadLayoutCollectionFromStorage();
+
+            expect(invalidLoad.loaded).toBe(false);
+            expect(invalidLoad.errors.length).toBeGreaterThan(0);
+            expect(invalid.layoutCollection.activeLayoutId).toBe('operator-default');
+            expect(invalid.dockModel).toEqual(invalid.layoutCollection.layouts['operator-default'].dockZone);
+            expect(invalid.refreshCount).toBe(0)
         })
     });
 


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 62551409-e136-4580-8062-d7e77fdbe413.

Resolves #13308
Related: #13158

Renders the standalone dashboard dock named-perspective switcher over the existing `DockZoneModel` saved-layout collection helpers. The example now seeds Operator/Review perspectives, restores through `restoreActiveSavedLayout()`, lets users save the current committed dock model, deletes the active perspective while preserving a valid replacement, and persists/reloads the collection through the main-thread `LocalStorage` addon without Memory Core coupling.

Evidence: L3 (focused unit coverage plus local Chromium browser-rendered smoke of seed/select/save/delete) → L3 required (rendered UI workflow with visual/manual evidence). No residuals.

## Deltas from ticket

Implemented the standalone dock example surface only. The ticket allowed standalone-first ownership, and the AgentOS viewport does not need to absorb this UI until its runtime docking surface owns the same model lifecycle.

Persistence uses the existing main-thread `LocalStorage` addon and tolerates both sync and promise-wrapped remote method returns. Invalid persisted collections fail closed to the seeded/current dock model.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/dashboard/DockZoneModel.spec.mjs` — 59 passed.
- `git diff --check` — clean.
- Browser smoke against `http://127.0.0.1:8090/examples/dashboard/dock/` — Operator/Review/Save Current/Delete Active rendered; selecting Review worked; Save Current created `Saved 1`; Delete Active removed `Saved 1` and left Operator/Review controls intact.
- Visual screenshot inspected: `dock-perspectives-smoke.png` was nonblank and showed the perspective toolbar plus dock content. The local webpack smoke still logged boot-only missing generated CSS / JSON asset errors before any perspective interaction; no interaction-phase errors were introduced by this change.

## Post-Merge Validation

- [ ] Verify the standalone dock example in a built/themed dev site where generated CSS assets are available.

## Commit

- `e1fe83e57` — `feat(dashboard): render dock perspective switcher (#13308)`
