### PR TITLE
docs(ai): add Chroma FTS5 repair runbook (#13467)

### DIFF
--- a/learn/agentos/tooling/RestorationRunbook.md
+++ b/learn/agentos/tooling/RestorationRunbook.md
@@ -35,7 +35,58 @@ Memory Core memories and session summaries live as the `neo-agent-memory` and `n
    ```
    *(Note: A dedicated `restore.mjs` CLI is deferred to #10871. Do **not** `rm -rf` the `chroma/unified` folder — it is shared with the Knowledge Base; MC restore is collection-scoped via the SDK above.)*
 
-### 3. Memory Core - Native Edge Graph
+### 3. Chroma FTS5 Integrity Repair
+The unified Chroma store is a shared physical SQLite database. `pragma quick_check`
+or `pragma integrity_check` can report `malformed inverted index for FTS5 table
+main.embedding_fulltext_search` while vector collections still answer normal
+queries. Treat this as a shared-store integrity incident: diagnose copy-first,
+stop all writers before touching the live database, and do not use Chroma defrag
+as a substitute for SQLite FTS5 repair.
+
+**Procedure:**
+1. Run the on-demand diagnostic and keep its copied SQLite snapshot:
+   ```bash
+   npm run ai:check-chroma-integrity -- --json --keep-snapshot
+   ```
+2. Validate the repair on the reported snapshot path, not on the live file:
+   ```bash
+   sqlite3 <snapshot>/chroma.sqlite3 "insert into embedding_fulltext_search(embedding_fulltext_search) values('rebuild'); pragma quick_check; pragma integrity_check;"
+   ```
+   Continue only if both pragmas return `ok`. If the copied snapshot remains
+   malformed, stop here and recover from backup or rebuild the affected
+   collection rather than experimenting on the live store.
+3. Stop every process that can reach the Chroma daemon or the unified Chroma
+   directory: Orchestrator, Memory Core, Knowledge Base, wake daemons, harness
+   MCP server instances, and the Chroma daemon itself.
+4. Capture a fresh backup bundle and a physical copy of the unified Chroma
+   directory:
+   ```bash
+   npm run ai:backup
+   cp -R .neo-ai-data/chroma/unified .neo-ai-data/chroma/unified.pre-fts5-rebuild-<timestamp>
+   ```
+5. Rebuild the live FTS5 table only after the writers are stopped and the
+   backups exist:
+   ```bash
+   sqlite3 .neo-ai-data/chroma/unified/chroma.sqlite3 "insert into embedding_fulltext_search(embedding_fulltext_search) values('rebuild'); pragma quick_check; pragma integrity_check;"
+   ```
+6. Restart Chroma and the dependent AI services, then verify both SQLite
+   integrity and API-level reachability:
+   ```bash
+   npm run ai:check-chroma-integrity -- --json
+   node ai/scripts/maintenance/probeCollectionQueryHealth.mjs
+   ```
+
+**Boundaries:**
+- `ai/scripts/maintenance/defragChromaDB.mjs` compacts collection storage; it is
+  not an FTS5 integrity repair tool.
+- KB rebuild (`npm run ai:sync-kb`) repairs the cache collection, not the shared
+  SQLite full-text index.
+- MC backup import restores collection rows, but it is not required when the
+  copied FTS5 rebuild validates cleanly.
+- API embedding-export failures such as `Error finding id` are a separate
+  Chroma read-path issue; do not conflate them with FTS5 index repair.
+
+### 4. Memory Core - Native Edge Graph
 The Memory Core Edge Graph is persisted in SQLite.
 
 **Procedure:**
@@ -48,7 +99,7 @@ The Memory Core Edge Graph is persisted in SQLite.
    node -e "import('./ai/services.mjs').then(s => s.default.memory.manageDatabaseBackup({action: 'import', file: '.neo-ai-data/backups/backup-<timestamp>/graph/graph-backup-<timestamp>.jsonl', mode: 'replace'}))"
    ```
 
-### 4. Concept Ontology
+### 5. Concept Ontology
 The Concept Ontology consists of nodes and edges defined in JSONL.
 
 **Procedure:**
@@ -61,7 +112,7 @@ The Concept Ontology consists of nodes and edges defined in JSONL.
    cp -r .neo-ai-data/backups/backup-<timestamp>/concepts/* .neo-ai-data/concepts/
    ```
 
-### 5. RLAIF Trajectories
+### 6. RLAIF Trajectories
 The RLAIF trajectories capture interaction feedback and metadata for offline RL alignment.
 
 **Procedure:**


### PR DESCRIPTION
Resolves #13467

Adds a dedicated Chroma FTS5 integrity-repair section to the restoration runbook. The procedure documents the copy-first diagnostic path, snapshot-only SQLite `rebuild` validation, stopped-writer requirements, backup/physical-copy safeguards, live repair command, and post-repair API/query verification. It also separates FTS5 index repair from KB rebuilds, MC restores, Chroma defrag, and the stored-embedding export issue.

Related: #13496

Evidence: L2 (copy-first local diagnostic + snapshot-only FTS5 rebuild validation + focused unit guard) -> L2 required (operator-run recovery procedure for a local/shared-store integrity incident). No residuals.

## Deltas from ticket

- Kept the fix as an operator runbook rather than adding live repair automation.
- Documented `ai/scripts/maintenance/defragChromaDB.mjs` as explicitly out-of-scope for FTS5 integrity repair.
- Documented the API embedding-export failure as a separate read-path issue, tracked by #13496.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` -> 4 passed
- Pre-patch V-B-A: `npm run ai:check-chroma-integrity -- --json --keep-snapshot` reproduced the malformed FTS5 index on the copied Chroma SQLite snapshot; running the SQLite FTS5 `rebuild` command on that snapshot made `pragma quick_check` and `pragma integrity_check` return `ok`. No live Chroma database mutation was performed.

## Post-Merge Validation

- [ ] Operator can run `npm run ai:check-chroma-integrity -- --json --keep-snapshot` and follow the runbook's copy-first repair validation.
- [ ] If live repair is needed, stop all Chroma writers and capture both `npm run ai:backup` and a physical `chroma/unified` copy before applying the SQLite rebuild.

## Slot Rationale

Added section: `Chroma FTS5 Integrity Repair`.
Disposition: keep in `learn/agentos/tooling/RestorationRunbook.md`, not always-loaded turn substrate.
Rating: trigger-frequency low, failure-severity high, enforceability medium. Decay mitigation comes from tying the procedure to `ai:check-chroma-integrity`, naming the out-of-scope defrag/restore boundaries, and leaving the procedure operator-run until live repair automation earns its own ticket.

## Commit

- `39faa656a` - `docs(ai): add Chroma FTS5 repair runbook (#13467)`

Authored by Euclid (GPT-5, Codex Desktop). Session c3a6e312-b858-4be4-ad97-9bc55cbad5ae.
