### PR TITLE
test(ai): shared openRawAgent + fixture-derived bridge port for WriteGuard e2es (#13330)

### DIFF
--- a/test/playwright/e2e/WriteGuardDisconnectReleaseNL.spec.mjs
+++ b/test/playwright/e2e/WriteGuardDisconnectReleaseNL.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures.mjs';
-import WebSocket        from 'ws';
+import { openRawAgent } from '../util/rawAgent.mjs';
 
 /**
  * @summary Live e2e proof that a writer's disconnect RELEASES its held WriteGuard lock, re-admitting an
@@ -37,15 +37,16 @@ test.describe('WriteGuard disconnect-release (live e2e)', () => {
 
         // writer-1 is established + HOLDING before writer-2 exists — the deterministic ordering (a back-to-back
         // open races the lock acquisition). The Bridge mints writer-1 a distinct sessionId for the connection.
-        const writer1 = await openRawAgent(BRIDGE_PORT, 'wg-disc-writer-1');
-        const acquired = await writer1.call(app.sessionId, 'set_instance_properties',
-            { id: componentA, properties: { text: 'writer-1-holds-A' } });
-        expect(acquired.error, 'writer-1 acquires + holds the lock on A').toBeFalsy();
-
-        // writer-2 — a distinct raw agent — only now connects and writes the SAME subtree.
-        const writer2 = await openRawAgent(BRIDGE_PORT, 'wg-disc-writer-2');
-
+        let writer1, writer2;
         try {
+            writer1 = await openRawAgent(neuralLink.bridgePort, 'wg-disc-writer-1');
+            const acquired = await writer1.call(app.sessionId, 'set_instance_properties',
+                { id: componentA, properties: { text: 'writer-1-holds-A' } });
+            expect(acquired.error, 'writer-1 acquires + holds the lock on A').toBeFalsy();
+
+            // writer-2 — a distinct raw agent — only now connects and writes the SAME subtree.
+            writer2 = await openRawAgent(neuralLink.bridgePort, 'wg-disc-writer-2');
+
             // (1) Overlapping write while writer-1 holds the lock → DENIED (conflict).
             const denied = await writer2.call(app.sessionId, 'set_instance_properties',
                 { id: componentA, properties: { text: 'writer-2-blocked' } });
@@ -54,79 +55,21 @@ test.describe('WriteGuard disconnect-release (live e2e)', () => {
             // writer-1 disconnects → Bridge agent_disconnected (sessionId-stamped to the app) → releaseAgent.
             writer1.close();
 
-            // (2) Once the lock is swept, writer-2's retry of the same subtree is ADMITTED.
+            // (2) Once the lock is swept, writer-2's retry of the same subtree is ADMITTED. The polled value
+            // carries the deny reason, so an admit-poll timeout names WHY it stayed denied in the diff.
             await expect.poll(async () => {
                 const res = await writer2.call(app.sessionId, 'set_instance_properties',
                     { id: componentA, properties: { text: 'writer-2-after-release' } });
-                return res.error ? 'denied' : 'admitted';
+                return res.error ? `denied: ${res.error.message ?? JSON.stringify(res.error)}` : 'admitted';
             }, {
                 message: 'writer-2 must be admitted once writer-1 disconnects and its lock is released',
                 timeout: 15000
             }).toBe('admitted');
         } finally {
-            writer2.close();
+            // Guard BOTH raw-ws writers: writer-1's close() above is the release trigger, but if an assertion
+            // throws before it, this prevents a leaked socket — a double close() is a safe no-op.
+            writer1?.close();
+            writer2?.close();
         }
     });
 });
-
-/** Bridge default port — see `ai/mcp/server/neural-link/Bridge.mjs`. */
-const BRIDGE_PORT = 8081;
-
-/**
- * Opens a raw agent connection to the live Neural Link Bridge — a distinct writer identity. The Bridge
- * accepts a `role=agent&id=` connection (no token = dev path), mints a per-connection `sessionId`, and
- * stamps the `agent_message` sidecar on every forward, so writes from this socket carry the
- * `(agentId, sessionId)` the WriteGuard keys locks on.
- *
- * @param {Number} port
- * @param {String} agentId A distinct agent id for this writer.
- * @returns {Promise<{call: Function, close: Function}>}
- */
-async function openRawAgent(port, agentId) {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}?role=agent&id=${encodeURIComponent(agentId)}`);
-
-    await new Promise((resolve, reject) => {
-        ws.on('open',  resolve);
-        ws.on('error', reject);
-    });
-
-    let nextId = 1;
-
-    return {
-        /**
-         * Sends a JSON-RPC method to the target App Worker over this raw agent socket and resolves with the
-         * App Worker's response (success or jsonrpc error), matched by request id, tolerating a bare frame
-         * or a `{message: <response>}` envelope.
-         */
-        call(targetSessionId, method, params) {
-            const id = nextId++;
-            return new Promise((resolve, reject) => {
-                const timer = setTimeout(() => {
-                    ws.off('message', onMessage);
-                    reject(new Error(`raw-agent call ${method} (#${id}) timed out`));
-                }, 15000);
-
-                const onMessage = data => {
-                    let frame;
-                    try { frame = JSON.parse(data.toString()); } catch { return; }
-                    const msg = frame?.message ?? frame;
-                    if (msg && msg.id === id) {
-                        clearTimeout(timer);
-                        ws.off('message', onMessage);
-                        resolve(msg);
-                    }
-                };
-
-                ws.on('message', onMessage);
-                ws.send(JSON.stringify({
-                    target : targetSessionId,
-                    message: { jsonrpc: '2.0', method, params, id }
-                }));
-            });
-        },
-
-        close() {
-            ws.close();
-        }
-    };
-}

