### PR TITLE
fix(ai): blocklist-symlink .neo-ai-data except concepts in bootstrapWorktree (#13542)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -52,9 +52,10 @@
  * hides the worktree's tracked `concepts/` files behind canonical's view; using `--force`
  * clobbers them entirely. Both outcomes break the worktree-local concepts substrate.
  *
- * The granular fix: symlink each gitignored substrate-data subdir individually
- * via the `DATA_SUBDIRS_TO_LINK` allowlist. `concepts/` is never in the allowlist → never
- * touched. This unifies the Memory Core substrate ({@link symlinkDataDir}) so AgentIdentity
+ * The fix: symlink every gitignored child of `.neo-ai-data/`, EXCEPT the
+ * {@link DATA_SUBDIRS_BLOCKLIST} entries (`concepts/` + the per-process daemon-pid dirs) → never touched. Excluding a blocklist
+ * (vs. an allowlist of names) unifies any new substrate child automatically.
+ * This unifies the Memory Core substrate ({@link symlinkDataDir}) so AgentIdentity
  * nodes seeded once are visible to every worktree's MCP server, A2A mailbox handoffs span
  * harnesses, AND the wake daemon's PID-lock singleton plus persistent log
  * span worktrees too — without the tracked `concepts/` clobber risk that
@@ -136,24 +137,28 @@ export const BOOTSTRAP_CONFIGS = [
 ];
 
 /**
- * Allowlist of `.neo-ai-data/` subdirs to symlink to canonical when `--link-data` is set.
- * All entries are gitignored substrate-data subdirs that benefit from cross-worktree
- * unification. The git-tracked `concepts/` subdir is deliberately NOT in this list —
- * symlinking it would hide the worktree's own tracked files; `--force` would clobber them.
+ * Blocklist of `.neo-ai-data/` children that must NEVER be symlinked to canonical.
  *
- * The order is informational (no semantic dependency between subdirs); each is symlinked
- * independently and per-subdir results are reported separately.
+ * **Blocklist, not allowlist.** The retired `DATA_SUBDIRS_TO_LINK` allowlist enumerated exactly
+ * which subdirs to link — and silently drifted: `memory-wal` was never added, so every
+ * non-canonical clone wrote its `add_memory` WAL to its own un-drained dir, orphaning thousands
+ * of records across clones for ~8 days. {@link symlinkDataDir} now links EVERY child of
+ * canonical's `.neo-ai-data/` EXCEPT the entries here, so a newly-introduced substrate child is
+ * unified automatically — the drift class is gone by construction.
  *
- * @see {@link symlinkDataDir} for the per-subdir symlink-or-skip-or-clobber logic.
+ * Two kinds of entry:
+ * 1. **`concepts/`** — the ONLY git-tracked item inside `.neo-ai-data/` (`.gitignore`:
+ *    `.neo-ai-data` then `!.neo-ai-data/concepts/`). Symlinking it would hide the worktree's own
+ *    tracked files behind canonical's view; `--force` would clobber them.
+ * 2. **Per-process daemon-pid dirs** (`orchestrator-daemon/`, `embed-daemon/`) — they hold the
+ *    orchestrator parent-pid (the SIGTERM-singleton) + the embed-daemon pid, so a shared pid dir
+ *    would let the orchestrator-singleton race / cross-signal across clones. Contrast
+ *    `wake-daemon/` (a DESIGNED cross-clone singleton that DOES share) and `memory-wal/` (shares
+ *    its records + markers + `.drain-lock` for cross-clone sole-drainer enforcement).
+ *
+ * @see {@link symlinkDataDir} for the per-item symlink-or-skip-or-clobber logic.
  */
-export const DATA_SUBDIRS_TO_LINK = [
-    'sqlite',       // Memory Core graph DB (memory-core-graph.sqlite + WAL/SHM)
-    'chroma',       // Vector DBs (knowledge-base + memory-core)
-    'wake-daemon',  // PID-lock + bridge.log + lastSyncId shared across worktrees
-    'backups',      // JSONL backups (Memory Core message + node history)
-    'datasets',     // Canonical CSVs ingested by knowledge-base sync
-    'neo-sqlite'    // Legacy DB (still referenced by older code paths)
-];
+export const DATA_SUBDIRS_BLOCKLIST = ['concepts', 'orchestrator-daemon', 'embed-daemon'];
 
 /**
  * Allowlist of gitignored single files (outside `.neo-ai-data/`) to symlink to canonical
@@ -162,7 +167,7 @@ export const DATA_SUBDIRS_TO_LINK = [
  * Antigravity-Gemini and Codex-GPT clones don't see the handoff at boot per
  * `AGENTS_STARTUP.md §6` step 4.
  *
- * **Allowlist discipline (parallel to `DATA_SUBDIRS_TO_LINK`):**
+ * **Allowlist discipline (curated — `.neo-ai-data/` uses the inverse {@link DATA_SUBDIRS_BLOCKLIST}):**
  *
  * Each entry MUST be:
  * 1. **Gitignored** — single file with its own `.gitignore` line. Symlinking a tracked file
@@ -313,10 +318,10 @@ async function exists(p) {
  * view; `--force` clobbers them entirely. Both outcomes break the worktree-local
  * concepts substrate.
  *
- * This function symlinks each gitignored subdir individually via the `subdirs` allowlist
- * (default: {@link DATA_SUBDIRS_TO_LINK}). `concepts/` is never in the default allowlist
+ * This function symlinks every gitignored child of canonical's `.neo-ai-data/` EXCEPT the
+ * `blocklist` (default: {@link DATA_SUBDIRS_BLOCKLIST}). `concepts/` is always blocklisted
  * → never touched, regardless of `--force`. The data-loss guard (refuse-clobber-without-
- * force) is preserved per-subdir, so a corrupted `sqlite/` can be reset without nuking
+ * force) is preserved per-item, so a corrupted `sqlite/` can be reset without nuking
  * everything else.
  *
  * **Why this is the right substrate (Anchor & Echo):**
@@ -339,66 +344,89 @@ async function exists(p) {
  * @param {object}   options
  * @param {string}   options.mainCheckout Absolute path to the primary git checkout.
  * @param {string}   options.projectRoot  Absolute path to the worktree root to link from.
- * @param {string[]} [options.subdirs]    Allowlist of subdirs to symlink; defaults to {@link DATA_SUBDIRS_TO_LINK}.
- * @param {boolean}  [options.force=false] If true, clobber existing non-symlink dirs in the allowlist (never touches subdirs not in the allowlist).
+ * @param {string[]} [options.blocklist]  Child names to NEVER symlink; defaults to {@link DATA_SUBDIRS_BLOCKLIST}.
+ * @param {boolean}  [options.force=false] If true, clobber an existing non-symlink dir/file at a non-blocklisted child (never touches blocklisted children).
  * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
- * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], mainCheckout: boolean}>} Per-subdir action map.
- * @throws {Error} When any subdir's dst is a non-symlink directory and `force` is false. The error message names the offending subdir.
+ * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], mainCheckout: boolean}>} Per-item action map.
+ * @throws {Error} When a non-blocklisted child's dst is a non-symlink dir/file and `force` is false. The error message names the offending child.
  */
 export async function symlinkDataDir({
     mainCheckout,
     projectRoot,
-    subdirs = DATA_SUBDIRS_TO_LINK,
-    force   = false,
-    log     = console.log
+    blocklist = DATA_SUBDIRS_BLOCKLIST,
+    force     = false,
+    log       = console.log
 }) {
     const result = {linked: [], alreadyLinked: [], clobbered: [], skippedNoSource: [], mainCheckout: false};
 
     if (path.resolve(projectRoot) === path.resolve(mainCheckout)) {
-        log(`symlink skip (main checkout): no per-subdir action`);
+        log(`symlink skip (main checkout): no per-item action`);
         result.mainCheckout = true;
         return result;
     }
+
+    const canonicalDataDir = path.join(mainCheckout, '.neo-ai-data');
 
     // Ensure the parent .neo-ai-data/ exists as a regular dir; we never symlink the parent.
     // This preserves the git-tracked concepts/ subdir already present in the worktree.
     const parentDst = path.join(projectRoot, '.neo-ai-data');
     await fs.mkdir(parentDst, {recursive: true});
 
-    for (const subdir of subdirs) {
-        const src   = path.join(mainCheckout, '.neo-ai-data', subdir);
-        const dst   = path.join(parentDst, subdir);
+    // Blocklist, not allowlist: enumerate EVERY child of canonical's .neo-ai-data and link all
+    // except the blocklist. A new substrate child is unified automatically, removing the
+    // allowlist-drift class that silently orphaned memory-wal across non-canonical clones.
+    const blocklistSet = new Set(blocklist);
+    let entries;
+    try {
+        entries = await fs.readdir(canonicalDataDir, {withFileTypes: true});
+    } catch (e) {
+        // Fresh canonical with no .neo-ai-data yet — nothing to link.
+        if (e?.code === 'ENOENT') return result;
+        throw e;
+    }
+
+    for (const entry of entries) {
+        const name = entry.name;
+
+        if (blocklistSet.has(name)) {
+            log(`symlink skip (blocklisted): ${name}`);
+            continue;
+        }
+
+        const src   = path.join(canonicalDataDir, name);
+        const dst   = path.join(parentDst, name);
         const lstat = await fs.lstat(dst).catch(() => null);
 
         if (lstat?.isSymbolicLink()) {
-            log(`symlink skip (already linked): ${subdir}`);
-            result.alreadyLinked.push(subdir);
+            log(`symlink skip (already linked): ${name}`);
+            result.alreadyLinked.push(name);
             continue;
         }
 
-        // Skip if canonical lacks the subdir — graceful for fresh repos.
+        // src came from readdir, so it exists barring a concurrent-removal race — guard anyway.
         const srcExists = await exists(src);
         if (!srcExists) {
-            log(`symlink skip (no source in main checkout): ${subdir}`);
-            result.skippedNoSource.push(subdir);
+            log(`symlink skip (no source in main checkout): ${name}`);
+            result.skippedNoSource.push(name);
             continue;
         }
 
-        if (lstat?.isDirectory()) {
+        if (lstat) {
+            // A real (non-symlink) dir or file already at dst would be shadowed by the link.
             if (!force) {
                 throw new Error(
                     `Refusing to replace non-symlink ${dst}; pass force=true (CLI --force) to opt in. ` +
-                    `This directory contains local data that would be lost.`
+                    `This path contains local data that would be lost.`
                 );
             }
-            log(`symlink clobber (force=true): removing ${subdir}`);
+            log(`symlink clobber (force=true): removing ${name}`);
             await fs.rm(dst, {recursive: true, force: true});
-            result.clobbered.push(subdir);
+            result.clobbered.push(name);
         }
 
-        await fs.symlink(src, dst, 'dir');
-        log(`symlinked: ${subdir} → ${src}`);
-        result.linked.push(subdir);
+        await fs.symlink(src, dst, entry.isDirectory() ? 'dir' : 'file');
+        log(`symlinked: ${name} → ${src}`);
+        result.linked.push(name);
     }
 
     return result;

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -39,7 +39,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     let parseWorktreePorcelain;
     let pruneStaleWorktrees;
     let BOOTSTRAP_CONFIGS;
-    let DATA_SUBDIRS_TO_LINK;
+    let DATA_SUBDIRS_BLOCKLIST;
     let GITIGNORED_FILES_TO_LINK;
     let fakeMainCheckout;
     let fakeWorktree;
@@ -64,7 +64,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
         parseWorktreePorcelain   = mod.parseWorktreePorcelain;
         pruneStaleWorktrees      = mod.pruneStaleWorktrees;
         BOOTSTRAP_CONFIGS        = mod.BOOTSTRAP_CONFIGS;
-        DATA_SUBDIRS_TO_LINK     = mod.DATA_SUBDIRS_TO_LINK;
+        DATA_SUBDIRS_BLOCKLIST   = mod.DATA_SUBDIRS_BLOCKLIST;
         GITIGNORED_FILES_TO_LINK = mod.GITIGNORED_FILES_TO_LINK;
     });
 
@@ -322,31 +322,59 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             }
         }
 
