### PR TITLE
fix(memory-core): guard graph-backed tools when graph db is unavailable (#13323)

### DIFF
--- a/ai/services/memory-core/FileSystemIngestor.mjs
+++ b/ai/services/memory-core/FileSystemIngestor.mjs
@@ -49,9 +49,10 @@ class FileSystemIngestor extends Base {
         // Precache existing mtimeMs dynamically bypassing RAM bloat cleanly natively
         const mtimeMap = new Map();
         const hashMap  = new Map();
-        if (GraphService.db.storage?.db) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (sqlite) {
             try {
-                const stmt = GraphService.db.storage.db.prepare("SELECT id, data FROM Nodes WHERE id LIKE 'file-%'");
+                const stmt = sqlite.prepare("SELECT id, data FROM Nodes WHERE id LIKE 'file-%'");
                 const rows = stmt.all();
                 for (const row of rows) {
                     const parsedData = JSON.parse(row.data);

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -177,6 +177,33 @@ class GraphService extends Base {
     }
 
     /**
+     * Builds the canonical degraded-graph error surfaced by graph-backed Memory Core tools.
+     * @param {String} surface Consumer surface reporting the unavailable graph.
+     * @returns {Error}
+     */
+    createUnavailableError(surface='GraphService') {
+        const reason = this.graphInitError?.message || 'graph database is unavailable';
+        return new Error(`[${surface}] GraphService unavailable: ${reason}`);
+    }
+
+    /**
+     * @summary Returns the mounted graph database or throws the canonical degraded-graph error.
+     *
+     * WAL-only paths such as `add_memory` must stay callable during graph startup degradation, but
+     * graph-backed tool paths must fail closed with a stable error instead of leaking `TypeError`
+     * from a `null` database dereference.
+     * @param {String} surface Consumer surface requiring the graph.
+     * @returns {Neo.ai.graph.Database}
+     */
+    requireDb(surface='GraphService') {
+        if (!this.db) {
+            throw this.createUnavailableError(surface);
+        }
+
+        return this.db;
+    }
+
+    /**
      * Upserts a Node representation into the graph securely linking the ID.
      * @important The `type` string is mapped directly to `node.label` to comply with strict Graph Database taxonomy (Node Labels).
      * @param {Object} nodeData

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -70,7 +70,7 @@ function normalizeMailboxTarget(to, sentBy) {
  *   resolves unambiguously via known alias patterns.
  * @private
  */
-function validateMailboxTarget(normalizedTo, originalTo) {
+function validateMailboxTarget(normalizedTo, originalTo, db = GraphService.requireDb('MailboxService.validateMailboxTarget')) {
     if (!normalizedTo || typeof normalizedTo !== 'string') {
         throw new Error(`Cannot send message: 'to' is required and must be a non-empty string. Received: ${JSON.stringify(originalTo)}.`);
     }
@@ -79,8 +79,6 @@ function validateMailboxTarget(normalizedTo, originalTo) {
     // target turns out to be orphan, the FK guard will surface that separately — this
     // validator focuses on the @<identity> + AGENT:<family>/<model> failure surface.
     if (normalizedTo.startsWith('role:') || normalizedTo.startsWith('human:')) return normalizedTo;
-
-    const db = GraphService.db;
 
     // Warm cache once before declaring "not found" so we don't reject legitimate targets
     // that exist in WAL but have not reached this connection's in-memory cache yet.
@@ -453,6 +451,7 @@ class MailboxService extends Base {
      * @returns {Promise<Object>}
      */
     async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = 'normal', partOfThread, taggedConcepts = [], wakeSuppressed = false, task }) {
+        const db = GraphService.requireDb('MailboxService.addMessage');
         const preNormalizeTo = to; // diagnostic payload captures caller-supplied target
         const sentBy = RequestContextService.getAgentIdentityNodeId();
         if (!sentBy) {
@@ -470,7 +469,7 @@ class MailboxService extends Base {
         // Reject or resolve invalid `to:` values BEFORE handing them to `GraphService.linkNodes`.
         // Alias-format mistakes must fail loudly instead of producing orphan messages invisible
         // to their intended recipient.
-        to = validateMailboxTarget(to, preNormalizeTo);
+        to = validateMailboxTarget(to, preNormalizeTo, db);
 
         const messageId = `MESSAGE:${crypto.randomUUID()}`;
         const timestamp = new Date().toISOString();
@@ -522,20 +521,20 @@ class MailboxService extends Base {
                 // invisible to this process, blocking first-message bootstrap even when SQLite
                 // has them. Bare `syncCache()` alone would invalidate without re-hydrating;
                 // `getAdjacentNodes` handles both steps. See listMessages for the full rationale.
-                GraphService.db.getAdjacentNodes(sentBy, 'inbound');
-                GraphService.db.getAdjacentNodes('AGENT:*', 'inbound');
+                db.getAdjacentNodes(sentBy, 'inbound');
+                db.getAdjacentNodes('AGENT:*', 'inbound');
 
-                for (const edge of GraphService.db.edges.items) {
+                for (const edge of db.edges.items) {
                     if (edge.type === 'SENT_TO' && (edge.target === sentBy || edge.target === 'AGENT:*')) {
                         // Per-message outbound vicinity lazy-load, symmetric with listMessages'
                         // inner loop. Without this, the SENT_BY edge scan below comes up empty
                         // for peer-process messages because the SENT_BY edge targets the author
                         // node, not sentBy or AGENT:*. That would cause priorSender to stay null
                         // and the trust-lift to falsely fail under cross-process writes.
-                        GraphService.db.getAdjacentNodes(edge.source, 'outbound');
+                        db.getAdjacentNodes(edge.source, 'outbound');
 
                         let priorSender = null;
-                        for (const srcEdge of GraphService.db.edges.items) {
+                        for (const srcEdge of db.edges.items) {
                             if (srcEdge.source === edge.source && srcEdge.type === 'SENT_BY') {
                                 priorSender = srcEdge.target;
                                 break;
@@ -630,7 +629,7 @@ class MailboxService extends Base {
             if (concepts && concepts.length > 0) {
                 for (const c of concepts) {
                     // Ensure the concept node exists before linking
-                    if (!GraphService.db.nodes.has(c)) {
+                    if (!db.nodes.has(c)) {
                         let type = c.split(':')[0];
                         let name = c.split(':').slice(1).join(':');
                         GraphService.upsertNode({
@@ -688,7 +687,7 @@ class MailboxService extends Base {
             }
         }
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('MailboxService.listMessages');
 
         // Consume WAL delta AND re-populate vicinity from SQLite before iterating
         // in-memory edges. A bare `syncCache()` call invalidates cached
@@ -848,7 +847,7 @@ class MailboxService extends Base {
             throw new Error("Cannot get message: no agent identity context bound.");
         }
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('MailboxService.getMessage');
 
         // Trigger syncCache + lazy-reload vicinity for this message node.
         // Ensures peer-process writes to this message's edges (e.g. late PART_OF_THREAD
@@ -927,7 +926,7 @@ class MailboxService extends Base {
             throw new Error("Cannot mark message read: no agent identity context bound.");
         }
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('MailboxService.markRead');
 
         // Trigger syncCache + lazy-reload vicinity. Ensures the SENT_TO edge
         // iteration sees peer-process writes. See listMessages for the full rationale.
@@ -1007,7 +1006,7 @@ class MailboxService extends Base {
             throw new Error("Cannot archive message: no agent identity context bound.");
         }
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('MailboxService.archiveMessage');
 
         // Trigger syncCache + lazy-reload vicinity — same pattern as markRead.
         db.getAdjacentNodes(messageId, 'both');
@@ -1086,7 +1085,7 @@ class MailboxService extends Base {
             throw new Error("Cannot delete message: no agent identity context bound.");
         }
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('MailboxService.deleteMessage');
 
         // Trigger syncCache + lazy-reload vicinity — same pattern as markRead.
         db.getAdjacentNodes(messageId, 'both');
@@ -1147,7 +1146,7 @@ class MailboxService extends Base {
             throw new Error("Cannot transition task: no agent identity context bound.");
         }
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('MailboxService.transitionTask');
 
         // Trigger syncCache to ensure we have latest vicinity
         db.getAdjacentNodes(taskId, 'both');
@@ -1270,6 +1269,10 @@ class MailboxService extends Base {
         const
             db        = GraphService.db,
             timestamp = new Date().toISOString();
+
+        if (!db?.storage?.db) {
+            return { success: true, sweptCount: 0 }
+        }
 
         const stmt = db.storage.db.prepare(`
             UPDATE Nodes

--- a/ai/services/memory-core/PermissionService.mjs
+++ b/ai/services/memory-core/PermissionService.mjs
@@ -68,7 +68,8 @@ class PermissionService extends Base {
         // implicit side-effect of a permission grant. Stubbing with type 'AGENT' + stripped
         // metadata destroys seed data and creates type-inconsistent nodes. Use the same
         // foreign-key style existence guard as graph-link writes.
-        const verifyStmt = GraphService.db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id = ?');
+        const db         = GraphService.requireDb('PermissionService.grantPermission');
+        const verifyStmt = db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id = ?');
         if (verifyStmt.get(to).count === 0) {
             throw new Error(`Cannot grant ${scope} to ${to}: target does not exist. Identity nodes must be pre-seeded via ai/scripts/setup/seedAgentIdentities.mjs.`);
         }
@@ -91,7 +92,7 @@ class PermissionService extends Base {
         const owner = RequestContextService.getAgentIdentityNodeId();
         if (!owner) throw new Error("Cannot revoke permission: no agent identity context bound.");
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('PermissionService.revokePermission');
         const edgesToRemove = [];
         for (const edge of db.edges.items) {
             if (edge.source === to && edge.target === owner && edge.type === scope) {
@@ -124,7 +125,7 @@ class PermissionService extends Base {
             throw new Error(`Unauthorized: Cannot enumerate permissions for ${targetId}`);
         }
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('PermissionService.listPermissions');
         const capabilities = [];     // Things targetId can do to others
         const grantedToOthers = [];  // Things others can do to targetId
 
@@ -165,7 +166,7 @@ class PermissionService extends Base {
         // Identity always has permission to their own resources
         if (caller === target) return true;
 
-        const db = GraphService.db;
+        const db = GraphService.requireDb('PermissionService.hasPermission');
         for (const edge of db.edges.items) {
             if (edge.source === caller && edge.target === target && edge.type === scope) {
                 return true;

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -289,6 +289,8 @@ class WakeSubscriptionService extends Base {
      * @returns {Promise<Object>}
      */
     async manage(opts = {}) {
+        GraphService.requireDb('WakeSubscriptionService.manage');
+
         const {action, ...rest} = opts;
         switch (action) {
             case 'bootstrap'  : return this.bootstrap  (rest);

--- a/test/playwright/unit/ai/services/memory-core/GraphServiceUnavailable.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphServiceUnavailable.spec.mjs
@@ -1,0 +1,79 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'GraphServiceUnavailableTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+test.describe('Memory Core graph unavailable guard', () => {
+    let GraphService, MailboxService, PermissionService, WakeSubscriptionService;
+    let originalDb, originalGraphInitError;
+
+    test.beforeAll(async () => {
+        GraphService            = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        MailboxService          = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default;
+        PermissionService       = (await import('../../../../../../ai/services/memory-core/PermissionService.mjs')).default;
+        WakeSubscriptionService = (await import('../../../../../../ai/services/memory-core/WakeSubscriptionService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalDb             = GraphService.db;
+        originalGraphInitError = GraphService.graphInitError;
+
+        GraphService.db             = null;
+        GraphService.graphInitError = {message: 'unit graph mount failed'};
+    });
+
+    test.afterEach(() => {
+        GraphService.db             = originalDb;
+        GraphService.graphInitError = originalGraphInitError;
+    });
+
+    test('throws a canonical degraded error for graph-backed mailbox tools', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@neo-gpt'}, async () => {
+            await expect(MailboxService.listMessages())
+                .rejects.toThrow('[MailboxService.listMessages] GraphService unavailable: unit graph mount failed');
+
+            await expect(MailboxService.addMessage({
+                to     : '@neo-opus-ada',
+                subject: 'db null guard',
+                body   : 'should fail before graph dereference'
+            })).rejects.toThrow('[MailboxService.addMessage] GraphService unavailable: unit graph mount failed');
+        });
+    });
+
+    test('throws a canonical degraded error for permission and wake-subscription tools', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@neo-gpt'}, async () => {
+            await expect(PermissionService.listPermissions())
+                .rejects.toThrow('[PermissionService.listPermissions] GraphService unavailable: unit graph mount failed');
+
+            expect(() => PermissionService.hasPermission('@neo-gpt', '@neo-opus-ada', 'CAN_REPLY_TO'))
+                .toThrow('[PermissionService.hasPermission] GraphService unavailable: unit graph mount failed');
+
+            await expect(WakeSubscriptionService.manage({action: 'list'}))
+                .rejects.toThrow('[WakeSubscriptionService.manage] GraphService unavailable: unit graph mount failed');
+        });
+    });
+
+    test('keeps maintenance count paths fail-soft when graph storage is absent', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@neo-gpt'}, async () => {
+            await expect(MailboxService.countMessages()).resolves.toEqual({count: 0});
+        });
+
+        await expect(MailboxService.sweepExpiredTasks()).resolves.toEqual({
+            success   : true,
+            sweptCount: 0
+        });
+    });
+});


### PR DESCRIPTION
Resolves #13323

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Adds a canonical `GraphService.requireDb()` guard for graph-backed Memory Core surfaces, then routes mailbox, permissions, and wake-subscription public tool paths through it so the degraded `db=null` state fails with a stable GraphService-unavailable error instead of leaking `TypeError`. Maintenance/readiness paths that are intentionally best-effort remain fail-soft, and the `add_memory` WAL contract is untouched.

Evidence: L2 (unit-level `GraphService.db = null` simulation plus adjacent Memory Core service suites) -> L2 required (internal graph-backed service guard contracts, no host-only ACs). No residuals.

## Deltas from ticket
- Kept WAL-only `add_memory` behavior out of scope; this PR does not add graph or Chroma work to that path.
- Guarded `WakeSubscriptionService.manage()` at the public action dispatcher while leaving background maintenance/pump no-op behavior intact.
- Made the patch independent of the pending degraded-startup initializer by tolerating an optional future `GraphService.graphInitError` message.

## Test Evidence
- `git diff --check` — passed.
- `git diff --cached --check` — passed.
- `npm run test-unit -- --workers=1 test/playwright/unit/ai/services/memory-core/GraphServiceUnavailable.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` — 134 passed.

## Post-Merge Validation
- [ ] In a live degraded GraphService startup, confirm graph-backed MCP actions surface the canonical GraphService-unavailable error while WAL-only `add_memory` remains callable.

## Commit
- `92cdba03e` — `fix(memory-core): guard graph-backed tools when graph db is unavailable (#13323)`