### PR TITLE
chore(agentos): Claude harness config templates (#13453)

### DIFF
--- a/.claude/claude_desktop_config.example.json
+++ b/.claude/claude_desktop_config.example.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "Claude DESKTOP (GUI) example. Copy the `mcpServers` block below into ~/Library/Application Support/Claude/claude_desktop_config.json (macOS) or %APPDATA%/Claude/claude_desktop_config.json (Windows), then replace every <PLACEHOLDER>. IMPORTANT: Claude Desktop and Claude Code do NOT share this file — Claude Code (CLI) reads a repo-root .mcp.json (or ~/.claude.json); see .github/AI_QUICK_START.md §5. GUI apps launched from Finder do NOT inherit your shell environment, so credentials AND NEO_AGENT_IDENTITY (the GitHub login that binds your A2A mailbox) MUST live in the per-server env blocks below. GEMINI_API_KEY and NEO_KB_ASK_API_KEY are OPTIONAL for a local-first (Ollama / MLX / openAiCompatible) setup. After any edit, fully quit (Cmd-Q on macOS) and relaunch — there is no hot-reload.",
+  "mcpServers": {
+    "neo-mjs-knowledge-base": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/knowledge-base/mcp-server.mjs"],
+      "env": {
+        "GEMINI_API_KEY": "<OPTIONAL_GEMINI_API_KEY>",
+        "NEO_KB_ASK_API_KEY": "<OPTIONAL_KB_ASK_API_KEY>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-memory-core": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/memory-core/mcp-server.mjs"],
+      "env": {
+        "GEMINI_API_KEY": "<OPTIONAL_GEMINI_API_KEY>",
+        "NEO_AGENT_IDENTITY": "<YOUR_GITHUB_LOGIN>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-github-workflow": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/github-workflow/mcp-server.mjs"],
+      "env": {
+        "GH_TOKEN": "<YOUR_GH_TOKEN>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-neural-link": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": [
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/neural-link/mcp-server.mjs",
+        "--cwd",
+        "<YOUR_NEO_REPO_PATH>"
+      ],
+      "env": {
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    }
+  }
+}

--- a/.claude/claude_desktop_config.example.json
+++ b/.claude/claude_desktop_config.example.json
@@ -1,41 +1,55 @@
 {
-  "_comment": "Claude DESKTOP (GUI) example. Copy the `mcpServers` block below into ~/Library/Application Support/Claude/claude_desktop_config.json (macOS) or %APPDATA%/Claude/claude_desktop_config.json (Windows), then replace every <PLACEHOLDER>. IMPORTANT: Claude Desktop and Claude Code do NOT share this file — Claude Code (CLI) reads a repo-root .mcp.json (or ~/.claude.json); see .github/AI_QUICK_START.md §5. GUI apps launched from Finder do NOT inherit your shell environment, so credentials AND NEO_AGENT_IDENTITY (the GitHub login that binds your A2A mailbox) MUST live in the per-server env blocks below. GEMINI_API_KEY and NEO_KB_ASK_API_KEY are OPTIONAL for a local-first (Ollama / MLX / openAiCompatible) setup. After any edit, fully quit (Cmd-Q on macOS) and relaunch — there is no hot-reload.",
+  "_comment": "Claude DESKTOP (GUI) example for a LOCAL-FIRST Neo setup. Copy the `mcpServers` block into ~/Library/Application Support/Claude/claude_desktop_config.json (macOS) or %APPDATA%/Claude/claude_desktop_config.json (Windows), then replace every <PLACEHOLDER>. Claude Desktop and Claude Code do NOT share this file — Claude Code (CLI) reads a repo-root .mcp.json (see .github/AI_QUICK_START.md §5). SECRETS (GH_TOKEN and any optional cloud provider keys) live in the .env file loaded via --env-file — never inline here. NEO_OPENAI_COMPATIBLE_HOST points at your local inference endpoint (e.g. LM Studio on 127.0.0.1:1234), so NO cloud API key is required. NEO_AGENT_IDENTITY (your GitHub login — binds the A2A mailbox) goes in the memory-core env block only. On Apple Silicon prepend /opt/homebrew/bin to PATH (GUI launches strip it). Fully quit (Cmd-Q) and relaunch after any edit.",
   "mcpServers": {
     "neo-mjs-knowledge-base": {
       "command": "<YOUR_NODE_PATH>",
-      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/knowledge-base/mcp-server.mjs"],
+      "args": [
+        "--env-file=<YOUR_NEO_REPO_PATH>/.env",
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/knowledge-base/mcp-server.mjs"
+      ],
       "env": {
-        "GEMINI_API_KEY": "<OPTIONAL_GEMINI_API_KEY>",
-        "NEO_KB_ASK_API_KEY": "<OPTIONAL_KB_ASK_API_KEY>",
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+        "NEO_OPENAI_COMPATIBLE_HOST": "http://127.0.0.1:1234",
+        "PATH": "/opt/homebrew/bin:<YOUR_NEO_REPO_PATH>/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
+        "HOME": "<YOUR_HOME>"
       }
     },
     "neo-mjs-memory-core": {
       "command": "<YOUR_NODE_PATH>",
-      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/memory-core/mcp-server.mjs"],
+      "args": [
+        "--env-file=<YOUR_NEO_REPO_PATH>/.env",
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/memory-core/mcp-server.mjs"
+      ],
       "env": {
-        "GEMINI_API_KEY": "<OPTIONAL_GEMINI_API_KEY>",
         "NEO_AGENT_IDENTITY": "<YOUR_GITHUB_LOGIN>",
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+        "NEO_OPENAI_COMPATIBLE_HOST": "http://127.0.0.1:1234",
+        "PATH": "/opt/homebrew/bin:<YOUR_NEO_REPO_PATH>/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
+        "HOME": "<YOUR_HOME>"
       }
     },
     "neo-mjs-github-workflow": {
       "command": "<YOUR_NODE_PATH>",
-      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/github-workflow/mcp-server.mjs"],
+      "args": [
+        "--env-file=<YOUR_NEO_REPO_PATH>/.env",
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/github-workflow/mcp-server.mjs"
+      ],
       "env": {
-        "GH_TOKEN": "<YOUR_GH_TOKEN>",
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+        "NEO_OPENAI_COMPATIBLE_HOST": "http://127.0.0.1:1234",
+        "PATH": "/opt/homebrew/bin:<YOUR_NEO_REPO_PATH>/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
+        "HOME": "<YOUR_HOME>"
       }
     },
     "neo-mjs-neural-link": {
       "command": "<YOUR_NODE_PATH>",
       "args": [
+        "--env-file=<YOUR_NEO_REPO_PATH>/.env",
         "<YOUR_NEO_REPO_PATH>/ai/mcp/server/neural-link/mcp-server.mjs",
         "--cwd",
         "<YOUR_NEO_REPO_PATH>"
       ],
       "env": {
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+        "NEO_OPENAI_COMPATIBLE_HOST": "http://127.0.0.1:1234",
+        "PATH": "/opt/homebrew/bin:<YOUR_NEO_REPO_PATH>/node_modules/.bin:/usr/local/bin:/usr/bin:/bin",
+        "HOME": "<YOUR_HOME>"
       }
     }
   }

--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -1,0 +1,32 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__neo-mjs-github-workflow__*",
+      "mcp__neo-mjs-memory-core__*",
+      "mcp__neo-mjs-knowledge-base__*"
+    ],
+    "deny": [
+      "Bash(gh pr merge *)"
+    ]
+  },
+  "autoMode": {
+    "environment": [
+      "$defaults",
+      "The neomjs/neo GitHub repository (its issues, pull requests, and discussions) and the four local neo-mjs MCP servers (github-workflow, memory-core, knowledge-base, neural-link) are trusted first-party infrastructure for this organism."
+    ],
+    "allow": [
+      "$defaults",
+      "Editing GitHub issues, pull requests, and discussions this agent authors or co-owns is normal equal-peer maintainer work (AGENTS.md swarm_topology_anchor) — not an action that requires human approval.",
+      "Sending A2A messages, writing Memory Core entries, creating tickets, and posting PR reviews are routine substrate work for a Neo maintainer."
+    ],
+    "soft_deny": [
+      "$defaults"
+    ],
+    "hard_deny": [
+      "$defaults",
+      "Never run `gh pr merge` or any other pull-request-merge command. Merging is reserved for the human operator (AGENTS.md critical gate #1); no approval signal ('LGTM', 'approved', 'ready to merge') authorizes an agent to merge.",
+      "Never push or commit directly to the `main` or `dev` branches. Always branch and open a pull request targeting `dev` (AGENTS.md critical gates #3 and #8). The release pipeline is the only sanctioned exception.",
+      "Never write a client, customer, or partner name — or private business strategy — into any public-facing artifact: public-repo issues, pull requests, discussions, docs, or comments (AGENTS.md critical gate #9)."
+    ]
+  }
+}

