### PR TITLE
fix(github-workflow): route createIssue through GraphqlService cached-token REST path (#13352)

### DIFF
--- a/ai/services/github-workflow/GraphqlService.mjs
+++ b/ai/services/github-workflow/GraphqlService.mjs
@@ -36,6 +36,14 @@ class GraphqlService extends Base {
          */
         apiUrl: 'https://api.github.com/graphql',
         /**
+         * The GitHub REST API base URL. REST requests share this service's cached `gh auth token`
+         * and retry machinery (see {@link #rest}), so REST writes run through the same
+         * authenticated, retry-equipped path as GraphQL instead of a fresh per-call `spawn('gh')`.
+         * @member {String} restApiUrl='https://api.github.com'
+         * @protected
+         */
+        restApiUrl: 'https://api.github.com',
+        /**
          * Optional explicit token override for tests or controlled embedded callers.
          * Normal runtime auth continues to use `gh auth token`.
          * @member {String|null} authTokenOverride=null
@@ -303,6 +311,85 @@ class GraphqlService extends Base {
         }
 
         return json.data;
+    }
+
+    /**
+     * @summary Executes an authenticated request against the GitHub REST API.
+     *
+     * Shares the cached `gh auth token` (`#getAuthToken`) and the transient-failure retry
+     * machinery used by {@link #query}, so REST writes run through the same single,
+     * cached-token, retry-equipped path as the GraphQL tools — instead of a fresh per-call
+     * `spawn('gh')` that re-resolves gh-auth on every invocation.
+     *
+     * REST is preferred (over a GraphQL mutation) where the operation accepts human-facing
+     * names/logins directly — e.g. issue labels and assignees — avoiding the extra node-ID
+     * resolution a GraphQL mutation would require, and preserving the exact semantics of the
+     * `gh` command it replaces.
+     *
+     * @param {String} method      HTTP method, e.g. 'GET', 'POST', 'PATCH', 'DELETE'.
+     * @param {String} path        REST path beginning with '/', e.g. '/repos/owner/name/issues'.
+     * @param {Object} [body=null] Optional JSON request body; omitted for bodyless methods.
+     * @returns {Promise<Object|null>} The parsed JSON response, or `null` for an empty `204` response.
+     * @throws {Error} If authentication fails, or the request fails after exhausting transient retries.
+     */
+    async rest(method, path, body=null) {
+        const token = await this.#getAuthToken();
+
+        const headers = {
+            'Accept'              : 'application/vnd.github+json',
+            'Authorization'       : `bearer ${token}`,
+            'X-GitHub-Api-Version': '2022-11-28'
+        };
+
+        const init = {method, headers};
+
+        if (body != null) {
+            headers['Content-Type'] = 'application/json';
+            init.body               = JSON.stringify(body);
+        }
+
+        const url = `${this.restApiUrl}${path}`;
+
+        let response;
+
+        for (let attempt = 0; attempt <= this.maxRetryAttempts; attempt++) {
+            try {
+                response = await fetch(url, init);
+            } catch (e) {
+                if (attempt < this.maxRetryAttempts && this.#isRetryableNetworkError(e)) {
+                    await this.#waitForRetry(`Transient GitHub REST transport failure (${e.message})`, attempt + 1);
+                    continue;
+                }
+
+                throw e;
+            }
+
+            if (response.ok) {
+                break;
+            }
+
+            if (attempt < this.maxRetryAttempts && this.#isRetryableHttpStatus(response.status)) {
+                await this.#waitForRetry(`GitHub REST ${method} ${path} -> ${response.status} ${response.statusText}`, attempt + 1, response);
+                continue;
+            }
+
+            let detail = '';
+
+            try {
+                const errorBody = await response.json();
+                detail = errorBody?.message ? ` - ${errorBody.message}` : '';
+            } catch (ignore) {
+                // Non-JSON error body; the status line is the best available detail.
+            }
+
+            throw new Error(`GitHub REST request failed: ${method} ${path} -> ${response.status} ${response.statusText}${detail}`);
+        }
+
+        if (response.status === 204) {
+            return null;
+        }
+
+        return response.json();
     }
 }
 

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -485,13 +485,14 @@ class IssueService extends Base {
             payload.labels = labels;
         }
 
-        if (assignees && assignees.length > 0) {
-            // `@me` is a gh-CLI alias the create_issue contract advertises (assigns the authenticated
-            // user); the REST issues endpoint expects concrete logins, so it must be normalized first.
-            payload.assignees = await this.#resolveAssigneeAliases(assignees);
-        }
-
         try {
+            if (assignees && assignees.length > 0) {
+                // `@me` is a gh-CLI alias the create_issue contract advertises (assigns the authenticated
+                // user); the REST issues endpoint expects concrete logins, so normalize it first. Inside
+                // the try so an alias-resolution failure returns the structured error rather than throwing.
+                payload.assignees = await this.#resolveAssigneeAliases(assignees);
+            }
+
             const issue = await GraphqlService.rest('POST', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues`, payload);
 
             const issueNumber = issue?.number,

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -6,7 +6,6 @@ import logger            from '../../mcp/server/github-workflow/logger.mjs';
 import {projectConversationTrust} from './shared/conversationTrust.mjs';
 import {exec}            from 'child_process';
 import {promisify}       from 'util';
-import {spawn}           from 'child_process';
 import {GET_ISSUE_LABEL_IDS, GET_PULL_REQUEST_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST} from './queries/issueQueries.mjs';
 import {GET_PULL_REQUEST_ID} from './queries/pullRequestQueries.mjs';
 import {
@@ -471,51 +470,33 @@ class IssueService extends Base {
             }
         }
 
-        const ghArgs = [
-            'issue', 'create',
-            '--title', title,
-            '--body', body || 'No additional details provided.',
-            '--repo', `${aiConfig.owner}/${aiConfig.repo}`
-        ];
+        // Route issue creation through GraphqlService's cached-token, retry-equipped REST path
+        // rather than a fresh per-call `spawn('gh', ['issue','create'])` that re-resolves
+        // gh-auth on every invocation. REST `POST /issues` accepts label names + assignee logins
+        // directly — identical semantics to `gh issue create`, with none of the label/user
+        // node-ID resolution a GraphQL `createIssue` mutation would require. The ProjectV2 attach
+        // below already runs through GraphqlService, so creation is now a single auth path.
+        const payload = {
+            title,
+            body: body || 'No additional details provided.'
+        };
 
         if (labels && labels.length > 0) {
-            labels.forEach(label => {
-                ghArgs.push('--label', label);
-            });
+            payload.labels = labels;
         }
 
         if (assignees && assignees.length > 0) {
-            assignees.forEach(assignee => {
-                ghArgs.push('--assignee', assignee);
-            });
+            payload.assignees = assignees;
         }
 
         try {
-            const ghProcess = spawn('gh', ghArgs);
+            const issue = await GraphqlService.rest('POST', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues`, payload);
 
-            let stdout = '';
-            let stderr = '';
-
-            for await (const chunk of ghProcess.stdout) {
-                stdout += chunk;
-            }
-            for await (const chunk of ghProcess.stderr) {
-                stderr += chunk;
-            }
-
-            const exitCode = await new Promise(resolve => {
-                ghProcess.on('close', resolve);
-            });
-
-            if (exitCode !== 0) {
-                throw new Error(stderr || 'Failed to create GitHub issue.');
-            }
-
-            const issueUrl = stdout.trim();
-            const issueNumber = parseInt(issueUrl.split('/').pop(), 10);
+            const issueNumber = issue?.number,
+                  issueUrl    = issue?.html_url;
 
             if (!issueNumber) {
-                throw new Error('Could not parse issue number from gh CLI output.');
+                throw new Error('Could not resolve the new issue number from the GitHub REST response.');
             }
 
             logger.info(`Successfully created GitHub issue #${issueNumber}: ${issueUrl}`);
@@ -538,9 +519,9 @@ class IssueService extends Base {
         } catch (error) {
             logger.error('Error creating GitHub issue:', error);
             return {
-                error  : 'GitHub CLI command failed',
+                error  : 'GitHub API request failed',
                 message: error.message,
-                code   : 'GH_CLI_ERROR'
+                code   : 'GITHUB_API_ERROR'
             };
         }
     }

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -486,7 +486,9 @@ class IssueService extends Base {
         }
 
         if (assignees && assignees.length > 0) {
-            payload.assignees = assignees;
+            // `@me` is a gh-CLI alias the create_issue contract advertises (assigns the authenticated
+            // user); the REST issues endpoint expects concrete logins, so it must be normalized first.
+            payload.assignees = await this.#resolveAssigneeAliases(assignees);
         }
 
         try {
@@ -524,6 +526,32 @@ class IssueService extends Base {
                 code   : 'GITHUB_API_ERROR'
             };
         }
+    }
+
+    /**
+     * @summary Resolves the `@me` assignee alias to the authenticated user's login.
+     *
+     * `create_issue` advertises `@me` (the gh-CLI convenience the prior `gh issue create` path relied
+     * on) as a valid assignee; GitHub's REST issues endpoint expects concrete user logins, so `@me`
+     * must be normalized before the REST call. Resolution uses the cached-token `GET /user` — a single
+     * round-trip, made only when the alias is actually present. Non-alias logins pass through unchanged.
+     * @param {String[]} assignees
+     * @returns {Promise<String[]>}
+     * @private
+     */
+    async #resolveAssigneeAliases(assignees) {
+        if (!assignees.includes('@me')) {
+            return assignees;
+        }
+
+        const viewer = await GraphqlService.rest('GET', '/user'),
+              login  = viewer?.login;
+
+        if (!login) {
+            throw new Error('Could not resolve the `@me` assignee alias: GitHub REST /user returned no login.');
+        }
+
+        return assignees.map(assignee => assignee === '@me' ? login : assignee);
     }
 
     /**

--- a/learn/agentos/GitHubWorkflow.md
+++ b/learn/agentos/GitHubWorkflow.md
@@ -93,7 +93,7 @@ The server exposes a comprehensive suite of tools via the Model Context Protocol
 
 ### 4.2 Issue Management
 
-*   **`create_issue`**: **Authoritative** tool for creating tickets. Uses `gh issue create`.
+*   **`create_issue`**: **Authoritative** tool for creating tickets. Routes through `GraphqlService`'s cached-token REST path (`POST /issues`); the `@me` assignee alias is normalized to the authenticated login before the call.
 *   **`list_issues`**: Lists issues with filtering. Uses client-side filtering for labels/assignees to reduce API complexity.
 *   **`get_local_issue_by_id`**: Fast, offline retrieval of an issue's full Markdown content from the local file system.
 *   **`add_labels` / `remove_labels`**: Manages labels via GraphQL mutations.
@@ -233,7 +233,7 @@ The `create_issue` MCP tool accepts an optional `projects` parameter:
 }
 ```
 
-The issue is created via `gh issue create`, then attached to each ProjectV2 board via `addProjectV2ItemById`. Partial-attach is the graceful failure mode (issue exists; orphan-rollback would be worse for agent workflows).
+The issue is created via `GraphqlService`'s cached-token REST path (`POST /issues`; the `@me` assignee alias above is normalized to the authenticated login), then attached to each ProjectV2 board via `addProjectV2ItemById`. Partial-attach is the graceful failure mode (issue exists; orphan-rollback would be worse for agent workflows).
 
 ### Agent ergonomics — post-create membership management
 

--- a/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/GraphqlService.spec.mjs
@@ -218,3 +218,151 @@ test.describe('Neo.ai.services.github-workflow.GraphqlService — transient retr
         expect(featureHeader).toBe('sub_issues');
     });
 });
+
+/**
+ * @summary Contract coverage for `GraphqlService.rest` — the authenticated REST path.
+ *
+ * `rest()` shares the cached `gh auth token` and the transient-retry machinery with `query()`,
+ * but targets the REST base URL and returns the parsed JSON body (or `null` for `204`). These
+ * tests pin request construction (method, `restApiUrl`-based URL, bearer auth, JSON body for
+ * write methods), `204`→`null`, retry on transient status + network failure, and the
+ * error-detail extraction for non-transient failures.
+ */
+test.describe('Neo.ai.services.github-workflow.GraphqlService — rest() authenticated REST path (#13352)', () => {
+    let GraphqlService;
+    let originalFetch;
+    let originalAuthTokenOverride;
+    let originalMaxRetryAttempts;
+    let originalRetryBaseDelayMs;
+    let originalRetryMaxDelayMs;
+    let originalRetryJitterRatio;
+
+    test.beforeAll(async () => {
+        GraphqlService = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalFetch             = globalThis.fetch;
+        originalAuthTokenOverride = GraphqlService.authTokenOverride;
+        originalMaxRetryAttempts  = GraphqlService.maxRetryAttempts;
+        originalRetryBaseDelayMs  = GraphqlService.retryBaseDelayMs;
+        originalRetryMaxDelayMs   = GraphqlService.retryMaxDelayMs;
+        originalRetryJitterRatio  = GraphqlService.retryJitterRatio;
+
+        GraphqlService.authTokenOverride = 'unit-test-token';
+        GraphqlService.maxRetryAttempts  = 2;
+        GraphqlService.retryBaseDelayMs  = 0;
+        GraphqlService.retryMaxDelayMs   = 0;
+        GraphqlService.retryJitterRatio  = 0;
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch = originalFetch;
+
+        GraphqlService.authTokenOverride = originalAuthTokenOverride;
+        GraphqlService.maxRetryAttempts  = originalMaxRetryAttempts;
+        GraphqlService.retryBaseDelayMs  = originalRetryBaseDelayMs;
+        GraphqlService.retryMaxDelayMs   = originalRetryMaxDelayMs;
+        GraphqlService.retryJitterRatio  = originalRetryJitterRatio;
+    });
+
+    test('POSTs to the REST base URL with bearer auth + JSON body and returns parsed data', async () => {
+        let captured;
+
+        globalThis.fetch = async (url, options) => {
+            captured = {url, options};
+            return new Response(JSON.stringify({number: 13999, html_url: 'https://github.com/o/r/issues/13999'}), {
+                status : 201,
+                headers: {'content-type': 'application/json'}
+            });
+        };
+
+        const result = await GraphqlService.rest('POST', '/repos/o/r/issues', {title: 'Hi'});
+
+        expect(captured.url).toBe('https://api.github.com/repos/o/r/issues');
+        expect(captured.options.method).toBe('POST');
+        expect(captured.options.headers.Authorization).toBe('bearer unit-test-token');
+        expect(captured.options.headers['Content-Type']).toBe('application/json');
+        expect(JSON.parse(captured.options.body)).toEqual({title: 'Hi'});
+        expect(result).toEqual({number: 13999, html_url: 'https://github.com/o/r/issues/13999'});
+    });
+
+    test('returns null for a 204 No Content response', async () => {
+        globalThis.fetch = async () => new Response(null, {status: 204, statusText: 'No Content'});
+
+        const result = await GraphqlService.rest('DELETE', '/repos/o/r/issues/1/assignees', {assignees: ['x']});
+
+        expect(result).toBeNull();
+    });
+
+    test('omits the request body + Content-Type header for bodyless calls', async () => {
+        let captured;
+
+        globalThis.fetch = async (url, options) => {
+            captured = options;
+            return new Response(JSON.stringify({ok: true}), {status: 200, headers: {'content-type': 'application/json'}});
+        };
+
+        await GraphqlService.rest('GET', '/repos/o/r');
+
+        expect(captured.body).toBeUndefined();
+        expect(captured.headers['Content-Type']).toBeUndefined();
+    });
+
+    test('retries a transient 503 response and returns the eventual data', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                return new Response('', {status: 503, statusText: 'Service Unavailable'});
+            }
+
+            return new Response(JSON.stringify({number: 1}), {status: 201, headers: {'content-type': 'application/json'}});
+        };
+
+        const result = await GraphqlService.rest('POST', '/repos/o/r/issues', {title: 'x'});
+
+        expect(result).toEqual({number: 1});
+        expect(callCount).toBe(2);
+    });
+
+    test('retries a transient fetch failure and returns the eventual data', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                const error = new TypeError('fetch failed');
+                error.cause = {message: 'terminated'};
+                throw error;
+            }
+
+            return new Response(JSON.stringify({number: 2}), {status: 201, headers: {'content-type': 'application/json'}});
+        };
+
+        const result = await GraphqlService.rest('POST', '/repos/o/r/issues', {title: 'y'});
+
+        expect(result).toEqual({number: 2});
+        expect(callCount).toBe(2);
+    });
+
+    test('throws with the GitHub error detail on a non-transient 422 (no retry)', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response(JSON.stringify({message: 'Validation Failed'}), {
+                status    : 422,
+                statusText: 'Unprocessable Entity',
+                headers   : {'content-type': 'application/json'}
+            });
+        };
+
+        await expect(GraphqlService.rest('POST', '/repos/o/r/issues', {title: 'z'}))
+            .rejects.toThrow('GitHub REST request failed: POST /repos/o/r/issues -> 422 Unprocessable Entity - Validation Failed');
+        expect(callCount).toBe(1);
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -1295,6 +1295,36 @@ test.describe('Neo.ai.services.github-workflow.IssueService — createIssue REST
         expect(captured.body.assignees).toEqual(['neo-opus-vega', 'tobiu']);
     });
 
