### PR TITLE
fix(docs): CI lint for unparseable JSDoc types + fix the docs-build breakers

### DIFF
--- a/.github/workflows/jsdoc-type-lint.yml
+++ b/.github/workflows/jsdoc-type-lint.yml
@@ -1,0 +1,47 @@
+name: JSDoc Type Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'src/**/*.mjs'
+      - 'ai/**/*.mjs'
+      - 'docs/app/**/*.mjs'
+      - 'apps/**/*.mjs'
+      - 'buildScripts/util/check-jsdoc-types.mjs'
+      - '.github/workflows/jsdoc-type-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'src/**/*.mjs'
+      - 'ai/**/*.mjs'
+      - 'docs/app/**/*.mjs'
+      - 'apps/**/*.mjs'
+      - 'buildScripts/util/check-jsdoc-types.mjs'
+      - '.github/workflows/jsdoc-type-lint.yml'
+
+concurrency:
+  group: jsdoc-type-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      # Unlike the dependency-free lint workflows, this one runs catharsis (the docs-build's own type
+      # parser, a transitive dep of jsdoc-api). --ignore-scripts skips the heavy postinstall (KB pull /
+      # server-config setup) we don't need — only node_modules must be present.
+      - name: Install dependencies (catharsis)
+        run: npm ci --ignore-scripts
+
+      - name: Lint JSDoc type expressions (docs-build parser check-mode)
+        run: node ./buildScripts/util/check-jsdoc-types.mjs

--- a/.github/workflows/jsdoc-type-lint.yml
+++ b/.github/workflows/jsdoc-type-lint.yml
@@ -8,6 +8,7 @@ on:
       - 'ai/**/*.mjs'
       - 'docs/app/**/*.mjs'
       - 'apps/**/*.mjs'
+      - 'examples/**/*.mjs'
       - 'buildScripts/util/check-jsdoc-types.mjs'
       - '.github/workflows/jsdoc-type-lint.yml'
   push:
@@ -17,6 +18,7 @@ on:
       - 'ai/**/*.mjs'
       - 'docs/app/**/*.mjs'
       - 'apps/**/*.mjs'
+      - 'examples/**/*.mjs'
       - 'buildScripts/util/check-jsdoc-types.mjs'
       - '.github/workflows/jsdoc-type-lint.yml'
 

