### PR TITLE
feat(memory-core): add MCP tool telemetry (#13506)

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -232,6 +232,7 @@ class BaseServer extends Base {
      * @param {Object} context
      * @param {String} context.toolName The MCP tool name being invoked.
      * @param {Object} context.args     The arguments passed to the tool call.
+     * @param {Number} context.t0       The Date.now() timestamp captured at handler entry.
      */
     async beforeToolDispatch(context) {
         // No-op default
@@ -360,7 +361,7 @@ class BaseServer extends Base {
 
                 // Pre-dispatch validation hook (e.g., memory-core's identity-spoof guard).
                 // Throws bubble to the outer catch and route to formatToolError.
-                await this.beforeToolDispatch({toolName: name, args});
+                await this.beforeToolDispatch({toolName: name, args, t0});
 
                 if (healthService && !exemptTools.includes(name)) {
                     try {

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -15,10 +15,11 @@ import {
     Memory_GraphService            as GraphService,
     Memory_HealthService           as HealthService,
     Memory_SessionService          as SessionService,
-    Memory_InferenceLifecycleService as InferenceLifecycleService,
-    Memory_StorageRouter           as StorageRouter,
-    Memory_WakeSubscriptionService as WakeSubscriptionService,
-    Memory_CoalescingEngineService as CoalescingEngineService
+    Memory_InferenceLifecycleService  as InferenceLifecycleService,
+    Memory_RecorderService            as RecorderService,
+    Memory_StorageRouter              as StorageRouter,
+    Memory_WakeSubscriptionService    as WakeSubscriptionService,
+    Memory_CoalescingEngineService    as CoalescingEngineService
 } from '../../../services.mjs';
 import {startDrainLoop}   from '../../../daemons/embed/drainCycle.mjs';
 import {acquireDrainLock} from '../../../daemons/embed/drainLock.mjs';
@@ -138,8 +139,35 @@ class Server extends BaseServer {
      * outer CallTool try/catch and route to `formatToolError`.
      * @param {{toolName: String, args: Object}} context
      */
-    async beforeToolDispatch({args}) {
-        AuthMiddleware.validateNoIdentitySpoof(args);
+    async beforeToolDispatch({toolName, args, t0}) {
+        try {
+            AuthMiddleware.validateNoIdentitySpoof(args);
+        } catch (error) {
+            RecorderService.logToolCall({
+                toolName,
+                args,
+                success     : false,
+                error,
+                failureStage: 'policy',
+                t0
+            });
+            throw error;
+        }
+    }
+
+    /**
+     * @summary Records health-gate rejects in the redacted MCP tool-call telemetry table.
+     * @param {{toolName: String, args: Object, error: Error, t0: Number}} context
+     */
+    async onHealthGateFailure({toolName, args, error, t0}) {
+        RecorderService.logToolCall({
+            toolName,
+            args,
+            success     : false,
+            error,
+            failureStage: 'health_gate',
+            t0
+        });
     }
 
     /**
@@ -208,6 +236,13 @@ class Server extends BaseServer {
             dependency: SessionService,
             start     : () => SessionService.ready(),
             degraded  : 'session/vector reads are degraded; add_memory remains WAL-available'
+        });
+
+        await this.prepareStartupDependency({
+            name      : 'tool-telemetry',
+            dependency: RecorderService,
+            start     : () => RecorderService.initAsync(),
+            degraded  : 'Memory Core tool telemetry is disabled; tool dispatch remains available'
         });
 
         // In-process WAL drain (containerized / single-process deployments): hosts the embed

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -206,6 +206,17 @@ class Config extends ConfigProvider {
                 hookWriteTimeoutMs: leaf(TURN_PRESENCE_DEFAULTS.hookWriteTimeoutMs, TURN_PRESENCE_ENV.hookWriteTimeoutMs, 'number')
             },
             /**
+             * Redacted Memory Core MCP tool-call telemetry. The recorder reads these resolved
+             * leaves at write/report time so deployments can tune observability without
+             * re-deriving defaults outside the Provider SSOT.
+             */
+            toolTelemetry: {
+                enabled: leaf(true, 'NEO_MC_TOOL_TELEMETRY_ENABLED', 'boolean'),
+                errorMaxChars: leaf(512, 'NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS', 'number'),
+                aggregateWindowMs: leaf(DAY_MS, 'NEO_MC_TOOL_TELEMETRY_WINDOW_MS', 'number'),
+                aggregateLimit: leaf(50, 'NEO_MC_TOOL_TELEMETRY_LIMIT', 'number')
+            },
+            /**
              * Data Schema/Table Names
              * This defines WHAT the tables/collections are called logically.
              */

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -39,6 +39,8 @@ tags:
     description: Agent permission operations
   - name: TurnPresence
     description: Agent active-turn liveness interval operations
+  - name: Diagnostics
+    description: On-demand operational diagnostics
 
 paths:
   /healthcheck:
@@ -91,6 +93,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /diagnostics/tool-metrics:
+    post:
+      summary: Get Memory Core Tool Metrics
+      operationId: get_memory_core_tool_metrics
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      description: |
+        Returns aggregate Memory Core MCP tool-call telemetry without exposing raw tool
+        arguments or results. Use this to diagnose slow or failing tools in long-running
+        local and shared deployments.
+      tags: [Diagnostics]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sinceMs:
+                  type: integer
+                  minimum: 1
+                  description: Lookback window in milliseconds. Defaults to the Memory Core telemetry config leaf.
+                limit:
+                  type: integer
+                  minimum: 1
+                  description: Maximum number of per-tool aggregate rows. Defaults to the Memory Core telemetry config leaf.
+      responses:
+        '200':
+          description: Aggregate Memory Core MCP tool-call metrics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemoryCoreToolMetricsResponse'
 
   /rem/pipeline-state:
     post:
@@ -1529,6 +1566,76 @@ paths:
 
 components:
   schemas:
+    MemoryCoreToolMetricsResponse:
+      type: object
+      required:
+        - status
+        - sinceMs
+        - limit
+        - totalCalls
+        - tools
+      properties:
+        status:
+          type: string
+          enum: [ok, disabled, unavailable]
+          description: Whether telemetry is available for the requested aggregate.
+          example: ok
+        sinceMs:
+          type: integer
+          description: Effective lookback window in milliseconds.
+          example: 86400000
+        limit:
+          type: integer
+          description: Effective maximum number of grouped tool rows.
+          example: 50
+        totalCalls:
+          type: integer
+          description: Total matching tool calls across all tools.
+          example: 128
+        tools:
+          type: array
+          description: Per-tool aggregate rows. Raw arguments and results are intentionally absent.
+          items:
+            type: object
+            required:
+              - tool
+              - calls
+              - failures
+            properties:
+              tool:
+                type: string
+                description: MCP operation id.
+                example: query_raw_memories
+              calls:
+                type: integer
+                description: Matching call count.
+                example: 42
+              failures:
+                type: integer
+                description: Matching calls recorded as failed.
+                example: 2
+              minDurationMs:
+                type: integer
+                nullable: true
+                description: Fastest recorded duration in milliseconds.
+                example: 12
+              avgDurationMs:
+                type: number
+                nullable: true
+                description: Average recorded duration in milliseconds.
+                example: 84.25
+              maxDurationMs:
+                type: integer
+                nullable: true
+                description: Slowest recorded duration in milliseconds.
+                example: 940
+              lastSeenAt:
+                type: string
+                format: date-time
+                nullable: true
+                description: ISO timestamp of the newest matching call.
+                example: "2026-06-19T03:30:00.000Z"
+
     RemPipelineStateResponse:
       type: object
       required:

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -1,15 +1,16 @@
 import path                    from 'path';
 import {fileURLToPath}         from 'url';
-import ToolService             from '../../ToolService.mjs';
-import GraphService            from '../../../services/memory-core/GraphService.mjs';
-import HealthService           from '../../../services/memory-core/HealthService.mjs';
-import MemoryService           from '../../../services/memory-core/MemoryService.mjs';
-import SessionService          from '../../../services/memory-core/SessionService.mjs';
-import SummaryService          from '../../../services/memory-core/SummaryService.mjs';
-import MailboxService          from '../../../services/memory-core/MailboxService.mjs';
-import PermissionService       from '../../../services/memory-core/PermissionService.mjs';
-import WakeSubscriptionService from '../../../services/memory-core/WakeSubscriptionService.mjs';
-import TurnPresenceService     from '../../../services/memory-core/TurnPresenceService.mjs';
+import ToolService               from '../../ToolService.mjs';
+import GraphService              from '../../../services/memory-core/GraphService.mjs';
+import HealthService             from '../../../services/memory-core/HealthService.mjs';
+import MemoryService             from '../../../services/memory-core/MemoryService.mjs';
+import SessionService            from '../../../services/memory-core/SessionService.mjs';
+import SummaryService            from '../../../services/memory-core/SummaryService.mjs';
+import MailboxService            from '../../../services/memory-core/MailboxService.mjs';
+import PermissionService         from '../../../services/memory-core/PermissionService.mjs';
+import WakeSubscriptionService   from '../../../services/memory-core/WakeSubscriptionService.mjs';
+import TurnPresenceService       from '../../../services/memory-core/TurnPresenceService.mjs';
+import MemoryCoreRecorderService from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
@@ -35,6 +36,8 @@ const serviceMapping = {
     query_recent_turns      : MemoryService          .queryRecentTurns        .bind(MemoryService),
     query_summaries         : SummaryService         .querySummaries          .bind(SummaryService),
     search_nodes            : GraphService           .searchNodes             .bind(GraphService),
+    get_memory_core_tool_metrics:
+                              MemoryCoreRecorderService.getMemoryCoreToolMetrics.bind(MemoryCoreRecorderService),
     add_message             : MailboxService         .addMessage              .bind(MailboxService),
     list_messages           : MailboxService         .listMessages            .bind(MailboxService),
     get_message             : MailboxService         .getMessage              .bind(MailboxService),
@@ -60,7 +63,32 @@ const toolService = Neo.create(ToolService, {
     serviceMapping
 });
 
-const callTool  = toolService.callTool .bind(toolService);
+const _callTool = toolService.callTool.bind(toolService);
+
+const callTool = async (name, args, options = {}) => {
+    const t0 = Date.now();
+
+    let result, success = false, error = null;
+
+    try {
+        result  = await _callTool(name, args, options);
+        success = true;
+        return result;
+    } catch (err) {
+        error = err;
+        throw err;
+    } finally {
+        MemoryCoreRecorderService.logToolCall({
+            toolName    : name,
+            args,
+            result,
+            success,
+            error,
+            failureStage: success ? null : 'dispatch',
+            t0
+        });
+    }
+};
 const listTools = toolService.listTools.bind(toolService);
 
 export {callTool, listTools};

--- a/ai/services.mjs
+++ b/ai/services.mjs
@@ -49,6 +49,7 @@ import _Memory_GraphService from './services/memory-core/GraphService.mjs';
 import _Memory_SummaryService from './services/memory-core/SummaryService.mjs';
 import _Memory_ChromaLifecycleService from './services/memory-core/lifecycle/ChromaLifecycleService.mjs';
 import _Memory_InferenceLifecycleService from './services/memory-core/lifecycle/InferenceLifecycleService.mjs';
+import _Memory_RecorderService from './services/memory-core/MemoryCoreRecorderService.mjs';
 import Memory_ChromaManager         from './services/memory-core/managers/ChromaManager.mjs';
 import Memory_StorageRouter         from './services/memory-core/managers/StorageRouter.mjs';
 import _Memory_LifecycleService from './services/memory-core/lifecycle/SystemLifecycleService.mjs';
@@ -226,6 +227,7 @@ const Memory_InferenceLifecycleService = makeSafe(_Memory_InferenceLifecycleServ
 const Memory_HealthService = makeSafe(_Memory_HealthService, memSpec);
 const Memory_GraphService = makeSafe(_Memory_GraphService, memSpec);
 const Memory_SummaryService = makeSafe(_Memory_SummaryService, memSpec);
+const Memory_RecorderService = makeSafe(_Memory_RecorderService, memSpec);
 const Memory_TextEmbeddingService = makeSafe(_Memory_TextEmbeddingService, memSpec);
 const Memory_WakeSubscriptionService = makeSafe(_Memory_WakeSubscriptionService, memSpec);
 const Memory_TurnPresenceService = makeSafe(_Memory_TurnPresenceService, memSpec);
@@ -302,6 +304,7 @@ export {
     Memory_InferenceLifecycleService,
     Memory_GraphService,
     Memory_HealthService,
+    Memory_RecorderService,
     Memory_StorageRouter,
     Memory_SummaryService,
     Memory_TextEmbeddingService,

--- a/ai/services/memory-core/MemoryCoreRecorderService.mjs
+++ b/ai/services/memory-core/MemoryCoreRecorderService.mjs
@@ -1,0 +1,292 @@
+import crypto                from 'crypto';
+import fs                    from 'fs-extra';
+import path                  from 'path';
+import Base                  from '../../../src/core/Base.mjs';
+import config                from '../../mcp/server/memory-core/config.mjs';
+import logger                from '../../mcp/server/memory-core/logger.mjs';
+import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
+
+const SENSITIVE_PAYLOAD_KEYS = new Set([
+    'body',
+    'content',
+    'message',
+    'prompt',
+    'response',
+    'text',
+    'thought'
+]);
+
+/**
+ * @summary Persists redacted Memory Core MCP tool-call telemetry.
+ *
+ * This is the Memory Core sibling of the Knowledge Base and Neural Link recorder services,
+ * but it deliberately stores operational metadata only. Memory Core tool arguments can carry
+ * prompts, thoughts, responses, and A2A message bodies; duplicating those payloads into a
+ * telemetry table would violate the recorder's diagnostic purpose and increase leakage risk.
+ *
+ * @class Neo.ai.services.memory-core.MemoryCoreRecorderService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class MemoryCoreRecorderService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.memory-core.MemoryCoreRecorderService'
+         * @protected
+         */
+        className: 'Neo.ai.services.memory-core.MemoryCoreRecorderService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {Object|null} db=null
+         * @summary SQLite connection to the Memory Core graph database.
+         * @protected
+         */
+        db: null
+    }
+
+    /**
+     * Initializes the SQLite schema for Memory Core MCP tool telemetry.
+     * @returns {Promise<void>}
+     */
+    async initAsync() {
+        await super.initAsync();
+
+        if (this.db) return;
+
+        try {
+            const dbPath = config.storagePaths.graph;
+            if (!dbPath) {
+                logger.warn('[MemoryCoreRecorderService] storagePaths.graph not configured. Disabling tool telemetry.');
+                return;
+            }
+
+            if (dbPath !== ':memory:') {
+                await fs.ensureDir(path.dirname(dbPath));
+            }
+
+            const Database = (await import('better-sqlite3')).default;
+
+            this.db = new Database(dbPath, {verbose: null});
+            if (dbPath !== ':memory:') {
+                this.db.pragma('journal_mode = WAL');
+            }
+
+            this.ensureSchema();
+            logger.info('[MemoryCoreRecorderService] Connected to Memory Core mc_tool_call_log.');
+        } catch (err) {
+            logger.warn('[MemoryCoreRecorderService] Failed to initialize SQLite connection:', err.message);
+        }
+    }
+
+    /**
+     * Creates the telemetry table and indexes if absent.
+     * @returns {void}
+     */
+    ensureSchema() {
+        if (!this.db) return;
+
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS mc_tool_call_log (
+                id            TEXT PRIMARY KEY,
+                agent_id      TEXT,
+                user_id       TEXT,
+                session_id    TEXT,
+                sequence_id   TEXT NOT NULL,
+                timestamp     INTEGER NOT NULL,
+                tool          TEXT NOT NULL,
+                success       INTEGER DEFAULT 0,
+                duration_ms   INTEGER,
+                failure_stage TEXT,
+                error_code    TEXT,
+                error_name    TEXT,
+                error_message TEXT,
+                args_bytes    INTEGER DEFAULT 0,
+                result_bytes  INTEGER DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS idx_mc_tool_call_log_timestamp ON mc_tool_call_log(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_mc_tool_call_log_tool      ON mc_tool_call_log(tool);
+            CREATE INDEX IF NOT EXISTS idx_mc_tool_call_log_success   ON mc_tool_call_log(success);
+            CREATE INDEX IF NOT EXISTS idx_mc_tool_call_log_session   ON mc_tool_call_log(session_id);
+        `);
+    }
+
+    /**
+     * Safely measures JSON payload size without storing the payload.
+     * @param {*} value Value to measure.
+     * @returns {Number}
+     */
+    measureBytes(value) {
+        if (value === undefined) return 0;
+
+        try {
+            return Buffer.byteLength(JSON.stringify(value), 'utf8');
+        } catch {
+            return Buffer.byteLength(String(value), 'utf8');
+        }
+    }
+
+    /**
+     * Collects sensitive string values from known Memory Core payload fields so error
+     * messages can redact direct echoes without storing the raw tool args.
+     * @param {*} value Candidate payload tree.
+     * @param {Set<String>} [values=new Set()] Accumulator.
+     * @returns {Set<String>}
+     */
+    collectSensitiveValues(value, values = new Set()) {
+        if (!value || typeof value !== 'object') return values;
+
+        for (const [key, child] of Object.entries(value)) {
+            if (typeof child === 'string' && SENSITIVE_PAYLOAD_KEYS.has(key) && child) {
+                values.add(child);
+            } else if (child && typeof child === 'object') {
+                this.collectSensitiveValues(child, values);
+            }
+        }
+
+        return values;
+    }
+
+    /**
+     * Redacts sensitive direct-echo values and bounds the retained error message.
+     * @param {Error|Object|null} error Error object.
+     * @param {Object} args Tool arguments.
+     * @returns {String|null}
+     */
+    buildErrorMessage(error, args) {
+        if (!error?.message) return null;
+
+        const maxChars = config.toolTelemetry.errorMaxChars;
+        if (!Number.isFinite(maxChars) || maxChars < 1) return null;
+
+        let message = String(error.message);
+
+        for (const value of this.collectSensitiveValues(args)) {
+            message = message.split(value).join('[redacted]');
+        }
+
+        return message.length > maxChars ? `${message.slice(0, maxChars)}...` : message;
+    }
+
+    /**
+     * Persists one redacted tool-call telemetry row. Best-effort only.
+     * @param {Object} entry Tool-call metadata.
+     * @returns {void}
+     */
+    logToolCall(entry = {}) {
+        if (!config.toolTelemetry.enabled || !this.db) return;
+
+        try {
+            const
+                timestamp = Number.isFinite(entry.timestamp) ? entry.timestamp : (Number.isFinite(entry.t0) ? entry.t0 : Date.now()),
+                context   = RequestContextService.get?.() || {},
+                agentId   = context.agentIdentityNodeId || process.env.NEO_AGENT_IDENTITY || process.env.NEO_AGENT_ID || process.env.USER || 'unknown',
+                userId    = context.userId || null,
+                sessionId = entry.args?.sessionId || context.sessionId || process.env.NEO_SESSION_ID || null,
+                duration  = Number.isFinite(entry.duration_ms)
+                    ? Math.max(0, entry.duration_ms)
+                    : Math.max(0, Date.now() - (entry.t0 || timestamp)),
+                error    = entry.error || null,
+                id       = entry.id || crypto.randomUUID?.() || `${timestamp}-${Math.random()}`,
+                sequence = entry.sequence_id || `${agentId}_${timestamp}_${id}`;
+
+            this.db.prepare(`
+                INSERT INTO mc_tool_call_log (
+                    id, agent_id, user_id, session_id, sequence_id, timestamp,
+                    tool, success, duration_ms, failure_stage, error_code,
+                    error_name, error_message, args_bytes, result_bytes
+                )
+                VALUES (
+                    @id, @agent_id, @user_id, @session_id, @sequence_id, @timestamp,
+                    @tool, @success, @duration_ms, @failure_stage, @error_code,
+                    @error_name, @error_message, @args_bytes, @result_bytes
+                )
+            `).run({
+                id,
+                agent_id     : agentId,
+                user_id      : userId,
+                session_id   : sessionId,
+                sequence_id  : sequence,
+                timestamp,
+                tool         : entry.toolName || entry.tool || 'unknown',
+                success      : entry.success ? 1 : 0,
+                duration_ms  : duration,
+                failure_stage: entry.failureStage || entry.failure_stage || null,
+                error_code   : error?.code || null,
+                error_name   : error?.name || null,
+                error_message: this.buildErrorMessage(error, entry.args),
+                args_bytes   : this.measureBytes(entry.args),
+                result_bytes : this.measureBytes(entry.result)
+            });
+        } catch (err) {
+            logger.warn('[MemoryCoreRecorderService] Failed to persist tool telemetry:', err.message);
+        }
+    }
+
+    /**
+     * Returns aggregate Memory Core MCP tool-call metrics without exposing raw payloads.
+     * @param {Object} options
+     * @param {Number} [options.sinceMs=config.toolTelemetry.aggregateWindowMs] Lookback window.
+     * @param {Number} [options.limit=config.toolTelemetry.aggregateLimit] Max grouped tools.
+     * @returns {Object}
+     */
+    getMemoryCoreToolMetrics({
+        sinceMs = config.toolTelemetry.aggregateWindowMs,
+        limit   = config.toolTelemetry.aggregateLimit
+    } = {}) {
+        if (!config.toolTelemetry.enabled) {
+            return {status: 'disabled', sinceMs, limit, totalCalls: 0, tools: []};
+        }
+
+        if (!this.db) {
+            return {status: 'unavailable', sinceMs, limit, totalCalls: 0, tools: []};
+        }
+
+        this.ensureSchema();
+
+        const
+            safeSinceMs = Number.isFinite(sinceMs) && sinceMs > 0 ? sinceMs : config.toolTelemetry.aggregateWindowMs,
+            safeLimit   = Number.isFinite(limit) && limit > 0 ? limit : config.toolTelemetry.aggregateLimit,
+            sinceTs     = Date.now() - safeSinceMs,
+            rows        = this.db.prepare(`
+                SELECT tool,
+                       COUNT(*) AS calls,
+                       SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS failures,
+                       MIN(duration_ms) AS min_duration_ms,
+                       MAX(duration_ms) AS max_duration_ms,
+                       ROUND(AVG(duration_ms), 2) AS avg_duration_ms,
+                       MAX(timestamp) AS last_seen_at
+                  FROM mc_tool_call_log
+                 WHERE timestamp >= @sinceTs
+                 GROUP BY tool
+                 ORDER BY calls DESC, tool ASC
+                 LIMIT @limit
+            `).all({sinceTs, limit: safeLimit}),
+            total = this.db.prepare(`
+                SELECT COUNT(*) AS total
+                  FROM mc_tool_call_log
+                 WHERE timestamp >= @sinceTs
+            `).get({sinceTs})?.total || 0;
+
+        return {
+            status    : 'ok',
+            sinceMs   : safeSinceMs,
+            limit     : safeLimit,
+            totalCalls: total,
+            tools     : rows.map(row => ({
+                tool         : row.tool,
+                calls        : row.calls,
+                failures     : row.failures || 0,
+                minDurationMs: row.min_duration_ms ?? null,
+                avgDurationMs: row.avg_duration_ms ?? null,
+                maxDurationMs: row.max_duration_ms ?? null,
+                lastSeenAt   : row.last_seen_at ? new Date(row.last_seen_at).toISOString() : null
+            }))
+        };
+    }
+}
+
+export default Neo.setupClass(MemoryCoreRecorderService);

--- a/learn/agentos/tooling/MemoryCoreMcpApi.md
+++ b/learn/agentos/tooling/MemoryCoreMcpApi.md
@@ -212,9 +212,9 @@ The initial implementation runs locally with no authentication. Future versions 
 
 ### Monitoring & Logging
 - **Health Checks**: The `healthcheck` tool should be monitored periodically.
-- **Request Logging**: Log all tool calls with timing information.
-- **Error Tracking**: Capture and log all errors with stack traces.
-- **Metrics**: Track memory growth, query performance, and summarization success rates.
+- **Request Logging**: Memory Core records redacted MCP tool-call telemetry with `tool`, `success`, `duration_ms`, failure stage, bounded error metadata, and payload sizes only.
+- **Error Tracking**: Dispatch, policy, and health-gate failures are recorded without raw Memory Core arguments or result JSON.
+- **Metrics**: Use `get_memory_core_tool_metrics` for on-demand per-tool call counts, failures, and latency summaries without bloating `healthcheck`.
 
 ## OpenAPI Specification
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -465,6 +465,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         const originalWakeInit = SDK.Memory_WakeSubscriptionService.init;
         const originalInferenceReady = SDK.Memory_InferenceLifecycleService.ready;
         const originalSessionReady = SDK.Memory_SessionService.ready;
+        const originalRecorderInitAsync = SDK.Memory_RecorderService.initAsync;
         const originalRecordStartupDependency = HealthService.recordStartupDependency;
         const originalSetStdioIdentityState = HealthService.setStdioIdentityState;
 
@@ -474,6 +475,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         };
         SDK.Memory_InferenceLifecycleService.ready = async () => calls.push('inferenceReady');
         SDK.Memory_SessionService.ready = async () => calls.push('sessionReady');
+        SDK.Memory_RecorderService.initAsync = async () => calls.push('toolTelemetryReady');
         HealthService.recordStartupDependency = (name, status, details) => {
             startupStates.push({name, status, error: details?.error});
         };
@@ -490,6 +492,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 'wakeInit',
                 'inferenceReady',
                 'sessionReady',
+                'toolTelemetryReady',
                 ['setStdioIdentityState', null],
                 'runHealthcheckAndLogStatus',
                 'logSiblingConcurrency',
@@ -499,12 +502,14 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             expect(startupStates).toEqual([
                 {name: 'wake-subscription', status: 'degraded', error: 'attempt to write a readonly database'},
                 {name: 'inference-lifecycle', status: 'ready', error: undefined},
-                {name: 'session-service', status: 'ready', error: undefined}
+                {name: 'session-service', status: 'ready', error: undefined},
+                {name: 'tool-telemetry', status: 'ready', error: undefined}
             ]);
         } finally {
             SDK.Memory_WakeSubscriptionService.init = originalWakeInit;
             SDK.Memory_InferenceLifecycleService.ready = originalInferenceReady;
             SDK.Memory_SessionService.ready = originalSessionReady;
+            SDK.Memory_RecorderService.initAsync = originalRecorderInitAsync;
             HealthService.recordStartupDependency = originalRecordStartupDependency;
             HealthService.setStdioIdentityState = originalSetStdioIdentityState;
             HealthService.clearStartupDependencyState();

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -1,0 +1,214 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MemoryCoreRecorderServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs';
+import path           from 'path';
+
+test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
+    const
+        secret     = 'SENTINEL_SECRET_13506',
+        testDbName = `mc-recorder-test-${process.pid}-${Date.now()}.sqlite`;
+
+    let originalEnv;
+    let testDbPath;
+    let MemoryCoreRecorderService;
+
+    test.beforeAll(async () => {
+        originalEnv = {
+            NEO_MC_TOOL_TELEMETRY_ENABLED        : process.env.NEO_MC_TOOL_TELEMETRY_ENABLED,
+            NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS: process.env.NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS,
+            NEO_MEMORY_DB_PATH_TEST              : process.env.NEO_MEMORY_DB_PATH_TEST,
+            UNIT_TEST_MODE                       : process.env.UNIT_TEST_MODE
+        };
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) {
+            fs.mkdirSync(tmpDir, {recursive: true});
+        }
+
+        testDbPath = path.join(tmpDir, testDbName);
+
+        process.env.UNIT_TEST_MODE = 'true';
+        process.env.NEO_MEMORY_DB_PATH_TEST = testDbPath;
+        process.env.NEO_MC_TOOL_TELEMETRY_ENABLED = 'true';
+        process.env.NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS = '80';
+
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+
+        MemoryCoreRecorderService = (await import('../../../../../../ai/services/memory-core/MemoryCoreRecorderService.mjs')).default;
+        await MemoryCoreRecorderService.initAsync();
+    });
+
+    test.beforeEach(() => {
+        MemoryCoreRecorderService.db.exec('DELETE FROM mc_tool_call_log;');
+    });
+
+    test.afterAll(() => {
+        if (MemoryCoreRecorderService?.db) {
+            try { MemoryCoreRecorderService.db.close(); } catch (e) {}
+            MemoryCoreRecorderService.db = null;
+        }
+
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+
+        for (const [key, value] of Object.entries(originalEnv || {})) {
+            if (value === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = value;
+            }
+        }
+    });
+
+    test('initializes the redacted Memory Core tool telemetry schema', () => {
+        const table = MemoryCoreRecorderService.db.prepare(`
+            SELECT name
+              FROM sqlite_master
+             WHERE type = 'table'
+               AND name = 'mc_tool_call_log'
+        `).get();
+
+        expect(table.name).toBe('mc_tool_call_log');
+    });
+
+    test('records bounded metadata without raw Memory Core payloads', () => {
+        MemoryCoreRecorderService.logToolCall({
+            toolName    : 'add_memory',
+            args        : {prompt: secret, thought: secret, metadata: {safe: true}},
+            result      : {response: secret},
+            success     : false,
+            error       : new Error(`provider echoed ${secret}`),
+            failureStage: 'dispatch',
+            t0          : Date.now() - 4
+        });
+
+        const row = MemoryCoreRecorderService.db.prepare(`
+            SELECT *
+              FROM mc_tool_call_log
+             WHERE tool = 'add_memory'
+        `).get();
+
+        expect(row.success).toBe(0);
+        expect(row.failure_stage).toBe('dispatch');
+        expect(row.args_bytes).toBeGreaterThan(0);
+        expect(row.result_bytes).toBeGreaterThan(0);
+        expect(row.error_message).toContain('[redacted]');
+        expect(JSON.stringify(row)).not.toContain(secret);
+    });
+
+    test('returns aggregate metrics without raw row payloads', () => {
+        MemoryCoreRecorderService.logToolCall({
+            toolName: 'query_raw_memories',
+            args    : {query: 'safe'},
+            result  : {count: 1},
+            success : true,
+            t0      : Date.now() - 12
+        });
+        MemoryCoreRecorderService.logToolCall({
+            toolName    : 'query_raw_memories',
+            args        : {query: 'safe'},
+            success     : false,
+            error       : new Error('query failed'),
+            failureStage: 'dispatch',
+            t0          : Date.now() - 20
+        });
+
+        const metrics = MemoryCoreRecorderService.getMemoryCoreToolMetrics({
+            sinceMs: 60_000,
+            limit  : 10
+        });
+
+        expect(metrics.status).toBe('ok');
+        expect(metrics.totalCalls).toBe(2);
+        expect(metrics.tools[0].tool).toBe('query_raw_memories');
+        expect(metrics.tools[0].calls).toBe(2);
+        expect(metrics.tools[0].failures).toBe(1);
+        expect(JSON.stringify(metrics)).not.toContain('safe');
+    });
+
+    test('captures Memory Core MCP wrapper success and dispatch failure', async () => {
+        const {callTool} = await import('../../../../../../ai/mcp/server/memory-core/toolService.mjs');
+
+        await callTool('get_memory_core_tool_metrics', {sinceMs: 60_000, limit: 5});
+        await expect(callTool('missing_memory_core_tool', {})).rejects.toThrow(/not found/);
+
+        const rows = MemoryCoreRecorderService.db.prepare(`
+            SELECT tool, success, failure_stage
+              FROM mc_tool_call_log
+             ORDER BY timestamp ASC
+        `).all();
+
+        expect(rows.some(row => row.tool === 'get_memory_core_tool_metrics' && row.success === 1)).toBe(true);
+        expect(rows.some(row => row.tool === 'missing_memory_core_tool' && row.success === 0 && row.failure_stage === 'dispatch')).toBe(true);
+    });
+
+    test('captures health-gate and policy failures through Memory Core server hooks', async () => {
+        const Server = (await import('../../../../../../ai/mcp/server/memory-core/Server.mjs')).default;
+        const server = Neo.create(Server);
+
+        await server.onHealthGateFailure({
+            toolName: 'query_summaries',
+            args    : {prompt: secret},
+            error   : new Error(`health gate saw ${secret}`),
+            t0      : Date.now() - 6
+        });
+
+        await expect(server.beforeToolDispatch({
+            toolName: 'add_message',
+            args    : {from: '@spoofed', body: secret},
+            t0      : Date.now() - 3
+        })).rejects.toThrow();
+
+        const rows = MemoryCoreRecorderService.db.prepare(`
+            SELECT tool, failure_stage, error_message
+              FROM mc_tool_call_log
+             WHERE success = 0
+             ORDER BY timestamp ASC
+        `).all();
+
+        expect(rows.some(row => row.tool === 'query_summaries' && row.failure_stage === 'health_gate')).toBe(true);
+        expect(rows.some(row => row.tool === 'add_message' && row.failure_stage === 'policy')).toBe(true);
+        expect(JSON.stringify(rows)).not.toContain(secret);
+    });
+
+    test('fails open when telemetry storage is unavailable', () => {
+        const originalDb = MemoryCoreRecorderService.db;
+        MemoryCoreRecorderService.db = null;
+
+        try {
+            expect(() => MemoryCoreRecorderService.logToolCall({
+                toolName: 'add_memory',
+                args    : {prompt: secret},
+                success : true,
+                t0      : Date.now()
+            })).not.toThrow();
+
+            expect(MemoryCoreRecorderService.getMemoryCoreToolMetrics()).toMatchObject({
+                status    : 'unavailable',
+                totalCalls: 0,
+                tools     : []
+            });
+        } finally {
+            MemoryCoreRecorderService.db = originalDb;
+        }
+    });
+});


### PR DESCRIPTION
Resolves #13506

Adds best-effort redacted telemetry for Memory Core MCP tool calls: a new recorder service persists bounded operational metadata, Memory Core dispatch records success/failure timing, policy and health-gate rejects are captured before response formatting, and a new on-demand `get_memory_core_tool_metrics` tool exposes per-tool aggregates without raw Memory Core payloads.

Evidence: L2 (focused Playwright unit coverage for recorder schema/redaction/fallback, MCP wrapper success/failure, BaseServer hook propagation, Memory Core server health/policy hooks, plus OpenAPI YAML parse) -> L2 required by #13506 ACs. No residuals.

## Deltas from ticket

- Implemented the aggregate surface as the MCP tool `get_memory_core_tool_metrics`.
- Added config leaves under `toolTelemetry`: `enabled`, `errorMaxChars`, `aggregateWindowMs`, and `aggregateLimit`.
- Added env vars: `NEO_MC_TOOL_TELEMETRY_ENABLED`, `NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS`, `NEO_MC_TOOL_TELEMETRY_WINDOW_MS`, and `NEO_MC_TOOL_TELEMETRY_LIMIT`.
- Env-var policy: new leaves only; no rename, no fallback chain, no deprecation alias.
- Config-template follow-up: active clones with gitignored local `ai/mcp/server/memory-core/config.mjs` should run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` after merge. The local config file is intentionally not committed.
- Runtime follow-up: restart/reconnect Memory Core MCP servers or harnesses after merge so the new config shape and OpenAPI tool schema are live.
- Documentation scope: updated the Memory Core API monitoring section from future tense to the implemented redacted telemetry contract. This is ordinary tooling documentation, not turn-loaded or skill-loaded instruction substrate.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs` -> 6 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs` -> 50 passed.
- `git diff --check` -> passed.
- `node -e "import('fs').then(fs=>import('js-yaml').then(yaml=>{yaml.load(fs.readFileSync('ai/mcp/server/memory-core/openapi.yaml','utf8')); console.log('memory-core openapi yaml ok')}))"` -> `memory-core openapi yaml ok`.
- Commit hook evidence: `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, and `check-ticket-archaeology` all passed during commit.

## Post-Merge Validation

- [ ] Run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` in active clones with local Memory Core config files.
- [ ] Restart/reconnect active Memory Core MCP server processes or harnesses.
- [ ] Call `get_memory_core_tool_metrics` after a few Memory Core tool calls and confirm `status: ok` with aggregate rows and no raw prompt/message payloads.

## Commit

- `da3f3ce3a` - `feat(memory-core): add MCP tool telemetry (#13506)`

Authored by Euclid (GPT-5, Codex Desktop). Session c3a6e312-b858-4be4-ad97-9bc55cbad5ae.
