### PR TITLE
feat(agentos): add review-request liveness gate (#13522)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -133,6 +133,13 @@ PR broadcasts a false board to the whole swarm (empirical: PR `#12950`'s `[merge
 landed 15s post-merge; PR `#12956`'s approval relay missed the merge by seconds — both
 operator-flagged 2026-06-12). Rule detail + verdict-not-enum companion: `pr-review-guide.md §10.1`.
 
+<!-- trigger: lifecycle boundary with assigned reviewRequests OR own clean review-requested PR stack lacking reviewer signal -> read ./review-request-liveness.md -->
+
+**Review-request liveness:** `reviewRequests` proves routing, not reviewer
+engagement. Before `verified-empty`, apply `review-request-liveness.md` when the
+active identity has assigned reviews pending, or when the active author has a
+clean own PR stack with routed-but-unmoving reviews.
+
 ## 2.5. Mandatory `lane-state:` Declaration at Every Lifecycle Boundary
 
 Per #11455 AC: at EACH broadened lifecycle boundary (reviewer post, author
@@ -292,6 +299,9 @@ backlog survey must name the surfaces checked. Minimum shape:
 - targeted review / re-review requests **where you are the assigned github
   reviewer** (verify: `gh pr view <N> --json reviewRequests`) — do not claim a PR
   review you were not assigned to;
+- own clean review-requested PR stacks with no review / decline / handoff /
+  blocker signal in the active window — route via `review-request-liveness.md`
+  before opening more implementation PRs into the same reviewer bottleneck;
 - assigned issues and currently self-authored PR follow-ups;
 - recent `[lanes-available]`, `[lane-claim]`, and `[lane-override]` A2A signals
   for collision state;

--- a/.agents/skills/post-review-pickup/references/review-request-liveness.md
+++ b/.agents/skills/post-review-pickup/references/review-request-liveness.md
@@ -1,0 +1,114 @@
+# Review-Request Liveness Gate
+
+Source: #13522, extracted from #10777's unclaimed-review-queue escalation.
+
+This payload governs the active-window state after a reviewer has already been
+assigned to a PR. It complements the pull-request workflow's 24-hour silence
+timeout; it does not replace that hard fallback.
+
+## Failure Mode
+
+`reviewRequests` proves that a reviewer was routed. It does not prove the review
+gate is live.
+
+The failure this gate prevents:
+
+- an author treats "reviewer assigned" as coordination-complete while clean PRs
+  sit with no review, decline, handoff, or blocker signal;
+- a reviewer reaches lifecycle boundaries while assigned review requests remain
+  invisible to their terminal state;
+- the swarm opens more implementation PRs into the same reviewer bottleneck
+  instead of making the existing review queue move.
+
+This is liveness routing, not fairness policy. No quotas, scoreboards, central
+assignment, or "slow the productive author" rule are introduced.
+
+## Signals
+
+A routed review request is live when at least one visible state transition
+exists after routing:
+
+- formal review posted;
+- reviewer declines and unassigns themselves, or asks the author to unassign;
+- reviewer hands off to a named alternate reviewer;
+- reviewer sends `blocked-task-state` with a concrete blocker;
+- reviewer sends an explicit CI-hold / scope-hold when the PR is not reviewable
+  yet.
+
+A routed review request is stale in the active window when the PR is clean/green,
+has a named reviewer, and none of the visible transitions above exists while the
+reviewer or author continues other lifecycle work.
+
+## Author-Side Protocol
+
+When the author has multiple clean own PRs with reviewers assigned and no visible
+reviewer transition in the active window:
+
+1. Stop treating additional implementation PRs as the highest-value next lane.
+2. Send a targeted, unsuppressed A2A to each assigned reviewer asking for one
+   state transition: review, decline/unassign, handoff, or blocked-task-state.
+3. Prefer non-reviewer-piling work until the stack moves: peer reviews,
+   ticket-only analysis, issue/body cleanup, or substrate evidence.
+4. If a reviewer remains completely silent for the existing 24-hour timeout,
+   use the pull-request workflow's silence-timeout path.
+
+One stale PR can still be urgent enough to route, but the systemic gate fires
+when the author is building a stack of routed-but-unmoving PRs.
+
+## Reviewer-Side Protocol
+
+Before a reviewer declares `verified-empty`, they must check whether any open PR
+is review-requested to their GitHub identity.
+
+If assigned review requests exist:
+
+- green/current-head PR: review it, decline/unassign, hand it off, or declare a
+  concrete blocker;
+- red/pending PR: use the existing CI hold/fail-fast path rather than a full
+  review;
+- wrong-family or overloaded reviewer: decline/unassign or hand off explicitly.
+
+An assigned review request invalidates `verified-empty` until one of those state
+transitions is visible.
+
+## A2A Template
+
+Use an actionable direct message. Do not set `wakeSuppressed`.
+
+```text
+Subject: [review-liveness][#PR] claim / decline / handoff requested
+
+V-B-A at <ISO time>: #PR is <CLEAN/green>, review-requested to <reviewer>,
+and has no review / decline / handoff / blocker signal after routing.
+
+Requested action: choose one visible state transition:
+- review now;
+- decline/unassign with reason;
+- hand off to <named peer>;
+- send blocked-task-state with the concrete blocker.
+
+This is review-liveness routing, not central assignment or throughput pressure.
+```
+
+## Terminal Guard
+
+`verified-empty` is invalid when either condition is true:
+
+- the active identity has assigned review requests still pending with no visible
+  state transition;
+- the active author has multiple clean own PRs with peer review requested and no
+  reviewer transition in the active window, but has not performed the targeted
+  liveness routing above.
+
+Use `next-lane (review-liveness routing for #PR...)`, `human-gate`, or
+`blocked-task-state` instead, depending on the verified state.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails |
+|---|---|
+| Opening another same-reviewer implementation PR while older green PRs have no reviewer signal | Adds load to the bottleneck instead of moving it |
+| Broadcasting a generic "reviewers needed" note | Does not create owner-visible state; use targeted reviewer messages |
+| Counting `reviewRequests` alone as coordination complete | Assignment is an invitation, not a response |
+| Treating this as a fairness band | Reintroduces retired quota logic; the goal is liveness |
+| Waiting only for the 24-hour timeout while the reviewer is demonstrably active | Misses active-window liveness and burns operator attention |

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -226,6 +226,8 @@ To prevent redundant parallel effort and reviewer collision, you MUST adhere to 
    - **Decline Protocol:** If a peer cannot review within 24 hours (due to queue load, context-mismatch, or loop exhaustion), they MUST formally decline via an A2A ping back to the author with `Requested action: unassign` and use `manage_pr_reviewers` to remove themselves. The author then assigns the remaining peer.
    - **Silence Timeout Path:** If the assigned reviewer is completely silent for 24 hours, the author MUST unilaterally unassign them via `manage_pr_reviewers`, assign the third peer, and note the timeout in a PR comment.
 
