### PR TITLE
docs(build): add JSDoc type guidance (#13433)

### DIFF
--- a/.github/CODING_GUIDELINES.md
+++ b/.github/CODING_GUIDELINES.md
@@ -21,6 +21,7 @@ In the long run, we are planning to convert as many of the rules as possible int
 8. Class methods
 9. data.Model fields
 10. Misc
+11. JSDoc type expressions
 
 
 ## 1. General rules
@@ -497,3 +498,28 @@ fields: [{
   + Bad: `let arr = [1,];`
   + Good: `let obj = {a: 1};`
   + Good: `let arr = [1];`
+
+## 11. JSDoc type expressions
+
+Neo's docs build parses every type expression with `jsdoc-x` and `catharsis` in JSDoc mode. This is the
+Closure/JSDoc grammar, not TypeScript. `node ./buildScripts/util/check-jsdoc-types.mjs` runs the same parser
+before `npm run generate-docs-json`, so fix the linted expression instead of treating the build failure as a
+docs-output problem.
+
+Verified parser outcomes:
+
+| Pattern checked | Catharsis result | Use |
+| --- | --- | --- |
+| `@returns {{value:Object|null}}` | Fails: no-space union inside a record value | `@returns {{value: Object|null}}` or `@returns {{value:(Object|null)}}` |
+| `@param {{name?:String}} data` | Fails: TypeScript optional-key syntax | `@param {Object} data` plus `@param {String} [data.name]` |
+| `@param {(value: String) => Boolean} fn` | Fails: TypeScript arrow-function syntax | `@param {function(String):Boolean} fn` |
+| `@returns {{value: Object|null}}` | Passes | Keep the space after the record colon |
+| `@returns {{value:(Object|null)}}` | Passes | Parenthesize ambiguous unions |
+| `@param {Array.<String>} items` | Passes | Prefer canonical JSDoc generic spelling in docs-facing code |
+| `@param {Object.<String, Number>} totals` | Passes | Prefer canonical JSDoc generic spelling in docs-facing code |
+
+If a type is hard to express in one line, define a named `@typedef` near the class or module and reference that
+name from `@param`, `@returns`, `@member`, or `@property`. The lint currently scans authored `.mjs` files in
+`src`, `ai`, `examples`, `apps`, and `docs/app`. `buildScripts` and `test` remain outside the CI scope because
+they are not consumed by the docs app today; extend the scope only with a ticket that also updates the relevant
+fixtures.

--- a/buildScripts/util/check-jsdoc-types.mjs
+++ b/buildScripts/util/check-jsdoc-types.mjs
@@ -196,6 +196,7 @@ function main() {
             console.error('and breaks the docs app. Most common cause: a TS-like type — typically a bare union inside a');
             console.error('record value with no space after the colon (`{a:Object|null}`). Fix: parenthesize the union');
             console.error('(`{a:(Object|null)}`) or add a space (`{a: Object|null}`); use a `@typedef` for complex shapes.')
+            console.error('See .github/CODING_GUIDELINES.md#11-jsdoc-type-expressions for accepted forms.')
         }
         process.exit(1)
     }

--- a/src/sitemap/Component.mjs
+++ b/src/sitemap/Component.mjs
@@ -16,29 +16,30 @@ class Component extends Base {
     static itemHideModes = ['removeDom', 'visibility']
 
     static config = {
-        /*
+        /**
          * @member {String} className='Neo.sitemap.Component'
          * @protected
          */
         className: 'Neo.sitemap.Component',
-        /*
+        /**
          * @member {String} ntype='sitemap'
          * @protected
          */
         ntype: 'sitemap',
-        /*
-         * @member {String[} baseCls=['neo-sitemap']
+        /**
+         * @member {String[]} baseCls=['neo-sitemap']
          */
         baseCls: ['neo-sitemap'],
         /**
          * Valid values: removeDom, visibility
          * Defines if the component items should use css visibility:'hidden' or vdom:removeDom
-         * @member {String} hideMode_='removeDom'
+         * @member {String} itemHideMode_='removeDom'
          * @reactive
          */
         itemHideMode_: 'removeDom',
-        /*
+        /**
          * @member {Neo.sitemap.Store|null} store_=null
+         * @reactive
          */
         store_: null
     }


### PR DESCRIPTION
Resolves #13433

Adds proactive JSDoc type-expression guidance to the coding guidelines, links the docs-build parser lint failure output to that guide, and resolves the `src/sitemap/Component.mjs` single-star member-doc gap by converting the affected config comments to real JSDoc with corrected types/tags.

Evidence: L1 (same catharsis parser gate + docs generation + static diff hygiene) -> L1 required (docs/build guidance and JSDoc source correctness). No residuals.

## Deltas from ticket

- Resolved the sitemap `/*` member-docs gap directly instead of deferring it; also corrected the adjacent `itemHideMode_` member name and `store_` reactive tag while converting those comments.
- Kept the lint scope at `src`, `ai`, `examples`, `apps`, and `docs/app`; the contributing note records that `buildScripts` and `test` stay outside CI scope until a dedicated ticket adds fixtures for that broader surface.

## Test Evidence

- `node ./buildScripts/util/check-jsdoc-types.mjs` -> 1535 files scanned, 0 unparseable type expressions.
- `node --input-type=module -e "import {findUnparseableTypes} from './buildScripts/util/check-jsdoc-types.mjs'; ..."` -> flagged the 3 expected TS-like rejected forms and accepted the spaced union control.
- `node ./buildScripts/util/check-whitespace.mjs .github/CODING_GUIDELINES.md buildScripts/util/check-jsdoc-types.mjs src/sitemap/Component.mjs` -> passed.
- `npm run generate-docs-json` -> completed successfully; no tracked docs-output diff.
- `git diff --check` -> passed.

## Post-Merge Validation

- [ ] Confirm `jsdoc-type-lint` CI remains green on the merged head.

## Commits

- `3dd0af041` — `docs(build): add jsdoc type guidance (#13433)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019eccf2-4ed2-79f2-9f66-fbfc935b4794.