### PR TITLE
feat(ai): fail net-positive skill markdown growth (#13533)

### DIFF
--- a/.agents/skills/create-skill/references/skill-authoring-guide.md
+++ b/.agents/skills/create-skill/references/skill-authoring-guide.md
@@ -134,11 +134,10 @@ Map vs World Atlas applies **recursively**. A workflow file (`references/<workfl
 ```
 
 **Mechanical enforcement (Sub-A of Epic #11319 via `skills.manifest.json` + `lint-skill-manifest.mjs`):**
-- `perFilePayloadBudget` per-skill (or `defaults.perFilePayloadBudget`) — lint fails any individual file in `references/` exceeding the cap
-- Default: 25,000 bytes (25 KB) — empirical-floor for clean skills
-- Temporary per-skill overrides for migration-period monoliths (e.g., `pr-review` at 66000, `pull-request` at 38000) — to be tightened as Sub-B+ migrations land
-- `checkSectionTriggers` heuristic: sections larger than 5,000 bytes declaring a rare-firing trigger (e.g., 'openapi', 'audit', 'deprecation', 'edge-case') are flagged for extraction to a sibling file.
-- Skill reference integrity: changed skill text surfaces (Markdown plus manifest prose) must not leave dangling numeric section refs to sibling skill files, broken relative Markdown pointers, or refs to files deleted in the same diff. Fix the reference in the same PR instead of relying on review cycles to catch anchor churn.
+- `perFilePayloadBudget` (per-skill/default) fails files over cap; default 25 KB, temporary monolith overrides shrink as reductions land.
+- `maxPositiveDeltaBytes` caps net `.agents/skills/**/*.md` growth; offset additions, or for new-skill/decay-mitigated exceptions put `[skill-growth-justified: <reason>]` in a commit message and cite the PR rationale.
+- `checkSectionTriggers` flags >5 KB rare-trigger sections for extraction behind a trigger pointer.
+- Skill reference integrity catches dangling numeric refs, broken relative links, and deleted-file refs; fix them in the same PR.
 
 **Empirical precedent:**
 - `pull-request` skill: workflow + 4 sub-rule siblings (`env-var-rename-rule.md`, `mcp-config-template-change-guide.md`, `sync-all-constraints.md`, `review-response-protocol.md`) — each conditionally loaded per workflow body trigger pointer

--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -20,6 +20,7 @@ const CLAUDE_DIR    = path.join(ROOT_DIR, '.claude/skills');
 const MANIFEST_PATH = path.join(SKILLS_DIR, 'skills.manifest.json');
 const SCHEMA_PATH   = path.join(SKILLS_DIR, 'skills.manifest.schema.json');
 const REPORT_TOP_N  = 15;
+const SKILL_GROWTH_JUSTIFIED_RE = /\[skill-growth-justified:\s*[^\]\n]+\]/i;
 
 function parseArgs(argv = process.argv.slice(2)) {
     const options = {
@@ -1028,6 +1029,24 @@ function changedSkillNames(base) {
     return names;
 }
 
+function commitMessages(base) {
+    if (!base) return '';
+
+    try {
+        return execFileSync('git', ['log', `${base}...HEAD`, '--pretty=%B'], {
+            cwd     : ROOT_DIR,
+            encoding: 'utf8'
+        });
+    } catch (error) {
+        console.warn(`[lint-skill-manifest] Warning: could not parse git log for commit-message gates: ${error.message}`);
+        return '';
+    }
+}
+
+function hasSkillGrowthJustification(messages) {
+    return SKILL_GROWTH_JUSTIFIED_RE.test(messages);
+}
+
 function checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn) {
     const errors = [];
     for (const file of changedFiles) {
@@ -1049,8 +1068,9 @@ function checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getS
 /**
  * @summary Blocks net-positive skill Markdown growth beyond the pointer allowance.
  */
-function checkSkillMarkdownNetDelta(changedFiles, maxDelta, getSizeFn, getBaseSizeFn) {
+function checkSkillMarkdownNetDelta(changedFiles, maxDelta, getSizeFn, getBaseSizeFn, options = {}) {
     if (!Number.isInteger(maxDelta) || maxDelta < 0) return [];
+    if (options.allowJustifiedGrowth) return [];
 
     const deltas = [];
 
@@ -1077,7 +1097,7 @@ function checkSkillMarkdownNetDelta(changedFiles, maxDelta, getSizeFn, getBaseSi
         .join(', ');
 
     return [
-        `Skill Markdown net grew by ${netDelta} bytes (max allowed net positive delta is ${maxDelta}). Reduce or replace existing .agents/skills Markdown so net growth stays pointer-sized; moving text into another skill file still counts. Largest deltas: ${details}`
+        `Skill Markdown net grew by ${netDelta} bytes (max allowed net positive delta is ${maxDelta}). Reduce or replace existing .agents/skills Markdown so net growth stays pointer-sized; moving text into another skill file still counts. For new-skill or decay-mitigated exceptions, include [skill-growth-justified: <reason>] in a commit message. Largest deltas: ${details}`
     ];
 }
 
@@ -1094,6 +1114,7 @@ async function lint({base = null} = {}) {
 
     const changed = new Set(changedFiles(base));
     const touchedSkillNames = changedSkillNames(base);
+    const messages = commitMessages(base);
 
     if (base) {
         const oversizedFiles = manifest.defaults.oversizedWorkflowMaps || [];
@@ -1126,7 +1147,8 @@ async function lint({base = null} = {}) {
                     return null;
                 }
             },
-            (file) => getBaseFileSize(base, file)
+            (file) => getBaseFileSize(base, file),
+            {allowJustifiedGrowth: hasSkillGrowthJustification(messages)}
         ));
     }
 
@@ -1182,13 +1204,7 @@ async function lint({base = null} = {}) {
         }
 
         if (base && touchedSkillNames.has(skillName)) {
-            let skipDocs = false;
-            try {
-                const commitMsgs = execFileSync('git', ['log', `${base}...HEAD`, '--pretty=%B'], {cwd: ROOT_DIR, encoding: 'utf8'});
-                if (commitMsgs.includes('[skip docs]')) skipDocs = true;
-            } catch (e) {
-                console.warn(`[lint-skill-manifest] Warning: could not parse git log for skip-docs check: ${e.message}`);
-            }
+            const skipDocs = messages.includes('[skip docs]');
 
             if (!skipDocs) {
                 let routerDiffText = null;
@@ -1281,6 +1297,7 @@ export {
     checkSkillMarkdownNetDelta,
     classifySizeReportRow,
     formatSkillMarkdownSizeReport,
+    hasSkillGrowthJustification,
     parseSectionTriggers,
     parseUnifiedDiffChangedLines,
     shouldSkipDownstreamDocsTargetForLinkPathOnlyChange,

--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -1046,6 +1046,41 @@ function checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getS
     return errors;
 }
 
+/**
+ * @summary Blocks net-positive skill Markdown growth beyond the pointer allowance.
+ */
+function checkSkillMarkdownNetDelta(changedFiles, maxDelta, getSizeFn, getBaseSizeFn) {
+    if (!Number.isInteger(maxDelta) || maxDelta < 0) return [];
+
+    const deltas = [];
+
+    for (const file of changedFiles) {
+        if (!file.startsWith('.agents/skills/') || !file.endsWith('.md')) continue;
+
+        const currentSize = getSizeFn(file);
+        const baseSize    = getBaseSizeFn(file);
+        const delta       = (currentSize === null ? 0 : currentSize) - baseSize;
+
+        if (delta !== 0) {
+            deltas.push({file, delta});
+        }
+    }
+
+    const netDelta = deltas.reduce((sum, entry) => sum + entry.delta, 0);
+
+    if (netDelta <= maxDelta) return [];
+
+    const details = deltas
+        .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta) || a.file.localeCompare(b.file))
+        .slice(0, 5)
+        .map(({file, delta}) => `${file} (${delta > 0 ? '+' : ''}${delta})`)
+        .join(', ');
+
+    return [
+        `Skill Markdown net grew by ${netDelta} bytes (max allowed net positive delta is ${maxDelta}). Reduce or replace existing .agents/skills Markdown so net growth stays pointer-sized; moving text into another skill file still counts. Largest deltas: ${details}`
+    ];
+}
+
 async function lint({base = null} = {}) {
     const schema       = readJson(SCHEMA_PATH);
     const manifest     = readJson(MANIFEST_PATH);
@@ -1078,6 +1113,21 @@ async function lint({base = null} = {}) {
             (file) => getBaseFileSize(base, file)
         );
         errors.push(...oversizedErrors);
+
+        const skillMarkdownDeltaFiles = new Set([...changed, ...removedFiles(base)]);
+
+        errors.push(...checkSkillMarkdownNetDelta(
+            skillMarkdownDeltaFiles,
+            maxDelta,
+            (file) => {
+                try {
+                    return statSync(path.join(ROOT_DIR, file)).size;
+                } catch(e) {
+                    return null;
+                }
+            },
+            (file) => getBaseFileSize(base, file)
+        ));
     }
 
     for (const skillName of skillDirs) {
@@ -1228,6 +1278,7 @@ export {
     checkRemovedSkillFileReferences,
     checkSectionTriggers,
     checkSkillReferenceIntegrity,
+    checkSkillMarkdownNetDelta,
     classifySizeReportRow,
     formatSkillMarkdownSizeReport,
     parseSectionTriggers,

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -9,6 +9,7 @@ import {
     checkRemovedSkillFileReferences,
     checkSectionTriggers,
     checkSkillReferenceIntegrity,
+    checkSkillMarkdownNetDelta,
     classifySizeReportRow,
     formatSkillMarkdownSizeReport,
     parseArgs,
@@ -470,6 +471,76 @@ ${padding}
 
         const errors = checkOversizedWorkflowMaps(changedFiles, oversizedFiles, maxDelta, getSizeFn, getBaseSizeFn);
         expect(errors).toEqual([]);
+    });
+
+    test('checkSkillMarkdownNetDelta fails when skill Markdown grows beyond the pointer allowance (#13533)', () => {
+        const changedFiles = new Set([
+            '.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md',
+            'learn/agentos/notes.md'
+        ]);
+
+        const getSizeFn     = file => file.startsWith('.agents/') ? 1500 : 5000;
+        const getBaseSizeFn = file => file.startsWith('.agents/') ? 1000 : 0;
+
+        const errors = checkSkillMarkdownNetDelta(changedFiles, 250, getSizeFn, getBaseSizeFn);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('Skill Markdown net grew by 500 bytes');
+        expect(errors[0]).toContain('max allowed net positive delta is 250');
+        expect(errors[0]).toContain('moving text into another skill file still counts');
+    });
+
+    test('checkSkillMarkdownNetDelta passes when additions are offset by skill Markdown reductions (#13533)', () => {
+        const changedFiles = new Set([
+            '.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md',
+            '.agents/skills/ticket-intake/references/ticket-intake-workflow.md'
+        ]);
+
+        const sizes = new Map([
+            ['.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md', {current: 1600, base: 1000}],
+            ['.agents/skills/ticket-intake/references/ticket-intake-workflow.md', {current: 600, base: 1000}]
+        ]);
+
+        const getSizeFn     = file => sizes.get(file).current;
+        const getBaseSizeFn = file => sizes.get(file).base;
+
+        expect(checkSkillMarkdownNetDelta(changedFiles, 250, getSizeFn, getBaseSizeFn)).toEqual([]);
+    });
+
+    test('checkSkillMarkdownNetDelta passes for pure reductions and deleted skill Markdown (#13533)', () => {
+        const changedFiles = new Set([
+            '.agents/skills/post-review-pickup/references/old-rule.md',
+            '.agents/skills/ticket-intake/references/ticket-intake-workflow.md'
+        ]);
+
+        const getSizeFn     = file => file.endsWith('old-rule.md') ? null : 800;
+        const getBaseSizeFn = file => file.endsWith('old-rule.md') ? 1000 : 1000;
+
+        expect(checkSkillMarkdownNetDelta(changedFiles, 250, getSizeFn, getBaseSizeFn)).toEqual([]);
+    });
+
+    test('checkSkillMarkdownNetDelta does not treat a same-size skill Markdown rename as growth (#13533)', () => {
+        const changedFiles = new Set([
+            '.agents/skills/example/references/new-name.md',
+            '.agents/skills/example/references/old-name.md'
+        ]);
+
+        const getSizeFn     = file => file.endsWith('old-name.md') ? null : 1000;
+        const getBaseSizeFn = file => file.endsWith('old-name.md') ? 1000 : 0;
+
+        expect(checkSkillMarkdownNetDelta(changedFiles, 250, getSizeFn, getBaseSizeFn)).toEqual([]);
+    });
+
+    test('checkSkillMarkdownNetDelta ignores non-skill Markdown files (#13533)', () => {
+        const changedFiles = new Set([
+            'learn/agentos/notes.md',
+            '.agents/skills/create-skill/references/skill-authoring-guide.txt'
+        ]);
+
+        const getSizeFn     = () => 1000;
+        const getBaseSizeFn = () => 0;
+
+        expect(checkSkillMarkdownNetDelta(changedFiles, 250, getSizeFn, getBaseSizeFn)).toEqual([]);
     });
 
     test('checkSkillReferenceIntegrity flags dangling numeric section refs (#12493)', () => {

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -12,6 +12,7 @@ import {
     checkSkillMarkdownNetDelta,
     classifySizeReportRow,
     formatSkillMarkdownSizeReport,
+    hasSkillGrowthJustification,
     parseArgs,
     parseFrontmatter,
     parseSectionTriggers,
@@ -541,6 +542,54 @@ ${padding}
         const getBaseSizeFn = () => 0;
 
         expect(checkSkillMarkdownNetDelta(changedFiles, 250, getSizeFn, getBaseSizeFn)).toEqual([]);
+    });
+
+    test('checkSkillMarkdownNetDelta blocks new-skill growth without justification (#13533)', () => {
+        const changedFiles = new Set([
+            '.agents/skills/example/SKILL.md',
+            '.agents/skills/example/references/example-workflow.md'
+        ]);
+
+        const sizes = new Map([
+            ['.agents/skills/example/SKILL.md', 900],
+            ['.agents/skills/example/references/example-workflow.md', 5000]
+        ]);
+
+        const getSizeFn     = file => sizes.get(file);
+        const getBaseSizeFn = () => 0;
+
+        const errors = checkSkillMarkdownNetDelta(changedFiles, 250, getSizeFn, getBaseSizeFn);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('[skill-growth-justified: <reason>]');
+    });
+
+    test('checkSkillMarkdownNetDelta allows justified new-skill growth (#13533)', () => {
+        const changedFiles = new Set([
+            '.agents/skills/example/SKILL.md',
+            '.agents/skills/example/references/example-workflow.md'
+        ]);
+
+        const sizes = new Map([
+            ['.agents/skills/example/SKILL.md', 900],
+            ['.agents/skills/example/references/example-workflow.md', 5000]
+        ]);
+
+        const getSizeFn     = file => sizes.get(file);
+        const getBaseSizeFn = () => 0;
+
+        expect(checkSkillMarkdownNetDelta(
+            changedFiles,
+            250,
+            getSizeFn,
+            getBaseSizeFn,
+            {allowJustifiedGrowth: true}
+        )).toEqual([]);
+    });
+
+    test('hasSkillGrowthJustification requires a non-empty commit-marker reason (#13533)', () => {
+        expect(hasSkillGrowthJustification('[skill-growth-justified: new skill with retirement trigger]')).toBe(true);
+        expect(hasSkillGrowthJustification('[skill-growth-justified:]')).toBe(false);
     });
 
     test('checkSkillReferenceIntegrity flags dangling numeric section refs (#12493)', () => {


### PR DESCRIPTION
Resolves #13533
Related: #10757

Adds a mechanical guard to `lint-skill-manifest.mjs` that fails base-mode lint when changed `.agents/skills/**/*.md` files grow by more than the existing `maxPositiveDeltaBytes` pointer allowance in net bytes. This closes the gap that let sub-cap workflow files keep accumulating prose while technically staying under `perFilePayloadBudget`.

Evidence: L2 (focused unit coverage + live linter/whitespace checks) -> L2 required (CI lint/tooling behavior). No residuals.

## Deltas from ticket

- Included deleted/renamed skill Markdown paths in the net-delta file set so same-size renames and pure deletions do not false-fail.
- Added a concise `@summary` for the new helper to satisfy contextual-completeness without adding skill prose.
- No `.agents/skills/**` Markdown, manifest, or directly loaded Agent OS prose was modified.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` — 40 passed
- `node ./ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — OK
- `node ./buildScripts/util/check-whitespace.mjs`
- `git diff --check`
- Pre-commit hook also ran `check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, and `check-ticket-archaeology`

## Post-Merge Validation

- [ ] A future PR that adds more than pointer-sized net bytes to `.agents/skills/**/*.md` fails `lint-skill-manifest.mjs --base origin/dev` unless it offsets the addition with skill Markdown reductions.

## Commit

- `352dc763d` - `feat(ai): fail net-positive skill markdown growth (#13533)`

Authored by Euclid (GPT-5, Codex Desktop). Session 0a1dbe52-d3d0-43c4-8eb5-53a9e8499236.
