### PR TITLE
feat(wake): log Codex wake scenario route (#13320)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -657,14 +657,15 @@ async function flushSubscription(subId) {
         return;
     }
 
-    const events = {messages, tasks, permissions, heartbeats};
-    const digest = buildWakeDigest(identity, events);
+    const events           = {messages, tasks, permissions, heartbeats};
+    const deliveryEvidence = buildWakeDeliveryEvidence(events);
+    const digest           = buildWakeDigest(identity, events);
 
     // Delivery to per-harness adapter. A 'failed' outcome (the adapter dispatch threw against a live
     // target) is re-queued for retry — carrying the EVENTS, not just this digest string, so a second
     // failure for the same subscription coalesces them without loss. Intentional skips and successful
     // deliveries are not re-queued.
-    const deliveryOutcome = await deliverDigest(subscription, digest);
+    const deliveryOutcome = await deliverDigest(subscription, digest, deliveryEvidence);
     if (deliveryOutcome === 'failed') {
         enqueueDeliveryRetry(subscription, identity, events);
     }
@@ -727,9 +728,10 @@ function resolveCodexCliPath() {
  *
  * @param {Object} subscription WAKE_SUBSCRIPTION node.
  * @param {String} digest Wake digest body.
+ * @param {String} [evidenceLabel=''] Formatted wake scenario / route evidence for validation logs.
  * @returns {Promise<void>}
  */
-async function deliverViaCodexAppServer(subscription, digest) {
+async function deliverViaCodexAppServer(subscription, digest, evidenceLabel = '') {
     const meta    = subscription.properties?.harnessTargetMetadata || {};
     const appName = meta.appName;
 
@@ -738,7 +740,7 @@ async function deliverViaCodexAppServer(subscription, digest) {
     }
 
     await spawnAsync(resolveCodexCliPath(), ['debug', 'app-server', 'send-message-v2', digest]);
-    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via codex-app-server send-message-v2`);
+    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via codex-app-server send-message-v2${evidenceLabel}`);
 }
 
 /**
@@ -758,18 +760,19 @@ async function deliverViaCodexAppServer(subscription, digest) {
  * @param {String[]} osascriptArgs The fully-built `osascript -e …` argument list.
  * @param {String} subscriptionId For log attribution.
  * @param {String} appName For log attribution.
+ * @param {String} [evidenceLabel=''] Formatted wake scenario / route evidence for validation logs.
  * @returns {Promise<void>}
  */
-async function deliverViaOsascriptWithRetry(osascriptArgs, subscriptionId, appName) {
+async function deliverViaOsascriptWithRetry(osascriptArgs, subscriptionId, appName, evidenceLabel = '') {
     const maxAttempts = 4,
           backoffMs   = 800;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
             await spawnAsync('osascript', osascriptArgs);
+            const attemptLabel = attempt > 1 ? ` (attempt ${attempt}/${maxAttempts})` : '';
             writeLog('INFO',
-                `[Wake Daemon] Delivered ${subscriptionId} via osascript to ${appName}` +
-                (attempt > 1 ? ` (attempt ${attempt}/${maxAttempts})` : ''));
+                `[Wake Daemon] Delivered ${subscriptionId} via osascript to ${appName}${attemptLabel}${evidenceLabel}`);
             return
         } catch (err) {
             const message         = err.message || '',
@@ -780,7 +783,7 @@ async function deliverViaOsascriptWithRetry(osascriptArgs, subscriptionId, appNa
             if (isFrontmostRace && afterSubmit) {
                 writeLog('WARN',
                     `[Wake Daemon] ${subscriptionId} wake landed but draft-restore lost frontmost; ` +
-                    `not retrying (avoids double-send). ${message}`);
+                    `not retrying (avoids double-send)${evidenceLabel}. ${message}`);
                 return
             }
 
@@ -796,6 +799,55 @@ async function deliverViaOsascriptWithRetry(osascriptArgs, subscriptionId, appNa
             throw err
         }
     }
+}
+
+/**
+ * @summary Classifies a queued wake digest into the scenario observed by the delivery adapter.
+ * @param {Object} events Wake event arrays.
+ * @returns {{scenario: String, counts: Object}}
+ */
+function buildWakeDeliveryEvidence({messages = [], tasks = [], permissions = [], heartbeats = []} = {}) {
+    const counts = {
+        messages   : messages.length,
+        tasks      : tasks.length,
+        permissions: permissions.length,
+        heartbeats : heartbeats.length
+    };
+
+    const actionableCount = counts.messages + counts.tasks + counts.permissions;
+
+    let scenario = 'empty';
+    if (counts.heartbeats > 0 && actionableCount === 0) {
+        scenario = 'pure-heartbeat';
+    } else if (counts.messages > 0 && counts.tasks === 0 && counts.permissions === 0 && counts.heartbeats === 0) {
+        scenario = 'direct-message';
+    } else if (counts.messages > 0 && counts.tasks === 0 && counts.permissions === 0 && counts.heartbeats > 0) {
+        scenario = 'mixed-message-heartbeat';
+    } else if (counts.heartbeats > 0 && actionableCount > 0) {
+        scenario = 'mixed-actionable-heartbeat';
+    } else if (actionableCount > 0) {
+        scenario = 'actionable';
+    }
+
+    return {scenario, counts};
+}
+
+/**
+ * @summary Formats Codex wake-delivery evidence for live route validation logs.
+ * @param {Object} evidence Scenario/count evidence from buildWakeDeliveryEvidence().
+ * @param {Object} options Adapter metadata.
+ * @returns {String}
+ */
+function formatWakeDeliveryEvidence(evidence, {adapter, adapterSource, appName}) {
+    if (!evidence) return '';
+
+    const counts = evidence.counts || {};
+
+    const scenario = evidence.scenario || 'unknown';
+
+    return ` (scenario=${scenario}; route=${adapter}; adapterSource=${adapterSource}; app=${appName || ''}; ` +
+        `counts=messages:${counts.messages || 0},tasks:${counts.tasks || 0},` +
+        `permissions:${counts.permissions || 0},heartbeats:${counts.heartbeats || 0})`;
 }
 
 /**
@@ -823,14 +875,22 @@ const MAX_DELIVERY_RETRIES   = Number(process.env.WAKE_MAX_DELIVERY_RETRIES) || 
 const pendingDeliveryRetries = new Map(); // subscriptionId -> {subscription, identity, events, attempts, nextAttemptAt}
 
 /**
- * Delivers the digest to the configured harness adapter.
+ * @summary Delivers the digest to the configured harness adapter.
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @param {String} digest Wake digest body.
+ * @param {Object} [deliveryEvidence={}] Scenario/count evidence for Codex validation logs.
+ * @returns {Promise<String|undefined>}
  */
