### PR TITLE
feat(ai): expose sqlite holder diagnostics (#13475)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -1,4 +1,3 @@
-import {execSync}                  from 'node:child_process';
 import BaseServer                  from '../BaseServer.mjs';
 import logger                      from './logger.mjs';
 import {listTools, callTool}       from './toolService.mjs';
@@ -7,8 +6,8 @@ import RequestContextService       from '../shared/services/RequestContextServic
 import StdioIdentityResolver       from '../shared/services/StdioIdentityResolver.mjs';
 import BootEnvelopeResolver        from '../shared/services/BootEnvelopeResolver.mjs';
 import {
-    formatHarnessGroups,
-    groupProcessesByHarness
+    buildSqliteHolderDiagnostics,
+    formatHarnessGroups
 } from '../../../services/memory-core/helpers/harnessClassifier.mjs';
 
 import {
@@ -504,49 +503,24 @@ class Server extends BaseServer {
         const dbPath = aiConfig.storagePaths.graph;
         if (!dbPath) return;
 
-        const files = [dbPath, `${dbPath}-wal`, `${dbPath}-shm`];
+        const diagnostics = buildSqliteHolderDiagnostics({
+            dbPath,
+            currentPid: process.pid
+        });
 
-        try {
-            const raw = execSync(`lsof -F pcn -- ${files.map(f => `'${f}'`).join(' ')}`, {
-                encoding: 'utf8',
-                stdio: ['ignore', 'pipe', 'pipe']
-            });
+        if (diagnostics.status === 'degraded') {
+            logger.debug(`[Startup] Failed to check sibling concurrency: ${diagnostics.error}`);
+            return;
+        }
 
-            let current = null;
-            const records = [];
-            for (const line of raw.split('\n')) {
-                if (!line) continue;
-                if (line[0] === 'p') {
-                    if (current && current.pid !== process.pid) records.push(current);
-                    current = {pid: parseInt(line.slice(1), 10)};
-                } else if (current && line[0] === 'c') {
-                    current.command = line.slice(1);
-                }
-            }
-            if (current && current.pid !== process.pid) records.push(current);
+        if (diagnostics.totalProcesses > 0) {
+            const summary = formatHarnessGroups(diagnostics.groups);
+            const message = `ℹ️  [Startup] Sibling concurrency: ${diagnostics.totalProcesses} peer process(es) holding SQLite files. Harnesses: ${summary}`;
 
-            const uniquePids = new Set();
-            const siblings = records.filter(r => {
-                if (uniquePids.has(r.pid)) return false;
-                uniquePids.add(r.pid);
-                return true;
-            });
-
-            if (siblings.length > 0) {
-                const groups  = groupProcessesByHarness(siblings);
-                const summary = formatHarnessGroups(groups);
-                const message = `ℹ️  [Startup] Sibling concurrency: ${siblings.length} peer process(es) holding SQLite files. Harnesses: ${summary}`;
-
-                if (groups.some(group => group.harness === 'unknown')) {
-                    logger.warn(message);
-                } else {
-                    logger.info(message);
-                }
-            }
-        } catch (error) {
-            // Ignore ENOENT (lsof missing on Windows) or status 1 (no matching processes)
-            if (error.status !== 1 && error.code !== 'ENOENT') {
-                logger.debug(`[Startup] Failed to check sibling concurrency: ${error.message}`);
+            if (diagnostics.warnings.length > 0) {
+                logger.warn(message);
+            } else {
+                logger.info(message);
             }
         }
     }

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -126,6 +126,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /diagnostics/sqlite-holders:
+    get:
+      summary: Get SQLite Holder Diagnostics
+      operationId: get_sqlite_holder_diagnostics
+      x-annotations:
+        readOnlyHint: true
+      description: |
+        Returns an on-demand, read-only snapshot of sibling processes currently holding
+        the Memory Core SQLite graph files open.
+
+        This diagnostic is intentionally outside the default healthcheck path. It may
+        shell out to process-inspection tools and should be called only when operators
+        need current holder details for local or cloud Agent OS triage. Probe failures
+        are reported as degraded diagnostic data, not as Memory Core health failures.
+      tags: [Health]
+      responses:
+        '200':
+          description: Current SQLite holder diagnostic snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SqliteHolderDiagnosticsResponse'
+        '500':
+          description: Operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /memories:
     post:
       summary: Add New Memory
@@ -1535,6 +1564,134 @@ components:
               type: integer
               description: Inbound graph entity/provenance edge count for the session.
               example: 17
+    SqliteHolderDiagnosticsResponse:
+      type: object
+      required:
+        - status
+        - measuredAt
+        - sqliteFile
+        - files
+        - existingFiles
+        - totalProcesses
+        - byHarness
+        - groups
+        - processes
+        - warnings
+      properties:
+        status:
+          type: string
+          enum: [ok, degraded]
+          description: Diagnostic probe status; degraded is diagnostic-only and does not imply Memory Core is unhealthy.
+          example: "ok"
+        measuredAt:
+          type: string
+          format: date-time
+          description: ISO timestamp for the diagnostic snapshot.
+          example: "2026-06-19T02:50:00.000Z"
+        sqliteFile:
+          type: string
+          nullable: true
+          description: Memory Core SQLite graph database path inspected by the probe.
+          example: "/repo/.neo-ai-data/sqlite/memory-core-graph.sqlite"
+        files:
+          type: array
+          description: WAL-mode SQLite file set that was considered by the probe.
+          items:
+            type: string
+        existingFiles:
+          type: array
+          description: Subset of files that existed at probe time and were passed to process inspection.
+          items:
+            type: string
+        totalProcesses:
+          type: integer
+          description: Number of sibling holder processes after PID deduplication and current-process exclusion.
+          example: 3
+        byHarness:
+          type: object
+          description: Holder counts keyed by harness classification.
+          additionalProperties:
+            type: integer
+          example:
+            antigravity: 2
+            unknown: 1
+        groups:
+          type: array
+          description: Holder processes grouped by harness classification.
+          items:
+            type: object
+            required: [harness, label, processes]
+            properties:
+              harness:
+                type: string
+                description: Stable harness classification key.
+                example: "antigravity"
+              label:
+                type: string
+                description: Human-readable harness label.
+                example: "Antigravity"
+              processes:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SqliteHolderProcess'
+        processes:
+          type: array
+          description: Flat process list for callers that do not want grouped projection.
+          items:
+            $ref: '#/components/schemas/SqliteHolderProcess'
+        warnings:
+          type: array
+          description: Non-fatal diagnostic warnings, such as unmapped holder harnesses.
+          items:
+            type: object
+            required: [code, message]
+            properties:
+              code:
+                type: string
+                example: "unknown-harness"
+              message:
+                type: string
+        error:
+          type: string
+          nullable: true
+          description: Present when status is degraded.
+    SqliteHolderProcess:
+      type: object
+      required:
+        - pid
+        - files
+        - harness
+        - chain
+      properties:
+        pid:
+          type: integer
+          description: Process id holding one or more SQLite files.
+          example: 12345
+        command:
+          type: string
+          nullable: true
+          description: Command name reported by lsof.
+          example: "node"
+        files:
+          type: array
+          description: SQLite files held by this process.
+          items:
+            type: string
+        harness:
+          type: string
+          description: Stable harness classification key.
+          example: "claude-desktop"
+        chain:
+          type: array
+          description: Parent process chain used to classify the holder.
+          items:
+            type: object
+            required: [pid, command]
+            properties:
+              pid:
+                type: integer
+              command:
+                type: string
     HealthCheckResponse:
       type: object
       properties:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -38,6 +38,8 @@ const serviceMapping = {
     list_messages           : MailboxService         .listMessages            .bind(MailboxService),
     get_message             : MailboxService         .getMessage              .bind(MailboxService),
     get_rem_pipeline_state  : HealthService          .getRemPipelineState     .bind(HealthService),
+    get_sqlite_holder_diagnostics:
+                              HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
     mark_read               : MailboxService         .markRead                .bind(MailboxService),
     archive_message         : MailboxService         .archiveMessage          .bind(MailboxService),
     delete_message          : MailboxService         .deleteMessage           .bind(MailboxService),

--- a/ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs
+++ b/ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs
@@ -36,11 +36,11 @@
  * @see ai/graph/storage/SQLite.mjs                           WAL pragma (storage layer is concurrency-safe)
  * @see learn/agentos/decisions/0001-cross-process-cache-coherence.md
  */
-import {execSync}      from 'child_process';
-import fs              from 'fs';
-import path            from 'path';
-import {fileURLToPath} from 'url';
-import {classifyHarness} from '../../services/memory-core/helpers/harnessClassifier.mjs';
+import {execSync}                     from 'child_process';
+import fs                             from 'fs';
+import path                           from 'path';
+import {fileURLToPath}                from 'url';
+import {buildSqliteHolderDiagnostics} from '../../services/memory-core/helpers/harnessClassifier.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -80,97 +80,7 @@ function resolvePrimaryCheckout() {
 const projectRoot = resolvePrimaryCheckout();
 const SQLITE_MAIN = path.resolve(projectRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
 
-// In WAL mode, SQLite opens three sibling files on each connection: the main DB, the
-// Write-Ahead Log, and the shared-memory index. Checking all three gives a complete
-// picture — a process briefly between checkpoints may only hold -wal / -shm open.
-const SQLITE_WAL  = `${SQLITE_MAIN}-wal`;
-const SQLITE_SHM  = `${SQLITE_MAIN}-shm`;
-
 const jsonOutput = process.argv.includes('--json');
-
-/**
- * @summary Shell out to `lsof -F pcn` to list processes holding a set of files open.
- *
- * `-F pcn` emits a machine-parseable record format: each attribute on its own line
- * with a single-letter tag prefix — `p` = PID, `c` = command name, `n` = file name.
- * Records for the same process across multiple open file descriptors repeat the
- * `p` line, so deduplication by PID happens downstream in {@link listHoldingProcesses}.
- *
- * `lsof` exits with status 1 when no matching processes are found. This is treated
- * as a successful "empty result," not an error — matching the Projection Layer
- * expectation that zero holders is a valid observation.
- *
- * @param {Array<String>} files Absolute paths to probe. Non-existent paths are silently skipped by lsof.
- * @returns {String} Raw lsof output (possibly empty string).
- */
-function runLsof(files) {
-    const existing = files.filter(f => fs.existsSync(f));
-    if (existing.length === 0) return '';
-
-    try {
-        return execSync(`lsof -F pcn -- ${existing.map(f => `'${f}'`).join(' ')}`, {
-            encoding: 'utf8',
-            stdio   : ['ignore', 'pipe', 'pipe']
-        });
-    } catch (error) {
-        // Exit code 1 = no matching processes; not an error
-        if (error.status === 1) return '';
-        if (error.code === 'ENOENT') {
-            console.error('Platform not supported: this diagnostic requires `lsof` (macOS / Linux).');
-            return '';
-        }
-        throw new Error(`lsof failed: ${error.message || error}`);
-    }
-}
-
-/**
- * @summary Parse `lsof -F pcn` output into structured process-file records.
- *
- * Each record in lsof's field-delimited format spans multiple lines; a new record
- * starts on every `p` (PID) tag. We accumulate the current record until the next
- * `p` flush, then push it. This preserves the architectural invariant that one
- * record represents one PID and its associated files. Deduplication by PID happens
- * at the caller boundary (see `uniqueProcesses` in main).
- *
- * @param {String} raw Raw lsof output.
- * @returns {Array<{pid: number, command: string, files: string[]}>}
- */
-function parseLsofOutput(raw) {
-    const records = [];
-    let current   = null;
-
-    for (const line of raw.split('\n')) {
-        if (!line) continue;
-        const tag   = line[0];
-        const value = line.slice(1);
-
-        if (tag === 'p') {
-            if (current && current.pid) records.push(current);
-            current = {pid: parseInt(value, 10), files: []};
-        } else if (current) {
-            if (tag === 'c') current.command = value;
-            else if (tag === 'n') current.files.push(value);
-        }
-    }
-    if (current && current.pid) records.push(current);
-
-    return records;
-}
-
-/**
- * @summary List processes currently holding any of the memory-core SQLite files open.
- *
- * Delegates to {@link runLsof} + {@link parseLsofOutput} to run the OS-level probe
- * and shape its raw output into the Projection Layer the rest of the script
- * consumes. Returns one entry per process with an array of its files. The caller
- * dedupes across records by PID.
- *
- * @returns {Array<{pid: number, command: string, files: string[]}>}
- */
-function listHoldingProcesses() {
-    const raw = runLsof([SQLITE_MAIN, SQLITE_WAL, SQLITE_SHM]);
-    return parseLsofOutput(raw);
-}
 
 /**
  * @summary Main entry point — gather empirical data, classify, render.
@@ -197,60 +107,36 @@ function main() {
         process.exit(1);
     }
 
-    const holders = listHoldingProcesses();
-
-    // Enrich with harness classification, then dedupe by PID (lsof emits one record
-    // per open file descriptor; a single process with main+wal+shm open yields 3
-    // entries that we collapse to one, merging the files array).
-    const enriched = holders.map(h => {
-        const {harness, chain} = classifyHarness(h.pid);
-        return {pid: h.pid, command: h.command, files: Array.from(new Set(h.files)), harness, chain};
-    });
-
-    const processMap = new Map();
-    for (const p of enriched) {
-        if (processMap.has(p.pid)) {
-            const existing = processMap.get(p.pid);
-            existing.files = Array.from(new Set([...existing.files, ...p.files]));
-        } else {
-            processMap.set(p.pid, p);
-        }
-    }
-    const uniqueProcesses = Array.from(processMap.values());
-
-    const byHarness = {};
-    for (const p of uniqueProcesses) {
-        byHarness[p.harness] = (byHarness[p.harness] || 0) + 1;
-    }
+    const diagnostics = buildSqliteHolderDiagnostics({dbPath: SQLITE_MAIN});
 
     if (jsonOutput) {
-        console.log(JSON.stringify({
-            sqliteFile    : SQLITE_MAIN,
-            totalProcesses: uniqueProcesses.length,
-            byHarness,
-            processes     : uniqueProcesses
-        }, null, 2));
+        console.log(JSON.stringify(diagnostics, null, 2));
         return;
     }
 
     console.log(`\nMCP Concurrency Diagnostic — ${SQLITE_MAIN}\n`);
 
-    if (uniqueProcesses.length === 0) {
+    if (diagnostics.status === 'degraded') {
+        console.log(`  Diagnostic degraded: ${diagnostics.error}\n`);
+        return;
+    }
+
+    if (diagnostics.totalProcesses === 0) {
         console.log('  No processes currently hold this SQLite file open.\n');
         console.log('  Expected when: no MCP memory-core server is running.');
         console.log('  Unexpected when: you have Claude Desktop / Claude Code / Antigravity open.\n');
         return;
     }
 
-    console.log(`  Total processes: ${uniqueProcesses.length}\n`);
+    console.log(`  Total processes: ${diagnostics.totalProcesses}\n`);
     console.log('  By harness:');
-    for (const [harness, count] of Object.entries(byHarness).sort((a, b) => b[1] - a[1])) {
+    for (const [harness, count] of Object.entries(diagnostics.byHarness).sort((a, b) => b[1] - a[1])) {
         console.log(`    ${harness.padEnd(18)} ${count}`);
     }
     console.log('\n  Process detail:');
     console.log('    PID       command          harness');
     console.log('    --------  ---------------  ------------------');
-    for (const p of uniqueProcesses) {
+    for (const p of diagnostics.processes) {
         const pidStr     = String(p.pid).padStart(8);
         const cmdStr     = (p.command || '').padEnd(15);
         console.log(`    ${pidStr}  ${cmdStr}  ${p.harness}`);

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -15,8 +15,9 @@ import {
     hasCoreSwarmParticipant,
     normalizeUserId
 } from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {readRecentRemRunStates} from './helpers/remRunStateStore.mjs';
-import {withTimeout}             from './helpers/withTimeout.mjs';
+import {buildSqliteHolderDiagnostics} from './helpers/harnessClassifier.mjs';
+import {readRecentRemRunStates}       from './helpers/remRunStateStore.mjs';
+import {withTimeout}                  from './helpers/withTimeout.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1695,6 +1696,23 @@ class HealthService extends Base {
      */
     async getRemPipelineState(options = {}) {
         return buildRemPipelineState(options);
+    }
+
+    /**
+     * @summary Returns an on-demand read-only diagnostic for sibling SQLite holder processes.
+     *
+     * The probe is intentionally outside the default healthcheck path: it shells out to `lsof`
+     * and walks process parent chains, which is useful for operator triage but too expensive for
+     * routine liveness. Probe failures degrade this diagnostic payload only; they do not change
+     * Memory Core health when the database itself is usable.
+     *
+     * @returns {Promise<Object>} Current SQLite holder diagnostic payload.
+     */
+    async getSqliteHolderDiagnostics() {
+        return buildSqliteHolderDiagnostics({
+            dbPath    : aiConfig.storagePaths.graph,
+            currentPid: process.pid
+        });
     }
 
     /**

--- a/ai/services/memory-core/helpers/harnessClassifier.mjs
+++ b/ai/services/memory-core/helpers/harnessClassifier.mjs
@@ -1,10 +1,13 @@
 import {execSync as defaultExecSync} from 'node:child_process';
+import {existsSync as defaultExistsSync} from 'node:fs';
 
 const harnessLabels = {
     'claude-code'   : 'Claude Code',
     'claude-desktop': 'Claude Desktop',
     antigravity    : 'Antigravity',
+    codex          : 'Codex',
     cursor         : 'Cursor',
+    orchestrator   : 'Neo Orchestrator',
     unknown        : 'unknown',
     vscode         : 'VS Code'
 };
@@ -55,6 +58,8 @@ export function classifyHarness(pid, {execSync = defaultExecSync, maxDepth = 8} 
         if (cmd === 'claude' || cmd.endsWith('/claude'))    return {harness: 'claude-code', chain};
         if (cmd.includes('claude'))                         return {harness: 'claude-desktop', chain};
         if (cmd.includes('antigravity'))                    return {harness: 'antigravity', chain};
+        if (cmd.includes('codex.app') || cmd.endsWith('/codex')) return {harness: 'codex', chain};
+        if (cmd.includes('ai:orchestrator'))                return {harness: 'orchestrator', chain};
         if (cmd.includes('cursor'))                         return {harness: 'cursor', chain};
         if (cmd.includes('code helper') || cmd.includes('vscode')) return {harness: 'vscode', chain};
     }
@@ -106,4 +111,173 @@ export function formatHarnessGroups(groups) {
 
         return `${group.processes.length} ${group.label} (${pidLabel}: ${pids})`;
     }).join(' + ');
+}
+
+function quoteShellArg(value) {
+    return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * @summary Returns the SQLite file set opened by a WAL-mode Memory Core graph connection.
+ *
+ * @param {String} dbPath Absolute path to the Memory Core SQLite graph database.
+ * @returns {Array<String>}
+ */
+export function getSqliteHolderFiles(dbPath) {
+    return dbPath ? [dbPath, `${dbPath}-wal`, `${dbPath}-shm`] : [];
+}
+
+/**
+ * @summary Parses `lsof -F pcn` output into process records with opened files.
+ *
+ * @param {String} raw Raw `lsof -F pcn` output.
+ * @returns {Array<{pid: Number, command: String, files: Array<String>}>}
+ */
+export function parseLsofOutput(raw) {
+    const records = [];
+    let current   = null;
+
+    for (const line of String(raw || '').split('\n')) {
+        if (!line) continue;
+
+        const tag   = line[0];
+        const value = line.slice(1);
+
+        if (tag === 'p') {
+            if (current?.pid) records.push(current);
+            current = {pid: parseInt(value, 10), files: []};
+        } else if (current) {
+            if (tag === 'c') current.command = value;
+            else if (tag === 'n') current.files.push(value);
+        }
+    }
+
+    if (current?.pid) records.push(current);
+
+    return records;
+}
+
+function dedupeProcesses(processes, currentPid) {
+    const processMap = new Map();
+
+    for (const processRecord of processes) {
+        if (!processRecord.pid || processRecord.pid === currentPid) continue;
+
+        if (processMap.has(processRecord.pid)) {
+            const existing = processMap.get(processRecord.pid);
+            existing.files = Array.from(new Set([
+                ...(existing.files || []),
+                ...(processRecord.files || [])
+            ]));
+        } else {
+            processMap.set(processRecord.pid, {
+                ...processRecord,
+                files: Array.from(new Set(processRecord.files || []))
+            });
+        }
+    }
+
+    return Array.from(processMap.values());
+}
+
+/**
+ * @summary Builds the read-only current-state diagnostic for Memory Core SQLite holder processes.
+ *
+ * The probe deliberately returns `status: 'degraded'` for platform/probe failures instead of
+ * throwing. Consumers use this as diagnostic data; a missing `lsof` binary or missing DB file
+ * must not become a Memory Core health verdict.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.dbPath] Absolute path to the Memory Core SQLite graph database.
+ * @param {Function} [options.execSync=defaultExecSync] Injectable command runner for tests.
+ * @param {Function} [options.existsSync=defaultExistsSync] Injectable file-existence reader.
+ * @param {Function} [options.classifier=classifyHarness] Injectable harness classifier.
+ * @param {Number} [options.currentPid=process.pid] PID to exclude from sibling diagnostics.
+ * @param {String} [options.measuredAt] Fixed timestamp for tests.
+ * @returns {Object}
+ */
+export function buildSqliteHolderDiagnostics({
+    dbPath,
+    execSync   = defaultExecSync,
+    existsSync = defaultExistsSync,
+    classifier = classifyHarness,
+    currentPid = process.pid,
+    measuredAt = new Date().toISOString()
+} = {}) {
+    const files         = getSqliteHolderFiles(dbPath);
+    const existingFiles = files.filter(file => existsSync(file));
+    const base = {
+        status        : 'ok',
+        measuredAt,
+        sqliteFile    : dbPath || null,
+        files,
+        existingFiles,
+        totalProcesses: 0,
+        byHarness     : {},
+        groups        : [],
+        processes     : [],
+        warnings      : []
+    };
+
+    if (!dbPath) {
+        return {
+            ...base,
+            status: 'degraded',
+            error : 'Memory Core SQLite graph path is not configured'
+        };
+    }
+
+    if (existingFiles.length === 0) {
+        return {
+            ...base,
+            status: 'degraded',
+            error : `Memory Core SQLite files not found for ${dbPath}`
+        };
+    }
+
+    let raw;
+    try {
+        raw = execSync(`lsof -F pcn -- ${existingFiles.map(quoteShellArg).join(' ')}`, {
+            encoding: 'utf8',
+            stdio   : ['ignore', 'pipe', 'pipe']
+        });
+    } catch (error) {
+        if (error.status === 1) {
+            raw = '';
+        } else {
+            return {
+                ...base,
+                status: 'degraded',
+                error : error.code === 'ENOENT'
+                    ? 'Platform not supported: this diagnostic requires `lsof` (macOS / Linux).'
+                    : `lsof failed: ${error.message || error}`
+            };
+        }
+    }
+
+    const processes = dedupeProcesses(parseLsofOutput(raw), currentPid);
+    const groups    = groupProcessesByHarness(processes, {classifier});
+    const enrichedProcesses = groups.flatMap(group => group.processes);
+    const byHarness = {};
+
+    for (const group of groups) {
+        byHarness[group.harness] = group.processes.length;
+    }
+
+    const warnings = [];
+    if (byHarness.unknown > 0) {
+        warnings.push({
+            code   : 'unknown-harness',
+            message: `${byHarness.unknown} SQLite holder process(es) could not be mapped to a known harness`
+        });
+    }
+
+    return {
+        ...base,
+        totalProcesses: processes.length,
+        byHarness,
+        groups,
+        processes: enrichedProcesses,
+        warnings
+    };
 }

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -117,6 +117,24 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(tool.inputSchema.properties.chromaProbeTimeoutMs.minimum).toBe(1);
         expect(tool.inputSchema.properties.embeddingWriteCanaryTimeoutMs.type).toBe('integer');
         expect(tool.inputSchema.properties.embeddingWriteCanaryTimeoutMs.minimum).toBe(1);
+        expect(tool.inputSchema.properties.includeSqliteHolders).toBeUndefined();
+    });
+
+    test('get_sqlite_holder_diagnostics exposes read-only grouped holder contract (#13475)', async () => {
+        const { tools } = await toolService.listTools();
+        const tool = tools.find(item => item.name === 'get_sqlite_holder_diagnostics');
+
+        expect(tool).toBeTruthy();
+        expect(tool.annotations.readOnlyHint).toBe(true);
+        expect(tool.inputSchema.properties).toEqual({});
+        expect(tool.outputSchema.properties.status.enum).toEqual(['ok', 'degraded']);
+        expect(tool.outputSchema.properties.totalProcesses.type).toBe('integer');
+        expect(tool.outputSchema.properties.byHarness.additionalProperties.type).toBe('integer');
+        expect(tool.outputSchema.properties.groups.items.properties.harness.type).toBe('string');
+        expect(tool.outputSchema.properties.groups.items.properties.processes.type).toBe('array');
+        expect(tool.outputSchema.properties.processes.items.properties.pid.type).toBe('integer');
+        expect(tool.outputSchema.properties.processes.items.properties.chain.type).toBe('array');
+        expect(tool.outputSchema.properties.warnings.items.properties.code.type).toBe('string');
     });
 
     test('healthcheck dispatch passes diagnostic options as one object (#13460)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/harnessClassifier.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/harnessClassifier.spec.mjs
@@ -18,7 +18,7 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * @summary Coverage for #10206 Memory Core harness-classified sibling diagnostics.
+ * @summary Coverage for Memory Core harness-classified sibling diagnostics.
  *
  * Pins the extracted classifier used by both `diagnoseMcpConcurrency.mjs` and
  * `MemoryCoreServer.logSiblingConcurrency()`. The helper remains read-only and testable
@@ -27,13 +27,15 @@ import * as core      from '../../../../../../src/core/_export.mjs';
  * @see ai.services.memory-core.helpers.HarnessClassifier#classifyHarness
  */
 test.describe('Memory Core HarnessClassifier #10206', () => {
-    let classifyHarness, groupProcessesByHarness, formatHarnessGroups;
+    let buildSqliteHolderDiagnostics, classifyHarness, groupProcessesByHarness, formatHarnessGroups, parseLsofOutput;
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../ai/services/memory-core/helpers/harnessClassifier.mjs');
-        classifyHarness        = mod.classifyHarness;
-        groupProcessesByHarness = mod.groupProcessesByHarness;
-        formatHarnessGroups     = mod.formatHarnessGroups;
+        buildSqliteHolderDiagnostics = mod.buildSqliteHolderDiagnostics;
+        classifyHarness              = mod.classifyHarness;
+        groupProcessesByHarness      = mod.groupProcessesByHarness;
+        formatHarnessGroups          = mod.formatHarnessGroups;
+        parseLsofOutput              = mod.parseLsofOutput;
     });
 
     function makeExecSync(responses) {
@@ -68,6 +70,24 @@ test.describe('Memory Core HarnessClassifier #10206', () => {
         expect(classifyHarness(301, {execSync}).harness).toBe('claude-code');
     });
 
+    test('classifies Codex desktop harnesses', () => {
+        const execSync = makeExecSync(new Map([
+            [351, '  352 node'],
+            [352, '    1 /Applications/Codex.app/Contents/MacOS/Codex']
+        ]));
+
+        expect(classifyHarness(351, {execSync}).harness).toBe('codex');
+    });
+
+    test('classifies Neo orchestrator-owned processes', () => {
+        const execSync = makeExecSync(new Map([
+            [361, '  362 node'],
+            [362, '    1 npm run ai:orchestrator']
+        ]));
+
+        expect(classifyHarness(361, {execSync}).harness).toBe('orchestrator');
+    });
+
     test('falls back to unknown when no recognizable harness exists', () => {
         const execSync = makeExecSync(new Map([
             [401, '  402 node'],
@@ -99,5 +119,99 @@ test.describe('Memory Core HarnessClassifier #10206', () => {
             unknown    : 1
         });
         expect(formatHarnessGroups(groups)).toBe('2 Antigravity (PIDs: 101, 102) + 1 unknown (PID: 201)');
+    });
+
+    test('parses lsof records with held SQLite files', () => {
+        const records = parseLsofOutput([
+            'p101',
+            'cnode',
+            'n/tmp/memory-core-graph.sqlite',
+            'n/tmp/memory-core-graph.sqlite-wal',
+            'p202',
+            'cClaude',
+            'n/tmp/memory-core-graph.sqlite-shm'
+        ].join('\n'));
+
+        expect(records).toEqual([{
+            pid    : 101,
+            command: 'node',
+            files  : [
+                '/tmp/memory-core-graph.sqlite',
+                '/tmp/memory-core-graph.sqlite-wal'
+            ]
+        }, {
+            pid    : 202,
+            command: 'Claude',
+            files  : ['/tmp/memory-core-graph.sqlite-shm']
+        }]);
+    });
+
+    test('builds grouped SQLite holder diagnostics and excludes the current process', () => {
+        const dbPath     = '/tmp/memory-core-graph.sqlite';
+        const existing   = new Set([dbPath, `${dbPath}-wal`, `${dbPath}-shm`]);
+        const diagnostics = buildSqliteHolderDiagnostics({
+            dbPath,
+            currentPid: 999,
+            measuredAt: '2026-06-19T00:00:00.000Z',
+            existsSync: file => existing.has(file),
+            execSync  : () => [
+                'p101',
+                'cnode',
+                `n${dbPath}`,
+                'p101',
+                'cnode',
+                `n${dbPath}-wal`,
+                'p201',
+                'cnode',
+                `n${dbPath}-shm`,
+                'p999',
+                'cnode',
+                `n${dbPath}`
+            ].join('\n'),
+            classifier(pid) {
+                return {
+                    harness: pid === 101 ? 'antigravity' : 'unknown',
+                    chain  : [{pid, command: 'node'}]
+                };
+            }
+        });
+
+        expect(diagnostics.status).toBe('ok');
+        expect(diagnostics.totalProcesses).toBe(2);
+        expect(diagnostics.byHarness).toEqual({
+            antigravity: 1,
+            unknown    : 1
+        });
+        expect(diagnostics.processes.map(processRecord => processRecord.pid)).toEqual([101, 201]);
+        expect(diagnostics.processes[0].files).toEqual([dbPath, `${dbPath}-wal`]);
+        expect(diagnostics.processes[0].harness).toBe('antigravity');
+        expect(diagnostics.processes[0].chain).toEqual([{pid: 101, command: 'node'}]);
+        expect(diagnostics.groups.map(group => [group.harness, group.processes.length])).toEqual([
+            ['antigravity', 1],
+            ['unknown', 1]
+        ]);
+        expect(diagnostics.warnings).toEqual([{
+            code   : 'unknown-harness',
+            message: '1 SQLite holder process(es) could not be mapped to a known harness'
+        }]);
+    });
+
+    test('returns degraded diagnostic data when process inspection is unavailable', () => {
+        const dbPath = '/tmp/memory-core-graph.sqlite';
+        const error  = new Error('spawn lsof ENOENT');
+        error.code = 'ENOENT';
+
+        const diagnostics = buildSqliteHolderDiagnostics({
+            dbPath,
+            existsSync: () => true,
+            execSync  : () => {
+                throw error;
+            }
+        });
+
+        expect(diagnostics.status).toBe('degraded');
+        expect(diagnostics.error).toContain('requires `lsof`');
+        expect(diagnostics.totalProcesses).toBe(0);
+        expect(diagnostics.groups).toEqual([]);
     });
 });


### PR DESCRIPTION
Resolves #13475

Adds an explicit read-only Memory Core diagnostic tool, `get_sqlite_holder_diagnostics`, for current SQLite holder process visibility. The existing `diagnoseMcpConcurrency.mjs` script and `Server.logSiblingConcurrency()` now share one projection helper, so boot logs, script output, and the MCP tool use the same lsof parsing, PID dedupe, harness grouping, warning, and degraded-fallback semantics.

Evidence: L3 (live read-only `diagnoseMcpConcurrency.mjs --json` process probe outside the sandbox + unit/OpenAPI schema smoke) -> L3 required (on-demand current-state diagnostic; no destructive handoff). No close-target residuals.

## Deltas from ticket
- Chose an explicit `get_sqlite_holder_diagnostics` read tool instead of adding a healthcheck option, keeping default healthchecks free of process-holder scans.
- Added Codex and Neo Orchestrator harness classification because the live probe showed those were otherwise preventable `unknown` buckets.
- Kept diagnostic failures local to the diagnostic payload (`status: degraded`) rather than feeding them into Memory Core health.

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/harnessClassifier.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` -> 37 passed.
- `node ai/scripts/diagnostics/diagnoseMcpConcurrency.mjs --json` outside sandbox -> `status: ok`, `byHarness: { claude-desktop: 12, antigravity: 2, orchestrator: 4, codex: 4 }`, `warnings: []`.
- `git diff --check` and `git diff --cached --check` passed.
- Commit hooks passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology.

## Post-Merge Validation
- [ ] Restart Memory Core MCP server and call `get_sqlite_holder_diagnostics` through the live MCP surface to confirm the deployed tool exposes the same grouped holder snapshot.

## Commits
- `64dac3ac9` - `feat(ai): expose sqlite holder diagnostics (#13475)`

Authored by Euclid (GPT-5, Codex Desktop). Session c3a6e312-b858-4be4-ad97-9bc55cbad5ae.