### PR TITLE
fix(github-workflow): re-chunk active content to ordinal-100 on rebuild (#13328)

### DIFF
--- a/ai/services/github-workflow/shared/reconcileActiveChunks.mjs
+++ b/ai/services/github-workflow/shared/reconcileActiveChunks.mjs
@@ -1,0 +1,104 @@
+import {existsSync}                                from 'fs';
+import fs                                          from 'fs/promises';
+import path                                        from 'path';
+import contentPath                                 from './contentPath.mjs';
+import pruneEmptyDirs                              from './pruneEmptyDirs.mjs';
+import {createContentIndexEntry, updateContentIndex} from './contentIndex.mjs';
+
+/**
+ * @module ai/services/github-workflow/shared/reconcileActiveChunks
+ * @summary Re-chunks an active content tier into the universal ordinal-100 layout.
+ *
+ * The active-tier sibling of the syncers' `reconcileClosed*Locations` (which only relocate
+ * **terminal** items to the sealed archive). Ordinal-100 chunking is **position-dependent**: each
+ * item's chunk is `Math.floor(rank / itemsPerChunk) + 1`, where `rank` is its position among ALL
+ * active items sorted ascending by GitHub id (the universal ordinal-100 rule). So whenever items are added or
+ * archived, the surviving items' ranks shift and their correct chunk changes. The delta-driven
+ * syncers only re-place the items they touch in a given run, leaving the rest in stale folders —
+ * the drift that lets `chunk-N/` folders fall off the exact-100 invariant (overlapping ranges,
+ * 1-item folders, etc.).
+ *
+ * This pass re-ranks the FULL active corpus on disk and `fs.rename`s any mis-located file to its
+ * ordinal target, then realigns the `_index.json` deep-link entries for the moved items. It is
+ * **idempotent** — a no-op when the tier is already ordinal-correct — so it is safe to run on every
+ * sync/rebuild. Archive tiers are sealed (immutable once a release is cut) and are never touched.
+ *
+ * @param {Object} issueSyncConfig The github-workflow `issueSync` config block. Only `contentRoot`
+ *     (absolute `resources/content`) is required; passing the full block is fine.
+ * @param {Object} options
+ * @param {'issues'|'pulls'|'discussions'} options.type Content type segment.
+ * @param {String} options.filePrefix File-leaf prefix (e.g. `'pr-'`, `'issue-'`, `'discussion-'`).
+ * @param {Number} [options.itemsPerChunk=100] Items per chunk (ADR-mandated 100).
+ * @returns {Promise<{type: String, total: Number, moved: Number, deduped: Number}>} Unique item
+ *     count + relocations made + duplicate copies removed.
+ * @see ai/services/github-workflow/shared/contentPath.mjs
+ * @see learn/agentos/decisions/0004-github-content-architecture.md
+ */
+export default async function reconcileActiveChunks(issueSyncConfig = {}, {type, filePrefix, itemsPerChunk = 100} = {}) {
+    const
+        contentRoot = issueSyncConfig.contentRoot,
+        activeDir   = path.join(contentRoot, type);
+
+    if (!existsSync(activeDir)) {
+        return {type, total: 0, moved: 0};
+    }
+
+    // Match `{prefix}<id>.md` leaves anywhere under the active tier (current chunk-* folders).
+    const idPattern = new RegExp(`(?:^|[\\\\/])${filePrefix}(\\d+)\\.md$`);
+
+    // Full active corpus, ranked ascending by id — the ordinal the chunk math is defined against.
+    const items = (await fs.readdir(activeDir, {recursive: true}))
+        .map(rel => {
+            const match = rel.match(idPattern);
+            return match ? {id: parseInt(match[1], 10), absPath: path.join(activeDir, rel)} : null
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.id - b.id || a.absPath.localeCompare(b.absPath));
+
+    // Dedup by id: a drifted tier can hold the same id in more than one chunk (a stale copy a prior
+    // sync left behind). Keep the first occurrence and unlink the rest — otherwise a duplicate
+    // consumes an ordinal slot and shifts every later item's chunk by one.
+    const unique  = [];
+    let   deduped = 0;
+
+    for (const item of items) {
+        if (unique.length > 0 && unique[unique.length - 1].id === item.id) {
+            await fs.unlink(item.absPath);
+            deduped++;
+            console.warn(`[reconcileActiveChunks] removed duplicate ${filePrefix}${item.id}.md at ${item.absPath}`)
+        } else {
+            unique.push(item)
+        }
+    }
+
+    const upsert = [];
+    let   moved  = 0;
+
+    for (let itemIndex = 0; itemIndex < unique.length; itemIndex++) {
+        const
+            {id, absPath} = unique[itemIndex],
+            filename      = `${filePrefix}${id}.md`,
+            targetPath    = contentPath({contentRoot, type, filename, itemIndex, itemsPerChunk});
+
+        if (absPath !== targetPath) {
+            await fs.mkdir(path.dirname(targetPath), {recursive: true});
+            await fs.rename(absPath, targetPath);
+            moved++
+        }
+
+        // Realign the deep-link index entry to the (possibly new) chunk so `getIssueById` / KB
+        // ingestion never resolve a stale path after a relocation.
+        upsert.push(createContentIndexEntry({
+            issueSyncConfig, type, id, filePath: targetPath, itemIndex, version: null, bucket: null, itemsPerChunk
+        }))
+    }
+
+    if (upsert.length > 0) {
+        await updateContentIndex(issueSyncConfig, {upsert})
+    }
+
+    // Drop folders emptied by relocation (e.g. the 1-item chunk-12/14/18 drift buckets).
+    await pruneEmptyDirs(activeDir);
+
+    return {type, total: unique.length, moved, deduped}
+}

--- a/buildScripts/docs/rebuildContentIndexesAndSeo.mjs
+++ b/buildScripts/docs/rebuildContentIndexesAndSeo.mjs
@@ -7,6 +7,7 @@ import createReleaseIndex          from './index/release.mjs';
 import createDiscussionIndex       from './index/discussions.mjs';
 import createPullRequestIndex      from './index/pulls.mjs';
 import createTicketIndex           from './index/tickets.mjs';
+import reconcileActiveChunks       from '../../ai/services/github-workflow/shared/reconcileActiveChunks.mjs';
 import {getLlmsTxt, getSitemapXml} from './seo/generate.mjs';
 
 const DEFAULT_BASE_URL = 'https://neomjs.com';
@@ -55,6 +56,7 @@ async function rebuildContentIndexesAndSeo({
     createDiscussionIndexFn  = createDiscussionIndex,
     createPullRequestIndexFn = createPullRequestIndex,
     createTicketIndexFn      = createTicketIndex,
+    reconcileActiveChunksFn  = reconcileActiveChunks,
     getSitemapXmlFn          = getSitemapXml,
     getLlmsTxtFn             = getLlmsTxt,
     writeFileSync            = fs.writeFileSync,
@@ -64,6 +66,14 @@ async function rebuildContentIndexesAndSeo({
         const labelIndexFn = createLabelIndexFn || (await import('./index/labels.mjs')).default;
         await labelIndexFn();
     }
+
+    // Ordinal-100 enforcement: re-chunk the active content tiers BEFORE indexing so the generators
+    // mirror exact-100 folders. Position-dependent chunking drifts when the delta-sync only re-places
+    // the items it touched; this idempotent pass re-ranks the full active corpus on disk. Archive is sealed.
+    const reChunkConfig = {contentRoot: path.join(root, 'resources/content')};
+    await reconcileActiveChunksFn(reChunkConfig, {type: 'pulls',       filePrefix: 'pr-'});
+    await reconcileActiveChunksFn(reChunkConfig, {type: 'issues',      filePrefix: 'issue-'});
+    await reconcileActiveChunksFn(reChunkConfig, {type: 'discussions', filePrefix: 'discussion-'});
 
     await createReleaseIndexFn();
     await createPullRequestIndexFn();

--- a/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/docs/RebuildContentIndexesAndSeo.spec.mjs
@@ -22,6 +22,7 @@ test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
             baseUrl                 : 'https://example.test',
             sitemapPath             : '/repo/apps/portal/sitemap.xml',
             llmsPath                : '/repo/apps/portal/llms.txt',
+            reconcileActiveChunksFn : record('rechunk'),
             createReleaseIndexFn    : record('releases'),
             createPullRequestIndexFn: record('pulls'),
             createDiscussionIndexFn : record('discussions'),
@@ -33,12 +34,21 @@ test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
         });
 
         expect(calls.map(call => call.name)).toEqual([
+            'rechunk',
+            'rechunk',
+            'rechunk',
             'releases',
             'pulls',
             'discussions',
             'tickets',
             'sitemap',
             'llms'
+        ]);
+        // The active-tier re-chunk runs for all three content types, before the index builders mirror them.
+        expect(calls.filter(call => call.name === 'rechunk').map(call => call.args[1].type)).toEqual([
+            'pulls',
+            'issues',
+            'discussions'
         ]);
         expect(calls.find(call => call.name === 'sitemap').args[0]).toEqual({
             baseUrl            : 'https://example.test',
@@ -68,6 +78,7 @@ test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
         await rebuildContentIndexesAndSeo({
             includeLabelIndex       : true,
             createLabelIndexFn      : record('labels'),
+            reconcileActiveChunksFn : record('rechunk'),
             createReleaseIndexFn    : record('releases'),
             createPullRequestIndexFn: record('pulls'),
             createDiscussionIndexFn : record('discussions'),
@@ -78,7 +89,7 @@ test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
             log                     : () => {}
         });
 
-        expect(calls).toEqual(['labels', 'releases', 'pulls', 'discussions', 'tickets']);
+        expect(calls).toEqual(['labels', 'rechunk', 'rechunk', 'rechunk', 'releases', 'pulls', 'discussions', 'tickets']);
     });
 
     test('fails closed when a derive step rejects before generated artifacts are written', async () => {
@@ -86,6 +97,7 @@ test.describe('rebuildContentIndexesAndSeo (#13260)', () => {
 
         await expect(rebuildContentIndexesAndSeo({
             createLabelIndexFn      : async () => {},
+            reconcileActiveChunksFn : async () => {},
             createReleaseIndexFn    : async () => {},
             createPullRequestIndexFn: async () => { throw new Error('pull index failed'); },
             createDiscussionIndexFn : async () => { throw new Error('must not run'); },

--- a/test/playwright/unit/ai/services/github-workflow/shared/reconcileActiveChunks.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/shared/reconcileActiveChunks.spec.mjs
@@ -1,0 +1,92 @@
+import {test, expect}    from '@playwright/test';
+import fs                from 'fs/promises';
+import os                from 'os';
+import path              from 'path';
+import reconcileActiveChunks from '../../../../../../../ai/services/github-workflow/shared/reconcileActiveChunks.mjs';
+
+/**
+ * @summary Falsifier coverage for the active-tier ordinal re-chunk.
+ *
+ * Builds a drifted active tier (items scattered across wrong chunk folders), runs the re-chunk with
+ * a small itemsPerChunk, and proves: items land in ascending-id ordinal chunks, empty drift folders
+ * are pruned, `_index.json` reflects the new chunk numbers, and the pass is idempotent.
+ */
+test.describe('Neo.ai.services.github-workflow.shared.reconcileActiveChunks', () => {
+    let tmpDir, contentRoot;
+
+    test.beforeEach(async () => {
+        tmpDir      = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-rechunk-'));
+        contentRoot = path.join(tmpDir, 'content');
+        await fs.mkdir(contentRoot, {recursive: true})
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(tmpDir, {recursive: true, force: true})
+    });
+
+    const writePr = async (chunk, id) => {
+        const dir = path.join(contentRoot, 'pulls', `chunk-${chunk}`);
+        await fs.mkdir(dir, {recursive: true});
+        await fs.writeFile(path.join(dir, `pr-${id}.md`), `# pr ${id}\n`, 'utf8')
+    };
+
+    const idsInChunk = async chunk => {
+        try {
+            return (await fs.readdir(path.join(contentRoot, 'pulls', `chunk-${chunk}`)))
+                .map(f => parseInt(f.match(/(\d+)/)[1], 10)).sort((a, b) => a - b)
+        } catch {
+            return []
+        }
+    };
+
+    test('re-ranks a drifted active tier into ascending-id ordinal chunks, idempotently', async () => {
+        // 7 items scattered across wrong chunk folders (the drift shape): pr-10..pr-70 in chunk-1/5/9.
+        await writePr(1, 50); await writePr(1, 10); await writePr(5, 70); await writePr(9, 20);
+        await writePr(1, 40); await writePr(5, 30); await writePr(9, 60);
+
+        const config = {contentRoot};
+        const first  = await reconcileActiveChunks(config, {type: 'pulls', filePrefix: 'pr-', itemsPerChunk: 3});
+
+        expect(first.total).toBe(7);
+        expect(first.moved).toBeGreaterThan(0);
+
+        // Ascending id → ordinal-3: chunk-1 = [10,20,30], chunk-2 = [40,50,60], chunk-3 = [70].
+        expect(await idsInChunk(1)).toEqual([10, 20, 30]);
+        expect(await idsInChunk(2)).toEqual([40, 50, 60]);
+        expect(await idsInChunk(3)).toEqual([70]);
+        // Emptied drift folders are pruned.
+        expect(await idsInChunk(5)).toEqual([]);
+        expect(await idsInChunk(9)).toEqual([]);
+
+        // _index.json deep-link entries realign to the new chunk numbers.
+        const index = JSON.parse(await fs.readFile(path.join(contentRoot, '_index.json'), 'utf8'));
+        const entry = id => index.find(e => e.type === 'pulls' && String(e.id) === String(id));
+        expect(entry(10).chunkNumber).toBe(1);
+        expect(entry(40).chunkNumber).toBe(2);
+        expect(entry(70).chunkNumber).toBe(3);
+
+        // Idempotent: a second run relocates nothing.
+        const second = await reconcileActiveChunks(config, {type: 'pulls', filePrefix: 'pr-', itemsPerChunk: 3});
+        expect(second.moved).toBe(0);
+        expect(await idsInChunk(1)).toEqual([10, 20, 30])
+    });
+
+    test('dedups an id present in two chunks, keeping one, so ranking stays exact', async () => {
+        await writePr(1, 10); await writePr(1, 20); await writePr(1, 30);
+        await writePr(5, 30); // duplicate of pr-30 in another chunk — the drift shape this fixes
+        await writePr(9, 40);
+
+        const result = await reconcileActiveChunks({contentRoot}, {type: 'pulls', filePrefix: 'pr-', itemsPerChunk: 3});
+
+        expect(result.deduped).toBe(1);
+        expect(result.total).toBe(4); // 4 unique ids, NOT 5 — the duplicate must not consume an ordinal slot.
+
+        // 4 unique sorted [10,20,30,40] -> ordinal-3: chunk-1 = [10,20,30], chunk-2 = [40].
+        expect(await idsInChunk(1)).toEqual([10, 20, 30]);
+        expect(await idsInChunk(2)).toEqual([40]);
+
+        // Exactly one pr-30 survives across the whole tier.
+        const survivors = (await fs.readdir(path.join(contentRoot, 'pulls'), {recursive: true})).filter(f => /pr-30\.md$/.test(f));
+        expect(survivors).toHaveLength(1)
+    })
+});


### PR DESCRIPTION
Resolves #13328

Authored by Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.

Active content chunks had drifted off the ordinal-100 invariant: neomjs.com/news listed wrong PR/issue numbers, and the active **issues** tier was smeared across 11 chunks (overlapping ranges, 1-item folders) instead of 4 exact-100 folders. Root cause is that ordinal-100 chunking is **position-dependent** — an item's chunk is `floor(rank / 100) + 1` over ALL active items sorted ascending by id — but the delta-driven syncers only re-place the items they touch in a given run. Archiving a terminal item shifts every surviving item's rank, so the rest stay in stale folders, and the index generators faithfully mirror the drift. The fix therefore belongs at **placement**, not indexing.

`reconcileActiveChunks` is the active-tier sibling of the syncers' existing `reconcileClosed*Locations` (which relocate terminal items into the sealed archive). It re-ranks the full active corpus on disk into ordinal-100 chunks, dedups any id present in more than one chunk (a stale drift copy — left in place it consumes an ordinal slot and shifts every later item by one), realigns the `_index.json` deep-links, and prunes emptied folders. It is idempotent, and it is wired into `rebuildContentIndexesAndSeo` ahead of the index generators so every sync/rebuild self-heals drift. Archive tiers are sealed and never touched.

Evidence: L3 (ran the real `rebuildContentIndexesAndSeo` against the live corpus — active issues `75/89/100/29/9/5/2/1/1/2/3` → `100/100/100/15`, the `issue-9904` duplicate removed, 0 duplicate ids; active pulls `100/45` idempotent no-op) → L4 required (portal lists correct PR/issue numbers after the data-sync pipeline regenerates and deploys). Residual: live portal-render verification [#13328].

## Deltas from ticket
- Discovered a **duplicate-id** drift shape live (`issue-9904` present in two chunks). Added dedup-by-id to the re-chunk so a stale copy cannot consume an ordinal slot; covered by a dedicated spec case.
- Reconciled `@neo-gpt`'s merged `RebuildContentIndexesAndSeo.spec.mjs` (#13260): the new re-chunk step is now seamed (`reconcileActiveChunksFn`) and pinned into the asserted call sequence, so the rebuild's unit tests stay hermetic instead of silently re-chunking the real `resources/content` during a unit run.

## Test Evidence
- `reconcileActiveChunks.spec.mjs` (new) — drift→ordinal re-rank, idempotency (2nd run moves nothing), folder prune, `_index.json` realign, and the duplicate-id dedup case. 2 passed.
- `RebuildContentIndexesAndSeo.spec.mjs` (#13260) — 4 passed with the re-chunk seamed into the call sequence plus a coverage assertion that all three active tiers (pulls/issues/discussions) re-chunk before the index builders.
- Real-corpus rebuild verified the distribution above. Data is **not** committed — the content/index corpus is data-sync-pipeline-owned — so this PR is code-only and the corrected data regenerates on the next sync.

## Post-Merge Validation
- [ ] Next data-sync pipeline run re-chunks the active tiers (the pipeline calls `node ./buildScripts/docs/rebuildContentIndexesAndSeo.mjs --include-labels`).
- [ ] neomjs.com/news Latest lists correct, contiguous PR/issue numbers (first folder exactly 100).
