### PR TITLE
docs(agentos): add gitlab-pat healthcheck troubleshooting (#13418)

### DIFF
--- a/learn/agentos/cloud-deployment/Day0Tutorial.md
+++ b/learn/agentos/cloud-deployment/Day0Tutorial.md
@@ -29,7 +29,10 @@ connect-error (Invalid Host, missing `Accept` header, the auth layers, the
 When using the optional ingress profile, `ai/deploy/Caddyfile` binds
 `tls internal` to `NEO_DEPLOY_HOSTNAME`, defaulting to `localhost`. Set
 `NEO_DEPLOY_HOSTNAME` before starting the ingress service when testing a named
-host.
+host. If you enable the `gitlab-pat` auth profile and compose reports unhealthy
+KB/MC containers or `dependency <svc> failed to start`, see the
+[Connection Troubleshooting](./Troubleshooting.md) entry for the required
+healthcheck bearer token.
 
 ## Prerequisites
 

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -75,6 +75,35 @@ A proxied deployment commonly has **two** auth layers, and an error at one is ea
 
 Identify which layer an error came from (via the ladder) before changing any config.
 
+### `dependency <svc> failed to start` after enabling `NEO_AUTH_MODE=gitlab-pat`
+
+**Symptom:** after switching a compose deployment to `NEO_AUTH_MODE=gitlab-pat`,
+`docker compose up` leaves `kb-server` or `mc-server` unhealthy, and dependent
+services report `dependency <svc> failed to start`.
+
+**Confirm it is the bearer healthcheck case, not a boot crash:** send a
+tokenless `initialize` request through the public ingress. A clean `401` with
+`WWW-Authenticate: Bearer` means the MCP server is up and enforcing auth; a
+`502`, timeout, or connection-refused result points at a process/proxy boot
+failure instead.
+
+**Cause:** the in-container healthcheck runs `mcpHealthcheck.mjs` against the
+same authenticated `/mcp` route. In `gitlab-pat` mode that self-probe must also
+send a bearer token. If `NEO_MCP_HEALTHCHECK_TOKEN` is unset or empty, the
+healthcheck gets `401`, the container never reaches `service_healthy`, and
+compose dependency waits abort.
+
+**Fix:** set `NEO_MCP_HEALTHCHECK_TOKEN=<read_user bearer>` in the deployment
+`.env` (a GitLab PAT or OAuth access token with the same `read_user` validation
+surface as other MCP clients), then recreate the affected services so the
+environment is reloaded:
+
+```bash
+docker compose -p <project> up -d --force-recreate kb-server mc-server orchestrator
+```
+
+This is an environment-only repair; no image rebuild is required.
+
 ## Test profile vs production auth profile
 
 Verify the wiring *before* real auth is enabled, but keep the two profiles distinct:


### PR DESCRIPTION
Resolves #13418

Adds a symptom-indexed cloud-deployment troubleshooting entry for the `NEO_AUTH_MODE=gitlab-pat` failure where an empty `NEO_MCP_HEALTHCHECK_TOKEN` makes the in-container MCP healthchecks 401, keeps KB/MC unhealthy, and causes compose dependents to fail with `dependency <svc> failed to start`. Also adds a Day-0 cross-reference from the production-ingress intro.

Evidence: L1 (current-source/doc audit + tree-json lint + commit whitespace hook) -> L1 required (doc-only operator troubleshooting ACs). No residuals.

## Deltas from ticket
No new nav node was needed: `learn/agentos/cloud-deployment/Troubleshooting.md` is already registered in `learn/tree.json`, and `npm run ai:lint-tree-json` confirms the public nav still mirrors the learn tree. Day-0 does not currently have a literal `gitlab-pat` enable step, so the cross-reference is placed at the production-ingress/auth troubleshooting entry point instead of inventing a new setup step.

## Test Evidence
- `git diff --check` -> passed.
- `npm run ai:lint-tree-json` -> passed (`learn/tree.json` mirrors the learn folder and SEO outputs).
- Commit hook ran `node ./buildScripts/util/check-whitespace.mjs` -> passed.

## Post-Merge Validation
- [ ] Operator searching for `dependency <svc> failed to start`, unhealthy KB/MC after `gitlab-pat`, or `NEO_MCP_HEALTHCHECK_TOKEN` lands on the new troubleshooting entry.

## Commits
- `a41bba20` — `docs(agentos): add gitlab-pat healthcheck troubleshooting (#13418)`

Authored by Euclid (GPT-5, Codex Desktop). Session 09850a49-643e-42cc-81dc-b2b38bf6f3a1.
