### PR TITLE
feat(build): check-block-alignment lint + --fix for import-from alignment (#13556)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -122,18 +122,26 @@ const
     fix   = args.includes('--fix'),
     files = args.filter(arg => arg !== '--fix');
 
-let drift = false;
+let
+    hadDrift = false,
+    hadError = false;
+
 for (const file of files) {
     try {
-        if (processFile(file, fix)) drift = true;
+        if (processFile(file, fix)) hadDrift = true;
     } catch (err) {
-        console.error(`Error processing ${file}:`, err.message);
-        drift = true;
+        console.error(`Error processing ${file}: ${err.message}`);
+        hadError = true;
     }
 }
 
-// In check mode, drift is a failure; in fix mode the drift was repaired, so exit clean.
-if (drift && !fix) {
+// A file that could NOT be processed (missing, unreadable, unwritable) is always a failure — including
+// under --fix, where a silent exit 0 would mask a repair that never happened. Alignment drift, by
+// contrast, fails only in check mode: --fix repairs it, so a clean repair exits 0.
+if (hadDrift && !fix) {
     console.error('\nBlock-alignment drift found. Run: node buildScripts/util/check-block-alignment.mjs --fix <files>');
+}
+
+if (hadError || (hadDrift && !fix)) {
     process.exit(1);
 }

--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -1,0 +1,139 @@
+import fs from 'fs';
+
+/**
+ * @module buildScripts/util/check-block-alignment
+ * @summary Lint (with `--fix`) that enforces Neo's aligned-block house style mechanically, so neither
+ * a human nor a frontier model has to hand-count alignment padding (the negative-ROI, mis-count-prone
+ * task that motivated this gate).
+ *
+ * **v1 scope: import-`from` alignment.** Within a run of consecutive single-line `import … from …`
+ * statements, the `from` keyword aligns to one shared column = the widest `import <clause>` in the run
+ * + one space. Object-literal colon alignment and `=`-declaration-block alignment are documented
+ * fast-follows (the `=` convention differs by tree — deferred as a documented follow-up).
+ *
+ * The column math is computed, never eyeballed — that is the entire point of the gate.
+ *
+ * Usage:
+ *   node buildScripts/util/check-block-alignment.mjs <file.mjs> [...]       # check; exit 1 on drift
+ *   node buildScripts/util/check-block-alignment.mjs --fix <file.mjs> [...] # rewrite to aligned form
+ *
+ * Multi-line imports (`import {\n  a\n} from …`) and lone single imports are intentionally NOT grouped
+ * in v1: a run is ≥ 2 consecutive single-line imports, so the gate never touches an un-alignable shape.
+ */
+
+/** Matches a single-line import that carries both a clause and a `from` source on one line. */
+const SINGLE_LINE_IMPORT = /^import\s+(.*?)\s+from\s+(.+)$/;
+const IMPORT_PREFIX       = 'import ';
+
+/**
+ * @summary Splits a file's lines into maximal runs of consecutive single-line imports, returning the
+ * parsed `{lineIndex, clause, source}` for each member. Any non-matching line (blank, comment,
+ * multi-line-import fragment, side-effect import) ends the current run.
+ * @param {String[]} lines
+ * @returns {Array<Array<{lineIndex: Number, clause: String, source: String}>>} runs of length ≥ 1
+ */
+function collectImportRuns(lines) {
+    const runs    = [];
+    let   current = [];
+
+    lines.forEach((line, lineIndex) => {
+        const match = line.match(SINGLE_LINE_IMPORT);
+        if (match) {
+            current.push({lineIndex, clause: match[1], source: match[2]});
+        } else if (current.length > 0) {
+            runs.push(current);
+            current = [];
+        }
+    });
+
+    if (current.length > 0) runs.push(current);
+
+    return runs;
+}
+
+/**
+ * @summary The aligned form of a single import line: the clause padded so `from` sits at `fromColumn`.
+ * @param {{clause: String, source: String}} entry
+ * @param {Number} fromColumn 0-based column where `from` must start.
+ * @returns {String}
+ */
+function alignedImportLine({clause, source}, fromColumn) {
+    const padding = ' '.repeat(fromColumn - (IMPORT_PREFIX.length + clause.length));
+    return `${IMPORT_PREFIX}${clause}${padding}from ${source}`;
+}
+
+/**
+ * @summary Evaluates a file for import-`from` alignment drift. Pure: returns the misaligned lines and
+ * the would-be-fixed line array, mutating nothing.
+ * @param {String[]} lines
+ * @returns {{violations: Array<{lineIndex: Number, expectedColumn: Number}>, fixedLines: String[]}}
+ */
+function evaluateImportAlignment(lines) {
+    const
+        violations = [],
+        fixedLines = lines.slice();
+
+    for (const run of collectImportRuns(lines)) {
+        if (run.length < 2) continue; // a lone import is not an alignment group
+
+        // The `from` column = widest `import <clause>` in the run + one space.
+        const fromColumn = Math.max(...run.map(entry => IMPORT_PREFIX.length + entry.clause.length)) + 1;
+
+        for (const entry of run) {
+            const expected = alignedImportLine(entry, fromColumn);
+            if (expected !== lines[entry.lineIndex]) {
+                violations.push({lineIndex: entry.lineIndex, expectedColumn: fromColumn});
+                fixedLines[entry.lineIndex] = expected;
+            }
+        }
+    }
+
+    return {violations, fixedLines};
+}
+
+/**
+ * @summary Checks (or, with `fix`, rewrites) one file's import-`from` alignment.
+ * @param {String}  file
+ * @param {Boolean} fix
+ * @returns {Boolean} whether the file had (in check mode) or had-and-fixed (in fix mode) drift.
+ */
+function processFile(file, fix) {
+    const
+        content = fs.readFileSync(file, 'utf8'),
+        lines   = content.split('\n'),
+        {violations, fixedLines} = evaluateImportAlignment(lines);
+
+    if (violations.length === 0) return false;
+
+    if (fix) {
+        fs.writeFileSync(file, fixedLines.join('\n'), 'utf8');
+        console.log(`Aligned ${violations.length} import line(s) in ${file}`);
+    } else {
+        for (const {lineIndex, expectedColumn} of violations) {
+            console.error(`Misaligned import 'from' in ${file}:${lineIndex + 1} — expected 'from' at column ${expectedColumn + 1}`);
+        }
+    }
+
+    return true;
+}
+
+const
+    args  = process.argv.slice(2),
+    fix   = args.includes('--fix'),
+    files = args.filter(arg => arg !== '--fix');
+
+let drift = false;
+for (const file of files) {
+    try {
+        if (processFile(file, fix)) drift = true;
+    } catch (err) {
+        console.error(`Error processing ${file}:`, err.message);
+        drift = true;
+    }
+}
+
+// In check mode, drift is a failure; in fix mode the drift was repaired, so exit clean.
+if (drift && !fix) {
+    console.error('\nBlock-alignment drift found. Run: node buildScripts/util/check-block-alignment.mjs --fix <files>');
+    process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -232,7 +232,8 @@
         "*.mjs": [
             "node ./buildScripts/util/check-shorthand.mjs",
             "node ./buildScripts/util/check-jsdoc-types.mjs",
-            "node ./buildScripts/util/check-ticket-archaeology.mjs"
+            "node ./buildScripts/util/check-ticket-archaeology.mjs",
+            "node ./buildScripts/util/check-block-alignment.mjs"
         ],
         "test/**/*.mjs": [
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs"

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -1,0 +1,89 @@
+import {test, expect}  from '@playwright/test';
+import {execSync}      from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    scriptPath = path.resolve(__dirname, '../../../../../../buildScripts/util/check-block-alignment.mjs');
+
+/**
+ * check-block-alignment.mjs — the lint that mechanizes Neo's import-`from` alignment so it is
+ * never hand-counted. Coverage is constructed WITHOUT any hand-aligned fixture (the exact error class
+ * this gate removes): the misaligned input is trivial to write, the aligned form is DERIVED via `--fix`,
+ * and the false-positive guards use ungrouped inputs that pass regardless of spacing.
+ */
+test.describe('check-block-alignment.mjs (#13556)', () => {
+    let tempDir;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-block-align-'));
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, {recursive: true, force: true});
+    });
+
+    const write = (name, content) => {
+        const filePath = path.join(tempDir, name);
+        fs.writeFileSync(filePath, content, 'utf8');
+        return filePath;
+    };
+
+    const run = (args) => {
+        try {
+            return {status: 0, output: execSync(`node ${scriptPath} ${args}`, {encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    const MISALIGNED = [
+        "import {a}        from './a.mjs';",
+        "import {bb, ccc} from './b.mjs';",
+        "import x          from './x.mjs';"
+    ].join('\n');
+
+    test('flags a misaligned import-from group with a file:line + expected-column diagnostic (exit 1)', () => {
+        const file             = write('m.mjs', MISALIGNED);
+        const {status, output} = run(file);
+
+        expect(status).toBe(1);
+        expect(output).toContain('Misaligned import');
+        expect(output).toMatch(/m\.mjs:1/);
+        expect(output).toMatch(/expected 'from' at column \d+/);
+    });
+
+    test('--fix aligns the group to one shared from-column and is idempotent', () => {
+        const file = write('m.mjs', MISALIGNED);
+
+        expect(run(`--fix ${file}`).status).toBe(0);
+
+        const
+            fixedLines = fs.readFileSync(file, 'utf8').split('\n').filter(line => line.startsWith('import')),
+            fromCols   = fixedLines.map(line => line.indexOf('from'));
+
+        expect(new Set(fromCols).size).toBe(1);        // every 'from' shares one column
+        expect(run(file).status).toBe(0);              // re-check passes — aligned file is clean
+        expect(run(`--fix ${file}`).status).toBe(0);   // idempotent — a second --fix changes nothing harmful
+    });
+
+    test('a lone single import is not a group — passes regardless of its spacing', () => {
+        const file = write('m.mjs', "import {something}        from './x.mjs';\n\nconst y = 1;\n");
+        expect(run(file).status).toBe(0);
+    });
+
+    test('multi-line imports break the run and are never aligned (no false positive)', () => {
+        const file = write('m.mjs', [
+            "import {",
+            "    alpha,",
+            "    beta",
+            "} from './ab.mjs';",
+            "import x from './x.mjs';"
+        ].join('\n'));
+        expect(run(file).status).toBe(0);
+    });
+});

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}  from '@playwright/test';
-import {execSync}      from 'node:child_process';
+import {execFileSync}  from 'node:child_process';
 import fs              from 'node:fs';
 import os              from 'node:os';
 import path            from 'node:path';
@@ -33,9 +33,11 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
         return filePath;
     };
 
-    const run = (args) => {
+    // execFileSync (not execSync): node is spawned directly with an argv array — no shell, so the
+    // absolute scriptPath + file args can never be interpolated into a shell command (CodeQL-clean).
+    const run = (...args) => {
         try {
-            return {status: 0, output: execSync(`node ${scriptPath} ${args}`, {encoding: 'utf8', stdio: 'pipe'})};
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {encoding: 'utf8', stdio: 'pipe'})};
         } catch (error) {
             return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
         }
@@ -60,7 +62,7 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
     test('--fix aligns the group to one shared from-column and is idempotent', () => {
         const file = write('m.mjs', MISALIGNED);
 
-        expect(run(`--fix ${file}`).status).toBe(0);
+        expect(run('--fix', file).status).toBe(0);
 
         const
             fixedLines = fs.readFileSync(file, 'utf8').split('\n').filter(line => line.startsWith('import')),
@@ -68,7 +70,7 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
 
         expect(new Set(fromCols).size).toBe(1);        // every 'from' shares one column
         expect(run(file).status).toBe(0);              // re-check passes — aligned file is clean
-        expect(run(`--fix ${file}`).status).toBe(0);   // idempotent — a second --fix changes nothing harmful
+        expect(run('--fix', file).status).toBe(0);   // idempotent — a second --fix changes nothing harmful
     });
 
     test('a lone single import is not a group — passes regardless of its spacing', () => {
@@ -92,7 +94,7 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
         // repair that never happened. An unprocessable (missing) file must fail in BOTH modes.
         const missing = path.join(tempDir, 'does-not-exist.mjs');
 
-        const fixResult = run(`--fix ${missing}`);
+        const fixResult = run('--fix', missing);
         expect(fixResult.status).toBe(1);
         expect(fixResult.output).toContain('Error processing');
 

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -86,4 +86,16 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
         ].join('\n'));
         expect(run(file).status).toBe(0);
     });
+
+    test('a file that cannot be processed fails (exit 1) even under --fix — no silent exit 0', () => {
+        // Guards the cycle-1 review bug: --fix swallowed a file-processing error and exited 0, masking a
+        // repair that never happened. An unprocessable (missing) file must fail in BOTH modes.
+        const missing = path.join(tempDir, 'does-not-exist.mjs');
+
+        const fixResult = run(`--fix ${missing}`);
+        expect(fixResult.status).toBe(1);
+        expect(fixResult.output).toContain('Error processing');
+
+        expect(run(missing).status).toBe(1); // check mode also fails
+    });
 });