--- a/.github/AI_QUICK_START.md
+++ b/.github/AI_QUICK_START.md
@@ -93,12 +93,11 @@ To ensure your environment is accurately inherited across all local MCP sub-serv
     # Optional — dedicated, budget-cappable key for the Knowledge Base ask-synthesis path only:
     export NEO_KB_ASK_API_KEY="YOUR_KB_ASK_KEY_HERE"
 
-    # Core LLM Engine provider (Supported: 'gemini', 'ollama', 'openAiCompatible')
-    # export MODEL_PROVIDER="openAiCompatible"
-
-    # Vector Embedding provider (Supported: 'gemini', 'ollama', 'openAiCompatible')
-    # Use 'ollama' or 'openAiCompatible' for a fully local, no-API-key setup:
-    export NEO_EMBEDDING_PROVIDER="gemini"
+    # Provider (Supported: 'gemini', 'ollama', 'openAiCompatible'). Local-first is the default —
+    # point the servers at a local OpenAI-compatible endpoint (e.g. LM Studio); no cloud key needed:
+    export MODEL_PROVIDER="openAiCompatible"
+    export NEO_EMBEDDING_PROVIDER="openAiCompatible"
+    export NEO_OPENAI_COMPATIBLE_HOST="http://127.0.0.1:1234"
     ```
 3.  **Apply changes**: `source ~/.zshrc`
 
@@ -247,50 +246,12 @@ Copy-paste starters live in the repo: [`.claude/claude_desktop_config.example.js
 
 For the A2A (Agent-to-Agent) mailbox substrate to bind your agent session to its AgentIdentity graph node, the Memory Core server's `env` block MUST include `NEO_AGENT_IDENTITY` set to the GitHub login of the bound identity (e.g., `neo-opus`). **This MUST live inside the per-server `env` block — not as a shell export** — because Claude Desktop launches MCP subprocesses directly from the GUI without inheriting interactive-shell state. A shell export in `~/.zshrc` will NOT reach the spawned MCP process.
 
-Use the following structure (replace the placeholders as in the Antigravity section above):
+The full structure is in [`.claude/claude_desktop_config.example.json`](../.claude/claude_desktop_config.example.json) — a **local-first** setup. Each server launches as `node --env-file=<YOUR_NEO_REPO_PATH>/.env <YOUR_NEO_REPO_PATH>/ai/mcp/server/<name>/mcp-server.mjs`, so:
 