--- a/buildScripts/util/check-jsdoc-types.mjs
+++ b/buildScripts/util/check-jsdoc-types.mjs
@@ -1,0 +1,206 @@
+import catharsis            from 'catharsis';
+import {execSync, spawnSync} from 'node:child_process';
+import {readFileSync}       from 'node:fs';
+import path                 from 'node:path';
+import process              from 'node:process';
+import {fileURLToPath}      from 'node:url';
+
+/*
+ * Substrate gate against unparseable JSDoc type expressions in the docs build.
+ *
+ * The docs build (`npm run generate-docs-json` — the last `build all` step) parses every `{type}` with
+ * `jsdoc-x` → `catharsis` (the Closure/JSDoc type grammar, NOT TypeScript). A TS-like expression catharsis
+ * cannot parse throws inside a parse batch; the build then fails the whole run (by design) and the
+ * docs app loses that content. That failure surfaces late (last build step) and aborts on the first bad
+ * batch without enumerating the rest. This lint runs the SAME parser, ahead of the build, over every
+ * offender — so authors see it at commit / PR time instead of in a broken `build all`.
+ *
+ * Dependency note: unlike the dependency-free lint workflows, this one imports `catharsis` (a transitive
+ * dep of `jsdoc-api`), so its CI workflow runs `npm ci --ignore-scripts`. Running the real parser — rather
+ * than approximating it with a regex — is deliberate: the failure mode is a catharsis tokenizer quirk (a
+ * bare union in a record value breaks only with no space after the colon), which no regex can classify
+ * without false-positives on the many valid spaced/parenthesized record-unions across the codebase.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
+
+// JSDoc tags whose {type} the docs build must be able to parse.
+const TYPE_TAG = /@(param|returns?|type|property|prop|typedef|yields?|throws|exception|augments|member|enum)\b/;
+
+// Mirror buildScripts/docs/jsdocx.mjs `files` scope + excludePattern (the surface the docs build parses):
+// underscore-prefixed paths, node_modules/dist, and the machine-local config overlays are out.
+const DEFAULT_DIRS = ['src', 'ai', 'docs/app', 'apps'];
+const EXCLUDE      = /(^|\/)_|\/node_modules\/|\/dist\/|(^|\/)ai\/config\.mjs$|(^|\/)ai\/mcp\/server\/[^/]+\/config\.mjs$/;
+
+/**
+ * @summary Reads the balanced `{type}` starting at `braceStart` on line `i`, spanning continuation lines.
+ *
+ * The OUTER braces are the tag wrapper, so the returned string is the inner type expression catharsis
+ * parses — e.g. `@returns {{a:String}}` yields `{a:String}`, `@param {String}` yields `String`. Continuation
+ * lines have their leading ` * ` stripped. Returns `''` if the braces never balance (malformed / not a type).
+ * @param {String[]} lines
+ * @param {Number} i Index of the line carrying the tag.
+ * @param {Number} braceStart Column of the tag's opening `{` on line `i`.
+ * @returns {String}
+ */
+export function extractType(lines, i, braceStart) {
+    let depth = 0, expr = '', li = i, done = false;
+
+    while (li < lines.length && !done) {
+        const l = lines[li];
+        let start = li === i ? braceStart : 0;
+
+        if (li !== i) {
+            const lead = l.match(/^\s*\*\s?/);
+            if (lead) start = lead[0].length
+        }
+
+        for (let k = start; k < l.length; k++) {
+            const ch = l[k];
+            if      (ch === '{') { depth++; if (depth > 1) expr += ch }
+            else if (ch === '}') { depth--; if (depth === 0) { done = true; break } expr += ch }
+            else if (depth >= 1) expr += ch
+        }
+
+        if (!done) { expr += ' '; li++ }
+    }
+
+    return done ? expr.trim() : ''
+}
+
+/**
+ * @summary Extracts each `/**`-block JSDoc type expression and returns the ones catharsis cannot parse.
+ *
+ * Only `/** … *\/` doc blocks are scanned — jsdoc ignores `/* … *\/` block comments and `//` lines, so a
+ * type-like token inside those is not a build input and flagging it would be a false positive. Within a doc
+ * block, the balanced `{type}` after a type-bearing tag is parsed with the SAME parser the docs build uses
+ * (`catharsis`, jsdoc dictionary), so a hit here is exactly what breaks `npm run generate-docs-json`.
+ * @param {String} content Raw file source.
+ * @returns {Object[]} `[{line, tag, expr}]` — one entry per unparseable type expression (1-based line).
+ */
+export function findUnparseableTypes(content) {
+    const lines    = content.split('\n'),
+          failures = [];
+
+    let inBlock = false, isDoc = false;
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        if (!inBlock) {
+            const open = line.indexOf('/*');
+            if (open !== -1) {
+                inBlock = true;
+                isDoc   = line[open + 2] === '*' // `/**` opens a doc block; `/*` (single star) does not
+            }
+        }
+
+        if (inBlock && isDoc) {
+            const tag = line.match(TYPE_TAG);
+
+            if (tag) {
+                const braceStart = line.indexOf('{', tag.index);
+
+                if (braceStart !== -1) {
+                    const expr = extractType(lines, i, braceStart);
+
+                    if (expr) {
+                        try { catharsis.parse(expr, {jsdoc: true}) }
+                        catch (e) { failures.push({line: i + 1, tag: tag[1], expr}) }
+                    }
+                }
+            }
+        }
+
+        if (inBlock && line.includes('*/')) {
+            inBlock = false;
+            isDoc   = false
+        }
+    }
+
+    return failures
+}
+
+/**
+ * @summary Normalizes an input path (absolute from lint-staged, or relative) to a repo-relative POSIX path.
+ * @param {String} file
+ * @param {String} gitRoot
+ * @returns {String}
+ */
+export function toRepoRelative(file, gitRoot) {
+    return path.relative(gitRoot, path.resolve(gitRoot, file)).split(path.sep).join('/')
+}
+
+/**
+ * @summary True when `file` (repo-relative POSIX) is inside the docs-build parse scope and not excluded.
+ * @param {String} file
+ * @returns {Boolean}
+ */
+export function inScope(file) {
+    if (!file.endsWith('.mjs') || EXCLUDE.test(file)) return false;
+    return DEFAULT_DIRS.some(dir => file === dir || file.startsWith(dir + '/'))
+}
+
+function collectDefaultFiles(gitRoot) {
+    const result = spawnSync('find', [...DEFAULT_DIRS, '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
+    // A missing optional dir makes `find` exit non-zero while still listing the others — tolerate stdout.
+    return (result.stdout || '').trim().split('\n').filter(Boolean)
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim()
+    } catch (e) {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1)
+    }
+
+    // Minimal argv parse — no extra dep. lint-staged passes staged paths as positional args; no args = the
+    // full docs-build-scope scan (CI). `--quiet` suppresses the per-violation listing.
+    const rawArgv   = process.argv.slice(2),
+          quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+          argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
+
+    const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles(gitRoot);
+    const files    = rawFiles.map(f => toRepoRelative(f, gitRoot)).filter(inScope);
+
+    if (files.length === 0) {
+        console.log('check-jsdoc-types: 0 in-scope .mjs files, nothing to check.');
+        process.exit(0)
+    }
+
+    const violations = [];
+    for (const file of files) {
+        let content;
+        try {
+            content = readFileSync(path.resolve(gitRoot, file), 'utf-8')
+        } catch (e) {
+            console.error(`check-jsdoc-types: could not read ${file}: ${e.message}`);
+            continue
+        }
+        findUnparseableTypes(content).forEach(({line, tag, expr}) => violations.push(`${file}:${line}  @${tag} {${expr}}`))
+    }
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-jsdoc-types: ${violations.length} unparseable JSDoc type expression(s):\x1b[0m`);
+        if (!quiet) {
+            violations.forEach(v => console.error('  ' + v));
+            console.error('\nThe docs build (`npm run generate-docs-json`, the last `build all` step) parses these with');
+            console.error('jsdoc-x → catharsis (Closure/JSDoc grammar, NOT TypeScript); an unparseable type fails the build');
+            console.error('and breaks the docs app. Most common cause: a TS-like type — typically a bare union inside a');
+            console.error('record value with no space after the colon (`{a:Object|null}`). Fix: parenthesize the union');
+            console.error('(`{a:(Object|null)}`) or add a space (`{a: Object|null}`); use a `@typedef` for complex shapes.')
+        }
+        process.exit(1)
+    }
+
+    console.log(`check-jsdoc-types: ${files.length} file(s) scanned, 0 unparseable type expressions.`)
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/buildScripts/util/check-jsdoc-types.mjs
+++ b/buildScripts/util/check-jsdoc-types.mjs
@@ -29,9 +29,12 @@ const scriptRoot = path.resolve(__dirname, '../..');
 // JSDoc tags whose {type} the docs build must be able to parse.
 const TYPE_TAG = /@(param|returns?|type|property|prop|typedef|yields?|throws|exception|augments|member|enum)\b/;
 
-// Mirror buildScripts/docs/jsdocx.mjs `files` scope + excludePattern (the surface the docs build parses):
-// underscore-prefixed paths, node_modules/dist, and the machine-local config overlays are out.
-const DEFAULT_DIRS = ['src', 'ai', 'docs/app', 'apps'];
+// The authored-source surface the team writes JSDoc in — intentionally BROADER than the docs build's
+// current parse set (which only covers configured apps): an unparseable type is a defect anywhere, even
+// where `generate-docs-json` does not yet reach (an unconfigured app/example becomes a build break the
+// moment it is wired in). Excludes underscore-prefixed aggregators, node_modules/dist, and the machine-
+// local config overlays.
+const DEFAULT_DIRS = ['src', 'ai', 'examples', 'apps', 'docs/app'];
 const EXCLUDE      = /(^|\/)_|\/node_modules\/|\/dist\/|(^|\/)ai\/config\.mjs$|(^|\/)ai\/mcp\/server\/[^/]+\/config\.mjs$/;
 
 /**

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -284,7 +284,7 @@ class MainContainer extends Viewport {
     /**
      * Reads the persisted named-perspective collection and applies it only when both the collection and active restore
      * validate. Invalid payloads fail closed to the seeded collection/current document.
-     * @returns {Promise<{collection:Object|null, document:Object|null, errors:String[], loaded:Boolean}>}
+     * @returns {Promise<{collection:(Object|null), document:(Object|null), errors:String[], loaded:Boolean}>}
      */
     async loadLayoutCollectionFromStorage() {
         let me      = this,
@@ -331,7 +331,7 @@ class MainContainer extends Viewport {
     /**
      * Persists the current named-perspective collection via the main-thread LocalStorage addon.
      * @param {Object} [collection=this.layoutCollection]
-     * @returns {Promise<{persisted:Boolean, error:String|null}>|undefined}
+     * @returns {Promise<{persisted:Boolean, error:(String|null)}>|undefined}
      */
     persistLayoutCollection(collection=this.layoutCollection) {
         let storage = Neo.main?.addon?.LocalStorage;
@@ -364,7 +364,7 @@ class MainContainer extends Viewport {
     /**
      * Selects and restores a named perspective through `DockZoneModel.restoreActiveSavedLayout()`.
      * @param {String} layoutId
-     * @returns {{collection:Object, document:Object|null, errors:String[]}}
+     * @returns {{collection:Object, document:(Object|null), errors:String[]}}
      */
     restorePerspective(layoutId) {
         let me       = this,
@@ -391,7 +391,7 @@ class MainContainer extends Viewport {
 
     /**
      * Saves the current committed dock document as a new named perspective and activates it.
-     * @returns {{collection:Object, layout:Object|null, errors:String[]}}
+     * @returns {{collection:Object, layout:(Object|null), errors:String[]}}
      */
     saveCurrentPerspective() {
         let me       = this,
@@ -426,7 +426,7 @@ class MainContainer extends Viewport {
 
     /**
      * Removes the active saved perspective and restores the next available replacement.
-     * @returns {{collection:Object, document:Object|null, errors:String[]}}
+     * @returns {{collection:Object, document:(Object|null), errors:String[]}}
      */
     removeActivePerspective() {
         let me             = this,

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
         ],
         "*.mjs": [
             "node ./buildScripts/util/check-shorthand.mjs",
+            "node ./buildScripts/util/check-jsdoc-types.mjs",
             "node ./buildScripts/util/check-ticket-archaeology.mjs"
         ],
         "test/**/*.mjs": [

--- a/src/dashboard/DockSplitter.mjs
+++ b/src/dashboard/DockSplitter.mjs
@@ -212,7 +212,7 @@ class DockSplitter extends Component {
 
     /**
      * @param {Object} descriptor
-     * @returns {{document:Object|null, errors:String[]}}
+     * @returns {{document:(Object|null), errors:String[]}}
      * @protected
      */
     commitResizeSplit(descriptor) {

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -652,7 +652,7 @@ class DockZoneModel extends Base {
      * credentials or runtime authority inside it.
      * @param {Object} document The committed dock-zone document to normalize and wrap.
      * @param {Object} [metadata={}] {layoutId, title, revision, metadata}
-     * @returns {{layout:Object|null, errors:String[]}}
+     * @returns {{layout:(Object|null), errors:String[]}}
      * @static
      */
     static createSavedLayout(document, metadata={}) {
@@ -731,7 +731,7 @@ class DockZoneModel extends Base {
      * and item `blueprint` fields are opaque JSON-only non-secret payloads; runtime fields beside the
      * known model are rejected rather than filtered or repaired.
      * @param {Object} savedLayout
-     * @returns {{document:Object|null, errors:String[]}}
+     * @returns {{document:(Object|null), errors:String[]}}
      * @static
      */
     static restoreSavedLayout(savedLayout) {
@@ -888,7 +888,7 @@ class DockZoneModel extends Base {
      * @summary Creates a storage-free collection of named saved-layout wrappers.
      * @param {Array<Object>|Object<String,Object>} [layouts=[]]
      * @param {Object} [options={}] {activeLayoutId, metadata, revision}
-     * @returns {{collection:Object|null, errors:String[]}}
+     * @returns {{collection:(Object|null), errors:String[]}}
      * @static
      */
     static createSavedLayoutCollection(layouts=[], options={}) {
@@ -1053,7 +1053,7 @@ class DockZoneModel extends Base {
     /**
      * @summary Restores the active saved-layout wrapper from a named layout collection.
      * @param {Object} collection
-     * @returns {{document:Object|null, errors:String[]}}
+     * @returns {{document:(Object|null), errors:String[]}}
      * @static
      */
     static restoreActiveSavedLayout(collection) {

--- a/test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs
@@ -1,12 +1,13 @@
 import {test, expect}                            from '@playwright/test';
-import {findUnparseableTypes, extractType, inScope} from '../../../../../buildScripts/util/check-jsdoc-types.mjs';
+import {findUnparseableTypes, extractType, inScope} from '../../../../../../buildScripts/util/check-jsdoc-types.mjs';
 
 /**
  * Self-test for the JSDoc-type lint: the mechanical gate that stops TS-like type expressions the
  * docs build (jsdoc-x → catharsis) cannot parse from breaking `npm run generate-docs-json` (the last
  * `build all` step) + the docs app. Verifies it flags the build-breaking no-space record-union (+ malformed
  * types), passes the catharsis-valid spaced / parenthesized / plain / top-level-union forms, scans only
- * `/**` doc blocks (not `/*` or `//`), and scopes to the docs-build parse surface.
+ * `/**` doc blocks (not `/*` or `//`), and scopes to the authored-source surface (src/ai/examples/apps/docs-app) —
+ * intentionally broader than the docs build (unparseable JSDoc is a defect anywhere, not only where it parses today).
  */
 const block = (...lines) => ['/**', ...lines.map(l => ' * ' + l), ' */'].join('\n');
 
@@ -52,11 +53,13 @@ test.describe('check-jsdoc-types guard', () => {
         expect(extractType([scalar], 0, scalar.indexOf('{'))).toBe('String')
     });
 
-    test('inScope mirrors the docs-build parse surface', () => {
+    test('inScope covers the authored-source surface (src/ai/examples/apps/docs-app), broader than the docs build', () => {
         expect(inScope('src/dashboard/DockZoneModel.mjs')).toBe(true);
         expect(inScope('ai/WriteGuard.mjs')).toBe(true);
+        expect(inScope('examples/dashboard/dock/MainContainer.mjs')).toBe(true);
         expect(inScope('docs/app/view/Main.mjs')).toBe(true);
         expect(inScope('apps/portal/view/Main.mjs')).toBe(true);
+        expect(inScope('apps/ai/view/Main.mjs')).toBe(true); // ALL apps, not only docs-build-configured ones
 
         // out of scope: build scripts, tests, underscore aggregators, the config overlays, non-.mjs
         expect(inScope('buildScripts/util/check-jsdoc-types.mjs')).toBe(false);

--- a/test/playwright/unit/buildScripts/util/check-jsdoc-types.spec.mjs
+++ b/test/playwright/unit/buildScripts/util/check-jsdoc-types.spec.mjs
@@ -1,0 +1,69 @@
+import {test, expect}                            from '@playwright/test';
+import {findUnparseableTypes, extractType, inScope} from '../../../../../buildScripts/util/check-jsdoc-types.mjs';
+
+/**
+ * Self-test for the JSDoc-type lint: the mechanical gate that stops TS-like type expressions the
+ * docs build (jsdoc-x → catharsis) cannot parse from breaking `npm run generate-docs-json` (the last
+ * `build all` step) + the docs app. Verifies it flags the build-breaking no-space record-union (+ malformed
+ * types), passes the catharsis-valid spaced / parenthesized / plain / top-level-union forms, scans only
+ * `/**` doc blocks (not `/*` or `//`), and scopes to the docs-build parse surface.
+ */
+const block = (...lines) => ['/**', ...lines.map(l => ' * ' + l), ' */'].join('\n');
+
+test.describe('check-jsdoc-types guard', () => {
+    test('flags a bare union in a record value with no space after the colon (the build-breaker)', () => {
+        const hits = findUnparseableTypes(block('@returns {{layout:Object|null, errors:String[]}}'));
+
+        expect(hits.map(h => h.line)).toEqual([2]);
+        expect(hits[0].tag).toBe('returns');
+        expect(hits[0].expr).toBe('{layout:Object|null, errors:String[]}')
+    });
+
+    test('passes the same union when spaced or parenthesized (the catharsis-valid forms)', () => {
+        expect(findUnparseableTypes(block('@returns {{layout: Object|null, errors: String[]}}'))).toEqual([]);
+        expect(findUnparseableTypes(block('@returns {{layout:(Object|null), errors:String[]}}'))).toEqual([])
+    });
+
+    test('passes plain / array / generic / top-level-union types', () => {
+        // a top-level `{Object|null}` union is valid — only a bare union INSIDE a record value breaks
+        expect(findUnparseableTypes(block(
+            '@param {String} a',
+            '@param {String[]} b',
+            '@param {Array<String>} c',
+            '@returns {Object|null}'
+        ))).toEqual([])
+    });
+
+    test('scans only /** doc blocks — ignores /* block comments and // lines', () => {
+        // sitemap-style: a malformed type inside a single-star /* block is not a build input → not flagged
+        expect(findUnparseableTypes(['/*', ' * @member {String[}', ' */'].join('\n'))).toEqual([]);
+        expect(findUnparseableTypes('// @returns {Object|null|}')).toEqual([])
+    });
+
+    test('flags a malformed type INSIDE a /** doc block', () => {
+        expect(findUnparseableTypes(block('@member {String[}')).map(h => h.line)).toEqual([2])
+    });
+
+    test('extractType returns the inner type expression (tag braces stripped)', () => {
+        const record = ' * @returns {{a:String}}';
+        expect(extractType([record], 0, record.indexOf('{'))).toBe('{a:String}');
+
+        const scalar = ' * @param {String} name';
+        expect(extractType([scalar], 0, scalar.indexOf('{'))).toBe('String')
+    });
+
+    test('inScope mirrors the docs-build parse surface', () => {
+        expect(inScope('src/dashboard/DockZoneModel.mjs')).toBe(true);
+        expect(inScope('ai/WriteGuard.mjs')).toBe(true);
+        expect(inScope('docs/app/view/Main.mjs')).toBe(true);
+        expect(inScope('apps/portal/view/Main.mjs')).toBe(true);
+
+        // out of scope: build scripts, tests, underscore aggregators, the config overlays, non-.mjs
+        expect(inScope('buildScripts/util/check-jsdoc-types.mjs')).toBe(false);
+        expect(inScope('test/playwright/unit/foo.spec.mjs')).toBe(false);
+        expect(inScope('src/core/_export.mjs')).toBe(false);
+        expect(inScope('ai/config.mjs')).toBe(false);
+        expect(inScope('ai/mcp/server/memory-core/config.mjs')).toBe(false);
+        expect(inScope('README.md')).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves #13426
Refs #12899

## Summary

The docs build (`npm run generate-docs-json` — the last `build all` step) parses every JSDoc `{type}` with `jsdoc-x` → **catharsis** (the Closure/JSDoc grammar, NOT TypeScript). A TS-like type catharsis can't parse fails the build and breaks the docs app. The *prevention* arm — a check-mode lint — was deferred by #12899 as out-of-scope, never filed, so the breakage recurred.

This PR (a) fixes the current breakers and (b) adds a catharsis-scan CI lint as a **broad source-quality gate**.

**Scope (operator directive):** the lint runs over the full authored-source surface — `src` + `ai` + `examples` + `apps` + `docs/app` — **intentionally broader than the docs build's configured-app slice**. Rationale: unparseable JSDoc is a defect *anywhere* the team writes it, even where `generate-docs-json` doesn't reach today (an unconfigured app/example becomes a build break the moment it's wired in). It is NOT a docs-build-scope mirror.

**V-B-A finding:** the precise trigger is a catharsis tokenizer quirk — a bare union inside a record value breaks **only with no space after the colon**:

| type expression | `catharsis.parse(expr, {jsdoc:true})` |
|---|---|
| `{layout:Object\|null, errors:String[]}` (no space) | **FAIL** |
| `{layout: Object\|null, errors: String[]}` (space) | OK |
| `{layout:(Object\|null), errors:String[]}` (parenthesized) | OK |

A regex lint is unviable (it would false-positive on the many valid spaced/parenthesized record-unions across `ai/**`). The lint runs the **same parser the build uses**, so it catches exactly the unparseable forms — and (the operator's point) a hit in an unconfigured app/example is a true defect, not a false positive.

Evidence: the lint reports **0 unparseable across 1543 files** post-fix; catches all **10 breakers pre-fix** (5 `src/dashboard/*` + 5 `examples/dashboard/dock/MainContainer.mjs`); unit spec 7/7; `generate-docs-json` green (1180 files); `JSDoc Type Lint` CI green on the runner.

## Test Evidence

Branch head `0e6d3bd63`:

- **`buildScripts/util/check-jsdoc-types.mjs`** (full broad-scope scan, **1543** `.mjs`):
  - post-fix → `0 unparseable type expressions`, exit 0.
  - catch-proof (real tree): the 5 `src/dashboard/*` breakers were caught pre-fix in cycle-1 (commit `9b7c7e831`); stashing the 5 `examples/dashboard/dock/MainContainer.mjs` fixes → the lint flags **exactly those 5** (incl. the `Promise<{…}>`-nested ones), exit 1. All 10 covered.
- **`npm run generate-docs-json`** (ground-truth gate) → **passes**: 1180 files, 8.5s, exit 0.
- **`test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs`** (`npm run test-unit`, canonical backend test tree) → **7 passed**: no-space union FAILs; spaced + parenthesized + plain/array/generic/top-level-union pass; `/*` block + `//` line ignored; malformed `{String[}` in a `/**` block FAILs; `extractType` + `inScope` (now src/ai/examples/apps/docs-app) correctness.
- Pre-commit lint-staged (incl. the new `check-jsdoc-types`) green on all staged files.

## Post-Merge Validation

- [ ] The `JSDoc Type Lint` workflow runs green on this PR (CI confirms the `npm ci --ignore-scripts` → catharsis path on the runner).
- [ ] After merge, a subsequent PR introducing a no-space record-union anywhere in src/ai/examples/apps/docs-app is blocked by the gate.

## Deltas

- `src/dashboard/DockZoneModel.mjs` (4) + `src/dashboard/DockSplitter.mjs` (1) + `examples/dashboard/dock/MainContainer.mjs` (5): parenthesize the `@returns` record-unions (`Object|null` → `(Object|null)`, `String|null` → `(String|null)`) — comment-only, zero behavior change.
- `buildScripts/util/check-jsdoc-types.mjs` (new): catharsis-scan lint; `/**`-blocks only; scope = `src`/`ai`/`examples`/`apps`/`docs/app` (broad source-quality gate); dual mode (lint-staged file-args / CI no-args full scan); exports `findUnparseableTypes`/`extractType`/`inScope` for the spec.
- `package.json`: lint-staged `*.mjs` entry.
- `.github/workflows/jsdoc-type-lint.yml` (new): the CI gate (`npm ci --ignore-scripts` for catharsis; path triggers incl. `examples/**`).
- `test/playwright/unit/ai/buildScripts/util/check-jsdoc-types.spec.mjs` (new): 7-case self-test, in the canonical backend/buildScripts tree (`unit-test.md`).

## Review cycles

- **c1** (`9b7c7e831`): the lint + the 5 `src/dashboard` fixes + lint-staged + CI workflow + spec. CI fully green.
- **c2** (`0e6d3bd63`): addressing @neo-gpt's review — broadened the scope to `src/ai/examples/apps/docs-app` (per @tobiu's directive — a source-quality gate, NOT a docs-build-scope mirror; supersedes the narrow-to-configured-apps ask), fixed the 5 `examples/dashboard/dock` breakers the broadened scope surfaced, and moved the spec to the canonical `unit/ai/buildScripts/util/` tree.

## Out of Scope

- `src/sitemap/Component.mjs:30` `@member {String[}` — a malformed type in a `/*` (single-star) comment jsdoc ignores → not a build-breaker; the `/**`-only lint correctly skips it (flagged as a separate task chip).
- The many valid spaced/parenthesized record-unions — untouched.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
