### PR TITLE
feat(ai): Neural Link named-transaction batching — begin/commit_transaction (#13331)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -1327,6 +1327,64 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /instance/begin_transaction:
+    post:
+      summary: Begin Named Transaction
+      operationId: begin_transaction
+      x-neo-tool-tier: write-locked
+      x-pass-as-object: true
+      description: Opens a named transaction for the requester so subsequent mutations are captured into one batch (undone/redone as a single unit); recoverable error when a batch is already open or the name is empty. Close it with commit_transaction.
+      tags: [Instance]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BeginTransactionRequest'
+      responses:
+        '200':
+          description: Begin-transaction result
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /instance/commit_transaction:
+    post:
+      summary: Commit Named Transaction
+      operationId: commit_transaction
+      x-neo-tool-tier: write-locked
+      x-pass-as-object: true
+      description: Commits the requester's open named transaction so its accumulated mutations become a single undoable unit; recoverable error when no batch is open or it captured no mutations.
+      tags: [Instance]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommitTransactionRequest'
+      responses:
+        '200':
+          description: Commit-transaction result
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /instance/method/call:
     post:
       summary: Call Instance Method
@@ -1848,6 +1906,23 @@ components:
           description: The target App Worker Session ID
 
     ListTransactionsRequest:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          description: The target App Worker Session ID
+
+    BeginTransactionRequest:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          description: The target App Worker Session ID
+        name:
+          type: string
+          description: A non-empty human-facing name for the batch (the user intent it groups); becomes the transaction's audit identity. An empty name is a recoverable error.
+
+    CommitTransactionRequest:
       type: object
       properties:
         sessionId:

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -17,8 +17,10 @@ import {getCurrentTurnId} from './Server.mjs';
 import RecorderService    from '../../../services/neural-link/RecorderService.mjs';
 
 const serviceMapping = {
+    begin_transaction            : InstanceService   .beginTransaction          .bind(InstanceService),
     call_method                 : InstanceService   .callMethod              .bind(InstanceService),
     check_namespace              : RuntimeService    .checkNamespace            .bind(RuntimeService),
+    commit_transaction           : InstanceService   .commitTransaction         .bind(InstanceService),
     create_component             : ComponentService  .createComponent           .bind(ComponentService),
     find_instances               : InstanceService   .findInstances             .bind(InstanceService),
     get_component_tree           : ComponentService  .getComponentTree          .bind(ComponentService),

--- a/ai/services/neural-link/InstanceService.mjs
+++ b/ai/services/neural-link/InstanceService.mjs
@@ -115,6 +115,31 @@ class InstanceService extends Base {
     }
 
     /**
+     * Opens a named transaction for the requester — forwards the `begin_transaction` tool to the connected App Worker,
+     * which captures subsequent mutations into one batch until `commit_transaction`. See
+     * {@link Neo.ai.client.InstanceService#beginTransaction}.
+     * @param {Object} opts
+     * @param {String} opts.sessionId
+     * @param {String} opts.name
+     * @returns {Promise<Object>}
+     */
+    async beginTransaction({sessionId, name}) {
+        return await ConnectionService.call(sessionId, 'begin_transaction', {name})
+    }
+
+    /**
+     * Commits the requester's open named transaction — forwards the `commit_transaction` tool to the connected App
+     * Worker, folding its accumulated mutations into a single undoable unit. See
+     * {@link Neo.ai.client.InstanceService#commitTransaction}.
+     * @param {Object} opts
+     * @param {String} opts.sessionId
+     * @returns {Promise<Object>}
+     */
+    async commitTransaction({sessionId}) {
+        return await ConnectionService.call(sessionId, 'commit_transaction', {})
+    }
+
+    /**
      * Calls a method on a specific instance.
      * @param {Object} opts
      * @param {String} opts.sessionId

--- a/learn/agentos/NeuralLink.md
+++ b/learn/agentos/NeuralLink.md
@@ -231,6 +231,8 @@ Generic tools for working with *any* Neo.mjs instance (Components, Stores, Manag
 | `call_method` | Calls a method on a specific instance (e.g. `store.load()`, `grid.scrollToRow()`) — the generic instance-action tool. |
 | `undo` | Reverts the requester's most-recent committed mutation (single-level), re-dispatching the captured reverse under live enforcement. |
 | `redo` | Re-applies the requester's most-recently undone mutation (single-level) — the symmetric counterpart of `undo`. |
+| `begin_transaction` | Opens a named transaction so the requester's subsequent mutations are captured into one batch — undone/redone as a single unit. Close it with `commit_transaction`. |
+| `commit_transaction` | Commits the requester's open named transaction, folding its accumulated mutations into one undoable unit. |
 | `list_transactions` | Read-only audit view of the requester's undo-stack history — the committed (undoable) transactions + the redo branch. |
 
 ### 4. Runtime & System

--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -128,6 +128,8 @@ class Client extends Base {
             set_instance_properties: instance,
             undo                   : instance,
             redo                   : instance,
+            begin_transaction      : instance,
+            commit_transaction     : instance,
             list_transactions      : instance,
 
             get_record            : data,

--- a/src/ai/TransactionService.mjs
+++ b/src/ai/TransactionService.mjs
@@ -376,6 +376,21 @@ class TransactionService extends Base {
     }
 
     /**
+     * @summary The id of the session's currently-open transaction, or `null` — a clone-free open-batch probe.
+     * The hot-path counterpart to {@link stackOf}: the capture hook ({@link Neo.ai.client.InstanceService#recordUndo})
+     * consults this on **every** mutation to route an op into an agent-opened named batch (`begin_transaction`) vs.
+     * auto-wrapping it as its own single-op transaction — and `stackOf` deep-copies the entire stack, the wrong cost
+     * for a per-mutation check (within an N-mutation batch the open tx grows, so probing it via `stackOf` is O(N²)).
+     * Fail-closed: an incomplete identity / unknown session → `null`.
+     * @param {Object} params
+     * @param {Object} params.id  `{agentId, sessionId}` — the Bridge-stamped writer pair
+     * @returns {String|null}
+     */
+    openTxId({id}) {
+        return this.sessions.get(stackKey(id) ?? '')?.open?.txId ?? null
+    }
+
+    /**
      * @summary A deep snapshot of a session's undo state (introspection / testing).
      * Every returned transaction + op is a copy, so a caller cannot mutate the live stack through the result.
      * @param {Object} params

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -285,11 +285,18 @@ class InstanceService extends Service {
     }
 
     /**
-     * Records a captured reverse-op as a single-op committed transaction on this heap's undo stack
-     * ({@link Neo.ai.Client#transactionService}) — `begin` → `record` → `commit`, keyed on the writer's
-     * `(agentId, sessionId)`. Best-effort: a `null` op, an absent stack authority, or a stack rejection (a malformed /
-     * unserializable reverse) is dropped cleanly (`abort`), never thrown — capturing an undo must never break the
-     * forward write it shadows.
+     * Captures a reverse-op onto this heap's undo stack ({@link Neo.ai.Client#transactionService}), keyed on the
+     * writer's `(agentId, sessionId)`. Two routes, decided by whether the writer has an **agent-opened named batch**
+     * in progress ({@link #beginTransaction}):
+     * - **named batch open** → `record` the op INTO it; no per-op commit (the batch accumulates, so the agent's
+     *   {@link #commitTransaction} closes it and multiple mutations undo as one unit). The auto-wrap below MUST be
+     *   skipped here — its `begin` would abort the open batch ({@link Neo.ai.TransactionService#begin} drops a prior
+     *   open tx).
+     * - **no open batch** → auto-wrap the op as its own single-op committed transaction (`begin` → `record` →
+     *   `commit`), the default per-mutation capture.
+     * Best-effort: a `null` op (incl. an undo replay, suppressed at the call site), an absent stack authority, or a
+     * stack rejection (a malformed / unserializable reverse) is dropped cleanly (`abort` on the auto-wrap path),
+     * never thrown — capturing an undo must never break the forward write it shadows.
      * @param {Object|null} context
      * @param {Object|null} op
      * @protected
@@ -302,8 +309,18 @@ class InstanceService extends Service {
         }
 
         const
-            stackId = {agentId: context.agentId, sessionId: context.sessionId},
-            txId    = `tx:${op.sequenceId}`;
+            stackId  = {agentId: context.agentId, sessionId: context.sessionId},
+            openTxId = transactionService.openTxId({id: stackId});
+
+        if (openTxId) {
+            // An agent-opened named batch is in progress — accumulate this op into it (no per-op commit). A record
+            // rejection drops the op cleanly (the batch stays open + intact).
+            transactionService.record({id: stackId, txId: openTxId, op});
+            return
+        }
+
+        // No open batch → auto-wrap this single mutation as its own committed transaction.
+        const txId = `tx:${op.sequenceId}`;
 
         transactionService.begin({id: stackId, txId});
 
@@ -460,6 +477,94 @@ class InstanceService extends Service {
             summarize         = tx => ({txId: tx.txId, status: tx.status, opCount: tx.ops.length, labels: tx.ops.map(op => op.label)});
 
         return {committed: committed.map(summarize), redo: redo.map(summarize)}
+    }
+
+    /**
+     * Opens a named transaction for the requester — the `begin_transaction` Neural Link tool. While a batch is open,
+     * the writer's subsequent mutations are captured INTO it (via {@link #recordUndo}) instead of auto-wrapped per-op,
+     * so a later {@link #undo} reverts the whole intent (e.g. *"add a summary grid"* = several mutations) as one unit.
+     * Close the batch with {@link #commitTransaction}.
+     *
+     * Fail-closed (never throws for an expected outcome): no writer identity, no stack authority, an empty `name`, or a
+     * batch already open (commit it first — opening over it would silently drop the in-flight ops) → `{opened: false,
+     * reason}`. The batch `txId` is `batch:<name>` — the agent-supplied name is its audit identity, namespaced apart
+     * from an auto-wrap's `tx:<sequenceId>`.
+     * @param {Object} params
+     * @param {String} params.name A non-empty human-facing name for the batch (the user intent it groups).
+     * @param {Object|null} [context] The Bridge-stamped `{agentId, sessionId}` writer pair (2nd dispatch arg).
+     * @returns {Promise<Object>} `{opened: Boolean, txId?: String, reason?: String}`
+     */
+    async beginTransaction({name}={}, context) {
+        const transactionService = this.client?.transactionService;
+
+        if (!context?.agentId || !context?.sessionId) {
+            return {opened: false, reason: 'no-writer-identity'}
+        }
+
+        if (!transactionService) {
+            return {opened: false, reason: 'no-transaction-service'}
+        }
+
+        if (typeof name !== 'string' || name.trim() === '') {
+            return {opened: false, reason: 'name-required'}
+        }
+
+        const stackId = {agentId: context.agentId, sessionId: context.sessionId};
+
+        // Reject rather than abort an in-flight batch — opening over an open one would silently drop its captured ops
+        // (TransactionService#begin aborts a prior open tx). The agent must commit the current batch first.
+        const openTxId = transactionService.openTxId({id: stackId});
+
+        if (openTxId) {
+            return {opened: false, reason: 'transaction-already-open', txId: openTxId}
+        }
+
+        const
+            txId         = `batch:${name.trim()}`,
+            {ok, reason} = transactionService.begin({id: stackId, txId});
+
+        return ok ? {opened: true, txId} : {opened: false, reason}
+    }
+
+    /**
+     * Commits the requester's open named transaction — the `commit_transaction` Neural Link tool. Closes the batch
+     * {@link #beginTransaction} opened (`open → committed`), so its accumulated mutations become a single undoable unit
+     * on the stack and the redo branch is cleared (a fresh committed mutation diverges history). The symmetric close of
+     * the batch lifecycle.
+     *
+     * Fail-closed (never throws for an expected outcome): no writer identity, no stack authority, no open batch, or an
+     * empty batch (no mutations captured — {@link Neo.ai.TransactionService#commit} drops it) → `{committed: false,
+     * reason}`.
+     * @param {Object} [params] No parameters — commits the requester's own open batch.
+     * @param {Object|null} [context] The Bridge-stamped `{agentId, sessionId}` writer pair (2nd dispatch arg).
+     * @returns {Promise<Object>} `{committed: Boolean, txId?: String, ops?: Number, reason?: String}`
+     */
+    async commitTransaction(params, context) {
+        const transactionService = this.client?.transactionService;
+
+        if (!context?.agentId || !context?.sessionId) {
+            return {committed: false, reason: 'no-writer-identity'}
+        }
+
+        if (!transactionService) {
+            return {committed: false, reason: 'no-transaction-service'}
+        }
+
+        const
+            stackId = {agentId: context.agentId, sessionId: context.sessionId},
+            {open}  = transactionService.stackOf({id: stackId});
+
+        if (!open) {
+            return {committed: false, reason: 'no-open-transaction'}
+        }
+
+        // op count from the pre-commit snapshot (commit returns only {ok, reason}) — reported so the agent knows how
+        // many mutations the batch folded into one undoable unit.
+        const
+            opCount      = open.ops.length,
+            {ok, reason} = transactionService.commit({id: stackId, txId: open.txId});
+
+        return ok ? {committed: true, txId: open.txId, ops: opCount} : {committed: false, reason}
     }
 
     /**

--- a/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
@@ -1,0 +1,127 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'InstanceServiceNamedTransactionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import InstanceService    from '../../../../src/ai/client/InstanceService.mjs';
+import TransactionService from '../../../../src/ai/TransactionService.mjs';
+
+// The `begin_transaction` / `commit_transaction` Neural Link tools group several agent mutations into ONE undoable
+// named transaction: while a batch is open, InstanceService.recordUndo captures each op INTO it (instead of
+// auto-wrapping per-op), so a later undo reverts the whole intent as a unit. These tests drive the two tools + the
+// recordUndo routing against a real TransactionService with a minimal client stub (no live tree).
+
+const ID = {agentId: 'agent-a', sessionId: 'sess-a'};
+
+// a minimal valid reverse-op carrying a re-dispatchable forward/reverse + a user-facing label
+const op = (label, seq) => ({
+    sequenceId       : seq,
+    originWriter     : {agentId: 'agent-a', sessionId: 'sess-a'},
+    targetSubtreePath: ['root', 'leaf'],
+    forward          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 1}}},
+    reverse          : {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 0}}},
+    label
+});
+
+test.describe('Neo.ai.client.InstanceService — named-transaction batching', () => {
+    let service, transactionService;
+
+    test.beforeEach(() => {
+        transactionService = Neo.create(TransactionService);
+        service            = Neo.create(InstanceService, {client: {transactionService}})
+    });
+
+    test('begin_transaction opens a named batch keyed `batch:<name>`', async () => {
+        const result = await service.beginTransaction({name: 'add-grid'}, ID);
+
+        expect(result).toEqual({opened: true, txId: 'batch:add-grid'});
+        expect(transactionService.openTxId({id: ID})).toBe('batch:add-grid')
+    });
+
+    test('begin_transaction fail-closed → no identity / empty name / already-open', async () => {
+        expect(await service.beginTransaction({name: 'x'}, null)).toEqual({opened: false, reason: 'no-writer-identity'});
+        expect(await service.beginTransaction({name: '   '}, ID)).toEqual({opened: false, reason: 'name-required'});
+        expect(await service.beginTransaction({}, ID)).toEqual({opened: false, reason: 'name-required'});
+
+        await service.beginTransaction({name: 'first'}, ID);
+        expect(await service.beginTransaction({name: 'second'}, ID))
+            .toEqual({opened: false, reason: 'transaction-already-open', txId: 'batch:first'}) // no silent abort of in-flight work
+    });
+
+    test('recordUndo accumulates into an open batch — no per-op commit', async () => {
+        await service.beginTransaction({name: 'add-grid'}, ID);
+        service.recordUndo(ID, op('set x', 's1'));
+        service.recordUndo(ID, op('set y', 's2'));
+
+        const {open, committed} = transactionService.stackOf({id: ID});
+        expect(open.txId).toBe('batch:add-grid');
+        expect(open.ops.length).toBe(2);   // both captured into the one open batch
+        expect(committed.length).toBe(0)   // nothing auto-wrapped/committed while the batch is open
+    });
+
+    test('recordUndo auto-wraps a standalone mutation when no batch is open', async () => {
+        service.recordUndo(ID, op('set x', 's1'));
+
+        const {open, committed} = transactionService.stackOf({id: ID});
+        expect(open).toBeNull();              // the auto-wrap opened + committed within the one call
+        expect(committed.length).toBe(1);
+        expect(committed[0].ops.length).toBe(1)
+    });
+
+    test('commit_transaction folds the batch into one committed tx + clears open', async () => {
+        await service.beginTransaction({name: 'add-grid'}, ID);
+        service.recordUndo(ID, op('set x', 's1'));
+        service.recordUndo(ID, op('set y', 's2'));
+
+        expect(await service.commitTransaction({}, ID)).toEqual({committed: true, txId: 'batch:add-grid', ops: 2});
+
+        const {open, committed} = transactionService.stackOf({id: ID});
+        expect(open).toBeNull();
+        expect(committed.length).toBe(1);
+        expect(committed[0].ops.length).toBe(2) // one undoable unit of two mutations
+    });
+
+    test('commit_transaction fail-closed → no identity / no open batch / empty batch', async () => {
+        expect(await service.commitTransaction({}, null)).toEqual({committed: false, reason: 'no-writer-identity'});
+        expect(await service.commitTransaction({}, ID)).toEqual({committed: false, reason: 'no-open-transaction'});
+
+        await service.beginTransaction({name: 'empty'}, ID); // opened but nothing captured
+        expect(await service.commitTransaction({}, ID)).toEqual({committed: false, reason: 'empty-transaction'})
+    });
+
+    test('a committed batch undoes as a single unit — all ops re-dispatched, tx consumed', async () => {
+        const
+            calls  = [],
+            client = {
+                transactionService,
+                async handleRequest(tool, args, context) { calls.push({tool, args, undoReplay: context?.undoReplay}) }
+            },
+            batchService = Neo.create(InstanceService, {client});
+
+        await batchService.beginTransaction({name: 'add-grid'}, ID);
+        batchService.recordUndo(ID, op('set x', 's1'));
+        batchService.recordUndo(ID, op('set y', 's2'));
+        await batchService.commitTransaction({}, ID);
+
+        const result = await batchService.undo({}, ID);
+
+        expect(result.undone).toBe(true);
+        expect(result.reverted).toBe(2);                              // both batched ops reverted as one undo
+        expect(calls.length).toBe(2);                                 // each reverse re-dispatched exactly once
+        expect(calls.every(call => call.undoReplay === true)).toBe(true); // under capture-suppression (no re-capture)
+        expect(transactionService.stackOf({id: ID}).committed.length).toBe(0) // the single batched tx consumed
+    });
+});

--- a/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
@@ -124,4 +124,37 @@ test.describe('Neo.ai.client.InstanceService — named-transaction batching', ()
         expect(calls.every(call => call.undoReplay === true)).toBe(true); // under capture-suppression (no re-capture)
         expect(transactionService.stackOf({id: ID}).committed.length).toBe(0) // the single batched tx consumed
     });
+
+    test('a committed batch redoes as a single unit — forwards re-dispatched in capture order, redo branch consumed', async () => {
+        const
+            calls  = [],
+            client = {
+                transactionService,
+                async handleRequest(tool, args, context) { calls.push({properties: args?.properties, undoReplay: context?.undoReplay}) }
+            },
+            batchService = Neo.create(InstanceService, {client}),
+            // distinct forwards so the redo re-dispatch order is observable (the shared op() helper's forwards are identical)
+            opA = {...op('set x', 's1'), forward: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {x: 1}}}},
+            opB = {...op('set y', 's2'), forward: {tool: 'set_instance_properties', args: {id: 'leaf', properties: {y: 2}}}};
+
+        await batchService.beginTransaction({name: 'add-grid'}, ID);
+        batchService.recordUndo(ID, opA);
+        batchService.recordUndo(ID, opB);
+        await batchService.commitTransaction({}, ID);
+
+        await batchService.undo({}, ID); // batch → undone, onto the redo branch
+        calls.length = 0;                // isolate the redo's forward re-dispatches from the undo's reverses
+
+        const result = await batchService.redo({}, ID);
+
+        expect(result.redone).toBe(true);
+        expect(result.reapplied).toBe(2);                              // both batched ops re-applied as ONE redo
+        expect(calls.map(call => call.properties)).toEqual([{x: 1}, {y: 2}]); // forwards, in capture order (opA → opB)
+        expect(calls.every(call => call.undoReplay === true)).toBe(true);     // under capture-suppression
+
+        const {committed, redo} = transactionService.stackOf({id: ID});
+        expect(redo.length).toBe(0);              // redo branch consumed
+        expect(committed.length).toBe(1);
+        expect(committed[0].ops.length).toBe(2)   // restored as one multi-op unit (undoable again)
+    });
 });

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -89,8 +89,10 @@ function findSilentlyStrippingOpenBags(node, pathLabel = '') {
 const neuralLinkToolTiers = ['read', 'write-locked', 'admin'];
 
 const expectedNeuralLinkToolTiers = {
+    begin_transaction            : 'write-locked',
     call_method                 : 'admin',
     check_namespace              : 'read',
+    commit_transaction           : 'write-locked',
     create_component             : 'write-locked',
     find_instances               : 'read',
     get_component_tree           : 'read',
@@ -134,7 +136,9 @@ const expectedNeuralLinkToolTiers = {
 };
 
 const neuralLinkDangerousReadForbidden = [
+    'begin_transaction',
     'call_method',
+    'commit_transaction',
     'create_component',
     'highlight_component',
     'manage_connection',


### PR DESCRIPTION
Resolves #13331

Adds the `begin_transaction` + `commit_transaction` Neural Link write tools — grouping several agent mutations into one **undoable named transaction**, so a conversational-UI intent like *"add a summary grid"* (several mutations) reverts with a single `undo` instead of N. The last named-batching piece of the #9848 undo-stack roadmap (after core #13230, undo #13221, redo #13304, list_transactions #13326).

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega). Session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.

Evidence: L1 (in-heap unit + MCP-compliance — exercised against a real `TransactionService` with no live bridge). No live-bridge-runtime ACs. No residuals.

## What changed

- **`src/ai/client/InstanceService.mjs`** — `recordUndo` routing: when the writer has an agent-opened named batch, the op is `record`ed INTO it (no per-op commit); otherwise it auto-wraps per-op exactly as before (the merged single-op capture is unchanged — an open batch MUST short-circuit first, since the auto-wrap's `begin` would abort it). Plus `beginTransaction({name})` (opens `batch:<name>`; fail-closed on no-identity / empty-name / already-open — **rejects** rather than silently aborting in-flight work) and `commitTransaction()` (commits the open batch, clears redo, reports the folded op count).
- **`src/ai/TransactionService.mjs`** — `openTxId({id})`: a clone-free open-batch probe for the per-mutation `recordUndo` hot path.
- **6-site wiring × 2 tools** (mirrors merged `undo`/`redo`/`list_transactions`): openapi `/instance/begin_transaction` + `/instance/commit_transaction` (`write-locked` tier) + `BeginTransactionRequest`/`CommitTransactionRequest`; `toolService` serviceMapping; server-side `InstanceService` forwards; `Client.mjs` dispatch; the in-app methods; the `OpenApiValidatorCompliance` tier + dangerous-read-forbidden fixtures.
- **`learn/agentos/NeuralLink.md`** — the two doc rows (the #13318 `GuideToolParity` guard stayed green).

## Deltas from ticket

- **AC4 re-scoped (per the #13333 review):** the named-batching guarantee — *a batched tx undoes/redoes as a unit* — is verified here. The `list_transactions`-reports-a-batch clause is a #13329 × #13331 cross-tool assertion → **split to follow-up #13335**, out of #13331's Resolves-scope. `Resolves #13331` is honest against the re-scoped AC4.
- **Rebased onto current `dev` (with #13329 merged).** The conflicts were additive — `list_transactions`, `begin_transaction`, and `commit_transaction` now coexist across openapi (3 paths + 3 schemas), `Client.mjs` dispatch, `toolService` mapping, server forwards, `NeuralLink.md` doc rows, and the compliance tier/dangerous-read fixtures. The `GuideToolParity` guard confirms doc==openapi parity across all three.
- **`openTxId` added to `TransactionService`** (not in the ticket's "check `stackOf().open`" sketch). V-B-A: `stackOf` deep-clones the entire stack on every call, and `recordUndo` is per-mutation, so probing via `stackOf` is O(N²) within a batch. Added a clone-free probe instead.
- `begin_transaction` **rejects** when a batch is already open (`transaction-already-open`); `abort_transaction` is the documented follow-up.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs <the specs below>` at rebased head `fb3ca0cce` — **92 passed**:
- `InstanceServiceNamedTransaction.spec.mjs` (new, **8 tests**) — begin opens `batch:<name>`; begin fail-closed (no-identity / empty-name / already-open); `recordUndo` accumulates into an open batch; `recordUndo` auto-wraps when none open; commit folds the batch; commit fail-closed; **undo-as-unit**; **redo-as-unit** (forwards re-dispatched in capture order, redo branch consumed, restored as one multi-op unit).
- `InstanceServiceListTransactions` / `InstanceServiceUndo` / `InstanceServiceRedo` / `InstanceServiceUndoCapture` / `InstanceServiceCreateUndoCapture` / `InstanceServiceRemoveUndoCapture` — regression green (post-rebase, all on the branch; the routing preserves the per-op auto-wrap they rely on).
- `TransactionService.spec.mjs` — regression green (`openTxId` is purely additive).
- `OpenApiValidatorCompliance.spec.mjs` + `GuideToolParity.spec.mjs` — green (the 3 transaction tools' tiers + dangerous-read coverage + doc==openapi parity, post-merge).

## Post-Merge Validation

- [x] Rebased onto `dev` after #13329 (list_transactions) merged — the 3 transaction tools coexist; combined set green (92).
- [ ] #13335 — verify `list_transactions` reports a named batch (opCount + labels) once this lands (both tools then on dev).

## Related

Parent: #9848 (undo-stack umbrella). Siblings: #13221 (undo), #13304 (redo), #13326 (list_transactions), #13318 (the doc-parity guard). Follow-up: #13335. Refs #13012 (Agent Harness Pillar-2).