### PR TITLE
feat(ai): supervise local dev-server (#13482)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -400,6 +400,18 @@ class Config extends ConfigProvider {
                     maxRuntimeMs: leaf(DAY_MS, 'NEO_CHROMA_MAX_RUNTIME_MS', 'number')
                 },
                 /**
+                 * Local webpack dev-server supervision policy. `enabled: null` means the
+                 * deployment profile decides (local enables, cloud disables); explicit true/false
+                 * lets operators opt in/out without changing the manual `server-start --open`
+                 * command. The orchestrator-owned task never passes `--open`.
+                 * @type {Object}
+                 */
+                devServer: {
+                    enabled               : leaf(null, 'NEO_ORCHESTRATOR_DEV_SERVER_ENABLED', 'boolean'),
+                    port                  : leaf(8080, 'NEO_ORCHESTRATOR_DEV_SERVER_PORT', 'port'),
+                    livenessProbeTimeoutMs: leaf(1000, 'NEO_ORCHESTRATOR_DEV_SERVER_LIVENESS_TIMEOUT_MS', 'number')
+                },
+                /**
                  * GraphLog compaction policy. The scheduled lane invokes the existing
                  * `compactGraphLog.mjs --apply` maintenance script; the script owns retention
                  * safety and cursor handling. `vacuum` stays explicit because SQLite VACUUM is

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -56,7 +56,7 @@ export async function initializeDatabaseSelfBootstrap(dbPath) {
  * @returns {Boolean}
  */
 function resolveLocalDeploymentDefault(cfg) {
-    if (cfg !== null && cfg !== undefined) return cfg;
+    if (cfg != null) return cfg;
     return AiConfig.orchestrator.deploymentMode !== 'cloud';
 }
 
