### PR TITLE
feat(memory-core): archiveMemoriesByAgentIdentity tombstone + recall-exclusion (#13384)

### DIFF
--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -869,7 +869,7 @@ class GraphService extends Base {
                 let node       = this.db.nodes.get(adjacentId);
 
                 // Actively filter out CLOSED structural paths plus RLS-invisible nodes/edges.
-                if (node && isRlsVisible(node, rlsUserId) && isRlsVisible(e, rlsUserId) && node.properties?.state !== 'CLOSED') {
+                if (node && isRlsVisible(node, rlsUserId) && isRlsVisible(e, rlsUserId) && node.properties?.state !== 'CLOSED' && !node.properties?.archivedAt) {
                     topology.strategicNeighbors.push({
                         id              : node.id,
                         type            : node.label,

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -527,7 +527,9 @@ class MemoryService extends Base {
                         name: `Memory: ${timestamp}`,
                         description: `Agent thought flow inside session ${sessionId}.`,
                         semanticVectorId: memoryId,
-                        properties: {...memoryProperties, miniSummary}
+                        // Archive-aware re-upsert: a tombstone set between the initial projection and this
+                        // post-summary re-mint must not be dropped (see _withArchiveState).
+                        properties: this._withArchiveState({...memoryProperties, miniSummary})
                     });
                 }
             }).catch(() => {});
@@ -809,6 +811,14 @@ class MemoryService extends Base {
      */
     async _readPendingWalRecencyRows({identity, userId, before, excludeIds = new Set()} = {}) {
         try {
+            // Identity-level tombstone short-circuit: archiveMemoriesByAgentIdentity sweeps ALL of an
+            // identity's memories + writes a durable marker, and the graph-SQL recency path already
+            // excludes archivedAt — so an archived identity's graph-PENDING rows must be excluded here
+            // too, else they leak into recency recall during projection lag.
+            if (this._archivedIdentityState(identity)) {
+                return [];
+            }
+
             // No raw read-limit here: readPendingWalRecords walks each daily segment in append
             // (oldest-first) order, so capping the raw count would drop the NEWEST graph-pending rows
             // — exactly the just-written, not-yet-projected turns the read-after-write overlay must
@@ -1498,7 +1508,9 @@ class MemoryService extends Base {
         }
 
         const existing   = JSON.parse(row.data),
-              properties = {...(existing.properties || {}), miniSummary},
+              // Archive-aware: this addNodes overwrites the node, so a tombstone set after `existing` was
+              // read (the merge-vs-archive race) must be replayed from the durable marker (_withArchiveState).
+              properties = this._withArchiveState({...(existing.properties || {}), miniSummary}),
               nodeData   = {
                   id        : existing.id || id,
                   label     : existing.label || 'AGENT_MEMORY',

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -621,7 +621,10 @@ class MemoryService extends Base {
             name: `Memory: ${timestamp}`,
             description: `Agent thought flow inside session ${sessionId}.`,
             semanticVectorId: memoryId,
-            properties: memoryProperties
+            // Archive-aware: a tombstone set while this record was graph-pending (the projection-lag
+            // window) is replayed onto the node here, so a deferred projection cannot reintroduce an
+            // archived row un-tombstoned. See _withArchiveState + the durable ARCHIVED_AGENT_IDENTITY marker.
+            properties: this._withArchiveState(memoryProperties)
         });
 
         // Stamp write-time provenance when the transport resolved a real AgentIdentity.
@@ -1039,6 +1042,21 @@ class MemoryService extends Base {
                 }
             }
 
+            // Durable tombstone marker — survives graph-projection lag. The SQL UPDATE + node-cache sweep
+            // above only reach ALREADY-projected nodes; a row embedded into Chroma but still graph-pending
+            // (graphProjectionVersion:1, no .graph.jsonl marker) has no node to stamp yet. This global,
+            // RLS-exempt marker lets the deferred projection drain (_projectMemoryToGraph → _withArchiveState)
+            // and the recency overlay tombstone it once projection catches up — even across a restart.
+            // Set unconditionally (not gated on live.length) so an identity archived entirely during
+            // projection lag is still covered.
+            GraphService.upsertGlobalNode({
+                id         : `ARCHIVED_AGENT_IDENTITY:${agentIdentity}`,
+                type       : 'ARCHIVED_AGENT_IDENTITY',
+                name       : `Archived identity: ${agentIdentity}`,
+                description: 'Tombstone marker: deferred graph projection + recency overlay exclude this identity.',
+                properties : {agentIdentity, archivedAt, archivedReason}
+            });
+
             logger.info(`[MemoryService] archiveMemoriesByAgentIdentity('${agentIdentity}'): matched ${matchedIds.length}, archived ${live.length}`);
             return {agentIdentity, matchedCount: matchedIds.length, archivedCount: live.length, dryRun: false};
         } catch (error) {
@@ -1107,12 +1125,52 @@ class MemoryService extends Base {
                 }
             }
 
+            // Remove the durable tombstone marker so future projections + the recency overlay re-admit
+            // the identity. Safe when absent (the identity was never archived) — removeNodes no-ops.
+            GraphService.removeNodes([`ARCHIVED_AGENT_IDENTITY:${agentIdentity}`]);
+
             logger.info(`[MemoryService] unarchiveMemoriesByAgentIdentity('${agentIdentity}'): restored ${restore.length}`);
             return {agentIdentity, restoredCount: restore.length};
         } catch (error) {
             logger.error('[MemoryService] Error unarchiving memories by agentIdentity:', error);
             return {error: 'Failed to unarchive memories', message: error.message, code: 'MEMORY_UNARCHIVE_ERROR'};
         }
+    }
+
+    /**
+     * @summary Looks up the durable tombstone marker for an agent identity.
+     *
+     * The archive op ({@link MemoryService#archiveMemoriesByAgentIdentity}) writes a global,
+     * RLS-exempt `ARCHIVED_AGENT_IDENTITY:<identity>` node; this reads it so the deferred
+     * graph-projection drain + the recency overlay can tombstone a record whose graph node did
+     * not exist when the archive ran (the projection-lag leak: Chroma embed and graph projection
+     * are independent derived states that catch up on different clocks).
+     * @param {String} agentIdentity The stamped write-identity.
+     * @returns {Object|null} `{archivedAt, archivedReason}` when archived, else `null`.
+     * @private
+     */
+    _archivedIdentityState(agentIdentity) {
+        if (!agentIdentity) {
+            return null;
+        }
+
+        const props = GraphService.getNodeRecord({id: `ARCHIVED_AGENT_IDENTITY:${agentIdentity}`})?.properties;
+        return props?.archivedAt ? {archivedAt: props.archivedAt, archivedReason: props.archivedReason || ''} : null;
+    }
+
+    /**
+     * @summary Returns `memoryProperties` augmented with `archivedAt`/`archivedReason` when the row's
+     * `agentIdentity` carries a durable tombstone marker — applied at every `AGENT_MEMORY` mint site so
+     * a tombstone set during projection lag survives a later (re)projection.
+     * @param {Object} memoryProperties The properties about to be projected onto the graph node.
+     * @returns {Object} The same object, or a tombstoned copy when the identity is archived.
+     * @private
+     */
+    _withArchiveState(memoryProperties) {
+        const archived = this._archivedIdentityState(memoryProperties?.agentIdentity);
+        return archived
+            ? {...memoryProperties, archivedAt: archived.archivedAt, archivedReason: archived.archivedReason}
+            : memoryProperties;
     }
 
     /**

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -913,6 +913,9 @@ class MemoryService extends Base {
             let records = result.ids.map((id, index) => {
                 const metadata = result.metadatas[index] || {};
 
+                // Tombstone exclusion: archived rows are dropped from recall.
+                if (metadata.archivedAt) return null;
+
                 return {
                     id,
                     sessionId: metadata.sessionId,
@@ -927,7 +930,7 @@ class MemoryService extends Base {
                     toolsUsed: metadata.toolsUsed || null,
                     _userId  : metadata.userId
                 };
-            });
+            }).filter(Boolean); // Tombstone exclusion (archived rows returned null above)
 
             if (userId && policy === 'legacy') {
                 records = records.filter(r => !r._userId || r._userId === userId || r._userId === SHARED_USER_ID);
@@ -955,6 +958,160 @@ class MemoryService extends Base {
                 message: error.message,
                 code   : 'MEMORY_LIST_ERROR'
             };
+        }
+    }
+
+    /**
+     * @summary Tombstones every memory stamped with `agentIdentity` so it stops surfacing in recall,
+     * while RETAINING the rows (forensics) and staying operator-reversible — the Memory-Core
+     * primitive the Fleet agent-removal reconciliation consumes via the `archiveMemoriesFn` seam.
+     *
+     * Sets `archivedAt` (+ `archivedReason`) across BOTH stores — the Chroma row metadata (read by
+     * `queryMemories` / `listMemories`) and the graph `AGENT_MEMORY` node (read by `queryRecentTurns`
+     * and the topology frontier) — so the recall paths that exclude `archivedAt` stop returning the
+     * rows. Idempotent: already-tombstoned rows are skipped. Keys on the STAMPED write-identity
+     * (`@<github-username>` for FM stdio+PAT agents, per the `add_memory` stamping) — NOT a registry id.
+     *
+     * @param {Object}  options
+     * @param {String}  options.agentIdentity The stamped `metadata.agentIdentity` value to sweep.
+     * @param {String}  [options.reason] Tombstone provenance, stored per row as `archivedReason`.
+     * @param {Boolean} [options.dryRun=false] Preview `matchedCount` without tombstoning.
+     * @returns {Promise<Object>} `{agentIdentity, matchedCount, archivedCount, dryRun}`.
+     */
+    async archiveMemoriesByAgentIdentity({agentIdentity, reason, dryRun = false} = {}) {
+        if (!agentIdentity) {
+            return {error: 'Bad Request', message: "'agentIdentity' is required.", code: 'MISSING_AGENT_IDENTITY'};
+        }
+
+        try {
+            const collection  = await StorageRouter.getMemoryCollection(),
+                  matched     = await collection.get({where: {agentIdentity}, include: ['metadatas']}),
+                  matchedIds  = matched.ids       || [],
+                  matchedMeta = matched.metadatas || [],
+                  live        = []; // not-already-tombstoned rows (idempotent: a re-run archives 0 new)
+
+            for (let i = 0; i < matchedIds.length; i++) {
+                if (!(matchedMeta[i] && matchedMeta[i].archivedAt)) {
+                    live.push({id: matchedIds[i], meta: matchedMeta[i] || {}});
+                }
+            }
+
+            if (dryRun) {
+                return {agentIdentity, matchedCount: matchedIds.length, archivedCount: 0, dryRun: true};
+            }
+
+            const archivedAt     = new Date().toISOString(),
+                  archivedReason = reason || '';
+
+            // Chroma side: stamp archivedAt onto the live rows' metadata (full-metadata-preserving).
+            if (live.length > 0) {
+                await collection.update({
+                    ids      : live.map(r => r.id),
+                    metadatas: live.map(r => ({...r.meta, archivedAt, archivedReason}))
+                });
+            }
+
+            // Graph side: stamp the projected AGENT_MEMORY nodes. The `archivedAt IS NULL` guard keeps
+            // it idempotent + scoped to the live rows. Mirrors the MailboxService `archivedAt` model.
+            const sqlite = GraphService.db?.storage?.db;
+            if (sqlite) {
+                sqlite.prepare(`
+                    UPDATE Nodes
+                    SET data = json_set(json_set(data, '$.properties.archivedAt', ?), '$.properties.archivedReason', ?)
+                    WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
+                      AND json_extract(data, '$.properties.agentIdentity') = ?
+                      AND json_extract(data, '$.properties.archivedAt') IS NULL
+                `).run(archivedAt, archivedReason, agentIdentity);
+            }
+
+            // In-memory node-cache coherence: getContextFrontier reads GraphService.db.nodes (the
+            // cache), which the SQL UPDATE above does NOT touch. The graph node id === the memory id
+            // (_projectMemoryToGraph), so mirror archivedAt onto any cached node so the topology
+            // frontier excludes it too.
+            const nodeCache = GraphService.db?.nodes;
+            if (nodeCache) {
+                for (const {id} of live) {
+                    const cached = nodeCache.get(id);
+                    if (cached && cached.properties) {
+                        cached.properties.archivedAt     = archivedAt;
+                        cached.properties.archivedReason = archivedReason;
+                    }
+                }
+            }
+
+            logger.info(`[MemoryService] archiveMemoriesByAgentIdentity('${agentIdentity}'): matched ${matchedIds.length}, archived ${live.length}`);
+            return {agentIdentity, matchedCount: matchedIds.length, archivedCount: live.length, dryRun: false};
+        } catch (error) {
+            logger.error('[MemoryService] Error archiving memories by agentIdentity:', error);
+            return {error: 'Failed to archive memories', message: error.message, code: 'MEMORY_ARCHIVE_ERROR'};
+        }
+    }
+
+    /**
+     * @summary Reverses {@link archiveMemoriesByAgentIdentity} — clears `archivedAt` for `agentIdentity`
+     * so the rows recall again (operator re-provisioning). A hard purge is a separate
+     * explicit op, never the tombstone default.
+     *
+     * Chroma metadata cannot hold `null`, so the cleared marker is the empty string `''` (falsy → the
+     * recall-exclusions re-admit the row); the graph node's marker is removed via `json_remove`.
+     *
+     * @param {Object} options
+     * @param {String} options.agentIdentity The stamped identity to restore.
+     * @returns {Promise<Object>} `{agentIdentity, restoredCount}`.
+     */
+    async unarchiveMemoriesByAgentIdentity({agentIdentity} = {}) {
+        if (!agentIdentity) {
+            return {error: 'Bad Request', message: "'agentIdentity' is required.", code: 'MISSING_AGENT_IDENTITY'};
+        }
+
+        try {
+            const collection  = await StorageRouter.getMemoryCollection(),
+                  matched     = await collection.get({where: {agentIdentity}, include: ['metadatas']}),
+                  matchedIds  = matched.ids       || [],
+                  matchedMeta = matched.metadatas || [],
+                  restore     = [];
+
+            for (let i = 0; i < matchedIds.length; i++) {
+                if (matchedMeta[i] && matchedMeta[i].archivedAt) {
+                    restore.push({id: matchedIds[i], meta: matchedMeta[i]});
+                }
+            }
+
+            if (restore.length > 0) {
+                await collection.update({
+                    ids      : restore.map(r => r.id),
+                    metadatas: restore.map(r => ({...r.meta, archivedAt: '', archivedReason: ''}))
+                });
+            }
+
+            const sqlite = GraphService.db?.storage?.db;
+            if (sqlite) {
+                sqlite.prepare(`
+                    UPDATE Nodes
+                    SET data = json_remove(data, '$.properties.archivedAt', '$.properties.archivedReason')
+                    WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
+                      AND json_extract(data, '$.properties.agentIdentity') = ?
+                      AND json_extract(data, '$.properties.archivedAt') IS NOT NULL
+                `).run(agentIdentity);
+            }
+
+            // In-memory node-cache coherence (mirror of the archive sweep): clear the cached marker.
+            const nodeCache = GraphService.db?.nodes;
+            if (nodeCache) {
+                for (const {id} of restore) {
+                    const cached = nodeCache.get(id);
+                    if (cached && cached.properties) {
+                        delete cached.properties.archivedAt;
+                        delete cached.properties.archivedReason;
+                    }
+                }
+            }
+
+            logger.info(`[MemoryService] unarchiveMemoriesByAgentIdentity('${agentIdentity}'): restored ${restore.length}`);
+            return {agentIdentity, restoredCount: restore.length};
+        } catch (error) {
+            logger.error('[MemoryService] Error unarchiving memories by agentIdentity:', error);
+            return {error: 'Failed to unarchive memories', message: error.message, code: 'MEMORY_UNARCHIVE_ERROR'};
         }
     }
 
@@ -1045,6 +1202,7 @@ class MemoryService extends Base {
                 WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
                   AND json_extract(memory.data, '$.properties.agentIdentity') = ?
                   AND json_extract(memory.data, '$.properties.userId')        = ?
+                  AND json_extract(memory.data, '$.properties.archivedAt') IS NULL
                   ${cursorClause}
                 ORDER BY json_extract(memory.data, '$.properties.timestamp') DESC, memory.id DESC
                 LIMIT ?
@@ -1501,6 +1659,19 @@ class MemoryService extends Base {
             let ids       = searchResult.ids?.[0] || [];
             let distances = searchResult.distances?.[0] || [];
             let metadatas = searchResult.metadatas?.[0] || [];
+
+            // Tombstone exclusion: archived rows (metadata.archivedAt set) are dropped from
+            // recall. UNCONDITIONAL — the legacy/trust post-filter below only runs for some policies,
+            // so the exclusion cannot live there. A dropped archived row reads as a genuine no-match.
+            if (metadatas.some(m => m && m.archivedAt)) {
+                const live = [];
+                for (let i = 0; i < metadatas.length; i++) {
+                    if (!(metadatas[i] && metadatas[i].archivedAt)) live.push(i);
+                }
+                ids       = live.map(i => ids[i]);
+                distances = live.map(i => distances[i]);
+                metadatas = live.map(i => metadatas[i]);
+            }
 
             if ((userId && policy === 'legacy') || minTrustTier) {
                 const filteredIndices = [];

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.PublicRecall.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.PublicRecall.spec.mjs
@@ -1,0 +1,161 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MemoryServiceArchivePublicRecallTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+import {drainMemoryWal}      from './util.mjs';
+
+/**
+ * Public graph-recall leak coverage for archiveMemoriesByAgentIdentity (the source-issue acceptance paths).
+ *
+ * The sibling ArchiveByIdentity spec pins the Chroma recall paths (queryMemories / listMemories)
+ * with a stubbed graph. The cycle-2 review correctly required the PUBLIC graph-backed recall
+ * surfaces the source issue names — queryRecentTurns + getContextFrontier — proven against the REAL graph,
+ * not only the private helpers. This spec runs the real in-memory SQLite graph (UNIT_TEST_MODE →
+ * storagePaths.graph = ':memory:', like QueryRecentTurns.spec) so the archive op's graph-SQL stamp
+ * + node-cache coherence sweep are exercised end-to-end, then asserts both public surfaces exclude
+ * the archived identity. The spy collection supports where/$exists/update so the archive sweep's
+ * Chroma get/update land — which populates `live` so the node-cache loop stamps the cached node
+ * getContextFrontier reads (the SQL-UPDATE alone stamps only the persisted row queryRecentTurns reads).
+ */
+function createSpyCollection() {
+    const rows = new Map();
+
+    const matchesWhere = (metadata, where) => {
+        if (!where) return true;
+        if (where.$and) return where.$and.every(cond => matchesWhere(metadata, cond));
+        if (where.$or)  return where.$or.some(cond => matchesWhere(metadata, cond));
+        return Object.entries(where).every(([key, value]) => {
+            if (value && typeof value === 'object' && '$exists' in value) {
+                const exists = metadata && Object.prototype.hasOwnProperty.call(metadata, key);
+                return value.$exists ? exists : !exists;
+            }
+            return metadata?.[key] === value;
+        });
+    };
+
+    return {
+        rows,
+        async add({ids, metadatas, documents}) {
+            ids.forEach((id, i) => rows.set(id, {id, metadata: metadatas?.[i] ?? {}, document: documents?.[i] ?? ''}));
+        },
+        async get({ids, where} = {}) {
+            let entries = ids ? ids.map(id => rows.get(id)).filter(Boolean) : Array.from(rows.values());
+            entries = entries.filter(entry => matchesWhere(entry.metadata, where));
+            return {ids: entries.map(e => e.id), metadatas: entries.map(e => e.metadata), documents: entries.map(e => e.document)};
+        },
+        async query({nResults, where}) {
+            const entries = Array.from(rows.values()).filter(entry => matchesWhere(entry.metadata, where)).slice(0, nResults);
+            return {ids: [entries.map(e => e.id)], distances: [entries.map(() => 0)], metadatas: [entries.map(e => e.metadata)], documents: [entries.map(e => e.document)]};
+        },
+        async update({ids, metadatas}) {
+            ids.forEach((id, i) => { const row = rows.get(id); if (row) row.metadata = {...metadatas[i]}; });
+        }
+    };
+}
+
+test.describe('MemoryService — archive excludes identities from the PUBLIC graph-recall surfaces (#13384)', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let MemoryService, GraphService, LifecycleService, TextEmbeddingService, StorageRouter, spy, origGetColl, origEmbed;
+
+    const CTX = {userId: 'tenant-arch', agentIdentityNodeId: '@agent-arch'};
+
+    test.beforeAll(async () => {
+        GraphService         = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        MemoryService        = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+        LifecycleService     = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+        TextEmbeddingService = (await import('../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
+        StorageRouter        = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+
+        spy         = createSpyCollection();
+        origGetColl = StorageRouter.getMemoryCollection;
+        StorageRouter.getMemoryCollection = async () => spy;
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService.ready();
+        }
+
+        origEmbed                      = TextEmbeddingService.embedText;
+        TextEmbeddingService.embedText = async () => new Array(4096).fill(0.1);
+
+        GraphService.upsertNode({id: '@agent-arch', type: 'AgentIdentity', name: 'AgentArch', properties: {}});
+    });
+
+    test.afterAll(async () => {
+        if (origGetColl) StorageRouter.getMemoryCollection = origGetColl;
+        if (origEmbed)   TextEmbeddingService.embedText     = origEmbed;
+        const {cleanupChromaManager} = await import('./util.mjs');
+        await cleanupChromaManager();
+    });
+
+    // Seed one memory under @agent-arch, drained into the spy + projected to the real graph.
+    async function seed(prompt) {
+        return RequestContextService.run(CTX, async () => {
+            const r = await MemoryService.addMemory({prompt, response: 'r', thought: 't'});
+            await drainMemoryWal({ids: [r.id]});
+            return r.id;
+        });
+    }
+
+    test('queryRecentTurns (public) excludes an archived identity; unarchive restores it (#13384 AC)', async () => {
+        const memId = await seed('archive-recency prompt');
+
+        // Pre-archive: recallable via the public recency surface.
+        let res = await RequestContextService.run(CTX, async () => MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 50}));
+        expect(res.turns.map(t => t.id)).toContain(memId);
+
+        // Archive the identity (real op: Chroma sweep + graph-SQL stamp + durable marker).
+        const arch = await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: '@agent-arch', reason: 'public-recall-test'});
+        expect(arch.code).toBeUndefined();
+
+        // Post-archive: excluded from the public recency surface.
+        res = await RequestContextService.run(CTX, async () => MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 50}));
+        expect(res.turns.map(t => t.id)).not.toContain(memId);
+
+        // Reversible.
+        await MemoryService.unarchiveMemoriesByAgentIdentity({agentIdentity: '@agent-arch'});
+        res = await RequestContextService.run(CTX, async () => MemoryService.queryRecentTurns({agentIdentity: '@me', limit: 50}));
+        expect(res.turns.map(t => t.id)).toContain(memId);
+    });
+
+    test('getContextFrontier (public) excludes a strategic neighbor once it carries archivedAt (#13384 AC)', async () => {
+        // getContextFrontier's frontier is agent-identity RLS-scoped (isRlsVisible keys on the acting
+        // agentIdentityNodeId, never a tenant userId), so a tenant memory node is never one of its
+        // strategic neighbors. Exercise the public surface's archivedAt exclusion directly with a
+        // globally-visible frontier neighbor carrying the same node-cache archivedAt state the archive
+        // op's coherence sweep stamps (the archive op's stamping itself is pinned in the sibling spec).
+        const nodeId = 'AGENT_MEMORY:frontier-archive-probe';
+
+        GraphService.upsertGlobalNode({id: nodeId, type: 'AGENT_MEMORY', name: 'frontier probe', properties: {agentIdentity: '@agent-arch'}});
+        GraphService.linkGlobalNodes('frontier', nodeId, 'SPAWNED_MEMORY', 0.8);
+
+        // Pre-archive: a high-weight (0.8) globally-visible neighbor surfaces in the frontier.
+        let frontier = await RequestContextService.run(CTX, async () => GraphService.getContextFrontier({depth: 2}));
+        expect((frontier?.strategicNeighbors ?? []).map(n => n.id)).toContain(nodeId);
+
+        // Stamp archivedAt exactly as the archive op's node-cache coherence loop does — a direct
+        // mutation of the cached node's properties (the op does `cached.properties.archivedAt = ts`).
+        GraphService.db.nodes.get(nodeId).properties.archivedAt = '2026-01-01T00:00:00.000Z';
+
+        // Post-archive: filtered out of the frontier neighborhood (the !archivedAt guard).
+        frontier = await RequestContextService.run(CTX, async () => GraphService.getContextFrontier({depth: 2}));
+        expect((frontier?.strategicNeighbors ?? []).map(n => n.id)).not.toContain(nodeId);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
@@ -1,0 +1,213 @@
+import { setup } from '../../../../setup.mjs';
+
+const appName = 'MemoryServiceArchiveByIdentityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import MemoryService         from '../../../../../../ai/services/memory-core/MemoryService.mjs';
+import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+import {drainMemoryWal}      from './util.mjs';
+
+/**
+ * The leak-test for `archiveMemoriesByAgentIdentity` (the tombstone + recall-exclusion op).
+ *
+ * Proves the tombstone (set `archivedAt`) makes a memory STOP surfacing in the Chroma-backed
+ * recall paths (`queryMemories` / `listMemories`) while remaining retained + operator-reversible,
+ * and that the sweep is identity-scoped, idempotent, and dry-runnable.
+ *
+ * Mirrors `MemoryService.TenantIsolation.spec.mjs`: a stateful in-memory spy collection records
+ * every add/get/query/UPDATE so the sweep's `collection.update` (set archivedAt) is reflected in
+ * subsequent queries. `GraphService.db` is stubbed to a no-op SQL + empty node-cache — the graph-SQL
+ * exclusion (`queryRecentTurns`) + frontier exclusion are the proven `buildMailboxDelta`
+ * `archivedAt IS NULL` pattern and are covered by a separate integration assertion; this spec pins
+ * the Chroma content-recall paths, which are the primary recall-pollution surface.
+ */
+function createSpyCollection() {
+    const rows = new Map();
+
+    const matchesWhere = (metadata, where) => {
+        if (!where) return true;
+        if (where.$and) return where.$and.every(cond => matchesWhere(metadata, cond));
+        if (where.$or)  return where.$or.some(cond => matchesWhere(metadata, cond));
+        return Object.entries(where).every(([key, value]) => {
+            if (value && typeof value === 'object' && '$exists' in value) {
+                const exists = metadata && Object.prototype.hasOwnProperty.call(metadata, key);
+                return value.$exists ? exists : !exists;
+            }
+            return metadata?.[key] === value;
+        });
+    };
+
+    return {
+        rows,
+
+        async add({ids, metadatas, documents}) {
+            ids.forEach((id, i) => rows.set(id, {id, metadata: metadatas?.[i] ?? {}, document: documents?.[i] ?? ''}));
+        },
+
+        async get({ids, where} = {}) {
+            let entries = ids ? ids.map(id => rows.get(id)).filter(Boolean) : Array.from(rows.values());
+            entries = entries.filter(entry => matchesWhere(entry.metadata, where));
+            return {
+                ids      : entries.map(e => e.id),
+                metadatas: entries.map(e => e.metadata),
+                documents: entries.map(e => e.document)
+            };
+        },
+
+        async query({nResults, where}) {
+            const entries = Array.from(rows.values()).filter(entry => matchesWhere(entry.metadata, where)).slice(0, nResults);
+            return {
+                ids      : [entries.map(e => e.id)],
+                distances: [entries.map(() => 0)],
+                metadatas: [entries.map(e => e.metadata)],
+                documents: [entries.map(e => e.document)]
+            };
+        },
+
+        // The sweep's mutation path: full-metadata replacement per id (matches the production
+        // `{...existingMeta, archivedAt, archivedReason}` payload).
+        async update({ids, metadatas}) {
+            ids.forEach((id, i) => {
+                const row = rows.get(id);
+                if (row) row.metadata = {...metadatas[i]};
+            });
+        }
+    };
+}
+
+test.describe('MemoryService — archiveMemoriesByAgentIdentity tombstone + recall-exclusion (#13384)', () => {
+    let spyCollection, originalGetMemoryCollection, GraphService, originalDb, originalUpsertNode, originalLinkNodes;
+
+    test.beforeAll(async () => {
+        GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        spyCollection                     = createSpyCollection();
+        originalGetMemoryCollection       = StorageRouter.getMemoryCollection;
+        StorageRouter.getMemoryCollection = async () => spyCollection;
+
+        originalUpsertNode      = GraphService.upsertNode;
+        originalLinkNodes       = GraphService.linkNodes;
+        GraphService.upsertNode = () => {};
+        GraphService.linkNodes  = () => {};
+
+        // The sweep runs a graph-side SQL UPDATE + an in-memory node-cache sync. Stub both to no-ops
+        // so the Chroma-path assertions are the spec's concern (the graph-SQL exclusion is the proven
+        // buildMailboxDelta pattern). `nodes` is an empty Map — the cache-sync loop finds nothing.
+        originalDb       = GraphService.db;
+        GraphService.db  = {storage: {db: {prepare: () => ({run: () => {}})}}, nodes: new Map()};
+    });
+
+    test.afterEach(() => {
+        StorageRouter.getMemoryCollection = originalGetMemoryCollection;
+        GraphService.upsertNode           = originalUpsertNode;
+        GraphService.linkNodes            = originalLinkNodes;
+        GraphService.db                   = originalDb;
+    });
+
+    // Seed one memory stamped to a distinct agent identity, drained into the spy collection.
+    async function seedMemory({sessionId, agent}) {
+        const r = await MemoryService.addMemory({
+            prompt   : `${agent} prompt`,
+            response : `${agent} response`,
+            thought  : `${agent} thought`,
+            sessionId,
+            agent
+        });
+        await drainMemoryWal({ids: [r.id]});
+        return r.id;
+    }
+
+    // Resolve the actually-stamped agentIdentity (robust to the canonical-stamping rules).
+    async function stampedIdentity(memoryId) {
+        const q = await MemoryService.queryMemories({query: 'prompt', nResults: 50});
+        return q.results.find(m => m.id === memoryId)?.agentIdentity;
+    }
+
+    test('archived memory is excluded from queryMemories + listMemories; unarchive restores it', async () => {
+        const memId    = await seedMemory({sessionId: 'session-ghost', agent: 'ghost-agent'});
+        const identity = await stampedIdentity(memId);
+        expect(identity, 'the seeded memory must carry a stamped agentIdentity').toBeTruthy();
+
+        // Pre-archive: the memory recalls via both Chroma paths.
+        let q = await MemoryService.queryMemories({query: 'prompt', nResults: 50});
+        expect(q.results.map(m => m.id)).toContain(memId);
+        let l = await MemoryService.listMemories({sessionId: 'session-ghost', limit: 50});
+        expect(l.memories.map(m => m.id)).toContain(memId);
+
+        // Archive.
+        const res = await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: identity, reason: 'leak-test'});
+        expect(res.matchedCount).toBe(1);
+        expect(res.archivedCount).toBe(1);
+        expect(res.dryRun).toBe(false);
+
+        // Post-archive: excluded from BOTH recall paths (a genuine no-match, not an error).
+        q = await MemoryService.queryMemories({query: 'prompt', nResults: 50});
+        expect(q.results.map(m => m.id)).not.toContain(memId);
+        l = await MemoryService.listMemories({sessionId: 'session-ghost', limit: 50});
+        expect(l.memories.map(m => m.id)).not.toContain(memId);
+
+        // Reversible: unarchive restores recall.
+        const un = await MemoryService.unarchiveMemoriesByAgentIdentity({agentIdentity: identity});
+        expect(un.restoredCount).toBe(1);
+        q = await MemoryService.queryMemories({query: 'prompt', nResults: 50});
+        expect(q.results.map(m => m.id)).toContain(memId);
+    });
+
+    test('dryRun reports matchedCount without tombstoning', async () => {
+        const memId    = await seedMemory({sessionId: 'session-dry', agent: 'dry-agent'});
+        const identity = await stampedIdentity(memId);
+
+        const dry = await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: identity, dryRun: true});
+        expect(dry.matchedCount).toBe(1);
+        expect(dry.archivedCount).toBe(0);
+        expect(dry.dryRun).toBe(true);
+
+        // Untouched — still recalls.
+        const l = await MemoryService.listMemories({sessionId: 'session-dry', limit: 50});
+        expect(l.memories.map(m => m.id)).toContain(memId);
+    });
+
+    test('idempotent: a second archive tombstones 0 new rows', async () => {
+        const memId    = await seedMemory({sessionId: 'session-idem', agent: 'idem-agent'});
+        const identity = await stampedIdentity(memId);
+
+        const first = await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: identity});
+        expect(first.archivedCount).toBe(1);
+
+        const second = await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: identity});
+        expect(second.matchedCount).toBe(1);   // the row still matches the identity
+        expect(second.archivedCount).toBe(0);  // but it is already tombstoned
+    });
+
+    test('identity-scoped: a different identity\'s memory is NOT swept', async () => {
+        const ghostId = await seedMemory({sessionId: 'session-ghost2', agent: 'ghost-agent-2'});
+        const keepId  = await seedMemory({sessionId: 'session-keep',   agent: 'live-agent'});
+        const ghostIdentity = await stampedIdentity(ghostId);
+
+        await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: ghostIdentity});
+
+        // The other identity's memory still recalls.
+        const l = await MemoryService.listMemories({sessionId: 'session-keep', limit: 50});
+        expect(l.memories.map(m => m.id)).toContain(keepId);
+    });
+
+    test('missing agentIdentity is rejected (fail-closed)', async () => {
+        const res = await MemoryService.archiveMemoriesByAgentIdentity({});
+        expect(res.code).toBe('MISSING_AGENT_IDENTITY');
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
@@ -33,9 +33,9 @@ import path                  from 'node:path';
  * Mirrors `MemoryService.TenantIsolation.spec.mjs`: a stateful in-memory spy collection records
  * every add/get/query/UPDATE so the sweep's `collection.update` (set archivedAt) is reflected in
  * subsequent queries. `GraphService.db` is stubbed to a no-op SQL + empty node-cache — the graph-SQL
- * exclusion (`queryRecentTurns`) + frontier exclusion are the proven `buildMailboxDelta`
- * `archivedAt IS NULL` pattern and are covered by a separate integration assertion; this spec pins
- * the Chroma content-recall paths, which are the primary recall-pollution surface.
+ * exclusion (`queryRecentTurns`) + frontier exclusion (`getContextFrontier`) are pinned directly,
+ * against the real `:memory:` graph, in the sibling `MemoryService.ArchiveByIdentity.PublicRecall.spec.mjs`;
+ * this spec pins the Chroma content-recall paths, which are the primary recall-pollution surface.
  */
 function createSpyCollection() {
     const rows = new Map();

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
@@ -19,6 +19,9 @@ import * as core             from '../../../../../../src/core/_export.mjs';
 import MemoryService         from '../../../../../../ai/services/memory-core/MemoryService.mjs';
 import StorageRouter         from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
 import {drainMemoryWal}      from './util.mjs';
+import {mkdtemp, rm}         from 'node:fs/promises';
+import os                    from 'node:os';
+import path                  from 'node:path';
 
 /**
  * The leak-test for `archiveMemoriesByAgentIdentity` (the tombstone + recall-exclusion op).
@@ -109,7 +112,10 @@ test.describe('MemoryService — archiveMemoriesByAgentIdentity tombstone + reca
         // so the Chroma-path assertions are the spec's concern (the graph-SQL exclusion is the proven
         // buildMailboxDelta pattern). `nodes` is an empty Map — the cache-sync loop finds nothing.
         originalDb       = GraphService.db;
-        GraphService.db  = {storage: {db: {prepare: () => ({run: () => {}})}}, nodes: new Map()};
+        // `transaction` + `removeNode` back the unarchive op's durable-marker removal (the real
+        // GraphService.removeNodes wraps removeNode in db.transaction); the real upsertGlobalNode routes
+        // through the stubbed upsertNode, so both marker ops no-op here.
+        GraphService.db  = {storage: {db: {prepare: () => ({run: () => {}})}}, nodes: new Map(), removeNode: () => {}, transaction: fn => fn()};
     });
 
     test.afterEach(() => {
@@ -209,5 +215,130 @@ test.describe('MemoryService — archiveMemoriesByAgentIdentity tombstone + reca
     test('missing agentIdentity is rejected (fail-closed)', async () => {
         const res = await MemoryService.archiveMemoriesByAgentIdentity({});
         expect(res.code).toBe('MISSING_AGENT_IDENTITY');
+    });
+});
+
+/**
+ * The projection-lag leak-test (the gpt change-request). Chroma embed and graph projection are independent
+ * derived states that catch up on different clocks: a memory can be embedded into Chroma (and so
+ * tombstoned by the archive sweep) while its graph node is still PENDING (graphProjectionVersion:1,
+ * no `.graph.jsonl` marker). When the deferred `drainPendingGraphProjections → _projectMemoryToGraph`
+ * later mints that node from the pre-archive WAL snapshot, nothing carried `archivedAt` — the row
+ * silently re-entered the graph un-tombstoned.
+ *
+ * Unlike the recall-exclusion suite above (which stubs the graph entirely), this exercises the REAL
+ * `_projectMemoryToGraph` mint + the durable `ARCHIVED_AGENT_IDENTITY` marker round-trip — the marker
+ * is the only state that bridges the lag (and survives a restart). `upsertNode` is captured so the
+ * projected node's properties are inspectable; the marker ops round-trip through an in-memory Store.
+ */
+test.describe('MemoryService — archive survives graph-projection lag (durable marker, #13384)', () => {
+    let GraphService, markers, projected, originals, tmpWalDir;
+
+    const MARKER = identity => `ARCHIVED_AGENT_IDENTITY:${identity}`;
+
+    test.beforeAll(async () => {
+        GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        tmpWalDir    = await mkdtemp(path.join(os.tmpdir(), 'mc-archive-lag-'));
+    });
+
+    test.afterAll(async () => {
+        await rm(tmpWalDir, {recursive: true, force: true});
+    });
+
+    test.beforeEach(() => {
+        markers   = new Map();
+        projected = new Map();
+        originals = {
+            getMemoryCollection: StorageRouter.getMemoryCollection,
+            upsertGlobalNode   : GraphService.upsertGlobalNode,
+            getNodeRecord      : GraphService.getNodeRecord,
+            removeNodes        : GraphService.removeNodes,
+            upsertNode         : GraphService.upsertNode,
+            linkNodes          : GraphService.linkNodes,
+            db                 : GraphService.db
+        };
+
+        // Chroma side: a fresh spy collection per archive/unarchive call (the marker, not the rows, is
+        // what bridges the lag, so empty collections are fine — they model archive-entirely-during-lag).
+        StorageRouter.getMemoryCollection = async () => createSpyCollection();
+
+        // Graph side: the durable marker round-trips through an in-memory node Store (upsertGlobalNode ->
+        // getNodeRecord -> removeNodes are exercised for real, not stubbed away); upsertNode is captured.
+        GraphService.upsertGlobalNode = spec  => markers.set(spec.id, {id: spec.id, type: spec.type, properties: {...spec.properties, userId: null}});
+        GraphService.getNodeRecord    = ({id}) => markers.get(id) || null;
+        GraphService.removeNodes      = ids   => ids.forEach(id => markers.delete(id));
+        GraphService.upsertNode       = spec  => projected.set(spec.id, spec);
+        GraphService.linkNodes        = ()    => {};
+        GraphService.db               = {storage: {db: {prepare: () => ({run: () => {}})}}, nodes: new Map()};
+    });
+
+    test.afterEach(() => {
+        StorageRouter.getMemoryCollection = originals.getMemoryCollection;
+        GraphService.upsertGlobalNode     = originals.upsertGlobalNode;
+        GraphService.getNodeRecord        = originals.getNodeRecord;
+        GraphService.removeNodes          = originals.removeNodes;
+        GraphService.upsertNode           = originals.upsertNode;
+        GraphService.linkNodes            = originals.linkNodes;
+        GraphService.db                   = originals.db;
+    });
+
+    test('durable marker round-trips: archive sets it, _withArchiveState stamps, unarchive clears it', async () => {
+        const identity = 'lag-ghost-identity';
+
+        // No marker yet -> the mint-helper passes properties through untouched.
+        expect(MemoryService._archivedIdentityState(identity)).toBeNull();
+        expect(MemoryService._withArchiveState({agentIdentity: identity, sessionId: 's'})).not.toHaveProperty('archivedAt');
+
+        // Archive sets the durable marker even with zero matched rows -> covers archive-entirely-during-lag.
+        const res = await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: identity, reason: 'lag-test'});
+        expect(res.code).toBeUndefined();
+        expect(markers.has(MARKER(identity))).toBe(true);
+
+        const state = MemoryService._archivedIdentityState(identity);
+        expect(state?.archivedAt).toBeTruthy();
+        expect(state?.archivedReason).toBe('lag-test');
+        expect(MemoryService._withArchiveState({agentIdentity: identity, sessionId: 's'}).archivedAt).toBe(state.archivedAt);
+
+        // Unarchive removes the marker -> the mint-helper passes through again.
+        await MemoryService.unarchiveMemoriesByAgentIdentity({agentIdentity: identity});
+        expect(markers.has(MARKER(identity))).toBe(false);
+        expect(MemoryService._archivedIdentityState(identity)).toBeNull();
+        expect(MemoryService._withArchiveState({agentIdentity: identity, sessionId: 's'})).not.toHaveProperty('archivedAt');
+    });
+
+    test('deferred projection of a graph-pending record carries the tombstone (the leak is closed)', async () => {
+        const identity = 'lag-projected-identity';
+
+        await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: identity, reason: 'lag-test'});
+
+        // The drain catches up AFTER the archive: project a record whose stored WAL properties (the
+        // pre-archive snapshot) never carried archivedAt. The fix must replay the tombstone here.
+        await MemoryService._projectMemoryToGraph({
+            memoryId        : 'mem-lagged',
+            timestamp       : '2026-01-01T00:00:00.000Z',
+            sessionId       : 'sess-lagged',
+            segmentKey      : '2026-01-01',
+            walDir          : tmpWalDir,
+            memoryProperties: {agentIdentity: identity, sessionId: 'sess-lagged'}
+        });
+
+        const node = projected.get('mem-lagged');
+        expect(node, 'the projection must have upserted the AGENT_MEMORY node').toBeTruthy();
+        expect(node.properties.archivedAt, 'a tombstone set during projection lag must be replayed onto the projected node').toBeTruthy();
+    });
+
+    test('a non-archived identity projects WITHOUT a tombstone (no false-positive exclusion)', async () => {
+        await MemoryService._projectMemoryToGraph({
+            memoryId        : 'mem-live',
+            timestamp       : '2026-01-01T00:00:00.000Z',
+            sessionId       : 'sess-live',
+            segmentKey      : '2026-01-01',
+            walDir          : tmpWalDir,
+            memoryProperties: {agentIdentity: 'live-identity', sessionId: 'sess-live'}
+        });
+
+        const node = projected.get('mem-live');
+        expect(node).toBeTruthy();
+        expect(node.properties.archivedAt).toBeUndefined();
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs
@@ -341,4 +341,15 @@ test.describe('MemoryService — archive survives graph-projection lag (durable 
         expect(node).toBeTruthy();
         expect(node.properties.archivedAt).toBeUndefined();
     });
+
+    test('recency overlay short-circuits for an archived identity (graph-pending rows excluded)', async () => {
+        const identity = 'lag-recency-identity';
+
+        await MemoryService.archiveMemoriesByAgentIdentity({agentIdentity: identity, reason: 'lag-test'});
+
+        // The durable marker makes _readPendingWalRecencyRows short-circuit before the WAL read, so an
+        // archived identity's graph-pending rows never reach recency recall (the graph-SQL path already
+        // excludes archivedAt; this closes the WAL-pending overlay gap).
+        expect(await MemoryService._readPendingWalRecencyRows({identity, userId: 'u-irrelevant'})).toEqual([]);
+    });
 });


