### PR TITLE
feat(ai): supervise Neural Link Bridge locally (#13483)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -423,6 +423,15 @@ class Config extends ConfigProvider {
                     vacuum : leaf(false, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_VACUUM', 'boolean')
                 },
                 /**
+                 * Neural Link Bridge local-supervision policy. The bridge port itself is owned
+                 * by `ai/mcp/server/neural-link/config.mjs` (`NEO_NL_PORT`); this block only
+                 * controls orchestrator-side probing.
+                 * @type {Object}
+                 */
+                neuralLinkBridge: {
+                    livenessProbeTimeoutMs: leaf(1000, 'NEO_ORCHESTRATOR_NL_BRIDGE_LIVENESS_TIMEOUT_MS', 'number')
+                },
+                /**
                  * Swarm-heartbeat target-resolver config. Controls which identity set
                  * `SwarmHeartbeatService.pulse()` targets per cycle via the resolver
                  * precedence chain. Env override: `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_TARGET_SOURCE`.
@@ -502,6 +511,7 @@ class Config extends ConfigProvider {
                     // reaches the compose-owned `chroma` peer container instead.
                     chromaDaemonEnabled            : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),
                     bridgeDaemonEnabled            : leaf(null, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
+                    neuralLinkBridgeEnabled        : leaf(null, 'NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED', 'boolean'),
                     // The embed daemon durably drains the add_memory WAL into the content store
                     // (ai/daemons/embed/daemon.mjs). Local profile supervises it as a child
                     // process; cloud deployments own their drain story per-container (mirror of

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -6,6 +6,7 @@ import path                        from 'path';
 import Base                        from '../../../src/core/Base.mjs';
 import ClassSystemUtil             from '../../../src/util/ClassSystem.mjs';
 import AiConfig                    from '../../config.mjs';
+import neuralLinkConfig            from '../../mcp/server/neural-link/config.mjs';
 import {buildLmsPreloadConfig}     from '../../services/graph/providerReadinessHelper.mjs';
 import HealthService               from '../../services/memory-core/HealthService.mjs';
 import SQLite                      from '../../graph/storage/SQLite.mjs';
@@ -207,10 +208,12 @@ export class Orchestrator extends Base {
     get chromaDaemonEnabled()            { return resolveDeploymentEnabled('chromaDaemonEnabled');            }
     get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
     get devServerEnabled()               { return resolveLocalDeploymentDefault(AiConfig.orchestrator.devServer.enabled); }
+    get neuralLinkBridgeEnabled()        { return resolveDeploymentEnabled('neuralLinkBridgeEnabled');        }
     get embedDaemonEnabled()             { return resolveDeploymentEnabled('embedDaemonEnabled');             }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
     get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction.enabled;      }
+    get neuralLinkBridgeLivenessTimeoutMs() { return AiConfig.orchestrator.neuralLinkBridge.livenessProbeTimeoutMs; }
 
     get mlxEnabled() { return !!AiConfig.orchestrator.mlx.enabled; }
     get lmsEnabled() { return !!AiConfig.orchestrator.lms.enabled; }
@@ -231,21 +234,23 @@ export class Orchestrator extends Base {
         const lmsPreloadConfig = this.lmsPreloadConfig;
         this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
-            nodeBin                    : options.nodeBin || process.argv[0],
-            chromaPort                 : AiConfig.engines.chroma.port,
-            devServerPort              : AiConfig.orchestrator.devServer.port,
-            devServerLivenessTimeoutMs : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
-            mlxEnabled                 : this.mlxEnabled,
-            mlxModel                   : AiConfig.orchestrator.mlx.model,
-            mlxPort                    : AiConfig.orchestrator.mlx.port,
-            lmsEnabled                 : this.lmsEnabled,
-            lmsModel                   : AiConfig.orchestrator.lms.model,
-            lmsModels                  : lmsPreloadConfig.models,
-            lmsHost                    : AiConfig.openAiCompatible.host,
-            lmsPort                    : AiConfig.orchestrator.lms.port,
-            lmsContextLengths          : lmsPreloadConfig.contextLengths,
-            providerReadiness          : AiConfig.orchestrator.providerReadiness,
-            graphLogCompactionVacuum   : AiConfig.orchestrator.graphLogCompaction.vacuum
+            nodeBin                            : options.nodeBin || process.argv[0],
+            chromaPort                         : AiConfig.engines.chroma.port,
+            devServerPort                      : AiConfig.orchestrator.devServer.port,
+            devServerLivenessTimeoutMs         : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
+            neuralLinkBridgePort               : neuralLinkConfig.port,
+            neuralLinkBridgeLivenessTimeoutMs  : this.neuralLinkBridgeLivenessTimeoutMs,
+            mlxEnabled                         : this.mlxEnabled,
+            mlxModel                           : AiConfig.orchestrator.mlx.model,
+            mlxPort                            : AiConfig.orchestrator.mlx.port,
+            lmsEnabled                         : this.lmsEnabled,
+            lmsModel                           : AiConfig.orchestrator.lms.model,
+            lmsModels                          : lmsPreloadConfig.models,
+            lmsHost                            : AiConfig.openAiCompatible.host,
+            lmsPort                            : AiConfig.orchestrator.lms.port,
+            lmsContextLengths                  : lmsPreloadConfig.contextLengths,
+            providerReadiness                  : AiConfig.orchestrator.providerReadiness,
+            graphLogCompactionVacuum           : AiConfig.orchestrator.graphLogCompaction.vacuum
         });
 
         this.dbPath                    = options.dbPath   || DEFAULT_DB_PATH;
@@ -357,6 +362,7 @@ export class Orchestrator extends Base {
             ...(this.chromaDaemonEnabled ? ['chroma'] : []),
             ...(this.bridgeDaemonEnabled ? ['bridgeDaemon'] : []),
             ...(this.devServerEnabled    ? ['devServer'] : []),
+            ...(this.neuralLinkBridgeEnabled ? ['neuralLinkBridge'] : []),
             ...(this.embedDaemonEnabled  ? ['embedDaemon'] : []),
             'mlx',
             'lms'

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -327,7 +327,7 @@ export class ProcessSupervisorService extends Base {
      * @param {Function} [onSuccess] Optional success hook.
      * @param {Object} [options] Optional configuration.
      * @param {Function} [options.onComplete] Optional completion hook called on both success and failure.
-     * @param {Object} [options.env] Optional extra environment variables to merge with process.env.
+     * @param {Object} [options.env] Optional call-site environment variables to merge after task env.
      * @returns {Boolean} True when a child was started.
      */
     runTask(taskName, reason, onSuccess, options = {}) {
@@ -349,7 +349,9 @@ export class ProcessSupervisorService extends Base {
 
         let child;
         try {
-            const env = options.env ? { ...process.env, ...options.env } : process.env;
+            const env = task.env || options.env
+                ? {...process.env, ...(task.env || {}), ...(options.env || {})}
+                : process.env;
             child = this.spawnFn(task.command, task.args, {stdio: ['ignore', 'ignore', 'pipe'], env});
 
             child.stderr?.on('data', data => {
@@ -548,16 +550,16 @@ export class ProcessSupervisorService extends Base {
     }
 
     /**
-     * @summary Enforces a single live process for a port-owning ("singleton") task by
-     * SIGKILLing any extra listeners on its port.
+     * @summary Enforces or observes a single live process for a port-owning task.
      *
-     * The orchestrator is the sole authority for these daemons (chroma). When more than one
-     * process binds the task's `singletonPort` — an externally-started instance, a
-     * pre-unification leftover, or a second orchestrator — the duplicates corrupt a shared
-     * persist dir. This keeps the orchestrator-tracked pid and SIGKILLs the rest. SIGTERM is
-     * deliberately not attempted: chroma does not honor it, so a graceful signal only delays
-     * the unavoidable SIGKILL. Each candidate's command is verified against `expectedCommand`
-     * first, so an unrelated process that merely happens to hold the port is never touched.
+     * Default policy is authoritative ownership: when more than one process binds the task's
+     * `singletonPort`, keep the orchestrator-tracked pid and SIGKILL verified duplicates. This
+     * is required for daemons like Chroma where duplicate writers corrupt a shared persist dir.
+     *
+     * Tasks that expose shared local infrastructure may opt into
+     * `duplicateListenerPolicy: 'defer'`: matching listeners are treated as externally-owned
+     * live instances and are never killed by this supervisor. The task's liveness probe then
+     * decides whether a restart is needed.
      *
      * @param {String} taskName Task key.
      * @returns {Number} Count of duplicate processes reaped.
@@ -575,6 +577,10 @@ export class ProcessSupervisorService extends Base {
         const listenerPids = this.listPortListeners(task.singletonPort);
         const canonicalPid = this.taskStateService.getTaskState(taskName)?.pid;
         let   reaped       = 0;
+
+        if (task.duplicateListenerPolicy === 'defer') {
+            return 0;
+        }
 
         for (const pid of listenerPids) {
             if (!Number.isInteger(pid) || pid === canonicalPid) {

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -1,5 +1,5 @@
-import net from 'net';
 import path from 'path';
+import net  from 'net';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -9,15 +9,35 @@ export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sq
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
 
+/**
+ * @summary Probes whether a local TCP port is accepting connections.
+ * @param {Object} options
+ * @param {String|Number} options.port Port to probe.
+ * @param {Number} [options.timeoutMs] Optional timeout in milliseconds.
+ * @returns {Promise<Boolean>}
+ */
 function probeTcpPort({port, timeoutMs}) {
+    const normalizedPort = Number(port);
+
+    if (!Number.isFinite(normalizedPort) || normalizedPort <= 0) {
+        return Promise.resolve(false);
+    }
+
     return new Promise(resolve => {
-        const socket = net.connect({host: 'localhost', port});
+        const socket = net.connect({host: '127.0.0.1', port: normalizedPort});
+        let settled  = false;
+
         const finish = result => {
+            if (settled) return;
+            settled = true;
             socket.destroy();
             resolve(result);
         };
 
-        socket.setTimeout(timeoutMs);
+        if (Number.isFinite(Number(timeoutMs)) && Number(timeoutMs) > 0) {
+            socket.setTimeout(Number(timeoutMs));
+        }
+
         socket.once('connect', () => finish(true));
         socket.once('timeout', () => finish(false));
         socket.once('error',   () => finish(false));
@@ -46,6 +66,8 @@ function probeTcpPort({port, timeoutMs}) {
  * @param {String|Number} [options.chromaPort] Chroma daemon port — used for the `--port` arg and as the chroma task's `singletonPort` (the port the orchestrator reaps duplicate listeners on).
  * @param {String|Number} [options.devServerPort] Local webpack dev-server port — used for the `--port` arg, singleton detection, and TCP liveness probe.
  * @param {Number} [options.devServerLivenessTimeoutMs] TCP liveness probe timeout.
+ * @param {String|Number} [options.neuralLinkBridgePort] Neural Link Bridge port — sourced from the Neural Link config provider by the orchestrator entrypoint.
+ * @param {Number} [options.neuralLinkBridgeLivenessTimeoutMs] TCP liveness probe timeout.
  * @param {Boolean} [options.mlxEnabled=false] Whether to launch an orchestrator-owned mlx_lm.server.
  * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
  * @param {String|Number} [options.mlxPort] MLX OpenAI-compatible local inference port.
@@ -65,6 +87,8 @@ export function buildTaskDefinitions({
     chromaPort,
     devServerPort,
     devServerLivenessTimeoutMs,
+    neuralLinkBridgePort,
+    neuralLinkBridgeLivenessTimeoutMs,
     mlxEnabled = false,
     mlxModel,
     mlxPort,
@@ -78,6 +102,7 @@ export function buildTaskDefinitions({
     graphLogCompactionVacuum
 } = {}) {
     const hasDevServerPort = devServerPort !== undefined && devServerPort !== null;
+    const hasNeuralLinkBridgePort = neuralLinkBridgePort !== undefined && neuralLinkBridgePort !== null;
 
     const tasks = {
         chroma: {
@@ -121,6 +146,22 @@ export function buildTaskDefinitions({
                 livenessProbe          : () => probeTcpPort({
                     port     : devServerPort,
                     timeoutMs: devServerLivenessTimeoutMs
+                })
+            }
+        } : {}),
+        ...(hasNeuralLinkBridgePort ? {
+            neuralLinkBridge: {
+                label                  : 'Neural Link Bridge',
+                command                : nodeBin,
+                args                   : [path.resolve(scriptDir, '../mcp/server/neural-link/run-bridge.mjs')],
+                pidFileName            : 'neural-link-bridge.pid',
+                expectedCommand        : 'mcp/server/neural-link/run-bridge.mjs',
+                env                    : {NEO_NL_PORT: String(neuralLinkBridgePort)},
+                singletonPort          : Number(neuralLinkBridgePort),
+                duplicateListenerPolicy: 'defer',
+                livenessProbe          : () => probeTcpPort({
+                    port     : neuralLinkBridgePort,
+                    timeoutMs: neuralLinkBridgeLivenessTimeoutMs
                 })
             }
         } : {}),

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -144,6 +144,7 @@ test.describe('Tier 1 Config Immutability', () => {
             kbSyncEnabled        : null,
             chromaDaemonEnabled  : null,
             bridgeDaemonEnabled  : null,
+            neuralLinkBridgeEnabled: null,
             embedDaemonEnabled   : null,
             goldenPathRepoEnrichmentEnabled: null,
             swarmHeartbeatEnabled: null,

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -4,6 +4,7 @@ import Neo from '../../../../../../src/Neo.mjs';
 import * as core from '../../../../../../src/core/_export.mjs';
 import AiConfig from '../../../../../../ai/config.mjs';
 import {Orchestrator} from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {ProcessSupervisorService} from '../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
 import {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
 } from '../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
@@ -14,6 +15,7 @@ import TaskStateService, { createInitialTaskState } from '../../../../../../ai/d
 
 let testOrchestratorSeq = 0;
 const TEST_DEV_SERVER_PORT = 18080;
+const TEST_NEURAL_LINK_BRIDGE_PORT = 18081;
 let savedIntervals = null;
 let savedLocalOnly = null;
 let savedCloudOnly = null;
@@ -21,6 +23,8 @@ let savedDevServer = null;
 let savedDevServerMissing = false;
 let savedGraphLogCompaction = null;
 let savedGraphLogCompactionMissing = false;
+let savedNeuralLinkBridge = null;
+let savedNeuralLinkBridgeMissing = false;
 let savedDeploymentMode = null;
 
 /**
@@ -35,11 +39,13 @@ let savedDeploymentMode = null;
  */
 function createTestOrchestrator(config = {}) {
     const taskDefinitions = config.taskDefinitions || buildTaskDefinitions({
-        scriptDir: '/repo/ai/scripts',
-        nodeBin  : '/node',
-        devServerPort              : config.devServerPort ?? TEST_DEV_SERVER_PORT,
-        devServerLivenessTimeoutMs : config.devServerLivenessTimeoutMs ?? 50,
-        graphLogCompactionVacuum: config.graphLogCompactionVacuum ?? false
+        scriptDir                           : '/repo/ai/scripts',
+        nodeBin                             : '/node',
+        devServerPort                       : config.devServerPort ?? TEST_DEV_SERVER_PORT,
+        devServerLivenessTimeoutMs          : config.devServerLivenessTimeoutMs ?? 50,
+        neuralLinkBridgePort                : config.neuralLinkBridgePort ?? TEST_NEURAL_LINK_BRIDGE_PORT,
+        neuralLinkBridgeLivenessTimeoutMs   : config.neuralLinkBridgeLivenessTimeoutMs ?? 50,
+        graphLogCompactionVacuum            : config.graphLogCompactionVacuum ?? false
     });
 
     const heavyMaintenanceLeasePath = config.heavyMaintenanceLeasePath
@@ -51,7 +57,7 @@ function createTestOrchestrator(config = {}) {
         writeLogFn     : () => {}
     });
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
-    ['chroma', 'bridgeDaemon', 'devServer', 'mlx', 'lms'].forEach(name => {
+    ['chroma', 'bridgeDaemon', 'devServer', 'neuralLinkBridge', 'mlx', 'lms'].forEach(name => {
         if (TaskStateService.taskState[name]) {
             TaskStateService.taskState[name].running = true;
         }
@@ -68,6 +74,10 @@ function createTestOrchestrator(config = {}) {
     if (savedGraphLogCompaction === null) {
         savedGraphLogCompactionMissing = AiConfig.orchestrator.graphLogCompaction === undefined;
         savedGraphLogCompaction = {...(AiConfig.orchestrator.graphLogCompaction || {})};
+    }
+    if (savedNeuralLinkBridge === null) {
+        savedNeuralLinkBridgeMissing = AiConfig.orchestrator.neuralLinkBridge === undefined;
+        savedNeuralLinkBridge = {...(AiConfig.orchestrator.neuralLinkBridge || {})};
     }
     savedDeploymentMode = savedDeploymentMode ?? AiConfig.orchestrator.deploymentMode;
 
@@ -89,6 +99,7 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.localOnly.kbSyncEnabled                  = config.kbSyncEnabled                  ?? true;
     AiConfig.orchestrator.localOnly.primaryDevSyncEnabled          = config.primaryDevSyncEnabled          ?? false;
     AiConfig.orchestrator.localOnly.bridgeDaemonEnabled            = config.bridgeDaemonEnabled            ?? true;
+    AiConfig.orchestrator.localOnly.neuralLinkBridgeEnabled        = Object.hasOwn(config, 'neuralLinkBridgeEnabled') ? config.neuralLinkBridgeEnabled : true;
     // Default-disabled like primaryDevSyncEnabled: the embed-daemon lane has its own dedicated
     // test; every other test's supervision expectations stay scoped to the lanes under test.
     AiConfig.orchestrator.localOnly.embedDaemonEnabled             = config.embedDaemonEnabled             ?? false;
@@ -104,6 +115,9 @@ function createTestOrchestrator(config = {}) {
     AiConfig.setData('orchestrator.graphLogCompaction', {
         enabled: config.graphLogCompactionEnabled ?? true,
         vacuum : config.graphLogCompactionVacuum ?? false
+    });
+    AiConfig.setData('orchestrator.neuralLinkBridge', {
+        livenessProbeTimeoutMs: config.neuralLinkBridgeLivenessTimeoutMs ?? 50
     });
 
     const orchestrator = Neo.create(Orchestrator, {
@@ -170,6 +184,15 @@ test.afterEach(() => {
         savedGraphLogCompaction = null;
         savedGraphLogCompactionMissing = false;
     }
+    if (savedNeuralLinkBridge) {
+        if (savedNeuralLinkBridgeMissing) {
+            AiConfig.setData('orchestrator.neuralLinkBridge', undefined);
+        } else {
+            AiConfig.setData('orchestrator.neuralLinkBridge', {...savedNeuralLinkBridge});
+        }
+        savedNeuralLinkBridge = null;
+        savedNeuralLinkBridgeMissing = false;
+    }
     if (savedDeploymentMode !== null) {
         AiConfig.orchestrator.deploymentMode = savedDeploymentMode;
         savedDeploymentMode = null;
@@ -189,11 +212,13 @@ function restoreConfigObject(target, prior) {
 test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     test('creates an isolated persisted-state envelope per task', () => {
         const state = createInitialTaskState(buildTaskDefinitions({
-            scriptDir: '/repo/ai/scripts',
-            nodeBin  : '/node'
+            scriptDir                         : '/repo/ai/scripts',
+            nodeBin                           : '/node',
+            neuralLinkBridgePort              : TEST_NEURAL_LINK_BRIDGE_PORT,
+            neuralLinkBridgeLivenessTimeoutMs : 50
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({
@@ -605,6 +630,141 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         await new Promise(resolve => setTimeout(resolve, 0));
 
         expect(started.find(entry => entry.taskName === 'devServer')).toBeUndefined();
+    });
+
+    test('defines Neural Link Bridge as a defer-safe local shared-infra task (#13483)', () => {
+        const taskDefinitions = buildTaskDefinitions({
+            scriptDir                         : '/repo/ai/scripts',
+            nodeBin                           : '/node',
+            neuralLinkBridgePort              : 4242,
+            neuralLinkBridgeLivenessTimeoutMs : 50
+        });
+
+        expect(taskDefinitions.neuralLinkBridge).toMatchObject({
+            label                  : 'Neural Link Bridge',
+            command                : '/node',
+            args                   : [path.resolve('/repo/ai/scripts', '../mcp/server/neural-link/run-bridge.mjs')],
+            pidFileName            : 'neural-link-bridge.pid',
+            expectedCommand        : 'mcp/server/neural-link/run-bridge.mjs',
+            env                    : {NEO_NL_PORT: '4242'},
+            singletonPort          : 4242,
+            duplicateListenerPolicy: 'defer'
+        });
+        expect(typeof taskDefinitions.neuralLinkBridge.livenessProbe).toBe('function');
+    });
+
+    test('supervises Neural Link Bridge in local mode and skips it in cloud mode (#13483)', async () => {
+        const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
+        const localStarted = [];
+        const localOrchestrator = createTestOrchestrator({
+            deploymentMode: 'local',
+            kbSyncEnabled : false
+        });
+
+        TaskStateService.taskState.neuralLinkBridge.running   = false;
+        TaskStateService.taskState.neuralLinkBridge.lastRunAt = 0;
+        localOrchestrator.taskDefinitions.neuralLinkBridge.livenessProbe = async () => false;
+        localOrchestrator.processSupervisorService.runTask = (taskName, reason) => {
+            localStarted.push({taskName, reason});
+            return true;
+        };
+
+        localOrchestrator.poll();
+        await flushProbe();
+
+        expect(localStarted).toContainEqual({
+            taskName: 'neuralLinkBridge',
+            reason  : 'supervisor-restart'
+        });
+
+        const cloudStarted = [];
+        const cloudOrchestrator = createTestOrchestrator({
+            deploymentMode             : 'cloud',
+            kbSyncEnabled              : false,
+            neuralLinkBridgeEnabled    : null
+        });
+
+        TaskStateService.taskState.neuralLinkBridge.running   = false;
+        TaskStateService.taskState.neuralLinkBridge.lastRunAt = 0;
+        cloudOrchestrator.processSupervisorService.runTask = (taskName, reason) => {
+            cloudStarted.push({taskName, reason});
+            return true;
+        };
+
+        cloudOrchestrator.poll();
+        await flushProbe();
+
+        expect(cloudStarted.find(entry => entry.taskName === 'neuralLinkBridge')).toBeUndefined();
+    });
+
+    test('does not kill externally owned Neural Link Bridge listeners (#13483)', () => {
+        const killed = [];
+        const supervisor = Neo.create(ProcessSupervisorService, {
+            dataDir        : '/tmp/orchestrator-test',
+            taskDefinitions: {
+                neuralLinkBridge: {
+                    label                  : 'Neural Link Bridge',
+                    pidFileName            : 'neural-link-bridge.pid',
+                    expectedCommand        : 'mcp/server/neural-link/run-bridge.mjs',
+                    singletonPort          : 4242,
+                    duplicateListenerPolicy: 'defer'
+                }
+            },
+            taskStateService: {
+                getTaskState() {
+                    return {pid: 222};
+                }
+            },
+            healthService: {recordTaskOutcome() {}},
+            writeLog     : () => {}
+        });
+
+        supervisor.listPortListeners = () => [111, 222];
+        supervisor.processCommand    = () => '/node ai/mcp/server/neural-link/run-bridge.mjs';
+        supervisor.killProcess       = pid => killed.push(pid);
+
+        expect(supervisor.reapDuplicateListeners('neuralLinkBridge')).toBe(0);
+        expect(killed).toEqual([]);
+    });
+
+    test('passes task-level environment variables to spawned children (#13483)', () => {
+        const spawned = [];
+        const taskState = {running: false, pid: null};
+        const noop = () => {};
+        const supervisor = Neo.create(ProcessSupervisorService, {
+            dataDir        : '/tmp/orchestrator-test',
+            taskDefinitions: {
+                neuralLinkBridge: {
+                    label          : 'Neural Link Bridge',
+                    command        : '/node',
+                    args           : ['/repo/ai/mcp/server/neural-link/run-bridge.mjs'],
+                    pidFileName    : 'neural-link-bridge.pid',
+                    expectedCommand: 'mcp/server/neural-link/run-bridge.mjs',
+                    env            : {NEO_NL_PORT: '4242'}
+                }
+            },
+            taskStateService: {
+                getTaskState()  { return taskState; },
+                markStarted     : noop,
+                markSpawned     : noop,
+                markCompleted   : noop,
+                markFailed      : noop,
+                markSpawnFailed : noop
+            },
+            healthService: {recordTaskOutcome() {}},
+            writeLog     : () => {},
+            spawnFn(command, args, options) {
+                spawned.push({command, args, options});
+                return {
+                    pid   : 333,
+                    stderr: {on() {}},
+                    on() {}
+                };
+            }
+        });
+
+        expect(supervisor.runTask('neuralLinkBridge', 'unit-test')).toBe(true);
+        expect(spawned[0].options.env.NEO_NL_PORT).toBe('4242');
     });
 
     test('supervises lms via the supervisor HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {


### PR DESCRIPTION
Resolves #13483

Adds orchestrator supervision for the local Neural Link Bridge without taking ownership away from manually started or peer-owned bridge instances. The orchestrator now builds a `neuralLinkBridge` continuous task from the existing Neural Link config port, passes `NEO_NL_PORT` into the child environment, probes TCP liveness before restart, and uses an opt-in `duplicateListenerPolicy: 'defer'` so shared local bridge listeners are never SIGKILLed like Chroma duplicates.

Evidence: L2 (focused orchestrator unit coverage for task definition, local/cloud gating, task env propagation, and defer-safe duplicate-listener policy) -> L4 required (live local orchestrator restart proving Neural Link Bridge supervision under real harness processes). Residual: post-merge live restart validation [#13483].

## Deltas from ticket

- Kept the bridge port in `ai/mcp/server/neural-link/config.mjs` (`NEO_NL_PORT`) instead of adding a second port source.
- Added only an orchestrator-side liveness timeout leaf in `ai/config.template.mjs`.
- Corrected the naive singleton approach: Neural Link Bridge is shared local infrastructure, so duplicate-listener handling defers instead of killing matching listeners.
- Cloud profile defaults this local bridge lane off; local profile supervises it unless explicitly disabled.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs` — 51/51 passed.
- `npm run ai:lint-config-template-ssot` — passed.
- `git diff --check` — passed.
- Commit hook checks passed during `git commit`.

## Post-Merge Validation

- [ ] Restart the local orchestrator and verify it supervises `ai/mcp/server/neural-link/run-bridge.mjs` on the configured `NEO_NL_PORT`.
- [ ] With an externally started bridge already listening, verify the orchestrator observes/probes the bridge without killing it.

## Commit

- `2f3975530` — `feat(ai): supervise Neural Link Bridge locally (#13483)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ed42c-f8fc-7e01-a1a1-a8b5bbf58b64.
