### PR TITLE
docs(agentos): compact stacked PR readiness guard (#13528)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -115,13 +115,10 @@ Do not search for a blocker to justify stopping; if the active lane exposes a
 real system defect, file or route the bug ticket, then continue lane selection.
 
 **PR-State Freshness Gate:** any `lane-state:`, A2A broadcast, or report that names a PR's
-review/merge status MUST be preceded by a live `gh pr view <N> --json state,mergedAt` read —
-the triggering signal (A2A, wake, comment) is a recovery hint, NOT the work gate. Under
-merge-on-approval, signals go stale in seconds: reporting an already-MERGED PR as
-awaiting operator merge broadcasts a false board to the whole swarm (empirical:
-PR `#12950`'s `[merge-eligible]` landed 15s post-merge; PR `#12956`'s approval
-relay missed the merge by seconds — both operator-flagged 2026-06-12). Rule
-detail + verdict-not-enum companion: `pr-review-guide.md §10.1`.
+review/merge status MUST first run live `gh pr view <N> --json state,mergedAt,baseRefName`;
+wakes are hints, not cache. For stacked PRs, also name base readiness; a dirty/stale
+base is routable, not `human-gate` / `verified-empty`. Relay the review body's §9 verdict,
+not the flattened enum.
 
 ## 2.5. Mandatory `lane-state:` Declaration at Every Lifecycle Boundary
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -241,7 +241,7 @@ Reviewers MUST verify testing claims and canonical file placement:
 
 ### 7.6 CI / Security Checks Audit
 
-Formal reviews assume CI is already green. Verify the current PR check state before `manage_pr_review`; if checks are pending, missing, or failing, stop and send a compact CI deferral instead of a full review. Load `.agents/skills/pr-review/audits/ci-security-audit.md` only for security-sensitive changes or ambiguous/failing check surfaces.
+Formal reviews assume green current-head CI. Verify it before `manage_pr_review`; if checks are pending, missing, or failing, send a compact CI deferral instead of a full review. For stacked PRs (`baseRefName` not `dev` / default), approval/merge-ready wording also names base state + retarget/full-CI status; child-green alone is delta evidence. Load `.agents/skills/pr-review/audits/ci-security-audit.md` only for security-sensitive changes or ambiguous/failing check surfaces.
 
 ### 7.7 Anti-Patterns
 

--- a/.agents/skills/pull-request/references/ci-green-review-routing.md
+++ b/.agents/skills/pull-request/references/ci-green-review-routing.md
@@ -20,7 +20,7 @@ gh pr checks <PR_NUMBER>
 
 Use an equivalent read-only GitHub status surface only if `gh pr checks` is unavailable, and state that substitution explicitly in the PR/A2A handoff. Re-run the check after any new push before requesting review or re-review.
 
-Treat the check as bound to the current PR head. If you leave the author lane to review a peer PR while CI runs, re-check your own PR afterward rather than relying on the earlier result.
+Treat the check as current-head scoped. Re-check after peer work; for stacked PRs (`baseRefName` not `dev` / default), green means delta evidence and the handoff names base PR / merge order / retarget-CI state.
 
 ## 3. Outcome Branches
 


### PR DESCRIPTION
Resolves #13528

Compacts the stacked-PR readiness guard into the existing lifecycle wording instead of reintroducing the closed #13529 Atlas-payload shape. Author routing now treats green checks on stacked PRs as delta evidence until base/retarget state is named; reviewer approval wording must name base state + retarget/full-CI status; post-review pickup cannot classify a dirty/stale stacked base as human-gate or verified-empty.

Evidence: L1 (static Agent OS workflow substrate validation) -> L1 required (#13528 workflow ACs). Residual: none.

## Deltas from ticket
- Successor to the closed-unmerged #13529: no new payload, no new skill file, no broad trigger fanout.
- Net skill Markdown size decreases across the touched surfaces (`wc -c`: 82,361 -> 82,247 bytes for the four audited lifecycle files).
- Removed older verbose freshness examples while adding the stacked-base readiness clause, keeping the guard compact.

## Slot Rationale / Turn Memory Pre-Flight
- Source ticket has a Contract Ledger matrix.
- Always-loaded routers are unchanged.
- Modified workflow-map sections use `rewrite` / `retire` disposition: they replace existing readiness prose rather than adding a new rule body.
- Trigger-frequency: edge-case (stacked PRs); failure-severity: high (false merge-readiness / review-liveness drift); enforceability: discipline-only until recurrence justifies a mechanical helper.
- Decision Record impact: none.

## Test Evidence
- `git diff --check` -> pass.
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` -> pass.
- `node ai/scripts/lint/lint-agents.mjs` -> pass.
- Pre-commit hook ran `node ./buildScripts/util/check-whitespace.mjs` -> pass.
- No Playwright run: markdown-only Agent OS workflow substrate.

## Post-Merge Validation
- [ ] On the next stacked PR, author/reviewer handoff names base PR readiness and retarget/full-CI status.
- [ ] `post-review-pickup` lane-state does not claim `human-gate` / `verified-empty` when a dirty or stale base PR is the next routable transition.

## Commits
- `2ce83d3df` — `docs(agentos): compact stacked PR readiness guard (#13528)`

## Evolution
#13529 proved the failure mode but was closed unmerged because it added another workflow book (+4.7KB). This PR keeps the useful invariant while net-reducing the loaded skill substrate.

Related: #13522, #13517, #13527, #13498, #13289

Authored by Euclid (GPT-5, Codex Desktop). Session c3a6e312-b858-4be4-ad97-9bc55cbad5ae.