### PR TITLE
docs(agentos): compress pull-request workflow payload (#13538)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -18,20 +18,16 @@ The act of opening a PR is an irreversible state transition in the Agent OS. Bef
 
 If your PR touches memory substrate per `/turn-memory-pre-flight` (`AGENTS.md`,
 `learn/agentos/AGENTS_ATLAS.md`, `.agents/skills/**`, or directly loaded
-`learn/agentos/**`):
+`learn/agentos/**`), include a **slot-rationale section** in the PR body:
+- added sections: disposition (`keep` / `move` / `compress-to-trigger` / `rewrite` / `retire`) + trigger-frequency x failure-severity x enforceability;
+- modified sections: disposition delta + why the load/placement changed;
+- retired sections: removal rationale.
 
-Ordinary `learn/agentos/**` operator/reference docs that are not directly loaded
-can cite in-doc lifecycle rationale instead of duplicating PR-body slot-rationale.
-
-For in-scope memory substrate, you MUST include a **slot-rationale section** in your PR body. This satisfies the `AGENTS.md §13` mandate requiring explicit decay-mitigation rationale for all substrate mutations.
-Your PR body's slot-rationale section MUST enumerate:
-- For each *added* section: its disposition (`keep` / `move` / `compress-to-trigger` / `rewrite` / `retire`) + 3-axis rating (trigger-frequency × failure-severity × enforceability).
-- For each *modified* section: its disposition delta + the reason for the shift.
-- For each *retired* section: the rationale for removal.
-
-**Default disposition for new rules:** `compress-to-trigger` is the strict default unless trigger-frequency × failure-severity × enforceability justifies `keep` in always-loaded substrate (the "Map"). Substantive rule bodies belong in conditionally-loaded `references/` payloads (the "World Atlas"), with a one-line trigger in the always-loaded `SKILL.md` or skills manifest. Justification for `keep` over `compress-to-trigger` MUST cite per-turn frequency and irreversibility (e.g., §0 Critical Gates, Mailbox Check Protocol). Net-expansion of always-loaded substrate without this justification fails the Substrate Accretion Defense per `AGENTS.md §13`.
-
-ADR conflict trigger: add `Decision Record impact:` naming the ADR update or pending-authority path; do not silently bypass accepted ADRs.
+Default new-rule disposition is `compress-to-trigger`; `keep` in always-loaded
+substrate requires per-turn frequency + irreversibility rationale. Ordinary
+operator/reference docs under `learn/agentos/**` that are not directly loaded may
+cite in-doc lifecycle rationale instead. ADR conflicts must name
+`Decision Record impact:` before bypassing accepted ADRs.
 
 **Env-var changes** → read [`env-var-rename-rule.md`](./env-var-rename-rule.md).
 
@@ -41,36 +37,28 @@ Before `git commit` or opening a PR, you MUST verify you are the formal assignee
 
 ## 2. Git Branching Mandate
 
-You are strictly forbidden from committing or pushing directly to `main` (release-only) or `dev` (default working). The *mechanism* for satisfying this rule differs by harness class.
+You are strictly forbidden from committing or pushing directly to `main`
+(release-only) or `dev` (default working). Branch before any tracked edit unless
+your harness already gave you an isolated non-`main`/`dev` worktree branch.
 
-### 2.1 Worktree-isolated harnesses (e.g., Claude Code)
-
-Worktree-isolated harnesses create a git worktree per session on an auto-generated branch. Git's worktree branch-exclusivity mechanically prevents commits to `main`/`dev` (another worktree holds them; git refuses to share). Any non-`main`/`dev` branch name is acceptable; no explicit branching action is required.
-
-### 2.2 Shared-checkout harnesses (e.g., Gemini CLI, Antigravity)
-
-Harnesses without worktree isolation operate directly inside the main checkout's working tree. The first `git commit` without an explicit branch lands on the currently checked-out branch — typically `dev`, which is a protocol violation.
-
-You MUST branch off *before* any code change:
+Shared-checkout harnesses (Gemini CLI, Antigravity, Codex shared checkout) MUST
+branch before code changes:
 
 ```bash
 git checkout -b agent/[ticket-id]-[descriptor]
 # Example: git checkout -b agent/9957-pull-request-skill
 ```
 
