### PR TITLE
test(ai): guard agent-guide ↔ openapi tool-coverage parity (#13318)

### DIFF
--- a/learn/agentos/NeuralLink.md
+++ b/learn/agentos/NeuralLink.md
@@ -230,6 +230,7 @@ Generic tools for working with *any* Neo.mjs instance (Components, Stores, Manag
 | `remove_component` | Destroys a component by ID, removing it from its parent and the DOM. |
 | `call_method` | Calls a method on a specific instance (e.g. `store.load()`, `grid.scrollToRow()`) — the generic instance-action tool. |
 | `undo` | Reverts the requester's most-recent committed mutation (single-level), re-dispatching the captured reverse under live enforcement. |
+| `redo` | Re-applies the requester's most-recently undone mutation (single-level) — the symmetric counterpart of `undo`. |
 
 ### 4. Runtime & System
 

--- a/test/playwright/unit/ai/mcp/validation/GuideToolParity.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/GuideToolParity.spec.mjs
@@ -1,0 +1,81 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import yaml            from 'js-yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../..');
+
+// Agent-consumed tool guides paired with their OpenAPI SSOT. A guide's curated domain tables are a
+// human-readable overview; this guard asserts they stay in TOOL-COVERAGE parity with the generated
+// operationId set, so a guide cannot silently drift from the surface it documents — the failure this
+// guards: a guide claiming "33 tools" while the live surface exposed 41 (the entire mutation surface
+// undocumented), caught only by a manual diff after it shipped. Per-tool DESCRIPTION prose stays
+// free-form; only tool-NAME presence is
+// checked. Extend the guard to another MCP-server guide by adding a {label, guide, openapi} row.
+const guidePairs = [
+    {label: 'neural-link', guide: 'learn/agentos/NeuralLink.md', openapi: 'ai/mcp/server/neural-link/openapi.yaml'}
+];
+
+/**
+ * Extracts the documented tool names from a guide's markdown tool-tables — rows shaped ``| `tool_name` | … |``.
+ * Assumes the tool tables are the guide's only backtick-first-column tables (true for the Neural Link guide);
+ * a guide that ever violates this surfaces here as a drift mismatch, prompting either a guide fix or a scoped
+ * extractor — the guard failing loud is the intended behavior, never a silent miss.
+ * @param {String} markdown
+ * @returns {Set<String>}
+ */
+function documentedToolNames(markdown) {
+    const names = new Set();
+
+    for (const line of markdown.split('\n')) {
+        const match = line.match(/^\|\s*`([a-z][a-z0-9_]*)`\s*\|/);
+
+        if (match) {
+            names.add(match[1])
+        }
+    }
+
+    return names
+}
+
+/**
+ * Extracts the `operationId` set (the canonical, generated tool surface) from a parsed OpenAPI document.
+ * @param {Object} doc
+ * @returns {Set<String>}
+ */
+function openapiOperationIds(doc) {
+    const ids = new Set();
+
+    for (const pathItem of Object.values(doc.paths || {})) {
+        for (const operation of Object.values(pathItem)) {
+            if (operation?.operationId) {
+                ids.add(operation.operationId)
+            }
+        }
+    }
+
+    return ids
+}
+
+test.describe('Agent-guide ↔ OpenAPI tool-coverage parity', () => {
+    for (const {label, guide, openapi} of guidePairs) {
+        test(`${label}: ${guide} documents exactly the OpenAPI tool surface`, () => {
+            const
+                documented = documentedToolNames(fs.readFileSync(path.join(repoRoot, guide), 'utf8')),
+                exposed    = openapiOperationIds(yaml.load(fs.readFileSync(path.join(repoRoot, openapi), 'utf8'))),
+                missing    = [...exposed].filter(id => !documented.has(id)).sort(),   // exposed but undocumented
+                extra      = [...documented].filter(id => !exposed.has(id)).sort();   // documented but not exposed
+
+            expect(missing,
+                `${guide} is missing tools the OpenAPI exposes (drift — add the rows): ${missing.join(', ') || '—'}`
+            ).toEqual([]);
+
+            expect(extra,
+                `${guide} documents tools absent from the OpenAPI (drift — stale rows): ${extra.join(', ') || '—'}`
+            ).toEqual([])
+        })
+    }
+});


### PR DESCRIPTION
Resolves #13318

Adds a unit guard asserting agent-consumed tool guides stay in **tool-coverage parity** with their OpenAPI SSOT — the friction→gold from #13309's doc-drift (a guide claiming "33 tools" while the live surface exposed 41, the entire mutation surface undocumented, caught only by a manual diff after it shipped and costing 3 review cycles on #13310). v1 covers `learn/agentos/NeuralLink.md` ↔ the neural-link openapi; the guard fails-loud on either-direction drift, naming the offending tools.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega). Session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.

Evidence: L1 (static unit guard — parses the guide's tool-table rows + the openapi operationIds and asserts set-equality; verified to FAIL on drift and PASS at parity). No runtime ACs. No residuals.

## What changed

- **`test/playwright/unit/ai/mcp/validation/GuideToolParity.spec.mjs`** (new) — the guard. A reusable `{label, guide, openapi}` table (v1: neural-link) drives a parity assertion: the guide's documented tool-NAME set == the openapi `operationId` set, failing-loud with the precise drift sets (missing / extra). Mirrors the sibling `OpenApiValidatorCompliance.spec` pattern (`fs` + `js-yaml`). Per-tool description prose stays free-form — only tool-NAME coverage is checked.
- **`learn/agentos/NeuralLink.md`** — adds the `redo` row (the deferred #13310 follow-up; now that #13307 merged, the openapi exposes `redo`), restoring doc==openapi=41 so the guard is green. This discharges the post-#13307-merge redo-doc-row I committed to on #13310.

## Deltas from ticket

Folded the deferred `redo` doc-row into this PR rather than a separate tiny one — it is the parity-fix that makes the new guard green, so the two belong in one change. #13318 was filed for the guard alone; the redo-row is the prerequisite that #13307's merge made due.

## Test Evidence

`UNIT_TEST_MODE=true playwright test -c …playwright.config.unit.mjs GuideToolParity.spec.mjs OpenApiValidatorCompliance.spec.mjs` — **31 passed (723ms)**:
- The new guard PASSES at parity (doc=41 == openapi=41).
- **Drift-detection proven** (not a tautology): with the `redo` row temporarily removed (doc=40 vs openapi=41), the guard FAILS with `learn/agentos/NeuralLink.md is missing tools the OpenAPI exposes (drift — add the rows): redo`. Restored → green.
- `OpenApiValidatorCompliance.spec` regression green (unaffected).
- `node --check` + `check-ticket-archaeology` + `check-whitespace` clean (husky green on commit).

## Post-Merge Validation

- [ ] None — the guard runs in CI's `unit` scope from merge onward; it is self-verifying (any future agent-guide↔openapi drift fails the build).

## Related

Friction source: #13309 / #13310 (the doc-drift + its 3-cycle fix). Sibling guard: `OpenApiValidatorCompliance.spec`. The folded redo-row closes the #13310 → #13307 follow-up. Refs #13012 (the tool surface IS the agent's body-interface — its guide must not lie to the agent reading it).
