### PR TITLE
fix(github-workflow): route assignIssue/unassignIssue gh-edits through GraphqlService.rest (#13400)

### DIFF
--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -4,8 +4,6 @@ import GraphqlService    from './GraphqlService.mjs';
 import RepositoryService from './RepositoryService.mjs';
 import logger            from '../../mcp/server/github-workflow/logger.mjs';
 import {projectConversationTrust} from './shared/conversationTrust.mjs';
-import {exec}            from 'child_process';
-import {promisify}       from 'util';
 import {GET_ISSUE_LABEL_IDS, GET_PULL_REQUEST_LABEL_IDS, GET_ISSUE_PARENT, GET_BLOCKED_BY, GET_ISSUE_ASSIGNEES, GET_ISSUE_CONVERSATION, FETCH_ISSUES_FOR_SYNC, FETCH_ISSUES_LIST} from './queries/issueQueries.mjs';
 import {GET_PULL_REQUEST_ID} from './queries/pullRequestQueries.mjs';
 import {
@@ -24,8 +22,6 @@ import {
     FIND_PROJECT_V2_ITEM_BY_CONTENT,
     UPDATE_PROJECT_V2_ITEM_SINGLE_SELECT
 } from './queries/mutations.mjs';
-
-const execAsync = promisify(exec);
 
 /**
  * @summary Service for interacting with GitHub issues via the GraphQL API.
@@ -187,7 +183,7 @@ class IssueService extends Base {
      * never simultaneous co-ownership.
      *
      * **Clear mode (empty assignees):** unchanged — clearing is always safe (no
-     * precondition needed); proceeds via `gh issue edit --remove-assignee ""`.
+     * precondition needed); proceeds via a REST `PATCH` with an empty `assignees` array.
      *
      * @param {object}   options                       The options object
      * @param {number}   options.issue_number          The number of the issue to modify.
@@ -215,9 +211,10 @@ class IssueService extends Base {
             // CLEAR MODE: empty assignees — no precondition needed; proceeds directly.
             if (!assignees || assignees.length === 0) {
                 logger.info(`Attempting to unassign all users from issue #${issue_number}`);
-                // Passing an empty string to --remove-assignee has been experimentally verified to clear all assignees.
-                const command  = `gh issue edit ${issue_number} --remove-assignee "" --repo ${aiConfig.owner}/${aiConfig.repo}`;
-                await execAsync(command);
+                // REST PATCH with an empty assignees array clears the full set atomically — the
+                // equivalent of the prior `gh issue edit --remove-assignee ""`, with no fetch and no
+                // intermediate state. (PATCH sends only `assignees`, so other issue fields are untouched.)
+                await GraphqlService.rest('PATCH', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues/${issue_number}`, {assignees: []});
                 const message  = `Successfully unassigned all users from issue #${issue_number}`;
                 logger.info(message);
                 return {message};
@@ -245,19 +242,19 @@ class IssueService extends Base {
                 };
             }
 
-            // Step 3 — strict-replacement override: clear existing first.
-            const isOverride = currentAssignees.length > 0 && acknowledgedReassign;
-            if (isOverride) {
-                logger.info(`Strict-replacement override on #${issue_number} (reason: "${acknowledgedReassign}"): clearing existing [${currentAssignees.join(',')}] before assigning [${assignees.join(',')}]`);
-                const clearCommand = `gh issue edit ${issue_number} --remove-assignee "" --repo ${aiConfig.owner}/${aiConfig.repo}`;
-                await execAsync(clearCommand);
-            }
+            // Step 3 — mutate: PATCH replaces the full assignee set. The conflict gate above
+            // guarantees we only reach here on an unassigned issue (fresh add) OR an acknowledged
+            // override (strict replacement) — replacing the set is the correct semantics for both,
+            // atomically (no intermediate empty state the prior clear-then-add carried). `@me` is
+            // normalized to the authenticated login first (REST takes concrete logins).
+            const isOverride        = currentAssignees.length > 0 && acknowledgedReassign;
+            const resolvedAssignees = await this.#resolveAssigneeAliases(assignees);
 
-            // Step 4 — mutate: add the new assignees.
-            logger.info(`Attempting to assign issue #${issue_number} to: ${assignees.join(', ')}`);
-            const assigneeFlags = assignees.map(a => `--add-assignee "${a}"`).join(' ');
-            const command       = `gh issue edit ${issue_number} ${assigneeFlags} --repo ${aiConfig.owner}/${aiConfig.repo}`;
-            await execAsync(command);
+            logger.info(isOverride
+                ? `Strict-replacement override on #${issue_number} (reason: "${acknowledgedReassign}"): replacing [${currentAssignees.join(',')}] with [${assignees.join(',')}]`
+                : `Attempting to assign issue #${issue_number} to: ${assignees.join(', ')}`);
+
+            await GraphqlService.rest('PATCH', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues/${issue_number}`, {assignees: resolvedAssignees});
 
             // Step 5 — post-verify: re-fetch and confirm the resulting assignee state.
             const verifiedAssignees = await this.#fetchCurrentAssignees(issue_number);
@@ -286,9 +283,9 @@ class IssueService extends Base {
         } catch (error) {
             logger.error(`Error updating assignees for issue #${issue_number}:`, error);
             return {
-                error  : 'GitHub CLI command failed',
+                error  : 'GitHub API request failed',
                 message: error.message,
-                code   : 'GH_CLI_ERROR'
+                code   : 'GITHUB_API_ERROR'
             };
         }
     }
@@ -1061,10 +1058,9 @@ class IssueService extends Base {
         logger.info(`Attempting to unassign issue #${issue_number} from: ${assignees.join(', ')}`);
 
         try {
-            const assigneeFlags = assignees.map(a => `--remove-assignee "${a}"`).join(' ');
-            const command       = `gh issue edit ${issue_number} ${assigneeFlags} --repo ${aiConfig.owner}/${aiConfig.repo}`;
-
-            await execAsync(command);
+            // DELETE removes the specified logins from the issue's assignee set (incremental remove,
+            // the equivalent of `gh issue edit --remove-assignee`); other assignees are preserved.
+            await GraphqlService.rest('DELETE', `/repos/${aiConfig.owner}/${aiConfig.repo}/issues/${issue_number}/assignees`, {assignees});
 
             const message = `Successfully unassigned ${assignees.join(', ')} from issue #${issue_number}`;
             logger.info(message);
@@ -1073,9 +1069,9 @@ class IssueService extends Base {
         } catch (error) {
             logger.error(`Error unassigning from issue #${issue_number}:`, error);
             return {
-                error  : 'GitHub CLI command failed',
+                error  : 'GitHub API request failed',
                 message: error.message,
-                code   : 'GH_CLI_ERROR'
+                code   : 'GITHUB_API_ERROR'
             };
         }
     }

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -889,12 +889,13 @@ test.describe('Neo.ai.services.github-workflow.IssueService — manageIssueProje
  * - Fetches current assignees via `GET_ISSUE_ASSIGNEES`.
  * - If non-empty and `requireUnassigned: true` (default), rejects with `ASSIGNEE_CONFLICT` (HTTP 409)
  *   unless `acknowledgedReassign: '<reason>'` is provided.
- * - On override, performs strict-replacement (clear + add) and posts an audit-trail comment on
- *   the issue capturing the reason (per GPT STEP_BACK AC8 carry-forward).
+ * - On override, performs strict-replacement (a single REST `PATCH` replacing the assignee set) and
+ *   posts an audit-trail comment on the issue capturing the reason (per GPT STEP_BACK AC8 carry-forward).
  *
- * This spec pins the **conflict-path** behavior — the substrate-discipline value-add of the gate.
- * Override/strict-replacement/audit-trail paths depend on `child_process.exec` (no ES-module-friendly
- * mock pattern in the current test harness), so this file keeps coverage at the service boundary.
+ * This spec pins the **conflict-path** behavior — the substrate-discipline value-add of the gate —
+ * plus the REST mutation paths (clear, fresh-add, `@me` normalization, strict-replacement override,
+ * and `GITHUB_API_ERROR` failure), hermetically covered by stubbing `GraphqlService.rest` (the
+ * assignee mutations route through it now; no `child_process.exec` remains).
  *
  * @see Neo.ai.services.github-workflow.IssueService#assignIssue
  * @see https://github.com/orgs/neomjs/discussions/11536 — graduation origin (Pre-Write Coordination Substrate)

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -904,6 +904,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — assignIssue prec
     let GraphqlService;
     let RepositoryService;
     let originalQuery;
+    let originalRest;
     let originalGetViewerPermission;
 
     test.beforeAll(async () => {
@@ -912,6 +913,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — assignIssue prec
         IssueService      = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
 
         originalQuery               = GraphqlService.query.bind(GraphqlService);
+        originalRest                = GraphqlService.rest.bind(GraphqlService);
         originalGetViewerPermission = RepositoryService.getViewerPermission.bind(RepositoryService);
 
         // Default permission stub — write-eligible for the duration of this describe block.
@@ -920,7 +922,17 @@ test.describe('Neo.ai.services.github-workflow.IssueService — assignIssue prec
 
     test.afterAll(() => {
         GraphqlService.query                  = originalQuery;
+        GraphqlService.rest                   = originalRest;
         RepositoryService.getViewerPermission = originalGetViewerPermission;
+    });
+
+    // Hermetic guard: the assignee mutations now route through GraphqlService.rest. Any test
+    // that reaches a mutation MUST stub rest explicitly; an unstubbed reach throws loudly here rather
+    // than hitting real GitHub. Conflict/permission tests return before the mutation and never trip it.
+    test.beforeEach(() => {
+        GraphqlService.rest = async (method, path) => {
+            throw new Error(`Unexpected GraphqlService.rest call in assignIssue test: ${method} ${path}`);
+        };
     });
 
     test.describe('conflict path (the substrate-discipline value-add)', () => {
@@ -1018,26 +1030,186 @@ test.describe('Neo.ai.services.github-workflow.IssueService — assignIssue prec
     });
 
     test.describe('clear-mode preservation (no precondition gate for empty assignees)', () => {
-        test('clear-mode (empty assignees array) does NOT trigger precondition fetch', async () => {
-            // Clear-mode hits the `if (!assignees || assignees.length === 0)` branch BEFORE the precondition.
-            // execAsync may fail in the test env (no real gh CLI) — the key assertion is that GraphqlService.query
-            // is NOT called (precondition skipped for clear-mode), pinning the gate-boundary.
+        test('clear-mode (empty assignees) PATCHes an empty set without a precondition fetch', async () => {
+            // Clear-mode hits the empty-assignees branch BEFORE the precondition. Invariants: (1) the
+            // precondition/conflict fetch (GraphqlService.query) is NOT called; (2) the clear is a REST
+            // PATCH with an empty assignees array — not a fetch-then-delete.
             let graphqlCalled = false;
+            GraphqlService.query = async () => { graphqlCalled = true; return {}; };
+
+            let captured;
+            GraphqlService.rest = async (method, path, body) => {
+                captured = {method, path, body};
+                return null;
+            };
+
+            const result = await IssueService.assignIssue({issue_number: 10148, assignees: []});
+
+            expect(graphqlCalled).toBe(false);
+            expect(captured.method).toBe('PATCH');
+            expect(captured.path).toMatch(/^\/repos\/.+\/.+\/issues\/10148$/);
+            expect(captured.body.assignees).toEqual([]);
+            expect(result.message).toContain('Successfully unassigned all users');
+        });
+    });
+
+    test.describe('REST mutation path (#13400)', () => {
+        test('fresh add (unassigned issue) PATCHes the resolved assignee set', async () => {
+            // precondition fetch → empty (unassigned); post-verify fetch → the new set.
+            let queryCount = 0;
             GraphqlService.query = async () => {
-                graphqlCalled = true;
+                queryCount++;
+                const nodes = queryCount === 1 ? [] : [{login: 'neo-opus-vega'}];
+                return {repository: {issue: {assignees: {nodes}}}};
+            };
+
+            let captured;
+            GraphqlService.rest = async (method, path, body) => {
+                captured = {method, path, body};
+                return {};
+            };
+
+            const result = await IssueService.assignIssue({issue_number: 11235, assignees: ['neo-opus-vega']});
+
+            expect(captured.method).toBe('PATCH');
+            expect(captured.path).toMatch(/^\/repos\/.+\/.+\/issues\/11235$/);
+            expect(captured.body.assignees).toEqual(['neo-opus-vega']);
+            expect(result.message).toContain('Successfully assigned');
+            expect(result.verifiedAssignees).toEqual(['neo-opus-vega']);
+        });
+
+        test('normalizes the @me alias to the authenticated login before the PATCH', async () => {
+            let queryCount = 0;
+            GraphqlService.query = async () => {
+                queryCount++;
+                const nodes = queryCount === 1 ? [] : [{login: 'neo-opus-vega'}];
+                return {repository: {issue: {assignees: {nodes}}}};
+            };
+
+            let captured;
+            GraphqlService.rest = async (method, path, body) => {
+                if (method === 'GET' && path === '/user') {
+                    return {login: 'neo-opus-vega'};
+                }
+                captured = {method, path, body};
+                return {};
+            };
+
+            await IssueService.assignIssue({issue_number: 11235, assignees: ['@me']});
+
+            expect(captured.method).toBe('PATCH');
+            expect(captured.body.assignees).toEqual(['neo-opus-vega']);
+        });
+
+        test('strict-replacement override PATCHes the new set + records previous assignees', async () => {
+            // precondition → occupied; post-verify → new; getIssueNodeId + ADD_COMMENT (audit) degrade gracefully.
+            let assigneeFetchCount = 0;
+            GraphqlService.query = async (query, variables) => {
+                if (variables?.maxAssignees !== undefined) {
+                    assigneeFetchCount++;
+                    const nodes = assigneeFetchCount === 1 ? [{login: 'tobiu'}] : [{login: 'neo-opus-vega'}];
+                    return {repository: {issue: {assignees: {nodes}}}};
+                }
+                if (variables?.subjectId) {
+                    return {addComment: {commentEdge: {node: {id: 'C_audit'}}}};
+                }
+                return {repository: {issue: {id: 'I_1'}}};
+            };
+
+            let captured;
+            GraphqlService.rest = async (method, path, body) => {
+                captured = {method, path, body};
                 return {};
             };
 
             const result = await IssueService.assignIssue({
-                issue_number: 10148,
-                assignees   : []
+                issue_number        : 11235,
+                assignees           : ['neo-opus-vega'],
+                acknowledgedReassign: 'reassigning per handoff'
             });
 
-            expect(graphqlCalled).toBe(false);
-            // Result will be either GH_CLI_ERROR (execAsync threw in test env) or success message — both acceptable;
-            // we are testing the gate-boundary, not the underlying CLI shell-through.
-            expect(result.code === 'GH_CLI_ERROR' || result.message?.includes('Successfully unassigned')).toBe(true);
+            expect(captured.method).toBe('PATCH');
+            expect(captured.body.assignees).toEqual(['neo-opus-vega']);
+            expect(result.acknowledgedReassign).toBe('reassigning per handoff');
+            expect(result.previousAssignees).toEqual(['tobiu']);
+            expect(result.message).toContain('reassigned');
         });
+
+        test('returns GITHUB_API_ERROR (not a throw) when the PATCH fails', async () => {
+            GraphqlService.query = async () => ({repository: {issue: {assignees: {nodes: []}}}});
+            GraphqlService.rest  = async () => { throw new Error('GitHub REST request failed: PATCH /repos/o/r/issues/11235 -> 422 Unprocessable Entity'); };
+
+            const result = await IssueService.assignIssue({issue_number: 11235, assignees: ['neo-opus-vega']});
+
+            expect(result.error).toBe('GitHub API request failed');
+            expect(result.code).toBe('GITHUB_API_ERROR');
+        });
+    });
+});
+
+/**
+ * @summary Contract coverage for `IssueService.unassignIssue` REST routing.
+ *
+ * `unassignIssue` now removes specific assignees via `DELETE /issues/{n}/assignees` (incremental
+ * remove, the equivalent of `gh issue edit --remove-assignee`) instead of `execAsync`. Pins the
+ * REST call shape, the empty-array BAD_REQUEST guard (no REST call), and structured
+ * `GITHUB_API_ERROR` failure handling. Each test stubs `GraphqlService.rest` (hermetic).
+ *
+ * @see Neo.ai.services.github-workflow.IssueService#unassignIssue
+ */
+test.describe('Neo.ai.services.github-workflow.IssueService — unassignIssue REST routing (#13400)', () => {
+    let IssueService;
+    let GraphqlService;
+    let RepositoryService;
+    let originalRest;
+    let originalGetViewerPermission;
+
+    test.beforeAll(async () => {
+        GraphqlService    = (await import('../../../../../../ai/services/github-workflow/GraphqlService.mjs')).default;
+        RepositoryService = (await import('../../../../../../ai/services/github-workflow/RepositoryService.mjs')).default;
+        IssueService      = (await import('../../../../../../ai/services/github-workflow/IssueService.mjs')).default;
+
+        originalRest                = GraphqlService.rest.bind(GraphqlService);
+        originalGetViewerPermission = RepositoryService.getViewerPermission.bind(RepositoryService);
+        RepositoryService.getViewerPermission = async () => ({permission: 'WRITE'});
+    });
+
+    test.afterAll(() => {
+        GraphqlService.rest                   = originalRest;
+        RepositoryService.getViewerPermission = originalGetViewerPermission;
+    });
+
+    test('DELETEs the specified assignees (incremental remove)', async () => {
+        let captured;
+        GraphqlService.rest = async (method, path, body) => {
+            captured = {method, path, body};
+            return {};
+        };
+
+        const result = await IssueService.unassignIssue({issue_number: 11235, assignees: ['tobiu']});
+
+        expect(captured.method).toBe('DELETE');
+        expect(captured.path).toMatch(/^\/repos\/.+\/.+\/issues\/11235\/assignees$/);
+        expect(captured.body.assignees).toEqual(['tobiu']);
+        expect(result.message).toContain('Successfully unassigned');
+    });
+
+    test('rejects an empty assignees array with BAD_REQUEST (no REST call)', async () => {
+        let called = false;
+        GraphqlService.rest = async () => { called = true; return {}; };
+
+        const result = await IssueService.unassignIssue({issue_number: 11235, assignees: []});
+
+        expect(result.code).toBe('BAD_REQUEST');
+        expect(called).toBe(false);
+    });
+
+    test('returns GITHUB_API_ERROR when the DELETE fails', async () => {
+        GraphqlService.rest = async () => { throw new Error('GitHub REST request failed: DELETE /repos/o/r/issues/11235/assignees -> 404 Not Found'); };
+
+        const result = await IssueService.unassignIssue({issue_number: 11235, assignees: ['tobiu']});
+
+        expect(result.code).toBe('GITHUB_API_ERROR');
     });
 });
 


### PR DESCRIPTION
Resolves #13400
Refs #13401

## Summary

Completes the github-workflow write-surface migration off per-call `spawn('gh')` / `execAsync('gh issue edit')` (createIssue landed in #13401 via `GraphqlService.rest()`). `assignIssue` + `unassignIssue`'s assignee mutations now route through the same cached-token, retry-equipped REST path.

- **assignIssue clear-mode** (empty assignees): `PATCH /issues/{n} {assignees: []}` — atomic clear, no fetch (the prior `--remove-assignee ""` equivalent).
- **assignIssue add/override**: `PATCH /issues/{n} {assignees: <resolved>}`. The #11537 conflict gate guarantees only an unassigned-add or an acknowledged strict-replacement reaches the mutation, so replacing the full set is correct for both — atomically, with no intermediate empty state the prior clear-then-add carried. `@me` is normalized to the authenticated login via the `#resolveAssigneeAliases` helper landed in #13401 (REST takes concrete logins).
- **unassignIssue**: `DELETE /issues/{n}/assignees {assignees}` — incremental remove (the `--remove-assignee` equivalent), preserving other assignees.
- Error code `GH_CLI_ERROR` → `GITHUB_API_ERROR` on both REST paths; the now-dead `exec`/`promisify`/`execAsync` removed.

Evidence: the #11537 precondition/conflict gate, the strict-replacement audit-trail comment, and the post-verify re-fetch are **unchanged** — only the mutation transport swaps. Verified all four mutation sites (assignIssue clear/override/add + unassignIssue) against the branch head.

## Test Evidence

Branch head `7a305329e` — `npm run test-unit`: **127 passed**.

- `IssueService.spec.mjs` → **55 passed**. The assignIssue block is now **hermetic** — a default `beforeEach` throws on any unstubbed `GraphqlService.rest` reach, so no test hits real GitHub (the prior clear-mode test relied on `execAsync` *failing* in CI). New/rewritten coverage: clear-mode PATCH-empty (no precondition fetch); fresh-add PATCH-replace; `@me` normalization before PATCH; strict-replacement override (PATCH + previous-assignee record + graceful audit); `GITHUB_API_ERROR` on PATCH failure; unassignIssue DELETE shape, empty-array `BAD_REQUEST` guard (no REST call), and `GITHUB_API_ERROR` on DELETE failure.
- Regression (tool / openapi / graphql layers unchanged): `GraphqlService.spec` + `ToolRegistration.spec` + `toolService.spec` + `OpenApiValidatorCompliance.spec` → 72 passed.
- `node buildScripts/util/check-ticket-archaeology.mjs <2 changed files>` → 0 violations; `git diff --check` → clean.

## Post-Merge Validation

- [ ] After the github-workflow MCP server restarts, confirm a real `manage_issue_assignees` add (incl. `@me` → self-assignment), strict-replacement override (with audit comment), clear-all, and an `unassignIssue` each succeed end-to-end.

## Deltas

- `assignIssue`: clear → `PATCH {assignees: []}`; add/override → `PATCH {assignees: <resolved>}` (replaces the prior clear-then-add); `@me` normalized; catch → `GITHUB_API_ERROR`.
- `unassignIssue`: → `DELETE /assignees {assignees}`; catch → `GITHUB_API_ERROR`.
- Removed the dead `exec`/`promisify` imports + `execAsync`; updated the stale clear-mode JSDoc.
- Test block made hermetic (rest-throw guard) + 7 new/rewritten assignee tests.

## Review cycles

- `965b9c94b` — assignee mutations → `rest()`; hermetic test rework + new coverage.
- Contract Ledger backfilled on #13400 (ticket-side, per the cycle-1 review — consumed-MCP-surface authority).
- `7a305329e` — corrected the stale assignIssue spec-block summary to the shipped REST coverage (cycle-2 rhetorical-drift catch).

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
