### PR TITLE
test(memory-core): add aiConfig snapshot/restore test-isolation helper (#13315)

### DIFF
--- a/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
@@ -45,11 +45,10 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
         }
         testDbPath = path.join(tmpDir, testDbName);
 
-        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'autoIngestFileSystem', 'handoffFilePath']);
+        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'handoffFilePath']);
 
-        aiConfig.storagePaths.graph   = testDbPath;
-        aiConfig.autoIngestFileSystem = false;
-        aiConfig.handoffFilePath      = path.join(tmpDir, 'mock_sandman_handoff_concept_ingestor.md');
+        aiConfig.storagePaths.graph = testDbPath;
+        aiConfig.handoffFilePath    = path.join(tmpDir, 'mock_sandman_handoff_concept_ingestor.md');
 
         GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         ConceptIngestor        = (await import('../../../../../../ai/services/ingestion/ConceptIngestor.mjs')).default;

--- a/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
@@ -19,7 +19,7 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs';
 import path           from 'path';
 import os             from 'os';
-import {TestLifecycleHelper} from '../../services/memory-core/util.mjs';
+import {snapshotAiConfig, TestLifecycleHelper} from '../../services/memory-core/util.mjs';
 
 test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
     let GraphService;
@@ -31,6 +31,7 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
     const testDbName = `memory-core-concept-ingestor-test-${process.pid}-${Date.now()}.sqlite`;
     let testDbPath;
     let tmpConceptsDir;
+    let restoreAiConfig;
 
     let originalWarn;
     let warnMessages = [];
@@ -43,6 +44,8 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
             fs.mkdirSync(tmpDir, {recursive: true});
         }
         testDbPath = path.join(tmpDir, testDbName);
+
+        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'autoIngestFileSystem', 'handoffFilePath']);
 
         aiConfig.storagePaths.graph   = testDbPath;
         aiConfig.autoIngestFileSystem = false;
@@ -67,6 +70,10 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
         } else {
             await SystemLifecycleService.ready();
         }
+    });
+
+    test.afterAll(() => {
+        restoreAiConfig?.();
     });
 
     test.beforeEach(() => {
@@ -221,7 +228,7 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
     });
 
     test('should count orphan concepts in stats without emitting per-orphan logger.warn (#10087)', async () => {
-        // Post-#10087: orphan surfacing moved from the ephemeral logger.warn channel to the
+        // Orphan surfacing moved from the ephemeral logger.warn channel to the
         // durable capabilityGap channel via GapInferenceEngine.inferConceptGraphGaps. ConceptIngestor
         // retains the count for the cycle-summary info line but no longer warns per orphan.
         writeFixture(

--- a/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
@@ -18,7 +18,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fs             from 'fs';
 import path           from 'path';
-import {TestLifecycleHelper} from '../../services/memory-core/util.mjs';
+import {snapshotAiConfig, TestLifecycleHelper} from '../../services/memory-core/util.mjs';
 
 test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
     // Serial within this describe — `beforeAll` performs a cold import cascade of the Neo
@@ -35,6 +35,7 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
 
     const testDbName = `memory-core-memory-session-ingestor-test-${process.pid}-${Date.now()}.sqlite`;
     let testDbPath;
+    let restoreAiConfig;
 
     let originalWarn;
     let warnMessages = [];
@@ -76,6 +77,8 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
         }
         testDbPath = path.join(tmpDir, testDbName);
 
+        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'autoIngestFileSystem', 'handoffFilePath']);
+
         aiConfig.storagePaths.graph   = testDbPath;
         aiConfig.autoIngestFileSystem = false;
         aiConfig.handoffFilePath      = path.join(tmpDir, 'mock_sandman_handoff_memory_session_ingestor.md');
@@ -98,6 +101,10 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
         } else {
             await SystemLifecycleService.ready();
         }
+    });
+
+    test.afterAll(() => {
+        restoreAiConfig?.();
     });
 
     test.beforeEach(() => {
@@ -343,9 +350,9 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
     });
 
     // ------------------------------------------------------------------------------------------
-    // ingestSingleRow (#10153) — per-row back-fill primitive. Consumed by
+    // ingestSingleRow — per-row back-fill primitive. Consumed by
     // `GraphService.ensureNodeExists` when `linkNodesAsync` hits a missing `memory:`/`session:`
