### PR TITLE
fix(wake): migrate Codex subscription adapter (#13350)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -441,9 +441,9 @@ export const IDENTITIES = [
                 trigger: 'SENT_TO_ME',
                 harnessTarget: 'bridge-daemon',
                 harnessTargetMetadata: {
+                    adapter: 'codex-app-server',
                     appName: 'Codex',
-                    tabShortcut: null,
-                    focusSeedKey: 'r'
+                    tabShortcut: null
                 }
             },
             // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md §neo_gpt.

--- a/ai/scripts/migrations/migrateWakeSubscriptions.mjs
+++ b/ai/scripts/migrations/migrateWakeSubscriptions.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 /**
  * @summary One-shot migration script that patches legacy bridge-daemon wake subscriptions
- * to eliminate hardcoded fallbacks and adopt the identity template-based metadata.
+ * to eliminate hardcoded fallbacks and adopt identity-template-based route metadata.
  *
- * Legacy `bridge-daemon` wake subscriptions can contain hardcoded `appName`
- * fallbacks when their metadata was not seeded from the owning identity. This
+ * Legacy `bridge-daemon` wake subscriptions can contain hardcoded or stale
+ * route metadata when they were not seeded from the owning identity. This
  * script updates existing `WAKE_SUBSCRIPTION` nodes by pulling the canonical
- * `appName` from their owner's `AgentIdentity` template.
+ * explicit metadata from `identityRoots.mjs`, with the durable `AgentIdentity`
+ * row as a fallback for out-of-tree identities.
  *
  * **Usage**:
  *   node ai/scripts/migrations/migrateWakeSubscriptions.mjs             # dry-run (default)
@@ -17,6 +18,7 @@
 
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {IDENTITIES} from '../../graph/identityRoots.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -49,7 +51,24 @@ Options:
 `);
 }
 
-function runMigration(db, apply) {
+/**
+ * @summary Resolves the canonical wake route template for an AgentIdentity.
+ *
+ * `identityRoots.mjs` is the source of truth for first-party Neo identities; the durable graph row
+ * remains a fallback for local or out-of-tree identities that are not part of the committed roster.
+ *
+ * @param {String} agentId AgentIdentity node id.
+ * @param {Object} agentData Parsed durable AgentIdentity graph node.
+ * @returns {Object|undefined} Subscription template.
+ */
+function resolveSubscriptionTemplate(agentId, agentData) {
+    const sourceIdentity = IDENTITIES.find(identity => identity.id === agentId),
+          sourceTemplate = sourceIdentity?.properties?.subscriptionTemplate;
+
+    return sourceTemplate || agentData.properties?.subscriptionTemplate;
+}
+
+export function runMigration(db, apply) {
     const stats = {
         subscriptionsPatched: 0,
         subscriptionsSkipped: 0
@@ -97,24 +116,33 @@ function runMigration(db, apply) {
                 continue;
             }
 
-            const template = agentData.properties?.subscriptionTemplate;
+            const template = resolveSubscriptionTemplate(agentId, agentData);
             if (!template || !template.harnessTargetMetadata || !template.harnessTargetMetadata.appName) {
                 stats.subscriptionsSkipped++;
                 continue;
             }
 
-            const expectedAppName = template.harnessTargetMetadata.appName;
-            const expectedTabShortcut = template.harnessTargetMetadata.tabShortcut;
-            const currentMetadata = props.harnessTargetMetadata || {};
+            const expectedMetadata = template.harnessTargetMetadata,
+                  currentMetadata  = props.harnessTargetMetadata || {},
+                  metadataPatch    = {};
 
-            if (currentMetadata.appName !== expectedAppName || currentMetadata.tabShortcut !== expectedTabShortcut) {
-                console.log(`  [PATCH] Subscription ${sub.id} (Owner: ${agentId}) | appName: ${currentMetadata.appName || 'none'} → ${expectedAppName}, tabShortcut: ${currentMetadata.tabShortcut !== undefined ? currentMetadata.tabShortcut : 'none'} → ${expectedTabShortcut !== undefined ? expectedTabShortcut : 'none'}`);
+            for (const [key, value] of Object.entries(expectedMetadata)) {
+                if (currentMetadata[key] !== value) {
+                    metadataPatch[key] = value;
+                }
+            }
+
+            if (Object.keys(metadataPatch).length > 0) {
+                const delta = Object.entries(metadataPatch)
+                    .map(([key, value]) => `${key}: ${currentMetadata[key] !== undefined ? currentMetadata[key] : 'none'} → ${value !== undefined ? value : 'none'}`)
+                    .join(', ');
+
+                console.log(`  [PATCH] Subscription ${sub.id} (Owner: ${agentId}) | ${delta}`);
 
                 if (apply) {
                     props.harnessTargetMetadata = {
                         ...currentMetadata,
-                        appName: expectedAppName,
-                        tabShortcut: expectedTabShortcut
+                        ...metadataPatch
                     };
                     data.properties = props;
 
@@ -173,7 +201,9 @@ async function main() {
     }
 }
 
-main().catch(err => {
-    console.error('[migrateWakeSubscriptions] FATAL:', err);
-    process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main().catch(err => {
+        console.error('[migrateWakeSubscriptions] FATAL:', err);
+        process.exit(1);
+    });
+}

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -102,3 +102,24 @@ test.describe('ai/graph/identityRoots — model assignments', () => {
         });
     }
 });
+
+test.describe('ai/graph/identityRoots — Codex wake route', () => {
+    const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
+
+    test('@neo-gpt routes SENT_TO_ME wake delivery through the Codex app-server adapter (#13350)', () => {
+        const entry = findIdentity('@neo-gpt');
+
+        expect(entry, '@neo-gpt must be a registered AgentIdentity root').toBeTruthy();
+        expect(entry.properties.subscriptionTemplate).toMatchObject({
+            trigger              : 'SENT_TO_ME',
+            harnessTarget        : 'bridge-daemon',
+            harnessTargetMetadata: {
+                adapter    : 'codex-app-server',
+                appName    : 'Codex',
+                tabShortcut: null
+            }
+        });
+        expect(entry.properties.subscriptionTemplate.harnessTargetMetadata)
+            .not.toHaveProperty('focusSeedKey');
+    });
+});

--- a/test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs
@@ -1,0 +1,153 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MigrateWakeSubscriptionsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {runMigration} from '../../../../../../ai/scripts/migrations/migrateWakeSubscriptions.mjs';
+
+/**
+ * @summary Creates the minimal SQLite graph schema used by the wake-subscription migration.
+ * @param {Object} db Open better-sqlite3 connection.
+ */
+function createGraphSchema(db) {
+    db.exec(`
+        CREATE TABLE Nodes (
+            id TEXT PRIMARY KEY,
+            data TEXT NOT NULL
+        );
+    `);
+}
+
+/**
+ * @summary Inserts one graph node fixture into the in-memory database.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {Object} node Node row.
+ */
+function insertNode(db, node) {
+    db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)')
+        .run(node.id, JSON.stringify(node.data));
+}
+
+/**
+ * @summary Reads and parses a graph node fixture by id.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {String} id Node id.
+ * @returns {Object}
+ */
+function getNode(db, id) {
+    return JSON.parse(db.prepare('SELECT data FROM Nodes WHERE id = ?').get(id).data);
+}
+
+test.describe('ai/scripts/migrations/migrateWakeSubscriptions', () => {
+    test('migrates legacy Codex subscriptions from stale durable identity rows onto the source identity-root adapter (#13350)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        insertNode(db, {
+            id  : '@neo-gpt',
+            data: {
+                id        : '@neo-gpt',
+                label     : 'AgentIdentity',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: {
+                            appName: 'Codex'
+                        }
+                    }
+                }
+            }
+        });
+        insertNode(db, {
+            id  : 'WAKE_SUB:codex-legacy',
+            data: {
+                id        : 'WAKE_SUB:codex-legacy',
+                label     : 'WAKE_SUBSCRIPTION',
+                properties: {
+                    agentIdentity: '@neo-gpt',
+                    trigger: 'SENT_TO_ME',
+                    harnessTarget: 'bridge-daemon',
+                    harnessTargetMetadata: {
+                        appName: 'Codex',
+                        focusSeedKey: 'r'
+                    },
+                    status: 'active'
+                }
+            }
+        });
+
+        const stats = runMigration(db, true);
+        const migrated = getNode(db, 'WAKE_SUB:codex-legacy');
+
+        expect(stats.subscriptionsPatched).toBe(1);
+        expect(migrated.properties.harnessTargetMetadata).toMatchObject({
+            adapter: 'codex-app-server',
+            appName: 'Codex',
+            tabShortcut: null,
+            focusSeedKey: 'r'
+        });
+    });
+
+    test('dry-run reports adapter drift without mutating durable subscription rows (#13350)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        insertNode(db, {
+            id  : '@neo-gpt',
+            data: {
+                id        : '@neo-gpt',
+                label     : 'AgentIdentity',
+                properties: {
+                    subscriptionTemplate: {
+                        trigger: 'SENT_TO_ME',
+                        harnessTarget: 'bridge-daemon',
+                        harnessTargetMetadata: {
+                            adapter: 'codex-app-server',
+                            appName: 'Codex',
+                            tabShortcut: null
+                        }
+                    }
+                }
+            }
+        });
+        insertNode(db, {
+            id  : 'WAKE_SUB:codex-dry-run',
+            data: {
+                id        : 'WAKE_SUB:codex-dry-run',
+                label     : 'WAKE_SUBSCRIPTION',
+                properties: {
+                    agentIdentity: '@neo-gpt',
+                    trigger: 'SENT_TO_ME',
+                    harnessTarget: 'bridge-daemon',
+                    harnessTargetMetadata: {
+                        appName: 'Codex'
+                    },
+                    status: 'active'
+                }
+            }
+        });
+
+        const stats = runMigration(db, false);
+        const unchanged = getNode(db, 'WAKE_SUB:codex-dry-run');
+
+        expect(stats.subscriptionsPatched).toBe(1);
+        expect(unchanged.properties.harnessTargetMetadata).toEqual({
+            appName: 'Codex'
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -362,6 +362,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                         trigger: 'SENT_TO_ME',
                         harnessTarget: 'bridge-daemon',
                         harnessTargetMetadata: {
+                            adapter: 'codex-app-server',
                             appName: 'Codex',
                             tabShortcut: null
                         }
@@ -381,9 +382,11 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
                 const subscriptionNode = GraphService.db.nodes.get(res.subscriptionId);
                 expect(subscriptionNode.properties.trigger).toBe('SENT_TO_ME');
+                expect(subscriptionNode.properties.harnessTargetMetadata.adapter).toBe('codex-app-server');
                 expect(subscriptionNode.properties.harnessTargetMetadata.appName).toBe('Codex');
 
                 const hydratedIdentity = GraphService.db.nodes.get('@neo-gpt');
+                expect(hydratedIdentity.properties.subscriptionTemplate.harnessTargetMetadata.adapter).toBe('codex-app-server');
                 expect(hydratedIdentity.properties.subscriptionTemplate.harnessTargetMetadata.appName).toBe('Codex');
             });
         });


