### PR TITLE
fix(mcp): inspect_store / list_stores accept an object model (#13372)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -488,7 +488,9 @@ paths:
                   count:
                     type: integer
                   model:
-                    type: string
+                    oneOf:
+                      - type: string
+                      - type: object
                   filters:
                     type: array
                     items:
@@ -532,7 +534,9 @@ paths:
                     id:
                       type: string
                     model:
-                      type: string
+                      oneOf:
+                        - type: string
+                        - type: object
                     count:
                       type: integer
 

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -364,6 +364,27 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(operationIds).toEqual(mappingIds);
     });
 
+    test('neural-link inspect_store + list_stores output schemas accept an object `model` (#13372)', () => {
+        const doc         = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
+              opsById     = getOperationsById(doc),
+              // A live store's `model` is the serialized Neo.data.Model — an object, not a className string.
+              objectModel = {className: 'Neo.data.Model', fields: [{name: 'id', type: 'String'}], keyProperty: 'id'};
+
+        const inspectStoreOut = buildOutputZodSchema(doc, opsById.inspect_store),
+              listStoresOut   = buildOutputZodSchema(doc, opsById.list_stores);
+
+        expect(inspectStoreOut, 'inspect_store has an output schema').toBeTruthy();
+        expect(listStoresOut,   'list_stores has an output schema').toBeTruthy();
+
+        // The -32602 regression: an object `model` must parse (was rejected by `model: type: string`).
+        expect(() => inspectStoreOut.parse({id: 'store-1', count: 2, model: objectModel, filters: [], sorters: [], items: []})).not.toThrow();
+        // A className-only string `model` still parses — backward-compatible.
+        expect(() => inspectStoreOut.parse({id: 'store-1', count: 2, model: 'Neo.data.Model', filters: [], sorters: [], items: []})).not.toThrow();
+        // list_stores: the top-level array response is wrapped as `{result: [...]}` by the output validator;
+        // each item's object `model` parses.
+        expect(() => listStoresOut.parse({result: [{id: 'store-1', model: objectModel, count: 2}]})).not.toThrow();
+    });
+
     for (const server of servers) {
         test(`${server}: every emitted input/output schema has items on array nodes (#10064)`, () => {
             const yamlPath = path.join(repoRoot, 'ai/mcp/server', server, 'openapi.yaml');


### PR DESCRIPTION
Resolves #13372

A live store's `model` is the serialized `Neo.data.Model` (an object — `{className, fields, keyProperty, …}`), but the neural-link OpenAPI declared `model: type: string` on both `inspect_store` and `list_stores`. Strict #10043 output validation rejected the object with `-32602` ("data/model must be string"), so **any object-model store was unreadable through the agent-facing `inspect_store` tool** — exactly the verification path #13362 AC4 needs.

Fix: declare `model` as `oneOf: [{type: string}, {type: object}]` at `openapi.yaml:490` (inspect_store) + `:534` (list_stores) — backward-compatible, since `buildOutputZodSchema` maps `oneOf` → `z.union` (verified at `openApiValidator.mjs:94`), so a className-only string model still validates.

Evidence: L2 (the real output-validation seam, unit-covered) → L3 for AC1/AC4 (a live `inspect_store` MCP call, post-merge). Residual: AC1/AC4 are the ticket's own post-merge items.

## Deltas from ticket (if any)
- The ticket's AC3 covers both ops; `list_stores`' top-level array response is wrapped by the validator as `{result: [...]}` (the `buildOutputZodSchema` non-object path), so the round-trip asserts that wrapping — not a bare array. (The `{stores:[…]}` / `isLoaded` envelope divergence stays #10072's, per the ticket's Out of Scope.)

## Test Evidence
- `OpenApiValidatorCompliance.spec.mjs`: new round-trip `neural-link inspect_store + list_stores output schemas accept an object model` — an object-`model` parses (the `-32602` regression), a string-`model` still parses (backward-compat), for both ops. Full spec **31/31 green** (`UNIT_TEST_MODE=true playwright -c …unit.mjs`).
- Verified `buildOutputZodSchema` maps `oneOf` → `z.union` (`openApiValidator.mjs:94`), so the schema fix actually changes the runtime validator (not just the doc). No trailing whitespace; no `#refs` in code comments.

## Post-Merge Validation
- [ ] An agent completes #13362 AC4's store verification through the **real** `inspect_store` MCP tool against an object-model store — no `-32602` (the live-tool path the in-process fixture in PR #13363 bypasses).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 73156d71-9a96-4bf1-bbc8-d6487ca7dddd.
