### PR TITLE
fix(ai): bound Neural Link bridge payload logs (#13473)

### DIFF
--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -90,6 +90,12 @@ class Config extends ConfigProvider {
                 timestampStyle: 'bracketed'
             }),
             /**
+             * Maximum characters written when `debug: true` enables full Bridge payload logging.
+             * Default/info Bridge receive logs always use bounded routing metadata instead.
+             * @type {number}
+             */
+            bridgePayloadDebugMaxChars: leaf(4096, 'NEO_NL_BRIDGE_PAYLOAD_DEBUG_MAX_CHARS', 'number'),
+            /**
              * Number of days to retain Action logs in the Neural Link Database.
              * @type {number}
              */

--- a/ai/services/neural-link/ConnectionService.mjs
+++ b/ai/services/neural-link/ConnectionService.mjs
@@ -14,6 +14,104 @@ import {
 import {resolveCallTarget} from './resolveCallTarget.mjs';
 
 /**
+ * @summary Validates the Neural Link bridge payload debug-log cap from AiConfig.
+ * @param {Number} maxChars
+ * @returns {Number}
+ */
+export const normalizeBridgePayloadDebugMaxChars = maxChars => {
+    const value = Number(maxChars);
+
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new Error('Invalid aiConfig.bridgePayloadDebugMaxChars value')
+    }
+
+    return Math.floor(value)
+};
+
+/**
+ * @summary Serializes a bridge payload for opt-in debug logging, capped for file safety.
+ * @param {*} payload
+ * @param {Number} maxChars
+ * @returns {String}
+ */
+export const stringifyBridgePayloadForDebug = (payload, maxChars) => {
+    let serialized;
+
+    if (payload instanceof Error) {
+        serialized = `${payload.name}: ${payload.message}\n${payload.stack || ''}`.trim()
+    } else {
+        try {
+            serialized = JSON.stringify(payload)
+        } catch {
+            serialized = String(payload)
+        }
+    }
+
+    serialized ??= String(payload);
+
+    const limit = normalizeBridgePayloadDebugMaxChars(maxChars);
+
+    if (serialized.length <= limit) {
+        return serialized
+    }
+
+    return `${serialized.slice(0, limit)}... [truncated ${serialized.length - limit} chars]`
+};
+
+/**
+ * @summary Measures a payload's serialized byte size without exposing its body.
+ * @param {*} payload
+ * @returns {Number|null}
+ */
+export const getBridgePayloadByteLength = payload => {
+    try {
+        return Buffer.byteLength(JSON.stringify(payload) ?? String(payload), 'utf8')
+    } catch {
+        return null
+    }
+};
+
+/**
+ * @summary Creates a bounded, payload-free bridge receive log line.
+ * @param {Object} payload
+ * @returns {String}
+ */
+export const formatBridgePayloadSummary = payload => {
+    const message = payload?.message ?? {},
+          error   = message?.error ?? payload?.error,
+          fields  = [
+              ['type',         payload?.type],
+              ['appWorkerId',  payload?.appWorkerId],
+              ['agentId',      payload?.agentId],
+              ['messageId',    message?.id],
+              ['method',       message?.method],
+              ['errorCode',    error?.code],
+              ['payloadBytes', getBridgePayloadByteLength(payload) ?? 'unknown']
+          ];
+
+    return `[ConnectionService] Bridge message ${fields
+        .filter(([, value]) => value !== undefined && value !== null && value !== '')
+        .map(([key, value]) => `${key}=${value}`)
+        .join(' ')}`
+};
+
+/**
+ * @summary Logs a bridge payload without dumping its full body unless debug is enabled.
+ * @param {Object} payload
+ * @param {Object} options
+ * @param {Object} options.logger
+ * @param {Boolean} options.debug
+ * @param {Number} options.maxChars
+ */
+export const logBridgePayload = (payload, {logger, debug, maxChars}) => {
+    logger.info(formatBridgePayloadSummary(payload));
+
+    if (debug) {
+        logger.debug(`[ConnectionService] Bridge payload ${stringifyBridgePayloadForDebug(payload, maxChars)}`);
+    }
+};
+
+/**
  * @summary Manages the connection to the Neural Link Bridge and orchestrates RPC calls.
  *
  * **Architecture Change (v2):**
@@ -448,7 +546,11 @@ class ConnectionService extends Base {
     handleBridgeMessage(data) {
         try {
             const payload = JSON.parse(data.toString());
-            logger.info(`[DEBUG] Received from Bridge: ${JSON.stringify(payload)}`);
+            logBridgePayload(payload, {
+                logger,
+                debug   : aiConfig.debug,
+                maxChars: aiConfig.bridgePayloadDebugMaxChars
+            });
 
             switch (payload.type) {
                 case 'app_connected':

--- a/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs
@@ -24,10 +24,17 @@ import {STALE_BRIDGE_ERROR_CODE} from '../../../../../../ai/mcp/server/neural-li
  * is what decides whether a stale shared Bridge is reused, spawned over, or failed loudly.
  */
 test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshness gate (#13299)', () => {
-    let ConnectionService, originalConnectToBridge, originalSpawnBridge;
+    let ConnectionService, logBridgePayload,
+        normalizeBridgePayloadDebugMaxChars, stringifyBridgePayloadForDebug,
+        originalConnectToBridge, originalSpawnBridge;
 
     test.beforeAll(async () => {
-        ConnectionService = (await import('../../../../../../ai/services/neural-link/ConnectionService.mjs')).default;
+        const module = await import('../../../../../../ai/services/neural-link/ConnectionService.mjs');
+
+        ConnectionService                    = module.default;
+        logBridgePayload                     = module.logBridgePayload;
+        normalizeBridgePayloadDebugMaxChars  = module.normalizeBridgePayloadDebugMaxChars;
+        stringifyBridgePayloadForDebug       = module.stringifyBridgePayloadForDebug;
     });
 
     test.beforeEach(() => {
@@ -50,6 +57,85 @@ test.describe('Neo.ai.services.neural-link.ConnectionService — bridge freshnes
         });
 
         expect(url).toBe('ws://127.0.0.1:19081/?role=agent&id=agent-test&token=token+with+spaces');
+    });
+
+    test('logs bridge receives as bounded metadata when debug is disabled (#13473)', () => {
+        const
+            largeResult = `payload-${'x'.repeat(500)}`,
+            calls       = [],
+            testLogger  = {
+                debug: (...args) => calls.push({level: 'debug', text: args.join(' ')}),
+                info : (...args) => calls.push({level: 'info',  text: args.join(' ')})
+            };
+
+        logBridgePayload({
+            type       : 'app_message',
+            appWorkerId: 'app-worker-1',
+            message    : {
+                id    : 42,
+                method: 'get_component_tree',
+                result: {
+                    tree: largeResult
+                }
+            }
+        }, {
+            logger  : testLogger,
+            debug   : false,
+            maxChars: 80
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].level).toBe('info');
+        expect(calls[0].text).toContain('type=app_message');
+        expect(calls[0].text).toContain('appWorkerId=app-worker-1');
+        expect(calls[0].text).toContain('messageId=42');
+        expect(calls[0].text).toContain('method=get_component_tree');
+        expect(calls[0].text).toContain('payloadBytes=');
+        expect(calls[0].text).not.toContain(largeResult);
+        expect(calls[0].text).not.toContain('result');
+    });
+
+    test('caps full bridge payload detail behind opt-in debug logging (#13473)', () => {
+        const
+            largeValue = `debug-${'y'.repeat(300)}`,
+            calls      = [],
+            testLogger = {
+                debug: (...args) => calls.push({level: 'debug', text: args.join(' ')}),
+                info : (...args) => calls.push({level: 'info',  text: args.join(' ')})
+            };
+
+        logBridgePayload({
+            type       : 'app_message',
+            appWorkerId: 'app-worker-2',
+            message    : {
+                id    : 7,
+                method: 'inspect',
+                result: {largeValue}
+            }
+        }, {
+            logger  : testLogger,
+            debug   : true,
+            maxChars: 90
+        });
+
+        expect(calls.map(call => call.level)).toEqual(['info', 'debug']);
+        expect(calls[1].text).toContain('[ConnectionService] Bridge payload ');
+        expect(calls[1].text).toContain('... [truncated ');
+        expect(calls[1].text.length).toBeLessThan(170);
+        expect(calls[1].text).not.toContain('y'.repeat(120));
+    });
+
+    test('serializes circular debug payloads without throwing (#13473)', () => {
+        const circular = {type: 'app_message'};
+        circular.self = circular;
+
+        expect(() => stringifyBridgePayloadForDebug(circular, 40)).not.toThrow();
+        expect(stringifyBridgePayloadForDebug(circular, 40)).toBe('[object Object]');
+    });
+
+    test('fails loudly instead of shadowing the AiConfig debug payload cap default (#13473)', () => {
+        expect(() => normalizeBridgePayloadDebugMaxChars(undefined)).toThrow(/bridgePayloadDebugMaxChars/);
+        expect(() => normalizeBridgePayloadDebugMaxChars(0)).toThrow(/bridgePayloadDebugMaxChars/);
     });
 
     test('spawns a Bridge only when the first connection attempt is a missing listener', async () => {


### PR DESCRIPTION
Resolves #13473

Bounds Neural Link Bridge receive logging so default/info logs carry routing metadata and payload byte size instead of serializing the full Bridge payload. Full payload detail is now gated behind `aiConfig.debug` before it reaches the always-on file sink, and that debug detail is capped through a new Neural Link config leaf.

Evidence: L2 (focused Playwright unit coverage for bounded info summary, debug opt-in cap, circular fallback, and fail-loud no-shadow-default validation) -> L2 required (ticket ACs are unit/static-verifiable). No residuals.

## Deltas from ticket

- Added `bridgePayloadDebugMaxChars` to `ai/mcp/server/neural-link/config.template.mjs`, env-bound as `NEO_NL_BRIDGE_PAYLOAD_DEBUG_MAX_CHARS`.
- Removed the service-local fallback default; the config leaf is the only default authority per ADR 0019.
- Did not touch global MCP log retention; that remains scoped to #13474.

## Config Template Change

- Changed config key: `bridgePayloadDebugMaxChars`.
- Local `ai/mcp/server/neural-link/config.mjs` copies should be migrated/refreshed after merge so active clones expose the new config leaf; no service-local fallback shadows the provider default.
- Harness restart is recommended for active Neural Link MCP processes so the updated source and config leaf are loaded.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/neural-link/ConnectionService.spec.mjs` passed: 7/7.
- `git diff --check` passed.
- `npm run ai:lint-config-template-ssot` passed.
- `npm run ai:check-retired-primitives` passed.
- `npm run ai:lint-mcp-test-locations` passed.
- Commit hook also ran whitespace, shorthand, AiConfig test-mutation, JSDoc type, and ticket archaeology checks.

## Post-Merge Validation

- [ ] Restart or reload active Neural Link MCP harnesses so the updated logging path is live.
- [ ] Refresh local ignored `config.mjs` copies if tuning `NEO_NL_BRIDGE_PAYLOAD_DEBUG_MAX_CHARS` is desired.

## Commit

- `6b9ff198e` - `fix(ai): bound Neural Link bridge payload logs (#13473)`

Authored by Euclid (GPT-5, Codex Desktop). Session ef8b263f-1cdc-431a-a730-2c6c2ff26f98.