+    test('returns GITHUB_API_ERROR (does not throw) when @me normalization GET /user fails', async () => {
+        GraphqlService.rest = async (method, path) => {
+            if (method === 'GET' && path === '/user') {
+                throw new Error('GET /user failed');
+            }
+            return {number: 1, html_url: 'https://github.com/neomjs/neo/issues/1'};
+        };
+
+        // The alias resolver runs inside createIssue's try, so a GET /user failure maps to the same
+        // structured error as a POST failure — it must NOT escape as a thrown exception.
+        const result = await IssueService.createIssue({title: 'Doomed alias', assignees: ['@me']});
+
+        expect(result.error).toBe('GitHub API request failed');
+        expect(result.code).toBe('GITHUB_API_ERROR');
+    });
+
+    test('returns GITHUB_API_ERROR when GET /user returns no login during @me normalization', async () => {
+        GraphqlService.rest = async (method, path) => {
+            if (method === 'GET' && path === '/user') {
+                return {};
+            }
+            return {number: 2, html_url: 'https://github.com/neomjs/neo/issues/2'};
+        };
+
+        const result = await IssueService.createIssue({title: 'No login', assignees: ['@me']});
+
+        expect(result.code).toBe('GITHUB_API_ERROR');
+        expect(result.message).toContain('@me');
+    });
+
     test('omits labels/assignees keys entirely when the arrays are empty', async () => {
         let captured;
         GraphqlService.rest = async (method, path, body) => {

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -1258,7 +1258,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — createIssue REST
         expect(result.error).toBeUndefined();
     });
 
-    test('passes label NAMES and assignee LOGINS verbatim (no node-ID resolution)', async () => {
+    test('passes label NAMES and concrete assignee LOGINS verbatim (no node-ID resolution)', async () => {
         let captured;
         GraphqlService.rest = async (method, path, body) => {
             captured = {method, path, body};
@@ -1268,11 +1268,31 @@ test.describe('Neo.ai.services.github-workflow.IssueService — createIssue REST
         await IssueService.createIssue({
             title    : 'Tagged',
             labels   : ['bug', 'ai'],
-            assignees: ['neo-opus-vega', '@me']
+            assignees: ['neo-opus-vega', 'tobiu']
         });
 
         expect(captured.body.labels).toEqual(['bug', 'ai']);
-        expect(captured.body.assignees).toEqual(['neo-opus-vega', '@me']);
+        expect(captured.body.assignees).toEqual(['neo-opus-vega', 'tobiu']);
+    });
+
+    test('normalizes the @me assignee alias to the authenticated login before the REST call', async () => {
+        let captured;
+        GraphqlService.rest = async (method, path, body) => {
+            if (method === 'GET' && path === '/user') {
+                return {login: 'neo-opus-vega'};
+            }
+            captured = {method, path, body};
+            return {number: 14002, html_url: 'https://github.com/neomjs/neo/issues/14002'};
+        };
+
+        await IssueService.createIssue({
+            title    : 'Self-assigned',
+            assignees: ['@me', 'tobiu']
+        });
+
+        // The create_issue contract promises `@me` resolves to the authenticated user; REST takes
+        // concrete logins, so it must be normalized via GET /user. Concrete logins pass through.
+        expect(captured.body.assignees).toEqual(['neo-opus-vega', 'tobiu']);
     });
 
     test('omits labels/assignees keys entirely when the arrays are empty', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -1202,3 +1202,111 @@ test.describe('Neo.ai.services.github-workflow.IssueService — getConversation 
         expect(result.message).toContain('authentication');
     });
 });
+
+/**
+ * @summary Contract coverage for `IssueService.createIssue` REST routing.
+ *
+ * `createIssue` now routes through `GraphqlService.rest` (cached-token, retry-equipped REST path)
+ * instead of a fresh per-call `spawn('gh', ['issue','create'])`. These tests pin: the REST request
+ * shape (`POST /repos/{owner}/{repo}/issues` with label NAMES + assignee LOGINS passed verbatim —
+ * no node-ID resolution), the empty-collection omission contract, success result mapping
+ * (`{issueNumber, url}` from REST `{number, html_url}`), and structured `GITHUB_API_ERROR`
+ * failure handling. Each test monkey-patches `GraphqlService.rest`, mirroring the established
+ * `GraphqlService.query` stub pattern used throughout this file.
+ *
+ * @see Neo.ai.services.github-workflow.IssueService#createIssue
+ */
+test.describe('Neo.ai.services.github-workflow.IssueService — createIssue REST routing (#13352)', () => {
+    let IssueService;
+    let GraphqlService;
+    let RepositoryService;
+    let originalRest;
+    let originalGetViewerPermission;
+
+    test.beforeAll(async () => {
+        GraphqlService    = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        RepositoryService = (await import('../../../../../../ai/services/github-workflow/RepositoryService.mjs')).default;
+        IssueService      = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+
+        originalRest                = GraphqlService.rest.bind(GraphqlService);
+        originalGetViewerPermission = RepositoryService.getViewerPermission.bind(RepositoryService);
+
+        // Default permission stub — write-eligible for the duration of this describe block.
+        RepositoryService.getViewerPermission = async () => ({permission: 'WRITE'});
+    });
+
+    test.afterAll(() => {
+        GraphqlService.rest                   = originalRest;
+        RepositoryService.getViewerPermission = originalGetViewerPermission;
+    });
+
+    test('routes creation through GraphqlService.rest (POST /issues) and maps the response', async () => {
+        let captured;
+        GraphqlService.rest = async (method, path, body) => {
+            captured = {method, path, body};
+            return {number: 13999, html_url: 'https://github.com/neomjs/neo/issues/13999'};
+        };
+
+        const result = await IssueService.createIssue({title: 'Hello', body: 'World'});
+
+        expect(captured.method).toBe('POST');
+        expect(captured.path).toMatch(/^\/repos\/.+\/.+\/issues$/);
+        expect(captured.body.title).toBe('Hello');
+        expect(captured.body.body).toBe('World');
+        expect(result.issueNumber).toBe(13999);
+        expect(result.url).toBe('https://github.com/neomjs/neo/issues/13999');
+        expect(result.error).toBeUndefined();
+    });
+
+    test('passes label NAMES and assignee LOGINS verbatim (no node-ID resolution)', async () => {
+        let captured;
+        GraphqlService.rest = async (method, path, body) => {
+            captured = {method, path, body};
+            return {number: 14000, html_url: 'https://github.com/neomjs/neo/issues/14000'};
+        };
+
+        await IssueService.createIssue({
+            title    : 'Tagged',
+            labels   : ['bug', 'ai'],
+            assignees: ['neo-opus-vega', '@me']
+        });
+
+        expect(captured.body.labels).toEqual(['bug', 'ai']);
+        expect(captured.body.assignees).toEqual(['neo-opus-vega', '@me']);
+    });
+
+    test('omits labels/assignees keys entirely when the arrays are empty', async () => {
+        let captured;
+        GraphqlService.rest = async (method, path, body) => {
+            captured = {method, path, body};
+            return {number: 14001, html_url: 'https://github.com/neomjs/neo/issues/14001'};
+        };
+
+        await IssueService.createIssue({title: 'Bare'});
+
+        expect('labels' in captured.body).toBe(false);
+        expect('assignees' in captured.body).toBe(false);
+        expect(captured.body.body).toBe('No additional details provided.');
+    });
+
+    test('returns structured GITHUB_API_ERROR when the REST request fails', async () => {
+        GraphqlService.rest = async () => {
+            throw new Error('GitHub REST request failed: POST /repos/o/r/issues -> 422 Unprocessable Entity');
+        };
+
+        const result = await IssueService.createIssue({title: 'Doomed'});
+
+        expect(result.error).toBe('GitHub API request failed');
+        expect(result.code).toBe('GITHUB_API_ERROR');
+        expect(result.message).toContain('422');
+    });
+
+    test('returns GITHUB_API_ERROR when the REST response lacks an issue number', async () => {
+        GraphqlService.rest = async () => ({html_url: 'https://github.com/neomjs/neo/issues/?'});
+
+        const result = await IssueService.createIssue({title: 'Numberless'});
+
+        expect(result.code).toBe('GITHUB_API_ERROR');
+        expect(result.message).toContain('issue number');
+    });
+});


### PR DESCRIPTION
Resolves #13352
Refs #13400

## Summary

`IssueService.createIssue` was the last per-call `spawn('gh','issue','create')` **write** in the github-workflow MCP server — it re-resolved gh-auth on every invocation, unlike the API-based sibling tools that route through `GraphqlService` (one cached `gh auth token` + transient retry). This routes creation onto a new `GraphqlService.rest()` helper that **reuses** the cached token + the existing transient-retry private helpers (`#getRetryDelay`/`#isRetryable*`/`#waitForRetry`) — **no change to the hot `query()` path** — POSTing to the REST issues endpoint.

REST `POST /repos/{owner}/{repo}/issues` accepts label **names** + assignee **logins** directly — none of the label/user node-ID resolution a GraphQL `createIssue` mutation would require (which would add new failure modes on the shared ticket-filing tool). The one CLI semantic that is **not** REST-native — the `@me` assignee alias the `create_issue` contract advertises — is normalized to the authenticated login via a cached-token `GET /user` (`#resolveAssigneeAliases`, run inside the structured-error `try`, only when `@me` is present). The ProjectV2 attach already ran through `GraphqlService`, so creation is now a single auth path.

Evidence: the divergence is source-verified — `GraphqlService.#getAuthToken` caches the token after one `gh auth token`; `createIssue` previously spawned a fresh `gh` per call. Severity is robustness / gh-spawn-surface reduction, **not** a reproduced-bug fix: per @neo-gpt's V-B-A the recent gh failure class was a sandbox-network issue misclassified as auth, not this spawn.

## Scope (slice)

createIssue only — the observed-failure surface, and the proof of the `rest()` primitive. The `gh issue edit` assignee-mutation conversion (reusing `rest()`, with the same `@me` normalization) is split to #13400. Re-scoped #13352's title to the createIssue slice so `Resolves` is accurate; backfilled a Contract Ledger on #13352 covering the consumed contract.

## Test Evidence

Consolidated run at branch head `0a8d45bac10f07d836148cfc63b8ef1fd218a309` — `npm run test-unit` (opus-vega working tree): **120 passed**.

- `GraphqlService.spec.mjs` → 9 existing `query()` + **6 new `rest()`** (REST URL/bearer-auth/JSON-body construction, `204`→`null`, transient `503` + network-failure retry, non-transient `422` error-detail).
- `IssueService.spec.mjs` → **48 passed**, of which the new `createIssue REST routing` block: rest-call shape; label-names + concrete assignee-logins verbatim; **`@me` normalized to the authenticated login** (`GET /user`); empty-array key omission; `GITHUB_API_ERROR` on REST failure, on missing issue number, on **`@me` `GET /user` throwing**, and on **`GET /user` returning no `login`**.
- Regression (tool/openapi layers unchanged): `ToolRegistration.spec.mjs` + `toolService.spec.mjs` + `OpenApiValidatorCompliance.spec.mjs` → 57 passed.
- `node buildScripts/util/check-ticket-archaeology.mjs <changed files>` → 0 violations; `git diff --check` → clean.

## Post-Merge Validation

- [ ] After the github-workflow MCP server restarts (picks up this code; the live daemon runs the prior spawn-based path until then), confirm a real `create_issue` call succeeds end-to-end: issue created + labels/assignees applied (incl. `@me` → self-assignment) + ProjectV2 attach intact.
- [ ] Confirm the failure path now returns `GITHUB_API_ERROR` (not `GH_CLI_ERROR`) on a malformed request.

## Deltas

- New `GraphqlService.rest(method, path, body)` + `restApiUrl` config — reuses `#getAuthToken` + the existing retry helpers; `query()` is untouched.
- `createIssue` rewired `spawn('gh')`→`rest('POST', …/issues)`; error code `GH_CLI_ERROR`→`GITHUB_API_ERROR` (accurate for the non-CLI path — the generic `ErrorResponse` openapi example + the assignee / PullRequest paths still legitimately return `GH_CLI_ERROR`, so `openapi.yaml` is unchanged).
- `@me` assignee alias preserved via `#resolveAssigneeAliases` (cached-token `GET /user`), run **inside** the `try` so alias-resolution failures return the structured `GITHUB_API_ERROR` rather than throwing.
- `GitHubWorkflow.md` §4.2 + create-with-project updated (no longer says `gh issue create`; `@me` example annotated as normalized under the REST path).
- Removed the now-dead `import {spawn}` from `IssueService.mjs`.
- Assignee-edit conversion explicitly deferred → #13400.

## Review cycles

- Commit `a1420c9e3` — createIssue → `rest()` + `rest()` helper + tests.
- Commit `162d5810d` — cycle-1 RC (@neo-gpt): `@me` alias normalization + Contract Ledger (#13352) + `GitHubWorkflow.md` doc.
- Commit `0a8d45bac` — cycle-2 RC (@neo-gpt): `@me` resolver moved inside the structured-error `try` + two failure-path lock tests.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