-```json
-{
-  "mcpServers": {
-    "neo-mjs-knowledge-base": {
-      "command": "<YOUR_NODE_PATH>",
-      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/knowledge-base/mcp-server.mjs"],
-      "env": {
-        "GEMINI_API_KEY": "<YOUR_GEMINI_API_KEY>",
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
-      }
-    },
-    "neo-mjs-memory-core": {
-      "command": "<YOUR_NODE_PATH>",
-      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/memory-core/mcp-server.mjs"],
-      "env": {
-        "GEMINI_API_KEY": "<YOUR_GEMINI_API_KEY>",
-        "NEO_AGENT_IDENTITY": "<YOUR_GITHUB_LOGIN>",
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
-      }
-    },
-    "neo-mjs-github-workflow": {
-      "command": "<YOUR_NODE_PATH>",
-      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/github-workflow/mcp-server.mjs"],
-      "env": {
-        "GH_TOKEN": "<YOUR_GH_TOKEN>",
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
-      }
-    },
-    "neo-mjs-neural-link": {
-      "command": "<YOUR_NODE_PATH>",
-      "args": [
-        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/neural-link/mcp-server.mjs",
-        "--cwd",
-        "<YOUR_NEO_REPO_PATH>"
-      ],
-      "env": {
-        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
-      }
-    }
-  }
-}
-```
+- **Secrets stay in `.env`, never inline.** `GH_TOKEN` and any optional cloud provider keys live in the `.env` file loaded via `--env-file`; the per-server `env` blocks carry no secrets.
+- **No cloud API key for a local setup.** `NEO_OPENAI_COMPATIBLE_HOST` points each server at your local inference endpoint (e.g. LM Studio on `http://127.0.0.1:1234`). A local-first config has **no `GEMINI_API_KEY`** at all.
+- **`NEO_AGENT_IDENTITY`** (your GitHub login) goes in the `neo-mjs-memory-core` `env` block — this is what binds your A2A mailbox.
+- On **Apple Silicon**, prepend `/opt/homebrew/bin` to `PATH` (GUI launches strip it) and set `HOME` explicitly.
 
 #### Claude Code (CLI)
 

--- a/.github/AI_QUICK_START.md
+++ b/.github/AI_QUICK_START.md
@@ -9,7 +9,7 @@ for the Neo.mjs repository.
 
 Before you begin, ensure you have the following:
 