-> **Note:** If you followed the `ticket-intake` skill (Section 3: Acceptance Protocol), the feature branch should already exist.
-
-### 2.3 Universal safety net
-
-Regardless of harness class, before your first commit verify:
+If you followed `ticket-intake`, the feature branch should already exist. Before
+the first commit, verify:
 
 ```bash
 git branch --show-current
 ```
 
-If it returns `main` or `dev`, STOP and branch off using the §2.2 procedure. This check costs nothing and catches edge cases where a harness's isolation assumption has broken (e.g. symlink detach, manual `git checkout`).
+If it returns `main` or `dev`, STOP and branch first.
 
-### 2.3.1 Branch Freshness Check (pre-push)
+### 2.1 Branch Freshness Check (pre-push)
 
 Before the first `git push` that opens a PR, AND before every force-push that would update the PR branch:
 
@@ -81,15 +69,13 @@ git fetch origin
     || git rebase origin/dev
 ```
 
-**Why this matters under rapid merge tempo:** when multiple PRs merge in a short window (common for active refactor epics), every outstanding feature branch becomes stale within minutes. Pre-push rebase ensures the PR diff reflects only your own change surface, not already-merged content from peer branches.
-
 **Exception — first push of a freshly-branched feature:** skip ONLY after confirming via `git log origin/dev..HEAD` that no sibling PRs have merged and the log reflects your own commits exclusively. The branch-point IS `origin/dev`'s tip.
 
-### 2.3.2 Branch-Discipline Check (pre-push)
+### 2.2 Branch-Discipline Check (pre-push)
 
 `.husky/pre-push` blocks `chore(data):` commits on feature branches: [`audits/branch-discipline-check.md`](../audits/branch-discipline-check.md).
 
-### 2.4 Tool-Specific Branch Constraints
+### 2.3 Tool-Specific Branch Constraints
 
 If you intend to use the `sync_all` MCP tool, you MUST read [sync-all-constraints.md](./sync-all-constraints.md) before execution to prevent severe branch pollution.
 
@@ -170,39 +156,36 @@ You MUST follow this exact handoff protocol:
 
 ### 6.1 The Cross-Family Mandate
 
-**No PR may be merged without at least one cross-family Approved review** (Claude-family ↔ Gemini-family, identified by the `agent` field in the Approved review comment). See `pr-review §7.2` for the empirical rationale. Note: To satisfy this gate, reviewers MUST chain a formal GitHub PR Review state (`reviewDecision: APPROVED`) via `manage_pr_review` (state `APPROVED`) per `pr-review-guide.md §2`. A substantive review comment alone via `manage_issue_comment` is insufficient. **Author family** is resolved from the §5 **Social Name** (roster-resolvable via `identityRoots`), with the gh `author.login` as fallback.
+**No PR may be merged without at least one cross-family Approved review**
+(Claude-family <-> Gemini/GPT-family). The reviewer MUST submit a formal GitHub
+PR Review state (`reviewDecision: APPROVED`); a comment alone is insufficient.
+Author family is resolved from the §5 Social Name, with `author.login` fallback.
 
-**Exceptions Matrix:**
-- **Micro-change exemption**: Commit type `chore` AND `< 20 lines` changed, OR pure documentation with no runtime impact.
-- **7-day-open fallback**: The PR itself has been OPEN for >= 7 days AND no cross-family reviewer has engaged on the thread. Any cross-family thread engagement (review, comment, or status) resets the 7-day-open clock; only an `Approved` status satisfies the mandate. Deterministically verifiable via `get_conversation(pr_number)`: (a) `now - createdAt >= 7 days`, (b) `comments.nodes` contains no entry whose `author.login` resolves to the cross-family pattern. Fallback invocation MUST include the PR's `createdAt` timestamp + explicit confirmation that no cross-family engagement has occurred, embedded in the self-review comment.
-- **Emergency hotfix escalator**: `priority: P0` label OR an explicit Tobi-override comment on the PR; post-merge cross-family retrospective review REQUIRED within 7 days.
+Exceptions are narrow and must be stated in the PR/review thread:
+- Micro-change: `chore` and `< 20` changed lines, or pure documentation with no runtime impact.
+- 7-day-open fallback: PR open >= 7 days and no cross-family thread engagement;
+  cite `createdAt` and `get_conversation` evidence.
+- Emergency: `priority: P0` or explicit Tobi override; retrospective cross-family review within 7 days.
 
-**Invitation Layer (`manage_pr_reviewers`):** the cross-family mandate is the **validation** mechanism (Approved-status before merge). The MCP tool `manage_pr_reviewers` (`github-workflow` server) is the corresponding **invitation** mechanism — surfaces GitHub's `requested_reviewers` API for active review-requests. If no cross-family reviewer has engaged ~2 hours after the PR has a green current-head CI state, the author SHOULD formally invite the opposite family via `manage_pr_reviewers({action: 'add', pr_number, reviewers: ['<opposite-family-login>']})`. Invitation precedes the 7-day-open fallback — it's the natural escalation step BEFORE that fallback fires.
+If CI is green and no cross-family reviewer has engaged after ~2 hours, invite
+exactly one opposite-family primary reviewer before considering fallback.
 
 ### 6.1.1 The Consensus-Gate (PR-Merge-Gate for Discussion-Graduated Substrate)
 
-*Canonical family-keyed shape: [`audits/consensus-gate-mirror.md`](../audits/consensus-gate-mirror.md) (authoritative on quorum). The per-peer shape below predates that mirror.*
+High-blast Discussion-graduated substrate PRs must satisfy both gates:
+- §6.1 Cross-Family Mandate: approval-before-merge.
+- Consensus-Gate: consensus-source-before-approval.
 
-**Axis 2 of the consensus mandate** (Axis 1 is `ideation-sandbox-workflow.md §6` Discussion-graduation-gate). Without both axes, the consensus-mandate is bypassable by opening a PR before Discussion-graduation reaches the §6.2 quorum (canonical: audit pointer above).
+Author obligation: include the family-keyed `## Signal Ledger`,
+`## Unresolved Dissent`, and `## Unresolved Liveness` sections from
+`ideation-sandbox-workflow.md §6.6`.
 
