### PR TITLE
feat(agentos): extract Accounts keeper-view from FleetSettingsPanel (#13491)

### DIFF
--- a/apps/agentos/store/AgentDefinitions.mjs
+++ b/apps/agentos/store/AgentDefinitions.mjs
@@ -5,8 +5,13 @@ import Store                from '../../../src/data/Store.mjs';
  * @class AgentOS.store.AgentDefinitions
  * @extends Neo.data.Store
  *
- * @summary Redacted Fleet Manager agent definition list for the settings pane. The seed row is a
+ * @summary Redacted Fleet Manager agent definition list — the shared fleet roster. The seed row is a
  * local bridge-state placeholder, not persisted registry data, and carries no credential bytes.
+ *
+ * Exposed as a **singleton** so the keeper-views that compose the cockpit bind one shared instance:
+ * `AgentOS.view.Accounts` writes redacted identities into it (after the Brain-side credential submit),
+ * and `AgentOS.view.FleetSettingsPanel`'s roster grid reads from it reactively. No credential bytes
+ * ever enter this Body-side store.
  */
 class AgentDefinitions extends Store {
     static config = {
@@ -15,6 +20,10 @@ class AgentDefinitions extends Store {
          * @protected
          */
         className: 'AgentOS.store.AgentDefinitions',
+        /**
+         * @member {Boolean} singleton=true
+         */
+        singleton: true,
         /**
          * @member {Object[]} data
          */

--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -1,0 +1,270 @@
+import AgentDefinitions from '../store/AgentDefinitions.mjs';
+import Button           from '../../../src/button/Base.mjs';
+import DashboardPanel   from '../../../src/dashboard/Panel.mjs';
+import FormContainer    from '../../../src/form/Container.mjs';
+import PasswordField    from '../../../src/form/field/Password.mjs';
+import Radio            from '../../../src/form/field/Radio.mjs';
+import TextField        from '../../../src/form/field/Text.mjs';
+import Toolbar          from '../../../src/toolbar/Base.mjs';
+
+/**
+ * @class AgentOS.view.Accounts
+ * @extends Neo.dashboard.Panel
+ *
+ * @summary The **Accounts keeper-view** — set up the cross-family fleet's agent identities (GitHub
+ * identity + harness type + provider credential). Extracted from `FleetSettingsPanel` per the cockpit
+ * keeper-view decomposition: this view owns identity *setup*; the Fleet view owns the live roster
+ * + lifecycle.
+ *
+ * Capability-security boundary (the load-bearing reason this is its own surface): a credential is
+ * collected only long enough to submit it to the Brain-side Fleet Registry bridge. If that bridge is
+ * absent, submission fails closed, the PAT field is cleared, and **nothing is stored in the browser /
+ * App Worker** — only a redacted projection reaches the shared `AgentDefinitions` roster, never a
+ * credential byte (mirrors `AgentOS.model.AgentDefinition`'s deliberately credential-free shape).
+ */
+class Accounts extends DashboardPanel {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.Accounts'
+         * @protected
+         */
+        className: 'AgentOS.view.Accounts',
+        /**
+         * @member {String[]} cls=['agent-panel-accounts']
+         * @reactive
+         */
+        cls: ['agent-panel-accounts'],
+        /**
+         * @member {Number} flex=1
+         */
+        flex: 1,
+        /**
+         * @member {Object[]} headers
+         */
+        headers: [{
+            dock: 'top',
+            cls : ['neo-draggable'],
+            text: 'Accounts'
+        }],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Function|String|null} popupUrl='apps/agentos/childapps/widget/index.html'
+         */
+        popupUrl: 'apps/agentos/childapps/widget/index.html',
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module   : FormContainer,
+            cls      : ['agent-definition-form'],
+            flex     : 'none',
+            layout   : {ntype: 'vbox', align: 'stretch'},
+            reference: 'agent-form',
+
+            items: [{
+                ntype: 'component',
+                cls  : ['agent-form-copy'],
+                vdom : {cn: [{tag: 'strong', text: 'Agent identity'}]}
+            }, {
+                module         : TextField,
+                clearable      : true,
+                labelText      : 'GitHub username',
+                labelWidth     : 118,
+                name           : 'githubUsername',
+                placeholderText: 'neo-gpt',
+                required       : true
+            }, {
+                module         : PasswordField,
+                clearable      : true,
+                labelText      : 'GitHub PAT',
+                labelWidth     : 118,
+                name           : 'credential',
+                placeholderText: 'stored Brain-side only',
+                required       : true
+            }, {
+                module: Toolbar,
+                cls   : ['agent-harness-picker'],
+                flex  : 'none',
+                items : [{
+                    module        : Radio,
+                    checked       : true,
+                    hideValueLabel: false,
+                    labelText     : 'Harness',
+                    labelWidth    : 118,
+                    name          : 'harnessType',
+                    value         : 'codex',
+                    valueLabel    : 'Codex'
+                }, {
+                    module        : Radio,
+                    hideValueLabel: false,
+                    labelText     : '',
+                    name          : 'harnessType',
+                    value         : 'claude-desktop',
+                    valueLabel    : 'Claude'
+                }, {
+                    module        : Radio,
+                    hideValueLabel: false,
+                    labelText     : '',
+                    name          : 'harnessType',
+                    value         : 'antigravity',
+                    valueLabel    : 'Antigravity'
+                }, {
+                    module        : Radio,
+                    hideValueLabel: false,
+                    labelText     : '',
+                    name          : 'harnessType',
+                    value         : 'native-neo',
+                    valueLabel    : 'Native'
+                }]
+            }, {
+                module: Toolbar,
+                cls   : ['agent-form-actions'],
+                flex  : 'none',
+                items : [{
+                    module : Button,
+                    cls    : ['agent-button', 'agent-submit-button'],
+                    handler: 'up.onSubmitAgentClick',
+                    iconCls: 'fa fa-lock',
+                    text   : 'Submit to Bridge'
+                }, {
+                    module : Button,
+                    cls    : ['agent-button'],
+                    handler: 'up.onLoadSampleClick',
+                    iconCls: 'fa fa-pen-to-square',
+                    text   : 'Edit Sample'
+                }]
+            }, {
+                ntype    : 'component',
+                cls      : ['agent-bridge-status', 'is-waiting'],
+                reference: 'bridge-status',
+                vdom     : {cn: [{text: 'Fleet Registry bridge unavailable in dev-server mode. Submit fails closed; no PAT is stored in browser state.'}]}
+            }]
+        }]
+    }
+
+    /**
+     * @summary Create the redacted projection that can safely render in the Body-side roster.
+     * @param {Object} values
+     * @returns {Object} Public agent definition suitable for the shared store; never includes a credential.
+     */
+    createPublicAgentDefinition(values) {
+        return {
+            id             : values.githubUsername,
+            githubUsername : values.githubUsername,
+            harnessType    : values.harnessType,
+            credentialState: 'stored-node-side',
+            lifecycleState : 'gated',
+            statusText     : 'Definition accepted by Fleet Registry bridge; lifecycle controls remain gated.',
+            updatedAt      : new Date().toISOString()
+        }
+    }
+
+    /**
+     * @summary Load a sample public identity without inserting credential bytes.
+     * @returns {Promise<void>}
+     */
+    async onLoadSampleClick() {
+        const form = this.getReference('agent-form');
+
+        await form.setValues({
+            credential    : '',
+            githubUsername: 'neo-gpt',
+            harnessType   : 'codex'
+        });
+
+        this.updateBridgeStatus(
+            'is-waiting',
+            'Sample loaded for editing. Enter a PAT to submit; the value will be cleared after the bridge attempt.'
+        )
+    }
+
+    /**
+     * @summary Validate the form, attempt the Brain-side bridge submit, then clear the PAT field.
+     * @returns {Promise<void>}
+     */
+    async onSubmitAgentClick() {
+        const
+            form   = this.getReference('agent-form'),
+            valid  = await form.validate(),
+            values = await form.getSubmitValues();
+
+        const githubUsername = values.githubUsername?.trim();
+
+        if (!valid || !githubUsername || !values.harnessType || !values.credential) {
+            this.updateBridgeStatus('is-error', 'Definition incomplete. GitHub username, harness type, and PAT are required.');
+            return
+        }
+
+        const payload = {
+            credential    : values.credential,
+            githubUsername,
+            harnessType   : values.harnessType
+        };
+
+        try {
+            await this.submitToFleetRegistryBridge(payload);
+            this.upsertPublicAgentDefinition(this.createPublicAgentDefinition(payload));
+            this.updateBridgeStatus('is-live', 'Definition submitted through the Fleet Registry bridge. PAT was not retained in the app worker.')
+        } catch (error) {
+            this.updateBridgeStatus('is-error', 'Fleet Registry bridge unavailable. Nothing was stored in browser state; PAT field was cleared.')
+        } finally {
+            await this.clearCredentialField()
+        }
+    }
+
+    /**
+     * @summary Remove credential bytes from the password field after every bridge attempt.
+     * @returns {Promise<void>}
+     */
+    async clearCredentialField() {
+        const field = await this.getReference('agent-form').getField('credential');
+        field?.reset('')
+    }
+
+    /**
+     * @summary Forward the definition to an injected Fleet Registry bridge, or fail closed.
+     * Submit via an injected bridge when a future Agent OS shell exposes one. The current dev-server
+     * app has no Brain-side bridge object, so the view fails closed instead of inventing browser
+     * persistence.
+     * @param {Object} payload
+     * @returns {Promise<*>}
+     */
+    async submitToFleetRegistryBridge(payload) {
+        const bridge = globalThis.AgentOS?.fleet?.registryBridge;
+
+        if (!bridge?.defineAgent) {
+            throw new Error('Fleet Registry bridge unavailable')
+        }
+
+        return bridge.defineAgent(payload)
+    }
+
+    /**
+     * @summary Write the redacted projection into the shared `AgentDefinitions` roster singleton,
+     * replacing any prior row for the same agent. The Fleet view's grid (bound to the same singleton)
+     * re-renders reactively — no cross-view reference is needed.
+     * @param {Object} definition
+     */
+    upsertPublicAgentDefinition(definition) {
+        AgentDefinitions.remove(definition.id);
+        AgentDefinitions.add(definition)
+    }
+
+    /**
+     * @summary Update the bridge-state message without persisting any submitted values.
+     * @param {String} stateCls
+     * @param {String} message
+     */
+    updateBridgeStatus(stateCls, message) {
+        const status = this.getReference('bridge-status');
+        status.cls             = ['agent-bridge-status', stateCls];
+        status.vdom.cn[0].text = message;
+        status.update()
+    }
+}
+
+export default Neo.setupClass(Accounts);

