### PR TITLE
feat(agentos): H2 first-widget chat-intake surface (#13357)

### DIFF
--- a/apps/agentos/childapps/widget/util/validateRequest.mjs
+++ b/apps/agentos/childapps/widget/util/validateRequest.mjs
@@ -1,0 +1,48 @@
+/**
+ * @module AgentOSWidget.util.validateRequest
+ * @summary Bounded, fail-closed validation for a first-widget chat request.
+ *
+ * The H2 chat-intake surface captures untrusted user text before it becomes request/evidence
+ * state. This is the safe boundary: it accepts only a bounded plain-text request and fails closed
+ * to a `{accepted:false, reason}` state — never throwing, never letting markup or an overlong
+ * payload through — so the intake surface can render the reason as bounded safe text rather than
+ * projecting unvalidated input. Deterministic: no model invocation, no orchestration; this leaf
+ * proves the intake boundary, not provider integration.
+ */
+
+/**
+ * The maximum accepted request length. A first-widget request is a short instruction
+ * ("build me a neo grid"); anything longer is rejected as overlong rather than truncated.
+ * @type {Number}
+ */
+const MAX_REQUEST_LENGTH = 200;
+
+/**
+ * Validates a first-widget chat request into a bounded, fail-closed result.
+ *
+ * @param {String} text the raw user request text
+ * @returns {{accepted: Boolean, value: String}|{accepted: Boolean, reason: String}}
+ *   `{accepted: true, value}` (trimmed) on success, or `{accepted: false, reason}` when the input
+ *   is non-string, empty / whitespace-only, longer than {@link MAX_REQUEST_LENGTH}, or contains markup.
+ */
+export function validateRequest(text) {
+    if (typeof text !== 'string') {
+        return {accepted: false, reason: 'Request must be text.'}
+    }
+
+    const trimmed = text.trim();
+
+    if (trimmed.length === 0) {
+        return {accepted: false, reason: 'Request is empty — type what to build.'}
+    }
+
+    if (trimmed.length > MAX_REQUEST_LENGTH) {
+        return {accepted: false, reason: `Request is too long (max ${MAX_REQUEST_LENGTH} characters).`}
+    }
+
+    if (/[<>]/.test(trimmed)) {
+        return {accepted: false, reason: 'Request must be plain text (no markup).'}
+    }
+
+    return {accepted: true, value: trimmed}
+}

--- a/apps/agentos/childapps/widget/view/RequestIntake.mjs
+++ b/apps/agentos/childapps/widget/view/RequestIntake.mjs
@@ -1,0 +1,66 @@
+import Button    from '../../../../../src/button/Base.mjs';
+import Container from '../../../../../src/container/Base.mjs';
+import TextField from '../../../../../src/form/field/Text.mjs';
+
+/**
+ * @class AgentOSWidget.view.RequestIntake
+ * @extends Neo.container.Base
+ * @summary Bounded first-widget chat-intake surface — a text input + submit affordance.
+ *
+ * The H2 intake gesture: a user types the first-widget request and submits it. The field is bounded
+ * (`maxLength`), the submit routes to the Viewport controller (which validates + projects the request
+ * into the evidence state), and the error line below renders any fail-closed reason as safe vdom
+ * `text` — never `html` / `innerHTML`, and never executable. Deterministic: no model call here.
+ */
+class RequestIntake extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOSWidget.view.RequestIntake'
+         * @protected
+         */
+        className: 'AgentOSWidget.view.RequestIntake',
+        /**
+         * @member {String} ntype='agent-os-request-intake'
+         * @protected
+         */
+        ntype: 'agent-os-request-intake',
+        /**
+         * @member {String[]} cls=['agent-os-request-intake']
+         * @reactive
+         */
+        cls: ['agent-os-request-intake'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype : 'container',
+            cls   : ['agent-os-request-row'],
+            layout: {ntype: 'hbox', align: 'stretch'},
+            items : [{
+                module         : TextField,
+                reference      : 'request-field',
+                flex           : 1,
+                labelText      : 'Request',
+                placeholderText: 'build me a neo grid',
+                maxLength      : 200
+            }, {
+                module : Button,
+                cls    : ['agent-os-request-submit'],
+                handler: 'onSubmitRequest',
+                text   : 'Build'
+            }]
+        }, {
+            ntype    : 'component',
+            reference: 'request-error',
+            cls      : ['agent-os-request-error'],
+            vdom     : {cn: [{text: ''}]}
+        }]
+    }
+}
+
+export default Neo.setupClass(RequestIntake);