--- a/test/playwright/e2e/WriteGuardMultiWriterNL.spec.mjs
+++ b/test/playwright/e2e/WriteGuardMultiWriterNL.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures.mjs';
-import WebSocket        from 'ws';
+import { openRawAgent } from '../util/rawAgent.mjs';
 
 /**
  * @summary LIVE two-writer proof for the multi-writer WriteGuard enforcement (the umbrella-closure proof) —
@@ -21,17 +21,17 @@ import WebSocket        from 'ws';
  * A control write by writer-2 to a sibling B → ADMITTED (no overlap) — proving writer-2's writes succeed
  * absent a conflict, so the deny on A is a genuine cross-writer conflict, not a broken writer-2.
  *
+ * Verifies the full path fires end-to-end — writer-1's `set_instance_properties` holds the lock; writer-2's
+ * overlapping write returns the jsonrpc error `-32603 "Write denied for <id>: conflict (held by <agentId> /
+ * <sessionId>)"` from `InstanceService.assertWritable`; writer-2's sibling write returns
+ * `{result:{success:true}}`. The raw-`ws` response arrives as a `{type:'app_message', message:<jsonrpc>}`
+ * frame, matched by request id.
+ *
  * ⚠️ REQUIRES A FRESH BRIDGE. A long-running bridge predating the `agent_message` sidecar-emit merge
  * forwards BARE frames → enforcement silently no-ops → writer-2's A write would wrongly ADMIT. CI (clean
  * port) spawns a fresh bridge from source via `ConnectionService.spawnBridge`. LOCALLY, kill any
- * neural-link bridge on :8081 first. A step-2 ADMIT (instead of deny) most likely means a stale bridge,
- * not a logic regression — a stale bridge fails the conflict assertion for an environment reason.
- *
- * LIVE-VERIFIED (fresh bridge, headless chromium): the full path fires end-to-end — writer-1's
- * `set_instance_properties` on `neo-button-1` holds the lock; writer-2's overlapping write returns the
- * jsonrpc error `-32603 "Write denied for <id>: conflict (held by <agentId> / <sessionId>)"` from
- * `InstanceService.assertWritable`; writer-2's sibling write returns `{result:{success:true}}`. The raw-`ws`
- * response arrives as a `{type:'app_message', message:<jsonrpc>}` frame, matched by request id below.
+ * neural-link bridge on the configured port first. A step-2 ADMIT (instead of deny) most likely means a
+ * stale bridge, not a logic regression — a stale bridge fails the conflict assertion for an environment reason.
  */
 test.describe('WriteGuard multi-writer enforcement (live two-writer e2e)', () => {
     test.setTimeout(90000);
@@ -71,7 +71,7 @@ test.describe('WriteGuard multi-writer enforcement (live two-writer e2e)', () =>
         await app.setProperties(componentA, { text: 'writer-1-holds-A' });
 
         // writer-2 — a RAW second agent ws with a DISTINCT identity (the bridge mints its own sessionId).
-        const writer2 = await openRawAgent(BRIDGE_PORT, 'neo-writer-2');
+        const writer2 = await openRawAgent(neuralLink.bridgePort, 'neo-writer-2');
 
         try {
             // (1) Overlapping write — same component A, different writer → DENIED (conflict).
@@ -92,65 +92,3 @@ test.describe('WriteGuard multi-writer enforcement (live two-writer e2e)', () =>
         }
     });
 });
