### PR TITLE
fix(ai): repair session summary drift (#13462)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -62,12 +62,15 @@ export function getPendingSummarizationCount(db) {
 }
 
 /**
- * Counts sessions that have `AGENT_MEMORY` turns but no `SESSION_SUMMARY` — the real
- * unsummarized-session backlog the periodic sweep drains (parallel to the mini-summary backlog
- * count, not the capped SummarizationJobs marker fetch).
+ * Counts sessions that have `AGENT_MEMORY` turns but no graph-visible summary evidence. The
+ * summary artifact itself is `SESSION_SUMMARY` (`summary_<sessionId>`), while the REM projection
+ * layer also creates `SESSION` nodes from Chroma summary rows (`session:<sessionId>` with
+ * `properties.chromaId = summary_<sessionId>`). Minimal `SESSION` placeholders without a summary
+ * Chroma id are deliberately excluded so they do not mask truly unsummarized sessions.
  *
- * @summary Feeds the periodic-sweep trigger reason so the orchestrator log reports the
- * session-summary backlog depth. Fail-soft: returns `null` when the graph table is unavailable.
+ * @summary Feeds the periodic-sweep trigger reason so the orchestrator log reports the best
+ * graph-backed session-summary backlog proxy available without opening Chroma. Fail-soft:
+ * returns `null` when the graph table is unavailable.
  * @param {Object} db SQLite database handle.
  * @returns {Number|null}
  */