-async function deliverDigest(subscription, digest) {
+async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
     const meta = subscription.properties?.harnessTargetMetadata || {};
     const {instanceAddress, addressType} = resolveInstanceAddress(meta);
     // Fall back to osascript on macOS by default, tmux otherwise
     const defaultAdapter = process.platform === 'darwin' ? 'osascript' : 'tmux';
-    const adapter = meta.adapter || defaultAdapter;
+    const adapter       = meta.adapter || defaultAdapter;
+    const adapterSource = meta.adapter ? 'metadata' : 'platform-default';
+    const evidenceLabel = meta.appName === 'Codex' || adapter === CODEX_APP_SERVER_ADAPTER
+        ? formatWakeDeliveryEvidence(deliveryEvidence, {adapter, adapterSource, appName: meta.appName})
+        : '';
 
     // Serialize execution to prevent focus collisions (Electron-Paradox defense)
     deliveryPromise = deliveryPromise.then(async () => {
@@ -854,7 +914,7 @@ async function deliverDigest(subscription, digest) {
         }
 
         if (adapter === CODEX_APP_SERVER_ADAPTER) {
-            await deliverViaCodexAppServer(subscription, digest);
+            await deliverViaCodexAppServer(subscription, digest, evidenceLabel);
             return;
         }
 
@@ -1103,7 +1163,7 @@ async function deliverDigest(subscription, digest) {
                 digest
             );
 
-            await deliverViaOsascriptWithRetry(osascriptArgs, subscription.id, appName);
+            await deliverViaOsascriptWithRetry(osascriptArgs, subscription.id, appName, evidenceLabel);
         } else if (adapter === 'test') {
             writeLog('INFO', `[Wake Daemon Test Adapter] Delivered ${subscription.id}: ${digest}`);
         } else if (adapter === 'test-fail') {
@@ -1236,8 +1296,10 @@ async function attemptDeliveryRetries() {
             continue;
         }
 
-        const digest  = buildWakeDigest(entry.identity, {...entry.events, messages: liveMessages});
-        const outcome = await deliverDigest(entry.subscription, digest);
+        const retryEvents      = {...entry.events, messages: liveMessages};
+        const deliveryEvidence = buildWakeDeliveryEvidence(retryEvents);
+        const digest           = buildWakeDigest(entry.identity, retryEvents);
+        const outcome          = await deliverDigest(entry.subscription, digest, deliveryEvidence);
 
         if (outcome === 'failed') {
             entry.attempts += 1;

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1019,11 +1019,14 @@ test.describe('Wake Daemon', () => {
             }
         });
 
+        let stdoutLog = '';
+
         const deliveryPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver Codex app-server digest within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
+                stdoutLog += out;
                 if (out.includes(`[Wake Daemon] Dispatched ${subId} via codex-app-server send-message-v2`)) {
                     clearTimeout(timeout);
                     resolve();
@@ -1051,6 +1054,10 @@ test.describe('Wake Daemon', () => {
         expect(args[3]).toContain('[WAKE][priority:normal]');
         expect(args[3]).toContain('Codex App Server Wake');
         expect(fs.existsSync(mockOsascriptOutPath)).toBe(false);
+        expect(stdoutLog).toContain(
+            'scenario=direct-message; route=codex-app-server; adapterSource=metadata; app=Codex; ' +
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:0'
+        );
     });
 
     test('uses the highest coalesced message priority in the wake digest header and preserves divergent latest priority', async () => {
@@ -1947,11 +1954,14 @@ test.describe('Wake Daemon', () => {
             env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
+        let stdoutLog = '';
+
         const deliveryPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Daemon did not deliver Codex wake within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
+                stdoutLog += out;
                 if (out.includes(`Delivered ${subId}`)) {
                     clearTimeout(timeout);
                     resolve();
@@ -2005,6 +2015,88 @@ test.describe('Wake Daemon', () => {
         expect(rawArgs.at(-1)).toContain('[WAKE][priority:normal]');
         expect(rawArgs.at(-1)).toContain('Test Codex Cleanup');
         expect(rawArgs.at(-1)).not.toContain('lifecycle-first');
+        expect(stdoutLog).toContain(
+            'scenario=direct-message; route=osascript; adapterSource=metadata; app=Codex; ' +
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:0'
+        );
+    });
+
+    test('Codex UI wake logs pure-heartbeat scenario and route evidence (#13320)', async () => {
+        const subId = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-pure-heartbeat';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id: agentId,
+            label: 'AGENT',
+            properties: { name: 'Test Agent Codex Pure Heartbeat' }
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id: subId,
+            label: 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity: agentId,
+                harnessTarget: 'bridge-daemon',
+                status: 'active',
+                trigger: 'SENT_TO_ME',
+                harnessTargetMetadata: {
+                    adapter: 'osascript',
+                    appName: 'Codex',
+                    coalesceWindow: 1,
+                    focusSeedKey: 'r'
+                }
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_pure_heartbeat_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        let stdoutLog = '';
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver pure-heartbeat Codex wake within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                stdoutLog += out;
+                if (out.includes(`Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
+
+        await deliveryPromise;
+
+        const rawArgs = JSON.parse(fs.readFileSync(mockOutPath, 'utf-8'));
+        const digest  = rawArgs.at(-1);
+
+        expect(digest).toContain('heartbeat pulses');
+        expect(digest).toContain('lifecycle-first');
+        expect(digest).not.toContain('new messages');
+        expect(stdoutLog).toContain(
+            'scenario=pure-heartbeat; route=osascript; adapterSource=metadata; app=Codex; ' +
+            'counts=messages:0,tasks:0,permissions:0,heartbeats:1'
+        );
     });
 
     test('Codex UI wake submits a mixed message + heartbeat digest with Enter and omits the heartbeat-only directive (#13287)', async () => {
@@ -2049,11 +2141,14 @@ test.describe('Wake Daemon', () => {
             env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
+        let stdoutLog = '';
+
         const deliveryPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Daemon did not deliver mixed Codex wake within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
+                stdoutLog += out;
                 if (out.includes(`Delivered ${subId}`)) {
                     clearTimeout(timeout);
                     resolve();
@@ -2083,6 +2178,10 @@ test.describe('Wake Daemon', () => {
         expect(digest).toContain('new messages');
         expect(digest).toContain('heartbeat pulses');
         expect(digest).not.toContain('lifecycle-first');
+        expect(stdoutLog).toContain(
+            'scenario=mixed-message-heartbeat; route=osascript; adapterSource=metadata; app=Codex; ' +
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:1'
+        );
     });
 
     test('getNodesData and getEdgesData deterministically chunk queries by SQLITE_IN_CLAUSE_BATCH_SIZE', () => {


### PR DESCRIPTION
Resolves #13320
Related: #13287
Related: #13012

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Adds Codex-only wake delivery evidence to wake-daemon logs so live validation can distinguish pure-heartbeat, direct-message, and mixed message+heartbeat wakes across osascript and codex-app-server routes without changing delivery mechanics.

Evidence: L2 (mock-bin dispatch across osascript/codex-app-server plus full wake-daemon unit coverage) → L2 required for `#13320` log observability. Residual: L4 live Codex AFK validation remains on `#13287`.

## Deltas from ticket
No delivery-route changes. Evidence labels are emitted only for Codex/app-server delivery logs to avoid log churn for non-Codex harnesses.

## Test Evidence
- `node --check ai/daemons/wake/daemon.mjs` — passed.
- `node --check test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` — passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs -g "Codex|app-server"` — passed, 5/5.
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` — passed, 32/32.
- `git diff --check` — passed.

## Post-Merge Validation
- [ ] During the next `#13287` live Codex AFK validation, compare wake-daemon logs for `scenario=pure-heartbeat`, `scenario=direct-message`, and `scenario=mixed-message-heartbeat` against observed submit behavior.

## Commits
- `cda2b7ce8` — `feat(wake): log Codex wake scenario route (#13320)`