### PR DESCRIPTION
Resolves #13350

Related: #13287
Related: #13067

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

This patches the route-metadata drift that kept committed and durable Codex wake subscriptions on the platform-default `osascript` path after the `codex-app-server` adapter shipped. `@neo-gpt` now declares `adapter: 'codex-app-server'` in the committed identity template, and the wake-subscription migration now reconciles all explicit identity-template metadata keys from `identityRoots.mjs`, with durable `AgentIdentity` rows only as fallback for out-of-tree identities.

Evidence: L3 (focused unit suite plus real live-graph dry-run against the current SQLite graph, no mutation) -> L3 required (template/migration drift proof for #13350). No residuals for #13350; #13287 retains the L4 Codex UI submit/start-turn matrix.

## Deltas from ticket

- This work was discovered during #13287 intake, but #13287 cannot be closed by backend/template evidence alone. #13350 was filed as the exact close-target leaf for the template + migration slice.
- The migration intentionally preserves extra durable metadata fields such as legacy `focusSeedKey` when applying template metadata. The committed template drops `focusSeedKey`, but migration does not destructively erase live extras.
- The migration resolves first-party templates from source `identityRoots.mjs` instead of trusting durable `AgentIdentity` rows, because the live graph row itself can be stale.

## Test Evidence

- `PATH="/Users/Shared/codex/neomjs/neo/node_modules/.bin:$PATH" UNIT_TEST_MODE=true /Users/Shared/codex/neomjs/neo/node_modules/.bin/playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/graph/identityRoots.spec.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs` -> 68 passed.
- `git diff --check` -> passed.
- `node ai/scripts/migrations/migrateWakeSubscriptions.mjs --db /Users/Shared/codex/neomjs/neo/.neo-ai-data/sqlite/memory-core-graph.sqlite` -> dry-run reports two current `@neo-gpt` wake subscriptions would patch `adapter: none -> codex-app-server`; no changes applied.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; branch history contains only `ac29d961f fix(wake): migrate Codex subscription adapter (#13350)`.

## Post-Merge Validation

- [ ] Run the migration dry-run from an updated checkout and apply only during an operator-approved maintenance window.
- [ ] Continue #13287 L4 validation separately: pure-heartbeat, direct-message, and mixed-message+heartbeat Codex wake rows must still prove prompt lands, prompt submits, and turn starts without operator Enter.

## Commit

- `ac29d961f` — `fix(wake): migrate Codex subscription adapter (#13350)`
