### PR TITLE
fix(ai): recover KB stale collection handles (#13464)

### DIFF
--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -73,7 +73,7 @@ class Server extends BaseServer {
      * @returns {Array<String>}
      */
     getHealthExemptTools() {
-        return ['healthcheck', 'list_agent_faqs'];
+        return ['healthcheck', 'list_agent_faqs', 'manage_knowledge_base'];
     }
 
     /**
@@ -128,9 +128,10 @@ class Server extends BaseServer {
             logger.warn('⚠️  [Startup] Knowledge Base is unhealthy. Server will start but tools will fail until resolved.');
             health.details.forEach(detail => logger.warn(`    ${detail}`));
 
-            if (!health.database.process.running) {
-                logger.warn('    💡 Tip: Start ChromaDB externally, or run:');
-                logger.warn(`       chroma run --path ${process.env.CHROMA_DATA_PATH || './data/chroma'} --port ${process.env.CHROMA_PORT || '8000'}`);
+            if (!health.database.connection.connected) {
+                logger.warn('    💡 Tip: Start or recover the orchestrator-managed ChromaDB instance.');
+            } else if (!health.database.process.running) {
+                logger.info('    Unified topology: Knowledge Base is connected to the orchestrator-managed ChromaDB instance.');
             }
             logger.warn('    The server will periodically retry and recover automatically once dependencies are met.');
         } else if (health.status === 'degraded') {
@@ -150,8 +151,11 @@ class Server extends BaseServer {
      * @param {Object} health
      */
     logCollectionStats(health) {
-        if (health.database.connection.collections) {
-            logger.info(`   - Knowledge Base: ${health.database.connection.collections.knowledgeBase.count}`);
+        const knowledgeBase = health.database.connection.collections?.knowledgeBase;
+
+        if (knowledgeBase) {
+            const suffix = knowledgeBase.exists ? knowledgeBase.count : 'unavailable';
+            logger.info(`   - Knowledge Base: ${suffix}`);
         }
     }
 }

--- a/ai/mcp/server/knowledge-base/openapi.yaml
+++ b/ai/mcp/server/knowledge-base/openapi.yaml
@@ -580,7 +580,7 @@ components:
       properties:
         status:
           type: string
-          description: Overall health status of the server.
+          description: Overall health status of the server. `unhealthy` means ChromaDB is unreachable; `degraded` means ChromaDB is reachable but corpus or provider readiness is incomplete.
           enum: [healthy, degraded, unhealthy]
           example: "healthy"
         timestamp:
@@ -626,7 +626,7 @@ components:
               properties:
                 running:
                   type: boolean
-                  description: True if the ChromaDB process is running.
+                  description: True if the ChromaDB process is locally observed as running. In unified topology this can be false while connection.connected is true because ChromaDB is orchestrator-managed.
                   example: true
                 pid:
                   type: integer
@@ -660,12 +660,15 @@ components:
                         count:
                           type: integer
                           example: 1234
+                        error:
+                          type: string
+                          description: Collection access error when the KB corpus is unavailable.
         features:
           type: object
           properties:
             embedding:
               type: boolean
-              description: "Indicates if the embedding feature is available (requires GEMINI_API_KEY)."
+              description: "Indicates if the configured embedding provider is available."
               example: true
         details:
           type: array
@@ -673,7 +676,7 @@ components:
             type: string
           description: "A list of human-readable details about the system's status."
           example:
-            - "ChromaDB is running and all collections are accessible"
+            - "Connected to the orchestrator-managed ChromaDB instance"
             - "All features are operational"
         version:
           type: string

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -192,6 +192,20 @@ class ChromaManager extends Base {
     }
 
     /**
+     * Public predicate for consumers that operate on an already-resolved collection handle.
+     *
+     * `getKnowledgeBaseCollection()` invalidates resolution failures itself. Callers that
+     * receive a later operation-level Chroma not-found need the same classifier to drop a
+     * stale handle before retrying the canonical collection name.
+     *
+     * @param {Error} error
+     * @returns {Boolean}
+     */
+    isCollectionNotFoundError(error) {
+        return this.#isCollectionNotFoundError(error);
+    }
+
+    /**
      * @param {Error} error
      * @returns {Boolean}
      */

--- a/ai/services/knowledge-base/HealthService.mjs
+++ b/ai/services/knowledge-base/HealthService.mjs
@@ -183,6 +183,62 @@ class HealthService extends Base {
     }
 
     /**
+     * Counts the canonical KB collection, invalidating a stale resolved handle once
+     * when Chroma reports the handle no longer points at a live collection.
+     *
+     * @returns {Promise<Object>} {name, exists, count, error?}
+     * @private
+     */
+    async #checkKnowledgeBaseCollection() {
+        const base = {
+            name  : aiConfig.collectionName,
+            exists: false,
+            count : 0
+        };
+
+        let collection;
+
+        try {
+            collection = await ChromaManager.getKnowledgeBaseCollection();
+        } catch (error) {
+            return {
+                ...base,
+                error: error.message
+            };
+        }
+
+        for (let attempt = 0; attempt < 2; attempt++) {
+            try {
+                return {
+                    ...base,
+                    exists: true,
+                    count : await collection.count()
+                };
+            } catch (error) {
+                if (attempt > 0 || !ChromaManager.isCollectionNotFoundError(error)) {
+                    return {
+                        ...base,
+                        error: error.message
+                    };
+                }
+
+                ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+                try {
+                    collection = await ChromaManager.getKnowledgeBaseCollection();
+                } catch (retryError) {
+                    return {
+                        ...base,
+                        error: retryError.message
+                    };
+                }
+            }
+        }
+
+        return base;
+    }
+
+    /**
      * Verifies that the required collections exist and are accessible.
      *
      * Intent: Even if ChromaDB is running, we need to ensure our specific collection
@@ -193,32 +249,23 @@ class HealthService extends Base {
      * @private
      */
     async #checkCollections() {
-        const result = {
-            knowledgeBase: null
-        };
-
         try {
-            // Check knowledge base collection
-            const knowledgeBaseCollection = await ChromaManager.getKnowledgeBaseCollection().catch(() => null);
-            if (knowledgeBaseCollection) {
-                const count = await knowledgeBaseCollection.count();
-                result.knowledgeBase = {
-                    name  : aiConfig.collectionName,
-                    exists: true,
-                    count
-                };
-            } else {
-                result.knowledgeBase = {
-                    name  : aiConfig.collectionName,
-                    exists: false,
-                    count : 0
-                };
+            const knowledgeBase = await this.#checkKnowledgeBaseCollection(),
+                  result        = {knowledgeBase};
+
+            if (knowledgeBase.error) {
+                result.error = `Failed to access collections: ${knowledgeBase.error}`;
             }
 
             return result;
         } catch (e) {
             return {
-                ...result,
+                knowledgeBase: {
+                    name  : aiConfig.collectionName,
+                    exists: false,
+                    count : 0,
+                    error : e.message
+                },
                 error: `Failed to access collections: ${e.message}`
             };
         }
@@ -269,9 +316,9 @@ class HealthService extends Base {
      * 3. Embedding provider readiness (needed for retrieval; only `gemini` needs a key)
      *
      * Status levels:
-     * - healthy: ChromaDB running, collections accessible, embedding provider ready
-     * - degraded: ChromaDB running, collections accessible, but embedding provider not ready
-     * - unhealthy: ChromaDB not running or collections not accessible
+     * - healthy: ChromaDB connected, KB corpus accessible, embedding provider ready
+     * - degraded: ChromaDB connected, but KB corpus or embedding provider unavailable
+     * - unhealthy: ChromaDB not reachable
      *
      * @returns {Promise<object>} A comprehensive health status payload
      * @private
@@ -312,16 +359,9 @@ class HealthService extends Base {
             knowledgeBase: collectionsCheck.knowledgeBase
         };
 
-        if (collectionsCheck.error) {
-            payload.status = 'unhealthy';
-            payload.details.push(collectionsCheck.error);
-            return payload;
-        }
-
-        if (!collectionsCheck.knowledgeBase?.exists) {
-            payload.status = 'unhealthy';
-            payload.details.push('The required knowledge base collection is missing');
-            return payload;
+        if (collectionsCheck.error || !collectionsCheck.knowledgeBase?.exists) {
+            payload.status = 'degraded';
+            payload.details.push(collectionsCheck.error || 'The required knowledge base collection is missing');
         }
 
         // Step 3: Check embedding provider readiness (provider-aware; only 'gemini' needs a key)
@@ -335,7 +375,7 @@ class HealthService extends Base {
 
         // If we made it here with no errors, report success
         if (payload.status === 'healthy') {
-            payload.details.push('ChromaDB is running and all collections are accessible');
+            payload.details.push('Connected to the orchestrator-managed ChromaDB instance');
             payload.details.push('All features are operational');
         }
 

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs
@@ -25,13 +25,13 @@ test.describe('Neo.ai.mcp.server.knowledge-base.Server', () => {
         Server = (await import('../../../../../../../ai/mcp/server/knowledge-base/Server.mjs')).default;
     });
 
-    test('#12752: health exemptions do not expose retired database lifecycle tools', () => {
+    test('#12752/#13464: health exemptions expose recovery tools but not retired database lifecycle tools', () => {
         const serverInstance = Neo.create(Server);
 
         try {
             const exemptTools = serverInstance.getHealthExemptTools();
 
-            expect(exemptTools).toEqual(['healthcheck', 'list_agent_faqs']);
+            expect(exemptTools).toEqual(['healthcheck', 'list_agent_faqs', 'manage_knowledge_base']);
             expect(exemptTools).not.toContain('start_database');
             expect(exemptTools).not.toContain('stop_database');
         } finally {

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -128,6 +128,15 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         });
     });
 
+    test('isCollectionNotFoundError exposes the canonical Chroma not-found classifier', () => {
+        const namedError = new Error('The requested resource could not be found');
+        namedError.name  = 'ChromaNotFoundError';
+
+        expect(ChromaManager.isCollectionNotFoundError(namedError)).toBe(true);
+        expect(ChromaManager.isCollectionNotFoundError(new Error('collection does not exist'))).toBe(true);
+        expect(ChromaManager.isCollectionNotFoundError(new Error('connection refused'))).toBe(false);
+    });
+
     test('getKnowledgeBaseCollection refuses to create canonical during active shadow-swap promotion', async () => {
         let createCount = 0;
 

--- a/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs
@@ -110,6 +110,121 @@ test.describe('Neo.ai.services.knowledge-base.HealthService provider-aware readi
     });
 });
 
+test.describe('Neo.ai.services.knowledge-base.HealthService stale collection handle recovery (#13464)', () => {
+    let HealthService, ChromaManager, DatabaseLifecycleService;
+    let originalClient, originalGetCollection, originalGetDbStatus, originalGeminiKey, originalInvalidateCache;
+
+    const createNotFoundError = () => {
+        const error = new Error('The requested resource could not be found');
+        error.name  = 'ChromaNotFoundError';
+        return error;
+    };
+
+    test.beforeAll(async () => {
+        HealthService            = (await import('../../../../../../ai/services/knowledge-base/HealthService.mjs')).default;
+        ChromaManager            = (await import('../../../../../../ai/services/knowledge-base/ChromaManager.mjs')).default;
+        DatabaseLifecycleService = (await import('../../../../../../ai/services/knowledge-base/DatabaseLifecycleService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalClient          = ChromaManager.client;
+        originalGetCollection   = ChromaManager.getKnowledgeBaseCollection;
+        originalGetDbStatus     = DatabaseLifecycleService.getDatabaseStatus;
+        originalGeminiKey       = process.env.GEMINI_API_KEY;
+        originalInvalidateCache = ChromaManager.invalidateKnowledgeBaseCollectionCache;
+
+        ChromaManager.client = {heartbeat: async () => ({})};
+        DatabaseLifecycleService.getDatabaseStatus = () => ({running: false});
+        delete process.env.GEMINI_API_KEY;
+
+        HealthService.clearCache();
+    });
+
+    test.afterEach(() => {
+        ChromaManager.client                         = originalClient;
+        ChromaManager.getKnowledgeBaseCollection     = originalGetCollection;
+        ChromaManager.invalidateKnowledgeBaseCollectionCache = originalInvalidateCache;
+        DatabaseLifecycleService.getDatabaseStatus   = originalGetDbStatus;
+
+        if (originalGeminiKey === undefined) {
+            delete process.env.GEMINI_API_KEY;
+        } else {
+            process.env.GEMINI_API_KEY = originalGeminiKey;
+        }
+
+        HealthService.clearCache();
+    });
+
+    test('retries once after a resolved collection handle fails with not-found', async () => {
+        let collectionReads = 0;
+        let invalidateCalls = 0;
+
+        ChromaManager.invalidateKnowledgeBaseCollectionCache = () => {
+            invalidateCalls++;
+        };
+        ChromaManager.getKnowledgeBaseCollection = async () => {
+            collectionReads++;
+
+            return {
+                count: async () => {
+                    if (collectionReads === 1) {
+                        throw createNotFoundError();
+                    }
+
+                    return 42;
+                }
+            };
+        };
+
+        const health = await HealthService.healthcheck();
+
+        expect(collectionReads).toBe(2);
+        expect(invalidateCalls).toBe(1);
+        expect(health.status).toBe('healthy');
+        expect(health.database.connection.collections.knowledgeBase).toMatchObject({
+            exists: true,
+            count : 42
+        });
+        expect(health.features.embedding).toBe(true);
+        expect(health.details).toContain('Connected to the orchestrator-managed ChromaDB instance');
+    });
+
+    test('reports degraded corpus readiness after retry fails without masking provider readiness', async () => {
+        let collectionReads = 0;
+        let invalidateCalls = 0;
+
+        ChromaManager.invalidateKnowledgeBaseCollectionCache = () => {
+            invalidateCalls++;
+        };
+        ChromaManager.getKnowledgeBaseCollection = async () => {
+            collectionReads++;
+
+            return {
+                count: async () => {
+                    throw createNotFoundError();
+                }
+            };
+        };
+
+        const health = await HealthService.healthcheck();
+
+        expect(collectionReads).toBe(2);
+        expect(invalidateCalls).toBe(1);
+        expect(health.status).toBe('degraded');
+        expect(health.features.embedding).toBe(true);
+        expect(health.database.connection.connected).toBe(true);
+        expect(health.database.connection.collections.knowledgeBase).toMatchObject({
+            exists: false,
+            count : 0,
+            error : 'The requested resource could not be found'
+        });
+        expect(health.details).toContain('Failed to access collections: The requested resource could not be found');
+        expect(health.details).not.toContain('All features are operational');
+
+        await expect(HealthService.ensureHealthy()).rejects.toThrow('Knowledge Base is not fully operational');
+    });
+});
+
 test.describe.serial('Neo.ai.services.knowledge-base.HealthService runtimeFreshness (#12774)', () => {
     let HealthService, ChromaManager, DatabaseLifecycleService,
         bootRuntimeIdentity, bootRuntimeFreshnessErrors;


### PR DESCRIPTION
Resolves #13464

This hardens the Knowledge Base MCP health/gate path for unified Chroma. A stale resolved KB collection handle now gets invalidated and retried once when `count()` returns a Chroma not-found/resource-not-found error; connected Chroma with unavailable corpus now reports `degraded` instead of a daemon-level `unhealthy`; provider readiness is still evaluated; and `manage_knowledge_base` is exempted from the full corpus-health gate so recovery/sync can run.

Evidence: L2 (focused unit tests for stale-handle retry, degraded health payload, and recovery-tool exemption) -> L2 required (close-target ACs are service/MCP contract behavior covered by unit tests). No residuals.

## Deltas from ticket
- Kept the payload shape compatible and documented the revised health semantics in `openapi.yaml`.
- Did not implement a cross-process invalidation bus or restore/rebuild the KB corpus; those remain explicitly out of scope.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/Server.spec.mjs` -> 20 passed.
- `git diff --check` -> passed.
- Commit hook passed whitespace, shorthand, AiConfig mutation, JSDoc types, and ticket archaeology checks.

## Post-Merge Validation
- [ ] Restart/reconnect the KB MCP runtime and rerun `healthcheck` to confirm live diagnostics use the updated degraded/healthy semantics against the current corpus state.
- [ ] Track KB corpus restoration/root-cause separately, per #13464 out-of-scope.

## Commits
- `90171b499` — `fix(ai): recover KB stale collection handles (#13464)`

Authored by Euclid (GPT-5 Codex, Codex Desktop). Session 4ce60429-2986-4543-be2d-741957c75b6c.