### PR TITLE
fix(neural-link): connectToApp resolves a childapp on a shared SharedWorker (#13439)

### DIFF
--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -622,7 +622,7 @@ class ConnectionService extends Base {
              // timeout rather than a TypeError. Callers should pass a string appWorkerId or appName.
              const targetLower = String(target ?? '').toLowerCase();
              for (const [id, meta] of this.sessionData.entries()) {
-                 if (id === target || (meta.appName && meta.appName.toLowerCase() === targetLower)) {
+                 if (id === target || meta.appName?.toLowerCase() === targetLower) {
                      return id;
                  }
              }

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -618,7 +618,9 @@ class ConnectionService extends Base {
      */
     async waitForSession(target, timeout = 10000) {
         const check = () => {
-             const targetLower = target.toLowerCase();
+             // Tolerate a non-string target (e.g. an unresolved worker-id envelope): degrade to a clean
+             // timeout rather than a TypeError. Callers should pass a string appWorkerId or appName.
+             const targetLower = String(target ?? '').toLowerCase();
              for (const [id, meta] of this.sessionData.entries()) {
                  if (id === target || (meta.appName && meta.appName.toLowerCase() === targetLower)) {
                      return id;

--- a/test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs
+++ b/test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs
@@ -1,0 +1,35 @@
+import {test, expect} from '../fixtures.mjs';
+
+/**
+ * @summary Regression proof: `neuralLink.connectToApp` works for a childapp on a shared SharedWorker.
+ *
+ * A childapp that joins an existing SharedWorker resolves `getWorkerId()` to a remote-reply ENVELOPE
+ * (`{action:'reply', data:<id>, ...}`) rather than a string, which used to leave `targetId` non-string and
+ * make `connectToApp` throw `target.toLowerCase is not a function` in `ConnectionService.waitForSession`.
+ * The fixture now treats a non-string worker id as absent and falls back to the appName (which
+ * `waitForSession` matches on `meta.appName`). This boots the AgentOSWidget childapp, connects, and reads
+ * back the live bootstrap grid — proving the fixture resolves a childapp end to end.
+ *
+ * @see test/playwright/fixtures.mjs (connectToApp targetId resolution)
+ * @see test/playwright/e2e/NeuralLinkCreateGrid.spec.mjs (the top-level-app counterpart)
+ */
+test.describe('Neural Link — childapp connect (SharedWorker topology)', () => {
+    test.setTimeout(90000);
+    test.use({viewport: {width: 1280, height: 720}});
+
+    test('connectToApp resolves a childapp + reads a live component', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/childapps/widget/index.html');
+        // the in-app bootstrap grid mounts — the app is live before we connect
+        await page.waitForSelector('.agent-os-first-widget-grid', {state: 'visible', timeout: 30000});
+
+        // a childapp joins the parent SharedWorker session (registered under the worker appName `agentos`);
+        // `AgentOSWidget` is a WINDOW within it, so the session is reached via the worker appName.
+        const app = await neuralLink.connectToApp('agentos');
+        expect(app.sessionId, 'connectToApp must resolve the childapp worker session').toBeTruthy();
+
+        // read back the live bootstrap grid through the connection — proves it works end to end
+        const grid = await app.getComponent('first-widget-grid', ['ntype', 'store.count']);
+        expect(grid.ntype).toBe('grid-container');
+        expect(grid['store.count']).toBe(3)
+    });
+});

--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -133,8 +133,11 @@ export const test = base.extend({
                     // Ignore, page might not exist or be blank
                 }
 
-                // Prefer the page's own worker id (exact-id match); fall back to explicit / inferred appName
-                const targetId = workerId || appName || inferredAppName;
+                // Prefer the page's own worker id (exact-id match); fall back to explicit / inferred appName.
+                // A top-level app's getWorkerId() resolves to a string, but a childapp that joined an existing
+                // SharedWorker gets the raw remote-reply envelope ({action:'reply', data, ...}) instead — not a
+                // usable session-id match — so treat a non-string workerId as absent and use the appName fallback.
+                const targetId = (typeof workerId === 'string' && workerId ? workerId : null) || appName || inferredAppName;
                 if (!targetId) {
                     throw new Error('neuralLink.connectToApp requires either an initialized Neo environment or an explicit appName to wait for.');
                 }


### PR DESCRIPTION
Resolves #13439

Fixes `neuralLink.connectToApp` for a childapp running on a shared SharedWorker — the `target.toLowerCase is not a function` TypeError that blocked childapp whitebox e2es (both I, building #13437, and @neo-gpt, reviewing it, hit this wall).

## Root cause (empirically confirmed)

A childapp that joins an existing SharedWorker resolves `await Neo.worker.App.getWorkerId()` to a remote-reply ENVELOPE `{action:'reply', data:<workerId>, ...}` rather than a string (a top-level app unwraps to a string). The fixture's `targetId = workerId || appName || inferredAppName` kept the truthy envelope object, so `ConnectionService.waitForSession`'s `target.toLowerCase()` threw. Confirmed the shape with a throwaway diagnostic before fixing.

## The fix

- **`test/playwright/fixtures.mjs`** — treat a non-string `workerId` as absent and fall back to the appName (`waitForSession` matches `meta.appName`): `targetId = (typeof workerId === 'string' && workerId ? workerId : null) || appName || inferredAppName`.
- **`ai/services/neural-link/ConnectionService.mjs`** — `waitForSession` defensively coerces `target` (`String(target ?? '')`) so a non-string degrades to a clean timeout, not a `TypeError` (the `@param` is already `String`; this hardens the contract for any caller).
- **`test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs` (new)** — boots the AgentOSWidget childapp, connects, reads back the live grid.

## Childapp whitebox pattern (documented in the new spec)

A childapp's components live in the **parent worker session** — the SharedWorker registers under the worker appName `agentos`, and `AgentOSWidget` is a *window* within it. So childapp whitebox tests connect via the **worker appName** (`agentos`), not the window appName; the new spec demonstrates it.

## Contract Ledger

The consumed surfaces this PR changes are documented in the Contract Ledger backfilled on the originating ticket #13439 (issuecomment-4719875960); the diff matches it with no drift. Shipped semantics:
- `neuralLink.connectToApp` (`test/playwright/fixtures.mjs`) treats a non-string `getWorkerId()` remote-reply envelope as absent and resolves `targetId` to the first usable string (string workerId → appName → inferredAppName).
- `ConnectionService.waitForSession` (`ai/services/neural-link/ConnectionService.mjs`) coerces nullable/non-string `target` before comparing → a clean timeout, not a `TypeError`.
- Childapp whitebox tests connect via the **worker appName** (`agentos`), not the window appName (`AgentOSWidget`) — the window appName is not a session.

Evidence: empirical root-cause diagnostic + the new childapp-connect e2e + the top-level-app regression, all on a fresh server (`:8080` killed).

## Deltas from ticket

- The ticket AC named `connectToApp('AgentOSWidget')` literally; the SharedWorker reality is that the *window* appName isn't a session — the session is the worker (`agentos`). So the fix + the e2e connect via the worker appName, which is the correct childapp-whitebox pattern (documented + in the Contract Ledger). The ticket's intent (childapp whitebox tests work) is met.
- The deeper behavior — `getWorkerId` returning an unwrapped remote-reply envelope for a SharedWorker childapp — is a production remote-call-resolution quirk (`src/worker/App.mjs` returns `this.id`; the childapp's remote reply isn't unwrapped). This PR fixes the e2e fixture (the ticket scope) + hardens `waitForSession`; unwrapping the envelope at the production layer is a separate, higher-blast concern, noted as a follow-up rather than reshaped here.

## Test Evidence

- `NeuralLinkChildappConnect.spec.mjs` (new) — boots `/apps/agentos/childapps/widget/index.html`, `connectToApp('agentos')`, `getComponent('first-widget-grid', ['ntype','store.count'])` → `grid-container`, `store.count` 3. Passes (1.5s, fresh server). Before the fix: `target.toLowerCase is not a function`.
- `NeuralLinkCreateGrid.spec.mjs` (top-level-app, unchanged) — still passes (2.2s). No regression.
- Root cause confirmed via throwaway diagnostic: `getWorkerId()` for the childapp returns `{action:'reply', data:'<uuid>', ...}` (object), not a string.

## Post-Merge Validation

- [ ] CI re-runs the neuralLink e2es green.
- [ ] #13355 external-agent `create_component` → evidence whitebox is now authorable (connect via the worker session + `createComponent` into the childapp's `widget-stage`).

## Out of scope / follow-ups

- Unwrapping the childapp `getWorkerId` remote-reply envelope at the production remote-call layer (so `connectToApp` could resolve the exact worker id instead of the appName fallback) — a separate production concern.
- The #13355 external-NL whitebox itself (now unblocked).

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Session 47b6dbc0-7673-4ad3-a9f5-bef3b606c56b.
