### PR TITLE
fix(wake): close Codex composer UI before submit (#13287)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1158,6 +1158,15 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                 '-e', '    tell frontmostProcess',
                 '-e', '      keystroke "v" using command down',
                 '-e', '      delay 0.5',
+                // Codex Desktop can leave composer-side UI (mention/autocomplete/completion popovers)
+                // active after a pasted A2A digest such as `from @neo-opus-ada)`. Escape closes that
+                // transient UI so the following Enter submits the prompt instead of being consumed
+                // by the composer. Keep this Codex-scoped; other harnesses already have validated
+                // Enter behavior and should not inherit an untested pre-submit key.
+                ...(appName === 'Codex' ? [
+                    '-e', '      key code 53',
+                    '-e', '      delay 0.1'
+                ] : []),
                 '-e', '      key code 36',
                 '-e', '      delay 1.0',
                 '-e', '    end tell',

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1988,7 +1988,7 @@ test.describe('Wake Daemon', () => {
         expect(fs.existsSync(mockOutPath)).toBe(false);
     });
 
-    test('Codex wake delivery emits specific sequence r -> Cmd+Z -> Cmd+A/X -> paste (#10667)', async () => {
+    test('Codex wake delivery emits specific sequence r -> Cmd+Z -> Cmd+A/X -> paste -> Esc -> Enter (#10667, #13287)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-cleanup';
 
@@ -2080,6 +2080,7 @@ test.describe('Wake Daemon', () => {
         const aIndex = scriptContent.indexOf('keystroke "a" using command down');
         const xIndex = scriptContent.indexOf('keystroke "x" using command down');
         const pasteIndex = scriptContent.indexOf('keystroke "v" using command down');
+        const escapeIndex = scriptContent.indexOf('key code 53');
         const enterIndex = scriptContent.indexOf('key code 36');
 
         expect(rIndex).toBeGreaterThan(-1);
@@ -2087,7 +2088,8 @@ test.describe('Wake Daemon', () => {
         expect(aIndex).toBeGreaterThan(zIndex);
         expect(xIndex).toBeGreaterThan(aIndex);
         expect(pasteIndex).toBeGreaterThan(xIndex);
-        expect(enterIndex).toBeGreaterThan(pasteIndex);
+        expect(escapeIndex).toBeGreaterThan(pasteIndex);
+        expect(enterIndex).toBeGreaterThan(escapeIndex);
         expect(rawArgs.at(-1)).toContain('[WAKE][priority:normal]');
         expect(rawArgs.at(-1)).toContain('Test Codex Cleanup');
         expect(rawArgs.at(-1)).not.toContain('lifecycle-first');
@@ -2245,11 +2247,13 @@ test.describe('Wake Daemon', () => {
         const rawArgs       = JSON.parse(fs.readFileSync(mockOutPath, 'utf-8'));
         const scriptContent = rawArgs.filter((_, i) => rawArgs[i - 1] === '-e').join('\n');
         const pasteIndex    = scriptContent.indexOf('keystroke "v" using command down');
+        const escapeIndex   = scriptContent.indexOf('key code 53');
         const enterIndex    = scriptContent.indexOf('key code 36');
         const digest        = rawArgs.at(-1);
 
         expect(pasteIndex).toBeGreaterThan(-1);
-        expect(enterIndex).toBeGreaterThan(pasteIndex);
+        expect(escapeIndex).toBeGreaterThan(pasteIndex);
+        expect(enterIndex).toBeGreaterThan(escapeIndex);
         expect(digest).toContain('Codex Mixed Submit');
         expect(digest).toContain('new messages');
         expect(digest).toContain('heartbeat pulses');


### PR DESCRIPTION
Resolves #13407
Refs #13287

Adds a Codex-only `Escape` keystroke between wake payload paste and Enter submit in the osascript wake path. The current-source L4 probe proved route selection and prompt landing are working, while direct-message submit/start-turn still fails. Current source already sent Enter after paste, so this narrows the fix to the likely Codex composer UI state left active by pasted direct-message digests such as `from @neo-opus-ada)`: close transient mention/autocomplete/completion UI first, then submit.

Evidence: L2 (mock-osascript dispatch sequence + full wake daemon unit suite) -> L4 required (Codex Desktop idle/AFK prompt submits and starts a turn without human Enter). Residual: AC2/AC3/AC4 [#13287].

## Deltas from ticket

- This is not another route switch. #13396 restored the direct Codex route to osascript and live evidence now proves backend route + prompt landing.
- Keeps the change Codex-scoped. Claude, Antigravity, tmux, webhook, and app-server adapter behavior are untouched.
- Leaves the final L4 matrix open for post-merge validation because CI cannot prove a proprietary desktop app starts a new Codex turn.
- Close-target topology repaired after review: #13407 is the fully delivered L2 Escape-before-Enter leaf; #13287 remains open for the L4 live Codex Desktop matrix.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs --grep "Codex wake delivery emits specific sequence|Codex UI wake submits a mixed message"` -> 2 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` -> 33 passed. First sandbox run failed only on the webhookUrl local listener with `listen EPERM: operation not permitted 127.0.0.1`; escalated rerun passed 33/33.
- `git diff --check` -> clean.
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `92584ab2e fix(wake): close Codex composer UI before submit (#13287)`.

## Post-Merge Validation

- [ ] Restart/recycle the live wake daemon from the merged `dev` source.
- [ ] Run a clean idle/AFK direct-message probe to `@neo-gpt` and record: backend current-source row, prompt lands, prompt submits, new Codex turn starts, and human Enter was not required.
- [ ] Run or schedule the remaining `pure-heartbeat` and `mixed-message-heartbeat` rows from `ai/docs/wake-prompt-landing-matrix.md`.
- [ ] Append the L4 matrix result to #13287 before final close if any row remains inconclusive after merge.

## Commit

- `92584ab2e` - `fix(wake): close Codex composer UI before submit (#13287)`

Authored by Euclid (GPT-5, Codex Desktop). Session 09850a49-643e-42cc-81dc-b2b38bf6f3a1.
