### PR TITLE
feat(rem): deterministic turn-aligned session chunker (#13513)

### DIFF
--- a/ai/services/graph/sessionChunker.mjs
+++ b/ai/services/graph/sessionChunker.mjs
@@ -38,10 +38,12 @@ export function estimateTokens(text, tokensPerChar = DEFAULT_TOKENS_PER_CHAR) {
 /**
  * @summary Split turn-aligned session content into deterministic, safe-band-bounded chunks.
  *
- * **Greedy left-to-right packing:** a chunk accretes whole turns until the next turn would push it over
- * `safeProcessingLimitTokens`, then a new chunk opens. Turns are NEVER split mid-turn — boundaries are
- * turn-aligned. A single turn that alone exceeds the limit becomes its own chunk flagged `oversizedTurn: true`
- * (kept intact, not split); the integration routes those through the existing guardrail/failure path.
+ * **Greedy left-to-right packing:** a chunk accretes whole turns until the next turn would push the *emitted*
+ * (separator-joined) chunk text over `safeProcessingLimitTokens`, then a new chunk opens. Bounds are measured on
+ * the joined text — never the bare per-turn sum — so a chunk's `estimatedTokens` always equals
+ * `estimateTokens(chunk.text)` and never under-counts the `\n` join separators. Turns are NEVER split mid-turn —
+ * boundaries are turn-aligned. A single turn that alone exceeds the limit becomes its own chunk flagged
+ * `oversizedTurn: true` (kept intact, not split); the integration routes those through the guardrail/failure path.
  *
  * **Small-session fast path:** when the whole session estimates at or below the limit, a single chunk is
  * returned with `chunked: false`, so the caller preserves the current single-pass behavior unchanged.
@@ -57,13 +59,14 @@ export function estimateTokens(text, tokensPerChar = DEFAULT_TOKENS_PER_CHAR) {
  * @returns {{chunked: Boolean, totalEstimatedTokens: Number, chunks: Array<{chunkId: String, turnIndices: Number[], text: String, estimatedTokens: Number, oversizedTurn: Boolean}>}}
  */
 export function chunkSession(turns, {sessionId, safeProcessingLimitTokens, estimate = estimateTokens} = {}) {
-    const safeTurns   = Array.isArray(turns) ? turns : [],
+    const SEP         = '\n',
+          safeTurns   = Array.isArray(turns) ? turns : [],
           limit       = Number.isFinite(safeProcessingLimitTokens) && safeProcessingLimitTokens > 0 ? safeProcessingLimitTokens : Infinity,
           turnTexts   = safeTurns.map(turn => typeof turn === 'string' ? turn : ''),
-          turnTokens  = turnTexts.map(text => estimate(text)),
-          totalTokens = turnTokens.reduce((sum, t) => sum + t, 0);
+          fullText    = turnTexts.join(SEP),
+          totalTokens = estimate(fullText);
 
-    // Small-session fast path: single chunk, single-pass behavior preserved.
+    // Small-session fast path: the whole joined document fits → single-pass behavior preserved.
     if (totalTokens <= limit) {
         return {
             chunked             : false,
@@ -71,7 +74,7 @@ export function chunkSession(turns, {sessionId, safeProcessingLimitTokens, estim
             chunks              : [{
                 chunkId        : `${sessionId}:chunk:0`,
                 turnIndices    : turnTexts.map((_, index) => index),
-                text           : turnTexts.join('\n'),
+                text           : fullText,
                 estimatedTokens: totalTokens,
                 oversizedTurn  : false
             }]
@@ -79,42 +82,43 @@ export function chunkSession(turns, {sessionId, safeProcessingLimitTokens, estim
     }
 
     const chunks  = [];
-    let   current = null; // {turnIndices, parts, tokens, oversizedTurn}
+    let   current = null; // {turnIndices, parts, oversizedTurn}
 
+    // Bounds are measured on the EMITTED (separator-joined) text, so a chunk's reported estimatedTokens
+    // always equals estimate(chunk.text) and can't under-count the `\n` join separators — a per-turn-sum
+    // bound would report under-limit while the joined text estimates over.
     const flush = () => {
         if (!current) return;
+        const text = current.parts.join(SEP);
         chunks.push({
             chunkId        : `${sessionId}:chunk:${chunks.length}`,
             turnIndices    : current.turnIndices,
-            text           : current.parts.join('\n'),
-            estimatedTokens: current.tokens,
+            text,
+            estimatedTokens: estimate(text),
             oversizedTurn  : current.oversizedTurn === true
         });
         current = null;
     };
 
     turnTexts.forEach((text, index) => {
-        const tokens = turnTokens[index];
-
-        // A single turn larger than the whole limit: keep it intact as its own flagged chunk
+        // A single turn whose own text exceeds the limit: keep it intact as its own flagged chunk
         // rather than splitting mid-turn. The integration routes oversized chunks to the guardrail/failure path.
-        if (tokens > limit) {
+        if (estimate(text) > limit) {
             flush();
-            current = {turnIndices: [index], parts: [text], tokens, oversizedTurn: true};
+            current = {turnIndices: [index], parts: [text], oversizedTurn: true};
             flush();
             return;
         }
 
-        // Adding this turn would overflow the open chunk → seal it and start fresh.
-        if (current && current.tokens + tokens > limit) {
+        // Would adding this turn push the EMITTED chunk text (join separators included) over the limit? Seal and start fresh.
+        if (current && estimate(current.parts.concat(text).join(SEP)) > limit) {
             flush();
         }
         if (!current) {
-            current = {turnIndices: [], parts: [], tokens: 0, oversizedTurn: false};
+            current = {turnIndices: [], parts: [], oversizedTurn: false};
         }
         current.turnIndices.push(index);
         current.parts.push(text);
-        current.tokens += tokens;
     });
 
     flush();

--- a/ai/services/graph/sessionChunker.mjs
+++ b/ai/services/graph/sessionChunker.mjs
@@ -1,0 +1,123 @@
+/**
+ * @summary Deterministic, turn-aligned session chunker for hierarchical Tri-Vector extraction.
+ *
+ * Sub 7 of the REM-pipeline epic (Orchestrator-as-SSOT). `SemanticGraphExtractor.executeTriVectorExtraction`
+ * runs a single LLM pass over the whole `session.document`; when that payload exceeds the local model's
+ * `safeProcessingLimitTokens` band, the consumer-friction guardrail skips invocation and extraction yields
+ * `null` — large sessions are lost. This module is the **chunking primitive** that the map→reduce integration
+ * wraps: it splits a session into bounded, turn-aligned chunks so each chunk stays under the safe band.
+ *
+ * Pure by design — no I/O, no LLM round-trip, no graph mutation — so chunk boundaries are deterministic and
+ * fully unit-testable. The estimator is a coarse char-based heuristic (no model call), which keeps boundaries
+ * reproducible across runs; the integration MAY inject the guardrail's own estimator for parity.
+ *
+ * @module ai/services/graph/sessionChunker
+ */
+
+/**
+ * ~4 characters per token — the standard coarse heuristic. Deterministic by construction (no model round-trip),
+ * which is what makes chunk boundaries reproducible.
+ * @type {Number}
+ */
+const DEFAULT_TOKENS_PER_CHAR = 0.25;
+
+/**
+ * @summary Coarse, deterministic token estimate (`ceil(chars × ratio)`).
+ *
+ * Intentionally NOT a model tokenizer: a pure char-based estimate is reproducible, so two runs over the same
+ * session produce identical chunk boundaries (the determinism AC). Non-string input estimates to `0`.
+ *
+ * @param {String} text
+ * @param {Number} [tokensPerChar=0.25]
+ * @returns {Number} Estimated token count.
+ */
+export function estimateTokens(text, tokensPerChar = DEFAULT_TOKENS_PER_CHAR) {
+    return typeof text === 'string' ? Math.ceil(text.length * tokensPerChar) : 0;
+}
+
+/**
+ * @summary Split turn-aligned session content into deterministic, safe-band-bounded chunks.
+ *
+ * **Greedy left-to-right packing:** a chunk accretes whole turns until the next turn would push it over
+ * `safeProcessingLimitTokens`, then a new chunk opens. Turns are NEVER split mid-turn — boundaries are
+ * turn-aligned. A single turn that alone exceeds the limit becomes its own chunk flagged `oversizedTurn: true`
+ * (kept intact, not split); the integration routes those through the existing guardrail/failure path.
+ *
+ * **Small-session fast path:** when the whole session estimates at or below the limit, a single chunk is
+ * returned with `chunked: false`, so the caller preserves the current single-pass behavior unchanged.
+ *
+ * Chunk ids are `<sessionId>:chunk:<N>`, zero-indexed and monotonic; each chunk carries `turnIndices` for
+ * source-coverage traceability.
+ *
+ * @param {String[]} turns Turn-aligned content units (already segmented by the caller).
+ * @param {Object} options
+ * @param {String} options.sessionId Source session id — chunk ids derive from it.
+ * @param {Number} options.safeProcessingLimitTokens Per-chunk token ceiling (non-positive / non-finite → no chunking).
+ * @param {Function} [options.estimate=estimateTokens] Token estimator `(text) => Number`; injectable for guardrail parity.
+ * @returns {{chunked: Boolean, totalEstimatedTokens: Number, chunks: Array<{chunkId: String, turnIndices: Number[], text: String, estimatedTokens: Number, oversizedTurn: Boolean}>}}
+ */
+export function chunkSession(turns, {sessionId, safeProcessingLimitTokens, estimate = estimateTokens} = {}) {
+    const safeTurns   = Array.isArray(turns) ? turns : [],
+          limit       = Number.isFinite(safeProcessingLimitTokens) && safeProcessingLimitTokens > 0 ? safeProcessingLimitTokens : Infinity,
+          turnTexts   = safeTurns.map(turn => typeof turn === 'string' ? turn : ''),
+          turnTokens  = turnTexts.map(text => estimate(text)),
+          totalTokens = turnTokens.reduce((sum, t) => sum + t, 0);
+
+    // Small-session fast path: single chunk, single-pass behavior preserved.
+    if (totalTokens <= limit) {
+        return {
+            chunked             : false,
+            totalEstimatedTokens: totalTokens,
+            chunks              : [{
+                chunkId        : `${sessionId}:chunk:0`,
+                turnIndices    : turnTexts.map((_, index) => index),
+                text           : turnTexts.join('\n'),
+                estimatedTokens: totalTokens,
+                oversizedTurn  : false
+            }]
+        };
+    }
+
+    const chunks  = [];
+    let   current = null; // {turnIndices, parts, tokens, oversizedTurn}
+
+    const flush = () => {
+        if (!current) return;
+        chunks.push({
+            chunkId        : `${sessionId}:chunk:${chunks.length}`,
+            turnIndices    : current.turnIndices,
+            text           : current.parts.join('\n'),
+            estimatedTokens: current.tokens,
+            oversizedTurn  : current.oversizedTurn === true
+        });
+        current = null;
+    };
+
+    turnTexts.forEach((text, index) => {
+        const tokens = turnTokens[index];
+
+        // A single turn larger than the whole limit: keep it intact as its own flagged chunk
+        // rather than splitting mid-turn. The integration routes oversized chunks to the guardrail/failure path.
+        if (tokens > limit) {
+            flush();
+            current = {turnIndices: [index], parts: [text], tokens, oversizedTurn: true};
+            flush();
+            return;
+        }
+
+        // Adding this turn would overflow the open chunk → seal it and start fresh.
+        if (current && current.tokens + tokens > limit) {
+            flush();
+        }
+        if (!current) {
+            current = {turnIndices: [], parts: [], tokens: 0, oversizedTurn: false};
+        }
+        current.turnIndices.push(index);
+        current.parts.push(text);
+        current.tokens += tokens;
+    });
+
+    flush();
+
+    return {chunked: true, totalEstimatedTokens: totalTokens, chunks};
+}

--- a/test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs
@@ -105,4 +105,31 @@ test.describe('ai/services/graph/sessionChunker', () => {
             expect(() => chunkSession(null, {sessionId: 's', safeProcessingLimitTokens: 250})).not.toThrow();
         });
     });
+
+    test.describe('chunkSession — emitted-text boundedness (#13514 review: join separators counted)', () => {
+        test('boundary-tight input: no chunk reports under-limit while its emitted text estimates over-limit', () => {
+            // GPT falsifier: ['aaaa','aaaa'] @ limit 2 — the per-turn sum was 2 (under), but the joined
+            // text (aaaa + newline + aaaa = 9 chars) estimates 3 (over). The bound must reflect the emitted text.
+            const {chunked, chunks} = chunkSession(['aaaa', 'aaaa'], {sessionId: 's', safeProcessingLimitTokens: 2});
+
+            expect(chunked).toBe(true);
+            for (const chunk of chunks) {
+                expect(chunk.estimatedTokens).toBe(estimateTokens(chunk.text)); // reported === actual emitted-text estimate
+                expect(estimateTokens(chunk.text)).toBeLessThanOrEqual(2);      // and within the limit
+            }
+        });
+
+        test('every chunk reports estimatedTokens === estimate(text); non-oversized chunks stay within the limit', () => {
+            const turns = Array.from({length: 7}, (_, i) => `turn${i}:` + 'y'.repeat(300)); // ~77 tokens each
+            const limit = 200;
+            const {chunks} = chunkSession(turns, {sessionId: 'inv', safeProcessingLimitTokens: limit});
+
+            for (const chunk of chunks) {
+                expect(chunk.estimatedTokens).toBe(estimateTokens(chunk.text));
+                if (!chunk.oversizedTurn) {
+                    expect(chunk.estimatedTokens).toBeLessThanOrEqual(limit);
+                }
+            }
+        });
+    });
 });

--- a/test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs
@@ -1,0 +1,108 @@
+import {test, expect}              from '@playwright/test';
+import {chunkSession, estimateTokens} from '../../../../../../ai/services/graph/sessionChunker.mjs';
+
+/**
+ * Pure-function unit coverage for the deterministic session chunker (Sub 7 of the REM-pipeline epic).
+ * No Neo bootstrap — the module is a pure helper, mirroring the queries.mjs / consumerFrictionHelper pattern.
+ */
+test.describe('ai/services/graph/sessionChunker', () => {
+    // A 400-char turn estimates to 100 tokens at the 0.25 ratio; a 40-token limit forces chunking.
+    const turn  = (label, chars) => `${label}:` + 'x'.repeat(Math.max(0, chars - label.length - 1));
+    const TOKENS_PER_CHAR = 0.25;
+
+    test.describe('estimateTokens', () => {
+        test('is a deterministic char-based estimate (ceil of chars × 0.25)', () => {
+            expect(estimateTokens('')).toBe(0);
+            expect(estimateTokens('x'.repeat(400))).toBe(100);
+            expect(estimateTokens('x'.repeat(401))).toBe(101); // ceil(100.25)
+        });
+
+        test('treats non-string input as zero tokens', () => {
+            expect(estimateTokens(null)).toBe(0);
+            expect(estimateTokens(undefined)).toBe(0);
+            expect(estimateTokens(42)).toBe(0);
+        });
+    });
+
+    test.describe('chunkSession — small-session fast path (AC8: preserve single-pass)', () => {
+        test('returns a single un-chunked chunk when the session fits the limit', () => {
+            const turns  = [turn('t0', 40), turn('t1', 40)]; // ~20 tokens total
+            const result = chunkSession(turns, {sessionId: 'session:abc', safeProcessingLimitTokens: 1000});
+
+            expect(result.chunked).toBe(false);
+            expect(result.chunks.length).toBe(1);
+            expect(result.chunks[0].chunkId).toBe('session:abc:chunk:0');
+            expect(result.chunks[0].turnIndices).toEqual([0, 1]);
+            expect(result.chunks[0].oversizedTurn).toBe(false);
+        });
+
+        test('no limit (non-positive / non-finite) → never chunks', () => {
+            const turns = [turn('t0', 4000), turn('t1', 4000)];
+            expect(chunkSession(turns, {sessionId: 's', safeProcessingLimitTokens: 0}).chunked).toBe(false);
+            expect(chunkSession(turns, {sessionId: 's', safeProcessingLimitTokens: undefined}).chunked).toBe(false);
+        });
+    });
+
+    test.describe('chunkSession — chunk activation (AC1) + boundaries (AC2)', () => {
+        // Four 400-char turns = 100 tokens each; limit 250 → packs 2 turns/chunk (200 ≤ 250, +100 would be 300 > 250).
+        const turns = [turn('t0', 400), turn('t1', 400), turn('t2', 400), turn('t3', 400)];
+
+        test('activates chunking above threshold and keeps every chunk within the limit', () => {
+            const {chunked, chunks} = chunkSession(turns, {sessionId: 'session:big', safeProcessingLimitTokens: 250});
+
+            expect(chunked).toBe(true);
+            expect(chunks.length).toBe(2);
+            for (const chunk of chunks) {
+                expect(chunk.estimatedTokens).toBeLessThanOrEqual(250);
+            }
+        });
+
+        test('chunk ids are <sessionId>:chunk:<N>, zero-indexed and monotonic', () => {
+            const {chunks} = chunkSession(turns, {sessionId: 'session:big', safeProcessingLimitTokens: 250});
+            expect(chunks.map(c => c.chunkId)).toEqual(['session:big:chunk:0', 'session:big:chunk:1']);
+        });
+
+        test('boundaries are turn-aligned — turnIndices are contiguous and cover every turn exactly once (AC3 traceability)', () => {
+            const {chunks} = chunkSession(turns, {sessionId: 'session:big', safeProcessingLimitTokens: 250});
+            const covered  = chunks.flatMap(c => c.turnIndices);
+
+            expect(covered).toEqual([0, 1, 2, 3]); // full coverage, in order, no duplicates, no mid-turn split
+            expect(chunks[0].turnIndices).toEqual([0, 1]);
+            expect(chunks[1].turnIndices).toEqual([2, 3]);
+        });
+
+        test('is deterministic — identical input yields byte-identical chunk shape across runs', () => {
+            const a = chunkSession(turns, {sessionId: 'session:big', safeProcessingLimitTokens: 250});
+            const b = chunkSession(turns, {sessionId: 'session:big', safeProcessingLimitTokens: 250});
+            expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+        });
+    });
+
+    test.describe('chunkSession — oversized single turn (Contract Ledger edge: keep intact, do not split)', () => {
+        test('a turn larger than the limit becomes its own chunk flagged oversizedTurn', () => {
+            const turns  = [turn('t0', 400), turn('huge', 4000), turn('t2', 400)]; // 100, 1000, 100 tokens; limit 250
+            const {chunks} = chunkSession(turns, {sessionId: 'session:x', safeProcessingLimitTokens: 250});
+
+            const oversized = chunks.find(c => c.oversizedTurn);
+            expect(oversized).toBeTruthy();
+            expect(oversized.turnIndices).toEqual([1]);             // the huge turn, intact, alone
+            expect(oversized.estimatedTokens).toBeGreaterThan(250); // not split despite exceeding the limit
+
+            // Full coverage preserved; neighbours are not merged into the oversized chunk.
+            expect(chunks.flatMap(c => c.turnIndices).sort((a, b) => a - b)).toEqual([0, 1, 2]);
+        });
+    });
+
+    test.describe('chunkSession — empty / defensive input', () => {
+        test('empty turn list yields a single empty chunk (no throw)', () => {
+            const result = chunkSession([], {sessionId: 'session:empty', safeProcessingLimitTokens: 250});
+            expect(result.chunked).toBe(false);
+            expect(result.chunks.length).toBe(1);
+            expect(result.chunks[0].turnIndices).toEqual([]);
+        });
+
+        test('non-array turns input does not throw', () => {
+            expect(() => chunkSession(null, {sessionId: 's', safeProcessingLimitTokens: 250})).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
Resolves #13513
Refs #12073

The deterministic, turn-aligned session chunker primitive — the safe foundation of #12073's hierarchical Tri-Vector summarization. Pure module with **no change to the existing extraction path**; the map→reduce integration into `executeTriVectorExtraction` is the next increment and stays in #12073.

Evidence: L1 (11 unit specs cover all delivered ACs — chunking strategy, deterministic boundaries/ids/order, traceability metadata, small-session single-pass, oversized-turn handling) → L1 required (pure function, no runtime-host AC). No residuals in #13513.

## What shipped
- `ai/services/graph/sessionChunker.mjs` (pure module, no Neo import, sibling of `SemanticGraphExtractor`): `chunkSession(turns, {sessionId, safeProcessingLimitTokens, estimate})` — greedy turn-aligned packing, `<sessionId>:chunk:<N>` zero-indexed ids, `turnIndices` source-coverage, a single over-limit turn kept intact + flagged `oversizedTurn`, small-session single-pass preserved (`chunked: false`); `estimateTokens()` — deterministic char-based estimate.

## Deltas from ticket
None — implements #13513 exactly. The deliberate split: this primitive lands now; the map→reduce integration (per-chunk extraction, reduce, `(type,name)` dedup, REM-state failure) stays in parent #12073, since it requires separating extraction-from-graph-commit inside the core `executeTriVectorExtraction` method.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/graph/sessionChunker.spec.mjs` → **11 passed**. Covers: small-session fast-path, chunk activation + within-limit, deterministic ids/order/byte-identical shape, turn-aligned full coverage, oversized-turn-kept-intact, empty/defensive input.

## Post-Merge Validation
- [ ] When the map→reduce integration (#12073) wires this in, confirm a real session above the safe band chunks + reduces instead of returning `null` (live REM run).

## Out of scope (remains in #12073)
- map→reduce integration into `executeTriVectorExtraction`: per-chunk extraction (AC4), deterministic reduce (AC5), cross-chunk dedup (AC6), per-chunk failure → REM run-state (AC7).

Authored by Grace (Claude Opus 4.8, Claude Code). Session 045a6048-1e1d-44c1-9738-7f09b62cc998.