### PR TITLE
fix(ai): suppress benched heartbeat wake submits (#13456)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -14,6 +14,30 @@ export const VALID_TARGET_SOURCES = Object.freeze([
     'disabled'
 ]);
 
+const identityParticipationById = new Map(
+    IDENTITIES
+        .filter(identity => identity.type === 'AgentIdentity')
+        .map(identity => [
+            normalizeAgentIdentityNodeId(identity.id),
+            identity.properties?.participationStatus || 'active'
+        ])
+);
+
+/**
+ * @summary True when a dynamic heartbeat source may include the identity.
+ *
+ * Dynamic sources are runtime-derived, so unknown identities are allowed for
+ * forks/local custom agents. Known repo identities with a non-active
+ * participationStatus are excluded; explicit target lists remain the operator
+ * override for diagnostics.
+ * @param {String} id Normalized agent identity.
+ * @returns {Boolean}
+ */
+function isDynamicHeartbeatTargetEligible(id) {
+    const participationStatus = identityParticipationById.get(id);
+    return !participationStatus || participationStatus === 'active';
+}
+
 /**
  * Swarm-heartbeat due-trigger projection. Returns a trigger descriptor when the
  * configured interval has elapsed since `lastRunAt`; null otherwise. Pure function.
@@ -60,12 +84,15 @@ export function getDueTask({state, now, swarmHeartbeatIntervalMs}) {
  * - **`'active-subscribers'`** — delegates to injected `activeSubscribersProvider`
  *   (the existing `WAKE_SUBSCRIPTION` SQL discovery in
  *   `SwarmHeartbeatService.getWakeSubscriptionIdentities()`); union with `selfIdentity`.
- *   Subscription-presence-based — degrades on dormant subscribers.
+ *   Subscription-presence-based — degrades on dormant subscribers. Known repo identities
+ *   are still gated by `participationStatus === 'active'` so stale subscriptions cannot
+ *   wake operator-benched harnesses.
  * - **`'active-a2a-participants'`** — delegates to injected
  *   `activeA2aParticipantsProvider` (the `SwarmHeartbeatService.getActiveA2aParticipants()`
  *   3h `MESSAGE`-edge query); union with `selfIdentity`. Activity-derived — per-MC-instance
  *   discovery, tenant-safe (no team-registry coupling), self-healing 3h sliding window.
- *   This is the tracked template default.
+ *   Known repo identities are still gated by `participationStatus === 'active'`. This is
+ *   the tracked template default.
  * - **`'disabled'`** — returns `[]` plus an info log. Downstream `pulse()` skips per-identity
  *   work (sunset detection, idle-out nudge) while identity-agnostic substrate maintenance
  *   (TTL sweep, all-agent-idle detection, liveness touch) still runs.
@@ -172,6 +199,10 @@ export async function resolveTargets({
             }
             for (const raw of subscribers) {
                 const id = normalizeAgentIdentityNodeId(raw);
+                if (id && !isDynamicHeartbeatTargetEligible(id)) {
+                    log('info', `[resolveSwarmHeartbeatTargets] targetSource='active-subscribers' skipped '${id}' because identityRoots participationStatus is not active`);
+                    continue;
+                }
                 if (id && !seen.has(id)) {
                     seen.add(id);
                     out.push(id);
@@ -199,6 +230,10 @@ export async function resolveTargets({
             }
             for (const raw of participants) {
                 const id = normalizeAgentIdentityNodeId(raw);
+                if (id && !isDynamicHeartbeatTargetEligible(id)) {
+                    log('info', `[resolveSwarmHeartbeatTargets] targetSource='active-a2a-participants' skipped '${id}' because identityRoots participationStatus is not active`);
+                    continue;
+                }
                 if (id && !seen.has(id)) {
                     seen.add(id);
                     out.push(id);

--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -24,16 +24,15 @@ const identityParticipationById = new Map(
 );
 
 /**
- * @summary True when a dynamic heartbeat source may include the identity.
+ * @summary True when heartbeat target discovery may include the identity.
  *
- * Dynamic sources are runtime-derived, so unknown identities are allowed for
- * forks/local custom agents. Known repo identities with a non-active
- * participationStatus are excluded; explicit target lists remain the operator
- * override for diagnostics.
+ * Unknown identities are allowed for forks/local custom agents. Known repo
+ * identities with a non-active participationStatus are excluded; explicit
+ * target lists remain the operator override for diagnostics.
  * @param {String} id Normalized agent identity.
  * @returns {Boolean}
  */
