### PR TITLE
feat(agentos): live-mutate the first widget via bounded follow-up edits (#13361)

### DIFF
--- a/apps/agentos/childapps/widget/util/firstWidgetEditModel.mjs
+++ b/apps/agentos/childapps/widget/util/firstWidgetEditModel.mjs
@@ -1,0 +1,69 @@
+/**
+ * @module AgentOSWidget.util.firstWidgetEditModel
+ * @summary The deterministic data model behind a bounded first-widget edit — the single source of the
+ * canonical seed rows and the pure mapping from a parsed edit to a live-grid mutation.
+ *
+ * {@link AgentOSWidget.util.parseEditRequest} is the safe GRAMMAR (text → a typed `edit`); this module is
+ * the safe MODEL (a typed `edit` → a bounded mutation descriptor). Keeping the model pure and free of any
+ * live-component reference means every accepted edit's effect is unit-testable without a controller
+ * harness, and the controller stays a thin applier: it asks this module WHAT to change, then sets exactly
+ * that on the live grid. No data is ever read back off the view, and every produced row is a fresh object
+ * with a unique key — so a mutation can never alias the seed rows or collide store keys.
+ */
+
+/**
+ * The canonical seed rows for the first widget. Used both to seed the bootstrap grid's store and as the
+ * `reset` target, so there is one source of truth for "the sample data". Treated as read-only — callers
+ * receive fresh copies via {@link sampleRows}, never this array.
+ * @type {Object[]}
+ */
+export const firstWidgetRows = [
+    {id: 'intent',   task: 'Verify intent', owner: 'Ada',           evidence: 'Blueprint'},
+    {id: 'render',   task: 'Render grid',   owner: 'Runtime',       evidence: 'Live widget'},
+    {id: 'evidence', task: 'Show evidence', owner: 'Evidence pane', evidence: 'Safe text'}
+];
+
+/**
+ * Builds exactly `count` deterministic rows as FRESH objects with unique `id` keys: the first rows reuse
+ * the canonical seed (so the meaningful rows survive a row-count change), and any beyond the seed are
+ * bounded deterministic filler. Fresh objects + unique ids keep the result safe to hand straight to a
+ * keyed store without aliasing the seed or colliding keys. `count` is already bounded by the grammar.
+ * @param {Number} count how many rows to produce
+ * @returns {Object[]} `count` fresh row objects
+ * @private
+ */
+function sampleRows(count) {
+    return Array.from({length: count}, (_, index) => {
+        const canonical = firstWidgetRows[index];
+
+        return canonical ? {...canonical} : {
+            id      : `row-${index + 1}`,
+            task    : `Sample task ${index + 1}`,
+            owner   : 'Agent',
+            evidence: 'Generated'
+        }
+    })
+}
+
+/**
+ * Maps a parsed, already-validated edit to a bounded live-grid mutation descriptor. Pure: it neither reads
+ * nor touches any live component — the controller applies the returned descriptor to the grid.
+ *
+ * @param {Object} edit a typed edit from {@link AgentOSWidget.util.parseEditRequest}
+ * @param {String} edit.type one of `'rename'` · `'rowCount'` · `'reset'`
+ * @returns {{title: String}|{rows: Object[]}|{}}
+ *   `{title}` for a rename, `{rows}` (fresh objects) for a row-count or reset, or `{}` for an
+ *   unrecognised edit type (defensive — the caller only applies accepted edits).
+ */
+export function resolveWidgetEdit(edit) {
+    switch (edit?.type) {
+        case 'rename':
+            return {title: edit.title};
+        case 'rowCount':
+            return {rows: sampleRows(edit.count)};
+        case 'reset':
+            return {rows: sampleRows(firstWidgetRows.length)}
+    }
+
+    return {}
+}

--- a/apps/agentos/childapps/widget/util/parseEditRequest.mjs
+++ b/apps/agentos/childapps/widget/util/parseEditRequest.mjs
@@ -1,0 +1,83 @@
+/**
+ * @module AgentOSWidget.util.parseEditRequest
+ * @summary Bounded, fail-closed parser for a first-widget follow-up EDIT request.
+ *
+ * After the first widget exists, the chat surface accepts bounded follow-up edits that mutate the
+ * EXISTING widget — not a new one. This is the safe boundary: it accepts only a small DETERMINISTIC edit
+ * grammar over known widget state and fails closed to a `{accepted:false, reason}` state — never
+ * throwing, never letting markup, an overlong payload, an unknown command, or an out-of-bounds value
+ * through. No model invocation, no arbitrary code: a fixed grammar over title / row-count / sample-data,
+ * so the controller can apply only safe, bounded mutations to the live grid.
+ */
+
+/** Max accepted edit length (a follow-up edit is a short instruction). @type {Number} */
+const MAX_REQUEST_LENGTH = 200;
+/** Max accepted title length. @type {Number} */
+const MAX_TITLE_LENGTH = 80;
+/** Inclusive row-count bounds. @type {Number} */
+const MIN_ROWS = 1;
+const MAX_ROWS = 20;
+
+/**
+ * Parses a follow-up edit request into a bounded, fail-closed result.
+ *
+ * @param {String} text the raw user edit text
+ * @returns {{accepted: true, edit: Object}|{accepted: false, reason: String}}
+ *   On success `{accepted:true, edit}` where `edit` is one of:
+ *   `{type:'rename', title:String}` · `{type:'rowCount', count:Number}` · `{type:'reset'}`.
+ *   Otherwise `{accepted:false, reason}` for non-string / empty / overlong / markup / unknown command /
+ *   out-of-bounds input.
+ */
+export function parseEditRequest(text) {
+    if (typeof text !== 'string') {
+        return {accepted: false, reason: 'Edit must be text.'}
+    }
+
+    const trimmed = text.trim();
+
+    if (trimmed.length === 0) {
+        return {accepted: false, reason: 'Edit is empty — type a change.'}
+    }
+
+    if (trimmed.length > MAX_REQUEST_LENGTH) {
+        return {accepted: false, reason: `Edit is too long (max ${MAX_REQUEST_LENGTH} characters).`}
+    }
+
+    if (/[<>]/.test(trimmed)) {
+        return {accepted: false, reason: 'Edit must be plain text (no markup).'}
+    }
+
+    // rename [it] to <title>
+    let match = trimmed.match(/^rename\s+(?:it\s+)?to\s+(.+)$/i);
+    if (match) {
+        const title = match[1].trim();
+
+        if (title.length === 0) {
+            return {accepted: false, reason: 'New title is empty.'}
+        }
+        if (title.length > MAX_TITLE_LENGTH) {
+            return {accepted: false, reason: `Title is too long (max ${MAX_TITLE_LENGTH} characters).`}
+        }
+
+        return {accepted: true, edit: {type: 'rename', title}}
+    }
+
+    // show <n> row(s)
+    match = trimmed.match(/^show\s+(\d+)\s+rows?$/i);
+    if (match) {
+        const count = Number(match[1]);
+
+        if (count < MIN_ROWS || count > MAX_ROWS) {
+            return {accepted: false, reason: `Row count must be between ${MIN_ROWS} and ${MAX_ROWS}.`}
+        }
+
+        return {accepted: true, edit: {type: 'rowCount', count}}
+    }
+
+    // reset [sample] data
+    if (/^reset(?:\s+sample)?\s+data$/i.test(trimmed)) {
+        return {accepted: true, edit: {type: 'reset'}}
+    }
+
+    return {accepted: false, reason: 'Unknown edit. Try "rename it to …", "show N rows", or "reset data".'}
+}

--- a/apps/agentos/childapps/widget/view/EvidencePane.mjs
+++ b/apps/agentos/childapps/widget/view/EvidencePane.mjs
@@ -48,6 +48,14 @@ class EvidencePane extends Container {
          */
         responseSummary_: 'Accepted a bounded grid blueprint and rendered it as a live widget.',
         /**
+         * The latest bounded follow-up edit outcome — an accepted-edit echo or a fail-closed
+         * `Rejected: …` reason. Rendered as a safe text node so neither an applied edit nor a rejection
+         * reason can reach the view as HTML.
+         * @member {String} editOutcome_=''
+         * @reactive
+         */
+        editOutcome_: '',
+        /**
          * The accepted first-widget blueprint. Rendered through `projectBlueprintEvidence`, so only
          * safe scalar metadata reaches the view; invalid input fails closed to a rejected line.
          * @member {Object|null} blueprint_
@@ -68,7 +76,8 @@ class EvidencePane extends Container {
             cls      : ['agent-os-evidence-transcript'],
             vdom     : {cn: [
                 {cls: ['agent-os-evidence-request']},
-                {cls: ['agent-os-evidence-response']}
+                {cls: ['agent-os-evidence-response']},
+                {cls: ['agent-os-evidence-edit-outcome']}
             ]}
         }, {
             ntype    : 'component',
@@ -104,6 +113,22 @@ class EvidencePane extends Container {
 
         if (transcript) {
             transcript.vdom.cn[1].text = value;
+            transcript.update?.()
+        }
+    }
+
+    /**
+     * Triggered after the editOutcome config changed; renders it as a safe text node so an applied-edit
+     * echo or a fail-closed rejection reason can never reach the view as HTML.
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetEditOutcome(value, oldValue) {
+        let transcript = this.getItem('transcript');
+
+        if (transcript) {
+            transcript.vdom.cn[2].text = value;
             transcript.update?.()
         }
     }

--- a/apps/agentos/childapps/widget/view/RequestIntake.mjs
+++ b/apps/agentos/childapps/widget/view/RequestIntake.mjs
@@ -11,6 +11,10 @@ import TextField from '../../../../../src/form/field/Text.mjs';
  * (`maxLength`), the submit routes to the Viewport controller (which validates + projects the request
  * into the evidence state), and the error line below renders any fail-closed reason as safe vdom
  * `text` — never `html` / `innerHTML`, and never executable. Deterministic: no model call here.
+ *
+ * Below the create row, a bounded follow-up EDIT row (a second field + `Edit` submit) routes to the
+ * controller's edit handler, which mutates the EXISTING widget through a small deterministic grammar
+ * (rename / row-count / reset) — the same one chat surface, not a second chat path.
  */
 class RequestIntake extends Container {
     static config = {
@@ -59,6 +63,23 @@ class RequestIntake extends Container {
             reference: 'request-error',
             cls      : ['agent-os-request-error'],
             vdom     : {cn: [{text: ''}]}
+        }, {
+            ntype : 'container',
+            cls   : ['agent-os-edit-row'],
+            layout: {ntype: 'hbox', align: 'stretch'},
+            items : [{
+                module         : TextField,
+                reference      : 'edit-field',
+                flex           : 1,
+                labelText      : 'Edit',
+                placeholderText: 'rename it to … · show 8 rows · reset data',
+                maxLength      : 200
+            }, {
+                module : Button,
+                cls    : ['agent-os-edit-submit'],
+                handler: 'onSubmitEdit',
+                text   : 'Edit'
+            }]
         }]
     }
 }

--- a/apps/agentos/childapps/widget/view/ViewportController.mjs
+++ b/apps/agentos/childapps/widget/view/ViewportController.mjs
@@ -1,7 +1,9 @@
-import Controller          from '../../../../../src/controller/Component.mjs';
-import GridContainer       from '../../../../../src/grid/Container.mjs';
-import {projectCreatedGrid} from '../util/createdGridEvidence.mjs';
-import {validateRequest}    from '../util/validateRequest.mjs';
+import Controller                       from '../../../../../src/controller/Component.mjs';
+import GridContainer                    from '../../../../../src/grid/Container.mjs';
+import {projectCreatedGrid}             from '../util/createdGridEvidence.mjs';
+import {parseEditRequest}               from '../util/parseEditRequest.mjs';
+import {firstWidgetRows, resolveWidgetEdit} from '../util/firstWidgetEditModel.mjs';
+import {validateRequest}                from '../util/validateRequest.mjs';
 
 /**
  * The first widget's grid config. The controller boots it by `add()`-ing it to the stage — the same
@@ -15,6 +17,9 @@ import {validateRequest}    from '../util/validateRequest.mjs';
  */
 const firstWidgetGridConfig = {
     id            : 'first-widget-grid',
+    // the controller resolves the live grid for follow-up edits via this reference (getReference matches
+    // `reference`, not `id`); an external `create_component` grid carries no reference and is unaffected
+    reference     : 'first-widget-grid',
     module        : GridContainer,
     cls           : ['agent-os-first-widget-grid'],
     columnDefaults: {width: 140},
@@ -33,26 +38,27 @@ const firstWidgetGridConfig = {
             {name: 'owner',    type: 'String'},
             {name: 'evidence', type: 'String'}
         ]},
-        data: [
-            {id: 'intent',   task: 'Verify intent', owner: 'Ada',           evidence: 'Blueprint'},
-            {id: 'render',   task: 'Render grid',   owner: 'Runtime',       evidence: 'Live widget'},
-            {id: 'evidence', task: 'Show evidence', owner: 'Evidence pane', evidence: 'Safe text'}
-        ]
+        // the canonical seed rows — the same source the `reset` edit restores (see firstWidgetEditModel)
+        data: firstWidgetRows
     }
 };
 
 /**
  * @class AgentOSWidget.view.ViewportController
  * @extends Neo.controller.Component
- * @summary Creates the first widget through the live create path and projects it into the evidence pane.
+ * @summary Creates the first widget through the live create path, projects it into the evidence pane, and
+ * applies bounded follow-up edits to it.
  *
- * Two responsibilities, one path. On construct it boots the first grid by `add()`-ing it to the stage
+ * One create path, then live mutation. On construct it boots the first grid by `add()`-ing it to the stage
  * container (the same `add → insert` path a Neural-Link `create_component` drives), so the live grid is
  * created through the stage insert seam rather than declared as a static item. It then observes the stage's
  * `insert` event — fired for that bootstrap AND for any later external `create_component` into the same
  * stage — and projects the inserted grid into the evidence pane via {@link projectCreatedGrid},
  * so the evidence always describes the grid that was inserted into the stage, not a hand-authored
- * blueprint. It also keeps the deterministic chat-intake submit handling. No model invocation / persistence.
+ * blueprint. After the widget exists, {@link onSubmitEdit} accepts a bounded follow-up edit grammar
+ * (rename / row-count / reset) and mutates the SAME live grid — never a replacement — then re-projects it
+ * from {@link projectCreatedGrid} so the evidence reflects the actual mutated state. It also keeps the
+ * deterministic chat-intake submit handling. No model invocation / persistence / git / admin tools.
  */
 class ViewportController extends Controller {
     static config = {
@@ -110,6 +116,80 @@ class ViewportController extends Controller {
 
         error.vdom.cn[0].text = result.accepted ? '' : result.reason;
         error.update()
+    }
+
+    /**
+     * Triggered by the follow-up edit submit button. Parses the edit field through the bounded
+     * {@link parseEditRequest} grammar and, on an accepted edit, mutates the EXISTING live first-widget
+     * grid (never a replacement), then re-projects it into the evidence pane via {@link projectCreatedGrid}
+     * so the evidence reflects the actual mutated state. An unaccepted edit — unknown command, overlong /
+     * markup input, out-of-bounds value, or a missing prerequisite widget — fails closed to a bounded
+     * rejected outcome line; the live grid is left untouched. Edit outcomes (accepted and rejected) render
+     * as safe text in the evidence pane's transcript, never as HTML.
+     * @param {Object} data
+     * @protected
+     */
+    onSubmitEdit(data) {
+        let me       = this,
+            field    = me.getReference('edit-field'),
+            evidence = me.getReference('evidence-pane'),
+            grid     = me.getReference('first-widget-grid'),
+            result   = parseEditRequest(field.value);
+
+        if (!result.accepted) {
+            evidence.editOutcome = `Rejected: ${result.reason}`;
+            return
+        }
+
+        // missing prerequisite widget state — fail closed without touching anything
+        if (!grid?.store) {
+            evidence.editOutcome = 'Rejected: no widget to edit yet.';
+            return
+        }
+
+        me.applyWidgetEdit(grid, result.edit);
+        evidence.blueprint   = projectCreatedGrid(grid);
+        evidence.editOutcome = me.describeEdit(result.edit)
+    }
+
+    /**
+     * Applies a bounded mutation descriptor — resolved purely by {@link resolveWidgetEdit} — to the live
+     * grid: a title relabel (read back by the evidence projection) and/or a full store-data replacement
+     * (the canonical seed for `reset`, deterministic sample rows for `rowCount`). Only the two bounded
+     * mutation keys are honoured; nothing else on the grid is touched.
+     * @param {Neo.grid.Container} grid the live first-widget grid
+     * @param {Object} edit the accepted, typed edit
+     * @protected
+     */
+    applyWidgetEdit(grid, edit) {
+        const mutation = resolveWidgetEdit(edit);
+
+        if ('title' in mutation) {
+            grid.title = mutation.title
+        }
+        if ('rows' in mutation) {
+            grid.store.data = mutation.rows
+        }
+    }
+
+    /**
+     * Deterministic, human-readable echo of an applied edit for the evidence transcript. Rendered as a
+     * safe text node; the title has already passed the grammar's plain-text + length bounds.
+     * @param {Object} edit the accepted, typed edit
+     * @returns {String}
+     * @protected
+     */
+    describeEdit(edit) {
+        switch (edit.type) {
+            case 'rename':
+                return `Renamed the widget to "${edit.title}".`;
+            case 'rowCount':
+                return `Updated the widget to show ${edit.count} rows.`;
+            case 'reset':
+                return 'Reset the widget to its sample data.'
+        }
+
+        return ''
     }
 }
 

--- a/test/playwright/e2e/FirstWidgetEditGrammar.spec.mjs
+++ b/test/playwright/e2e/FirstWidgetEditGrammar.spec.mjs
@@ -1,0 +1,72 @@
+import {test, expect} from '../fixtures.mjs';
+
+/**
+ * @summary H2 live-mutate proof: bounded follow-up edits change the EXISTING first widget in place and the
+ * evidence pane reflects the actual mutated state — closing the "live-mutable, not generated once" gap.
+ *
+ * Drives the real follow-up edit surface against a live app (no stubs): type an edit → submit → the SAME
+ * first-widget grid and its evidence re-render. Each accepted edit is asserted against the grid's
+ * re-projected store/title truth (not a loose match): `show 8 rows` grows the live grid + the evidence Rows
+ * count; `rename` relabels the evidence Title; an unknown command fails closed to a `Rejected:` outcome
+ * with the grid left untouched; `reset` restores the seed. A no-op submit or a replacement-widget path must
+ * fail these assertions.
+ *
+ * @see apps/agentos/childapps/widget/view/ViewportController.mjs
+ * @see apps/agentos/childapps/widget/util/parseEditRequest.mjs
+ * @see apps/agentos/childapps/widget/util/firstWidgetEditModel.mjs
+ */
+test.describe('AgentOS first widget — bounded follow-up edits (H2 live mutation)', () => {
+    test.setTimeout(90000);
+    test.use({viewport: {width: 1280, height: 720}});
+
+    test('accepted edits mutate the live grid + evidence; unknown edits fail closed', async ({page}) => {
+        await page.goto('/apps/agentos/childapps/widget/index.html');
+
+        const
+            editField    = page.locator('.agent-os-edit-row input'),
+            editButton   = page.locator('.agent-os-edit-submit'),
+            outcome      = page.locator('.agent-os-evidence-edit-outcome'),
+            // VISIBLE cells only — the grid recycles a row pool and hides surplus rows (`display:none`)
+            // rather than removing them, so a count/content assertion must ignore the hidden pool nodes
+            cells        = page.locator('.agent-os-first-widget-grid .neo-grid-cell:visible'),
+            evidenceMeta = page.locator('.agent-os-evidence-meta dd'); // [schema, title, columns, rows]
+
+        // baseline: the bootstrap grid rendered (3 seed rows × 4 cols) and the evidence reflects it
+        await expect(editField).toBeVisible({timeout: 30000});
+        await expect(cells).toHaveCount(12, {timeout: 30000});
+        await expect(evidenceMeta.nth(3)).toHaveText('3'); // Rows
+        await expect(evidenceMeta.nth(1)).toHaveText('first-widget-grid'); // Title (grid.id fallback)
+
+        // accepted grid-shape edit: the SAME grid grows to 8 rows; store-truth re-projects into evidence
+        await editField.fill('show 8 rows');
+        await editButton.click();
+        await expect(evidenceMeta.nth(3)).toHaveText('8', {timeout: 15000}); // Rows — store.count, re-projected
+        await expect(cells).toHaveCount(32); // 8 rows × 4 cols, rendered in place
+        await expect(cells.filter({hasText: 'Sample task 4'})).toHaveCount(1); // a row beyond the seed rendered
+        await expect(outcome).toContainText('show 8 rows');
+
+        // accepted label edit: the live grid's title relabels; evidence Title reflects the live read
+        await editField.fill('rename it to Q3 Metrics');
+        await editButton.click();
+        await expect(evidenceMeta.nth(1)).toHaveText('Q3 Metrics', {timeout: 15000});
+        await expect(outcome).toContainText('Q3 Metrics');
+        await expect(evidenceMeta.nth(3)).toHaveText('8'); // row count unchanged by a rename
+
+        // unknown command fails closed: a Rejected outcome, and the live grid is left untouched
+        await editField.fill('delete everything');
+        await editButton.click();
+        await expect(outcome).toContainText(/Rejected.*Unknown edit/i, {timeout: 15000});
+        await expect(evidenceMeta.nth(3)).toHaveText('8');          // rows untouched
+        await expect(evidenceMeta.nth(1)).toHaveText('Q3 Metrics'); // title untouched
+        await expect(cells).toHaveCount(32);
+
+        // reset restores the canonical seed rows in place — the grid visibly shrinks back to 3 rows
+        await editField.fill('reset data');
+        await editButton.click();
+        await expect(evidenceMeta.nth(3)).toHaveText('3', {timeout: 15000});
+        await expect(cells).toHaveCount(12); // back to 3 visible rows × 4 cols (surplus rows hidden)
+        await expect(cells.filter({hasText: 'Verify intent'})).toHaveCount(1);   // a canonical seed row is back
+        await expect(cells.filter({hasText: 'Sample task 4'})).toHaveCount(0);   // generated filler no longer visible
+        await expect(outcome).toContainText('Reset the widget')
+    });
+});

--- a/test/playwright/unit/apps/agentos/childapps/widget/util/firstWidgetEditModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/util/firstWidgetEditModel.spec.mjs
@@ -1,0 +1,84 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'FirstWidgetEditModelTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Unit coverage for the pure first-widget edit MODEL — the mapping from a parsed edit to a
+ * bounded live-grid mutation descriptor.
+ *
+ * Verifies the deterministic shape the controller applies to the live grid: a `rename` maps to a `{title}`
+ * descriptor; a `rowCount` / `reset` maps to a `{rows}` descriptor of FRESH row objects with unique keys
+ * (so a mutation can never alias the seed rows or collide store keys); the canonical seed rows survive a
+ * row-count change; and an unrecognised edit maps to an empty (no-op) descriptor. This is the unit half of
+ * the live-mutate proof — the render smoke proves it reaches the live grid + evidence pane.
+ *
+ * @see apps/agentos/childapps/widget/util/firstWidgetEditModel.mjs
+ */
+test.describe('AgentOSWidget.util.firstWidgetEditModel', () => {
+    let firstWidgetRows, resolveWidgetEdit;
+
+    test.beforeAll(async () => {
+        ({firstWidgetRows, resolveWidgetEdit} = await import('../../../../../../../../apps/agentos/childapps/widget/util/firstWidgetEditModel.mjs'))
+    });
+
+    test('maps a rename edit to a title descriptor', () => {
+        expect(resolveWidgetEdit({type: 'rename', title: 'Q3 Metrics'})).toEqual({title: 'Q3 Metrics'})
+    });
+
+    test('maps a row-count edit to exactly that many fresh rows with unique keys', () => {
+        const {rows} = resolveWidgetEdit({type: 'rowCount', count: 8});
+
+        expect(Array.isArray(rows)).toBe(true);
+        expect(rows.length).toBe(8);
+        // unique keys — a keyed store must not collide
+        expect(new Set(rows.map(row => row.id)).size).toBe(8);
+        // every row carries the full field shape
+        for (const row of rows) {
+            expect(typeof row.id).toBe('string');
+            expect(typeof row.task).toBe('string');
+            expect(typeof row.owner).toBe('string');
+            expect(typeof row.evidence).toBe('string')
+        }
+        // the canonical seed rows survive a row-count change (first rows are the meaningful ones)
+        expect(rows[0].id).toBe('intent');
+        expect(rows[1].id).toBe('render');
+        expect(rows[2].id).toBe('evidence')
+    });
+
+    test('maps a reset edit to the canonical seed rows', () => {
+        const {rows} = resolveWidgetEdit({type: 'reset'});
+
+        expect(rows.length).toBe(firstWidgetRows.length);
+        expect(rows.map(row => row.id)).toEqual(firstWidgetRows.map(row => row.id))
+    });
+
+    test('returns FRESH row objects — never an alias of the seed rows', () => {
+        const {rows} = resolveWidgetEdit({type: 'reset'});
+
+        rows.forEach((row, index) => expect(row).not.toBe(firstWidgetRows[index]));
+        // mutating a produced row must not bleed into the shared seed
+        rows[0].task = 'mutated';
+        expect(firstWidgetRows[0].task).toBe('Verify intent')
+    });
+
+    test('maps an unrecognised edit to an empty no-op descriptor', () => {
+        expect(resolveWidgetEdit({type: 'nope'})).toEqual({});
+        expect(resolveWidgetEdit(null)).toEqual({});
+        expect(resolveWidgetEdit(undefined)).toEqual({})
+    })
+});

--- a/test/playwright/unit/apps/agentos/childapps/widget/util/parseEditRequest.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/widget/util/parseEditRequest.spec.mjs
@@ -1,0 +1,93 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'ParseEditRequestTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Unit coverage for the fail-closed first-widget follow-up EDIT grammar.
+ *
+ * Verifies the safe boundary the H2 live-mutate surface relies on: a bounded deterministic grammar
+ * (rename / show N rows / reset data) is accepted into a typed `edit`; everything else — non-string,
+ * empty, overlong, markup, unknown command, out-of-bounds row count, empty / overlong title — fails
+ * closed to a bounded `{accepted:false, reason}` state, so no unvalidated payload or arbitrary command
+ * can reach the live-widget mutation path.
+ *
+ * @see apps/agentos/childapps/widget/util/parseEditRequest.mjs
+ */
+test.describe('AgentOSWidget.util.parseEditRequest', () => {
+    let parseEditRequest;
+
+    test.beforeAll(async () => {
+        ({parseEditRequest} = await import('../../../../../../../../apps/agentos/childapps/widget/util/parseEditRequest.mjs'))
+    });
+
+    test('accepts the rename edit (label)', () => {
+        expect(parseEditRequest('rename it to Q3 Metrics')).toEqual({accepted: true, edit: {type: 'rename', title: 'Q3 Metrics'}});
+        expect(parseEditRequest('rename to Tasks')).toEqual({accepted: true, edit: {type: 'rename', title: 'Tasks'}})
+    });
+
+    test('accepts the row-count edit (grid shape)', () => {
+        expect(parseEditRequest('show 8 rows')).toEqual({accepted: true, edit: {type: 'rowCount', count: 8}});
+        expect(parseEditRequest('show 1 row')).toEqual({accepted: true, edit: {type: 'rowCount', count: 1}})
+    });
+
+    test('accepts the reset-data edit', () => {
+        expect(parseEditRequest('reset data')).toEqual({accepted: true, edit: {type: 'reset'}});
+        expect(parseEditRequest('reset sample data')).toEqual({accepted: true, edit: {type: 'reset'}})
+    });
+
+    test('is case-insensitive and whitespace-tolerant', () => {
+        expect(parseEditRequest('  RENAME IT TO Foo  ')).toEqual({accepted: true, edit: {type: 'rename', title: 'Foo'}});
+        expect(parseEditRequest('Show 5 Rows')).toEqual({accepted: true, edit: {type: 'rowCount', count: 5}})
+    });
+
+    test('fails closed on out-of-bounds row count', () => {
+        for (const bad of ['show 0 rows', 'show 21 rows', 'show 999 rows']) {
+            const result = parseEditRequest(bad);
+            expect(result.accepted).toBe(false);
+            expect(result.reason).toMatch(/between 1 and 20/i)
+        }
+    });
+
+    test('fails closed on an empty or overlong rename title', () => {
+        expect(parseEditRequest('rename it to    ').accepted).toBe(false);
+        const overlong = parseEditRequest(`rename it to ${'x'.repeat(81)}`);
+        expect(overlong.accepted).toBe(false);
+        expect(overlong.reason).toMatch(/too long/i)
+    });
+
+    test('fails closed on an unknown command', () => {
+        for (const bad of ['delete everything', 'make it blue', 'drop table', 'add 3 columns']) {
+            const result = parseEditRequest(bad);
+            expect(result.accepted).toBe(false);
+            expect(result.reason).toMatch(/unknown edit/i)
+        }
+    });
+
+    test('fails closed on non-string / empty / overlong / markup input', () => {
+        for (const bad of [null, undefined, 42, {}, []]) {
+            expect(parseEditRequest(bad).accepted).toBe(false)
+        }
+        expect(parseEditRequest('   ').accepted).toBe(false);
+        expect(parseEditRequest('show ' + 'x'.repeat(201)).accepted).toBe(false);
+
+        // markup must never reach the mutation path, even on an otherwise-valid-looking command
+        const markup = parseEditRequest('rename it to <b>x</b>');
+        expect(markup.accepted).toBe(false);
+        expect(markup.reason).toMatch(/plain text|markup/i)
+    })
+});


### PR DESCRIPTION
Resolves #13361

The H2 live-mutate capstone: a follow-up **Edit** request (rename / row-count / reset) mutates the **existing** first-widget grid in place — the keeper "request → live widget → use / continue" loop — with accepted/rejected echoes surfaced as safe text in the evidence inspector. Bounded + fail-closed: unknown / overlong / markup / out-of-bounds / missing-widget all reject without mutating. No LLM, no persistence, no git/admin-NL, no Electron — a deterministic edit grammar over the existing `add → insert` seam.

Builds on the merged H2 loop (#13409 / #13416 / #13437 create→evidence + #13442 external-NL proof). Per the #13445 cockpit reclassification, the EvidencePane's role here is the provenance / edit-echo **inspector** (keeper = the live widget); this PR does not center EvidencePane as product chrome.

Evidence: L3 (fresh-`:8080` Chromium e2e — accepted edits mutate visible grid cells + re-projected evidence; unknown edits fail closed) + L1 (pure-logic unit). The e2e is local-validated (Neo e2e is outside the CI gate — `test.yml` = integration + unit); the unit specs ARE CI-gated. No residual ACs.

## Deltas from ticket
None. All ACs met: ≥2 deterministic edits (rename label + row-count shape) + reset; fail-closed on unknown / overlong / markup / out-of-bounds / missing-widget; accepted + rejected reflected in the evidence surface as safe text; mutates the existing grid (no replacement, no 2nd demo path); unit coverage + render smoke. Contract Ledger is on the #13361 ticket body (the bounded edit-grammar surface).

## Test Evidence
- `UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs firstWidgetEditModel parseEditRequest` → **13 passed** (5 model + 8 parser), 977ms.
- `playwright test -c test/playwright/playwright.config.e2e.mjs FirstWidgetEditGrammar` (prior `:8080` killed → fresh server) → **1 passed**, 1.9s (grow 3→8 + rename→`Q3 Metrics` + reject `delete everything` fail-closed + reset→3, all asserted on visible grid cells + re-projected evidence).

## Commits
- `1f8f70dd4` — bounded fail-closed edit grammar (`parseEditRequest` + spec)
- `c7769d40f` — controller wiring (`onSubmitEdit` / `applyWidgetEdit`) + `firstWidgetEditModel` + EvidencePane edit-echo + e2e

## Post-Merge Validation
- [ ] CI re-runs the unit specs green (the e2e is local-only per Neo's CI posture).

Authored by Ada (Claude Opus 4.8, Claude Code). Session c94823b9-7756-4a7f-99af-78a097e28b28 (lands a prior Ada-session built increment).
