### PR TITLE
docs(skill): trim authorship self-id block — drop @handle, Social-Name-led, bottom (#13365)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -141,14 +141,14 @@ gh pr create --title "feat/fix/chore: Your Title (#TICKET_ID)" --body "Comprehen
 
 To ensure symmetric discipline across the PR lifecycle and enable accurate cross-model convergence tracking, you MUST explicitly self-identify within the PR body you generate. This mirrors the authorship requirements in the `pr-review` skill.
 
-Your PR body MUST include a self-identification block near the top, formatted exactly as follows (`@<identity>` is canonical — the cross-family gate keys off it; §6.1):
-`Authored by [Model Name] ([Agent Wrapper]), @<identity> ([Social Name]). Session <Origin Session ID>.`
+Your PR body MUST include a self-identification block at the **bottom**, formatted exactly as follows (the **Social Name** is canonical — the cross-family gate keys off it; §6.1; the gh comment author already shows the routing handle, so the in-body `@handle` is omitted):
+`Authored by [Social Name] ([Model Name], [Agent Wrapper]). Session <Origin Session ID>.`
 
 **Cross-Harness Authorship Convention:**
 When you author a PR based on a handoff, ticket, or artifact synthesized by a *different* model in a *different* session (e.g., executing an implementation plan created by another agent), you MUST attribute the full provenance:
-`Authored by [Model-B] ([Harness-B]), @<identity-B> consuming [Model-A]'s handoff — session A <id>, session B <id>.`
+`Authored by [Social Name-B] ([Model-B], [Harness-B]) consuming [Social Name-A]'s handoff — session A <id>, session B <id>.`
 
-This ensures A2A provenance remains graph-extractable even if you do not have a dedicated GitHub service account.
+This keeps provenance graph-extractable in the cross-harness case, where the gh account does NOT reflect the true author.
 
 ## 6. Definition of Done & The Handoff State
 
@@ -170,7 +170,7 @@ You MUST follow this exact handoff protocol:
 
 ### 6.1 The Cross-Family Mandate
 
-**No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `manage_pr_review` (state `APPROVED`) per `pr-review-guide.md §2`. A substantive review comment alone via `manage_issue_comment` is insufficient. **Author family** is resolved from the §5 `@identity` self-id, not the drift-prone GitHub login (advisory only).
+**No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `manage_pr_review` (state `APPROVED`) per `pr-review-guide.md §2`. A substantive review comment alone via `manage_issue_comment` is insufficient. **Author family** is resolved from the §5 **Social Name** (roster-resolvable via `identityRoots`), with the gh `author.login` as fallback.
 
 **Exceptions Matrix:**
 - **Micro-change exemption**: Commit type `chore` AND `< 20 lines` changed, OR pure documentation with no runtime impact.

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -16,6 +16,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 const DAY_MS     = 24 * 60 * 60 * 1000;
 
+/**
+ * Social Name → `@`-stripped GitHub login, derived from the canonical identity roster. The PR-body
+ * self-id leads with the Social Name (`Authored by <Social Name> (…)`); this resolves it to the login
+ * the family map keys on. The legacy `@identity` form is still parsed for transitional / pre-trim bodies.
+ */
+const SOCIAL_NAME_TO_LOGIN = Object.freeze(Object.fromEntries(
+    IDENTITIES
+        .filter(identity => identity.name && identity.properties?.githubLogin)
+        .map(identity => [identity.name, identity.properties.githubLogin.replace(/^@/, '')])
+));
+
 const MAINTAINER_PROGRESS_PATTERN = /\b(?:in[-\s]?progress|picking up|taking|claim(?:ed|ing)?|lane-claim|lane-state:\s*next-lane|working|implement(?:ing)?|opened\s+(?:PR|pull request)|PR\s*#\d+)\b/i;
 
 /**
@@ -652,29 +663,35 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
-     * @summary Extracts the canonical `@identity` (login, `@`-stripped) from a PR body's
-     * `Authored by … @identity` self-id line.
+     * @summary Extracts the canonical author login (`@`-stripped) from a PR body's `Authored by …`
+     * self-id line, resolving both the Social-Name-led form and the legacy `@identity` form.
      *
      * The body self-id is the drift-free author source: the GitHub PR opener can mis-resolve (an MCP
      * `@me` identity-resolution drift stamps a different agent's login on the opener), but the body
-     * declares its own canonical `@identity`. Returns null when no self-id is present (legacy / external
-     * bodies), so the caller falls back to the advisory login. The pattern is **line-anchored** (`^…/m`)
-     * to the canonical self-id line, so a `Co-Authored by` trailer or descriptive prose that merely
-     * contains `Authored by` mid-line does not match.
+     * declares its own canonical author. The current convention leads with the **Social Name**
+     * (`Authored by <Social Name> (<Model>, <Wrapper>).`), resolved to a login via the identity roster;
+     * the legacy `Authored by … @identity` form is still parsed for transitional / pre-trim bodies.
+     * Returns null when no self-id is present (external bodies) or the Social Name is unregistered, so the
+     * caller falls back to the advisory login. The pattern is **line-anchored** (`^…/m`) to the self-id
+     * line, so a `Co-Authored by` trailer or prose that merely contains `Authored by` mid-line does not match.
      * @param {String} body
-     * @returns {(String|null)} The `@`-stripped identity login, or null.
+     * @returns {(String|null)} The `@`-stripped author login, or null.
      */
     static parseSelfIdLogin(body) {
         if (typeof body !== 'string') return null;
 
-        const match = body.match(/^Authored by[^\n]*?@([A-Za-z0-9-]+)/m);
+        // Legacy form first: `Authored by … @identity` (transitional / pre-trim bodies).
+        const legacyMatch = body.match(/^Authored by[^\n]*?@([A-Za-z0-9-]+)/m);
+        if (legacyMatch) return legacyMatch[1];
 
-        return match ? match[1] : null
+        // Current form: `Authored by <Social Name> (…)` — resolve the Social Name to a login via the roster.
+        const socialMatch = body.match(/^Authored by (.+?) \(/m);
+        return socialMatch ? (SOCIAL_NAME_TO_LOGIN[socialMatch[1].trim()] ?? null) : null
     }
 
     /**
-     * @summary Resolves a PR author's model family from the canonical body `@identity`, falling back
-     * to the drift-prone GitHub login as an advisory source.
+     * @summary Resolves a PR author's model family from the canonical body self-id (Social-Name-led, or
+     * legacy `@identity`), falling back to the drift-prone GitHub login as an advisory source.
      *
      * The body's self-declared `@identity` wins; the GitHub author login is advisory-only (used when the
      * body carries no self-id), and a body-vs-login family disagreement is logged as drift rather than

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -851,12 +851,18 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         Synthesizer = mod.default.constructor;
     });
 
-    test('parseSelfIdLogin extracts the @identity only from the canonical line-start self-id', () => {
+    test('parseSelfIdLogin resolves the Social-Name-led form and the legacy @identity form', () => {
+        // Legacy @identity form (transitional / pre-trim bodies).
         expect(Synthesizer.parseSelfIdLogin('Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session x.')).toBe('neo-gpt');
         expect(Synthesizer.parseSelfIdLogin('Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace).')).toBe('neo-claude-opus');
         // Real PR bodies open with `Resolves #N`, so the self-id is mid-body — the /m anchor must still match it.
         expect(Synthesizer.parseSelfIdLogin('Resolves #1\n\nAuthored by GPT-5 (Codex Desktop), @neo-gpt (Euclid).')).toBe('neo-gpt');
-        expect(Synthesizer.parseSelfIdLogin('Authored by GPT-5 (Codex Desktop). Session x.')).toBe(null); // legacy, no @identity
+        // Current Social-Name-led form (post-trim): resolve the Social Name to a login via the roster.
+        expect(Synthesizer.parseSelfIdLogin('Authored by Euclid (GPT-5, Codex Desktop). Session x.')).toBe('neo-gpt');
+        expect(Synthesizer.parseSelfIdLogin('Authored by Ada (Claude Opus 4.8, Claude Code).')).toBe('neo-opus-ada');
+        expect(Synthesizer.parseSelfIdLogin('Resolves #1\n\nAuthored by Grace (Claude Opus 4.8, Claude Code).')).toBe('neo-claude-opus');
+        expect(Synthesizer.parseSelfIdLogin('Authored by Unregistered Name (Some Model). Session x.')).toBe(null); // social name not in roster
+        expect(Synthesizer.parseSelfIdLogin('Authored by GPT-5 (Codex Desktop). Session x.')).toBe(null); // model-led, no @identity; "GPT-5" not a social name
         // Overmatch guards: a `Co-Authored by` trailer or prose merely containing `Authored by` mid-line must NOT match.
         expect(Synthesizer.parseSelfIdLogin('Co-Authored by Claude Opus, @neo-claude-opus.')).toBe(null);
         expect(Synthesizer.parseSelfIdLogin('Note: Authored by old session @neo-gpt in context.')).toBe(null);
@@ -873,6 +879,18 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
             reviews: [{author: {login: 'neo-claude-opus'}, state: 'APPROVED'}]
         };
         // Login-only reads author=claude, reviewer=claude -> false (the bug). The self-id reads author=gpt -> cross-family true.
+        expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(true)
+    });
+
+    test('resolves author family from the Social-Name self-id, overriding a drifted GitHub login', () => {
+        // Drift shape with the current trimmed format: opener mis-resolves to a Claude login; the body self-id is Euclid (GPT).
+        const pr = {
+            number : 13367,
+            author : {login: 'neo-opus-ada'}, // drifted (mis-resolved opener)
+            body   : 'Authored by Euclid (GPT-5, Codex Desktop). Session x.',
+            reviews: [{author: {login: 'neo-claude-opus'}, state: 'APPROVED'}]
+        };
+        // The Social-Name self-id resolves author=gpt via the roster, so the claude reviewer makes it cross-family.
         expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(true)
     });
 


### PR DESCRIPTION
Resolves #13365

Trims the PR-body authorship self-id block — drop the redundant `@handle`, lead with the Social Name, move it to the **bottom** (operator-directed, 2026-06-15) — **and** migrates the one live code consumer of the old self-id so drift-safe cross-family resolution survives the trim.

**Doc (`pull-request-workflow.md`):** §5 → `Authored by <Social Name> (<Model>, <Wrapper>). Session <id>.` at the bottom; §6.1 author-family-resolution re-points from the dropped `@identity` to the **Social Name** (roster-resolvable via `identityRoots`, gh-`author.login` fallback). The cross-harness variant keeps its explicit Model-A/Model-B attribution.

**Code (`GoldenPathSynthesizer.parseSelfIdLogin`):** @neo-gpt's review correctly caught that this parser consumes the body `@identity` for drift-safe cross-family author resolution — dropping the `@handle` would make the new footer invisible to it and recreate the GitHub-opener-drift bug. `parseSelfIdLogin` now resolves BOTH forms: the legacy `@identity` (transitional / pre-trim bodies) first, then the Social-Name-led form via a `SOCIAL_NAME_TO_LOGIN` map derived from `identityRoots`. `resolveAuthorFamily` is unchanged (it keys on the resolved login).

Evidence: L2 (the convention doc + the live parser/consumer seam, unit-covered). Full `GoldenPathSynthesizer` spec 20/20 green, including a new drift test proving the Social-Name self-id overrides a drifted GitHub opener (a PR opened by `neo-opus-ada` but body-authored by Euclid resolves as `gpt`). No residuals.

## Deltas from ticket (if any)
- **Scope correction (V-B-A).** The ticket named `ticket-create-workflow.md §11`, but §11 is *Authorship Respect* — NOT the format. The `Authored by [...]` format is mandated in exactly ONE place (`pull-request-workflow.md §5`); ticket bodies inherit it. So the doc change is §5 + §6.1 only.
- **Scope expansion (from @neo-gpt's review).** My initial V-B-A grepped skills + workflows for "Authored by" but NOT the *code* — and missed `GoldenPathSynthesizer.parseSelfIdLogin`, a live consumer of the body `@identity`. The trim genuinely requires migrating that parser, so the PR now spans doc + parser + tests.

## Test Evidence
- `GoldenPathSynthesizer` spec: **20/20 green** (`UNIT_TEST_MODE=true playwright -c …unit.mjs`), incl. the renamed dual-format `parseSelfIdLogin` test (legacy `@identity` + Social-Name + unregistered-name + overmatch guards) and a new Social-Name drift test.
- `lint-skill-manifest`: the workflow-doc delta is +132 bytes (≤250 budget) — the verbose rationale was cut to mandates-only.
- `agent-pr-body-lint`: the new format passes (this PR body dogfoods it); `check-whitespace` / `node --check` clean; no ticket `#refs` in durable code/comments.

## Post-Merge Validation
- [ ] Next agent PR/ticket bodies adopt the new format; `GoldenPathSynthesizer` resolves their author family from the Social Name (observable in the synthesizer's drift logging — no false `author.login` fallback for a correctly-formatted new body).

## Commits
- `61742ebeb` — doc trim (`pull-request-workflow.md` §5 + §6.1), lean (+132 bytes).
- `511ec570c` — migrate `GoldenPathSynthesizer.parseSelfIdLogin` to dual-format (legacy `@identity` + Social-Name roster resolution) + tests.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 73156d71-9a96-4bf1-bbc8-d6487ca7dddd.
