### PR TITLE
feat(agentos): first-widget evidence pane + live grid render-together (#13355)

### DIFF
--- a/apps/agentos/childapps/widget/util/blueprintEvidence.mjs
+++ b/apps/agentos/childapps/widget/util/blueprintEvidence.mjs
@@ -33,7 +33,7 @@ const ALLOWED_KEYS = ['schema', 'title', 'columns', 'rows'];
  *   `{accepted: false, reason}` when the input is missing, malformed, or carries unexpected keys.
  */
 export function projectBlueprintEvidence(blueprint) {
-    if (!blueprint || typeof blueprint !== 'object' || Array.isArray(blueprint)) {
+    if (!Neo.isObject(blueprint)) {
         return {accepted: false, reason: 'Blueprint evidence is missing or not an object.'}
     }
 

--- a/apps/agentos/childapps/widget/util/blueprintEvidence.mjs
+++ b/apps/agentos/childapps/widget/util/blueprintEvidence.mjs
@@ -1,0 +1,53 @@
+/**
+ * @module AgentOSWidget.util.blueprintEvidence
+ * @summary Safe projection of a first-widget blueprint into inspectable evidence metadata.
+ *
+ * The H2 transcript/evidence pane must show *what* blueprint produced the live widget — but it must
+ * never render the raw blueprint as trusted HTML or executable code. This projection is that safe
+ * boundary: it accepts the blueprint object the first-widget pane consumed and returns ONLY
+ * non-executable scalar metadata (the schema / class id, a title, and the column + row counts).
+ * Anything malformed — non-object input, unexpected keys, or missing required metadata — fails
+ * closed to a bounded `{accepted: false, reason}` state the pane renders as plain rejected text,
+ * rather than throwing or letting unvalidated data reach the view.
+ *
+ * Contract (decide-and-document): the first-widget foundation is a bare child-app Viewport that did
+ * not pin a blueprint-output shape, so this evidence leaf defines the deterministic shape as
+ * `{schema:String, title:String, columns:Array, rows:Array}` — mirroring a grid blueprint's column
+ * definitions + data rows. A later live-integration leaf can feed the real create-instance output
+ * through this same projection unchanged.
+ */
+
+/**
+ * The only top-level keys a blueprint-evidence object may carry. Any other key fails the projection
+ * closed — an allowlist, not a denylist, so an unexpected/executable field can never slip through.
+ * @type {String[]}
+ */
+const ALLOWED_KEYS = ['schema', 'title', 'columns', 'rows'];
+
+/**
+ * Projects an accepted first-widget blueprint into safe, render-ready evidence metadata.
+ *
+ * @param {Object} blueprint the accepted first-widget blueprint evidence
+ * @returns {{accepted: Boolean, schema: String, title: String, columnCount: Number, rowCount: Number}|{accepted: Boolean, reason: String}}
+ *   `{accepted: true, schema, title, columnCount, rowCount}` on success, or
+ *   `{accepted: false, reason}` when the input is missing, malformed, or carries unexpected keys.
+ */
+export function projectBlueprintEvidence(blueprint) {
+    if (!blueprint || typeof blueprint !== 'object' || Array.isArray(blueprint)) {
+        return {accepted: false, reason: 'Blueprint evidence is missing or not an object.'}
+    }
+
+    const unknownKeys = Object.keys(blueprint).filter(key => !ALLOWED_KEYS.includes(key));
+
+    if (unknownKeys.length > 0) {
+        return {accepted: false, reason: `Blueprint evidence has unexpected keys: ${unknownKeys.join(', ')}.`}
+    }
+
+    const {schema, title, columns, rows} = blueprint;
+
+    if (typeof schema !== 'string' || typeof title !== 'string' || !Array.isArray(columns) || !Array.isArray(rows)) {
+        return {accepted: false, reason: 'Blueprint evidence requires a string schema + title and array columns + rows.'}
+    }
+
+    return {accepted: true, schema, title, columnCount: columns.length, rowCount: rows.length}
+}

--- a/apps/agentos/childapps/widget/view/EvidencePane.mjs
+++ b/apps/agentos/childapps/widget/view/EvidencePane.mjs
@@ -1,0 +1,144 @@
+import Container                 from '../../../../../src/container/Base.mjs';
+import {projectBlueprintEvidence} from '../util/blueprintEvidence.mjs';
+
+/**
+ * @class AgentOSWidget.view.EvidencePane
+ * @extends Neo.container.Base
+ * @summary Safe transcript + blueprint-evidence pane for the H2 first widget.
+ *
+ * Shows the visible provenance for the first widget — the user request, a short agent response
+ * summary, and the accepted blueprint's metadata — so a reviewer can see this is a conversational
+ * creation loop rather than a hardcoded demo. All request / response / evidence text renders as
+ * vdom text nodes (never `html` / `innerHTML`), and the blueprint is passed through
+ * {@link projectBlueprintEvidence} so only safe scalar metadata reaches the view; an invalid
+ * blueprint fails closed to a bounded rejected-state line instead of rendering anything unvalidated.
+ */
+class EvidencePane extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOSWidget.view.EvidencePane'
+         * @protected
+         */
+        className: 'AgentOSWidget.view.EvidencePane',
+        /**
+         * @member {String} ntype='agent-os-evidence-pane'
+         * @protected
+         */
+        ntype: 'agent-os-evidence-pane',
+        /**
+         * @member {String[]} cls=['agent-os-evidence-pane']
+         * @reactive
+         */
+        cls: ['agent-os-evidence-pane'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * The deterministic user request that produced the first widget.
+         * @member {String} request_='build me a neo grid'
+         * @reactive
+         */
+        request_: 'build me a neo grid',
+        /**
+         * A short deterministic agent response summary.
+         * @member {String} responseSummary_='Accepted a bounded grid blueprint and rendered it as a live widget.'
+         * @reactive
+         */
+        responseSummary_: 'Accepted a bounded grid blueprint and rendered it as a live widget.',
+        /**
+         * The accepted first-widget blueprint. Rendered through `projectBlueprintEvidence`, so only
+         * safe scalar metadata reaches the view; invalid input fails closed to a rejected line.
+         * @member {Object|null} blueprint_
+         * @reactive
+         */
+        blueprint_: {
+            schema : 'Neo.grid.Container',
+            title  : 'First Neo Grid',
+            columns: [{dataField: 'id'}, {dataField: 'firstname'}, {dataField: 'lastname'}],
+            rows   : [{id: 1}, {id: 2}, {id: 3}]
+        },
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype    : 'component',
+            reference: 'transcript',
+            cls      : ['agent-os-evidence-transcript'],
+            vdom     : {cn: [
+                {cls: ['agent-os-evidence-request']},
+                {cls: ['agent-os-evidence-response']}
+            ]}
+        }, {
+            ntype    : 'component',
+            reference: 'blueprint-evidence',
+            cls      : ['agent-os-evidence-blueprint'],
+            vdom     : {cn: []}
+        }]
+    }
+
+    /**
+     * Triggered after the request config changed; renders it as a safe text node.
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetRequest(value, oldValue) {
+        let transcript = this.getItem('transcript');
+
+        if (transcript) {
+            transcript.vdom.cn[0].text = value;
+            transcript.update?.()
+        }
+    }
+
+    /**
+     * Triggered after the responseSummary config changed; renders it as a safe text node.
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetResponseSummary(value, oldValue) {
+        let transcript = this.getItem('transcript');
+
+        if (transcript) {
+            transcript.vdom.cn[1].text = value;
+            transcript.update?.()
+        }
+    }
+
+    /**
+     * Triggered after the blueprint config changed. Projects it to safe metadata and renders the
+     * accepted metadata list, or a bounded rejected-state line when the projection fails closed.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetBlueprint(value, oldValue) {
+        let pane = this.getItem('blueprint-evidence');
+
+        if (!pane) {
+            return
+        }
+
+        const projection = projectBlueprintEvidence(value);
+
+        if (projection.accepted) {
+            pane.cls     = ['agent-os-evidence-blueprint'];
+            pane.vdom.cn = [{tag: 'dl', cls: ['agent-os-evidence-meta'], cn: [
+                {tag: 'dt', text: 'Schema'},  {tag: 'dd', text: projection.schema},
+                {tag: 'dt', text: 'Title'},   {tag: 'dd', text: projection.title},
+                {tag: 'dt', text: 'Columns'}, {tag: 'dd', text: `${projection.columnCount}`},
+                {tag: 'dt', text: 'Rows'},    {tag: 'dd', text: `${projection.rowCount}`}
+            ]}]
+        } else {
+            pane.cls     = ['agent-os-evidence-blueprint', 'agent-os-evidence-rejected'];
+            pane.vdom.cn = [{cls: ['agent-os-evidence-rejected-text'], text: projection.reason}]
+        }
+
+        pane.update?.()
+    }
+}
+
+export default Neo.setupClass(EvidencePane);

--- a/apps/agentos/childapps/widget/view/Viewport.mjs
+++ b/apps/agentos/childapps/widget/view/Viewport.mjs
@@ -1,4 +1,31 @@
-import BaseViewport from '../../../../../src/container/Viewport.mjs';
+import BaseViewport  from '../../../../../src/container/Viewport.mjs';
+import EvidencePane  from './EvidencePane.mjs';
+import GridContainer from '../../../../../src/grid/Container.mjs';
+
+/**
+ * The deterministic first-widget blueprint — the single source of truth shared by the evidence
+ * pane (which shows its metadata) and the live grid (which renders its columns + rows). Keeping
+ * ONE blueprint object is the whole provenance point: the metadata a reviewer inspects in the
+ * evidence pane is the exact blueprint that produced the live grid below it, not a parallel
+ * hand-built demo. Natural-language orchestration is intentionally out of scope for this leaf, so
+ * the blueprint is fixed — the render stays deterministic and smoke-testable.
+ * @type {Object}
+ */
+const firstWidgetBlueprint = {
+    schema : 'Neo.grid.Container',
+    title  : 'First Neo Grid',
+    columns: [
+        {dataField: 'id',       text: 'ID'},
+        {dataField: 'task',     text: 'Task'},
+        {dataField: 'owner',    text: 'Owner'},
+        {dataField: 'evidence', text: 'Evidence'}
+    ],
+    rows: [
+        {id: 'intent',   task: 'Verify intent', owner: 'Ada',           evidence: 'Blueprint'},
+        {id: 'render',   task: 'Render grid',   owner: 'Runtime',       evidence: 'Live widget'},
+        {id: 'evidence', task: 'Show evidence', owner: 'Evidence pane', evidence: 'Safe text'}
+    ]
+};
 
 /**
  * @class AgentOSWidget.view.Viewport
@@ -19,7 +46,33 @@ class Viewport extends BaseViewport {
          * @member {String[]} cls=['agent-os-viewport']
          * @reactive
          */
-        cls: ['agent-os-viewport']
+        cls: ['agent-os-viewport'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * The first-widget surface: the evidence pane (request / response / accepted blueprint
+         * metadata) above the live grid that the same blueprint produced.
+         * @member {Object[]} items
+         */
+        items: [{
+            module   : EvidencePane,
+            blueprint: firstWidgetBlueprint
+        }, {
+            module        : GridContainer,
+            reference     : 'first-widget-grid',
+            cls           : ['agent-os-first-widget-grid'],
+            flex          : 1,
+            columnDefaults: {width: 140},
+            columns       : firstWidgetBlueprint.columns.map(column => ({...column})),
+            store         : {
+                keyProperty: 'id',
+                model      : {fields: firstWidgetBlueprint.columns.map(column => ({name: column.dataField, type: 'String'}))},
+                data       : [...firstWidgetBlueprint.rows]
+            }
+        }]
     }
 }
 

