### PR TITLE
fix(memory-core): expose healthcheck MCP options (#13460)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -43,6 +43,7 @@ paths:
     get:
       summary: Health Check
       operationId: healthcheck
+      x-pass-as-object: true
       x-annotations:
         readOnlyHint: true
       description: |
@@ -51,6 +52,30 @@ paths:
         **When to Use:**
         Use this as a first-step diagnostic tool to ensure the memory system is operational before attempting other operations.
       tags: [Health]
+      parameters:
+        - name: freshObservability
+          in: query
+          required: false
+          description: Refresh request-facing fields on cached healthy results.
+          schema:
+            type: boolean
+            default: true
+        - name: chromaProbeTimeoutMs
+          in: query
+          required: false
+          description: Max time to wait for Chroma readiness, connection, and collection-count probes.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1500
+        - name: embeddingWriteCanaryTimeoutMs
+          in: query
+          required: false
+          description: Max time to wait for the active embedding provider during the write canary.
+          schema:
+            type: integer
+            minimum: 1
+            default: 5000
       responses:
         '200':
           description: Server is healthy and database is accessible

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -13,15 +13,23 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../../src/core/_export.mjs';
+import ToolService     from '../../../../../../../ai/mcp/ToolService.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    repoRoot   = path.resolve(__dirname, '../../../../../../..');
 
 test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
     let toolService;
 
     test.beforeAll(async () => {
-        // ADR 0019 B4: storagePaths.graph resolves to ':memory:' by construction under
+        // ADR 0019 B4: storagePaths.graph resolves to ':memory:' by construction under // ticket-ref-ok: ADR id
         // UNIT_TEST_MODE — no singleton mutation, no temp DB path needed.
 
         const ToolServiceModule = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs');
@@ -96,5 +104,43 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(tool.outputSchema.properties.recentCycles.items.properties.cycleOverflowSignal.type).toBe('boolean');
         const perSession = tool.outputSchema.properties.perSession.anyOf.find(item => item.type === 'object');
         expect(perSession.properties.entityCount.type).toBe('integer');
+    });
+
+    test('healthcheck exposes diagnostic options through the MCP schema (#13460)', async () => {
+        const { tools } = await toolService.listTools();
+        const tool = tools.find(item => item.name === 'healthcheck');
+
+        expect(tool).toBeTruthy();
+        expect(tool.annotations.readOnlyHint).toBe(true);
+        expect(tool.inputSchema.properties.freshObservability.type).toBe('boolean');
+        expect(tool.inputSchema.properties.chromaProbeTimeoutMs.type).toBe('integer');
+        expect(tool.inputSchema.properties.chromaProbeTimeoutMs.minimum).toBe(1);
+        expect(tool.inputSchema.properties.embeddingWriteCanaryTimeoutMs.type).toBe('integer');
+        expect(tool.inputSchema.properties.embeddingWriteCanaryTimeoutMs.minimum).toBe(1);
+    });
+
+    test('healthcheck dispatch passes diagnostic options as one object (#13460)', async () => {
+        const observedArgs = [];
+        const spyToolService = Neo.create(ToolService, {
+            openApiFilePath: path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'),
+            serviceMapping : {
+                healthcheck: async args => {
+                    observedArgs.push(args);
+                    return {status: 'healthy', args};
+                }
+            }
+        });
+
+        const args = {
+            freshObservability           : false,
+            chromaProbeTimeoutMs         : 1234,
+            embeddingWriteCanaryTimeoutMs: 5678
+        };
+
+        await expect(spyToolService.callTool('healthcheck', args)).resolves.toEqual({
+            status: 'healthy',
+            args
+        });
+        expect(observedArgs).toEqual([args]);
     });
 });


### PR DESCRIPTION
Resolves #13460

Exposes the existing Memory Core healthcheck diagnostic options through the MCP tool schema so clients can call `freshObservability` and probe timeout budgets directly. Marks `healthcheck` with `x-pass-as-object` so `ToolService` forwards the option bag intact to `HealthService` instead of positional args.

Evidence: L2 (focused Playwright unit coverage for MCP schema exposure, object dispatch, list-tools smoke, and OpenAPI validator compliance) -> L2 required (MCP schema contract). No residuals.

## Deltas from ticket
No runtime scope expansion. The change only exposes options already supported by `HealthService`; it does not change provider, Chroma, or health probe behavior.

Also annotates an existing ADR 0019 test comment with `ticket-ref-ok` because the staged-file ticket archaeology hook treats `0019` as a ticket reference when this test file is committed.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` (6 passed)
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` (21 passed)
- `npm run test-unit -- test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` (31 passed)
- `git diff --cached --check`
- Pre-commit hooks during `git commit`

## Post-Merge Validation
- [ ] In a fresh MCP client session, confirm `healthcheck` lists `freshObservability`, `chromaProbeTimeoutMs`, and `embeddingWriteCanaryTimeoutMs`.
- [ ] Call `healthcheck` with `freshObservability: false` and explicit timeout budgets against a mounted deployment and verify it returns rather than dropping the arguments.

## Commits
- `2548af2a8` - `fix(memory-core): expose healthcheck MCP options (#13460)`

Authored by Euclid (GPT-5, Codex Desktop). Session 4ce60429-2986-4543-be2d-741957c75b6c.