--- a/apps/agentos/childapps/widget/view/Viewport.mjs
+++ b/apps/agentos/childapps/widget/view/Viewport.mjs
@@ -1,6 +1,8 @@
-import BaseViewport  from '../../../../../src/container/Viewport.mjs';
-import EvidencePane  from './EvidencePane.mjs';
-import GridContainer from '../../../../../src/grid/Container.mjs';
+import BaseViewport       from '../../../../../src/container/Viewport.mjs';
+import EvidencePane       from './EvidencePane.mjs';
+import GridContainer      from '../../../../../src/grid/Container.mjs';
+import RequestIntake      from './RequestIntake.mjs';
+import ViewportController from './ViewportController.mjs';
 
 /**
  * The deterministic first-widget blueprint — the single source of truth shared by the evidence
@@ -39,6 +41,11 @@ class Viewport extends BaseViewport {
          */
         className: 'AgentOSWidget.view.Viewport',
         /**
+         * @member {Neo.controller.Component} controller=AgentOSWidget.view.ViewportController
+         * @reactive
+         */
+        controller: ViewportController,
+        /**
          * @member {String[]} additionalThemeFiles=['AgentOS.view.Viewport']
          */
         additionalThemeFiles: ['AgentOS.view.Viewport'],
@@ -53,12 +60,15 @@ class Viewport extends BaseViewport {
          */
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
-         * The first-widget surface: the evidence pane (request / response / accepted blueprint
-         * metadata) above the live grid that the same blueprint produced.
+         * The first-widget surface: a bounded chat intake, the evidence pane (request / response /
+         * accepted blueprint metadata), and the live grid the same blueprint produced.
          * @member {Object[]} items
          */
         items: [{
+            module: RequestIntake
+        }, {
             module   : EvidencePane,
+            reference: 'evidence-pane',
             blueprint: firstWidgetBlueprint
         }, {
             module        : GridContainer,

--- a/apps/agentos/childapps/widget/view/ViewportController.mjs
+++ b/apps/agentos/childapps/widget/view/ViewportController.mjs
@@ -1,0 +1,44 @@
+import Controller        from '../../../../../src/controller/Component.mjs';
+import {validateRequest} from '../util/validateRequest.mjs';
+
+/**
+ * @class AgentOSWidget.view.ViewportController
+ * @extends Neo.controller.Component
+ * @summary Wires the first-widget chat intake to the evidence pane.
+ *
+ * Handles the intake submit: validates the typed request through {@link validateRequest} and either
+ * projects the accepted request into the existing EvidencePane request state (reusing the deterministic
+ * first-widget path — no second widget path), or renders the bounded fail-closed reason as safe vdom
+ * text in the intake's error line. No model invocation / orchestration / persistence — deterministic.
+ */
+class ViewportController extends Controller {
+    static config = {
+        /**
+         * @member {String} className='AgentOSWidget.view.ViewportController'
+         * @protected
+         */
+        className: 'AgentOSWidget.view.ViewportController'
+    }
+
+    /**
+     * Triggered by the intake submit button. Reads the current request field value, validates it,
+     * and projects an accepted request into the evidence pane or shows the rejected reason.
+     * @param {Object} data
+     * @protected
+     */
+    onSubmitRequest(data) {
+        let me     = this,
+            field  = me.getReference('request-field'),
+            error  = me.getReference('request-error'),
+            result = validateRequest(field.value);
+
+        if (result.accepted) {
+            me.getReference('evidence-pane').request = result.value
+        }
+
+        error.vdom.cn[0].text = result.accepted ? '' : result.reason;
+        error.update()
+    }
+}
+
+export default Neo.setupClass(ViewportController);

--- a/test/playwright/e2e/FirstWidgetChatIntake.spec.mjs
+++ b/test/playwright/e2e/FirstWidgetChatIntake.spec.mjs
@@ -1,0 +1,47 @@
+import {test, expect} from '../fixtures.mjs';
+
+/**
+ * @summary H2 chat-intake proof: a typed first-widget request is captured into the evidence state,
+ * and markup / invalid input fails closed without projecting an unsafe payload.
+ *
+ * Exercises the real flow against a live app (no stubs): type → submit → the EvidencePane request
+ * line shows the typed request; then type markup → submit → the intake error line shows a bounded
+ * fail-closed reason AND the evidence request is NOT replaced by the unsafe input. Assertions check
+ * actual rendered text (not a loose match) so an unwired submit or a leaked payload must fail.
+ *
+ * @see apps/agentos/childapps/widget/view/RequestIntake.mjs
+ * @see apps/agentos/childapps/widget/view/ViewportController.mjs
+ */
+test.describe('AgentOS first widget — chat intake (H2 request capture)', () => {
+    test.setTimeout(90000);
+
+    test('captures a valid request into the evidence state + fails closed on markup', async ({page}) => {
+        await page.goto('/apps/agentos/childapps/widget/index.html');
+
+        const
+            field   = page.locator('.agent-os-request-intake input').first(),
+            build   = page.locator('.agent-os-request-submit'),
+            request = page.locator('.agent-os-evidence-request'),
+            error   = page.locator('.agent-os-request-error');
+
+        await expect(field).toBeVisible({timeout: 30000});
+        await expect(build).toBeVisible();
+        // baseline: the evidence pane shows the deterministic default request
+        await expect(request).toContainText('build me a neo grid', {timeout: 30000});
+        // all three surfaces render together (intake + evidence + live grid) — 3 rows x 4 cols
+        await expect(page.locator('.agent-os-first-widget-grid .neo-grid-cell')).toHaveCount(12, {timeout: 30000});
+
+        // valid submit → the typed request is projected into the evidence request state
+        await field.fill('build me a neo dashboard');
+        await build.click();
+        await expect(request).toContainText('build me a neo dashboard', {timeout: 15000});
+        await expect(error).toHaveText('');
+
+        // markup submit → bounded fail-closed reason shown, evidence request NOT replaced by unsafe input
+        await field.fill('<script>oops</script>');
+        await build.click();
+        await expect(error).toContainText(/plain text|markup/i, {timeout: 15000});
+        await expect(request).toContainText('build me a neo dashboard');
+        await expect(request).not.toContainText('script')
+    });
+});

--- a/test/playwright/unit/apps/agentos/childapps/widget/util/validateRequest.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/util/validateRequest.spec.mjs
@@ -1,0 +1,68 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'ValidateRequestTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Unit coverage for the fail-closed first-widget chat-request validation.
+ *
+ * Verifies the safe boundary the H2 chat-intake surface relies on: a bounded plain-text request is
+ * accepted (trimmed); empty / whitespace-only, non-string, overlong, and markup-bearing input all
+ * fail closed to a bounded `{accepted:false, reason}` state, so no unvalidated payload ever reaches
+ * the request/evidence projection.
+ *
+ * @see apps/agentos/childapps/widget/util/validateRequest.mjs
+ */
+test.describe('AgentOSWidget.util.validateRequest', () => {
+    let validateRequest;
+
+    test.beforeAll(async () => {
+        ({validateRequest} = await import('../../../../../../../../apps/agentos/childapps/widget/util/validateRequest.mjs'))
+    });
+
+    test('accepts a bounded plain-text request, trimmed', () => {
+        expect(validateRequest('  build me a neo grid  ')).toEqual({accepted: true, value: 'build me a neo grid'})
+    });
+
+    test('fails closed on empty / whitespace-only input', () => {
+        for (const bad of ['', '   ', '\t\n']) {
+            const result = validateRequest(bad);
+            expect(result.accepted).toBe(false);
+            expect(result.reason).toMatch(/empty/i)
+        }
+    });
+
+    test('fails closed on non-string input', () => {
+        for (const bad of [null, undefined, 42, {}, []]) {
+            expect(validateRequest(bad).accepted).toBe(false)
+        }
+    });
+
+    test('fails closed on overlong input', () => {
+        const result = validateRequest('x'.repeat(201));
+        expect(result.accepted).toBe(false);
+        expect(result.reason).toMatch(/too long/i)
+    });
+
+    test('fails closed on markup / HTML-like input — no unsafe payload through', () => {
+        for (const bad of ['<script>alert(1)</script>', 'build <b>grid</b>', 'a > b']) {
+            const result = validateRequest(bad);
+            expect(result.accepted).toBe(false);
+            expect(result.reason).toMatch(/plain text|markup/i)
+        }
+    })
+});

--- a/test/playwright/unit/apps/agentos/childapps/widget/view/RequestIntake.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/view/RequestIntake.spec.mjs
@@ -1,0 +1,45 @@
+import {test, expect}  from '@playwright/test';
+import {readFileSync}  from 'fs';
+import {fileURLToPath} from 'url';
+import {dirname, join} from 'path';
+
+/**
+ * @summary Source-level safe-render + blueprint-path-reuse constraints for the H2 chat intake.
+ *
+ * The intake submit routes through the Viewport controller, which renders any fail-closed reason as
+ * safe vdom `text` (never `html` / `innerHTML`) and projects an accepted request into the EXISTING
+ * evidence pane — it must NOT spin up a second widget / grid path. These are source assertions (the
+ * Contract Ledger's safe-render + reuse evidence), independent of the App-Worker render pipeline.
+ *
+ * @see apps/agentos/childapps/widget/view/RequestIntake.mjs
+ * @see apps/agentos/childapps/widget/view/ViewportController.mjs
+ */
+const viewDir = dirname(fileURLToPath(import.meta.url));
+
+const read = name => readFileSync(
+    join(viewDir, '../../../../../../../../apps/agentos/childapps/widget/view/', name),
+    'utf8'
+).replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+const intake     = read('RequestIntake.mjs'),
+      controller = read('ViewportController.mjs');
+
+test.describe('AgentOSWidget chat intake — safe-render + blueprint-path-reuse source constraints', () => {
+    test('intake + controller use no unsafe raw-HTML render path', () => {
+        for (const src of [intake, controller]) {
+            expect(src).not.toMatch(/innerHTML/);
+            expect(src).not.toMatch(/\bhtml\s*:/)
+        }
+    });
+
+    test('controller validates input and projects into the EXISTING evidence pane', () => {
+        expect(controller).toMatch(/validateRequest/);
+        expect(controller).toMatch(/evidence-pane/)
+    });
+
+    test('introduces no duplicate widget / grid path (reuses the first-widget blueprint path)', () => {
+        for (const src of [intake, controller]) {
+            expect(src).not.toMatch(/createComponent|grid-container|new\s+Grid/)
+        }
+    })
+});


### PR DESCRIPTION
Resolves #13357

The next H2 leaf: a bounded **chat-intake surface** so the first-widget request comes from a user gesture instead of hardcoded state. Builds on the merged EvidencePane (#13409 / #13413).

A `Neo.form.field.Text` + submit (`RequestIntake`) routes to a `ViewportController` that:
- validates the typed request **fail-closed** via `validateRequest` (empty / overlong / markup → a bounded safe-text reason in the intake error line — never `html` / `innerHTML`, never executable),
- projects an **accepted** request into the EXISTING `EvidencePane` request state — reusing the deterministic first-widget path, **no duplicate widget / grid path**.

Deterministic per the ticket: no LLM provider call, no streaming, no persistence / git-write, no Electron.

Evidence: L2 unit (8 new tests green) + L3 e2e (the real type→submit→evidence flow + markup fail-closed + all-three-surfaces render-together), verified vs a **fresh** server (kill `:8080`) per the #13409 false-green lesson.

## Decision Record impact
Aligned with ADR 0020. Builds on the merged EvidencePane (#13409). No ADR amendment.

## Deltas from ticket
**One source-authority correction (per the #13416 review):** AC4's blueprint-path authority is the **merged #13409 / #13413** path (the EvidencePane + deterministic grid), NOT the superseded static `#13353` route. `#13353` closed unmerged; the live prerequisite chain is `#13362 → #13355 → #13357` per #13357's correction comment. All 7 ACs delivered:
- **AC1** intake surface (text input + submit) → `RequestIntake` (e2e asserts visible).
- **AC2** valid submit projects into the evidence request state → `ViewportController` (e2e asserts the typed request appears in the evidence pane).
- **AC3** empty / overlong / HTML-like fail closed → `validateRequest` (5 unit) + e2e markup case.
- **AC4** reuses the merged **#13409 / #13413** first-widget blueprint path (EvidencePane + deterministic grid; the static `#13353` route was superseded), no duplicate widget → source assertion (no `createComponent` / `grid-container`) + e2e (request updates the existing surface, no new grid).
- **AC5** no LLM / persist / git / Electron → deterministic.
- **AC6** unit: valid / invalid / safe-render / blueprint-reuse → `validateRequest` (5) + `RequestIntake` source spec (3).
- **AC7** render smoke: intake + evidence + grid together → chat-intake e2e (`toHaveCount(12)` grid + intake field + evidence request).

## Test Evidence
- `npm run test-unit -- .../widget/` → **14 passed** (validateRequest 5 + RequestIntake-source 3 + the prior blueprintEvidence 4 + EvidencePane 2 — no regression).
- `npm run test-e2e -- .../FirstWidgetChatIntake.spec.mjs` → **green, 3× `--repeat-each`** — type→submit→evidence; markup→fail-closed + no payload leak; intake + evidence + grid render together.
- `npm run test-e2e -- .../FirstWidgetEvidencePane.spec.mjs` → **green** (grid-render regression — the intake addition didn't break the grid's 12 rendered cells).
- All e2e verified against a **fresh** dev-server (`lsof -ti:8080 | xargs kill -9`) to avoid the stale-server false-green from #13409.

## Post-Merge Validation
- [ ] CI re-runs the widget unit + e2e specs green on the merge commit.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Session 47b6dbc0-7673-4ad3-a9f5-bef3b606c56b.
