### PR TITLE
feat(memory-core): per-append WAL write-lock for shared-dir serialization (#13543)

### DIFF
--- a/ai/services/memory-core/helpers/memoryWalStore.mjs
+++ b/ai/services/memory-core/helpers/memoryWalStore.mjs
@@ -1,5 +1,6 @@
-import fs   from 'fs/promises';
-import path from 'path';
+import fs               from 'fs/promises';
+import path             from 'path';
+import {withAppendLock} from './walAppendLock.mjs';
 
 /**
  * @summary Durable JSONL write-ahead store for `add_memory` payloads.
@@ -11,16 +12,20 @@ import path from 'path';
  * the orchestrator-managed `ai/daemons/embed/` drain daemon). A crash, embed failure, or stalled
  * embedding model never loses the payload: it stays pending in the WAL until an embed pass succeeds.
  *
- * ## File layout (two files per UTC-day segment, each with exactly ONE writer)
+ * ## File layout (two files per UTC-day segment, one writer at a time)
  *
- * - `wal-YYYY-MM-DD.jsonl`          — memory records; written only by the MCP-server process.
+ * - `wal-YYYY-MM-DD.jsonl`          — memory records; written by the MCP-server process(es).
  * - `wal-YYYY-MM-DD.embedded.jsonl` — embed markers; written only by the embedder of the era
  *                                     (Phase 1: the server's deferred embed; Phase 2: the daemon).
  *
- * Records and markers are deliberately split into separate single-writer files instead of one
- * shared append stream: POSIX `O_APPEND` atomicity is only dependable for small writes, and memory
- * records (multi-KB `thought` payloads) appended concurrently with tiny markers from a second
- * process could interleave. One writer per file removes the interleave class by construction.
+ * Records and markers are deliberately split into separate files instead of one shared append
+ * stream: POSIX `O_APPEND` atomicity is only dependable for small writes, and memory records
+ * (multi-KB `thought` payloads) appended concurrently with tiny markers from a second process could
+ * interleave. For a per-clone dir, one writer per file removes the interleave class by construction;
+ * for a SHARED dir (multiple harness clones draining through one embedder),
+ * {@link module:ai/services/memory-core/helpers/walAppendLock} serializes the record writers across
+ * processes to preserve the same no-interleave guarantee — best-effort, never blocking the never-fail
+ * `add_memory` turn-save.
  * A record is "pending" when its id has no marker; a segment is "reconciled" when no record in it
  * is pending. Reads tolerate corrupt lines (skip, never throw) — sibling discipline to
  * {@link module:ai/services/memory-core/helpers/remRunStateStore}.
@@ -107,9 +112,11 @@ export function getWalGraphMarkersFileName(segmentKey) {
  * @param {Object} options
  * @param {String} options.dir Directory for WAL segment files.
  * @param {Date|Number} [options.now] Clock source for the segment key (defaults to record.timestamp).
+ * @param {Object} [options.lockOptions] Forwarded to {@link withAppendLock} (tuning + spec injection of
+ *     fs/clock/liveness/sleep). Omit for the default per-append serialization.
  * @returns {Promise<{filePath: String, segmentKey: String}>}
  */
-export async function appendWalMemory(record, {dir, now} = {}) {
+export async function appendWalMemory(record, {dir, now, lockOptions} = {}) {
     if (!dir) {
         throw new TypeError('appendWalMemory: dir is required');
     }
@@ -121,8 +128,12 @@ export async function appendWalMemory(record, {dir, now} = {}) {
 
     const segmentKey = getWalSegmentKey(now ?? record.timestamp ?? new Date());
     const filePath   = path.join(dir, getWalRecordsFileName(segmentKey));
+    const line       = `${JSON.stringify({...record, segmentKey})}\n`;
 
-    await fs.appendFile(filePath, `${JSON.stringify({...record, segmentKey})}\n`, 'utf8');
+    // Serialize cross-process writers so a SHARED WAL dir cannot interleave multi-KB records; on a
+    // bounded acquire-timeout it falls through and writes UNLOCKED, so the never-fail turn-save
+    // (§critical_gates #5) is never blocked by a contended/hung lock.
+    await withAppendLock(filePath, () => fs.appendFile(filePath, line, 'utf8'), lockOptions);
 
     return {filePath, segmentKey};
 }

--- a/ai/services/memory-core/helpers/walAppendLock.mjs
+++ b/ai/services/memory-core/helpers/walAppendLock.mjs
@@ -12,7 +12,8 @@ import fs   from 'fs/promises';
  * PER-APPEND semantics:
  *  - **retry, not refuse** — a live holder mid-append (milliseconds) is waited out, then re-claimed;
  *  - **stale-reclaim** — a holder with a dead pid OR held past `ttlMs` (a hung/crashed writer; a real
- *    append is ms, never seconds) is reclaimed;
+ *    append is ms, never seconds) is reclaimed, fenced by a re-read byte-match so a racing reclaimer
+ *    can never path-unlink a successor's fresh lock;
  *  - **never-fail fall-through** — if the lock can't be acquired within `acquireTimeoutMs`, the write
  *    runs UNLOCKED rather than blocking. This is load-bearing: `add_memory` is the never-fail turn-save
  *    (AGENTS.md §critical_gates #5). The lock is best-effort serialization, NEVER a gate on the durable
@@ -55,18 +56,71 @@ function defaultIsAlive(pid) {
 }
 
 /**
- * Reads + parses the lock holder descriptor, or `null` when absent (raced away) or corrupt. A `null`
- * holder is reclaimable — a corrupt lock must never permanently wedge the never-fail write path.
+ * Reads the lock file's RAW bytes, or `null` when absent (raced away). The raw string is used both to
+ * judge staleness (via {@link parseHolder}) AND as the exact compare-token that fences reclaim against
+ * a racing successor (see {@link reclaimStaleLock}).
  * @param {String} lockPath
  * @param {Object} fsImpl
- * @returns {Promise<{pid: Number, startedAt: Number}|null>}
+ * @returns {Promise<String|null>}
  */
-async function readHolder(lockPath, fsImpl) {
+async function readLockRaw(lockPath, fsImpl) {
     try {
-        const parsed = JSON.parse(await fsImpl.readFile(lockPath, 'utf8'));
+        return await fsImpl.readFile(lockPath, 'utf8');
+    } catch (err) {
+        return null;
+    }
+}
+
+/**
+ * Parses a holder descriptor from raw lock bytes, or `null` when absent or corrupt. A `null` holder is
+ * reclaimable — a corrupt lock must never permanently wedge the never-fail write path.
+ * @param {String|null} raw
+ * @returns {{pid: Number, startedAt: Number}|null}
+ */
+function parseHolder(raw) {
+    if (raw === null) return null;
+    try {
+        const parsed = JSON.parse(raw);
         return (parsed && Number.isInteger(parsed.pid)) ? parsed : null;
     } catch (err) {
         return null;
+    }
+}
+
+/** Reads + parses the holder descriptor in one step (used by the idempotent release path). */
+async function readHolder(lockPath, fsImpl) {
+    return parseHolder(await readLockRaw(lockPath, fsImpl));
+}
+
+/**
+ * @summary Reclaims a stale lock WITHOUT clobbering a successor. A bare path-unlink is content-blind:
+ * in the window between our staleness read and the unlink, another writer can reclaim + re-lock, and an
+ * unconditional unlink would delete its fresh, valid lock — leaving BOTH writers "holding" (exactly the
+ * interleave the lock exists to prevent). So we re-read immediately before removing and unlink ONLY
+ * while the byte-identical stale content is still present; a successor's fresh lock (or an already-gone
+ * lock) makes us back off and re-evaluate on the next claim attempt.
+ *
+ * This narrows the clobber window to a single syscall; the irreducible residual is bounded by never-fail
+ * (a rare interleaved line is tolerated by the lock-free drainer). Fully closing it would require
+ * encoding holder identity in the lock-file NAME, breaking the fixed `.lock` path the drainer relies on
+ * to skip lock files — disproportionate for a best-effort lock.
+ * @param {String}      lockPath
+ * @param {String|null} observedRaw The raw bytes we judged stale.
+ * @param {Object}      fsImpl
+ * @param {Function}    log
+ * @returns {Promise<Boolean>} whether we removed the stale lock.
+ */
+async function reclaimStaleLock(lockPath, observedRaw, fsImpl, log) {
+    const current = await readLockRaw(lockPath, fsImpl);
+    // Gone already (a peer reclaimed it) or replaced by a successor's fresh lock → never clobber it.
+    if (current === null || current !== observedRaw) return false;
+    try {
+        await fsImpl.unlink(lockPath);
+        return true;
+    } catch (err) {
+        // ENOENT = raced away between our re-read and the unlink; the next wx claim settles it.
+        if (err.code !== 'ENOENT') log('warn', `[wal-append-lock] reclaim unlink failed (${err.code})`);
+        return false;
     }
 }
 
@@ -117,20 +171,18 @@ export async function withAppendLock(filePath, fn, {
                 break;
             }
 
-            const holder = await readHolder(lockPath, fsImpl);
+            // Read the holder's RAW bytes once — both to judge staleness AND as the compare-token that
+            // fences reclaim against a racing successor (see reclaimStaleLock).
+            const raw    = await readLockRaw(lockPath, fsImpl);
+            const holder = parseHolder(raw);
             const stale  = !holder || !isAlive(holder.pid) || (now() - holder.startedAt > ttlMs);
 
-            if (stale) {
-                try {
-                    await fsImpl.unlink(lockPath);
-                } catch (unlinkErr) {
-                    // ENOENT = raced away (another writer reclaimed); the next wx claim settles it.
-                    if (unlinkErr.code !== 'ENOENT') log('warn', `[wal-append-lock] reclaim unlink failed (${unlinkErr.code})`);
-                }
-                continue; // retry the wx claim immediately
+            if (stale && await reclaimStaleLock(lockPath, raw, fsImpl, log)) {
+                continue; // we removed the exact stale lock — retry the wx claim immediately
             }
 
-            await sleep(retryIntervalMs); // live holder mid-append (ms) — brief wait, then retry
+            // A live holder mid-append (ms), or a successor we must NOT clobber — brief wait, re-evaluate.
+            await sleep(retryIntervalMs);
         }
     }
 

--- a/ai/services/memory-core/helpers/walAppendLock.mjs
+++ b/ai/services/memory-core/helpers/walAppendLock.mjs
@@ -1,0 +1,153 @@
+import fs   from 'fs/promises';
+
+/**
+ * @module ai/services/memory-core/helpers/walAppendLock
+ * @summary Per-segment-file exclusive write-lock that serializes concurrent `appendWalMemory` writers
+ * ACROSS PROCESSES, so a SHARED WAL directory (multiple harness clones draining through one embedder)
+ * preserves the one-writer-per-segment invariant of {@link module:ai/services/memory-core/helpers/memoryWalStore}
+ * without interleaving multi-KB records.
+ *
+ * Mirrors the embed-daemon `ai/daemons/embed/drainLock.mjs` sole-drainer-lock primitives — atomic `wx` lockfile, a holder
+ * descriptor, a `process.kill(pid, 0)` liveness probe, stale-reclaim, idempotent release — but with
+ * PER-APPEND semantics:
+ *  - **retry, not refuse** — a live holder mid-append (milliseconds) is waited out, then re-claimed;
+ *  - **stale-reclaim** — a holder with a dead pid OR held past `ttlMs` (a hung/crashed writer; a real
+ *    append is ms, never seconds) is reclaimed;
+ *  - **never-fail fall-through** — if the lock can't be acquired within `acquireTimeoutMs`, the write
+ *    runs UNLOCKED rather than blocking. This is load-bearing: `add_memory` is the never-fail turn-save
+ *    (AGENTS.md §critical_gates #5). The lock is best-effort serialization, NEVER a gate on the durable
+ *    write. A rare unlocked fall-through risks at most a single interleaved line, which the drainer
+ *    already tolerates (corrupt lines are skipped); a blocked turn-save would be the worse failure.
+ *
+ * Writer-vs-writer only: the drainer keeps reading lock-free (tolerating a trailing partial line, as it
+ * already must), so this adds no drainer or file-format change.
+ *
+ * Pure + fully injectable (fs, clock, liveness probe, sleep, log) — unit-tested against a real temp dir.
+ */
+
+/** Lock-file suffix appended to the WAL segment path (`wal-DATE.jsonl` → `wal-DATE.jsonl.lock`). */
+export const APPEND_LOCK_SUFFIX = '.lock';
+
+/** A lock held longer than this is treated as a hung/crashed holder and reclaimed. A real append is ms. */
+const DEFAULT_TTL_MS = 2000;
+
+/** Bounded acquire wait. On timeout the write falls through UNLOCKED (never-fail). > `DEFAULT_TTL_MS`
+ *  so a hung holder is detected + reclaimed within the wait window before the fall-through. */
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 5000;
+
+/** Spin interval while a live holder finishes its millisecond append. */
+const DEFAULT_RETRY_INTERVAL_MS = 15;
+
+/**
+ * @summary Default process-liveness probe. `process.kill(pid, 0)` sends no signal but performs the
+ * existence/permission check: `ESRCH` → dead (reclaimable); `EPERM` → alive but unsignalable (a real
+ * holder we must NOT displace).
+ * @param {Number} pid
+ * @returns {Boolean}
+ */
+function defaultIsAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (err) {
+        return err.code === 'EPERM';
+    }
+}
+
+/**
+ * Reads + parses the lock holder descriptor, or `null` when absent (raced away) or corrupt. A `null`
+ * holder is reclaimable — a corrupt lock must never permanently wedge the never-fail write path.
+ * @param {String} lockPath
+ * @param {Object} fsImpl
+ * @returns {Promise<{pid: Number, startedAt: Number}|null>}
+ */
+async function readHolder(lockPath, fsImpl) {
+    try {
+        const parsed = JSON.parse(await fsImpl.readFile(lockPath, 'utf8'));
+        return (parsed && Number.isInteger(parsed.pid)) ? parsed : null;
+    } catch (err) {
+        return null;
+    }
+}
+
+const defaultSleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * @summary Runs `fn` while holding an exclusive lock on `${filePath}${APPEND_LOCK_SUFFIX}`, or — if the
+ * lock can't be acquired within `acquireTimeoutMs` — runs it UNLOCKED (never-fail). `fn` ALWAYS runs.
+ *
+ * @param {String}   filePath The WAL segment path to guard (the lock is `filePath + .lock`).
+ * @param {Function} fn       The append to perform; `() => Promise<*>`. Runs locked when acquired, else unlocked.
+ * @param {Object}   [options]
+ * @param {Number}   [options.pid]              Owning pid (defaults to `process.pid`).
+ * @param {Function} [options.now]              Clock `() => epochMs` (defaults to `Date.now`).
+ * @param {Number}   [options.ttlMs]            Hung-holder reclaim threshold.
+ * @param {Number}   [options.acquireTimeoutMs] Bounded acquire wait before the unlocked fall-through.
+ * @param {Number}   [options.retryIntervalMs]  Spin interval while a live holder finishes.
+ * @param {Object}   [options.fs]               Filesystem impl (injected for specs). Defaults to `fs/promises`.
+ * @param {Function} [options.isAlive]          Liveness probe `(pid) => boolean`.
+ * @param {Function} [options.sleep]            `(ms) => Promise` (injected for specs).
+ * @param {Function} [options.log]              `(level, message)` sink. Defaults to a no-op.
+ * @returns {Promise<{result: *, locked: Boolean}>} `fn`'s result + whether the lock was held during it.
+ */
+export async function withAppendLock(filePath, fn, {
+    pid              = process.pid,
+    now              = Date.now,
+    ttlMs            = DEFAULT_TTL_MS,
+    acquireTimeoutMs = DEFAULT_ACQUIRE_TIMEOUT_MS,
+    retryIntervalMs  = DEFAULT_RETRY_INTERVAL_MS,
+    fs: fsImpl       = fs,
+    isAlive          = defaultIsAlive,
+    sleep            = defaultSleep,
+    log              = () => {}
+} = {}) {
+    const lockPath = `${filePath}${APPEND_LOCK_SUFFIX}`;
+    const deadline = now() + acquireTimeoutMs;
+    let locked = false;
+
+    while (now() < deadline) {
+        try {
+            await fsImpl.writeFile(lockPath, JSON.stringify({pid, startedAt: now()}), {encoding: 'utf8', flag: 'wx'});
+            locked = true;
+            break;
+        } catch (err) {
+            if (err.code !== 'EEXIST') {
+                // Unexpected error claiming the lock — never block the never-fail write; fall through unlocked.
+                log('warn', `[wal-append-lock] unexpected claim error (${err.code ?? err.name}); writing unlocked`);
+                break;
+            }
+
+            const holder = await readHolder(lockPath, fsImpl);
+            const stale  = !holder || !isAlive(holder.pid) || (now() - holder.startedAt > ttlMs);
+
+            if (stale) {
+                try {
+                    await fsImpl.unlink(lockPath);
+                } catch (unlinkErr) {
+                    // ENOENT = raced away (another writer reclaimed); the next wx claim settles it.
+                    if (unlinkErr.code !== 'ENOENT') log('warn', `[wal-append-lock] reclaim unlink failed (${unlinkErr.code})`);
+                }
+                continue; // retry the wx claim immediately
+            }
+
+            await sleep(retryIntervalMs); // live holder mid-append (ms) — brief wait, then retry
+        }
+    }
+
+    try {
+        const result = await fn();
+        return {result, locked};
+    } finally {
+        if (locked) {
+            try {
+                // Release only if the lock still records OUR pid — a reclaimed-as-stale lock now owned by a
+                // successor must not be unlinked by our late release.
+                const holder = await readHolder(lockPath, fsImpl);
+                if (holder && holder.pid === pid) await fsImpl.unlink(lockPath);
+            } catch (err) {
+                // Best-effort: a leftover lock is reclaimed next time via the TTL / liveness probe — never a
+                // correctness hazard, only a one-append reclaim cost.
+            }
+        }
+    }
+}

--- a/test/playwright/unit/ai/services/memory-core/helpers/walAppendLock.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/walAppendLock.spec.mjs
@@ -1,0 +1,117 @@
+import {test, expect}                          from '@playwright/test';
+import Neo                                     from '../../../../../../../src/Neo.mjs';
+import * as core                               from '../../../../../../../src/core/_export.mjs';
+import {mkdtemp, rm, readFile, writeFile, access} from 'fs/promises';
+import os                                      from 'os';
+import path                                    from 'path';
+
+import {withAppendLock, APPEND_LOCK_SUFFIX} from '../../../../../../../ai/services/memory-core/helpers/walAppendLock.mjs';
+
+/**
+ * walAppendLock — the per-append cross-process write-lock that lets a SHARED WAL dir serialize
+ * concurrent `appendWalMemory` writers without interleaving multi-KB records. Falsifier coverage:
+ *
+ *   - acquire   — the lock is held during `fn` and released (iff still ours) after.
+ *   - never-fail — `fn` ALWAYS runs and returns its result: locked, OR (on a bounded acquire-timeout
+ *                  against a live holder) UNLOCKED. A contended/hung lock never blocks the turn-save.
+ *   - stale     — a dead-pid holder, a TTL-exceeded live holder, or a corrupt lock is reclaimed.
+ *   - release   — removes the lock only when it still records our pid (never clobbers a successor).
+ *
+ * Real temp dir + real fs (the lock IS atomic-write behavior); clock / sleep / liveness are injected
+ * so contention + reclaim are deterministic without spawning real PIDs.
+ */
+test.describe('Neo.ai.services.memory-core.helpers.walAppendLock', () => {
+    let dir, walPath;
+
+    test.beforeEach(async () => {
+        dir     = await mkdtemp(path.join(os.tmpdir(), 'neo-wal-append-lock-'));
+        walPath = path.join(dir, 'wal-2026-06-19.jsonl');
+    });
+
+    test.afterEach(async () => {
+        await rm(dir, {recursive: true, force: true});
+    });
+
+    const lockPath = () => `${walPath}${APPEND_LOCK_SUFFIX}`;
+    const noSleep  = async () => {};
+
+    test('acquires the lock, holds it during fn, and releases it after', async () => {
+        let heldDuringFn = false;
+
+        const {result, locked} = await withAppendLock(walPath, async () => {
+            try { await access(lockPath()); heldDuringFn = true; } catch (e) {}
+            return 'written';
+        }, {pid: 4242, now: () => 1000, isAlive: () => false, sleep: noSleep});
+
+        expect(locked).toBe(true);
+        expect(heldDuringFn).toBe(true);
+        expect(result).toBe('written');
+        await expect(access(lockPath())).rejects.toThrow(); // released after fn
+    });
+
+    test('NEVER-FAIL: a live holder held throughout → falls through UNLOCKED, but fn still runs', async () => {
+        // Pre-existing lock owned by a different, "alive" pid that never releases.
+        await writeFile(lockPath(), JSON.stringify({pid: 9999, startedAt: 1000}), 'utf8');
+
+        let clock   = 1000;
+        const now   = () => clock;
+        const sleep = async ms => { clock += ms; }; // each retry advances the clock past the deadline
+
+        let ran = false;
+        const {result, locked} = await withAppendLock(walPath, async () => { ran = true; return 'fallthrough-write'; }, {
+            pid: 4242, now, sleep, isAlive: () => true, ttlMs: 1_000_000, acquireTimeoutMs: 50, retryIntervalMs: 15
+        });
+
+        expect(locked).toBe(false);                 // could not acquire (live holder, never stale)
+        expect(ran).toBe(true);                     // but the durable write STILL happened — never-fail
+        expect(result).toBe('fallthrough-write');
+        // the live holder's lock is left untouched (we must never displace a live holder)
+        expect(JSON.parse(await readFile(lockPath(), 'utf8')).pid).toBe(9999);
+    });
+
+    test('stale-reclaim: a DEAD-pid holder is reclaimed and the lock acquired', async () => {
+        await writeFile(lockPath(), JSON.stringify({pid: 9999, startedAt: 1000}), 'utf8');
+
+        const {locked, result} = await withAppendLock(walPath, async () => 'wrote', {
+            pid: 4242, now: () => 2000, isAlive: () => false, sleep: noSleep, ttlMs: 1_000_000, acquireTimeoutMs: 5000
+        });
+
+        expect(locked).toBe(true);                          // reclaimed the dead holder + acquired
+        expect(result).toBe('wrote');
+        await expect(access(lockPath())).rejects.toThrow(); // released after
+    });
+
+    test('stale-reclaim: a TTL-exceeded live holder is reclaimed', async () => {
+        await writeFile(lockPath(), JSON.stringify({pid: 9999, startedAt: 1000}), 'utf8');
+
+        const {locked} = await withAppendLock(walPath, async () => 'x', {
+            // alive, but held 5000ms (now 6000 − startedAt 1000) > ttl 2000 → hung → reclaim
+            pid: 4242, now: () => 6000, isAlive: () => true, sleep: noSleep, ttlMs: 2000, acquireTimeoutMs: 5000
+        });
+
+        expect(locked).toBe(true);
+    });
+
+    test('stale-reclaim: a corrupt lock never wedges the never-fail write path', async () => {
+        await writeFile(lockPath(), 'not-json{', 'utf8');
+
+        const {locked, result} = await withAppendLock(walPath, async () => 'x', {
+            pid: 4242, now: () => 1000, isAlive: () => true, sleep: noSleep, acquireTimeoutMs: 5000
+        });
+
+        expect(locked).toBe(true);   // an unparseable holder is reclaimable
+        expect(result).toBe('x');
+    });
+
+    test('release removes the lock only when it still records our pid (no successor clobber)', async () => {
+        const {locked} = await withAppendLock(walPath, async () => {
+            // a successor reclaims + re-owns the lock DURING our fn
+            await writeFile(lockPath(), JSON.stringify({pid: 7777, startedAt: 2000}), 'utf8');
+            return 'x';
+        }, {pid: 4242, now: () => 1000, isAlive: () => false, sleep: noSleep});
+
+        expect(locked).toBe(true);
+        // our release saw holder.pid 7777 ≠ our 4242 → did NOT unlink; the successor's lock survives
+        expect(JSON.parse(await readFile(lockPath(), 'utf8')).pid).toBe(7777);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/helpers/walAppendLock.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/walAppendLock.spec.mjs
@@ -15,6 +15,7 @@ import {withAppendLock, APPEND_LOCK_SUFFIX} from '../../../../../../../ai/servic
  *   - never-fail — `fn` ALWAYS runs and returns its result: locked, OR (on a bounded acquire-timeout
  *                  against a live holder) UNLOCKED. A contended/hung lock never blocks the turn-save.
  *   - stale     — a dead-pid holder, a TTL-exceeded live holder, or a corrupt lock is reclaimed.
+ *   - reclaim-fence — stale-reclaim never path-unlinks a successor lock that re-locks in the race window.
  *   - release   — removes the lock only when it still records our pid (never clobbers a successor).
  *
  * Real temp dir + real fs (the lock IS atomic-write behavior); clock / sleep / liveness are injected
@@ -113,5 +114,47 @@ test.describe('Neo.ai.services.memory-core.helpers.walAppendLock', () => {
         expect(locked).toBe(true);
         // our release saw holder.pid 7777 ≠ our 4242 → did NOT unlink; the successor's lock survives
         expect(JSON.parse(await readFile(lockPath(), 'utf8')).pid).toBe(7777);
+    });
+
+    test('REGRESSION (#13544 RA): stale-reclaim NEVER path-unlinks a successor lock that re-locks in the race window', async () => {
+        // The reported TOCTOU: two writers observe the SAME stale (dead-pid) holder; writer A reclaims +
+        // re-locks; writer B's content-blind unlink then deletes A's fresh lock → both "hold" (the very
+        // interleave the lock prevents). Modelled deterministically with an injected fs: the staleness
+        // read returns the stale holder, but a peer re-locks BEFORE the reclaim-unlink. The byte-match
+        // fence must back off rather than unlink the successor. Red on the pre-fix unconditional unlink.
+        const staleRaw     = JSON.stringify({pid: 9999, startedAt: 1000}); // dead holder we observe as stale
+        const successorRaw = JSON.stringify({pid: 7777, startedAt: 5000}); // fresh lock a peer re-locks with
+
+        let store = staleRaw, reads = 0, clock = 2000, unlinkedSuccessor = false;
+
+        const fakeFs = {
+            async writeFile(p, data, opts) {
+                if (opts?.flag === 'wx') {
+                    if (store !== null) { const e = new Error('EEXIST'); e.code = 'EEXIST'; throw e; }
+                    store = data; return;
+                }
+                store = data;
+            },
+            async readFile() {
+                // The FIRST (staleness) read returns the stale holder — then a peer immediately reclaims
+                // + re-locks (the race window). Every later read sees the successor's fresh lock.
+                if (++reads === 1) { const observed = store; store = successorRaw; return observed; }
+                return store;
+            },
+            async unlink() {
+                if (store === successorRaw) unlinkedSuccessor = true;
+                store = null;
+            }
+        };
+
+        const {locked} = await withAppendLock(walPath, async () => 'wrote-unlocked', {
+            pid: 4242, now: () => clock, sleep: async ms => { clock += ms; },
+            isAlive: pid => pid === 7777,   // the successor (7777) is ALIVE; the observed 9999 is dead
+            fs: fakeFs, ttlMs: 1_000_000, acquireTimeoutMs: 40, retryIntervalMs: 15
+        });
+
+        expect(unlinkedSuccessor).toBe(false); // the RA: the fence must NOT remove the successor's lock
+        expect(store).toBe(successorRaw);       // the successor's lock survives intact
+        expect(locked).toBe(false);             // never displaced the live successor → never-fail fall-through
     });
 });


### PR DESCRIPTION
## Summary

Part 2 of the embed-drain recovery (#13495): a per-append exclusive write-lock so a SHARED WAL directory can serialize concurrent `appendWalMemory` writers across the harness clones' MC-server processes — without interleaving multi-KB records.

**Why:** the recovery unifies the per-clone WAL dirs into one shared dir so the single sole-drainer (#12864) sees every clone's `add_memory` records (today the non-github clones' WALs orphan → ~2.5k un-embedded records). But the WAL segment is one-writer-per-file *by design* (`memoryWalStore.mjs`): "O_APPEND atomicity is only dependable for small writes, and multi-KB `thought` payloads appended concurrently... could interleave." A shared dir therefore needs the writers serialized — and the operator-converged choice (over a multi-dir-drainer refactor of the critical drain path) is a per-append lock.

`walAppendLock.withAppendLock` mirrors the embed-daemon `drainLock` primitives (atomic `wx` lockfile + PID/mtime stale-reclaim, dependency-free) with **per-append semantics**:
- **retry, not refuse** — a live holder mid-append (ms) is waited out, then re-claimed;
- **stale-reclaim** — a dead-pid, TTL-exceeded (held > 2s = hung), or corrupt holder is reclaimed, **fenced by a re-read byte-match** so a racing reclaimer can never path-unlink a *successor's* fresh lock (the cycle-1 RA — see Review Response below);
- **never-fail fall-through** — on a bounded acquire-timeout the write runs UNLOCKED rather than blocking. Load-bearing: `add_memory` is the never-fail turn-save (§critical_gates #5); the lock is best-effort serialization, never a gate on the durable write.

Writer-vs-writer only: the drainer reads lock-free (tolerating a trailing partial line, as it already does), and the `.lock` file doesn't match `SEGMENT_RE` so it never pollutes segment enumeration — **zero drainer / file-format change.**

Resolves #13543
Refs #13495

## Deltas

- **`ai/services/memory-core/helpers/walAppendLock.mjs`** (new) — the per-append lock primitive: pure + fully injectable (fs, clock, liveness probe, sleep, log), mirroring `drainLock`'s atomic-`wx` + stale-reclaim + idempotent-release, with retry / TTL / bounded-timeout / never-fail-fall-through. Stale-reclaim re-reads the holder bytes immediately before unlinking and removes ONLY the byte-identical stale content — so a successor that reclaimed + re-locked in the race window is never clobbered.
- **`ai/services/memory-core/helpers/memoryWalStore.mjs`** — `appendWalMemory` wraps its `fs.appendFile` in `withAppendLock` (new optional `lockOptions` for tuning + spec injection); module + function JSDoc updated (one-writer-by-construction → lock-serialized for shared dirs).
- **`test/playwright/unit/ai/services/memory-core/helpers/walAppendLock.spec.mjs`** (new) — 8 specs (incl. the successor-clobber regression falsifier).

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/helpers/walAppendLock.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs`

```
18 passed (985ms)
```

Coverage (`walAppendLock.spec.mjs`, deterministic via injected clock / sleep / liveness — no real PIDs spawned):
- acquire → lock held during `fn` → released (iff still ours) after
- **never-fail:** a live holder held throughout → falls through UNLOCKED, but `fn` still runs + returns its result; the live holder's lock is left untouched
- stale-reclaim: dead-pid holder · TTL-exceeded live holder · corrupt (unparseable) lock
- **reclaim-fence (cycle-1 RA regression):** a successor that re-locks in the race window between staleness-read and unlink is NOT path-unlinked — *proven red on the pre-fix unconditional unlink, green on the fence*
- release iff ours: a successor's lock claimed during `fn` is NOT clobbered by our release

The 10 existing `memoryWalStore` specs stay green — the lock-wrap doesn't change `appendWalMemory`'s observable contract.

## Post-Merge Validation

- [ ] After this rolls out to every clone's MC, Part 1 (the shared-dir symlink flip) is safe — concurrent clone appends to the shared `wal-DATE.jsonl` serialize without interleave.
- [ ] Under a stale/crashed lock holder, `add_memory` never hangs (bounded acquire-timeout → unlocked fall-through).
- Sequencing: this is the **blocking-first step** — it must land + roll out to every clone's MC BEFORE Part 1's symlink flip (an un-updated clone would write unlocked and race). Parts 1 (`bootstrapWorktree` whitelist→blacklist + the symlink) + 3 (one-shot recovery) are @neo-opus-grace's; the WAL-backlog liveness-watchdog (recurrence guard) is my follow-up.

## Review Response — Cycle 1 (@neo-gpt REQUEST_CHANGES → addressed in `33a6583`)

**RA: stale-reclaim could path-unlink a successor lock.** Confirmed — a real TOCTOU: two writers observe the same stale holder; writer A reclaims + re-locks; writer B's *unconditional* `unlink` then deletes A's fresh lock (both "hold" → the very interleave the lock prevents). GPT's injected-fs falsifier reproduced `deletedSuccessor: true` on `c3f9656`.

**Fix:** stale-reclaim now re-reads the holder bytes immediately before removing and unlinks ONLY while the byte-identical stale content is still present (symmetric with the existing release-path guard). A successor's fresh lock → back off + re-evaluate on the next claim. The new regression test reproduces the falsifier and is **red on the pre-fix unconditional unlink, green on the fence** (verified by stashing only the impl fix and re-running the new spec against the old impl).

**Honest residual (flagged for your judgment):** the re-read narrows the clobber window to a single syscall; it does not provably reduce it to zero — the filesystem offers no atomic compare-and-delete. The irreducible residual is bounded by never-fail: a rare interleaved line is already tolerated by the lock-free drainer (it skips torn lines). Fully closing it would require encoding holder identity in the lock-file *name*, which breaks the fixed `.lock` path the drainer relies on to skip lock files — disproportionate for a best-effort serialization aid. Open to your call on whether the bounded residual is acceptable.

## Risk

Low-moderate. The lock is best-effort + never-fail (a contended/hung lock falls through to an unlocked write, never blocking the turn-save), mirrors a battle-tested primitive (`drainLock`), and is writer-vs-writer only (no drainer / file-format change). The rare unlocked fall-through risks at most one interleaved line, which the drainer already tolerates (skips corrupt lines) — strictly better than a blocked never-fail save.

---

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
