### PR TITLE
feat(ai): Neural Link abort_transaction — discard an open named batch (#13343)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -1327,6 +1327,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /instance/abort_transaction:
+    post:
+      summary: Abort Named Transaction
+      operationId: abort_transaction
+      x-neo-tool-tier: write-locked
+      x-pass-as-object: true
+      description: Discards the requester's open named transaction without committing (the open batch is dropped, never undoable); recoverable error when no batch is open. The applied UI mutations remain; only the undo record is discarded.
+      tags: [Instance]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AbortTransactionRequest'
+      responses:
+        '200':
+          description: Abort-transaction result
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /instance/begin_transaction:
     post:
       summary: Begin Named Transaction
@@ -1906,6 +1935,13 @@ components:
           description: The target App Worker Session ID
 
     ListTransactionsRequest:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          description: The target App Worker Session ID
+
+    AbortTransactionRequest:
       type: object
       properties:
         sessionId:

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -17,6 +17,7 @@ import {getCurrentTurnId} from './Server.mjs';
 import RecorderService    from '../../../services/neural-link/RecorderService.mjs';
 
 const serviceMapping = {
+    abort_transaction            : InstanceService   .abortTransaction          .bind(InstanceService),
     begin_transaction            : InstanceService   .beginTransaction          .bind(InstanceService),
     call_method                 : InstanceService   .callMethod              .bind(InstanceService),
     check_namespace              : RuntimeService    .checkNamespace            .bind(RuntimeService),

--- a/ai/services/neural-link/InstanceService.mjs
+++ b/ai/services/neural-link/InstanceService.mjs
@@ -115,6 +115,17 @@ class InstanceService extends Base {
     }
 
     /**
+     * Aborts the requester's open named transaction — forwards the `abort_transaction` tool to the connected App
+     * Worker, discarding the open batch without committing. See {@link Neo.ai.client.InstanceService#abortTransaction}.
+     * @param {Object} opts
+     * @param {String} opts.sessionId
+     * @returns {Promise<Object>}
+     */
+    async abortTransaction({sessionId}) {
+        return await ConnectionService.call(sessionId, 'abort_transaction', {})
+    }
+
+    /**
      * Opens a named transaction for the requester — forwards the `begin_transaction` tool to the connected App Worker,
      * which captures subsequent mutations into one batch until `commit_transaction`. See
      * {@link Neo.ai.client.InstanceService#beginTransaction}.

--- a/learn/agentos/NeuralLink.md
+++ b/learn/agentos/NeuralLink.md
@@ -231,6 +231,7 @@ Generic tools for working with *any* Neo.mjs instance (Components, Stores, Manag
 | `call_method` | Calls a method on a specific instance (e.g. `store.load()`, `grid.scrollToRow()`) — the generic instance-action tool. |
 | `undo` | Reverts the requester's most-recent committed mutation (single-level), re-dispatching the captured reverse under live enforcement. |
 | `redo` | Re-applies the requester's most-recently undone mutation (single-level) — the symmetric counterpart of `undo`. |
+| `abort_transaction` | Discards the requester's open named transaction without committing — drops the batch's undo-record (the applied UI changes remain). The third arm of the begin/commit/abort lifecycle. |
 | `begin_transaction` | Opens a named transaction so the requester's subsequent mutations are captured into one batch — undone/redone as a single unit. Close it with `commit_transaction`. |
 | `commit_transaction` | Commits the requester's open named transaction, folding its accumulated mutations into one undoable unit. |
 | `list_transactions` | Read-only audit view of the requester's undo-stack history — the committed (undoable) transactions + the redo branch. |

--- a/src/ai/Client.mjs
+++ b/src/ai/Client.mjs
@@ -128,6 +128,7 @@ class Client extends Base {
             set_instance_properties: instance,
             undo                   : instance,
             redo                   : instance,
+            abort_transaction      : instance,
             begin_transaction      : instance,
             commit_transaction     : instance,
             list_transactions      : instance,

--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -568,6 +568,43 @@ class InstanceService extends Service {
     }
 
     /**
+     * Aborts the requester's open named transaction — the `abort_transaction` Neural Link tool. Discards the batch
+     * {@link #beginTransaction} opened (`open → aborted`, dropped, never undoable) WITHOUT committing it. The forward
+     * mutations **remain applied** to the UI (they were enforcement-granted when made); only the undo-record is
+     * discarded — this is NOT a rollback. Reverting the UI is composable ({@link #undo} the changes before aborting) or
+     * a future dedicated rollback tool. The third arm of the batch lifecycle alongside {@link #commitTransaction}.
+     *
+     * Fail-closed (never throws for an expected outcome): no writer identity, no stack authority, or no open batch
+     * (idempotent — nothing to abort) → `{aborted: false, reason}`.
+     * @param {Object} [params] No parameters — aborts the requester's own open batch.
+     * @param {Object|null} [context] The Bridge-stamped `{agentId, sessionId}` writer pair (2nd dispatch arg).
+     * @returns {Promise<Object>} `{aborted: Boolean, txId?: String, reason?: String}`
+     */
+    async abortTransaction(params, context) {
+        const transactionService = this.client?.transactionService;
+
+        if (!context?.agentId || !context?.sessionId) {
+            return {aborted: false, reason: 'no-writer-identity'}
+        }
+
+        if (!transactionService) {
+            return {aborted: false, reason: 'no-transaction-service'}
+        }
+
+        const
+            stackId  = {agentId: context.agentId, sessionId: context.sessionId},
+            openTxId = transactionService.openTxId({id: stackId});
+
+        if (!openTxId) {
+            return {aborted: false, reason: 'no-open-transaction'}
+        }
+
+        transactionService.abort({id: stackId, txId: openTxId});
+
+        return {aborted: true, txId: openTxId}
+    }
+
+    /**
      * Calls a method on a specific instance.
      * @param {Object} params
      * @param {String} params.id

--- a/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
@@ -171,4 +171,25 @@ test.describe('Neo.ai.client.InstanceService — named-transaction batching', ()
         // the batch folded 2 mutations into one auditable unit — labels in capture order, raw ops excluded
         expect(committed[0]).toEqual({txId: 'batch:add-grid', status: 'committed', opCount: 2, labels: ['set width', 'set height']})
     });
+
+    test('abort_transaction discards the open batch — committed stack + redo branch untouched', async () => {
+        await service.beginTransaction({name: 'keep'}, ID);
+        service.recordUndo(ID, op('kept', 'k1'));
+        await service.commitTransaction({}, ID);            // committed[0] = batch:keep
+
+        await service.beginTransaction({name: 'discard'}, ID);
+        service.recordUndo(ID, op('throwaway', 'd1'));      // open batch:discard, 1 op
+
+        expect(await service.abortTransaction({}, ID)).toEqual({aborted: true, txId: 'batch:discard'});
+
+        const {open, committed, redo} = transactionService.stackOf({id: ID});
+        expect(open).toBeNull();                            // the open batch dropped (never undoable)
+        expect(committed.map(t => t.txId)).toEqual(['batch:keep']); // the prior committed batch untouched
+        expect(redo).toEqual([])                            // redo branch untouched
+    });
+
+    test('abort_transaction fail-closed → no identity / no open batch', async () => {
+        expect(await service.abortTransaction({}, null)).toEqual({aborted: false, reason: 'no-writer-identity'});
+        expect(await service.abortTransaction({}, ID)).toEqual({aborted: false, reason: 'no-open-transaction'}) // nothing open (idempotent)
+    });
 });

--- a/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs
@@ -192,4 +192,12 @@ test.describe('Neo.ai.client.InstanceService — named-transaction batching', ()
         expect(await service.abortTransaction({}, null)).toEqual({aborted: false, reason: 'no-writer-identity'});
         expect(await service.abortTransaction({}, ID)).toEqual({aborted: false, reason: 'no-open-transaction'}) // nothing open (idempotent)
     });
+
+    test('the batch tools fail closed without a stack authority → no-transaction-service', async () => {
+        const bare = Neo.create(InstanceService, {client: {}}); // a client with no transactionService
+
+        expect(await bare.beginTransaction({name: 'x'}, ID)).toEqual({opened: false, reason: 'no-transaction-service'});
+        expect(await bare.commitTransaction({}, ID)).toEqual({committed: false, reason: 'no-transaction-service'});
+        expect(await bare.abortTransaction({}, ID)).toEqual({aborted: false, reason: 'no-transaction-service'})
+    });
 });

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -89,6 +89,7 @@ function findSilentlyStrippingOpenBags(node, pathLabel = '') {
 const neuralLinkToolTiers = ['read', 'write-locked', 'admin'];
 
 const expectedNeuralLinkToolTiers = {
+    abort_transaction            : 'write-locked',
     begin_transaction            : 'write-locked',
     call_method                 : 'admin',
     check_namespace              : 'read',
@@ -136,6 +137,7 @@ const expectedNeuralLinkToolTiers = {
 };
 
 const neuralLinkDangerousReadForbidden = [
+    'abort_transaction',
     'begin_transaction',
     'call_method',
     'commit_transaction',


### PR DESCRIPTION
Resolves #13343

Adds the `abort_transaction` Neural Link write tool — the third batch-lifecycle arm, completing the `begin_transaction` / `commit_transaction` / `abort_transaction` triad (#13331). Discards the writer's open named batch without committing.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega). Session a0bc6b23-78c5-4bd7-b944-9db5e236f42d.

Evidence: L1 (in-heap unit + MCP-compliance — exercised against a real `TransactionService`, no live bridge). No live-bridge-runtime ACs. No residuals.

## What changed

- **`src/ai/client/InstanceService.mjs`** — `abortTransaction(params, context)`: aborts the writer's open batch via `TransactionService.abort` (`open → aborted`, dropped, never undoable) → `{aborted: true, txId}`. Uses the clone-free `openTxId` probe; fail-closed on no-identity / no-stack-authority / no-open-batch (idempotent).
- **Semantic (decided + flagged in #13343 for review):** abort = discard the undo-**record**, **not** a UI rollback. The applied mutations remain (they were enforcement-granted when made); only the batch's reverse-ops are dropped. Reverting the UI is composable (`undo` before `abort`) or a future dedicated tool — explicitly out of scope.
- **6-site wiring** (mirrors begin/commit): openapi `/instance/abort_transaction` (`write-locked`) + `AbortTransactionRequest`; `toolService` serviceMapping; server-side `InstanceService` forward; `Client.mjs` dispatch; the in-app method; the `OpenApiValidatorCompliance` tier + dangerous-read-forbidden fixtures.
- **`learn/agentos/NeuralLink.md`** — the `abort_transaction` doc row (the #13318 `GuideToolParity` guard stayed green).

## Deltas from ticket

None — scope as filed. The just-drop-vs-rollback semantic choice is flagged in #13343 (and the `[lane-claim]` A2A) for reviewer objection.

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/InstanceServiceNamedTransaction.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs test/playwright/unit/ai/mcp/validation/GuideToolParity.spec.mjs test/playwright/unit/ai/TransactionService.spec.mjs` at head `b28c5fd41` — **67 passed**:
- `InstanceServiceNamedTransaction.spec.mjs` — abort coverage: abort drops the open batch (committed stack + redo branch untouched); fail-closed (no-identity / no-open-batch); + a triad `no-transaction-service` fail-closed test covering begin/commit/abort (added per this review). Plus the existing begin/commit/undo/redo/list-integration coverage.
- `OpenApiValidatorCompliance.spec.mjs` — green: the openapi parses (the new path + `AbortTransactionRequest`), the `abort_transaction: 'write-locked'` tier + dangerous-read-forbidden, serviceMapping↔tier parity.
- `GuideToolParity.spec.mjs` (#13318) — green: doc==openapi parity held with the new doc-row.
- `TransactionService.spec.mjs` — regression green.

## Post-Merge Validation

- [ ] None — fully unit/compliance-covered; no live-bridge AC.

## Related

Parent: #9848 (undo-stack umbrella). Completes the named-batching triad with #13331 (begin/commit). Siblings: #13326 (list_transactions), #13318 (the doc-parity guard). Refs #13012 (Agent Harness Pillar-2). Core: `src/ai/TransactionService.mjs` `abort`.