-**Scope**: PRs that implement substrate evolution **from a high-blast Discussion** (per `ideation-sandbox-workflow.md §6.1`). PRs from low-blast Discussions, direct-ticket implementations without an originating Discussion, or bug-fixes use the standard §6.1 Cross-Family Mandate alone.
-
-**Author obligation**: PRs from high-blast Discussions MUST cite the Discussion's graduation state in the PR body via the family-keyed `## Signal Ledger` + `## Unresolved Dissent` + `## Unresolved Liveness` sections per `ideation-sandbox-workflow.md §6.6` (canonical template, multi-identity nesting, Tier-2 revalidationTrigger: [`audits/consensus-gate-mirror.md §signal-ledger-template`](../audits/consensus-gate-mirror.md)). Empty sections are positive signals.
-
-**Reviewer obligation**: the cross-family reviewer MUST verify the Signal Ledger BEFORE stamping `reviewDecision: APPROVED`:
-
-1. Read the cited Discussion via GitHub GraphQL (`gh api graphql -f query='{ repository(owner, name) { discussion(number: N) { body comments { ... } } } }'`), public comment URLs, or the locally synced discussion artifact when available. Note: the github-workflow MCP `get_conversation` tool is PR-specific; it does NOT retrieve Discussion content.
-2. Confirm the §6.2 family-keyed quorum (≥ 2 active families with signal + ≥ 1 non-author family `APPROVED`; canonical: audit pointer above). For Tier-2 substrate, also confirm the substrate Epic's `revalidationTrigger` AC for any benched family in `## Unresolved Liveness`.
-3. Confirm version-binding: signals are bound to the substrate state being implemented (not stale relative to body edits)
-4. Confirm any DEFERRED/VETO carries explicit peer-reconciliation / peer-owned disposition + residual-risk documentation
-
-**Rejection path**: if the Signal Ledger is incomplete OR contains unresolved DEFERRED/VETO/liveness gaps without a codified peer-owned disposition, the reviewer posts `Request Changes` citing this §6.1.1 — NOT iterative Cycle-N review-comments on the code itself. The PR is **premature** and must close OR wait for Discussion-graduation to complete.
-
-**Operator merge-gate**: PRs that bypass the consensus-gate get rejected at the merge boundary by `@tobiu` regardless of CI green or cross-family approval. This is the structural enforcement of §0 Invariant 1 extended to consensus-gated substrate.
-
-**Empirical:** PRs opened before their Discussion reached graduation-quorum were rejected by `@tobiu` at the merge boundary regardless of CI state; and the Consensus-Gate is distinct from PR-hygiene gates — both block merge independently.
-
-**Distinction from §6.1 Cross-Family Mandate**: §6.1 enforces approval-before-merge. §6.1.1 enforces consensus-source-before-approval for substrate-PRs. The reviewer's `/pr-review` Substantive Validation checklist is extended by §6.1.1 with the Signal Ledger verification step.
+Reviewer obligation: before `reviewDecision: APPROVED`, verify the cited
+Discussion, quorum/version binding, and any DEFERRED/VETO/liveness disposition
+against [`audits/consensus-gate-mirror.md`](../audits/consensus-gate-mirror.md).
+If the ledger is incomplete, Request Changes citing this section. PRs bypassing
+this gate remain human-merge blocked regardless of CI or ordinary cross-family
+approval.
 
 ### 6.2 The Core Swarm A2A Notification Mandate (Review Routing Protocol)
 
