### PR TITLE
feat(ai): cap MCP file-log retention (#13474)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -233,6 +233,20 @@ class Config extends ConfigProvider {
              */
             logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
             /**
+             * @summary Retention policy for Knowledge Base MCP diagnostic log files.
+             *
+             * The shared logger applies this policy only to files matching the `kb-server`
+             * prefix in `logPath`. `maxFiles` counts historical files; the active current-day
+             * file is always preserved. Set `enabled=false` to delegate retention entirely to
+             * deployment infrastructure.
+             * @type {Object}
+             */
+            loggerRetention: {
+                enabled   : leaf(true, 'NEO_KB_LOG_RETENTION_ENABLED', 'boolean'),
+                maxAgeDays: leaf(14, 'NEO_KB_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
+                maxFiles  : leaf(30, 'NEO_KB_LOG_RETENTION_MAX_FILES', 'number')
+            },
+            /**
              * @summary Shared MCP logger policy for Knowledge Base.
              *
              * Always-on file sink plus debug-gated stderr. The shared logger reads this

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -437,6 +437,20 @@ class Config extends ConfigProvider {
              */
             logPath: leaf(path.resolve(cwd, '.neo-ai-data/logs')),
             /**
+             * @summary Retention policy for Memory Core MCP diagnostic log files.
+             *
+             * The shared logger applies this policy only to files matching the `mc-server`
+             * prefix in `logPath`. `maxFiles` counts historical files; the active current-day
+             * file is always preserved. Set `enabled=false` to delegate retention entirely to
+             * deployment infrastructure.
+             * @type {Object}
+             */
+            loggerRetention: {
+                enabled   : leaf(true, 'NEO_MEMORY_LOG_RETENTION_ENABLED', 'boolean'),
+                maxAgeDays: leaf(14, 'NEO_MEMORY_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
+                maxFiles  : leaf(30, 'NEO_MEMORY_LOG_RETENTION_MAX_FILES', 'number')
+            },
+            /**
              * @summary Shared MCP logger policy for Memory Core.
              *
              * Always-on file sink plus debug-gated stderr. `flush: true` preserves the

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -77,6 +77,20 @@ class Config extends ConfigProvider {
              */
             logPath: leaf(path.resolve(neoRootDir, '.neo-ai-data/logs')),
             /**
+             * @summary Retention policy for Neural Link MCP diagnostic log files.
+             *
+             * The shared logger applies this policy only to files matching the `nl-server`
+             * prefix in `logPath`. `maxFiles` counts historical files; the active current-day
+             * file is always preserved. Set `enabled=false` to delegate retention entirely to
+             * deployment infrastructure.
+             * @type {Object}
+             */
+            loggerRetention: {
+                enabled   : leaf(true, 'NEO_NL_LOG_RETENTION_ENABLED', 'boolean'),
+                maxAgeDays: leaf(14, 'NEO_NL_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
+                maxFiles  : leaf(30, 'NEO_NL_LOG_RETENTION_MAX_FILES', 'number')
+            },
+            /**
              * @summary Shared MCP logger policy for Neural Link.
              *
              * Always-on file sink plus tier-gated stderr: info/warn/error write without

--- a/ai/mcp/server/shared/logger.mjs
+++ b/ai/mcp/server/shared/logger.mjs
@@ -18,6 +18,8 @@ const DEFAULT_LOGGER_CONFIG = {
     timestampStyle: 'plain'
 };
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
  * @summary Extracts the live config data from either a ConfigProvider proxy or a plain object.
  *
@@ -40,6 +42,52 @@ const getLoggerConfig = (aiConfig, fallbackLoggerConfig = {}) => ({
     ...fallbackLoggerConfig,
     ...(getConfigData(aiConfig).logger ?? {})
 });
+
+/**
+ * @summary Normalizes a non-negative finite number; invalid values disable that dimension.
+ * @param {*} value
+ * @param {Boolean} [integer=false]
+ * @returns {Number|null}
+ */
+const normalizeRetentionNumber = (value, integer = false) => {
+    if (!Number.isFinite(value) || value < 0) {
+        return null;
+    }
+
+    return integer ? Math.floor(value) : value;
+};
+
+/**
+ * @summary Resolves the durable MCP file-log retention policy from config.
+ *
+ * The shared logger reads the Provider-owned `loggerRetention` namespace used by MCP
+ * server config templates first, then `logger.retention` for direct test/fallback configs.
+ * Invalid numeric values degrade to a disabled dimension instead of crashing the server.
+ *
+ * `maxFiles` caps historical matching files; the active current-day file is always kept.
+ *
+ * @param {Object} aiConfig
+ * @param {Object} loggerConfig
+ * @returns {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null)}}
+ */
+export const resolveLoggerRetention = (aiConfig, loggerConfig = {}) => {
+    const data   = getConfigData(aiConfig);
+    const policy = data.loggerRetention ?? loggerConfig.retention ?? {};
+
+    if (policy.enabled === false) {
+        return {
+            enabled   : false,
+            maxAgeDays: null,
+            maxFiles  : null
+        };
+    }
+
+    return {
+        enabled   : true,
+        maxAgeDays: normalizeRetentionNumber(policy.maxAgeDays),
+        maxFiles  : normalizeRetentionNumber(policy.maxFiles, true)
+    };
+};
 
 /**
  * @summary Serializes arbitrary log arguments without throwing inside the logger.
@@ -76,6 +124,144 @@ export const formatLogLine = (level, args, loggerConfig) => {
     }
 
     return `${timestamp} [${upper}] ${args.map(stringifyLogArg).join(' ')}\n`;
+};
+
+/**
+ * @summary Emits a bounded retention-prune warning to stderr without throwing.
+ * @param {*} error
+ * @param {Object} loggerConfig
+ * @returns {void}
+ */
+const warnRetentionFailure = (error, loggerConfig) => {
+    const message = error instanceof Error ? error.message : String(error);
+
+    try {
+        process.stderr.write(formatLogLine(
+            'warn',
+            [`MCP logger retention prune failed for prefix "${loggerConfig.filePrefix}": ${message}`],
+            loggerConfig
+        ));
+    } catch {
+        // Logging must never make the MCP server fail to boot.
+    }
+};
+
+/**
+ * @summary Builds metadata for historical log files matching the active logger prefix.
+ * @param {Object} options
+ * @param {String} options.logDir
+ * @param {String} options.filePrefix
+ * @param {String} options.today
+ * @param {Function} [options.readDir]
+ * @returns {Array<{name:String,filePath:String,date:String,time:Number}>}
+ */
+export const listHistoricalLogFiles = ({
+    logDir,
+    filePrefix,
+    today,
+    readDir = fs.readdirSync
+}) => {
+    const escapedPrefix = filePrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const matcher       = new RegExp(`^${escapedPrefix}-(\\d{4}-\\d{2}-\\d{2})\\.log$`);
+
+    return readDir(logDir, {withFileTypes: true})
+        .filter(entry => entry.isFile())
+        .map(entry => {
+            const match = entry.name.match(matcher);
+
+            if (!match || match[1] === today) {
+                return null;
+            }
+
+            return {
+                name    : entry.name,
+                filePath: path.join(logDir, entry.name),
+                date    : match[1],
+                time    : Date.parse(`${match[1]}T00:00:00.000Z`)
+            };
+        })
+        .filter(Boolean)
+        .filter(entry => Number.isFinite(entry.time));
+};
+
+/**
+ * @summary Selects matching historical MCP log files that exceed the retention policy.
+ * @param {Object} options
+ * @param {Array<{filePath:String,date:String,time:Number}>} options.files
+ * @param {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null)}} options.retention
+ * @param {String} options.today
+ * @returns {Array<{filePath:String,date:String,time:Number}>}
+ */
+export const selectPrunableLogFiles = ({files, retention, today}) => {
+    if (!retention?.enabled || (retention.maxAgeDays == null && retention.maxFiles == null)) {
+        return [];
+    }
+
+    const prunable = new Set();
+    const todayTime = Date.parse(`${today}T00:00:00.000Z`);
+
+    if (Number.isFinite(retention.maxAgeDays) && Number.isFinite(todayTime)) {
+        const maxAgeMs = retention.maxAgeDays * DAY_MS;
+
+        files.forEach(file => {
+            if (todayTime - file.time > maxAgeMs) {
+                prunable.add(file.filePath);
+            }
+        });
+    }
+
+    if (Number.isInteger(retention.maxFiles)) {
+        [...files]
+            .sort((a, b) => b.time - a.time || b.filePath.localeCompare(a.filePath))
+            .slice(retention.maxFiles)
+            .forEach(file => prunable.add(file.filePath));
+    }
+
+    return files.filter(file => prunable.has(file.filePath));
+};
+
+/**
+ * @summary Prunes historical MCP log files for one logger prefix.
+ *
+ * The active current-day file is excluded before selection, so a retention pass can never
+ * delete the file the stream is about to append to.
+ *
+ * @param {Object} options
+ * @param {String} options.logDir
+ * @param {String} options.filePrefix
+ * @param {String} options.today
+ * @param {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null)}} options.retention
+ * @param {Object} options.loggerConfig
+ * @param {Function} [options.readDir]
+ * @param {Function} [options.unlinkFile]
+ * @param {Function} [options.warn]
+ * @returns {Number}
+ */
+export const pruneLoggerRetention = ({
+    logDir,
+    filePrefix,
+    today,
+    retention,
+    loggerConfig,
+    readDir = fs.readdirSync,
+    unlinkFile = fs.unlinkSync,
+    warn = warnRetentionFailure
+}) => {
+    if (!retention?.enabled || (retention.maxAgeDays == null && retention.maxFiles == null)) {
+        return 0;
+    }
+
+    try {
+        const files = listHistoricalLogFiles({logDir, filePrefix, today, readDir});
+        const prune = selectPrunableLogFiles({files, retention, today});
+
+        prune.forEach(file => unlinkFile(file.filePath));
+
+        return prune.length;
+    } catch (error) {
+        warn(error, loggerConfig);
+        return 0;
+    }
 };
 
 /**
@@ -131,6 +317,14 @@ export const createLogger = (aiConfig = {}, fallbackLoggerConfig = {}) => {
             if (currentStream) currentStream.end();
 
             fs.mkdirSync(logDir, {recursive: true});
+            pruneLoggerRetention({
+                logDir,
+                today,
+                loggerConfig,
+                filePrefix: loggerConfig.filePrefix,
+                retention : resolveLoggerRetention(aiConfig, loggerConfig)
+            });
+
             currentStreamKey = key;
             currentStream    = fs.createWriteStream(path.join(logDir, `${loggerConfig.filePrefix}-${today}.log`), {flags: 'a'});
         }

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -244,4 +244,26 @@ test.describe('Tier 1 Config Immutability', () => {
             expect(source).toMatch(/data\s*:/);
         }
     });
+
+    test('exposes MCP file-log retention leaves in file-sink server templates', async () => {
+        const templates = [{
+            envPrefix  : 'NEO_KB_LOG_RETENTION',
+            templateUrl: '../../../../ai/mcp/server/knowledge-base/config.template.mjs'
+        }, {
+            envPrefix  : 'NEO_MEMORY_LOG_RETENTION',
+            templateUrl: '../../../../ai/mcp/server/memory-core/config.template.mjs'
+        }, {
+            envPrefix  : 'NEO_NL_LOG_RETENTION',
+            templateUrl: '../../../../ai/mcp/server/neural-link/config.template.mjs'
+        }];
+
+        for (const {envPrefix, templateUrl} of templates) {
+            const source = await fs.readFile(new URL(templateUrl, import.meta.url), 'utf8');
+
+            expect(source).toContain('loggerRetention');
+            expect(source).toContain(`${envPrefix}_ENABLED`);
+            expect(source).toContain(`${envPrefix}_MAX_AGE_DAYS`);
+            expect(source).toContain(`${envPrefix}_MAX_FILES`);
+        }
+    });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
@@ -19,10 +19,19 @@ import os              from 'os';
 import path            from 'path';
 import Neo             from '../../../../../../../src/Neo.mjs';
 import * as core       from '../../../../../../../src/core/_export.mjs';
-import {createLogger}  from '../../../../../../../ai/mcp/server/shared/logger.mjs';
+import {
+    createLogger,
+    pruneLoggerRetention,
+    resolveLoggerRetention,
+    selectPrunableLogFiles
+} from '../../../../../../../ai/mcp/server/shared/logger.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const dayStamp = daysAgo => new Date(Date.now() - (daysAgo * DAY_MS)).toISOString().slice(0, 10);
 
 /**
- * @summary Shared MCP logger primitive coverage for #11878.
+ * @summary Shared MCP logger primitive coverage.
  *
  * The shared logger is intentionally not `Neo.util.Logger`: MCP servers must keep
  * stdout protocol-clean, log errors without throwing, and preserve per-server sink
@@ -158,5 +167,123 @@ test.describe('Neo.ai.mcp.server.shared.Logger', () => {
                 fs.rmSync(tmpLogDir, {recursive: true, force: true});
             }
         }
+    });
+
+    test('prunes old matching file logs while preserving active and unrelated files', async () => {
+        const tmpLogDir = path.resolve(os.tmpdir(), `shared-logger-retention-${process.pid}-${Date.now()}`);
+        const today     = dayStamp(0);
+        const keepDay   = dayStamp(1);
+        const oldDay    = dayStamp(2);
+        const olderDay  = dayStamp(3);
+
+        try {
+            fs.ensureDirSync(tmpLogDir);
+
+            const activePath    = path.join(tmpLogDir, `shared-test-${today}.log`);
+            const keepPath      = path.join(tmpLogDir, `shared-test-${keepDay}.log`);
+            const oldPath       = path.join(tmpLogDir, `shared-test-${oldDay}.log`);
+            const olderPath     = path.join(tmpLogDir, `shared-test-${olderDay}.log`);
+            const unrelatedPath = path.join(tmpLogDir, `other-test-${olderDay}.log`);
+            const malformedPath = path.join(tmpLogDir, 'shared-test-not-a-date.log');
+
+            fs.writeFileSync(activePath, 'active-before\n');
+            fs.writeFileSync(keepPath, 'keep\n');
+            fs.writeFileSync(oldPath, 'old\n');
+            fs.writeFileSync(olderPath, 'older\n');
+            fs.writeFileSync(unrelatedPath, 'unrelated\n');
+            fs.writeFileSync(malformedPath, 'malformed\n');
+
+            const logger = createLogger({
+                debug          : false,
+                logPath        : tmpLogDir,
+                loggerRetention: {
+                    enabled   : true,
+                    maxAgeDays: 1,
+                    maxFiles  : 1
+                },
+                logger: {
+                    filePrefix    : 'shared-test',
+                    fileSink      : true,
+                    flush         : true,
+                    stderrMode    : 'debug',
+                    timestampStyle: 'plain'
+                }
+            });
+
+            logger.info('after-retention');
+            await logger.flush();
+
+            expect(fs.existsSync(activePath)).toBe(true);
+            expect(fs.readFileSync(activePath, 'utf8')).toContain('active-before');
+            expect(fs.readFileSync(activePath, 'utf8')).toContain('after-retention');
+            expect(fs.existsSync(keepPath)).toBe(true);
+            expect(fs.existsSync(oldPath)).toBe(false);
+            expect(fs.existsSync(olderPath)).toBe(false);
+            expect(fs.existsSync(unrelatedPath)).toBe(true);
+            expect(fs.existsSync(malformedPath)).toBe(true);
+        } finally {
+            if (fs.existsSync(tmpLogDir)) {
+                fs.rmSync(tmpLogDir, {recursive: true, force: true});
+            }
+        }
+    });
+
+    test('treats disabled or invalid retention config as preserve-all', () => {
+        const today = '2026-06-18';
+        const files = [{
+            filePath: '/tmp/shared-test-2026-06-17.log',
+            date    : '2026-06-17',
+            time    : Date.parse('2026-06-17T00:00:00.000Z')
+        }];
+
+        expect(resolveLoggerRetention({
+            loggerRetention: {
+                enabled   : false,
+                maxAgeDays: 0,
+                maxFiles  : 0
+            }
+        })).toEqual({
+            enabled   : false,
+            maxAgeDays: null,
+            maxFiles  : null
+        });
+
+        const invalid = resolveLoggerRetention({
+            loggerRetention: {
+                maxAgeDays: -1,
+                maxFiles  : 'many'
+            }
+        });
+
+        expect(invalid).toEqual({
+            enabled   : true,
+            maxAgeDays: null,
+            maxFiles  : null
+        });
+        expect(selectPrunableLogFiles({files, retention: invalid, today})).toEqual([]);
+    });
+
+    test('turns retention prune failures into bounded warnings', () => {
+        const warnings = [];
+        const count = pruneLoggerRetention({
+            logDir      : '/tmp',
+            filePrefix  : 'shared-test',
+            today       : '2026-06-18',
+            retention   : {enabled: true, maxAgeDays: 0, maxFiles: null},
+            loggerConfig: {filePrefix: 'shared-test', timestampStyle: 'plain'},
+            readDir     : () => [{
+                isFile: () => true,
+                name  : 'shared-test-2026-06-17.log'
+            }],
+            unlinkFile: () => {
+                throw new Error('blocked unlink');
+            },
+            warn: (error, loggerConfig) => warnings.push({error, loggerConfig})
+        });
+
+        expect(count).toBe(0);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].error.message).toBe('blocked unlink');
+        expect(warnings[0].loggerConfig.filePrefix).toBe('shared-test');
     });
 });


### PR DESCRIPTION
Resolves #13474

Adds config-driven retention for shared MCP file logs so long-running local harnesses and cloud MCP deployments no longer rely on external logrotate to avoid unbounded daily log-file growth. The shared logger now prunes only historical files matching the active logger prefix, never deletes the current-day stream, and converts prune failures into bounded stderr warnings instead of blocking server startup.

Evidence: L2 (focused shared-logger unit coverage, config-template lint, wrapper logger smoke coverage, pre-commit hooks) -> L2 required (retention behavior and provider-owned config shape are fully testable locally). No residuals.

## Deltas from ticket

- Added provider-owned `loggerRetention` leaves beside each file-sink MCP server `logPath`.
- `resolveLoggerRetention()` reads `data.loggerRetention` first, with `logger.retention` only as direct fallback/test input.
- Removed a stale durable JSDoc ticket reference in the touched shared-logger spec because the pre-commit archaeology hook now enforces this file.

## MCP Config Template Guidance

Changed config keys:

- `memory-core`: `loggerRetention.enabled`, `loggerRetention.maxAgeDays`, `loggerRetention.maxFiles`
- `knowledge-base`: `loggerRetention.enabled`, `loggerRetention.maxAgeDays`, `loggerRetention.maxFiles`
- `neural-link`: `loggerRetention.enabled`, `loggerRetention.maxAgeDays`, `loggerRetention.maxFiles`

Local `config.mjs` follow-up: run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` in each active clone after merge so gitignored local configs receive the new shape. No gitignored `config.mjs` files are committed here.

Harness/server restart: recommended for already-running MCP server processes after local config migration so the new retention policy is picked up immediately. Fresh starts pick it up automatically.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` -> 14 passed
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/knowledge-base/logger.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs` -> 6 passed
- `npm run ai:lint-config-template-ssot` -> OK
- `git diff --check` -> OK
- `git diff --cached --check` -> OK
- Pre-commit hooks -> passed

## Post-Merge Validation

- [ ] Run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` in active Neo clones.
- [ ] Restart active MCP server processes or harnesses where immediate retention behavior is wanted.
- [ ] Verify `.neo-ai-data/logs` no longer grows without bound across day rollovers or repeated MCP restarts.

## Commit

- `bc5cdfe9d` - `feat(ai): cap MCP file-log retention (#13474)`

Authored by Euclid (GPT-5, Codex Desktop). Session c3a6e312-b858-4be4-ad97-9bc55cbad5ae.
