### PR TITLE
fix(github-workflow): post comment bodies as authored (#13369)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -405,8 +405,8 @@ paths:
 
         **Action: 'create'**
         - Creates a new comment on an issue or PR.
-        - Requires `agent`, `body`, and either `issue_number` or `pr_number`.
-        - Automatically formats the comment with the agent's identity.
+        - Requires `body` and either `issue_number` or `pr_number`.
+        - Posts `body` as-authored; GitHub's authenticated author is the attribution.
         - **When to use:** To provide feedback, approve PRs (with "LGTM"), or ask questions.
 
         **Action: 'update'**
@@ -447,7 +447,7 @@ paths:
                   description: The content of the comment.
                 agent:
                   type: string
-                  description: The agent identity in the format '[Model Name] ([Agent Wrapper])' (required for 'create').
+                  description: Deprecated no-op retained for backward compatibility; comments are no longer auto-formatted with an agent identity byline.
                   example: "Gemini 3.1 Pro (Antigravity)"
       responses:
         '200':
@@ -1381,7 +1381,8 @@ paths:
 
         **Action: 'create'**
         - Creates a new comment on a discussion.
-        - Requires `agent`, `body`, and `discussion_number`.
+        - Requires `body` and `discussion_number`.
+        - Posts `body` as-authored; GitHub's authenticated author is the attribution.
         - Returns `commentId` for scoped hand-off via `get_discussion_conversation`.
 
         **Action: 'update'**
@@ -1416,7 +1417,7 @@ paths:
                   description: The content of the comment.
                 agent:
                   type: string
-                  description: The agent identity in the format '[Model Name] ([Agent Wrapper])' (required for 'create').
+                  description: Deprecated no-op retained for backward compatibility; discussion comments are no longer auto-formatted with an agent identity byline.
                   example: "Gemini 3.1 Pro (Antigravity)"
       responses:
         '200':

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -445,10 +445,6 @@ paths:
                 body:
                   type: string
                   description: The content of the comment.
-                agent:
-                  type: string
-                  description: Deprecated no-op retained for backward compatibility; comments are no longer auto-formatted with an agent identity byline.
-                  example: "Gemini 3.1 Pro (Antigravity)"
       responses:
         '200':
           description: |
@@ -1415,10 +1411,6 @@ paths:
                 body:
                   type: string
                   description: The content of the comment.
-                agent:
-                  type: string
-                  description: Deprecated no-op retained for backward compatibility; discussion comments are no longer auto-formatted with an agent identity byline.
-                  example: "Gemini 3.1 Pro (Antigravity)"
       responses:
         '200':
           description: Comment created or updated successfully.

--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -7,13 +7,6 @@ import {projectConversationTrust} from './shared/conversationTrust.mjs';
 import {GET_DISCUSSION_CONVERSATION, GET_REPO_AND_DISCUSSION_CATEGORIES, GET_DISCUSSION_ID} from './queries/discussionQueries.mjs';
 import {CREATE_DISCUSSION, ADD_DISCUSSION_COMMENT, UPDATE_DISCUSSION, UPDATE_DISCUSSION_COMMENT} from './queries/mutations.mjs';
 
-const AGENT_ICONS = {
-    gemini : '✦',
-    claude : '❋',
-    gpt    : '●',
-    default: '◆'
-};
-
 /**
  * @summary Service for interacting with GitHub Discussions via the GraphQL API.
  *
@@ -196,45 +189,13 @@ class DiscussionService extends Base {
     }
 
     /**
-     * Extracts the agent type from the agent string for icon selection.
-     * @param {string} agent The full agent identifier
-     * @returns {string} The agent type key for AGENT_ICONS lookup
-     */
-    getAgentType(agent) {
-        const agentLower = agent.toLowerCase();
-
-        if (agentLower.includes('gemini')) return 'gemini';
-        if (agentLower.includes('claude')) return 'claude';
-        if (agentLower.includes('gpt'))    return 'gpt';
-
-        return 'default';
-    }
-
-    /**
      * Creates a comment on a specific discussion.
      * @param {object} options                      The options object
      * @param {number} options.discussion_number    The number of the discussion.
      * @param {string} options.body                 The raw content of the comment.
-     * @param {string} options.agent                The identity of the calling agent.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async createComment({discussion_number, body, agent}) {
-        // Agent Header Formatting
-        const header       = `**Input from ${agent}:**\n\n`;
-        const agentIcon    = AGENT_ICONS[this.getAgentType(agent)];
-        const headingMatch = body.match(/^(#+\s*)(.*)$/);
-        let processedBody;
-
-        if (headingMatch) {
-            const headingMarkers = headingMatch[1];
-            const headingContent = headingMatch[2];
-            processedBody = `${headingMarkers}${agentIcon} ${headingContent}\n${body.substring(headingMatch[0].length)}`;
-        } else {
-            processedBody = `${agentIcon} ${body}`;
-        }
-
-        const finalBody = `${header}${processedBody.split('\n').map(line => `> ${line}`).join('\n')}`;
-
+    async createComment({discussion_number, body}) {
         try {
             // Get Discussion subjectId
             const idData = await GraphqlService.query(GET_DISCUSSION_ID, {
@@ -254,7 +215,7 @@ class DiscussionService extends Base {
             const discussionId = idData.repository.discussion.id;
 
             // Use ADD_DISCUSSION_COMMENT mutation
-            const result = await GraphqlService.query(ADD_DISCUSSION_COMMENT, { discussionId, body: finalBody });
+            const result = await GraphqlService.query(ADD_DISCUSSION_COMMENT, { discussionId, body });
             const comment = result.addDiscussionComment.comment;
 
             return {
@@ -309,11 +270,11 @@ class DiscussionService extends Base {
      * @param {number} [options.discussion_number]    The number of the discussion (required for create).
      * @param {string} [options.comment_id]           The global node ID of the comment (required for update).
      * @param {string} options.body                   The content of the comment.
-     * @param {string} [options.agent]                The identity of the calling agent (required for create).
+     * @param {string} [options.agent]                Deprecated no-op retained for backward compatibility.
      * @param {string} options.action                 The action to perform: 'create' or 'update'.
      * @returns {Promise<object>}
      */
-    async manageDiscussionComment({discussion_number, comment_id, body, agent, action}) {
+    async manageDiscussionComment({discussion_number, comment_id, body, action}) {
         if (!['create', 'update'].includes(action)) {
             return {
                 error: 'Bad Request',
@@ -323,14 +284,14 @@ class DiscussionService extends Base {
         }
 
         if (action === 'create') {
-            if (!agent || !discussion_number) {
+            if (!discussion_number) {
                 return {
                     error: 'Bad Request',
-                    message: "Missing required argument: 'agent' and 'discussion_number' are required for creating comments.",
+                    message: "Missing required argument: 'discussion_number' is required for creating comments.",
                     code: 'MISSING_ARGUMENTS'
                 };
             }
-            return this.createComment({discussion_number, body, agent});
+            return this.createComment({discussion_number, body});
         } else {
             if (!comment_id) {
                 return {

--- a/ai/services/github-workflow/DiscussionService.mjs
+++ b/ai/services/github-workflow/DiscussionService.mjs
@@ -270,7 +270,6 @@ class DiscussionService extends Base {
      * @param {number} [options.discussion_number]    The number of the discussion (required for create).
      * @param {string} [options.comment_id]           The global node ID of the comment (required for update).
      * @param {string} options.body                   The content of the comment.
-     * @param {string} [options.agent]                Deprecated no-op retained for backward compatibility.
      * @param {string} options.action                 The action to perform: 'create' or 'update'.
      * @returns {Promise<object>}
      */

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -28,13 +28,6 @@ import {
 
 const execAsync = promisify(exec);
 
-const AGENT_ICONS = {
-    gemini : '✦',
-    claude : '❋',
-    gpt    : '●',
-    default: '◆'
-};
-
 /**
  * @summary Service for interacting with GitHub issues via the GraphQL API.
  *
@@ -326,9 +319,8 @@ class IssueService extends Base {
      * graph-readable provenance via the Native Edge Graph + Retrospective daemon's
      * comment-ingestion path.
      *
-     * Posts the comment via raw `ADD_COMMENT` (not via `createComment`) to avoid the
-     * agent-attribution header (`**Input from <agent>:**`); the audit comment is system-
-     * generated, not agent-authored.
+     * Posts the comment via raw `ADD_COMMENT` because the audit comment is system-
+     * generated provenance rather than caller-authored feedback.
      *
      * Comment failure does NOT roll back the assignee mutation — graceful degradation,
      * mirroring `createIssue`'s projectAttach partial-failure pattern. Audit-trail tests
@@ -371,10 +363,9 @@ class IssueService extends Base {
      * @param {number} [options.issue_number] The number of the issue.
      * @param {number} [options.pr_number]    The number of the pull request.
      * @param {string} options.body           The raw content of the comment.
-     * @param {string} options.agent          The identity of the calling agent.
      * @returns {Promise<object>} A promise that resolves to a success message.
      */
-    async createComment({issue_number, pr_number, body, agent}) {
+    async createComment({issue_number, pr_number, body}) {
         // Input Validation
         if (issue_number && pr_number) {
             return {
@@ -400,22 +391,6 @@ class IssueService extends Base {
             [isPR ? 'prNumber' : 'number']: number
         };
 
-        // Agent Header Formatting
-        const header       = `**Input from ${agent}:**\n\n`;
-        const agentIcon    = AGENT_ICONS[this.getAgentType(agent)];
-        const headingMatch = body.match(/^(#+\s*)(.*)$/);
-        let processedBody;
-
-        if (headingMatch) {
-            const headingMarkers = headingMatch[1];
-            const headingContent = headingMatch[2];
-            processedBody = `${headingMarkers}${agentIcon} ${headingContent}\n${body.substring(headingMatch[0].length)}`;
-        } else {
-            processedBody = `${agentIcon} ${body}`;
-        }
-
-        const finalBody = `${header}${processedBody.split('\n').map(line => `> ${line}`).join('\n')}`;
-
         try {
             // Divergent ID Lookup
             const query = isPR ? GET_PULL_REQUEST_ID : GET_ISSUE_ID;
@@ -431,7 +406,7 @@ class IssueService extends Base {
             // via mailbox DM to the author; the author fetches just-this-comment via
             // `get_conversation({comment_id: ...})` instead of re-walking the whole thread.
             // Symmetric with `updateComment`'s existing `{commentId, url, updatedAt}` shape.
-            const result = await GraphqlService.query(ADD_COMMENT, { subjectId, body: finalBody });
+            const result = await GraphqlService.query(ADD_COMMENT, { subjectId, body });
             const node   = result.addComment.commentEdge.node;
 
             return {
@@ -945,21 +920,6 @@ class IssueService extends Base {
     }
 
     /**
-     * Extracts the agent type from the agent string for icon selection.
-     * @param {string} agent The full agent identifier
-     * @returns {string} The agent type key for AGENT_ICONS lookup
-     */
-    getAgentType(agent) {
-        const agentLower = agent.toLowerCase();
-
-        if (agentLower.includes('gemini')) return 'gemini';
-        if (agentLower.includes('claude')) return 'claude';
-        if (agentLower.includes('gpt'))    return 'gpt';
-
-        return 'default';
-    }
-
-    /**
      * Convenience shortcut
      * @returns {Promise<Boolean>}
      */
@@ -1006,11 +966,11 @@ class IssueService extends Base {
      * @param {number} [options.pr_number]    The number of the pull request (required for create if issue_number omitted).
      * @param {string} [options.comment_id]   The global node ID of the comment (required for update).
      * @param {string} options.body           The content of the comment.
-     * @param {string} [options.agent]        The identity of the calling agent (required for create).
+     * @param {string} [options.agent]        Deprecated no-op retained for backward compatibility.
      * @param {string} options.action         The action to perform: 'create' or 'update'.
      * @returns {Promise<object>}
      */
-    async manageIssueComment({issue_number, pr_number, comment_id, body, agent, action}) {
+    async manageIssueComment({issue_number, pr_number, comment_id, body, action}) {
         if (!['create', 'update'].includes(action)) {
             return {
                 error: 'Bad Request',
@@ -1020,14 +980,7 @@ class IssueService extends Base {
         }
 
         if (action === 'create') {
-            if (!agent) {
-                return {
-                    error: 'Bad Request',
-                    message: "Missing required argument: 'agent' is required for creating comments.",
-                    code: 'MISSING_ARGUMENTS'
-                };
-            }
-            return this.createComment({issue_number, pr_number, body, agent});
+            return this.createComment({issue_number, pr_number, body});
         } else {
             if (!comment_id) {
                 return {

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -966,7 +966,6 @@ class IssueService extends Base {
      * @param {number} [options.pr_number]    The number of the pull request (required for create if issue_number omitted).
      * @param {string} [options.comment_id]   The global node ID of the comment (required for update).
      * @param {string} options.body           The content of the comment.
-     * @param {string} [options.agent]        Deprecated no-op retained for backward compatibility.
      * @param {string} options.action         The action to perform: 'create' or 'update'.
      * @returns {Promise<object>}
      */

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
@@ -87,52 +87,6 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
             expect(callCount).toBe(2);
         });
 
-        test('accepts deprecated agent argument without formatting the body', async () => {
-            const DISCUSSION_NODE_ID = 'D_kwDOABcD1234567890';
-            const NEW_COMMENT_ID     = 'DC_kwDOABcD_legacy_agent_9876';
-            const NEW_COMMENT_URL    = 'https://github.com/neomjs/neo/discussions/10841#discussioncomment-4309098999';
-            const NEW_COMMENT_TS     = '2026-05-07T01:49:00Z';
-
-            let callCount = 0;
-            GraphqlService.query = async (query, variables) => {
-                callCount++;
-                if (callCount === 1) {
-                    return {repository: {discussion: {id: DISCUSSION_NODE_ID}}};
-                }
-                if (callCount === 2) {
-                    expect(variables).toMatchObject({
-                        discussionId: DISCUSSION_NODE_ID,
-                        body        : 'Legacy discussion body'
-                    });
-                    return {
-                        addDiscussionComment: {
-                            comment: {
-                                id       : NEW_COMMENT_ID,
-                                url      : NEW_COMMENT_URL,
-                                createdAt: NEW_COMMENT_TS
-                            }
-                        }
-                    };
-                }
-                throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
-            };
-
-            const result = await DiscussionService.manageDiscussionComment({
-                discussion_number: 10841,
-                body             : 'Legacy discussion body',
-                agent            : 'Gemini 3.1 Pro (Antigravity)',
-                action           : 'create'
-            });
-
-            expect(result).toEqual({
-                message  : 'Successfully created comment on discussion #10841',
-                commentId: NEW_COMMENT_ID,
-                url      : NEW_COMMENT_URL,
-                createdAt: NEW_COMMENT_TS
-            });
-            expect(callCount).toBe(2);
-        });
-
         test('propagates GraphQL error shape on API failure', async () => {
             GraphqlService.query = async () => {
                 throw new Error('GitHub API rate limit exceeded');

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs
@@ -54,6 +54,10 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
                 }
                 if (callCount === 2) {
                     // ADD_DISCUSSION_COMMENT mutation
+                    expect(variables).toMatchObject({
+                        discussionId: DISCUSSION_NODE_ID,
+                        body        : 'Test comment body'
+                    });
                     return {
                         addDiscussionComment: {
                             comment: {
@@ -70,7 +74,6 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
             const result = await DiscussionService.manageDiscussionComment({
                 discussion_number: 10841,
                 body             : 'Test comment body',
-                agent            : 'Gemini 3.1 Pro (Antigravity)',
                 action           : 'create'
             });
 
@@ -84,19 +87,50 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
             expect(callCount).toBe(2);
         });
 
-        test('rejects missing agent on create', async () => {
+        test('accepts deprecated agent argument without formatting the body', async () => {
+            const DISCUSSION_NODE_ID = 'D_kwDOABcD1234567890';
+            const NEW_COMMENT_ID     = 'DC_kwDOABcD_legacy_agent_9876';
+            const NEW_COMMENT_URL    = 'https://github.com/neomjs/neo/discussions/10841#discussioncomment-4309098999';
+            const NEW_COMMENT_TS     = '2026-05-07T01:49:00Z';
+
             let callCount = 0;
-            GraphqlService.query = async () => { callCount++; return null; };
+            GraphqlService.query = async (query, variables) => {
+                callCount++;
+                if (callCount === 1) {
+                    return {repository: {discussion: {id: DISCUSSION_NODE_ID}}};
+                }
+                if (callCount === 2) {
+                    expect(variables).toMatchObject({
+                        discussionId: DISCUSSION_NODE_ID,
+                        body        : 'Legacy discussion body'
+                    });
+                    return {
+                        addDiscussionComment: {
+                            comment: {
+                                id       : NEW_COMMENT_ID,
+                                url      : NEW_COMMENT_URL,
+                                createdAt: NEW_COMMENT_TS
+                            }
+                        }
+                    };
+                }
+                throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+            };
 
             const result = await DiscussionService.manageDiscussionComment({
                 discussion_number: 10841,
-                body             : 'Missing agent',
+                body             : 'Legacy discussion body',
+                agent            : 'Gemini 3.1 Pro (Antigravity)',
                 action           : 'create'
             });
 
-            expect(result.error).toBe('Bad Request');
-            expect(result.code).toBe('MISSING_ARGUMENTS');
-            expect(callCount).toBe(0);
+            expect(result).toEqual({
+                message  : 'Successfully created comment on discussion #10841',
+                commentId: NEW_COMMENT_ID,
+                url      : NEW_COMMENT_URL,
+                createdAt: NEW_COMMENT_TS
+            });
+            expect(callCount).toBe(2);
         });
 
         test('propagates GraphQL error shape on API failure', async () => {
@@ -107,7 +141,6 @@ test.describe('Neo.ai.services.github-workflow.DiscussionService — manageDiscu
             const result = await DiscussionService.manageDiscussionComment({
                 discussion_number: 10841,
                 body             : 'Will fail',
-                agent            : 'Gemini 3.1 Pro (Antigravity)',
                 action           : 'create'
             });
 

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -199,6 +199,10 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
                 }
                 if (callCount === 2) {
                     // ADD_COMMENT mutation — matches the shape IssueService.createComment consumes
+                    expect(variables).toMatchObject({
+                        subjectId: ISSUE_NODE_ID,
+                        body     : 'Test comment body'
+                    });
                     return {
                         addComment: {
                             commentEdge: {
@@ -217,7 +221,6 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
             const result = await IssueService.manageIssueComment({
                 issue_number: 10272,
                 body        : 'Test comment body',
-                agent       : 'Claude Opus 4.7 (Claude Code)',
                 action      : 'create'
             });
 
@@ -248,6 +251,10 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
                     return {repository: {pullRequest: {id: PR_NODE_ID}}};
                 }
                 if (callCount === 2) {
+                    expect(variables).toMatchObject({
+                        subjectId: PR_NODE_ID,
+                        body     : 'PR review comment body'
+                    });
                     return {
                         addComment: {
                             commentEdge: {
@@ -266,7 +273,6 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
             const result = await IssueService.manageIssueComment({
                 pr_number: 10268,
                 body     : 'PR review comment body',
-                agent    : 'Claude Opus 4.7 (Claude Code)',
                 action   : 'create'
             });
 
@@ -287,7 +293,6 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
                 issue_number: 10272,
                 pr_number   : 10268,
                 body        : 'Ambiguous',
-                agent       : 'Claude Opus 4.7 (Claude Code)',
                 action      : 'create'
             });
 
@@ -296,19 +301,52 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
             expect(callCount).toBe(0);
         });
 
-        test('rejects missing agent on create', async () => {
+        test('accepts deprecated agent argument without formatting the body', async () => {
+            const ISSUE_NODE_ID     = 'I_kwDOABcD1234567890';
+            const NEW_COMMENT_ID    = 'IC_kwDOABcD_legacy_agent_9876';
+            const NEW_COMMENT_URL   = 'https://github.com/neomjs/neo/issues/10272#issuecomment-4309098999';
+            const NEW_COMMENT_TS    = '2026-04-24T01:49:00Z';
+
             let callCount = 0;
-            GraphqlService.query = async () => { callCount++; return null; };
+            GraphqlService.query = async (query, variables) => {
+                callCount++;
+                if (callCount === 1) {
+                    return {repository: {issue: {id: ISSUE_NODE_ID}}};
+                }
+                if (callCount === 2) {
+                    expect(variables).toMatchObject({
+                        subjectId: ISSUE_NODE_ID,
+                        body     : 'Legacy caller body'
+                    });
+                    return {
+                        addComment: {
+                            commentEdge: {
+                                node: {
+                                    id       : NEW_COMMENT_ID,
+                                    url      : NEW_COMMENT_URL,
+                                    createdAt: NEW_COMMENT_TS
+                                }
+                            }
+                        }
+                    };
+                }
+                throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
+            };
 
             const result = await IssueService.manageIssueComment({
                 issue_number: 10272,
-                body        : 'Missing agent',
+                body        : 'Legacy caller body',
+                agent       : 'Claude Opus 4.7 (Claude Code)',
                 action      : 'create'
             });
 
-            expect(result.error).toBe('Bad Request');
-            expect(result.code).toBe('MISSING_ARGUMENTS');
-            expect(callCount).toBe(0);
+            expect(result).toEqual({
+                message  : 'Successfully created comment on issue #10272',
+                commentId: NEW_COMMENT_ID,
+                url      : NEW_COMMENT_URL,
+                createdAt: NEW_COMMENT_TS
+            });
+            expect(callCount).toBe(2);
         });
 
         test('propagates GraphQL error shape on API failure', async () => {
@@ -319,7 +357,6 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
             const result = await IssueService.manageIssueComment({
                 issue_number: 10272,
                 body        : 'Will fail',
-                agent       : 'Claude Opus 4.7 (Claude Code)',
                 action      : 'create'
             });
 

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -301,54 +301,6 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueComme
             expect(callCount).toBe(0);
         });
 
-        test('accepts deprecated agent argument without formatting the body', async () => {
-            const ISSUE_NODE_ID     = 'I_kwDOABcD1234567890';
-            const NEW_COMMENT_ID    = 'IC_kwDOABcD_legacy_agent_9876';
-            const NEW_COMMENT_URL   = 'https://github.com/neomjs/neo/issues/10272#issuecomment-4309098999';
-            const NEW_COMMENT_TS    = '2026-04-24T01:49:00Z';
-
-            let callCount = 0;
-            GraphqlService.query = async (query, variables) => {
-                callCount++;
-                if (callCount === 1) {
-                    return {repository: {issue: {id: ISSUE_NODE_ID}}};
-                }
-                if (callCount === 2) {
-                    expect(variables).toMatchObject({
-                        subjectId: ISSUE_NODE_ID,
-                        body     : 'Legacy caller body'
-                    });
-                    return {
-                        addComment: {
-                            commentEdge: {
-                                node: {
-                                    id       : NEW_COMMENT_ID,
-                                    url      : NEW_COMMENT_URL,
-                                    createdAt: NEW_COMMENT_TS
-                                }
-                            }
-                        }
-                    };
-                }
-                throw new Error(`Unexpected additional GraphqlService.query call: ${callCount}`);
-            };
-
-            const result = await IssueService.manageIssueComment({
-                issue_number: 10272,
-                body        : 'Legacy caller body',
-                agent       : 'Claude Opus 4.7 (Claude Code)',
-                action      : 'create'
-            });
-
-            expect(result).toEqual({
-                message  : 'Successfully created comment on issue #10272',
-                commentId: NEW_COMMENT_ID,
-                url      : NEW_COMMENT_URL,
-                createdAt: NEW_COMMENT_TS
-            });
-            expect(callCount).toBe(2);
-        });
-
         test('propagates GraphQL error shape on API failure', async () => {
             GraphqlService.query = async () => {
                 throw new Error('GitHub API rate limit exceeded');


### PR DESCRIPTION
Resolves #13369

Authored by GPT-5 (Codex Desktop), @neo-gpt (Euclid). Session 019ec8a7-1f8e-75a3-b223-fe59cc444776.

Drops the shared-account-era comment wrapper from `manage_issue_comment` and `manage_discussion_comment`. Create calls now submit the caller Markdown body directly to GitHub, and the public tool contract no longer exposes an `agent` argument for these comment paths. GitHub authenticated author identity is the attribution source.

Evidence: L2 (mocked GraphQL unit coverage for issue/PR and discussion comment creation, plus stale-contract sweep) -> L2 required (comment-tool contract behavior). No residuals.

## Deltas from ticket
- Removed the legacy `agent` input from the OpenAPI request schemas instead of retaining a compatibility no-op.
- Updated the assignee audit-comment note that previously documented bypassing the old agent wrapper.

## Test Evidence
- `git diff --check` -> clean before commit.
- `git diff --cached --check` -> clean before commit.
- `rg -n "Deprecated no-op|deprecated agent|legacy agent|agent\s*:|agent\b.*backward compatibility|options\.agent|agent identity in the format|Automatically formats|Input from|AGENT_ICONS|getAgentType|finalBody|Missing required argument: 'agent'|rejects missing agent" ai/services/github-workflow/IssueService.mjs ai/services/github-workflow/DiscussionService.mjs ai/mcp/server/github-workflow/openapi.yaml test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs` -> no matches.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs` -> 61 passed before rebase.
- `git rebase origin/dev` -> clean.
- `git diff --check origin/dev..HEAD` -> clean after rebase.
- Reran `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs test/playwright/unit/ai/services/github-workflow/DiscussionService.spec.mjs` after rebase -> 61 passed.

## Post-Merge Validation
- [ ] Create an issue/PR comment through `manage_issue_comment` and confirm the posted Markdown has no `Input from ...` wrapper.
- [ ] Create a discussion comment through `manage_discussion_comment` and confirm the posted Markdown has no injected icon/byline.
- [ ] Regenerated MCP tool metadata does not expose an `agent` input for either comment-management tool.

## Commits
- `ede7f15d2` — `fix(github-workflow): post comment bodies as authored (#13369)`
- `c92002057` — `fix(github-workflow): remove deprecated comment agent input (#13369)`