### PR TITLE
fix(ai): set local chat context default to half-native floor (#13390)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,4 +1,5 @@
 import path                                  from 'path';
+import os                                    from 'os';
 import {fileURLToPath}                       from 'url';
 import ConfigProvider, {createConfigProxy, leaf} from './ConfigProvider.mjs';
 
@@ -10,6 +11,36 @@ const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
+
+/**
+ * @summary Resolves host-RAM-appropriate defaults for the local chat model's context-window
+ * limits, so the bundled model loads out-of-the-box instead of assuming a ~90GB host.
+ *
+ * The `gemma-4-31b-it` native 256K context needs ~90GB RAM for its KV cache; on smaller hosts the
+ * model fails to load (or the inference server OOMs). This tiers the DEFAULT context limit by total
+ * system memory so it loads, while a ~96GB+ host still gets the full native context. The explicit
+ * `NEO_LOCAL_MODELS_CHAT_*` env overrides always win — the leaf owns env-resolution, this only
+ * supplies the host-appropriate base default.
+ *
+ * Bands are conservative (err toward loading), anchored on the 256K ≈ 90GB figure; the per-tier
+ * `safeProcessingLimitTokens` is the explicit ~76% headroom band (avoids `0.75 × cap` derivation
+ * drift). Operators should validate the actual load on their host and tune via the env override or
+ * these constants — exact headroom depends on model quant + other RAM users. Pure function of
+ * `totalMemBytes` for host-agnostic unit testing.
+ *
+ * @param {Number} totalMemBytes Total system memory in bytes (e.g. `os.totalmem()`).
+ * @returns {{contextLimitTokens:Number, safeProcessingLimitTokens:Number}}
+ */
+export function resolveLocalModelChatContextBand(totalMemBytes) {
+    const ramGb = totalMemBytes / (1024 ** 3);
+
+    if (ramGb >= 96) return {contextLimitTokens: 262144, safeProcessingLimitTokens: 200000}; // native 256K
+    if (ramGb >= 72) return {contextLimitTokens: 131072, safeProcessingLimitTokens: 100000}; // 128K
+    if (ramGb >= 56) return {contextLimitTokens: 65536,  safeProcessingLimitTokens: 50000};  // 64K
+    if (ramGb >= 40) return {contextLimitTokens: 32768,  safeProcessingLimitTokens: 25000};  // 32K
+    if (ramGb >= 24) return {contextLimitTokens: 16384,  safeProcessingLimitTokens: 12000};  // 16K
+    return {contextLimitTokens: 8192, safeProcessingLimitTokens: 6000};                       // 8K floor
+}
 
 /**
  * @class Neo.ai.Config
@@ -210,8 +241,11 @@ class Config extends ConfigProvider {
                 /**
                  * @summary Chat-model context limits in tokens.
                  *
-                 * Tuned for `gemma-4-31b-it` (native 256K context). Operators serving
-                 * smaller chat models should pin this to the actual loaded-model capacity;
+                 * Tuned for `gemma-4-31b-it` (native 256K context, ~90GB RAM). The DEFAULT is
+                 * host-RAM-tiered via `resolveLocalModelChatContextBand(os.totalmem())` so
+                 * the model loads on sub-90GB hosts; a ~96GB+ host gets the full native context.
+                 * Operators serving a different model/quant should pin the actual capacity via the
+                 * env overrides below (which always win — the leaf owns env-resolution);
                  * `ConsumerFrictionHelper.invokeWithGuardrail` uses these values to fire
                  * the upstream pre-check skip (emits `'context-overflow'` /
                  * `'size-precheck-skip'` friction) when composed input exceeds the safe
@@ -227,8 +261,8 @@ class Config extends ConfigProvider {
                  * @type {Object}
                  */
                 chat: {
-                    contextLimitTokens       : leaf(262144, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(200000, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
+                    contextLimitTokens       : leaf(resolveLocalModelChatContextBand(os.totalmem()).contextLimitTokens,        'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(resolveLocalModelChatContextBand(os.totalmem()).safeProcessingLimitTokens, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
                 },
                 /**
                  * @summary Embedding-model context limits in tokens.

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -38,8 +38,8 @@ export function resolveLocalModelChatContextBand(totalMemBytes) {
     if (ramGb >= 72) return {contextLimitTokens: 131072, safeProcessingLimitTokens: 100000}; // 128K
     if (ramGb >= 56) return {contextLimitTokens: 65536,  safeProcessingLimitTokens: 50000};  // 64K
     if (ramGb >= 40) return {contextLimitTokens: 32768,  safeProcessingLimitTokens: 25000};  // 32K
-    if (ramGb >= 24) return {contextLimitTokens: 16384,  safeProcessingLimitTokens: 12000};  // 16K
-    return {contextLimitTokens: 8192, safeProcessingLimitTokens: 6000};                       // 8K floor
+    if (ramGb >= 24) return {contextLimitTokens: 16384,  safeProcessingLimitTokens: 12500};  // 16K
+    return {contextLimitTokens: 8192, safeProcessingLimitTokens: 6250};                       // 8K floor
 }
 
 /**

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,5 +1,4 @@
 import path                                  from 'path';
-import os                                    from 'os';
 import {fileURLToPath}                       from 'url';
 import ConfigProvider, {createConfigProxy, leaf} from './ConfigProvider.mjs';
 
@@ -11,36 +10,6 @@ const projectRoot = process.cwd() === '/' ? neoRootDir : process.cwd();
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS  = 24 * HOUR_MS;
-
-/**
- * @summary Resolves host-RAM-appropriate defaults for the local chat model's context-window
- * limits, so the bundled model loads out-of-the-box instead of assuming a ~90GB host.
- *
- * The `gemma-4-31b-it` native 256K context needs ~90GB RAM for its KV cache; on smaller hosts the
- * model fails to load (or the inference server OOMs). This tiers the DEFAULT context limit by total
- * system memory so it loads, while a ~96GB+ host still gets the full native context. The explicit
- * `NEO_LOCAL_MODELS_CHAT_*` env overrides always win — the leaf owns env-resolution, this only
- * supplies the host-appropriate base default.
- *
- * Bands are conservative (err toward loading), anchored on the 256K ≈ 90GB figure; the per-tier
- * `safeProcessingLimitTokens` is the explicit ~76% headroom band (avoids `0.75 × cap` derivation
- * drift). Operators should validate the actual load on their host and tune via the env override or
- * these constants — exact headroom depends on model quant + other RAM users. Pure function of
- * `totalMemBytes` for host-agnostic unit testing.
- *
- * @param {Number} totalMemBytes Total system memory in bytes (e.g. `os.totalmem()`).
- * @returns {{contextLimitTokens:Number, safeProcessingLimitTokens:Number}}
- */
-export function resolveLocalModelChatContextBand(totalMemBytes) {
-    const ramGb = totalMemBytes / (1024 ** 3);
-
-    if (ramGb >= 96) return {contextLimitTokens: 262144, safeProcessingLimitTokens: 200000}; // native 256K
-    if (ramGb >= 72) return {contextLimitTokens: 131072, safeProcessingLimitTokens: 100000}; // 128K
-    if (ramGb >= 56) return {contextLimitTokens: 65536,  safeProcessingLimitTokens: 50000};  // 64K
-    if (ramGb >= 40) return {contextLimitTokens: 32768,  safeProcessingLimitTokens: 25000};  // 32K
-    if (ramGb >= 24) return {contextLimitTokens: 16384,  safeProcessingLimitTokens: 12500};  // 16K
-    return {contextLimitTokens: 8192, safeProcessingLimitTokens: 6250};                       // 8K floor
-}
 
 /**
  * @class Neo.ai.Config
@@ -239,30 +208,32 @@ class Config extends ConfigProvider {
              */
             localModels: {
                 /**
-                 * @summary Chat-model context limits in tokens.
+                 * @summary Chat-model context limits in tokens — a WORKLOAD FLOOR, not a RAM-fit target.
                  *
-                 * Tuned for `gemma-4-31b-it` (native 256K context, ~90GB RAM). The DEFAULT is
-                 * host-RAM-tiered via `resolveLocalModelChatContextBand(os.totalmem())` so
-                 * the model loads on sub-90GB hosts; a ~96GB+ host gets the full native context.
-                 * Operators serving a different model/quant should pin the actual capacity via the
-                 * env overrides below (which always win — the leaf owns env-resolution);
-                 * `ConsumerFrictionHelper.invokeWithGuardrail` uses these values to fire
-                 * the upstream pre-check skip (emits `'context-overflow'` /
-                 * `'size-precheck-skip'` friction) when composed input exceeds the safe
-                 * processing band.
+                 * Default is HALF of `gemma-4-31b-it`'s native 256K context (131072). This is a
+                 * deliberate floor, NOT a value auto-shrunk to fit free host RAM: graph extraction
+                 * (`SemanticGraphExtractor`, `TopologyInferenceEngine`) and session summaries
+                 * (`SessionService`) read this via the AiConfig SSOT and degrade below ~half. The
+                 * host is sized to load the model at this window (free co-resident RAM / raise the
+                 * env), rather than the config shrinking the window to whatever RAM is spare — total
+                 * system RAM does not predict a co-resident model's actual headroom.
+                 * `ConsumerFrictionHelper.invokeWithGuardrail` uses these values to fire the upstream
+                 * pre-check skip (emits `'context-overflow'` / `'size-precheck-skip'` friction) when
+                 * composed input exceeds the safe-processing band.
                  *
-                 * `safeProcessingLimitTokens` is the explicit ~76% headroom band — leaves
-                 * ~62K tokens for system-prompt envelope + LLM response generation. Explicit
-                 * value avoids implicit `0.75 × cap` derivation drift if the cap moves.
+                 * `safeProcessingLimitTokens` is the explicit ~76% headroom band (100000) — leaves
+                 * ~31K tokens for system-prompt envelope + LLM response generation. Explicit value
+                 * avoids implicit `0.75 × cap` derivation drift if the cap moves.
                  *
-                 * Env overrides: `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS`,
+                 * Per-host tuning is the env override, not a host-RAM heuristic:
+                 * `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS`,
                  * `NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS`.
                  *
                  * @type {Object}
                  */
                 chat: {
-                    contextLimitTokens       : leaf(resolveLocalModelChatContextBand(os.totalmem()).contextLimitTokens,        'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
-                    safeProcessingLimitTokens: leaf(resolveLocalModelChatContextBand(os.totalmem()).safeProcessingLimitTokens, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
+                    contextLimitTokens       : leaf(131072, 'NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 'number'),
+                    safeProcessingLimitTokens: leaf(100000, 'NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS', 'number')
                 },
                 /**
                  * @summary Embedding-model context limits in tokens.

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -123,9 +123,10 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         requireParallelModels   : Number(process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS) || 2
     },
     localModels: {
-        // chat.* context defaults are host-RAM-tiered at runtime via
-        // resolveLocalModelChatContextBand (ai/config.template.mjs) — not a fixed static default, so
-        // not mirrored here; config.template.spec.mjs asserts the per-tier values + env-override precedence.
+        chat: {
+            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
+            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000
+        },
         embedding: {
             contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
             safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -123,10 +123,9 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         requireParallelModels   : Number(process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS) || 2
     },
     localModels: {
-        chat: {
-            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144,
-            safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
-        },
+        // chat.* context defaults are host-RAM-tiered at runtime via
+        // resolveLocalModelChatContextBand (ai/config.template.mjs) — not a fixed static default, so
+        // not mirrored here; config.template.spec.mjs asserts the per-tier values + env-override precedence.
         embedding: {
             contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
             safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -140,14 +140,16 @@ test.describe('Tier 1 Config Immutability', () => {
         expect(resolveLocalModelChatContextBand(80 * GB)).toEqual({contextLimitTokens: 131072, safeProcessingLimitTokens: 100000});
         expect(resolveLocalModelChatContextBand(64 * GB)).toEqual({contextLimitTokens: 65536,  safeProcessingLimitTokens: 50000});
         expect(resolveLocalModelChatContextBand(48 * GB)).toEqual({contextLimitTokens: 32768,  safeProcessingLimitTokens: 25000});
-        expect(resolveLocalModelChatContextBand(32 * GB)).toEqual({contextLimitTokens: 16384,  safeProcessingLimitTokens: 12000});
-        expect(resolveLocalModelChatContextBand(16 * GB)).toEqual({contextLimitTokens: 8192,   safeProcessingLimitTokens: 6000});
+        expect(resolveLocalModelChatContextBand(32 * GB)).toEqual({contextLimitTokens: 16384,  safeProcessingLimitTokens: 12500});
+        expect(resolveLocalModelChatContextBand(16 * GB)).toEqual({contextLimitTokens: 8192,   safeProcessingLimitTokens: 6250});
 
-        // safeProcessingLimitTokens is the ~76% headroom band of the resolved context limit (every tier).
+        // safeProcessingLimitTokens is the ~76% headroom band of the resolved context limit — EVERY tier.
         for (const ramGb of [16, 32, 48, 64, 80, 128]) {
-            const band = resolveLocalModelChatContextBand(ramGb * GB);
+            const band  = resolveLocalModelChatContextBand(ramGb * GB),
+                  ratio = band.safeProcessingLimitTokens / band.contextLimitTokens;
             expect(band.safeProcessingLimitTokens).toBeLessThan(band.contextLimitTokens);
-            expect(band.safeProcessingLimitTokens / band.contextLimitTokens).toBeGreaterThan(0.7);
+            expect(ratio).toBeGreaterThan(0.75);
+            expect(ratio).toBeLessThan(0.77);
         }
     });
 

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs/promises';
+import os from 'os';
 import Neo from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 import ConfigProvider from '../../../../ai/ConfigProvider.mjs';
@@ -8,6 +9,7 @@ import {CHROMA_TEST_DATABASE} from '../../../../ai/services/shared/vector/chroma
 
 test.describe('Tier 1 Config Immutability', () => {
     let Config;
+    let resolveLocalModelChatContextBand;
     let originalConfig;
     let originalClassHierarchy;
 
@@ -22,7 +24,9 @@ test.describe('Tier 1 Config Immutability', () => {
             delete Neo.classHierarchyMap['Neo.ai.Config'];
         }
 
-        Config = (await import('../../../../ai/config.template.mjs')).default;
+        const configModule = await import('../../../../ai/config.template.mjs');
+        Config                           = configModule.default;
+        resolveLocalModelChatContextBand = configModule.resolveLocalModelChatContextBand;
     });
 
     test.afterAll(() => {
@@ -91,8 +95,8 @@ test.describe('Tier 1 Config Immutability', () => {
         });
         expect(Config.localModels).toMatchObject({
             chat: {
-                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144,
-                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 200000
+                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || resolveLocalModelChatContextBand(os.totalmem()).contextLimitTokens,
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || resolveLocalModelChatContextBand(os.totalmem()).safeProcessingLimitTokens
             },
             embedding: {
                 contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
@@ -120,10 +124,40 @@ test.describe('Tier 1 Config Immutability', () => {
             contextLimitTokens      : 12345,
             safeProcessingLimitTokens: 11111
         });
-        expect(Config.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 262144);
+        expect(Config.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || resolveLocalModelChatContextBand(os.totalmem()).contextLimitTokens);
 
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', originalContext);
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', originalSafe);
+    });
+
+    test('resolveLocalModelChatContextBand tiers the chat context default by host RAM (#13390)', () => {
+        const GB = 1024 ** 3;
+
+        // High-RAM hosts keep the full native gemma-4-31b-it 256K context.
+        expect(resolveLocalModelChatContextBand(128 * GB)).toEqual({contextLimitTokens: 262144, safeProcessingLimitTokens: 200000});
+        expect(resolveLocalModelChatContextBand(96  * GB)).toEqual({contextLimitTokens: 262144, safeProcessingLimitTokens: 200000});
+        // Sub-90GB hosts tier down so the model loads instead of OOMing on a 256K KV cache.
+        expect(resolveLocalModelChatContextBand(80 * GB)).toEqual({contextLimitTokens: 131072, safeProcessingLimitTokens: 100000});
+        expect(resolveLocalModelChatContextBand(64 * GB)).toEqual({contextLimitTokens: 65536,  safeProcessingLimitTokens: 50000});
+        expect(resolveLocalModelChatContextBand(48 * GB)).toEqual({contextLimitTokens: 32768,  safeProcessingLimitTokens: 25000});
+        expect(resolveLocalModelChatContextBand(32 * GB)).toEqual({contextLimitTokens: 16384,  safeProcessingLimitTokens: 12000});
+        expect(resolveLocalModelChatContextBand(16 * GB)).toEqual({contextLimitTokens: 8192,   safeProcessingLimitTokens: 6000});
+
+        // safeProcessingLimitTokens is the ~76% headroom band of the resolved context limit (every tier).
+        for (const ramGb of [16, 32, 48, 64, 80, 128]) {
+            const band = resolveLocalModelChatContextBand(ramGb * GB);
+            expect(band.safeProcessingLimitTokens).toBeLessThan(band.contextLimitTokens);
+            expect(band.safeProcessingLimitTokens / band.contextLimitTokens).toBeGreaterThan(0.7);
+        }
+    });
+
+    test('explicit chat-context env override wins over the RAM-tiered default (#13390)', () => {
+        const original = Config.localModels.chat.contextLimitTokens;
+
+        Config.setEnvOverride('NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 54321);
+        expect(Config.localModels.chat.contextLimitTokens).toBe(54321);
+
+        Config.setEnvOverride('NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', original);
     });
 
     test('ships top-level deployment and maintenance policy defaults', async () => {

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs/promises';
-import os from 'os';
 import Neo from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
 import ConfigProvider from '../../../../ai/ConfigProvider.mjs';
@@ -9,7 +8,6 @@ import {CHROMA_TEST_DATABASE} from '../../../../ai/services/shared/vector/chroma
 
 test.describe('Tier 1 Config Immutability', () => {
     let Config;
-    let resolveLocalModelChatContextBand;
     let originalConfig;
     let originalClassHierarchy;
 
@@ -24,9 +22,7 @@ test.describe('Tier 1 Config Immutability', () => {
             delete Neo.classHierarchyMap['Neo.ai.Config'];
         }
 
-        const configModule = await import('../../../../ai/config.template.mjs');
-        Config                           = configModule.default;
-        resolveLocalModelChatContextBand = configModule.resolveLocalModelChatContextBand;
+        Config = (await import('../../../../ai/config.template.mjs')).default;
     });
 
     test.afterAll(() => {
@@ -95,8 +91,8 @@ test.describe('Tier 1 Config Immutability', () => {
         });
         expect(Config.localModels).toMatchObject({
             chat: {
-                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || resolveLocalModelChatContextBand(os.totalmem()).contextLimitTokens,
-                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || resolveLocalModelChatContextBand(os.totalmem()).safeProcessingLimitTokens
+                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
+                safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000
             },
             embedding: {
                 contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
@@ -124,42 +120,10 @@ test.describe('Tier 1 Config Immutability', () => {
             contextLimitTokens      : 12345,
             safeProcessingLimitTokens: 11111
         });
-        expect(Config.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || resolveLocalModelChatContextBand(os.totalmem()).contextLimitTokens);
+        expect(Config.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072);
 
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS', originalContext);
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', originalSafe);
-    });
-
-    test('resolveLocalModelChatContextBand tiers the chat context default by host RAM (#13390)', () => {
-        const GB = 1024 ** 3;
-
-        // High-RAM hosts keep the full native gemma-4-31b-it 256K context.
-        expect(resolveLocalModelChatContextBand(128 * GB)).toEqual({contextLimitTokens: 262144, safeProcessingLimitTokens: 200000});
-        expect(resolveLocalModelChatContextBand(96  * GB)).toEqual({contextLimitTokens: 262144, safeProcessingLimitTokens: 200000});
-        // Sub-90GB hosts tier down so the model loads instead of OOMing on a 256K KV cache.
-        expect(resolveLocalModelChatContextBand(80 * GB)).toEqual({contextLimitTokens: 131072, safeProcessingLimitTokens: 100000});
-        expect(resolveLocalModelChatContextBand(64 * GB)).toEqual({contextLimitTokens: 65536,  safeProcessingLimitTokens: 50000});
-        expect(resolveLocalModelChatContextBand(48 * GB)).toEqual({contextLimitTokens: 32768,  safeProcessingLimitTokens: 25000});
-        expect(resolveLocalModelChatContextBand(32 * GB)).toEqual({contextLimitTokens: 16384,  safeProcessingLimitTokens: 12500});
-        expect(resolveLocalModelChatContextBand(16 * GB)).toEqual({contextLimitTokens: 8192,   safeProcessingLimitTokens: 6250});
-
-        // safeProcessingLimitTokens is the ~76% headroom band of the resolved context limit — EVERY tier.
-        for (const ramGb of [16, 32, 48, 64, 80, 128]) {
-            const band  = resolveLocalModelChatContextBand(ramGb * GB),
-                  ratio = band.safeProcessingLimitTokens / band.contextLimitTokens;
-            expect(band.safeProcessingLimitTokens).toBeLessThan(band.contextLimitTokens);
-            expect(ratio).toBeGreaterThan(0.75);
-            expect(ratio).toBeLessThan(0.77);
-        }
-    });
-
-    test('explicit chat-context env override wins over the RAM-tiered default (#13390)', () => {
-        const original = Config.localModels.chat.contextLimitTokens;
-
-        Config.setEnvOverride('NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', 54321);
-        expect(Config.localModels.chat.contextLimitTokens).toBe(54321);
-
-        Config.setEnvOverride('NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS', original);
     });
 
     test('ships top-level deployment and maintenance policy defaults', async () => {


### PR DESCRIPTION
Resolves #13390

The local chat model's context default was a fixed 256K (`gemma-4-31b-it` native), whose KV cache needs ~90GB of **free** RAM — so the model failed to load on hosts where that much isn't free, undermining local-first inference.

**This is a manual config-default change, not a RAM heuristic.** An earlier revision of this PR tried to auto-tier the default by `os.totalmem()`. That was wrong on two counts:

1. **Total system RAM ≠ a co-resident model's free headroom.** The operator's box is 128GB total but only ~4.6GB *free* — the embedding model, several IDEs, desktop + agent processes are all resident. `os.totalmem()` can't see that.
2. **Auto-shrinking the window to fit spare RAM is the wrong goal.** The chat context window is a **workload floor**: graph extraction (`SemanticGraphExtractor`, `TopologyInferenceEngine`) and session summaries (`SessionService`) read it via the AiConfig SSOT and degrade below ~half. Shrinking it to whatever RAM is spare silently breaks them.

So the default drops to **half the native window — `131072` / `100000`** (the ~76% safe band preserved), a usable floor for graph processing + summaries. Per-host sizing is the **existing env override** (`NEO_LOCAL_MODELS_CHAT_*`), not config-side logic: hosts that can't free the RAM for 128K lower the env; the host is otherwise sized (free co-resident RAM) to load the model at the floor.

Evidence: L2 (unit — `config.template.spec` + `aiConfigDefaults.spec` 12/12 green; `lint-config-template-ssot` OK) → L3/L4 host-only (operator confirms the model loads at the 128K floor and graph extraction + session summaries function).

## Decision Record impact
`aligned-with ADR 0019` (AiConfig reactive Provider SSOT): a plain declarative leaf with a static default + env resolution — no resolver, no host-derived module-eval value, no B4 mutation, no parallel sizing alias. Consumers read the resolved leaf at the use site (the reactive-Provider / "State Provider" pattern); host-awareness lives in the operator's env, not in config logic.

## Deltas from the original ticket
- The ticket framed this as "tier by host RAM." That premise was wrong (total RAM ≠ free headroom); corrected to a static half-native default + env. The downstream impact on graph extraction + session summaries is *why* the floor is half, not a small RAM-fit value.
- The operator's live `ai/config.mjs` overlay (gitignored) still carries the old `262144`/`200000`; it picks up the new template default via `node ai/scripts/setup/initServerConfigs.mjs --migrate-config`, or the operator sets `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS` for immediate relief.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs` → **12 passed** (chat-default assertions + fixture-mirrors-template sanity check updated to 131072/100000).
- `node ai/scripts/lint/lint-config-template-ssot.mjs` → OK.

## Post-Merge Validation (host-only — not CI-verifiable)
- [ ] Operator confirms the local chat model **loads** at the 128K floor (after freeing co-resident RAM or via the env) and graph extraction + session summaries function.
- [ ] Existing `config.mjs` clones pick up `131072`/`100000` after `--migrate-config`; the `NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS` env is the immediate workaround.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Session 47b6dbc0-7673-4ad3-a9f5-bef3b606c56b.
