### PR TITLE
feat(ai): Neural Link list_transactions — undo-stack audit/history tool (#13326)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -1298,6 +1298,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /instance/transactions:
+    post:
+      summary: List Transactions
+      operationId: list_transactions
+      x-neo-tool-tier: read
+      x-pass-as-object: true
+      description: Returns a read-only audit summary of the requester's undo-stack history — the committed (undoable) transactions plus the redo branch, each as {txId, status, opCount, labels}. No mutation.
+      tags: [Instance]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListTransactionsRequest'
+      responses:
+        '200':
+          description: Transaction history
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /instance/method/call:
     post:
       summary: Call Instance Method
@@ -1812,6 +1841,13 @@ components:
           description: The target App Worker Session ID
 
     RedoRequest:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          description: The target App Worker Session ID
+
+    ListTransactionsRequest:
       type: object
       properties:
         sessionId:

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -43,6 +43,7 @@ const serviceMapping = {
     inspect_state_provider       : DataService       .inspectStateProvider      .bind(DataService),
     inspect_store                : DataService       .inspectStore              .bind(DataService),
     list_stores                  : DataService       .listStores                .bind(DataService),
+    list_transactions            : InstanceService   .listTransactions          .bind(InstanceService),
     manage_connection            : ConnectionService .manageConnection          .bind(ConnectionService),
     manage_neo_config            : RuntimeService    .manageNeoConfig           .bind(RuntimeService),
     modify_state_provider        : DataService       .modifyStateProvider       .bind(DataService),

--- a/ai/services/neural-link/InstanceService.mjs
+++ b/ai/services/neural-link/InstanceService.mjs
@@ -103,6 +103,18 @@ class InstanceService extends Base {
     }
 
     /**
+     * Lists the requester's Neural Link transaction history — forwards the `list_transactions` tool to the
+     * connected App Worker, which returns a read-only audit summary of the writer's undo stack + redo branch.
+     * See {@link Neo.ai.client.InstanceService#listTransactions}.
+     * @param {Object} opts
+     * @param {String} opts.sessionId
+     * @returns {Promise<Object>}
+     */
+    async listTransactions({sessionId}) {
+        return await ConnectionService.call(sessionId, 'list_transactions', {})
+    }
+
+    /**
      * Calls a method on a specific instance.
      * @param {Object} opts
      * @param {String} opts.sessionId

--- a/learn/agentos/NeuralLink.md
+++ b/learn/agentos/NeuralLink.md
@@ -231,6 +231,7 @@ Generic tools for working with *any* Neo.mjs instance (Components, Stores, Manag
 | `call_method` | Calls a method on a specific instance (e.g. `store.load()`, `grid.scrollToRow()`) — the generic instance-action tool. |
 | `undo` | Reverts the requester's most-recent committed mutation (single-level), re-dispatching the captured reverse under live enforcement. |
 | `redo` | Re-applies the requester's most-recently undone mutation (single-level) — the symmetric counterpart of `undo`. |
+| `list_transactions` | Read-only audit view of the requester's undo-stack history — the committed (undoable) transactions + the redo branch. |
 
 ### 4. Runtime & System
 

--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -128,6 +128,7 @@ class Client extends Base {
             set_instance_properties: instance,
             undo                   : instance,
             redo                   : instance,
+            list_transactions      : instance,
 
             get_record            : data,
             inspect_state_provider: data,

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -437,6 +437,32 @@ class InstanceService extends Service {
     }
 
     /**
+     * Lists the requester's transaction history — the `list_transactions` Neural Link tool (read-only audit view).
+     *
+     * A non-consuming projection of the writer's undo state ({@link Neo.ai.TransactionService#stackOf}): the
+     * `committed` stack (undoable, newest last) + the `redo` branch (redoable). Each entry is summarized to
+     * `{txId, status, opCount, labels}` — the user-facing op labels, NOT the raw forward/reverse descriptors (those
+     * are internal). Read-only: no enforcement, no replay, never mutates the stack. Returns empty lists (never
+     * throws) for a legacy / no-writer-identity caller or an absent stack authority.
+     * @param {Object} [params] No parameters — lists the requester's own stack.
+     * @param {Object|null} [context] The Bridge-stamped `{agentId, sessionId}` writer pair (2nd dispatch arg).
+     * @returns {Promise<Object>} `{committed: Object[], redo: Object[]}` — each entry `{txId, status, opCount, labels}`.
+     */
+    async listTransactions(params, context) {
+        const transactionService = this.client?.transactionService;
+
+        if (!context?.agentId || !context?.sessionId || !transactionService) {
+            return {committed: [], redo: []}
+        }
+
+        const
+            {committed, redo} = transactionService.stackOf({id: {agentId: context.agentId, sessionId: context.sessionId}}),
+            summarize         = tx => ({txId: tx.txId, status: tx.status, opCount: tx.ops.length, labels: tx.ops.map(op => op.label)});
+
+        return {committed: committed.map(summarize), redo: redo.map(summarize)}
+    }
+
+    /**
      * Calls a method on a specific instance.
      * @param {Object} params
      * @param {String} params.id

--- a/test/playwright/unit/ai/InstanceServiceListTransactions.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceListTransactions.spec.mjs
@@ -1,0 +1,84 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'InstanceServiceListTransactionsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import InstanceService    from '../../../../src/ai/client/InstanceService.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+
+// Neo.ai.client.InstanceService.listTransactions is the read-only `list_transactions` tool: a non-consuming
+// projection of the writer's undo state (TransactionService.stackOf) into a {committed, redo} audit summary
+// ({txId, status, opCount, labels} per tx). Pure read — no live tree, no handleRequest, no enforcement — so
+// these tests drive it against a real TransactionService with a minimal client stub.
+
+const ID = {agentId: 'agent-a', sessionId: 'sess-a'};
+
+// a minimal valid reverse-op carrying a user-facing label
+const op = (label, seq) => ({
+    sequenceId       : seq,
+    originWriter     : {agentId: 'agent-a', sessionId: 'sess-a'},
+    targetSubtreePath: ['root', 'leaf'],
+    forward          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 1}}},
+    reverse          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 0}}},
+    label
+});
+
+test.describe('Neo.ai.client.InstanceService — the `list_transactions` tool', () => {
+    let service, transactionService;
+
+    test.beforeEach(() => {
+        transactionService = Neo.create(TransactionService);
+        service            = Neo.create(InstanceService, {client: {transactionService}})
+    });
+
+    const commit = (txId, label) => {
+        transactionService.begin ({id: ID, txId});
+        transactionService.record({id: ID, txId, op: op(label, `${txId}:1`)});
+        return transactionService.commit({id: ID, txId})
+    };
+
+    test('projects the committed stack + the redo branch to an audit summary', async () => {
+        commit('tx-1', 'set x on leaf');
+        commit('tx-2', 'set y on panel');
+        transactionService.undo({id: ID}); // tx-2 → undone, onto the redo branch
+
+        const result = await service.listTransactions({}, ID);
+
+        expect(result.committed.map(t => t.txId)).toEqual(['tx-1']);                  // tx-1 still undoable
+        expect(result.committed[0]).toEqual({txId: 'tx-1', status: 'committed', opCount: 1, labels: ['set x on leaf']});
+        expect(result.redo.map(t => t.txId)).toEqual(['tx-2']);                       // tx-2 redoable
+        expect(result.redo[0].status).toBe('undone');
+        expect(result.redo[0].labels).toEqual(['set y on panel'])
+    });
+
+    test('read-only — multiple reads never mutate the stack', async () => {
+        commit('tx-1', 'a');
+
+        await service.listTransactions({}, ID);
+        await service.listTransactions({}, ID);
+
+        expect(transactionService.stackOf({id: ID}).committed.map(t => t.txId)).toEqual(['tx-1']) // unchanged + still undoable
+    });
+
+    test('fail-closed → empty lists for a no-writer-identity caller or an absent stack service', async () => {
+        commit('tx-1', 'a');
+
+        expect(await service.listTransactions({}, null)).toEqual({committed: [], redo: []}); // no writer identity
+
+        const bare = Neo.create(InstanceService, {client: {}});
+        expect(await bare.listTransactions({}, ID)).toEqual({committed: [], redo: []})       // no transactionService
+    });
+});

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -115,6 +115,7 @@ const expectedNeuralLinkToolTiers = {
     inspect_state_provider       : 'read',
     inspect_store                : 'read',
     list_stores                  : 'read',
+    list_transactions            : 'read',
     manage_connection            : 'admin',
     manage_neo_config            : 'admin',
     modify_state_provider        : 'write-locked',


### PR DESCRIPTION
Resolves #13326

Adds the read-only `list_transactions` Neural Link tool — a non-consuming projection of the writer's undo-stack (`TransactionService.stackOf`) into a `{committed, redo}` audit summary (`{txId, status, opCount, labels}` per tx), so an agent (or a conversational-UI user) can answer *"what have you changed?"* before deciding to undo/redo. Another tool from the #9848 undo-stack roadmap.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega). Session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.

Evidence: L1 (in-heap unit + MCP-compliance — exercised against a real `TransactionService` with no live bridge; 47 specs green). No live-bridge-runtime ACs. No residuals.

## What changed

- **`src/ai/client/InstanceService.mjs`** — `listTransactions(params, context)`: reads `stackOf({writer-pair})`, projects `committed` + `redo` to `{txId, status, opCount, labels}`. Read-only (no enforcement, no replay, never mutates the stack); fail-closed to empty lists on no-writer-identity / no-stack-service.
- **6-site wiring** (mirrors merged `undo`/`redo`, #13257/#13304): openapi `/instance/transactions` (`read` tier) + `ListTransactionsRequest`; `toolService` serviceMapping; server-side `InstanceService.listTransactions` forward; `Client.mjs` dispatch; the in-app method; the `OpenApiValidatorCompliance` read-tier fixture.
- **`learn/agentos/NeuralLink.md`** — the `list_transactions` row. The just-merged #13318 `GuideToolParity` guard enforces doc==openapi parity, so the doc-row is mandatory — and it kept the guard green (doc=42 == openapi=42).

## Deltas from ticket

None — scope as filed.

## Test Evidence

`UNIT_TEST_MODE=true playwright test -c …playwright.config.unit.mjs` over the new + adjacent surface — **47 passed (919ms)**:
- `InstanceServiceListTransactions.spec.mjs` (new) — the projection (committed + redo summaries, labels/opCount/status), read-only (multiple reads don't mutate the stack), fail-closed (no-writer-identity / no-stack-service → empty lists).
- `OpenApiValidatorCompliance.spec.mjs` — green: validates the openapi parse (the new path + `ListTransactionsRequest`), the `list_transactions: 'read'` tier, and the serviceMapping↔tier parity.
- `GuideToolParity.spec.mjs` (#13318) — green: doc==openapi parity held (42=42) with the new doc-row.
- `InstanceServiceUndo` / `InstanceServiceRedo` — regression green (the InstanceService change is purely additive).

## Post-Merge Validation

- [ ] None — fully unit/compliance-covered; no live-bridge AC. (A live `list_transactions` e2e could later fold into the bridge-gated undo/redo e2e suite, but it isn't required for this read-only tool.)

## Related

Parent: #9848 (undo-stack umbrella). Siblings: #13221 (undo), #13304 (redo), #13318 (the drift guard enforcing the doc-row). Refs #13012 (Agent Harness Pillar-2). Read API: `src/ai/TransactionService.mjs` `stackOf`.
