### PR TITLE
fix(ai): FleetLifecycleService.restart preserves the spawn cwd (#13344)

### DIFF
--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -178,11 +178,11 @@ class FleetLifecycleService extends Base {
         try {
             child = this.getSpawnFn()(command, args, spawnOptions);
         } catch (error) {
-            this.processes.set(id, {id, state: 'failed', pid: null, startedAt: null, exitCode: null, exitedAt: new Date().toISOString(), error: error.message});
+            this.processes.set(id, {id, cwd: opts.cwd ?? null, state: 'failed', pid: null, startedAt: null, exitCode: null, exitedAt: new Date().toISOString(), error: error.message});
             throw error;
         }
 
-        const record = {id, child, pid: child.pid ?? null, state: 'running', startedAt: new Date().toISOString(), exitCode: null, signal: null, exitedAt: null, stderrBytes: 0};
+        const record = {id, child, cwd: opts.cwd ?? null, pid: child.pid ?? null, state: 'running', startedAt: new Date().toISOString(), exitCode: null, signal: null, exitedAt: null, stderrBytes: 0};
         this.processes.set(id, record);
 
         // Drain stderr so a noisy harness can't block on a full pipe buffer. Retain only a byte
@@ -249,13 +249,17 @@ class FleetLifecycleService extends Base {
     }
 
     /**
-     * Stop (settling the pending stop) then start. `restart` of a non-running agent is just `start`.
+     * Stop (settling the pending stop) then start, **re-using the spawn `cwd`** the agent was started with
+     * (read from the persisted process record) — so a provisioned agent restarts inside its own checkout,
+     * not this process's directory, and its checkout-path-keyed auto-memory does not fork. `restart` of a
+     * non-running agent is just `start` (at the recorded `cwd` when one exists).
      * @param {String} id
      * @returns {Promise<Object>} status
      */
     async restart(id) {
+        const priorCwd = this.processes.get(id)?.cwd ?? null;
         await this.stop(id);
-        return this.start(id);
+        return this.start(id, priorCwd != null ? {cwd: priorCwd} : {});
     }
 
     /**

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -238,6 +238,25 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(after.pid).not.toBe(first.pid);
     });
 
+    test('restart re-spawns at the cwd the agent was started with (provisioned restart preserves the checkout)', async () => {
+        const spawn = install({agents: {a: agentDef('a')}, creds: {a: 'ghp_x'}});
+        FleetLifecycleService.start('a', {cwd: '/managed/a/neomjs-neo'});
+        await FleetLifecycleService.restart('a');
+
+        expect(spawn.calls).toHaveLength(2);
+        // The re-spawn re-uses the recorded cwd → it lands in the agent's checkout, not the FM dir
+        // (otherwise the checkout-path-keyed auto-memory would silently fork).
+        expect(spawn.calls[1].opts.cwd).toBe('/managed/a/neomjs-neo');
+    });
+
+    test('restart of a cwd-less agent re-spawns with no cwd (unchanged legacy behavior)', async () => {
+        const spawn = install({agents: {a: agentDef('a')}, creds: {a: 'ghp_x'}});
+        FleetLifecycleService.start('a');
+        await FleetLifecycleService.restart('a');
+
+        expect(spawn.calls[1].opts.cwd).toBeUndefined();
+    });
+
     test('listRunning reflects the running set', () => {
         install({agents: {a: agentDef('a'), b: agentDef('b')}, creds: {a: 'x', b: 'y'}});
         FleetLifecycleService.start('a');


### PR DESCRIPTION
Resolves #13344
Refs #13015
Refs #13049

`FleetLifecycleService.restart(id)` re-started with no `cwd`, so a provisioned agent restarted in the Fleet Manager's directory instead of its checkout — silently forking the checkout-path-keyed auto-memory (the path-keyed-memory class fixed for the *start* path in #13177). Latent today (only the spec called `restart`); the upcoming MCP-control-plane / settings-pane callers would hit it. `FleetManager.restartAgent` (#13338) already routes around it via the provisioned path — this closes the lower-level primitive for direct callers.

**Fix:** `start()` records the spawn `cwd` in the process record (both the running and the failed-spawn paths, uniform); `restart()` reads it back from the persisted record and re-supplies it to `start()`. A cwd-less agent restarts with no `cwd` (unchanged legacy behavior).

Evidence: L1 (unit-tested cwd-preservation + cwd-less-unchanged via the recording spawn stub) → L1 required (pure in-memory record / spawn-opts contract; no runtime-only surface). No residuals.

## Deltas from ticket (if any)
None — implemented exactly as scoped.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/FleetLifecycleService.spec.mjs`
→ **21 passed** (19 prior + 2 new):
1. `restart` re-spawns at the cwd the agent was started with — asserts `spawn.calls[1].opts.cwd` equals the original `/managed/a/neomjs-neo`.
2. restart of a cwd-less agent re-spawns with no `cwd` (unchanged legacy behavior).

## Post-Merge Validation
- [ ] None beyond CI — pure Node-side state, fully unit-covered.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-ada (Ada). Session 73156d71-9a96-4bf1-bbc8-d6487ca7dddd.