@@ -77,22 +80,34 @@ export function getPendingSessionSummaryCount(db) {
     }
 
     try {
-        // Null-safe anti-join: a correlated NOT EXISTS rather than `NOT IN (subquery)`. A single
-        // SESSION_SUMMARY row with a NULL sessionId would make `NOT IN` evaluate to NULL for every
-        // row, silently collapsing the backlog count to 0; NOT EXISTS is immune to that.
+        // Null-safe set anti-join. `NOT IN` would still collapse to 0 if any summary row has a
+        // NULL sessionId, while the former correlated NOT EXISTS plan full-scanned the summary set
+        // for every memory session on live graphs. Materialize both distinct sets once instead.
         const row = db.prepare(`
-            SELECT COUNT(*) AS n FROM (
+            WITH memory_sessions AS (
                 SELECT DISTINCT json_extract(memory.data, '$.properties.sessionId') AS sessionId
                 FROM Nodes memory
                 WHERE json_extract(memory.data, '$.label')                = 'AGENT_MEMORY'
                   AND json_extract(memory.data, '$.properties.sessionId') IS NOT NULL
-                  AND NOT EXISTS (
-                      SELECT 1
-                      FROM Nodes summary
-                      WHERE json_extract(summary.data, '$.label')                = 'SESSION_SUMMARY'
-                        AND json_extract(summary.data, '$.properties.sessionId') = json_extract(memory.data, '$.properties.sessionId')
-                  )
+            ),
+            summary_sessions AS (
+                SELECT DISTINCT json_extract(summary.data, '$.properties.sessionId') AS sessionId
+                FROM Nodes summary
+                WHERE json_extract(summary.data, '$.label')                = 'SESSION_SUMMARY'
+                  AND json_extract(summary.data, '$.properties.sessionId') IS NOT NULL
+                UNION
+                SELECT DISTINCT json_extract(summary.data, '$.properties.sessionId') AS sessionId
+                FROM Nodes summary
+                WHERE json_extract(summary.data, '$.label')                = 'SESSION'
+                  -- REM/provenance projection derived from an actual Chroma summary row. Minimal
+                  -- back-fill placeholders have no summary_ chromaId and remain countable.
+                  AND json_extract(summary.data, '$.properties.chromaId') LIKE 'summary_%'
+                  AND json_extract(summary.data, '$.properties.sessionId') IS NOT NULL
             )
+            SELECT COUNT(*) AS n
+            FROM memory_sessions memory
+            LEFT JOIN summary_sessions summary ON summary.sessionId = memory.sessionId
+            WHERE summary.sessionId IS NULL
         `).get();
 
         return Number.isInteger(row?.n) ? row.n : null;

--- a/ai/scripts/lifecycle/summarize-sessions.mjs
+++ b/ai/scripts/lifecycle/summarize-sessions.mjs
@@ -22,12 +22,14 @@ import InstanceManager from '../../../src/manager/Instance.mjs';
 
 import { Memory_SessionService } from '../../services.mjs';
 
+const logInfo = message => console.error(`[INFO] ${message}`);
+
 async function summarize() {
-    console.log('[summarize-sessions] Initializing SessionService...');
+    logInfo('[summarize-sessions] Initializing SessionService...');
     try {
         await Memory_SessionService.initAsync();
 
-        console.log('[summarize-sessions] Draining pending session summarization markers...');
+        logInfo('[summarize-sessions] Draining pending session summarization markers...');
         const pendingResult = await Memory_SessionService.summarizePendingSessions();
 
         if (pendingResult && pendingResult.error) {
@@ -35,9 +37,9 @@ async function summarize() {
             process.exit(1);
         }
 
-        console.log(`[summarize-sessions] Pending drain complete. Pending: ${pendingResult?.pending || 0}; processed: ${pendingResult?.processed || 0}`);
+        logInfo(`[summarize-sessions] Pending drain complete. Pending: ${pendingResult?.pending || 0}; processed: ${pendingResult?.processed || 0}`);
 
-        console.log('[summarize-sessions] Starting drift-detection session summarization...');
+        logInfo('[summarize-sessions] Starting drift-detection session summarization...');
         // All-time scope: summarizes every unsummarized session (the 30-day window was removed).
         const result = await Memory_SessionService.summarizeSessions();
 
@@ -46,7 +48,7 @@ async function summarize() {
             process.exit(1);
         }
 
-        console.log(`[summarize-sessions] Summarization complete. Processed: ${result?.processed || 0}`);
+        logInfo(`[summarize-sessions] Summarization complete. Processed: ${result?.processed || 0}`);
         process.exit(0);
     } catch (err) {
         console.error('[summarize-sessions] Error:', err);

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -1190,13 +1190,22 @@ ${sessionContent}
      * @summary Provides exclusive lock acquisition for the background summarization coordinator loop.
      * @param {String} sessionId
      * @param {String} leaseToken
-     * @param {Number} [ttlMs=300000] Default 5-minute lease
+     * @param {Number|Object} [ttlMs=300000] Default 5-minute lease, or options.
+     * @param {Object} [options]
+     * @param {Boolean} [options.allowCompletedRepair=false] Reclaim `completed` rows when a caller
+     *     already proved summary-artifact drift and needs to rebuild the missing/outdated artifact.
      * @returns {Boolean} true if the lease was claimed successfully, false otherwise.
      */
-    claimSummarizationJob(sessionId, leaseToken, ttlMs = 300000) {
+    claimSummarizationJob(sessionId, leaseToken, ttlMs = 300000, options = {}) {
         const db = GraphService.db?.storage?.db;
         if (!db) return true; // Fallback: allow execution if DB is somehow missing
 
+        if (ttlMs && typeof ttlMs === 'object') {
+            options = ttlMs;
+            ttlMs   = 300000;
+        }
+
+        const allowCompletedRepair = options.allowCompletedRepair === true;
         const now = Date.now();
         const expiresAt = now + ttlMs;
 
@@ -1213,6 +1222,14 @@ ${sessionContent}
                 }
 
                 if (existing.status === 'completed') {
+                    if (allowCompletedRepair) {
+                        db.prepare(`
+                            UPDATE SummarizationJobs
+                            SET status = 'in_progress', lease_token = ?, expires_at = ?, retry_count = retry_count + 1
+                            WHERE session_id = ?
+                        `).run(leaseToken, expiresAt, sessionId);
+                        return true;
+                    }
                     return false;
                 }
 
@@ -1328,14 +1345,16 @@ ${sessionContent}
 
                 logger.info(`[SessionService] Found ${total} sessions to summarize. Processing in batches of ${batchSize}...`);
 
-                let completed = 0;
+                let completed = 0,
+                    skippedClaims = 0;
 
                 for (let i = 0; i < total; i += batchSize) {
                     const chunk = sessionsToSummarize.slice(i, i + batchSize);
                     logger.info(`[SessionService] Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(total / batchSize)} (${chunk.length} sessions)...`);
 
                     const promises = chunk.map(async (id) => {
-                        if (!this.claimSummarizationJob(id, leaseToken)) {
+                        if (!this.claimSummarizationJob(id, leaseToken, {allowCompletedRepair: true})) {
+                            skippedClaims++;
                             logger.info(`[SessionService] Skipping session ${id} - active lease held by another instance or already completed.`);
                             return null;
                         }
@@ -1365,6 +1384,8 @@ ${sessionContent}
 
                     processed.push(...batchResult);
                 }
+
+                console.error(`[INFO] [SessionService] session summarization drift complete: candidates=${total}; processed=${processed.length}; skippedClaims=${skippedClaims}`);
             }
 
             return { processed: processed.length, sessions: processed };

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs
@@ -20,10 +20,10 @@ import {getPendingSessionSummaryCount} from '../../../../../../../ai/daemons/orc
 /**
  * getPendingSessionSummaryCount real-graph coverage.
  *
- * The count drives the orchestrator periodic-sweep log. Its anti-join (sessions with AGENT_MEMORY
- * but no SESSION_SUMMARY) must be null-safe: a single SESSION_SUMMARY row with a NULL sessionId
- * must not collapse the count to 0 (the `NOT IN (subquery)` trap). Real :memory: graph under
- * UNIT_TEST_MODE — no Chroma / live model, CI-safe.
+ * The count drives the orchestrator periodic-sweep log. Its anti-join must be null-safe and must
+ * distinguish the two intentional graph surfaces: direct SESSION_SUMMARY artifacts and REM
+ * SESSION projections derived from Chroma summary rows. Minimal SESSION placeholders are not
+ * summary evidence. Real :memory: graph under UNIT_TEST_MODE — no Chroma / live model, CI-safe.
  */
 test.describe('orchestrator/scheduling getPendingSessionSummaryCount (#12821)', () => {
     test.describe.configure({mode: 'serial'});
@@ -43,7 +43,7 @@ test.describe('orchestrator/scheduling getPendingSessionSummaryCount (#12821)', 
         sqlite = GraphService.db?.storage?.db;
     });
 
-    test('counts unsummarized sessions and is null-safe against a SESSION_SUMMARY with a NULL sessionId', () => {
+    test('counts unsummarized sessions and is null-safe against summary graph drift', () => {
         const before = getPendingSessionSummaryCount(sqlite);
         expect(Number.isInteger(before)).toBe(true);
 
@@ -52,15 +52,24 @@ test.describe('orchestrator/scheduling getPendingSessionSummaryCount (#12821)', 
         GraphService.upsertNode({id: 'summary_bk-sess-A', type: 'SESSION_SUMMARY', name: 'sum A', properties: {sessionId: 'bk-sess-A'}});
         // sB: memory, no summary (unsummarized → the one new row the count must report).
         GraphService.upsertNode({id: 'bk-mem-B', type: 'AGENT_MEMORY', name: 'mem B', properties: {sessionId: 'bk-sess-B', timestamp: 1, miniSummary: 'b'}});
+        // sC: memory + REM projection emitted as a SESSION node pointing at a summary_* Chroma
+        // artifact (summarized → not counted even if the direct SESSION_SUMMARY node is missing).
+        GraphService.upsertNode({id: 'bk-mem-C', type: 'AGENT_MEMORY', name: 'mem C', properties: {sessionId: 'bk-sess-C', timestamp: 1, miniSummary: 'c'}});
+        GraphService.upsertNode({id: 'session_bk-sess-C', type: 'SESSION', name: 'sum C', properties: {sessionId: 'bk-sess-C', chromaId: 'summary_bk-sess-C'}});
+        // sD: memory + minimal SESSION placeholder only. This is not summary evidence and must
+        // still count as unsummarized.
+        GraphService.upsertNode({id: 'bk-mem-D', type: 'AGENT_MEMORY', name: 'mem D', properties: {sessionId: 'bk-sess-D', timestamp: 1, miniSummary: 'd'}});
+        GraphService.upsertNode({id: 'session_bk-sess-D', type: 'SESSION', name: 'minimal D', properties: {sessionId: 'bk-sess-D', minimal: true}});
         // The trap: a SESSION_SUMMARY with a NULL sessionId. With `NOT IN` this would null out the
         // whole anti-join and force the count to 0; NOT EXISTS must be immune.
         GraphService.upsertNode({id: 'summary_bk-null', type: 'SESSION_SUMMARY', name: 'sum null', properties: {sessionId: null}});
 
         const after = getPendingSessionSummaryCount(sqlite);
 
-        // Exactly one new unsummarized session (sB); sA is summarized; the null-sessionId summary
-        // must NOT collapse the count.
-        expect(after).toBe(before + 1);
+        // Exactly two new unsummarized sessions (sB + minimal-placeholder sD); sA and the
+        // summary-backed REM projection sC are summarized; the null-sessionId summary must NOT
+        // collapse the count.
+        expect(after).toBe(before + 2);
         expect(after).toBeGreaterThan(0);
     });
 

--- a/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs
@@ -208,6 +208,89 @@ test.describe('SessionService validateSessionForResume (#10725)', () => {
         }
     });
 
+    test('#13462: claimSummarizationJob keeps completed rows terminal by default', async () => {
+        const sessionId    = `completed-terminal-${crypto.randomUUID()}`;
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'completed', NULL, NULL, 2)
+        `).run(sessionId);
+
+        try {
+            expect(SDK.Memory_SessionService.claimSummarizationJob(sessionId, 'default-token')).toBe(false);
+
+            const row = sqlite.prepare('SELECT status, lease_token, expires_at, retry_count FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+
+            expect(row.status).toBe('completed');
+            expect(row.lease_token).toBeNull();
+            expect(row.expires_at).toBeNull();
+            expect(row.retry_count).toBe(2);
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+
+    test('#13462: claimSummarizationJob can repair completed rows when drift was proven', async () => {
+        const sessionId    = `completed-repair-${crypto.randomUUID()}`;
+        const GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        await GraphService.ready();
+
+        const sqlite = GraphService.db?.storage?.db;
+        expect(sqlite).toBeTruthy();
+
+        sqlite.prepare(`
+            INSERT INTO SummarizationJobs (session_id, status, lease_token, expires_at, retry_count)
+            VALUES (?, 'completed', NULL, NULL, 2)
+        `).run(sessionId);
+
+        try {
+            expect(SDK.Memory_SessionService.claimSummarizationJob(sessionId, 'repair-token', {allowCompletedRepair: true})).toBe(true);
+
+            const row = sqlite.prepare('SELECT status, lease_token, expires_at, retry_count FROM SummarizationJobs WHERE session_id = ?').get(sessionId);
+
+            expect(row.status).toBe('in_progress');
+            expect(row.lease_token).toBe('repair-token');
+            expect(row.expires_at).toBeGreaterThan(Date.now());
+            expect(row.retry_count).toBe(3);
+        } finally {
+            sqlite.prepare('DELETE FROM SummarizationJobs WHERE session_id = ?').run(sessionId);
+        }
+    });
+
+    test('#13462: summarizeSessions enables completed-row repair for drift candidates', async () => {
+        const originalFind      = SDK.Memory_SessionService.findSessionsToSummarize;
+        const originalClaim     = SDK.Memory_SessionService.claimSummarizationJob;
+        const originalSummarize = SDK.Memory_SessionService.summarizeSession;
+        const claimCalls        = [];
+
+        SDK.Memory_SessionService.findSessionsToSummarize = async () => ['drift-repair-candidate'];
+        SDK.Memory_SessionService.claimSummarizationJob = (sessionId, leaseToken, options) => {
+            claimCalls.push({sessionId, leaseToken, options});
+            return false;
+        };
+        SDK.Memory_SessionService.summarizeSession = async () => {
+            throw new Error('summarizeSession should not be called when claim fails');
+        };
+
+        try {
+            const result = await SDK.Memory_SessionService.summarizeSessions();
+
+            expect(result.processed).toBe(0);
+            expect(claimCalls).toHaveLength(1);
+            expect(claimCalls[0].sessionId).toBe('drift-repair-candidate');
+            expect(claimCalls[0].options).toEqual({allowCompletedRepair: true});
+        } finally {
+            SDK.Memory_SessionService.findSessionsToSummarize = originalFind;
+            SDK.Memory_SessionService.claimSummarizationJob   = originalClaim;
+            SDK.Memory_SessionService.summarizeSession        = originalSummarize;
+        }
+    });
+
     test('#12199: summarizePendingSessions drains explicit pending ids through summarizeSessions', async () => {
         const calls = [];
         const originalGetPending = SDK.Memory_SessionService.getPendingSummarizationJobIds;


### PR DESCRIPTION
Resolves #13462

Reworks the session-summary maintenance path so the periodic sweep no longer combines an expensive correlated graph count with completed coordinator rows that suppress repair. The scheduler count now materializes distinct memory and summary-evidence session sets once: direct `SESSION_SUMMARY` artifacts and summary-backed REM `SESSION` projections (`properties.chromaId LIKE 'summary_%'`) both count as graph-visible summary evidence, while minimal `SESSION` placeholders remain countable as unsummarized. The drift sweep can explicitly reclaim completed `SummarizationJobs` rows only when drift detection already selected the session as missing or outdated, and the summary child emits normal lifecycle progress on the stderr stream captured by the orchestrator log.

Evidence: L2 (focused unit coverage plus read-only local graph probes) -> L3 required (post-merge live daemon run showing the local `pending-session-summary` lease makes progress). Residual: post-merge validation below.

Related: #12065

## Deltas from ticket

The ticket mentioned possible watchdog/config follow-up. This PR deliberately leaves that out: the low-risk fix is to remove the no-progress coordinator/projection drift and expose child-run diagnostics first. Provider or Chroma stall root cause work remains a separate lane if live validation still shows long-running synthesis after this lands.

During review/exploration we verified that `SESSION_SUMMARY` and `SESSION` are not competing spellings of the same label. `SESSION_SUMMARY` is the direct summary artifact written by `SessionService.summarizeSession()`. `SESSION` is the REM/provenance projection written by `MemorySessionIngestor` from Chroma summary rows, with a separate minimal-placeholder mode for never-summarized sessions. This PR keeps both labels and constrains the telemetry predicate to summary-backed `SESSION` rows only.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/SessionSummaryBacklogCount.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.ResumeValidation.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs` -> 31 passed.
- `git diff --check` -> clean.
- Pre-push freshness check: `merge-base HEAD origin/dev == origin/dev`; outgoing log contained only `74438b151 fix(ai): repair session summary drift (#13462)`.

## Post-Merge Validation

- [ ] On the local Agent OS checkout, run the summary child/orchestrator cycle and verify `orchestrator.log` includes pending drain, drift start, processed/skipped counts, and no repeated no-progress `pending-session-summary` lease caused by completed coordinator rows.
- [ ] Re-run `/opt/homebrew/bin/npm run ai:sync-github-workflow` after the summary lane clears and verify any deferral is transient rather than repeatedly blocked by the same completed-job drift.

## Commits

- `74438b151` - repair session-summary drift and focused tests.

Authored by Euclid (GPT-5, Codex Desktop). Session 019ed42c-f8fc-7e01-a1a1-a8b5bbf58b64.