+<!-- trigger: assigned reviewer + clean PR stack lacks reviewer signal -> read ../../post-review-pickup/references/review-request-liveness.md -->
+
 3. **Optional Visibility (The Observer):** If the second peer requires awareness without action, send an explicit no-action note.
    - Include `Review role: observer` and `Requested action: none`.
    - *Note:* This should be rare. Most PRs do not need observer notification.


### PR DESCRIPTION
Resolves #13522

Related: #10777

Adds an active-window review-request liveness gate to the agent PR lifecycle substrate. The change keeps the detailed rule in a conditional `post-review-pickup` reference payload, then adds short trigger pointers from author-side PR routing and reviewer-side pickup so `reviewRequests` stops being treated as coordination-complete without a visible reviewer state transition.

Evidence: L1 (static skill-substrate diff + skill-manifest lint) -> L1 required (documentation/workflow ACs only). No residuals.

## Deltas from ticket

The ticket suggested either a conditional sibling payload or small workflow sections. I used the conditional payload shape:

- New `review-request-liveness.md` owns the full protocol, A2A template, terminal guard, and anti-FAIR-band boundary.
- `pull-request-workflow.md` gets only a compact trigger pointer, because `lint-skill-manifest` rejected the larger inline text as workflow-map bloat.
- `post-review-pickup-workflow.md` gets a short terminal-guard hook plus a survey bullet so reviewers and authors both load the same payload when the trigger fires.

## Slot Rationale

This PR mutates skill-loaded memory substrate, so `/turn-memory-pre-flight` was applied.

- Added payload: `.agents/skills/post-review-pickup/references/review-request-liveness.md`
  - Disposition: `compress-to-trigger`.
  - 3-axis rating: trigger-frequency = edge-case lifecycle boundary; failure-severity = high (review gates silently age and operators must intervene); enforceability = discipline-only until mechanical lane-state substrate exists.
  - Placement: World-Atlas payload under `post-review-pickup` because both author-side and reviewer-side lifecycle boundaries consume it.
- Modified map pointers: `pull-request-workflow.md` and `post-review-pickup-workflow.md`
  - Disposition delta: `rewrite` / `compress-to-trigger`.
  - Reason: each map gets only the trigger needed to load the payload; the substantive rule body is not duplicated in always-loaded routers or broad workflow text.

Substrate sufficiency audit: existing layers were insufficient. CI cannot enforce reviewer engagement; `AGENTS.md` only names the general lifecycle cycle; the pull-request workflow had only the 24-hour silence fallback; and `post-review-pickup` did not invalidate `verified-empty` for active assigned `reviewRequests`.

## Test Evidence

- `git diff --cached --check` -> passed.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> passed.
- Husky pre-commit `check-whitespace` -> passed.

## Post-Merge Validation

- [ ] Next clean PR stack with stale routed reviews loads `review-request-liveness.md` from the author-side trigger instead of opening more implementation PRs into the same reviewer bottleneck.
- [ ] Next reviewer lifecycle boundary with assigned `reviewRequests` treats `verified-empty` as invalid until review / decline-unassign / handoff / blocked-task-state is visible.

## Commits

- `74f434074` - add active-window review-request liveness gate

Authored by Euclid (GPT-5, Codex Desktop). Session 22d7a821-c417-459f-9308-7216c920ecb0.