--- a/test/playwright/e2e/FirstWidgetEvidencePane.spec.mjs
+++ b/test/playwright/e2e/FirstWidgetEvidencePane.spec.mjs
@@ -1,0 +1,38 @@
+import {test, expect} from '../fixtures.mjs';
+
+/**
+ * @summary H2 render smoke: the first-widget evidence pane and the live grid render TOGETHER.
+ *
+ * This is the AC6 counterpart to the unit specs (which prove the projection + safe-render source
+ * boundary). It boots the AgentOSWidget child app and verifies end-to-end that the EvidencePane
+ * (request / response / accepted-blueprint metadata) and the live grid BOTH render, and that the
+ * grid actually rendered the SAME deterministic blueprint's rows the evidence pane describes — the
+ * H2 provenance point. No Neural Link / NL orchestration is involved (out of scope for the leaf);
+ * the blueprint is fixed, so the render is deterministic.
+ *
+ * @see apps/agentos/childapps/widget/view/Viewport.mjs
+ */
+test.describe('AgentOS first widget — evidence pane + live grid (H2 render smoke)', () => {
+    test.setTimeout(90000);
+
+    test('renders the evidence pane and the live grid together from one blueprint', async ({page}) => {
+        await page.goto('/apps/agentos/childapps/widget/index.html');
+
+        const evidence = page.locator('.agent-os-evidence-pane'),
+              grid     = page.locator('.agent-os-first-widget-grid');
+
+        // 1) the evidence pane renders
+        await expect(evidence).toBeVisible({timeout: 30000});
+        // 2) the live grid renders alongside it (render TOGETHER)
+        await expect(grid).toBeVisible({timeout: 30000});
+
+        // 3) the evidence pane shows the deterministic request + accepted-blueprint metadata
+        await expect(evidence).toContainText('build me a neo grid');
+        await expect(evidence).toContainText('Neo.grid.Container');
+        await expect(evidence).toContainText('First Neo Grid');
+
+        // 4) the live grid actually rendered the SAME blueprint's rows (provenance: evidence == grid)
+        await expect(grid).toContainText('Verify intent', {timeout: 30000});
+        await expect(grid).toContainText('Show evidence');
+    });
+});

