### PR TITLE
feat(memory-core): who_is_online liveness via add_memory-recency (#13524)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -209,9 +209,10 @@ paths:
 
 
         Layers (precedence): (1) participationStatus hard gate — operator_benched /
-        temporarily_unreachable report offline; (2) turn-started beacon — reserved as the future
-        primary active-turn proof, but not yet emitted, so currently an inert null slot the code never
-        reads (never faked); (3) HarnessPresence freshness — the corroboration that decides availability today.
+        temporarily_unreachable report offline; (2) add_memory-recency (primary) — the most-recent
+        caller-visible AGENT_MEMORY write within the freshness window means recently active. add_memory
+        is the universal, deployment-agnostic activity write (no harness beacon); the read is RLS-scoped
+        (never cross-tenant) and graph-backed (survives an embed-drain).
       tags: [Health]
       requestBody:
         required: false
@@ -234,9 +235,9 @@ paths:
                   generatedAt:
                     type: string
                     description: ISO timestamp the projection was computed at.
-                  beaconStatus:
+                  signalStatus:
                     type: string
-                    description: Status of the primary turn-started beacon signal (pending Substrate A).
+                    description: Describes the liveness signal — add_memory-recency, RLS-scoped and graph-backed.
                   agents:
                     type: array
                     items:

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -520,16 +520,15 @@ class WakeSubscriptionService extends Base {
      * Composes the liveness layers, in precedence order:
      * 1. **`participationStatus` hard gate** — `operator_benched` / `temporarily_unreachable`
      *    report `online:false` regardless of any softer signal.
-     * 2. **Turn-started beacon (reserved)** — the trusted per-turn beacon (`AGENT_TURN_PRESENCE`)
-     *    is not yet emitted, so this is a reserved slot that always returns `signals.beacon:null`
-     *    today. When that writer lands, a follow-up extends this projection to read the beacon's
-     *    freshness as the primary active-turn proof (demoting HarnessPresence to corroboration);
-     *    it is NOT auto-activated by the current code, which never reads a beacon. Reserved, never
-     *    faked: a running harness is not a live agent, and a fail-closeable write-tool (`add_memory`)
-     *    is not a reliable liveness primary either (it false-negatives under the load that proves life).
-     * 3. **HarnessPresence freshness (corroboration)** — the best available liveness signal until
-     *    the beacon ships: `freshUntil` (the {@link WakeSubscriptionService#harnessPresenceFreshMs}
-     *    window) still ahead of now ⇒ corroborated-online; stale or absent ⇒ probably-dark.
+     * 2. **`add_memory`-recency (primary)** — the deployment-agnostic, tenant-scoped activity signal
+     *    ({@link WakeSubscriptionService#_readActivityRecency}): the most-recent caller-visible
+     *    `AGENT_MEMORY` write within the freshness window ⇒ recently active ⇒ online; stale or none ⇒
+     *    dark. `add_memory` is the universal activity write every authenticated agent produces — so the
+     *    signal works identically in the swarm and a multi-tenant cloud deployment, unlike a harness
+     *    beacon (emitted only by the neo-swarm harness, inert elsewhere) or process-presence
+     *    (pid/clone-local — the "local neo activity" coupling that is not mergeable). The read is
+     *    RLS-scoped (never cross-tenant) and graph-backed (survives an embed-drain — it reads the
+     *    durable node, not Chroma).
      *
      * Deliberately **advisory**: it surfaces *probably-dark* maintainers for review-routing /
      * lane-handoff / lead-baton / wake-targeting so a request to a dark agent fails loud instead
@@ -538,7 +537,7 @@ class WakeSubscriptionService extends Base {
      * @param {Object} [opts]
      * @param {String} [opts.family] Optional model-family filter (e.g. `'claude'`, `'gpt'`).
      * @param {Date|String|Number} [opts.now=new Date()] Clock source (unit-test seam).
-     * @returns {Promise<Object>} `{generatedAt, beaconStatus, agents}` where each agent is
+     * @returns {Promise<Object>} `{generatedAt, signalStatus, agents}` where each agent is
      *   `{identity, name, family, participationStatus, online, reason, signals}`.
      */
     async whoIsOnline({family, now = new Date()} = {}) {
@@ -547,8 +546,10 @@ class WakeSubscriptionService extends Base {
 
         return {
             generatedAt : new Date(nowMs).toISOString(),
-            beaconStatus: 'turn-started beacon (reserved as the future primary signal) pending Substrate A (the turn-presence writer); ' +
-                          'availability below is decided by the participationStatus gate + HarnessPresence corroboration',
+            signalStatus: 'add_memory-recency: per maintainer, the most-recent caller-visible AGENT_MEMORY ' +
+                          'write within the freshness window. Deployment-agnostic (add_memory is the universal ' +
+                          'activity write — no harness beacon), RLS-scoped (never cross-tenant), and graph-backed ' +
+                          '(survives an embed-drain). Advisory, not a hard routing gate.',
             agents
         };
     }
@@ -603,7 +604,7 @@ class WakeSubscriptionService extends Base {
               name                = node.name || props.displayName || node.id,
               family              = props.family || props.modelFamily || null,
               participationStatus = props.participationStatus || 'active',
-              signals             = {participationStatus, beacon: null, harnessPresence: null};
+              signals             = {participationStatus, activityRecency: null};
 
         // 1. participationStatus HARD GATE — benched/unreachable overrides every softer signal.
         if (participationStatus !== 'active') {
@@ -611,75 +612,89 @@ class WakeSubscriptionService extends Base {
                 reason: `roster: participationStatus is '${participationStatus}' (benched / unreachable)`, signals};
         }
 
-        // 2. Turn-started beacon (primary) — Substrate A pending; slot stays null (never faked).
+        // 2. add_memory-recency — the deployment-agnostic, tenant-scoped activity signal. Every
+        //    authenticated agent's memory write stamps an AGENT_MEMORY node (agentIdentity + timestamp);
+        //    a fresh most-recent caller-visible write ⇒ recently active ⇒ online. Unlike a harness
+        //    beacon (emitted only by the neo-swarm harness, inert in a multi-tenant/cloud deployment),
+        //    add_memory is universal — and the read is RLS-scoped (never cross-tenant) and graph-backed
+        //    (survives an embed-drain).
+        const activity = this._readActivityRecency(identity, nowMs);
+        signals.activityRecency = activity;
 
-        // 3. HarnessPresence freshness (corroboration).
-        const presence = this._readActiveHarnessPresence(identity, nowMs);
-        signals.harnessPresence = presence;
-
-        if (!presence) {
+        if (!activity) {
             return {identity, name, family, participationStatus, online: false,
-                reason: 'no live HarnessPresence (dark — process down or never connected)', signals};
+                reason: 'no caller-visible add_memory activity (dark — inactive, or no shared/team activity visible to the caller)', signals};
         }
-        if (!presence.fresh) {
+        if (!activity.fresh) {
             return {identity, name, family, participationStatus, online: false,
-                reason: `stale HarnessPresence (last seen ${presence.lastSeenAt || 'unknown'}; process may be up but outside the freshness window)`, signals};
+                reason: `stale add_memory activity (last write ${activity.lastActivityAt} — none within the freshness window)`, signals};
         }
 
         return {identity, name, family, participationStatus, online: true,
-            reason: 'fresh HarnessPresence corroboration (beacon-primary pending Substrate A)', signals};
+            reason: `recent add_memory activity (last write ${activity.lastActivityAt})`, signals};
     }
 
     /**
-     * @summary Reads an agent's most-recent active `HARNESS_PRESENCE` overlay and computes its
-     * freshness against now. Returns null when no active presence row exists (dark agent).
+     * @summary Reads an agent's most-recent caller-visible `add_memory` activity — the
+     * deployment-agnostic, tenant-scoped liveness signal that replaced the harness beacon.
+     *
+     * Every authenticated agent's memory write stamps an `AGENT_MEMORY` graph node with
+     * `agentIdentity` + `timestamp` + `userId` ({@link Neo.ai.services.memory-core.MemoryService#addMemory}).
+     * This returns the freshness verdict for the most-recent such node the CALLER is entitled to see,
+     * RLS-scoped by the same `(user_id = ? OR user_id IS NULL OR sharedEntity OR visibility:team)`
+     * predicate `GraphService.searchNodes` uses — so who_is_online reads THROUGH tenant isolation
+     * rather than bypassing it via a raw owner-only read (the original cross-tenant defect this pivot
+     * fixes). It reads the durable graph node, not Chroma, so it survives an embed-drain; and
+     * `add_memory` is the universal activity write (no harness hook, no per-deployment beacon), so the
+     * signal works identically in the swarm and a multi-tenant cloud.
+     *
+     * Freshness window: `add_memory` lands at turn boundaries (the consolidate-then-save gate), so the
+     * window must exceed a typical turn to avoid marking a mid-turn agent dark — the false-negative the
+     * beacon design feared. 15 min covers "active within the last few turns" for an advisory tool.
      * @param {String} owner AgentIdentity node id.
      * @param {Number} nowMs Clock epoch ms.
-     * @returns {Object|null} `{fresh, expired, activeTurnId, state, lastSeenAt, freshUntil, expiresAt}` or null.
+     * @returns {Object|null} `{lastActivityAt, ageMs, fresh}` or null when no caller-visible activity.
      * @protected
      */
-    _readActiveHarnessPresence(owner, nowMs) {
+    _readActivityRecency(owner, nowMs) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite || !owner) return null;
 
-        const rows = sqlite.prepare(`
-            SELECT data FROM Nodes
-            WHERE json_extract(data, '$.label') = 'HARNESS_PRESENCE'
-              AND json_extract(data, '$.properties.agentIdentity') = ?
-              AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
-        `).all(owner);
+        // RLS: scope to activity the caller is entitled to see — mirror GraphService's read predicate
+        // (own tenant + null-owner system + sharedEntity + visibility:team) keyed on the caller's bound
+        // identity, so this read goes THROUGH tenant isolation rather than bypassing it.
+        const callerUserId = GraphService.db?.storage?.RequestContextService?.getAgentIdentityNodeId?.() ?? null;
 
-        let latest = null, latestMs = -1;
-
-        for (const row of rows) {
-            let props;
-            try {
-                props = JSON.parse(row.data).properties || {};
-            } catch (error) {
-                logger.warn(`[WakeSubscription] who_is_online: skipped unparseable HarnessPresence row: ${error.message}`);
-                continue;
-            }
-
-            const lastSeenMs = props.lastSeenAt ? new Date(props.lastSeenAt).getTime() : 0;
-            if (lastSeenMs > latestMs) {
-                latest   = props;
-                latestMs = lastSeenMs;
-            }
+        let latest;
+        try {
+            const row = sqlite.prepare(`
+                SELECT MAX(json_extract(data, '$.properties.timestamp')) AS latest
+                FROM Nodes
+                WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
+                  AND json_extract(data, '$.properties.agentIdentity') = ?
+                  AND (user_id = ?
+                       OR user_id IS NULL
+                       OR json_extract(data, '$.properties.sharedEntity') = 1
+                       OR json_extract(data, '$.properties.visibility') = 'team')
+            `).get(owner, callerUserId);
+            latest = row?.latest || null;
+        } catch (error) {
+            logger.warn(`[WakeSubscription] who_is_online: activity-recency read failed for ${owner}: ${error.message}`);
+            return null;
         }
 
         if (!latest) return null;
 
-        const freshUntilMs = latest.freshUntil ? new Date(latest.freshUntil).getTime() : NaN,
-              expiresAtMs  = latest.expiresAt  ? new Date(latest.expiresAt).getTime()  : NaN;
+        const lastMs = new Date(latest).getTime();
+        if (!Number.isFinite(lastMs)) return null;
+
+        const ageMs   = nowMs - lastMs,
+              freshMs = 15 * 60 * 1000;
 
         return {
-            fresh       : Number.isFinite(freshUntilMs) && freshUntilMs > nowMs,
-            expired     : Number.isFinite(expiresAtMs)  && expiresAtMs <= nowMs,
-            activeTurnId: latest.activeTurnId || null,
-            state       : latest.state || 'unknown',
-            lastSeenAt  : latest.lastSeenAt || null,
-            freshUntil  : latest.freshUntil || null,
-            expiresAt   : latest.expiresAt  || null
+            lastActivityAt: new Date(lastMs).toISOString(),
+            ageMs,
+            fresh: ageMs >= 0 && ageMs <= freshMs
         };
     }
 

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1654,26 +1654,21 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
         }
 
-        function seedPresence(owner, {freshUntil, activeTurnId = null} = {}) {
+        function seedActivity(owner, {timestamp = T0} = {}) {
+            // Mirrors a swarm (stdio) add_memory graph projection: an AGENT_MEMORY node carrying
+            // agentIdentity + timestamp and NO userId (→ user_id NULL → RLS-visible to every caller,
+            // as stdio-mode memories are). The who_is_online recency read keys on this node.
             GraphService.upsertNode({
-                id        : `HARNESS_PRESENCE:${owner}:test-boot`,
-                type      : 'HARNESS_PRESENCE',
-                name      : `HarnessPresence ${owner}`,
-                properties: {
-                    agentIdentity: owner,
-                    status       : 'active',
-                    activeTurnId,
-                    state        : 'unknown',
-                    lastSeenAt   : T0,
-                    freshUntil,
-                    expiresAt    : iso(new Date(freshUntil).getTime() + 5 * 60 * 1000)
-                }
+                id        : `AGENT_MEMORY:${owner}:${timestamp}`,
+                type      : 'AGENT_MEMORY',
+                name      : `Memory: ${timestamp}`,
+                properties: {agentIdentity: owner, timestamp, sessionId: 'sess-test'}
             });
         }
 
-        test('participationStatus hard gate: benched reports offline even with fresh presence', async () => {
+        test('participationStatus hard gate: benched reports offline even with fresh activity', async () => {
             seedAgent('@neo-benched', {participationStatus: 'operator_benched'});
-            seedPresence('@neo-benched', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+            seedActivity('@neo-benched', {timestamp: T0});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-benched');
@@ -1684,49 +1679,87 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.reason).toContain('benched');
         });
 
-        test('fresh HarnessPresence corroborates online within the freshness window', async () => {
-            seedAgent('@neo-fresh');
-            seedPresence('@neo-fresh', {freshUntil: iso(T0ms + 5 * 60 * 1000), activeTurnId: 'turn-123'});
+        test('fresh add_memory activity → online (recency-primary)', async () => {
+            seedAgent('@neo-active');
+            seedActivity('@neo-active', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0ms + 60 * 1000)});
-            const entry    = agents.find(a => a.identity === '@neo-fresh');
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-active');
 
             expect(entry.online).toBe(true);
-            expect(entry.reason).toContain('fresh HarnessPresence');
-            expect(entry.signals.harnessPresence.activeTurnId).toBe('turn-123');
+            expect(entry.reason).toContain('recent add_memory activity');
+            expect(entry.signals.activityRecency.fresh).toBe(true);
         });
 
-        test('stale HarnessPresence reports offline past the freshness window', async () => {
+        test('stale add_memory activity → offline (past the freshness window)', async () => {
             seedAgent('@neo-stale');
-            seedPresence('@neo-stale', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+            // last write 20 min ago — beyond the 15-min freshness window
+            seedActivity('@neo-stale', {timestamp: iso(T0ms - 20 * 60 * 1000)});
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0ms + 6 * 60 * 1000)});
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-stale');
 
             expect(entry.online).toBe(false);
-            expect(entry.reason).toContain('stale HarnessPresence');
+            expect(entry.reason).toContain('stale add_memory activity');
+            expect(entry.signals.activityRecency.fresh).toBe(false);
         });
 
-        test('no HarnessPresence reports offline (dark)', async () => {
+        test('no add_memory activity → offline (dark) + signals.activityRecency null', async () => {
             seedAgent('@neo-dark');
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-dark');
 
             expect(entry.online).toBe(false);
-            expect(entry.reason).toContain('dark');
-            expect(entry.signals.harnessPresence).toBeNull();
+            expect(entry.reason).toContain('no caller-visible add_memory activity');
+            expect(entry.signals.activityRecency).toBeNull();
         });
 
-        test('beacon slot is null and beaconStatus flags Substrate A pending', async () => {
-            seedAgent('@neo-beacon');
-            seedPresence('@neo-beacon', {freshUntil: iso(T0ms + 5 * 60 * 1000)});
+        test('tenant-scoping: a different-user_id (private) AGENT_MEMORY does NOT mark online (RLS-filtered → dark)', async () => {
+            seedAgent('@neo-other-tenant');
+            // Fresh activity, but owned by a DIFFERENT tenant: userId set (not NULL), not shared, not team —
+            // so the RLS predicate (user_id = caller OR NULL OR sharedEntity OR visibility:'team') admits none
+            // of it for a non-matching caller. The private cross-tenant activity must stay invisible.
+            GraphService.upsertNode({
+                id        : 'AGENT_MEMORY:@neo-other-tenant:private',
+                type      : 'AGENT_MEMORY',
+                name      : 'Memory: private',
+                properties: {agentIdentity: '@neo-other-tenant', timestamp: iso(T0ms - 2 * 60 * 1000), userId: 'some-other-tenant', sessionId: 'sess-test'}
+            });
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-other-tenant');
+
+            expect(entry.online).toBe(false);
+            expect(entry.reason).toContain('no caller-visible add_memory activity');
+            expect(entry.signals.activityRecency).toBeNull();
+        });
+
+        test('tenant-scoping: a team-visible AGENT_MEMORY (foreign user_id) DOES mark online (RLS-admitted)', async () => {
+            seedAgent('@neo-team-vis');
+            // Foreign userId, but visibility:'team' → the RLS predicate admits it cross-caller (the shared-board path),
+            // so caller-visible activity still reads online even when its userId is not the caller's.
+            GraphService.upsertNode({
+                id        : 'AGENT_MEMORY:@neo-team-vis:teamvis',
+                type      : 'AGENT_MEMORY',
+                name      : 'Memory: teamvis',
+                properties: {agentIdentity: '@neo-team-vis', timestamp: iso(T0ms - 2 * 60 * 1000), userId: 'some-other-tenant', visibility: 'team', sessionId: 'sess-test'}
+            });
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-team-vis');
+
+            expect(entry.online).toBe(true);
+            expect(entry.signals.activityRecency.fresh).toBe(true);
+        });
+
+        test('signalStatus names the add_memory-recency signal (no beacon field)', async () => {
+            seedAgent('@neo-sig');
 
             const result = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
-            const entry  = result.agents.find(a => a.identity === '@neo-beacon');
 
-            expect(result.beaconStatus).toContain('Substrate A');
-            expect(entry.signals.beacon).toBeNull();
+            expect(result.signalStatus).toContain('add_memory-recency');
+            expect(result.beaconStatus).toBeUndefined();
         });
 
         test('family filter narrows the roster', async () => {
@@ -1746,7 +1779,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             const res = await callTool('who_is_online', {});
 
             expect(Array.isArray(res.agents)).toBe(true);
-            expect(res.beaconStatus).toContain('Substrate A');
+            expect(res.signalStatus).toContain('add_memory-recency');
             expect(res.agents.some(a => a.identity === '@neo-dispatch')).toBe(true);
         });
     });


### PR DESCRIPTION
## Summary
Pivots `who_is_online` liveness from the `AGENT_TURN_PRESENCE` beacon (the design #13517 merged) to **`add_memory`-recency** — operator-directed. who_is_online's signal must be `add_memory`: the universal activity write every authenticated agent produces, not a harness beacon that only the neo-swarm harness emits (inert in a multi-tenant cloud) and is pid/clone-local-coupled.

This supersedes the beacon-primary / reserved-slot design (#13515 / #13517, merged) and its HarnessPresence corroboration — both were deployment-coupled. `add_memory`-recency is deployment-agnostic, tenant-scoped, and multi-tenant-safe.

## What it does
`_projectAgentLiveness` per maintainer: `participationStatus` hard gate → **`add_memory`-recency** (the beacon + HarnessPresence reads are dropped).

New `_readActivityRecency(owner, nowMs)`:
- Reads `MAX(AGENT_MEMORY.timestamp)` for the identity — the most-recent activity.
- **RLS-scoped** by the same predicate `GraphService.searchNodes` uses — `(user_id = ? OR user_id IS NULL OR sharedEntity OR visibility:'team')` keyed on the bound caller — so it reads *through* tenant isolation, never around it (no raw owner-only cross-tenant read).
- **Graph-backed** (the durable `AGENT_MEMORY` node, not Chroma) → survives an embed-drain.
- **15-min freshness window** — `add_memory` lands at turn boundaries, so the window exceeds a typical turn to avoid marking a mid-turn agent dark (the false-negative the beacon design feared).

Why it is deployment-agnostic + tenant-safe:
- **Swarm (stdio):** memories carry no `userId` → `user_id` NULL → cross-visible → the shared maintainer board works.
- **Multi-tenant (SSE):** memories are `userId`-stamped → RLS-scoped → no cross-tenant activity leak.

## Deltas from ticket
- Re-scoped #13524 from "wire the beacon into who_is_online" to "who_is_online via add_memory-recency" — the operator's pivot direction supersedes the beacon mechanism (same goal: who_is_online liveness).
- Response field `beaconStatus` → `signalStatus`; `signals.beacon` / `signals.harnessPresence` → `signals.activityRecency`.
- Removed the now-unused `_readActiveTurnPresence` + `_readActiveHarnessPresence` reads; the `record_turn_presence` writer (TurnPresenceService, #13500) is untouched.

## Test Evidence
Evidence: L1 (unit, deterministic `now`-seam; no live DB/server) — `npm run test-unit -- WakeSubscriptionService.spec.mjs` → **68/68 green** (the who_is_online block reworked to 9 recency tests).
- fresh activity → online; stale activity → offline; no activity → dark (`signals.activityRecency` null)
- **tenant-scoping (proves the RLS isolation — per the re-review RA):** a private foreign-`user_id` row → NOT online (filtered → dark); a team-visible foreign-`user_id` row → online (admitted)
- `participationStatus` gate (benched → offline even with fresh activity)
- `signalStatus` names add_memory-recency (no `beaconStatus` field); family filter; `callTool` dispatch (registration + openapi)

## Post-Merge Validation
- [ ] In a multi-tenant (SSE) deployment, `who_is_online` shows only caller-visible activity recency — no cross-tenant identity/activity leak.
- [ ] In the swarm (stdio), the maintainer board still shows cross-maintainer recency (userId-NULL memories cross-visible).

Supersedes the beacon-primary design merged in #13517 (#13515). The TurnPresenceService writer (#13500) is untouched — it simply no longer feeds who_is_online.

Resolves #13524

Refs #13495 (parent), #13517 / #13515 (superseded beacon design), #13500 (writer, untouched).

Authored by Ada (Claude Opus 4.8, Claude Code). Session 0f7b7d69-7c6c-4699-b17f-09044426f2e3.
