### PR TITLE
docs(skills): add the replace-don't-append temporal axis to update-roadmap (#13404)

### DIFF
--- a/.agents/skills/update-roadmap/references/update-roadmap-workflow.md
+++ b/.agents/skills/update-roadmap/references/update-roadmap-workflow.md
@@ -10,9 +10,11 @@ A roadmap names the **load-bearing direction** of the next release — the few c
 
 Clarity comes as much from the visible **out** (deferred) as the **in** (cornerstones). A roadmap with no deferred set leaves every un-named epic silently-abstract — the "abstract goals to chase" friction this skill exists to kill.
 
+**Replace, don't append (the temporal axis).** The roadmap holds the CURRENT next-release ONLY — each run **REPLACES** the prior next-scope; it never accretes a `## Shipped: vN` layer per release. Prior-release history + the framework vision are relocated, not inlined (see MUST NOT).
+
 ## The beat — celebrate, then plan (in order)
 
-1. **Celebrate first.** Name the shipped release and its headline (PRs merged, issues closed, the thesis it delivered). The win + reward-continuity are an institution-health goal, not ceremony — skipping it is a rejected shape. A short A2A broadcast / release-note acknowledgement suffices.
+1. **Celebrate first.** Name the shipped release and its headline (PRs merged, issues closed, the thesis it delivered). The win + reward-continuity are an institution-health goal, not ceremony — skipping it is a rejected shape. A short A2A broadcast / release-note acknowledgement suffices — never a permanent `ROADMAP.md` section.
 2. **Assess what landed** (Verify-Before-Assert). Confirm the shipped version, that its milestone closed, and which epics resolved. Read the truth — release tags (`13.0.0`, *not* `v13.0.0` — empirical substrate), milestone state, `package.json` — never assume.
 3. **Open / identify the next release milestone.** The milestone is the durable container that cornerstone epics get assigned to. (Cite the milestone tool / `gh` behavior; do not re-document its mechanics here.)
 4. **Scope the cornerstones + rationale.** Name the few load-bearing epics and the one-paragraph "why this release" thesis. Prefer epics that already exist; file new ones via `epic-create` only when a cornerstone has no home.
@@ -31,7 +33,7 @@ Each cornerstone epic has exactly **one named steward** — accountable that the
 
 **SHOULD:** the release thesis (rationale); the cornerstone epics (linked to the milestone); the explicit deferred set; the steward map; a budget/cadence note (steady-state ≈ 100–150 merged PRs — sequence any over-budget stretch as a capstone, keep the deferred set firm).
 
-**MUST NOT:** an exhaustive prose item-list (stales → FAIL); a scope with no visible deferred set; pre-assigned peer steward lanes; a graduation rubber-stamped to fit the scope.
+**MUST NOT:** an exhaustive prose item-list (stales → FAIL); a scope with no visible deferred set; pre-assigned peer steward lanes; a graduation rubber-stamped to fit the scope; a framework-vision restatement (→ `.github/VISION.md`); prior-release shipped-history (→ `resources/content/release-notes/`).
 
 ## Avoided traps / rejected shapes
 
@@ -67,3 +69,4 @@ The inaugural run scoped **v13.1 → milestone #8**:
 - [ ] Each cornerstone epic is **assigned to the milestone** and has **one self-selected steward**.
 - [ ] Any folded Discussion graduation **met cross-family quorum** (no rubber-stamp).
 - [ ] Over-budget stretch (vs the ≈ 100–150 PR cadence) is sequenced as a **capstone**, deferred set held firm.
+- [ ] No prior-release history or vision restatement remains **inline** (relocated, not duplicated).


### PR DESCRIPTION
Resolves #13404

The `update-roadmap` skill (#13380) was strong on next-scope SHAPE (cornerstones + rationale + deferred set + stewards, not exhaustive lists) but silent on the **temporal / replace axis** — so applying it let the roadmap re-accumulate a `## Shipped: vN` layer + vision/foundation sediment per release (the bloat the operator flagged; sibling to the one-time ROADMAP trim #13403). This adds the missing axis to the conditionally-loaded `references/` World Atlas (the always-loaded `SKILL.md` router stays a one-liner):

- **Replace, don't append rule:** the roadmap holds the CURRENT next-release ONLY — each run REPLACES the prior next-scope, never stacking `## Shipped: vN` layers.
- **2 MUST-NOTs:** a framework-vision restatement (→ `.github/VISION.md`); prior-release shipped-history (→ `resources/content/release-notes/`) — relocate, a 1-line pointer suffices.
- **A Verify checkbox:** no prior-release history or vision restatement remains inline (relocated, not duplicated).
- **Clarified the Celebrate beat:** the celebration is the A2A / release-note acknowledgement — never a permanent `ROADMAP.md` section.

Evidence: L1 (skill-substrate docs; `lint-skill-manifest` OK; +562 bytes references-payload; frontmatter `description` unchanged → no manifest / downstream-doc sync needed). Zero runtime surface.

## Decision Record impact
`aligned-with` the skill's existing cornerstones-not-lists Core Rule — extends it from the *breadth* axis to the *temporal/replace* axis. No ADR.

## Deltas from ticket
None — all four ACs delivered (replace rule + 2 MUST-NOTs + Verify checkbox + clarified Celebrate). Kept terse: the rationale lives in the ticket + this PR + the commit, not the always-loaded doc.

## Substrate Slot-Rationale (§1.1)
Additions land in the conditionally-loaded `references/` workflow (World Atlas), not the always-loaded `SKILL.md` router → `keep` in the payload. Net-positive: ~6 lines that prevent a recurring per-release roadmap-bloat (a higher standing cost than the addition).

## Turn-Memory Pre-Flight — load-effect audit (`/turn-memory-pre-flight`)
Decision-tree walk for this substrate mutation (`.agents/skills/**/references/*.md` = IN-SCOPE per the workflow's Substrate Boundary):
- **Step 1 (universal every-turn rule?)** → NO. This governs one lifecycle event (post-release roadmap planning), not every turn.
- **Step 2 (specific lifecycle event / workflow?)** → **YES → it's a Skill.** The `update-roadmap` skill already exists (#13380); this edit extends its existing World-Atlas payload — no new skill, no new router entry, no frontmatter `description` change.
- **Placement:** the rule lands in the conditionally-loaded `references/update-roadmap-workflow.md` (World Atlas), NOT the always-loaded `SKILL.md` router → the router stays a one-liner; zero added always-on boot cost. Slot disposition = `keep` in the payload.
- **Mechanical load-effect verification:** `lint-skill-manifest --base origin/dev` → OK; `description` unchanged → no downstream-doc / manifest sync. No ambiguity flag — placement is unambiguous (an edit to an existing skill's existing payload).

Contract Ledger (T3) backfilled on the source ticket: #13404 (comment), per `create-skill` §189.

## Test Evidence
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → **OK**.
- Byte delta: +562 bytes (references payload); the ≤250-byte budget my notes referenced governs the `SKILL.md` router map, not the conditionally-loaded `references/` Atlas (verified: lint green at +562).

## Post-Merge Validation
- [ ] The next `update-roadmap` run (or the #13403 ROADMAP trim) applies the replace-don't-append rule — the roadmap stays next-only, with vision/history relocated behind pointers.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Session 47b6dbc0-7673-4ad3-a9f5-bef3b606c56b.