-
-/** Bridge default port — see `ai/mcp/server/neural-link/Bridge.mjs` (`port: 8081`). */
-const BRIDGE_PORT = 8081;
-
-/**
- * Opens a raw second agent connection to the live Neural Link Bridge — a writer identity DISTINCT from
- * the fixture's writer-1. The Bridge accepts a `role=agent&id=` connection (no token = dev path), mints a
- * per-connection `sessionId`, and stamps the `agent_message` sidecar on every forward, so writes from
- * this socket carry a `(agentId, sessionId)` the WriteGuard sees as a separate writer.
- *
- * @param {Number} port
- * @param {String} agentId A distinct agent id for this writer.
- * @returns {Promise<{call: Function, close: Function}>}
- */
-async function openRawAgent(port, agentId) {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}?role=agent&id=${encodeURIComponent(agentId)}`);
-
-    await new Promise((resolve, reject) => {
-        ws.on('open',  resolve);
-        ws.on('error', reject);
-    });
-
-    let nextId = 1;
-
-    return {
-        /**
-         * Sends a JSON-RPC method to the target App Worker over this raw agent socket and resolves with the
-         * App Worker's response (success or jsonrpc error). The Bridge routes the response back to this
-         * socket; we match by request id, tolerating a bare response or a `{message: <response>}` envelope.
-         */
-        call(targetSessionId, method, params) {
-            const id = nextId++;
-            return new Promise((resolve, reject) => {
-                const timer = setTimeout(() => {
-                    ws.off('message', onMessage);
-                    reject(new Error(`raw-agent call ${method} (#${id}) timed out`));
-                }, 15000);
-
-                const onMessage = data => {
-                    let frame;
-                    try { frame = JSON.parse(data.toString()); } catch { return; }
-                    const msg = frame?.message ?? frame;
-                    if (msg && msg.id === id) {
-                        clearTimeout(timer);
-                        ws.off('message', onMessage);
-                        resolve(msg);
-                    }
-                };
-
-                ws.on('message', onMessage);
-                ws.send(JSON.stringify({
-                    target : targetSessionId,
-                    message: { jsonrpc: '2.0', method, params, id }
-                }));
-            });
-        },
-
-        close() {
-            ws.close();
-        }
-    };
-}

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -8,6 +8,7 @@ import {
     NeuralLink_RuntimeService,
     NeuralLink_InteractionService
 } from '../../ai/services.mjs';
+import aiConfig from '../../ai/mcp/server/neural-link/config.mjs';
 
 export const test = base.extend({
     /**
@@ -82,6 +83,14 @@ export const test = base.extend({
 
         // 2. Define the Neural Link Fixture object
         const nl = {
+            /**
+             * The live Neural Link Bridge port the fixture's `ConnectionService` connected (or spawned) on —
+             * the canonical `aiConfig.port`, NOT the hardcoded `:8081` literal the WriteGuard e2es used to
+             * carry. Raw-agent writers (`openRawAgent`) target the SAME Bridge the fixture uses via this.
+             * @member {Number} bridgePort
+             */
+            bridgePort: aiConfig.port,
+
             /**
              * Waits for the Test's specific App Worker to connect to the Bridge and returns an SDK wrapper.
              *

--- a/test/playwright/util/rawAgent.mjs
+++ b/test/playwright/util/rawAgent.mjs
@@ -1,0 +1,71 @@
+import WebSocket from 'ws';
+
+/**
+ * Opens a raw `role=agent` WebSocket connection to the live Neural Link Bridge — a writer identity
+ * DISTINCT from the fixture's primary `ConnectionService` writer. The Bridge accepts a `role=agent&id=`
+ * connection (no token = dev path), mints a per-connection `sessionId`, and stamps the `agent_message`
+ * sidecar on every forward, so writes from this socket carry the `(agentId, sessionId)` pair the
+ * `WriteGuard` keys locks on — i.e. a genuinely separate writer for multi-writer / disconnect-release proofs.
+ *
+ * Shared by the WriteGuard live e2es (`WriteGuardMultiWriterNL`, `WriteGuardDisconnectReleaseNL`). Pass the
+ * fixture-derived `neuralLink.bridgePort` so the raw writer targets the SAME Bridge the fixture connected
+ * (or spawned) on, rather than a hardcoded `:8081` literal.
+ *
+ * @param {Number} port    The live Bridge port — pass `neuralLink.bridgePort`.
+ * @param {String} agentId A distinct agent id for this writer.
+ * @returns {Promise<{call: Function, close: Function}>} A thin client: `call(targetSessionId, method, params)`
+ * resolves with the App Worker's id-matched response (success or jsonrpc error); `close()` drops the socket.
+ */
+export async function openRawAgent(port, agentId) {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}?role=agent&id=${encodeURIComponent(agentId)}`);
+
+    await new Promise((resolve, reject) => {
+        ws.on('open',  resolve);
+        ws.on('error', reject);
+    });
+
+    let nextId = 1;
+
+    return {
+        /**
+         * Sends a JSON-RPC method to the target App Worker over this raw agent socket and resolves with the
+         * App Worker's response (success or jsonrpc error), matched by request id, tolerating a bare frame
+         * or a `{message: <response>}` envelope.
+         * @param {String} targetSessionId
+         * @param {String} method
+         * @param {Object} params
+         * @returns {Promise<Object>}
+         */
+        call(targetSessionId, method, params) {
+            const id = nextId++;
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    ws.off('message', onMessage);
+                    reject(new Error(`raw-agent call ${method} (#${id}) timed out`));
+                }, 15000);
+
+                const onMessage = data => {
+                    let frame;
+                    try { frame = JSON.parse(data.toString()); } catch { return; }
+                    const msg = frame?.message ?? frame;
+                    if (msg && msg.id === id) {
+                        clearTimeout(timer);
+                        ws.off('message', onMessage);
+                        resolve(msg);
+                    }
+                };
+
+                ws.on('message', onMessage);
+                ws.send(JSON.stringify({
+                    target : targetSessionId,
+                    message: { jsonrpc: '2.0', method, params, id }
+                }));
+            });
+        },
+
+        /** Closes the raw agent socket — the Bridge `agent_disconnected` sweep then releases any held locks. */
+        close() {
+            ws.close();
+        }
+    };
+}


