### PR TITLE
feat(ai): cap MCP log retention by size (#13508)

### DIFF
--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -236,15 +236,16 @@ class Config extends ConfigProvider {
              * @summary Retention policy for Knowledge Base MCP diagnostic log files.
              *
              * The shared logger applies this policy only to files matching the `kb-server`
-             * prefix in `logPath`. `maxFiles` counts historical files; the active current-day
-             * file is always preserved. Set `enabled=false` to delegate retention entirely to
-             * deployment infrastructure.
+             * prefix in `logPath`. `maxFiles` and `maxTotalBytes` count historical files;
+             * the active current-day file is always preserved. Set `enabled=false` to
+             * delegate retention entirely to deployment infrastructure.
              * @type {Object}
              */
             loggerRetention: {
-                enabled   : leaf(true, 'NEO_KB_LOG_RETENTION_ENABLED', 'boolean'),
-                maxAgeDays: leaf(14, 'NEO_KB_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
-                maxFiles  : leaf(30, 'NEO_KB_LOG_RETENTION_MAX_FILES', 'number')
+                enabled      : leaf(true, 'NEO_KB_LOG_RETENTION_ENABLED', 'boolean'),
+                maxAgeDays   : leaf(14, 'NEO_KB_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
+                maxFiles     : leaf(30, 'NEO_KB_LOG_RETENTION_MAX_FILES', 'number'),
+                maxTotalBytes: leaf(100 * 1024 * 1024, 'NEO_KB_LOG_RETENTION_MAX_TOTAL_BYTES', 'number')
             },
             /**
              * @summary Shared MCP logger policy for Knowledge Base.

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -440,15 +440,16 @@ class Config extends ConfigProvider {
              * @summary Retention policy for Memory Core MCP diagnostic log files.
              *
              * The shared logger applies this policy only to files matching the `mc-server`
-             * prefix in `logPath`. `maxFiles` counts historical files; the active current-day
-             * file is always preserved. Set `enabled=false` to delegate retention entirely to
-             * deployment infrastructure.
+             * prefix in `logPath`. `maxFiles` and `maxTotalBytes` count historical files;
+             * the active current-day file is always preserved. Set `enabled=false` to
+             * delegate retention entirely to deployment infrastructure.
              * @type {Object}
              */
             loggerRetention: {
-                enabled   : leaf(true, 'NEO_MEMORY_LOG_RETENTION_ENABLED', 'boolean'),
-                maxAgeDays: leaf(14, 'NEO_MEMORY_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
-                maxFiles  : leaf(30, 'NEO_MEMORY_LOG_RETENTION_MAX_FILES', 'number')
+                enabled      : leaf(true, 'NEO_MEMORY_LOG_RETENTION_ENABLED', 'boolean'),
+                maxAgeDays   : leaf(14, 'NEO_MEMORY_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
+                maxFiles     : leaf(30, 'NEO_MEMORY_LOG_RETENTION_MAX_FILES', 'number'),
+                maxTotalBytes: leaf(100 * 1024 * 1024, 'NEO_MEMORY_LOG_RETENTION_MAX_TOTAL_BYTES', 'number')
             },
             /**
              * @summary Shared MCP logger policy for Memory Core.

--- a/ai/mcp/server/neural-link/config.template.mjs
+++ b/ai/mcp/server/neural-link/config.template.mjs
@@ -80,15 +80,16 @@ class Config extends ConfigProvider {
              * @summary Retention policy for Neural Link MCP diagnostic log files.
              *
              * The shared logger applies this policy only to files matching the `nl-server`
-             * prefix in `logPath`. `maxFiles` counts historical files; the active current-day
-             * file is always preserved. Set `enabled=false` to delegate retention entirely to
-             * deployment infrastructure.
+             * prefix in `logPath`. `maxFiles` and `maxTotalBytes` count historical files;
+             * the active current-day file is always preserved. Set `enabled=false` to
+             * delegate retention entirely to deployment infrastructure.
              * @type {Object}
              */
             loggerRetention: {
-                enabled   : leaf(true, 'NEO_NL_LOG_RETENTION_ENABLED', 'boolean'),
-                maxAgeDays: leaf(14, 'NEO_NL_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
-                maxFiles  : leaf(30, 'NEO_NL_LOG_RETENTION_MAX_FILES', 'number')
+                enabled      : leaf(true, 'NEO_NL_LOG_RETENTION_ENABLED', 'boolean'),
+                maxAgeDays   : leaf(14, 'NEO_NL_LOG_RETENTION_MAX_AGE_DAYS', 'number'),
+                maxFiles     : leaf(30, 'NEO_NL_LOG_RETENTION_MAX_FILES', 'number'),
+                maxTotalBytes: leaf(100 * 1024 * 1024, 'NEO_NL_LOG_RETENTION_MAX_TOTAL_BYTES', 'number')
             },
             /**
              * @summary Shared MCP logger policy for Neural Link.

--- a/ai/mcp/server/shared/logger.mjs
+++ b/ai/mcp/server/shared/logger.mjs
@@ -58,17 +58,29 @@ const normalizeRetentionNumber = (value, integer = false) => {
 };
 
 /**
+ * @summary Normalizes a positive finite byte budget; invalid values disable that dimension.
+ * @param {*} value
+ * @returns {Number|null}
+ */
+const normalizeRetentionByteSize = value => {
+    const normalized = normalizeRetentionNumber(value, true);
+
+    return normalized > 0 ? normalized : null;
+};
+
+/**
  * @summary Resolves the durable MCP file-log retention policy from config.
  *
  * The shared logger reads the Provider-owned `loggerRetention` namespace used by MCP
  * server config templates first, then `logger.retention` for direct test/fallback configs.
  * Invalid numeric values degrade to a disabled dimension instead of crashing the server.
  *
- * `maxFiles` caps historical matching files; the active current-day file is always kept.
+ * `maxFiles` and `maxTotalBytes` cap historical matching files; the active current-day
+ * file is always kept.
  *
  * @param {Object} aiConfig
  * @param {Object} loggerConfig
- * @returns {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null)}}
+ * @returns {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null),maxTotalBytes:(Number|null)}}
  */
 export const resolveLoggerRetention = (aiConfig, loggerConfig = {}) => {
     const data   = getConfigData(aiConfig);
@@ -76,16 +88,18 @@ export const resolveLoggerRetention = (aiConfig, loggerConfig = {}) => {
 
     if (policy.enabled === false) {
         return {
-            enabled   : false,
-            maxAgeDays: null,
-            maxFiles  : null
+            enabled      : false,
+            maxAgeDays   : null,
+            maxFiles     : null,
+            maxTotalBytes: null
         };
     }
 
     return {
-        enabled   : true,
-        maxAgeDays: normalizeRetentionNumber(policy.maxAgeDays),
-        maxFiles  : normalizeRetentionNumber(policy.maxFiles, true)
+        enabled      : true,
+        maxAgeDays   : normalizeRetentionNumber(policy.maxAgeDays),
+        maxFiles     : normalizeRetentionNumber(policy.maxFiles, true),
+        maxTotalBytes: normalizeRetentionByteSize(policy.maxTotalBytes)
     };
 };
 
@@ -152,14 +166,18 @@ const warnRetentionFailure = (error, loggerConfig) => {
  * @param {String} options.logDir
  * @param {String} options.filePrefix
  * @param {String} options.today
+ * @param {Boolean} [options.includeSize=false]
  * @param {Function} [options.readDir]
- * @returns {Array<{name:String,filePath:String,date:String,time:Number}>}
+ * @param {Function} [options.statFile]
+ * @returns {Array<{name:String,filePath:String,date:String,time:Number,size:(Number|undefined)}>}
  */
 export const listHistoricalLogFiles = ({
     logDir,
     filePrefix,
     today,
-    readDir = fs.readdirSync
+    includeSize = false,
+    readDir = fs.readdirSync,
+    statFile = fs.statSync
 }) => {
     const escapedPrefix = filePrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const matcher       = new RegExp(`^${escapedPrefix}-(\\d{4}-\\d{2}-\\d{2})\\.log$`);
@@ -173,11 +191,14 @@ export const listHistoricalLogFiles = ({
                 return null;
             }
 
+            const filePath = path.join(logDir, entry.name);
+
             return {
                 name    : entry.name,
-                filePath: path.join(logDir, entry.name),
+                filePath,
                 date    : match[1],
-                time    : Date.parse(`${match[1]}T00:00:00.000Z`)
+                time    : Date.parse(`${match[1]}T00:00:00.000Z`),
+                size    : includeSize ? statFile(filePath).size : undefined
             };
         })
         .filter(Boolean)
@@ -187,13 +208,14 @@ export const listHistoricalLogFiles = ({
 /**
  * @summary Selects matching historical MCP log files that exceed the retention policy.
  * @param {Object} options
- * @param {Array<{filePath:String,date:String,time:Number}>} options.files
- * @param {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null)}} options.retention
+ * @param {Array<{filePath:String,date:String,time:Number,size:(Number|undefined)}>} options.files
+ * @param {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null),maxTotalBytes:(Number|null)}} options.retention
  * @param {String} options.today
- * @returns {Array<{filePath:String,date:String,time:Number}>}
+ * @returns {Array<{filePath:String,date:String,time:Number,size:(Number|undefined)}>}
  */
 export const selectPrunableLogFiles = ({files, retention, today}) => {
-    if (!retention?.enabled || (retention.maxAgeDays == null && retention.maxFiles == null)) {
+    if (!retention?.enabled ||
+        (retention.maxAgeDays == null && retention.maxFiles == null && retention.maxTotalBytes == null)) {
         return [];
     }
 
@@ -217,6 +239,22 @@ export const selectPrunableLogFiles = ({files, retention, today}) => {
             .forEach(file => prunable.add(file.filePath));
     }
 
+    if (Number.isFinite(retention.maxTotalBytes)) {
+        let retainedBytes = 0;
+
+        [...files]
+            .sort((a, b) => b.time - a.time || b.filePath.localeCompare(a.filePath))
+            .forEach(file => {
+                const size = Number.isFinite(file.size) ? file.size : 0;
+
+                retainedBytes += size;
+
+                if (retainedBytes > retention.maxTotalBytes) {
+                    prunable.add(file.filePath);
+                }
+            });
+    }
+
     return files.filter(file => prunable.has(file.filePath));
 };
 
@@ -230,9 +268,10 @@ export const selectPrunableLogFiles = ({files, retention, today}) => {
  * @param {String} options.logDir
  * @param {String} options.filePrefix
  * @param {String} options.today
- * @param {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null)}} options.retention
+ * @param {{enabled:Boolean,maxAgeDays:(Number|null),maxFiles:(Number|null),maxTotalBytes:(Number|null)}} options.retention
  * @param {Object} options.loggerConfig
  * @param {Function} [options.readDir]
+ * @param {Function} [options.statFile]
  * @param {Function} [options.unlinkFile]
  * @param {Function} [options.warn]
  * @returns {Number}
@@ -244,15 +283,24 @@ export const pruneLoggerRetention = ({
     retention,
     loggerConfig,
     readDir = fs.readdirSync,
+    statFile = fs.statSync,
     unlinkFile = fs.unlinkSync,
     warn = warnRetentionFailure
 }) => {
-    if (!retention?.enabled || (retention.maxAgeDays == null && retention.maxFiles == null)) {
+    if (!retention?.enabled ||
+        (retention.maxAgeDays == null && retention.maxFiles == null && retention.maxTotalBytes == null)) {
         return 0;
     }
 
     try {
-        const files = listHistoricalLogFiles({logDir, filePrefix, today, readDir});
+        const files = listHistoricalLogFiles({
+            logDir,
+            filePrefix,
+            today,
+            readDir,
+            statFile,
+            includeSize: Number.isFinite(retention.maxTotalBytes)
+        });
         const prune = selectPrunableLogFiles({files, retention, today});
 
         prune.forEach(file => unlinkFile(file.filePath));

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -269,6 +269,7 @@ test.describe('Tier 1 Config Immutability', () => {
             expect(source).toContain(`${envPrefix}_ENABLED`);
             expect(source).toContain(`${envPrefix}_MAX_AGE_DAYS`);
             expect(source).toContain(`${envPrefix}_MAX_FILES`);
+            expect(source).toContain(`${envPrefix}_MAX_TOTAL_BYTES`);
         }
     });
 });

--- a/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs
@@ -238,29 +238,98 @@ test.describe('Neo.ai.mcp.server.shared.Logger', () => {
 
         expect(resolveLoggerRetention({
             loggerRetention: {
-                enabled   : false,
-                maxAgeDays: 0,
-                maxFiles  : 0
+                enabled      : false,
+                maxAgeDays   : 0,
+                maxFiles     : 0,
+                maxTotalBytes: 1
             }
         })).toEqual({
-            enabled   : false,
-            maxAgeDays: null,
-            maxFiles  : null
+            enabled      : false,
+            maxAgeDays   : null,
+            maxFiles     : null,
+            maxTotalBytes: null
         });
 
         const invalid = resolveLoggerRetention({
             loggerRetention: {
-                maxAgeDays: -1,
-                maxFiles  : 'many'
+                maxAgeDays   : -1,
+                maxFiles     : 'many',
+                maxTotalBytes: 0
             }
         });
 
         expect(invalid).toEqual({
-            enabled   : true,
-            maxAgeDays: null,
-            maxFiles  : null
+            enabled      : true,
+            maxAgeDays   : null,
+            maxFiles     : null,
+            maxTotalBytes: null
         });
         expect(selectPrunableLogFiles({files, retention: invalid, today})).toEqual([]);
+    });
+
+    test('prunes oldest historical files until the byte budget is satisfied', () => {
+        const today = '2026-06-18';
+        const files = [{
+            filePath: '/tmp/shared-test-2026-06-17.log',
+            date    : '2026-06-17',
+            time    : Date.parse('2026-06-17T00:00:00.000Z'),
+            size    : 40
+        }, {
+            filePath: '/tmp/shared-test-2026-06-16.log',
+            date    : '2026-06-16',
+            time    : Date.parse('2026-06-16T00:00:00.000Z'),
+            size    : 50
+        }, {
+            filePath: '/tmp/shared-test-2026-06-15.log',
+            date    : '2026-06-15',
+            time    : Date.parse('2026-06-15T00:00:00.000Z'),
+            size    : 60
+        }];
+
+        expect(selectPrunableLogFiles({
+            files,
+            today,
+            retention: {
+                enabled      : true,
+                maxAgeDays   : null,
+                maxFiles     : null,
+                maxTotalBytes: 90
+            }
+        }).map(file => file.filePath)).toEqual([
+            '/tmp/shared-test-2026-06-15.log'
+        ]);
+    });
+
+    test('applies byte-budget retention to matching historical files only', () => {
+        const unlinked = [];
+
+        const count = pruneLoggerRetention({
+            logDir      : '/tmp',
+            filePrefix  : 'shared-test',
+            today       : '2026-06-18',
+            retention   : {enabled: true, maxAgeDays: null, maxFiles: null, maxTotalBytes: 90},
+            loggerConfig: {filePrefix: 'shared-test', timestampStyle: 'plain'},
+            readDir     : () => [{
+                isFile: () => true,
+                name  : 'shared-test-2026-06-18.log'
+            }, {
+                isFile: () => true,
+                name  : 'shared-test-2026-06-17.log'
+            }, {
+                isFile: () => true,
+                name  : 'shared-test-2026-06-16.log'
+            }, {
+                isFile: () => true,
+                name  : 'other-test-2026-06-15.log'
+            }],
+            statFile: filePath => ({
+                size: filePath.includes('2026-06-17') ? 70 : 60
+            }),
+            unlinkFile: filePath => unlinked.push(filePath)
+        });
+
+        expect(count).toBe(1);
+        expect(unlinked).toEqual(['/tmp/shared-test-2026-06-16.log']);
     });
 
     test('turns retention prune failures into bounded warnings', () => {
@@ -269,12 +338,15 @@ test.describe('Neo.ai.mcp.server.shared.Logger', () => {
             logDir      : '/tmp',
             filePrefix  : 'shared-test',
             today       : '2026-06-18',
-            retention   : {enabled: true, maxAgeDays: 0, maxFiles: null},
+            retention   : {enabled: true, maxAgeDays: 0, maxFiles: null, maxTotalBytes: null},
             loggerConfig: {filePrefix: 'shared-test', timestampStyle: 'plain'},
             readDir     : () => [{
                 isFile: () => true,
                 name  : 'shared-test-2026-06-17.log'
             }],
+            statFile: () => {
+                throw new Error('stat should not run without byte-budget retention');
+            },
             unlinkFile: () => {
                 throw new Error('blocked unlink');
             },


### PR DESCRIPTION
Resolves #13508

Adds a provider-owned size-budget dimension to MCP file-log retention. The shared logger still keeps the active current-day file, still applies age/count pruning, and now prunes oldest historical files for a prefix when `loggerRetention.maxTotalBytes` is exceeded.

Evidence: L2 (focused Playwright unit coverage + config-template lint + staged-file hooks) -> L2 required (shared logger/config contract). No residuals.

## Deltas from ticket

The implementation avoids a stat regression: historical file sizes are read only when `maxTotalBytes` is active, so age/count-only pruning does not gain a new `statSync` dependency.

Default size budget is provider-owned only:

- `NEO_MEMORY_LOG_RETENTION_MAX_TOTAL_BYTES`
- `NEO_KB_LOG_RETENTION_MAX_TOTAL_BYTES`
- `NEO_NL_LOG_RETENTION_MAX_TOTAL_BYTES`

Each template leaf defaults to `100 * 1024 * 1024`. No module-level retention default constant was introduced.

## MCP Config Template Sync

Changed config key:

- `loggerRetention.maxTotalBytes`

Affected templates:

- `ai/mcp/server/memory-core/config.template.mjs`
- `ai/mcp/server/knowledge-base/config.template.mjs`
- `ai/mcp/server/neural-link/config.template.mjs`

Existing clones with gitignored local `config.mjs` overlays should run `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` after merge to add the new local key. Until that happens, the new size cap stays disabled for that clone and existing age/count retention continues to work.

Harness/MCP restart is recommended after the local config migration so long-running MCP processes reload the updated retention shape.

## Test Evidence

- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/shared/logger.spec.mjs test/playwright/unit/ai/config.template.spec.mjs` -> 16 passed
- `npm run ai:lint-config-template-ssot` -> OK
- `npm run ai:lint-mcp-test-locations` -> OK
- `git diff --cached --check`
- Commit hook suite -> whitespace, shorthand, AiConfig mutation, JSDoc type, and ticket archaeology checks passed

## Post-Merge Validation

- [ ] Refresh active clone overlays with `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config`.
- [ ] Restart long-running MCP/harness processes that should enforce the size cap.

## Commit

- `6597b50ce` — `feat(ai): cap MCP log retention by size (#13508)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ed42c-f8fc-7e01-a1a1-a8b5bbf58b64.
