### PR TITLE
fix(ai): expose Chroma exportability diagnostics (#13501)

### DIFF
--- a/ai/scripts/maintenance/checkChromaIntegrity.mjs
+++ b/ai/scripts/maintenance/checkChromaIntegrity.mjs
@@ -36,6 +36,8 @@ import {
 const execFileAsync = promisify(execFile);
 void Neo;
 
+export const DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE = 5;
+
 registerNeoChromaEmbeddingFunctions({
     dummyEmbeddingFunction: AiConfig.dummyEmbeddingFunction
 });
@@ -168,12 +170,96 @@ async function runStep(label, fn) {
 }
 
 /**
+ * @param {*} value
+ * @returns {Number}
+ */
+export function normalizeExportabilitySampleSize(value) {
+    const parsed = Number(value);
+
+    if (!Number.isFinite(parsed) || parsed < 1) {
+        return DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE
+    }
+
+    return Math.floor(parsed)
+}
+
+/**
+ * @param {Object} options
+ * @param {Object} options.collection
+ * @param {Number} [options.sampleSize=DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE]
+ * @returns {Promise<Object>}
+ */
+export async function probeStoredEmbeddingExportability({
+    collection,
+    sampleSize = DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE
+} = {}) {
+    const label          = 'stored embedding exportability',
+          normalizedSize = normalizeExportabilitySampleSize(sampleSize);
+
+    let ids = [];
+    try {
+        const response = await collection.get({
+            limit  : normalizedSize,
+            include: []
+        });
+
+        ids = response.ids || [];
+    } catch (error) {
+        return {
+            label,
+            ok   : false,
+            error: error.message
+        }
+    }
+
+    const failures = [];
+    let succeeded  = 0;
+
+    for (const id of ids) {
+        try {
+            const response = await collection.get({
+                ids    : [id],
+                include: ['embeddings']
+            });
+
+            const embedding = response.embeddings?.[0];
+            if (!response.ids?.length || !embedding?.length) {
+                throw new Error('Stored embedding missing from single-id export')
+            }
+
+            succeeded++;
+        } catch (error) {
+            failures.push({
+                id,
+                error: error.message
+            });
+        }
+    }
+
+    return {
+        label,
+        ok   : failures.length === 0,
+        value: {
+            sampled: ids.length,
+            succeeded,
+            failed : failures.length,
+            failures
+        }
+    }
+}
+
+/**
  * @param {Object} options
  * @param {Object} options.collection
  * @param {String} options.name
+ * @param {Number} [options.exportabilitySampleSize=DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE]
  * @returns {Promise<Object>}
  */
-export async function probeCollection({collection, name}) {
+export async function probeCollection({
+    collection,
+    name,
+    exportabilitySampleSize = DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE
+}) {
     const result = {
         name,
         steps: []
@@ -188,8 +274,14 @@ export async function probeCollection({collection, name}) {
 
     result.steps.push(idsStep);
 
+    const exportabilityStep = await probeStoredEmbeddingExportability({
+        collection,
+        sampleSize: exportabilitySampleSize
+    });
+
     const id = idsStep.ok ? idsStep.value?.[0] : null;
     if (!id) {
+        result.steps.push(exportabilityStep);
         return result
     }
 
@@ -222,6 +314,8 @@ export async function probeCollection({collection, name}) {
 
     result.steps.push(embeddingStep);
 
+    result.steps.push(exportabilityStep);
+
     if (embedding?.length) {
         result.steps.push(await runStep('query by existing embedding', async () => {
             const response = await collection.query({
@@ -245,12 +339,14 @@ export async function probeCollection({collection, name}) {
  * @param {Object} [options.memoryCoreConfig=mcConfig]
  * @param {Object} [options.knowledgeBaseConfig=kbConfig]
  * @param {Function} [options.Client=ChromaClient]
+ * @param {Number} [options.exportabilitySampleSize=DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE]
  * @returns {Promise<Object[]>}
  */
 export async function probeChromaApi({
     memoryCoreConfig    = mcConfig,
     knowledgeBaseConfig = kbConfig,
-    Client              = ChromaClient
+    Client                  = ChromaClient,
+    exportabilitySampleSize = DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE
 } = {}) {
     const chroma = memoryCoreConfig.engines.chroma,
           client = new Client({
@@ -290,7 +386,8 @@ export async function probeChromaApi({
         });
         const collectionResult = await probeCollection({
             collection: getCollection.value,
-            name
+            name,
+            exportabilitySampleSize
         });
 
         result.steps.push(...collectionResult.steps);
@@ -298,6 +395,24 @@ export async function probeChromaApi({
     }
 
     return results
+}
+
+/**
+ * @param {Object} value
+ * @returns {String}
+ */
+function formatStepValue(value) {
+    if (!value || typeof value !== 'object' || !('sampled' in value)) {
+        return ''
+    }
+
+    const failurePreview = (value.failures || []).slice(0, 3).map(failure => {
+        return `${failure.id}: ${failure.error}`
+    }).join('; ');
+
+    const failures = failurePreview ? `; failures=${failurePreview}` : '';
+
+    return ` (sampled=${value.sampled}, succeeded=${value.succeeded}, failed=${value.failed}${failures})`
 }
 
 /**
@@ -320,7 +435,8 @@ function printHuman(result) {
     for (const collection of result.api.collections) {
         console.log(`- ${collection.name}`);
         for (const step of collection.steps) {
-            console.log(`  - ${step.label}: ${step.ok ? 'ok' : `failed (${step.error})`}`);
+            const details = step.error ? ` (${step.error})` : formatStepValue(step.value);
+            console.log(`  - ${step.label}: ${step.ok ? 'ok' : 'failed'}${details}`);
         }
     }
 }
@@ -335,6 +451,11 @@ export async function run(argv = process.argv) {
         .description('Copy-first Chroma SQLite integrity check plus read-only API probes.')
         .option('--sqlite <path>', 'Path to chroma.sqlite3. Defaults to configured unified store.')
         .option('--skip-api', 'Skip live read-only Chroma API probes.', false)
+        .option(
+            '--exportability-sample-size <count>',
+            'Number of ids to sample for stored-embedding exportability probes.',
+            String(DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE)
+        )
         .option('--keep-snapshot', 'Keep the copied SQLite snapshot instead of removing the temp dir.', false)
         .option('--json', 'Print machine-readable JSON.', false)
         .parse(argv);
@@ -361,7 +482,9 @@ export async function run(argv = process.argv) {
 
     if (!options.skipApi) {
         try {
-            const collections = await probeChromaApi();
+            const collections = await probeChromaApi({
+                exportabilitySampleSize: normalizeExportabilitySampleSize(options.exportabilitySampleSize)
+            });
             result.api = {
                 collections,
                 failedSteps: countFailedApiSteps(collections)

--- a/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
@@ -2,6 +2,10 @@ import {test, expect} from '@playwright/test';
 import {
     classifySqliteCheck,
     countFailedApiSteps,
+    DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE,
+    normalizeExportabilitySampleSize,
+    probeCollection,
+    probeStoredEmbeddingExportability,
     resolveCollectionNames,
     resolveSqlitePath
 } from '../../../../../../ai/scripts/maintenance/checkChromaIntegrity.mjs';
@@ -54,5 +58,150 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
         }, {
             steps: [{ok: false}, {ok: false}]
         }])).toBe(3);
+    });
+
+    test('normalizes invalid exportability sample sizes to the default', () => {
+        expect(normalizeExportabilitySampleSize('3')).toBe(3);
+        expect(normalizeExportabilitySampleSize('0')).toBe(
+            DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE
+        );
+        expect(normalizeExportabilitySampleSize('bad')).toBe(
+            DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE
+        );
+    });
+
+    test('reports stored-embedding exportability failures per sampled id', async () => {
+        const collection = {
+            async get(options) {
+                if (options.limit) {
+                    return {
+                        ids: ['good-a', 'bad', 'good-b']
+                    }
+                }
+
+                if (options.ids[0] === 'bad') {
+                    throw new Error('Error finding id')
+                }
+
+                return {
+                    ids       : options.ids,
+                    embeddings: [[0.1, 0.2]]
+                }
+            }
+        };
+
+        const result = await probeStoredEmbeddingExportability({
+            collection,
+            sampleSize: 3
+        });
+
+        expect(result).toEqual({
+            label: 'stored embedding exportability',
+            ok   : false,
+            value: {
+                sampled  : 3,
+                succeeded: 2,
+                failed   : 1,
+                failures : [{
+                    id   : 'bad',
+                    error: 'Error finding id'
+                }]
+            }
+        });
+    });
+
+    test('treats empty collections as exportable with zero sampled ids', async () => {
+        const collection = {
+            async get() {
+                return {
+                    ids: []
+                }
+            }
+        };
+
+        await expect(probeStoredEmbeddingExportability({
+            collection,
+            sampleSize: 3
+        })).resolves.toEqual({
+            label: 'stored embedding exportability',
+            ok   : true,
+            value: {
+                sampled  : 0,
+                succeeded: 0,
+                failed   : 0,
+                failures : []
+            }
+        });
+    });
+
+    test('includes stored exportability when a collection has no ids', async () => {
+        const collection = {
+            async count() {
+                return 0
+            },
+            async get() {
+                return {
+                    ids: []
+                }
+            }
+        };
+
+        const result = await probeCollection({
+            collection,
+            name: 'empty'
+        });
+
+        expect(result.steps.map(step => [step.label, step.ok])).toEqual([
+            ['count', true],
+            ['get ids limit 1', true],
+            ['stored embedding exportability', true]
+        ]);
+    });
+
+    test('keeps stored exportability separate from query health', async () => {
+        const collection = {
+            async count() {
+                return 2
+            },
+            async get(options) {
+                if (options.limit) {
+                    return {
+                        ids: ['good', 'bad']
+                    }
+                }
+
+                if (options.ids[0] === 'bad') {
+                    throw new Error('Error finding id')
+                }
+
+                return {
+                    ids       : options.ids,
+                    documents : ['doc'],
+                    embeddings: [[0.1, 0.2]],
+                    metadatas : [{}]
+                }
+            },
+            async query() {
+                return {
+                    ids      : [['good']],
+                    distances: [[0]]
+                }
+            }
+        };
+
+        const result = await probeCollection({
+            collection,
+            name                   : 'memory',
+            exportabilitySampleSize: 2
+        });
+
+        expect(result.steps.map(step => [step.label, step.ok])).toEqual([
+            ['count', true],
+            ['get ids limit 1', true],
+            ['get metadata/document by id', true],
+            ['get embedding by id', true],
+            ['stored embedding exportability', false],
+            ['query by existing embedding', true]
+        ]);
     });
 });


### PR DESCRIPTION
Resolves #13501
Related: #13496

Adds a bounded, read-only stored-embedding exportability probe to `checkChromaIntegrity.mjs` so operators can distinguish query reachability from backup/exportability risk. The diagnostic now samples ids per collection, checks single-id `include: ['embeddings']` reads, and reports a separate `stored embedding exportability` step with sampled/succeeded/failed counts plus per-id failure detail.

Evidence: L2 (focused unit coverage over mocked Chroma collection failure modes + syntax/diff checks; local smoke reached copy-first SQLite checks) -> L2 required (maintenance diagnostic logic is unit-testable without mutating live Chroma). Residual: live API smoke against this local checkout is blocked by the current Chroma HTTP connection failure; post-merge validation should rerun with the daemon online.

## Deltas from ticket

This is the narrow diagnostic leaf for the broader #13496 repair investigation. It does not repair stored-vector corruption, rebuild collections, or change backup/restore payloads.

The exportability sample size is CLI-configurable with `--exportability-sample-size <count>` and invalid values normalize to the exported script default.

## Test Evidence

- `node --check ai/scripts/maintenance/checkChromaIntegrity.mjs`
- `node --check test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` -> 9 passed
- `node ai/scripts/maintenance/checkChromaIntegrity.mjs --exportability-sample-size 2 --json` -> exited 1 as expected for the current environment; copied SQLite snapshot and reported existing FTS5 malformed-index findings, but the Chroma API branch returned `Failed to connect to chromadb`

## Post-Merge Validation

- [ ] Run `node ai/scripts/maintenance/checkChromaIntegrity.mjs --exportability-sample-size 2 --json` with the local Chroma daemon online and confirm each collection reports a `stored embedding exportability` step.
- [ ] Use the reported sample failures, if any, to decide the next #13496 repair slice.

## Commits

- `be66c48c4` - `fix(ai): report Chroma exportability probe (#13501)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ed42c-f8fc-7e01-a1a1-a8b5bbf58b64.