--- a/apps/agentos/view/FleetSettingsPanel.mjs
+++ b/apps/agentos/view/FleetSettingsPanel.mjs
@@ -1,21 +1,18 @@
-import Button             from '../../../src/button/Base.mjs';
-import DashboardPanel     from '../../../src/dashboard/Panel.mjs';
-import FormContainer      from '../../../src/form/Container.mjs';
-import GridContainer      from '../../../src/grid/Container.mjs';
-import PasswordField      from '../../../src/form/field/Password.mjs';
-import Radio              from '../../../src/form/field/Radio.mjs';
-import TextField          from '../../../src/form/field/Text.mjs';
-import Toolbar            from '../../../src/toolbar/Base.mjs';
-import AgentDefinitions   from '../store/AgentDefinitions.mjs';
+import AgentDefinitions from '../store/AgentDefinitions.mjs';
+import Button           from '../../../src/button/Base.mjs';
+import DashboardPanel   from '../../../src/dashboard/Panel.mjs';
+import GridContainer    from '../../../src/grid/Container.mjs';
+import Toolbar          from '../../../src/toolbar/Base.mjs';
 
 /**
  * @class AgentOS.view.FleetSettingsPanel
  * @extends Neo.dashboard.Panel
  *
- * @summary First Body-side Fleet Manager settings pane. It renders public agent definitions and
- * collects a credential only long enough to submit it to the Brain-side Fleet Registry bridge. If
- * that bridge is absent, submission fails closed, clears the PAT field, and stores nothing in the
- * browser/App Worker surface.
+ * @summary The **Fleet view** — run the fleet: the live, redacted roster (grid) + the lifecycle
+ * controls (Start / Stop / Restart, gated until the service bridge is consumed). Reads the shared
+ * `AgentDefinitions` roster singleton that `AgentOS.view.Accounts` writes into; identity *setup* +
+ * all credential handling now live in `Accounts` (the cockpit keeper-view split). This view
+ * holds no credential logic and writes nothing — it is read + lifecycle only.
  */
 class FleetSettingsPanel extends DashboardPanel {
     static config = {
@@ -39,7 +36,7 @@ class FleetSettingsPanel extends DashboardPanel {
         headers: [{
             dock: 'top',
             cls : ['neo-draggable'],
-            text: 'Fleet Settings'
+            text: 'Fleet'
         }],
         /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
@@ -56,8 +53,7 @@ class FleetSettingsPanel extends DashboardPanel {
         items: [{
             module   : GridContainer,
             cls      : ['agent-definition-grid'],
-            flex     : 'none',
-            height   : 150,
+            flex     : 1,
             reference: 'agent-grid',
             store    : AgentDefinitions,
 
@@ -91,243 +87,44 @@ class FleetSettingsPanel extends DashboardPanel {
                 text     : 'Status'
             }]
         }, {
-            module   : FormContainer,
-            cls      : ['agent-definition-form'],
-            flex     : 'none',
-            layout   : {ntype: 'vbox', align: 'stretch'},
-            reference: 'agent-form',
-
-            items: [{
-                ntype: 'component',
-                cls  : ['agent-form-copy'],
-                vdom : {cn: [{tag: 'strong', text: 'Agent definition'}]}
+            module: Toolbar,
+            cls   : ['agent-fleet-actions'],
+            flex  : 'none',
+            items : ['->', {
+                module  : Button,
+                cls     : ['agent-button', 'agent-lifecycle-button'],
+                disabled: true,
+                iconCls : 'fa fa-play',
+                text    : 'Start',
+                tooltip : {
+                    text     : 'Lifecycle controls are gated until the service bridge is consumed.',
+                    showDelay: 0,
+                    hideDelay: 0
+                }
             }, {
-                module         : TextField,
-                clearable      : true,
-                labelText      : 'GitHub username',
-                labelWidth     : 118,
-                name           : 'githubUsername',
-                placeholderText: 'neo-gpt',
-                required       : true
+                module  : Button,
+                cls     : ['agent-button', 'agent-lifecycle-button'],
+                disabled: true,
+                iconCls : 'fa fa-stop',
+                text    : 'Stop',
+                tooltip : {
+                    text     : 'Lifecycle controls are gated until the service bridge is consumed.',
+                    showDelay: 0,
+                    hideDelay: 0
+                }
             }, {
-                module         : PasswordField,
-                clearable      : true,
-                labelText      : 'GitHub PAT',
-                labelWidth     : 118,
-                name           : 'credential',
-                placeholderText: 'stored Brain-side only',
-                required       : true
-            }, {
-                module: Toolbar,
-                cls   : ['agent-harness-picker'],
-                flex  : 'none',
-                items : [{
-                    module        : Radio,
-                    checked       : true,
-                    hideValueLabel: false,
-                    labelText     : 'Harness',
-                    labelWidth    : 118,
-                    name          : 'harnessType',
-                    value         : 'codex',
-                    valueLabel    : 'Codex'
-                }, {
-                    module        : Radio,
-                    hideValueLabel: false,
-                    labelText     : '',
-                    name          : 'harnessType',
-                    value         : 'claude-desktop',
-                    valueLabel    : 'Claude'
-                }, {
-                    module        : Radio,
-                    hideValueLabel: false,
-                    labelText     : '',
-                    name          : 'harnessType',
-                    value         : 'antigravity',
-                    valueLabel    : 'Antigravity'
-                }, {
-                    module        : Radio,
-                    hideValueLabel: false,
-                    labelText     : '',
-                    name          : 'harnessType',
-                    value         : 'native-neo',
-                    valueLabel    : 'Native'
-                }]
-            }, {
-                module: Toolbar,
-                cls   : ['agent-form-actions'],
-                flex  : 'none',
-                items : [{
-                    module : Button,
-                    cls    : ['agent-button', 'agent-submit-button'],
-                    handler: 'up.onSubmitAgentClick',
-                    iconCls: 'fa fa-lock',
-                    text   : 'Submit to Bridge'
-                }, {
-                    module : Button,
-                    cls    : ['agent-button'],
-                    handler: 'up.onLoadSampleClick',
-                    iconCls: 'fa fa-pen-to-square',
-                    text   : 'Edit Sample'
-                }, '->', {
-                    module  : Button,
-                    cls     : ['agent-button', 'agent-lifecycle-button'],
-                    disabled: true,
-                    iconCls : 'fa fa-play',
-                    text    : 'Start',
-                    tooltip : {
-                        text     : 'Lifecycle controls are gated until the service bridge is consumed.',
-                        showDelay: 0,
-                        hideDelay: 0
-                    }
-                }, {
-                    module  : Button,
-                    cls     : ['agent-button', 'agent-lifecycle-button'],
-                    disabled: true,
-                    iconCls : 'fa fa-stop',
-                    text    : 'Stop',
-                    tooltip : {
-                        text     : 'Lifecycle controls are gated until the service bridge is consumed.',
-                        showDelay: 0,
-                        hideDelay: 0
-                    }
-                }, {
-                    module  : Button,
-                    cls     : ['agent-button', 'agent-lifecycle-button'],
-                    disabled: true,
-                    iconCls : 'fa fa-rotate-right',
-                    text    : 'Restart',
-                    tooltip : {
-                        text     : 'Lifecycle controls are gated until the service bridge is consumed.',
-                        showDelay: 0,
-                        hideDelay: 0
-                    }
-                }]
-            }, {
-                ntype    : 'component',
-                cls      : ['agent-bridge-status', 'is-waiting'],
-                reference: 'bridge-status',
-                vdom     : {cn: [{text: 'Fleet Registry bridge unavailable in dev-server mode. Submit fails closed; no PAT is stored in browser state.'}]}
+                module  : Button,
+                cls     : ['agent-button', 'agent-lifecycle-button'],
+                disabled: true,
+                iconCls : 'fa fa-rotate-right',
+                text    : 'Restart',
+                tooltip : {
+                    text     : 'Lifecycle controls are gated until the service bridge is consumed.',
+                    showDelay: 0,
+                    hideDelay: 0
+                }
             }]
         }]
-    }
-
-    /**
-     * @summary Create the redacted projection that can safely render in the Body-side app.
-     * @param {Object} values
-     * @returns {Object} Public agent definition suitable for the grid; never includes a credential.
-     */
-    createPublicAgentDefinition(values) {
-        return {
-            id             : values.githubUsername,
-            githubUsername : values.githubUsername,
-            harnessType    : values.harnessType,
-            credentialState: 'stored-node-side',
-            lifecycleState : 'gated',
-            statusText     : 'Definition accepted by Fleet Registry bridge; lifecycle controls remain gated.',
-            updatedAt      : new Date().toISOString()
-        }
-    }
-
-    /**
-     * @summary Load a sample public identity without inserting credential bytes.
-     * @returns {Promise<void>}
-     */
-    async onLoadSampleClick() {
-        const form = this.getReference('agent-form');
-
-        await form.setValues({
-            credential    : '',
-            githubUsername: 'neo-gpt',
-            harnessType   : 'codex'
-        });
-
-        this.updateBridgeStatus(
-            'is-waiting',
-            'Sample loaded for editing. Enter a PAT to submit; the value will be cleared after the bridge attempt.'
-        )
-    }
-
-    /**
-     * @summary Validate the form, attempt the Brain-side bridge submit, then clear the PAT field.
-     * @returns {Promise<void>}
-     */
-    async onSubmitAgentClick() {
-        const
-            form   = this.getReference('agent-form'),
-            valid  = await form.validate(),
-            values = await form.getSubmitValues();
-
-        const githubUsername = values.githubUsername?.trim();
-
-        if (!valid || !githubUsername || !values.harnessType || !values.credential) {
-            this.updateBridgeStatus('is-error', 'Definition incomplete. GitHub username, harness type, and PAT are required.');
-            return
-        }
-
-        const payload = {
-            credential    : values.credential,
-            githubUsername,
-            harnessType   : values.harnessType
-        };
-
-        try {
-            await this.submitToFleetRegistryBridge(payload);
-            this.upsertPublicAgentDefinition(this.createPublicAgentDefinition(payload));
-            this.updateBridgeStatus('is-live', 'Definition submitted through the Fleet Registry bridge. PAT was not retained in the app worker.')
-        } catch (error) {
-            this.updateBridgeStatus('is-error', 'Fleet Registry bridge unavailable. Nothing was stored in browser state; PAT field was cleared.')
-        } finally {
-            await this.clearCredentialField()
-        }
-    }
-
-    /**
-     * @summary Remove credential bytes from the password field after every bridge attempt.
-     * @returns {Promise<void>}
-     */
-    async clearCredentialField() {
-        const field = await this.getReference('agent-form').getField('credential');
-        field?.reset('')
-    }
-
-    /**
-     * @summary Forward the definition to an injected Fleet Registry bridge, or fail closed.
-     * Submit via an injected bridge when a future Agent OS shell exposes one. The current dev-server
-     * app has no Brain-side bridge object, so the pane fails closed instead of inventing browser
-     * persistence.
-     * @param {Object} payload
-     * @returns {Promise<*>}
-     */
-    async submitToFleetRegistryBridge(payload) {
-        const bridge = globalThis.AgentOS?.fleet?.registryBridge;
-
-        if (!bridge?.defineAgent) {
-            throw new Error('Fleet Registry bridge unavailable')
-        }
-
-        return bridge.defineAgent(payload)
-    }
-
-    /**
-     * @summary Replace any prior public row for the same agent with the redacted projection.
-     * @param {Object} definition
-     */
-    upsertPublicAgentDefinition(definition) {
-        const store = this.getReference('agent-grid').store;
-        store.remove(definition.id);
-        store.add(definition)
-    }
-
-    /**
-     * @summary Update the bridge-state message without persisting any submitted values.
-     * @param {String} stateCls
-     * @param {String} message
-     */
-    updateBridgeStatus(stateCls, message) {
-        const status = this.getReference('bridge-status');
-        status.cls             = ['agent-bridge-status', stateCls];
-        status.vdom.cn[0].text = message;
-        status.update()
     }
 }
 

--- a/apps/agentos/view/Viewport.mjs
+++ b/apps/agentos/view/Viewport.mjs
@@ -1,3 +1,4 @@
+import Accounts           from './Accounts.mjs';
 import BaseViewport       from '../../../src/container/Viewport.mjs';
 import Dashboard          from '../../../src/dashboard/Container.mjs';
 import FleetSettingsPanel from './FleetSettingsPanel.mjs';
@@ -31,7 +32,7 @@ class Viewport extends BaseViewport {
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
          * The cockpit: a header toolbar (logo, title, theme switch) above a dashboard hosting the
-         * Fleet Manager settings. Renders through `neo-theme-neo-dark` / `neo-theme-neo-light`.
+         * Accounts + Fleet keeper-views. Renders through `neo-theme-neo-dark` / `neo-theme-neo-light`.
          * @member {Object[]} items
          */
         items: [{
@@ -68,9 +69,13 @@ class Viewport extends BaseViewport {
             style            : {margin: '20px'},
 
             items: [{
+                module   : Accounts,
+                flex     : 1,
+                reference: 'accounts'
+            }, {
                 module   : FleetSettingsPanel,
                 flex     : 1,
-                reference: 'settings'
+                reference: 'fleet'
             }]
         }]
     }

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -1,0 +1,59 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSAccountsTest'
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import Accounts        from '../../../../../apps/agentos/view/Accounts.mjs';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    repoRoot   = path.resolve(__dirname, '../../../../..'),
+    viewPath   = path.join(repoRoot, 'apps/agentos/view/Accounts.mjs');
+
+test.describe('AgentOS.view.Accounts credential boundary', () => {
+    test('public definition projection strips submitted credential material', () => {
+        const values = {
+            credential    : 'ghp_should_not_escape',
+            githubUsername: 'neo-gpt',
+            harnessType   : 'codex',
+            pat           : 'also-secret'
+        };
+
+        const publicDefinition = Accounts.prototype.createPublicAgentDefinition(values);
+
+        expect(publicDefinition.githubUsername).toBe('neo-gpt');
+        expect(publicDefinition.harnessType).toBe('codex');
+        expect(JSON.stringify(publicDefinition)).not.toContain('ghp_should_not_escape');
+        expect(publicDefinition.credential).toBeUndefined();
+        expect(publicDefinition.pat).toBeUndefined()
+    });
+
+    test('view source fails closed without browser persistence or credential logging', () => {
+        const source = fs.readFileSync(viewPath, 'utf8');
+
+        expect(source).toContain('Fleet Registry bridge unavailable');
+        expect(source).toContain('clearCredentialField');
+        expect(source).not.toMatch(/localStorage|sessionStorage|indexedDB/);
+        expect(source).not.toMatch(/console\.(log|warn|error)/)
+    });
+
+    test('identity setup writes only the redacted projection to the shared roster', () => {
+        const source = fs.readFileSync(viewPath, 'utf8');
+
+        // upsert goes through the AgentDefinitions singleton with the redacted projection,
+        // never the raw form values / credential.
+        expect(source).toContain('AgentDefinitions.add');
+        expect(source).toContain('createPublicAgentDefinition');
+        expect(source).not.toMatch(/AgentDefinitions\.add\(\s*values/)
+    })
+});

--- a/test/playwright/unit/apps/agentos/FleetSettingsPanel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/FleetSettingsPanel.spec.mjs
@@ -6,14 +6,13 @@ setup({
     }
 });
 
-import {test, expect}    from '@playwright/test';
-import fs                from 'fs';
-import path              from 'path';
-import {fileURLToPath}   from 'url';
-import Neo               from '../../../../../src/Neo.mjs';
-import * as core         from '../../../../../src/core/_export.mjs';
-import AgentDefinitions  from '../../../../../apps/agentos/store/AgentDefinitions.mjs';
-import FleetSettingsPanel from '../../../../../apps/agentos/view/FleetSettingsPanel.mjs';
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import AgentDefinitions from '../../../../../apps/agentos/store/AgentDefinitions.mjs';
 
 const
     __filename = fileURLToPath(import.meta.url),
@@ -22,53 +21,32 @@ const
     appPath    = path.join(repoRoot, 'apps/agentos/app.mjs'),
     panelPath  = path.join(repoRoot, 'apps/agentos/view/FleetSettingsPanel.mjs');
 
-test.describe('AgentOS.view.FleetSettingsPanel credential boundary', () => {
-    test('agent definition store exposes only redacted public fields', () => {
-        const store = Neo.create(AgentDefinitions, {
-            id: 'agentos-fleet-settings-agent-definitions-test'
-        });
+test.describe('AgentOS.view.FleetSettingsPanel fleet roster', () => {
+    test('shared agent-definition roster (singleton) exposes only redacted public fields', () => {
+        // AgentDefinitions is a singleton: Accounts writes, this view's grid reads the same instance.
+        const [record] = AgentDefinitions.getRange();
 
-        try {
-            const [record] = store.getRange();
-
-            expect(record.credentialState).toBe('redacted');
-            expect(record.statusText).toContain('PAT values are never loaded');
-            expect(record.credential).toBeUndefined();
-            expect(record.pat).toBeUndefined();
-            expect(record.token).toBeUndefined()
-        } finally {
-            store.destroy()
-        }
+        expect(record.credentialState).toBe('redacted');
+        expect(record.statusText).toContain('PAT values are never loaded');
+        expect(record.credential).toBeUndefined();
+        expect(record.pat).toBeUndefined();
+        expect(record.token).toBeUndefined()
     });
 
-    test('public definition projection strips submitted credential material', () => {
-        const values = {
-            credential    : 'ghp_should_not_escape',
-            githubUsername: 'neo-gpt',
-            harnessType   : 'codex',
-            pat           : 'also-secret'
-        };
-
-        const publicDefinition = FleetSettingsPanel.prototype.createPublicAgentDefinition(values);
-
-        expect(publicDefinition.githubUsername).toBe('neo-gpt');
-        expect(publicDefinition.harnessType).toBe('codex');
-        expect(JSON.stringify(publicDefinition)).not.toContain('ghp_should_not_escape');
-        expect(publicDefinition.credential).toBeUndefined();
-        expect(publicDefinition.pat).toBeUndefined()
-    });
-
-    test('pane source fails closed without browser persistence or credential logging', () => {
+    test('fleet view is read + lifecycle only — identity setup + credential logic moved to Accounts', () => {
         const source = fs.readFileSync(panelPath, 'utf8');
 
-        expect(source).toContain('Fleet Registry bridge unavailable');
-        expect(source).toContain('clearCredentialField');
-        expect(source).toContain('disabled: true');
+        // The cockpit keeper-view split: this view keeps the gated lifecycle controls + the roster grid,
+        // and holds NO credential handling (that lives in AgentOS.view.Accounts).
+        expect(source).toContain('disabled: true');            // lifecycle controls stay, gated
+        expect(source).toContain('GridContainer');             // the roster grid stays
+        expect(source).not.toContain('clearCredentialField');
+        expect(source).not.toContain('PasswordField');
         expect(source).not.toMatch(/localStorage|sessionStorage|indexedDB/);
         expect(source).not.toMatch(/console\.(log|warn|error)/)
     });
 
-    test('root app shell loads AgentOS styles for the settings pane', () => {
+    test('root app shell loads AgentOS styles for the cockpit', () => {
         const source = fs.readFileSync(appPath, 'utf8');
 
         expect(source).toContain("appThemeFolder: 'agentos'")


### PR DESCRIPTION
Resolves #13491
Refs #13448
Refs #13512
Refs #13521

Extracts the **Accounts keeper-view** out of the conflated `FleetSettingsPanel`, executing the graduated #13448 cockpit decomposition (separate Accounts + Fleet keeper-views). This is my corrective per the #13512 watch-the-shipper flag — a real authored substrate PR, executing graduated work (graduation = build-authorization; this PR is the merge-gate's to check, not a pre-merge read I manufactured).

Evidence: L2 (Neo view component + unit tests covering the credential boundary, the redacted-projection contract, and the split itself). Head `16b5ea986`. The live worker-app render of the cockpit is the post-merge validation (outside the unit sandbox) — see below.

## The split (what moved where)

`FleetSettingsPanel` conflated two of the epic's keeper-views (the #13491 pre-build finding). This PR separates them along the graduated boundary:

| Surface | Before | After |
|---|---|---|
| identity-setup form + credential boundary | `FleetSettingsPanel` | **`AgentOS.view.Accounts`** (new keeper-view) |
| roster grid + lifecycle controls (gated) | `FleetSettingsPanel` | `FleetSettingsPanel` (now the Fleet view; read + lifecycle only) |
| `AgentOS.store.AgentDefinitions` | per-grid instance | **`singleton: true`** — shared roster both views bind |

- **Accounts writes, Fleet reads, one shared store.** `Accounts.upsertPublicAgentDefinition()` writes the redacted projection into the `AgentDefinitions` singleton; `FleetSettingsPanel`'s grid (bound to the same singleton) re-renders reactively. No cross-view reference — the Body's reactive store is the seam.
- **Capability-security boundary preserved + now isolated to one surface:** the PAT is collected, submitted to the Brain-side Fleet Registry bridge, then cleared; nothing is stored in the browser/App Worker; only a credential-free projection reaches the store. `FleetSettingsPanel` now holds **zero** credential logic.

## Deltas from ticket

- #13491 was scope-corrected last cycle from "greenfield Accounts view" to "extract from the conflated `FleetSettingsPanel`" (the view already existed). This PR delivers the **extract**, not a duplicate.
- **Close-target reconciled (per Euclid's cross-family review):** #13491's body now marks ACs 4/5/6 — AiConfig provider-login, basic NL-MCP entry, v14 `IdentityState` slot — as **deferred to follow-up #13521**. So `Resolves #13491` honestly closes the extraction scope (ACs 1/2/3/7/8 delivered; the redacted *listing* renders in the Fleet view per the split), not the enhancements. No code change — close-target honesty only.
- `AgentDefinitions` promoted to a singleton — the architecturally-correct shape for an app-wide roster two keeper-views share (only one prior consumer, so zero migration risk).
- Scope held to the **Accounts** keeper-view + the enabling split. The Fleet-view rename (`FleetSettingsPanel` → `Fleet`), the structure/nav left-rail sub, and the who_is_online live-status consumer remain separate #13448 subs.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/` → **76 passed** (locally on head `16b5ea986`), including:
  - new `Accounts.spec.mjs`: redacted-projection strips credential material; view source fails closed (no `localStorage`/`console`); upsert writes only the projection through the singleton.
  - rewritten `FleetSettingsPanel.spec.mjs`: shared singleton roster exposes only redacted fields; the Fleet view is read + lifecycle only (no `PasswordField`/`clearCredentialField`/credential logic), gated lifecycle controls retained.
  - all sibling agentos specs (DockPreview, childapps widget) green — the singleton + split rippled cleanly.
- `git diff --check` clean; husky `check-jsdoc-types` + `check-ticket-archaeology` + `check-whitespace` passed at `16b5ea986`.

## Post-Merge Validation

- [ ] Render the agentos cockpit (`apps/agentos`): both **Accounts** and **Fleet** keeper-views mount in the dashboard; theme switch unaffected.
- [ ] Submit an identity in Accounts (dev-server mode, bridge absent) → fails closed, PAT field clears, nothing persists in browser state; with a bridge present, the redacted row appears in the **Fleet** roster (singleton-store reactivity across the split).

## Cross-Family Review

Claude-authored (Vega) → requesting **@neo-gpt (Euclid, GPT)** as the cross-family reviewer per the mandate + tonight's Claude↔GPT routing.

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