-function isDynamicHeartbeatTargetEligible(id) {
+function isHeartbeatTargetEligible(id) {
     const participationStatus = identityParticipationById.get(id);
     return !participationStatus || participationStatus === 'active';
 }
@@ -75,8 +74,8 @@ export function getDueTask({state, now, swarmHeartbeatIntervalMs}) {
  *
  * **Per-source semantics:**
  *
- * - **`'self'`** — pulses only the harness owner (`selfIdentity`); deployment-portable
- *   minimal-fan-out shape.
+ * - **`'self'`** — pulses only the active harness owner (`selfIdentity`); deployment-
+ *   portable minimal-fan-out shape.
  * - **`'active-local-team'`** — reads `identityRoots.IDENTITIES` filtered on
  *   `type === 'AgentIdentity'` AND `properties.participationStatus === 'active'`. Team-
  *   registry coupled (suitable for Neo team workspace; external forks customize
@@ -142,6 +141,7 @@ export async function resolveTargets({
             log('info', `[resolveSwarmHeartbeatTargets] '${resolvedFrom}' resolved to self but selfIdentity is null — disabled (no pulse targets). Set NEO_AGENT_IDENTITY or orchestrator.swarmHeartbeat.targetSource='disabled' explicitly to silence this notice.`);
             return [];
         }
+        if (!isHeartbeatTargetEligible(normalizedSelf)) return [];
         return [normalizedSelf];
     };
 
@@ -199,10 +199,7 @@ export async function resolveTargets({
             }
             for (const raw of subscribers) {
                 const id = normalizeAgentIdentityNodeId(raw);
-                if (id && !isDynamicHeartbeatTargetEligible(id)) {
-                    log('info', `[resolveSwarmHeartbeatTargets] targetSource='active-subscribers' skipped '${id}' because identityRoots participationStatus is not active`);
-                    continue;
-                }
+                if (id && !isHeartbeatTargetEligible(id)) continue;
                 if (id && !seen.has(id)) {
                     seen.add(id);
                     out.push(id);
@@ -230,10 +227,7 @@ export async function resolveTargets({
             }
             for (const raw of participants) {
                 const id = normalizeAgentIdentityNodeId(raw);
-                if (id && !isDynamicHeartbeatTargetEligible(id)) {
-                    log('info', `[resolveSwarmHeartbeatTargets] targetSource='active-a2a-participants' skipped '${id}' because identityRoots participationStatus is not active`);
-                    continue;
-                }
+                if (id && !isHeartbeatTargetEligible(id)) continue;
                 if (id && !seen.has(id)) {
                     seen.add(id);
                     out.push(id);

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1378,14 +1378,10 @@ async function attemptDeliveryRetries() {
             }
         } else {
             pendingDeliveryRetries.delete(subId);
-            if (outcome === 'skipped') {
-                writeLog('INFO',
-                    `[Wake Daemon] Wake delivery for ${subId} skipped on retry (attempt ${entry.attempts + 1}).`
-                );
-            } else {
+            if (outcome !== 'skipped') {
                 writeLog('INFO',
                     `[Wake Daemon] Wake delivery for ${subId} succeeded on retry (attempt ${entry.attempts + 1}).`
-                );
+                )
             }
         }
     }

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -54,7 +54,10 @@ import {
     getActiveHarnessPresence,
     isHarnessPresenceFresh
 } from './queries.mjs';
-import {applyHarnessMetadataDefaults} from '../../scripts/lifecycle/harnessRouting.mjs';
+import {
+    applyHarnessMetadataDefaults,
+    normalizeAgentIdentityNodeId
+} from '../../scripts/lifecycle/harnessRouting.mjs';
 import {
     getDefaultInstancePid,
     resolveGuiInstancePid
@@ -66,6 +69,7 @@ import {
     shouldDeferFlush
 } from './flushDeferPolicy.mjs';
 import {clampWatermark, filterEventsByWatermark, maxLogId} from './wokenWatermark.mjs';
+import {IDENTITIES} from '../../graph/identityRoots.mjs';
 
 const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
 const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
@@ -82,6 +86,15 @@ const WAKE_PRIORITY_RANKS      = {
     normal: 1,
     high  : 2
 };
+
+const identityParticipationById = new Map(
+    IDENTITIES
+        .filter(identity => identity.type === 'AgentIdentity')
+        .map(identity => [
+            normalizeAgentIdentityNodeId(identity.id),
+            identity.properties?.participationStatus || 'active'
+        ])
+);
 
 // Ensure daemon data dir exists
 fs.ensureDirSync(DAEMON_DATA_DIR);
@@ -406,6 +419,8 @@ async function pollLoop() {
  * edges are created nowhere), and task `from`-OR-`assignee` targeting (formerly assignee-only).
  */
 function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
+    if (!isWakeTargetEligible(sub.properties?.agentIdentity)) return null;
+
     const result = match(sub.properties || {}, {
         entity,
         getNode            : id    => nodesMap.get(id) ?? getDbNode(db, id),
@@ -413,6 +428,7 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
     }, trace);
 
     if (!result) return null;
+    if (result.type === 'heartbeat_pulse' && isPromptSubmittingSubscription(sub)) return null;
 
     // Map the shared evaluator's {type, payload, logId} onto the daemon's flat coalescing payload.
     const {payload, logId} = result;
@@ -428,6 +444,43 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
         default:
             return null;
     }
+}
+
+/**
+ * @summary True when a wake subscription target may receive wake delivery.
+ *
+ * Unknown identities stay eligible for forks/local custom agents. Known repo
+ * identities with non-active participationStatus are filtered before coalescing
+ * so they never create delivery attempts or retries.
+ * @param {String} identity Agent identity.
+ * @returns {Boolean}
+ */
+function isWakeTargetEligible(identity) {
+    if (!identity) return true;
+    const normalizedIdentity  = normalizeAgentIdentityNodeId(identity),
+          participationStatus = identityParticipationById.get(normalizedIdentity);
+
+    return !participationStatus || participationStatus === 'active';
+}
+
+/**
+ * @summary Resolves the effective wake adapter for a subscription.
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @returns {String}
+ */
+function getSubscriptionAdapter(subscription) {
+    const meta = subscription.properties?.harnessTargetMetadata || {};
+    return meta.adapter || (process.platform === 'darwin' ? 'osascript' : 'tmux');
+}
+
+/**
+ * @summary True when heartbeat-only delivery would submit into an interactive prompt.
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @returns {Boolean}
+ */
+function isPromptSubmittingSubscription(subscription) {
+    const adapter = getSubscriptionAdapter(subscription);
+    return adapter === 'osascript' || adapter === 'tmux';
 }
 
 /**
@@ -679,8 +732,8 @@ async function flushSubscription(subId) {
 
     // Delivery to per-harness adapter. A 'failed' outcome (the adapter dispatch threw against a live
     // target) is re-queued for retry — carrying the EVENTS, not just this digest string, so a second
-    // failure for the same subscription coalesces them without loss. Intentional skips and successful
-    // deliveries are not re-queued.
+    // failure for the same subscription coalesces them without loss. Successful deliveries are not
+    // re-queued.
     const deliveryOutcome = await deliverDigest(subscription, digest, deliveryEvidence);
     if (deliveryOutcome === 'failed') {
         enqueueDeliveryRetry(subscription, identity, events);
@@ -886,21 +939,6 @@ function formatWakeDeliveryEvidence(evidence, {adapter, adapterSource, appName})
 }
 
 /**
- * @summary Blocks heartbeat-only wakes from prompt-submitting interactive adapters.
- *
- * Pure heartbeat pulses are scheduler nudges, not actionable user/peer messages.
- * `osascript` and `tmux` both submit by pressing Enter, so they must not deliver
- * heartbeat-only digests into a harness composer. Direct-message and mixed
- * actionable wakes keep the proven interactive route.
- * @param {String} adapter Delivery adapter.
- * @param {Object} evidence Scenario/count evidence.
- * @returns {Boolean}
- */
-function shouldSuppressPromptSubmittingHeartbeat(adapter, evidence = {}) {
-    return evidence.scenario === 'pure-heartbeat' && (adapter === 'osascript' || adapter === 'tmux');
-}
-
-/**
  * @summary Escapes values interpolated into AppleScript string literals.
  * @param {String} value
  * @returns {String}
@@ -915,8 +953,8 @@ function escapeAppleScriptString(value) {
  */
 let deliveryPromise = Promise.resolve();
 
-// Bounded retry store for wakes whose adapter dispatch THREW (a live-target delivery failure, not an
-// intentional skip). The global lastSyncId tail cursor consumes the source GraphLog events regardless
+// Bounded retry store for wakes whose adapter dispatch THREW (a live-target delivery failure). The
+// global lastSyncId tail cursor consumes the source GraphLog events regardless
 // of delivery outcome, so a failed delivery is otherwise lost; this holds the failed EVENTS and
 // rebuilds + re-attempts the digest on later poll cycles, independent of the cursor — coalescing
 // repeated same-subscription failures so no earlier wake is overwritten. After the cap the wake is
@@ -944,14 +982,6 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
     deliveryPromise = deliveryPromise.then(async () => {
 
     try {
-        if (shouldSuppressPromptSubmittingHeartbeat(adapter, deliveryEvidence)) {
-            writeLog('INFO',
-                `[Wake Daemon] Suppressed ${subscription.id} ${adapter} delivery for pure-heartbeat; ` +
-                `not submitting into interactive harness${evidenceLabel}`
-            );
-            return 'skipped';
-        }
-
         // `userDataDir` is exempt from the freshness veto: the dispatch below resolves it through
         // `getInstancePid({userDataDir})`, which fails closed when no live process maps to the
         // address — a live liveness proof, unlike the volatile presence overlay (written once at
@@ -1063,8 +1093,9 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
             // [Anchor & Echo] The Key Code 36 (Enter) Defense:
             // Actionable wakes specifically use \`key code 36\` (Enter) to submit the payload after
             // pasting. This is load-bearing for Claude Desktop with Tab 3 (Claude Code) and Google
-            // Antigravity. Pure-heartbeat digests are suppressed before this branch because a
-            // scheduler nudge must not submit into an interactive composer.
+            // Antigravity. Pure-heartbeat digests for prompt-submitting adapters are filtered
+            // before coalescing because a scheduler nudge must not submit into an interactive
+            // composer.
             // Instance-addressed wake raises the resolved pid's process to frontmost (verified
             // addressable via System Events `whose unix id`); single-instance wakes keep the
             // app-activate path unchanged.
@@ -1307,6 +1338,8 @@ function buildWakeDigest(identity, {messages = [], tasks = [], permissions = [],
  * @returns {void}
  */
 function enqueueDeliveryRetry(subscription, identity, events) {
+    if (!isWakeTargetEligible(identity)) return;
+
     const subId    = subscription.id,
           existing = pendingDeliveryRetries.get(subId);
 
@@ -1330,8 +1363,8 @@ function enqueueDeliveryRetry(subscription, identity, events) {
 }
 
 /**
- * @summary Re-attempts due wake-delivery retries; called once per poll cycle. A success or skip
- * clears the entry; a repeat failure increments the attempt count with linear backoff; exceeding
+ * @summary Re-attempts due wake-delivery retries; called once per poll cycle. A success clears the
+ * entry; a repeat failure increments the attempt count with linear backoff; exceeding
  * `MAX_DELIVERY_RETRIES` drops the entry with a terminal ERROR so a persistently-unreachable target
  * cannot storm or wedge the loop.
  * @returns {Promise<void>}
@@ -1343,6 +1376,10 @@ async function attemptDeliveryRetries() {
 
     for (const [subId, entry] of pendingDeliveryRetries) {
         if (entry.nextAttemptAt > now) continue;
+        if (!isWakeTargetEligible(entry.subscription.properties?.agentIdentity || entry.identity)) {
+            pendingDeliveryRetries.delete(subId);
+            continue;
+        }
 
         // Re-apply the read-state reconcile the initial digest used (see `flushSubscription`): a message
         // the recipient read between the failed delivery and this retry must NOT be re-delivered. The
@@ -1378,11 +1415,9 @@ async function attemptDeliveryRetries() {
             }
         } else {
             pendingDeliveryRetries.delete(subId);
-            if (outcome !== 'skipped') {
-                writeLog('INFO',
-                    `[Wake Daemon] Wake delivery for ${subId} succeeded on retry (attempt ${entry.attempts + 1}).`
-                )
-            }
+            writeLog('INFO',
+                `[Wake Daemon] Wake delivery for ${subId} succeeded on retry (attempt ${entry.attempts + 1}).`
+            )
         }
     }
 }

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -868,7 +868,7 @@ function buildWakeDeliveryEvidence({messages = [], tasks = [], permissions = [],
 }
 
 /**
- * @summary Formats Codex wake-delivery evidence for live route validation logs.
+ * @summary Formats wake-delivery evidence for live route validation logs.
  * @param {Object} evidence Scenario/count evidence from buildWakeDeliveryEvidence().
  * @param {Object} options Adapter metadata.
  * @returns {String}
@@ -883,6 +883,21 @@ function formatWakeDeliveryEvidence(evidence, {adapter, adapterSource, appName})
     return ` (scenario=${scenario}; route=${adapter}; adapterSource=${adapterSource}; app=${appName || ''}; ` +
         `counts=messages:${counts.messages || 0},tasks:${counts.tasks || 0},` +
         `permissions:${counts.permissions || 0},heartbeats:${counts.heartbeats || 0})`;
+}
+
+/**
+ * @summary Blocks heartbeat-only wakes from prompt-submitting interactive adapters.
+ *
+ * Pure heartbeat pulses are scheduler nudges, not actionable user/peer messages.
+ * `osascript` and `tmux` both submit by pressing Enter, so they must not deliver
+ * heartbeat-only digests into a harness composer. Direct-message and mixed
+ * actionable wakes keep the proven interactive route.
+ * @param {String} adapter Delivery adapter.
+ * @param {Object} evidence Scenario/count evidence.
+ * @returns {Boolean}
+ */
+function shouldSuppressPromptSubmittingHeartbeat(adapter, evidence = {}) {
+    return evidence.scenario === 'pure-heartbeat' && (adapter === 'osascript' || adapter === 'tmux');
 }
 
 /**
@@ -923,14 +938,20 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
     const defaultAdapter = process.platform === 'darwin' ? 'osascript' : 'tmux';
     const adapter       = meta.adapter || defaultAdapter;
     const adapterSource = meta.adapter ? 'metadata' : 'platform-default';
-    const evidenceLabel = meta.appName === 'Codex' || adapter === CODEX_APP_SERVER_ADAPTER
-        ? formatWakeDeliveryEvidence(deliveryEvidence, {adapter, adapterSource, appName: meta.appName})
-        : '';
+    const evidenceLabel = formatWakeDeliveryEvidence(deliveryEvidence, {adapter, adapterSource, appName: meta.appName});
 
     // Serialize execution to prevent focus collisions (Electron-Paradox defense)
     deliveryPromise = deliveryPromise.then(async () => {
 
     try {
+        if (shouldSuppressPromptSubmittingHeartbeat(adapter, deliveryEvidence)) {
+            writeLog('INFO',
+                `[Wake Daemon] Suppressed ${subscription.id} ${adapter} delivery for pure-heartbeat; ` +
+                `not submitting into interactive harness${evidenceLabel}`
+            );
+            return 'skipped';
+        }
+
         // `userDataDir` is exempt from the freshness veto: the dispatch below resolves it through
         // `getInstancePid({userDataDir})`, which fails closed when no live process maps to the
         // address — a live liveness proof, unlike the volatile presence overlay (written once at
@@ -958,7 +979,7 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                 ? instanceAddress
                 : meta.tmuxSession || process.env.TMUX_SESSION || 'neo-agent';
             await spawnAsync('tmux', ['send-keys', '-t', tmuxSession, digest, 'C-m']);
-            writeLog('INFO', `[Wake Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}`);
+            writeLog('INFO', `[Wake Daemon] Delivered ${subscription.id} via tmux to session ${tmuxSession}${evidenceLabel}`);
         } else if (adapter === 'osascript') {
             const appName = meta.appName;
             if (!appName) {
@@ -967,7 +988,7 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                     `harnessTargetMetadata.appName is missing/empty. ` +
                     `Skipping delivery to avoid misrouting. ` +
                     `Verify subscription template via 'manage_wake_subscription({action: \\'list\\'})' ` +
-                    `or fix the AgentIdentity subscriptionTemplate.`
+                    `or fix the AgentIdentity subscriptionTemplate.${evidenceLabel}`
                 );
                 return;
             }
@@ -1040,10 +1061,10 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
             // the \`first application process whose frontmost is true\`.
             //
             // [Anchor & Echo] The Key Code 36 (Enter) Defense:
-            // We specifically use \`key code 36\` (Enter) to submit the payload after pasting.
-            // This is load-bearing for Claude Desktop with Tab 3 (Claude Code) and Google Antigravity.
-            // Do NOT "clean this up" or revert to \`tell process\` or try to replace the Enter key
-            // without empiric validation across both harnesses.
+            // Actionable wakes specifically use \`key code 36\` (Enter) to submit the payload after
+            // pasting. This is load-bearing for Claude Desktop with Tab 3 (Claude Code) and Google
+            // Antigravity. Pure-heartbeat digests are suppressed before this branch because a
+            // scheduler nudge must not submit into an interactive composer.
             // Instance-addressed wake raises the resolved pid's process to frontmost (verified
             // addressable via System Events `whose unix id`); single-instance wakes keep the
             // app-activate path unchanged.
@@ -1357,9 +1378,15 @@ async function attemptDeliveryRetries() {
             }
         } else {
             pendingDeliveryRetries.delete(subId);
-            writeLog('INFO',
-                `[Wake Daemon] Wake delivery for ${subId} succeeded on retry (attempt ${entry.attempts + 1}).`
-            );
+            if (outcome === 'skipped') {
+                writeLog('INFO',
+                    `[Wake Daemon] Wake delivery for ${subId} skipped on retry (attempt ${entry.attempts + 1}).`
+                );
+            } else {
+                writeLog('INFO',
+                    `[Wake Daemon] Wake delivery for ${subId} succeeded on retry (attempt ${entry.attempts + 1}).`
+                );
+            }
         }
     }
 }

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
@@ -92,10 +92,10 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
         const result = await resolveTargets({
             selfIdentity   : '@neo-opus-4-7',
             targetSource   : 'active-local-team',   // would normally be honored
-            explicitTargets: ['@some-external-agent', 'neo-gpt'],  // wins; gets normalized
+            explicitTargets: ['@some-external-agent', 'neo-gpt', '@neo-gemini-pro'],  // wins; gets normalized
             logger
         });
-        expect(result).toEqual(['@some-external-agent', '@neo-gpt']);
+        expect(result).toEqual(['@some-external-agent', '@neo-gpt', '@neo-gemini-pro']);
         expect(logger.calls).toEqual([]);
     });
 
@@ -164,15 +164,24 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
         expect(logger.calls.some(c => c.level === 'info' && c.msg.includes('disabled'))).toBe(true);
     });
 
-    test('active-subscribers — unions self with provider output', async () => {
-        const subscribers = ['@neo-gpt', '@neo-opus-4-7', 'neo-gemini-3-1-pro'];
+    test('active-subscribers — unions self with eligible provider output', async () => {
+        const logger      = captureLogger();
+        const subscribers = ['@neo-gpt', '@neo-opus-4-7', '@neo-gemini-pro', '@custom-local-agent'];
         const result = await resolveTargets({
             selfIdentity              : '@neo-opus-4-7',
             targetSource              : 'active-subscribers',
-            activeSubscribersProvider: async () => subscribers
+            activeSubscribersProvider: async () => subscribers,
+            logger
         });
-        // Self appears first; subscribers union (no duplicates); 3rd entry gets normalized.
-        expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@neo-gemini-3-1-pro']);
+        // Self appears first; subscribers union (no duplicates); known benched identities are
+        // filtered, while unknown local/fork identities remain eligible.
+        expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@custom-local-agent']);
+        expect(logger.calls.some(c =>
+            c.level === 'info' &&
+            c.msg.includes("targetSource='active-subscribers'") &&
+            c.msg.includes('@neo-gemini-pro') &&
+            c.msg.includes('not active')
+        )).toBe(true);
     });
 
     test('active-subscribers without provider — falls back to self with warn', async () => {
@@ -255,15 +264,24 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
 
     // ----- active-a2a-participants: activity-derived candidate discovery -----
 
-    test('active-a2a-participants — unions self with provider output (3h A2A activity)', async () => {
-        const participants = ['@neo-gpt', '@neo-opus-4-7', 'neo-gemini-3-1-pro'];
+    test('active-a2a-participants — unions self with eligible provider output (3h A2A activity)', async () => {
+        const logger       = captureLogger();
+        const participants = ['@neo-gpt', '@neo-opus-4-7', '@neo-gemini-pro', '@custom-local-agent'];
         const result = await resolveTargets({
             selfIdentity                  : '@neo-opus-4-7',
             targetSource                  : 'active-a2a-participants',
-            activeA2aParticipantsProvider : async () => participants
+            activeA2aParticipantsProvider : async () => participants,
+            logger
         });
-        // Self appears first; participants union (no duplicates); 3rd entry gets normalized.
-        expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@neo-gemini-3-1-pro']);
+        // Self appears first; participants union (no duplicates); known benched identities are
+        // filtered, while unknown local/fork identities remain eligible.
+        expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@custom-local-agent']);
+        expect(logger.calls.some(c =>
+            c.level === 'info' &&
+            c.msg.includes("targetSource='active-a2a-participants'") &&
+            c.msg.includes('@neo-gemini-pro') &&
+            c.msg.includes('not active')
+        )).toBe(true);
     });
 
     test('active-a2a-participants without provider — falls back to self with warn', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs
@@ -87,6 +87,17 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
         expect(logger.calls).toEqual([]);
     });
 
+    test('self targetSource excludes known non-active identities', async () => {
+        const logger = captureLogger();
+        const result = await resolveTargets({
+            selfIdentity: '@neo-gemini-pro',
+            targetSource: 'self',
+            logger
+        });
+        expect(result).toEqual([]);
+        expect(logger.calls).toEqual([]);
+    });
+
     test('explicit target list wins over targetSource', async () => {
         const logger = captureLogger();
         const result = await resolveTargets({
@@ -176,12 +187,7 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
         // Self appears first; subscribers union (no duplicates); known benched identities are
         // filtered, while unknown local/fork identities remain eligible.
         expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@custom-local-agent']);
-        expect(logger.calls.some(c =>
-            c.level === 'info' &&
-            c.msg.includes("targetSource='active-subscribers'") &&
-            c.msg.includes('@neo-gemini-pro') &&
-            c.msg.includes('not active')
-        )).toBe(true);
+        expect(logger.calls).toEqual([]);
     });
 
     test('active-subscribers without provider — falls back to self with warn', async () => {
@@ -276,12 +282,7 @@ test.describe('resolveTargets — deployment-portable swarm-heartbeat target res
         // Self appears first; participants union (no duplicates); known benched identities are
         // filtered, while unknown local/fork identities remain eligible.
         expect(result).toEqual(['@neo-opus-4-7', '@neo-gpt', '@custom-local-agent']);
-        expect(logger.calls.some(c =>
-            c.level === 'info' &&
-            c.msg.includes("targetSource='active-a2a-participants'") &&
-            c.msg.includes('@neo-gemini-pro') &&
-            c.msg.includes('not active')
-        )).toBe(true);
+        expect(logger.calls).toEqual([]);
     });
 
     test('active-a2a-participants without provider — falls back to self with warn', async () => {

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1352,12 +1352,15 @@ test.describe('Wake Daemon', () => {
             env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
+        let stdoutLog = '';
+
         // We know bridge-daemon will log INFO when it finishes osascript
         const deliveryPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver event within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
+                stdoutLog += out;
                 if (out.includes('[Wake Daemon] Delivered ' + subId)) {
                     clearTimeout(timeout);
                     resolve();
@@ -1398,6 +1401,10 @@ test.describe('Wake Daemon', () => {
         expect(args.join(' ')).toContain('keystroke "i" using {command down, shift down}');
         expect(args.join(' ')).toContain('tell application "Antigravity" to activate');
         expect(args.join(' ')).not.toContain('key code 49');
+        expect(stdoutLog).toContain(
+            'scenario=direct-message; route=osascript; adapterSource=metadata; app=Antigravity; ' +
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:0'
+        );
     });
 
     test('Claude default focus seed emits r -> Cmd+Z before prompt clear and guards frontmost (#10987, #10422)', async () => {
@@ -1833,6 +1840,60 @@ test.describe('Wake Daemon', () => {
         expect(args.at(-1)).toBe('C-m');
     });
 
+    test('tmux wake suppresses pure-heartbeat interactive submit and logs route evidence (#13456)', async () => {
+        const agentId = '@test-agent-tmux-pure-heartbeat';
+        const subId = insertWakeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter: 'tmux',
+                appName: 'Antigravity',
+                coalesceWindow: 1
+            }
+        });
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        const mockTmuxPath = path.join(binDir, 'tmux');
+        const mockOutPath = path.join(DAEMON_DIR, 'mock_tmux_pure_heartbeat_out.json');
+        fs.writeFileSync(mockTmuxPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockTmuxPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        let stdoutLog = '';
+
+        const suppressionPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not suppress pure-heartbeat tmux wake within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                stdoutLog += out;
+                if (out.includes(`Suppressed ${subId} tmux delivery for pure-heartbeat`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
+
+        await suppressionPromise;
+
+        expect(fs.existsSync(mockOutPath)).toBe(false);
+        expect(stdoutLog).toContain(
+            'scenario=pure-heartbeat; route=tmux; adapterSource=metadata; app=Antigravity; ' +
+            'counts=messages:0,tasks:0,permissions:0,heartbeats:1'
+        );
+    });
+
     test('addressType webhookUrl dispatch POSTs the wake digest to the instanceAddress (#12422)', async () => {
         const received = new Promise((resolve, reject) => {
             const server = http.createServer((req, res) => {
@@ -2106,7 +2167,7 @@ test.describe('Wake Daemon', () => {
         );
     });
 
-    test('Codex UI wake logs pure-heartbeat scenario and route evidence (#13320)', async () => {
+    test('Codex UI wake suppresses pure-heartbeat interactive submit and logs route evidence (#13456)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-pure-heartbeat';
 
@@ -2151,12 +2212,12 @@ test.describe('Wake Daemon', () => {
         let stdoutLog = '';
 
         const deliveryPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver pure-heartbeat Codex wake within timeout')), 10000);
+            const timeout = setTimeout(() => reject(new Error('Daemon did not suppress pure-heartbeat Codex wake within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
                 stdoutLog += out;
-                if (out.includes(`Delivered ${subId}`)) {
+                if (out.includes(`Suppressed ${subId} osascript delivery for pure-heartbeat`)) {
                     clearTimeout(timeout);
                     resolve();
                 }
@@ -2172,12 +2233,8 @@ test.describe('Wake Daemon', () => {
 
         await deliveryPromise;
 
-        const rawArgs = JSON.parse(fs.readFileSync(mockOutPath, 'utf-8'));
-        const digest  = rawArgs.at(-1);
-
-        expect(digest).toContain('heartbeat pulses');
-        expect(digest).toContain('lifecycle-first');
-        expect(digest).not.toContain('new messages');
+        expect(fs.existsSync(mockOutPath)).toBe(false);
+        expect(stdoutLog).toContain('not submitting into interactive harness');
         expect(stdoutLog).toContain(
             'scenario=pure-heartbeat; route=osascript; adapterSource=metadata; app=Codex; ' +
             'counts=messages:0,tasks:0,permissions:0,heartbeats:1'

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -886,6 +886,36 @@ test.describe('Wake Daemon', () => {
         expect(storedMessage.properties.wakeSuppressed).toBe(true);
     });
 
+    test('does not queue wake delivery for known non-active identities (#13456)', async () => {
+        const agentId = '@neo-gemini-pro';
+        const subId = insertWakeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter: 'test',
+                coalesceWindow: 1
+            }
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+        });
+
+        let stdoutLog = '';
+
+        daemonProcess.stdout.on('data', data => stdoutLog += data.toString());
+        daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        insertMessageWake(db, {agentId, subject: 'Benched Gemini Wake'});
+
+        await new Promise(resolve => setTimeout(resolve, 5500));
+
+        expect(stdoutLog).not.toContain(`[Wake Daemon Test Adapter] Delivered ${subId}`);
+        expect(stdoutLog).not.toContain('Benched Gemini Wake');
+    });
+
     test('deduplicates multiple triggers for the same message in the coalescing window', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-dedup';
@@ -1840,7 +1870,7 @@ test.describe('Wake Daemon', () => {
         expect(args.at(-1)).toBe('C-m');
     });
 
-    test('tmux wake suppresses pure-heartbeat interactive submit and logs route evidence (#13456)', async () => {
+    test('tmux wake does not queue pure-heartbeat interactive submit (#13456)', async () => {
         const agentId = '@test-agent-tmux-pure-heartbeat';
         const subId = insertWakeSubscription(db, {
             agentId,
@@ -1865,33 +1895,19 @@ test.describe('Wake Daemon', () => {
 
         let stdoutLog = '';
 
-        const suppressionPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon did not suppress pure-heartbeat tmux wake within timeout')), 10000);
-
-            daemonProcess.stdout.on('data', (data) => {
-                const out = data.toString();
-                stdoutLog += out;
-                if (out.includes(`Suppressed ${subId} tmux delivery for pure-heartbeat`)) {
-                    clearTimeout(timeout);
-                    resolve();
-                }
-            });
-            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
-            daemonProcess.on('error', reject);
-        });
+        daemonProcess.stdout.on('data', data => stdoutLog += data.toString());
+        daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
 
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
 
-        await suppressionPromise;
+        await new Promise(resolve => setTimeout(resolve, 5000));
 
         expect(fs.existsSync(mockOutPath)).toBe(false);
-        expect(stdoutLog).toContain(
-            'scenario=pure-heartbeat; route=tmux; adapterSource=metadata; app=Antigravity; ' +
-            'counts=messages:0,tasks:0,permissions:0,heartbeats:1'
-        );
+        expect(stdoutLog).not.toContain(`Delivered ${subId}`);
+        expect(stdoutLog).not.toContain(`Suppressed ${subId}`);
     });
 
     test('addressType webhookUrl dispatch POSTs the wake digest to the instanceAddress (#12422)', async () => {
@@ -2167,7 +2183,7 @@ test.describe('Wake Daemon', () => {
         );
     });
 
-    test('Codex UI wake suppresses pure-heartbeat interactive submit and logs route evidence (#13456)', async () => {
+    test('Codex UI wake does not queue pure-heartbeat interactive submit (#13456)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-pure-heartbeat';
 
@@ -2211,37 +2227,22 @@ test.describe('Wake Daemon', () => {
 
         let stdoutLog = '';
 
-        const deliveryPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon did not suppress pure-heartbeat Codex wake within timeout')), 10000);
-
-            daemonProcess.stdout.on('data', (data) => {
-                const out = data.toString();
-                stdoutLog += out;
-                if (out.includes(`Suppressed ${subId} osascript delivery for pure-heartbeat`)) {
-                    clearTimeout(timeout);
-                    resolve();
-                }
-            });
-            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
-            daemonProcess.on('error', reject);
-        });
+        daemonProcess.stdout.on('data', data => stdoutLog += data.toString());
+        daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
 
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         const pulseId = `HEARTBEAT_PULSE:${agentId}:${crypto.randomUUID()}`;
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
 
-        await deliveryPromise;
+        await new Promise(resolve => setTimeout(resolve, 5000));
 
         expect(fs.existsSync(mockOutPath)).toBe(false);
-        expect(stdoutLog).toContain('not submitting into interactive harness');
-        expect(stdoutLog).toContain(
-            'scenario=pure-heartbeat; route=osascript; adapterSource=metadata; app=Codex; ' +
-            'counts=messages:0,tasks:0,permissions:0,heartbeats:1'
-        );
+        expect(stdoutLog).not.toContain(`Delivered ${subId}`);
+        expect(stdoutLog).not.toContain(`Suppressed ${subId}`);
     });
 
-    test('Codex UI wake submits a mixed message + heartbeat digest with Enter and omits the heartbeat-only directive (#13287)', async () => {
+    test('Codex UI wake submits actionable message and drops coalesced heartbeat event (#13456)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-mixed-submit';
 
@@ -2286,7 +2287,7 @@ test.describe('Wake Daemon', () => {
         let stdoutLog = '';
 
         const deliveryPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver mixed Codex wake within timeout')), 10000);
+            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver actionable Codex wake within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
@@ -2320,11 +2321,11 @@ test.describe('Wake Daemon', () => {
         expect(enterIndex).toBeGreaterThan(escapeIndex);
         expect(digest).toContain('Codex Mixed Submit');
         expect(digest).toContain('new messages');
-        expect(digest).toContain('heartbeat pulses');
+        expect(digest).not.toContain('heartbeat pulses');
         expect(digest).not.toContain('lifecycle-first');
         expect(stdoutLog).toContain(
-            'scenario=mixed-message-heartbeat; route=osascript; adapterSource=metadata; app=Codex; ' +
-            'counts=messages:1,tasks:0,permissions:0,heartbeats:1'
+            'scenario=direct-message; route=osascript; adapterSource=metadata; app=Codex; ' +
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:0'
         );
     });
 


### PR DESCRIPTION
Resolves #13456

Stops heartbeat-only wake pulses from behaving like actionable chat interrupts and stops non-active repo identities from entering wake delivery. Dynamic heartbeat discovery now excludes known repo identities whose `participationStatus` is not `active`, including the `self` source, while preserving explicit target-list overrides for operator diagnostics. The wake daemon also filters known non-active subscription identities before coalescing and silently drops any pending retry whose target becomes non-active, so inactive agents do not create delivery attempts, retries, or skipped-message logs.

For prompt-submitting adapters (`osascript` and `tmux`), heartbeat-only events are now filtered before coalescing instead of being delivered and then suppressed. Direct-message wakes still submit normally, and mixed actionable-message + heartbeat wakes deliver the actionable message while dropping the coalesced heartbeat event.

Evidence: L2 (focused unit daemon/resolver tests with mock `osascript`/`tmux`, non-active identity queue assertions, and negative delivery-log assertions) -> L4 required (live operator harness after daemon restart must show no inactive-agent wake attempts and no heartbeat-only prompt submits). Residual: post-merge validation [#13456].

## Deltas from ticket

- Preserved explicit target-list overrides so operator diagnostics can still intentionally target a non-active identity.
- Kept unknown external/fork identities eligible in dynamic sources; only known repo identities with non-active participation are filtered.
- Removed the downstream pure-heartbeat `Suppressed` / `skipped` delivery outcome; prompt-submitting heartbeat-only events are filtered before coalescing.
- Added retry-path protection so an already queued retry cannot keep hammering a target that is now non-active.

## Test Evidence

- `git diff --check`
- `git diff --cached --check`
- Commit hook ran staged-file checks: whitespace, shorthand, AiConfig test-mutation, JSDoc types, and ticket archaeology.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs`
  - Sandbox run: 60 passed, 1 failed on the existing webhook test with `listen EPERM: operation not permitted 127.0.0.1`.
  - Escalated rerun of the same narrow command before rebase: 61 passed.
  - Rebased onto `origin/dev` `d24ceda42`; escalated rerun of the same narrow command: 61 passed.

## Post-Merge Validation

- [ ] Restart the wake/orchestrator daemons and confirm known non-active identities do not create wake delivery attempts or retry logs.
- [ ] Confirm heartbeat-only events for prompt-submitting adapters do not paste/submit into Antigravity, Codex, or tmux harnesses.
- [ ] Confirm direct A2A message wakes still log `scenario=direct-message` and deliver normally after restart.

## Related

Related: #13012
Related: #11993
Related: #12479

## Commits

- `c509350b7` - `fix(ai): suppress benched heartbeat wake submits (#13456)`
- `fcd52ee44` - `Update daemon.mjs`
- `5014b9ac1` - `fix(ai): stop inactive heartbeat wake enqueue (#13456)`

Authored by Euclid (GPT-5.5, Codex Desktop). Session 019ed42c-f8fc-7e01-a1a1-a8b5bbf58b64.
