### PR TITLE
fix(memory-core): lifecycle-manage the graph-projection drain loop (#13313)

### DIFF
--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -800,14 +800,15 @@ class MemoryService extends Base {
      * @returns {Promise<Object[]>} Row-shaped pending turns.
      * @private
      */
-    async _readPendingWalRecencyRows({identity, userId, before, limit, excludeIds = new Set()} = {}) {
+    async _readPendingWalRecencyRows({identity, userId, before, excludeIds = new Set()} = {}) {
         try {
-            // Bound the WAL scan: graph projection normally keeps the pending set tiny, but under a
-            // projection-lag/outage the set grows — an unbounded read would turn every recency query
-            // into an O(pending) disk scan. readPendingWalRecords reads newest-segment-first, so a
-            // page-sized cap protects the recency-critical newest page; deeper pages under heavy lag
-            // fill in once projection catches up.
-            const records = await readPendingWalRecords({dir: aiConfig.memoryWal.dir, limit, markerType: 'graph'});
+            // No raw read-limit here: readPendingWalRecords walks each daily segment in append
+            // (oldest-first) order, so capping the raw count would drop the NEWEST graph-pending rows
+            // — exactly the just-written, not-yet-projected turns the read-after-write overlay must
+            // surface. The recency bound belongs at the recency-eligible level instead: the caller
+            // (queryRecentTurns) sorts the identity-filtered merge and slices to the page size. The
+            // pending set is naturally bounded by the drain cadence + write rate.
+            const records = await readPendingWalRecords({dir: aiConfig.memoryWal.dir, markerType: 'graph'});
             const rows    = [];
 
             for (const record of records) {
@@ -1029,7 +1030,7 @@ class MemoryService extends Base {
             // this method, the row is either present in this pending snapshot or visible in the
             // graph query below; querying graph first creates a race where the graph marker can
             // land between the two reads and hide the row from both surfaces.
-            const pendingRows = await this._readPendingWalRecencyRows({identity, userId, before, limit: boundedLimit});
+            const pendingRows = await this._readPendingWalRecencyRows({identity, userId, before});
 
             const graphRows = sqlite.prepare(`
                 SELECT memory.id                                            AS id,

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -314,7 +314,36 @@ class MemoryService extends Base {
     async initAsync() {
         await super.initAsync();
         await StorageRouter.ready();
-        this._startGraphProjectionDrainLoop();
+    }
+
+    /**
+     * Triggered once this singleton reaches its ready state (after `initAsync` resolves).
+     *
+     * The hosted graph-projection drain loop is a perpetual background process, NOT mandatory
+     * startup work, so it is started here rather than inside `initAsync` (which `Neo.core.Base`
+     * reserves for awaited startup that gates `isReady`). It is skipped under `unitTestMode` so
+     * unit specs importing this singleton stay hermetic — no live drain interval and no
+     * real-WAL-dir startup drain.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetIsReady(value, oldValue) {
+        super.afterSetIsReady(value, oldValue);
+
+        if (value && !Neo.config.unitTestMode) {
+            this._startGraphProjectionDrainLoop()
+        }
+    }
+
+    /**
+     * Clears the hosted graph-projection drain interval and any in-flight projection retry timers
+     * on teardown, so neither fires against a torn-down singleton.
+     * @override
+     */
+    destroy() {
+        this._clearGraphProjectionTimers();
+        super.destroy()
     }
 
     /**
@@ -538,23 +567,34 @@ class MemoryService extends Base {
      * @private
      */
     _scheduleMemoryGraphProjection(options, attempt = 1) {
-        const delayMs = attempt === 1
-            ? 0
-            : Math.min(GRAPH_PROJECTION_RETRY_BASE_MS * 2 ** (attempt - 2), GRAPH_PROJECTION_RETRY_MAX_MS);
+        const me      = this,
+              delayMs = attempt === 1
+                  ? 0
+                  : Math.min(GRAPH_PROJECTION_RETRY_BASE_MS * 2 ** (attempt - 2), GRAPH_PROJECTION_RETRY_MAX_MS);
 
-        setTimeout(async () => {
+        me.graphProjectionRetryTimers ??= new Set();
+
+        const timer = setTimeout(async () => {
+            me.graphProjectionRetryTimers.delete(timer);
+
             try {
-                await this._projectMemoryToGraph(options);
+                await me._projectMemoryToGraph(options);
             } catch (error) {
                 if (attempt < GRAPH_PROJECTION_MAX_ATTEMPTS) {
                     logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} (attempt ${attempt}/${GRAPH_PROJECTION_MAX_ATTEMPTS}); retrying: ${error.message}`);
-                    this._scheduleMemoryGraphProjection(options, attempt + 1);
+                    me._scheduleMemoryGraphProjection(options, attempt + 1);
                     return;
                 }
 
                 logger.warn(`[MemoryService] Deferred graph projection failed for ${options.memoryId} after ${GRAPH_PROJECTION_MAX_ATTEMPTS} attempts; WAL row remains projection-pending: ${error.message}`);
             }
         }, delayMs);
+
+        // Track + unref the retry timer: destroy() must cancel in-flight retries (they would
+        // otherwise fire against a torn-down singleton), and a one-shot CLI add_memory must be able
+        // to exit without the backoff chain holding the event loop open.
+        timer.unref?.();
+        me.graphProjectionRetryTimers.add(timer)
     }
 
     /**
@@ -620,6 +660,26 @@ class MemoryService extends Base {
             });
         }, GRAPH_PROJECTION_DRAIN_INTERVAL_MS);
         this.graphProjectionDrainTimer.unref?.();
+    }
+
+    /**
+     * @summary Stops the drain interval and cancels in-flight projection retry timers.
+     *
+     * Invoked by `destroy()`; kept as its own method so the teardown is unit-testable without
+     * tearing down the shared singleton.
+     * @returns {void}
+     * @private
+     */
+    _clearGraphProjectionTimers() {
+        const me = this;
+
+        if (me.graphProjectionDrainTimer) {
+            clearInterval(me.graphProjectionDrainTimer);
+            me.graphProjectionDrainTimer = null;
+        }
+
+        me.graphProjectionRetryTimers?.forEach(timer => clearTimeout(timer));
+        me.graphProjectionRetryTimers?.clear()
     }
 
     /**
@@ -740,9 +800,14 @@ class MemoryService extends Base {
      * @returns {Promise<Object[]>} Row-shaped pending turns.
      * @private
      */
-    async _readPendingWalRecencyRows({identity, userId, before, excludeIds = new Set()} = {}) {
+    async _readPendingWalRecencyRows({identity, userId, before, limit, excludeIds = new Set()} = {}) {
         try {
-            const records = await readPendingWalRecords({dir: aiConfig.memoryWal.dir, markerType: 'graph'});
+            // Bound the WAL scan: graph projection normally keeps the pending set tiny, but under a
+            // projection-lag/outage the set grows — an unbounded read would turn every recency query
+            // into an O(pending) disk scan. readPendingWalRecords reads newest-segment-first, so a
+            // page-sized cap protects the recency-critical newest page; deeper pages under heavy lag
+            // fill in once projection catches up.
+            const records = await readPendingWalRecords({dir: aiConfig.memoryWal.dir, limit, markerType: 'graph'});
             const rows    = [];
 
             for (const record of records) {
@@ -964,7 +1029,7 @@ class MemoryService extends Base {
             // this method, the row is either present in this pending snapshot or visible in the
             // graph query below; querying graph first creates a race where the graph marker can
             // land between the two reads and hide the row from both surfaces.
-            const pendingRows = await this._readPendingWalRecencyRows({identity, userId, before});
+            const pendingRows = await this._readPendingWalRecencyRows({identity, userId, before, limit: boundedLimit});
 
             const graphRows = sqlite.prepare(`
                 SELECT memory.id                                            AS id,

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs
@@ -1,0 +1,94 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'MemoryServiceLifecycleTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Lifecycle coverage for the MemoryService graph-projection drain loop + retry timers.
+ *
+ * The drain loop is a perpetual background process; it must (a) NOT start while unitTestMode keeps
+ * the singleton hermetic, (b) start when a real host reaches the ready state, and (c) be fully
+ * torn down — interval + in-flight retry timers — so nothing fires against a destroyed singleton.
+ * These tests exercise the teardown via the `_clearGraphProjectionTimers` seam instead of calling
+ * the real `destroy()`, which would tear down the shared singleton for every other spec.
+ */
+test.describe('Neo.ai.services.memory-core.MemoryService — graph-projection lifecycle (#13313)', () => {
+    let MemoryService;
+
+    test.beforeAll(async () => {
+        MemoryService = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+    });
+
+    test.afterEach(() => {
+        // Never leave a live interval or pending retry behind for the next spec.
+        MemoryService._clearGraphProjectionTimers();
+    });
+
+    test('afterSetIsReady does NOT start the drain loop under unitTestMode', () => {
+        expect(Neo.config.unitTestMode).toBe(true);
+
+        MemoryService._clearGraphProjectionTimers();
+        // Reaching ready must not spin up a live drain interval while unitTestMode is on — this is
+        // the hermetic-singleton-import guarantee (no real-WAL-dir startup drain either).
+        MemoryService.afterSetIsReady(true, false);
+
+        expect(MemoryService.graphProjectionDrainTimer == null).toBe(true);
+    });
+
+    test('_startGraphProjectionDrainLoop sets an interval that _clearGraphProjectionTimers tears down', () => {
+        const originalDrain = MemoryService.drainPendingGraphProjections;
+
+        // Keep the startup drain + interval callback off the real WAL dir.
+        MemoryService.drainPendingGraphProjections = async () => ({pending: 0, projected: 0, failed: 0});
+
+        try {
+            MemoryService._startGraphProjectionDrainLoop();
+            expect(MemoryService.graphProjectionDrainTimer != null).toBe(true);
+
+            // Idempotent: a second call must not replace the live timer.
+            const firstTimer = MemoryService.graphProjectionDrainTimer;
+            MemoryService._startGraphProjectionDrainLoop();
+            expect(MemoryService.graphProjectionDrainTimer).toBe(firstTimer);
+
+            MemoryService._clearGraphProjectionTimers();
+            expect(MemoryService.graphProjectionDrainTimer == null).toBe(true);
+        } finally {
+            MemoryService.drainPendingGraphProjections = originalDrain;
+        }
+    });
+
+    test('_scheduleMemoryGraphProjection tracks an unref-d retry timer that teardown cancels', () => {
+        const originalProject = MemoryService._projectMemoryToGraph;
+
+        // Hang the projection so the scheduled timer stays pending + observable.
+        MemoryService._projectMemoryToGraph = () => new Promise(() => {});
+
+        try {
+            // attempt 2 → a real (250ms) backoff delay, so the timer is still pending on inspection.
+            MemoryService._scheduleMemoryGraphProjection({memoryId: 'lifecycle-test'}, 2);
+
+            expect(MemoryService.graphProjectionRetryTimers.size).toBe(1);
+
+            const [timer] = [...MemoryService.graphProjectionRetryTimers];
+            // unref'd so a one-shot CLI add_memory exits without waiting on the backoff chain.
+            expect(typeof timer.hasRef !== 'function' || timer.hasRef() === false).toBe(true);
+
+            MemoryService._clearGraphProjectionTimers();
+            expect(MemoryService.graphProjectionRetryTimers.size).toBe(0);
+        } finally {
+            MemoryService._projectMemoryToGraph = originalProject;
+        }
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs
@@ -258,6 +258,43 @@ test.describe('Neo.ai.services.memory-core.MemoryService.writeAhead', () => {
         }
     });
 
+    test('RA1: the newest graph-pending turn stays recency-visible when the segment exceeds the page size', async () => {
+        const originalSchedule     = MemoryService._scheduleMemoryGraphProjection;
+        const originalBuildSummary = MemoryService.buildMiniSummary;
+
+        // Leave every write graph-pending (never projected), and silence summarization noise.
+        MemoryService._scheduleMemoryGraphProjection = () => {};
+        MemoryService.buildMiniSummary               = async () => null;
+
+        try {
+            const writes = [];
+
+            // Write more turns than the recency page size below, all graph-pending in the same
+            // UTC-day segment. A 2ms gap gives each a strictly-increasing timestamp so "newest" is
+            // unambiguous under the (timestamp, id) ordering.
+            for (let i = 0; i < 5; i++) {
+                writes.push(await asTenant(() => MemoryService.addMemory({
+                    prompt: `ra1 prompt ${i}`, thought: `ra1 thought ${i}`, response: `ra1 response ${i}`
+                })));
+                await new Promise(resolve => setTimeout(resolve, 2));
+            }
+
+            const newest = writes[writes.length - 1];
+
+            // Page size 3 < 5 pending. A raw read-limit would walk the append-ordered segment and
+            // return the OLDEST 3, dropping the newest just-written turn; the recency-eligible bound
+            // (sort + slice in queryRecentTurns) must keep it visible and first.
+            const recent = await asTenant(() => MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 3}));
+
+            expect(recent.turns.map(turn => turn.id)).toContain(newest.id);
+            expect(recent.turns[0].id).toBe(newest.id);
+            expect(recent.turns[0].projectionPending).toBe(true);
+        } finally {
+            MemoryService._scheduleMemoryGraphProjection = originalSchedule;
+            MemoryService.buildMiniSummary               = originalBuildSummary;
+        }
+    });
+
     test('AC3: with the embed down, a just-written turn is immediately recency-visible and the WAL overlay serves BOTH detail levels', async () => {
         collectionMode = 'throw';
 


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.

Resolves #13313

Operator-flagged during the #13288 merge: the new graph-projection drain loop is started from `initAsync` — which `Neo.core.Base` reserves for **awaited mandatory startup that gates `isReady`** (`src/core/Base.mjs:596-619`) — with no teardown and no test-mode gate. #13288's durability decoupling is correct; this only brings the async machinery it introduced back into the `Base` lifecycle contract.

Evidence: L2 (focused lifecycle unit specs via the `_clearGraphProjectionTimers` seam + the `RA1` recency regression + the full existing memory-core suite green) -> L2 required (in-process timer lifecycle + hermetic-singleton-import contract + recency-overlay newest-row preservation). No residuals.

## Implementation

Five gaps, one theme — lifecycle-unmanaged async:

1. **Loop out of `initAsync` -> `afterSetIsReady`, gated `!unitTestMode`.** `initAsync` keeps only `await super.initAsync()` + `await StorageRouter.ready()`. Under `unitTestMode` the loop never starts, so unit specs importing the singleton are hermetic — no live interval, no real-WAL-dir startup drain.
2. **`destroy()` teardown.** A new `destroy()` + `_clearGraphProjectionTimers()` `clearInterval`s the drain timer and cancels in-flight retries, so neither fires against a torn-down singleton.
3. **Tracked + `unref`'d retry timer.** `_scheduleMemoryGraphProjection`'s `setTimeout` is added to a tracked `Set` and `unref`'d: `destroy()` cancels it, and a one-shot CLI `add_memory` exits without the backoff chain holding the event loop open.
4. **Recency-overlay bound at the recency-eligible level (NOT the raw WAL read).** The raw graph-pending WAL read in `_readPendingWalRecencyRows` is intentionally **unbounded** — a raw page-size cap walks the daily segment in append (oldest-first) order and would drop the NEWEST just-written rows. The effective bound is applied *after* identity-filtered graph + pending rows are merged, sorted `(timestamp, id)` DESC, and sliced to the page size in `queryRecentTurns`; the pending set is naturally bounded by the drain cadence + write rate. (This was a raw-read `limit` in the first revision — reverted per the `RA1` cross-family review; the WriteAhead `RA1` regression test proves the newest own-agent pending turn stays visible and first.)

Distinct boundary from #13312 (graph *startup/tool-availability* coupling, gpt).

## Deltas from Ticket

- Extracted `_clearGraphProjectionTimers()` (not named in the ticket) so the teardown is unit-testable without calling the real `destroy()` on the shared singleton.
- The retry timers are tracked in an explicit `Set` + `unref`'d rather than routed through `Base.timeout()`/`registerAsync()`: in this Node host `setTimeout` returns a `Timeout` object (not a numeric id), so `Base.destroy()`'s `Neo.isNumber(id)`-gated `clearTimeout` is a no-op for Node timers — explicit tracking is the Node-correct teardown the AC intends. (Latent `Base.mjs` Node/browser-timer gap — filed as #13319.)
- The #13313 AC's "bound `_readPendingWalRecencyRows`" landed at the recency-eligible (sorted) level rather than the raw WAL read, per the `RA1` review — a raw read-limit drops the newest pending rows.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryService.Lifecycle.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.WriteAhead.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.Schema.spec.mjs test/playwright/unit/ai/services/memory-core/QueryRecentTurns.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs` -> **39 passed** (3 lifecycle specs + the `RA1` recency regression + the existing memory-core specs, no regressions).
- Husky pre-commit gates passed: whitespace, shorthand, AiConfig test-mutation, ticket-archaeology.

## Post-Merge Validation

- [ ] On a running memory-core MCP server the drain loop runs in production (`graphProjectionDrainTimer` set after ready); a one-shot `ai:mcp-client ... add_memory` CLI call exits promptly without hanging on projection retries.

## Commits

- `3cdfbbcac` - `fix(memory-core): lifecycle-manage the graph-projection drain loop (#13313)`
- `feded558f` - `fix(memory-core): bound the recency overlay at the sorted level, not the raw WAL read (#13313)`
