### PR TITLE
fix(core): clear Node timeout handles on destroy (#13319)

### DIFF
--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -187,7 +187,7 @@ class Base {
 
     /**
      * Internal cache for all async reject functions (timeouts, remote calls, promises).
-     * @member {Map<Number|Symbol, Function>} #asyncRejects=new Map()
+     * @member {Map<Number|Object|Symbol, Function>} #asyncRejects=new Map()
      * @private
      */
     #asyncRejects = new Map()
@@ -509,7 +509,7 @@ class Base {
         let me = this;
 
         me.#asyncRejects.forEach((reject, id) => {
-            if (Neo.isNumber(id)) {
+            if (typeof id !== 'symbol') {
                 clearTimeout(id)
             }
 
@@ -1189,7 +1189,7 @@ class Base {
 
     /**
      * Unregisters an async operation.
-     * @param {Number|Symbol} id - The unique ID for the async operation.
+     * @param {Number|Object|Symbol} id - The unique ID for the async operation.
      */
     unregisterAsync(id) {
         this.#asyncRejects.delete(id)
@@ -1198,7 +1198,7 @@ class Base {
     /**
      * Registers an async operation (via its reject function) to be cancelled (rejected)
      * when the component is destroyed.
-     * @param {Number|Symbol} id - The unique ID for the async operation.
+     * @param {Number|Object|Symbol} id - The unique ID for the async operation.
      * @param {Function} reject - The reject function of the promise.
      */
     registerAsync(id, reject) {

--- a/test/playwright/unit/core/BaseTimeout.spec.mjs
+++ b/test/playwright/unit/core/BaseTimeout.spec.mjs
@@ -45,6 +45,100 @@ test.describe('core/Base Timeout Handling', () => {
         expect(error).toBe(Neo.isDestroyed);
     });
 
+    test('destroy() should clear Node Timeout object ids from timeout()', async () => {
+        class TestClass extends core.Base {
+            static config = {
+                className: 'Neo.test.NodeTimeoutDestroyTestClass'
+            }
+        }
+        TestClass = Neo.setupClass(TestClass);
+
+        const
+            instance     = Neo.create(TestClass),
+            clearTimeout = globalThis.clearTimeout,
+            clearedIds   = [];
+
+        globalThis.clearTimeout = id => {
+            clearedIds.push(id);
+            return clearTimeout(id)
+        };
+
+        try {
+            const timeoutPromise = instance.timeout(500);
+
+            instance.destroy();
+
+            await expect(timeoutPromise).rejects.toBe(Neo.isDestroyed);
+        } finally {
+            globalThis.clearTimeout = clearTimeout
+        }
+
+        expect(clearedIds).toHaveLength(1);
+        expect(typeof clearedIds[0]).toBe('object');
+        expect(clearedIds[0]?.constructor?.name).toBe('Timeout');
+    });
+
+    test('destroy() should still clear browser-style numeric timeout ids', () => {
+        class TestClass extends core.Base {
+            static config = {
+                className: 'Neo.test.NumericTimeoutDestroyTestClass'
+            }
+        }
+        TestClass = Neo.setupClass(TestClass);
+
+        const
+            instance     = Neo.create(TestClass),
+            clearTimeout = globalThis.clearTimeout,
+            clearedIds   = [];
+
+        let rejectedWith;
+
+        globalThis.clearTimeout = id => {
+            clearedIds.push(id);
+            return clearTimeout(id)
+        };
+
+        try {
+            instance.registerAsync(42, reason => { rejectedWith = reason });
+            instance.destroy()
+        } finally {
+            globalThis.clearTimeout = clearTimeout
+        }
+
+        expect(clearedIds).toEqual([42]);
+        expect(rejectedWith).toBe(Neo.isDestroyed);
+    });
+
+    test('destroy() should not pass trap() Symbol ids to clearTimeout', async () => {
+        class TestClass extends core.Base {
+            static config = {
+                className: 'Neo.test.TrapSymbolDestroyTestClass'
+            }
+        }
+        TestClass = Neo.setupClass(TestClass);
+
+        const
+            instance     = Neo.create(TestClass),
+            clearTimeout = globalThis.clearTimeout,
+            clearedIds   = [],
+            trapped      = instance.trap(new Promise(() => {}));
+
+        globalThis.clearTimeout = id => {
+            clearedIds.push(id);
+            return clearTimeout(id)
+        };
+
+        try {
+            instance.destroy();
+
+            await expect(trapped).rejects.toBe(Neo.isDestroyed);
+        } finally {
+            globalThis.clearTimeout = clearTimeout
+        }
+
+        expect(clearedIds).toEqual([]);
+    });
+
     test('Multiple timeouts should be handled correctly', async () => {
         class TestClass extends core.Base {
             static config = {


### PR DESCRIPTION
Resolves #13319

Authored by GPT-5.5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

`Base.destroy()` now clears async timeout handles by excluding only `trap()` Symbol ids from `clearTimeout()`. Browser-style numeric timeout ids and Node `Timeout` object ids are both torn down, while trapped promises still reject without passing Symbol ids into timer cleanup.

Evidence: L1 (focused core unit tests + core suite + syntax/diff/freshness checks) -> L1 required (Base async-lifecycle behavior and test coverage). No residuals.

## Deltas from ticket

The fix keeps the ticket's intended shape and adds regression coverage for all three registered async id classes: Node `Timeout` objects, browser-style numeric ids, and `trap()` Symbol ids.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/core/BaseTimeout.spec.mjs` - 7 passed
- `npm run test-unit -- test/playwright/unit/core` - 41 passed
- `git diff --check` - passed
- `node --check src/core/Base.mjs` - passed
- `node --check test/playwright/unit/core/BaseTimeout.spec.mjs` - passed
- `git fetch origin`; `merge-base HEAD origin/dev == origin/dev` - passed before push

## Post-Merge Validation

- [ ] Confirm #13319 auto-closes after merge.
- [ ] Watch current-head CI for broader async lifecycle regressions beyond the focused core suite.

## Commits

- `358fa6db3` - `fix(core): clear Node timeout handles on destroy (#13319)`