### PR DESCRIPTION
## Summary

Mechanizes Neo's import-`from` alignment as a lint + `--fix`, so it is **never hand-counted** — the negative-ROI, mis-count-prone task @tobiu flagged after a build agent AND two reviewer hand-passes each got #13553's alignment wrong (and the lint then caught a **third**: this PR's own test imports). The column is computed deterministically (widest `import <clause>` + one space); humans/agents never count padding again.

v1 scope = import-`from`. Object-literal colon + `=`-declaration-block alignment are documented fast-follows (the `=` convention differs by tree — see the ticket's Open Question).

Resolves #13556
Refs #13553

## Deltas

- **`buildScripts/util/check-block-alignment.mjs`** (new) — **check** mode (exit 1 + `file:line` + expected column) and **`--fix`** (rewrites to the aligned form). A group = a run of **≥ 2 consecutive single-line imports**; lone imports and multi-line imports are never touched, so the gate cannot false-positive on an un-alignable shape. Pure/injectable column math.
- **`package.json`** — wired into the lint-staged `*.mjs` gate alongside `check-shorthand` / `check-jsdoc-types` / `check-ticket-archaeology`.
- **`test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs`** (new) — 4 specs (flag-misaligned / `--fix`-aligns-idempotently / lone-import-skipped / multi-line-skipped). Constructed with **no hand-aligned fixture** — the aligned form is derived via `--fix`.

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs`

```
5 passed (708ms)
```

**Cycle-1 (GPT) addressed in `95c22d894`:** `--fix` swallowed a file-processing error and exited 0 (falsifier: `--fix` on a missing file printed ENOENT yet `exit=0`). Split `hadError` (unprocessable file — fails in ANY mode) from `hadDrift` (alignment diff — fails only in check mode, since `--fix` repairs it); added a spec covering the missing-file/`--fix` path. Verified: `--fix /tmp/missing` now `exit=1`; `--fix` on a real misaligned file still `exit=0`.

**Cycle-2 (CodeQL) addressed in `68b075efa`:** a code-scanning alert (`github-advanced-security`) flagged the spec's `execSync` as a shell command built from an uncontrolled absolute path. Switched to `execFileSync('node', [scriptPath, ...args])` — node is spawned directly with an argv array, no shell, so neither the path nor the file args can be interpolated into a shell command. Import block re-aligned for the new clause width (self-verified by the lint). 5 specs still green.

Dogfood: the lint flagged + `--fix`ed this PR's own test-import lines, and the lint-staged gate it adds ran clean on the new files at commit-time. Run against #13553's branch it correctly flags the imports the build agent + my hand-passes mis-aligned (`pipeline.mjs:1-2` → col 54; `spec:1-4` → col 23, where a hand-pass had over-padded to 25).

## Post-Merge Validation

- [ ] **v1b fast-follow:** object-literal colon + `=`-declaration-block alignment (the `=` convention differs `ai/daemons` vs `src/` — needs a house decision per the ticket Open Question). Once v1b lands, a full `--fix` pass cleans #13553's remaining (object / `=`) alignment drift in one shot.
- [ ] Optional: a swarm-wide `--fix` sweep over changed surfaces (the check runs on changed files only by design).

## Risk

Low. Pure dev-tooling lint. Check-mode blocks on drift with a clear `--fix` hint; `--fix` is idempotent; groups never include un-alignable shapes (lone / multi-line imports) so no false positives; no runtime/app surface touched. Net-reduces recurring formatting-correction friction (Substrate-Accretion-Defense satisfied).

---

Authored by Vega (Claude Opus 4.8, Claude Code). Session 64ee317e-53b6-4f76-8241-f4eade1c084d.
