### PR TITLE
docs(agentos): surface stacked PR retarget gates (#13528)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -133,6 +133,8 @@ PR broadcasts a false board to the whole swarm (empirical: PR `#12950`'s `[merge
 landed 15s post-merge; PR `#12956`'s approval relay missed the merge by seconds — both
 operator-flagged 2026-06-12). Rule detail + verdict-not-enum companion: `pr-review-guide.md §10.1`.
 
+<!-- trigger: lane-state/report names a stacked PR (`baseRefName` is not the default branch) -> read ../../pull-request/references/stacked-pr-ci-routing.md before `human-gate`, `verified-empty`, approval, or merge-readiness wording -->
+
 ## 2.5. Mandatory `lane-state:` Declaration at Every Lifecycle Boundary
 
 Per #11455 AC: at EACH broadened lifecycle boundary (reviewer post, author

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -299,6 +299,8 @@ Reviewers MUST verify testing claims and canonical file placement:
 
 ### 7.6 CI / Security Checks Audit
 
+<!-- trigger: PR is stacked (`baseRefName` is not the default branch) OR full CI is deferred until retarget -> read ../../pull-request/references/stacked-pr-ci-routing.md before approval or merge-readiness claims -->
+
 Formal reviews assume CI is already green. Verify the current PR check state before `manage_pr_review`; if checks are pending, missing, or failing, stop and send a compact CI deferral instead of a full review. Load `.agents/skills/pr-review/audits/ci-security-audit.md` only for security-sensitive changes or ambiguous/failing check surfaces.
 
 ### 7.7 Anti-Patterns

--- a/.agents/skills/pull-request/references/ci-green-review-routing.md
+++ b/.agents/skills/pull-request/references/ci-green-review-routing.md
@@ -12,6 +12,8 @@ The goal is to preserve lifecycle visibility without waking a reviewer into work
 
 ## 2. CI-Green Gate
 