-    // endpoint, and by `LazyEdgeDrainer` when draining the #10165 lazy-edges JSONL queue.
+    // endpoint, and by `LazyEdgeDrainer` when draining the lazy-edges JSONL queue.
     // ------------------------------------------------------------------------------------------
 
     /**
@@ -465,7 +472,7 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
             {id: 'chroma-summary-upper', metadata: {sessionId: 'sess-upper', createdAt: '2026-04-21T09:00:00Z', userId: 'tobiu'}}
         ]);
 
-        // Caller passes the uppercase prefix (Gemini's #10165 extractor convention); the
+        // Caller passes the uppercase prefix (Gemini's extractor convention); the
         // back-fill must land under the canonical lowercase form so the node is discoverable
         // by the existing ingestor's `session:`/`memory:` ID contract.
         const result = await MemorySessionIngestor.ingestSingleRow('MEMORY:mem-upper', {memoryCollection, summaryCollection});
@@ -493,7 +500,7 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
         expect(sessionNode.properties.liveIngested).toBe(true);
         expect(memoryNode.properties.liveIngested).toBe(true);
         // `backfilled` should remain undefined on live-ingested nodes; the two markers are
-        // mutually exclusive provenance tags per ticket #10153.
+        // mutually exclusive provenance tags.
         expect(sessionNode.properties.backfilled).toBeUndefined();
         expect(memoryNode.properties.backfilled).toBeUndefined();
     });

--- a/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
@@ -77,11 +77,10 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
         }
         testDbPath = path.join(tmpDir, testDbName);
 
-        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'autoIngestFileSystem', 'handoffFilePath']);
+        restoreAiConfig = snapshotAiConfig(aiConfig, ['storagePaths.graph', 'handoffFilePath']);
 
-        aiConfig.storagePaths.graph   = testDbPath;
-        aiConfig.autoIngestFileSystem = false;
-        aiConfig.handoffFilePath      = path.join(tmpDir, 'mock_sandman_handoff_memory_session_ingestor.md');
+        aiConfig.storagePaths.graph = testDbPath;
+        aiConfig.handoffFilePath    = path.join(tmpDir, 'mock_sandman_handoff_memory_session_ingestor.md');
 
         GraphService           = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
         MemorySessionIngestor  = (await import('../../../../../../ai/services/ingestion/MemorySessionIngestor.mjs')).default;

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -116,6 +116,42 @@ export async function drainMemoryWal({ids, collection, SDK} = {}) {
     });
 }
 
+/**
+ * @summary Snapshots the given dot-path `aiConfig` leaves and returns a `restore()` thunk.
+ *
+ * `aiConfig` is a Provider singleton imported once per module graph; a spec that writes its leaves
+ * in setup (e.g. `storagePaths.graph`, `autoIngestFileSystem`) without restoring leaks that state
+ * into the next `--workers=1` spec — the latent cross-spec config bleed this isolation helper
+ * targets. Capture BEFORE the first mutation; call the returned thunk in `afterAll`/`afterEach`.
+ *
+ * @param {Object} aiConfig The memory-core `aiConfig` Provider singleton.
+ * @param {String[]} paths Dot-paths to snapshot, e.g. `['storagePaths.graph', 'autoIngestFileSystem']`.
+ * @returns {Function} `restore()` — reassigns each captured leaf to its original value, or deletes a
+ *     leaf that did not exist at capture time.
+ */
+export function snapshotAiConfig(aiConfig, paths) {
+    const captured = paths.map(dotPath => {
+        const segments = dotPath.split('.'),
+              key      = segments.pop(),
+              parent   = segments.reduce((node, segment) => node?.[segment], aiConfig),
+              existed  = parent ? Object.prototype.hasOwnProperty.call(parent, key) : false;
+
+        return {parent, key, existed, value: parent ? parent[key] : undefined};
+    });
+
+    return function restore() {
+        captured.forEach(({parent, key, existed, value}) => {
+            if (!parent) return;
+
+            if (existed) {
+                parent[key] = value;
+            } else {
+                delete parent[key];
+            }
+        });
+    };
+}
+
 export class TestLifecycleHelper {
     static async cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, strategy = 'destroy') {
         if (strategy === 'clear') {

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -121,33 +121,48 @@ export async function drainMemoryWal({ids, collection, SDK} = {}) {
  *
  * `aiConfig` is a Provider singleton imported once per module graph; a spec that writes its leaves
  * in setup (e.g. `storagePaths.graph`, `autoIngestFileSystem`) without restoring leaks that state
- * into the next `--workers=1` spec — the latent cross-spec config bleed this isolation helper
+ * into the next `--workers=1` spec — the shared-singleton mutation hazard (B4) this isolation helper
  * targets. Capture BEFORE the first mutation; call the returned thunk in `afterAll`/`afterEach`.
  *
- * @param {Object} aiConfig The memory-core `aiConfig` Provider singleton.
- * @param {String[]} paths Dot-paths to snapshot, e.g. `['storagePaths.graph', 'autoIngestFileSystem']`.
- * @returns {Function} `restore()` — reassigns each captured leaf to its original value, or deletes a
- *     leaf that did not exist at capture time.
+ * **Contract — existing leaves only.** `restore()` reassigns each captured leaf via the proxy set
+ * trap (routed to the owning provider's `setData`), which faithfully restores a leaf that EXISTED at
+ * capture. A leaf that was ABSENT cannot be undone: the Provider exposes no delete API and the proxy
+ * has no `deleteProperty` trap, so neither `delete` nor a re-set to `undefined` removes the path a
+ * test added — the written value keeps resolving via the get trap. Rather than hand back a
+ * `restore()` that silently leaks, the helper throws on a path that does not already resolve to a
+ * leaf. Isolate leaves you ADD during a test by construction (`unitTestMode`), not with this helper.
+ *
+ * @param {Object} aiConfig The memory-core `aiConfig` Provider singleton (or a plain fixture).
+ * @param {String[]} paths Dot-paths to scalar leaves that EXIST at capture, e.g.
+ *     `['storagePaths.graph', 'handoffFilePath']`.
+ * @returns {Function} `restore()` — reassigns each captured leaf to its original value.
+ * @throws {Error} If any path does not resolve to an existing leaf at capture time.
+ * @see learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
  */
 export function snapshotAiConfig(aiConfig, paths) {
     const captured = paths.map(dotPath => {
         const segments = dotPath.split('.'),
               key      = segments.pop(),
               parent   = segments.reduce((node, segment) => node?.[segment], aiConfig),
-              existed  = parent ? Object.prototype.hasOwnProperty.call(parent, key) : false;
+              value    = parent ? parent[key] : undefined;
 
-        return {parent, key, existed, value: parent ? parent[key] : undefined};
+        // Existence is judged by the resolved value, not `hasOwnProperty`: the proxy's
+        // getOwnPropertyDescriptor trap misses leaves its get trap resolves, so hasOwnProperty is
+        // unreliable here (it is false for `handoffFilePath` even though the leaf resolves to a value).
+        if (value === undefined) {
+            throw new Error(
+                `snapshotAiConfig: "${dotPath}" does not resolve to a value at capture time. The ` +
+                `Provider exposes no delete API, so a leaf a test adds cannot be undone — snapshot ` +
+                `only leaves that already resolve to a value.`
+            );
+        }
+
+        return {parent, key, value};
     });
 
     return function restore() {
-        captured.forEach(({parent, key, existed, value}) => {
-            if (!parent) return;
-
-            if (existed) {
-                parent[key] = value;
-            } else {
-                delete parent[key];
-            }
+        captured.forEach(({parent, key, value}) => {
+            parent[key] = value
         });
     };
 }

--- a/test/playwright/unit/ai/services/memory-core/util.snapshotAiConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.snapshotAiConfig.spec.mjs
@@ -19,41 +19,71 @@ import {snapshotAiConfig} from './util.mjs';
 /**
  * @summary Unit coverage for the snapshotAiConfig test-isolation helper.
  *
- * The helper captures aiConfig leaves and returns a restore() thunk; it is pure, so these tests
- * exercise it against a plain fixture object — never the real aiConfig Provider singleton.
+ * Two layers: pure-fixture tests pin the restore-existing / throw-on-absent contract against a plain
+ * object, and a Provider-backed block proves the same contract on the real aiConfig Provider
+ * singleton — whose proxy has no delete API, the surface the helper actually guards.
  */
 test.describe('Neo.ai test-isolation — snapshotAiConfig (#12435)', () => {
     test('restores mutated leaves to their captured values', () => {
-        const cfg = {storagePaths: {graph: '/orig/graph.sqlite'}, autoIngestFileSystem: true};
+        const cfg = {storagePaths: {graph: '/orig/graph.sqlite'}, handoffFilePath: '/orig/handoff.md'};
 
-        const restore = snapshotAiConfig(cfg, ['storagePaths.graph', 'autoIngestFileSystem']);
+        const restore = snapshotAiConfig(cfg, ['storagePaths.graph', 'handoffFilePath']);
 
-        cfg.storagePaths.graph   = '/tmp/test.sqlite';
-        cfg.autoIngestFileSystem = false;
+        cfg.storagePaths.graph = '/tmp/test.sqlite';
+        cfg.handoffFilePath    = '/tmp/handoff.md';
 
         restore();
 
         expect(cfg.storagePaths.graph).toBe('/orig/graph.sqlite');
-        expect(cfg.autoIngestFileSystem).toBe(true);
+        expect(cfg.handoffFilePath).toBe('/orig/handoff.md');
     });
 
-    test('deletes a leaf that did not exist at capture time', () => {
+    test('throws on a leaf that does not exist at capture time', () => {
         const cfg = {storagePaths: {graph: '/orig/graph.sqlite'}};
 
-        const restore = snapshotAiConfig(cfg, ['handoffFilePath']);
-
-        cfg.handoffFilePath = '/tmp/handoff.md';
-        restore();
-
-        expect(Object.prototype.hasOwnProperty.call(cfg, 'handoffFilePath')).toBe(false);
+        // No delete API on the real target, so the helper refuses a path it cannot undo rather than
+        // hand back a restore() that silently leaks the test-written value.
+        expect(() => snapshotAiConfig(cfg, ['handoffFilePath'])).toThrow(/does not resolve to a value/);
     });
 
-    test('tolerates a missing parent without throwing', () => {
+    test('throws when a snapshotted path has no parent', () => {
         const cfg = {};
 
-        const restore = snapshotAiConfig(cfg, ['engines.chroma.database']);
+        expect(() => snapshotAiConfig(cfg, ['engines.chroma.database'])).toThrow(/does not resolve to a value/);
+    });
+});
 
-        expect(() => restore()).not.toThrow();
-        expect(cfg.engines).toBeUndefined();
+test.describe('Neo.ai test-isolation — snapshotAiConfig on the real aiConfig Provider', () => {
+    let aiConfig;
+
+    test.beforeAll(async () => {
+        aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+    });
+
+    test('restores an existing leaf on the real Provider singleton via the set trap', () => {
+        // handoffFilePath is a declared scalar leaf, not a storage/DB path, so this
+        // snapshot→mutate→restore round-trip cannot bleed test state into a live DB (B4). restore()
+        // runs in `finally`, so the shared singleton returns to its captured value even if the
+        // mid-flight assertion throws.
+        const original = aiConfig.handoffFilePath,
+              restore  = snapshotAiConfig(aiConfig, ['handoffFilePath']);
+
+        try {
+            aiConfig.handoffFilePath = '/tmp/__neo_probe_handoff__.md';
+            expect(aiConfig.handoffFilePath).toBe('/tmp/__neo_probe_handoff__.md') // set trap wrote through
+        } finally {
+            restore()
+        }
+
+        expect(aiConfig.handoffFilePath).toBe(original) // get trap reads the restored value
+    });
+
+    test('refuses an absent leaf it cannot undo, instead of returning a leaky restore', () => {
+        // Closes the delete-added falsifier at its source: the proxy cannot remove a path a test
+        // adds, so the helper throws at capture rather than hand back a restore() that leaks.
+        const probe = '__neoAbsentLeafProbe__';
+
+        expect(aiConfig[probe]).toBeUndefined(); // absent on the real Provider
+        expect(() => snapshotAiConfig(aiConfig, [probe])).toThrow(/does not resolve to a value/)
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/util.snapshotAiConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.snapshotAiConfig.spec.mjs
@@ -1,0 +1,59 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'SnapshotAiConfigTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../../../src/Neo.mjs';
+import * as core          from '../../../../../../src/core/_export.mjs';
+import {snapshotAiConfig} from './util.mjs';
+
+/**
+ * @summary Unit coverage for the snapshotAiConfig test-isolation helper.
+ *
+ * The helper captures aiConfig leaves and returns a restore() thunk; it is pure, so these tests
+ * exercise it against a plain fixture object — never the real aiConfig Provider singleton.
+ */
+test.describe('Neo.ai test-isolation — snapshotAiConfig (#12435)', () => {
+    test('restores mutated leaves to their captured values', () => {
+        const cfg = {storagePaths: {graph: '/orig/graph.sqlite'}, autoIngestFileSystem: true};
+
+        const restore = snapshotAiConfig(cfg, ['storagePaths.graph', 'autoIngestFileSystem']);
+
+        cfg.storagePaths.graph   = '/tmp/test.sqlite';
+        cfg.autoIngestFileSystem = false;
+
+        restore();
+
+        expect(cfg.storagePaths.graph).toBe('/orig/graph.sqlite');
+        expect(cfg.autoIngestFileSystem).toBe(true);
+    });
+
+    test('deletes a leaf that did not exist at capture time', () => {
+        const cfg = {storagePaths: {graph: '/orig/graph.sqlite'}};
+
+        const restore = snapshotAiConfig(cfg, ['handoffFilePath']);
+
+        cfg.handoffFilePath = '/tmp/handoff.md';
+        restore();
+
+        expect(Object.prototype.hasOwnProperty.call(cfg, 'handoffFilePath')).toBe(false);
+    });
+
+    test('tolerates a missing parent without throwing', () => {
+        const cfg = {};
+
+        const restore = snapshotAiConfig(cfg, ['engines.chroma.database']);
+
+        expect(() => restore()).not.toThrow();
+        expect(cfg.engines).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.

Resolves #13315
Refs #12435

`aiConfig` is a Provider singleton imported once per module graph; specs that write its leaves in setup without restoring leak that state into the next `--workers=1` spec (the #12435 cross-spec bleed). This delivers the reusable snapshot/restore helper #12435's migration needs and proves it on the two simplest ingestion specs.

Evidence: L2 (helper unit spec + 2 adopted specs green under `--workers=1`, incl. Provider-backed coverage against the real `aiConfig` singleton) -> L2 required (helper contract + capture/restore in real specs). No residuals.

## Implementation

- `snapshotAiConfig(aiConfig, paths)` in `test/playwright/unit/ai/services/memory-core/util.mjs` — captures each dot-path leaf's resolved value and returns a `restore()` thunk that reassigns it via the proxy set trap (identical on the Provider and a plain fixture). It **throws** on a path that does not resolve to a value at capture: the Provider exposes no delete API and the proxy has no `deleteProperty` trap, so a leaf a test *adds* cannot be undone — the helper refuses what it cannot restore instead of returning a leaky `restore()`. Pure + dependency-free.
- `util.snapshotAiConfig.spec.mjs` (new): plain-fixture restore-existing / throw-on-absent / throw-on-missing-parent, plus a Provider-backed block — restore an existing leaf on the real singleton via the set trap (restore-in-`finally` so the shared singleton is never left dirty), and refuse an absent leaf.
- `ConceptIngestor.spec` + `MemorySessionIngestor.spec`: capture in `beforeAll`, restore in `afterAll`.

## Deltas from Ticket

- V-B-A found the true #12435 footprint is ~16 specs (not the ticketed 11) — escape-marker-grandfathered by the `check-aiconfig-test-mutation` husky guard; that scope correction belongs on #12435 (this leaf is just the helper + proof).
- Removed a **dead write to the retired `autoIngestFileSystem` flag** (`RETIRED_CONFIG_FLAGS`) from both adopted specs — it was the only absent leaf they snapshotted, and nothing reads it.
- Dropped 5 pre-existing rot-prone ticket-refs from the two touched specs' comments (the ticket-archaeology hook scans the whole staged file, so touching it forces the cleanup).

## Test Evidence

- `npm run test-unit -- --workers=1 test/playwright/unit/ai/services/memory-core/util.snapshotAiConfig.spec.mjs test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs` -> **26 passed**.
- Husky pre-commit gates passed: whitespace, shorthand, AiConfig test-mutation, ticket-archaeology.

## Evolution

- RA1 (cross-family review): the original `restore()` *deleted* leaves absent at capture, but the aiConfig Provider has no delete path — no `deleteProperty` trap, no `deleteData`, and `setData(path, undefined)` is a no-op — so an added leaf silently leaked (the falsifier finding). A live probe of the real singleton also showed `hasOwnProperty` is unreliable on the proxy (false for `handoffFilePath` even though the leaf resolves to its default). Reworked to a value-based contract: restore existing leaves via the set trap, throw on absent ones, and drop the retired-flag write that was the lone absent-path caller.

## Post-Merge Validation

- [ ] The broad ~13-spec adoption (tracked on #12435) builds on this helper; MC `Server.spec` adoption sequences after #13312 (gpt) to avoid a collision.

## Commits

- `765e8122f` - `test(memory-core): add aiConfig snapshot/restore test-isolation helper (#13315)`
- `93404afb9` - `fix(memory-core): snapshotAiConfig restores existing leaves, throws on absent (#13315)`
