### PR TITLE
test(agentos): prove external Neural-Link create_component projects into the first-widget evidence (#13355)

### DIFF
--- a/test/playwright/e2e/FirstWidgetEvidenceNeuralLink.spec.mjs
+++ b/test/playwright/e2e/FirstWidgetEvidenceNeuralLink.spec.mjs
@@ -49,13 +49,33 @@ test.describe('AgentOS first widget — external Neural-Link create → evidence
             }
         });
 
-        // the evidence pane projects the EXTERNALLY-created grid: its id (proves the write was followed)
-        // + its schema. `nl-external-grid` cannot appear unless the external insert was projected.
+        // ENGINE STATE: the external write produced the INTENDED live grid WITH content (not a shell) —
+        // asserted as test truth, not read from bridge debug output. Poll store.count (populates async).
+        let grid;
+        await expect.poll(async () => {
+            grid = await app.getComponent(gridId, ['ntype', 'className', 'parentId', 'store.count']);
+            return grid?.['store.count']
+        }, {message: 'the external grid must register a live store of 2 rows', timeout: 15000}).toBe(2);
+        expect(grid.ntype).toBe('grid-container');
+        expect(grid.className).toBe('Neo.grid.Container');
+        expect(grid.parentId).toBe('widget-stage');
+
+        // EVIDENCE: projects the EXTERNAL grid — id + schema + its ACTUAL column/row counts (2 / 2, NOT
+        // the bootstrap grid's 4 / 3), so id/schema-only projection cannot satisfy this.
         const evidence = page.locator('.agent-os-evidence-pane');
         await expect(evidence).toContainText('nl-external-grid', {timeout: 30000});
         await expect(evidence).toContainText('Neo.grid.Container');
+        const evidenceMeta = evidence.locator('.agent-os-evidence-meta dd'); // [schema, title, columns, rows]
+        await expect(evidenceMeta.nth(2)).toHaveText('2'); // Columns — the external grid's count
+        await expect(evidenceMeta.nth(3)).toHaveText('2'); // Rows
 
-        // and the externally-created grid is live in the running app
-        await expect(page.locator(`#${gridId}.neo-grid-container`)).toHaveCount(1, {timeout: 15000})
+        // RENDERED CONTENT: the external grid renders its real data — 2 cols × 2 rows = 4 cells, with the
+        // created values (not a zero-content grid-shaped shell).
+        const gridEl = page.locator(`#${gridId}.neo-grid-container`);
+        await expect(gridEl).toBeVisible({timeout: 15000});
+        await expect(gridEl.locator('.neo-grid-cell')).toHaveCount(4);
+        for (const value of ['latency', '12ms', 'throughput', '1k/s']) {
+            await expect(gridEl.locator('.neo-grid-cell', {hasText: value})).toHaveCount(1)
+        }
     });
 });

