### PR TITLE
feat(memory-core): who_is_online liveness projection — Substrate B (#13515)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -172,9 +172,9 @@ paths:
 
 
         Layers (precedence): (1) participationStatus hard gate — operator_benched /
-        temporarily_unreachable report offline; (2) turn-started beacon (primary active-turn proof)
-        — pending the turn-presence writer (not yet emitted), currently inert and never faked; (3) HarnessPresence
-        freshness — corroboration until the beacon ships.
+        temporarily_unreachable report offline; (2) turn-started beacon — reserved as the future
+        primary active-turn proof, but not yet emitted, so currently an inert null slot the code never
+        reads (never faked); (3) HarnessPresence freshness — the corroboration that decides availability today.
       tags: [Health]
       requestBody:
         required: false

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -157,6 +157,68 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /who-is-online:
+    post:
+      summary: Who Is Online
+      operationId: who_is_online
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      description: >
+        Reports per-maintainer live availability — "is the agent completing turns right now," not
+        "is the process up." Advisory liveness for review-routing, lane-handoff, lead-baton, and
+        wake-targeting: surfaces probably-dark maintainers so a request to a dark agent fails loud
+        instead of stalling the merge gate silently.
+
+
+        Layers (precedence): (1) participationStatus hard gate — operator_benched /
+        temporarily_unreachable report offline; (2) turn-started beacon (primary active-turn proof)
+        — pending the turn-presence writer (not yet emitted), currently inert and never faked; (3) HarnessPresence
+        freshness — corroboration until the beacon ships.
+      tags: [Health]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                family:
+                  type: string
+                  description: Optional model-family filter (e.g. 'claude', 'gpt').
+      responses:
+        '200':
+          description: Per-maintainer liveness projection.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  generatedAt:
+                    type: string
+                    description: ISO timestamp the projection was computed at.
+                  beaconStatus:
+                    type: string
+                    description: Status of the primary turn-started beacon signal (pending Substrate A).
+                  agents:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        identity: {type: string}
+                        name: {type: string}
+                        family: {type: string, nullable: true}
+                        participationStatus: {type: string}
+                        online: {type: boolean}
+                        reason: {type: string}
+                        signals: {type: object}
+        '500':
+          description: Operation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /memories:
     post:
       summary: Add New Memory

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -50,6 +50,7 @@ const serviceMapping = {
     list_permissions        : PermissionService      .listPermissions         .bind(PermissionService),
     manage_wake_subscription: WakeSubscriptionService.manage                  .bind(WakeSubscriptionService),
     record_turn_presence    : TurnPresenceService    .recordTurnPresence      .bind(TurnPresenceService),
+    who_is_online           : WakeSubscriptionService.whoIsOnline             .bind(WakeSubscriptionService),
     purge_session           : SessionService         .purgeSession            .bind(SessionService),
     resume_session          : SessionService         .validateSessionForResume.bind(SessionService),
     set_session_id          : SessionService         .setSessionId            .bind(SessionService)

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -515,6 +515,173 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
+     * @summary Projects per-maintainer live availability — the `who_is_online` read tool.
+     *
+     * Composes the liveness layers, in precedence order:
+     * 1. **`participationStatus` hard gate** — `operator_benched` / `temporarily_unreachable`
+     *    report `online:false` regardless of any softer signal.
+     * 2. **Turn-started beacon (primary)** — the trusted per-turn beacon (`AGENT_TURN_PRESENCE`)
+     *    is not yet emitted, so this slot is inert (`signals.beacon:null`). When that writer lands,
+     *    its freshness becomes the primary active-turn proof. Stubbed, never faked: a running
+     *    harness is not a live agent, and a fail-closeable write-tool (`add_memory`) is not a
+     *    reliable liveness primary either (it false-negatives under the very load that proves life).
+     * 3. **HarnessPresence freshness (corroboration)** — the best available liveness signal until
+     *    the beacon ships: `freshUntil` (the {@link WakeSubscriptionService#harnessPresenceFreshMs}
+     *    window) still ahead of now ⇒ corroborated-online; stale or absent ⇒ probably-dark.
+     *
+     * Deliberately **advisory**: it surfaces *probably-dark* maintainers for review-routing /
+     * lane-handoff / lead-baton / wake-targeting so a request to a dark agent fails loud instead
+     * of stalling silently; it is not a hard routing gate.
+     *
+     * @param {Object} [opts]
+     * @param {String} [opts.family] Optional model-family filter (e.g. `'claude'`, `'gpt'`).
+     * @param {Date|String|Number} [opts.now=new Date()] Clock source (unit-test seam).
+     * @returns {Promise<Object>} `{generatedAt, beaconStatus, agents}` where each agent is
+     *   `{identity, name, family, participationStatus, online, reason, signals}`.
+     */
+    async whoIsOnline({family, now = new Date()} = {}) {
+        const nowMs  = this._coerceDate(now).getTime(),
+              agents = this._listAgentIdentityNodes(family).map(node => this._projectAgentLiveness(node, nowMs));
+
+        return {
+            generatedAt : new Date(nowMs).toISOString(),
+            beaconStatus: 'turn-started beacon (primary active-turn proof) pending Substrate A (the turn-presence writer); ' +
+                          'availability below is participationStatus-gated + HarnessPresence-corroborated',
+            agents
+        };
+    }
+
+    /**
+     * @summary Reads live `AgentIdentity` nodes for the liveness projection (authoritative,
+     * runtime-mutable `participationStatus`), optionally filtered by model family. Uses the same
+     * `json_extract($.label)` SQLite pattern as the presence reads so the projection reflects the
+     * durable node row, not a possibly-stripped in-memory cache stub.
+     * @param {String} [family] Optional model-family filter.
+     * @returns {Object[]} Parsed AgentIdentity node objects.
+     * @protected
+     */
+    _listAgentIdentityNodes(family) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite) return [];
+
+        const rows  = sqlite.prepare(`
+            SELECT data FROM Nodes
+            WHERE json_extract(data, '$.label') = 'AgentIdentity'
+        `).all();
+        const nodes = [];
+
+        for (const row of rows) {
+            let node;
+            try {
+                node = JSON.parse(row.data);
+            } catch (error) {
+                logger.warn(`[WakeSubscription] who_is_online: skipped unparseable AgentIdentity row: ${error.message}`);
+                continue;
+            }
+
+            const nodeFamily = node.properties?.family || node.properties?.modelFamily || null;
+            if (family && nodeFamily !== family) continue;
+            nodes.push(node);
+        }
+
+        return nodes;
+    }
+
+    /**
+     * @summary Projects a single AgentIdentity node to its liveness verdict via the
+     * gate → beacon → corroboration precedence.
+     * @param {Object} node Parsed AgentIdentity node.
+     * @param {Number} nowMs Clock epoch ms.
+     * @returns {Object} `{identity, name, family, participationStatus, online, reason, signals}`.
+     * @protected
+     */
+    _projectAgentLiveness(node, nowMs) {
+        const props               = node.properties || {},
+              identity            = node.id,
+              name                = node.name || props.displayName || node.id,
+              family              = props.family || props.modelFamily || null,
+              participationStatus = props.participationStatus || 'active',
+              signals             = {participationStatus, beacon: null, harnessPresence: null};
+
+        // 1. participationStatus HARD GATE — benched/unreachable overrides every softer signal.
+        if (participationStatus !== 'active') {
+            return {identity, name, family, participationStatus, online: false,
+                reason: `roster: participationStatus is '${participationStatus}' (benched / unreachable)`, signals};
+        }
+
+        // 2. Turn-started beacon (primary) — Substrate A pending; slot stays null (never faked).
+
+        // 3. HarnessPresence freshness (corroboration).
+        const presence = this._readActiveHarnessPresence(identity, nowMs);
+        signals.harnessPresence = presence;
+
+        if (!presence) {
+            return {identity, name, family, participationStatus, online: false,
+                reason: 'no live HarnessPresence (dark — process down or never connected)', signals};
+        }
+        if (!presence.fresh) {
+            return {identity, name, family, participationStatus, online: false,
+                reason: `stale HarnessPresence (last seen ${presence.lastSeenAt || 'unknown'}; process may be up but outside the freshness window)`, signals};
+        }
+
+        return {identity, name, family, participationStatus, online: true,
+            reason: 'fresh HarnessPresence corroboration (beacon-primary pending Substrate A)', signals};
+    }
+
+    /**
+     * @summary Reads an agent's most-recent active `HARNESS_PRESENCE` overlay and computes its
+     * freshness against now. Returns null when no active presence row exists (dark agent).
+     * @param {String} owner AgentIdentity node id.
+     * @param {Number} nowMs Clock epoch ms.
+     * @returns {Object|null} `{fresh, expired, activeTurnId, state, lastSeenAt, freshUntil, expiresAt}` or null.
+     * @protected
+     */
+    _readActiveHarnessPresence(owner, nowMs) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite || !owner) return null;
+
+        const rows = sqlite.prepare(`
+            SELECT data FROM Nodes
+            WHERE json_extract(data, '$.label') = 'HARNESS_PRESENCE'
+              AND json_extract(data, '$.properties.agentIdentity') = ?
+              AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+        `).all(owner);
+
+        let latest = null, latestMs = -1;
+
+        for (const row of rows) {
+            let props;
+            try {
+                props = JSON.parse(row.data).properties || {};
+            } catch (error) {
+                logger.warn(`[WakeSubscription] who_is_online: skipped unparseable HarnessPresence row: ${error.message}`);
+                continue;
+            }
+
+            const lastSeenMs = props.lastSeenAt ? new Date(props.lastSeenAt).getTime() : 0;
+            if (lastSeenMs > latestMs) {
+                latest   = props;
+                latestMs = lastSeenMs;
+            }
+        }
+
+        if (!latest) return null;
+
+        const freshUntilMs = latest.freshUntil ? new Date(latest.freshUntil).getTime() : NaN,
+              expiresAtMs  = latest.expiresAt  ? new Date(latest.expiresAt).getTime()  : NaN;
+
+        return {
+            fresh       : Number.isFinite(freshUntilMs) && freshUntilMs > nowMs,
+            expired     : Number.isFinite(expiresAtMs)  && expiresAtMs <= nowMs,
+            activeTurnId: latest.activeTurnId || null,
+            state       : latest.state || 'unknown',
+            lastSeenAt  : latest.lastSeenAt || null,
+            freshUntil  : latest.freshUntil || null,
+            expiresAt   : latest.expiresAt  || null
+        };
+    }
+
+    /**
      * @summary Resolves an AgentIdentity wake subscription template with a durable read-through fallback.
      *
      * Bootstrap sits on the restart boundary between the Memory Core graph cache and the Shape C

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -520,11 +520,13 @@ class WakeSubscriptionService extends Base {
      * Composes the liveness layers, in precedence order:
      * 1. **`participationStatus` hard gate** — `operator_benched` / `temporarily_unreachable`
      *    report `online:false` regardless of any softer signal.
-     * 2. **Turn-started beacon (primary)** — the trusted per-turn beacon (`AGENT_TURN_PRESENCE`)
-     *    is not yet emitted, so this slot is inert (`signals.beacon:null`). When that writer lands,
-     *    its freshness becomes the primary active-turn proof. Stubbed, never faked: a running
-     *    harness is not a live agent, and a fail-closeable write-tool (`add_memory`) is not a
-     *    reliable liveness primary either (it false-negatives under the very load that proves life).
+     * 2. **Turn-started beacon (reserved)** — the trusted per-turn beacon (`AGENT_TURN_PRESENCE`)
+     *    is not yet emitted, so this is a reserved slot that always returns `signals.beacon:null`
+     *    today. When that writer lands, a follow-up extends this projection to read the beacon's
+     *    freshness as the primary active-turn proof (demoting HarnessPresence to corroboration);
+     *    it is NOT auto-activated by the current code, which never reads a beacon. Reserved, never
+     *    faked: a running harness is not a live agent, and a fail-closeable write-tool (`add_memory`)
+     *    is not a reliable liveness primary either (it false-negatives under the load that proves life).
      * 3. **HarnessPresence freshness (corroboration)** — the best available liveness signal until
      *    the beacon ships: `freshUntil` (the {@link WakeSubscriptionService#harnessPresenceFreshMs}
      *    window) still ahead of now ⇒ corroborated-online; stale or absent ⇒ probably-dark.
@@ -545,8 +547,8 @@ class WakeSubscriptionService extends Base {
 
         return {
             generatedAt : new Date(nowMs).toISOString(),
-            beaconStatus: 'turn-started beacon (primary active-turn proof) pending Substrate A (the turn-presence writer); ' +
-                          'availability below is participationStatus-gated + HarnessPresence-corroborated',
+            beaconStatus: 'turn-started beacon (reserved as the future primary signal) pending Substrate A (the turn-presence writer); ' +
+                          'availability below is decided by the participationStatus gate + HarnessPresence corroboration',
             agents
         };
     }

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1596,4 +1596,115 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(emittedEvents.length).toBe(1);
         });
     });
+
+    test.describe('who_is_online (#13498 Substrate B)', () => {
+        const T0   = '2026-06-19T12:00:00.000Z',
+              T0ms = new Date(T0).getTime(),
+              iso  = ms => new Date(ms).toISOString();
+
+        function seedAgent(id, {participationStatus = 'active', family = 'claude'} = {}) {
+            GraphService.upsertNode({
+                id,
+                type      : 'AgentIdentity',
+                name      : id,
+                properties: {participationStatus, family, displayName: id}
+            });
+        }
+
+        function seedPresence(owner, {freshUntil, activeTurnId = null} = {}) {
+            GraphService.upsertNode({
+                id        : `HARNESS_PRESENCE:${owner}:test-boot`,
+                type      : 'HARNESS_PRESENCE',
+                name      : `HarnessPresence ${owner}`,
+                properties: {
+                    agentIdentity: owner,
+                    status       : 'active',
+                    activeTurnId,
+                    state        : 'unknown',
+                    lastSeenAt   : T0,
+                    freshUntil,
+                    expiresAt    : iso(new Date(freshUntil).getTime() + 5 * 60 * 1000)
+                }
+            });
+        }
+
+        test('participationStatus hard gate: benched reports offline even with fresh presence', async () => {
+            seedAgent('@neo-benched', {participationStatus: 'operator_benched'});
+            seedPresence('@neo-benched', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-benched');
+
+            expect(entry).toBeTruthy();
+            expect(entry.online).toBe(false);
+            expect(entry.participationStatus).toBe('operator_benched');
+            expect(entry.reason).toContain('benched');
+        });
+
+        test('fresh HarnessPresence corroborates online within the freshness window', async () => {
+            seedAgent('@neo-fresh');
+            seedPresence('@neo-fresh', {freshUntil: iso(T0ms + 5 * 60 * 1000), activeTurnId: 'turn-123'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0ms + 60 * 1000)});
+            const entry    = agents.find(a => a.identity === '@neo-fresh');
+
+            expect(entry.online).toBe(true);
+            expect(entry.reason).toContain('fresh HarnessPresence');
+            expect(entry.signals.harnessPresence.activeTurnId).toBe('turn-123');
+        });
+
+        test('stale HarnessPresence reports offline past the freshness window', async () => {
+            seedAgent('@neo-stale');
+            seedPresence('@neo-stale', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0ms + 6 * 60 * 1000)});
+            const entry    = agents.find(a => a.identity === '@neo-stale');
+
+            expect(entry.online).toBe(false);
+            expect(entry.reason).toContain('stale HarnessPresence');
+        });
+
+        test('no HarnessPresence reports offline (dark)', async () => {
+            seedAgent('@neo-dark');
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-dark');
+
+            expect(entry.online).toBe(false);
+            expect(entry.reason).toContain('dark');
+            expect(entry.signals.harnessPresence).toBeNull();
+        });
+
+        test('beacon slot is null and beaconStatus flags Substrate A pending', async () => {
+            seedAgent('@neo-beacon');
+            seedPresence('@neo-beacon', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+
+            const result = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const entry  = result.agents.find(a => a.identity === '@neo-beacon');
+
+            expect(result.beaconStatus).toContain('Substrate A');
+            expect(entry.signals.beacon).toBeNull();
+        });
+
+        test('family filter narrows the roster', async () => {
+            seedAgent('@neo-claude-x', {family: 'claude'});
+            seedAgent('@neo-gpt-x',    {family: 'gpt'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({family: 'gpt', now: new Date(T0)});
+            const ids      = agents.map(a => a.identity);
+
+            expect(ids).toContain('@neo-gpt-x');
+            expect(ids).not.toContain('@neo-claude-x');
+        });
+
+        test('callable through the MCP callTool dispatch (registration + openapi)', async () => {
+            seedAgent('@neo-dispatch');
+
+            const res = await callTool('who_is_online', {});
+
+            expect(Array.isArray(res.agents)).toBe(true);
+            expect(res.beaconStatus).toContain('Substrate A');
+            expect(res.agents.some(a => a.identity === '@neo-dispatch')).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Adds the `who_is_online` Memory Core MCP read-tool — **Substrate B** of #13498 (graduated from Discussion #13495). Projects per-maintainer live availability so a request to a dark agent fails loud instead of stalling the merge gate silently.

A running harness is not a live agent. The converged design (#13495 → Option D) keys liveness on a trusted turn-started beacon with corroboration layers — and explicitly rejects `add_memory`-recency as the *primary* signal, because it false-negatives under exactly the load that proves liveness (lived twice this same nightshift: `add_memory` failed under load for two maintainers, who would then have read "offline" at peak activity).

## What it does
Per maintainer, the projection composes three layers in precedence:
1. **`participationStatus` hard gate** — `operator_benched` / `temporarily_unreachable` → offline regardless of any softer signal.
2. **Turn-started beacon (reserved)** — Substrate A (`AGENT_TURN_PRESENCE`) is not emitted yet, so this is a reserved slot the code never reads — always `signals.beacon: null` today, never faked. Once the writer lands, a small follow-up extends this projection to read the beacon's freshness as the primary signal; it is **not** auto-activated by this PR (the current code has no beacon-read path).
3. **HarnessPresence freshness (corroboration)** — fresh `freshUntil` window → online; stale/absent → probably-dark.

Advisory, not a hard routing gate (per #13495 OQ5): it surfaces probably-dark maintainers for review-routing / lane-handoff / lead-baton / wake-targeting.

## Deltas
- `ai/services/memory-core/WakeSubscriptionService.mjs` — `whoIsOnline()` + `_listAgentIdentityNodes` / `_projectAgentLiveness` / `_readActiveHarnessPresence` helpers (the proven `json_extract($.label)` SQLite pattern; `now`-seam for deterministic tests).
- `ai/mcp/server/memory-core/toolService.mjs` — registered `who_is_online` in `serviceMapping`.
- `ai/mcp/server/memory-core/openapi.yaml` — `/who-is-online` tool schema.
- `test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` — 7 unit tests.

## Test Evidence
Evidence: `npm run test-unit -- WakeSubscriptionService.spec.mjs` → **63/63 green** (the existing 56 + my 7). Class: unit, deterministic (`now`-seam; no live DB/server, so no stale-server false-green risk).
- participationStatus hard gate — benched reports offline *even with* fresh presence
- fresh HarnessPresence → online; stale → offline; no presence → dark
- beacon slot is `null` + `beaconStatus` flags the pending writer (never faked)
- model-family filter narrows the roster
- `callTool('who_is_online')` dispatch — validates registration + openapi + the method end-to-end

## Post-Merge Validation
- A live `who_is_online` call on the memory-core MCP returns the roster with each maintainer's `{online, reason, signals}`; benched/unreachable read offline, fresh-presence agents read online, stale/dark read offline with a named reason.
- When Substrate A (#13498, @neo-gpt) lands the turn-presence writer, a follow-up wires the `signals.beacon` slot to read the beacon's freshness as the primary signal (today it is a reserved inert `null` slot, tested as such; the code never reads a beacon yet).

## Close-target
Resolves #13515 (the Substrate-B delivery leaf). Refs #13498 (parent — stays open for Substrate A, @neo-gpt's domain), Refs #13495 (source discussion), Refs #13012 (epic).

## Cross-family review
Routing to @neo-gpt for the §6.1 cross-family gate (Claude↔GPT tonight). Substrate A is GPT's domain, so the beacon-slot contract is squarely in Euclid's wheelhouse — a useful reviewer for the seam where B will consume A.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 0f7b7d69-7c6c-4699-b17f-09044426f2e3.