### PR DESCRIPTION
Resolves #13330

Batches the five non-blocking test-quality follow-ups from the #13294 (deny-while-held) and #13325 (release-on-disconnect) WriteGuard-e2e review threads into one shared cleanup — DRY-ing the now-duplicated `openRawAgent` raw-`ws` helper and dropping the hardcoded `:8081` coupling, with no runtime behavior change. Net **−39 lines** (two ~50-line duplicated helpers collapse into one shared 71-line util).

Evidence: L1 (static refactor — `node --check` ×4, shared-helper import/export smoke, `aiConfig.port`→`8081` in the services-loaded order the fixture reads it, no leftover `BRIDGE_PORT`/`ws`/local-helper refs) → L3 achievable only manually (the WriteGuard deny+release behavior; these playwright e2es are not CI-run). Behavior unchanged and already live-proven in #13294 / #13325. No residuals.

## Deltas from ticket (if any)
- The fixture-derived-port fix (the ticket's AC 2) was gated on #13299 (test-isolated fresh Bridge); #13299 merged earlier today, so the gate is cleared and all 5 ACs ship here rather than splitting off a port follow-up.
- The shared `openRawAgent(port, agentId)` keeps an explicit `port` param (the spec passes `neuralLink.bridgePort`) rather than deriving the port inside the helper — keeps the helper a pure `ws` function and the port visible at the call site. The fixture exposes `bridgePort: aiConfig.port` (ADR-0019 resolved-leaf read at the use site; `check-aiconfig-test-mutation` passes).

## Test Evidence
- `node --check` — clean on all 4 files.
- Shared-helper smoke: `import('test/playwright/util/rawAgent.mjs')` → exports `['openRawAgent']`.
- Port-fix data path: `aiConfig.port` resolves to `8081` (number) in the `services.mjs`→`config.mjs` load order the fixture uses (Neo + Provider initialized).
- Structural: no leftover `BRIDGE_PORT` / `ws` import / local `openRawAgent` in either spec; no trailing whitespace; no ticket `#refs` in durable JSDoc; all 4 pre-commit hooks green (incl. `check-aiconfig-test-mutation`).
- Behavior-preserving: the extracted helper is byte-identical to the two prior copies; the only deltas are strictly additive cleanup — a `finally`-guard covering both raw writers, a deny-reason-carrying admit-poll value, and a config-derived port whose value is still `8081`.
- The deny + release behavior these specs exercise was already live-proven in #13294 + #13325; they are manual/local L3 e2es (fresh Bridge + served app + browser; not in the neo CI playwright run), so not re-run here.

## Post-Merge Validation
- [ ] Local L3 re-run of both WriteGuard NL e2es against a fresh Bridge — deny-while-held + release-on-disconnect both green via the shared helper + `neuralLink.bridgePort`.

## Commits
- `73f3c47d7` — shared `openRawAgent` + fixture-derived bridge port for the WriteGuard e2es (all 5 ACs)

---
Authored by Claude Opus 4.8 (1M context), @neo-opus-ada (Ada). Session 471435c5-9f55-4a85-8b73-0e6192ec31a5.