--- a/test/playwright/e2e/FirstWidgetEvidencePane.spec.mjs
+++ b/test/playwright/e2e/FirstWidgetEvidencePane.spec.mjs
@@ -1,38 +1,43 @@
 import {test, expect} from '../fixtures.mjs';
 
 /**
- * @summary H2 render smoke: the first-widget evidence pane and the live grid render TOGETHER.
+ * @summary H2 render proof: the first-widget evidence pane and the live grid render together, and
+ * the grid actually renders the blueprint's content ROWS — not an empty grid.
  *
- * This is the AC6 counterpart to the unit specs (which prove the projection + safe-render source
- * boundary). It boots the AgentOSWidget child app and verifies end-to-end that the EvidencePane
- * (request / response / accepted-blueprint metadata) and the live grid BOTH render, and that the
- * grid actually rendered the SAME deterministic blueprint's rows the evidence pane describes — the
- * H2 provenance point. No Neural Link / NL orchestration is involved (out of scope for the leaf);
- * the blueprint is fixed, so the render is deterministic.
+ * The AC6 counterpart to the unit specs (which prove the projection + safe-render boundary). It
+ * boots the AgentOSWidget child app and verifies the EvidencePane (request + accepted-blueprint
+ * metadata) AND that the live grid renders ALL of the SAME deterministic blueprint's rows — the
+ * provenance point of the leaf. The cell-COUNT + per-row cell-VALUE assertions are deliberate: a
+ * grid that mounts but renders zero content rows MUST fail here. (An earlier weak `toContainText`-
+ * only check passed against a stale dev-server render and never validated a real row — fixed.)
  *
  * @see apps/agentos/childapps/widget/view/Viewport.mjs
  */