@@ -75,7 +75,7 @@ function resolveDeploymentEnabled(key) {
  */
 function resolveCloudOnlyEnabled(key) {
     const cfg = AiConfig.orchestrator.cloudOnly[key];
-    if (cfg !== null && cfg !== undefined) return cfg;
+    if (cfg != null) return cfg;
     return AiConfig.orchestrator.deploymentMode === 'cloud';
 }
 
@@ -231,21 +231,21 @@ export class Orchestrator extends Base {
         const lmsPreloadConfig = this.lmsPreloadConfig;
         this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
-            nodeBin   : options.nodeBin || process.argv[0],
-            chromaPort: AiConfig.engines.chroma.port,
+            nodeBin                    : options.nodeBin || process.argv[0],
+            chromaPort                 : AiConfig.engines.chroma.port,
             devServerPort              : AiConfig.orchestrator.devServer.port,
             devServerLivenessTimeoutMs : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
-            mlxEnabled: this.mlxEnabled,
-            mlxModel  : AiConfig.orchestrator.mlx.model,
-            mlxPort   : AiConfig.orchestrator.mlx.port,
-            lmsEnabled: this.lmsEnabled,
-            lmsModel  : AiConfig.orchestrator.lms.model,
-            lmsModels : lmsPreloadConfig.models,
-            lmsHost   : AiConfig.openAiCompatible.host,
-            lmsPort   : AiConfig.orchestrator.lms.port,
-            lmsContextLengths: lmsPreloadConfig.contextLengths,
-            providerReadiness: AiConfig.orchestrator.providerReadiness,
-            graphLogCompactionVacuum: AiConfig.orchestrator.graphLogCompaction.vacuum
+            mlxEnabled                 : this.mlxEnabled,
+            mlxModel                   : AiConfig.orchestrator.mlx.model,
+            mlxPort                    : AiConfig.orchestrator.mlx.port,
+            lmsEnabled                 : this.lmsEnabled,
+            lmsModel                   : AiConfig.orchestrator.lms.model,
+            lmsModels                  : lmsPreloadConfig.models,
+            lmsHost                    : AiConfig.openAiCompatible.host,
+            lmsPort                    : AiConfig.orchestrator.lms.port,
+            lmsContextLengths          : lmsPreloadConfig.contextLengths,
+            providerReadiness          : AiConfig.orchestrator.providerReadiness,
+            graphLogCompactionVacuum   : AiConfig.orchestrator.graphLogCompaction.vacuum
         });
 
         this.dbPath                    = options.dbPath   || DEFAULT_DB_PATH;

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -55,10 +55,13 @@ export async function initializeDatabaseSelfBootstrap(dbPath) {
  * @param {String} key
  * @returns {Boolean}
  */
-function resolveDeploymentEnabled(key) {
-    const cfg = AiConfig.orchestrator.localOnly[key];
+function resolveLocalDeploymentDefault(cfg) {
     if (cfg !== null && cfg !== undefined) return cfg;
     return AiConfig.orchestrator.deploymentMode !== 'cloud';
+}
+
+function resolveDeploymentEnabled(key) {
+    return resolveLocalDeploymentDefault(AiConfig.orchestrator.localOnly[key]);
 }
 
 /**
@@ -203,6 +206,7 @@ export class Orchestrator extends Base {
     get tenantRepoSyncEnabled()          { return resolveCloudOnlyEnabled('tenantRepoSyncEnabled');           }
     get chromaDaemonEnabled()            { return resolveDeploymentEnabled('chromaDaemonEnabled');            }
     get bridgeDaemonEnabled()            { return resolveDeploymentEnabled('bridgeDaemonEnabled');            }
+    get devServerEnabled()               { return resolveLocalDeploymentDefault(AiConfig.orchestrator.devServer.enabled); }
     get embedDaemonEnabled()             { return resolveDeploymentEnabled('embedDaemonEnabled');             }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
@@ -229,6 +233,8 @@ export class Orchestrator extends Base {
             scriptDir,
             nodeBin   : options.nodeBin || process.argv[0],
             chromaPort: AiConfig.engines.chroma.port,
+            devServerPort              : AiConfig.orchestrator.devServer.port,
+            devServerLivenessTimeoutMs : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
             mlxEnabled: this.mlxEnabled,
             mlxModel  : AiConfig.orchestrator.mlx.model,
             mlxPort   : AiConfig.orchestrator.mlx.port,
@@ -350,6 +356,7 @@ export class Orchestrator extends Base {
         const continuousTasks = [
             ...(this.chromaDaemonEnabled ? ['chroma'] : []),
             ...(this.bridgeDaemonEnabled ? ['bridgeDaemon'] : []),
+            ...(this.devServerEnabled    ? ['devServer'] : []),
             ...(this.embedDaemonEnabled  ? ['embedDaemon'] : []),
             'mlx',
             'lms'

--- a/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
+++ b/ai/daemons/orchestrator/services/ProcessSupervisorService.mjs
@@ -568,6 +568,10 @@ export class ProcessSupervisorService extends Base {
             return 0;
         }
 
+        if (task.duplicateListenerPolicy === 'defer') {
+            return 0;
+        }
+
         const listenerPids = this.listPortListeners(task.singletonPort);
         const canonicalPid = this.taskStateService.getTaskState(taskName)?.pid;
         let   reaped       = 0;

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -1,3 +1,4 @@
+import net from 'net';
 import path from 'path';
 import {fileURLToPath} from 'url';
 
@@ -7,6 +8,21 @@ const __dirname  = path.dirname(__filename);
 export const DEFAULT_DB_PATH    = process.env.NEO_AI_DB_PATH || '.neo-ai-data/sqlite/memory-core-graph.sqlite';
 export const DEFAULT_DATA_DIR   = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
+
+function probeTcpPort({port, timeoutMs}) {
+    return new Promise(resolve => {
+        const socket = net.connect({host: 'localhost', port});
+        const finish = result => {
+            socket.destroy();
+            resolve(result);
+        };
+
+        socket.setTimeout(timeoutMs);
+        socket.once('connect', () => finish(true));
+        socket.once('timeout', () => finish(false));
+        socket.once('error',   () => finish(false));
+    });
+}
 
 /**
  * @summary Builds child-process commands for orchestrator-owned maintenance tasks.
@@ -28,6 +44,8 @@ export const DEFAULT_SCRIPT_DIR = path.resolve(__dirname, '../../scripts');
  * @param {String} [options.scriptDir] Script directory.
  * @param {String} [options.nodeBin] Node executable.
  * @param {String|Number} [options.chromaPort] Chroma daemon port — used for the `--port` arg and as the chroma task's `singletonPort` (the port the orchestrator reaps duplicate listeners on).
+ * @param {String|Number} [options.devServerPort] Local webpack dev-server port — used for the `--port` arg, singleton detection, and TCP liveness probe.
+ * @param {Number} [options.devServerLivenessTimeoutMs] TCP liveness probe timeout.
  * @param {Boolean} [options.mlxEnabled=false] Whether to launch an orchestrator-owned mlx_lm.server.
  * @param {String} [options.mlxModel] MLX launch model: a Hugging Face repo id or local path.
  * @param {String|Number} [options.mlxPort] MLX OpenAI-compatible local inference port.
@@ -45,6 +63,8 @@ export function buildTaskDefinitions({
     scriptDir  = DEFAULT_SCRIPT_DIR,
     nodeBin    = process.argv[0],
     chromaPort,
+    devServerPort,
+    devServerLivenessTimeoutMs,
     mlxEnabled = false,
     mlxModel,
     mlxPort,
@@ -57,6 +77,8 @@ export function buildTaskDefinitions({
     providerReadiness,
     graphLogCompactionVacuum
 } = {}) {
+    const hasDevServerPort = devServerPort !== undefined && devServerPort !== null;
+
     const tasks = {
         chroma: {
             label          : 'chroma daemon',
@@ -80,6 +102,28 @@ export function buildTaskDefinitions({
             pidFileName    : 'wake-daemon.pid',
             expectedCommand: 'daemons/wake/daemon.mjs'
         },
+        ...(hasDevServerPort ? {
+            devServer: {
+                label                  : 'local dev-server',
+                command                : nodeBin,
+                args                   : [
+                    path.resolve(scriptDir, '../../node_modules/webpack/bin/webpack.js'),
+                    'serve',
+                    '-c',
+                    './buildScripts/webpack/webpack.server.config.mjs',
+                    '--port',
+                    String(devServerPort)
+                ],
+                pidFileName            : 'dev-server.pid',
+                expectedCommand        : 'node_modules/webpack/bin/webpack.js',
+                singletonPort          : Number(devServerPort),
+                duplicateListenerPolicy: 'defer',
+                livenessProbe          : () => probeTcpPort({
+                    port     : devServerPort,
+                    timeoutMs: devServerLivenessTimeoutMs
+                })
+            }
+        } : {}),
         embedDaemon: {
             label          : 'embed daemon (add_memory WAL drain)',
             command        : nodeBin,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -149,6 +149,11 @@ test.describe('Tier 1 Config Immutability', () => {
             swarmHeartbeatEnabled: null,
             wakeDispatchEnabled  : null
         });
+        expect(Config.orchestrator.devServer).toEqual({
+            enabled               : null,
+            port                  : 8080,
+            livenessProbeTimeoutMs: 1000
+        });
 
         // The swarm-heartbeat candidate-discovery default is the activity-derived source
         // ("activity-derived signals" framing).

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -13,9 +13,12 @@ import {
 import TaskStateService, { createInitialTaskState } from '../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
 
 let testOrchestratorSeq = 0;
+const TEST_DEV_SERVER_PORT = 18080;
 let savedIntervals = null;
 let savedLocalOnly = null;
 let savedCloudOnly = null;
+let savedDevServer = null;
+let savedDevServerMissing = false;
 let savedGraphLogCompaction = null;
 let savedGraphLogCompactionMissing = false;
 let savedDeploymentMode = null;
@@ -34,6 +37,8 @@ function createTestOrchestrator(config = {}) {
     const taskDefinitions = config.taskDefinitions || buildTaskDefinitions({
         scriptDir: '/repo/ai/scripts',
         nodeBin  : '/node',
+        devServerPort              : config.devServerPort ?? TEST_DEV_SERVER_PORT,
+        devServerLivenessTimeoutMs : config.devServerLivenessTimeoutMs ?? 50,
         graphLogCompactionVacuum: config.graphLogCompactionVacuum ?? false
     });
 
@@ -46,7 +51,7 @@ function createTestOrchestrator(config = {}) {
         writeLogFn     : () => {}
     });
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
-    ['chroma', 'bridgeDaemon', 'mlx', 'lms'].forEach(name => {
+    ['chroma', 'bridgeDaemon', 'devServer', 'mlx', 'lms'].forEach(name => {
         if (TaskStateService.taskState[name]) {
             TaskStateService.taskState[name].running = true;
         }
@@ -56,6 +61,10 @@ function createTestOrchestrator(config = {}) {
     savedIntervals = savedIntervals || {...AiConfig.orchestrator.intervals};
     savedLocalOnly = savedLocalOnly || {...AiConfig.orchestrator.localOnly};
     savedCloudOnly = savedCloudOnly || {...AiConfig.orchestrator.cloudOnly};
+    if (savedDevServer === null) {
+        savedDevServerMissing = AiConfig.orchestrator.devServer === undefined;
+        savedDevServer = {...(AiConfig.orchestrator.devServer || {})};
+    }
     if (savedGraphLogCompaction === null) {
         savedGraphLogCompactionMissing = AiConfig.orchestrator.graphLogCompaction === undefined;
         savedGraphLogCompaction = {...(AiConfig.orchestrator.graphLogCompaction || {})};
@@ -87,6 +96,11 @@ function createTestOrchestrator(config = {}) {
     AiConfig.orchestrator.localOnly.goldenPathRepoEnrichmentEnabled = config.goldenPathRepoEnrichmentEnabled ?? true;
 
     AiConfig.orchestrator.cloudOnly.tenantRepoSyncEnabled = config.tenantRepoSyncEnabled ?? false;
+    AiConfig.setData('orchestrator.devServer', {
+        enabled               : Object.hasOwn(config, 'devServerEnabled') ? config.devServerEnabled : null,
+        port                  : config.devServerPort ?? TEST_DEV_SERVER_PORT,
+        livenessProbeTimeoutMs: config.devServerLivenessTimeoutMs ?? 50
+    });
     AiConfig.setData('orchestrator.graphLogCompaction', {
         enabled: config.graphLogCompactionEnabled ?? true,
         vacuum : config.graphLogCompactionVacuum ?? false
@@ -137,6 +151,15 @@ test.afterEach(() => {
     if (savedCloudOnly) {
         restoreConfigObject(AiConfig.orchestrator.cloudOnly, savedCloudOnly);
         savedCloudOnly = null;
+    }
+    if (savedDevServer) {
+        if (savedDevServerMissing) {
+            AiConfig.setData('orchestrator.devServer', undefined);
+        } else {
+            AiConfig.setData('orchestrator.devServer', {...savedDevServer});
+        }
+        savedDevServer = null;
+        savedDevServerMissing = false;
     }
     if (savedGraphLogCompaction) {
         if (savedGraphLogCompactionMissing) {
@@ -484,6 +507,104 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             taskName: 'embedDaemon',
             reason  : 'supervisor-restart'
         });
+    });
+
+    test('defines the local dev-server task without browser auto-open (#13482)', () => {
+        const taskDefinitions = buildTaskDefinitions({
+            scriptDir                    : '/repo/ai/scripts',
+            nodeBin                      : '/node',
+            devServerPort                : 4242,
+            devServerLivenessTimeoutMs   : 50
+        });
+
+        expect(taskDefinitions.devServer).toMatchObject({
+            label                  : 'local dev-server',
+            command                : '/node',
+            pidFileName            : 'dev-server.pid',
+            expectedCommand        : 'node_modules/webpack/bin/webpack.js',
+            singletonPort          : 4242,
+            duplicateListenerPolicy: 'defer'
+        });
+        expect(taskDefinitions.devServer.args).toEqual([
+            '/repo/node_modules/webpack/bin/webpack.js',
+            'serve',
+            '-c',
+            './buildScripts/webpack/webpack.server.config.mjs',
+            '--port',
+            '4242'
+        ]);
+        expect(taskDefinitions.devServer.args).not.toContain('--open');
+        expect(typeof taskDefinitions.devServer.livenessProbe).toBe('function');
+    });
+
+    test('supervises the local dev-server in local mode and skips it in cloud mode (#13482)', async () => {
+        const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
+        const cloudStarted = [];
+        const cloudOrchestrator = createTestOrchestrator({
+            deploymentMode   : 'cloud',
+            kbSyncEnabled    : false,
+            devServerEnabled : null
+        });
+
+        TaskStateService.taskState.devServer.running   = false;
+        TaskStateService.taskState.devServer.lastRunAt = 0;
+        cloudOrchestrator.taskDefinitions.devServer.livenessProbe = async () => false;
+        cloudOrchestrator.processSupervisorService.taskDefinitions.devServer.livenessProbe = async () => false;
+        cloudOrchestrator.processSupervisorService.runTask = (taskName, reason) => {
+            cloudStarted.push({taskName, reason});
+            return true;
+        };
+
+        cloudOrchestrator.poll();
+        await flushProbe();
+
+        expect(cloudStarted.find(entry => entry.taskName === 'devServer')).toBeUndefined();
+
+        const localStarted = [];
+        const localOrchestrator = createTestOrchestrator({
+            deploymentMode   : 'local',
+            kbSyncEnabled    : false,
+            devServerEnabled : null
+        });
+
+        TaskStateService.taskState.devServer.running   = false;
+        TaskStateService.taskState.devServer.lastRunAt = 0;
+        localOrchestrator.taskDefinitions.devServer.livenessProbe = async () => false;
+        localOrchestrator.processSupervisorService.taskDefinitions.devServer.livenessProbe = async () => false;
+        localOrchestrator.processSupervisorService.runTask = (taskName, reason) => {
+            localStarted.push({taskName, reason});
+            return true;
+        };
+
+        localOrchestrator.poll();
+        await flushProbe();
+
+        expect(localStarted).toContainEqual({
+            taskName: 'devServer',
+            reason  : 'supervisor-restart'
+        });
+    });
+
+    test('does not spawn over a healthy manually started dev-server (#13482)', async () => {
+        const started = [];
+        const orchestrator = createTestOrchestrator({
+            deploymentMode: 'local',
+            kbSyncEnabled : false
+        });
+
+        TaskStateService.taskState.devServer.running   = false;
+        TaskStateService.taskState.devServer.lastRunAt = 0;
+        orchestrator.taskDefinitions.devServer.livenessProbe = async () => true;
+        orchestrator.processSupervisorService.taskDefinitions.devServer.livenessProbe = async () => true;
+        orchestrator.processSupervisorService.runTask = (taskName, reason) => {
+            started.push({taskName, reason});
+            return true;
+        };
+
+        orchestrator.poll();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(started.find(entry => entry.taskName === 'devServer')).toBeUndefined();
     });
 
     test('supervises lms via the supervisor HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs
@@ -334,6 +334,21 @@ test.describe('Neo.ai.daemons.services.ProcessSupervisorService', () => {
         expect(probed).toBe(false);
     });
 
+    test('reapDuplicateListeners defers shared local services without touching listeners', () => {
+        const { service } = createTestService();
+        const killed = [];
+        let probed = false;
+
+        service.taskDefinitions.mockTask.singletonPort = 8000;
+        service.taskDefinitions.mockTask.duplicateListenerPolicy = 'defer';
+        service.listPortListeners = () => { probed = true; return [200]; };
+        service.killProcess       = pid => killed.push(pid);
+
+        expect(service.reapDuplicateListeners('mockTask')).toBe(0);
+        expect(probed).toBe(false);
+        expect(killed).toEqual([]);
+    });
+
     test('reapDuplicateListeners reaps every matching listener when no canonical pid is tracked', () => {
         const { service } = createTestService();
         const killed = [];


### PR DESCRIPTION
Resolves #13482
Refs #13012

Adds local-only orchestrator supervision for the webpack dev-server without using `--open`. The task launches webpack through the local JS entrypoint with a config-backed port, checks TCP liveness before restart, and uses an explicit shared-service defer policy so a manually started dev-server is treated as healthy infrastructure instead of something to kill or double-spawn.

Evidence: L2 (task-shape, config-SSOT, supervisor policy, and orchestrator unit coverage) -> L4 required (live local orchestrator restart proves no browser tab opens and no duplicate dev-server is spawned). Residual: post-merge live restart validation [#13482].

## Deltas from ticket

Added `orchestrator.devServer.livenessProbeTimeoutMs` as an env-backed provider leaf so the TCP probe timeout is not hardcoded. The enabled gate lives under `orchestrator.devServer.enabled`, matching the ticket's dedicated dev-server policy surface.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/services/ProcessSupervisorService.spec.mjs`
- `npm run ai:lint-config-template-ssot`
- `git diff --check`
- `git diff --cached --check`
- Commit hook: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-ticket-archaeology`

## Post-Merge Validation

- [ ] Start the local orchestrator with no dev-server running and verify it starts `webpack serve` on the configured port without opening a browser tab.
- [ ] Start a manual dev-server first, then start/restart the orchestrator and verify it defers to the healthy listener without killing it or spawning another server.

## Commit

- `780cb6a24` - `feat(ai): supervise local dev-server (#13482)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ed42c-f8fc-7e01-a1a1-a8b5bbf58b64.