--- a/test/playwright/e2e/FirstWidgetEvidenceNeuralLink.spec.mjs
+++ b/test/playwright/e2e/FirstWidgetEvidenceNeuralLink.spec.mjs
@@ -1,0 +1,61 @@
+import {test, expect} from '../fixtures.mjs';
+
+/**
+ * @summary H2 provenance proof: an EXTERNAL Neural-Link `create_component` into the widget stage is
+ * reflected by the evidence pane — closing the agent-driven conversational-creation loop end to end.
+ *
+ * The render-together spec proves the in-app bootstrap. This proves the same insert seam carries an
+ * external agent's write: connect to the childapp's worker session, `create_component` a DISTINCT grid
+ * into the known `widget-stage`, and the controller projects that actually-created grid into the
+ * evidence pane. The pane shows the EXTERNAL grid's id (`nl-external-grid`) — which cannot appear unless
+ * a real `create_component` crossed the bridge and was projected. (Connect via the worker appName
+ * `agentos`, not the window appName — a childapp's components live in the parent worker session.)
+ *
+ * @see apps/agentos/childapps/widget/view/ViewportController.mjs
+ * @see test/playwright/e2e/NeuralLinkChildappConnect.spec.mjs
+ */
+test.describe('AgentOS first widget — external Neural-Link create → evidence (H2 provenance)', () => {
+    test.setTimeout(90000);
+    test.use({viewport: {width: 1280, height: 720}});
+
+    test('an external create_component into the stage projects into the evidence pane', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/childapps/widget/index.html');
+        // the in-app bootstrap grid mounts first — the app is live before the external write
+        await page.waitForSelector('.agent-os-first-widget-grid', {state: 'visible', timeout: 30000});
+
+        const app = await neuralLink.connectToApp('agentos');
+
+        const gridId = 'nl-external-grid';
+
+        // an external agent creates a DISTINCT grid (2 columns / 2 rows) into the known widget stage
+        await app.createComponent('widget-stage', {
+            id     : gridId,
+            ntype  : 'grid-container',
+            flex   : 1,
+            columns: [
+                {dataField: 'metric', text: 'Metric'},
+                {dataField: 'value',  text: 'Value'}
+            ],
+            store: {
+                keyProperty: 'metric',
+                model: {fields: [
+                    {name: 'metric', type: 'String'},
+                    {name: 'value',  type: 'String'}
+                ]},
+                data: [
+                    {metric: 'latency',    value: '12ms'},
+                    {metric: 'throughput', value: '1k/s'}
+                ]
+            }
+        });
+
+        // the evidence pane projects the EXTERNALLY-created grid: its id (proves the write was followed)
+        // + its schema. `nl-external-grid` cannot appear unless the external insert was projected.
+        const evidence = page.locator('.agent-os-evidence-pane');
+        await expect(evidence).toContainText('nl-external-grid', {timeout: 30000});
+        await expect(evidence).toContainText('Neo.grid.Container');
+
+        // and the externally-created grid is live in the running app
+        await expect(page.locator(`#${gridId}.neo-grid-container`)).toHaveCount(1, {timeout: 15000})
+    });
+});


### PR DESCRIPTION
Resolves #13355

The H2 **agent-driven** create→evidence whitebox — the residual after the deterministic half (#13413 / PR #13409) + the inserted-grid projection (#13437). It closes the conversational-creation loop end to end: an **EXTERNAL** Neural-Link `create_component` into the childapp's `widget-stage` is reflected by the evidence pane, asserted at the engine + content level.

## What it proves (as test truth, not bridge-log observation)

An external agent connects via the worker session (the #13440 childapp pattern), `create_component`s a 2-col / 2-row grid into `widget-stage`, and the test asserts:
- **Engine state** (`getComponent`): `ntype: grid-container`, `className: Neo.grid.Container`, `parentId: widget-stage`, and a polled `store.count` of **2** — the intended live grid with content, not an empty shell.
- **Evidence projection**: the pane shows the external grid's id (`nl-external-grid`) + schema **and its actual column/row counts (2 / 2)** — distinct from the bootstrap grid's 4 / 3, so id/schema-only projection cannot pass.
- **Rendered content**: the grid renders **4 cells** (2×2) with the created values (`latency` / `12ms` / `throughput` / `1k/s`).

## Scope

- **Test-only**: one new e2e (`FirstWidgetEvidenceNeuralLink.spec.mjs`). NO source changes — the #13437 insert-seam already carries an external write; this is the whitebox that proves it. No consumed-surface change, so no Contract Ledger applies.
- Builds on #13440 (the `connectToApp` childapp fixture, merged — enables the worker-session connect) + #13437 (the insert-seam projection, merged).

Evidence: the e2e passes (1.2s, fresh server, `:8080` killed) against dev with the merged #13440 fix; engine state, evidence col/row counts, and rendered content are all asserted as test truth.

## Deltas from ticket

None — this closes the #13355 residual (the external-agent provenance) the deterministic split (#13413) left open; the M2 agent-driven create→evidence path (Discussion #13436 critical-path) is now proven.

## Test Evidence

- `FirstWidgetEvidenceNeuralLink.spec.mjs` (new) — boots the AgentOSWidget childapp, `connectToApp('agentos')`, `createComponent` a 2-col / 2-row grid into `widget-stage`, then asserts: engine `store.count` 2 + `parentId widget-stage` (`getComponent`); the evidence pane's projected Columns 2 / Rows 2 + id + schema; and the 4 rendered cells with the created values. Passes 1.2s, fresh server.

## Post-Merge Validation

- [ ] CI re-runs the e2e green.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Session 47b6dbc0-7673-4ad3-a9f5-bef3b606c56b.
