### PR TITLE
fix(memory-core): keep add_memory callable during graph startup degradation (#13312)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -174,8 +174,9 @@ class Server extends BaseServer {
      * @summary Custom boot order (override of `BaseServer.boot`). Memory Core's bootstrap
      * has three constraints that the canonical sequence doesn't satisfy:
      *
-     * 1. `WakeSubscriptionService.init()` must complete BEFORE `createMcpServer()` so the
-     *    experimental wake-substrate capability has its substrate ready when clients connect.
+     * 1. The MCP server/tool registry must come up before graph/vector startup tiers are awaited,
+     *    so WAL-local tools (`add_memory`) remain callable during graph SQLite or Chroma startup
+     *    faults.
      * 2. Stdio identity resolution must complete BEFORE healthcheck, so the boot-time
      *    healthcheck snapshot reflects the bound identity state.
      * 3. The wake-subscription auto-bootstrap is fire-and-forget within an async IIFE for
@@ -186,14 +187,28 @@ class Server extends BaseServer {
     async boot() {
         await this.loadCustomConfig();
 
-        // Pre-mcpServer init: WakeSubscriptionService substrate ready.
-        await WakeSubscriptionService.init();
-
         this.mcpServer = this.createMcpServer();
 
-        // Wait for dependent services.
-        await InferenceLifecycleService.ready();
-        await SessionService.ready();
+        await this.prepareStartupDependency({
+            name      : 'wake-subscription',
+            dependency: WakeSubscriptionService,
+            start     : () => WakeSubscriptionService.init(),
+            degraded  : 'wake subscriptions are degraded; WAL-local tools remain available'
+        });
+
+        await this.prepareStartupDependency({
+            name      : 'inference-lifecycle',
+            dependency: InferenceLifecycleService,
+            start     : () => InferenceLifecycleService.ready(),
+            degraded  : 'inference readiness is degraded; WAL-local tools remain available'
+        });
+
+        await this.prepareStartupDependency({
+            name      : 'session-service',
+            dependency: SessionService,
+            start     : () => SessionService.ready(),
+            degraded  : 'session/vector reads are degraded; add_memory remains WAL-available'
+        });
 
         // In-process WAL drain (containerized / single-process deployments): hosts the embed
         // daemon's exact drain loop inside this server when no orchestrator-supervised daemon
@@ -268,6 +283,37 @@ class Server extends BaseServer {
 
         if (aiConfig.transport !== 'sse') {
             this.logIdentityStatus();
+        }
+    }
+
+    /**
+     * @summary Initializes a non-WAL startup dependency as best-effort readiness.
+     *
+     * Memory Core's minimum availability tier is the local `memoryWal` append surface. Graph,
+     * wake-subscription, inference, and vector/session readiness must be observable but must not
+     * veto MCP server startup; otherwise the mandatory `add_memory` final-turn save disappears
+     * exactly when a degraded deployment most needs lossless WAL capture.
+     *
+     * @param {Object} options
+     * @param {String} options.name Stable healthcheck key.
+     * @param {Object} options.dependency Dependency object for diagnostic naming.
+     * @param {Function} options.start Async startup callback.
+     * @param {String} options.degraded Operator-facing degraded-mode summary.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async prepareStartupDependency({name, dependency, start, degraded}) {
+        try {
+            await start();
+            HealthService.recordStartupDependency(name, 'ready', {
+                className: dependency?.className || dependency?.constructor?.name || name
+            });
+        } catch (error) {
+            logger.warn(`[neo-memory-core MCP] ${name} startup degraded: ${error.message}. ${degraded}.`);
+            HealthService.recordStartupDependency(name, 'degraded', {
+                className: dependency?.className || dependency?.constructor?.name || name,
+                error    : error.message
+            });
         }
     }
 

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -72,6 +72,10 @@ class GraphService extends Base {
          */
         db: null,
         /**
+         * @member {Object|null} graphInitError=null
+         */
+        graphInitError: null,
+        /**
          * @member {Boolean} singleton=true
          */
         singleton: true
@@ -91,86 +95,96 @@ class GraphService extends Base {
         }
 
         this._initPromise = (async () => {
-            const dbPath              = aiConfig.storagePaths.graph;
-            let storage               = Neo.create(SQLite, {dbPath: dbPath});
-            await storage.ready();
-
-            let memoryCoreGraph = Neo.get ? Neo.get('memory-core-graph') : Neo.idMap?.['memory-core-graph'];
-            if (memoryCoreGraph) {
-                this.db         = memoryCoreGraph;
-                this.db.storage = storage;
-            } else {
-                this.db = Neo.create(CoreDatabase, {
-                    id     : 'memory-core-graph',
-                    storage: storage
-                });
-            }
-
-            await storage.load();
-
-            // Ensure the frontier node exists to prevent context frontier errors
             try {
-                this.db.getAdjacentNodes('frontier', 'both'); // trigger lazy load
-                if (!this.db.nodes.has('frontier')) {
-                    this.upsertGlobalNode({
-                        id         : 'frontier',
-                        type       : 'SYSTEM_ANCHOR',
-                        name       : 'Active Context Frontier',
-                        description: 'The shifting focal point of the active Neo OS agent session.'
+                const dbPath              = aiConfig.storagePaths.graph;
+                let storage               = Neo.create(SQLite, {dbPath: dbPath});
+                await storage.ready();
+
+                let memoryCoreGraph = Neo.get ? Neo.get('memory-core-graph') : Neo.idMap?.['memory-core-graph'];
+                if (memoryCoreGraph) {
+                    this.db         = memoryCoreGraph;
+                    this.db.storage = storage;
+                } else {
+                    this.db = Neo.create(CoreDatabase, {
+                        id     : 'memory-core-graph',
+                        storage: storage
                     });
                 }
-            } catch (error) {
-                logger.warn(`[GraphService] Non-fatal DB contention during 'frontier' seed: ${error.message}`);
-            }
 
-            // --- 1. THE GLOBAL SYSTEM PRIMER ---
-            // Inject the Master Architecture Tenets directly into the Native Graph at boot.
-            // Because this is anchored to the 'frontier' with a protected SYSTEM_TENET edge,
-            // it acts as a deterministic onboarding payload for every agent session.
-            try {
-                this.db.getAdjacentNodes('Neo-Master-Architecture', 'both');
-                if (!this.db.nodes.has('Neo-Master-Architecture')) {
-                    this.upsertGlobalNode({
-                        id         : 'Neo-Master-Architecture',
-                        type       : 'System',
-                        name       : 'Global System Primer',
-                        description: 'Core framework tenets: 1. All Playwright tests must be run using "npm run test-unit -- [file]". No npx. 2. UI debugging and application state inspection must use the Neural Link MCP tools. 3. Look at .agents/skills for reusable agent workflows.'
-                    });
-                }
-                this.linkGlobalNodes('frontier', 'Neo-Master-Architecture', 'SYSTEM_TENET', 1.0);
-            } catch (error) {
-                logger.warn(`[GraphService] Non-fatal DB contention during Master Architecture seed: ${error.message}`);
-            }
+                await storage.load();
+                this.graphInitError = null;
 
-            // --- 2. AGENT IDENTITY SUBSTRATE SEEDING ---
-            // Eliminates the "seed → restart-again" recovery loop for fresh local setups.
-            // Auto-provision identity roots at boot so bindAgentIdentity doesn't throw on fresh setups.
-            try {
-                for (const identity of IDENTITIES) {
-                    // We use getAdjacentNodes as a trigger for lazy-loading into the cache
-                    this.db.getAdjacentNodes(identity.id, 'both');
-
-                    if (!this.db.nodes.has(identity.id)) {
-                        this.upsertGlobalNode(identity);
-                    } else {
-                        // Defensive createdAt retention: Peek SQLite to preserve original timestamp
-                        const row = storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(identity.id);
-                        if (row) {
-                            const rawData = JSON.parse(row.data);
-                            if (rawData.properties?.createdAt) {
-                                const preserved = {...identity, properties: {...identity.properties, createdAt: rawData.properties.createdAt}};
-                                this.upsertGlobalNode(preserved);
-                                continue;
-                            }
-                        }
-                        this.upsertGlobalNode(identity);
+                // Ensure the frontier node exists to prevent context frontier errors
+                try {
+                    this.db.getAdjacentNodes('frontier', 'both'); // trigger lazy load
+                    if (!this.db.nodes.has('frontier')) {
+                        this.upsertGlobalNode({
+                            id         : 'frontier',
+                            type       : 'SYSTEM_ANCHOR',
+                            name       : 'Active Context Frontier',
+                            description: 'The shifting focal point of the active Neo OS agent session.'
+                        });
                     }
+                } catch (error) {
+                    logger.warn(`[GraphService] Non-fatal DB contention during 'frontier' seed: ${error.message}`);
                 }
-            } catch (error) {
-                logger.warn(`[GraphService] Non-fatal DB contention during Identity Substrate seed: ${error.message}`);
-            }
 
-            logger.log('[GraphService] SQLite database mounted securely via ai.graph.Database.');
+                // --- 1. THE GLOBAL SYSTEM PRIMER ---
+                // Inject the Master Architecture Tenets directly into the Native Graph at boot.
+                // Because this is anchored to the 'frontier' with a protected SYSTEM_TENET edge,
+                // it acts as a deterministic onboarding payload for every agent session.
+                try {
+                    this.db.getAdjacentNodes('Neo-Master-Architecture', 'both');
+                    if (!this.db.nodes.has('Neo-Master-Architecture')) {
+                        this.upsertGlobalNode({
+                            id         : 'Neo-Master-Architecture',
+                            type       : 'System',
+                            name       : 'Global System Primer',
+                            description: 'Core framework tenets: 1. All Playwright tests must be run using "npm run test-unit -- [file]". No npx. 2. UI debugging and application state inspection must use the Neural Link MCP tools. 3. Look at .agents/skills for reusable agent workflows.'
+                        });
+                    }
+                    this.linkGlobalNodes('frontier', 'Neo-Master-Architecture', 'SYSTEM_TENET', 1.0);
+                } catch (error) {
+                    logger.warn(`[GraphService] Non-fatal DB contention during Master Architecture seed: ${error.message}`);
+                }
+
+                // --- 2. AGENT IDENTITY SUBSTRATE SEEDING ---
+                // Eliminates the "seed → restart-again" recovery loop for fresh local setups.
+                // Auto-provision identity roots at boot so bindAgentIdentity doesn't throw on fresh setups.
+                try {
+                    for (const identity of IDENTITIES) {
+                        // We use getAdjacentNodes as a trigger for lazy-loading into the cache
+                        this.db.getAdjacentNodes(identity.id, 'both');
+
+                        if (!this.db.nodes.has(identity.id)) {
+                            this.upsertGlobalNode(identity);
+                        } else {
+                            // Defensive createdAt retention: Peek SQLite to preserve original timestamp
+                            const row = storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(identity.id);
+                            if (row) {
+                                const rawData = JSON.parse(row.data);
+                                if (rawData.properties?.createdAt) {
+                                    const preserved = {...identity, properties: {...identity.properties, createdAt: rawData.properties.createdAt}};
+                                    this.upsertGlobalNode(preserved);
+                                    continue;
+                                }
+                            }
+                            this.upsertGlobalNode(identity);
+                        }
+                    }
+                } catch (error) {
+                    logger.warn(`[GraphService] Non-fatal DB contention during Identity Substrate seed: ${error.message}`);
+                }
+
+                logger.log('[GraphService] SQLite database mounted securely via ai.graph.Database.');
+            } catch (error) {
+                this.db = null;
+                this.graphInitError = {
+                    message: error.message,
+                    name   : error.name
+                };
+                logger.warn(`[GraphService] SQLite graph unavailable during init (degraded, graph-backed tools may fail): ${error.message}`);
+            }
         })();
 
         await this._initPromise;

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -831,6 +831,15 @@ class HealthService extends Base {
     #stdioIdentityState = null;
 
     /**
+     * Startup dependency observations recorded by the Memory Core server boot path. These are
+     * intentionally separate from the request-time health probes: the MCP server must still expose
+     * WAL-local tools such as `add_memory` when graph/vector startup tiers degrade.
+     * @member {Object}
+     * @private
+     */
+    #startupDependencies = {};
+
+    /**
      * Shared runtime freshness tracker.
      * @member {RuntimeFreshnessTracker} #runtimeFreshnessTracker
      * @private
@@ -1333,6 +1342,9 @@ class HealthService extends Base {
                 embedding: buildEmbeddingProviderBlock(aiConfig),
                 summary  : buildSummaryProviderBlock(aiConfig)
             },
+            startup : {
+                dependencies: this.getStartupDependencyState()
+            },
             backup   : await buildBackupStateBlock(aiConfig.backupPath, fsExtra, path),
             details  : [],
             version  : process.env.npm_package_version || '1.0.0',
@@ -1385,6 +1397,15 @@ class HealthService extends Base {
                 payload.status = 'degraded';
             }
             payload.details.push(`WARN: ${payload.identity.warning}`);
+        }
+
+        for (const [name, dependency] of Object.entries(payload.startup.dependencies)) {
+            if (dependency.status === 'ready') continue;
+
+            if (payload.status === 'healthy') {
+                payload.status = 'degraded';
+            }
+            payload.details.push(`Startup dependency '${name}' is ${dependency.status}: ${dependency.error || 'see startup.dependencies'}`);
         }
 
         // If we made it here with no errors, report success
@@ -1581,6 +1602,40 @@ class HealthService extends Base {
      */
     setStdioIdentityState(stdioIdentityState) {
         this.#stdioIdentityState = stdioIdentityState;
+        this.clearCache();
+    }
+
+    /**
+     * Records startup dependency readiness without turning degraded graph/vector tiers into MCP
+     * server boot failures. Exposed through `healthcheck().startup.dependencies`.
+     * @param {String} name Stable dependency key.
+     * @param {String} status Readiness status, e.g. 'ready' or 'degraded'.
+     * @param {Object|null} details Optional diagnostic details.
+     */
+    recordStartupDependency(name, status, details=null) {
+        this.#startupDependencies[name] = {
+            status,
+            ...(details || {}),
+            recordedAt: new Date().toISOString()
+        };
+        this.clearCache();
+    }
+
+    /**
+     * @returns {Object} Shallow-cloned startup dependency status map.
+     */
+    getStartupDependencyState() {
+        return Object.fromEntries(
+            Object.entries(this.#startupDependencies).map(([key, value]) => [key, {...value}])
+        );
+    }
+
+    /**
+     * @summary Clears startup dependency observations for test/restart boundaries.
+     * @returns {void}
+     */
+    clearStartupDependencyState() {
+        this.#startupDependencies = {};
         this.clearCache();
     }
 

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -309,11 +309,15 @@ class MemoryService extends Base {
     }
 
     /**
+     * @summary Starts MemoryService without awaiting graph/vector storage readiness.
+     *
+     * `add_memory` acceptance is the local WAL. GraphService/StorageRouter work is reached only by
+     * read/query/projection paths, so startup degradation there must not make the mandatory turn-save
+     * tool unavailable before it can append its WAL row.
      * @returns {Promise<void>}
      */
     async initAsync() {
         await super.initAsync();
-        await StorageRouter.ready();
     }
 
     /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -149,6 +149,10 @@ class WakeSubscriptionService extends Base {
      */
     async init() {
         await GraphService.ready();
+        if (!GraphService.db) {
+            const reason = GraphService.graphInitError?.message || 'graph database is not mounted';
+            throw new Error(`GraphService unavailable: ${reason}`);
+        }
         const storage = GraphService.db?.storage;
         if (storage?.db) {
             try {

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -25,17 +25,41 @@ import '../../../../../../../src/manager/Instance.mjs';
 test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
     let Server;
     let GraphService;
+    let aiConfig;
+    let hadGraphStoragePath;
+    let hadStoragePaths;
+    let originalGraphStoragePath;
     const testDbName = `memory-core-server-test-${process.pid}-${Date.now()}.sqlite`;
     let testDbPath;
 
+    async function createServerWithoutBoot() {
+        const originalBoot = Server.prototype.boot;
+
+        Server.prototype.boot = async () => {};
+
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+
+        try {
+            await serverInstance.ready();
+        } finally {
+            Server.prototype.boot = originalBoot;
+        }
+
+        return serverInstance;
+    }
+
     test.beforeAll(async () => {
-        const aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
 
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
         }
         testDbPath = path.join(tmpDir, testDbName);
+
+        hadStoragePaths       = Boolean(aiConfig.storagePaths);
+        hadGraphStoragePath  = Object.prototype.hasOwnProperty.call(aiConfig.storagePaths || {}, 'graph');
+        originalGraphStoragePath = aiConfig.storagePaths?.graph;
 
         if (!aiConfig.storagePaths) aiConfig.storagePaths = {};
         aiConfig.storagePaths.graph = testDbPath;
@@ -58,6 +82,14 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
     test.afterAll(async () => {
         const { TestLifecycleHelper } = await import('../../../../ai/services/memory-core/util.mjs');
         await TestLifecycleHelper.cleanupGraphService(GraphService, null, testDbPath, fs, 'clear');
+
+        if (!hadStoragePaths) {
+            delete aiConfig.storagePaths;
+        } else if (hadGraphStoragePath) {
+            aiConfig.storagePaths.graph = originalGraphStoragePath;
+        } else {
+            delete aiConfig.storagePaths.graph;
+        }
     });
 
     test('bindAgentIdentity should correctly retrieve identity without cache manipulation', async () => {
@@ -69,7 +101,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         await new Promise(resolve => setTimeout(resolve, 50));
 
         // Let the identity node stay in the natural cache (which is the case right after init/upsert)
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const serverInstance = await createServerWithoutBoot();
 
         const boundId = await serverInstance.bindAgentIdentity('neo-opus-4-7');
         expect(boundId).toBe('@neo-opus-4-7');
@@ -88,7 +120,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
         await GraphService.initAsync();
 
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const serverInstance = await createServerWithoutBoot();
 
         const originalGetNode = GraphService.getNode.bind(GraphService);
         GraphService.getNode = function({id}) {
@@ -133,7 +165,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             GraphService.db.autoSave = wasAutoSave;
         }
 
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const serverInstance = await createServerWithoutBoot();
 
         const boundId = await serverInstance.bindAgentIdentity('neo-opus-4-7');
 
@@ -144,7 +176,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
 
     test('#12199: onSessionClosed writes a pending summarization marker without summarizing inline', async () => {
         const SDK = await import('../../../../../../../ai/services.mjs');
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const serverInstance = await createServerWithoutBoot();
         const mcpServerInstance = {id: 'mcp-session-server'};
         const calls = [];
         const removed = [];
@@ -173,7 +205,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
     });
 
     test('#12838: mailbox + add_memory bypass the summary-degraded health gate (never-fail WAL); embed-dependent reads do not', async () => {
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const serverInstance = await createServerWithoutBoot();
         const handlers = new Map();
         const healthCalls = [];
         const toolCalls = [];
@@ -189,6 +221,8 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 }
             }
         };
+        const originalGetToolService   = serverInstance.getToolService;
+        const originalGetHealthService = serverInstance.getHealthService;
 
         serverInstance.getToolService = () => ({
             listTools: () => ({tools: [], nextCursor: undefined}),
@@ -262,12 +296,14 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             expect(healthCalls).toEqual(['ensureHealthy']);
             expect(toolCalls).toHaveLength(2);
         } finally {
+            serverInstance.getToolService   = originalGetToolService;
+            serverInstance.getHealthService = originalGetHealthService;
             serverInstance.destroy();
         }
     });
 
     test('#12978: non-embedding reads (get_session_memories, query_recent_turns) bypass the embedder-degraded health gate; embed-dependent reads do not', async () => {
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const serverInstance = await createServerWithoutBoot();
         const handlers = new Map();
         const healthCalls = [];
         const toolCalls = [];
@@ -283,6 +319,8 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 }
             }
         };
+        const originalGetToolService   = serverInstance.getToolService;
+        const originalGetHealthService = serverInstance.getHealthService;
 
         serverInstance.getToolService = () => ({
             listTools: () => ({tools: [], nextCursor: undefined}),
@@ -348,12 +386,14 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             expect(healthCalls).toEqual(['ensureHealthy']);
             expect(toolCalls).toHaveLength(2);
         } finally {
+            serverInstance.getToolService   = originalGetToolService;
+            serverInstance.getHealthService = originalGetHealthService;
             serverInstance.destroy();
         }
     });
 
-    test('#12978: logStartupStatus tolerates a null health result (BaseServer passes null when the health service has no healthcheck)', () => {
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+    test('#12978: logStartupStatus tolerates a null health result (BaseServer passes null when the health service has no healthcheck)', async () => {
+        const serverInstance = await createServerWithoutBoot();
 
         try {
             // Regression pin: BaseServer.runHealthcheckAndLogStatus calls logStartupStatus(null)
@@ -365,8 +405,8 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
-    test('#12752: health exemptions do not expose retired database lifecycle tools', () => {
-        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+    test('#12752: health exemptions do not expose retired database lifecycle tools', async () => {
+        const serverInstance = await createServerWithoutBoot();
 
         try {
             const exemptTools = serverInstance.getHealthExemptTools();
@@ -374,6 +414,92 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             expect(exemptTools).not.toContain('start_database');
             expect(exemptTools).not.toContain('stop_database');
         } finally {
+            serverInstance.destroy();
+        }
+    });
+
+    test('#13312: boot keeps MCP handlers available when graph startup tiers degrade', async () => {
+        const SDK = await import('../../../../../../../ai/services.mjs');
+        const HealthService = (await import('../../../../../../../ai/services/memory-core/HealthService.mjs')).default;
+        const serverInstance = Neo.create('Neo.ai.mcp.server.memory-core.Server');
+        const calls = [];
+        const startupStates = [];
+        const wakeFailure = new Error('attempt to write a readonly database');
+        const originalServerMethods = new Map([
+            'loadCustomConfig',
+            'createMcpServer',
+            'runHealthcheckAndLogStatus',
+            'connectTransport',
+            'resolveStdioIdentity',
+            'logIdentityStatus',
+            'logSiblingConcurrency'
+        ].map(name => [name, serverInstance[name]]));
+
+        serverInstance.loadCustomConfig = async () => calls.push('loadCustomConfig');
+        serverInstance.createMcpServer = () => {
+            calls.push('createMcpServer');
+            return {server: {setRequestHandler() {}}};
+        };
+        serverInstance.runHealthcheckAndLogStatus = async () => {
+            calls.push('runHealthcheckAndLogStatus');
+            return {status: 'degraded'};
+        };
+        serverInstance.connectTransport = async () => calls.push('connectTransport');
+        serverInstance.resolveStdioIdentity = async () => null;
+        serverInstance.logIdentityStatus = () => calls.push('logIdentityStatus');
+        serverInstance.logSiblingConcurrency = () => calls.push('logSiblingConcurrency');
+
+        const originalWakeInit = SDK.Memory_WakeSubscriptionService.init;
+        const originalInferenceReady = SDK.Memory_InferenceLifecycleService.ready;
+        const originalSessionReady = SDK.Memory_SessionService.ready;
+        const originalRecordStartupDependency = HealthService.recordStartupDependency;
+        const originalSetStdioIdentityState = HealthService.setStdioIdentityState;
+
+        SDK.Memory_WakeSubscriptionService.init = async () => {
+            calls.push('wakeInit');
+            throw wakeFailure;
+        };
+        SDK.Memory_InferenceLifecycleService.ready = async () => calls.push('inferenceReady');
+        SDK.Memory_SessionService.ready = async () => calls.push('sessionReady');
+        HealthService.recordStartupDependency = (name, status, details) => {
+            startupStates.push({name, status, error: details?.error});
+        };
+        HealthService.setStdioIdentityState = (identity) => {
+            calls.push(['setStdioIdentityState', identity]);
+        };
+
+        try {
+            await expect(serverInstance.ready()).resolves.toBeUndefined();
+
+            expect(calls).toEqual([
+                'loadCustomConfig',
+                'createMcpServer',
+                'wakeInit',
+                'inferenceReady',
+                'sessionReady',
+                ['setStdioIdentityState', null],
+                'runHealthcheckAndLogStatus',
+                'logSiblingConcurrency',
+                'connectTransport',
+                'logIdentityStatus'
+            ]);
+            expect(startupStates).toEqual([
+                {name: 'wake-subscription', status: 'degraded', error: 'attempt to write a readonly database'},
+                {name: 'inference-lifecycle', status: 'ready', error: undefined},
+                {name: 'session-service', status: 'ready', error: undefined}
+            ]);
+        } finally {
+            SDK.Memory_WakeSubscriptionService.init = originalWakeInit;
+            SDK.Memory_InferenceLifecycleService.ready = originalInferenceReady;
+            SDK.Memory_SessionService.ready = originalSessionReady;
+            HealthService.recordStartupDependency = originalRecordStartupDependency;
+            HealthService.setStdioIdentityState = originalSetStdioIdentityState;
+            HealthService.clearStartupDependencyState();
+            HealthService.setStdioIdentityState(null);
+            HealthService.clearCache();
+            for (const [name, method] of originalServerMethods) {
+                serverInstance[name] = method;
+            }
             serverInstance.destroy();
         }
     });

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -165,6 +165,40 @@ test.describe('HealthService #10176 — buildIdentityBlock', () => {
     });
 });
 
+test.describe('HealthService #13312 — startup dependency observability', () => {
+    let HealthService;
+
+    test.beforeAll(async () => {
+        HealthService = (await import('../../../../../../ai/services/memory-core/HealthService.mjs')).default;
+    });
+
+    test('records degraded startup tiers without exposing mutable internal state', () => {
+        const dependencyName = `unit-startup-dependency-${Date.now()}`;
+
+        try {
+            HealthService.recordStartupDependency(dependencyName, 'degraded', {
+                className: 'Test.Unit.MemoryCore.StartupDependency',
+                error    : 'attempt to write a readonly database'
+            });
+
+            const state = HealthService.getStartupDependencyState();
+
+            expect(state[dependencyName]).toMatchObject({
+                status   : 'degraded',
+                className: 'Test.Unit.MemoryCore.StartupDependency',
+                error    : 'attempt to write a readonly database'
+            });
+            expect(state[dependencyName].recordedAt).toEqual(expect.any(String));
+
+            state[dependencyName].status = 'mutated';
+
+            expect(HealthService.getStartupDependencyState()[dependencyName].status).toBe('degraded');
+        } finally {
+            HealthService.clearStartupDependencyState();
+        }
+    });
+});
+
 /**
  * @summary Coverage for the Memory Core runtime freshness diagnostic.
  *
@@ -363,6 +397,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         HealthService.setStdioIdentityState(null);
         HealthService.runtimeFreshnessReader = null;
+        HealthService.clearStartupDependencyState();
         HealthService.clearCache();
     });
 
@@ -385,13 +420,19 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         HealthService.setStdioIdentityState(null);
         HealthService.runtimeFreshnessReader = null;
+        HealthService.clearStartupDependencyState();
         HealthService.clearCache();
     });
 
     test('direct healthcheck refreshes cached timestamp and collection counts without mutating the cache', async () => {
         const cached = await HealthService.healthcheck();
 
-        expect(cached.status).toBe('healthy');
+        expect(cached.status, JSON.stringify({
+            details  : cached.details,
+            startup  : cached.startup,
+            identity : cached.identity,
+            providers: cached.providers
+        }, null, 2)).toBe('healthy');
         expect(cached.database.connection.collections.memories.count).toBe(10);
         expect(cached.database.connection.collections.summaries.count).toBe(20);
 
@@ -435,7 +476,12 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
 
         const cached = await HealthService.healthcheck();
 
-        expect(cached.status).toBe('healthy');
+        expect(cached.status, JSON.stringify({
+            details  : cached.details,
+            startup  : cached.startup,
+            identity : cached.identity,
+            providers: cached.providers
+        }, null, 2)).toBe('healthy');
         expect(cached.runtimeFreshness.status).toBe('current');
 
         currentConfigDigest = 'sha256:migrated-config';


### PR DESCRIPTION
Authored by GPT-5.5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Resolves #13312

Evidence: L2 (unit-level boot-degradation simulation + focused Memory Core suites) → L4 required (live degraded daemon/cloud deployment with add_memory accepted during real graph startup failure). Residual: post-merge/runtime deployment validation [#13312].

## Summary
- Boots the Memory Core MCP server and registers tools before graph/vector startup tiers finish, so WAL-local add_memory remains callable during graph startup degradation.
- Records startup dependency state in healthcheck output instead of collapsing boot on GraphService/WakeSubscriptionService/session/inference readiness errors.
- Keeps graph-projection and wake-subscription degradation observable while preserving local memory capture.

## Deltas from Ticket
- Added explicit startup-dependency observability on HealthService so degraded graph startup is visible to operators and cloud deployments.
- Added the narrow test reset seam needed to prevent HealthService singleton state leakage between cached-health tests.
- Deliberately leaves per-call drain-loop work from `#13288` and `#13314` out of scope.

## Test Evidence
- `git diff --check origin/dev..HEAD` passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` → 9 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs` → 55 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` → 31 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs` → 95 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs --workers=1` → 95 passed.

## Post-Merge Validation
- [ ] In a real degraded Memory Core process with graph startup failing, verify `add_memory` remains callable and accepted to WAL while graph-backed tools degrade observably.
- [ ] Confirm the cloud deployment profile surfaces startup dependency degradation without gating WAL-local memory capture.

## Evolution
Verification exposed a HealthService singleton-state leak between cached-health tests. The fix adds an explicit cleanup seam rather than hiding the failure with test ordering.

## Commits
- `218090b28` — `fix(memory-core): keep add_memory callable during graph startup degradation (#13312)`