### PR TITLE
fix(ai): create_instance redo retains ntype/className — snapshot config pre-instantiation (#13412)

### DIFF
--- a/src/ai/client/InstanceService.mjs
+++ b/src/ai/client/InstanceService.mjs
@@ -92,7 +92,12 @@ class InstanceService extends Service {
     createInstance({className, config={}, ntype, parentId}, context) {
         const
             createConfig = this.buildCreateInstanceConfig({className, config, ntype}),
-            parent       = parentId ? Neo.getComponent(parentId) : null;
+            // Deep-snapshot the resolved config BEFORE instantiation: Neo.ntype / Neo.create → construct
+            // consumes the `ntype` / `className` meta keys off createConfig, so the redo forward-op must
+            // capture them from a pre-instantiation copy — else a redo re-dispatch has no class to
+            // instantiate and fails closed ("provide `className` or `ntype`").
+            reverseConfig = this.safeSerialize(createConfig),
+            parent        = parentId ? Neo.getComponent(parentId) : null;
 
         if (parentId) {
             if (!parent) {
@@ -124,7 +129,7 @@ class InstanceService extends Service {
         }
 
         this.recordUndo(context, this.buildCreateInstanceReverse({
-            config  : createConfig,
+            config  : reverseConfig,
             context,
             instance: attachedInstance,
             parentId

--- a/test/playwright/e2e/NeuralLinkRedo.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkRedo.spec.mjs
@@ -1,0 +1,71 @@
+import { test, expect }               from '../fixtures.mjs';
+import { NeuralLink_InstanceService } from '../../../ai/services.mjs';
+
+/**
+ * @summary Live Neural Link proof for the `redo` MCP tool — the e2e counterpart to the unit specs
+ * (which mock the transport).
+ *
+ * Drives the full undo↔redo cycle over the live bridge: `create_instance` a component → `undo` (gone
+ * from the App-Worker component tree + the live DOM) → `redo` → assert the component is **restored** to
+ * both the tree and the DOM. Restoration is asserted by a unique text label rather than the original id,
+ * because a create re-apply is documented to mint a fresh id (single-level Slice-2 boundary). Sibling:
+ * NeuralLinkCreateInstance.spec (the create/undo proof this extends with the redo leg).
+ */
+test.describe('Neural Link - redo (e2e)', () => {
+    test.setTimeout(90000);
+
+    test('restores an undone agent-created component: create -> undo -> redo -> back in the live tree + DOM', async ({ page, neuralLink }) => {
+        await page.goto('/examples/button/base/index.html');
+        await expect(page.locator('.neo-button').first()).toBeVisible({ timeout: 30000 });
+
+        const app = await neuralLink.connectToApp('Neo.examples.button.base');
+        expect(app.sessionId).toBeTruthy();
+
+        const pick = res => res?.[0]?.id ?? res?.components?.[0]?.id ?? res?.instances?.[0]?.id ?? res?.id ?? null;
+
+        let containerId = pick(await app.findInstances({ ntype: 'viewport' }, ['id']));
+
+        if (!containerId) {
+            containerId = pick(await app.findInstances({ ntype: 'container' }, ['id']));
+        }
+
+        expect(containerId, 'could not resolve a target container id for the create').toBeTruthy();
+
+        const
+            suffix   = Date.now(),
+            buttonId = `nl-redo-button-${suffix}`,
+            label    = `NL-redo-${suffix}`;
+
+        // create_instance → present in the tree + DOM
+        const createResult = await app.createInstance({
+            ntype   : 'button',
+            parentId: containerId,
+            config  : {id: buttonId, text: label}
+        });
+
+        expect(createResult).toEqual({id: buttonId, className: 'Neo.button.Base', parentId: containerId});
+
+        await expect.poll(async () => JSON.stringify(await app.getComponentTree()).includes(label), {
+            message: 'the created button should appear before undo', timeout: 15000
+        }).toBe(true);
+        await expect(page.locator(`.neo-button:has-text("${label}")`)).toBeVisible({ timeout: 10000 });
+
+        // undo → gone from the tree + DOM
+        const undoResult = await NeuralLink_InstanceService.undo({sessionId: app.sessionId});
+        expect(undoResult.undone, `undo returned: ${JSON.stringify(undoResult)}`).toBe(true);
+
+        await expect.poll(async () => JSON.stringify(await app.getComponentTree()).includes(label), {
+            message: 'the button should be gone from the tree after undo', timeout: 15000
+        }).toBe(false);
+        await expect(page.locator(`.neo-button:has-text("${label}")`)).toHaveCount(0);
+
+        // redo → restored to the tree + DOM (asserted by the unique label; a create re-apply may mint a fresh id)
+        const redoResult = await NeuralLink_InstanceService.redo({sessionId: app.sessionId});
+        expect(redoResult.redone, `redo returned: ${JSON.stringify(redoResult)}`).toBe(true);
+
+        await expect.poll(async () => JSON.stringify(await app.getComponentTree()).includes(label), {
+            message: 'the button should be restored to the tree after redo', timeout: 15000
+        }).toBe(true);
+        await expect(page.locator(`.neo-button:has-text("${label}")`)).toBeVisible({ timeout: 10000 });
+    });
+});

--- a/test/playwright/e2e/NeuralLinkRedo.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkRedo.spec.mjs
@@ -21,6 +21,12 @@ test.describe('Neural Link - redo (e2e)', () => {
         const app = await neuralLink.connectToApp('Neo.examples.button.base');
         expect(app.sessionId).toBeTruthy();
 
+        // ⚠️ Fresh-bridge diagnostic guard: an `{undone:false}` / `{redone:false, reason:'no-writer-identity'}`
+        // below means a STALE `:8081` bridge — one predating the `agent_message` sidecar-emit that threads the
+        // writer `{agentId, sessionId}` into the App Worker — NOT a logic regression. Restart `run-bridge.mjs`
+        // and rerun. (The undo/redo capture + replay key on that writer identity; the assertion messages below
+        // surface the raw `{reason}`, so a stale bridge is diagnosable at a glance. Mirrors the undo-e2e story.)
+
         const pick = res => res?.[0]?.id ?? res?.components?.[0]?.id ?? res?.instances?.[0]?.id ?? res?.id ?? null;
 
         let containerId = pick(await app.findInstances({ ntype: 'viewport' }, ['id']));

--- a/test/playwright/unit/ai/InstanceServiceCreateInstance.spec.mjs
+++ b/test/playwright/unit/ai/InstanceServiceCreateInstance.spec.mjs
@@ -146,4 +146,39 @@ test.describe('Neo.ai.client.InstanceService - create_instance', () => {
         expect(() => service.destroyInstance({id: 'created-store'}, ID)).toThrow(/internal undo\/redo replay/);
         expect(Neo.get('created-store')).toBeInstanceOf(Store)
     });
+
+    test('the captured create forward-op retains a top-level ntype despite instantiation (regression lock, #13412)', () => {
+        service.createInstance({
+            ntype   : 'component',
+            parentId: 'create-instance-container',
+            config  : {id: 'capture-button', text: 'Captured'}
+        }, ID);
+
+        const op = transactionService.stackOf({id: ID}).committed[0].ops[0];
+
+        expect(op.forward.tool).toBe('create_instance');
+        // Neo.ntype / Neo.create consume the meta keys off the live createConfig during instantiation,
+        // so the redo forward-op must carry a pre-instantiation snapshot — else a redo re-dispatch has
+        // no class to instantiate and fails closed.
+        expect(op.forward.args.config.ntype).toBe('component')
+    });
+
+    test('create -> undo -> redo re-applies the create (the undo/redo cycle, #13412)', async () => {
+        service.createInstance({
+            ntype   : 'component',
+            parentId: 'create-instance-container',
+            config  : {id: 'redo-button', text: 'Redo me'}
+        }, ID);
+        expect(Neo.getComponent('redo-button')).toBeInstanceOf(Component);
+
+        const undo = await service.undo({}, ID);
+        expect(undo.undone).toBe(true);
+        expect(Neo.getComponent('redo-button')?.isDestroyed ?? true).toBe(true);
+
+        // Pre-fix this returned {redone:false, reason:'redo-denied: provide className or ntype'} — the
+        // captured forward-op had lost its ntype. redone:true + reapplied:1 locks the re-dispatch.
+        const redo = await service.redo({}, ID);
+        expect(redo.redone).toBe(true);
+        expect(redo.reapplied).toBe(1)
+    })
 });


### PR DESCRIPTION
Resolves #13412
Resolves #13306

## Summary

Redo of a `create_instance` was broken: `create → undo → redo` returned `{redone:false, reason:"redo-denied: create_instance: provide className or ntype"}`. The #13306 redo e2e surfaced it — the unit specs mocked the transport, so they passed while the live capability was broken; the e2e is what proved the capability doesn't work.

**Root cause** (`src/ai/client/InstanceService.mjs#createInstance`): `Neo.ntype`/`Neo.create` → `construct` consumes the `ntype`/`className` meta keys off the live `createConfig` during instantiation; `buildCreateInstanceReverse` then captured that *mutated* config, so the redo forward-op had no class to re-instantiate.

**Fix:** deep-snapshot `createConfig` (via `safeSerialize`) **before** instantiation, and capture the redo forward-op from the snapshot. Low-blast (capture-only; the create path is unchanged) and behavior-restoring (re-apply-the-undone-create is the already-documented redo contract → no new Contract Ledger, per the bug-fix-restoring-documented-contract exclusion).

Evidence: the e2e goes from red (`redo-denied`) to green (`{redone:true, reapplied:1}` → component restored to the live tree + DOM).

## Close-target — #13306 AC disposition

Per the [#13306 re-scope comment](https://github.com/neomjs/neo/issues/13306#issuecomment-4716610328) (addressing @neo-gpt's close-target catch): **AC1** (live `create→undo→redo→assert-restored` e2e, tree + DOM) ✓ green; **AC2** (a `redo()` fixture helper mirroring `undo()`) **obsolete/superseded** — there is no `undo()` helper to mirror, and the landed `NeuralLinkCreateInstance.spec` calls `NeuralLink_InstanceService.undo/redo({sessionId})` directly (the established pattern this e2e follows for consistency); **AC3** (fresh-bridge diagnostic guard) ✓ added (`498a7d73a`). So `Resolves #13306` is honest alongside `Resolves #13412`.

## Test Evidence

Branch head `498a7d73a` (the `3fc7feced`→`498a7d73a` delta is the comment-only AC3 fresh-bridge guard — no behavior change; the e2e/unit runs below hold):

- `test/playwright/e2e/NeuralLinkRedo.spec.mjs` (L3 — `npm run test-e2e` on the fresh `:8081` bridge, self-served `:8080`) → **1 passed**: `create_instance → undo → redo →` restored to the live `get_component_tree` + DOM (asserted by a unique text label, since a create re-apply may mint a fresh id).
- `test/playwright/unit/ai/InstanceServiceCreateInstance.spec.mjs` → **7 passed**, incl. 2 new CI-catchable regression locks: the captured forward-op retains `ntype`; `create → undo → redo` returns `redone:true`/`reapplied:1`.
- Regression — the full InstanceService undo/redo/capture unit suite (`CreateUndoCapture` · `Redo` · `Undo` · `UndoCapture` · `RemoveUndoCapture` · `ListTransactions` · `NamedTransaction` · `CreateInstance`) → **46 passed**, no regression from the capture change.

## Post-Merge Validation

- [ ] CI confirms the new unit locks stay green (e2e is not in CI — L3-verified here on the fresh bridge).

## Deltas

- `src/ai/client/InstanceService.mjs#createInstance`: added a pre-instantiation `reverseConfig = safeSerialize(createConfig)` snapshot; `buildCreateInstanceReverse` now captures from it (was the post-instantiation, meta-stripped `createConfig`).
- `InstanceServiceCreateInstance.spec.mjs`: +2 regression locks (capture retains `ntype`; the redo cycle).
- `NeuralLinkRedo.spec.mjs` (the reproducing e2e, committed earlier as `347b17fde`): now green with the fix.

## Review cycles

- `347b17fde` — NL redo e2e (reproducing proof; red on the bug — surfaced it).
- `3fc7feced` — the fix (pre-instantiation config snapshot) + unit regression locks → e2e green.
- `498a7d73a` — AC3 fresh-bridge diagnostic guard on the e2e (comment-only; per the cycle-1 close-target review).

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