+<!-- trigger: PR base branch is not the default branch OR full CI is deferred until retarget -> read ./stacked-pr-ci-routing.md before review/re-review routing -->
+
 Before sending any actionable primary-reviewer request, run:
 
 ```bash

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -209,6 +209,7 @@ You MUST follow this exact handoff protocol:
 If you are operating inside the canonical `neomjs/neo` repository as a core swarm member (e.g., `@neo-opus-ada`, `@neo-gemini-pro`, `@neo-gpt`), immediately after successfully opening a PR, you MUST send a lifecycle A2A notification.
 
 <!-- trigger: author-side review/re-review request -> read ./ci-green-review-routing.md before reviewer assignment -->
+<!-- trigger: stacked PR (`baseRefName` is not the default branch) -> read ./stacked-pr-ci-routing.md before PR-body handoff or review routing -->
 
 To prevent redundant parallel effort and reviewer collision, you MUST adhere to this explicit role-routing protocol rather than broadcasting naked multi-peer pings:
 

--- a/.agents/skills/pull-request/references/stacked-pr-ci-routing.md
+++ b/.agents/skills/pull-request/references/stacked-pr-ci-routing.md
@@ -1,0 +1,66 @@
+# Stacked PR Retarget-CI Routing
+
+This payload governs PR lifecycle wording when a pull request targets another feature branch instead of the repo default branch (`dev` in canonical Neo). Stacked PRs are allowed, but they have two readiness surfaces: the child delta against its stacked base, and the base PR's ability to merge to `dev` so the child can retarget and run full CI.
+
+## 1. Trigger
+
+Use this payload whenever a PR's `baseRefName` is not the default branch, or when a PR body/comment says full CI is deferred until retarget.
+
+Terms:
+- **Child PR:** the stacked PR being opened, reviewed, or reported.
+- **Base PR:** the open PR whose `headRefName` equals the child PR's `baseRefName`.
+
+## 2. Required Projection
+
+Before declaring the child PR ready, human-gated, approved, or verified-empty, project both surfaces:
+
+| Surface | Required state |
+|---|---|
+| Child PR | `state`, `baseRefName`, `headRefOid`, `mergeStateStatus`, current checks |
+| Base PR | `state`, `mergeStateStatus`, `reviewDecision`, current checks, author/current owner |
+
+If the base PR cannot be resolved, stack readiness is unknown. Route a blocker or ask the author to name the base PR; do not infer readiness from the child PR's clean merge state.
+
+## 3. Decision Matrix
+
+| Base PR state | Child PR wording / action |
+|---|---|
+| `DIRTY`, conflicted, or behind `dev` | Child delta review may continue, but readiness is blocked by the base PR. Route targeted A2A or PR comment to the base PR author/current owner; do not call the child human-gated or final-approved. |
+| `UNSTABLE`, failing, pending required checks, or missing required review | Child delta review may be recorded as a `COMMENT`, but formal `APPROVED` waits for base readiness plus child retarget/full CI. Name the pending base gate explicitly. |
+| Base PR clean, approved, and green but unmerged | Child is stack-clean and waiting on base human merge plus retarget/full CI. The base PR may be human-gated; the child is not final merge-ready yet. |
+| Base PR merged and child retargeted to `dev` | Run the normal CI-green / reviewer / approval flow on the child at its retargeted head. |
+
+## 4. Author-Side Rules
+
+When opening or updating a stacked PR:
+
+1. State the merge order in the PR body.
+2. State that full CI is deferred until the child retargets to `dev`, if only stack-limited checks run now.
+3. Name the base PR readiness state in review-request A2A: clean/dirty, approved/unreviewed, checks green/pending/failing.
+4. If the base PR is dirty or otherwise blocking retarget, route that blocker before requesting final review on the child.
+
+Allowed wording:
+
+```text
+Stack status: child PR is clean against base PR #N; base PR #N is <state>. Full CI for this child remains deferred until #N merges and this PR retargets to dev.
+```
+
+## 5. Reviewer-Side Rules
+
+Reviewers may verify the child delta against the stacked base. That is useful work. Keep the verdict precise:
+
+- **Delta verified:** code/body/test surface is clear against the stacked base.
+- **Final approval / merge-readiness:** only after the base PR is ready, the child retargets to `dev`, and full CI is green on the retargeted child head.
+
+If a previous Required Action is fixed but stack/full-CI remains unavailable, post a `COMMENTED` follow-up naming the resolved RA and the remaining stack gate. Do not use `APPROVED` merely to clear a metadata-era `CHANGES_REQUESTED` while full CI is still structurally deferred.
+
+## 6. Post-Review Pickup Rules
+
+`human-gate` / `verified-empty` is invalid when the next visible transition is a dirty/stale base PR that can be routed. Send a targeted A2A or PR comment to the base PR author/current owner with:
+
+- child PR number,
+- base PR number or unresolved base branch,
+- base blocker (`DIRTY`, pending checks, missing review, failing checks),
+- requested next action.
+
+Do not steal another maintainer's branch unless a maintainer-polish path or explicit operator instruction applies.


### PR DESCRIPTION
Resolves #13528

Adds a conditional stacked-PR retarget-CI payload and one-line triggers from the author, reviewer, and post-review pickup workflows. The new rule preserves stacked PR delta reviews, but stops agents from calling the child PR final-approved, human-gated, or verified-empty while the base PR or retarget/full-CI path is still unresolved.

Evidence: L1 (static workflow substrate validation) -> L1 required (skill/workflow guidance and manifest integrity). No residuals.

## Deltas from ticket
- Implemented as `.agents/skills/pull-request/references/stacked-pr-ci-routing.md` so the full rule body loads only when a PR is stacked or full CI is deferred until retarget.
- Added compact trigger pointers from `pull-request`, `ci-green-review-routing`, `pr-review`, and `post-review-pickup` surfaces.
- Kept this as workflow substrate only; no stack graph service or auto-rebase helper is added.

## Slot Rationale / Turn Memory Pre-Flight
- Source ticket has a Contract Ledger matrix; this PR keeps implementation aligned to that surface.
- Always-loaded routers are unchanged.
- New payload disposition: `compress-to-trigger`. Trigger-frequency is edge-case, failure-severity is high for stacked PR lifecycle liveness, enforceability is discipline-only until recurrence justifies a mechanical helper.
- Modified workflow-map sections: `compress-to-trigger` one-line pointers only. The rule body stays in the conditional World Atlas payload.
- Decision Record impact: none.

## Test Evidence
- `git diff --cached --check` -> pass.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> pass.
- Pre-commit hook ran `node ./buildScripts/util/check-whitespace.mjs` -> pass.
- No Playwright run: markdown-only Agent OS workflow substrate.

## Post-Merge Validation
- [ ] On the next stacked PR, author/reviewer handoff names base PR readiness and retarget/full-CI status.
- [ ] `post-review-pickup` lane-state does not claim `human-gate` / `verified-empty` when a dirty or unstable base PR is the next routable transition.

## Commit
- `2ba5a9c00` — `docs(agentos): surface stacked PR retarget gates (#13528)`

Related: #13522, #13517, #13527, #13498, #13289

Authored by Euclid (GPT-5, Codex Desktop). Session c3a6e312-b858-4be4-ad97-9bc55cbad5ae.