### PR TITLE
feat(ai): FleetManager turnkey stopAgent + restartAgent (#13336)

### DIFF
--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -139,6 +139,33 @@ class FleetManager extends Base {
             managedRoot: this.getManagedRoot()
         });
     }
+
+    /**
+     * @summary Turnkey stop: gracefully stop an agent's harness process (`SIGTERM`, then `SIGKILL` after
+     * the timeout) via the lifecycle collaborator. A thin delegation — stopping a process needs no
+     * `managedRoot` / provisioning, so it forwards straight to `FleetLifecycleService.stop`, mirroring how
+     * `fleetRepoStatus` forwards to its aggregator.
+     * @param {String} agentId Registry agent id.
+     * @returns {Promise<Object>} `{success, id, state}` from the lifecycle service's `stop`.
+     */
+    stopAgent(agentId) {
+        return this.getLifecycleService().stop(agentId);
+    }
+
+    /**
+     * @summary Turnkey restart: stop the agent, then start it again through the provisioned path
+     * ({@link startAgent}) — so the restarted harness re-ensures its repo and runs inside ITS checkout,
+     * not the Fleet Manager's own directory. Deliberately NOT a delegation to the lifecycle service's own
+     * `restart`, which re-starts with no `cwd`: that would re-spawn a provisioned agent in the wrong
+     * directory, and the checkout-path-keyed auto-memory would silently fork (the exact failure the
+     * provisioned start path prevents). Restarting a non-running agent is just a provisioned start.
+     * @param {String} agentId Registry agent id.
+     * @returns {Promise<Object>} the agent's lifecycle status (see {@link startAgent}).
+     */
+    async restartAgent(agentId) {
+        await this.stopAgent(agentId);
+        return this.startAgent(agentId);
+    }
 }
 
 export default Neo.setupClass(FleetManager);

--- a/test/playwright/unit/ai/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/FleetManager.spec.mjs
@@ -89,6 +89,35 @@ test.describe('Neo.ai.services.fleet.FleetManager', () => {
         expect(result).toEqual([{agentId: 'a'}]);
     });
 
+    test('stopAgent delegates to the lifecycle service stop with the agent id', async () => {
+        const calls     = [],
+              lifecycle = {stop: id => { calls.push(id); return Promise.resolve({success: true, id, state: 'stopped'}); }};
+
+        FleetManager.lifecycleService = lifecycle;
+
+        const result = await FleetManager.stopAgent('agent-a');
+
+        expect(calls).toEqual(['agent-a']);
+        expect(result).toMatchObject({success: true, id: 'agent-a', state: 'stopped'});
+    });
+
+    test('restartAgent stops then re-starts via the PROVISIONED path (preserving the repo cwd)', async () => {
+        const order     = [],
+              lifecycle = {stop: id => { order.push(`stop:${id}`); return Promise.resolve({success: true, id, state: 'stopped'}); }};
+
+        FleetManager.managedRoot         = '/managed/root';
+        FleetManager.lifecycleService    = lifecycle;
+        FleetManager.provisionAndStartFn = async args => { order.push(`provisionStart:${args.agentId}`); return {state: 'running'}; };
+
+        const status = await FleetManager.restartAgent('agent-a');
+
+        // stop runs BEFORE the provisioned start, and the start goes through the provision-then-start
+        // composer (NOT lifecycleService.restart, which the stub deliberately omits) → the restarted
+        // agent re-runs in its provisioned checkout, not the Fleet Manager's dir.
+        expect(order).toEqual(['stop:agent-a', 'provisionStart:agent-a']);
+        expect(status.state).toBe('running');
+    });
+
     test('seams default to the real composers (a no-injection construction wires them)', () => {
         expect(FleetManager.getProvisionAndStartFn()).toBe(startAgentProvisioned);
         expect(FleetManager.getRepoStatusFn()).toBe(inspectFleetRepos);


### PR DESCRIPTION
Resolves #13336
Refs #13015

Exposes the mutating lifecycle verbs on the `FleetManager` control-plane facade — `stopAgent(id)` + `restartAgent(id)` — completing the start→stop→restart operator surface that #13015's MVP criterion names (*"whole-fleet start/stop/restart/health"*). Pure exposure of the already-merged `FleetLifecycleService` primitives, mirroring the facade's existing `startAgent` / `fleetRepoStatus` delegation idiom.

`stopAgent` thin-delegates to `FleetLifecycleService.stop`. `restartAgent` deliberately does **NOT** delegate to `lifecycleService.restart` — that re-`start`s with no `cwd` (`FleetLifecycleService.mjs:256`), which would re-spawn a *provisioned* agent in the Fleet Manager's own directory and silently fork the checkout-path-keyed auto-memory (the failure the provisioned start path was built to prevent). Instead `restartAgent` = `stop` then the facade's own provisioned `startAgent`, so a restarted agent re-ensures its repo and runs inside ITS checkout. `removeAgent` is out of scope by design (the blocked #13190 — needs a Memory-Core delete/archive/tombstone policy, and `removeAgentRepo` forbids auto-wiring removal into `removeAgent`).

Evidence: L1 (unit-tested delegation + provisioned-restart ordering contract) → L1 required (ACs fully covered by unit tests; both methods are pure composition over already-merged primitives). No residuals.

## Deltas from ticket (if any)
None — implemented exactly as scoped. The scoping V-B-A surfaced a latent footgun noted for a potential follow-up: `FleetLifecycleService.restart` drops `cwd` for *any* caller restarting a provisioned agent; `restartAgent` routes around it rather than consuming it. A primitive-level fix (or a JSDoc caveat on `restart`) is a candidate follow-up, deliberately not bundled here.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/FleetManager.spec.mjs`
→ **8 passed** (6 pre-existing + 2 new: `stopAgent` delegation; `restartAgent` stop-then-provisioned-start ordering). The `restartAgent` test deliberately omits `restart` from the injected lifecycle stub, so a wrong delegation to `lifecycleService.restart` would throw `TypeError` — the test therefore *proves* the impl routes through the provisioned `startAgent` path, not the cwd-dropping primitive.

## Post-Merge Validation
- [ ] None beyond CI — the change is pure Node-side delegation, fully covered by the unit suite.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada (Ada). Session 73156d71-9a96-4bf1-bbc8-d6487ca7dddd.
