### PR TITLE
fix(memory-core): bound health probes (#13458)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -232,6 +232,29 @@ class Config extends ConfigProvider {
              */
             remRunRetentionLimit: leaf(200, 'NEO_REM_RUN_RETENTION_LIMIT', 'number'),
             /**
+             * Healthcheck probe budgets. These bound dependency probes so a stalled
+             * Chroma client, embedding provider, or REM axis returns unhealthy/degraded
+             * observability instead of keeping the MCP request open indefinitely.
+             * @type {Object}
+             */
+            healthcheck: {
+                /**
+                 * Max time to wait for Chroma readiness, connection, and collection-count probes.
+                 * @type {number}
+                 */
+                chromaProbeTimeoutMs: leaf(1500, 'NEO_MEMORY_HEALTHCHECK_CHROMA_PROBE_TIMEOUT_MS', 'number'),
+                /**
+                 * Max time to wait for the active embedding provider during the write canary.
+                 * @type {number}
+                 */
+                embeddingWriteCanaryTimeoutMs: leaf(5000, 'NEO_MEMORY_HEALTHCHECK_EMBEDDING_WRITE_CANARY_TIMEOUT_MS', 'number'),
+                /**
+                 * Max time to wait for each REM pipeline-state axis.
+                 * @type {number}
+                 */
+                remAxisTimeoutMs: leaf(1500, 'NEO_MEMORY_HEALTHCHECK_REM_AXIS_TIMEOUT_MS', 'number')
+            },
+            /**
              * Durable JSONL write-ahead store for `add_memory` payloads.
              *
              * The mandated per-turn save appends its full payload here BEFORE any model-dependent

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1458,6 +1458,13 @@ components:
           type: integer
           description: Conflict entries currently present in the Sandman handoff file.
           example: 2
+        axisErrors:
+          type: object
+          description: Optional per-axis degradation map. Present only when an axis probe timed out or failed and its numeric value fell back to 0.
+          additionalProperties:
+            type: string
+          example:
+            undigested: "REM axis undigested timed out after 1500ms"
         recentCycles:
           type: array
           description: Recent REM cycle summaries read from the gitignored JSONL run-state store.

--- a/ai/scripts/diagnostics/mcpHealthcheck.mjs
+++ b/ai/scripts/diagnostics/mcpHealthcheck.mjs
@@ -19,6 +19,27 @@ import {pathToFileURL}                 from 'url';
  */
 
 export const DEFAULT_URL = 'http://127.0.0.1:3000';
+export const DEFAULT_TIMEOUT_MS = 8000;
+
+/**
+ * @summary Bounds an MCP SDK operation and aborts the underlying HTTP transport on timeout.
+ * @param {Promise} promise Operation promise returned by the SDK.
+ * @param {Number} timeoutMs Maximum wait time before rejecting.
+ * @param {String} label Human-readable operation label for the error message.
+ * @param {AbortController} abortController Controller tied to the transport requestInit.
+ * @returns {Promise<*>}
+ */
+function withAbortableTimeout(promise, timeoutMs, label, abortController) {
+    let timer;
+    const timeout = new Promise((resolve, reject) => {
+        timer = setTimeout(() => {
+            abortController?.abort?.();
+            reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+    });
+
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
 
 /**
  * @summary Parses CLI arguments and dotenv-backed environment defaults.
@@ -38,7 +59,8 @@ export function parseArgs(argv = [], env = process.env) {
         .option('--identity <identity>', 'Trusted proxy identity header value.', env.NEO_MCP_HEALTHCHECK_IDENTITY || 'neo-container-healthcheck')
         .option('--bearer-token-env <name>', 'Environment variable containing an OAuth bearer token.', env.NEO_MCP_HEALTHCHECK_TOKEN_ENV || 'NEO_MCP_HEALTHCHECK_TOKEN')
         .option('--expected-status <status>', 'Expected healthcheck status value.', env.NEO_MCP_HEALTHCHECK_EXPECTED_STATUS || 'healthy')
-        .option('--client-name <name>', 'MCP client name.', env.NEO_MCP_HEALTHCHECK_CLIENT_NAME || 'neo-container-healthcheck');
+        .option('--client-name <name>', 'MCP client name.', env.NEO_MCP_HEALTHCHECK_CLIENT_NAME || 'neo-container-healthcheck')
+        .option('--timeout-ms <ms>', 'Maximum time to wait for MCP connect/tool-call operations.', env.NEO_MCP_HEALTHCHECK_TIMEOUT_MS || String(DEFAULT_TIMEOUT_MS));
 
     program.parse(argv, {from: 'user'});
 
@@ -50,7 +72,8 @@ export function parseArgs(argv = [], env = process.env) {
         bearerToken   : env[options.bearerTokenEnv] || null,
         bearerTokenEnv: options.bearerTokenEnv,
         expectedStatus: options.expectedStatus,
-        clientName    : options.clientName
+        clientName    : options.clientName,
+        timeoutMs     : Number(options.timeoutMs) || DEFAULT_TIMEOUT_MS
     };
 }
 
@@ -101,6 +124,7 @@ export function readToolJson(result) {
  * @param {String|null} [options.bearerToken]
  * @param {String} [options.expectedStatus='healthy']
  * @param {String} [options.clientName='neo-container-healthcheck']
+ * @param {Number} [options.timeoutMs=DEFAULT_TIMEOUT_MS]
  * @param {Function} [options.ClientClass=Client] Injectable SDK client constructor for tests.
  * @param {Function} [options.TransportClass=StreamableHTTPClientTransport] Injectable transport constructor for tests.
  * @returns {Promise<Object>}
@@ -111,14 +135,19 @@ export async function runHealthcheck({
     bearerToken    = null,
     expectedStatus = 'healthy',
     clientName     = 'neo-container-healthcheck',
+    timeoutMs      = DEFAULT_TIMEOUT_MS,
     ClientClass    = Client,
     TransportClass = StreamableHTTPClientTransport
 }) {
     const baseUrl = new URL(url);
     const headers = buildHeaders({identity, bearerToken});
+    const abortController = new AbortController();
 
     const transport = new TransportClass(new URL('/mcp', baseUrl), {
-        requestInit: {headers}
+        requestInit: {
+            headers,
+            signal: abortController.signal
+        }
     });
 
     const client = new ClientClass({
@@ -128,10 +157,20 @@ export async function runHealthcheck({
         capabilities: {}
     });
 
-    await client.connect(transport);
-
     try {
-        const result = await client.callTool({name: 'healthcheck', arguments: {}});
+        await withAbortableTimeout(
+            client.connect(transport),
+            timeoutMs,
+            'MCP healthcheck connect',
+            abortController
+        );
+
+        const result = await withAbortableTimeout(
+            client.callTool({name: 'healthcheck', arguments: {}}),
+            timeoutMs,
+            'MCP healthcheck tool call',
+            abortController
+        );
 
         if (result?.isError) {
             throw new Error('MCP healthcheck tool returned isError=true.');

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -16,12 +16,16 @@ import {
     normalizeUserId
 } from '../../mcp/server/shared/services/RequestContextService.mjs';
 import {readRecentRemRunStates} from './helpers/remRunStateStore.mjs';
+import {withTimeout}             from './helpers/withTimeout.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const
     configPath  = path.resolve(__dirname, '../../config.mjs'),
     openApiPath = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
+    CHROMA_HEALTH_PROBE_TIMEOUT_MS = 1500,
+    EMBEDDING_WRITE_CANARY_TIMEOUT_MS = 5000,
+    REM_AXIS_TIMEOUT_MS = 1500,
     runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
         files  : [{
             key       : 'configDigest',
@@ -173,6 +177,7 @@ export function buildEmbeddingProviderBlock(cfg) {
  * @param {Function} [options.embedText] Optional test seam matching `TextEmbeddingService.embedText`.
  * @param {String} [options.input='neo-healthcheck-embedding-write-canary'] Probe text.
  * @param {Function} [options.now=Date.now] Time source for deterministic tests.
+ * @param {Number} [options.timeoutMs=EMBEDDING_WRITE_CANARY_TIMEOUT_MS] Max time to wait for the provider.
  * @returns {Promise<{status: String, provider: String, dimensions: Number|null,
  *     expectedDimensions: Number|null, durationMs: Number, error: String|undefined}>}
  */
@@ -180,7 +185,8 @@ export async function buildEmbeddingWriteCanaryBlock({
     cfg       = aiConfig,
     embedText = null,
     input     = 'neo-healthcheck-embedding-write-canary',
-    now       = Date.now
+    now       = Date.now,
+    timeoutMs = EMBEDDING_WRITE_CANARY_TIMEOUT_MS
 } = {}) {
     const readNow            = typeof now === 'function' ? now : () => (typeof now === 'number' ? now : now.getTime()),
           startedAt          = readNow(),
@@ -192,7 +198,11 @@ export async function buildEmbeddingWriteCanaryBlock({
             const {default: TextEmbeddingService} = await import('./TextEmbeddingService.mjs');
             return TextEmbeddingService.embedText(text, explicitProvider);
         });
-        const embedding = await probe(input, provider),
+        const embedding = await withTimeout(
+                  Promise.resolve(probe(input, provider)),
+                  timeoutMs,
+                  'Embedding write canary'
+              ),
               dimensions = Array.isArray(embedding) ? embedding.length : null,
               durationMs = Math.max(0, readNow() - startedAt);
 
@@ -639,14 +649,21 @@ export function buildChromaMigrationStats(metadatas, {summaryCollection = false}
  *
  * @param {String} label Human-readable axis label for warning logs
  * @param {Function} fn Probe function returning the axis count
- * @returns {Promise<Number>} Axis count or `0` on failure
+ * @param {Number} [timeoutMs=REM_AXIS_TIMEOUT_MS] Max time to wait for the axis.
+ * @returns {Promise<{value: Number, error: String|null}>} Axis count and optional degradation reason
  */
-async function resolveRemAxis(label, fn) {
+async function resolveRemAxis(label, fn, timeoutMs = REM_AXIS_TIMEOUT_MS) {
     try {
-        return await fn();
+        return {
+            value: await withTimeout(Promise.resolve(fn()), timeoutMs, `REM axis ${label}`),
+            error: null
+        };
     } catch (e) {
         logger.warn(`[HealthService] get_rem_pipeline_state axis ${label} failed:`, e?.message ?? e);
-        return 0;
+        return {
+            value: 0,
+            error: e?.message || String(e)
+        };
     }
 }
 
@@ -677,13 +694,14 @@ async function resolveRemBlock(label, fn, fallback) {
  *
  * @param {Object} [options]
  * @param {String} [options.sessionId] Optional session id for per-session entity yield
+ * @param {Number} [options.axisTimeoutMs=REM_AXIS_TIMEOUT_MS] Max time to wait for each axis.
  * @returns {Promise<Object>} REM pipeline state projection
  * @see ChromaManager#getUndigestedSessionCount
  * @see ChromaManager#getGraphDigestedCount
  * @see Neo.ai.services.memory-core.GraphService#getSessionNodeCount
  * @see Neo.ai.daemons.services.TopologyInferenceEngine#getTopologyConflictCount
  */
-export async function buildRemPipelineState({sessionId} = {}) {
+export async function buildRemPipelineState({sessionId, axisTimeoutMs = REM_AXIS_TIMEOUT_MS} = {}) {
     const [
         {default: GraphService},
         {default: TopologyInferenceEngine}
@@ -692,17 +710,19 @@ export async function buildRemPipelineState({sessionId} = {}) {
         import('../graph/TopologyInferenceEngine.mjs')
     ]);
 
-    const [
-        undigested,
-        digested,
-        sessionNodes,
-        topologyConflicts
-    ] = await Promise.all([
-        resolveRemAxis('undigested',        () => ChromaManager.getUndigestedSessionCount()),
-        resolveRemAxis('digested',          () => ChromaManager.getGraphDigestedCount()),
-        resolveRemAxis('sessionNodes',      () => GraphService.getSessionNodeCount()),
-        resolveRemAxis('topologyConflicts', () => TopologyInferenceEngine.getTopologyConflictCount())
+    const axisEntries = await Promise.all([
+        resolveRemAxis('undigested',        () => ChromaManager.getUndigestedSessionCount(), axisTimeoutMs),
+        resolveRemAxis('digested',          () => ChromaManager.getGraphDigestedCount(), axisTimeoutMs),
+        resolveRemAxis('sessionNodes',      () => GraphService.getSessionNodeCount(), axisTimeoutMs),
+        resolveRemAxis('topologyConflicts', () => TopologyInferenceEngine.getTopologyConflictCount(), axisTimeoutMs)
     ]);
+
+    const [undigested, digested, sessionNodes, topologyConflicts] = axisEntries.map(entry => entry.value),
+          axisErrors = Object.fromEntries(
+              ['undigested', 'digested', 'sessionNodes', 'topologyConflicts']
+                  .map((key, index) => [key, axisEntries[index].error])
+                  .filter(([, error]) => error)
+          );
 
     const recentCycles = await resolveRemBlock('recentCycles', async () => {
         const entries = await readRecentRemRunStates({
@@ -727,11 +747,28 @@ export async function buildRemPipelineState({sessionId} = {}) {
         recentCycles
     };
 
+    if (Object.keys(axisErrors).length) {
+        state.axisErrors = axisErrors;
+    }
+
     if (sessionId) {
+        const entityCount = await resolveRemAxis(
+            'perSession.entityCount',
+            () => GraphService.getSessionEntityCount(sessionId),
+            axisTimeoutMs
+        );
+
         state.perSession = {
             sessionId,
-            entityCount: await resolveRemAxis('perSession.entityCount', () => GraphService.getSessionEntityCount(sessionId))
+            entityCount: entityCount.value
         };
+
+        if (entityCount.error) {
+            state.axisErrors = {
+                ...(state.axisErrors || {}),
+                'perSession.entityCount': entityCount.error
+            };
+        }
     }
 
     return state;
@@ -895,6 +932,18 @@ class HealthService extends Base {
     runtimeFreshnessCacheDuration = 30 * 1000;
 
     /**
+     * Max time a Chroma health probe may spend waiting for a downstream promise.
+     * @member {Number} chromaHealthProbeTimeoutMs=1500
+     */
+    chromaHealthProbeTimeoutMs = CHROMA_HEALTH_PROBE_TIMEOUT_MS;
+
+    /**
+     * Max time the embedding write canary may spend waiting for the active provider.
+     * @member {Number} embeddingWriteCanaryTimeoutMs=5000
+     */
+    embeddingWriteCanaryTimeoutMs = EMBEDDING_WRITE_CANARY_TIMEOUT_MS;
+
+    /**
      * Checks if the active vector and graph databases are running and accessible.
      * @returns {Promise<Object>} {running: boolean, error: string|undefined, engines: Object}
      * @private
@@ -906,8 +955,16 @@ class HealthService extends Base {
 
             // 2. Vector Chroma DB (Hybrid & Standalone Chroma)
             if (engine === 'chroma' || engine === 'hybrid') {
-                await ChromaManager.ready();
-                if (!ChromaManager.connected && !(await ChromaManager.connect())) {
+                await withTimeout(
+                    ChromaManager.ready(),
+                    this.chromaHealthProbeTimeoutMs,
+                    'ChromaManager.ready health probe'
+                );
+                if (!ChromaManager.connected && !(await withTimeout(
+                    ChromaManager.connect(),
+                    this.chromaHealthProbeTimeoutMs,
+                    'ChromaManager.connect health probe'
+                ))) {
                     throw new Error("ChromaDB is not accessible");
                 }
                 engines.chroma = true;
@@ -940,14 +997,43 @@ class HealthService extends Base {
 
         try {
             // Check memory collection
-            const memoryCollection = await StorageRouter.getMemoryCollection().catch(() => null);
-            if (memoryCollection) {
+            const memoryCollection = await withTimeout(
+                StorageRouter.getMemoryCollection(),
+                this.chromaHealthProbeTimeoutMs,
+                'memory collection resolution health probe'
+            ).catch(error => {
                 result.memories = {
                     name  : aiConfig.collections.memory,
-                    exists: true,
-                    count : await memoryCollection.count().catch(() => 0)
+                    exists: false,
+                    count : 0,
+                    error : error.message
                 };
-            } else {
+                return null;
+            });
+            if (memoryCollection) {
+                let memoryCount = 0;
+                try {
+                    memoryCount = await withTimeout(
+                        memoryCollection.count(),
+                        this.chromaHealthProbeTimeoutMs,
+                        'memory collection count health probe'
+                    );
+                } catch (error) {
+                    result.memories = {
+                        name  : aiConfig.collections.memory,
+                        exists: true,
+                        count : 0,
+                        error : error.message
+                    };
+                }
+
+                result.memories = {
+                    name : aiConfig.collections.memory,
+                    exists: true,
+                    count: memoryCount,
+                    ...(result.memories?.error ? {error: result.memories.error} : {})
+                };
+            } else if (!result.memories) {
                 result.memories = {
                     name  : aiConfig.collections.memory,
                     exists: false,
@@ -956,19 +1042,53 @@ class HealthService extends Base {
             }
 
             // Check summary collection
-            const summaryCollection = await StorageRouter.getSummaryCollection().catch(() => null);
-            if (summaryCollection) {
+            const summaryCollection = await withTimeout(
+                StorageRouter.getSummaryCollection(),
+                this.chromaHealthProbeTimeoutMs,
+                'summary collection resolution health probe'
+            ).catch(error => {
                 result.summaries = {
                     name  : aiConfig.collections.session,
-                    exists: true,
-                    count : await summaryCollection.count().catch(() => 0)
+                    exists: false,
+                    count : 0,
+                    error : error.message
                 };
-            } else {
+                return null;
+            });
+            if (summaryCollection) {
+                let summaryCount = 0;
+                try {
+                    summaryCount = await withTimeout(
+                        summaryCollection.count(),
+                        this.chromaHealthProbeTimeoutMs,
+                        'summary collection count health probe'
+                    );
+                } catch (error) {
+                    result.summaries = {
+                        name  : aiConfig.collections.session,
+                        exists: true,
+                        count : 0,
+                        error : error.message
+                    };
+                }
+
+                result.summaries = {
+                    name : aiConfig.collections.session,
+                    exists: true,
+                    count: summaryCount,
+                    ...(result.summaries?.error ? {error: result.summaries.error} : {})
+                };
+            } else if (!result.summaries) {
                 result.summaries = {
                     name  : aiConfig.collections.session,
                     exists: false,
                     count : 0
                 };
+            }
+
+            const errors = [result.memories?.error, result.summaries?.error].filter(Boolean);
+            if (errors.length) {
+                result.error = `Failed to access collections: ${errors.join('; ')}`;
             }
 
             return result;
@@ -1283,7 +1403,9 @@ class HealthService extends Base {
             return {...cached.result};
         }
 
-        const result = await buildEmbeddingWriteCanaryBlock();
+        const result = await buildEmbeddingWriteCanaryBlock({
+            timeoutMs: this.embeddingWriteCanaryTimeoutMs
+        });
 
         if (result.status === 'healthy') {
             this.#embeddingWriteCanaryCache = {

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -23,9 +23,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const
     configPath  = path.resolve(__dirname, '../../config.mjs'),
     openApiPath = path.resolve(__dirname, '../../mcp/server/memory-core/openapi.yaml'),
-    CHROMA_HEALTH_PROBE_TIMEOUT_MS = 1500,
-    EMBEDDING_WRITE_CANARY_TIMEOUT_MS = 5000,
-    REM_AXIS_TIMEOUT_MS = 1500,
     runtimeFreshnessTracker = RuntimeFreshnessService.createTracker({
         files  : [{
             key       : 'configDigest',
@@ -177,7 +174,7 @@ export function buildEmbeddingProviderBlock(cfg) {
  * @param {Function} [options.embedText] Optional test seam matching `TextEmbeddingService.embedText`.
  * @param {String} [options.input='neo-healthcheck-embedding-write-canary'] Probe text.
  * @param {Function} [options.now=Date.now] Time source for deterministic tests.
- * @param {Number} [options.timeoutMs=EMBEDDING_WRITE_CANARY_TIMEOUT_MS] Max time to wait for the provider.
+ * @param {Number} [options.timeoutMs=aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs] Max time to wait for the provider.
  * @returns {Promise<{status: String, provider: String, dimensions: Number|null,
  *     expectedDimensions: Number|null, durationMs: Number, error: String|undefined}>}
  */
@@ -186,7 +183,7 @@ export async function buildEmbeddingWriteCanaryBlock({
     embedText = null,
     input     = 'neo-healthcheck-embedding-write-canary',
     now       = Date.now,
-    timeoutMs = EMBEDDING_WRITE_CANARY_TIMEOUT_MS
+    timeoutMs = aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs
 } = {}) {
     const readNow            = typeof now === 'function' ? now : () => (typeof now === 'number' ? now : now.getTime()),
           startedAt          = readNow(),
@@ -649,10 +646,10 @@ export function buildChromaMigrationStats(metadatas, {summaryCollection = false}
  *
  * @param {String} label Human-readable axis label for warning logs
  * @param {Function} fn Probe function returning the axis count
- * @param {Number} [timeoutMs=REM_AXIS_TIMEOUT_MS] Max time to wait for the axis.
+ * @param {Number} [timeoutMs=aiConfig.healthcheck.remAxisTimeoutMs] Max time to wait for the axis.
  * @returns {Promise<{value: Number, error: String|null}>} Axis count and optional degradation reason
  */
-async function resolveRemAxis(label, fn, timeoutMs = REM_AXIS_TIMEOUT_MS) {
+async function resolveRemAxis(label, fn, timeoutMs = aiConfig.healthcheck.remAxisTimeoutMs) {
     try {
         return {
             value: await withTimeout(Promise.resolve(fn()), timeoutMs, `REM axis ${label}`),
@@ -694,14 +691,14 @@ async function resolveRemBlock(label, fn, fallback) {
  *
  * @param {Object} [options]
  * @param {String} [options.sessionId] Optional session id for per-session entity yield
- * @param {Number} [options.axisTimeoutMs=REM_AXIS_TIMEOUT_MS] Max time to wait for each axis.
+ * @param {Number} [options.axisTimeoutMs=aiConfig.healthcheck.remAxisTimeoutMs] Max time to wait for each axis.
  * @returns {Promise<Object>} REM pipeline state projection
  * @see ChromaManager#getUndigestedSessionCount
  * @see ChromaManager#getGraphDigestedCount
  * @see Neo.ai.services.memory-core.GraphService#getSessionNodeCount
  * @see Neo.ai.daemons.services.TopologyInferenceEngine#getTopologyConflictCount
  */
-export async function buildRemPipelineState({sessionId, axisTimeoutMs = REM_AXIS_TIMEOUT_MS} = {}) {
+export async function buildRemPipelineState({sessionId, axisTimeoutMs = aiConfig.healthcheck.remAxisTimeoutMs} = {}) {
     const [
         {default: GraphService},
         {default: TopologyInferenceEngine}
@@ -932,23 +929,12 @@ class HealthService extends Base {
     runtimeFreshnessCacheDuration = 30 * 1000;
 
     /**
-     * Max time a Chroma health probe may spend waiting for a downstream promise.
-     * @member {Number} chromaHealthProbeTimeoutMs=1500
-     */
-    chromaHealthProbeTimeoutMs = CHROMA_HEALTH_PROBE_TIMEOUT_MS;
-
-    /**
-     * Max time the embedding write canary may spend waiting for the active provider.
-     * @member {Number} embeddingWriteCanaryTimeoutMs=5000
-     */
-    embeddingWriteCanaryTimeoutMs = EMBEDDING_WRITE_CANARY_TIMEOUT_MS;
-
-    /**
      * Checks if the active vector and graph databases are running and accessible.
+     * @param {Number} chromaProbeTimeoutMs Chroma probe timeout budget.
      * @returns {Promise<Object>} {running: boolean, error: string|undefined, engines: Object}
      * @private
      */
-    async #checkDatabaseConnections() {
+    async #checkDatabaseConnections(chromaProbeTimeoutMs) {
         try {
             const engine = aiConfig.engine;
             const engines = { chroma: false };
@@ -957,12 +943,12 @@ class HealthService extends Base {
             if (engine === 'chroma' || engine === 'hybrid') {
                 await withTimeout(
                     ChromaManager.ready(),
-                    this.chromaHealthProbeTimeoutMs,
+                    chromaProbeTimeoutMs,
                     'ChromaManager.ready health probe'
                 );
                 if (!ChromaManager.connected && !(await withTimeout(
                     ChromaManager.connect(),
-                    this.chromaHealthProbeTimeoutMs,
+                    chromaProbeTimeoutMs,
                     'ChromaManager.connect health probe'
                 ))) {
                     throw new Error("ChromaDB is not accessible");
@@ -986,10 +972,11 @@ class HealthService extends Base {
      * Intent: Confirms both memory and summary collections
      * are available for operations on the active StorageRouter.
      *
+     * @param {Number} chromaProbeTimeoutMs Chroma probe timeout budget.
      * @returns {Promise<Object>} {memories: Object|null, summaries: Object|null, error: string|undefined}
      * @private
      */
-    async #checkCollections() {
+    async #checkCollections(chromaProbeTimeoutMs) {
         const result = {
             memories : null,
             summaries: null
@@ -999,7 +986,7 @@ class HealthService extends Base {
             // Check memory collection
             const memoryCollection = await withTimeout(
                 StorageRouter.getMemoryCollection(),
-                this.chromaHealthProbeTimeoutMs,
+                chromaProbeTimeoutMs,
                 'memory collection resolution health probe'
             ).catch(error => {
                 result.memories = {
@@ -1015,7 +1002,7 @@ class HealthService extends Base {
                 try {
                     memoryCount = await withTimeout(
                         memoryCollection.count(),
-                        this.chromaHealthProbeTimeoutMs,
+                        chromaProbeTimeoutMs,
                         'memory collection count health probe'
                     );
                 } catch (error) {
@@ -1044,7 +1031,7 @@ class HealthService extends Base {
             // Check summary collection
             const summaryCollection = await withTimeout(
                 StorageRouter.getSummaryCollection(),
-                this.chromaHealthProbeTimeoutMs,
+                chromaProbeTimeoutMs,
                 'summary collection resolution health probe'
             ).catch(error => {
                 result.summaries = {
@@ -1060,7 +1047,7 @@ class HealthService extends Base {
                 try {
                     summaryCount = await withTimeout(
                         summaryCollection.count(),
-                        this.chromaHealthProbeTimeoutMs,
+                        chromaProbeTimeoutMs,
                         'summary collection count health probe'
                     );
                 } catch (error) {
@@ -1110,10 +1097,16 @@ class HealthService extends Base {
      *
      * @param {Object} cachedHealth Previously cached healthy healthcheck payload.
      * @param {Number|Date} now Request time used for the returned `timestamp`.
+     * @param {Object} [options]
+     * @param {Number} [options.chromaProbeTimeoutMs=aiConfig.healthcheck.chromaProbeTimeoutMs] Chroma probe timeout budget.
+     * @param {Number} [options.embeddingWriteCanaryTimeoutMs=aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs] Embedding canary timeout budget.
      * @returns {Promise<Object|null>} Fresh request snapshot or `null` when a full healthcheck is required.
      * @private
      */
-    async #buildRequestFreshCachedHealth(cachedHealth, now) {
+    async #buildRequestFreshCachedHealth(cachedHealth, now, {
+        chromaProbeTimeoutMs = aiConfig.healthcheck.chromaProbeTimeoutMs,
+        embeddingWriteCanaryTimeoutMs = aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs
+    } = {}) {
         if (!cachedHealth) {
             return null;
         }
@@ -1121,7 +1114,7 @@ class HealthService extends Base {
         let collectionsCheck;
 
         try {
-            collectionsCheck = await this.#checkCollections();
+            collectionsCheck = await this.#checkCollections(chromaProbeTimeoutMs);
         } catch (e) {
             return null;
         }
@@ -1151,7 +1144,7 @@ class HealthService extends Base {
             }
         };
 
-        return this.#applyEmbeddingWriteCanary(freshPayload);
+        return this.#applyEmbeddingWriteCanary(freshPayload, embeddingWriteCanaryTimeoutMs);
     }
 
     /**
@@ -1366,11 +1359,12 @@ class HealthService extends Base {
      * surfaces a starved embedding write path without shipping the full per-call canary sub-object.
      *
      * @param {Object} payload Mutable healthcheck payload under construction.
+     * @param {Number} embeddingWriteCanaryTimeoutMs Embedding canary timeout budget.
      * @returns {Promise<Object>}
      * @private
      */
-    async #applyEmbeddingWriteCanary(payload) {
-        const canary = await this.#getEmbeddingWriteCanary();
+    async #applyEmbeddingWriteCanary(payload, embeddingWriteCanaryTimeoutMs) {
+        const canary = await this.#getEmbeddingWriteCanary(embeddingWriteCanaryTimeoutMs);
 
         if (canary.status !== 'healthy') {
             payload.status = payload.status === 'unhealthy' ? 'unhealthy' : 'degraded';
@@ -1389,12 +1383,13 @@ class HealthService extends Base {
      * Cache key includes the active provider and expected vector dimension so config changes do
      * not reuse a canary from a different embedding route.
      *
+     * @param {Number} embeddingWriteCanaryTimeoutMs Embedding canary timeout budget.
      * @returns {Promise<Object>} Embedding write-canary block.
      * @private
      */
-    async #getEmbeddingWriteCanary() {
+    async #getEmbeddingWriteCanary(embeddingWriteCanaryTimeoutMs) {
         const now = Date.now(),
-              key = `${aiConfig.embeddingProvider}:${aiConfig.vectorDimension}`,
+              key = `${aiConfig.embeddingProvider}:${aiConfig.vectorDimension}:${embeddingWriteCanaryTimeoutMs}`,
               cached = this.#embeddingWriteCanaryCache;
 
         if (cached &&
@@ -1404,7 +1399,7 @@ class HealthService extends Base {
         }
 
         const result = await buildEmbeddingWriteCanaryBlock({
-            timeoutMs: this.embeddingWriteCanaryTimeoutMs
+            timeoutMs: embeddingWriteCanaryTimeoutMs
         });
 
         if (result.status === 'healthy') {
@@ -1437,10 +1432,16 @@ class HealthService extends Base {
      * - degraded: ChromaDB running, collections accessible, but a configured provider is missing credentials
      * - unhealthy: ChromaDB not running or collections not accessible
      *
+     * @param {Object} [options]
+     * @param {Number} [options.chromaProbeTimeoutMs=aiConfig.healthcheck.chromaProbeTimeoutMs] Chroma probe timeout budget.
+     * @param {Number} [options.embeddingWriteCanaryTimeoutMs=aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs] Embedding canary timeout budget.
      * @returns {Promise<object>} A comprehensive health status payload
      * @private
      */
-    async #performHealthCheck() {
+    async #performHealthCheck({
+        chromaProbeTimeoutMs = aiConfig.healthcheck.chromaProbeTimeoutMs,
+        embeddingWriteCanaryTimeoutMs = aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs
+    } = {}) {
         const payload = {
             status          : 'healthy',
             timestamp       : new Date().toISOString(),
@@ -1474,7 +1475,7 @@ class HealthService extends Base {
         };
 
         // Step 1: Check Database connectivity
-        const connectionCheck = await this.#checkDatabaseConnections();
+        const connectionCheck = await this.#checkDatabaseConnections(chromaProbeTimeoutMs);
         payload.database.connection.connected = connectionCheck.running;
         payload.database.connection.engines = connectionCheck.engines;
 
@@ -1485,7 +1486,7 @@ class HealthService extends Base {
         }
 
         // Step 2: Check collections
-        const collectionsCheck = await this.#checkCollections();
+        const collectionsCheck = await this.#checkCollections(chromaProbeTimeoutMs);
         payload.database.connection.collections = {
             memories : collectionsCheck.memories,
             summaries: collectionsCheck.summaries
@@ -1503,7 +1504,7 @@ class HealthService extends Base {
             return payload;
         }
 
-        await this.#applyEmbeddingWriteCanary(payload);
+        await this.#applyEmbeddingWriteCanary(payload, embeddingWriteCanaryTimeoutMs);
 
         // Step 3: Check configured provider prerequisites.
         const providerPrerequisites = this.#checkProviderPrerequisites();
@@ -1560,9 +1561,15 @@ class HealthService extends Base {
      *
      * @param {Object} [options]
      * @param {Boolean} [options.freshObservability=true] Refresh request-facing fields on cached healthy results.
+     * @param {Number} [options.chromaProbeTimeoutMs=aiConfig.healthcheck.chromaProbeTimeoutMs] Chroma probe timeout budget.
+     * @param {Number} [options.embeddingWriteCanaryTimeoutMs=aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs] Embedding canary timeout budget.
      * @returns {Promise<object>} A health status payload with session information
      */
-    async healthcheck({freshObservability = true} = {}) {
+    async healthcheck({
+        freshObservability = true,
+        chromaProbeTimeoutMs = aiConfig.healthcheck.chromaProbeTimeoutMs,
+        embeddingWriteCanaryTimeoutMs = aiConfig.healthcheck.embeddingWriteCanaryTimeoutMs
+    } = {}) {
         try {
             const now = Date.now();
 
@@ -1582,7 +1589,10 @@ class HealthService extends Base {
                         return this.#cachedHealth;
                     }
 
-                    const freshCachedHealth = await this.#buildRequestFreshCachedHealth(this.#cachedHealth, now);
+                    const freshCachedHealth = await this.#buildRequestFreshCachedHealth(this.#cachedHealth, now, {
+                        chromaProbeTimeoutMs,
+                        embeddingWriteCanaryTimeoutMs
+                    });
 
                     if (freshCachedHealth) {
                         return freshCachedHealth;
@@ -1602,7 +1612,10 @@ class HealthService extends Base {
             logger.debug('[HealthService] Performing fresh health check');
 
             // Create the promise and store it
-            this.#healthCheckPromise = this.#performHealthCheck().finally(() => {
+            this.#healthCheckPromise = this.#performHealthCheck({
+                chromaProbeTimeoutMs,
+                embeddingWriteCanaryTimeoutMs
+            }).finally(() => {
                 // Always clear the promise when done, success or fail
                 this.#healthCheckPromise = null;
             });

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -883,15 +883,20 @@ class MemoryService extends Base {
      * @param {Number} options.limit     The maximum number of memories to return.
      * @param {Number} options.offset    The number of memories to skip.
      * @param {String} [options.memorySharing] Optional tenant-isolation policy override (mirrors queryMemories) — lets callers and tests select 'team' / 'private' without depending on ambient defaultPolicy resolution.
+     * @param {Number} [options.chromaTimeoutMs=CHROMA_FETCH_TIMEOUT_MS] Test seam for bounding Chroma metadata reads.
      * @returns {Promise<{sessionId: string, count: number, total: number, memories: Object[]}>}
      */
-    async listMemories({sessionId, limit=100, offset=0, memorySharing} = {}) {
+    async listMemories({sessionId, limit=100, offset=0, memorySharing, chromaTimeoutMs=CHROMA_FETCH_TIMEOUT_MS} = {}) {
         try {
             if (!sessionId) {
                 return { sessionId, count: 0, total: 0, memories: [] };
             }
 
-            const collection = await StorageRouter.getMemoryCollection();
+            const collection = await withTimeout(
+                StorageRouter.getMemoryCollection(),
+                chromaTimeoutMs,
+                'listMemories getMemoryCollection'
+            );
 
             // Tenant read-filter with additive shared-commons access: when a
             // userId resolves, the filter returns the tenant's own records AND records tagged
@@ -918,10 +923,14 @@ class MemoryService extends Base {
 
             const where = tenantScope ? {$and: [{sessionId}, tenantScope]} : {sessionId};
 
-            const result = await collection.get({
-                where,
-                include: ['metadatas']
-            });
+            const result = await withTimeout(
+                collection.get({
+                    where,
+                    include: ['metadatas']
+                }),
+                chromaTimeoutMs,
+                'listMemories collection.get'
+            );
 
             let records = result.ids.map((id, index) => {
                 const metadata = result.metadatas[index] || {};

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -20,6 +20,8 @@ import RequestContextService, {
     resolveSummaryVisibilityUserId
 } from '../../mcp/server/shared/services/RequestContextService.mjs';
 
+const CHROMA_SESSION_READ_TIMEOUT_MS = 10000;
+
 /**
  * @summary Service for handling session summarization and drift detection.
  *
@@ -938,13 +940,14 @@ ${sessionContent}
      *
      * @param {Object} args
      * @param {String} args.sessionId The session ID to validate.
+     * @param {Number} [args.chromaTimeoutMs=CHROMA_SESSION_READ_TIMEOUT_MS] Test seam for bounding Chroma metadata reads.
      * @returns {Promise<Object>} Either a success payload (`{success: true, sessionId, status:
      *     'resumable', memoryCount, lastActivityAt, summarizationStatus}`) OR a structured error
      *     with one of `INVALID_SESSION_ID`, `SESSION_NOT_FOUND`, `SESSION_FINALIZED`, `SESSION_BUSY`.
      * @see RequestContextService — transport-layer session binding
      * @see SummarizationJobs — lease semantics (TTL + status enum)
      */
-    async validateSessionForResume({sessionId} = {}) {
+    async validateSessionForResume({sessionId, chromaTimeoutMs = CHROMA_SESSION_READ_TIMEOUT_MS} = {}) {
         if (!sessionId || typeof sessionId !== 'string') {
             return {error: 'Invalid sessionId', code: 'INVALID_SESSION_ID'};
         }
@@ -992,17 +995,25 @@ ${sessionContent}
         let memoryCount    = 0;
         let lastActivityAt = null;
         try {
-            const collection = await StorageRouter.getMemoryCollection();
+            const collection = await withTimeout(
+                StorageRouter.getMemoryCollection(),
+                chromaTimeoutMs,
+                'validateSessionForResume getMemoryCollection'
+            );
             if (collection) {
                 const userId = normalizeUserId(RequestContextService.getUserId());
                 const where  = userId
                     ? {$and: [{sessionId}, {$or: [{userId}, {userId: SHARED_USER_ID}]}]}
                     : {sessionId};
 
-                const result = await collection.get({
-                    where,
-                    include: ['metadatas']
-                });
+                const result = await withTimeout(
+                    collection.get({
+                        where,
+                        include: ['metadatas']
+                    }),
+                    chromaTimeoutMs,
+                    'validateSessionForResume collection.get'
+                );
 
                 memoryCount = result.ids?.length || 0;
 

--- a/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs
@@ -34,7 +34,8 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             NEO_MCP_HEALTHCHECK_TOKEN_ENV      : 'TOKEN_SLOT',
             TOKEN_SLOT                         : 'secret-token',
             NEO_MCP_HEALTHCHECK_EXPECTED_STATUS: 'ready',
-            NEO_MCP_HEALTHCHECK_CLIENT_NAME    : 'deploy-client'
+            NEO_MCP_HEALTHCHECK_CLIENT_NAME    : 'deploy-client',
+            NEO_MCP_HEALTHCHECK_TIMEOUT_MS     : '7000'
         });
 
         expect(args).toEqual({
@@ -43,7 +44,8 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             bearerToken   : 'secret-token',
             bearerTokenEnv: 'TOKEN_SLOT',
             expectedStatus: 'ready',
-            clientName    : 'deploy-client'
+            clientName    : 'deploy-client',
+            timeoutMs     : 7000
         });
     });
 
@@ -53,7 +55,8 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             '--identity', 'cli-identity',
             '--bearer-token-env', 'CLI_TOKEN',
             '--expected-status', 'healthy',
-            '--client-name', 'cli-client'
+            '--client-name', 'cli-client',
+            '--timeout-ms', '6000'
         ], {
             NEO_MCP_HEALTHCHECK_URL      : 'http://ignored:3000',
             NEO_MCP_HEALTHCHECK_IDENTITY : 'ignored',
@@ -66,7 +69,8 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             identity      : 'cli-identity',
             bearerToken   : 'cli-secret',
             expectedStatus: 'healthy',
-            clientName    : 'cli-client'
+            clientName    : 'cli-client',
+            timeoutMs     : 6000
         });
     });
 
@@ -152,6 +156,57 @@ test.describe('ai/scripts/diagnostics/mcpHealthcheck (#11725)', () => {
             ClientClass   : FakeClient,
             TransportClass: FakeTransport
         })).rejects.toThrow("Expected healthcheck status 'healthy', got 'degraded'.");
+    });
+
+    test('#13458: runHealthcheck times out a hanging MCP connect and closes the client', async () => {
+        const calls = [];
+
+        class FakeTransport {}
+        class FakeClient {
+            async connect() {
+                calls.push({type: 'connect'});
+                return new Promise(() => {});
+            }
+            async close() {
+                calls.push({type: 'close'});
+            }
+        }
+
+        await expect(runHealthcheck({
+            url           : 'http://127.0.0.1:3000',
+            timeoutMs     : 5,
+            ClientClass   : FakeClient,
+            TransportClass: FakeTransport
+        })).rejects.toThrow('MCP healthcheck connect timed out after 5ms');
+
+        expect(calls).toEqual([{type: 'connect'}, {type: 'close'}]);
+    });
+
+    test('#13458: runHealthcheck times out a hanging healthcheck tool call and closes the client', async () => {
+        const calls = [];
+
+        class FakeTransport {}
+        class FakeClient {
+            async connect() {
+                calls.push({type: 'connect'});
+            }
+            async callTool() {
+                calls.push({type: 'callTool'});
+                return new Promise(() => {});
+            }
+            async close() {
+                calls.push({type: 'close'});
+            }
+        }
+
+        await expect(runHealthcheck({
+            url           : 'http://127.0.0.1:3000',
+            timeoutMs     : 5,
+            ClientClass   : FakeClient,
+            TransportClass: FakeTransport
+        })).rejects.toThrow('MCP healthcheck tool call timed out after 5ms');
+
+        expect(calls).toEqual([{type: 'connect'}, {type: 'callTool'}, {type: 'close'}]);
     });
 
     test('formatHealthcheckError appends a bearer-token hint only when no token was configured', () => {

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -343,6 +343,8 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     let originalEmbedText;
     let originalGeminiApiKey;
     let originals;
+    let originalChromaHealthProbeTimeoutMs;
+    let originalEmbeddingWriteCanaryTimeoutMs;
     let summaryCount;
     let summaryGetCalls;
     let summaryUnavailableOnCall;
@@ -361,6 +363,8 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         originalDateNow    = Date.now;
         originalEmbedText  = TextEmbeddingService.embedText;
         originalGeminiApiKey = process.env.GEMINI_API_KEY;
+        originalChromaHealthProbeTimeoutMs = HealthService.chromaHealthProbeTimeoutMs;
+        originalEmbeddingWriteCanaryTimeoutMs = HealthService.embeddingWriteCanaryTimeoutMs;
         memoryCount        = 10;
         summaryCount       = 20;
         summaryGetCalls    = 0;
@@ -417,6 +421,8 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         StorageRouter.getSummaryCollection     = originals.getSummaryCollection;
         ChromaLifecycleService.getDatabaseStatus = originals.getDatabaseStatus;
         TextEmbeddingService.embedText            = originalEmbedText;
+        HealthService.chromaHealthProbeTimeoutMs = originalChromaHealthProbeTimeoutMs;
+        HealthService.embeddingWriteCanaryTimeoutMs = originalEmbeddingWriteCanaryTimeoutMs;
 
         HealthService.setStdioIdentityState(null);
         HealthService.runtimeFreshnessReader = null;
@@ -612,6 +618,36 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(result.providers.embedding).not.toHaveProperty('writeCanary');
         expect(result.details).toContain('Embedding write canary failed: embedding provider busy');
         expect(result.details).not.toContain('All features are operational');
+    });
+
+    test('#13458: embedding write canary timeout degrades healthcheck instead of hanging', async () => {
+        HealthService.embeddingWriteCanaryTimeoutMs = 5;
+        TextEmbeddingService.embedText = async () => new Promise(() => {});
+
+        const result = await HealthService.healthcheck();
+
+        expect(result.status).toBe('degraded');
+        expect(result.details).toContain('Embedding write canary failed: Embedding write canary timed out after 5ms');
+        expect(result.details).not.toContain('All features are operational');
+    });
+
+    test('#13458: collection count timeout makes healthcheck resolve unhealthy instead of hanging', async () => {
+        HealthService.chromaHealthProbeTimeoutMs = 5;
+
+        StorageRouter.getMemoryCollection = async () => ({
+            count: async () => new Promise(() => {}),
+            get  : async () => ({ids: [], metadatas: []})
+        });
+
+        const result = await HealthService.healthcheck();
+
+        expect(result.status).toBe('unhealthy');
+        expect(result.database.connection.collections.memories).toMatchObject({
+            exists: true,
+            count : 0,
+            error : 'memory collection count health probe timed out after 5ms'
+        });
+        expect(result.details).toContain('Failed to access collections: memory collection count health probe timed out after 5ms');
     });
 });
 
@@ -847,6 +883,27 @@ test.describe('HealthService #12487 — buildEmbeddingWriteCanaryBlock', () => {
             expectedDimensions: 4096,
             durationMs        : 0,
             error             : 'embedding provider busy'
+        });
+    });
+
+    test('#13458: reports failed when the active provider never resolves', async () => {
+        const result = await buildEmbeddingWriteCanaryBlock({
+            cfg: {
+                embeddingProvider: 'openAiCompatible',
+                vectorDimension  : 4096
+            },
+            embedText: async () => new Promise(() => {}),
+            now: () => 100,
+            timeoutMs: 5
+        });
+
+        expect(result).toMatchObject({
+            status            : 'failed',
+            provider          : 'openAiCompatible',
+            dimensions        : null,
+            expectedDimensions: 4096,
+            durationMs        : 0,
+            error             : 'Embedding write canary timed out after 5ms'
         });
     });
 

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -343,8 +343,6 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     let originalEmbedText;
     let originalGeminiApiKey;
     let originals;
-    let originalChromaHealthProbeTimeoutMs;
-    let originalEmbeddingWriteCanaryTimeoutMs;
     let summaryCount;
     let summaryGetCalls;
     let summaryUnavailableOnCall;
@@ -363,8 +361,6 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         originalDateNow    = Date.now;
         originalEmbedText  = TextEmbeddingService.embedText;
         originalGeminiApiKey = process.env.GEMINI_API_KEY;
-        originalChromaHealthProbeTimeoutMs = HealthService.chromaHealthProbeTimeoutMs;
-        originalEmbeddingWriteCanaryTimeoutMs = HealthService.embeddingWriteCanaryTimeoutMs;
         memoryCount        = 10;
         summaryCount       = 20;
         summaryGetCalls    = 0;
@@ -421,8 +417,6 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         StorageRouter.getSummaryCollection     = originals.getSummaryCollection;
         ChromaLifecycleService.getDatabaseStatus = originals.getDatabaseStatus;
         TextEmbeddingService.embedText            = originalEmbedText;
-        HealthService.chromaHealthProbeTimeoutMs = originalChromaHealthProbeTimeoutMs;
-        HealthService.embeddingWriteCanaryTimeoutMs = originalEmbeddingWriteCanaryTimeoutMs;
 
         HealthService.setStdioIdentityState(null);
         HealthService.runtimeFreshnessReader = null;
@@ -621,10 +615,11 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     });
 
     test('#13458: embedding write canary timeout degrades healthcheck instead of hanging', async () => {
-        HealthService.embeddingWriteCanaryTimeoutMs = 5;
         TextEmbeddingService.embedText = async () => new Promise(() => {});
 
-        const result = await HealthService.healthcheck();
+        const result = await HealthService.healthcheck({
+            embeddingWriteCanaryTimeoutMs: 5
+        });
 
         expect(result.status).toBe('degraded');
         expect(result.details).toContain('Embedding write canary failed: Embedding write canary timed out after 5ms');
@@ -632,14 +627,14 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
     });
 
     test('#13458: collection count timeout makes healthcheck resolve unhealthy instead of hanging', async () => {
-        HealthService.chromaHealthProbeTimeoutMs = 5;
-
         StorageRouter.getMemoryCollection = async () => ({
             count: async () => new Promise(() => {}),
             get  : async () => ({ids: [], metadatas: []})
         });
 
-        const result = await HealthService.healthcheck();
+        const result = await HealthService.healthcheck({
+            chromaProbeTimeoutMs: 5
+        });
 
         expect(result.status).toBe('unhealthy');
         expect(result.database.connection.collections.memories).toMatchObject({

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs
@@ -219,6 +219,24 @@ test.describe('MemoryService — tenant isolation (#10000)', () => {
         expect(getCall.where).toEqual({sessionId: 'session-local'});
     });
 
+    test('#13458: listMemories returns a bounded error when Chroma metadata fetch never resolves', async () => {
+        StorageRouter.getMemoryCollection = async () => ({
+            get: async () => new Promise(() => {})
+        });
+
+        const result = await MemoryService.listMemories({
+            sessionId       : 'session-hung-chroma',
+            limit           : 10,
+            chromaTimeoutMs : 5
+        });
+
+        expect(result).toMatchObject({
+            error  : 'Failed to list memories',
+            message: 'listMemories collection.get timed out after 5ms',
+            code   : 'MEMORY_LIST_ERROR'
+        });
+    });
+
     test('queryMemories merges userId with caller-provided sessionId in the where clause', async () => {
         await RequestContextService.run({userId: 'u-alice'}, () =>
             MemoryService.queryMemories({

--- a/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
@@ -44,7 +44,6 @@ test.describe('SessionService validateSessionForResume (#10725)', () => {
         const tmpDir = path.resolve(process.cwd(), "tmp");
         aiConfig.storagePaths.graph = path.join(tmpDir, "test-graph-" + Date.now() + "-" + Math.random().toString(36).substring(7) + ".db");
 
-        
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, {recursive: true});
         }
@@ -85,6 +84,50 @@ test.describe('SessionService validateSessionForResume (#10725)', () => {
         expect(result.success).toBeUndefined();
         expect(result.code).toBe('SESSION_NOT_FOUND');
         expect(result.sessionId).toBe(sessionId);
+    });
+
+    test('#13458: stalled Chroma metadata read falls through to graph fallback', async () => {
+        const sessionId     = `graph-fallback-${crypto.randomUUID()}`;
+        const memoryNodeId  = `memory:${sessionId}`;
+        const timestamp     = new Date().toISOString();
+        const GraphService  = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        const StorageRouter = (await import('../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
+
+        await GraphService.ready();
+        const originalGetMemoryCollection = StorageRouter.getMemoryCollection;
+
+        StorageRouter.getMemoryCollection = async () => ({
+            get: async () => new Promise(() => {})
+        });
+
+        GraphService.upsertNode({
+            id        : memoryNodeId,
+            type      : 'AGENT_MEMORY',
+            properties: {
+                sessionId,
+                timestamp
+            }
+        });
+
+        try {
+            const result = await SDK.Memory_SessionService.validateSessionForResume({
+                sessionId,
+                chromaTimeoutMs: 5
+            });
+
+            expect(result).toMatchObject({
+                success            : true,
+                sessionId,
+                status             : 'resumable',
+                memoryCount        : 1,
+                lastActivityAt     : timestamp,
+                summarizationStatus: 'none'
+            });
+        } finally {
+            StorageRouter.getMemoryCollection = originalGetMemoryCollection;
+            GraphService.db?.storage?.db?.prepare('DELETE FROM Nodes WHERE id = ?').run(memoryNodeId);
+            GraphService.db?.nodes?.delete?.(memoryNodeId);
+        }
     });
 
     test('#12199: queueSummarizationJob writes an idempotent pending marker', async () => {

--- a/test/playwright/unit/ai/services/rem-observability.spec.mjs
+++ b/test/playwright/unit/ai/services/rem-observability.spec.mjs
@@ -28,9 +28,9 @@ import {
 
 /**
  * @summary Cross-service unit coverage for the 5-axis REM observability primitive
- * shipped by Epic #12065 Sub 2 / #12068 Phase 1 Part A.
+ * shipped for REM pipeline divergence detection.
  *
- * The 5 axes per Discussion #12062 §2.6:
+ * The 5 axes covered by the REM divergence model:
  * - **A** — Chroma summary count (via existing tooling, not under test here)
  * - **A2 (positive)** — `ChromaManager.getGraphDigestedCount`
  * - **A2 (negative)** — `ChromaManager.getUndigestedSessionCount`
@@ -49,8 +49,6 @@ import {
  * @see ai/services/memory-core/managers/ChromaManager.mjs — axis helpers
  * @see ai/services/memory-core/GraphService.mjs — axis helpers
  * @see ai/services/graph/TopologyInferenceEngine.mjs — axis helper
- * @see Epic #12065 Sub 2 #12068 — 5-axis observability primitive ticket
- * @see Discussion #12062 §2.6 — axis-divergence framing
  */
 
 const __filename = fileURLToPath(import.meta.url);
@@ -426,6 +424,39 @@ test.describe('ai/services REM observability axis helpers (#12068 Sub 2 Part A)'
                     entityCount: 9
                 }
             });
+        });
+
+        test('#13458: a stalled REM axis returns a bounded numeric fallback plus axisErrors', async () => {
+            const originalGetUndigestedSessionCount = ChromaManager.getUndigestedSessionCount;
+            const originalGetGraphDigestedCount     = ChromaManager.getGraphDigestedCount;
+            const originalGetSessionNodeCount       = GraphService.getSessionNodeCount;
+            const originalGetTopologyConflictCount  = TopologyInferenceEngine.getTopologyConflictCount;
+
+            ChromaManager.getUndigestedSessionCount = async () => new Promise(() => {});
+            ChromaManager.getGraphDigestedCount     = async () => 7;
+            GraphService.getSessionNodeCount        = async () => 11;
+            TopologyInferenceEngine.getTopologyConflictCount = async () => 2;
+
+            try {
+                const {buildRemPipelineState} = await import('../../../../../ai/services/memory-core/HealthService.mjs');
+                const state = await buildRemPipelineState({axisTimeoutMs: 5});
+
+                expect(state).toMatchObject({
+                    undigested       : 0,
+                    digested         : 7,
+                    sessionNodes     : 11,
+                    topologyConflicts: 2,
+                    recentCycles     : [],
+                    axisErrors       : {
+                        undigested: 'REM axis undigested timed out after 5ms'
+                    }
+                });
+            } finally {
+                ChromaManager.getUndigestedSessionCount = originalGetUndigestedSessionCount;
+                ChromaManager.getGraphDigestedCount     = originalGetGraphDigestedCount;
+                GraphService.getSessionNodeCount        = originalGetSessionNodeCount;
+                TopologyInferenceEngine.getTopologyConflictCount = originalGetTopologyConflictCount;
+            }
         });
 
         test('projects recent JSONL cycle state through the MCP tool', async () => {


### PR DESCRIPTION
Authored by Euclid (GPT-5, Codex Desktop). Session 4ce60429-2986-4543-be2d-741957c75b6c.

**Does this PR resolve an issue?** (Required)

Resolves #13458

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

**Other information:**

## Deltas

- Bounds Memory Core health dependency probes so stalled Chroma/provider promises return unhealthy/degraded responses instead of hanging the caller.
- Defines the health probe budgets as Memory Core AiConfig leaves (`aiConfig.healthcheck.*`) with env overrides, instead of module-level timeout constants.
- Adds an aborting timeout to the standalone MCP healthcheck diagnostic for both SDK connect and tool-call phases.
- Bounds raw memory listing, session-resume Chroma reads, and REM axis probes; REM keeps numeric fallback values and now exposes optional `axisErrors` when an axis times out or fails.
- Updates the Memory Core OpenAPI contract for `axisErrors` and cleans stale durable ticket references from a touched REM observability test header.

Evidence: L2 (deterministic unit coverage with never-resolving provider, Chroma, REM-axis, and MCP SDK promises) -> L2 required (bounded-failure contract is observable at service and diagnostic boundaries). Residual: deployed Memory Core smoke should be rerun after merge/deploy to verify the live container path returns within the configured timeout.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryService.TenantIsolation.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs test/playwright/unit/ai/services/rem-observability.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` -> 127 passed.
- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/mcpHealthcheck.spec.mjs` -> 13 passed after the diagnostic helper JSDoc addition.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/services/rem-observability.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` -> 87 passed after moving timeout budgets into AiConfig.
- `node ai/scripts/lint/lint-config-template-ssot.mjs` -> passed.
- `node ./buildScripts/util/check-jsdoc-types.mjs` -> passed.
- `node ./buildScripts/util/check-aiconfig-test-mutation.mjs` -> passed.
- `git diff --check` -> passed.
- Commit hook passed: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, and staged-file `check-ticket-archaeology`.

## Post-Merge Validation

- [ ] After merge/deploy, run the deployed Memory Core healthcheck; expected behavior is a bounded unhealthy/degraded response if Chroma or the embedding provider stalls, not an open-ended SSE hang.
- [ ] Re-run one deployed raw-memory/read smoke after the healthcheck; if any remaining MCP tool path still hangs, file a follow-up scoped to that specific path with logs.
