### PR TITLE
feat(ai): embed-drain liveness watchdog alarms on a silently-stalled WAL backlog (#13551)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -386,7 +386,16 @@ class Config extends ConfigProvider {
                      * a layer ABOVE the wake-coalescing window (the 300s digest-batching cap, an orthogonal
                      * mechanism), so widening it does not change coalescing semantics.
                      */
-                    swarmHeartbeatMs      : leaf(20 * 60 * 1000, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS', 'number')
+                    swarmHeartbeatMs      : leaf(20 * 60 * 1000, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_INTERVAL_MS', 'number'),
+                    /**
+                     * Cadence of the embed-drain liveness watchdog — the read-only, never-fail health
+                     * check that computes the age of the oldest un-embedded WAL record and raises a
+                     * one-shot alarm when it exceeds `memoryWal.embedDrainStallThresholdMs`. Hourly is
+                     * frequent enough to surface a stalled drain in hours (not the ~8 days of the silent
+                     * drain-death incident) while staying far below the threshold so the check itself adds
+                     * negligible load. `<= 0` disables the lane.
+                     */
+                    embedDrainLivenessWatchdogCheckMs: leaf(HOUR_MS, 'NEO_ORCHESTRATOR_EMBED_DRAIN_WATCHDOG_INTERVAL_MS', 'number')
                 },
                 /**
                  * Chroma daemon recycle policy. The orchestrator kills and respawns the supervised

--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -1,5 +1,5 @@
-import path                                  from 'path';
-import {fileURLToPath}                       from 'url';
+import path                                      from 'path';
+import {fileURLToPath}                           from 'url';
 import ConfigProvider, {createConfigProxy, leaf} from './ConfigProvider.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -175,19 +175,19 @@ class Config extends ConfigProvider {
              * @type {Object}
              */
             openAiCompatible: {
-                host                    : leaf('http://127.0.0.1:11434', 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
-                model                   : leaf('gemma-4-31b-it', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
-                embeddingModel          : leaf('text-embedding-qwen3-embedding-8b', 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
-                apiKey                  : leaf('', 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
-                unloadRetryCount        : leaf(3, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
-                unloadRetryDelayMs      : leaf(500, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', 'number'),
-                contentionRetryCount    : leaf(2, 'NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT', 'number'),
-                contentionRetryDelayMs  : leaf(1000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS', 'number'),
-                contentionTimeoutMs     : leaf(15000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS', 'number'),
+                host                   : leaf('http://127.0.0.1:11434', 'NEO_OPENAI_COMPATIBLE_HOST', 'string'),
+                model                  : leaf('gemma-4-31b-it', 'NEO_OPENAI_COMPATIBLE_MODEL', 'string'),
+                embeddingModel         : leaf('text-embedding-qwen3-embedding-8b', 'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL', 'string'),
+                apiKey                 : leaf('', 'NEO_OPENAI_COMPATIBLE_API_KEY', 'string'),
+                unloadRetryCount       : leaf(3, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT', 'number'),
+                unloadRetryDelayMs     : leaf(500, 'NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS', 'number'),
+                contentionRetryCount   : leaf(2, 'NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT', 'number'),
+                contentionRetryDelayMs : leaf(1000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS', 'number'),
+                contentionTimeoutMs    : leaf(15000, 'NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS', 'number'),
                 batchEmbeddingChunkSize: leaf(5, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE', 'number'),
-                batchEmbeddingYieldMs   : leaf(0, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS', 'number'),
-                keep_alive              : leaf(-1, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
-                requireParallelModels   : leaf(2, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')
+                batchEmbeddingYieldMs  : leaf(0, 'NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS', 'number'),
+                keep_alive             : leaf(-1, 'NEO_OPENAI_COMPATIBLE_KEEP_ALIVE', 'keepAlive'),
+                requireParallelModels  : leaf(2, 'NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS', 'number')
             },
             /**
              * @summary Local-model role-keyed context limits.
@@ -293,9 +293,9 @@ class Config extends ConfigProvider {
              */
             engines: {
                 chroma: {
-                    dataDir : leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
-                    host    : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
-                    port    : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
+                    dataDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
+                    host   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
+                    port   : leaf(8000, 'NEO_CHROMA_PORT', 'port'),
                     /**
                      * Chroma database selection — three declarative leaves, all SSOT-inline (config.template
                      * imports no config values):
@@ -361,14 +361,14 @@ class Config extends ConfigProvider {
                  * @type {Object}
                  */
                 intervals: {
-                    pollMs                : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
-                    summarySweepMs        : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
-                    kbSyncMs              : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
-                    backupMs              : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
-                    graphLogCompactionMs  : leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
-                    primaryDevSyncMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
-                    tenantRepoSyncMs      : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),
-                    dreamMs               : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS', 'number'),
+                    pollMs              : leaf(3000, 'NEO_ORCHESTRATOR_POLL_INTERVAL_MS', 'number'),
+                    summarySweepMs      : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_SUMMARY_SWEEP_INTERVAL_MS', 'number'),
+                    kbSyncMs            : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_KB_SYNC_INTERVAL_MS', 'number'),
+                    backupMs            : leaf(DAY_MS, 'NEO_ORCHESTRATOR_BACKUP_INTERVAL_MS', 'number'),
+                    graphLogCompactionMs: leaf(DAY_MS, 'NEO_ORCHESTRATOR_GRAPHLOG_COMPACTION_INTERVAL_MS', 'number'),
+                    primaryDevSyncMs    : leaf(10 * 60 * 1000, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_INTERVAL_MS', 'number'),
+                    tenantRepoSyncMs    : leaf(30 * 60 * 1000, 'NEO_ORCHESTRATOR_TENANT_REPO_SYNC_INTERVAL_MS', 'number'),
+                    dreamMs             : leaf(HOUR_MS, 'NEO_ORCHESTRATOR_DREAM_INTERVAL_MS', 'number'),
                     /**
                      * Fraction of `dreamMs` runtime that triggers completion-time cooldown for the
                      * next dream cycle. This is intentionally below the cycle-overflow telemetry
@@ -514,13 +514,13 @@ class Config extends ConfigProvider {
                  * @type {Object}
                  */
                 localOnly: {
-                    primaryDevSyncEnabled          : leaf(null, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', 'boolean'),
-                    kbSyncEnabled                  : leaf(null, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', 'boolean'),
+                    primaryDevSyncEnabled: leaf(null, 'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED', 'boolean'),
+                    kbSyncEnabled        : leaf(null, 'NEO_ORCHESTRATOR_KB_SYNC_ENABLED', 'boolean'),
                     // Local profile may supervise a child Chroma process; cloud profile
                     // reaches the compose-owned `chroma` peer container instead.
-                    chromaDaemonEnabled            : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),
-                    bridgeDaemonEnabled            : leaf(null, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
-                    neuralLinkBridgeEnabled        : leaf(null, 'NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED', 'boolean'),
+                    chromaDaemonEnabled    : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),
+                    bridgeDaemonEnabled    : leaf(null, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
+                    neuralLinkBridgeEnabled: leaf(null, 'NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED', 'boolean'),
                     // The embed daemon durably drains the add_memory WAL into the content store
                     // (ai/daemons/embed/daemon.mjs). Local profile supervises it as a child
                     // process; cloud deployments own their drain story per-container (mirror of
@@ -637,7 +637,7 @@ class Config extends ConfigProvider {
                  */
                 backup: {
                     intervalMs: DAY_MS,
-                    retention: {
+                    retention : {
                         keepMinimum: 3,
                         maxDays    : 30
                     }
@@ -650,7 +650,7 @@ class Config extends ConfigProvider {
                  * @type {Object}
                  */
                 defrag: {
-                    intervalMs: 7 * DAY_MS,
+                    intervalMs       : 7 * DAY_MS,
                     snapshotRetention: {
                         keepMinimum: 3,
                         maxDays    : 7

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -22,6 +22,12 @@ import {getDueTask as graphLogCompactionGetDueTaskImport} from './scheduling/gra
 import {getDueTask as primaryDevSyncGetDueTaskImport} from './scheduling/primaryDevSync.mjs';
 import {getDueTask as goldenPathGetDueTaskImport} from './scheduling/goldenPath.mjs';
 import {getDueTask as dreamGetDueTaskImport}          from './scheduling/dream.mjs';
+import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport} from './scheduling/embedDrainLivenessWatchdog.mjs';
+import memoryCoreConfig                  from '../../mcp/server/memory-core/config.mjs';
+import MailboxService                    from '../../services/memory-core/MailboxService.mjs';
+import WakeSubscriptionService           from '../../services/memory-core/WakeSubscriptionService.mjs';
+import RequestContextService             from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {normalizeAgentIdentityNodeId}    from '../../scripts/lifecycle/resumeHarness.mjs';
 import TaskStateService                  from './services/TaskStateService.mjs';
 import ProcessSupervisorService          from './services/ProcessSupervisorService.mjs';
 import DreamService                      from './services/DreamService.mjs';
@@ -122,6 +128,7 @@ export class Orchestrator extends Base {
     tenantRepoSyncGetDueTask = tenantRepoSyncGetDueTaskImport
     dreamGetDueTask          = dreamGetDueTaskImport
     goldenPathGetDueTask     = goldenPathGetDueTaskImport
+    embedDrainLivenessWatchdogGetDueTask = embedDrainLivenessWatchdogGetDueTaskImport
 
     isPolling                     = false
     pollHandle                    = null
@@ -136,6 +143,61 @@ export class Orchestrator extends Base {
 
     processSupervisorWriteLog = (level, msg) => this.writeLog(level, msg)
     maintenanceBackpressureWriteLog = (level, msg) => this.writeLog(level, msg)
+
+    /**
+     * @summary One-shot active alarm dispatcher for the embed-drain liveness watchdog.
+     *
+     * The watchdog's PASSIVE leg is its `recordTaskOutcome` health record (every check); this is the
+     * ACTIVE leg, fired once on stall-onset by the scheduling pipeline. It broadcasts a swarm- and
+     * operator-visible A2A alarm (`MailboxService.addMessage` to the `AGENT:*` sentinel — the
+     * `KbAlertingService.dispatchA2A` precedent) carrying the stall payload, then best-effort nudges a
+     * wake via `WakeSubscriptionService.emitHeartbeatPulse` to the harness owner. A2A is the durable
+     * carrier (heartbeat pulses have no payload column); the pulse is only a wake nudge.
+     *
+     * Bound arrow field so it can be passed as `services.embedDrainLivenessAlarmDispatcher`. The
+     * pipeline wraps the call, but each leg is also independently guarded so one failing leg never
+     * suppresses the other.
+     *
+     * @param {Object} payload
+     * @param {Number} payload.ageMs Age of the oldest un-embedded WAL record.
+     * @param {Number} payload.pendingCount Pending (un-embedded) record count.
+     * @param {Number} payload.thresholdMs Stall threshold that tripped.
+     * @param {Number|null} payload.stalledSince Epoch ms the stall was first observed.
+     * @returns {Promise<void>}
+     */
+    embedDrainLivenessAlarmDispatcher = async ({ageMs, pendingCount, thresholdMs, stalledSince} = {}) => {
+        const sender = process.env.NEO_AGENT_IDENTITY
+            ? normalizeAgentIdentityNodeId(process.env.NEO_AGENT_IDENTITY)
+            : '@system';
+        const stalledSinceIso = Number.isFinite(stalledSince) ? new Date(stalledSince).toISOString() : 'unknown';
+        const ageHours        = (ageMs / (60 * 60 * 1000)).toFixed(1);
+        const subject = `[embed-drain-stall] oldest un-embedded WAL record is ${ageHours}h old`;
+        const body =
+            `The embed-drain liveness watchdog detected a STALLED embed pipeline.\n\n` +
+            `- oldest un-embedded WAL record age: ${ageMs}ms (~${ageHours}h)\n` +
+            `- pending (un-embedded) record count: ${pendingCount}\n` +
+            `- stall threshold: ${thresholdMs}ms\n` +
+            `- stalled since: ${stalledSinceIso}\n\n` +
+            `The embed drain has stopped reconciling the WAL (process-alive != draining). Semantic recall ` +
+            `degrades while the backlog grows. Investigate the embed daemon / drain lock on the drainer clone.`;
+
+        try {
+            await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
+                await MailboxService.addMessage({to: 'AGENT:*', subject, body, priority: 'high'});
+            });
+        } catch (e) {
+            this.writeLog('ERROR', `[Orchestrator] embed-drain stall-alarm A2A broadcast failed: ${e.message}`);
+        }
+
+        const targetIdentity = this.swarmHeartbeatIdentity;
+        if (targetIdentity) {
+            try {
+                await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: normalizeAgentIdentityNodeId(targetIdentity)});
+            } catch (e) {
+                this.writeLog('ERROR', `[Orchestrator] embed-drain stall-alarm wake pulse failed: ${e.message}`);
+            }
+        }
+    }
 
     /**
      * @param {Neo.ai.daemons.services.ProcessSupervisorService|Object|null} value
@@ -210,6 +272,8 @@ export class Orchestrator extends Base {
     get devServerEnabled()               { return resolveLocalDeploymentDefault(AiConfig.orchestrator.devServer.enabled); }
     get neuralLinkBridgeEnabled()        { return resolveDeploymentEnabled('neuralLinkBridgeEnabled');        }
     get embedDaemonEnabled()             { return resolveDeploymentEnabled('embedDaemonEnabled');             }
+    get embedDrainLivenessWatchdogWalDir()      { return memoryCoreConfig.memoryWal.dir; }
+    get embedDrainLivenessWatchdogThresholdMs() { return memoryCoreConfig.memoryWal.embedDrainStallThresholdMs; }
     get swarmHeartbeatEnabled()          { return resolveDeploymentEnabled('swarmHeartbeatEnabled');          }
     get goldenPathRepoEnrichmentEnabled(){ return resolveDeploymentEnabled('goldenPathRepoEnrichmentEnabled');}
     get graphLogCompactionEnabled()      { return AiConfig.orchestrator.graphLogCompaction.enabled;      }

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -1,40 +1,40 @@
 // Class bootstrap belongs to `daemon.mjs`; this consumed class relies on global Neo.
-import fs                          from 'fs-extra';
-import {spawn}                     from 'child_process';
-import net                         from 'net';
-import path                        from 'path';
-import Base                        from '../../../src/core/Base.mjs';
-import ClassSystemUtil             from '../../../src/util/ClassSystem.mjs';
-import AiConfig                    from '../../config.mjs';
-import neuralLinkConfig            from '../../mcp/server/neural-link/config.mjs';
-import {buildLmsPreloadConfig}     from '../../services/graph/providerReadinessHelper.mjs';
-import HealthService               from '../../services/memory-core/HealthService.mjs';
-import SQLite                      from '../../graph/storage/SQLite.mjs';
+import fs                      from 'fs-extra';
+import {spawn}                 from 'child_process';
+import net                     from 'net';
+import path                    from 'path';
+import Base                    from '../../../src/core/Base.mjs';
+import ClassSystemUtil         from '../../../src/util/ClassSystem.mjs';
+import AiConfig                from '../../config.mjs';
+import neuralLinkConfig        from '../../mcp/server/neural-link/config.mjs';
+import {buildLmsPreloadConfig} from '../../services/graph/providerReadinessHelper.mjs';
+import HealthService           from '../../services/memory-core/HealthService.mjs';
+import SQLite                  from '../../graph/storage/SQLite.mjs';
 import MaintenanceBackpressureService, {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES,
     DEFAULT_GOLDEN_PATH_DEPENDENCY_TASK_NAMES
 } from './services/MaintenanceBackpressureService.mjs';
-import PrimaryRepoSyncService from './services/PrimaryRepoSyncService.mjs';
-import TenantRepoSyncService             from './services/TenantRepoSyncService.mjs';
-import {getDueTask as summaryGetDueTaskImport}        from './scheduling/summary.mjs';
-import {getDueTask as backupGetDueTaskImport}         from './scheduling/backup.mjs';
-import {getDueTask as graphLogCompactionGetDueTaskImport} from './scheduling/graphLogCompaction.mjs';
-import {getDueTask as primaryDevSyncGetDueTaskImport} from './scheduling/primaryDevSync.mjs';
-import {getDueTask as goldenPathGetDueTaskImport} from './scheduling/goldenPath.mjs';
-import {getDueTask as dreamGetDueTaskImport}          from './scheduling/dream.mjs';
+import PrimaryRepoSyncService                                     from './services/PrimaryRepoSyncService.mjs';
+import TenantRepoSyncService                                      from './services/TenantRepoSyncService.mjs';
+import {getDueTask as summaryGetDueTaskImport}                    from './scheduling/summary.mjs';
+import {getDueTask as backupGetDueTaskImport}                     from './scheduling/backup.mjs';
+import {getDueTask as graphLogCompactionGetDueTaskImport}         from './scheduling/graphLogCompaction.mjs';
+import {getDueTask as primaryDevSyncGetDueTaskImport}             from './scheduling/primaryDevSync.mjs';
+import {getDueTask as goldenPathGetDueTaskImport}                 from './scheduling/goldenPath.mjs';
+import {getDueTask as dreamGetDueTaskImport}                      from './scheduling/dream.mjs';
 import {getDueTask as embedDrainLivenessWatchdogGetDueTaskImport} from './scheduling/embedDrainLivenessWatchdog.mjs';
-import memoryCoreConfig                  from '../../mcp/server/memory-core/config.mjs';
-import MailboxService                    from '../../services/memory-core/MailboxService.mjs';
-import WakeSubscriptionService           from '../../services/memory-core/WakeSubscriptionService.mjs';
-import RequestContextService             from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {normalizeAgentIdentityNodeId}    from '../../scripts/lifecycle/resumeHarness.mjs';
-import TaskStateService                  from './services/TaskStateService.mjs';
-import ProcessSupervisorService          from './services/ProcessSupervisorService.mjs';
-import DreamService                      from './services/DreamService.mjs';
-import SwarmHeartbeatService             from './services/SwarmHeartbeatService.mjs';
-import GoldenPathSynthesizer             from '../../services/graph/GoldenPathSynthesizer.mjs';
-import {getDueTask as tenantRepoSyncGetDueTaskImport} from './scheduling/tenantRepoSync.mjs';
-import {TASK_REGISTRY}                   from './scheduling/registry.mjs';
+import memoryCoreConfig                                           from '../../mcp/server/memory-core/config.mjs';
+import MailboxService                                             from '../../services/memory-core/MailboxService.mjs';
+import WakeSubscriptionService                                    from '../../services/memory-core/WakeSubscriptionService.mjs';
+import RequestContextService                                      from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {normalizeAgentIdentityNodeId}                             from '../../scripts/lifecycle/resumeHarness.mjs';
+import TaskStateService                                           from './services/TaskStateService.mjs';
+import ProcessSupervisorService                                   from './services/ProcessSupervisorService.mjs';
+import DreamService                                               from './services/DreamService.mjs';
+import SwarmHeartbeatService                                      from './services/SwarmHeartbeatService.mjs';
+import GoldenPathSynthesizer                                      from '../../services/graph/GoldenPathSynthesizer.mjs';
+import {getDueTask as tenantRepoSyncGetDueTaskImport}             from './scheduling/tenantRepoSync.mjs';
+import {TASK_REGISTRY}                                            from './scheduling/registry.mjs';
 import {
     buildOrchestratorSchedulingOptions,
     runSchedulingPipeline
@@ -103,16 +103,16 @@ function resolveCloudOnlyEnabled(key) {
  */
 export class Orchestrator extends Base {
     static config = {
-        className: 'Neo.ai.daemons.Orchestrator',
-        singleton: true,
-        processSupervisorService_: null,
+        className                      : 'Neo.ai.daemons.Orchestrator',
+        singleton                      : true,
+        processSupervisorService_      : null,
         maintenanceBackpressureService_: MaintenanceBackpressureService,
-        dataDir_: DEFAULT_DATA_DIR,
-        taskDefinitions_: null,
-        taskStateService_: TaskStateService,
-        healthService_: HealthService,
-        spawnFn_: spawn,
-        heavyMaintenanceLeasePath_: null
+        dataDir_                       : DEFAULT_DATA_DIR,
+        taskDefinitions_               : null,
+        taskStateService_              : TaskStateService,
+        healthService_                 : HealthService,
+        spawnFn_                       : spawn,
+        heavyMaintenanceLeasePath_     : null
     }
 
     primaryRepoSyncService   = PrimaryRepoSyncService
@@ -298,23 +298,23 @@ export class Orchestrator extends Base {
         const lmsPreloadConfig = this.lmsPreloadConfig;
         this.taskDefinitions   = options.taskDefinitions || buildTaskDefinitions({
             scriptDir,
-            nodeBin                            : options.nodeBin || process.argv[0],
-            chromaPort                         : AiConfig.engines.chroma.port,
-            devServerPort                      : AiConfig.orchestrator.devServer.port,
-            devServerLivenessTimeoutMs         : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
-            neuralLinkBridgePort               : neuralLinkConfig.port,
-            neuralLinkBridgeLivenessTimeoutMs  : this.neuralLinkBridgeLivenessTimeoutMs,
-            mlxEnabled                         : this.mlxEnabled,
-            mlxModel                           : AiConfig.orchestrator.mlx.model,
-            mlxPort                            : AiConfig.orchestrator.mlx.port,
-            lmsEnabled                         : this.lmsEnabled,
-            lmsModel                           : AiConfig.orchestrator.lms.model,
-            lmsModels                          : lmsPreloadConfig.models,
-            lmsHost                            : AiConfig.openAiCompatible.host,
-            lmsPort                            : AiConfig.orchestrator.lms.port,
-            lmsContextLengths                  : lmsPreloadConfig.contextLengths,
-            providerReadiness                  : AiConfig.orchestrator.providerReadiness,
-            graphLogCompactionVacuum           : AiConfig.orchestrator.graphLogCompaction.vacuum
+            nodeBin                          : options.nodeBin || process.argv[0],
+            chromaPort                       : AiConfig.engines.chroma.port,
+            devServerPort                    : AiConfig.orchestrator.devServer.port,
+            devServerLivenessTimeoutMs       : AiConfig.orchestrator.devServer.livenessProbeTimeoutMs,
+            neuralLinkBridgePort             : neuralLinkConfig.port,
+            neuralLinkBridgeLivenessTimeoutMs: this.neuralLinkBridgeLivenessTimeoutMs,
+            mlxEnabled                       : this.mlxEnabled,
+            mlxModel                         : AiConfig.orchestrator.mlx.model,
+            mlxPort                          : AiConfig.orchestrator.mlx.port,
+            lmsEnabled                       : this.lmsEnabled,
+            lmsModel                         : AiConfig.orchestrator.lms.model,
+            lmsModels                        : lmsPreloadConfig.models,
+            lmsHost                          : AiConfig.openAiCompatible.host,
+            lmsPort                          : AiConfig.orchestrator.lms.port,
+            lmsContextLengths                : lmsPreloadConfig.contextLengths,
+            providerReadiness                : AiConfig.orchestrator.providerReadiness,
+            graphLogCompactionVacuum         : AiConfig.orchestrator.graphLogCompaction.vacuum
         });
 
         this.dbPath                    = options.dbPath   || DEFAULT_DB_PATH;

--- a/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.mjs
+++ b/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.mjs
@@ -1,0 +1,140 @@
+import {readPendingWalRecords} from '../../../services/memory-core/helpers/memoryWalStore.mjs';
+
+/**
+ * @summary Read-only liveness watchdog for the embed-drain WAL backlog.
+ *
+ * The per-turn `add_memory` save appends a durable WAL record (`appendWalMemory`) and the embed is
+ * decoupled — a separate drain (`ai/daemons/embed/daemon.mjs`) embeds pending records asynchronously.
+ * That decoupling is correct (the save must never fail or stall on a model-dependent embed) but it
+ * means a dead/stalled drain produces NO user-visible error: the WAL just grows un-reconciled until a
+ * human notices stale semantic recall. In the recovery incident the drain died silently and no alarm
+ * fired for ~8 days.
+ *
+ * This module closes that detection gap. It periodically computes the AGE of the oldest un-embedded
+ * (pending) WAL record and raises a one-shot alarm when that age first exceeds a threshold. It is the
+ * progress check the orchestrator's existing process-existence supervision could not provide
+ * (process-alive != draining).
+ *
+ * ## Hard constraints
+ *
+ * - **Read-only.** It only READS the WAL via `readPendingWalRecords`; it never writes a record, a
+ *   marker, or any file in the WAL directory. It can never touch or slow the never-fail
+ *   `appendWalMemory` write path.
+ * - **Never-fail.** A failure in the check degrades to "no alarm," never to a write failure or a
+ *   thrown error into the scheduling pipeline. The execute branch in `pipeline.mjs` wraps the call and
+ *   records the outcome; this module's `getEmbedDrainPendingAge` additionally fails soft (returns a
+ *   zero-backlog reading on a read error) so a transient FS error does not look like a stall.
+ * - **One-shot alarm.** The active alarm fires once on stall-onset and stays latched (no re-alarm on
+ *   consecutive stalled checks); a healthy check below threshold clears the latch so a later stall can
+ *   re-alarm. This avoids a per-check alarm storm.
+ *
+ * The cadence projection (`getDueTask`) is a pure, I/O-free function mirroring the other scheduling
+ * descriptors; the WAL read happens only in the execute branch.
+ *
+ * @module ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog
+ * @see ai/services/memory-core/helpers/memoryWalStore.mjs — `readPendingWalRecords` (the pending primitive)
+ * @see ai/daemons/orchestrator/scheduling/pipeline.mjs — the `health-check` execute branch + outcome record
+ * @see ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs — the sibling pure-cadence `getDueTask` precedent
+ */
+
+/**
+ * @summary Computes the age and count of the oldest un-embedded (pending) WAL record. Read-only.
+ *
+ * Reads the pending WAL records (appended but not yet embed-marked) and derives the oldest age as
+ * `now - min(record.timestamp)`. The WAL store already tolerates corrupt/torn lines and a missing
+ * directory (returns `[]`), so an empty/clean WAL yields a zero-backlog reading. Any unexpected read
+ * error fails SOFT to a zero-backlog reading — a watchdog read fault must never be misread as a stall
+ * (it would false-alarm), and it must never propagate into the never-fail write path.
+ *
+ * Records missing a finite `timestamp` are ignored for the age computation but still counted as
+ * pending, so a malformed record cannot suppress a real backlog signal.
+ *
+ * @param {Object} options
+ * @param {String} options.walDir Directory holding the WAL day-segment files (`aiConfig.memoryWal.dir`).
+ * @param {Number} options.now Current epoch milliseconds (injected clock).
+ * @param {Function} [options.readPending] Async `({dir}) => Promise<Object[]>` WAL reader; defaults to
+ *   {@link readPendingWalRecords}. Injectable for unit isolation.
+ * @returns {Promise<{oldestAgeMs: Number, pendingCount: Number, oldestTimestamp: (Number|null)}>}
+ *   `oldestAgeMs` is `0` when nothing is pending; `oldestTimestamp` is `null` when no pending record
+ *   carries a finite timestamp.
+ */
+export async function getEmbedDrainPendingAge({walDir, now, readPending = readPendingWalRecords} = {}) {
+    let records;
+    try {
+        records = await readPending({dir: walDir});
+    } catch {
+        // Read fault → zero-backlog reading. A watchdog fault degrades to "no alarm", never to a
+        // false stall signal and never to a thrown error in the scheduling pipeline.
+        return {oldestAgeMs: 0, pendingCount: 0, oldestTimestamp: null};
+    }
+
+    if (!Array.isArray(records) || records.length === 0) {
+        return {oldestAgeMs: 0, pendingCount: 0, oldestTimestamp: null};
+    }
+
+    let oldestTimestamp = null;
+    for (const record of records) {
+        const timestamp = Number(record?.timestamp);
+        if (!Number.isFinite(timestamp)) continue;
+        if (oldestTimestamp === null || timestamp < oldestTimestamp) {
+            oldestTimestamp = timestamp;
+        }
+    }
+
+    const oldestAgeMs = oldestTimestamp === null ? 0 : Math.max(0, now - oldestTimestamp);
+
+    return {oldestAgeMs, pendingCount: records.length, oldestTimestamp};
+}
+
+/**
+ * @summary Pure stall-edge evaluation with one-shot latch semantics.
+ *
+ * Compares the oldest pending age against the threshold and applies the latch: an alarm fires only on
+ * the transition into the stalled state (`stalled && !alreadyAlarmed`); once latched it stays quiet on
+ * subsequent stalled checks; a healthy (below-threshold) check clears the latch so a later stall can
+ * re-alarm.
+ *
+ * @param {Object} options
+ * @param {Number} options.oldestAgeMs Age of the oldest pending record (from {@link getEmbedDrainPendingAge}).
+ * @param {Number} options.pendingCount Pending record count.
+ * @param {Number} options.thresholdMs Stall threshold; `<= 0` disables alarming (never stalled).
+ * @param {Object} [options.alarmState] Prior latch state `{alarmed, stalledSince}` from task state.
+ * @returns {{stalled: Boolean, shouldAlarm: Boolean, nextAlarmState: {alarmed: Boolean, stalledSince: (Number|null)}}}
+ */
+export function evaluateStallAlarm({oldestAgeMs, pendingCount, thresholdMs, alarmState} = {}) {
+    const alreadyAlarmed = !!alarmState?.alarmed;
+    const stalled        = thresholdMs > 0 && pendingCount > 0 && oldestAgeMs > thresholdMs;
+
+    if (!stalled) {
+        // Healthy check: clear the latch so a future stall re-alarms.
+        return {stalled: false, shouldAlarm: false, nextAlarmState: {alarmed: false, stalledSince: null}};
+    }
+
+    const shouldAlarm  = !alreadyAlarmed;
+    const stalledSince = alreadyAlarmed ? (alarmState?.stalledSince ?? null) : null;
+
+    return {stalled: true, shouldAlarm, nextAlarmState: {alarmed: true, stalledSince}};
+}
+
+/**
+ * @summary Cadence due-trigger projection. Returns a trigger descriptor when the configured check
+ * interval has elapsed since `lastRunAt`; null otherwise. Pure function — no I/O (the WAL read happens
+ * in the execute branch, never here), mirroring `swarmHeartbeat.getDueTask`.
+ *
+ * @param {Object} options
+ * @param {Object} [options.state] Current task state for this lane (`{lastRunAt}`).
+ * @param {Number} options.now Current epoch milliseconds.
+ * @param {Number} options.embedDrainLivenessWatchdogCheckMs Check cadence; `<= 0` disables the lane.
+ * @returns {Object|null} A watchdog task trigger or null when no check is due.
+ */
+export function getDueTask({state, now, embedDrainLivenessWatchdogCheckMs}) {
+    const lastRunAt = state?.lastRunAt ?? 0;
+    if (embedDrainLivenessWatchdogCheckMs > 0 && now - lastRunAt >= embedDrainLivenessWatchdogCheckMs) {
+        return {
+            taskName: 'embed-drain-liveness-watchdog',
+            source  : 'periodic-health-check',
+            reason  : `periodic-health-check:${embedDrainLivenessWatchdogCheckMs}`
+        };
+    }
+    return null;
+}

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -1,5 +1,6 @@
-import {collectDueCandidates} from './collector.mjs';
-import {pickNextCandidate}    from './picker.mjs';
+import {collectDueCandidates}                  from './collector.mjs';
+import {pickNextCandidate}                      from './picker.mjs';
+import {evaluateStallAlarm, getEmbedDrainPendingAge} from './embedDrainLivenessWatchdog.mjs';
 
 /**
  * @summary Builds the read-only context consumed by scheduling descriptors.
@@ -36,7 +37,8 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 dream                 : config.orchestrator.intervals.dreamMs,
                 dreamOverflowThreshold: config.orchestrator.intervals.dreamOverflowThreshold,
                 goldenPath            : config.orchestrator.intervals.goldenPathMs,
-                swarmHeartbeat        : config.orchestrator.intervals.swarmHeartbeatMs
+                swarmHeartbeat        : config.orchestrator.intervals.swarmHeartbeatMs,
+                embedDrainLivenessWatchdogCheck: config.orchestrator.intervals.embedDrainLivenessWatchdogCheckMs
             },
             enables: {
                 kbSync            : orchestrator.kbSyncEnabled,
@@ -55,7 +57,8 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 dreamGetDueTask           : orchestrator.dreamGetDueTask,
                 goldenPathGetDueTask      : orchestrator.goldenPathGetDueTask,
                 swarmHeartbeatGetDueTask  : orchestrator.swarmHeartbeatGetDueTask,
-                swarmHeartbeatInitFailed  : !!orchestrator.swarmHeartbeatService.initFailed
+                swarmHeartbeatInitFailed  : !!orchestrator.swarmHeartbeatService.initFailed,
+                embedDrainLivenessWatchdogGetDueTask: orchestrator.embedDrainLivenessWatchdogGetDueTask
             }
         }),
         services: {
@@ -67,13 +70,17 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
             processSupervisorService     : orchestrator.processSupervisorService,
             swarmHeartbeatService        : orchestrator.swarmHeartbeatService,
             taskStateService             : orchestrator.taskStateService,
-            tenantRepoSyncService        : orchestrator.tenantRepoSyncService
+            tenantRepoSyncService        : orchestrator.tenantRepoSyncService,
+            embedDrainLivenessAlarmDispatcher: orchestrator.embedDrainLivenessAlarmDispatcher
         },
         runtime: {
             goldenPathRepoEnrichmentEnabled: orchestrator.goldenPathRepoEnrichmentEnabled,
             primaryDevSyncRootsConfig      : orchestrator.primaryDevSyncRootsConfig,
             tenantRepoSyncGlobalCadenceMs  : config.orchestrator.intervals.tenantRepoSyncMs,
             tenantRepoSyncJitterRatio      : config.orchestrator.tenantRepoSync.jitterRatio,
+            embedDrainLivenessWatchdogWalDir     : orchestrator.embedDrainLivenessWatchdogWalDir,
+            embedDrainLivenessWatchdogThresholdMs: orchestrator.embedDrainLivenessWatchdogThresholdMs,
+            embedDrainLivenessWatchdogAlarmEnabled: orchestrator.embedDaemonEnabled,
             writeLog                       : orchestrator.writeLog.bind(orchestrator)
         }
     };
@@ -254,7 +261,8 @@ export function executeCandidate({candidate, activeHeavyTask, services, runtime}
     const dispatch = {
         'supervised-child-process': executeSupervisedCandidate,
         'service-runner'          : executeServiceRunnerCandidate,
-        'in-process-async'        : executeInProcessCandidate
+        'in-process-async'        : executeInProcessCandidate,
+        'health-check'            : executeHealthCheckCandidate
     };
 
     const execute = dispatch[candidate.descriptor.executionKind];
@@ -474,6 +482,148 @@ async function runSwarmHeartbeatTask({taskName, reason, services}) {
             error   : e.message,
             failedAt: new Date().toISOString()
         });
+    }
+}
+
+/**
+ * @summary Dispatches the read-only `health-check` execution kind.
+ *
+ * Currently a single lane (`embed-drain-liveness-watchdog`). Unlike the heavy/service kinds, a
+ * health-check takes no maintenance lease and runs directly — it is read-only and lightweight, so it
+ * must never be gated by backpressure. The runner itself is fully wrapped so a check failure degrades
+ * to "no alarm" and never propagates into the pipeline.
+ *
+ * @param {Object} options
+ * @returns {*}
+ */
+function executeHealthCheckCandidate({candidate, services, runtime}) {
+    const runners = {
+        'embed-drain-liveness-watchdog': (taskName, reason) =>
+            runEmbedDrainLivenessWatchdogTask({taskName, reason, services, runtime})
+    };
+
+    const executeFn = runners[candidate.taskName];
+    if (!executeFn) {
+        recordUnsupportedCandidate({
+            candidate,
+            error        : `Unsupported health-check task: ${candidate.taskName}`,
+            healthService: services.healthService,
+            writeLog     : runtime.writeLog
+        });
+        return false;
+    }
+
+    return executeFn(candidate.taskName, candidate.trigger.reason);
+}
+
+/**
+ * @summary Runs the embed-drain liveness watchdog: read-only WAL-backlog age check, passive
+ * health-record, and a one-shot active stall alarm. Never throws.
+ *
+ * Dual alarm per the ticket: (1) PASSIVE — `healthService.recordTaskOutcome` every check (`failed`
+ * when stalled, `completed` otherwise); (2) ACTIVE — a one-shot swarm/operator alarm fired only on
+ * stall-onset, latched so consecutive stalled checks do not re-alarm; a healthy check clears the
+ * latch. The active alarm is additionally gated by `embedDrainLivenessWatchdogAlarmEnabled` (the
+ * orchestrator's `embedDaemonEnabled`) so a deployment with no local drainer never false-alarms on a
+ * backlog another host is responsible for draining.
+ *
+ * The latch (`{alarmed, stalledSince}`) is persisted on the task-state envelope so it survives across
+ * poll cycles and orchestrator restarts. The whole body is wrapped: any unexpected error is recorded
+ * and swallowed — a watchdog fault must never block the never-fail `add_memory`/`appendWalMemory` path
+ * nor break the scheduling loop.
+ *
+ * @param {Object} options
+ * @param {String} options.taskName
+ * @param {String} options.reason Scheduling reason.
+ * @param {Object} options.services Runtime collaborators (`taskStateService`, `healthService`,
+ *   `embedDrainLivenessAlarmDispatcher`).
+ * @param {Object} options.runtime Runtime policy values (`embedDrainLivenessWatchdogWalDir`,
+ *   `embedDrainLivenessWatchdogThresholdMs`, `embedDrainLivenessWatchdogAlarmEnabled`, `writeLog`).
+ * @returns {Promise<void>}
+ */
+async function runEmbedDrainLivenessWatchdogTask({taskName, reason, services, runtime}) {
+    try {
+        services.taskStateService.markStarted(taskName, reason);
+        services.healthService?.recordTaskOutcome?.(taskName, 'running', {reason, startedAt: new Date().toISOString()});
+
+        const now = Date.now();
+        const {oldestAgeMs, pendingCount, oldestTimestamp} = await getEmbedDrainPendingAge({
+            walDir: runtime.embedDrainLivenessWatchdogWalDir,
+            now
+        });
+
+        const state      = services.taskStateService.getTaskState(taskName);
+        const alarmState  = state?.embedDrainAlarm ?? null;
+        const thresholdMs = runtime.embedDrainLivenessWatchdogThresholdMs;
+
+        const {stalled, shouldAlarm, nextAlarmState} = evaluateStallAlarm({
+            oldestAgeMs, pendingCount, thresholdMs, alarmState
+        });
+
+        // Stamp the stall-onset timestamp (the clock-free evaluator leaves it null on the latching
+        // transition); preserve it across subsequent latched checks.
+        const stalledSince = stalled
+            ? (shouldAlarm ? now : (alarmState?.stalledSince ?? now))
+            : null;
+        if (state) state.embedDrainAlarm = {alarmed: nextAlarmState.alarmed, stalledSince};
+
+        const details = {reason, ageMs: oldestAgeMs, pendingCount, thresholdMs, checkedAt: new Date(now).toISOString()};
+
+        if (stalled) {
+            services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                ...details,
+                stalledSince: stalledSince === null ? null : new Date(stalledSince).toISOString(),
+                oldestTimestamp: oldestTimestamp === null ? null : new Date(oldestTimestamp).toISOString()
+            });
+
+            if (shouldAlarm && runtime.embedDrainLivenessWatchdogAlarmEnabled) {
+                await dispatchEmbedDrainStallAlarm({
+                    dispatcher  : services.embedDrainLivenessAlarmDispatcher,
+                    ageMs       : oldestAgeMs,
+                    pendingCount,
+                    thresholdMs,
+                    stalledSince,
+                    writeLog    : runtime.writeLog
+                });
+            }
+        } else {
+            services.healthService?.recordTaskOutcome?.(taskName, 'completed', details);
+        }
+
+        services.taskStateService.markCompleted(taskName);
+    } catch (e) {
+        // Degrade to "no alarm": record the fault and clear running state, never rethrow. The
+        // bookkeeping itself is guarded so even a failing health/state collaborator cannot turn a
+        // watchdog fault into an unhandled rejection that breaks the scheduling loop.
+        try {
+            const state = services.taskStateService.getTaskState(taskName);
+            if (state) state.lastReason = e.message;
+            services.taskStateService.markFailed(taskName, 1);
+            services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
+                reason,
+                phase   : 'watchdog-error',
+                error   : e.message,
+                failedAt: new Date().toISOString()
+            });
+            runtime.writeLog?.('ERROR', `[Orchestrator] embed-drain-liveness-watchdog check failed (degraded to no-alarm): ${e.message}`);
+        } catch {
+            // Last-resort swallow: the never-fail guarantee dominates all observability.
+        }
+    }
+}
+
+/**
+ * @summary Fires the one-shot active stall alarm via the injected dispatcher. Never throws — an alarm
+ * dispatch failure is logged and swallowed (the passive health-record already captured the stall).
+ * @param {Object} options
+ * @returns {Promise<void>}
+ */
+async function dispatchEmbedDrainStallAlarm({dispatcher, ageMs, pendingCount, thresholdMs, stalledSince, writeLog}) {
+    if (typeof dispatcher !== 'function') return;
+    try {
+        await dispatcher({ageMs, pendingCount, thresholdMs, stalledSince});
+    } catch (e) {
+        writeLog?.('ERROR', `[Orchestrator] embed-drain stall-alarm dispatch failed: ${e.message}`);
     }
 }
 

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -1,5 +1,5 @@
-import {collectDueCandidates}                  from './collector.mjs';
-import {pickNextCandidate}                      from './picker.mjs';
+import {collectDueCandidates}                        from './collector.mjs';
+import {pickNextCandidate}                           from './picker.mjs';
 import {evaluateStallAlarm, getEmbedDrainPendingAge} from './embedDrainLivenessWatchdog.mjs';
 
 /**
@@ -28,16 +28,16 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
             state    : orchestrator.taskStateService.getState(),
             now,
             intervals: {
-                summarySweep          : config.orchestrator.intervals.summarySweepMs,
-                kbSync                : config.orchestrator.intervals.kbSyncMs,
-                backup                : config.orchestrator.intervals.backupMs,
-                graphLogCompaction    : config.orchestrator.intervals.graphLogCompactionMs,
-                primaryDevSync        : config.orchestrator.intervals.primaryDevSyncMs,
-                tenantRepoSync        : config.orchestrator.tenantRepoSync.sweepCadenceMs,
-                dream                 : config.orchestrator.intervals.dreamMs,
-                dreamOverflowThreshold: config.orchestrator.intervals.dreamOverflowThreshold,
-                goldenPath            : config.orchestrator.intervals.goldenPathMs,
-                swarmHeartbeat        : config.orchestrator.intervals.swarmHeartbeatMs,
+                summarySweep                   : config.orchestrator.intervals.summarySweepMs,
+                kbSync                         : config.orchestrator.intervals.kbSyncMs,
+                backup                         : config.orchestrator.intervals.backupMs,
+                graphLogCompaction             : config.orchestrator.intervals.graphLogCompactionMs,
+                primaryDevSync                 : config.orchestrator.intervals.primaryDevSyncMs,
+                tenantRepoSync                 : config.orchestrator.tenantRepoSync.sweepCadenceMs,
+                dream                          : config.orchestrator.intervals.dreamMs,
+                dreamOverflowThreshold         : config.orchestrator.intervals.dreamOverflowThreshold,
+                goldenPath                     : config.orchestrator.intervals.goldenPathMs,
+                swarmHeartbeat                 : config.orchestrator.intervals.swarmHeartbeatMs,
                 embedDrainLivenessWatchdogCheck: config.orchestrator.intervals.embedDrainLivenessWatchdogCheckMs
             },
             enables: {
@@ -48,40 +48,40 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
                 swarmHeartbeat    : orchestrator.swarmHeartbeatEnabled
             },
             hooks: {
-                log                       : orchestrator.writeLog.bind(orchestrator),
-                summaryGetDueTask         : orchestrator.summaryGetDueTask,
-                backupGetDueTask          : orchestrator.backupGetDueTask,
-                graphLogCompactionGetDueTask: orchestrator.graphLogCompactionGetDueTask,
-                primaryDevSyncGetDueTask  : orchestrator.primaryDevSyncGetDueTask,
-                tenantRepoSyncGetDueTask  : orchestrator.tenantRepoSyncGetDueTask,
-                dreamGetDueTask           : orchestrator.dreamGetDueTask,
-                goldenPathGetDueTask      : orchestrator.goldenPathGetDueTask,
-                swarmHeartbeatGetDueTask  : orchestrator.swarmHeartbeatGetDueTask,
-                swarmHeartbeatInitFailed  : !!orchestrator.swarmHeartbeatService.initFailed,
+                log                                 : orchestrator.writeLog.bind(orchestrator),
+                summaryGetDueTask                   : orchestrator.summaryGetDueTask,
+                backupGetDueTask                    : orchestrator.backupGetDueTask,
+                graphLogCompactionGetDueTask        : orchestrator.graphLogCompactionGetDueTask,
+                primaryDevSyncGetDueTask            : orchestrator.primaryDevSyncGetDueTask,
+                tenantRepoSyncGetDueTask            : orchestrator.tenantRepoSyncGetDueTask,
+                dreamGetDueTask                     : orchestrator.dreamGetDueTask,
+                goldenPathGetDueTask                : orchestrator.goldenPathGetDueTask,
+                swarmHeartbeatGetDueTask            : orchestrator.swarmHeartbeatGetDueTask,
+                swarmHeartbeatInitFailed            : !!orchestrator.swarmHeartbeatService.initFailed,
                 embedDrainLivenessWatchdogGetDueTask: orchestrator.embedDrainLivenessWatchdogGetDueTask
             }
         }),
         services: {
-            dreamService                 : orchestrator.dreamService,
-            goldenPathSynthesizer        : orchestrator.goldenPathSynthesizer,
-            healthService                : orchestrator.healthService,
-            maintenanceBackpressureService: orchestrator.maintenanceBackpressureService,
-            primaryRepoSyncService       : orchestrator.primaryRepoSyncService,
-            processSupervisorService     : orchestrator.processSupervisorService,
-            swarmHeartbeatService        : orchestrator.swarmHeartbeatService,
-            taskStateService             : orchestrator.taskStateService,
-            tenantRepoSyncService        : orchestrator.tenantRepoSyncService,
+            dreamService                     : orchestrator.dreamService,
+            goldenPathSynthesizer            : orchestrator.goldenPathSynthesizer,
+            healthService                    : orchestrator.healthService,
+            maintenanceBackpressureService   : orchestrator.maintenanceBackpressureService,
+            primaryRepoSyncService           : orchestrator.primaryRepoSyncService,
+            processSupervisorService         : orchestrator.processSupervisorService,
+            swarmHeartbeatService            : orchestrator.swarmHeartbeatService,
+            taskStateService                 : orchestrator.taskStateService,
+            tenantRepoSyncService            : orchestrator.tenantRepoSyncService,
             embedDrainLivenessAlarmDispatcher: orchestrator.embedDrainLivenessAlarmDispatcher
         },
         runtime: {
-            goldenPathRepoEnrichmentEnabled: orchestrator.goldenPathRepoEnrichmentEnabled,
-            primaryDevSyncRootsConfig      : orchestrator.primaryDevSyncRootsConfig,
-            tenantRepoSyncGlobalCadenceMs  : config.orchestrator.intervals.tenantRepoSyncMs,
-            tenantRepoSyncJitterRatio      : config.orchestrator.tenantRepoSync.jitterRatio,
-            embedDrainLivenessWatchdogWalDir     : orchestrator.embedDrainLivenessWatchdogWalDir,
-            embedDrainLivenessWatchdogThresholdMs: orchestrator.embedDrainLivenessWatchdogThresholdMs,
+            goldenPathRepoEnrichmentEnabled       : orchestrator.goldenPathRepoEnrichmentEnabled,
+            primaryDevSyncRootsConfig             : orchestrator.primaryDevSyncRootsConfig,
+            tenantRepoSyncGlobalCadenceMs         : config.orchestrator.intervals.tenantRepoSyncMs,
+            tenantRepoSyncJitterRatio             : config.orchestrator.tenantRepoSync.jitterRatio,
+            embedDrainLivenessWatchdogWalDir      : orchestrator.embedDrainLivenessWatchdogWalDir,
+            embedDrainLivenessWatchdogThresholdMs : orchestrator.embedDrainLivenessWatchdogThresholdMs,
             embedDrainLivenessWatchdogAlarmEnabled: orchestrator.embedDaemonEnabled,
-            writeLog                       : orchestrator.writeLog.bind(orchestrator)
+            writeLog                              : orchestrator.writeLog.bind(orchestrator)
         }
     };
 }
@@ -121,8 +121,8 @@ export function runSchedulingPipeline({registry, context, services, runtime}) {
 
     const winner = pickNextCandidate({
         candidates,
-        runningTasks  : runningTaskNames,
-        policyContext : {
+        runningTasks : runningTaskNames,
+        policyContext: {
             runningHeavyTasks,
             isHeavyMaintenanceConflict: services.maintenanceBackpressureService.isHeavyMaintenanceConflict?.bind(
                 services.maintenanceBackpressureService
@@ -132,7 +132,7 @@ export function runSchedulingPipeline({registry, context, services, runtime}) {
 
     if (winner) {
         executeCandidate({
-            candidate: winner,
+            candidate      : winner,
             activeHeavyTask: {
                 name: services.maintenanceBackpressureService.getActiveHeavyMaintenanceTask({
                     candidateTaskName: winner.taskName
@@ -284,9 +284,9 @@ function executeSupervisedCandidate({candidate, activeHeavyTask, services}) {
     const {taskName, trigger} = candidate;
     return executeWithMaintenance({
         taskName,
-        reason      : trigger.reason,
-        onSuccess   : trigger.onSuccess,
-        executeFn   : services.processSupervisorService.runTask.bind(services.processSupervisorService),
+        reason                        : trigger.reason,
+        onSuccess                     : trigger.onSuccess,
+        executeFn                     : services.processSupervisorService.runTask.bind(services.processSupervisorService),
         activeHeavyTask,
         maintenanceBackpressureService: services.maintenanceBackpressureService
     });
@@ -325,9 +325,9 @@ function executeServiceRunnerCandidate({candidate, activeHeavyTask, services, ru
     }
 
     return executeWithMaintenance({
-        taskName    : candidate.taskName,
-        reason      : candidate.trigger.reason,
-        onSuccess   : candidate.trigger.onSuccess,
+        taskName                      : candidate.taskName,
+        reason                        : candidate.trigger.reason,
+        onSuccess                     : candidate.trigger.onSuccess,
         executeFn,
         activeHeavyTask,
         maintenanceBackpressureService: services.maintenanceBackpressureService
@@ -336,7 +336,7 @@ function executeServiceRunnerCandidate({candidate, activeHeavyTask, services, ru
 
 function executeInProcessCandidate({candidate, activeHeavyTask, services, runtime}) {
     const runners = {
-        dream: (taskName, reason) => runDreamTask({taskName, reason, services}),
+        dream        : (taskName, reason) => runDreamTask({taskName, reason, services}),
         'golden-path': (taskName, reason) => runGoldenPathTask({
             taskName,
             reason,
@@ -361,7 +361,7 @@ function executeInProcessCandidate({candidate, activeHeavyTask, services, runtim
         return services.maintenanceBackpressureService.executeWithGoldenPathDependencyGate({
             taskName: candidate.taskName,
             executeFn,
-            reason: candidate.trigger.reason,
+            reason  : candidate.trigger.reason,
             activeHeavyTask
         });
     }
@@ -371,9 +371,9 @@ function executeInProcessCandidate({candidate, activeHeavyTask, services, runtim
     }
 
     return executeWithMaintenance({
-        taskName    : candidate.taskName,
-        reason      : candidate.trigger.reason,
-        onSuccess   : candidate.trigger.onSuccess,
+        taskName                      : candidate.taskName,
+        reason                        : candidate.trigger.reason,
+        onSuccess                     : candidate.trigger.onSuccess,
         executeFn,
         activeHeavyTask,
         maintenanceBackpressureService: services.maintenanceBackpressureService
@@ -572,18 +572,18 @@ async function runEmbedDrainLivenessWatchdogTask({taskName, reason, services, ru
         if (stalled) {
             services.healthService?.recordTaskOutcome?.(taskName, 'failed', {
                 ...details,
-                stalledSince: stalledSince === null ? null : new Date(stalledSince).toISOString(),
+                stalledSince   : stalledSince === null ? null : new Date(stalledSince).toISOString(),
                 oldestTimestamp: oldestTimestamp === null ? null : new Date(oldestTimestamp).toISOString()
             });
 
             if (shouldAlarm && runtime.embedDrainLivenessWatchdogAlarmEnabled) {
                 await dispatchEmbedDrainStallAlarm({
-                    dispatcher  : services.embedDrainLivenessAlarmDispatcher,
-                    ageMs       : oldestAgeMs,
+                    dispatcher: services.embedDrainLivenessAlarmDispatcher,
+                    ageMs     : oldestAgeMs,
                     pendingCount,
                     thresholdMs,
                     stalledSince,
-                    writeLog    : runtime.writeLog
+                    writeLog  : runtime.writeLog
                 });
             }
         } else {

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -552,7 +552,7 @@ async function runEmbedDrainLivenessWatchdogTask({taskName, reason, services, ru
             now
         });
 
-        const state      = services.taskStateService.getTaskState(taskName);
+        const state       = services.taskStateService.getTaskState(taskName);
         const alarmState  = state?.embedDrainAlarm ?? null;
         const thresholdMs = runtime.embedDrainLivenessWatchdogThresholdMs;
 

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -1,12 +1,12 @@
-import {getDueTask as getSummaryDueTask}             from './summary.mjs';
-import {getDueTask as getBackupDueTask}              from './backup.mjs';
-import {getDueTask as getDreamDueTask}               from './dream.mjs';
-import {getDueTask as getGraphLogCompactionDueTask}  from './graphLogCompaction.mjs';
-import {getDueTask as getGoldenPathDueTask}          from './goldenPath.mjs';
-import {getDueTask as getMemorySummaryBackfillDueTask} from './memorySummaryBackfill.mjs';
-import {getDueTask as getPrimaryDevSyncDueTask}      from './primaryDevSync.mjs';
-import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs';
-import {getDueTask as getTenantRepoSyncDueTask}      from './tenantRepoSync.mjs';
+import {getDueTask as getSummaryDueTask}                    from './summary.mjs';
+import {getDueTask as getBackupDueTask}                     from './backup.mjs';
+import {getDueTask as getDreamDueTask}                      from './dream.mjs';
+import {getDueTask as getGraphLogCompactionDueTask}         from './graphLogCompaction.mjs';
+import {getDueTask as getGoldenPathDueTask}                 from './goldenPath.mjs';
+import {getDueTask as getMemorySummaryBackfillDueTask}      from './memorySummaryBackfill.mjs';
+import {getDueTask as getPrimaryDevSyncDueTask}             from './primaryDevSync.mjs';
+import {getDueTask as getSwarmHeartbeatDueTask}             from './swarmHeartbeat.mjs';
+import {getDueTask as getTenantRepoSyncDueTask}             from './tenantRepoSync.mjs';
 import {getDueTask as getEmbedDrainLivenessWatchdogDueTask} from './embedDrainLivenessWatchdog.mjs';
 
 /**
@@ -106,7 +106,7 @@ export const TASK_REGISTRY = Object.freeze([
                 state,
                 now,
                 graphLogCompactionIntervalMs: intervals.graphLogCompaction,
-                enabled                      : enables.graphLogCompaction
+                enabled                     : enables.graphLogCompaction
             });
         }
     },
@@ -193,7 +193,7 @@ export const TASK_REGISTRY = Object.freeze([
         dependencies    : [],
         getDueTask({state, now, intervals, hooks}) {
             return (hooks.embedDrainLivenessWatchdogGetDueTask || getEmbedDrainLivenessWatchdogDueTask)({
-                state: state['embed-drain-liveness-watchdog'] ?? {},
+                state                            : state['embed-drain-liveness-watchdog'] ?? {},
                 now,
                 embedDrainLivenessWatchdogCheckMs: intervals.embedDrainLivenessWatchdogCheck
             });

--- a/ai/daemons/orchestrator/scheduling/registry.mjs
+++ b/ai/daemons/orchestrator/scheduling/registry.mjs
@@ -7,6 +7,7 @@ import {getDueTask as getMemorySummaryBackfillDueTask} from './memorySummaryBack
 import {getDueTask as getPrimaryDevSyncDueTask}      from './primaryDevSync.mjs';
 import {getDueTask as getSwarmHeartbeatDueTask}      from './swarmHeartbeat.mjs';
 import {getDueTask as getTenantRepoSyncDueTask}      from './tenantRepoSync.mjs';
+import {getDueTask as getEmbedDrainLivenessWatchdogDueTask} from './embedDrainLivenessWatchdog.mjs';
 
 /**
  * Coordinator-descriptor registry for the Orchestrator scheduling pipeline.
@@ -181,6 +182,20 @@ export const TASK_REGISTRY = Object.freeze([
                 state                   : state['swarm-heartbeat'] ?? {},
                 now,
                 swarmHeartbeatIntervalMs: intervals.swarmHeartbeat
+            });
+        }
+    },
+    {
+        taskName        : 'embed-drain-liveness-watchdog',
+        executionKind   : 'health-check',
+        maintenanceClass: 'health-monitor',
+        backpressure    : 'none',
+        dependencies    : [],
+        getDueTask({state, now, intervals, hooks}) {
+            return (hooks.embedDrainLivenessWatchdogGetDueTask || getEmbedDrainLivenessWatchdogDueTask)({
+                state: state['embed-drain-liveness-watchdog'] ?? {},
+                now,
+                embedDrainLivenessWatchdogCheckMs: intervals.embedDrainLivenessWatchdogCheck
             });
         }
     }

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -1,5 +1,5 @@
-import path from 'path';
-import net  from 'net';
+import path            from 'path';
+import net             from 'net';
 import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -106,8 +106,8 @@ export function buildTaskDefinitions({
 
     const tasks = {
         chroma: {
-            label          : 'chroma daemon',
-            command        : 'chroma',
+            label  : 'chroma daemon',
+            command: 'chroma',
             // The --path persist dir resolves to the same dir as AiConfig.engines.chroma.dataDir
             // — the SSOT that KB/MC configs + defragChromaDB read — under the standard
             // cwd==repoRoot. Kept as a relative literal here (not SSOT-sourced) for daemon-launch
@@ -129,9 +129,9 @@ export function buildTaskDefinitions({
         },
         ...(hasDevServerPort ? {
             devServer: {
-                label                  : 'local dev-server',
-                command                : nodeBin,
-                args                   : [
+                label  : 'local dev-server',
+                command: nodeBin,
+                args   : [
                     path.resolve(scriptDir, '../../node_modules/webpack/bin/webpack.js'),
                     'serve',
                     '-c',
@@ -204,9 +204,9 @@ export function buildTaskDefinitions({
             expectedCommand: 'backup.mjs'
         },
         'graphlog-compaction': {
-            label          : 'GraphLog compaction',
-            command        : nodeBin,
-            args           : [
+            label  : 'GraphLog compaction',
+            command: nodeBin,
+            args   : [
                 path.join(scriptDir, 'maintenance', 'compactGraphLog.mjs'),
                 '--apply',
                 ...(graphLogCompactionVacuum ? ['--vacuum'] : [])
@@ -320,13 +320,13 @@ export function buildTaskDefinitions({
                 }
 
                 return ensureLmsModelsLoaded({
-                    host           : lmsHost,
-                    models         : requiredModels,
-                    contextLengths : lmsContextLengths,
-                    allowPartial   : true,
-                    attempts       : providerReadiness?.attempts,
-                    delayMs        : providerReadiness?.delayMs,
-                    timeoutMs      : providerReadiness?.timeoutMs
+                    host          : lmsHost,
+                    models        : requiredModels,
+                    contextLengths: lmsContextLengths,
+                    allowPartial  : true,
+                    attempts      : providerReadiness?.attempts,
+                    delayMs       : providerReadiness?.delayMs,
+                    timeoutMs     : providerReadiness?.timeoutMs
                 });
             }
         };

--- a/ai/daemons/orchestrator/taskDefinitions.mjs
+++ b/ai/daemons/orchestrator/taskDefinitions.mjs
@@ -253,6 +253,17 @@ export function buildTaskDefinitions({
             pidFileName    : 'swarm-heartbeat.pid',
             expectedCommand: 'SwarmHeartbeatService',
             serviceTask    : true
+        },
+        // In-process read-only health-check (no child process is ever spawned): the embed-drain
+        // liveness watchdog runs entirely inside the orchestrator's scheduling pipeline. The entry
+        // exists only so the task gets a persisted state envelope (cadence `lastRunAt` + the
+        // one-shot stall-alarm latch). `pidFileName`/`expectedCommand` are inert — no PID file is
+        // ever written, so process recovery/supervision short-circuits on the missing file.
+        'embed-drain-liveness-watchdog': {
+            label          : 'embed-drain liveness watchdog',
+            pidFileName    : 'embed-drain-liveness-watchdog.pid',
+            expectedCommand: 'EmbedDrainLivenessWatchdog',
+            serviceTask    : true
         }
     };
 

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -360,6 +360,18 @@ class Config extends ConfigProvider {
                  */
                 backoffBaseMs  : leaf(1000, 'NEO_MEMORY_WAL_BACKOFF_BASE_MS', 'number'),
                 /**
+                 * Stall threshold for the embed-drain liveness watchdog: when the OLDEST un-embedded
+                 * WAL record is older than this, the (orchestrator-hosted, read-only) watchdog raises a
+                 * one-shot alarm. Conservative default of 6h — hours, NOT days: the whole point is to
+                 * catch a silently-stalled drain same-session, not after a week (the silent drain-death
+                 * incident went ~8 days unnoticed). It must exceed the worst-case healthy drain latency
+                 * (per-turn saves arrive minutes apart; the drain polls every `pollIntervalMs`) so a
+                 * healthy backlog never false-alarms. `<= 0` disables alarming. The watchdog only READS
+                 * the WAL — it never touches the never-fail `add_memory` write path.
+                 * @type {number}
+                 */
+                embedDrainStallThresholdMs: leaf(6 * 60 * 60 * 1000, 'NEO_MEMORY_WAL_EMBED_DRAIN_STALL_THRESHOLD_MS', 'number'),
+                /**
                  * Hosts the WAL drain loop INSIDE the memory-core server process — the
                  * containerized / single-process deployment shape (dockerized MC, npx-neo-app
                  * workspaces) where no orchestrator-supervised embed daemon exists.

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -187,8 +187,8 @@ class Config extends ConfigProvider {
              * Durable wake-daemon watermarks consumed by GraphLog maintenance.
              */
             wakeDaemon: {
-                dataDir: leaf(wakeDaemonDataDir, 'NEO_AI_DAEMON_DIR', 'string'),
-                bridgeLastSyncIdPath: leaf(path.join(wakeDaemonDataDir, 'lastSyncId'), 'NEO_BRIDGE_LAST_SYNC_ID_PATH', 'string'),
+                dataDir                       : leaf(wakeDaemonDataDir, 'NEO_AI_DAEMON_DIR', 'string'),
+                bridgeLastSyncIdPath          : leaf(path.join(wakeDaemonDataDir, 'lastSyncId'), 'NEO_BRIDGE_LAST_SYNC_ID_PATH', 'string'),
                 wakeSubscriptionLiveCursorPath: leaf(path.join(wakeDaemonDataDir, 'wakeSubscriptionLiveCursor'), 'NEO_AI_WAKE_SUBSCRIPTION_CURSOR_FILE', 'string')
             },
             /**
@@ -211,10 +211,10 @@ class Config extends ConfigProvider {
              * re-deriving defaults outside the Provider SSOT.
              */
             toolTelemetry: {
-                enabled: leaf(true, 'NEO_MC_TOOL_TELEMETRY_ENABLED', 'boolean'),
-                errorMaxChars: leaf(512, 'NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS', 'number'),
+                enabled          : leaf(true, 'NEO_MC_TOOL_TELEMETRY_ENABLED', 'boolean'),
+                errorMaxChars    : leaf(512, 'NEO_MC_TOOL_TELEMETRY_ERROR_MAX_CHARS', 'number'),
                 aggregateWindowMs: leaf(DAY_MS, 'NEO_MC_TOOL_TELEMETRY_WINDOW_MS', 'number'),
-                aggregateLimit: leaf(50, 'NEO_MC_TOOL_TELEMETRY_LIMIT', 'number')
+                aggregateLimit   : leaf(50, 'NEO_MC_TOOL_TELEMETRY_LIMIT', 'number')
             },
             /**
              * Data Schema/Table Names

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -88,7 +88,7 @@ function parseKeepAlive(value, fallback) {
  */
 export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     backupPath: process.env.NEO_BACKUP_PATH || path.resolve(neoRootDir, '.neo-ai-data/backups'),
-    auth: {
+    auth      : {
         host              : process.env.NEO_AUTH_HOST || null,
         port              : Number(process.env.NEO_AUTH_PORT) || 8080,
         realm             : process.env.NEO_AUTH_REALM || 'master',
@@ -100,7 +100,7 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
     modelProvider    : process.env.NEO_MODEL_PROVIDER || 'openAiCompatible',
     graphProvider    : process.env.NEO_GRAPH_PROVIDER || 'openAiCompatible',
     embeddingProvider: process.env.NEO_EMBEDDING_PROVIDER || 'openAiCompatible',
-    ollama: {
+    ollama           : {
         host                 : process.env.NEO_OLLAMA_HOST || 'http://127.0.0.1:11434',
         model                : process.env.NEO_OLLAMA_MODEL || 'gemma4:31b',
         embeddingModel       : process.env.NEO_OLLAMA_EMBEDDING_MODEL || 'qwen3-embedding',
@@ -108,34 +108,34 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
         requireParallelModels: Number(process.env.NEO_OLLAMA_REQUIRE_PARALLEL_MODELS) || 2
     },
     openAiCompatible: {
-        host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-        model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
-        embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
-        apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
-        unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
-        unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-        contentionRetryCount    : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT) || 2,
-        contentionRetryDelayMs  : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS) || 1000,
-        contentionTimeoutMs     : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS) || 15000,
+        host                   : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+        model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+        embeddingModel         : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+        apiKey                 : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+        unloadRetryCount       : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+        unloadRetryDelayMs     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+        contentionRetryCount   : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT) || 2,
+        contentionRetryDelayMs : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS) || 1000,
+        contentionTimeoutMs    : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS) || 15000,
         batchEmbeddingChunkSize: Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE) || 5,
-        batchEmbeddingYieldMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS) || 0,
-        keep_alive              : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1),
-        requireParallelModels   : Number(process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS) || 2
+        batchEmbeddingYieldMs  : Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS) || 0,
+        keep_alive             : parseKeepAlive(process.env.NEO_OPENAI_COMPATIBLE_KEEP_ALIVE, -1),
+        requireParallelModels  : Number(process.env.NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS) || 2
     },
     localModels: {
         chat: {
-            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
+            contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
             safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000
         },
         embedding: {
-            contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
+            contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
             safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672
         }
     },
     vectorDimension: Number(process.env.NEO_VECTOR_DIMENSION) || 4096,
     modelName      : 'gemini-3.5-flash',
     embeddingModel : 'gemini-embedding-001',
-    engines: {
+    engines        : {
         chroma: {
             dataDir: path.resolve(neoRootDir, '.neo-ai-data/chroma/unified'),
             host   : process.env.NEO_CHROMA_HOST || 'localhost',
@@ -149,15 +149,15 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             timeoutMs: Number(process.env.NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS) || 3000
         },
         intervals: {
-            pollMs           : 3000,
-            summarySweepMs   : 10 * 60 * 1000,
-            kbSyncMs         : 30 * 60 * 1000,
-            backupMs         : DAY_MS,
-            primaryDevSyncMs : 10 * 60 * 1000,
-            tenantRepoSyncMs : 30 * 60 * 1000,
-            dreamMs          : HOUR_MS,
-            goldenPathMs     : HOUR_MS,
-            swarmHeartbeatMs : 20 * 60 * 1000,
+            pollMs                           : 3000,
+            summarySweepMs                   : 10 * 60 * 1000,
+            kbSyncMs                         : 30 * 60 * 1000,
+            backupMs                         : DAY_MS,
+            primaryDevSyncMs                 : 10 * 60 * 1000,
+            tenantRepoSyncMs                 : 30 * 60 * 1000,
+            dreamMs                          : HOUR_MS,
+            goldenPathMs                     : HOUR_MS,
+            swarmHeartbeatMs                 : 20 * 60 * 1000,
             embedDrainLivenessWatchdogCheckMs: HOUR_MS
         }
     }

--- a/test/playwright/fixtures/aiConfigDefaults.mjs
+++ b/test/playwright/fixtures/aiConfigDefaults.mjs
@@ -157,7 +157,8 @@ export const TIER1_DEFAULTS = deepFreeze(Neo.clone({
             tenantRepoSyncMs : 30 * 60 * 1000,
             dreamMs          : HOUR_MS,
             goldenPathMs     : HOUR_MS,
-            swarmHeartbeatMs : 20 * 60 * 1000
+            swarmHeartbeatMs : 20 * 60 * 1000,
+            embedDrainLivenessWatchdogCheckMs: HOUR_MS
         }
     }
 }, true, true));

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -137,7 +137,8 @@ test.describe('Tier 1 Config Immutability', () => {
             primaryDevSyncMs: 10 * 60 * 1000,
             dreamMs         : 60 * 60 * 1000,
             goldenPathMs    : 60 * 60 * 1000,
-            swarmHeartbeatMs: 20 * 60 * 1000
+            swarmHeartbeatMs: 20 * 60 * 1000,
+            embedDrainLivenessWatchdogCheckMs: 60 * 60 * 1000
         });
         expect(Config.orchestrator.localOnly).toEqual({
             primaryDevSyncEnabled: null,

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
-import fs from 'fs/promises';
-import Neo from '../../../../src/Neo.mjs';
+import fs               from 'fs/promises';
+import Neo              from '../../../../src/Neo.mjs';
 import '../../../../src/core/_export.mjs';
-import ConfigProvider from '../../../../ai/ConfigProvider.mjs';
-import {TIER1_DEFAULTS} from '../../fixtures/aiConfigDefaults.mjs';
+import ConfigProvider         from '../../../../ai/ConfigProvider.mjs';
+import {TIER1_DEFAULTS}       from '../../fixtures/aiConfigDefaults.mjs';
 import {CHROMA_TEST_DATABASE} from '../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
 test.describe('Tier 1 Config Immutability', () => {
@@ -75,27 +75,27 @@ test.describe('Tier 1 Config Immutability', () => {
             requireParallelModels: TIER1_DEFAULTS.ollama.requireParallelModels
         });
         expect(Config.openAiCompatible).toMatchObject({
-            host                    : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
-            model                   : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
-            embeddingModel          : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
-            apiKey                  : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
-            unloadRetryCount        : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
-            unloadRetryDelayMs      : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
-            contentionRetryCount    : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT) || 2,
-            contentionRetryDelayMs  : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS) || 1000,
-            contentionTimeoutMs     : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS) || 15000,
+            host                   : process.env.NEO_OPENAI_COMPATIBLE_HOST || 'http://127.0.0.1:11434',
+            model                  : process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'gemma-4-31b-it',
+            embeddingModel         : process.env.NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b',
+            apiKey                 : process.env.NEO_OPENAI_COMPATIBLE_API_KEY || '',
+            unloadRetryCount       : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT) || 3,
+            unloadRetryDelayMs     : Number(process.env.NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS) || 500,
+            contentionRetryCount   : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT) || 2,
+            contentionRetryDelayMs : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS) || 1000,
+            contentionTimeoutMs    : Number(process.env.NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS) || 15000,
             batchEmbeddingChunkSize: Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE) || 5,
-            batchEmbeddingYieldMs   : Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS) || 0,
-            keep_alive              : TIER1_DEFAULTS.openAiCompatible.keep_alive,
-            requireParallelModels   : TIER1_DEFAULTS.openAiCompatible.requireParallelModels
+            batchEmbeddingYieldMs  : Number(process.env.NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS) || 0,
+            keep_alive             : TIER1_DEFAULTS.openAiCompatible.keep_alive,
+            requireParallelModels  : TIER1_DEFAULTS.openAiCompatible.requireParallelModels
         });
         expect(Config.localModels).toMatchObject({
             chat: {
-                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
+                contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072,
                 safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_CHAT_SAFE_PROCESSING_LIMIT_TOKENS) || 100000
             },
             embedding: {
-                contextLimitTokens      : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
+                contextLimitTokens       : Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS) || 32768,
                 safeProcessingLimitTokens: Number(process.env.NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS) || 28672
             }
         });
@@ -117,7 +117,7 @@ test.describe('Tier 1 Config Immutability', () => {
         Config.setEnvOverride('NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS', 11111);
 
         expect(Config.localModels.embedding).toMatchObject({
-            contextLimitTokens      : 12345,
+            contextLimitTokens       : 12345,
             safeProcessingLimitTokens: 11111
         });
         expect(Config.localModels.chat.contextLimitTokens).toBe(Number(process.env.NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS) || 131072);
@@ -129,27 +129,27 @@ test.describe('Tier 1 Config Immutability', () => {
     test('ships top-level deployment and maintenance policy defaults', async () => {
         expect(Config.orchestrator.deploymentMode).toBe('local');
         expect(Config.orchestrator.intervals).toMatchObject({
-            pollMs          : 3000,
-            summarySweepMs  : 10 * 60 * 1000,
-            kbSyncMs        : 30 * 60 * 1000,
-            backupMs        : 24 * 60 * 60 * 1000,
-            graphLogCompactionMs: 24 * 60 * 60 * 1000,
-            primaryDevSyncMs: 10 * 60 * 1000,
-            dreamMs         : 60 * 60 * 1000,
-            goldenPathMs    : 60 * 60 * 1000,
-            swarmHeartbeatMs: 20 * 60 * 1000,
+            pollMs                           : 3000,
+            summarySweepMs                   : 10 * 60 * 1000,
+            kbSyncMs                         : 30 * 60 * 1000,
+            backupMs                         : 24 * 60 * 60 * 1000,
+            graphLogCompactionMs             : 24 * 60 * 60 * 1000,
+            primaryDevSyncMs                 : 10 * 60 * 1000,
+            dreamMs                          : 60 * 60 * 1000,
+            goldenPathMs                     : 60 * 60 * 1000,
+            swarmHeartbeatMs                 : 20 * 60 * 1000,
             embedDrainLivenessWatchdogCheckMs: 60 * 60 * 1000
         });
         expect(Config.orchestrator.localOnly).toEqual({
-            primaryDevSyncEnabled: null,
-            kbSyncEnabled        : null,
-            chromaDaemonEnabled  : null,
-            bridgeDaemonEnabled  : null,
-            neuralLinkBridgeEnabled: null,
-            embedDaemonEnabled   : null,
+            primaryDevSyncEnabled          : null,
+            kbSyncEnabled                  : null,
+            chromaDaemonEnabled            : null,
+            bridgeDaemonEnabled            : null,
+            neuralLinkBridgeEnabled        : null,
+            embedDaemonEnabled             : null,
             goldenPathRepoEnrichmentEnabled: null,
-            swarmHeartbeatEnabled: null,
-            wakeDispatchEnabled  : null
+            swarmHeartbeatEnabled          : null,
+            wakeDispatchEnabled            : null
         });
         expect(Config.orchestrator.devServer).toEqual({
             enabled               : null,
@@ -164,8 +164,8 @@ test.describe('Tier 1 Config Immutability', () => {
         // optional explicit-handle-list override (highest resolver precedence) — null by
         // default so the resolver falls through to `targetSource` semantics.
         expect(Config.orchestrator.swarmHeartbeat).toEqual({
-            targetSource           : 'active-a2a-participants',
-            targets                : null,
+            targetSource: 'active-a2a-participants',
+            targets     : null,
             // Wake-policy leaves: NEO_-prefixed env names bound (NEO_IDLE_THRESHOLD_MS /
             // NEO_SWARM_WAKE_COOLDOWN_SECONDS / NEO_SWARM_IDENTITIES), deployment-portable defaults.
             idleThresholdMs         : 10 * 60 * 1000,
@@ -201,13 +201,13 @@ test.describe('Tier 1 Config Immutability', () => {
 
         expect(Config.maintenance.backup).toEqual({
             intervalMs: 24 * 60 * 60 * 1000,
-            retention: {
+            retention : {
                 keepMinimum: 3,
                 maxDays    : 30
             }
         });
         expect(Config.maintenance.defrag).toEqual({
-            intervalMs: 7 * 24 * 60 * 60 * 1000,
+            intervalMs       : 7 * 24 * 60 * 60 * 1000,
             snapshotRetention: {
                 keepMinimum: 3,
                 maxDays    : 7

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -218,7 +218,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             neuralLinkBridgeLivenessTimeoutMs : 50
         }));
 
-        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat']);
+        expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog']);
         expect(state.mlx).toBeUndefined();
         expect(state.memoryCoreChroma).toBeUndefined();
         expect(state.summary).toMatchObject({

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -1,9 +1,9 @@
-import {test, expect} from '@playwright/test';
-import path from 'path';
-import Neo from '../../../../../../src/Neo.mjs';
-import * as core from '../../../../../../src/core/_export.mjs';
-import AiConfig from '../../../../../../ai/config.mjs';
-import {Orchestrator} from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
+import {test, expect}             from '@playwright/test';
+import path                       from 'path';
+import Neo                        from '../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../src/core/_export.mjs';
+import AiConfig                   from '../../../../../../ai/config.mjs';
+import {Orchestrator}             from '../../../../../../ai/daemons/orchestrator/Orchestrator.mjs';
 import {ProcessSupervisorService} from '../../../../../../ai/daemons/orchestrator/services/ProcessSupervisorService.mjs';
 import {
     DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES
@@ -39,22 +39,22 @@ let savedDeploymentMode = null;
  */
 function createTestOrchestrator(config = {}) {
     const taskDefinitions = config.taskDefinitions || buildTaskDefinitions({
-        scriptDir                           : '/repo/ai/scripts',
-        nodeBin                             : '/node',
-        devServerPort                       : config.devServerPort ?? TEST_DEV_SERVER_PORT,
-        devServerLivenessTimeoutMs          : config.devServerLivenessTimeoutMs ?? 50,
-        neuralLinkBridgePort                : config.neuralLinkBridgePort ?? TEST_NEURAL_LINK_BRIDGE_PORT,
-        neuralLinkBridgeLivenessTimeoutMs   : config.neuralLinkBridgeLivenessTimeoutMs ?? 50,
-        graphLogCompactionVacuum            : config.graphLogCompactionVacuum ?? false
+        scriptDir                        : '/repo/ai/scripts',
+        nodeBin                          : '/node',
+        devServerPort                    : config.devServerPort ?? TEST_DEV_SERVER_PORT,
+        devServerLivenessTimeoutMs       : config.devServerLivenessTimeoutMs ?? 50,
+        neuralLinkBridgePort             : config.neuralLinkBridgePort ?? TEST_NEURAL_LINK_BRIDGE_PORT,
+        neuralLinkBridgeLivenessTimeoutMs: config.neuralLinkBridgeLivenessTimeoutMs ?? 50,
+        graphLogCompactionVacuum         : config.graphLogCompactionVacuum ?? false
     });
 
     const heavyMaintenanceLeasePath = config.heavyMaintenanceLeasePath
         || `/tmp/orchestrator-test/heavy-maintenance-lease-${process.pid}-${++testOrchestratorSeq}.json`;
 
     TaskStateService.configure({
-        stateFile      : '/tmp/orchestrator-test/state.json',
+        stateFile : '/tmp/orchestrator-test/state.json',
         taskDefinitions,
-        writeLogFn     : () => {}
+        writeLogFn: () => {}
     });
     TaskStateService.taskState = createInitialTaskState(taskDefinitions);
     ['chroma', 'bridgeDaemon', 'devServer', 'neuralLinkBridge', 'mlx', 'lms'].forEach(name => {
@@ -212,10 +212,10 @@ function restoreConfigObject(target, prior) {
 test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     test('creates an isolated persisted-state envelope per task', () => {
         const state = createInitialTaskState(buildTaskDefinitions({
-            scriptDir                         : '/repo/ai/scripts',
-            nodeBin                           : '/node',
-            neuralLinkBridgePort              : TEST_NEURAL_LINK_BRIDGE_PORT,
-            neuralLinkBridgeLivenessTimeoutMs : 50
+            scriptDir                        : '/repo/ai/scripts',
+            nodeBin                          : '/node',
+            neuralLinkBridgePort             : TEST_NEURAL_LINK_BRIDGE_PORT,
+            neuralLinkBridgeLivenessTimeoutMs: 50
         }));
 
         expect(Object.keys(state)).toEqual(['chroma', 'bridgeDaemon', 'neuralLinkBridge', 'embedDaemon', 'summary', 'memory-summary-backfill', 'kbSync', 'backup', 'graphlog-compaction', 'chromaDefrag', 'primary-dev-sync', 'tenant-repo-sync', 'dream', 'golden-path', 'swarm-heartbeat', 'embed-drain-liveness-watchdog']);
@@ -388,7 +388,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         const orchestrator = createTestOrchestrator({
             bridgeDaemonEnabled: false,
-            kbSyncEnabled     : false
+            kbSyncEnabled      : false
         });
 
         TaskStateService.taskState.bridgeDaemon.running   = false;
@@ -413,7 +413,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         const orchestrator = createTestOrchestrator({
             goldenPathIntervalMs: 600000,
-            healthService: {
+            healthService       : {
                 recordTaskOutcome(taskName, status, details) {
                     outcomes.push({taskName, status, details});
                 }
@@ -451,7 +451,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const calls = [];
 
         const orchestrator = createTestOrchestrator({
-            goldenPathIntervalMs: 600000,
+            goldenPathIntervalMs : 600000,
             goldenPathSynthesizer: {
                 synthesizeGoldenPath() {
                     calls.push('golden-path');
@@ -472,10 +472,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const calls = [];
 
         const orchestrator = createTestOrchestrator({
-            kbSyncEnabled: false,
-            goldenPathIntervalMs: 600000,
+            kbSyncEnabled                  : false,
+            goldenPathIntervalMs           : 600000,
             goldenPathRepoEnrichmentEnabled: false,
-            goldenPathSynthesizer: {
+            goldenPathSynthesizer          : {
                 synthesizeGoldenPath(options) {
                     calls.push(options);
                     return Promise.resolve();
@@ -536,10 +536,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
     test('defines the local dev-server task without browser auto-open (#13482)', () => {
         const taskDefinitions = buildTaskDefinitions({
-            scriptDir                    : '/repo/ai/scripts',
-            nodeBin                      : '/node',
-            devServerPort                : 4242,
-            devServerLivenessTimeoutMs   : 50
+            scriptDir                 : '/repo/ai/scripts',
+            nodeBin                   : '/node',
+            devServerPort             : 4242,
+            devServerLivenessTimeoutMs: 50
         });
 
         expect(taskDefinitions.devServer).toMatchObject({
@@ -566,9 +566,9 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const flushProbe = () => new Promise(resolve => setTimeout(resolve, 0));
         const cloudStarted = [];
         const cloudOrchestrator = createTestOrchestrator({
-            deploymentMode   : 'cloud',
-            kbSyncEnabled    : false,
-            devServerEnabled : null
+            deploymentMode  : 'cloud',
+            kbSyncEnabled   : false,
+            devServerEnabled: null
         });
 
         TaskStateService.taskState.devServer.running   = false;
@@ -587,9 +587,9 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         const localStarted = [];
         const localOrchestrator = createTestOrchestrator({
-            deploymentMode   : 'local',
-            kbSyncEnabled    : false,
-            devServerEnabled : null
+            deploymentMode  : 'local',
+            kbSyncEnabled   : false,
+            devServerEnabled: null
         });
 
         TaskStateService.taskState.devServer.running   = false;
@@ -634,10 +634,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
     test('defines Neural Link Bridge as a defer-safe local shared-infra task (#13483)', () => {
         const taskDefinitions = buildTaskDefinitions({
-            scriptDir                         : '/repo/ai/scripts',
-            nodeBin                           : '/node',
-            neuralLinkBridgePort              : 4242,
-            neuralLinkBridgeLivenessTimeoutMs : 50
+            scriptDir                        : '/repo/ai/scripts',
+            nodeBin                          : '/node',
+            neuralLinkBridgePort             : 4242,
+            neuralLinkBridgeLivenessTimeoutMs: 50
         });
 
         expect(taskDefinitions.neuralLinkBridge).toMatchObject({
@@ -679,9 +679,9 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         const cloudStarted = [];
         const cloudOrchestrator = createTestOrchestrator({
-            deploymentMode             : 'cloud',
-            kbSyncEnabled              : false,
-            neuralLinkBridgeEnabled    : null
+            deploymentMode         : 'cloud',
+            kbSyncEnabled          : false,
+            neuralLinkBridgeEnabled: null
         });
 
         TaskStateService.taskState.neuralLinkBridge.running   = false;
@@ -745,11 +745,11 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             },
             taskStateService: {
                 getTaskState()  { return taskState; },
-                markStarted     : noop,
-                markSpawned     : noop,
-                markCompleted   : noop,
-                markFailed      : noop,
-                markSpawnFailed : noop
+                markStarted    : noop,
+                markSpawned    : noop,
+                markCompleted  : noop,
+                markFailed     : noop,
+                markSpawnFailed: noop
             },
             healthService: {recordTaskOutcome() {}},
             writeLog     : () => {},
@@ -769,12 +769,12 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
     test('supervises lms via the supervisor HTTP liveness probe — (re)start only when the endpoint is down (#12262 / #12090)', async () => {
         const taskDefinitions = buildTaskDefinitions({
-            scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
-            nodeBin   : process.argv[0],
-            lmsEnabled: true,
-            lmsModels : ['chat-model', 'embedding-model'],
-            lmsHost   : 'http://127.0.0.1:1234',
-            lmsPort   : 1234,
+            scriptDir        : path.resolve(process.cwd(), 'ai/scripts'),
+            nodeBin          : process.argv[0],
+            lmsEnabled       : true,
+            lmsModels        : ['chat-model', 'embedding-model'],
+            lmsHost          : 'http://127.0.0.1:1234',
+            lmsPort          : 1234,
             providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50}
         });
         // `lms server start` is fire-and-exit, so liveness is the HTTP endpoint, not the launcher
@@ -905,8 +905,8 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         });
 
         expect(buildTaskDefinitions({
-            scriptDir: '/repo/ai/scripts',
-            nodeBin  : '/node',
+            scriptDir               : '/repo/ai/scripts',
+            nodeBin                 : '/node',
             graphLogCompactionVacuum: true
         })['graphlog-compaction'].args).toEqual([
             '/repo/ai/scripts/maintenance/compactGraphLog.mjs',
@@ -919,12 +919,12 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const started = [];
         const dueCalls = [];
         const orchestrator = createTestOrchestrator({
-            deploymentMode               : 'cloud',
-            kbSyncIntervalMs             : 0,
-            backupIntervalMs             : 0,
-            graphLogCompactionEnabled    : true,
-            graphLogCompactionIntervalMs : 600000,
-            graphLogCompactionGetDueTask : options => {
+            deploymentMode              : 'cloud',
+            kbSyncIntervalMs            : 0,
+            backupIntervalMs            : 0,
+            graphLogCompactionEnabled   : true,
+            graphLogCompactionIntervalMs: 600000,
+            graphLogCompactionGetDueTask: options => {
                 dueCalls.push(options);
                 return {
                     taskName: 'graphlog-compaction',
@@ -932,11 +932,11 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                     reason  : 'periodic-graphlog-compaction:600000'
                 };
             },
-            primaryDevSyncIntervalMs     : 0,
-            tenantRepoSyncIntervalMs     : 0,
-            dreamIntervalMs              : Number.MAX_SAFE_INTEGER,
-            goldenPathIntervalMs         : Number.MAX_SAFE_INTEGER,
-            swarmHeartbeatIntervalMs     : Number.MAX_SAFE_INTEGER
+            primaryDevSyncIntervalMs: 0,
+            tenantRepoSyncIntervalMs: 0,
+            dreamIntervalMs         : Number.MAX_SAFE_INTEGER,
+            goldenPathIntervalMs    : Number.MAX_SAFE_INTEGER,
+            swarmHeartbeatIntervalMs: Number.MAX_SAFE_INTEGER
         });
 
         orchestrator.processSupervisorService = {
@@ -961,18 +961,18 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     test('passes graphlog-compaction cadence from config verbatim (#12394 / #12061)', () => {
         const dueCalls = [];
         const orchestrator = createTestOrchestrator({
-            kbSyncIntervalMs             : 0,
-            backupIntervalMs             : 123456,
-            graphLogCompactionIntervalMs : 777777,
-            graphLogCompactionGetDueTask : options => {
+            kbSyncIntervalMs            : 0,
+            backupIntervalMs            : 123456,
+            graphLogCompactionIntervalMs: 777777,
+            graphLogCompactionGetDueTask: options => {
                 dueCalls.push(options);
                 return null;
             },
-            primaryDevSyncIntervalMs     : 0,
-            tenantRepoSyncIntervalMs     : 0,
-            dreamIntervalMs              : Number.MAX_SAFE_INTEGER,
-            goldenPathIntervalMs         : Number.MAX_SAFE_INTEGER,
-            swarmHeartbeatIntervalMs     : Number.MAX_SAFE_INTEGER
+            primaryDevSyncIntervalMs: 0,
+            tenantRepoSyncIntervalMs: 0,
+            dreamIntervalMs         : Number.MAX_SAFE_INTEGER,
+            goldenPathIntervalMs    : Number.MAX_SAFE_INTEGER,
+            swarmHeartbeatIntervalMs: Number.MAX_SAFE_INTEGER
         });
 
         orchestrator.poll();
@@ -986,22 +986,22 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const started = [];
         const dueCalls = [];
         const orchestrator = createTestOrchestrator({
-            kbSyncIntervalMs             : 0,
-            backupIntervalMs             : 0,
-            graphLogCompactionEnabled    : false,
-            graphLogCompactionIntervalMs : 600000,
-            graphLogCompactionGetDueTask : options => {
+            kbSyncIntervalMs            : 0,
+            backupIntervalMs            : 0,
+            graphLogCompactionEnabled   : false,
+            graphLogCompactionIntervalMs: 600000,
+            graphLogCompactionGetDueTask: options => {
                 dueCalls.push(options);
                 return options.enabled ? {
                     taskName: 'graphlog-compaction',
                     reason  : 'periodic-graphlog-compaction:600000'
                 } : null;
             },
-            primaryDevSyncIntervalMs     : 0,
-            tenantRepoSyncIntervalMs     : 0,
-            dreamIntervalMs              : Number.MAX_SAFE_INTEGER,
-            goldenPathIntervalMs         : Number.MAX_SAFE_INTEGER,
-            swarmHeartbeatIntervalMs     : Number.MAX_SAFE_INTEGER
+            primaryDevSyncIntervalMs: 0,
+            tenantRepoSyncIntervalMs: 0,
+            dreamIntervalMs         : Number.MAX_SAFE_INTEGER,
+            goldenPathIntervalMs    : Number.MAX_SAFE_INTEGER,
+            swarmHeartbeatIntervalMs: Number.MAX_SAFE_INTEGER
         });
 
         orchestrator.processSupervisorService = {
@@ -1062,14 +1062,14 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const orchestrator = Neo.create(Orchestrator);
         orchestrator.dataDir         = '/tmp/orchestrator-test-lms-port';
         orchestrator.taskDefinitions = buildTaskDefinitions({
-            scriptDir : path.resolve(process.cwd(), 'ai/scripts'),
-            nodeBin   : process.argv[0],
-            lmsEnabled: true,
-            lmsModel  : 'qwen3-embedding-8b',
-            lmsModels : ['gemma4-31b', 'qwen3-8b'],
-            lmsHost   : 'http://127.0.0.1:4242',
+            scriptDir        : path.resolve(process.cwd(), 'ai/scripts'),
+            nodeBin          : process.argv[0],
+            lmsEnabled       : true,
+            lmsModel         : 'qwen3-embedding-8b',
+            lmsModels        : ['gemma4-31b', 'qwen3-8b'],
+            lmsHost          : 'http://127.0.0.1:4242',
             providerReadiness: {attempts: 2, delayMs: 0, timeoutMs: 50},
-            lmsPort   : 4242
+            lmsPort          : 4242
         });
 
         expect(orchestrator.taskDefinitions.lms.command).toBe('lms');
@@ -1146,7 +1146,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
             backupIntervalMs        : 0,
             tenantRepoSyncEnabled   : false,
             tenantRepoSyncIntervalMs: 600000,
-            tenantRepoSyncService: {
+            tenantRepoSyncService   : {
                 runTask({taskName, reason}) {
                     started.push({taskName, reason});
                 }
@@ -1165,12 +1165,12 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
     test('delegates the configured dev-sync roots to PrimaryRepoSyncService via options.devSyncRootsConfig', () => {
         const received = [];
         const orchestrator = createTestOrchestrator({
-            kbSyncIntervalMs          : 0,
-            backupIntervalMs          : 0,
-            primaryDevSyncEnabled     : true,
-            primaryDevSyncIntervalMs  : 600000,
-            primaryDevSyncRootsConfig : ['/config/neo'],
-            primaryDevSyncGetDueTask  : () => ({
+            kbSyncIntervalMs         : 0,
+            backupIntervalMs         : 0,
+            primaryDevSyncEnabled    : true,
+            primaryDevSyncIntervalMs : 600000,
+            primaryDevSyncRootsConfig: ['/config/neo'],
+            primaryDevSyncGetDueTask : () => ({
                 taskName: 'primary-dev-sync',
                 reason  : 'periodic-sweep:600000'
             }),
@@ -1346,10 +1346,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
                     outcomes.push({taskName, status, details});
                 }
             },
-            backupIntervalMs             : Number.MAX_SAFE_INTEGER,
-            graphLogCompactionIntervalMs : Number.MAX_SAFE_INTEGER,
-            primaryDevSyncIntervalMs     : Number.MAX_SAFE_INTEGER,
-            dreamIntervalMs              : Number.MAX_SAFE_INTEGER
+            backupIntervalMs            : Number.MAX_SAFE_INTEGER,
+            graphLogCompactionIntervalMs: Number.MAX_SAFE_INTEGER,
+            primaryDevSyncIntervalMs    : Number.MAX_SAFE_INTEGER,
+            dreamIntervalMs             : Number.MAX_SAFE_INTEGER
         });
 
         orchestrator.db = {
@@ -1535,7 +1535,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
 
         const orchestratorA = createTestOrchestrator({
             heavyMaintenanceLeasePath: sharedLeasePath,
-            healthService: {
+            healthService            : {
                 recordTaskOutcome(taskName, status, details) {
                     outcomesA.push({taskName, status, details});
                 }
@@ -1555,7 +1555,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         // Second orchestrator on the same shared lease path — must defer cross-process.
         const orchestratorB = createTestOrchestrator({
             heavyMaintenanceLeasePath: sharedLeasePath,
-            healthService: {
+            healthService            : {
                 recordTaskOutcome(taskName, status, details) {
                     outcomesB.push({taskName, status, details});
                 }
@@ -1599,10 +1599,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const pulseCalls = [];
 
         const orchestrator = createTestOrchestrator({
-            kbSyncEnabled          : false,
-            swarmHeartbeatEnabled  : true,
+            kbSyncEnabled           : false,
+            swarmHeartbeatEnabled   : true,
             swarmHeartbeatIntervalMs: 600000,
-            swarmHeartbeatService  : {
+            swarmHeartbeatService   : {
                 initAsync() { return Promise.resolve(); },
                 pulse() {
                     pulseCalls.push('pulse');
@@ -1621,10 +1621,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const pulseCalls = [];
 
         const orchestrator = createTestOrchestrator({
-            kbSyncEnabled          : false,
-            swarmHeartbeatEnabled  : false,
+            kbSyncEnabled           : false,
+            swarmHeartbeatEnabled   : false,
             swarmHeartbeatIntervalMs: 600000,
-            swarmHeartbeatService  : {
+            swarmHeartbeatService   : {
                 initAsync() { return Promise.resolve(); },
                 pulse() {
                     pulseCalls.push('pulse');
@@ -1643,10 +1643,10 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         const outcomes = [];
 
         const orchestrator = createTestOrchestrator({
-            kbSyncEnabled          : false,
-            swarmHeartbeatEnabled  : true,
+            kbSyncEnabled           : false,
+            swarmHeartbeatEnabled   : true,
             swarmHeartbeatIntervalMs: 600000,
-            healthService          : {
+            healthService           : {
                 recordTaskOutcome(taskName, status, details) {
                     outcomes.push({taskName, status, details});
                 }
@@ -1693,7 +1693,7 @@ test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
         };
 
         const orchestrator = createTestOrchestrator({
-            kbSyncEnabled : false,
+            kbSyncEnabled  : false,
             dreamIntervalMs: 1,
             healthService  : {
                 recordTaskOutcome(taskName, status, details) {

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}  from '@playwright/test';
-import {mkdtemp, rm}   from 'fs/promises';
+import {test, expect}   from '@playwright/test';
+import {mkdtemp, rm}    from 'fs/promises';
 import os               from 'os';
 import path             from 'path';
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
@@ -1,7 +1,7 @@
-import {test, expect}   from '@playwright/test';
-import {mkdtemp, rm}    from 'fs/promises';
-import os               from 'os';
-import path             from 'path';
+import {test, expect} from '@playwright/test';
+import {mkdtemp, rm}  from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
 
 import {appendWalEmbedMarker, appendWalMemory} from '../../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
 import {
@@ -244,9 +244,9 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
     /** Runs exactly the watchdog lane through the pipeline (it is the only due candidate). */
     async function runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime}) {
         const context = buildSchedulingContext({
-            db       : {},
-            state    : taskStateService.getState(),
-            now      : Date.now(),
+            db   : {},
+            state: taskStateService.getState(),
+            now  : Date.now(),
             // Only the watchdog cadence is enabled; force it due via a huge elapsed window.
             intervals: {embedDrainLivenessWatchdogCheck: 1},
             enables  : {},
@@ -366,7 +366,7 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
         const taskStateService = makeTaskStateService();
 
         const services = {
-            healthService: { recordTaskOutcome() { throw new Error('health record blew up'); } },
+            healthService                 : { recordTaskOutcome() { throw new Error('health record blew up'); } },
             maintenanceBackpressureService: {
                 getActiveHeavyMaintenanceTask() { return null; },
                 isHeavyMaintenanceTask() { return false; },
@@ -378,7 +378,7 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline i
         };
 
         const context = buildSchedulingContext({
-            db: {}, state: taskStateService.getState(), now: Date.now(),
+            db       : {}, state: taskStateService.getState(), now: Date.now(),
             intervals: {embedDrainLivenessWatchdogCheck: 1}, enables: {}, hooks: {}
         });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}  from '@playwright/test';
-import {mkdtemp, rm}    from 'fs/promises';
+import {mkdtemp, rm}   from 'fs/promises';
 import os               from 'os';
 import path             from 'path';
 
@@ -51,7 +51,7 @@ test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — getEmbedDr
     });
 
     test('(a) reports oldest age + pending count over a fixture WAL (oldest = max age)', async () => {
-        const now   = Date.UTC(2026, 5, 3, 12);
+        const now    = Date.UTC(2026, 5, 3, 12);
         const oldest = now - 5 * HOUR_MS;       // 5h old (the oldest pending)
         const newer  = now - 1 * HOUR_MS;       // 1h old
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.spec.mjs
@@ -1,0 +1,396 @@
+import {test, expect}  from '@playwright/test';
+import {mkdtemp, rm}    from 'fs/promises';
+import os               from 'os';
+import path             from 'path';
+
+import {appendWalEmbedMarker, appendWalMemory} from '../../../../../../../ai/services/memory-core/helpers/memoryWalStore.mjs';
+import {
+    evaluateStallAlarm,
+    getDueTask,
+    getEmbedDrainPendingAge
+}                       from '../../../../../../../ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.mjs';
+import {
+    buildSchedulingContext,
+    runSchedulingPipeline
+}                       from '../../../../../../../ai/daemons/orchestrator/scheduling/pipeline.mjs';
+
+/**
+ * Embed-drain liveness watchdog — the read-only, never-fail WAL-backlog progress check that
+ * closes the silent-drain-death detection gap. Falsifier coverage:
+ *
+ *   (a) getEmbedDrainPendingAge derives oldest-age + count over a real fixture WAL
+ *   (b) getDueTask cadence trip / no-trip / disabled
+ *   (c) threshold trip → 'failed' outcome + one-shot alarm fired (spy) via the scheduling pipeline
+ *   (d) below-threshold → 'completed' outcome, NO alarm
+ *   (e) one-shot latch: consecutive stalled checks do NOT re-alarm until a healthy check resets it
+ *   (f) a thrown error in the check degrades to "no alarm" and never propagates into the pipeline
+ *
+ * No real daemon/drain is spawned — the WAL is a temp-dir fixture and the clock + collaborators are
+ * injected.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/** A WAL record carrying an explicit write timestamp so age is deterministic. */
+const record = (id, timestampMs) => ({
+    id,
+    timestamp: timestampMs,
+    metadata : {prompt: `p-${id}`, response: `r-${id}`, thought: `t-${id}`},
+    document : `doc-${id}`
+});
+
+test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — getEmbedDrainPendingAge (#13551)', () => {
+    let walDir;
+
+    test.beforeEach(async () => {
+        walDir = await mkdtemp(path.join(os.tmpdir(), 'neo-embed-drain-watchdog-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(walDir, {recursive: true, force: true});
+    });
+
+    test('(a) reports oldest age + pending count over a fixture WAL (oldest = max age)', async () => {
+        const now   = Date.UTC(2026, 5, 3, 12);
+        const oldest = now - 5 * HOUR_MS;       // 5h old (the oldest pending)
+        const newer  = now - 1 * HOUR_MS;       // 1h old
+
+        await appendWalMemory(record('m-old', oldest), {dir: walDir});
+        await appendWalMemory(record('m-new', newer),  {dir: walDir});
+
+        const result = await getEmbedDrainPendingAge({walDir, now});
+
+        expect(result.pendingCount).toBe(2);
+        expect(result.oldestTimestamp).toBe(oldest);
+        expect(result.oldestAgeMs).toBe(5 * HOUR_MS);
+    });
+
+    test('(a) embed-marked records are no longer pending (drain progress shrinks the backlog)', async () => {
+        const now    = Date.UTC(2026, 5, 3, 12);
+        const oldest = now - 5 * HOUR_MS;
+        const newer  = now - 1 * HOUR_MS;
+
+        const {segmentKey: oldKey} = await appendWalMemory(record('m-old', oldest), {dir: walDir});
+        await appendWalMemory(record('m-new', newer), {dir: walDir});
+
+        // Embed the OLDEST record → only the newer record stays pending.
+        await appendWalEmbedMarker({id: 'm-old', segmentKey: oldKey}, {dir: walDir});
+
+        const result = await getEmbedDrainPendingAge({walDir, now});
+        expect(result.pendingCount).toBe(1);
+        expect(result.oldestTimestamp).toBe(newer);
+        expect(result.oldestAgeMs).toBe(1 * HOUR_MS);
+    });
+
+    test('(a) a clean / empty WAL yields a zero-backlog reading (no false stall)', async () => {
+        const result = await getEmbedDrainPendingAge({walDir, now: Date.now()});
+        expect(result).toEqual({oldestAgeMs: 0, pendingCount: 0, oldestTimestamp: null});
+    });
+
+    test('(f) a thrown error in the WAL read degrades to a zero-backlog reading (never throws)', async () => {
+        const throwingReader = async () => { throw new Error('simulated WAL read fault'); };
+        const result = await getEmbedDrainPendingAge({walDir, now: Date.now(), readPending: throwingReader});
+        // Fails SOFT: a read fault must look like "no backlog" (→ no alarm), never a stall or a throw.
+        expect(result).toEqual({oldestAgeMs: 0, pendingCount: 0, oldestTimestamp: null});
+    });
+
+    test('a malformed record (no finite timestamp) is still counted but never anchors the age', async () => {
+        const now = Date.UTC(2026, 5, 3, 12);
+        const reader = async () => [
+            {id: 'good', timestamp: now - 2 * HOUR_MS},
+            {id: 'bad',  timestamp: 'not-a-number'}
+        ];
+        const result = await getEmbedDrainPendingAge({walDir, now, readPending: reader});
+        expect(result.pendingCount).toBe(2);
+        expect(result.oldestTimestamp).toBe(now - 2 * HOUR_MS);
+        expect(result.oldestAgeMs).toBe(2 * HOUR_MS);
+    });
+});
+
+test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — getDueTask cadence (#13551)', () => {
+    test('(b) returns a periodic-health-check trigger when the interval has elapsed', () => {
+        expect(getDueTask({
+            state                            : {lastRunAt: 0},
+            now                              : HOUR_MS,
+            embedDrainLivenessWatchdogCheckMs: HOUR_MS
+        })).toEqual({
+            taskName: 'embed-drain-liveness-watchdog',
+            source  : 'periodic-health-check',
+            reason  : `periodic-health-check:${HOUR_MS}`
+        });
+    });
+
+    test('(b) returns null when the interval has not yet elapsed', () => {
+        expect(getDueTask({
+            state                            : {lastRunAt: 0},
+            now                              : HOUR_MS - 1,
+            embedDrainLivenessWatchdogCheckMs: HOUR_MS
+        })).toBeNull();
+    });
+
+    test('(b) treats intervalMs <= 0 as disabled', () => {
+        expect(getDueTask({state: {lastRunAt: 0}, now: 9e12, embedDrainLivenessWatchdogCheckMs: 0})).toBeNull();
+        expect(getDueTask({state: {lastRunAt: 0}, now: 9e12, embedDrainLivenessWatchdogCheckMs: -1})).toBeNull();
+    });
+
+    test('(b) handles missing state gracefully (lastRunAt defaults to 0)', () => {
+        expect(getDueTask({state: undefined, now: HOUR_MS, embedDrainLivenessWatchdogCheckMs: HOUR_MS})).toEqual({
+            taskName: 'embed-drain-liveness-watchdog',
+            source  : 'periodic-health-check',
+            reason  : `periodic-health-check:${HOUR_MS}`
+        });
+    });
+});
+
+test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — evaluateStallAlarm one-shot latch (#13551)', () => {
+    const THRESHOLD = 6 * HOUR_MS;
+
+    test('below threshold → not stalled, no alarm, latch cleared', () => {
+        const r = evaluateStallAlarm({oldestAgeMs: 3 * HOUR_MS, pendingCount: 5, thresholdMs: THRESHOLD, alarmState: null});
+        expect(r.stalled).toBe(false);
+        expect(r.shouldAlarm).toBe(false);
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null});
+    });
+
+    test('above threshold from a clear latch → stalled, alarm fires, latch set', () => {
+        const r = evaluateStallAlarm({oldestAgeMs: 7 * HOUR_MS, pendingCount: 5, thresholdMs: THRESHOLD, alarmState: {alarmed: false}});
+        expect(r.stalled).toBe(true);
+        expect(r.shouldAlarm).toBe(true);
+        expect(r.nextAlarmState.alarmed).toBe(true);
+    });
+
+    test('above threshold while already latched → stalled but NO re-alarm', () => {
+        const r = evaluateStallAlarm({oldestAgeMs: 8 * HOUR_MS, pendingCount: 5, thresholdMs: THRESHOLD, alarmState: {alarmed: true, stalledSince: 123}});
+        expect(r.stalled).toBe(true);
+        expect(r.shouldAlarm).toBe(false);
+        expect(r.nextAlarmState).toEqual({alarmed: true, stalledSince: 123});
+    });
+
+    test('a healthy check clears the latch so a later stall can re-alarm', () => {
+        const healthy = evaluateStallAlarm({oldestAgeMs: 1 * HOUR_MS, pendingCount: 0, thresholdMs: THRESHOLD, alarmState: {alarmed: true, stalledSince: 123}});
+        expect(healthy.nextAlarmState).toEqual({alarmed: false, stalledSince: null});
+
+        const reStall = evaluateStallAlarm({oldestAgeMs: 9 * HOUR_MS, pendingCount: 3, thresholdMs: THRESHOLD, alarmState: healthy.nextAlarmState});
+        expect(reStall.shouldAlarm).toBe(true);
+    });
+
+    test('threshold <= 0 disables alarming even with a large backlog', () => {
+        const r = evaluateStallAlarm({oldestAgeMs: 99 * HOUR_MS, pendingCount: 99, thresholdMs: 0, alarmState: null});
+        expect(r.stalled).toBe(false);
+        expect(r.shouldAlarm).toBe(false);
+    });
+
+    test('an empty backlog is never stalled regardless of age field', () => {
+        const r = evaluateStallAlarm({oldestAgeMs: 99 * HOUR_MS, pendingCount: 0, thresholdMs: THRESHOLD, alarmState: null});
+        expect(r.stalled).toBe(false);
+    });
+});
+
+/**
+ * Integration: drive the watchdog lane through the real `runSchedulingPipeline` execute branch with
+ * injected collaborators, asserting the dual alarm (passive `recordTaskOutcome` + active one-shot
+ * dispatcher) end-to-end. The WAL is a temp-dir fixture; the alarm dispatcher is a spy.
+ */
+test.describe('orchestrator/scheduling/embedDrainLivenessWatchdog — pipeline integration (#13551)', () => {
+    let walDir;
+
+    test.beforeEach(async () => {
+        walDir = await mkdtemp(path.join(os.tmpdir(), 'neo-embed-drain-watchdog-pipeline-'));
+    });
+
+    test.afterEach(async () => {
+        await rm(walDir, {recursive: true, force: true});
+    });
+
+    /** Minimal task-state service with a single live envelope for the watchdog lane. */
+    function makeTaskStateService(initialLaneState = {}) {
+        const taskState = {'embed-drain-liveness-watchdog': {running: false, lastRunAt: 0, ...initialLaneState}};
+        return {
+            taskState,
+            getState() { return taskState; },
+            getTaskState(name) { return taskState[name]; },
+            markStarted(name) { taskState[name].running = true; taskState[name].lastRunAt = Date.now(); },
+            markCompleted(name) { taskState[name].running = false; },
+            markFailed(name) { taskState[name].running = false; }
+        };
+    }
+
+    function makeServices({taskStateService, outcomes, dispatcher}) {
+        return {
+            healthService: {
+                recordTaskOutcome(taskName, status, details) { outcomes.push({taskName, status, details}); }
+            },
+            maintenanceBackpressureService: {
+                getActiveHeavyMaintenanceTask() { return null; },
+                isHeavyMaintenanceTask() { return false; },
+                isHeavyMaintenanceConflict() { return false; },
+                recordDeferral() {}
+            },
+            taskStateService,
+            embedDrainLivenessAlarmDispatcher: dispatcher
+        };
+    }
+
+    function makeRuntime(overrides = {}) {
+        return {
+            embedDrainLivenessWatchdogWalDir      : walDir,
+            embedDrainLivenessWatchdogThresholdMs : 6 * HOUR_MS,
+            embedDrainLivenessWatchdogAlarmEnabled: true,
+            writeLog                              : () => {},
+            ...overrides
+        };
+    }
+
+    /** Runs exactly the watchdog lane through the pipeline (it is the only due candidate). */
+    async function runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime}) {
+        const context = buildSchedulingContext({
+            db       : {},
+            state    : taskStateService.getState(),
+            now      : Date.now(),
+            // Only the watchdog cadence is enabled; force it due via a huge elapsed window.
+            intervals: {embedDrainLivenessWatchdogCheck: 1},
+            enables  : {},
+            hooks    : {}
+        });
+
+        runSchedulingPipeline({
+            registry: [
+                (await import('../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs')).TASK_REGISTRY
+                    .find(d => d.taskName === 'embed-drain-liveness-watchdog')
+            ],
+            context,
+            services: makeServices({taskStateService, outcomes, dispatcher}),
+            runtime
+        });
+
+        // The execute branch is async; allow its microtasks to settle.
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+
+    test('(c) a stalled backlog records a failed outcome AND fires the one-shot alarm', async () => {
+        const now = Date.now();
+        await appendWalMemory(record('m-stale', now - 8 * HOUR_MS), {dir: walDir}); // 8h > 6h threshold
+
+        const outcomes = [];
+        const alarmCalls = [];
+        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime: makeRuntime()});
+
+        const failed = outcomes.find(o => o.status === 'failed');
+        expect(failed, 'a failed outcome was recorded').toBeTruthy();
+        expect(failed.details.pendingCount).toBe(1);
+        expect(failed.details.ageMs).toBeGreaterThanOrEqual(8 * HOUR_MS);
+
+        expect(alarmCalls).toHaveLength(1);
+        expect(alarmCalls[0].pendingCount).toBe(1);
+        expect(alarmCalls[0].thresholdMs).toBe(6 * HOUR_MS);
+        expect(typeof alarmCalls[0].stalledSince).toBe('number');
+
+        // Latch is set so a subsequent stalled check will not re-alarm.
+        expect(taskStateService.getTaskState('embed-drain-liveness-watchdog').embedDrainAlarm.alarmed).toBe(true);
+    });
+
+    test('(d) a fresh backlog records a completed outcome and fires NO alarm', async () => {
+        const now = Date.now();
+        await appendWalMemory(record('m-fresh', now - 1 * HOUR_MS), {dir: walDir}); // 1h < 6h threshold
+
+        const outcomes = [];
+        const alarmCalls = [];
+        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime: makeRuntime()});
+
+        expect(outcomes.some(o => o.status === 'completed')).toBe(true);
+        expect(outcomes.some(o => o.status === 'failed')).toBe(false);
+        expect(alarmCalls).toHaveLength(0);
+        expect(taskStateService.getTaskState('embed-drain-liveness-watchdog').embedDrainAlarm).toEqual({alarmed: false, stalledSince: null});
+    });
+
+    test('(e) consecutive stalled checks fire the alarm exactly once until a healthy check resets it', async () => {
+        const now = Date.now();
+        await appendWalMemory(record('m-stale', now - 9 * HOUR_MS), {dir: walDir});
+
+        const outcomes = [];
+        const alarmCalls = [];
+        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+        const runtime = makeRuntime();
+
+        // Two consecutive stalled checks → ONE alarm (one-shot latch).
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
+        expect(alarmCalls).toHaveLength(1);
+
+        // Drain recovers: empty the backlog → healthy check clears the latch (no new alarm).
+        await rm(walDir, {recursive: true, force: true});
+        walDir = await mkdtemp(path.join(os.tmpdir(), 'neo-embed-drain-watchdog-pipeline-'));
+        const healthyRuntime = makeRuntime();
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime: healthyRuntime});
+        expect(alarmCalls).toHaveLength(1);
+        expect(taskStateService.getTaskState('embed-drain-liveness-watchdog').embedDrainAlarm.alarmed).toBe(false);
+
+        // A NEW stall re-alarms (latch was cleared by the healthy check).
+        await appendWalMemory(record('m-stale-2', Date.now() - 9 * HOUR_MS), {dir: walDir});
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime: makeRuntime()});
+        expect(alarmCalls).toHaveLength(2);
+    });
+
+    test('(d/gate) alarm is suppressed when embedDaemonEnabled is false (no local drainer to blame)', async () => {
+        const now = Date.now();
+        await appendWalMemory(record('m-stale', now - 8 * HOUR_MS), {dir: walDir});
+
+        const outcomes = [];
+        const alarmCalls = [];
+        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+
+        await runWatchdogOnce({
+            taskStateService, outcomes, dispatcher,
+            runtime: makeRuntime({embedDrainLivenessWatchdogAlarmEnabled: false})
+        });
+
+        // The passive health record still fires (observability), but the active alarm does not.
+        expect(outcomes.some(o => o.status === 'failed')).toBe(true);
+        expect(alarmCalls).toHaveLength(0);
+    });
+
+    test('(f) a health-service that throws does NOT propagate and fires no alarm', async () => {
+        const now = Date.now();
+        await appendWalMemory(record('m-stale', now - 8 * HOUR_MS), {dir: walDir});
+
+        const alarmCalls = [];
+        const dispatcher = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+
+        const services = {
+            healthService: { recordTaskOutcome() { throw new Error('health record blew up'); } },
+            maintenanceBackpressureService: {
+                getActiveHeavyMaintenanceTask() { return null; },
+                isHeavyMaintenanceTask() { return false; },
+                isHeavyMaintenanceConflict() { return false; },
+                recordDeferral() {}
+            },
+            taskStateService,
+            embedDrainLivenessAlarmDispatcher: dispatcher
+        };
+
+        const context = buildSchedulingContext({
+            db: {}, state: taskStateService.getState(), now: Date.now(),
+            intervals: {embedDrainLivenessWatchdogCheck: 1}, enables: {}, hooks: {}
+        });
+
+        const registry = [
+            (await import('../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs')).TASK_REGISTRY
+                .find(d => d.taskName === 'embed-drain-liveness-watchdog')
+        ];
+
+        // Must not throw, even though recordTaskOutcome throws inside the runner.
+        await expect((async () => {
+            runSchedulingPipeline({registry, context, services, runtime: makeRuntime()});
+            await new Promise(resolve => setTimeout(resolve, 20));
+        })()).resolves.toBeUndefined();
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect} from '@playwright/test';
-import {TASK_REGISTRY} from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
+import {test, expect}                         from '@playwright/test';
+import {TASK_REGISTRY}                        from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
 import {DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES} from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 
 const VALID_EXECUTION_KINDS = ['supervised-child-process', 'service-runner', 'in-process-async', 'local-only-service', 'health-check'];

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/registry.spec.mjs
@@ -2,8 +2,8 @@ import {test, expect} from '@playwright/test';
 import {TASK_REGISTRY} from '../../../../../../../ai/daemons/orchestrator/scheduling/registry.mjs';
 import {DEFAULT_HEAVY_MAINTENANCE_TASK_NAMES} from '../../../../../../../ai/daemons/orchestrator/services/MaintenanceBackpressureService.mjs';
 
-const VALID_EXECUTION_KINDS = ['supervised-child-process', 'service-runner', 'in-process-async', 'local-only-service'];
-const VALID_MAINTENANCE_CLASSES = ['continuous', 'heavy', 'graph-dependent', 'lightweight-signal', 'local-only'];
+const VALID_EXECUTION_KINDS = ['supervised-child-process', 'service-runner', 'in-process-async', 'local-only-service', 'health-check'];
+const VALID_MAINTENANCE_CLASSES = ['continuous', 'heavy', 'graph-dependent', 'lightweight-signal', 'local-only', 'health-monitor'];
 const VALID_BACKPRESSURE = ['none', 'exclusive-heavy', 'after-heavy'];
 
 test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
@@ -45,6 +45,16 @@ test.describe('orchestrator/scheduling/registry (#11862 Sub 18)', () => {
             'primary-dev-sync', 'tenant-repo-sync', 'dream',
             'golden-path', 'swarm-heartbeat'
         ]));
+    });
+
+    test('embed-drain-liveness-watchdog is registered as a read-only, no-backpressure health-check (#13551)', () => {
+        const descriptor = TASK_REGISTRY.find(d => d.taskName === 'embed-drain-liveness-watchdog');
+        expect(descriptor, 'embed-drain-liveness-watchdog is registered').toBeTruthy();
+        expect(descriptor.executionKind).toBe('health-check');
+        expect(descriptor.maintenanceClass).toBe('health-monitor');
+        // Read-only lightweight check: it must never take a heavy lease or be gated by backpressure.
+        expect(descriptor.backpressure).toBe('none');
+        expect(descriptor.dependencies).toEqual([]);
     });
 
     test('cloud-deployable graph lanes are registered once Orchestrator.poll() consumes the registry', () => {


### PR DESCRIPTION
## Summary

Recurrence-guard for the silent embed-drain-death incident (#13495): the orchestrator supervised the embed daemon's *process existence*, but nothing watched drain *progress* — so a dead/stalled drain grew the un-embedded WAL un-reconciled with **no alarm for ~8 days** (semantic recall silently frozen). Process-alive != draining.

This adds a periodic, **read-only**, **never-fail** liveness watchdog as a new orchestrator scheduling lane (`executionKind: 'health-check'`). It computes the age of the oldest un-embedded WAL record via the existing `readPendingWalRecords` primitive and raises a **dual alarm** so a stalled drain surfaces in HOURS, not days.

**Substrate decision (per the ticket's converge-in-design AC):** the orchestrator scheduling pipeline, NOT continuous-task supervision. The embed daemon is *already* process-supervised; what was missing is a progress health-check — the scheduling pipeline (ADR 0014 scheduler-task taxonomy) is the natural host, alongside the other cadence lanes (`swarm-heartbeat`, `dream`, …). It is registered as a task so it gets passive observability "for free", and the `health-check` kind keeps it lease-free / backpressure-free (a read-only check must never queue behind heavy maintenance).

**Alarm = BOTH** (per the ticket):
- **PASSIVE** — `healthService.recordTaskOutcome(taskName, 'failed'|'completed', details)` on every check, by registering as a pipeline task (the established observability surface).
- **ACTIVE, one-shot** — on stall-*onset* only, an `AGENT:*` A2A broadcast (the `KbAlertingService.dispatchA2A` precedent — the durable, swarm- and operator-visible carrier) carrying `{ageMs, pendingCount, thresholdMs, stalledSince}`, plus a best-effort `WakeSubscriptionService.emitHeartbeatPulse` wake nudge. The alarm is **latched**: consecutive stalled checks do NOT re-alarm; a healthy (below-threshold) check clears the latch so a later stall can re-alarm. Heartbeat pulses have no payload column, so A2A is the carrier and the pulse is only the nudge.

**Read-only + never-fail (hard constraints):** the watchdog only READS the WAL — it never touches a record, a marker, or the never-fail `add_memory`/`appendWalMemory` write path. Every leg is wrapped: a WAL-read fault fails *soft* to a zero-backlog reading (a fault must look like "no backlog" → no alarm, never a false stall), and any unexpected error in the runner degrades to "no alarm" and never propagates into the scheduling loop. The active alarm is additionally gated by `embedDaemonEnabled` so a clone with no local drainer never false-alarms on a backlog another host owns.

Resolves #13551

Refs #13495, #13544, #12864

## Deltas

- **`ai/daemons/orchestrator/scheduling/embedDrainLivenessWatchdog.mjs`** (new) — pure + fully injectable: `getEmbedDrainPendingAge({walDir, now, readPending?})` → `{oldestAgeMs, pendingCount, oldestTimestamp}` (the read-only WAL-age read; fails soft on error); `evaluateStallAlarm({oldestAgeMs, pendingCount, thresholdMs, alarmState})` → one-shot latch edge logic (clock-free, pure); `getDueTask({state, now, embedDrainLivenessWatchdogCheckMs})` → cadence trigger (I/O-free, mirrors `swarmHeartbeat.getDueTask`).
- **`ai/daemons/orchestrator/scheduling/registry.mjs`** — registers the `embed-drain-liveness-watchdog` descriptor (`executionKind: 'health-check'`, `maintenanceClass: 'health-monitor'`, `backpressure: 'none'`).
- **`ai/daemons/orchestrator/scheduling/pipeline.mjs`** — adds the `health-check` dispatch branch + `runEmbedDrainLivenessWatchdogTask` (reads age → evaluates latch → records outcome → fires the one-shot alarm gated by `embedDaemonEnabled` → persists the latch on the task-state envelope; fully wrapped so it never throws); wires the cadence/hook/walDir/threshold/alarm-dispatcher through `buildOrchestratorSchedulingOptions`.
- **`ai/daemons/orchestrator/Orchestrator.mjs`** — wires the lane: `embedDrainLivenessWatchdogGetDueTask` hook, `embedDrainLivenessWatchdogWalDir` / `embedDrainLivenessWatchdogThresholdMs` getters (read-only leaf reads off the MC `memoryWal` config — no AiConfig mutation), and the bound `embedDrainLivenessAlarmDispatcher` (the `AGENT:*` A2A broadcast + best-effort wake pulse, each leg independently guarded).
- **`ai/daemons/orchestrator/taskDefinitions.mjs`** — adds the `embed-drain-liveness-watchdog` definition so the lane gets a persisted state envelope (cadence `lastRunAt` + the alarm latch). No child process is ever spawned; the inert `pidFileName`/`expectedCommand` short-circuit process recovery on the missing PID file.
- **`ai/config.template.mjs`** — `orchestrator.intervals.embedDrainLivenessWatchdogCheckMs` (default 1h, env `NEO_ORCHESTRATOR_EMBED_DRAIN_WATCHDOG_INTERVAL_MS`).
- **`ai/mcp/server/memory-core/config.template.mjs`** — `memoryWal.embedDrainStallThresholdMs` (default 6h — conservative, **hours not days**, env `NEO_MEMORY_WAL_EMBED_DRAIN_STALL_THRESHOLD_MS`).
- **Tests** — new `embedDrainLivenessWatchdog.spec.mjs` (20 specs) + updated `registry.spec.mjs` (new lane assertion + extended kind/class enums), `Orchestrator.spec.mjs` (state-envelope key list), `config.template.spec.mjs` + `fixtures/aiConfigDefaults.mjs` (the cadence default dual-site).

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/ test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/test/fixtures/aiConfigDefaults.spec.mjs test/playwright/unit/ai/services/memory-core/helpers/memoryWalStore.spec.mjs`

```
190 passed (2.1s)
```

The new `embedDrainLivenessWatchdog.spec.mjs` (20 specs, injected clock + temp-dir WAL fixtures, NO real daemon/drain spawned) covers every required path:
- **(a)** `getEmbedDrainPendingAge` over a fixture WAL — oldest-age + count; embed-marked records drop out of pending; clean/empty WAL → zero-backlog.
- **(b)** `getDueTask` cadence trip / no-trip / disabled / missing-state.
- **(c)** threshold trip → `'failed'` outcome **AND** one-shot alarm fired (spy), via the real `runSchedulingPipeline`.
- **(d)** below-threshold → `'completed'` outcome, NO alarm; plus the `embedDaemonEnabled=false` gate suppressing the active alarm while keeping the passive record.
- **(e)** one-shot latch: two consecutive stalled checks fire the alarm exactly **once**; a healthy check clears the latch; a NEW stall re-alarms.
- **(f)** a thrown error in the WAL read degrades to a zero-backlog reading (never throws); a health-service that throws inside the runner does NOT propagate and fires no alarm.

`Orchestrator.spec.mjs` runs green except a pre-existing in-file flake at `:656` (`supervises Neural Link Bridge…` #13483) — it fails the same way on clean `dev` (1e563a17d) within the full-file run and passes in isolation; it is unrelated to this change (it exercises the continuous-task `poll()` supervision path, which this PR does not touch). My touched assertion in that file (`:213` state-envelope key list) passes.

## Post-Merge Validation

**Deployment prerequisite — refresh config overlays + restart (per @neo-gpt cycle-2 review).** This PR adds two leaves to tracked templates: `orchestrator.intervals.embedDrainLivenessWatchdogCheckMs` (`ai/config.template.mjs`) and `memoryWal.embedDrainStallThresholdMs` (`ai/mcp/server/memory-core/config.template.mjs`). Live clones run from **gitignored materialized overlays** (`ai/config.mjs`, `ai/mcp/server/memory-core/config.mjs`) that do **not** auto-absorb new template leaves — a stale overlay leaves both leaves `undefined`, so the watchdog cadence never trips and the threshold read is empty (the same stale-overlay class that surfaced as a cryptic MC-wide `reading 'enabled'` crash during this work). After merge, on each clone:

1. **Refresh the overlays:** `node ai/scripts/setup/initServerConfigs.mjs --migrate-config` (the bare command only *warns* on drift; `--migrate-config` rewrites the gitignored overlays — safe, they are untracked).
2. **Restart** the orchestrator (resolves `embedDrainLivenessWatchdogCheckMs` + the MC `memoryWal` threshold at scheduling-init) and the Memory Core server (owner of the `memoryWal` overlay). Config leaves are resolved at process boot, not live-per-read, so the new cadence/threshold go live only after restart.

Validation steps once the overlays are refreshed + processes restarted:

- [ ] On the drainer clone, after a deliberately stopped embed daemon, confirm a `failed` `embed-drain-liveness-watchdog` health record appears within `embedDrainLivenessWatchdogCheckMs` once the oldest pending record crosses `embedDrainStallThresholdMs`, and exactly ONE `AGENT:*` stall-alarm A2A is broadcast (no re-alarm storm on subsequent checks).
- [ ] After the drain recovers and the backlog clears, confirm the next check records `completed` and the latch resets (a later stall can re-alarm).
- [ ] Confirm a clone with `embedDaemonEnabled=false` records the passive health outcome but does NOT broadcast the active alarm.
- [ ] Confirm `add_memory` latency/behavior is unchanged — the watchdog is read-only and must never touch the write path.

## Risk

Low. The lane is read-only and never-fail by construction (every leg wrapped; a fault degrades to "no alarm", never to a write failure or a broken scheduling loop), takes no maintenance lease, and adds negligible load (hourly check, far below the 6h threshold). The active alarm is gated by `embedDaemonEnabled` so non-drainer clones never false-alarm. Defaults are conservative (1h cadence / 6h threshold) and fully env-overridable; `<= 0` disables either knob.

---

Authored by Vega (Claude Opus 4.8, Claude Code). Session 64ee317e-53b6-4f76-8241-f4eade1c084d.