-        test('exports the canonical DATA_SUBDIRS_TO_LINK list', () => {
-            // The exact list is documented in the source; we assert the load-bearing
-            // invariants rather than the precise sequence (which may evolve).
-            expect(Array.isArray(DATA_SUBDIRS_TO_LINK)).toBe(true);
-            expect(DATA_SUBDIRS_TO_LINK).toContain('sqlite');
-            expect(DATA_SUBDIRS_TO_LINK).toContain('chroma');
-            expect(DATA_SUBDIRS_TO_LINK).toContain('wake-daemon');
+        test('exports the canonical DATA_SUBDIRS_BLOCKLIST', () => {
+            expect(Array.isArray(DATA_SUBDIRS_BLOCKLIST)).toBe(true);
 
-            // CRITICAL invariant: concepts/ is git-tracked and MUST NEVER be in the
-            // default allowlist. This is the load-bearing safety check that prevents
-            // the parent-level symlink clobber bug from regressing.
-            expect(DATA_SUBDIRS_TO_LINK).not.toContain('concepts');
+            // CRITICAL invariant: concepts/ is git-tracked and MUST be blocklisted so it is
+            // NEVER symlinked — the load-bearing safety check that prevents the parent-level
+            // symlink clobber bug from regressing.
+            expect(DATA_SUBDIRS_BLOCKLIST).toContain('concepts');
+
+            // Per-process daemon-pid dirs MUST be blocklisted — sharing the orchestrator
+            // parent-pid (the SIGTERM-singleton) across clones would race / cross-signal.
+            expect(DATA_SUBDIRS_BLOCKLIST).toContain('orchestrator-daemon');
+            expect(DATA_SUBDIRS_BLOCKLIST).toContain('embed-daemon');
+
+            // Shared substrate children must NOT be blocklisted — they link by enumeration
+            // (memory-wal carries records + markers + .drain-lock; wake-daemon is a designed singleton).
+            expect(DATA_SUBDIRS_BLOCKLIST).not.toContain('sqlite');
+            expect(DATA_SUBDIRS_BLOCKLIST).not.toContain('memory-wal');
+            expect(DATA_SUBDIRS_BLOCKLIST).not.toContain('wake-daemon');
         });
 
-        test('symlinks every allowlisted subdir from canonical when none exist in worktree', async () => {
+        test('blocklists the per-process daemon-pid dirs (SIGTERM-singleton stays per-clone)', async () => {
+            // orchestrator-daemon/ + embed-daemon/ hold the orchestrator parent-pid + embed pid;
+            // sharing them across clones would race the singleton, so they must NOT be symlinked.
+            for (const d of ['orchestrator-daemon', 'embed-daemon']) {
+                await fs.ensureDir(path.join(fakeMainCheckout, dataDir, d));
+                await fs.writeFile(path.join(fakeMainCheckout, dataDir, d, 'pid'), '12345\n', 'utf-8');
+            }
+            await seedMainSubdirs(['memory-wal']); // a shared child alongside the daemon dirs
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            });
+
+            // memory-wal links; the daemon-pid dirs do not.
+            expect(result.linked).toContain('memory-wal');
+            expect(result.linked).not.toContain('orchestrator-daemon');
+            expect(result.linked).not.toContain('embed-daemon');
+            expect(await fs.pathExists(path.join(fakeWorktree, dataDir, 'orchestrator-daemon'))).toBe(false);
+            expect(await fs.pathExists(path.join(fakeWorktree, dataDir, 'embed-daemon'))).toBe(false);
+        });
+
+        test('symlinks every canonical child except the blocklist when none exist in worktree', async () => {
             await seedMainSubdirs();
 
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
-                subdirs     : fixtureSubdirs,
                 log         : () => {}
             });
 
-            expect(result.linked).toEqual(fixtureSubdirs);
+            expect(result.linked.sort()).toEqual([...fixtureSubdirs].sort());
             expect(result.alreadyLinked).toHaveLength(0);
             expect(result.clobbered).toHaveLength(0);
             expect(result.skippedNoSource).toHaveLength(0);
@@ -369,14 +397,51 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(parentLstat.isSymbolicLink()).toBe(false);
         });
 