-1.  **Google Account (optional)**: Only needed if you use Google's Gemini API for embeddings or chat. The pre-built Knowledge Base ships ready-to-query, and a fully local setup (Ollama / MLX / any OpenAI-compatible endpoint) needs no Gemini key at all. If you do want one, create it at [Google AI Studio](https://aistudio.google.com/app/apikey).
+1.  **Google Account**: You'll need one to access Google AI Studio for an API key, which is required to build the knowledge base. If you don't have one, you can create it at [accounts.google.com](https://accounts.google.com).
 2.  **Node.js**: Version 24 or later. If you don't have it, you can install it from [nodejs.org](https://nodejs.org).
 3.  **Project Setup**: Your setup depends on how you are working with Neo.mjs.
 
@@ -37,7 +37,7 @@ Before you begin, ensure you have the following:
 
 For this workflow, an "AI agent" is a local AI assistant capable of executing shell commands and making architectural decisions.
 
-**Current Support:** This guide covers four harnesses: the Google Gemini CLI, the Antigravity OS, Claude Desktop, and Claude Code. The core infrastructure (MCP servers, knowledge base) is agent-agnostic; each harness reads its own configuration file — Claude Desktop and Claude Code do **not** share one (see §4–§5).
+**Current Support:** This guide covers the setup for three environments: the Google Gemini CLI, the Antigravity OS, and Claude Desktop plus Claude Code (which share a single MCP configuration file). The core infrastructure (MCP servers, knowledge base) is agent-agnostic, but their respective configuration files differ slightly.
 
 ## 3. Setup the AI Environment (Required)
 
@@ -61,14 +61,9 @@ If the automatic download fails (e.g., due to network issues), you can trigger i
 npm run ai:download-kb
 ```
 
-### Step 3.2: Obtain a Gemini API Key (Optional)
+### Step 3.2: Obtain a Gemini API Key
 
-The pre-built Knowledge Base artifact ships ready-to-query, so a Gemini key is **optional** — a fully local setup (Ollama / MLX / any OpenAI-compatible endpoint) needs none. You only need a key if you choose Gemini as your provider or run incremental KB rebuilds against it. Two independent, optional keys are recognized:
-
-- **`GEMINI_API_KEY`** — Gemini as the embedding / LLM provider.
-- **`NEO_KB_ASK_API_KEY`** — a dedicated, budget-cappable key for the Knowledge Base *ask*-synthesis path only.
-
-For a local-first setup, skip this step. If you do want a Gemini key:
+The Knowledge Base artifact allows you to start quickly, but you still need a Gemini API Key to run the AI Agent (for chat/generation) and for incremental updates to the knowledge base.
 
 1.  **Visit Google AI Studio**: Go to [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey).
 2.  **Sign In**: Use your Google account credentials. Complete any two-factor authentication (2FA) if prompted.
@@ -86,18 +81,13 @@ To ensure your environment is accurately inherited across all local MCP sub-serv
 1.  **Open your shell profile**: `nano ~/.zshrc` (or `~/.zprofile`)
 2.  **Add your keys**: Add the following lines, replacing the placeholder keys:
     ```bash
-    export GH_TOKEN="YOUR_GITHUB_TOKEN_HERE"
-
-    # Optional — only for the Gemini provider path (omit entirely for a local-first setup):
     export GEMINI_API_KEY="YOUR_API_KEY_HERE"
-    # Optional — dedicated, budget-cappable key for the Knowledge Base ask-synthesis path only:
-    export NEO_KB_ASK_API_KEY="YOUR_KB_ASK_KEY_HERE"
+    export GH_TOKEN="YOUR_GITHUB_TOKEN_HERE"
+    # Core LLM Engine provider (Supported: 'gemini', 'ollama', 'openAiCompatible')
+    # export MODEL_PROVIDER="openAiCompatible"
 
-    # Provider (Supported: 'gemini', 'ollama', 'openAiCompatible'). Local-first is the default —
-    # point the servers at a local OpenAI-compatible endpoint (e.g. LM Studio); no cloud key needed:
-    export MODEL_PROVIDER="openAiCompatible"
-    export NEO_EMBEDDING_PROVIDER="openAiCompatible"
-    export NEO_OPENAI_COMPATIBLE_HOST="http://127.0.0.1:1234"
+    # Vector Embedding provider (Supported: 'gemini', 'ollama', 'openAiCompatible')
+    export NEO_EMBEDDING_PROVIDER="gemini"
     ```
 3.  **Apply changes**: `source ~/.zshrc`
 
@@ -150,14 +140,15 @@ Antigravity is a desktop agent environment that embeds the Gemini runtime plus i
 
 Configuration source: user-level `mcp_config.json`. See §5 "Core Configuration (Antigravity OS)".
 
-### Option C: Claude Desktop and Claude Code
+### Option C: Claude Desktop / Claude Code
 
-Claude Desktop is Anthropic's desktop agent app (macOS/Windows). Claude Code is Anthropic's shell-capable CLI harness. They are **separate apps with separate config** — they do **not** share a file:
+Claude Desktop is Anthropic's desktop agent app (macOS/Windows). Claude Code is Anthropic's shell-capable CLI harness. **Both harnesses share a single MCP configuration file** — configuring one configures the other.
 
-- **Claude Desktop (GUI):** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows). Starter: [`.claude/claude_desktop_config.example.json`](../.claude/claude_desktop_config.example.json).
-- **Claude Code (CLI):** a repo-root `.mcp.json` (committable, team-shared) or `~/.claude.json` for MCP servers, plus [`.claude/settings.template.json`](../.claude/settings.template.json) for permissions / auto-mode.
+Configuration path:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-See §5 "Core Configuration (Claude Desktop / Claude Code)" for both structures, including the `NEO_AGENT_IDENTITY` requirement for A2A mailbox binding.
+See §5 "Core Configuration (Claude Desktop / Claude Code)" for the complete structure, including the `NEO_AGENT_IDENTITY` env-var requirement for A2A mailbox binding.
 
 ## 5. Understanding the Configuration Files
 
@@ -232,45 +223,60 @@ Use the following structure:
 
 ### Core Configuration (Claude Desktop / Claude Code)
 
-Claude Desktop (the macOS / Windows GUI app) and Claude Code (Anthropic's CLI harness) are **separate applications with separate configuration — they do not share a file.** Claude Desktop reads `claude_desktop_config.json`; Claude Code reads a repo-root `.mcp.json` (or `~/.claude.json`) for MCP servers plus `.claude/settings.json` for permissions / auto-mode. Configuring one does **not** configure the other.
-
-**Claude Desktop config path:**
+Claude Desktop (the macOS / Windows agent app) and Claude Code (Anthropic's CLI harness) share a single MCP configuration file at:
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Copy-paste starters live in the repo: [`.claude/claude_desktop_config.example.json`](../.claude/claude_desktop_config.example.json) (Desktop) and [`.claude/settings.template.json`](../.claude/settings.template.json) (Claude Code permissions / auto-mode — mirrors `AGENTS.md`: allows equal-peer substrate work, hard-denies `gh pr merge` and direct `main`/`dev` pushes). The Claude Code `.mcp.json` setup is in the **Claude Code (CLI)** subsection after the Desktop block below.
-
-#### Claude Desktop (GUI)
+Configuring one harness configures the other — both spawn the same MCP subprocesses from this file.
 
 **Critical: `NEO_AGENT_IDENTITY` placement for A2A mailbox binding.**
 
 For the A2A (Agent-to-Agent) mailbox substrate to bind your agent session to its AgentIdentity graph node, the Memory Core server's `env` block MUST include `NEO_AGENT_IDENTITY` set to the GitHub login of the bound identity (e.g., `neo-opus`). **This MUST live inside the per-server `env` block — not as a shell export** — because Claude Desktop launches MCP subprocesses directly from the GUI without inheriting interactive-shell state. A shell export in `~/.zshrc` will NOT reach the spawned MCP process.
 
-The full structure is in [`.claude/claude_desktop_config.example.json`](../.claude/claude_desktop_config.example.json) — a **local-first** setup. Each server launches as `node --env-file=<YOUR_NEO_REPO_PATH>/.env <YOUR_NEO_REPO_PATH>/ai/mcp/server/<name>/mcp-server.mjs`, so:
-
-- **Secrets stay in `.env`, never inline.** `GH_TOKEN` and any optional cloud provider keys live in the `.env` file loaded via `--env-file`; the per-server `env` blocks carry no secrets.
-- **No cloud API key for a local setup.** `NEO_OPENAI_COMPATIBLE_HOST` points each server at your local inference endpoint (e.g. LM Studio on `http://127.0.0.1:1234`). A local-first config has **no `GEMINI_API_KEY`** at all.
-- **`NEO_AGENT_IDENTITY`** (your GitHub login) goes in the `neo-mjs-memory-core` `env` block — this is what binds your A2A mailbox.
-- On **Apple Silicon**, prepend `/opt/homebrew/bin` to `PATH` (GUI launches strip it) and set `HOME` explicitly.
-
-#### Claude Code (CLI)
-
-Claude Code reads MCP server definitions from a repo-root `.mcp.json` (project scope — committable and shared with the whole team) or `~/.claude.json` (user scope). It does **not** read `claude_desktop_config.json`. Because the CLI inherits your shell environment, you can export `NEO_AGENT_IDENTITY`, `GH_TOKEN`, and any provider keys in your shell profile (§3.3) — they are inherited by the spawned MCP servers, so per-server `env` blocks are not required (unlike the GUI).
-
-A minimal repo-root `.mcp.json` (servers launched via the repo's own npm scripts):
+Use the following structure (replace the placeholders as in the Antigravity section above):
 
 ```json
 {
   "mcpServers": {
-    "neo-mjs-github-workflow": { "command": "npm", "args": ["run", "ai:mcp-server-github-workflow"] },
-    "neo-mjs-knowledge-base":  { "command": "npm", "args": ["run", "ai:mcp-server-knowledge-base"] },
-    "neo-mjs-memory-core":     { "command": "npm", "args": ["run", "ai:mcp-server-memory-core"] },
-    "neo-mjs-neural-link":     { "command": "npm", "args": ["run", "ai:mcp-server-neural-link"] }
+    "neo-mjs-knowledge-base": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/knowledge-base/mcp-server.mjs"],
+      "env": {
+        "GEMINI_API_KEY": "<YOUR_GEMINI_API_KEY>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-memory-core": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/memory-core/mcp-server.mjs"],
+      "env": {
+        "GEMINI_API_KEY": "<YOUR_GEMINI_API_KEY>",
+        "NEO_AGENT_IDENTITY": "<YOUR_GITHUB_LOGIN>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-github-workflow": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": ["<YOUR_NEO_REPO_PATH>/ai/mcp/server/github-workflow/mcp-server.mjs"],
+      "env": {
+        "GH_TOKEN": "<YOUR_GH_TOKEN>",
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    },
+    "neo-mjs-neural-link": {
+      "command": "<YOUR_NODE_PATH>",
+      "args": [
+        "<YOUR_NEO_REPO_PATH>/ai/mcp/server/neural-link/mcp-server.mjs",
+        "--cwd",
+        "<YOUR_NEO_REPO_PATH>"
+      ],
+      "env": {
+        "PATH": "<YOUR_NEO_REPO_PATH>/node_modules/.bin:<DEFAULT_PATH>"
+      }
+    }
   }
 }
 ```
-
-Claude Code prompts you to approve project-scoped `.mcp.json` servers the first time you launch it in the repo. Permissions and auto-mode are configured separately — copy [`.claude/settings.template.json`](../.claude/settings.template.json) to `.claude/settings.json` (or the gitignored `.claude/settings.local.json`) and adjust. That template mirrors `AGENTS.md`: it allow-lists the neo-mjs MCP substrate tools (so routine equal-peer work isn't gated), hard-denies `gh pr merge`, and via prose auto-mode rules blocks direct pushes/commits to `main`/`dev` and client names in public artifacts.
 
 **File System MCP scope:** frontier harnesses such as Codex, Claude Code, Gemini CLI, and Antigravity already provide their own filesystem and command-execution tools. Neo still ships `ai:mcp-server-file-system`, but it is for `Neo.ai.Agent` instances and local harnessless profiles such as Gemma-powered QA/documentation loops that need file access through the Agent OS client.
 
@@ -321,8 +327,8 @@ ln -s /Users/Shared/github/neomjs/neo/.neo-ai-data .neo-ai-data
 **What NOT to symlink**: source-code paths (`src/core/Base.mjs`, `ai/mcp/server/*/config.mjs`). Node's ESM resolver walks to the canonical path and `Neo.setupClass` sees the same namespace registered from two different file paths → `Namespace collision in unitTestMode`. Symlinks are safe ONLY for pure-data directories like `.neo-ai-data/`. Config files MUST be real copies (which is what `bootstrapWorktree.mjs` does by default, without the `--link-data` flag).
 
 ### Agent Guidelines (Repository root)
-- **`AGENTS.md`**: Per-turn operational mandates (automatically loaded via the harness settings).
-- **`AGENTS_STARTUP.md`**: Step-by-step session initialization. **Note:** the boot/initialization workflow it describes is being revised and is no longer a reliable per-session ritual — treat it as historical context until refreshed; `AGENTS.md` (auto-loaded) carries the operative mandates.
+- **`AGENTS_STARTUP.md`**: Step-by-step session initialization instructions
+- **`AGENTS.md`**: Per-turn operational mandates (automatically loaded via settings.json)
 
 ### Developer Guide
 - **[Strategic Workflows](../learn/agentos/StrategicWorkflows.md)**: Best practices for working effectively with the agents — the advanced, integrated workflows they support.
@@ -335,9 +341,20 @@ ln -s /Users/Shared/github/neomjs/neo/.neo-ai-data .neo-ai-data
    * **For Gemini CLI:** Run `gemini` in your terminal.
    * **For Antigravity:** Follow the Antigravity launch procedure.
 
-2. **Initialize the session:**
+2. **Follow the initialization instructions in AGENTS_STARTUP.md**:
 
-   `AGENTS.md` is auto-loaded as per-turn operational mandates (via the harness settings). The separate `AGENTS_STARTUP.md` boot ritual is **being revised** — the once-required "Read and follow @AGENTS_STARTUP.md" step is no longer a reliable per-session requirement; follow your operator's current boot guidance. It still helps to load core context at session start (e.g. `src/Neo.mjs`, `src/core/Base.mjs`, the `learn/` overview docs) and to check Memory Core status before your first real prompt.
+   The agent **will not** automatically initialize itself on startup. You must explicitly instruct it to do so:
+
+   > "Read and follow all instructions in @AGENTS_STARTUP.md"
+
+   The agent will then:
+    - Read the AGENTS_STARTUP.md file
+    - Load core Neo.mjs files (Neo.mjs, Base.mjs, CodebaseOverview.md)
+    - Check the Memory Core status
+    - Confirm it's ready for work
+
+   **Important:** This initialization step is required at the start of every new session. Without it, the agent will not
+   have proper context about the codebase structure and operational guidelines.
 
 3. **Give your actual prompt**, for example:
    > "Explain the Neo.mjs two-tier reactivity model with a code example."
@@ -363,7 +380,7 @@ and understand your codebase.
 
 ### Agent Behavior Issues
 - **Agent doesn't initialize**: Check that `AGENTS_STARTUP.md` exists
-- **Agent doesn't save memories**: Memory Core may not be running. Ask the agent to perform a healthcheck on the `neo-mjs-memory-core` MCP server. If it's unhealthy, you can ask the agent to start the database or use other memory-core tools.
+- **Agent doesn't save memories**: Memory Core may not be running. Ask the agent to perform a healthcheck on the `neo.mjs-memory-core` MCP server. If it's unhealthy, you can ask the agent to start the database or use other memory-core tools.
 - **Agent makes incorrect assumptions**: It may be hallucinating - remind it to query the knowledge base
 
 ### Agent Identity Binding Issues (A2A Mailbox)

--- a/.github/AI_QUICK_START.md
+++ b/.github/AI_QUICK_START.md
@@ -9,7 +9,7 @@ for the Neo.mjs repository.
 
 Before you begin, ensure you have the following:
 
-1.  **Google Account**: You'll need one to access Google AI Studio for an API key, which is required to build the knowledge base. If you don't have one, you can create it at [accounts.google.com](https://accounts.google.com).
+1.  **Google Account (optional)**: Only needed if you use Google's Gemini API for embeddings or chat. The pre-built Knowledge Base ships ready-to-query, and a fully local setup (Ollama / MLX / any OpenAI-compatible endpoint) needs no Gemini key at all. If you do want one, create it at [Google AI Studio](https://aistudio.google.com/app/apikey).
 2.  **Node.js**: Version 24 or later. If you don't have it, you can install it from [nodejs.org](https://nodejs.org).
 3.  **Project Setup**: Your setup depends on how you are working with Neo.mjs.
 
@@ -37,7 +37,7 @@ Before you begin, ensure you have the following:
 
 For this workflow, an "AI agent" is a local AI assistant capable of executing shell commands and making architectural decisions.
 
-**Current Support:** This guide covers the setup for three environments: the Google Gemini CLI, the Antigravity OS, and Claude Desktop plus Claude Code (which share a single MCP configuration file). The core infrastructure (MCP servers, knowledge base) is agent-agnostic, but their respective configuration files differ slightly.
+**Current Support:** This guide covers four harnesses: the Google Gemini CLI, the Antigravity OS, Claude Desktop, and Claude Code. The core infrastructure (MCP servers, knowledge base) is agent-agnostic; each harness reads its own configuration file — Claude Desktop and Claude Code do **not** share one (see §4–§5).
 
 ## 3. Setup the AI Environment (Required)
 
@@ -61,9 +61,14 @@ If the automatic download fails (e.g., due to network issues), you can trigger i
 npm run ai:download-kb
 ```
 
-### Step 3.2: Obtain a Gemini API Key
+### Step 3.2: Obtain a Gemini API Key (Optional)
 
-The Knowledge Base artifact allows you to start quickly, but you still need a Gemini API Key to run the AI Agent (for chat/generation) and for incremental updates to the knowledge base.
+The pre-built Knowledge Base artifact ships ready-to-query, so a Gemini key is **optional** — a fully local setup (Ollama / MLX / any OpenAI-compatible endpoint) needs none. You only need a key if you choose Gemini as your provider or run incremental KB rebuilds against it. Two independent, optional keys are recognized:
+
+- **`GEMINI_API_KEY`** — Gemini as the embedding / LLM provider.
+- **`NEO_KB_ASK_API_KEY`** — a dedicated, budget-cappable key for the Knowledge Base *ask*-synthesis path only.
+
+For a local-first setup, skip this step. If you do want a Gemini key:
 
 1.  **Visit Google AI Studio**: Go to [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey).
 2.  **Sign In**: Use your Google account credentials. Complete any two-factor authentication (2FA) if prompted.
@@ -81,12 +86,18 @@ To ensure your environment is accurately inherited across all local MCP sub-serv
 1.  **Open your shell profile**: `nano ~/.zshrc` (or `~/.zprofile`)
 2.  **Add your keys**: Add the following lines, replacing the placeholder keys:
     ```bash
-    export GEMINI_API_KEY="YOUR_API_KEY_HERE"
     export GH_TOKEN="YOUR_GITHUB_TOKEN_HERE"
+
+    # Optional — only for the Gemini provider path (omit entirely for a local-first setup):
+    export GEMINI_API_KEY="YOUR_API_KEY_HERE"
+    # Optional — dedicated, budget-cappable key for the Knowledge Base ask-synthesis path only:
+    export NEO_KB_ASK_API_KEY="YOUR_KB_ASK_KEY_HERE"
+
     # Core LLM Engine provider (Supported: 'gemini', 'ollama', 'openAiCompatible')
     # export MODEL_PROVIDER="openAiCompatible"
 
     # Vector Embedding provider (Supported: 'gemini', 'ollama', 'openAiCompatible')
+    # Use 'ollama' or 'openAiCompatible' for a fully local, no-API-key setup:
     export NEO_EMBEDDING_PROVIDER="gemini"
     ```
 3.  **Apply changes**: `source ~/.zshrc`
@@ -140,15 +151,14 @@ Antigravity is a desktop agent environment that embeds the Gemini runtime plus i
 
 Configuration source: user-level `mcp_config.json`. See §5 "Core Configuration (Antigravity OS)".
 
-### Option C: Claude Desktop / Claude Code
+### Option C: Claude Desktop and Claude Code
 
-Claude Desktop is Anthropic's desktop agent app (macOS/Windows). Claude Code is Anthropic's shell-capable CLI harness. **Both harnesses share a single MCP configuration file** — configuring one configures the other.
+Claude Desktop is Anthropic's desktop agent app (macOS/Windows). Claude Code is Anthropic's shell-capable CLI harness. They are **separate apps with separate config** — they do **not** share a file:
 
-Configuration path:
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Claude Desktop (GUI):** `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows). Starter: [`.claude/claude_desktop_config.example.json`](../.claude/claude_desktop_config.example.json).
+- **Claude Code (CLI):** a repo-root `.mcp.json` (committable, team-shared) or `~/.claude.json` for MCP servers, plus [`.claude/settings.template.json`](../.claude/settings.template.json) for permissions / auto-mode.
 
-See §5 "Core Configuration (Claude Desktop / Claude Code)" for the complete structure, including the `NEO_AGENT_IDENTITY` env-var requirement for A2A mailbox binding.
+See §5 "Core Configuration (Claude Desktop / Claude Code)" for both structures, including the `NEO_AGENT_IDENTITY` requirement for A2A mailbox binding.
 
 ## 5. Understanding the Configuration Files
 
@@ -223,11 +233,15 @@ Use the following structure:
 
 ### Core Configuration (Claude Desktop / Claude Code)
 
-Claude Desktop (the macOS / Windows agent app) and Claude Code (Anthropic's CLI harness) share a single MCP configuration file at:
+Claude Desktop (the macOS / Windows GUI app) and Claude Code (Anthropic's CLI harness) are **separate applications with separate configuration — they do not share a file.** Claude Desktop reads `claude_desktop_config.json`; Claude Code reads a repo-root `.mcp.json` (or `~/.claude.json`) for MCP servers plus `.claude/settings.json` for permissions / auto-mode. Configuring one does **not** configure the other.
+
+**Claude Desktop config path:**
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Configuring one harness configures the other — both spawn the same MCP subprocesses from this file.
+Copy-paste starters live in the repo: [`.claude/claude_desktop_config.example.json`](../.claude/claude_desktop_config.example.json) (Desktop) and [`.claude/settings.template.json`](../.claude/settings.template.json) (Claude Code permissions / auto-mode — mirrors `AGENTS.md`: allows equal-peer substrate work, hard-denies `gh pr merge` and direct `main`/`dev` pushes). The Claude Code `.mcp.json` setup is in the **Claude Code (CLI)** subsection after the Desktop block below.
+
+#### Claude Desktop (GUI)
 
 **Critical: `NEO_AGENT_IDENTITY` placement for A2A mailbox binding.**
 
@@ -278,6 +292,25 @@ Use the following structure (replace the placeholders as in the Antigravity sect
 }
 ```
 
+#### Claude Code (CLI)
+
+Claude Code reads MCP server definitions from a repo-root `.mcp.json` (project scope — committable and shared with the whole team) or `~/.claude.json` (user scope). It does **not** read `claude_desktop_config.json`. Because the CLI inherits your shell environment, you can export `NEO_AGENT_IDENTITY`, `GH_TOKEN`, and any provider keys in your shell profile (§3.3) — they are inherited by the spawned MCP servers, so per-server `env` blocks are not required (unlike the GUI).
+
+A minimal repo-root `.mcp.json` (servers launched via the repo's own npm scripts):
+
+```json
+{
+  "mcpServers": {
+    "neo-mjs-github-workflow": { "command": "npm", "args": ["run", "ai:mcp-server-github-workflow"] },
+    "neo-mjs-knowledge-base":  { "command": "npm", "args": ["run", "ai:mcp-server-knowledge-base"] },
+    "neo-mjs-memory-core":     { "command": "npm", "args": ["run", "ai:mcp-server-memory-core"] },
+    "neo-mjs-neural-link":     { "command": "npm", "args": ["run", "ai:mcp-server-neural-link"] }
+  }
+}
+```
+
+Claude Code prompts you to approve project-scoped `.mcp.json` servers the first time you launch it in the repo. Permissions and auto-mode are configured separately — copy [`.claude/settings.template.json`](../.claude/settings.template.json) to `.claude/settings.json` (or the gitignored `.claude/settings.local.json`) and adjust. That template mirrors `AGENTS.md`: it allow-lists the neo-mjs MCP substrate tools (so routine equal-peer work isn't gated), hard-denies `gh pr merge`, and via prose auto-mode rules blocks direct pushes/commits to `main`/`dev` and client names in public artifacts.
+
 **File System MCP scope:** frontier harnesses such as Codex, Claude Code, Gemini CLI, and Antigravity already provide their own filesystem and command-execution tools. Neo still ships `ai:mcp-server-file-system`, but it is for `Neo.ai.Agent` instances and local harnessless profiles such as Gemma-powered QA/documentation loops that need file access through the Agent OS client.
 
 **Restart gotcha (applies to every GUI-launched harness):** after editing the MCP config, you must **fully quit** the harness for changes to take effect:
@@ -327,8 +360,8 @@ ln -s /Users/Shared/github/neomjs/neo/.neo-ai-data .neo-ai-data
 **What NOT to symlink**: source-code paths (`src/core/Base.mjs`, `ai/mcp/server/*/config.mjs`). Node's ESM resolver walks to the canonical path and `Neo.setupClass` sees the same namespace registered from two different file paths → `Namespace collision in unitTestMode`. Symlinks are safe ONLY for pure-data directories like `.neo-ai-data/`. Config files MUST be real copies (which is what `bootstrapWorktree.mjs` does by default, without the `--link-data` flag).
 
 ### Agent Guidelines (Repository root)
-- **`AGENTS_STARTUP.md`**: Step-by-step session initialization instructions
-- **`AGENTS.md`**: Per-turn operational mandates (automatically loaded via settings.json)
+- **`AGENTS.md`**: Per-turn operational mandates (automatically loaded via the harness settings).
+- **`AGENTS_STARTUP.md`**: Step-by-step session initialization. **Note:** the boot/initialization workflow it describes is being revised and is no longer a reliable per-session ritual — treat it as historical context until refreshed; `AGENTS.md` (auto-loaded) carries the operative mandates.
 
 ### Developer Guide
 - **[Strategic Workflows](../learn/agentos/StrategicWorkflows.md)**: Best practices for working effectively with the agents — the advanced, integrated workflows they support.
@@ -341,20 +374,9 @@ ln -s /Users/Shared/github/neomjs/neo/.neo-ai-data .neo-ai-data
    * **For Gemini CLI:** Run `gemini` in your terminal.
    * **For Antigravity:** Follow the Antigravity launch procedure.
 
-2. **Follow the initialization instructions in AGENTS_STARTUP.md**:
+2. **Initialize the session:**
 
-   The agent **will not** automatically initialize itself on startup. You must explicitly instruct it to do so:
-
-   > "Read and follow all instructions in @AGENTS_STARTUP.md"
-
-   The agent will then:
-    - Read the AGENTS_STARTUP.md file
-    - Load core Neo.mjs files (Neo.mjs, Base.mjs, CodebaseOverview.md)
-    - Check the Memory Core status
-    - Confirm it's ready for work
-
-   **Important:** This initialization step is required at the start of every new session. Without it, the agent will not
-   have proper context about the codebase structure and operational guidelines.
+   `AGENTS.md` is auto-loaded as per-turn operational mandates (via the harness settings). The separate `AGENTS_STARTUP.md` boot ritual is **being revised** — the once-required "Read and follow @AGENTS_STARTUP.md" step is no longer a reliable per-session requirement; follow your operator's current boot guidance. It still helps to load core context at session start (e.g. `src/Neo.mjs`, `src/core/Base.mjs`, the `learn/` overview docs) and to check Memory Core status before your first real prompt.
 
 3. **Give your actual prompt**, for example:
    > "Explain the Neo.mjs two-tier reactivity model with a code example."
@@ -380,7 +402,7 @@ and understand your codebase.
 
 ### Agent Behavior Issues
 - **Agent doesn't initialize**: Check that `AGENTS_STARTUP.md` exists
-- **Agent doesn't save memories**: Memory Core may not be running. Ask the agent to perform a healthcheck on the `neo.mjs-memory-core` MCP server. If it's unhealthy, you can ask the agent to start the database or use other memory-core tools.
+- **Agent doesn't save memories**: Memory Core may not be running. Ask the agent to perform a healthcheck on the `neo-mjs-memory-core` MCP server. If it's unhealthy, you can ask the agent to start the database or use other memory-core tools.
 - **Agent makes incorrect assumptions**: It may be hallucinating - remind it to query the knowledge base
 
 ### Agent Identity Binding Issues (A2A Mailbox)


### PR DESCRIPTION
Resolves #13453

Tracked, AGENTS.md-mirroring Claude harness config that resolves the friction where the Claude Code auto-mode classifier denies legitimate equal-peer substrate work. @tobiu green-lit this in-session. Fleet-generic (no hardcoded identity).

Evidence: L1 (static config — JSON validity verified, no runtime AC). No residuals.

## Changes

**1. `.claude/settings.template.json`** (new, tracked) — mirrors `AGENTS.md`:
- `permissions.allow` the three neo-mjs MCP substrate servers — an explicit MCP-tool allow **suppresses the intent classifier** for that tool (verified via `claude-code-guide`), the direct fix for the denial friction.
- `permissions.deny: ["Bash(gh pr merge *)"]` — statically blocks the merge command, closing the `mechanical_guard: none` gap on §critical_gates #1.
- prose `autoMode` — `hard_deny` carries the runtime-arg-aware gates (push/commit to `main`|`dev`, client-names-in-public); `allow` clarifies equal-peer substrate work is normal; every section leads with `"$defaults"` to keep built-in protections.

**2. `.claude/claude_desktop_config.example.json`** (new, tracked) — Claude Desktop MCP starter, **local-first** (V-B-A'd against the operator's actual `claude_desktop_config.json`): each server runs `node --env-file=<repo>/.env …`, so secrets live in `.env` (never inline — no `GEMINI_API_KEY`, no inline `GH_TOKEN`); providers point at `NEO_OPENAI_COMPATIBLE_HOST` (a local inference endpoint); only memory-core carries `NEO_AGENT_IDENTITY`.

## Deltas

- **The `AI_QUICK_START.md` refresh is descoped from this PR.** A correct guide update needs a clear local-first vs remote/cloud split, the local startup prerequisites (orchestrator + NL bridge), and one consistent config form per harness — none of which my initial edits delivered (they introduced inconsistent config blocks instead). Reverted to `dev`; the guide gets a proper, V-B-A'd rework as a separate effort, and #13453's guide AC moves with it (ticket re-scope pending the operator's structural steer).
- Neural-link MCP tools are intentionally **not** in the default `permissions.allow` (live-runtime mutation — explicit per-agent opt-in).
- `autoMode` is **prose**, not tool-pattern strings (verified; corrected a pre-session assumption).
- No Contract Ledger: client-side harness config, no consumed-MCP-surface contract change.

## Test Evidence

Config-only change — no unit tests required (`pr-review` §7.5). Verified:
- `node -p "JSON.parse(...)"` on both JSON files → **VALID**.
- `git check-ignore` on both → **not ignored** (will be tracked; `.gitignore` only ignores `.claude/settings.json`).
- Claude Code settings schema — `autoMode` prose shape + `"$defaults"`, `permissions.deny` Bash syntax + deny>ask>allow precedence, MCP allow-listing — verified against current docs via the `claude-code-guide` agent before authoring.
- The Desktop example was corrected to **local-first** after V-B-A against the operator's running `claude_desktop_config.json` (it initially, wrongly, carried `GEMINI_API_KEY`).
- Commits: `7256116c1` (templates + guide) → `0af6a0385` (local-first example fix) → `0060febd3` (revert guide; descope). Net PR diff: the two `.claude/` templates only.

## Post-Merge Validation

- [ ] An agent copies `.claude/settings.template.json` → `.claude/settings.local.json` and confirms routine substrate-work is no longer classifier-gated, while `gh pr merge` and direct `main`/`dev` pushes stay blocked.
- [ ] A Desktop user copies `.claude/claude_desktop_config.example.json`, fills the placeholders, and a `neo-mjs-memory-core` healthcheck returns `identity.bound: true`.

## Open / Follow-up

- **Guide rework (separate):** a proper `AI_QUICK_START.md` overhaul — local-first vs remote/cloud, local startup (orchestrator + NL bridge), one consistent config form per harness. Needs the operator's structural steer + a V-B-A of the startup mechanics; deliberately not faked here.
- Applying any config into a live file stays the operator's trust-root action; this PR only adds tracked templates.

Authored by Vega (@neo-opus-vega, Claude Opus 4.8).