-test.describe('AgentOS first widget — evidence pane + live grid (H2 render smoke)', () => {
+test.describe('AgentOS first widget — evidence pane + live grid rows (H2 render proof)', () => {
     test.setTimeout(90000);
 
-    test('renders the evidence pane and the live grid together from one blueprint', async ({page}) => {
+    test('renders the evidence pane and the grid with all blueprint content rows', async ({page}) => {
         await page.goto('/apps/agentos/childapps/widget/index.html');
 
         const evidence = page.locator('.agent-os-evidence-pane'),
               grid     = page.locator('.agent-os-first-widget-grid');
 
-        // 1) the evidence pane renders
         await expect(evidence).toBeVisible({timeout: 30000});
-        // 2) the live grid renders alongside it (render TOGETHER)
         await expect(grid).toBeVisible({timeout: 30000});
 
-        // 3) the evidence pane shows the deterministic request + accepted-blueprint metadata
+        // evidence pane: deterministic request + accepted-blueprint metadata (scalar, safe text)
         await expect(evidence).toContainText('build me a neo grid');
         await expect(evidence).toContainText('Neo.grid.Container');
         await expect(evidence).toContainText('First Neo Grid');
 
-        // 4) the live grid actually rendered the SAME blueprint's rows (provenance: evidence == grid)
-        await expect(grid).toContainText('Verify intent', {timeout: 30000});
-        await expect(grid).toContainText('Show evidence');
+        // the live grid renders ALL blueprint rows — 3 rows × 4 columns = 12 cells. `toHaveCount`
+        // auto-waits for the async render to settle; an empty grid (0 cells) FAILS this assertion.
+        await expect(grid.locator('.neo-grid-cell')).toHaveCount(12, {timeout: 30000});
+
+        // and each content row's value is actually rendered in the grid (not just buffered) — the
+        // provenance link: what the evidence pane describes is what the grid below it renders.
+        for (const value of ['Verify intent', 'Render grid', 'Show evidence']) {
+            await expect(grid.locator('.neo-grid-cell', {hasText: value})).toHaveCount(1)
+        }
     });
 });

--- a/test/playwright/unit/apps/agentos/childapps/widget/util/blueprintEvidence.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/util/blueprintEvidence.spec.mjs
@@ -1,0 +1,86 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'BlueprintEvidenceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Unit coverage for the safe first-widget blueprint-evidence projection.
+ *
+ * Verifies the safe boundary the H2 transcript/evidence pane relies on: a valid blueprint projects
+ * to scalar metadata only; malformed input (non-object, unexpected keys, missing/wrong-typed required
+ * fields) fails closed to a bounded `{accepted: false, reason}` state; and the raw columns/rows arrays
+ * never leak into the projection, so no executable payload can reach the view.
+ *
+ * @see apps/agentos/childapps/widget/util/blueprintEvidence.mjs
+ */
+test.describe('AgentOSWidget.util.blueprintEvidence', () => {
+    let projectBlueprintEvidence;
+
+    test.beforeAll(async () => {
+        ({projectBlueprintEvidence} = await import('../../../../../../../../apps/agentos/childapps/widget/util/blueprintEvidence.mjs'))
+    });
+
+    test('projects a valid grid blueprint to safe scalar metadata only', () => {
+        const result = projectBlueprintEvidence({
+            schema : 'Neo.grid.Container',
+            title  : 'My First Grid',
+            columns: [{dataField: 'id'}, {dataField: 'name'}, {dataField: 'role'}],
+            rows   : [{id: 1}, {id: 2}]
+        });
+
+        expect(result).toEqual({
+            accepted   : true,
+            schema     : 'Neo.grid.Container',
+            title      : 'My First Grid',
+            columnCount: 3,
+            rowCount   : 2
+        });
+
+        // the raw arrays must NOT leak through — only scalar counts reach the view
+        expect(result).not.toHaveProperty('columns');
+        expect(result).not.toHaveProperty('rows')
+    });
+
+    test('fails closed on non-object input', () => {
+        for (const bad of [null, undefined, 'a string', 42, ['an', 'array']]) {
+            const result = projectBlueprintEvidence(bad);
+            expect(result.accepted).toBe(false);
+            expect(typeof result.reason).toBe('string')
+        }
+    });
+
+    test('fails closed on unexpected (allowlist-violating) keys', () => {
+        const result = projectBlueprintEvidence({
+            schema : 'Neo.grid.Container',
+            title  : 'X',
+            columns: [],
+            rows   : [],
+            onClick: 'doSomething()' // an executable-looking field must be rejected, never projected
+        });
+
+        expect(result.accepted).toBe(false);
+        expect(result.reason).toMatch(/unexpected keys/);
+        expect(result.reason).toMatch(/onClick/)
+    });
+
+    test('fails closed on missing or wrong-typed required metadata', () => {
+        expect(projectBlueprintEvidence({title: 'X', columns: [], rows: []}).accepted).toBe(false);              // no schema
+        expect(projectBlueprintEvidence({schema: 'G', columns: [], rows: []}).accepted).toBe(false);             // no title
+        expect(projectBlueprintEvidence({schema: 'G', title: 'X', columns: 3, rows: []}).accepted).toBe(false);  // columns not array
+        expect(projectBlueprintEvidence({schema: 'G', title: 'X', columns: [], rows: 'two'}).accepted).toBe(false) // rows not array
+    })
+});

--- a/test/playwright/unit/apps/agentos/childapps/widget/view/EvidencePane.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/view/EvidencePane.spec.mjs
@@ -1,0 +1,43 @@
+import {test, expect}  from '@playwright/test';
+import {readFileSync}  from 'fs';
+import {fileURLToPath} from 'url';
+import {dirname, join} from 'path';
+
+/**
+ * @summary Source-level safe-render constraints for the H2 first-widget evidence pane.
+ *
+ * The EvidencePane renders agent- or user-authored request / response / blueprint-evidence text.
+ * Per the safe-transcript constraint, that text must reach the DOM only through bounded Neo vdom
+ * `text` nodes — never an unsafe raw-HTML path (`html` / `innerHTML`), which Neo treats as trusted
+ * markup. This is a source
+ * assertion (the Contract Ledger's rendering-safety evidence), so it stays a fast deterministic
+ * unit check independent of the App-Worker render pipeline (a live render is the e2e's job).
+ *
+ * @see apps/agentos/childapps/widget/view/EvidencePane.mjs
+ */
+const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '../../../../../../../../apps/agentos/childapps/widget/view/EvidencePane.mjs'),
+    'utf8'
+);
+
+// Strip block + line comments so the assertions check the executable CODE, not the JSDoc prose that
+// deliberately NAMES the forbidden patterns it guards against.
+const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+test.describe('AgentOSWidget.view.EvidencePane — safe-render source constraints', () => {
+    test('uses no unsafe raw-HTML render path', () => {
+        // `innerHTML` and a vdom `html:` property both inject trusted markup — forbidden for the
+        // agent/user-authored evidence text.
+        expect(code).not.toMatch(/innerHTML/);
+        expect(code).not.toMatch(/\bhtml\s*:/);
+    });
+
+    test('renders evidence as bounded vdom text routed through the safe projection', () => {
+        // request / response / metadata reach the view as `text` (the safe vdom node) ...
+        expect(code).toMatch(/\btext\s*:/);
+        // ... and the blueprint is projected to scalar metadata, never rendered raw.
+        expect(code).toMatch(/projectBlueprintEvidence/);
+    });
+});


### PR DESCRIPTION
Resolves #13413
Refs #13355

The first H2 leaf (#13362) proved a grid can be created live through Neural Link; this PR delivers the **deterministic** evidence/provenance slice: an **EvidencePane** (deterministic request, agent response summary, accepted blueprint metadata) **above a live grid** inside the `AgentOSWidget` child-app Viewport — both driven from **ONE shared deterministic blueprint** (the metadata a reviewer inspects is the exact blueprint that produced the live grid below it).

All request / response / evidence text renders through bounded Neo vdom `text` nodes — never `html` / `innerHTML` — and the blueprint passes through `projectBlueprintEvidence`, an allowlist projection returning only safe scalar metadata that **fails closed** on malformed input.

**Close-target re-scope (per the #13409 cross-family review):** #13355 was re-scoped onto the #13362/#13363 Neural-Link-created-grid seam. This PR delivers the deterministic half (evidence-pane UI + a local blueprint-driven grid render-together), **not** the NL-create-path provenance integration — so it now **Resolves the narrower fully-delivered leaf #13413** and **Refs #13355**, which stays open for the residual NL-created-grid provenance (the grid arriving via the `create_component` seam, with the evidence pane tied to it). Thanks to @neo-gpt for catching the source-of-authority mismatch — it's exactly the foundation question flagged in the original lane-claim.

Evidence: L2 unit (6 tests green, runnable) + L3 e2e render smoke (green locally + CI). This is the deterministic slice's ceiling **by design** — the NL-create-path provenance is the #13355 residual, not a sandbox ceiling.

## Decision Record impact
Aligned with ADR 0020. Resolves the deterministic-slice leaf #13413 (split from #13355). No ADR amendment.

## Deltas from ticket
All 5 ACs of the deterministic leaf #13413 delivered (evidence pane + accepted-blueprint metadata + fail-closed + render-together grid + unit/e2e coverage). #13355's broader re-scoped intent (NL-created-grid provenance) is explicitly **not** in this PR — it remains a residual on #13355 (see Post-Merge Validation).

## Test Evidence
- `npm run test-unit -- .../widget/util/blueprintEvidence.spec.mjs` → **4 passed**.
- `npm run test-unit -- .../widget/view/EvidencePane.spec.mjs` → **2 passed** (safe-render source assertion).
- `npm run test-e2e -- test/playwright/e2e/FirstWidgetEvidencePane.spec.mjs` → **1 passed** (render-together).

## Post-Merge Validation
- [ ] **#13355 residual (NL-created-grid provenance):** tie the evidence pane to a grid created via the #13362/#13363 `create_component` seam (not a deterministic config). Tracked on #13355 (left open) — `[L3-deferred — needs the AgentOSWidget NL-create seam]`; a properly-designed leaf, not delivered here.
- [ ] CI re-runs the unit + e2e specs green on the merge commit.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Session 47b6dbc0-7673-4ad3-a9f5-bef3b606c56b.