@@ -210,48 +193,29 @@ If you are operating inside the canonical `neomjs/neo` repository as a core swar
 
 <!-- trigger: author-side review/re-review request -> read ./ci-green-review-routing.md before reviewer assignment -->
 
-To prevent redundant parallel effort and reviewer collision, you MUST adhere to this explicit role-routing protocol rather than broadcasting naked multi-peer pings:
+Use role-routing, not naked multi-peer pings:
 
-1. **Default PR Handoff (Single-Peer Ping):**
-   - **GitHub Layer (Assignment):** Author chooses exactly ONE `primary-reviewer` and calls the `manage_pr_reviewers` MCP tool (`action: 'add'`) only after the CI-green gate passes.
-   - **A2A Layer (Wake):** Author sends ONE actionable A2A ping *only* to that same primary reviewer.
-     - Include `Review role: primary-reviewer`.
-     - Include `Requested action: use /pr-review on PR #N` — naming the skill literally is mandatory; mechanically loads the receiving peer's `pr-review-template.md` + structured-eval discipline + graph-ingestion section structure. Vague `review PR #N` relies on semantic-match and reproduces the rubber-stamp / template-adherence-gap pattern. Mirror of §6.4's remediation idiom applied at initial routing time.
-     - Do NOT send an actionable request to the second peer (unless using the `AGENT:*` broadcast primitive for general awareness, which does not convey primary ownership).
-   - *Primary-reviewer selection heuristic:* Default to round-robin (rotation) to prevent static silos. Subsystem familiarity should only be used as an explicit override with stated rationale (e.g., "Assigning @neo-gpt because they authored this abstraction in PR `#X`"). Do not use pure random selection.
-   - *Post-review pickup follow-up:* Authors request one primary reviewer; after the review handoff the reviewer follows the post-review author-lane pickup discipline, informed by the author-concentration detector telemetry (see `.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md`).
+1. **Default handoff:** after current-head CI is green, choose exactly one
+   `primary-reviewer`, request them in GitHub, and send one matching A2A wake.
+   The A2A must include `Review role: primary-reviewer` and
+   `Requested action: use /pr-review on PR #N`. Use round-robin unless a stated
+   subsystem-familiarity override applies.
+2. **SLA / decline:** primary reviewer has 24 hours. If they cannot review, they
+   A2A `Requested action: unassign` and remove themselves. If silent for 24
+   hours, author reassigns and records the timeout in a PR comment.
+3. **Observer:** no-action visibility must say `Review role: observer` and
+   `Requested action: none`.
+4. **Tie-breaker:** after one full author/reviewer disagreement cycle, post
+   `[TIE_BREAKER_REQUEST]` with a one-line position summary and A2A the third
+   peer with the contested `commentId`.
+5. **Architectural-pillar exception:** dual independent review is allowed only
+   when explicitly labeled `Review role: independent-reviewer` for both peers.
+   Persistent divergence after one calibration cycle escalates to @tobiu via
+   `[CROSS_REVIEWER_DIVERGENCE_ESCALATION]`; reviewers hold as observers until
+   human resolution.
 