-        test('is idempotent per-subdir — re-running over partial state surfaces alreadyLinked + linked', async () => {
+        test('links a previously-non-allowlisted child like memory-wal (regression guard)', async () => {
+            // The exact bug: memory-wal was never in the retired DATA_SUBDIRS_TO_LINK allowlist,
+            // so it was never symlinked → per-clone orphaned WALs. Enumeration must link it now.
+            await seedMainSubdirs(['memory-wal']);
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            });
+
+            expect(result.linked).toContain('memory-wal');
+
+            const dst   = path.join(fakeWorktree, dataDir, 'memory-wal');
+            const lstat = await fs.lstat(dst);
+            expect(lstat.isSymbolicLink()).toBe(true);
+            expect(await fs.readFile(path.join(dst, 'canary.txt'), 'utf-8')).toBe('main-memory-wal-canary\n');
+        });
+
+        test('symlinks a top-level FILE child, not just directories', async () => {
+            // .neo-ai-data can hold file children (e.g. memory-core.sqlite); they must link too.
+            await fs.ensureDir(path.join(fakeMainCheckout, dataDir));
+            await fs.writeFile(path.join(fakeMainCheckout, dataDir, 'memory-core.sqlite'), 'db-bytes\n', 'utf-8');
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            });
+
+            expect(result.linked).toContain('memory-core.sqlite');
+
+            const dst   = path.join(fakeWorktree, dataDir, 'memory-core.sqlite');
+            const lstat = await fs.lstat(dst);
+            expect(lstat.isSymbolicLink()).toBe(true);
+            expect(await fs.readFile(dst, 'utf-8')).toBe('db-bytes\n');
+        });
+
+        test('is idempotent per-child — re-running over partial state surfaces alreadyLinked + linked', async () => {
             await seedMainSubdirs();
 
             // First call links all three subdirs.
             await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
-                subdirs     : fixtureSubdirs,
                 log         : () => {}
             });
 
