### PR TITLE
fix(wake): instance-address-aware route disambiguation (#13510)

### DIFF
--- a/ai/daemons/wake/queries.mjs
+++ b/ai/daemons/wake/queries.mjs
@@ -183,7 +183,11 @@ export function isHarnessPresenceFresh(presence, {
  * active row survives an MCP restart, dispatching every row wakes the same agent multiple times
  * for the same mailbox event. This defense-in-depth guard mirrors the Memory Core
  * `subscribe` idempotency contract: one active route per `(agentIdentity, trigger, filters,
- * appName)` tuple, with the newest updated/created row winning when legacy duplicates exist.
+ * appName, adapter, addressType, instanceAddress, userDataDir)` tuple. The instance-address
+ * fields are load-bearing: two routes that share an app (e.g. multiple Claude instances) but
+ * target different instances MUST stay distinct, or a wake for one named peer can collapse onto
+ * another's route and deliver to the wrong instance. The newest updated/created row wins when
+ * genuine duplicates (same tuple) exist.
  *
  * @param {Object[]} subscriptions Parsed WAKE_SUBSCRIPTION graph nodes.
  * @returns {Object[]} Deduplicated subscriptions for wake delivery.
@@ -213,7 +217,11 @@ function buildShapeCRouteKey(subscription) {
         filters      : props.filters || {},
         harnessTarget: props.harnessTarget,
         routeMetadata: {
-            appName: metadata.appName || null
+            appName        : metadata.appName || null,
+            adapter        : metadata.adapter || null,
+            addressType    : metadata.addressType || null,
+            instanceAddress: metadata.instanceAddress || null,
+            userDataDir    : metadata.userDataDir || null
         }
     });
 }

--- a/ai/scripts/migrations/migrateWakeSubscriptions.mjs
+++ b/ai/scripts/migrations/migrateWakeSubscriptions.mjs
@@ -25,10 +25,11 @@ const __dirname  = path.dirname(__filename);
 const neoRoot    = path.resolve(__dirname, '../..');
 
 function parseArgs(argv) {
-    const args = {apply: false, db: null, help: false};
+    const args = {apply: false, audit: false, db: null, help: false};
     for (let i = 2; i < argv.length; i++) {
         const a = argv[i];
         if (a === '--apply')       args.apply = true;
+        else if (a === '--audit')  args.audit = true;
         else if (a === '--help')   args.help = true;
         else if (a === '--db')     args.db = argv[++i];
         else {
@@ -46,6 +47,7 @@ Usage: node ai/scripts/migrations/migrateWakeSubscriptions.mjs [options]
 Options:
   (no flags)     Dry-run mode — print the migration plan without committing
   --apply        Commit the migration atomically in a single transaction
+  --audit        Read-only audit — report instance-addressing-unsafe wake routes (no changes)
   --db <path>    Override SQLite file path (default: .neo-ai-data/sqlite/memory-core-graph.sqlite)
   --help         Print this usage message
 `);
@@ -165,6 +167,92 @@ export function runMigration(db, apply) {
     return stats;
 }
 
+/**
+ * @summary Resolve a wake route's effective instance address, mirroring
+ * `WakeSubscriptionService._resolvePresenceAddress` / the wake daemon's resolver: an explicit
+ * `addressType` wins, else a legacy `userDataDir` field implies the `userDataDir` type; the address
+ * comes from `instanceAddress`, falling back to `userDataDir` for that type.
+ * @param {Object} [meta] harnessTargetMetadata.
+ * @returns {{addressType: (String|null), instanceAddress: (String|null)}}
+ */
+export function resolveRouteAddress(meta = {}) {
+    const addressType     = meta.addressType || (meta.userDataDir ? 'userDataDir' : null),
+          instanceAddress = meta.instanceAddress || (addressType === 'userDataDir' ? meta.userDataDir : null);
+
+    return {addressType: addressType || null, instanceAddress: instanceAddress || null};
+}
+
+/**
+ * @summary Read-only audit surfacing bridge-daemon wake routes that are unsafe under same-app
+ * multi-instance addressing. Two categories:
+ *
+ * - `emptyAddress`: an `addressType` (or legacy `userDataDir`) is present but resolves to NO
+ *   instance address. The wake daemon fails closed on these at delivery, so the owning peer
+ *   silently misses every wake — a liveness hole (not a cross-leak).
+ * - `genericNamedPeer`: a first-party named identity (in `identityRoots`) on an `appName`-only
+ *   route with no resolvable instance address. Once more than one instance of that app runs, a
+ *   generic route is ambiguous — verify it's the deliberate default instance or assign an address.
+ *
+ * Pairs with the registration-time guard (`WakeSubscriptionService.validateHarnessTargetMetadata`),
+ * which blocks NEW unsafe rows; this audit surfaces pre-existing ones for cleanup.
+ *
+ * @param {Object} db Open better-sqlite3 connection.
+ * @returns {{emptyAddress: Object[], genericNamedPeer: Object[], scanned: Number}}
+ */
+export function auditWakeRoutes(db) {
+    const namedIds         = new Set(IDENTITIES.map(identity => identity.id)),
+          subs             = db.prepare(`SELECT id, data FROM Nodes WHERE json_extract(data, '$.label') = ?`).all('WAKE_SUBSCRIPTION'),
+          emptyAddress     = [],
+          genericNamedPeer = [];
+
+    let scanned = 0;
+
+    for (const sub of subs) {
+        let data;
+        try {
+            data = JSON.parse(sub.data);
+        } catch (e) {
+            continue;
+        }
+
+        const props = data.properties || {};
+        if (props.harnessTarget !== 'bridge-daemon') continue;
+        scanned++;
+
+        const meta = props.harnessTargetMetadata || {},
+              {addressType, instanceAddress} = resolveRouteAddress(meta);
+
+        if (addressType && !instanceAddress) {
+            emptyAddress.push({id: sub.id, agentIdentity: props.agentIdentity || null, addressType, appName: meta.appName || null});
+        } else if (!addressType && meta.appName && namedIds.has(props.agentIdentity)) {
+            genericNamedPeer.push({id: sub.id, agentIdentity: props.agentIdentity, appName: meta.appName});
+        }
+    }
+
+    return {emptyAddress, genericNamedPeer, scanned};
+}
+
+/**
+ * @summary Print an {@link auditWakeRoutes} result to stdout.
+ * @param {{emptyAddress: Object[], genericNamedPeer: Object[], scanned: Number}} audit
+ * @returns {void}
+ */
+function reportAudit({emptyAddress, genericNamedPeer, scanned}) {
+    console.log(`[migrateWakeSubscriptions] AUDIT — scanned ${scanned} bridge-daemon wake route(s)`);
+    console.log();
+    console.log(`  empty-address (addressType set, no resolvable instance address → fails closed at delivery, peer misses wakes): ${emptyAddress.length}`);
+    for (const r of emptyAddress) {
+        console.log(`    [EMPTY]   ${r.id}  owner=${r.agentIdentity}  addressType=${r.addressType}  app=${r.appName}`);
+    }
+    console.log();
+    console.log(`  generic-named-peer (named identity on an appName-only route → ambiguous with multiple same-app instances; verify default instance or assign an address): ${genericNamedPeer.length}`);
+    for (const r of genericNamedPeer) {
+        console.log(`    [GENERIC] ${r.id}  owner=${r.agentIdentity}  app=${r.appName}`);
+    }
+    console.log();
+    console.log(`[migrateWakeSubscriptions] AUDIT complete (read-only; no changes).`);
+}
+
 async function main() {
     const args = parseArgs(process.argv);
     if (args.help) {
@@ -174,13 +262,18 @@ async function main() {
 
     const dbPath = args.db || path.resolve(neoRoot, '.neo-ai-data/sqlite/memory-core-graph.sqlite');
     console.log(`[migrateWakeSubscriptions] target: ${dbPath}`);
-    console.log(`[migrateWakeSubscriptions] mode:   ${args.apply ? 'APPLY' : 'DRY-RUN'}`);
+    console.log(`[migrateWakeSubscriptions] mode:   ${args.audit ? 'AUDIT (read-only)' : args.apply ? 'APPLY' : 'DRY-RUN'}`);
     console.log();
 
     const Database = (await import('better-sqlite3')).default;
     const db = new Database(dbPath, {verbose: null});
 
     try {
+        if (args.audit) {
+            reportAudit(auditWakeRoutes(db));
+            return;
+        }
+
         const stats = runMigration(db, args.apply);
 
         console.log();

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -798,12 +798,22 @@ class WakeSubscriptionService extends Base {
         if (metadata.appName && !this.validAppNames.includes(metadata.appName)) {
             throw new Error(`Invalid appName '${metadata.appName}'. Must be one of: ${this.validAppNames.join(', ')}`);
         }
-        if (metadata.instanceAddress || metadata.addressType) {
-            if (!metadata.instanceAddress || !metadata.addressType) {
-                throw new Error('Shape C generic instance addressing requires both harnessTargetMetadata.instanceAddress and harnessTargetMetadata.addressType.');
+        // Instance-addressed routes — explicit addressType/instanceAddress, or the legacy
+        // userDataDir field — must RESOLVE to a complete, non-empty address. Mirror
+        // _resolvePresenceAddress (the same resolver the wake daemon dispatches through) so a legacy
+        // userDataDir row stays valid, while an addressType that resolves to no address fails closed
+        // at registration. A route that can never target an instance is the same-app cross-leak /
+        // silent-miss hazard — worse than no route at all.
+        if (metadata.instanceAddress || metadata.addressType || metadata.userDataDir) {
+            const {instanceAddress, addressType} = this._resolvePresenceAddress(metadata);
+            if (!addressType) {
+                throw new Error('Shape C instance addressing requires harnessTargetMetadata.addressType (or a legacy userDataDir).');
             }
-            if (!this.validAddressTypes.includes(metadata.addressType)) {
-                throw new Error(`Invalid addressType '${metadata.addressType}'. Must be one of: ${this.validAddressTypes.join(', ')}`);
+            if (!this.validAddressTypes.includes(addressType)) {
+                throw new Error(`Invalid addressType '${addressType}'. Must be one of: ${this.validAddressTypes.join(', ')}`);
+            }
+            if (!instanceAddress) {
+                throw new Error(`Shape C addressType '${addressType}' requires a non-empty instance address (harnessTargetMetadata.instanceAddress, or a non-empty userDataDir for the userDataDir type).`);
             }
         }
     }

--- a/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/queries.spec.mjs
@@ -3,7 +3,7 @@ import Database from 'better-sqlite3';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-import { getLastSyncId, getUnreadSunsetHandovers, markNodesAsRead, writeLastSyncId } from '../../../../../../ai/daemons/wake/queries.mjs';
+import { collapseDuplicateShapeCRoutes, getLastSyncId, getUnreadSunsetHandovers, markNodesAsRead, writeLastSyncId } from '../../../../../../ai/daemons/wake/queries.mjs';
 
 test.describe('ai/daemons/wake/queries', () => {
     let db;
@@ -205,6 +205,57 @@ test.describe('ai/daemons/wake/queries', () => {
                 expect(fs.readFileSync(stateFile, 'utf8')).toBe('2');
                 expect(fs.existsSync(`${stateFile}.tmp`)).toBe(false);
             });
+        });
+    });
+
+    test.describe('collapseDuplicateShapeCRoutes (instance-address aware)', () => {
+        // A same-app route (appName) is NOT a stable identity address once multiple named peers
+        // run the same app (e.g. several Claude instances). The collapse key must therefore include
+        // the instance-address fields, or a wake for one named peer collapses onto another's route
+        // and delivers to the wrong instance.
+        const makeSub = (id, metadata, updatedAt = '2026-01-01T00:00:00.000Z') => ({
+            id,
+            properties: {
+                agentIdentity        : '@neo-opus-ada',
+                trigger              : 'SENT_TO_ME',
+                filters              : {},
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: metadata,
+                updatedAt
+            }
+        });
+
+        test('keeps two same-app routes that target different instances distinct', () => {
+            const result = collapseDuplicateShapeCRoutes([
+                makeSub('sub-ada',  {appName: 'Claude', addressType: 'userDataDir', instanceAddress: '/Users/x/.claude-ada'}),
+                makeSub('sub-vega', {appName: 'Claude', addressType: 'userDataDir', instanceAddress: '/Users/x/.claude-vega'})
+            ]);
+            expect(result.length).toBe(2);
+        });
+
+        test('keeps a generic same-app route distinct from an instance-addressed one', () => {
+            const result = collapseDuplicateShapeCRoutes([
+                makeSub('sub-generic',  {appName: 'Claude'}),
+                makeSub('sub-addressed', {appName: 'Claude', addressType: 'userDataDir', instanceAddress: '/Users/x/.claude-vega'})
+            ]);
+            expect(result.length).toBe(2);
+        });
+
+        test('does not collapse a legacy userDataDir route onto a different instanceAddress route', () => {
+            const result = collapseDuplicateShapeCRoutes([
+                makeSub('sub-legacy',    {appName: 'Claude', userDataDir: '/Users/x/.claude-ada'}),
+                makeSub('sub-canonical', {appName: 'Claude', addressType: 'userDataDir', instanceAddress: '/Users/x/.claude-vega'})
+            ]);
+            expect(result.length).toBe(2);
+        });
+
+        test('still collapses genuine duplicates (identical route tuple), newest wins', () => {
+            const result = collapseDuplicateShapeCRoutes([
+                makeSub('sub-old', {appName: 'Claude', addressType: 'userDataDir', instanceAddress: '/Users/x/.claude-ada'}, '2026-01-01T00:00:00.000Z'),
+                makeSub('sub-new', {appName: 'Claude', addressType: 'userDataDir', instanceAddress: '/Users/x/.claude-ada'}, '2026-02-01T00:00:00.000Z')
+            ]);
+            expect(result.length).toBe(1);
+            expect(result[0].id).toBe('sub-new');
         });
     });
 });

--- a/test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/migrateWakeSubscriptions.spec.mjs
@@ -17,7 +17,7 @@ import {test, expect} from '@playwright/test';
 import Database       from 'better-sqlite3';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
-import {runMigration} from '../../../../../../ai/scripts/migrations/migrateWakeSubscriptions.mjs';
+import {auditWakeRoutes, runMigration} from '../../../../../../ai/scripts/migrations/migrateWakeSubscriptions.mjs';
 
 /**
  * @summary Creates the minimal SQLite graph schema used by the wake-subscription migration.
@@ -148,6 +148,70 @@ test.describe('ai/scripts/migrations/migrateWakeSubscriptions', () => {
         expect(stats.subscriptionsPatched).toBe(1);
         expect(unchanged.properties.harnessTargetMetadata).toEqual({
             appName: 'Codex'
+        });
+    });
+
+    test.describe('auditWakeRoutes (read-only #13481 audit)', () => {
+        const insertSub = (db, id, agentIdentity, harnessTargetMetadata) => insertNode(db, {
+            id,
+            data: {
+                id,
+                label     : 'WAKE_SUBSCRIPTION',
+                properties: {agentIdentity, trigger: 'SENT_TO_ME', harnessTarget: 'bridge-daemon', harnessTargetMetadata, status: 'active'}
+            }
+        });
+
+        test('flags an addressType route that resolves to no instance address (empty-address)', () => {
+            const db = new Database(':memory:');
+            createGraphSchema(db);
+            insertSub(db, 'WAKE_SUB:empty', '@neo-opus-ada', {appName: 'Claude', addressType: 'userDataDir', userDataDir: ''});
+
+            const audit = auditWakeRoutes(db);
+            expect(audit.emptyAddress.length).toBe(1);
+            expect(audit.emptyAddress[0].id).toBe('WAKE_SUB:empty');
+            expect(audit.genericNamedPeer.length).toBe(0);
+        });
+
+        test('flags a named peer on an appName-only generic route', () => {
+            const db = new Database(':memory:');
+            createGraphSchema(db);
+            insertSub(db, 'WAKE_SUB:generic', '@neo-opus-ada', {appName: 'Claude'});
+
+            const audit = auditWakeRoutes(db);
+            expect(audit.genericNamedPeer.length).toBe(1);
+            expect(audit.genericNamedPeer[0].agentIdentity).toBe('@neo-opus-ada');
+            expect(audit.emptyAddress.length).toBe(0);
+        });
+
+        test('does not flag an instance-addressed route', () => {
+            const db = new Database(':memory:');
+            createGraphSchema(db);
+            insertSub(db, 'WAKE_SUB:safe', '@neo-opus-ada', {appName: 'Claude', addressType: 'userDataDir', instanceAddress: '/Users/x/.claude-ada'});
+
+            const audit = auditWakeRoutes(db);
+            expect(audit.emptyAddress.length).toBe(0);
+            expect(audit.genericNamedPeer.length).toBe(0);
+            expect(audit.scanned).toBe(1);
+        });
+
+        test('does not flag a generic route owned by a non-roster identity', () => {
+            const db = new Database(':memory:');
+            createGraphSchema(db);
+            insertSub(db, 'WAKE_SUB:alice', '@alice', {appName: 'Claude'});
+
+            const audit = auditWakeRoutes(db);
+            expect(audit.genericNamedPeer.length).toBe(0);
+            expect(audit.emptyAddress.length).toBe(0);
+        });
+
+        test('treats a legacy userDataDir field as a resolvable address (not flagged)', () => {
+            const db = new Database(':memory:');
+            createGraphSchema(db);
+            insertSub(db, 'WAKE_SUB:legacy', '@neo-opus-ada', {appName: 'Claude', userDataDir: '/Users/x/.claude-ada'});
+
+            const audit = auditWakeRoutes(db);
+            expect(audit.emptyAddress.length).toBe(0);
+            expect(audit.genericNamedPeer.length).toBe(0);
         });
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -724,7 +724,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                     appName: 'Antigravity',
                     instanceAddress: '4242'
                 }
-            })).rejects.toThrow('requires both harnessTargetMetadata.instanceAddress and harnessTargetMetadata.addressType');
+            })).rejects.toThrow('Shape C instance addressing requires harnessTargetMetadata.addressType');
         });
     });
 
@@ -739,6 +739,49 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                     addressType: 'frontmost'
                 }
             })).rejects.toThrow("Invalid addressType 'frontmost'. Must be one of: userDataDir, pid, tmuxSession, webhookUrl");
+        });
+    });
+
+    test('subscribe rejects an addressType that resolves to no instance address (#13481)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(WakeSubscriptionService.subscribe({
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName    : 'Claude',
+                    addressType: 'userDataDir',
+                    userDataDir: ''
+                }
+            })).rejects.toThrow("addressType 'userDataDir' requires a non-empty instance address");
+        });
+    });
+
+    test('subscribe accepts a legacy userDataDir field as a complete instance address (#13481)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@grace-13481-legacy'}, async () => {
+            const res = await WakeSubscriptionService.subscribe({
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName    : 'Claude',
+                    userDataDir: '/Users/x/.claude-grace'
+                }
+            });
+            expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
+        });
+    });
+
+    test('subscribe accepts a canonical instanceAddress + addressType pair (#13481)', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@grace-13481-canonical'}, async () => {
+            const res = await WakeSubscriptionService.subscribe({
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
+                harnessTargetMetadata: {
+                    appName        : 'Claude',
+                    addressType    : 'userDataDir',
+                    instanceAddress: '/Users/x/.claude-grace'
+                }
+            });
+            expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
         });
     });
 


### PR DESCRIPTION
Resolves #13510
Refs #13481

Makes the Claude wake-route identity instance-address-aware so same-app routes no longer collapse onto — or deliver to — the wrong instance. Ships the **prevention + distinction + detection** layer of #13481; the parent retains the live-remediation of existing generic routes and the `defaultInstance` seed policy (identityRoots — @neo-gpt's domain).

Evidence: L1 (88 unit specs cover all #13510 ACs — validation rejection, collapse distinctness, audit categorization) → L1 required (no runtime-host AC in #13510's scope). No residuals in #13510; #13481 retains the L2 live-remediation.

## What shipped
- `WakeSubscriptionService.validateHarnessTargetMetadata` — resolver-consistent Shape C validation (`addressType` + `instanceAddress` / legacy `userDataDir`), replacing the rigid pairing check; an `addressType` route that resolves to no instance address now fails registration.
- `queries.collapseDuplicateShapeCRoutes` — collapse key now includes the instance-address fields, so two same-app routes targeting different instances stay distinct, and a generic `appName`-only route no longer collapses onto an instance-addressed one.
- `migrateWakeSubscriptions` — read-only `auditWakeRoutes()` + `--audit` CLI flag surfacing pre-existing unsafe routes (`emptyAddress`, `genericNamedPeer`) for cleanup.

## Deltas from ticket
None — #13510 was filed as the close-target for already-implemented work (the deliverable hardening slice of #13481). The implementation matches #13510's ACs exactly; the only deliberate split is the close-target itself: AC1–3 + the new-route portion of AC4 land here, while AC4 live-remediation + the `defaultInstance` policy stay with parent #13481.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs` on the 3 specs → **88 passed** (post-rebase on current dev). Covers: empty-address validation rejection, same-app distinct-instance non-collapse, legacy-userDataDir collapse, generic-vs-addressed non-collapse, audit categorization (empty / generic-named-peer / safe / non-roster).

## Post-Merge Validation
- [ ] Run `node ai/scripts/migrations/migrateWakeSubscriptions.mjs --audit` against the live Memory Core graph to enumerate pre-existing unsafe routes (the concrete input to #13481's remediation).
- [ ] Confirm a live wake-subscription registration with an `addressType` but no resolvable instance address is rejected by the MCP validation path.

## Out of scope (remains in #13481)
- Live remediation of EXISTING generic routes + any daemon fail-closed on generic-named delivery — live-impacting (changes a running peer's current route delivery), needs coordination.
- The `defaultInstance` seed policy (identityRoots — @neo-gpt's domain).

Authored by Grace (Claude Opus 4.8, Claude Code). Session 045a6048-1e1d-44c1-9738-7f09b62cc998.