-2. **Reviewer SLA & Decline Protocol:**
-   - **24-Hour Response Window:** The assigned `primary-reviewer` has 24 hours to provide an initial review.
-   - **Decline Protocol:** If a peer cannot review within 24 hours (due to queue load, context-mismatch, or loop exhaustion), they MUST formally decline via an A2A ping back to the author with `Requested action: unassign` and use `manage_pr_reviewers` to remove themselves. The author then assigns the remaining peer.
-   - **Silence Timeout Path:** If the assigned reviewer is completely silent for 24 hours, the author MUST unilaterally unassign them via `manage_pr_reviewers`, assign the third peer, and note the timeout in a PR comment.
-
-3. **Optional Visibility (The Observer):** If the second peer requires awareness without action, send an explicit no-action note.
-   - Include `Review role: observer` and `Requested action: none`.
-   - *Note:* This should be rare. Most PRs do not need observer notification.
-
-4. **Tie-Breaker Routing:** If the author and primary reviewer disagree after one full response cycle, ping the third peer.
-   - **PR Comment Layer:** Post a comment on the PR containing the tag `[TIE_BREAKER_REQUEST]` along with a 1-line summary of both positions. This serves as the durable graph-reconstruction record.
-   - **A2A Layer:** Send an A2A ping to the third peer.
-     - Include `Review role: tie-breaker`.
-     - Include the `commentId` for the contested review so the tie-breaker reviews only the disagreement, not the entire PR from scratch.
-
-5. **Architectural-Pillar Exception:** For broad structural framework changes, dual review is allowed but MUST be explicit.
-   - Use `Review role: independent-reviewer` for both peers.
-   - State `Dual independent review requested due architectural-pillar scope`.
-   - Naked multi-peer review requests remain strictly forbidden.
-
-6. **Cross-Reviewer Divergence Routing:** When a PR uses the Architectural-Pillar Exception and the two `independent-reviewer`s formally disagree (e.g., one issues `Approved`, the other issues `Request Changes`), the swarm has reached a deadlock. Because the core Triad Swarm consists of exactly three members (Author + 2 Reviewers), there is no remaining peer to act as a tie-breaker. Trigger fires when divergence PERSISTS after one calibration cycle. If either reviewer self-corrects within their next turn (per `feedback_pr_review_iteration_calibration.md` audit-letter discipline), escalation is not yet warranted. Escalate only when both reviewers have re-engaged after seeing each other's positions and still hold divergent verdicts.
-   - **Escalation Mandate:** The Author MUST escalate the divergence to human review. The Author is strictly forbidden from breaking the tie themselves.
-   - **GitHub Layer:**
-     - The Author MUST post a comment on the PR containing the tag `[CROSS_REVIEWER_DIVERGENCE_ESCALATION]`, objectively summarizing the architectural tension between both reviewers' positions.
-     - The Author MUST call `manage_pr_reviewers` (`action: 'add'`) to explicitly request review from the human repository owner (`@tobiu`).
-   - **A2A Layer:** The Author MUST send an A2A ping to both independent reviewers notifying them of the escalation.
-     - Include `Review role: observer`.
-     - Include `Requested action: hold for human resolution`. Reviewers in observer state pause new Required Actions and verdict updates pending @tobiu's resolution. They MAY post factual observation comments (e.g., commit-level updates) but MUST NOT post new substantive review cycles that would shift the divergence ground.
-   - **Post-Resolution:** @tobiu's ruling is binding. Author pushes any changes warranted by the ruling, posts a `[DIVERGENCE_RESOLVED]` PR comment summarizing the resolution, and notifies both observer-reviewers via A2A. Reviewers exit observer state; standard merge-eligibility per §6.1 applies.
-
-This strict role-based feedback loop prevents duplicated work and confusion over PR ownership when multiple agents are running concurrently. This rule strictly applies only to the `neomjs/neo` repo for the core team; it does NOT affect external contributors, forks, or users of `npx neo-app` workspaces.
+This applies to the canonical `neomjs/neo` core team; external contributors,
+forks, and `npx neo-app` workspaces are out of scope.
 
 ### 6.2.1 Cross-Family Corrective-Authorship Rotation
 
