### PR TITLE
test(ai): list_transactions reports a named batch — opCount + labels (#13335)

### DIFF
--- a/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
@@ -157,4 +157,18 @@ test.describe('Neo.ai.client.InstanceService — named-transaction batching', ()
         expect(committed.length).toBe(1);
         expect(committed[0].ops.length).toBe(2)   // restored as one multi-op unit (undoable again)
     });
+
+    test('list_transactions reports a committed named batch — opCount + all labels (cross-tool integration)', async () => {
+        await service.beginTransaction({name: 'add-grid'}, ID);
+        service.recordUndo(ID, op('set width',  's1'));
+        service.recordUndo(ID, op('set height', 's2'));
+        await service.commitTransaction({}, ID);
+
+        const {committed, redo} = await service.listTransactions({}, ID);
+
+        expect(redo).toEqual([]);
+        expect(committed).toHaveLength(1);
+        // the batch folded 2 mutations into one auditable unit — labels in capture order, raw ops excluded
+        expect(committed[0]).toEqual({txId: 'batch:add-grid', status: 'committed', opCount: 2, labels: ['set width', 'set height']})
+    });
 });


### PR DESCRIPTION
Resolves #13335

The cross-tool integration test split from #13331 AC4 — now buildable since `list_transactions` (#13329) and named-batching (#13331 / #13333) both merged to dev. Asserts the named-batching tools produce a batch that `list_transactions` reports correctly.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega). Session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.

Evidence: L1 (in-heap unit — exercised against a real `TransactionService`, no live bridge). No live-bridge-runtime ACs. No residuals.

## What changed

- **`test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs`** — one new test: `begin_transaction` → `recordUndo` ×2 → `commit_transaction` produces a committed named batch (`batch:add-grid`, 2 ops), and `list_transactions` reports it in `committed` as `{txId, status: 'committed', opCount: 2, labels: ['set width', 'set height']}` — all labels in capture order, raw forward/reverse ops excluded (data-not-code); `redo` empty. Test-only; no production change (the `list_transactions` projection already maps any multi-op tx — this proves the named-batching × audit-tool path end-to-end at the unit level).

## Deltas from ticket

None — scope as filed (the #13331 AC4 clause split here).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs test/playwright/unit/ai/InstanceServiceListTransactions.spec.mjs test/playwright/unit/ai/TransactionService.spec.mjs` at head `68833aa10` — **36 passed** (the new integration test + the named-transaction / list_transactions / TransactionService regression; all three specs present on this branch).

## Post-Merge Validation

- [ ] None — fully unit-covered; no live-bridge AC.

## Related

Parent: #9848 (undo-stack umbrella). Split from #13331 AC4 (the #13333 review). Tools: `list_transactions` (#13329), `begin`/`commit_transaction` (#13331). Refs #13012 (Agent Harness Pillar-2).