### PR TITLE
feat(agentos): project the inserted first-widget grid into the evidence pane (#13438)

### DIFF
--- a/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
+++ b/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
@@ -20,7 +20,22 @@
  */
 
 /**
- * Reads the live row count off a grid's store without copying any record data.
+ * Whether a value is a usable object to read metadata off — a live `NeoInstance` (the grid + its
+ * store are class instances, NOT plain objects) OR a plain config object (the defensive / unit path).
+ * `Neo.isObject` is deliberately NOT used here: it is plain-object-only (`constructor.name === 'Object'`)
+ * and would reject the live grid instance this projection exists to read.
+ * @param {*} value
+ * @returns {Boolean}
+ * @private
+ */
+function isObjectLike(value) {
+    const type = Neo.typeOf(value);
+    return type === 'Object' || type === 'NeoInstance'
+}
+
+/**
+ * Reads the live row count off a grid's store without copying any record data. A live store is a
+ * Neo collection (`count` / `items`); a plain `{data}` config array is also accepted defensively.
  * @param {Object} store the grid's live store instance
  * @returns {Number} the row count (0 when it cannot be determined)
  * @private
@@ -30,11 +45,32 @@ function readRowCount(store) {
         return store.count
     }
 
-    if (Array.isArray(store.data)) {
-        return store.data.length
+    for (const candidate of [store.items, store.data]) {
+        if (Array.isArray(candidate)) {
+            return candidate.length
+        }
     }
 
     return 0
+}
+
+/**
+ * Resolves a grid's columns to a plain array of column definitions. A live grid's `columns` is a Neo
+ * collection (its `.items` are the column components); a plain config array is also accepted.
+ * @param {Object} grid the live grid component
+ * @returns {Object[]|null} the column array, or `null` when columns cannot be read
+ * @private
+ */
+function readColumns(grid) {
+    if (Array.isArray(grid.columns?.items)) {
+        return grid.columns.items
+    }
+
+    if (Array.isArray(grid.columns)) {
+        return grid.columns
+    }
+
+    return null
 }
 
 /**
@@ -47,20 +83,21 @@ function readRowCount(store) {
  *   so the caller can fail the evidence pane closed.
  */
 export function projectCreatedGrid(grid) {
-    if (!Neo.isObject(grid)) {
+    if (!isObjectLike(grid)) {
         return null
     }
 
     const
-        schema = typeof grid.className === 'string' && grid.className ? grid.className : null,
-        store  = Neo.isObject(grid.store) ? grid.store : null;
+        schema      = typeof grid.className === 'string' && grid.className ? grid.className : null,
+        store       = isObjectLike(grid.store) ? grid.store : null,
+        columnItems = readColumns(grid);
 
-    if (!schema || !Array.isArray(grid.columns) || !store) {
+    if (!schema || !columnItems || !store) {
         return null
     }
 
     // safe scalar metadata only — never the live column instances or record data
-    const columns = grid.columns.map(column => ({
+    const columns = columnItems.map(column => ({
         dataField: typeof column?.dataField === 'string' ? column.dataField : '',
         text     : typeof column?.text === 'string' ? column.text : ''
     }));

--- a/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
+++ b/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
@@ -76,7 +76,7 @@ function readColumns(grid) {
 /**
  * Projects a live created grid into the deterministic first-widget blueprint shape.
  *
- * @param {Object} grid the live grid component inserted via the Neural-Link create path
+ * @param {Object} grid the live grid component received from the stage's insert event
  * @returns {{schema: String, title: String, columns: Object[], rows: Array}|null}
  *   the blueprint object (exactly the `schema`/`title`/`columns`/`rows` keys
  *   `projectBlueprintEvidence` allowlists) on success, or `null` when `grid` is not a usable grid —

--- a/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
+++ b/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
@@ -1,14 +1,14 @@
 /**
  * @module AgentOSWidget.util.createdGridEvidence
- * @summary Projects a live, Neural-Link-created grid into the first-widget evidence blueprint shape.
+ * @summary Projects a live inserted grid into the first-widget evidence blueprint shape.
  *
  * The deterministic first-widget path fed a hand-authored blueprint object straight into the evidence
- * pane. This leaf closes the H2 provenance loop: the grid is now created through the Neural-Link
- * `create_component` path and inserted into a live container, which fires
- * `insert {index, item}` (see `src/container/Base.mjs`). The `item` is the real, mounted grid — not a
- * config object. This projection turns that live grid into the SAME
+ * pane. This leaf moves the provenance to a live inserted grid: the grid is added to a stage container,
+ * which fires `insert {index, item}` (see `src/container/Base.mjs`) — the same `add → insert` seam a
+ * Neural-Link `create_component` drives (it calls `add` on the parent container). The `item` is the
+ * real, mounted grid — not a config object. This projection turns that live grid into the SAME
  * `{schema:String, title:String, columns:Array, rows:Array}` shape `projectBlueprintEvidence` already
- * consumes, so the evidence pane reflects the grid that actually crossed the bridge.
+ * consumes, so the evidence pane reflects the grid that was actually inserted into the stage.
  *
  * It is deliberately NOT the safety boundary — `projectBlueprintEvidence` remains that. This function
  * only reads safe scalar metadata off the live grid (its class id, a title label, the column

--- a/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
+++ b/apps/agentos/childapps/widget/util/createdGridEvidence.mjs
@@ -1,0 +1,76 @@
+/**
+ * @module AgentOSWidget.util.createdGridEvidence
+ * @summary Projects a live, Neural-Link-created grid into the first-widget evidence blueprint shape.
+ *
+ * The deterministic first-widget path fed a hand-authored blueprint object straight into the evidence
+ * pane. This leaf closes the H2 provenance loop: the grid is now created through the Neural-Link
+ * `create_component` path and inserted into a live container, which fires
+ * `insert {index, item}` (see `src/container/Base.mjs`). The `item` is the real, mounted grid — not a
+ * config object. This projection turns that live grid into the SAME
+ * `{schema:String, title:String, columns:Array, rows:Array}` shape `projectBlueprintEvidence` already
+ * consumes, so the evidence pane reflects the grid that actually crossed the bridge.
+ *
+ * It is deliberately NOT the safety boundary — `projectBlueprintEvidence` remains that. This function
+ * only reads safe scalar metadata off the live grid (its class id, a title label, the column
+ * definitions, and the live row COUNT) and assembles exactly the four allowlisted blueprint keys.
+ * Row data is never copied — only `Array.from({length: rowCount})` — so no live record payload can
+ * ride into the view through the evidence path. Anything that is not a usable grid (non-object, no
+ * class id, no columns array, no store) fails closed to `null`, which the pane renders as its bounded
+ * rejected state via the downstream projection.
+ */
+
+/**
+ * Reads the live row count off a grid's store without copying any record data.
+ * @param {Object} store the grid's live store instance
+ * @returns {Number} the row count (0 when it cannot be determined)
+ * @private
+ */
+function readRowCount(store) {
+    if (Number.isInteger(store.count)) {
+        return store.count
+    }
+
+    if (Array.isArray(store.data)) {
+        return store.data.length
+    }
+
+    return 0
+}
+
+/**
+ * Projects a live created grid into the deterministic first-widget blueprint shape.
+ *
+ * @param {Object} grid the live grid component inserted via the Neural-Link create path
+ * @returns {{schema: String, title: String, columns: Object[], rows: Array}|null}
+ *   the blueprint object (exactly the `schema`/`title`/`columns`/`rows` keys
+ *   `projectBlueprintEvidence` allowlists) on success, or `null` when `grid` is not a usable grid —
+ *   so the caller can fail the evidence pane closed.
+ */
+export function projectCreatedGrid(grid) {
+    if (!Neo.isObject(grid)) {
+        return null
+    }
+
+    const
+        schema = typeof grid.className === 'string' && grid.className ? grid.className : null,
+        store  = Neo.isObject(grid.store) ? grid.store : null;
+
+    if (!schema || !Array.isArray(grid.columns) || !store) {
+        return null
+    }
+
+    // safe scalar metadata only — never the live column instances or record data
+    const columns = grid.columns.map(column => ({
+        dataField: typeof column?.dataField === 'string' ? column.dataField : '',
+        text     : typeof column?.text === 'string' ? column.text : ''
+    }));
+
+    const title = [grid.title, grid.id].find(value => typeof value === 'string' && value) || schema;
+
+    return {
+        schema,
+        title,
+        columns,
+        rows: Array.from({length: readRowCount(store)})
+    }
+}

--- a/apps/agentos/childapps/widget/view/Viewport.mjs
+++ b/apps/agentos/childapps/widget/view/Viewport.mjs
@@ -12,9 +12,9 @@ import ViewportController from './ViewportController.mjs';
  * declarative child — the {@link AgentOSWidget.view.ViewportController controller} creates it through
  * the same `add → insert` path a Neural-Link `create_component` drives, then projects the actually
  * created grid into the evidence pane. That keeps a single create path: the evidence describes the
- * grid that crossed the bridge, and an external agent's `create_component` into the stage flows through
- * the identical projection. The evidence pane starts on its own default blueprint until the first
- * insert projects the real grid over it.
+ * grid that was inserted into the stage, and an external agent's `create_component` into the stage flows
+ * through the identical projection. The evidence pane starts on its own default blueprint until the
+ * first insert projects the real grid over it.
  */
 class Viewport extends BaseViewport {
     static config = {

--- a/apps/agentos/childapps/widget/view/Viewport.mjs
+++ b/apps/agentos/childapps/widget/view/Viewport.mjs
@@ -1,37 +1,20 @@
 import BaseViewport       from '../../../../../src/container/Viewport.mjs';
 import EvidencePane       from './EvidencePane.mjs';
-import GridContainer      from '../../../../../src/grid/Container.mjs';
 import RequestIntake      from './RequestIntake.mjs';
 import ViewportController from './ViewportController.mjs';
 
 /**
- * The deterministic first-widget blueprint — the single source of truth shared by the evidence
- * pane (which shows its metadata) and the live grid (which renders its columns + rows). Keeping
- * ONE blueprint object is the whole provenance point: the metadata a reviewer inspects in the
- * evidence pane is the exact blueprint that produced the live grid below it, not a parallel
- * hand-built demo. Natural-language orchestration is intentionally out of scope for this leaf, so
- * the blueprint is fixed — the render stays deterministic and smoke-testable.
- * @type {Object}
- */
-const firstWidgetBlueprint = {
-    schema : 'Neo.grid.Container',
-    title  : 'First Neo Grid',
-    columns: [
-        {dataField: 'id',       text: 'ID'},
-        {dataField: 'task',     text: 'Task'},
-        {dataField: 'owner',    text: 'Owner'},
-        {dataField: 'evidence', text: 'Evidence'}
-    ],
-    rows: [
-        {id: 'intent',   task: 'Verify intent', owner: 'Ada',           evidence: 'Blueprint'},
-        {id: 'render',   task: 'Render grid',   owner: 'Runtime',       evidence: 'Live widget'},
-        {id: 'evidence', task: 'Show evidence', owner: 'Evidence pane', evidence: 'Safe text'}
-    ]
-};
-
-/**
  * @class AgentOSWidget.view.Viewport
  * @extends Neo.container.Viewport
+ *
+ * The H2 first-widget surface: a bounded chat intake, the evidence pane (request / response /
+ * accepted-blueprint metadata), and a stage the live grid is created INTO. The grid is no longer a
+ * declarative child — the {@link AgentOSWidget.view.ViewportController controller} creates it through
+ * the same `add → insert` path a Neural-Link `create_component` drives, then projects the actually
+ * created grid into the evidence pane. That keeps a single create path: the evidence describes the
+ * grid that crossed the bridge, and an external agent's `create_component` into the stage flows through
+ * the identical projection. The evidence pane starts on its own default blueprint until the first
+ * insert projects the real grid over it.
  */
 class Viewport extends BaseViewport {
     static config = {
@@ -60,28 +43,22 @@ class Viewport extends BaseViewport {
          */
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
-         * The first-widget surface: a bounded chat intake, the evidence pane (request / response /
-         * accepted blueprint metadata), and the live grid the same blueprint produced.
          * @member {Object[]} items
          */
         items: [{
             module: RequestIntake
         }, {
             module   : EvidencePane,
-            reference: 'evidence-pane',
-            blueprint: firstWidgetBlueprint
+            reference: 'evidence-pane'
         }, {
-            module        : GridContainer,
-            reference     : 'first-widget-grid',
-            cls           : ['agent-os-first-widget-grid'],
-            flex          : 1,
-            columnDefaults: {width: 140},
-            columns       : firstWidgetBlueprint.columns.map(column => ({...column})),
-            store         : {
-                keyProperty: 'id',
-                model      : {fields: firstWidgetBlueprint.columns.map(column => ({name: column.dataField, type: 'String'}))},
-                data       : [...firstWidgetBlueprint.rows]
-            }
+            ntype    : 'container',
+            // a fixed, known id so an external agent can `create_component` a widget INTO this stage —
+            // the same mount point the in-app bootstrap uses; both fire the projected `insert`
+            id       : 'widget-stage',
+            reference: 'widget-stage',
+            cls      : ['agent-os-widget-stage'],
+            flex     : 1,
+            layout   : {ntype: 'fit'}
         }]
     }
 }

--- a/apps/agentos/childapps/widget/view/ViewportController.mjs
+++ b/apps/agentos/childapps/widget/view/ViewportController.mjs
@@ -48,7 +48,7 @@ const firstWidgetGridConfig = {
  *
  * Two responsibilities, one path. On construct it boots the first grid by `add()`-ing it to the stage
  * container (the same `add → insert` path a Neural-Link `create_component` drives), so the live grid is
- * created through the create seam rather than declared as a static item. It then observes the stage's
+ * created through the stage insert seam rather than declared as a static item. It then observes the stage's
  * `insert` event — fired for that bootstrap AND for any later external `create_component` into the same
  * stage — and projects the inserted grid into the evidence pane via {@link projectCreatedGrid},
  * so the evidence always describes the grid that was inserted into the stage, not a hand-authored

--- a/apps/agentos/childapps/widget/view/ViewportController.mjs
+++ b/apps/agentos/childapps/widget/view/ViewportController.mjs
@@ -1,15 +1,58 @@
-import Controller        from '../../../../../src/controller/Component.mjs';
-import {validateRequest} from '../util/validateRequest.mjs';
+import Controller          from '../../../../../src/controller/Component.mjs';
+import GridContainer       from '../../../../../src/grid/Container.mjs';
+import {projectCreatedGrid} from '../util/createdGridEvidence.mjs';
+import {validateRequest}    from '../util/validateRequest.mjs';
+
+/**
+ * The first widget's grid config. The controller boots it by `add()`-ing it to the stage — the same
+ * `add → insert` path a Neural-Link `create_component` drives (it calls
+ * `call_method(parentId, 'add', [config])`). Keeping ONE create path is the provenance point: whatever
+ * lands in the stage — this in-app bootstrap or an external agent's `create_component` — is what the
+ * evidence pane projects, so the evidence always describes the grid that actually crossed the create
+ * path. The bootstrap uses `module` (the class is imported here, registering the live app); an external
+ * agent sends `ntype`/`className` instead, since a module reference cannot cross the Neural Link wire.
+ * @type {Object}
+ */
+const firstWidgetGridConfig = {
+    id            : 'first-widget-grid',
+    module        : GridContainer,
+    cls           : ['agent-os-first-widget-grid'],
+    columnDefaults: {width: 140},
+    flex          : 1,
+    columns: [
+        {dataField: 'id',       text: 'ID'},
+        {dataField: 'task',     text: 'Task'},
+        {dataField: 'owner',    text: 'Owner'},
+        {dataField: 'evidence', text: 'Evidence'}
+    ],
+    store: {
+        keyProperty: 'id',
+        model      : {fields: [
+            {name: 'id',       type: 'String'},
+            {name: 'task',     type: 'String'},
+            {name: 'owner',    type: 'String'},
+            {name: 'evidence', type: 'String'}
+        ]},
+        data: [
+            {id: 'intent',   task: 'Verify intent', owner: 'Ada',           evidence: 'Blueprint'},
+            {id: 'render',   task: 'Render grid',   owner: 'Runtime',       evidence: 'Live widget'},
+            {id: 'evidence', task: 'Show evidence', owner: 'Evidence pane', evidence: 'Safe text'}
+        ]
+    }
+};
 
 /**
  * @class AgentOSWidget.view.ViewportController
  * @extends Neo.controller.Component
- * @summary Wires the first-widget chat intake to the evidence pane.
+ * @summary Creates the first widget through the live create path and projects it into the evidence pane.
  *
- * Handles the intake submit: validates the typed request through {@link validateRequest} and either
- * projects the accepted request into the existing EvidencePane request state (reusing the deterministic
- * first-widget path — no second widget path), or renders the bounded fail-closed reason as safe vdom
- * text in the intake's error line. No model invocation / orchestration / persistence — deterministic.
+ * Two responsibilities, one path. On construct it boots the first grid by `add()`-ing it to the stage
+ * container (the same `add → insert` path a Neural-Link `create_component` drives), so the live grid is
+ * created through the create seam rather than declared as a static item. It then observes the stage's
+ * `insert` event — fired for that bootstrap AND for any later external `create_component` into the same
+ * stage — and projects the actually-created grid into the evidence pane via {@link projectCreatedGrid},
+ * so the evidence always describes the grid that crossed the bridge, not a hand-authored blueprint.
+ * It also keeps the deterministic chat-intake submit handling. No model invocation / persistence.
  */
 class ViewportController extends Controller {
     static config = {
@@ -18,6 +61,35 @@ class ViewportController extends Controller {
          * @protected
          */
         className: 'AgentOSWidget.view.ViewportController'
+    }
+
+    /**
+     * Boots the first widget through the live create path: binds the stage's `insert` observer, then
+     * `add()`s the grid config (firing `insert`, which {@link onStageInsert} projects into the evidence
+     * pane). Binding before the add ensures the bootstrap insert is observed, exactly as a later
+     * external `create_component` into the same stage would be.
+     * @protected
+     */
+    onComponentConstructed() {
+        let me    = this,
+            stage = me.getReference('widget-stage');
+
+        stage.on('insert', me.onStageInsert, me);
+        stage.add(firstWidgetGridConfig)
+    }
+
+    /**
+     * Triggered by the stage container's `insert` event — for the in-app bootstrap and for any external
+     * Neural-Link `create_component` into the same stage. Projects the created grid into the evidence
+     * pane; a non-grid insert or an unprojectable grid leaves the pane to fail closed downstream.
+     * @param {Object} data
+     * @param {Neo.component.Base} data.item the just-inserted, mounted component
+     * @protected
+     */
+    onStageInsert({item}) {
+        if (item?.ntype === 'grid-container') {
+            this.getReference('evidence-pane').blueprint = projectCreatedGrid(item)
+        }
     }
 
     /**

--- a/apps/agentos/childapps/widget/view/ViewportController.mjs
+++ b/apps/agentos/childapps/widget/view/ViewportController.mjs
@@ -8,8 +8,8 @@ import {validateRequest}    from '../util/validateRequest.mjs';
  * `add → insert` path a Neural-Link `create_component` drives (it calls
  * `call_method(parentId, 'add', [config])`). Keeping ONE create path is the provenance point: whatever
  * lands in the stage — this in-app bootstrap or an external agent's `create_component` — is what the
- * evidence pane projects, so the evidence always describes the grid that actually crossed the create
- * path. The bootstrap uses `module` (the class is imported here, registering the live app); an external
+ * evidence pane projects, so the evidence always describes the grid that was actually inserted into the
+ * stage. The bootstrap uses `module` (the class is imported here, registering the live app); an external
  * agent sends `ntype`/`className` instead, since a module reference cannot cross the Neural Link wire.
  * @type {Object}
  */
@@ -50,9 +50,9 @@ const firstWidgetGridConfig = {
  * container (the same `add → insert` path a Neural-Link `create_component` drives), so the live grid is
  * created through the create seam rather than declared as a static item. It then observes the stage's
  * `insert` event — fired for that bootstrap AND for any later external `create_component` into the same
- * stage — and projects the actually-created grid into the evidence pane via {@link projectCreatedGrid},
- * so the evidence always describes the grid that crossed the bridge, not a hand-authored blueprint.
- * It also keeps the deterministic chat-intake submit handling. No model invocation / persistence.
+ * stage — and projects the inserted grid into the evidence pane via {@link projectCreatedGrid},
+ * so the evidence always describes the grid that was inserted into the stage, not a hand-authored
+ * blueprint. It also keeps the deterministic chat-intake submit handling. No model invocation / persistence.
  */
 class ViewportController extends Controller {
     static config = {
@@ -64,7 +64,7 @@ class ViewportController extends Controller {
     }
 
     /**
-     * Boots the first widget through the live create path: binds the stage's `insert` observer, then
+     * Boots the first widget through the stage insert seam: binds the stage's `insert` observer, then
      * `add()`s the grid config (firing `insert`, which {@link onStageInsert} projects into the evidence
      * pane). Binding before the add ensures the bootstrap insert is observed, exactly as a later
      * external `create_component` into the same stage would be.

--- a/test/playwright/e2e/FirstWidgetEvidencePane.spec.mjs
+++ b/test/playwright/e2e/FirstWidgetEvidencePane.spec.mjs
@@ -1,22 +1,24 @@
 import {test, expect} from '../fixtures.mjs';
 
 /**
- * @summary H2 render proof: the first-widget evidence pane and the live grid render together, and
- * the grid actually renders the blueprint's content ROWS — not an empty grid.
+ * @summary H2 render proof: the live grid is CREATED through the insert seam and the evidence pane
+ * projects from it — the two render together and describe the SAME created grid, not an empty grid.
  *
- * The AC6 counterpart to the unit specs (which prove the projection + safe-render boundary). It
- * boots the AgentOSWidget child app and verifies the EvidencePane (request + accepted-blueprint
- * metadata) AND that the live grid renders ALL of the SAME deterministic blueprint's rows — the
- * provenance point of the leaf. The cell-COUNT + per-row cell-VALUE assertions are deliberate: a
- * grid that mounts but renders zero content rows MUST fail here. (An earlier weak `toContainText`-
- * only check passed against a stale dev-server render and never validated a real row — fixed.)
+ * The AC6 counterpart to the unit specs (which prove the projection + safe-render boundary). It boots
+ * the AgentOSWidget child app, where the controller creates the grid via the `add → insert` path a
+ * Neural-Link `create_component` drives and projects the actually-created grid into the evidence pane.
+ * The pane therefore shows the created grid's identity (`first-widget-grid`, its id) — NOT the
+ * `EvidencePane` default (`First Neo Grid`), so this assertion fails if the projection never fired.
+ * The cell-COUNT + per-row cell-VALUE assertions are deliberate: a grid that mounts but renders zero
+ * content rows MUST fail. (An earlier weak `toContainText`-only check passed against a stale
+ * dev-server render and never validated a real row — fixed.)
  *
- * @see apps/agentos/childapps/widget/view/Viewport.mjs
+ * @see apps/agentos/childapps/widget/view/ViewportController.mjs
  */
-test.describe('AgentOS first widget — evidence pane + live grid rows (H2 render proof)', () => {
+test.describe('AgentOS first widget — created grid + projected evidence (H2 render proof)', () => {
     test.setTimeout(90000);
 
-    test('renders the evidence pane and the grid with all blueprint content rows', async ({page}) => {
+    test('creates the grid via the insert seam and projects it into the evidence pane', async ({page}) => {
         await page.goto('/apps/agentos/childapps/widget/index.html');
 
         const evidence = page.locator('.agent-os-evidence-pane'),
@@ -25,17 +27,19 @@ test.describe('AgentOS first widget — evidence pane + live grid rows (H2 rende
         await expect(evidence).toBeVisible({timeout: 30000});
         await expect(grid).toBeVisible({timeout: 30000});
 
-        // evidence pane: deterministic request + accepted-blueprint metadata (scalar, safe text)
+        // evidence pane: deterministic request + the projected CREATED grid's metadata (scalar text).
+        // `first-widget-grid` is the created grid's id — its appearance proves the projection ran and
+        // overwrote the EvidencePane default title (`First Neo Grid`).
         await expect(evidence).toContainText('build me a neo grid');
         await expect(evidence).toContainText('Neo.grid.Container');
-        await expect(evidence).toContainText('First Neo Grid');
+        await expect(evidence).toContainText('first-widget-grid');
 
-        // the live grid renders ALL blueprint rows — 3 rows × 4 columns = 12 cells. `toHaveCount`
-        // auto-waits for the async render to settle; an empty grid (0 cells) FAILS this assertion.
+        // the live grid renders ALL rows — 3 rows × 4 columns = 12 cells. `toHaveCount` auto-waits for
+        // the async create+render to settle; an empty grid (0 cells) FAILS this assertion.
         await expect(grid.locator('.neo-grid-cell')).toHaveCount(12, {timeout: 30000});
 
         // and each content row's value is actually rendered in the grid (not just buffered) — the
-        // provenance link: what the evidence pane describes is what the grid below it renders.
+        // provenance link: what the evidence pane describes is what the created grid renders.
         for (const value of ['Verify intent', 'Render grid', 'Show evidence']) {
             await expect(grid.locator('.neo-grid-cell', {hasText: value})).toHaveCount(1)
         }

--- a/test/playwright/unit/apps/agentos/childapps/widget/util/createdGridEvidence.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/util/createdGridEvidence.spec.mjs
@@ -20,11 +20,13 @@ import * as core      from '../../../../../../../../src/core/_export.mjs';
 /**
  * @summary Unit coverage for projecting a live Neural-Link-created grid into evidence.
  *
- * Verifies the H2 provenance seam: a live created grid projects to the deterministic
- * `{schema, title, columns, rows}` blueprint shape, the projection reads only safe scalar metadata
- * (never the live store's record data or the grid's other props/methods), the title falls back
- * sensibly, and anything that is not a usable grid fails closed to `null`. A final case proves the
- * output flows cleanly through the existing `projectBlueprintEvidence` safe boundary unchanged.
+ * Verifies the H2 provenance seam against the REAL live-grid shape (its `columns` is a Neo collection
+ * whose `.items` are the column components, its `store` a collection with a `count`): a live created
+ * grid projects to the deterministic `{schema, title, columns, rows}` blueprint shape, reading only
+ * safe scalar metadata — never the column components' internals (renderers, widths) or the store's
+ * record data. The title falls back sensibly, a plain-array config is accepted defensively, anything
+ * that is not a usable grid fails closed to `null`, and the output flows cleanly through the existing
+ * `projectBlueprintEvidence` safe boundary unchanged.
  *
  * @see apps/agentos/childapps/widget/util/createdGridEvidence.mjs
  */
@@ -37,24 +39,28 @@ test.describe('AgentOSWidget.util.createdGridEvidence', () => {
     });
 
     /**
-     * A live-grid stand-in: the shape the `insert {index, item}` event hands the controller — a class
-     * id, column definitions, a live store with a count, plus extra props/methods that must NOT leak.
+     * A live-grid stand-in matching the real instance the `insert {index, item}` event hands the
+     * controller: a class id, a columns COLLECTION (its `.items` are full column components), a store
+     * COLLECTION with a count, plus extra props/methods that must NOT leak.
      */
     const liveGrid = () => ({
         className: 'Neo.grid.Container',
         id       : 'nl-created-grid-h2-proof',
-        columns  : [
-            {dataField: 'task',     text: 'Task'},
-            {dataField: 'owner',    text: 'Owner'},
-            {dataField: 'evidence', text: 'Evidence'}
-        ],
+        columns  : {
+            count: 3,
+            items: [
+                {dataField: 'task',     text: 'Task',     renderer: () => 'x', cellAlign: 'left'},
+                {dataField: 'owner',    text: 'Owner',    width: 140},
+                {dataField: 'evidence', text: 'Evidence', hidden: false}
+            ]
+        },
         store: {
             count: 3,
-            data : [{id: 'a'}, {id: 'b'}, {id: 'c'}]
+            items: [{id: 'a'}, {id: 'b'}, {id: 'c'}]
         },
         // hostile / irrelevant surface that must never reach the evidence blueprint
-        destroy   : () => 'boom',
-        vdom      : {cn: [{tag: 'script'}]},
+        destroy      : () => 'boom',
+        vdom         : {cn: [{tag: 'script'}]},
         onConstructed: 'doSomething()'
     });
 
@@ -73,10 +79,12 @@ test.describe('AgentOSWidget.util.createdGridEvidence', () => {
         })
     });
 
-    test('reads only the four blueprint keys — no live grid props/methods leak', () => {
+    test('reads only the four blueprint keys — no column internals, props or record data leak', () => {
         const result = projectCreatedGrid(liveGrid());
 
         expect(Object.keys(result).sort()).toEqual(['columns', 'rows', 'schema', 'title']);
+        // column components carry renderers/widths — only dataField + text survive
+        expect(Object.keys(result.columns[0]).sort()).toEqual(['dataField', 'text']);
         // row COUNT is preserved but no record data is copied through
         expect(result.rows).toHaveLength(3);
         expect(result.rows.some(row => row !== undefined)).toBe(false)
@@ -88,23 +96,41 @@ test.describe('AgentOSWidget.util.createdGridEvidence', () => {
         expect(projectCreatedGrid({...liveGrid(), id: undefined}).title).toBe('Neo.grid.Container') // no title/id -> schema
     });
 
-    test('derives the row count from store.data when count is absent', () => {
-        const grid = liveGrid();
-        delete grid.store.count;
-        expect(projectCreatedGrid(grid).rows).toHaveLength(3);
+    test('derives the row count from store.items or a plain-array store.data when count is absent', () => {
+        const noCount = liveGrid();
+        delete noCount.store.count;
+        expect(projectCreatedGrid(noCount).rows).toHaveLength(3); // falls to the store collection's items
 
-        const empty = liveGrid();
-        empty.store = {count: 0, data: []};
+        const dataShape = {...liveGrid(), store: {data: [{id: 1}, {id: 2}]}};
+        expect(projectCreatedGrid(dataShape).rows).toHaveLength(2); // defensive {data} config
+
+        const empty = {...liveGrid(), store: {count: 0, items: []}};
         expect(projectCreatedGrid(empty).rows).toHaveLength(0)
+    });
+
+    test('accepts a plain-array columns config defensively', () => {
+        const arrayShape = {
+            className: 'Neo.grid.Container',
+            id       : 'cfg-grid',
+            columns  : [{dataField: 'a', text: 'A'}, {dataField: 'b', text: 'B'}],
+            store    : {count: 1, data: [{a: 1}]}
+        };
+
+        expect(projectCreatedGrid(arrayShape)).toEqual({
+            schema : 'Neo.grid.Container',
+            title  : 'cfg-grid',
+            columns: [{dataField: 'a', text: 'A'}, {dataField: 'b', text: 'B'}],
+            rows   : [undefined]
+        })
     });
 
     test('fails closed to null when the input is not a usable grid', () => {
         const bad = [
             null, undefined, 'a string', 42, ['an', 'array'],
-            {columns: [], store: {count: 0}},                          // no className
-            {className: 'Neo.grid.Container', store: {count: 0}},       // no columns array
-            {className: 'Neo.grid.Container', columns: []},             // no store
-            {className: '', columns: [], store: {count: 0}}             // empty className
+            {columns: {items: []}, store: {count: 0}},                  // no className
+            {className: 'Neo.grid.Container', store: {count: 0}},       // no columns
+            {className: 'Neo.grid.Container', columns: {items: []}},    // no store
+            {className: '', columns: {items: []}, store: {count: 0}}    // empty className
         ];
 
         for (const input of bad) {

--- a/test/playwright/unit/apps/agentos/childapps/widget/util/createdGridEvidence.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/util/createdGridEvidence.spec.mjs
@@ -18,7 +18,7 @@ import Neo            from '../../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Unit coverage for projecting a live Neural-Link-created grid into evidence.
+ * @summary Unit coverage for projecting a live inserted grid into evidence.
  *
  * Verifies the H2 provenance seam against the REAL live-grid shape (its `columns` is a Neo collection
  * whose `.items` are the column components, its `store` a collection with a `count`): a live created
@@ -45,7 +45,7 @@ test.describe('AgentOSWidget.util.createdGridEvidence', () => {
      */
     const liveGrid = () => ({
         className: 'Neo.grid.Container',
-        id       : 'nl-created-grid-h2-proof',
+        id       : 'inserted-grid-h2',
         columns  : {
             count: 3,
             items: [
@@ -69,7 +69,7 @@ test.describe('AgentOSWidget.util.createdGridEvidence', () => {
 
         expect(result).toEqual({
             schema : 'Neo.grid.Container',
-            title  : 'nl-created-grid-h2-proof',
+            title  : 'inserted-grid-h2',
             columns: [
                 {dataField: 'task',     text: 'Task'},
                 {dataField: 'owner',    text: 'Owner'},
@@ -92,7 +92,7 @@ test.describe('AgentOSWidget.util.createdGridEvidence', () => {
 
     test('prefers an explicit title, then the id, then the schema', () => {
         expect(projectCreatedGrid({...liveGrid(), title: 'First Neo Grid'}).title).toBe('First Neo Grid');
-        expect(projectCreatedGrid(liveGrid()).title).toBe('nl-created-grid-h2-proof'); // no title -> id
+        expect(projectCreatedGrid(liveGrid()).title).toBe('inserted-grid-h2'); // no title -> id
         expect(projectCreatedGrid({...liveGrid(), id: undefined}).title).toBe('Neo.grid.Container') // no title/id -> schema
     });
 
@@ -145,7 +145,7 @@ test.describe('AgentOSWidget.util.createdGridEvidence', () => {
         expect(evidence).toEqual({
             accepted   : true,
             schema     : 'Neo.grid.Container',
-            title      : 'nl-created-grid-h2-proof',
+            title      : 'inserted-grid-h2',
             columnCount: 3,
             rowCount   : 3
         })

--- a/test/playwright/unit/apps/agentos/childapps/widget/util/createdGridEvidence.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/util/createdGridEvidence.spec.mjs
@@ -1,0 +1,127 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'CreatedGridEvidenceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Unit coverage for projecting a live Neural-Link-created grid into evidence.
+ *
+ * Verifies the H2 provenance seam: a live created grid projects to the deterministic
+ * `{schema, title, columns, rows}` blueprint shape, the projection reads only safe scalar metadata
+ * (never the live store's record data or the grid's other props/methods), the title falls back
+ * sensibly, and anything that is not a usable grid fails closed to `null`. A final case proves the
+ * output flows cleanly through the existing `projectBlueprintEvidence` safe boundary unchanged.
+ *
+ * @see apps/agentos/childapps/widget/util/createdGridEvidence.mjs
+ */
+test.describe('AgentOSWidget.util.createdGridEvidence', () => {
+    let projectCreatedGrid, projectBlueprintEvidence;
+
+    test.beforeAll(async () => {
+        ({projectCreatedGrid}       = await import('../../../../../../../../apps/agentos/childapps/widget/util/createdGridEvidence.mjs'));
+        ({projectBlueprintEvidence} = await import('../../../../../../../../apps/agentos/childapps/widget/util/blueprintEvidence.mjs'))
+    });
+
+    /**
+     * A live-grid stand-in: the shape the `insert {index, item}` event hands the controller — a class
+     * id, column definitions, a live store with a count, plus extra props/methods that must NOT leak.
+     */
+    const liveGrid = () => ({
+        className: 'Neo.grid.Container',
+        id       : 'nl-created-grid-h2-proof',
+        columns  : [
+            {dataField: 'task',     text: 'Task'},
+            {dataField: 'owner',    text: 'Owner'},
+            {dataField: 'evidence', text: 'Evidence'}
+        ],
+        store: {
+            count: 3,
+            data : [{id: 'a'}, {id: 'b'}, {id: 'c'}]
+        },
+        // hostile / irrelevant surface that must never reach the evidence blueprint
+        destroy   : () => 'boom',
+        vdom      : {cn: [{tag: 'script'}]},
+        onConstructed: 'doSomething()'
+    });
+
+    test('projects a live created grid to the deterministic blueprint shape', () => {
+        const result = projectCreatedGrid(liveGrid());
+
+        expect(result).toEqual({
+            schema : 'Neo.grid.Container',
+            title  : 'nl-created-grid-h2-proof',
+            columns: [
+                {dataField: 'task',     text: 'Task'},
+                {dataField: 'owner',    text: 'Owner'},
+                {dataField: 'evidence', text: 'Evidence'}
+            ],
+            rows: [undefined, undefined, undefined]
+        })
+    });
+
+    test('reads only the four blueprint keys — no live grid props/methods leak', () => {
+        const result = projectCreatedGrid(liveGrid());
+
+        expect(Object.keys(result).sort()).toEqual(['columns', 'rows', 'schema', 'title']);
+        // row COUNT is preserved but no record data is copied through
+        expect(result.rows).toHaveLength(3);
+        expect(result.rows.some(row => row !== undefined)).toBe(false)
+    });
+
+    test('prefers an explicit title, then the id, then the schema', () => {
+        expect(projectCreatedGrid({...liveGrid(), title: 'First Neo Grid'}).title).toBe('First Neo Grid');
+        expect(projectCreatedGrid(liveGrid()).title).toBe('nl-created-grid-h2-proof'); // no title -> id
+        expect(projectCreatedGrid({...liveGrid(), id: undefined}).title).toBe('Neo.grid.Container') // no title/id -> schema
+    });
+
+    test('derives the row count from store.data when count is absent', () => {
+        const grid = liveGrid();
+        delete grid.store.count;
+        expect(projectCreatedGrid(grid).rows).toHaveLength(3);
+
+        const empty = liveGrid();
+        empty.store = {count: 0, data: []};
+        expect(projectCreatedGrid(empty).rows).toHaveLength(0)
+    });
+
+    test('fails closed to null when the input is not a usable grid', () => {
+        const bad = [
+            null, undefined, 'a string', 42, ['an', 'array'],
+            {columns: [], store: {count: 0}},                          // no className
+            {className: 'Neo.grid.Container', store: {count: 0}},       // no columns array
+            {className: 'Neo.grid.Container', columns: []},             // no store
+            {className: '', columns: [], store: {count: 0}}             // empty className
+        ];
+
+        for (const input of bad) {
+            expect(projectCreatedGrid(input)).toBeNull()
+        }
+    });
+
+    test('output flows cleanly through the projectBlueprintEvidence safe boundary', () => {
+        const projected = projectCreatedGrid(liveGrid()),
+              evidence  = projectBlueprintEvidence(projected);
+
+        expect(evidence).toEqual({
+            accepted   : true,
+            schema     : 'Neo.grid.Container',
+            title      : 'nl-created-grid-h2-proof',
+            columnCount: 3,
+            rowCount   : 3
+        })
+    })
+});

--- a/test/playwright/unit/apps/agentos/childapps/widget/view/RequestIntake.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/view/RequestIntake.spec.mjs
@@ -4,12 +4,14 @@ import {fileURLToPath} from 'url';
 import {dirname, join} from 'path';
 
 /**
- * @summary Source-level safe-render + blueprint-path-reuse constraints for the H2 chat intake.
+ * @summary Source-level safe-render + single-create-path constraints for the H2 chat intake.
  *
  * The intake submit routes through the Viewport controller, which renders any fail-closed reason as
  * safe vdom `text` (never `html` / `innerHTML`) and projects an accepted request into the EXISTING
- * evidence pane — it must NOT spin up a second widget / grid path. These are source assertions (the
- * Contract Ledger's safe-render + reuse evidence), independent of the App-Worker render pipeline.
+ * evidence pane. The first widget is created exactly once — through the stage's `add → insert` seam,
+ * projected into the evidence pane — so there is no forked second grid/demo path: the intake form
+ * itself never instantiates a widget. These are source assertions (the Contract Ledger's safe-render
+ * + single-path evidence), independent of the App-Worker render pipeline.
  *
  * @see apps/agentos/childapps/widget/view/RequestIntake.mjs
  * @see apps/agentos/childapps/widget/view/ViewportController.mjs
@@ -37,9 +39,13 @@ test.describe('AgentOSWidget chat intake — safe-render + blueprint-path-reuse 
         expect(controller).toMatch(/evidence-pane/)
     });
 
-    test('introduces no duplicate widget / grid path (reuses the first-widget blueprint path)', () => {
-        for (const src of [intake, controller]) {
-            expect(src).not.toMatch(/createComponent|grid-container|new\s+Grid/)
-        }
+    test('creates the first widget once through the stage insert seam (no forked demo path)', () => {
+        // the controller boots the grid through the stage's add/insert seam and projects it — one path
+        expect(controller).toMatch(/widget-stage/);
+        expect(controller).toMatch(/projectCreatedGrid/);
+        // ...not a direct `new Grid(...)` instantiation that would bypass the create seam
+        expect(controller).not.toMatch(/new\s+Grid/);
+        // and the intake FORM itself never spins up a widget / grid path
+        expect(intake).not.toMatch(/createComponent|grid-container|new\s+Grid/)
     })
 });


### PR DESCRIPTION
Resolves #13438
Refs #13355

Delivers the MECHANISM for the H2 first-widget evidence pane to reflect a grid CREATED at runtime via the container insert seam — the same `add → insert` path a Neural-Link `create_component` drives (`ComponentService.createComponent` → `call_method(parentId, 'add', [config])` → `container.add` → `insert`) — instead of a hand-authored blueprint. The deterministic half (#13413 / PR #13409) fed a static blueprint; this replaces it with the live inserted grid, projected into the evidence pane.

**Close-target note (per @neo-gpt's review):** this head proves the insert-seam projection via the in-app `stage.add` bootstrap. It does NOT execute an EXTERNAL `create_component` into the stage (that whitebox is blocked on the childapp `connectToApp` fixture — SharedWorker topology). So it Resolves the delivery leaf #13438 (the seam + projector) and only Refs the parent #13355, which stays open for the external-agent provenance proof.

## What changed
- **`util/createdGridEvidence.mjs` (new)** — `projectCreatedGrid`: maps a LIVE inserted grid (the `item` handed by the container `insert` event) into the `{schema, title, columns, rows}` blueprint shape the evidence pane already consumes via `projectBlueprintEvidence`. Safe scalar metadata only — class id, a title (`title → id → schema`), the columns collection's definitions, and the live row COUNT (never copying record data). Fails closed to `null`. Accepts live `NeoInstance`s (the live grid + store are class instances, which `Neo.isObject` — plain-object-only — rejects).
- **`view/ViewportController.mjs`** — on construct, boots the grid by `add()`-ing it to the stage (the same `add → insert` seam `create_component` drives), observes the stage's `insert`, and projects the inserted grid into the evidence pane. One create path: the in-app bootstrap and any external `create_component` into the same stage flow through the identical projection.
- **`view/Viewport.mjs`** — the grid is no longer a static child; a `widget-stage` container (known id) hosts it, so the evidence describes the grid that was inserted and an external agent can `create_component` into the same stage.

## Contract Ledger
| Target Surface | Source of Authority | Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| Inserted-grid → evidence projection | #13438 ACs, the container `insert` seam (source-equivalent to `create_component`) | `projectCreatedGrid` maps a live inserted grid to safe `{schema,title,columns,rows}` metadata, projected through the existing safe boundary | non-grid / unreadable input → `null` → pane fails closed | JSDoc / @summary on the util + controller methods | 7 unit tests + the render-together e2e |

Evidence: 7 unit tests (`createdGridEvidence.spec`) + the render-together e2e proving the evidence reflects the INSERTED grid (its id, not the default), on a fresh server with `:8080` killed.

## Deltas from ticket
- Close-target retargeted from the parent #13355 to the delivery leaf #13438 (per review): this head proves the insert-seam projection (in-app bootstrap), not an external `create_component` invocation. The external-agent → evidence whitebox stays the #13355 residual, blocked on the childapp `connectToApp` e2e fixture (`target.toLowerCase` on a non-string for SharedWorker topology) — filed as a separate task. Wording across the PR / JSDoc / test summaries is scoped to source-equivalence ("the same `add → insert` seam that `create_component` drives"), not "crossed the bridge".

## Test Evidence
- `createdGridEvidence.spec.mjs` (unit) — 7 tests: live-grid projection, no-leak (four keys only — no column internals / record data), title fallback, row-count from store `count` / `items` / `data`, plain-array defensive path, fail-closed `null` cases, and boundary-integration through `projectBlueprintEvidence`.
- `FirstWidgetEvidencePane.spec.mjs` (e2e) — boots the widget app; asserts the evidence pane shows the INSERTED grid's id `first-widget-grid` (NOT the `EvidencePane` default title, so it FAILS if the projection never fired) + schema, and the grid renders 12 cells (4×3) + the three row values. Fresh server, stale `:8080` killed.
- `RequestIntake.spec.mjs` (unit) — the source constraint is updated to the single-create-path design: the controller creates via `widget-stage` + projects via `projectCreatedGrid`, and the intake form itself never spins up a grid.
- Full widget unit suite: 21 passed. `FirstWidgetChatIntake.spec.mjs` e2e: passed (regression after the Viewport restructure).

## Post-Merge Validation
- [ ] CI re-runs the widget unit + e2e green.
- [ ] #13355 residual: the external-agent `create_component` → evidence whitebox once the childapp `connectToApp` fixture lands.

## Out of scope / follow-ups
- External `create_component` → evidence whitebox — the #13355 residual (childapp `connectToApp` fixture).
- Durable transcript persistence / Memory Core write-through — a later leaf.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Session 47b6dbc0-7673-4ad3-a9f5-bef3b606c56b.