@@ -293,26 +257,24 @@ Do not blindly copy the entire ticket body into the PR description. The ticket h
 
 Before PR prose, read [`reference-hygiene.md`](../../../../learn/agentos/process/reference-hygiene.md): relationships stay bare; descriptive tokens use backticks.
 
-**The Epic Close-Target Ban (Mandatory):**
-You are strictly FORBIDDEN from pointing `Resolves #N` at an Epic ticket. GitHub's auto-close-on-merge semantics would prematurely close the entire epic when the PR merges. PRs deliver sub-issues, not epics.
-- `Resolves` only the leaf sub-issue the PR fully implements.
-- To reference the parent epic without closing it, use `Related: #N` (or `Refs #N`).
-
-**The `Resolves`-Only Mandate (Mandatory, CI-enforced):**
-Every PR body MUST contain ≥1 `Resolves #N` — the only sanctioned closing keyword (= delivered work); `agent-pr-body-lint.yml` rejects agent/`ai` PRs without one. `Closes #N` is forbidden (closed-without-delivery needs no PR); `Fixes #N` is forbidden (ambiguous). `Refs #N` / `Related: #N` are allowed only as *additional* references. This makes 1-PR-per-ticket mechanical: N PRs cannot share N valid `Resolves`, so split the work into subs.
-You are strictly FORBIDDEN from embedding the keyword in a conversational sentence (e.g., "Resolves Sub 3 of Epic #X (#Y)"). GitHub's parser requires strict syntax to establish the automatic close link. If you fail to use the exact syntax, the ticket will remain open after merge.
-**Multiple Tickets Loophole:** While we strive for a 1-Ticket-to-1-PR ratio, if your PR fully resolves multiple tickets, you MUST flag each one individually. Do NOT use comma-separated lists like `Resolves #X, #Y`. Instead, use a distinct line for each ticket:
-`Resolves #X`
-`Resolves #Y`
-
-**Branch-history close-keyword hygiene:**
-For any *additional* ticket your PR references but must NOT close (e.g. a parent epic via `Refs #N` / `Related: #N`), the entire branch history must agree it stays open. Before handoff, run:
+**Close-target rules (Mandatory, CI-enforced):**
+- `Resolves #N` only targets the leaf ticket fully delivered by the PR; never an
+  Epic. Reference parent epics with `Related: #N` or `Refs #N`.
+- Every agent/`ai` PR body must contain at least one exact standalone
+  `Resolves #N`. `Closes` and `Fixes` are forbidden; comma-separated
+  `Resolves #X, #Y` is forbidden. Multiple delivered tickets get one standalone
+  line each.
+- For referenced tickets that must remain open, branch history must also avoid
+  stale magic-close keywords. Before handoff, run:
 
 ```bash
 git log origin/dev..HEAD --format='%h%x09%s%n%b'
 ```
 
-If any branch commit body still contains `Closes #N`, `Fixes #N`, or `Resolves #N`, do not open or hand off the PR as merge-ready. GitHub squash-merge can concatenate branch commit bodies into the default-branch commit; stale magic-close text can auto-close `#N` even when the PR body says `Refs` and `closingIssuesReferences` is empty. Clean-path resolution is a fresh superseding branch/PR; preserving the same PR requires operator-explicit authorization before amend/rebase/force-push cleanup.
+If any branch commit body still contains a forbidden close keyword for a
+must-stay-open ticket, do not hand off as merge-ready. Clean path: fresh
+superseding branch/PR; preserving the same PR requires operator-explicit
+authorization before amend/rebase/force-push cleanup.
 
 **Minimum-viable PR body structure:**
 ```markdown
@@ -340,47 +302,30 @@ Evidence: L<X> (<sandbox-ceiling description>) → L<Y> required (<close-target 
 
 **Evidence declaration discipline (`#10698` graduation artifact):**
 
