### PR TITLE
fix(orchestrator): split miniSummary from kbSync backpressure (#13358)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/picker.mjs
+++ b/ai/daemons/orchestrator/scheduling/picker.mjs
@@ -7,7 +7,7 @@
  *
  * Stage order (matters — earlier stages narrow the candidate set before later stages):
  *   1. `filterAlreadyRunning`           — drop candidates whose task is already in `runningTasks`
- *   2. `filterExclusiveHeavyConflict`   — drop heavy candidates if another heavy is running
+ *   2. `filterExclusiveHeavyConflict`   — drop heavy candidates if a conflicting heavy is running
  *   3. `filterUnmetDependencies`        — drop candidates whose `dependencies` are in `runningTasks`
  *   4. `selectFirstCandidate`           — pick the first remaining (registry-order priority)
  *
@@ -23,8 +23,7 @@
  * @param {Array<Object>} options.candidates Due candidates from `collectDueCandidates`.
  * @param {Set<String>|Array<String>} options.runningTasks Task names currently running
  *   (derived from the current task-state snapshot).
- * @param {Object} options.policyContext Additional policy state (currently unused;
- *   reserved for future deployment-profile + cross-daemon-lease integration).
+ * @param {Object} options.policyContext Additional policy state.
  * @returns {Object|null} The winning candidate, or null if no candidate survives the pipeline.
  */
 export function pickNextCandidate({candidates, runningTasks, policyContext = {}}) {
@@ -56,14 +55,16 @@ function filterAlreadyRunning(candidates, runningSet) {
 }
 
 /**
- * Heavy-class candidates (`maintenanceClass: 'heavy'`) require exclusive heavy access.
- * If ANY task with `maintenanceClass: 'heavy'` is already running, drop all heavy
- * candidates from this poll cycle.
+ * Heavy-class candidates (`maintenanceClass: 'heavy'`) require exclusive heavy access
+ * unless the policy service declares the running/candidate pair compatible.
  *
  * The caller must pre-compute `runningHeavyTasks` (a Set of currently-running task names
  * whose descriptors carry `maintenanceClass: 'heavy'`) and pass it via `policyContext`.
  * The picker cannot derive this from `runningSet` alone because running tasks are just
  * names — they have no descriptor metadata. The caller owns the registry lookup.
+ *
+ * When `policyContext.isHeavyMaintenanceConflict` is absent, this preserves the legacy
+ * conservative behavior: any other running heavy task blocks the heavy candidate.
  *
  * Lightweight, continuous, and graph-dependent candidates are unaffected by this filter.
  */
@@ -71,7 +72,19 @@ function filterExclusiveHeavyConflict(candidates, policyContext) {
     const runningHeavy = policyContext.runningHeavyTasks;
     if (!runningHeavy || runningHeavy.size === 0) return candidates;
 
-    return candidates.filter(candidate => candidate.descriptor.maintenanceClass !== 'heavy');
+    return candidates.filter(candidate => {
+        if (candidate.descriptor.maintenanceClass !== 'heavy') return true;
+
+        for (const runningTaskName of runningHeavy) {
+            if (runningTaskName === candidate.taskName) continue;
+            const isConflict = typeof policyContext.isHeavyMaintenanceConflict === 'function'
+                ? policyContext.isHeavyMaintenanceConflict(candidate.taskName, runningTaskName)
+                : true;
+            if (isConflict) return false;
+        }
+
+        return true;
+    });
 }
 
 /**

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -115,14 +115,21 @@ export function runSchedulingPipeline({registry, context, services, runtime}) {
     const winner = pickNextCandidate({
         candidates,
         runningTasks  : runningTaskNames,
-        policyContext : {runningHeavyTasks}
+        policyContext : {
+            runningHeavyTasks,
+            isHeavyMaintenanceConflict: services.maintenanceBackpressureService.isHeavyMaintenanceConflict?.bind(
+                services.maintenanceBackpressureService
+            )
+        }
     });
 
     if (winner) {
         executeCandidate({
             candidate: winner,
             activeHeavyTask: {
-                name: services.maintenanceBackpressureService.getActiveHeavyMaintenanceTask()
+                name: services.maintenanceBackpressureService.getActiveHeavyMaintenanceTask({
+                    candidateTaskName: winner.taskName
+                })
             },
             services,
             runtime
@@ -181,10 +188,15 @@ export function recordPickerDeferrals({
     maintenanceBackpressureService
 }) {
     const runningSet        = new Set(runningTaskNames);
-    const blockingHeavyTask = runningHeavyTasks.values().next().value;
 
     for (const candidate of candidates) {
         if (runningSet.has(candidate.taskName)) continue;
+
+        const blockingHeavyTask = findBlockingHeavyTask({
+            candidate,
+            runningHeavyTasks,
+            maintenanceBackpressureService
+        });
 
         if (blockingHeavyTask && candidate.descriptor.maintenanceClass === 'heavy') {
             maintenanceBackpressureService.recordDeferral({
@@ -208,6 +220,30 @@ export function recordPickerDeferrals({
             });
         }
     }
+}
+
+/**
+ * @param {Object} options
+ * @param {Object} options.candidate Scheduling candidate.
+ * @param {Set<String>} options.runningHeavyTasks Running heavy task names.
+ * @param {Object} options.maintenanceBackpressureService Backpressure policy service.
+ * @returns {String|null}
+ */
+function findBlockingHeavyTask({candidate, runningHeavyTasks, maintenanceBackpressureService}) {
+    if (candidate.descriptor.maintenanceClass !== 'heavy') return null;
+
+    for (const runningTaskName of runningHeavyTasks) {
+        if (runningTaskName === candidate.taskName) continue;
+        if (typeof maintenanceBackpressureService.isHeavyMaintenanceConflict === 'function') {
+            if (maintenanceBackpressureService.isHeavyMaintenanceConflict(candidate.taskName, runningTaskName)) {
+                return runningTaskName;
+            }
+            continue;
+        }
+        return runningTaskName;
+    }
+
+    return null;
 }
 
 /**

--- a/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
+++ b/ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs
@@ -26,6 +26,18 @@ export const DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES = Object.freeze([
 ]);
 
 /**
+ * Heavy-maintenance pairs whose resource envelopes are compatible enough to run
+ * concurrently. This is intentionally narrow: Memory Core miniSummary backfill
+ * must not wait behind local-only KB embedding work, while every other heavy task
+ * pair keeps the historical single-heavy invariant.
+ *
+ * @type {ReadonlyArray<ReadonlyArray<String>>}
+ */
+export const DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS = Object.freeze([
+    Object.freeze(['kbSync', 'memory-summary-backfill'])
+]);
+
+/**
  * Tasks whose graph writes must complete before Golden Path frontier refresh runs.
  *
  * @type {ReadonlyArray<String>}
@@ -63,21 +75,51 @@ export function isGoldenPathDependencyTask({taskName, goldenPathDependencyTaskNa
 }
 
 /**
- * @summary Finds the first running heavy-maintenance task other than the excluded one.
+ * @summary Checks whether two heavy-maintenance tasks are a documented compatible pair.
+ *
+ * @param {Object} options
+ * @param {String|null|undefined} options.taskName Stable orchestrator task name.
+ * @param {String|null|undefined} options.otherTaskName Stable orchestrator task name.
+ * @param {ReadonlyArray<ReadonlyArray<String>>} options.compatibleHeavyMaintenanceTaskPairs Pair allow-list.
+ * @returns {Boolean}
+ */
+export function areHeavyMaintenanceTasksCompatible({
+    taskName,
+    otherTaskName,
+    compatibleHeavyMaintenanceTaskPairs = []
+}) {
+    if (!taskName || !otherTaskName || taskName === otherTaskName) return false;
+
+    return compatibleHeavyMaintenanceTaskPairs.some(pair => (
+        pair.includes(taskName) && pair.includes(otherTaskName)
+    ));
+}
+
+/**
+ * @summary Finds the first running heavy-maintenance task that conflicts with a candidate.
  *
  * @param {Object} options
  * @param {ReadonlyArray<String>} options.heavyMaintenanceTaskNames Heavy-classification set.
  * @param {Object} options.taskStateService Service exposing `getTaskState(name)`.
  * @param {String|null} [options.excludeTaskName=null] Task name to ignore.
+ * @param {String|null} [options.candidateTaskName=null] Candidate task whose compatibility is checked.
+ * @param {ReadonlyArray<ReadonlyArray<String>>} [options.compatibleHeavyMaintenanceTaskPairs=[]] Pair allow-list.
  * @returns {String|null}
  */
 export function getActiveHeavyMaintenanceTask({
     heavyMaintenanceTaskNames,
     taskStateService,
-    excludeTaskName = null
+    excludeTaskName = null,
+    candidateTaskName = null,
+    compatibleHeavyMaintenanceTaskPairs = []
 }) {
     for (const taskName of heavyMaintenanceTaskNames) {
         if (taskName === excludeTaskName) continue;
+        if (areHeavyMaintenanceTasksCompatible({
+            taskName: candidateTaskName,
+            otherTaskName: taskName,
+            compatibleHeavyMaintenanceTaskPairs
+        })) continue;
         if (taskStateService.getTaskState(taskName)?.running) return taskName;
     }
     return null;
@@ -230,6 +272,11 @@ export function recordDeferral({
  * replace them. Lease IO (acquire / release / inspect) remains in that service; this
  * service owns the policy of WHEN to acquire, defer, or record.
  *
+ * `DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS` is the only compatibility
+ * allow-list. It exists so local-only `kbSync` embedding work cannot starve Memory
+ * Core miniSummary backfill. Any future pair must be justified explicitly at this
+ * policy surface instead of weakening the whole heavy-maintenance mutex.
+ *
  * @class Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureService
  * @extends Neo.core.Base
  */
@@ -245,6 +292,11 @@ export class MaintenanceBackpressureService extends Base {
          * @reactive
          */
         heavyMaintenanceTaskNames_: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+        /**
+         * @member {ReadonlyArray<ReadonlyArray<String>>} compatibleHeavyMaintenanceTaskPairs_=DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+         * @reactive
+         */
+        compatibleHeavyMaintenanceTaskPairs_: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS,
         /**
          * @member {ReadonlyArray<String>} goldenPathDependencyTaskNames_=DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
          * @reactive
@@ -317,15 +369,43 @@ export class MaintenanceBackpressureService extends Base {
     }
 
     /**
+     * @param {String} taskName Stable orchestrator task name.
+     * @param {String|null|undefined} otherTaskName Stable orchestrator task name.
+     * @returns {Boolean}
+     */
+    areHeavyMaintenanceTasksCompatible(taskName, otherTaskName) {
+        return areHeavyMaintenanceTasksCompatible({
+            taskName,
+            otherTaskName,
+            compatibleHeavyMaintenanceTaskPairs: this.compatibleHeavyMaintenanceTaskPairs
+        });
+    }
+
+    /**
+     * @param {String} taskName Candidate heavy-maintenance task name.
+     * @param {String|null|undefined} otherTaskName Running or lease-holding task name.
+     * @returns {Boolean}
+     */
+    isHeavyMaintenanceConflict(taskName, otherTaskName) {
+        if (!taskName || !otherTaskName || taskName === otherTaskName) return false;
+        return this.isHeavyMaintenanceTask(taskName)
+            && this.isHeavyMaintenanceTask(otherTaskName)
+            && !this.areHeavyMaintenanceTasksCompatible(taskName, otherTaskName);
+    }
+
+    /**
      * @param {Object} [options]
      * @param {String|null} [options.excludeTaskName=null]
+     * @param {String|null} [options.candidateTaskName=null]
      * @returns {String|null}
      */
-    getActiveHeavyMaintenanceTask({excludeTaskName = null} = {}) {
+    getActiveHeavyMaintenanceTask({excludeTaskName = null, candidateTaskName = null} = {}) {
         return getActiveHeavyMaintenanceTask({
             heavyMaintenanceTaskNames: this.heavyMaintenanceTaskNames,
             taskStateService         : this.taskStateService,
-            excludeTaskName
+            excludeTaskName,
+            candidateTaskName,
+            compatibleHeavyMaintenanceTaskPairs: this.compatibleHeavyMaintenanceTaskPairs
         });
     }
 
@@ -419,9 +499,16 @@ export class MaintenanceBackpressureService extends Base {
             return executeFn(taskName, reason, onSuccess);
         }
 
-        const blockingTaskName = activeHeavyTask?.name && activeHeavyTask.name !== taskName
+        let blockingTaskName = activeHeavyTask?.name && this.isHeavyMaintenanceConflict(taskName, activeHeavyTask.name)
             ? activeHeavyTask.name
-            : this.getActiveHeavyMaintenanceTask({excludeTaskName: taskName});
+            : null;
+
+        if (!blockingTaskName) {
+            blockingTaskName = this.getActiveHeavyMaintenanceTask({
+                excludeTaskName : taskName,
+                candidateTaskName: taskName
+            });
+        }
 
         if (blockingTaskName) {
             this.recordDeferral({
@@ -452,7 +539,12 @@ export class MaintenanceBackpressureService extends Base {
             return false;
         }
 
-        if (!acquisition.acquired) {
+        // Compatible-pair bypass: the incumbent keeps the global lease token; the
+        // candidate runs without inheriting it so every non-compatible heavy task
+        // remains serialized by the existing cross-daemon lease.
+        const leaseToken = acquisition.acquired ? acquisition.lease.token : null;
+
+        if (!acquisition.acquired && !this.areHeavyMaintenanceTasksCompatible(taskName, acquisition.lease?.owner)) {
             this.recordDeferral({
                 taskName,
                 reasonCode  : 'heavy-maintenance-lease-held',
@@ -465,9 +557,10 @@ export class MaintenanceBackpressureService extends Base {
         this.clearDeferralLogState(taskName);
 
         const releaseLease = () => {
+            if (!leaseToken) return;
             try {
                 this.releaseLeaseFn({
-                    token    : acquisition.lease.token,
+                    token    : leaseToken,
                     leasePath: this.resolveHeavyMaintenanceLeasePath()
                 });
             } catch (e) {
@@ -476,7 +569,7 @@ export class MaintenanceBackpressureService extends Base {
         };
 
         const taskOptions = {
-            env       : {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: acquisition.lease.token},
+            env       : leaseToken ? {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: leaseToken} : {},
             onComplete: releaseLease
         };
 

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1055,6 +1055,60 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         });
     });
 
+    test('runs memory miniSummary backfill while kbSync is already running (#13358)', () => {
+        const outcomes = [];
+        const started  = [];
+
+        const orchestrator = createTestOrchestrator({
+            healthService: {
+                recordTaskOutcome(taskName, status, details) {
+                    outcomes.push({taskName, status, details});
+                }
+            },
+            backupIntervalMs             : Number.MAX_SAFE_INTEGER,
+            graphLogCompactionIntervalMs : Number.MAX_SAFE_INTEGER,
+            primaryDevSyncIntervalMs     : Number.MAX_SAFE_INTEGER,
+            dreamIntervalMs              : Number.MAX_SAFE_INTEGER
+        });
+
+        orchestrator.db = {
+            prepare(sql) {
+                if (sql.includes('COUNT(*)')) {
+                    return {
+                        get: () => ({n: 3647})
+                    };
+                }
+
+                return {
+                    all: () => [{id: 'memory-1'}]
+                };
+            }
+        };
+
+        TaskStateService.taskState.kbSync.running = true;
+        orchestrator.processSupervisorService = {
+            runTask(taskName, reason) {
+                started.push({taskName, reason});
+                return true;
+            }
+        };
+
+        orchestrator.poll();
+
+        expect(started).toContainEqual({
+            taskName: 'memory-summary-backfill',
+            reason  : 'pending-memory-minisummary:3647'
+        });
+        expect(outcomes).not.toContainEqual({
+            taskName: 'memory-summary-backfill',
+            status  : 'skipped',
+            details : expect.objectContaining({
+                blockingTaskName: 'kbSync',
+                reasonCode      : 'heavy-maintenance-backpressure'
+            })
+        });
+    });
+
     test('defers due dream when another heavy maintenance task is already running (#11513 AC4 — umbrella AC2 gap fill)', () => {
         const dreamCalls = [];
         const outcomes   = [];

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs
@@ -58,6 +58,44 @@ test.describe('orchestrator/scheduling/picker (#11862 Sub 18)', () => {
         expect(winner.taskName).toBe('summary');
     });
 
+    test('filterExclusiveHeavyConflict: keeps compatible miniSummary backfill behind kbSync (#13358)', () => {
+        const candidates = [
+            makeCandidate('memory-summary-backfill', {maintenanceClass: 'heavy'}),
+            makeCandidate('summary', {maintenanceClass: 'continuous'})
+        ];
+        const winner = pickNextCandidate({
+            candidates,
+            runningTasks : ['kbSync'],
+            policyContext: {
+                runningHeavyTasks: new Set(['kbSync']),
+                isHeavyMaintenanceConflict(candidateTaskName, runningTaskName) {
+                    return !(candidateTaskName === 'memory-summary-backfill' && runningTaskName === 'kbSync');
+                }
+            }
+        });
+
+        expect(winner.taskName).toBe('memory-summary-backfill');
+    });
+
+    test('filterExclusiveHeavyConflict: keeps incompatible heavy task blocked when kbSync runs (#13358)', () => {
+        const candidates = [
+            makeCandidate('backup', {maintenanceClass: 'heavy'}),
+            makeCandidate('summary', {maintenanceClass: 'continuous'})
+        ];
+        const winner = pickNextCandidate({
+            candidates,
+            runningTasks : ['kbSync'],
+            policyContext: {
+                runningHeavyTasks: new Set(['kbSync']),
+                isHeavyMaintenanceConflict() {
+                    return true;
+                }
+            }
+        });
+
+        expect(winner.taskName).toBe('summary');
+    });
+
     test('filterExclusiveHeavyConflict: no-op when no heavy is running', () => {
         const candidates = [
             makeCandidate('backup', {maintenanceClass: 'heavy'}),

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -171,6 +171,54 @@ test.describe('orchestrator/scheduling/pipeline (#11862/#11900)', () => {
         }]);
     });
 
+    test('does not record picker deferral for miniSummary backfill while compatible kbSync runs (#13358)', () => {
+        const deferrals = [];
+        const started   = [];
+
+        const result = runSchedulingPipeline({
+            registry: [
+                makeCandidateDescriptor({taskName: 'memory-summary-backfill', maintenanceClass: 'heavy'})
+            ],
+            context : makeContext({
+                state: {
+                    kbSync: {running: true},
+                    ['memory-summary-backfill']: {running: false}
+                }
+            }),
+            services: makeServices({
+                maintenanceBackpressureService: {
+                    acquireLeaseAndExecute({executeFn, taskName, reason, onSuccess, activeHeavyTask}) {
+                        return executeFn(taskName, reason, onSuccess, {activeHeavyTask});
+                    },
+                    getActiveHeavyMaintenanceTask() { return null; },
+                    isHeavyMaintenanceTask(taskName) {
+                        return taskName === 'kbSync' || taskName === 'memory-summary-backfill';
+                    },
+                    isHeavyMaintenanceConflict(taskName, otherTaskName) {
+                        return !(taskName === 'memory-summary-backfill' && otherTaskName === 'kbSync');
+                    },
+                    recordDeferral(deferral) {
+                        deferrals.push(deferral);
+                    }
+                },
+                processSupervisorService: {
+                    runTask(taskName, reason) {
+                        started.push({taskName, reason});
+                        return true;
+                    }
+                }
+            }),
+            runtime: makeRuntime()
+        });
+
+        expect(result.winner.taskName).toBe('memory-summary-backfill');
+        expect(deferrals).toEqual([]);
+        expect(started).toEqual([{
+            taskName: 'memory-summary-backfill',
+            reason  : 'memory-summary-backfill-reason'
+        }]);
+    });
+
     test('dispatches service-runner candidates through runtime-provided collaborators', () => {
         const calls = [];
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs
@@ -2,9 +2,11 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import {
+    DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS,
     DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES,
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     MaintenanceBackpressureService,
+    areHeavyMaintenanceTasksCompatible,
     clearDeferralLogState,
     getActiveGoldenPathDependencyTask,
     getActiveHeavyMaintenanceTask,
@@ -73,6 +75,14 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(Object.isFrozen(DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES)).toBe(true);
     });
 
+    test('DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS keeps miniSummary backfill independent of kbSync', () => {
+        expect(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS).toEqual([
+            ['kbSync', 'memory-summary-backfill']
+        ]);
+        expect(Object.isFrozen(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS)).toBe(true);
+        expect(Object.isFrozen(DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS[0])).toBe(true);
+    });
+
     // ====================================================================
     // Group 1 — Pure predicates + finders
     // ====================================================================
@@ -99,6 +109,29 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         })).toBe(false);
     });
 
+    test('areHeavyMaintenanceTasksCompatible is symmetric and deny-by-default', () => {
+        expect(areHeavyMaintenanceTasksCompatible({
+            taskName: 'kbSync',
+            otherTaskName: 'memory-summary-backfill',
+            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+        })).toBe(true);
+        expect(areHeavyMaintenanceTasksCompatible({
+            taskName: 'memory-summary-backfill',
+            otherTaskName: 'kbSync',
+            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+        })).toBe(true);
+        expect(areHeavyMaintenanceTasksCompatible({
+            taskName: 'summary',
+            otherTaskName: 'kbSync',
+            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+        })).toBe(false);
+        expect(areHeavyMaintenanceTasksCompatible({
+            taskName: 'kbSync',
+            otherTaskName: 'kbSync',
+            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+        })).toBe(false);
+    });
+
     test('getActiveHeavyMaintenanceTask returns first running heavy task, honors exclude', () => {
         const taskStateService = buildTaskStateService({
             summary: {running: true},
@@ -120,6 +153,22 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
             heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
             taskStateService         : buildTaskStateService({})
         })).toBeNull();
+    });
+
+    test('getActiveHeavyMaintenanceTask ignores compatible running heavy task for a candidate', () => {
+        expect(getActiveHeavyMaintenanceTask({
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService         : buildTaskStateService({kbSync: {running: true}}),
+            candidateTaskName        : 'memory-summary-backfill',
+            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+        })).toBeNull();
+
+        expect(getActiveHeavyMaintenanceTask({
+            heavyMaintenanceTaskNames: DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
+            taskStateService         : buildTaskStateService({summary: {running: true}, kbSync: {running: true}}),
+            candidateTaskName        : 'memory-summary-backfill',
+            compatibleHeavyMaintenanceTaskPairs: DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS
+        })).toBe('summary');
     });
 
     test('getActiveGoldenPathDependencyTask prioritizes activeTaskName when it is a dependency', () => {
@@ -346,6 +395,37 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(outcomeCalls[0].p.blockingTaskName).toBe('summary');
     });
 
+    test('acquireLeaseAndExecute allows memory-summary-backfill behind active kbSync (#13358)', () => {
+        const outcomeCalls = [];
+        const executions   = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({kbSync: {running: true}}),
+            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn  : () => ({acquired: true, lease: {token: 'memory-token'}}),
+            releaseLeaseFn  : () => {}
+        });
+
+        const activeHeavyTask = {name: 'kbSync'};
+        const result = service.acquireLeaseAndExecute({
+            taskName : 'memory-summary-backfill',
+            executeFn: (taskName, reason, onSuccess, taskOptions) => {
+                executions.push({taskName, reason, env: taskOptions.env});
+                return true;
+            },
+            reason: 'pending-memory-minisummary:3647',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(true);
+        expect(executions).toEqual([{
+            taskName: 'memory-summary-backfill',
+            reason  : 'pending-memory-minisummary:3647',
+            env     : {NEO_HEAVY_MAINTENANCE_LEASE_INHERITED_TOKEN: 'memory-token'}
+        }]);
+        expect(outcomeCalls).toEqual([]);
+        expect(activeHeavyTask.name).toBe('memory-summary-backfill');
+    });
+
     test('Sub 9 hypotheses 4 and 5: acquireLeaseAndExecute records held lease as skipped (#12617)', () => {
         const outcomeCalls = [];
         const service      = buildService({
@@ -366,6 +446,39 @@ test.describe('Neo.ai.daemons.orchestrator.services.MaintenanceBackpressureServi
         expect(result).toBe(false);
         expect(outcomeCalls[0].p.reasonCode).toBe('heavy-maintenance-lease-held');
         expect(outcomeCalls[0].p.holdingOwner).toBe('sandman');
+    });
+
+    test('acquireLeaseAndExecute allows memory-summary-backfill when compatible kbSync owns the lease (#13358)', () => {
+        const outcomeCalls = [];
+        const executions   = [];
+        const releases     = [];
+        const service      = buildService({
+            taskStateService: buildTaskStateService({}),
+            healthService   : {recordTaskOutcome: (t, s, p) => outcomeCalls.push({t, s, p})},
+            acquireLeaseFn  : () => ({acquired: false, lease: {owner: 'kbSync', pid: 77}}),
+            releaseLeaseFn  : opts => releases.push(opts)
+        });
+
+        const activeHeavyTask = {name: null};
+        const result = service.acquireLeaseAndExecute({
+            taskName : 'memory-summary-backfill',
+            executeFn: (taskName, reason, onSuccess, taskOptions) => {
+                executions.push({taskName, reason, env: taskOptions.env});
+                return true;
+            },
+            reason: 'pending-memory-minisummary:3647',
+            activeHeavyTask
+        });
+
+        expect(result).toBe(true);
+        expect(executions).toEqual([{
+            taskName: 'memory-summary-backfill',
+            reason  : 'pending-memory-minisummary:3647',
+            env     : {}
+        }]);
+        expect(outcomeCalls).toEqual([]);
+        expect(releases).toEqual([]);
+        expect(activeHeavyTask.name).toBe('memory-summary-backfill');
     });
 
     test('acquireLeaseAndExecute records failure outcome on lease-acquire throw', () => {


### PR DESCRIPTION
Resolves #13358
Related: #12065

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

MiniSummary backfill now has a narrow compatibility exception with `kbSync`: both tasks remain heavy-classified, but the picker, picker-deferral telemetry, execution active-heavy check, and cross-daemon lease wrapper all use the same conflict predicate so `memory-summary-backfill` can run while `kbSync` is active. Every other heavy pair keeps the existing mutex behavior.

Evidence: L2 (focused unit coverage for scheduler/service execution with fake DB and lease states) -> L2 required (orchestrator scheduling/backpressure ACs). No residuals.

## Deltas from ticket
- Kept `kbSync` and `memory-summary-backfill` in `DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES`.
- Added `DEFAULT_COMPATIBLE_HEAVY_MAINTENANCE_TASK_PAIRS` as a narrow policy allow-list instead of changing deployment classification or disabling the global heavy-maintenance lease.

## Test Evidence
- `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` materialized ignored config overlays in the isolated worktree for test imports.
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/MaintenanceBackpressureService.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 92 passed after rebase onto `origin/dev` `9ab312920`.

## Post-Merge Validation
- [ ] During active KB sync, a pending miniSummary backlog starts `memory-summary-backfill` instead of logging `Deferring memory miniSummary backfill; heavy maintenance task knowledge base sync is active`.

## Commit
- `0c9778034` — `fix(orchestrator): split miniSummary from kbSync backpressure (#13358)`
