### PR TITLE
fix(ai): enforce pr-review template fidelity (#13547)

### DIFF
--- a/.agents/skills/pr-review/assets/pr-review-followup-template.md
+++ b/.agents/skills/pr-review/assets/pr-review-followup-template.md
@@ -8,7 +8,7 @@
 
 ---
 
-### Patch-Blind Premise Snapshot
+### 🧭 Patch-Blind Premise Snapshot
 
 *For follow-ups, ground the expected shape in the prior review anchor plus the current delta. Do not let the author's response framing replace the source-of-authority substrate.*
 
@@ -18,7 +18,7 @@
 
 ---
 
-### Strategic-Fit Decision
+### 🪜 Strategic-Fit Decision
 
 Per §9 Strategic-Fit Step-Back:
 - **Decision**: [Approve / Approve+Follow-Up / Request Changes / Drop+Supersede]
@@ -26,7 +26,7 @@ Per §9 Strategic-Fit Step-Back:
 
 ---
 
-### Prior Review Anchor
+### ⚓ Prior Review Anchor
 
 *   **PR:** #[PR Number]
 *   **Target Issue:** #[Issue Number]
@@ -36,7 +36,7 @@ Per §9 Strategic-Fit Step-Back:
 
 ---
 
-### Delta Scope
+### 🔁 Delta Scope
 
 Summarize what changed since the prior review:
 
@@ -46,7 +46,7 @@ Summarize what changed since the prior review:
 
 ---
 
-### Previous Required Actions Audit
+### ✅ Previous Required Actions Audit
 
 For each prior Required Action, mark the current state:
 
@@ -56,7 +56,7 @@ For each prior Required Action, mark the current state:
 
 ---
 
-### Delta Depth Floor
+### 🔬 Delta Depth Floor
 
 Provide ONE of the following:
 
@@ -70,7 +70,7 @@ This is the follow-up form of the Depth Floor. Do not omit it because the prior 
 
 ---
 
-### Conditional Audit Delta
+### 🔎 Conditional Audit Delta
 
 Expand only audits affected by the delta. If 2+ dimensions would otherwise render N/A, collapse them:
 
@@ -83,7 +83,7 @@ N/A across listed dimensions: <one-line reason for the delta-scope justification
 
 ---
 
-### Test-Execution & Location Audit
+### 🧪 Test-Execution & Location Audit
 
 *   **Changed surface class:** [code / test / docs-template only / PR body only]
 *   **Location check:** [pass / incorrect placement flagged / N/A]
@@ -92,7 +92,7 @@ N/A across listed dimensions: <one-line reason for the delta-scope justification
 
 ---
 
-### Contract Completeness Audit
+### 📑 Contract Completeness Audit
 
 *(Required per guide §5.4 if the delta touches public/consumed surfaces)*
 
@@ -100,7 +100,7 @@ N/A across listed dimensions: <one-line reason for the delta-scope justification
 
 ---
 
-### Metrics Delta
+### 📊 Metrics Delta
 
 Metrics are unchanged from the prior review unless an explicit delta is listed below.
 
@@ -114,7 +114,7 @@ Metrics are unchanged from the prior review unless an explicit delta is listed b
 
 ---
 
-### Required Actions
+### 📋 Required Actions
 
 **For follow-ups with new or remaining required actions:**
 
@@ -129,6 +129,6 @@ No required actions — eligible for human merge.
 
 ---
 
-### A2A Hand-Off
+### 📨 A2A Hand-Off
 
 After posting this follow-up review, capture the new `commentId` and send it via A2A to the next actor so they can fetch the delta directly.

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -135,6 +135,8 @@ The PR cannot be approved if the implemented contract and the ticket's Contract 
 
 Before drafting your review, classify the review cycle. Template choice is a context-budget gate: Cycle 1 / cold-cache needs the full structure; Cycle N / warm-cache uses delta shape unless evidence shows the prior anchors are no longer reliable.
 
+Template fidelity is mandatory in both cycle shapes: copy selected-template headings, icons, order, and null-state wording; compact follow-up means delta content, not lower quality.
+
 > **Symmetry Note:** The `pull-request` skill enforces an author-side template-adherence check (see `pull-request-workflow.md §6.4`). If you fail to use the correct template structure specified below, the author is mandated to reject your review and A2A you for a complete rewrite. Substantive content without structural adherence is not merge-eligible.
 
 ### 6.1 Full Review Template

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -671,7 +671,7 @@ paths:
 
         Mandatory pre-step: read `.agents/skills/pr-review/SKILL.md` and use the cycle-appropriate template.
 
-        Validation: `body` must include the 7 visible metric anchors plus silent structural template anchors; failures return `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` pointing at the skill/template. Do not synthesize substitute headings. #12448 premise-snapshot fields (`Inputs Read Before Patch`, `Expected Solution Shape`, `Patch Verdict`) are optional during migration: omit all three or include all three together.
+        Validation: `body` must include the 7 visible metric anchors plus silent structural template anchors and preserve the selected template's canonical skeleton; failures return `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` pointing at the skill/template. Do not synthesize substitute headings. #12448 premise-snapshot fields (`Inputs Read Before Patch`, `Expected Solution Shape`, `Patch Verdict`) are optional during migration: omit all three or include all three together.
       tags: [PullRequests]
       parameters:
         - name: pr_number

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -100,6 +100,65 @@ const OPTIONAL_PR_REVIEW_PREMISE_ANCHORS = [
     {label: 'Patch Verdict',             token: '**Patch Verdict:**'}
 ];
 
+const FOLLOWUP_PR_REVIEW_SHAPE_HINTS = [
+    '# PR Review Follow-Up Summary',
+    '**Cycle:**',
+    '### ⚓ Prior Review Anchor',
+    '### 🔁 Delta Scope',
+    '### Prior Review Anchor',
+    '### Delta Scope',
+    '### ✅ Previous Required Actions Audit',
+    '### Previous Required Actions Audit',
+    '### 🔬 Delta Depth Floor',
+    '### Delta Depth Floor',
+    '### 📊 Metrics Delta',
+    '### Metrics Delta'
+];
+
+const FULL_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS = [
+    '# PR Review Summary',
+    '### 🪜 Strategic-Fit Decision',
+    '### 🧭 Patch-Blind Premise Snapshot',
+    '### 🕸️ Context & Graph Linking',
+    '### 🔬 Depth Floor',
+    '### 🧠 Graph Ingestion Notes',
+    '### 📋 Required Actions',
+    '### 📊 Evaluation Metrics'
+];
+
+const FOLLOWUP_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS = [
+    '# PR Review Follow-Up Summary',
+    '**Cycle:**',
+    '### 🧭 Patch-Blind Premise Snapshot',
+    '### 🪜 Strategic-Fit Decision',
+    '### ⚓ Prior Review Anchor',
+    '### 🔁 Delta Scope',
+    '### ✅ Previous Required Actions Audit',
+    '### 🔬 Delta Depth Floor',
+    '### 📊 Metrics Delta',
+    '### 📋 Required Actions'
+];
+
+/**
+ * @summary Returns missing cycle-template skeleton anchors for review-body validation.
+ *
+ * The broad visible/invisible anchor layers catch metric and structural omissions. This
+ * layer catches skeleton-fidelity regressions: review bodies that carry semantic anchors,
+ * but rename/drop the selected template's canonical icon-bearing scaffold.
+ *
+ * @param {String} body The candidate PR review body.
+ * @returns {String[]} Missing skeleton anchors, intentionally never exposed to callers.
+ */
+function getPrReviewTemplateSkeletonMisses(body) {
+    const hasFollowupShape = FOLLOWUP_PR_REVIEW_SHAPE_HINTS.some(anchor => body.includes(anchor));
+
+    if (hasFollowupShape) {
+        return FOLLOWUP_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS.filter(anchor => !body.includes(anchor));
+    }
+
+    return FULL_PR_REVIEW_TEMPLATE_SKELETON_ANCHORS.filter(anchor => !body.includes(anchor));
+}
+
 function normalizeCheckoutOptions(options) {
     if (typeof options === 'number') {
         return {pr_number: options};
@@ -566,6 +625,7 @@ class PullRequestService extends Base {
         // to compose a substitute structure.
         const missingVisible          = VISIBLE_PR_REVIEW_ANCHORS          .filter(anchor => !body.includes(anchor));
         const missingInvisible        = INVISIBLE_PR_REVIEW_ANCHORS        .filter(anchor => !body.includes(anchor));
+        const missingTemplateSkeleton = getPrReviewTemplateSkeletonMisses(body);
         const presentPremiseSnapshot  = OPTIONAL_PR_REVIEW_PREMISE_ANCHORS .filter(anchor =>  body.includes(anchor.token));
         const missingPremiseSnapshot  = presentPremiseSnapshot.length === 0
             ? []
@@ -573,7 +633,12 @@ class PullRequestService extends Base {
                 .filter(anchor => !body.includes(anchor.token))
                 .map(anchor => anchor.label);
 
-        if (missingVisible.length > 0 || missingInvisible.length > 0 || missingPremiseSnapshot.length > 0) {
+        if (
+            missingVisible.length > 0          ||
+            missingInvisible.length > 0        ||
+            missingTemplateSkeleton.length > 0 ||
+            missingPremiseSnapshot.length > 0
+        ) {
             // Compose a message that guides toward the skill without enumerating invisible anchors.
             // Even the visible-list naming is bounded — at most ONE diagnostic example, not the
             // full list — to reduce the "stuff just these tags" attack surface further.

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -493,7 +493,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         databaseId : 12345
     };
 
-    // Minimal review body that passes BOTH layers of the tool-boundary template-anchor validator:
+    // Compact review body that passes BOTH layers of the tool-boundary template-anchor validator:
     // - VISIBLE layer: the 7 evaluation-metric tags from pr-review-template.md / pr-review-followup-template.md
     // - INVISIBLE layer: structural anchors NOT enumerated in error responses; see
     //   `INVISIBLE_PR_REVIEW_ANCHORS` constant in `ai/services/github-workflow/PullRequestService.mjs`
@@ -504,14 +504,32 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
     // this constant only satisfies the mechanical depth-floor gate so the downstream behavior under test
     // (action dispatch, GraphQL error handling, PR_NOT_FOUND) can be exercised.
     const VALID_REVIEW_BODY = [
+        '# PR Review Summary',
+        '',
+        '**Status:** Approved',
+        '',
         '### 🪜 Strategic-Fit Decision',
         '- Decision: Approve',
+        '',
+        '### 🧭 Patch-Blind Premise Snapshot',
+        '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
+        '* **Expected Solution Shape:** preserve the selected review template skeleton.',
+        '* **Patch Verdict:** matches the expected shape.',
+        '',
+        '### 🕸️ Context & Graph Linking',
+        '* **Target Epic / Issue ID:** Resolves #11273',
+        '* **Related Graph Nodes:** #11491',
         '',
         '### 🔬 Depth Floor',
         '- Documented search: scanned all relevant surfaces.',
         '',
+        '### 🧠 Graph Ingestion Notes',
+        '* **`[KB_GAP]`**: N/A.',
+        '* **`[TOOLING_GAP]`**: N/A.',
+        '* **`[RETROSPECTIVE]`**: Template validator fixture.',
+        '',
         '### 📋 Required Actions',
-        '- None.',
+        'No required actions — eligible for human merge.',
         '',
         '### 📊 Evaluation Metrics',
         '[ARCH_ALIGNMENT]: 80 - structural fit',
@@ -521,6 +539,56 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         '[IMPACT]: 60 - localized substrate fix',
         '[COMPLEXITY]: 40 - mechanical change',
         '[EFFORT_PROFILE]: Quick Win'
+    ].join('\n');
+
+    const VALID_FOLLOWUP_REVIEW_BODY = [
+        '# PR Review Follow-Up Summary',
+        '',
+        '**Status:** Approved',
+        '',
+        '**Cycle:** Cycle 2 follow-up',
+        '',
+        '**Opening:** Re-checking the addressed delta.',
+        '',
+        '### 🧭 Patch-Blind Premise Snapshot',
+        '* **Inputs Read Before Patch:** prior review, author response, changed-file list.',
+        '* **Expected Solution Shape:** narrow delta preserves prior approval anchors.',
+        '* **Patch Verdict:** matches the expected delta.',
+        '',
+        '### 🪜 Strategic-Fit Decision',
+        '- **Decision**: Approve',
+        '- **Rationale**: The delta resolves the prior blocker.',
+        '',
+        '### ⚓ Prior Review Anchor',
+        '* **PR:** #11273',
+        '* **Target Issue:** #11491',
+        '* **Prior Review Comment ID:** PRR_123',
+        '* **Author Response Comment ID:** IC_456',
+        '* **Latest Head SHA:** abc1234',
+        '',
+        '### 🔁 Delta Scope',
+        '* **Files changed:** PR body only',
+        '* **PR body / close-target changes:** pass',
+        '* **Branch freshness / merge state:** clean',
+        '',
+        '### ✅ Previous Required Actions Audit',
+        '* **Addressed:** prior template miss — current body keeps canonical headings.',
+        '',
+        '### 🔬 Delta Depth Floor',
+        '* **Documented delta search:** I actively checked changed metadata, the prior blocker, and close-target state and found no new concerns.',
+        '',
+        '### 📊 Metrics Delta',
+        '* **`[ARCH_ALIGNMENT]`**: unchanged from prior review',
+        '* **`[CONTENT_COMPLETENESS]`**: unchanged from prior review',
+        '* **`[EXECUTION_QUALITY]`**: unchanged from prior review',
+        '* **`[PRODUCTIVITY]`**: unchanged from prior review',
+        '* **`[IMPACT]`**: unchanged from prior review',
+        '* **`[COMPLEXITY]`**: unchanged from prior review',
+        '* **`[EFFORT_PROFILE]`**: unchanged from prior review',
+        '',
+        '### 📋 Required Actions',
+        '',
+        'No required actions — eligible for human merge.'
     ].join('\n');
 
     test.beforeAll(async () => {
@@ -833,6 +901,115 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(graphqlCallCount).toBe(0);
     });
 
+    test('#13547: rejects plain-heading cycle-1 review skeleton drift', async () => {
+        const plainFullReviewBody = [
+            '# PR Review Summary',
+            '',
+            '**Status:** Approved',
+            '',
+            '### Strategic-Fit Decision',
+            '- Decision: Approve',
+            '',
+            '### Patch-Blind Premise Snapshot',
+            '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
+            '* **Expected Solution Shape:** preserve the selected review template skeleton.',
+            '* **Patch Verdict:** matches the expected shape.',
+            '',
+            '### Context & Graph Linking',
+            '* **Target Epic / Issue ID:** Resolves #13547',
+            '',
+            '### Depth Floor',
+            '- Documented search: scanned all relevant surfaces.',
+            '',
+            '### Graph Ingestion Notes',
+            '* **`[KB_GAP]`**: N/A.',
+            '* **`[TOOLING_GAP]`**: N/A.',
+            '* **`[RETROSPECTIVE]`**: Plain-heading regression fixture.',
+            '',
+            '### Required Actions',
+            'No required actions — eligible for human merge.',
+            '',
+            '### Evaluation Metrics',
+            '[ARCH_ALIGNMENT]: 90 - aligned',
+            '[CONTENT_COMPLETENESS]: 90 - complete',
+            '[EXECUTION_QUALITY]: 90 - verified',
+            '[PRODUCTIVITY]: 90 - delivers scope',
+            '[IMPACT]: 70 - workflow guard',
+            '[COMPLEXITY]: 40 - bounded validator',
+            '[EFFORT_PROFILE]: Quick Win'
+        ].join('\n');
+
+        let graphqlCallCount = 0;
+        GraphqlService.query = async () => {
+            graphqlCallCount++;
+            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 13547,
+            state    : 'APPROVED',
+            body     : plainFullReviewBody
+        });
+
+        expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        expect(result.missing_visible).toEqual([]);
+        expect(result.missing_premise_snapshot).toEqual([]);
+        expect(result.message).toContain('does not match the pr-review template structure');
+        expect(graphqlCallCount).toBe(0);
+    });
+
+    test('#13547: accepts icon-bearing follow-up review skeleton', async () => {
+        let graphqlCallCount = 0;
+        GraphqlService.query = async (queryString) => {
+            graphqlCallCount++;
+            if (queryString.includes('GetPullRequestId')) return {repository: {pullRequest: {id: PR_NODE_ID}}};
+            if (queryString.includes('AddPullRequestReview')) return {addPullRequestReview: {pullRequestReview: REVIEW_NODE}};
+            return null;
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 13547,
+            state    : 'APPROVED',
+            body     : VALID_FOLLOWUP_REVIEW_BODY
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.reviewId).toBe('PRR_kwDOABcD1111111111');
+        expect(graphqlCallCount).toBe(2);
+    });
+
+    test('#13547: rejects old plain-heading follow-up review skeleton', async () => {
+        const plainFollowupBody = VALID_FOLLOWUP_REVIEW_BODY
+            .replaceAll('### 🧭 Patch-Blind Premise Snapshot', '### Patch-Blind Premise Snapshot')
+            .replaceAll('### 🪜 Strategic-Fit Decision', '### Strategic-Fit Decision')
+            .replaceAll('### ⚓ Prior Review Anchor', '### Prior Review Anchor')
+            .replaceAll('### 🔁 Delta Scope', '### Delta Scope')
+            .replaceAll('### ✅ Previous Required Actions Audit', '### Previous Required Actions Audit')
+            .replaceAll('### 🔬 Delta Depth Floor', '### Delta Depth Floor')
+            .replaceAll('### 📊 Metrics Delta', '### Metrics Delta')
+            .replaceAll('### 📋 Required Actions', '### Required Actions');
+
+        let graphqlCallCount = 0;
+        GraphqlService.query = async () => {
+            graphqlCallCount++;
+            return {repository: {pullRequest: {id: PR_NODE_ID}}};
+        };
+
+        const result = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 13547,
+            state    : 'APPROVED',
+            body     : plainFollowupBody
+        });
+
+        expect(result.code).toBe('PR_REVIEW_TEMPLATE_VALIDATION_FAILED');
+        expect(result.missing_visible).toEqual([]);
+        expect(result.missing_premise_snapshot).toEqual([]);
+        expect(graphqlCallCount).toBe(0);
+    });
+
     test('#11491: rejects body missing some visible anchors and names ONE diagnostic anchor only', async () => {
         // Operator-directed change: even when visible anchors are missing, the error names AT MOST
         // one diagnostic anchor rather than the full list, reducing the "stuff just these tags"
@@ -935,10 +1112,38 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         };
 
         const body = [
-            '### Patch-Blind Premise Snapshot',
+            '# PR Review Summary',
+            '',
+            '**Status:** Approved',
+            '',
+            '### 🪜 Strategic-Fit Decision',
+            '- Decision: Approve',
+            '',
+            '### 🧭 Patch-Blind Premise Snapshot',
             '* **Inputs Read Before Patch:** ticket, changed-file list, current dev source.',
             '',
-            VALID_REVIEW_BODY
+            '### 🕸️ Context & Graph Linking',
+            '* **Target Epic / Issue ID:** Resolves #12448',
+            '',
+            '### 🔬 Depth Floor',
+            '- Documented search: scanned all relevant surfaces.',
+            '',
+            '### 🧠 Graph Ingestion Notes',
+            '* **`[KB_GAP]`**: N/A.',
+            '* **`[TOOLING_GAP]`**: N/A.',
+            '* **`[RETROSPECTIVE]`**: Partial snapshot fixture.',
+            '',
+            '### 📋 Required Actions',
+            'No required actions — eligible for human merge.',
+            '',
+            '### 📊 Evaluation Metrics',
+            '[ARCH_ALIGNMENT]: 80 - structural fit',
+            '[CONTENT_COMPLETENESS]: 80 - covers AC matrix',
+            '[EXECUTION_QUALITY]: 80 - tests pass',
+            '[PRODUCTIVITY]: 70 - bounded scope',
+            '[IMPACT]: 60 - localized substrate fix',
+            '[COMPLEXITY]: 40 - mechanical change',
+            '[EFFORT_PROFILE]: Quick Win'
         ].join('\n');
 
         const result = await PullRequestService.managePrReview({


### PR DESCRIPTION
Resolves #13547

This restores `pr-review` template fidelity without reverting the guide compression: normal follow-up reviews now keep icon-bearing canonical headings, the guide states that compact follow-up means delta content rather than lower-quality structure, and `manage_pr_review` rejects bodies that preserve broad metric anchors while dropping the selected template skeleton.

Evidence: L2 (focused unit coverage for the MCP review validator + skill/static lint) -> L2 required (agent-consumed template and validator contract). No residuals.

## Deltas from ticket

The operator correction during implementation is included: the normal follow-up template is now icon-bearing too. The micro-delta Review-Loop Cost Circuit Breaker artifact remains out of scope.

The validator keeps its existing generic `PR_REVIEW_TEMPLATE_VALIDATION_FAILED` response rather than exposing the new hidden skeleton anchors.

## Contract Ledger

Source-ticket PR-open gate posted on #13547:
https://github.com/neomjs/neo/issues/13547#issuecomment-4751070732

Rows covered:

| Target Surface | Source of Authority | Proposed Behavior | Fallback / Edge Case | Docs | Evidence |
|---|---|---|---|---|---|
| `.agents/skills/pr-review/references/pr-review-guide.md §6` | #13547 operator correction; current full/follow-up templates | Preserve selected-template canonical headings/icons/order/null-state wording | One compact invariant; mechanical validator carries enforcement | Same guide section | `lint-skill-manifest`; diff audit |
| `.agents/skills/pr-review/assets/pr-review-followup-template.md` | #13547 operator correction; cycle-N template path | Follow-up reviews use icon-bearing headings while retaining compact delta sections | Micro-delta artifact untouched | Follow-up template asset | validator accepts updated follow-up body |
| `manage_pr_review` body validation | Existing `manage_pr_review` validation contract | Reject broad-anchor review bodies that drop canonical template-skeleton headings/icons | Return generic validation failure without exposing hidden anchors | OpenAPI tool description | focused unit tests |

## Slot Rationale

`pr-review-guide.md §6`: `rewrite`. This adds one compact invariant to a conditionally loaded workflow payload. Trigger frequency is high within `/pr-review`, failure severity is high for graph-readable review consistency, and enforceability is now partly mechanical through `manage_pr_review`.

`pr-review-followup-template.md`: `rewrite`. This changes headings in the normal follow-up asset, not the always-loaded skill router. It restores visual/template fidelity while preserving compact delta content.

## /turn-memory-pre-flight Load-Effect Audit

No always-loaded router file changed. The changed skill files are conditional `/pr-review` payload/template surfaces. The additional guide text is intentionally one sentence, and `node ./ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` passes, so this does not bypass the skill-growth guard.

## Test Evidence

- `node ./buildScripts/util/check-ticket-archaeology.mjs ai/services/github-workflow/PullRequestService.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` -> pass, 2 files scanned.
- `git diff --cached --check` -> pass.
- `node ./buildScripts/util/check-whitespace.mjs` -> pass.
- `node ./ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> pass.
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs -g "#13547|#11491|#12448|action:create"` -> 16 passed.
- Earlier full file run: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` -> 44 passed, 3 failed from live GitHub network/diff-view paths unrelated to #13547.

## Post-Merge Validation

- [ ] Restart/reload the github-workflow MCP server so the updated `manage_pr_review` tool description and validator are live in agent harnesses.
- [ ] Have one normal cycle-N review use the updated follow-up template and verify the body passes `manage_pr_review`.

## Commit

- `6d681983a` - `fix(ai): enforce pr-review template fidelity (#13547)`

Authored by Euclid (GPT-5, Codex Desktop). Session current Codex Desktop session, 2026-06-19; runtime did not expose a session UUID.
