### PR TITLE
test(ai): aiConfig snapshot/restore isolation helper (#13519)

### DIFF
--- a/test/playwright/unit/util/aiConfigSnapshot.spec.mjs
+++ b/test/playwright/unit/util/aiConfigSnapshot.spec.mjs
@@ -1,0 +1,81 @@
+import {test, expect}       from '@playwright/test';
+import {snapshotConfigKeys} from '../../util/aiConfigSnapshot.mjs';
+
+/**
+ * Pure-function coverage for the aiConfig snapshot/restore test-isolation helper.
+ * No Neo bootstrap — the util operates on a plain object handed in.
+ */
+test.describe('test/playwright/util/aiConfigSnapshot', () => {
+    const makeConfig = () => ({
+        autoIngestFileSystem: true,
+        storagePaths        : {graph: '/orig/graph.sqlite'},
+        engines             : {chroma: {database: '/orig/chroma'}}
+    });
+
+    test('restores a top-level key mutated after the snapshot', () => {
+        const cfg     = makeConfig(),
+              restore = snapshotConfigKeys(cfg, ['autoIngestFileSystem']);
+
+        cfg.autoIngestFileSystem = false;
+        expect(cfg.autoIngestFileSystem).toBe(false);
+
+        restore();
+        expect(cfg.autoIngestFileSystem).toBe(true);
+    });
+
+    test('restores a deep dotted key', () => {
+        const cfg     = makeConfig(),
+              restore = snapshotConfigKeys(cfg, ['storagePaths.graph']);
+
+        cfg.storagePaths.graph = '/tmp/test-graph.sqlite';
+        restore();
+        expect(cfg.storagePaths.graph).toBe('/orig/graph.sqlite');
+    });
+
+    test('restores multiple mixed-depth keys in one call', () => {
+        const cfg     = makeConfig(),
+              restore = snapshotConfigKeys(cfg, ['storagePaths.graph', 'engines.chroma.database', 'autoIngestFileSystem']);
+
+        cfg.storagePaths.graph      = '/tmp/g';
+        cfg.engines.chroma.database = '/tmp/c';
+        cfg.autoIngestFileSystem    = false;
+
+        restore();
+        expect(cfg.storagePaths.graph).toBe('/orig/graph.sqlite');
+        expect(cfg.engines.chroma.database).toBe('/orig/chroma');
+        expect(cfg.autoIngestFileSystem).toBe(true);
+    });
+
+    test('restore is idempotent — calling twice is safe', () => {
+        const cfg     = makeConfig(),
+              restore = snapshotConfigKeys(cfg, ['storagePaths.graph']);
+
+        cfg.storagePaths.graph = '/tmp/g';
+        restore();
+        restore();
+        expect(cfg.storagePaths.graph).toBe('/orig/graph.sqlite');
+    });
+
+    test('captures the value at snapshot time, not at restore time', () => {
+        const cfg = makeConfig();
+        cfg.storagePaths.graph = '/first';
+        const restore = snapshotConfigKeys(cfg, ['storagePaths.graph']); // captures '/first'
+        cfg.storagePaths.graph = '/second';
+
+        restore();
+        expect(cfg.storagePaths.graph).toBe('/first');
+    });
+
+    test('missing intermediate path does not throw (capture undefined, restore no-op)', () => {
+        const cfg = makeConfig();
+        expect(() => {
+            const restore = snapshotConfigKeys(cfg, ['nope.missing.deep']);
+            restore();
+        }).not.toThrow();
+    });
+
+    test('non-array keys yields a no-op restore (no throw)', () => {
+        const cfg = makeConfig();
+        expect(() => snapshotConfigKeys(cfg, undefined)()).not.toThrow();
+    });
+});

--- a/test/playwright/util/aiConfigSnapshot.mjs
+++ b/test/playwright/util/aiConfigSnapshot.mjs
@@ -1,0 +1,73 @@
+/**
+ * @summary Capture/restore helper for spec setups that mutate the shared `aiConfig` Provider singleton.
+ *
+ * `aiConfig` is imported once per module graph; a mutation in a spec's setup (e.g.
+ * `aiConfig.storagePaths.graph = tmp`) STICKS across files in a full-suite `--workers=1` run and bleeds
+ * into later specs — a latent live-DB-bleed hazard that per-file isolation and CI retries mask. This util
+ * generalizes the in-tree capture/restore precedent
+ * (`test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs`) so a spec can
+ * snapshot exactly the keys it mutates and restore them in `afterEach` / `afterAll`.
+ *
+ * Pure by design — it operates on the object handed in, so it is unit-testable with a plain object and
+ * carries no import-time coupling to the singleton. Dotted deep paths (`storagePaths.graph`) are supported.
+ *
+ * @module test/playwright/util/aiConfigSnapshot
+ */
+
+/**
+ * @summary Read a dotted deep path off an object, tolerating missing intermediate nodes.
+ * @param {Object} obj
+ * @param {String} dottedKey e.g. `storagePaths.graph`
+ * @returns {*} The value at the path, or `undefined` if any segment is missing.
+ */
+function getPath(obj, dottedKey) {
+    return dottedKey.split('.').reduce((node, key) => (node == null ? undefined : node[key]), obj);
+}
+
+/**
+ * @summary Assign a dotted deep path on an object; no-op if an intermediate node is missing.
+ * @param {Object} obj
+ * @param {String} dottedKey
+ * @param {*} value
+ * @returns {void}
+ */
+function setPath(obj, dottedKey, value) {
+    const keys = dottedKey.split('.'),
+          last = keys.pop(),
+          host = keys.reduce((node, key) => (node == null ? undefined : node[key]), obj);
+
+    if (host != null) {
+        host[last] = value;
+    }
+}
+
+/**
+ * @summary Snapshot the given dotted keys on `target` and return a `restore()` closure that puts them back.
+ *
+ * Captures each key's current value at call time; the returned `restore()` re-assigns every captured key to
+ * that value. Idempotent — calling `restore()` more than once is safe.
+ *
+ * Usage in a spec that mutates `aiConfig`:
+ * ```js
+ * import {snapshotConfigKeys} from '../../../util/aiConfigSnapshot.mjs';
+ * let restore;
+ * test.beforeEach(() => {
+ *     restore = snapshotConfigKeys(aiConfig, ['storagePaths.graph', 'autoIngestFileSystem']);
+ *     aiConfig.storagePaths.graph = tmpGraphPath;
+ * });
+ * test.afterEach(() => restore());
+ * ```
+ *
+ * @param {Object} target The object to snapshot (e.g. the `aiConfig` singleton).
+ * @param {String[]} keys Dotted key paths to capture (and later restore).
+ * @returns {Function} `restore()` — re-assigns each captured key to its original value.
+ */
+export function snapshotConfigKeys(target, keys) {
+    const captured = (Array.isArray(keys) ? keys : []).map(key => [key, getPath(target, key)]);
+
+    return function restore() {
+        for (const [key, value] of captured) {
+            setPath(target, key, value);
+        }
+    };
+}


### PR DESCRIPTION
Resolves #13519
Refs #12435

The aiConfig snapshot/restore test-isolation helper — the AC1 foundation of #12435 (specs mutate the `aiConfig` Provider singleton in setup without restoring, bleeding config across files in a full-suite `--workers=1` run). New `test/playwright/util/aiConfigSnapshot.mjs`; **no production code touched**.

Evidence: L1 (7 unit specs cover the helper contract — capture/restore, deep dotted paths, idempotency, capture-at-snapshot-time, defensive) → L1 required (pure util, no runtime-host AC). No residuals in #13519.

## What shipped
- `test/playwright/util/aiConfigSnapshot.mjs`: `snapshotConfigKeys(target, keys)` → a `restore()` closure; captures dotted deep keys at snapshot time; pure, idempotent. Generalizes the in-tree `DestructiveOperationGuard.spec` capture/restore precedent.

## Deltas from ticket
None — implements #13519 exactly. Deliberate split: the helper lands now; adopting it across the ~11 specs + the negative full-suite `--workers=1` isolation run stay in parent #12435.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/util/aiConfigSnapshot.spec.mjs` → **7 passed**.

## Post-Merge Validation
- [ ] On adopting the helper across the ~11 specs (#12435), a full-suite `--workers=1` run is green with no cross-spec config bleed.

## Cross-family note
Test-only infra (no production runtime); §6.1 cross-family gate still applies (code, not pure docs). @neo-gpt is the only active non-Claude reviewer — no rush given his queue.

Authored by Grace (Claude Opus 4.8, Claude Code). Session 045a6048-1e1d-44c1-9738-7f09b62cc998.