### PR TITLE
feat(ai): per-agent modelProvider resolves via the AiConfig SSOT (#13525)

### DIFF
--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -2,6 +2,7 @@ import crypto          from 'crypto';
 import fs              from 'fs';
 import path            from 'path';
 import {fileURLToPath} from 'url';
+import aiConfig        from '../../config.mjs';
 import Base            from '../../../src/core/Base.mjs';
 
 const
@@ -18,8 +19,9 @@ const
  * This is the first leaf of the Fleet Manager MVP: the `define` surface of the operator loop
  * *define agents → start/stop → repos managed under the hood*.
  *
- * An **agent definition** is `{id, githubUsername, harnessType, metadata, createdAt, updatedAt}` —
- * never a secret. The associated **credential** (a GitHub PAT) is stored separately, encrypted at
+ * An **agent definition** is `{id, githubUsername, harnessType, modelProvider, metadata, createdAt, updatedAt}` —
+ * never a secret. `modelProvider` (the agent's model-provider login) resolves via the AiConfig
+ * `modelProvider` SSOT leaf when not supplied — read-only, no service-local default shadow. The associated **credential** (a GitHub PAT) is stored separately, encrypted at
  * rest, and is the load-bearing security boundary of this service:
  *
  * **Two-hemisphere security rule** (the graduated Agent Harness design rule): the PAT is a
@@ -111,9 +113,10 @@ class FleetRegistryService extends Base {
      * @param {String} [opts.credential]        The GitHub PAT — stored Node-side encrypted; never echoed back.
      * @param {String} [opts.id=githubUsername] Stable id; pass an explicit id to register multiple instances per user.
      * @param {Object} [opts.metadata={}]       Free-form non-secret metadata.
+     * @param {String} [opts.modelProvider]     The agent's model-provider login (e.g. `openAiCompatible`, `ollama`). Resolves via the AiConfig `modelProvider` SSOT leaf when omitted — no service-local default shadow. Non-secret; carried in the public definition.
      * @returns {Object} The public agent definition (no credential).
      */
-    defineAgent({githubUsername, harnessType, credential, id, metadata={}} = {}) {
+    defineAgent({githubUsername, harnessType, credential, id, metadata={}, modelProvider} = {}) {
         if (!githubUsername) throw new Error("FleetRegistryService.defineAgent: 'githubUsername' is required.");
         if (!harnessType)    throw new Error("FleetRegistryService.defineAgent: 'harnessType' is required.");
 
@@ -131,6 +134,9 @@ class FleetRegistryService extends Base {
                 id            : agentId,
                 githubUsername,
                 harnessType,
+                // provider-login resolves via the AiConfig SSOT leaf when unset (no service-local
+                // default shadow); an explicit arg wins, else a prior value is preserved on update.
+                modelProvider : modelProvider || existing?.modelProvider || aiConfig.modelProvider,
                 metadata,
                 createdAt     : existing?.createdAt || now,
                 updatedAt     : now

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -20,6 +20,7 @@ import crypto          from 'crypto';
 import Neo                  from '../../../../src/Neo.mjs';
 import * as core            from '../../../../src/core/_export.mjs';
 import FleetRegistryService from '../../../../ai/services/fleet/FleetRegistryService.mjs';
+import aiConfig             from '../../../../ai/config.mjs';
 
 const createdDirs = [];
 
@@ -69,6 +70,23 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         expect(def.id).toBe('neo-claude-opus');
         expect(def.credential).toBeUndefined();
         expect(JSON.stringify(def)).not.toContain('ghp_secretTokenAAA');
+    });
+
+    test('modelProvider resolves via the AiConfig SSOT leaf when unset, honors an explicit value, and is preserved on update', () => {
+        // unset -> resolves via the AiConfig modelProvider SSOT (read-only; no service-local default shadow)
+        const defaulted = FleetRegistryService.defineAgent({githubUsername: 'prov-default', harnessType: 'codex'});
+        expect(defaulted.modelProvider).toBe(aiConfig.modelProvider);
+
+        // an explicit value wins over the SSOT default
+        const explicit = FleetRegistryService.defineAgent({githubUsername: 'prov-explicit', harnessType: 'codex', modelProvider: 'ollama'});
+        expect(explicit.modelProvider).toBe('ollama');
+
+        // a prior value is preserved when the agent is re-defined without modelProvider
+        const updated = FleetRegistryService.defineAgent({githubUsername: 'prov-explicit', harnessType: 'codex'});
+        expect(updated.modelProvider).toBe('ollama');
+
+        // non-secret: the provider-login is carried in the public projection
+        expect(FleetRegistryService.getAgent('prov-explicit').modelProvider).toBe('ollama');
     });
 
     test('CRUD round-trip: define -> list -> get -> remove', () => {


### PR DESCRIPTION
## Summary

`FleetRegistryService.defineAgent` gains an optional `modelProvider` param — the agent's model-provider login (`openAiCompatible`, `ollama`, …). When omitted it resolves via the `aiConfig.modelProvider` **SSOT leaf** (ADR 0019): read the resolved leaf at the use site, no service-local default shadow, no mutation of the shared singleton (B4-safe; #12435). An explicit value wins; a prior value is preserved on re-define (parity with `createdAt`). Carried in the public projection (`toPublic`) as a **non-secret** field — the PAT/credential boundary is untouched.

Delivers **#13521 AC1** (provider-login resolves via the AiConfig provider SSOT), split out per the 1-PR-per-ticket model (`agent-pr-body-lint.yml`). #13521 retains AC2 (basic NL-MCP entry) + AC3 (v14 `IdentityState` slot).

Resolves #13525
Refs #13521

## Deltas

- `ai/services/fleet/FleetRegistryService.mjs`
  - import the `aiConfig` SSOT (`../../config.mjs`).
  - `defineAgent({…, modelProvider})`: new optional param. Def field is `modelProvider: modelProvider || existing?.modelProvider || aiConfig.modelProvider` — explicit value → prior value preserved on update → SSOT default.
  - JSDoc: `@param modelProvider` added; class `@summary` updated so the agent-definition shape carries the field.
  - `toPublic` unchanged — `modelProvider` flows through as a non-secret field (the PAT path is untouched).
- `test/playwright/unit/ai/FleetRegistryService.spec.mjs`
  - import `aiConfig`; +1 test, 4 assertions.

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/FleetRegistryService.spec.mjs`

```
Running 18 tests using 9 workers
  18 passed (754ms)
```

New test — `modelProvider resolves via the AiConfig SSOT leaf when unset, honors an explicit value, and is preserved on update` — asserts:
- unset → `def.modelProvider === aiConfig.modelProvider` (SSOT resolution; read-only)
- explicit `'ollama'` wins over the SSOT default
- re-define without it → preserved `'ollama'`
- present in the public projection (`getAgent('…').modelProvider`)

Husky gates green on commit — including `check-aiconfig-test-mutation`, which mechanically confirms the spec **reads** `aiConfig` without mutating the shared singleton (B4-safe).

## Post-Merge Validation

- CI `test-unit` stays green (`FleetRegistryService.spec` 18/18).
- No consumer migration: `defineAgent` is additive / backward-compatible — existing callers omit `modelProvider` and receive the SSOT default. `defineAgent` is a Brain-side service method (not an MCP tool surface), so no Contract Ledger / OpenAPI-compliance fixture applies.
- Follow-on (remain open on #13521): AC2 (basic NL-MCP external-harness entry) + AC3 (v14 `IdentityState` slot verification, gated on #13444).

## Risk

Low. Additive optional param; read-only SSOT access at the use site; non-secret field; the PAT/credential boundary is unchanged. Reversible in a single commit (Tier-2).

---

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