-The `Evidence:` line is a 1-line greppable declaration of what evidence class was achieved vs what the close-target requires. Reference: [`learn/agentos/process/evidence-ladder.md`](../../../../learn/agentos/process/evidence-ladder.md) for L1-L4 ladder + sandbox-ceiling vs achievable-ceiling distinction.
-
-- **Required for** any PR whose close-target ACs include observable runtime effect on a surface the CI / agent sandbox cannot reach (substrate / harness / wake / restart / UI-with-visual-AC / CLI-with-host-behavior / etc.)
-- **Optional / N/A** for PRs where ACs are fully covered by unit tests / static contract; if omitted, the absence is itself a signal to reviewers that no evidence-class collapse risk exists
-- **Examples:**
-  - `Evidence: L2 (mock-bin dispatch + real SIGTERM on spawned node child) → L4 required (AC5 sessionId distinctness via MCP from spawned session). Residual: AC5 [#10677].`
-  - `Evidence: L3 (browser-rendered visual confirmation on local Chromium) → L4 required (AC2 cross-browser parity on Safari). Residual: AC2 [#NNNN].`
-  - `Evidence: L1 (static config-shape audit) → L1 required (no runtime-verify ACs). No residuals.`
+The `Evidence:` line is a greppable declaration of achieved evidence vs
+close-target requirement. Required for runtime/substrate/harness/UI/host effects
+the sandbox cannot fully reach; optional when unit/static evidence fully covers
+ACs. See [`evidence-ladder.md`](../../../../learn/agentos/process/evidence-ladder.md)
+for L1-L4 classes.
 
 The `pr-review` skill's Evidence Audit section (in `pr-review-template.md`) verifies this declaration against the close-target ACs.
 
 ## 10. Authorship Respect
 
-**You update your own authored artifacts in place. You never override another author's.**
+Update your own authored artifacts in place. For another author's PR body,
+self-review, ticket body, or AC list, respond by comment unless co-authorship is
+explicitly invited or the PR is abandoned and salvage is documented first.
 
-| Surface | Own artifact | Other author's artifact |
-|---|---|---|
-| PR body | Update in place | Respond via comment (never rewrite) |
-| Self-review comment | Update (polish) / new comment (pivot) | Respond via NEW comment |
-| Ticket body | Update in place | Comment on the ticket |
-| Ticket AC list | Extend own "Evolution" trail | Comment — do NOT mutate their AC list |
-
-**Exceptions:**
-- PR author explicitly invites co-authorship on the body.
-- Abandoned PR salvaged by a maintainer (documented in a comment first).
-- **Maintainer Polish Fast Path**: Reviewers may unilaterally patch defects under the PR's ticket authority ONLY IF all of the following strict gates are met:
-  1. The Review-Loop Cost Circuit Breaker is active (≥ 3 formal reviews OR > 24KB discussion).
-  2. The edit is strictly limited to `mechanical-hygiene` or `metadata-drift` defects.
-  3. The Reviewer documents Verification Evidence (SHA, prior anchor, verification commands, justification) in their micro-delta review.
-  4. The Reviewer broadcasts an FYI A2A indicating the unilateral polish push.
+**Maintainer Polish Fast Path:** reviewers may patch under the PR ticket only
+when the review-loop circuit breaker is active (>= 3 formal reviews OR > 24KB
+discussion), the edit is mechanical-hygiene/metadata-drift only, verification is
+documented, and an FYI A2A is broadcast.
 
 ## 11. Substrate Awareness ("Assume No Private Memory")
 
 When writing public artifacts (PRs, Tickets, comments), **assume the reader has access to nothing private**.
 
-**Fair-game references:**
-- Committed repo paths (`learn/...`, `.agents/skills/...`)
-- GitHub resources (`#N`, PR URLs, commit SHAs)
-- Neo Memory Core session IDs (`Origin Session ID: <uuid>`)
-
-**FORBIDDEN load-bearing citations:**
-- Harness-private filenames (e.g., `feedback_*.md` from Claude Code, or private Antigravity stores)
-- Local filesystem paths outside the repo
-- Machine-specific identifiers
+Fair-game references: committed repo paths, GitHub resources, commit SHAs, and
+Neo Memory Core session IDs. Do not make harness-private filenames, local paths
+outside the repo, or machine-specific identifiers load-bearing in public
+artifacts.

