### PR TITLE
feat(agentos): render first widget blueprint (#13353)

### DIFF
--- a/apps/agentos/childapps/widget/view/Viewport.mjs
+++ b/apps/agentos/childapps/widget/view/Viewport.mjs
@@ -1,8 +1,183 @@
 import BaseViewport from '../../../../../src/container/Viewport.mjs';
+import DataModel    from '../../../../../src/data/Model.mjs';
+import GridContainer from '../../../../../src/grid/Container.mjs';
+import Panel         from '../../../../../src/container/Panel.mjs';
+
+export const FIRST_WIDGET_BLUEPRINT_SCHEMA = 'neo.harness.firstWidget.v1';
+
+const
+    allowedBlueprintKeys = ['columns', 'liveState', 'rows', 'schema', 'summary', 'title'],
+    allowedColumnKeys    = ['cellAlign', 'dataField', 'flex', 'text', 'width'],
+    allowedLiveStateKeys = ['status', 'updatedAt'];
+
+/**
+ * @summary Deterministic constrained blueprint for the first H2 Agent Harness widget.
+ *
+ * The payload is deliberately plain data: no functions, no executable strings, and no framework class
+ * references. Later conversational leaves can swap the source of this blueprint, but this first leaf proves
+ * that a small serializable contract can become a live Neo grid pane.
+ * @type {Object}
+ */
+export const FIRST_WIDGET_BLUEPRINT = Object.freeze({
+    schema: FIRST_WIDGET_BLUEPRINT_SCHEMA,
+    title : 'Pipeline Snapshot',
+    summary: 'Static sample data rendered through a constrained blueprint contract.',
+    liveState: Object.freeze({
+        status   : 'live',
+        updatedAt: 'demo-seed'
+    }),
+    columns: Object.freeze([
+        Object.freeze({dataField: 'stage',      text: 'Stage',      flex: 1.4}),
+        Object.freeze({dataField: 'owner',      text: 'Owner',      flex: 1}),
+        Object.freeze({dataField: 'confidence', text: 'Confidence', width: 120}),
+        Object.freeze({dataField: 'nextStep',   text: 'Next step',  flex: 1.6})
+    ]),
+    rows: Object.freeze([
+        Object.freeze({id: 'lead-intake',       stage: 'Lead intake',       owner: 'Agent', confidence: '92%', nextStep: 'Qualify request'}),
+        Object.freeze({id: 'blueprint-emit',    stage: 'Blueprint emit',    owner: 'Agent', confidence: '88%', nextStep: 'Render live pane'}),
+        Object.freeze({id: 'human-review',      stage: 'Human review',      owner: 'Human', confidence: '81%', nextStep: 'Adjust data'}),
+        Object.freeze({id: 'write-through-plan', stage: 'Write-through plan', owner: 'Agent', confidence: '67%', nextStep: 'Future leaf'})
+    ])
+});
+
+/**
+ * @class AgentOSWidget.model.FirstWidgetRow
+ * @extends Neo.data.Model
+ *
+ * @summary Data model for the constrained first-widget blueprint rows.
+ */
+class FirstWidgetRowModel extends DataModel {
+    static config = {
+        /**
+         * @member {String} className='AgentOSWidget.model.FirstWidgetRow'
+         * @protected
+         */
+        className: 'AgentOSWidget.model.FirstWidgetRow',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: FIRST_WIDGET_BLUEPRINT.columns.map(column => ({
+            name: column.dataField,
+            type: 'String'
+        }))
+    }
+}
+
+export const FirstWidgetRow = Neo.setupClass(FirstWidgetRowModel);
+
+/**
+ * @summary Returns true when an object only carries keys from the allow-list.
+ * @param {Object} value Object to inspect.
+ * @param {String[]} allowedKeys Permitted keys.
+ * @returns {Boolean}
+ */
+function hasOnlyAllowedKeys(value, allowedKeys) {
+    return Object.keys(value).every(key => allowedKeys.includes(key))
+}
+
+/**
+ * @summary Validates the constrained first-widget blueprint payload.
+ * @param {Object} blueprint Candidate blueprint.
+ * @returns {Boolean}
+ */
+export function isValidFirstWidgetBlueprint(blueprint) {
+    if (!blueprint || typeof blueprint !== 'object' || !hasOnlyAllowedKeys(blueprint, allowedBlueprintKeys)) {
+        return false
+    }
+
+    const {columns, liveState, rows, schema, title} = blueprint;
+
+    if (schema !== FIRST_WIDGET_BLUEPRINT_SCHEMA || typeof title !== 'string' || !title.trim()) {
+        return false
+    }
+
+    if (blueprint.summary !== undefined && typeof blueprint.summary !== 'string') {
+        return false
+    }
+
+    if (!Array.isArray(columns) || columns.length === 0 || !Array.isArray(rows) || rows.length === 0) {
+        return false
+    }
+
+    if (liveState && (typeof liveState !== 'object' || !hasOnlyAllowedKeys(liveState, allowedLiveStateKeys))) {
+        return false
+    }
+
+    if (liveState && (
+        liveState.status !== undefined && typeof liveState.status !== 'string' ||
+        liveState.updatedAt !== undefined && typeof liveState.updatedAt !== 'string'
+    )) {
+        return false
+    }
+
+    const dataFields = new Set();
+
+    for (const column of columns) {
+        if (!column || typeof column !== 'object' || !hasOnlyAllowedKeys(column, allowedColumnKeys)) {
+            return false
+        }
+
+        if (typeof column.dataField !== 'string' || !column.dataField.trim() || typeof column.text !== 'string') {
+            return false
+        }
+
+        dataFields.add(column.dataField)
+    }
+
+    for (const row of rows) {
+        if (!row || typeof row !== 'object' || typeof row.id !== 'string' || !row.id.trim()) {
+            return false
+        }
+
+        const allowedRowKeys = new Set(['id', ...dataFields]);
+
+        if (!Object.keys(row).every(key => allowedRowKeys.has(key))) {
+            return false
+        }
+
+        for (const dataField of dataFields) {
+            if (row[dataField] !== undefined && typeof row[dataField] !== 'string') {
+                return false
+            }
+        }
+    }
+
+    return true
+}
+
+/**
+ * @summary Creates the live grid item config for the first-widget pane.
+ * @param {Object} blueprint Constrained first-widget blueprint.
+ * @returns {Object} Neo component config.
+ */
+export function createFirstWidgetGridItem(blueprint = FIRST_WIDGET_BLUEPRINT) {
+    if (!isValidFirstWidgetBlueprint(blueprint)) {
+        return {
+            ntype: 'component',
+            cls  : ['agent-first-widget-empty'],
+            html : 'First widget blueprint rejected.'
+        }
+    }
+
+    return {
+        module   : GridContainer,
+        cls      : ['agent-first-widget-grid'],
+        reference: 'first-widget-grid',
+        flex     : 1,
+        store    : {
+            keyProperty: 'id',
+            model      : FirstWidgetRow,
+            data       : blueprint.rows.map(row => ({...row}))
+        },
+        columns: blueprint.columns.map(column => ({...column}))
+    }
+}
 
 /**
  * @class AgentOSWidget.view.Viewport
  * @extends Neo.container.Viewport
+ *
+ * @summary First-widget child app viewport for the Agent Harness H2 live-blueprint proof.
  */
 class Viewport extends BaseViewport {
     static config = {
@@ -16,10 +191,34 @@ class Viewport extends BaseViewport {
          */
         additionalThemeFiles: ['AgentOS.view.Viewport'],
         /**
-         * @member {String[]} cls=['agent-os-viewport']
+         * @member {String[]} cls=['agent-os-viewport','agent-first-widget-viewport']
          * @reactive
          */
-        cls: ['agent-os-viewport']
+        cls: ['agent-os-viewport', 'agent-first-widget-viewport'],
+        /**
+         * @member {Object} containerConfig
+         */
+        containerConfig: {
+            layout: {ntype: 'vbox', align: 'stretch'}
+        },
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module : Panel,
+            cls    : ['agent-first-widget-panel'],
+            headers: [{
+                dock: 'top',
+                text: FIRST_WIDGET_BLUEPRINT.title
+            }],
+            items: [{
+                ntype: 'component',
+                cls  : ['agent-first-widget-blueprint-meta'],
+                flex : 'none',
+                height: 48,
+                html : `<span class="agent-first-widget-state">${FIRST_WIDGET_BLUEPRINT.liveState.status}</span>${FIRST_WIDGET_BLUEPRINT.summary}`
+            }, createFirstWidgetGridItem()]
+        }]
     }
 }
 

