### PR TITLE
feat(ai): mcpHealthcheck self-diagnoses a missing healthcheck token on 401 (#13431)

### DIFF
--- a/ai/scripts/diagnostics/mcpHealthcheck.mjs
+++ b/ai/scripts/diagnostics/mcpHealthcheck.mjs
@@ -48,6 +48,7 @@ export function parseArgs(argv = [], env = process.env) {
         url           : options.url,
         identity      : options.identity,
         bearerToken   : env[options.bearerTokenEnv] || null,
+        bearerTokenEnv: options.bearerTokenEnv,
         expectedStatus: options.expectedStatus,
         clientName    : options.clientName
     };
@@ -151,6 +152,27 @@ export async function runHealthcheck({
     }
 }
 
+/**
+ * @summary Augments a healthcheck failure message with an actionable bearer-token hint when
+ * no token was configured. Under `NEO_AUTH_MODE=gitlab-pat` the in-container self-probe 401s
+ * with an opaque transport error; this surfaces the likely cause at the failure site (visible
+ * in `docker logs`) instead of leaving it only in the troubleshooting doc.
+ * @param {Error} error The failure thrown by `runHealthcheck` / the transport.
+ * @param {Object} [options]
+ * @param {String|null} [options.bearerToken] The configured bearer token (`null` when unset).
+ * @param {String} [options.bearerTokenEnv='NEO_MCP_HEALTHCHECK_TOKEN'] The env var the token reads from.
+ * @returns {String} `error.message`, plus the hint when no bearer token was sent.
+ */
+export function formatHealthcheckError(error, {bearerToken = null, bearerTokenEnv = 'NEO_MCP_HEALTHCHECK_TOKEN'} = {}) {
+    const message = error?.message || String(error);
+
+    if (bearerToken) {
+        return message;
+    }
+
+    return `${message}\nNo bearer token was sent (${bearerTokenEnv} is unset). If the server runs NEO_AUTH_MODE=gitlab-pat, that is the likely cause of a 401 — set ${bearerTokenEnv} to a GitLab token that validates at /api/v4/user (a read_user PAT, or a read_api OAuth-app / group token). See learn/agentos/cloud-deployment/Troubleshooting.md.`;
+}
+
 async function main() {
     let options;
 
@@ -167,7 +189,7 @@ async function main() {
         const result = await runHealthcheck(options);
         console.log(JSON.stringify(result));
     } catch (error) {
-        console.error(error.message);
+        console.error(formatHealthcheckError(error, options));
         process.exitCode = 1;
     }
 }

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -7,6 +7,7 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
     let buildHeaders;
     let readToolJson;
     let runHealthcheck;
+    let formatHealthcheckError;
     const readProductionCompose = () => yaml.load(fs.readFileSync(
         new URL('../../../../../../ai/deploy/docker-compose.yml', import.meta.url),
         'utf8'
@@ -19,10 +20,11 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/scripts/diagnostics/mcpHealthcheck.mjs');
 
-        parseArgs      = mod.parseArgs;
-        buildHeaders   = mod.buildHeaders;
-        readToolJson   = mod.readToolJson;
-        runHealthcheck = mod.runHealthcheck;
+        parseArgs              = mod.parseArgs;
+        buildHeaders           = mod.buildHeaders;
+        readToolJson           = mod.readToolJson;
+        runHealthcheck         = mod.runHealthcheck;
+        formatHealthcheckError = mod.formatHealthcheckError;
     });
 
     test('parseArgs uses dotenv-compatible environment defaults', () => {
@@ -39,6 +41,7 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             url           : 'http://mc-server:3001',
             identity      : 'deploy-probe',
             bearerToken   : 'secret-token',
+            bearerTokenEnv: 'TOKEN_SLOT',
             expectedStatus: 'ready',
             clientName    : 'deploy-client'
         });
@@ -149,6 +152,28 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             ClientClass   : FakeClient,
             TransportClass: FakeTransport
         })).rejects.toThrow("Expected healthcheck status 'healthy', got 'degraded'.");
+    });
+
+    test('formatHealthcheckError appends a bearer-token hint only when no token was configured', () => {
+        const error = new Error('HTTP 401');
+
+        const withToken = formatHealthcheckError(error, {bearerToken: 'secret'});
+        expect(withToken).toBe('HTTP 401');
+        expect(withToken).not.toContain('NEO_MCP_HEALTHCHECK_TOKEN');
+
+        const withoutToken = formatHealthcheckError(error, {bearerToken: null});
+        expect(withoutToken).toContain('HTTP 401');
+        expect(withoutToken).toContain('NEO_MCP_HEALTHCHECK_TOKEN is unset');
+        expect(withoutToken).toContain('NEO_AUTH_MODE=gitlab-pat');
+        expect(withoutToken).toContain('/api/v4/user');
+        expect(withoutToken).toContain('Troubleshooting.md');
+    });
+
+    test('formatHealthcheckError names the configured bearer-token env var', () => {
+        const hint = formatHealthcheckError(new Error('boom'), {bearerToken: null, bearerTokenEnv: 'TOKEN_SLOT'});
+
+        expect(hint).toContain('TOKEN_SLOT is unset');
+        expect(hint).not.toContain('NEO_MCP_HEALTHCHECK_TOKEN');
     });
 
     test('production compose wires KB/MC MCP healthchecks before cloud orchestrator startup', () => {


### PR DESCRIPTION
Resolves #13431

First instance of the #13432 "meaningful deployment errors / required-env-var validation" iceberg, surfaced by an operator premise-challenge on PR #13423: documenting a cryptic error isn't enough — fix it at the failure site.

When `NEO_AUTH_MODE=gitlab-pat` is on and `NEO_MCP_HEALTHCHECK_TOKEN` is unset, the in-container self-probe 401s and `mcpHealthcheck.mjs` printed only the raw SDK transport error — no actionable guidance. The operator saw a bare 401 / `dependency <svc> failed to start` and had to already know to find the troubleshooting doc.

Evidence: L1 — added an exported, pure `formatHealthcheckError()` (unit-tested) wired into `main()`'s catch; the 401 is otherwise unchanged (gate-preserving — the requirement still holds, it just explains itself). Verified locally: `mcpHealthcheck.spec` 11/11.

## Deltas

No deviation from #13431's AC. The hint is **generic** (no client/host name): it points at `/api/v4/user` + the token options (a `read_user` PAT, or a `read_api` OAuth-app / group token) + `learn/agentos/cloud-deployment/Troubleshooting.md`. `parseArgs` now also returns `bearerTokenEnv` so the hint names the **actual** configured env var (default `NEO_MCP_HEALTHCHECK_TOKEN`, or a `--bearer-token-env` override). No auth behavior change.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs` → **11 passed**. Two new `formatHealthcheckError` cases (hint-only-when-tokenless incl. the `/api/v4/user` + doc pointers; names-the-configured-env-var), plus the updated `parseArgs` exact-match for the new `bearerTokenEnv` return field.
- The hint fires **only** when `bearerToken` is null, so a configured-token failure (unrelated cause) shows the raw error with no false hint.

## Post-Merge Validation

- [ ] A `gitlab-pat` deploy with an empty `NEO_MCP_HEALTHCHECK_TOKEN` shows the actionable hint in `docker logs <kb|mc>`, not just a bare 401.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 0b27b21a-2146-4976-945f-f1682c6a1c9c.
