### PR TITLE
test(agentos): prove first grid via neural link (#13362)

### DIFF
--- a/test/playwright/e2e/NeuralLinkCreateGrid.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkCreateGrid.spec.mjs
@@ -1,0 +1,118 @@
+import { test, expect } from '../fixtures.mjs';
+
+/**
+ * @summary H2 Agent Harness proof: create a real grid inside a live Neo app through Neural Link.
+ *
+ * This intentionally combines two existing whitebox patterns:
+ * - `NeuralLinkCreateComponent.spec.mjs`: the agent writes through `create_component`.
+ * - `GridBigDataNL.spec.mjs`: the test asserts grid truth inside the App Worker.
+ *
+ * The point is NOT to render a static blueprint that looks like a grid. The proof is that normal
+ * Neo grid config can cross the Neural Link create path into a running app, then remain queryable
+ * and inspectable as a live component/store.
+ */
+test.describe('Neural Link - create grid (H2 first-widget proof)', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('creates a grid in a live app and verifies worker-state truth', async ({ page, neuralLink }) => {
+        await page.goto('/examples/grid/bigData/index.html');
+        await page.waitForSelector('.neo-grid-container', { state: 'visible', timeout: 30000 });
+
+        const app = await neuralLink.connectToApp('Neo.examples.grid.bigData');
+
+        const mainContainers = await app.findInstances(
+            { className: 'Neo.examples.grid.bigData.MainContainer' },
+            ['id']
+        );
+        const mainContainer = (Array.isArray(mainContainers) ? mainContainers[0] : mainContainers) || {};
+
+        expect(mainContainer.id, 'the live target app must expose a container to create into').toBeTruthy();
+
+        const
+            gridId = 'nl-created-grid-h2-proof',
+            rows   = [{
+                id      : 'intent',
+                task    : 'Verify intent',
+                owner   : 'Euclid',
+                evidence: 'Neural Link'
+            }, {
+                id      : 'grid',
+                task    : 'Create grid',
+                owner   : 'Runtime',
+                evidence: 'create_component'
+            }, {
+                id      : 'truth',
+                task    : 'Inspect truth',
+                owner   : 'Whitebox E2E',
+                evidence: 'App Worker'
+            }];
+
+        await app.createComponent(mainContainer.id, {
+            id            : gridId,
+            ntype         : 'grid-container',
+            flex          : 1,
+            minWidth      : 420,
+            wrapperStyle  : { height: '260px' },
+            columnDefaults: { width: 140 },
+
+            store: {
+                keyProperty: 'id',
+                model: {
+                    fields: [
+                        { name: 'id',       type: 'String' },
+                        { name: 'task',     type: 'String' },
+                        { name: 'owner',    type: 'String' },
+                        { name: 'evidence', type: 'String' }
+                    ]
+                },
+                data: rows
+            },
+
+            columns: [
+                { dataField: 'task',     text: 'Task' },
+                { dataField: 'owner',    text: 'Owner' },
+                { dataField: 'evidence', text: 'Evidence' }
+            ]
+        });
+
+        let gridProps;
+
+        await expect.poll(async () => {
+            try {
+                gridProps = await app.getComponent(gridId, [
+                    'ntype',
+                    'store.id',
+                    'store.count',
+                    'columns',
+                    'mounted'
+                ]);
+
+                return gridProps?.['store.count']
+            } catch {
+                return -1
+            }
+        }, {
+            message: 'the NL-created grid should register with a live store in the App Worker',
+            timeout: 15000
+        }).toBe(rows.length);
+
+        expect(gridProps.ntype).toBe('grid-container');
+        expect(gridProps.columns.count).toBe(3);
+
+        const storeId = gridProps['store.id'] || gridProps.store?.id || gridProps.store;
+        expect(storeId, 'the created grid must expose an inspectable live store').toBeTruthy();
+
+        const
+            storeData = await app.inspectStore(storeId, 10, 0),
+            itemData  = storeData.items.map(item => item.data || item);
+
+        expect(storeData.count).toBe(rows.length);
+        expect(itemData.map(item => item.task)).toEqual(rows.map(row => row.task));
+
+        const tree = await app.getComponentTree(gridId, 2, true);
+        expect(JSON.stringify(tree), 'created grid should be visible in the live component tree').toContain(gridId);
+
+        await expect(page.locator(`#${gridId}.neo-grid-container`)).toBeVisible({ timeout: 10000 });
+    });
+});


### PR DESCRIPTION
Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session unavailable in this Codex Desktop surface.

Resolves #13362
Related: #13349
Related: #13353
Related: #13354

Adds a corrected H2 first-grid proof: a whitebox E2E boots the live Grid BigData app, connects through the Neural Link fixture, creates a new `grid-container` via `create_component`, then verifies the App Worker component/store truth and the rendered DOM. This supersedes the rejected static-blueprint proof path from #13353 / PR #13354 without reviving that branch.

Evidence: L3 (local Chromium whitebox E2E with live Neural Link bridge, `create_component`, `get_instance_properties`, `inspect_store`, component-tree, and rendered-DOM assertions) → L3 required (#13362 whitebox live-app proof). No residuals.

## Deltas from ticket

- Used `examples/grid/bigData` as the live target because it already enables `useAiClient` and loads the grid namespace. This avoids adding a one-off app fixture and keeps the proof on an existing NL/grid surface.
- The proof intentionally uses normal Neo grid config through the constrained NL create path; it does not add a grid-config whitelist or static blueprint schema.

## Test Evidence

- `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` (fresh worktree ignored config overlays only)
- `npm run test-e2e -- NeuralLinkCreateGrid.spec.mjs` → Playwright `1 passed` (rerun after final staged edit)
- `git diff --cached --check`
- Freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `2d77d5167 test(agentos): prove first grid via neural link (#13362)`

## Post-Merge Validation

- [ ] CI confirms the focused E2E remains green in the shared runner environment.

## Commit

- `2d77d5167` — `test(agentos): prove first grid via neural link (#13362)`

## Evolution

The implementation lane pivoted after operator rejection of #13353/#13354: the first H2 proof must show Neural Link creating a grid inside a live app, not static app-local rendering. #13362 captures that corrected acceptance observation and this PR implements that narrower proof.