### PR DESCRIPTION
Resolves #13384
Refs #13190

Authored by Claude Opus 4.8 (Claude Code), @neo-claude-opus (Grace). Session 0f5d9f1d-0683-452d-aac1-f467297186ac.

The Memory-Core primitive the Fleet agent-removal reconciliation (#13190) consumes via the `archiveMemoriesFn` seam — split per @neo-opus-ada's 1-ticket-1-PR coordination (her FM-pass `Resolves #13190`; this `Resolves #13384`).

## What

- **`archiveMemoriesByAgentIdentity({agentIdentity, reason, dryRun})`** → `{matchedCount, archivedCount, dryRun}` — dual-store tombstone (sets `archivedAt` + `archivedReason` on the Chroma row metadata, the graph `AGENT_MEMORY` node via SQL, and the in-memory node-cache for `getContextFrontier` coherence). Idempotent (already-tombstoned rows skipped). Keys on the **stamped write-identity** (`@<github-username>` for FM stdio+PAT agents, per `MemoryService.mjs:449-453`) — not the registry id.
- **`unarchiveMemoriesByAgentIdentity({agentIdentity})`** → `{restoredCount}` — reversible (Chroma `''` since Chroma metadata cannot hold `null`; graph `json_remove`; cache clear).
- **`archivedAt`-exclusion across the recall paths**: `queryMemories` + `listMemories` (Chroma post-filter), `queryRecentTurns` (graph SQL, mirroring the proven `buildMailboxDelta` `archivedAt IS NULL` pattern), and `GraphService.getContextFrontier` (frontier filter — keeps archived nodes out of the topology).

## Deltas from ticket

- The op is a **service-method seam** (the FM-pass consumes it via `archiveMemoriesFn`), not a new MCP tool — matches the contract; an MCP-tool wrapper for operator manual use can be a follow-up if wanted.
- **GraphService topology/search paths** (`getNeighbors` / `queryNodeTopology` / `searchNodes`) are structural graph reads, not memory-content recall — a noted completeness follow-up, not in scope (the four content-recall paths are the recall-pollution surface).
- The `queryRecentTurns` WAL-pending path is not filtered: a not-yet-projected memory cannot be tombstoned yet (archive operates on projected rows), so WAL-pending rows are by-definition not-archived — noted, not a gap.

Evidence: L2 (mocked-store unit coverage) → L2 required (Memory-Core service-method contract behavior). No residuals.

## Test Evidence

- New leak-test `test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveByIdentity.spec.mjs` — 5 cases: archived row excluded from `queryMemories` + `listMemories` (and unarchive restores it); `dryRun` counts without tombstoning; idempotent re-archive (0 new); identity-scoped (no collateral); fail-closed on missing `agentIdentity`. → `npm run test-unit -- …ArchiveByIdentity.spec.mjs` = **5 passed (942ms)**.
- Regression: `MemoryService.TenantIsolation` + `QueryRecentTurns` + `MemoryService.Frontier` + `GraphService` = **59 passed (1.3s)** (the edited recall paths unbroken).

## Post-Merge Validation

- [ ] @neo-opus-ada wires `archiveMemoriesFn` → this op on `agent/13190-fm-pass` + adds the FM-pass integration test.
- [ ] (Follow-up) An integration assertion for the `queryRecentTurns` graph-SQL exclusion against a real graph DB — this PR's leak-test covers the Chroma content paths; the graph-SQL clause mirrors the already-tested `buildMailboxDelta` filter.

Cross-family review requested — a Memory-Core recall-path change worth a second-family check.