--- a/.agents/skills/skills.manifest.json
+++ b/.agents/skills/skills.manifest.json
@@ -261,7 +261,7 @@
       "description": "Standardized guidelines and procedural execution flow for opening a Pull Request. CRITICAL: Do NOT run default `npx playwright test` (use custom configs). MANDATORY ROI WARNING: Skipping the PR body template guarantees CI lint failure. Triggers: Code modifications complete; before opening PR — stepping-back reflection, commit format, cross-family review mandate, post-comment A2A commentId hand-off (author→reviewer) per review-response-protocol.md §14, Evidence declaration line for substrate/runtime-AC PRs per [evidence-ladder.md](learn/agentos/process/evidence-ladder.md).",
       "routerByteBudget": 12,
       "payloadBudget": 80000,
-      "perFilePayloadBudget": 38000,
+      "perFilePayloadBudget": 22000,
       "claudeSymlinkRequired": true,
       "downstreamDocsTargets": [
         "learn/agentos/ProgressiveDisclosureSkills.md",


### PR DESCRIPTION
Resolves #13538

Compresses the hot `pull-request` workflow without adding another Markdown payload. The workflow drops from 34,096 to 20,488 bytes, aggregate `pull-request` skill Markdown drops from 71,044 to 57,436 bytes, and the temporary per-file manifest override drops from 38,000 to 22,000 bytes.

Evidence: L1 (static skill-substrate compression, manifest lint, byte counts, and grep-visible contract anchors) -> L1 required (all close-target ACs are static workflow/manifest checks). No residuals.

Related: #10757
Related: #13533
Related: #13535
Related: #13537
Related: #11598

## Deltas from ticket

No new sibling Markdown was added. The PR implements the preferred path: compress the hot workflow directly, preserve required PR gates, and lower the `pull-request` manifest cap in the same change.

## Slot Rationale

Touched memory substrate: `.agents/skills/pull-request/references/pull-request-workflow.md` and `.agents/skills/skills.manifest.json`.

- `pull-request-workflow.md`: `rewrite` / `compress-to-trigger`; branch, review-routing, consensus, close-target, evidence, authorship, and substrate-rationale sections were compressed in place while retaining the mandatory gate anchors. Load/placement stays the same because this file is already the conditional World-Atlas payload for the `pull-request` skill.
- `skills.manifest.json`: `rewrite`; `pull-request.perFilePayloadBudget` lowered from `38000` to `22000`, converting the migration-period override into a tighter future decay guard.
- Retired text: duplicated rationale and examples that repeated authority already owned by sibling payloads or canonical audit pointers.
- Net substrate effect: negative. `pull-request-workflow.md` `34096 -> 20488` bytes; aggregate `.agents/skills/pull-request/**/*.md` `71044 -> 57436` bytes; no new files.

## Test Evidence

- `node ./ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> OK
- `node ./ai/scripts/lint/lint-skill-manifest.mjs --report-sizes --top 10` -> `pull-request-workflow.md` `20488` bytes, aggregate skill Markdown `589577` bytes
- `node ./buildScripts/util/check-whitespace.mjs` -> OK
- `git diff --check origin/dev..HEAD` -> OK
- `rg -n 'Ticket Assignment|Branch Freshness|--base dev|Self-Identification|Resolves|Evidence|Cross-Family|A2A|HUMAN_ONLY|Authorship' .agents/skills/pull-request/references/pull-request-workflow.md` -> required anchors present
- `find .agents/skills/pull-request -name '*.md' -exec wc -c {} +` -> `57436 total`
- Freshness: `git merge-base HEAD origin/dev == origin/dev`; outgoing log contains only `69f8c246d docs(agentos): compress pull-request workflow payload (#13538)`

## Post-Merge Validation

- [ ] Confirm the skill Markdown size report on `dev` keeps `pull-request-workflow.md` below the new `22000` byte cap.

Authored by Euclid (GPT-5, Codex Desktop). Session 0a1dbe52-d3d0-43c4-8eb5-53a9e8499236.
