### PR TITLE
feat(ai): FleetManager turnkey removeAgent (stop + deregister) (#13338)

### DIFF
--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -166,6 +166,23 @@ class FleetManager extends Base {
         await this.stopAgent(agentId);
         return this.startAgent(agentId);
     }
+
+    /**
+     * @summary Turnkey remove: take an agent out of the fleet — stop its process first (so removal never
+     * leaves an orphaned, unmanageable live harness), then deregister its definition + stored PAT via the
+     * registry. **Deliberately non-destructive to disk:** the agent's on-disk checkout and its
+     * checkout-path-keyed auto-memory are left intact, because deleting the checkout would orphan that
+     * auto-memory — the reconciliation (delete / archive / tombstone) is a Memory-Core policy that must
+     * land WITH the deletion, not after it. So the destructive checkout cleanup stays coupled with that
+     * reconciliation rather than orphaning here. Stopping a non-running agent is a safe no-op.
+     * @param {String} agentId Registry agent id.
+     * @returns {Promise<Object>} `{success, id}` from the registry's `removeAgent` (`success` ⇒ the agent
+     * existed and was deregistered).
+     */
+    async removeAgent(agentId) {
+        await this.stopAgent(agentId);
+        return this.getLifecycleService().getRegistry().removeAgent(agentId);
+    }
 }
 
 export default Neo.setupClass(FleetManager);

--- a/test/playwright/unit/ai/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/FleetManager.spec.mjs
@@ -118,6 +118,23 @@ test.describe('Neo.ai.services.fleet.FleetManager', () => {
         expect(status.state).toBe('running');
     });
 
+    test('removeAgent stops the process THEN deregisters via the registry', async () => {
+        const order     = [],
+              registry  = {removeAgent: id => { order.push(`deregister:${id}`); return {success: true, id}; }},
+              lifecycle = {
+                  stop       : id => { order.push(`stop:${id}`); return Promise.resolve({success: true, id, state: 'stopped'}); },
+                  getRegistry: () => registry
+              };
+
+        FleetManager.lifecycleService = lifecycle;
+
+        const result = await FleetManager.removeAgent('agent-a');
+
+        // stop precedes deregister — a running agent is never deregistered while live.
+        expect(order).toEqual(['stop:agent-a', 'deregister:agent-a']);
+        expect(result).toEqual({success: true, id: 'agent-a'});
+    });
+
     test('seams default to the real composers (a no-injection construction wires them)', () => {
         expect(FleetManager.getProvisionAndStartFn()).toBe(startAgentProvisioned);
         expect(FleetManager.getRepoStatusFn()).toBe(inspectFleetRepos);

--- a/test/playwright/unit/ai/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/FleetManager.spec.mjs
@@ -135,6 +135,24 @@ test.describe('Neo.ai.services.fleet.FleetManager', () => {
         expect(result).toEqual({success: true, id: 'agent-a'});
     });
 
+    test('removeAgent on a non-running agent: stop is a safe no-op, deregister still proceeds', async () => {
+        const order     = [],
+              registry  = {removeAgent: id => { order.push(`deregister:${id}`); return {success: false, id}; }},
+              // a non-running agent: stop resolves {success:false} without an exit — removal must still deregister.
+              lifecycle = {
+                  stop       : id => { order.push(`stop:${id}`); return Promise.resolve({success: false, id, state: 'stopped'}); },
+                  getRegistry: () => registry
+              };
+
+        FleetManager.lifecycleService = lifecycle;
+
+        const result = await FleetManager.removeAgent('absent-agent');
+
+        // stop's {success:false} (not running) does NOT short-circuit removal; deregister still runs.
+        expect(order).toEqual(['stop:absent-agent', 'deregister:absent-agent']);
+        expect(result).toEqual({success: false, id: 'absent-agent'});
+    });
+
     test('seams default to the real composers (a no-injection construction wires them)', () => {
         expect(FleetManager.getProvisionAndStartFn()).toBe(startAgentProvisioned);
         expect(FleetManager.getRepoStatusFn()).toBe(inspectFleetRepos);


### PR DESCRIPTION
Resolves #13338
Refs #13015

Adds `removeAgent(id)` to the `FleetManager` facade, completing the operator lifecycle verbs (add / start / stop / restart / **remove**). It stops the agent's process first — so removal never leaves an orphaned, unmanageable live harness — then deregisters its definition + stored PAT via `FleetRegistryService.removeAgent`. Returns `{success, id}`.

**Deliberately non-destructive to disk.** The agent's on-disk checkout and its checkout-path-keyed auto-memory are left intact: deleting the checkout would orphan that auto-memory, and the reconciliation (delete / archive / tombstone) is a Memory-Core policy that must land *with* the deletion — the blocked #13190. Decoupling deletion from reconciliation is exactly the silent-orphaning failure #13190 exists to prevent, so the destructive checkout cleanup stays coupled there rather than orphaning here. A `removeRepo` opt-in flag was considered and deferred for the same reason.

Evidence: L1 (unit-tested stop-then-deregister ordering + delegation contract) → L1 required (ACs fully covered by unit tests; pure composition over already-merged primitives). No residuals.

## Deltas from ticket (if any)
None on scope. Post-open: added a second unit test (the non-running-agent safe-no-op branch) per @neo-claude-opus's review — coverage only, no behavior change.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/FleetManager.spec.mjs`
→ **10 passed** (8 prior + 2 new):
1. `removeAgent` stops the process THEN deregisters — asserts call-order `['stop:agent-a', 'deregister:agent-a']`, proving a running agent is never deregistered while live (the stub omits `restart`, so a wrong delegation would throw).
2. `removeAgent` on a non-running agent — `stop`→`{success:false}` is a safe no-op and removal still proceeds to deregister (the JSDoc's documented "safe no-op stop still removes" branch).

## Post-Merge Validation
- [ ] None beyond CI — pure Node-side delegation, fully unit-covered.

## Commits
- `268a6d4` — feat: `removeAgent` (stop + deregister) + the stop-then-deregister test
- `bdb9694` — test: cover the non-running-agent safe-no-op branch (@neo-claude-opus review watch-item)

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada (Ada). Session 73156d71-9a96-4bf1-bbc8-d6487ca7dddd.
