### PR TITLE
fix(ai): classify Codex wake submit evidence (#13480)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -840,11 +840,11 @@ async function deliverViaCodexAppServer(subscription, digest, evidenceLabel = ''
  * "lost frontmost status" error. Focus contention is transient, so we re-attempt the whole
  * delivery a few times before giving up.
  *
- * Phase-aware idempotency guard: the wake payload is submitted (`key code 36` / Enter) BEFORE
- * the "user input restore" phases. A frontmost-loss reported for a restore phase therefore means
- * the wake already landed — only the user's draft-restore failed (cosmetic). We must NOT retry
- * that case (it would double-submit the wake). Non-race errors (syntax/permissions) re-throw
- * immediately.
+ * Phase-aware idempotency guard: the wake payload submit is attempted (`key code 36` / Enter)
+ * BEFORE the "user input restore" phases. A frontmost-loss reported for a restore phase therefore
+ * means the submit step already ran — only the user's draft-restore failed (cosmetic). We must NOT
+ * retry that case (it would double-submit the wake). Non-race errors (syntax/permissions) re-throw
+ * immediately. For Codex Desktop, an `osascript` exit proves adapter completion, not turn start.
  * @param {String[]} osascriptArgs The fully-built `osascript -e …` argument list.
  * @param {String} subscriptionId For log attribution.
  * @param {String} appName For log attribution.
@@ -858,19 +858,21 @@ async function deliverViaOsascriptWithRetry(osascriptArgs, subscriptionId, appNa
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
             await spawnAsync('osascript', osascriptArgs);
-            const attemptLabel = attempt > 1 ? ` (attempt ${attempt}/${maxAttempts})` : '';
+            const attemptLabel = attempt > 1 ? ` (attempt ${attempt}/${maxAttempts})` : '',
+                  outcomeLabel = appName === 'Codex' ? 'Submit attempted' : 'Delivered';
             writeLog('INFO',
-                `[Wake Daemon] Delivered ${subscriptionId} via osascript to ${appName}${attemptLabel}${evidenceLabel}`);
+                `[Wake Daemon] ${outcomeLabel} ${subscriptionId} via osascript to ${appName}${attemptLabel}${evidenceLabel}`);
             return
         } catch (err) {
             const message         = err.message || '',
                   isFrontmostRace = /lost frontmost status|-2700/.test(message),
                   afterSubmit     = /user input restore/.test(message);
 
-            // Wake already submitted; only the draft-restore lost frontmost → delivered, do not retry.
+            // Submit step already ran; only the draft-restore lost frontmost → do not retry.
             if (isFrontmostRace && afterSubmit) {
+                const outcomeLabel = appName === 'Codex' ? 'wake submit attempted' : 'wake landed';
                 writeLog('WARN',
-                    `[Wake Daemon] ${subscriptionId} wake landed but draft-restore lost frontmost; ` +
+                    `[Wake Daemon] ${subscriptionId} ${outcomeLabel} but draft-restore lost frontmost; ` +
                     `not retrying (avoids double-send)${evidenceLabel}. ${message}`);
                 return
             }
@@ -931,11 +933,14 @@ function formatWakeDeliveryEvidence(evidence, {adapter, adapterSource, appName})
 
     const counts = evidence.counts || {};
 
-    const scenario = evidence.scenario || 'unknown';
+    const scenario       = evidence.scenario || 'unknown',
+          submitBoundary = adapter === 'osascript' && appName === 'Codex'
+              ? '; submitProof=attempted; turnStartProof=live-required'
+              : '';
 
     return ` (scenario=${scenario}; route=${adapter}; adapterSource=${adapterSource}; app=${appName || ''}; ` +
         `counts=messages:${counts.messages || 0},tasks:${counts.tasks || 0},` +
-        `permissions:${counts.permissions || 0},heartbeats:${counts.heartbeats || 0})`;
+        `permissions:${counts.permissions || 0},heartbeats:${counts.heartbeats || 0}${submitBoundary})`;
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -2031,11 +2031,14 @@ test.describe('Wake Daemon', () => {
                     clearTimeout(timeout);
                     resolve();
                 }
-                // Negative case: if the daemon ever logs "Delivered" for this subId, the
+                // Negative case: if the daemon ever logs an osascript attempt for this subId, the
                 // fail-closed guard didn't fire. Reject so the test fails loudly.
-                if (out.includes(`[Wake Daemon] Delivered ${subId}`)) {
+                if (
+                    out.includes(`[Wake Daemon] Delivered ${subId}`) ||
+                    out.includes(`[Wake Daemon] Submit attempted ${subId}`)
+                ) {
                     clearTimeout(timeout);
-                    reject(new Error('Daemon delivered Codex wake despite missing focusSeedKey — fail-closed guard regressed'));
+                    reject(new Error('Daemon attempted Codex wake despite missing focusSeedKey — fail-closed guard regressed'));
                 }
             });
             daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
@@ -2072,7 +2075,7 @@ test.describe('Wake Daemon', () => {
         expect(fs.existsSync(mockOutPath)).toBe(false);
     });
 
-    test('Codex wake delivery emits specific sequence r -> Cmd+Z -> Cmd+A/X -> paste -> Esc -> Enter (#10667, #13287)', async () => {
+    test('Codex wake submit attempt emits specific sequence r -> Cmd+Z -> Cmd+A/X -> paste -> Esc -> Enter (#10667, #13287, #13480)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-cleanup';
 
@@ -2117,12 +2120,12 @@ test.describe('Wake Daemon', () => {
         let stdoutLog = '';
 
         const deliveryPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver Codex wake within timeout')), 10000);
+            const timeout = setTimeout(() => reject(new Error('Daemon did not attempt Codex wake submit within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
                 stdoutLog += out;
-                if (out.includes(`Delivered ${subId}`)) {
+                if (out.includes(`Submit attempted ${subId}`)) {
                     clearTimeout(timeout);
                     resolve();
                 }
@@ -2177,9 +2180,12 @@ test.describe('Wake Daemon', () => {
         expect(rawArgs.at(-1)).toContain('[WAKE][priority:normal]');
         expect(rawArgs.at(-1)).toContain('Test Codex Cleanup');
         expect(rawArgs.at(-1)).not.toContain('lifecycle-first');
+        expect(stdoutLog).toContain(`[Wake Daemon] Submit attempted ${subId} via osascript to Codex`);
+        expect(stdoutLog).not.toContain(`[Wake Daemon] Delivered ${subId} via osascript to Codex`);
         expect(stdoutLog).toContain(
             'scenario=direct-message; route=osascript; adapterSource=metadata; app=Codex; ' +
-            'counts=messages:1,tasks:0,permissions:0,heartbeats:0'
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:0; ' +
+            'submitProof=attempted; turnStartProof=live-required'
         );
     });
 
@@ -2239,10 +2245,11 @@ test.describe('Wake Daemon', () => {
 
         expect(fs.existsSync(mockOutPath)).toBe(false);
         expect(stdoutLog).not.toContain(`Delivered ${subId}`);
+        expect(stdoutLog).not.toContain(`Submit attempted ${subId}`);
         expect(stdoutLog).not.toContain(`Suppressed ${subId}`);
     });
 
-    test('Codex UI wake submits actionable message and drops coalesced heartbeat event (#13456)', async () => {
+    test('Codex UI wake attempts actionable message submit and drops coalesced heartbeat event (#13456, #13480)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-mixed-submit';
 
@@ -2287,12 +2294,12 @@ test.describe('Wake Daemon', () => {
         let stdoutLog = '';
 
         const deliveryPromise = new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => reject(new Error('Daemon did not deliver actionable Codex wake within timeout')), 10000);
+            const timeout = setTimeout(() => reject(new Error('Daemon did not attempt actionable Codex wake submit within timeout')), 10000);
 
             daemonProcess.stdout.on('data', (data) => {
                 const out = data.toString();
                 stdoutLog += out;
-                if (out.includes(`Delivered ${subId}`)) {
+                if (out.includes(`Submit attempted ${subId}`)) {
                     clearTimeout(timeout);
                     resolve();
                 }
@@ -2323,9 +2330,12 @@ test.describe('Wake Daemon', () => {
         expect(digest).toContain('new messages');
         expect(digest).not.toContain('heartbeat pulses');
         expect(digest).not.toContain('lifecycle-first');
+        expect(stdoutLog).toContain(`[Wake Daemon] Submit attempted ${subId} via osascript to Codex`);
+        expect(stdoutLog).not.toContain(`[Wake Daemon] Delivered ${subId} via osascript to Codex`);
         expect(stdoutLog).toContain(
             'scenario=direct-message; route=osascript; adapterSource=metadata; app=Codex; ' +
-            'counts=messages:1,tasks:0,permissions:0,heartbeats:0'
+            'counts=messages:1,tasks:0,permissions:0,heartbeats:0; ' +
+            'submitProof=attempted; turnStartProof=live-required'
         );
     });
 


### PR DESCRIPTION
Resolves #13487
Refs #13480

Codex `osascript` wake delivery no longer overclaims final turn delivery. The daemon now logs Codex UI route completion as `Submit attempted` and appends explicit submit/turn-start evidence fields, while non-Codex `osascript` routes keep the existing `Delivered` vocabulary. The wake-daemon unit coverage now locks the Codex sequence, the new evidence wording, and the #13457 pure-heartbeat no-submit behavior.

Evidence: L2 (mock-bin `osascript` dispatch + focused wake-daemon unit coverage) -> L4 required for live Codex Desktop turn-start proof. Residual: post-merge live matrix validation confirms the active Codex route no longer presents adapter completion as full delivery.

## Deltas from ticket

This PR targets the low-risk evidence/classification path rather than changing the submit primitive. That matches the fresh failures: the daemon can prove the script exited, but it cannot prove Codex accepted Enter and started a turn.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` failed once inside the sandbox on `listen EPERM` for the webhook-address test.
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` passed outside the sandbox: 35/35.
- Rebased onto latest `origin/dev` and reran `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs`: 35/35.
- `git diff --check` passed.

## Post-Merge Validation

- [ ] Restart the wake daemon and validate that a direct A2A wake to `@neo-gpt` logs `Submit attempted ... app=Codex ... submitProof=attempted; turnStartProof=live-required` until a live turn-start proof exists.
- [ ] Record a live Codex matrix sample for the latest intermittent prompt-landed/no-submit behavior.

Authored by Euclid (GPT-5, Codex Desktop). Session c3a6e312-b858-4be4-ad97-9bc55cbad5ae.
