### PR TITLE
feat(agentos): basic NL-MCP connect entry in the Accounts keeper-view (#13548)

### DIFF
--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -14,7 +14,8 @@ import Toolbar          from '../../../src/toolbar/Base.mjs';
  * @summary The **Accounts keeper-view** — set up the cross-family fleet's agent identities (GitHub
  * identity + harness type + provider credential). Extracted from `FleetSettingsPanel` per the cockpit
  * keeper-view decomposition: this view owns identity *setup*; the Fleet view owns the live roster
- * + lifecycle.
+ * + lifecycle. It also surfaces a **basic NL-MCP connect entry** (the external-harness
+ * `manage_connection` start path) through the same fail-closed injected-bridge discipline.
  *
  * Capability-security boundary (the load-bearing reason this is its own surface): a credential is
  * collected only long enough to submit it to the Brain-side Fleet Registry bridge. If that bridge is
@@ -136,6 +137,12 @@ class Accounts extends DashboardPanel {
                     handler: 'up.onLoadSampleClick',
                     iconCls: 'fa fa-pen-to-square',
                     text   : 'Edit Sample'
+                }, {
+                    module : Button,
+                    cls    : ['agent-button', 'agent-connect-button'],
+                    handler: 'up.onConnectExternalHarnessClick',
+                    iconCls: 'fa fa-plug',
+                    text   : 'Connect Harness (NL-MCP)'
                 }]
             }, {
                 ntype    : 'component',
@@ -217,6 +224,22 @@ class Accounts extends DashboardPanel {
     }
 
     /**
+     * @summary Attempt the basic NL-MCP external-harness connect through an injected Neural Link
+     * connection bridge, or fail closed. Mirrors {@link onSubmitAgentClick}'s bridge discipline: the
+     * connect carries no credential, and when no bridge is injected (the dev-server app has none) the
+     * view reports the failure without inventing any browser-side connection state.
+     * @returns {Promise<void>}
+     */
+    async onConnectExternalHarnessClick() {
+        try {
+            const result = await this.connectExternalHarnessBridge({action: 'start'});
+            this.updateBridgeStatus('is-live', result?.message || 'External harness connected through the Neural Link bridge.')
+        } catch (error) {
+            this.updateBridgeStatus('is-error', 'Neural Link connection bridge unavailable in dev-server mode. Connect fails closed; no connection state was stored in the app worker.')
+        }
+    }
+
+    /**
      * @summary Remove credential bytes from the password field after every bridge attempt.
      * @returns {Promise<void>}
      */
@@ -241,6 +264,25 @@ class Accounts extends DashboardPanel {
         }
 
         return bridge.defineAgent(payload)
+    }
+
+    /**
+     * @summary Forward a basic NL-MCP connect request to an injected Neural Link connection bridge,
+     * or fail closed. Mirrors {@link submitToFleetRegistryBridge}: an injected bridge is used when a
+     * future Agent OS shell exposes one; the current dev-server app has none, so the view fails closed
+     * instead of inventing a connection. Carries no credential — the App-Worker → Brain capability
+     * boundary is preserved.
+     * @param {Object} request The NL-MCP connection request, e.g. `{action:'start'}`.
+     * @returns {Promise<*>}
+     */
+    async connectExternalHarnessBridge(request) {
+        const bridge = globalThis.AgentOS?.neuralLink?.connectionBridge;
+
+        if (!bridge?.manageConnection) {
+            throw new Error('Neural Link connection bridge unavailable')
+        }
+
+        return bridge.manageConnection(request)
     }
 
     /**

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -57,3 +57,71 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
         expect(source).not.toMatch(/AgentDefinitions\.add\(\s*values/)
     })
 });
+
+test.describe('AgentOS.view.Accounts NL-MCP connect entry (#13548)', () => {
+    let savedAgentOS;
+
+    test.beforeEach(() => { savedAgentOS = globalThis.AgentOS });
+    test.afterEach(()  => { globalThis.AgentOS = savedAgentOS });
+
+    test('connectExternalHarnessBridge fails closed when no Neural Link connection bridge is injected', async () => {
+        globalThis.AgentOS = undefined; // dev-server / un-shelled app — no Brain-side bridge
+
+        await expect(Accounts.prototype.connectExternalHarnessBridge({action: 'start'}))
+            .rejects.toThrow('Neural Link connection bridge unavailable')
+    });
+
+    test('connectExternalHarnessBridge forwards exactly the connect request — carries no credential', async () => {
+        let received;
+        globalThis.AgentOS = {neuralLink: {connectionBridge: {
+            manageConnection: async req => { received = req; return {message: 'External harness started'} }
+        }}};
+
+        const result = await Accounts.prototype.connectExternalHarnessBridge({action: 'start'});
+
+        expect(received).toEqual({action: 'start'}); // exactly the NL-MCP request shape...
+        expect(received.credential).toBeUndefined();  // ...with no credential crossing the boundary
+        expect(result.message).toBe('External harness started')
+    });
+
+    test('onConnectExternalHarnessClick reports is-live on a successful connect', async () => {
+        const calls = [];
+        const stub  = {
+            connectExternalHarnessBridge: async request => {
+                expect(request).toEqual({action: 'start'});
+                return {message: 'External harness started'}
+            },
+            updateBridgeStatus: (stateCls, message) => calls.push({stateCls, message})
+        };
+
+        await Accounts.prototype.onConnectExternalHarnessClick.call(stub);
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].stateCls).toBe('is-live');
+        expect(calls[0].message).toContain('External harness started')
+    });
+
+    test('onConnectExternalHarnessClick fails closed to is-error when the bridge is unavailable', async () => {
+        const calls = [];
+        const stub  = {
+            connectExternalHarnessBridge: async () => { throw new Error('Neural Link connection bridge unavailable') },
+            updateBridgeStatus: (stateCls, message) => calls.push({stateCls, message})
+        };
+
+        await Accounts.prototype.onConnectExternalHarnessClick.call(stub);
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].stateCls).toBe('is-error');     // never throws out of the handler...
+        expect(calls[0].message).toMatch(/fails closed/i) // ...reports the fail-closed state instead
+    });
+
+    test('the connect path stays credential-free and fails closed in source', () => {
+        const source = fs.readFileSync(viewPath, 'utf8');
+
+        expect(source).toContain('connectExternalHarnessBridge');
+        expect(source).toContain('neuralLink?.connectionBridge');
+        expect(source).toContain('Neural Link connection bridge unavailable');
+        // the connect handler/bridge invoke manage_connection with {action} only — never a credential
+        expect(source).toMatch(/connectExternalHarnessBridge\(\{action: 'start'\}\)/)
+    })
+});


### PR DESCRIPTION
## Summary

AC2 of the Accounts keeper-view enhancements (#13521): surface a **basic NL-MCP external-harness connect entry** from the Accounts keeper-view, so an operator can start an external harness's Neural Link bridge session from the cockpit.

**Why:** the extracted Accounts view (#13491 / PR #13516) sets up agent *identities* and submits them through a future-injected Fleet Registry bridge, but exposes no path for an external harness to register/connect via the NL-MCP `manage_connection` entry. The App-Worker side had zero reference to it.

The connect affordance **mirrors the established fail-closed injected-bridge pattern** (`submitToFleetRegistryBridge`): it invokes a future-injected `globalThis.AgentOS.neuralLink.connectionBridge.manageConnection({action})` seam (the Brain-side `ConnectionService.manageConnection` shape) and **fails closed** with a `bridge-status` message when no shell has injected one — the current dev-server app has none. The connect carries **no credential**; the App-Worker → Brain capability boundary is preserved. Extended multi-agent NL coordination (`#13056` / H3) stays fenced.

Resolves #13548
Refs #13521, #13525

## Deltas

- **`apps/agentos/view/Accounts.mjs`** — a "Connect Harness (NL-MCP)" action-toolbar button + `onConnectExternalHarnessClick()` handler + `connectExternalHarnessBridge(request)` fail-closed injected-bridge method (mirrors `submitToFleetRegistryBridge`); class JSDoc notes the new connect entry.
- **`test/playwright/unit/apps/agentos/Accounts.spec.mjs`** — 5 new specs (absent-bridge fail-closed · request-forwarding with no credential · handler `is-live` success · handler `is-error` fail-closed · source credential-free + fail-closed assertion).

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/apps/agentos/Accounts.spec.mjs`

```
8 passed (915ms)
```

The 3 existing credential-boundary specs stay green; 5 new specs cover:
- `connectExternalHarnessBridge` rejects `Neural Link connection bridge unavailable` when no bridge is injected (fail-closed)
- forwards exactly `{action:'start'}` — `received.credential` is `undefined` (no credential crosses the boundary)
- `onConnectExternalHarnessClick` → `is-live` on success (carrying the bridge's message)
- `onConnectExternalHarnessClick` → `is-error` fail-closed when the bridge throws (never throws out of the handler)
- source assertion: the connect path references `neuralLink?.connectionBridge` + the fail-closed string, and invokes `manageConnection` with `{action:'start'}` only

## Contract Ledger

| Target Surface | Source of Authority | Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `globalThis.AgentOS.neuralLink.connectionBridge.manageConnection({action})` — NEW view→shell injected contract | `ConnectionService.manageConnection` (`ai/services/neural-link/ConnectionService.mjs:639`); ADR 0020 | view invokes `{action:'start'}` → `is-live` on success | fail closed: status message only, no App-Worker state | JSDoc on `connectExternalHarnessBridge` | `Accounts.spec.mjs` (5 specs); `toolService.mjs:52` binding |

The `manage_connection` NL-MCP tool itself is **unchanged** — no tool / transport / error-code change. This row covers only the NEW view→shell injected-bridge contract.

## Post-Merge Validation

- [ ] When a future Agent OS shell injects `globalThis.AgentOS.neuralLink.connectionBridge`, the Accounts connect button starts the external harness's NL bridge session and reports `is-live`.
- [ ] In the dev-server app (no bridge), clicking Connect reports the fail-closed `is-error` status and stores no connection state.

## Risk

Low. Purely additive and mirrors the proven `submitToFleetRegistryBridge` fail-closed pattern; the button config mirrors the two adjacent action-toolbar buttons. No credential in the connect path; no cross-boundary import (the view reaches the Brain-side `manage_connection` only through the injected bridge seam). The `manage_connection` NL-MCP tool itself is unchanged.

---

Authored by Claude Opus 4.8 (Claude Code), @neo-opus-vega (Vega).
