### PR TITLE
fix(ai): recover stale Chroma handles (#13466)

### DIFF
--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -7,11 +7,11 @@ import {
     chromaConnect,
     chromaDeleteCollection,
     createSilentExecutor,
+    isChromaCollectionNotFoundError,
     registerNeoChromaEmbeddingFunctions
 } from '../shared/vector/chromaClientPrimitives.mjs';
 
 const COLLECTION_ALREADY_EXISTS_RE = /already exists|already contains|conflict/i;
-const COLLECTION_NOT_FOUND_RE      = /does not exist|not found|not be found|could not be found|404/i;
 const SWAP_ACTIVE_PHASES           = ['parking', 'shadow'];
 
 registerNeoChromaEmbeddingFunctions({
@@ -188,7 +188,7 @@ class ChromaManager extends Base {
      * @returns {Boolean}
      */
     #isCollectionNotFoundError(error) {
-        return error?.name === 'ChromaNotFoundError' || COLLECTION_NOT_FOUND_RE.test(error?.message || '');
+        return isChromaCollectionNotFoundError(error)
     }
 
     /**

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -983,95 +983,23 @@ class HealthService extends Base {
         };
 
         try {
-            // Check memory collection
-            const memoryCollection = await withTimeout(
-                StorageRouter.getMemoryCollection(),
-                chromaProbeTimeoutMs,
-                'memory collection resolution health probe'
-            ).catch(error => {
-                result.memories = {
-                    name  : aiConfig.collections.memory,
-                    exists: false,
-                    count : 0,
-                    error : error.message
-                };
-                return null;
+            result.memories = await this.#checkCollectionCount({
+                collectionType : 'memory',
+                name           : aiConfig.collections.memory,
+                getCollection  : () => StorageRouter.getMemoryCollection(),
+                resolutionLabel: 'memory collection resolution health probe',
+                countLabel     : 'memory collection count health probe',
+                chromaProbeTimeoutMs
             });
-            if (memoryCollection) {
-                let memoryCount = 0;
-                try {
-                    memoryCount = await withTimeout(
-                        memoryCollection.count(),
-                        chromaProbeTimeoutMs,
-                        'memory collection count health probe'
-                    );
-                } catch (error) {
-                    result.memories = {
-                        name  : aiConfig.collections.memory,
-                        exists: true,
-                        count : 0,
-                        error : error.message
-                    };
-                }
 
-                result.memories = {
-                    name : aiConfig.collections.memory,
-                    exists: true,
-                    count: memoryCount,
-                    ...(result.memories?.error ? {error: result.memories.error} : {})
-                };
-            } else if (!result.memories) {
-                result.memories = {
-                    name  : aiConfig.collections.memory,
-                    exists: false,
-                    count : 0
-                };
-            }
-
-            // Check summary collection
-            const summaryCollection = await withTimeout(
-                StorageRouter.getSummaryCollection(),
-                chromaProbeTimeoutMs,
-                'summary collection resolution health probe'
-            ).catch(error => {
-                result.summaries = {
-                    name  : aiConfig.collections.session,
-                    exists: false,
-                    count : 0,
-                    error : error.message
-                };
-                return null;
+            result.summaries = await this.#checkCollectionCount({
+                collectionType : 'summary',
+                name           : aiConfig.collections.session,
+                getCollection  : () => StorageRouter.getSummaryCollection(),
+                resolutionLabel: 'summary collection resolution health probe',
+                countLabel     : 'summary collection count health probe',
+                chromaProbeTimeoutMs
             });
-            if (summaryCollection) {
-                let summaryCount = 0;
-                try {
-                    summaryCount = await withTimeout(
-                        summaryCollection.count(),
-                        chromaProbeTimeoutMs,
-                        'summary collection count health probe'
-                    );
-                } catch (error) {
-                    result.summaries = {
-                        name  : aiConfig.collections.session,
-                        exists: true,
-                        count : 0,
-                        error : error.message
-                    };
-                }
-
-                result.summaries = {
-                    name : aiConfig.collections.session,
-                    exists: true,
-                    count: summaryCount,
-                    ...(result.summaries?.error ? {error: result.summaries.error} : {})
-                };
-            } else if (!result.summaries) {
-                result.summaries = {
-                    name  : aiConfig.collections.session,
-                    exists: false,
-                    count : 0
-                };
-            }
 
             const errors = [result.memories?.error, result.summaries?.error].filter(Boolean);
             if (errors.length) {
@@ -1084,6 +1012,105 @@ class HealthService extends Base {
                 ...result,
                 error: `Failed to access collections: ${e.message}`
             };
+        }
+    }
+
+    /**
+     * Resolves and counts one Memory Core Chroma collection.
+     *
+     * Operation-level not-found failures on a resolved collection object are treated as
+     * stale-handle evidence: invalidate that collection cache and retry resolution once.
+     *
+     * @param {Object} options
+     * @param {'memory'|'summary'} options.collectionType
+     * @param {String} options.name
+     * @param {Function} options.getCollection
+     * @param {String} options.resolutionLabel
+     * @param {String} options.countLabel
+     * @param {Number} options.chromaProbeTimeoutMs
+     * @returns {Promise<Object>}
+     * @private
+     */
+    async #checkCollectionCount({
+        collectionType,
+        name,
+        getCollection,
+        resolutionLabel,
+        countLabel,
+        chromaProbeTimeoutMs
+    }) {
+        let collection = await withTimeout(
+            getCollection(),
+            chromaProbeTimeoutMs,
+            resolutionLabel
+        ).catch(error => ({
+            __resolutionError: error
+        }));
+
+        if (collection?.__resolutionError) {
+            return {
+                name,
+                exists: false,
+                count : 0,
+                error : collection.__resolutionError.message
+            }
+        }
+
+        if (!collection) {
+            return {
+                name,
+                exists: false,
+                count : 0
+            }
+        }
+
+        for (let attempt = 0; attempt < 2; attempt++) {
+            try {
+                return {
+                    name,
+                    exists: true,
+                    count : await withTimeout(
+                        collection.count(),
+                        chromaProbeTimeoutMs,
+                        countLabel
+                    )
+                }
+            } catch (error) {
+                if (attempt > 0 || !ChromaManager.isCollectionNotFoundError(error)) {
+                    return {
+                        name,
+                        exists: true,
+                        count : 0,
+                        error : error.message
+                    }
+                }
+
+                ChromaManager.invalidateCollectionCache(collectionType);
+                collection = await withTimeout(
+                    getCollection(),
+                    chromaProbeTimeoutMs,
+                    resolutionLabel
+                ).catch(resolveError => ({
+                    __resolutionError: resolveError
+                }));
+
+                if (collection?.__resolutionError) {
+                    return {
+                        name,
+                        exists: false,
+                        count : 0,
+                        error : collection.__resolutionError.message
+                    }
+                }
+
+                if (!collection) {
+                    return {
+                        name,
+                        exists: false,
+                        count : 0
+                    }
+                }
+            }
         }
     }
 

--- a/ai/services/memory-core/managers/ChromaManager.mjs
+++ b/ai/services/memory-core/managers/ChromaManager.mjs
@@ -8,6 +8,7 @@ import {
     chromaDeleteCollection,
     createDynamicTextEmbeddingFunction,
     createSilentExecutor,
+    isChromaCollectionNotFoundError,
     registerNeoChromaEmbeddingFunctions
 } from '../../shared/vector/chromaClientPrimitives.mjs';
 import {ensureChromaTestDatabase} from '../../shared/vector/chromaTestIsolation.mjs';
@@ -253,6 +254,47 @@ class ChromaManager extends AbstractVectorManager {
 
         this.graphCollection = await this._graphCollectionPromise;
         return this.graphCollection;
+    }
+
+    /**
+     * Public predicate for consumers operating on already-resolved collection handles.
+     *
+     * A long-lived MCP process can hold a collection object across an orchestrator-owned
+     * Chroma recycle. Operation-level Chroma not-found failures should invalidate the
+     * memoized handle and retry the canonical collection name once.
+     *
+     * @param {Error} error
+     * @returns {Boolean}
+     */
+    isCollectionNotFoundError(error) {
+        return isChromaCollectionNotFoundError(error)
+    }
+
+    /**
+     * @summary Invalidates memoized Memory Core Chroma collection handles.
+     *
+     * This is the production-safe subset of the test-only lifecycle reset: it clears only
+     * cached Chroma collection promises/objects, leaving service readiness and graph state
+     * untouched so the next operation lazily re-resolves by canonical collection name.
+     *
+     * @param {'memory'|'summary'|'graph'|'all'} [collectionType='all']
+     * @returns {void}
+     */
+    invalidateCollectionCache(collectionType = 'all') {
+        const types = collectionType === 'all' ? ['memory', 'summary', 'graph'] : [collectionType];
+
+        for (const type of types) {
+            if (type === 'memory') {
+                this._memoryCollectionPromise = null;
+                this.memoryCollection         = null;
+            } else if (type === 'summary') {
+                this._summaryCollectionPromise = null;
+                this.summaryCollection         = null;
+            } else if (type === 'graph') {
+                this._graphCollectionPromise = null;
+                this.graphCollection         = null;
+            }
+        }
     }
 
     /**

--- a/ai/services/shared/vector/chromaClientPrimitives.mjs
+++ b/ai/services/shared/vector/chromaClientPrimitives.mjs
@@ -1,6 +1,7 @@
 import {knownEmbeddingFunctions, registerEmbeddingFunction} from 'chromadb';
 
 export const CHROMA_DYNAMIC_TEXT_EMBEDDING_FUNCTION_NAME = 'dynamic_text_embedding_service';
+const CHROMA_COLLECTION_NOT_FOUND_RE = /does not exist|not found|not be found|could not be found|404/i;
 
 /**
  * @summary Local Chroma embedding placeholder for collections that always provide raw vectors.
@@ -112,6 +113,21 @@ export function registerNeoChromaEmbeddingFunctions({
     }
 
     return registered
+}
+
+/**
+ * @summary Classifies Chroma collection-handle failures that should trigger re-resolution.
+ *
+ * Long-lived MCP processes can keep a collection object across a Chroma daemon recycle,
+ * shadow-swap, or restore. The next operation on that object can fail with Chroma's
+ * not-found signatures even though the canonical collection is available to a fresh
+ * lookup. Callers use this predicate to invalidate their memoized handle and retry once.
+ *
+ * @param {Error} error
+ * @returns {Boolean}
+ */
+export function isChromaCollectionNotFoundError(error) {
+    return error?.name === 'ChromaNotFoundError' || CHROMA_COLLECTION_NOT_FOUND_RE.test(error?.message || '')
 }
 
 /**

--- a/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs
@@ -351,6 +351,11 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         count: async () => countGetter(),
         get  : async () => ({ids: [], metadatas: []})
     });
+    const createNotFoundError = () => {
+        const error = new Error('The requested resource could not be found');
+        error.name  = 'ChromaNotFoundError';
+        return error
+    };
 
     test.beforeAll(async () => {
         HealthService = (await import('../../../../../../ai/services/memory-core/HealthService.mjs')).default;
@@ -373,6 +378,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
             chromaConnected         : ChromaManager.connected,
             chromaReady             : ChromaManager.ready,
             chromaConnect           : ChromaManager.connect,
+            invalidateCollectionCache: ChromaManager.invalidateCollectionCache,
             getMemoryCollection     : StorageRouter.getMemoryCollection,
             getSummaryCollection    : StorageRouter.getSummaryCollection,
             getDatabaseStatus       : ChromaLifecycleService.getDatabaseStatus
@@ -413,6 +419,7 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         ChromaManager.connected = originals.chromaConnected;
         ChromaManager.ready     = originals.chromaReady;
         ChromaManager.connect   = originals.chromaConnect;
+        ChromaManager.invalidateCollectionCache = originals.invalidateCollectionCache;
         StorageRouter.getMemoryCollection      = originals.getMemoryCollection;
         StorageRouter.getSummaryCollection     = originals.getSummaryCollection;
         ChromaLifecycleService.getDatabaseStatus = originals.getDatabaseStatus;
@@ -597,6 +604,70 @@ test.describe('HealthService #12382 — cached healthcheck freshness', () => {
         expect(refreshed).not.toBe(cached);
         expect(refreshed.database.connection.collections.memories.count).toBe(12);
         expect(refreshed.database.connection.collections.summaries.count).toBe(22);
+    });
+
+    test('#13466: memory count stale handle invalidates and retries once', async () => {
+        let memoryReads = 0;
+        const invalidated = [];
+
+        ChromaManager.invalidateCollectionCache = type => invalidated.push(type);
+        StorageRouter.getMemoryCollection = async () => {
+            memoryReads++;
+
+            return {
+                count: async () => {
+                    if (memoryReads === 1) {
+                        throw createNotFoundError()
+                    }
+
+                    return 13
+                },
+                get: async () => ({ids: [], metadatas: []})
+            }
+        };
+
+        const result = await HealthService.healthcheck();
+
+        expect(memoryReads).toBe(2);
+        expect(invalidated).toEqual(['memory']);
+        expect(result.status).toBe('healthy');
+        expect(result.database.connection.collections.memories).toMatchObject({
+            exists: true,
+            count : 13
+        });
+        expect(result.details).toContain('All features are operational');
+    });
+
+    test('#13466: summary count stale handle invalidates and retries once', async () => {
+        let summaryReads = 0;
+        const invalidated = [];
+
+        ChromaManager.invalidateCollectionCache = type => invalidated.push(type);
+        StorageRouter.getSummaryCollection = async () => {
+            summaryReads++;
+
+            return {
+                count: async () => {
+                    if (summaryReads === 1) {
+                        throw createNotFoundError()
+                    }
+
+                    return 23
+                },
+                get: async () => ({ids: [], metadatas: []})
+            }
+        };
+
+        const result = await HealthService.healthcheck();
+
+        expect(summaryReads).toBe(2);
+        expect(invalidated).toEqual(['summary']);
+        expect(result.status).toBe('healthy');
+        expect(result.database.connection.collections.summaries).toMatchObject({
+            exists: true,
+            count : 23
+        });
+        expect(result.details).toContain('All features are operational');
     });
 
     test('embedding write canary failure degrades healthcheck status', async () => {

--- a/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs
@@ -25,7 +25,7 @@ import StorageRouter  from '../../../../../../../ai/services/memory-core/manager
 import SystemLifecycleService from '../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs';
 import {resetMemoryCoreLifecycle} from '../util.mjs';
 
-// ADR 0019 B4: storagePaths.graph resolves to ':memory:' by construction under UNIT_TEST_MODE.
+// Unit test mode resolves storagePaths.graph to ':memory:' by construction.
 
 test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
     test('logs an operator-actionable config error before throwing on missing Chroma coordinates', () => {
@@ -113,6 +113,44 @@ test.describe('Neo.ai.services.memory-core.managers.ChromaManager', () => {
         expect(ChromaManager.memoryCollection).toBeNull();
         expect(ChromaManager.summaryCollection).toBeNull();
         expect(ChromaManager.graphCollection).toBeNull();
+    });
+
+    test('invalidateCollectionCache clears targeted and all collection handles', () => {
+        const stalePromise = Promise.resolve({name: 'stale-collection'});
+
+        ChromaManager._memoryCollectionPromise  = stalePromise;
+        ChromaManager._summaryCollectionPromise = stalePromise;
+        ChromaManager._graphCollectionPromise   = stalePromise;
+        ChromaManager.memoryCollection  = {name: 'stale-memory'};
+        ChromaManager.summaryCollection = {name: 'stale-summary'};
+        ChromaManager.graphCollection   = {name: 'stale-graph'};
+
+        ChromaManager.invalidateCollectionCache('summary');
+
+        expect(ChromaManager._memoryCollectionPromise).toBe(stalePromise);
+        expect(ChromaManager.memoryCollection).toEqual({name: 'stale-memory'});
+        expect(ChromaManager._summaryCollectionPromise).toBeNull();
+        expect(ChromaManager.summaryCollection).toBeNull();
+        expect(ChromaManager._graphCollectionPromise).toBe(stalePromise);
+        expect(ChromaManager.graphCollection).toEqual({name: 'stale-graph'});
+
+        ChromaManager.invalidateCollectionCache();
+
+        expect(ChromaManager._memoryCollectionPromise).toBeNull();
+        expect(ChromaManager._summaryCollectionPromise).toBeNull();
+        expect(ChromaManager._graphCollectionPromise).toBeNull();
+        expect(ChromaManager.memoryCollection).toBeNull();
+        expect(ChromaManager.summaryCollection).toBeNull();
+        expect(ChromaManager.graphCollection).toBeNull();
+    });
+
+    test('isCollectionNotFoundError classifies Chroma stale-handle signatures', () => {
+        const namedError = new Error('boom');
+        namedError.name  = 'ChromaNotFoundError';
+
+        expect(ChromaManager.isCollectionNotFoundError(namedError)).toBe(true);
+        expect(ChromaManager.isCollectionNotFoundError(new Error('The requested resource could not be found'))).toBe(true);
+        expect(ChromaManager.isCollectionNotFoundError(new Error('connection refused'))).toBe(false);
     });
 
     test('should prevent console.warn global state theft during concurrent collection fetching', async () => {


### PR DESCRIPTION
Resolves #13466

Memory Core healthchecks now recover from stale Chroma collection handles the same way the Knowledge Base path already does: classify Chroma not-found operation failures, invalidate the memoized collection handle, re-resolve by canonical collection name, and retry the count once. This targets long-lived MCP processes that outlive an orchestrator-owned Chroma recycle without masking provider/readiness failures.

Evidence: L2 (unit-level stale collection-handle simulation for MC memory/summary counts plus existing KB stale-handle regression tests) -> L4 required (live MCP servers held across an orchestrator-owned Chroma recycle). Residual: live recycle validation after merge/deploy [#13466].

## Deltas from ticket

- Extracted the Chroma collection-not-found classifier to shared vector primitives so KB and MC use one predicate.
- Added production-safe MC collection cache invalidation for memory, summary, and graph handles; the healthcheck currently uses the memory and summary retry paths.
- Left malformed FTS5/index diagnosis out of this PR; tracked separately in #13467.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs test/playwright/unit/ai/services/memory-core/HealthService.spec.mjs test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs test/playwright/unit/ai/services/knowledge-base/HealthService.providerReady.spec.mjs` -> 88 passed (2.2s)
- `git diff --check`
- `git diff --cached --check`
- `node ./buildScripts/util/check-jsdoc-types.mjs ai/services/memory-core/HealthService.mjs`
- `node ./buildScripts/util/check-ticket-archaeology.mjs test/playwright/unit/ai/services/memory-core/managers/ChromaManager.spec.mjs`
- Pre-commit hook passed: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-ticket-archaeology`

## Post-Merge Validation

- [ ] Restart/recycle shared Chroma while MC and KB MCP servers stay alive, then verify healthcheck/count paths recover without stale counts.
- [ ] Re-run raw memory and KB corpus smoke checks against the updated deployment.

## Commits

- `df763e510` - `fix(ai): recover stale Chroma handles (#13466)`

Authored by Euclid (GPT-5, Codex Desktop). Session 4ce60429-2986-4543-be2d-741957c75b6c.