@@ -387,7 +452,6 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
-                subdirs     : fixtureSubdirs,
                 log         : () => {}
             });
 
@@ -410,7 +474,6 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 symlinkDataDir({
                     mainCheckout: fakeMainCheckout,
                     projectRoot : fakeWorktree,
-                    subdirs     : fixtureSubdirs,
                     log         : () => {}
                 })
             ).rejects.toThrow(/Refusing to replace non-symlink/);
@@ -420,7 +483,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(preserved).toBe('worktree-specific\n');
         });
 
-        test('clobbers per-subdir with force=true and creates the link', async () => {
+        test('clobbers per-child with force=true and creates the link', async () => {
             await seedMainSubdirs();
 
             const worktreeSubdir = path.join(fakeWorktree, dataDir, 'sqlite');
@@ -430,12 +493,11 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
-                subdirs     : fixtureSubdirs,
                 force       : true,
                 log         : () => {}
             });
 
-            expect(result.linked).toEqual(fixtureSubdirs);
+            expect(result.linked.sort()).toEqual([...fixtureSubdirs].sort());
             expect(result.clobbered).toEqual(['sqlite']);
 
             // Clobbered subdir is now a symlink + canary reachable.
@@ -446,19 +508,35 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(canary).toBe('main-sqlite-canary\n');
         });
 
