### PR TITLE
fix(wake): resolve Codex Desktop CLI path (#13366)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -37,6 +37,7 @@ import {WAKE_LANE_DIRECTIVE} from './wakeLaneDirective.mjs';
 import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { constants as fsConstants } from 'fs';
 import { spawn, execSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -75,6 +76,7 @@ const LOG_RETENTION_DAYS       = 30;
 const POLL_INTERVAL_MS         = 3000;
 const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
 const CODEX_APP_SERVER_ADAPTER   = 'codex-app-server';
+const DEFAULT_CODEX_DESKTOP_CLI_PATH = '/Applications/Codex.app/Contents/Resources/codex';
 const WAKE_PRIORITY_RANKS      = {
     low   : 0,
     normal: 1,
@@ -704,13 +706,32 @@ function spawnAsync(command, args) {
 /**
  * @summary Resolves the Codex CLI used by the app-server wake adapter.
  *
- * `CODEX_CLI_PATH` mirrors the resume-harness test hook so unit tests can assert
- * the command shape without reaching a live Codex Desktop app-server.
+ * `CODEX_CLI_PATH` mirrors the resume-harness test hook and always wins. When
+ * unset on macOS, the daemon probes the Codex Desktop bundled CLI path because
+ * launchd / daemon environments often lack the user's interactive shell PATH.
  *
  * @returns {String}
  */
 function resolveCodexCliPath() {
-    return process.env.CODEX_CLI_PATH || 'codex';
+    if (process.env.CODEX_CLI_PATH) return process.env.CODEX_CLI_PATH;
+    const desktopCliPath = process.env.CODEX_DESKTOP_CLI_PATH || DEFAULT_CODEX_DESKTOP_CLI_PATH;
+    if (process.platform === 'darwin' && fileIsExecutableSync(desktopCliPath)) return desktopCliPath;
+    return 'codex';
+}
+
+/**
+ * @summary Checks whether a file exists and can be executed.
+ *
+ * @param {String} filePath
+ * @returns {Boolean}
+ */
+function fileIsExecutableSync(filePath) {
+    try {
+        fs.accessSync(filePath, fsConstants.X_OK);
+        return true;
+    } catch (err) {
+        return false;
+    }
 }
 
 /**

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -119,14 +119,17 @@ async function resolveClaudeCliPath() {
 /**
  * @summary Resolve the Codex CLI binary used by the Codex Desktop app-server adapter.
  *
- * The default `codex` executable is intentionally overridable for tests via
- * `CODEX_CLI_PATH`. Specs pair the override with `CODEX_APP_SERVER_MOCK=1`
- * to capture the command shape without creating a real Codex Desktop thread.
+ * `CODEX_CLI_PATH` always wins. When unset on macOS, the resolver probes the
+ * Codex Desktop bundled CLI path because daemon / app-spawned environments often
+ * lack the user's interactive shell PATH.
  *
- * @returns {string} The Codex CLI command or test override path.
+ * @returns {Promise<string>} The Codex CLI command or resolved Desktop path.
  */
-function resolveCodexCliPath() {
-    return process.env.CODEX_CLI_PATH || 'codex';
+async function resolveCodexCliPath() {
+    if (process.env.CODEX_CLI_PATH) return process.env.CODEX_CLI_PATH;
+    const desktopCliPath = process.env.CODEX_DESKTOP_CLI_PATH || '/Applications/Codex.app/Contents/Resources/codex';
+    if (process.platform === 'darwin' && await fileIsExecutable(desktopCliPath)) return desktopCliPath;
+    return 'codex';
 }
 
 /**
@@ -230,12 +233,13 @@ export function selectHarnessAdapter(harnessTarget, hostPlatform = process.platf
  * `codex debug app-server send-message-v2` creates/injects into a real Codex
  * Desktop thread. Live-host probes must require an explicit operator opt-in.
  * Unit tests satisfy this guard with
- * `CODEX_APP_SERVER_MOCK=1` plus `CODEX_CLI_PATH` pointing at a mock
+ * `CODEX_APP_SERVER_MOCK=1` plus `CODEX_CLI_PATH` or `CODEX_DESKTOP_CLI_PATH` pointing at a mock
  * executable, preserving always-on coverage without host side effects.
  */
 function assertCodexAppServerAllowed() {
     const hasLiveOptIn = process.env.RUN_LIVE_CODEX_APP_SERVER === '1';
-    const hasMockOptIn = process.env.CODEX_APP_SERVER_MOCK === '1' && Boolean(process.env.CODEX_CLI_PATH);
+    const hasMockOptIn = process.env.CODEX_APP_SERVER_MOCK === '1' &&
+        (Boolean(process.env.CODEX_CLI_PATH) || Boolean(process.env.CODEX_DESKTOP_CLI_PATH));
 
     if (!hasLiveOptIn && !hasMockOptIn) {
         throw new Error(
@@ -458,12 +462,11 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
              * thread proves healthy Memory Core startup plus a first `add_memory`
              * sessionId change.
              *
-             * Tests use `CODEX_APP_SERVER_MOCK=1` plus `CODEX_CLI_PATH` to point at a
-             * mock executable, verifying the command shape without creating real Codex
-             * threads.
+             * Tests use `CODEX_APP_SERVER_MOCK=1` plus a mock CLI path, verifying the
+             * command shape without creating real Codex threads.
              */
             assertCodexAppServerAllowed();
-            const cliPath = resolveCodexCliPath();
+            const cliPath = await resolveCodexCliPath();
             const args = ['debug', 'app-server', 'send-message-v2', payload];
             await spawnAsync(cliPath, args);
             console.log(`Successfully resumed ${identity} via codex-app-server`);

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1060,6 +1060,82 @@ test.describe('Wake Daemon', () => {
         );
     });
 
+    test('resolves bundled Codex Desktop CLI when daemon PATH lacks bare codex (#13287)', async () => {
+        test.skip(process.platform !== 'darwin', 'Codex Desktop bundled CLI path is currently mac-specific');
+
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-codex-desktop-cli';
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'codex-app-server',
+                appName       : 'Codex',
+                coalesceWindow: 1
+            }
+        });
+
+        const binDir           = path.join(DAEMON_DIR, 'bin');
+        const mockCodexPath    = path.join(DAEMON_DIR, 'Codex.app', 'Contents', 'Resources', 'codex');
+        const mockCodexOutPath = path.join(DAEMON_DIR, 'mock_codex_desktop_cli_out.json');
+
+        fs.ensureDirSync(binDir);
+        fs.ensureDirSync(path.dirname(mockCodexPath));
+        writeMockPs(binDir);
+        fs.writeFileSync(mockCodexPath,
+            `#!/usr/bin/env node\n` +
+            `const fs = require('fs');\n` +
+            `fs.writeFileSync(${JSON.stringify(mockCodexOutPath)}, JSON.stringify(process.argv.slice(2)));\n`
+        );
+        fs.chmodSync(mockCodexPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                CODEX_CLI_PATH        : '',
+                CODEX_DESKTOP_CLI_PATH: mockCodexPath,
+                NEO_MEMORY_DB_PATH    : DB_PATH,
+                NEO_AI_DAEMON_DIR     : DAEMON_DIR,
+                PATH                  : `${path.dirname(process.execPath)}${path.delimiter}${path.resolve(binDir)}`
+            }
+        });
+
+        let stdoutLog = '';
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver Codex app-server digest via Desktop CLI fallback')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                stdoutLog += out;
+                if (out.includes(`[Wake Daemon] Dispatched ${subId} via codex-app-server send-message-v2`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {
+            agentId,
+            subject: 'Codex Desktop CLI Wake'
+        });
+
+        await deliveryPromise;
+
+        const args = JSON.parse(fs.readFileSync(mockCodexOutPath, 'utf8'));
+        expect(args.slice(0, 3)).toEqual(['debug', 'app-server', 'send-message-v2']);
+        expect(args[3]).toContain('Codex Desktop CLI Wake');
+        expect(stdoutLog).toContain(
+            'scenario=direct-message; route=codex-app-server; adapterSource=metadata; app=Codex; ' +
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:0'
+        );
+    });
+
     test('uses the highest coalesced message priority in the wake digest header and preserves divergent latest priority', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-priority';

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -65,8 +65,8 @@ test.describe('ai/scripts/resumeHarness', () => {
      *
      * Codex live-host opt-in: `codex debug app-server send-message-v2`
      * creates/injects into a real Codex Desktop thread. Default tests MUST use
-     * `CODEX_APP_SERVER_MOCK=1` plus a `CODEX_CLI_PATH` mock. Real probes require
-     * `RUN_LIVE_CODEX_APP_SERVER=1`.
+     * `CODEX_APP_SERVER_MOCK=1` plus a mock CLI path (`CODEX_CLI_PATH` or
+     * `CODEX_DESKTOP_CLI_PATH`). Real probes require `RUN_LIVE_CODEX_APP_SERVER=1`.
      */
     let gatePath, overrideEnv;
     const gateOnlyEnv = () => ({...process.env, WAKE_GATE_FILE_PATH: gatePath});
@@ -630,6 +630,42 @@ test.describe('ai/scripts/resumeHarness', () => {
             expect(args[0]).toBe('debug');
             expect(args[1]).toBe('app-server');
             expect(args[2]).toBe('send-message-v2');
+            expect(args[3]).toContain('@AGENTS_STARTUP.md');
+            expect(args[3]).toContain('testReason');
+        } finally {
+            if (fs.existsSync(mockPath)) fs.unlinkSync(mockPath);
+            if (fs.existsSync(outPath)) fs.unlinkSync(outPath);
+        }
+    });
+
+    test('Codex app-server: adapter resolves bundled Desktop CLI when PATH lacks bare codex (#13287)', async () => {
+        test.skip(process.platform !== 'darwin', 'Codex Desktop app-server adapter is currently mac-specific');
+        test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
+
+        const mockPath = path.join(os.tmpdir(), `mock-codex-desktop-${randomUUID()}`);
+        const outPath  = path.join(os.tmpdir(), `out-codex-desktop-${randomUUID()}`);
+
+        fs.writeFileSync(mockPath,
+            `#!/usr/bin/env node\n` +
+            `const fs = require('fs');\n` +
+            `fs.writeFileSync(${JSON.stringify(outPath)}, JSON.stringify(process.argv.slice(2)));\n`,
+            {mode: 0o755}
+        );
+
+        try {
+            const env = {
+                ...overrideEnv,
+                CODEX_APP_SERVER_MOCK : '1',
+                CODEX_CLI_PATH        : '',
+                CODEX_DESKTOP_CLI_PATH: mockPath,
+                PATH                  : path.dirname(process.execPath)
+            };
+
+            execFileSync('node', [scriptPath, '@neo-gpt', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
+
+            expect(fs.existsSync(outPath)).toBe(true);
+            const args = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
+            expect(args.slice(0, 3)).toEqual(['debug', 'app-server', 'send-message-v2']);
             expect(args[3]).toContain('@AGENTS_STARTUP.md');
             expect(args[3]).toContain('testReason');
         } finally {


### PR DESCRIPTION
Resolves #13366
Related: #13287
Related: #13012

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session unavailable in this Codex Desktop surface.

After applying the #13350 / #13351 migration, live wake evidence changed from the old `osascript` route ambiguity to a new `codex-app-server` process-resolution blocker: the wake daemon retried `WAKE_SUB:7648b86c-2f1e-43a8-95a6-cc399f66a938`, failed with `spawn codex ENOENT`, and dropped the wake. This PR keeps explicit `CODEX_CLI_PATH` authoritative, adds a macOS Codex Desktop bundled-CLI fallback for daemon/app-spawned environments whose `PATH` lacks bare `codex`, and applies the same resolver shape to the resume harness sibling route.

Evidence: L2 (mock-bin daemon/resume-harness dispatch plus live wake log falsifier for `spawn codex ENOENT`) -> L4 required (#13287 prompt-submit/start-turn matrix). Residual: #13287 still needs migrated-route L4 rows after this PR lands.

## Deltas from ticket

- `CODEX_DESKTOP_CLI_PATH` is available as a test/relocation override for the macOS Desktop bundled CLI fallback.
- The PR intentionally does not fall back to `osascript` for a configured `codex-app-server` route.
- This PR does not claim #13287 completion; it resolves the narrower #13366 route blocker that prevents the matrix from running on the migrated route.

## Test Evidence

- `git diff --check origin/dev..HEAD` -> clean.
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs --grep "Codex"` -> 6 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs --grep "Codex app-server"` -> 3 passed.

## Post-Merge Validation

- [ ] Let the next migrated Codex wake hit `codex-app-server` and confirm the wake log no longer reports `spawn codex ENOENT`.
- [ ] Continue #13287's L4 matrix: prompt lands, prompt submits, turn starts, and human-Enter-required for pure-heartbeat, direct-message, and mixed-message-heartbeat scenarios.

## Evolution

The route migration from #13351 exposed a second-order runtime assumption: daemon environments cannot rely on the interactive shell's `PATH`. The fix keeps cloud/custom deployments explicit-first while making the macOS Desktop default work without reintroducing GUI focus delivery.