--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -90,6 +90,54 @@
             color : var(--agent-accent-swarm);
         }
     }
+
+    .agent-first-widget-panel.neo-panel {
+        background-color : var(--agent-surface-grid);
+        border           : 1px solid var(--agent-border);
+        min-height       : 360px;
+
+        .neo-panel-header {
+            background-color : var(--agent-bg-panel);
+            border-bottom    : 2px solid var(--agent-accent-grid);
+        }
+
+        .neo-panel-header-text {
+            color : var(--agent-accent-grid);
+        }
+    }
+
+    .agent-first-widget-blueprint-meta {
+        align-items      : center;
+        background-color : var(--agent-bg-panel);
+        border-bottom    : 1px solid var(--agent-border);
+        color            : var(--agent-text-secondary);
+        display          : flex;
+        flex             : none;
+        gap              : 12px;
+        min-height       : 44px;
+        padding          : 0 16px;
+    }
+
+    .agent-first-widget-state {
+        color          : var(--agent-state-live);
+        font-family    : var(--agent-font-mono);
+        font-weight    : 700;
+        text-transform : uppercase;
+    }
+
+    .agent-first-widget-grid {
+        background-color : var(--agent-surface-grid);
+        min-height       : 300px;
+    }
+
+    .agent-first-widget-empty {
+        align-items      : center;
+        background-color : var(--agent-surface-grid);
+        color            : var(--agent-state-muted);
+        display          : flex;
+        justify-content  : center;
+        min-height       : 300px;
+    }
 }
 
 @media (max-width: 560px) {

--- a/test/playwright/unit/apps/agentos/FirstWidgetViewport.spec.mjs
+++ b/test/playwright/unit/apps/agentos/FirstWidgetViewport.spec.mjs
@@ -1,0 +1,106 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSFirstWidgetViewportTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs';
+import path           from 'path';
+import {fileURLToPath} from 'url';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import Viewport, {
+    createFirstWidgetGridItem,
+    FIRST_WIDGET_BLUEPRINT,
+    FIRST_WIDGET_BLUEPRINT_SCHEMA,
+    isValidFirstWidgetBlueprint
+} from '../../../../../apps/agentos/childapps/widget/view/Viewport.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    repoRoot   = path.resolve(__dirname, '../../../../..'),
+    scssPath   = path.join(repoRoot, 'resources/scss/src/apps/agentos/Viewport.scss'),
+    viewportPath = path.join(repoRoot, 'apps/agentos/childapps/widget/view/Viewport.mjs');
+
+test.describe('AgentOSWidget.view.Viewport first-widget blueprint', () => {
+    test('accepts the constrained static first-widget blueprint', () => {
+        expect(FIRST_WIDGET_BLUEPRINT.schema).toBe(FIRST_WIDGET_BLUEPRINT_SCHEMA);
+        expect(isValidFirstWidgetBlueprint(FIRST_WIDGET_BLUEPRINT)).toBe(true)
+    });
+
+    test('rejects unknown executable or schema fields', () => {
+        expect(isValidFirstWidgetBlueprint({
+            ...FIRST_WIDGET_BLUEPRINT,
+            render: 'alert(1)'
+        })).toBe(false);
+
+        expect(isValidFirstWidgetBlueprint({
+            ...FIRST_WIDGET_BLUEPRINT,
+            schema: 'neo.harness.firstWidget.v2'
+        })).toBe(false);
+
+        expect(isValidFirstWidgetBlueprint({
+            ...FIRST_WIDGET_BLUEPRINT,
+            columns: [{...FIRST_WIDGET_BLUEPRINT.columns[0], renderer: 'danger'}]
+        })).toBe(false);
+
+        expect(isValidFirstWidgetBlueprint({
+            ...FIRST_WIDGET_BLUEPRINT,
+            summary: {html: '<script></script>'}
+        })).toBe(false);
+
+        expect(isValidFirstWidgetBlueprint({
+            ...FIRST_WIDGET_BLUEPRINT,
+            liveState: {...FIRST_WIDGET_BLUEPRINT.liveState, status: 1}
+        })).toBe(false);
+
+        expect(isValidFirstWidgetBlueprint({
+            ...FIRST_WIDGET_BLUEPRINT,
+            rows: [{...FIRST_WIDGET_BLUEPRINT.rows[0], nextStep: {html: '<script></script>'}}]
+        })).toBe(false)
+    });
+
+    test('creates a live grid component config from the blueprint', () => {
+        const gridItem = createFirstWidgetGridItem(FIRST_WIDGET_BLUEPRINT);
+
+        expect(gridItem.module?.prototype?.className).toBe('Neo.grid.Container');
+        expect(gridItem.reference).toBe('first-widget-grid');
+        expect(gridItem.store.data).toHaveLength(FIRST_WIDGET_BLUEPRINT.rows.length);
+        expect(gridItem.columns.map(column => column.dataField)).toEqual(
+            FIRST_WIDGET_BLUEPRINT.columns.map(column => column.dataField)
+        );
+        expect(JSON.stringify(gridItem)).not.toContain('alert')
+    });
+
+    test('fails closed to a bounded component for invalid blueprints', () => {
+        const item = createFirstWidgetGridItem({schema: 'invalid'});
+
+        expect(item.ntype).toBe('component');
+        expect(item.cls).toContain('agent-first-widget-empty');
+        expect(item.html).toContain('rejected')
+    });
+
+    test('viewport publishes the first-widget pane inside the child app shell', () => {
+        const source = fs.readFileSync(viewportPath, 'utf8');
+
+        expect(source).toContain("cls: ['agent-os-viewport', 'agent-first-widget-viewport']");
+        expect(source).toContain("cls    : ['agent-first-widget-panel']");
+        expect(source).toContain("reference: 'first-widget-grid'");
+        expect(source).toContain("layout: {ntype: 'vbox', align: 'stretch'}");
+        expect(source).toContain("flex : 'none'");
+        expect(source).toContain('height: 48')
+    });
+
+    test('stylesheet consumes the AgentOS grid surface tokens', () => {
+        const scss = fs.readFileSync(scssPath, 'utf8');
+
+        expect(scss).toContain('.agent-first-widget-panel');
+        expect(scss).toContain('var(--agent-surface-grid)');
+        expect(scss).toContain('var(--agent-accent-grid)');
+        expect(scss).toContain('var(--agent-state-live)')
+    })
+});


### PR DESCRIPTION
Resolves #13353
Related: #13349
Related: #13012

Authored by GPT-5.5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Renders the Agent Harness H2 first-widget child app as a live Neo grid pane from a constrained static blueprint. The implementation keeps the contract serializable and fail-closed: unknown executable fields, object-valued text fields, and invalid schemas are rejected before a grid config is produced.

Evidence: L3 (local Chromium smoke of the AgentOS widget child app plus focused and neighboring AgentOS unit coverage) -> L3 required (live child-app pane visual AC). No residual close-target ACs.

## Deltas from ticket
- Added an explicit `AgentOSWidget.model.FirstWidgetRow` model after browser smoke showed the grid shell rendered without cell data when using raw row objects only.
- Added a fixed-height, non-flexing meta row contract after visual smoke exposed excess vertical dead space above the grid.
- Structural fast-path audit was performed for the new unit spec: `test/playwright/unit/apps/agentos/FirstWidgetViewport.spec.mjs` matches the existing `test/playwright/unit/apps/agentos/*.spec.mjs` sibling pattern; no map or ADR update needed.

## Test Evidence
- `PATH="/Users/Shared/codex/neomjs/neo/node_modules/.bin:$PATH" UNIT_TEST_MODE=true /Users/Shared/codex/neomjs/neo/node_modules/.bin/playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos/FirstWidgetViewport.spec.mjs` -> 6 passed.
- `PATH="/Users/Shared/codex/neomjs/neo/node_modules/.bin:$PATH" UNIT_TEST_MODE=true /Users/Shared/codex/neomjs/neo/node_modules/.bin/playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos/FirstWidgetViewport.spec.mjs test/playwright/unit/apps/agentos/FleetSettingsPanel.spec.mjs test/playwright/unit/apps/agentos/DockPreview.spec.mjs` -> 46 passed.
- `git diff --check` and `git diff --cached --check` -> clean.
- `node ./buildScripts/build/themes.mjs -f -n -t all -e dev` -> succeeded for local style generation before browser smoke.
- Local Chromium smoke at the AgentOS widget child app confirmed title `Pipeline Snapshot`, panel present, grid present, 4 rendered rows, meta height 48, grid top 79.

Residual during local smoke: the dev server still emitted the FontAwesome stylesheet MIME warning and one generic `undefined` console error. This PR does not touch that loader path, and the first-widget pane rendered correctly despite those existing app/server warnings.

## Post-Merge Validation
- [ ] Open the AgentOS widget child app and confirm the Pipeline Snapshot pane renders the live blueprint grid with four rows.

## Commits
- d83d2fb38 — `feat(agentos): render first widget blueprint (#13353)`