-        test('gracefully skips subdirs missing in the main checkout', async () => {
-            // Seed only two of three; third (chroma) is absent in the main checkout.
+        test('children absent in the canonical checkout are simply not linked', async () => {
+            // Seed only two of three; the third (chroma) is absent in canonical → never
+            // enumerated, so it is neither linked nor reported (graceful by construction).
             await seedMainSubdirs(['sqlite', 'wake-daemon']);
 
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
-                subdirs     : fixtureSubdirs, // includes chroma which isn't in main
                 log         : () => {}
             });
 
             expect(result.linked.sort()).toEqual(['sqlite', 'wake-daemon'].sort());
-            expect(result.skippedNoSource).toEqual(['chroma']);
+            expect(result.linked).not.toContain('chroma');
+            expect(await fs.pathExists(path.join(fakeWorktree, dataDir, 'chroma'))).toBe(false);
+        });
+
+        test('returns empty + does not throw when canonical .neo-ai-data is absent', async () => {
+            // Fresh canonical that has never created .neo-ai-data — must be a graceful no-op.
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout, // no .neo-ai-data seeded
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            });
+
+            expect(result.linked).toHaveLength(0);
+            expect(result.alreadyLinked).toHaveLength(0);
+            expect(result.clobbered).toHaveLength(0);
+            expect(result.skippedNoSource).toHaveLength(0);
+            expect(result.mainCheckout).toBe(false);
         });
 
         test('NEVER touches concepts/ even when present in main checkout and force=true', async () => {
@@ -478,7 +556,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
                 'worktree-tracked-concept\n', 'utf-8'
             );
 
-            // Use the DEFAULT allowlist (which deliberately omits concepts/), and force=true.
+            // Use the DEFAULT blocklist (which contains concepts/), and force=true.
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeWorktree,
@@ -511,7 +589,6 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             const result = await symlinkDataDir({
                 mainCheckout: fakeMainCheckout,
                 projectRoot : fakeMainCheckout, // same path = primary working tree
-                subdirs     : fixtureSubdirs,
                 log         : () => {}
             });
 


### PR DESCRIPTION
Resolves #13542

Authored by @neo-opus-grace (Grace · Opus 4.8).

Replaces the drift-prone `DATA_SUBDIRS_TO_LINK` allowlist in `bootstrapWorktree.mjs` with a **blocklist**. `symlinkDataDir` now enumerates canonical's `.neo-ai-data` children and symlinks all except the blocklist — so `memory-wal` (the subdir whose allowlist omission orphaned ~2,500 `add_memory` WAL records across 6 clones for ~8 days, freezing semantic recall since ~06-10) and any future substrate child unify **automatically**. The same code path serves git worktrees and new-peer onboarding, so "new repo setups use it" holds by construction.

Root cause was the allowlist's structural failure mode — a new substrate subdir is silently un-linked until someone remembers to add it. The `.gitignore` boundary (`.neo-ai-data` then `!.neo-ai-data/concepts/`) is now the source of truth for tracked-vs-gitignored; the blocklist adds only the per-process daemon-pid dirs (see below).

Evidence: L2 (unit specs over tmp-dir fake checkouts, 42 green) → L2 required (the close-target AC is the pure symlink-selection logic, fully unit-covered; the live flip is a separate, explicitly out-of-scope op). No residual for this ticket's scope.

## Deltas
- `DATA_SUBDIRS_TO_LINK` allowlist → `DATA_SUBDIRS_BLOCKLIST = ['concepts', 'orchestrator-daemon', 'embed-daemon']` — `concepts/` is git-tracked; the two daemon-pid dirs stay per-clone (the orchestrator parent-pid is the SIGTERM-singleton; sharing would race/cross-signal across clones).
- `symlinkDataDir({…, subdirs})` → `symlinkDataDir({…, blocklist})`: enumerates `<canonical>/.neo-ai-data` children (dirs **and** files), skips the blocklist, symlinks the rest (dir→`'dir'`, file→`'file'`); graceful `ENOENT` when canonical has no `.neo-ai-data`.
- Preserved verbatim: parent-`.neo-ai-data`-stays-a-real-dir (protects the tracked `concepts/`), idempotent already-linked skip, force-guard (refuse to clobber a non-symlink without `--force`), skip-no-source race-guard, mainCheckout no-op, per-item result buckets.
- JSDoc updated (file-head, const, function, `GITIGNORED_FILES_TO_LINK` cross-ref) — no dangling `{@link}`. Inclusive allowlist/blocklist terminology throughout.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs` → **42 passed**.

New / changed coverage:
- exports `DATA_SUBDIRS_BLOCKLIST` (contains `concepts` + the daemon-pid dirs; excludes `sqlite`/`memory-wal`/`wake-daemon`);
- links every canonical child except the blocklist;
- **`memory-wal` regression guard** — the exact bug this PR fixes;
- **daemon-pid dirs blocklisted** (`orchestrator-daemon`/`embed-daemon` stay per-clone — SIGTERM-singleton);
- top-level **file**-child is symlinked (not just dirs);
- absent canonical child is simply not linked;
- absent canonical `.neo-ai-data` → graceful empty no-op;
- retained: the load-bearing **`NEVER touches concepts/` even with `force=true`** safety test.

## Post-Merge Validation
- This PR is the **code only**. The live `memory-wal` symlink flip on running clones MUST wait until the per-append WAL write-lock (#13543 / PR #13544, @neo-opus-vega) is live on every clone's MC — otherwise an un-updated clone appends to the shared `wal-DATE.jsonl` concurrently and violates the one-writer-per-segment invariant (`getWalSegmentKey` is UTC-date-only, not clone-unique).
- **Daemon-scope (resolved — @neo-opus-ada caught it, @neo-opus-vega refined):** the per-process daemon-pid dirs (`orchestrator-daemon/`, `embed-daemon/`) are blocklisted so they stay per-clone — the orchestrator parent-pid is the SIGTERM-singleton; a shared pid dir would race/cross-signal. `memory-wal/` still shares its records + markers + `.drain-lock` (the `.drain-lock` is the cross-clone sole-drainer feature); `wake-daemon/` stays shared (designed singleton). The embed-daemon also stays github-only via deployment config (`embedDaemonEnabled=false` non-github) — orthogonal to this PR.
- The ~2,500-record one-shot recovery and the operational flip are coordinated separately (ephemeral, not committed — no repo bloat).
- Refs #13495, #12864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)