### PR TITLE
fix(memory-core): add Chroma vector coverage audit (#13503)

### DIFF
--- a/ai/scripts/maintenance/checkChromaIntegrity.mjs
+++ b/ai/scripts/maintenance/checkChromaIntegrity.mjs
@@ -37,6 +37,10 @@ const execFileAsync = promisify(execFile);
 void Neo;
 
 export const DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE = 5;
+export const DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE                = 5;
+
+const METADATA_SEGMENT_SCOPE = 'METADATA',
+      VECTOR_SEGMENT_SCOPE   = 'VECTOR';
 
 registerNeoChromaEmbeddingFunctions({
     dummyEmbeddingFunction: AiConfig.dummyEmbeddingFunction
@@ -95,6 +99,15 @@ export function countFailedApiSteps(collectionResults = []) {
     return collectionResults.reduce((count, collection) => {
         return count + (collection.steps || []).filter(step => step.ok === false).length
     }, 0)
+}
+
+/**
+ * @summary Counts vector-coverage rows which found metadata/vector drift or missing vector metadata.
+ * @param {Object[]} coverageResults
+ * @returns {Number}
+ */
+export function countFailedCoverageRows(coverageResults = []) {
+    return coverageResults.filter(row => row.ok === false).length
 }
 
 /**
@@ -181,6 +194,291 @@ export function normalizeExportabilitySampleSize(value) {
     }
 
     return Math.floor(parsed)
+}
+
+/**
+ * @summary Normalizes the bounded sample size for metadata/vector coverage drift previews.
+ * @param {*} value
+ * @returns {Number}
+ */
+export function normalizeVectorCoverageSampleSize(value) {
+    const parsed = Number(value);
+
+    if (!Number.isFinite(parsed) || parsed < 1) {
+        return DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE
+    }
+
+    return Math.floor(parsed)
+}
+
+/**
+ * @summary Parses sqlite3's JSON projection into a stable array.
+ * @param {String} stdout
+ * @returns {Object[]}
+ */
+export function parseSqliteJsonRows(stdout) {
+    const trimmed = String(stdout || '').trim();
+
+    if (!trimmed) {
+        return []
+    }
+
+    return JSON.parse(trimmed)
+}
+
+/**
+ * @summary Reads configured collection rows and their metadata/vector segment ids from a SQLite snapshot.
+ * @param {Object} options
+ * @param {String} options.snapshotPath
+ * @param {String[]} [options.collectionNames=[]]
+ * @param {Function} [options.execFn=execFileAsync]
+ * @returns {Promise<Object[]>}
+ */
+export async function readCollectionSegmentRows({
+    snapshotPath,
+    collectionNames = [],
+    execFn          = execFileAsync
+} = {}) {
+    const sql = `
+        select
+            c.name        as collectionName,
+            c.id          as collectionId,
+            c.database_id as databaseId,
+            c.dimension   as dimension,
+            ms.id         as metadataSegmentId,
+            vs.id         as vectorSegmentId
+        from collections c
+        left join segments ms
+            on ms.collection = c.id
+            and ms.scope = '${METADATA_SEGMENT_SCOPE}'
+        left join segments vs
+            on vs.collection = c.id
+            and vs.scope = '${VECTOR_SEGMENT_SCOPE}'
+        order by c.name, c.id
+    `;
+
+    const {stdout} = await execFn('sqlite3', ['-json', snapshotPath, sql], {
+        maxBuffer: 64 * 1024 * 1024
+    });
+
+    const names = new Set(collectionNames.filter(Boolean));
+
+    return parseSqliteJsonRows(stdout)
+        .filter(row => !names.size || names.has(row.collectionName))
+}
+
+/**
+ * @summary Reads all metadata-row ids for one Chroma metadata segment from a SQLite snapshot.
+ * @param {Object} options
+ * @param {String} options.snapshotPath
+ * @param {String} options.metadataSegmentId
+ * @param {Function} [options.execFn=execFileAsync]
+ * @returns {Promise<String[]>}
+ */
+export async function readMetadataEmbeddingIds({
+    snapshotPath,
+    metadataSegmentId,
+    execFn = execFileAsync
+} = {}) {
+    if (!metadataSegmentId) {
+        return []
+    }
+
+    const sql = `
+        select embedding_id as id
+        from embeddings
+        where segment_id = '${String(metadataSegmentId).replaceAll("'", "''")}'
+        order by embedding_id
+    `;
+
+    const {stdout} = await execFn('sqlite3', ['-json', snapshotPath, sql], {
+        maxBuffer: 128 * 1024 * 1024
+    });
+
+    return parseSqliteJsonRows(stdout).map(row => row.id)
+}
+
+/**
+ * @summary Reads Chroma's persisted HNSW id map from `index_metadata.pickle` for one vector segment.
+ * @param {Object} options
+ * @param {String} options.persistDir
+ * @param {String} options.vectorSegmentId
+ * @param {Function} [options.execFn=execFileAsync]
+ * @param {Object} [options.fsModule=fs]
+ * @returns {Promise<Object>}
+ */
+export async function readVectorIndexIds({
+    persistDir,
+    vectorSegmentId,
+    execFn   = execFileAsync,
+    fsModule = fs
+} = {}) {
+    const metadataPath = vectorSegmentId
+        ? path.join(persistDir, vectorSegmentId, 'index_metadata.pickle')
+        : null;
+
+    if (!metadataPath || !await fsModule.pathExists(metadataPath)) {
+        return {
+            ok   : false,
+            path : metadataPath,
+            ids  : [],
+            error: metadataPath
+                ? `Vector index metadata file not found: ${metadataPath}`
+                : 'Vector segment id missing'
+        }
+    }
+
+    const script = [
+        'import json, pickle, sys',
+        'with open(sys.argv[1], "rb") as handle:',
+        '    data = pickle.load(handle)',
+        'ids = list((data.get("id_to_label") or {}).keys())',
+        'print(json.dumps(ids))'
+    ].join('\n');
+
+    try {
+        const {stdout} = await execFn('python3', ['-c', script, metadataPath], {
+            maxBuffer: 128 * 1024 * 1024
+        });
+
+        return {
+            ok  : true,
+            path: metadataPath,
+            ids : JSON.parse(stdout || '[]')
+        }
+    } catch (error) {
+        return {
+            ok   : false,
+            path : metadataPath,
+            ids  : [],
+            error: error.message
+        }
+    }
+}
+
+/**
+ * @summary Computes exact overlap and drift samples between SQLite metadata ids and HNSW vector ids.
+ * @param {Object} options
+ * @param {String[]} [options.metadataIds=[]]
+ * @param {String[]} [options.vectorIds=[]]
+ * @param {Number} [options.sampleSize=DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE]
+ * @returns {Object}
+ */
+export function compareMetadataToVectorIds({
+    metadataIds = [],
+    vectorIds   = [],
+    sampleSize  = DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE
+} = {}) {
+    const metadataSet = new Set(metadataIds),
+          vectorSet   = new Set(vectorIds),
+          missing     = [],
+          extra       = [];
+
+    let overlapCount = 0;
+
+    for (const id of metadataSet) {
+        if (vectorSet.has(id)) {
+            overlapCount++;
+        } else if (missing.length < sampleSize) {
+            missing.push(id);
+        }
+    }
+
+    for (const id of vectorSet) {
+        if (!metadataSet.has(id) && extra.length < sampleSize) {
+            extra.push(id);
+        }
+    }
+
+    return {
+        metadataRowCount      : metadataSet.size,
+        vectorIndexIdCount    : vectorSet.size,
+        overlapCount,
+        missingFromVectorCount: metadataSet.size - overlapCount,
+        extraInVectorCount    : vectorSet.size - overlapCount,
+        missingFromVectorSample: missing,
+        extraInVectorSample   : extra
+    }
+}
+
+/**
+ * @summary Audits collection-level metadata row coverage against persisted HNSW vector index ids.
+ * @param {Object} options
+ * @param {String} options.snapshotPath
+ * @param {String} options.persistDir
+ * @param {String[]} [options.collectionNames=[]]
+ * @param {Number} [options.sampleSize=DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE]
+ * @param {Function} [options.execFn=execFileAsync]
+ * @param {Object} [options.fsModule=fs]
+ * @returns {Promise<Object>}
+ */
+export async function auditChromaVectorCoverage({
+    snapshotPath,
+    persistDir,
+    collectionNames = [],
+    sampleSize      = DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE,
+    execFn          = execFileAsync,
+    fsModule        = fs
+} = {}) {
+    const rows = await readCollectionSegmentRows({
+              snapshotPath,
+              collectionNames,
+              execFn
+          }),
+          names = rows.reduce((map, row) => {
+              const list = map.get(row.collectionName) || [];
+              list.push(row.collectionId);
+              map.set(row.collectionName, list);
+              return map
+          }, new Map()),
+          duplicateCollectionNames = [...names.entries()]
+              .filter(([, ids]) => ids.length > 1)
+              .map(([name, collectionIds]) => ({name, collectionIds}));
+
+    const duplicateNames = new Set(duplicateCollectionNames.map(entry => entry.name)),
+          collections    = [];
+
+    for (const row of rows) {
+        const metadataIds = await readMetadataEmbeddingIds({
+                  snapshotPath,
+                  metadataSegmentId: row.metadataSegmentId,
+                  execFn
+              }),
+              vectorResult = await readVectorIndexIds({
+                  persistDir,
+                  vectorSegmentId: row.vectorSegmentId,
+                  execFn,
+                  fsModule
+              }),
+              comparison = compareMetadataToVectorIds({
+                  metadataIds,
+                  vectorIds : vectorResult.ids,
+                  sampleSize: normalizeVectorCoverageSampleSize(sampleSize)
+              }),
+              ok = vectorResult.ok &&
+                  comparison.missingFromVectorCount === 0 &&
+                  comparison.extraInVectorCount === 0;
+
+        collections.push({
+            name                   : row.collectionName,
+            collectionId           : row.collectionId,
+            databaseId             : row.databaseId,
+            dimension              : row.dimension,
+            metadataSegmentId      : row.metadataSegmentId,
+            vectorSegmentId        : row.vectorSegmentId,
+            vectorMetadataPath     : vectorResult.path,
+            duplicateCollectionName: duplicateNames.has(row.collectionName),
+            ok,
+            error                  : vectorResult.ok ? null : vectorResult.error,
+            ...comparison
+        });
+    }
+
+    return {
+        collections,
+        failedCollections     : countFailedCoverageRows(collections),
+        duplicateCollectionNames
+    }
 }
 
 /**
@@ -427,6 +725,29 @@ function printHuman(result) {
         console.log(`- ${check.pragma}: ${status}${check.output ? ` (${check.output})` : ''}${check.error ? ` (${check.error})` : ''}`);
     }
 
+    if (result.coverage) {
+        if (result.coverage.error) {
+            console.log(`Chroma vector coverage: failed (${result.coverage.error})`);
+        } else {
+            console.log('Chroma vector coverage:');
+            for (const collection of result.coverage.collections) {
+                const status   = collection.ok ? 'ok' : 'failed',
+                      duplicate = collection.duplicateCollectionName ? ' duplicate-name' : '';
+
+                console.log(`- ${collection.name} [${collection.collectionId}]: ${status}${duplicate} metadata=${collection.metadataRowCount} vector=${collection.vectorIndexIdCount} overlap=${collection.overlapCount} missing=${collection.missingFromVectorCount} extra=${collection.extraInVectorCount}`);
+                if (collection.error) {
+                    console.log(`  - vector metadata: ${collection.error}`);
+                }
+                if (collection.missingFromVectorSample.length) {
+                    console.log(`  - missing sample: ${collection.missingFromVectorSample.join(', ')}`);
+                }
+                if (collection.extraInVectorSample.length) {
+                    console.log(`  - extra sample: ${collection.extraInVectorSample.join(', ')}`);
+                }
+            }
+        }
+    }
+
     if (!result.api) {
         return
     }
@@ -456,6 +777,12 @@ export async function run(argv = process.argv) {
             'Number of ids to sample for stored-embedding exportability probes.',
             String(DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE)
         )
+        .option('--skip-vector-coverage', 'Skip local metadata-vs-vector-index coverage audit.', false)
+        .option(
+            '--vector-coverage-sample-size <count>',
+            'Number of missing/extra ids to preview for vector coverage drift.',
+            String(DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE)
+        )
         .option('--keep-snapshot', 'Keep the copied SQLite snapshot instead of removing the temp dir.', false)
         .option('--json', 'Print machine-readable JSON.', false)
         .parse(argv);
@@ -470,6 +797,7 @@ export async function run(argv = process.argv) {
             snapshotPath: snapshot.snapshotPath,
             checks      : []
         },
+        coverage: null,
         api: null
     };
 
@@ -478,6 +806,21 @@ export async function run(argv = process.argv) {
             pragma,
             ...await runSqlitePragma({snapshotPath: snapshot.snapshotPath, pragma})
         });
+    }
+
+    if (!options.skipVectorCoverage) {
+        try {
+            result.coverage = await auditChromaVectorCoverage({
+                snapshotPath    : snapshot.snapshotPath,
+                persistDir      : path.dirname(sourcePath),
+                collectionNames : resolveCollectionNames(),
+                sampleSize      : normalizeVectorCoverageSampleSize(options.vectorCoverageSampleSize)
+            });
+        } catch (error) {
+            result.coverage = {
+                error: error.message
+            };
+        }
     }
 
     if (!options.skipApi) {
@@ -507,11 +850,12 @@ export async function run(argv = process.argv) {
     }
 
     const sqliteFailed = result.sqlite.checks.some(check => !check.ok),
+          coverageFailed = Boolean(result.coverage?.error || result.coverage?.failedCollections),
           apiFailed    = Boolean(result.api?.error || result.api?.failedSteps);
 
     return {
         result,
-        exitCode: sqliteFailed || apiFailed ? 1 : 0
+        exitCode: sqliteFailed || coverageFailed || apiFailed ? 1 : 0
     }
 }
 

--- a/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
@@ -1,14 +1,25 @@
+import {execFile} from 'child_process';
+import fs         from 'fs-extra';
+import os         from 'os';
+import path       from 'path';
+import {promisify} from 'util';
 import {test, expect} from '@playwright/test';
 import {
+    auditChromaVectorCoverage,
     classifySqliteCheck,
+    compareMetadataToVectorIds,
     countFailedApiSteps,
     DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE,
+    DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE,
     normalizeExportabilitySampleSize,
+    normalizeVectorCoverageSampleSize,
     probeCollection,
     probeStoredEmbeddingExportability,
     resolveCollectionNames,
     resolveSqlitePath
 } from '../../../../../../ai/scripts/maintenance/checkChromaIntegrity.mjs';
+
+const execFileAsync = promisify(execFile);
 
 test.describe('checkChromaIntegrity maintenance helpers', () => {
     test('classifies SQLite pragma output strictly', () => {
@@ -68,6 +79,32 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
         expect(normalizeExportabilitySampleSize('bad')).toBe(
             DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE
         );
+    });
+
+    test('normalizes invalid vector coverage sample sizes to the default', () => {
+        expect(normalizeVectorCoverageSampleSize('2')).toBe(2);
+        expect(normalizeVectorCoverageSampleSize('0')).toBe(
+            DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE
+        );
+        expect(normalizeVectorCoverageSampleSize('bad')).toBe(
+            DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE
+        );
+    });
+
+    test('compares metadata rows to vector index ids with bounded drift samples', () => {
+        expect(compareMetadataToVectorIds({
+            metadataIds: ['a', 'b', 'c', 'd'],
+            vectorIds  : ['a', 'b', 'extra-1', 'extra-2'],
+            sampleSize : 1
+        })).toEqual({
+            metadataRowCount       : 4,
+            vectorIndexIdCount     : 4,
+            overlapCount           : 2,
+            missingFromVectorCount : 2,
+            extraInVectorCount     : 2,
+            missingFromVectorSample: ['c'],
+            extraInVectorSample    : ['extra-1']
+        });
     });
 
     test('reports stored-embedding exportability failures per sampled id', async () => {
@@ -203,5 +240,112 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
             ['stored embedding exportability', false],
             ['query by existing embedding', true]
         ]);
+    });
+
+    test('audits exact vector coverage with duplicate collection rows and missing pickle files', async () => {
+        const tmpDir     = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-chroma-coverage-')),
+              sqlitePath = path.join(tmpDir, 'chroma.sqlite3'),
+              vectorDir  = path.join(tmpDir, 'vec-a'),
+              picklePath = path.join(vectorDir, 'index_metadata.pickle');
+
+        try {
+            await fs.ensureDir(vectorDir);
+
+            await execFileAsync('sqlite3', [sqlitePath, `
+                create table collections (
+                    id text primary key,
+                    name text not null,
+                    dimension integer,
+                    database_id text not null
+                );
+                create table segments (
+                    id text primary key,
+                    type text not null,
+                    scope text not null,
+                    collection text not null
+                );
+                create table embeddings (
+                    id integer primary key,
+                    segment_id text not null,
+                    embedding_id text not null,
+                    seq_id blob not null,
+                    created_at timestamp not null default current_timestamp,
+                    unique(segment_id, embedding_id)
+                );
+                insert into collections (id, name, dimension, database_id) values
+                    ('collection-a', 'neo-native-graph', 4096, 'db-a'),
+                    ('collection-b', 'neo-native-graph', 4096, 'db-b');
+                insert into segments (id, type, scope, collection) values
+                    ('meta-a', 'urn:chroma:segment/metadata/sqlite', 'METADATA', 'collection-a'),
+                    ('vec-a', 'urn:chroma:segment/vector/hnsw-local-persisted', 'VECTOR', 'collection-a'),
+                    ('meta-b', 'urn:chroma:segment/metadata/sqlite', 'METADATA', 'collection-b'),
+                    ('vec-missing', 'urn:chroma:segment/vector/hnsw-local-persisted', 'VECTOR', 'collection-b');
+                insert into embeddings (segment_id, embedding_id, seq_id) values
+                    ('meta-a', 'a', x'01'),
+                    ('meta-a', 'b', x'02'),
+                    ('meta-a', 'c', x'03'),
+                    ('meta-a', 'missing', x'04'),
+                    ('meta-b', 'orphan', x'05');
+            `]);
+
+            const pickleScript = [
+                'import json, pickle, sys',
+                'ids = json.loads(sys.argv[2])',
+                'data = {"id_to_label": {id_: index for index, id_ in enumerate(ids)}}',
+                'with open(sys.argv[1], "wb") as handle:',
+                '    pickle.dump(data, handle)'
+            ].join('\n');
+
+            await execFileAsync('python3', [
+                '-c',
+                pickleScript,
+                picklePath,
+                JSON.stringify(['a', 'b', 'c', 'extra'])
+            ]);
+
+            const result = await auditChromaVectorCoverage({
+                snapshotPath   : sqlitePath,
+                persistDir     : tmpDir,
+                collectionNames: ['neo-native-graph'],
+                sampleSize     : 2
+            });
+
+            expect(result.duplicateCollectionNames).toEqual([{
+                name         : 'neo-native-graph',
+                collectionIds: ['collection-a', 'collection-b']
+            }]);
+            expect(result.failedCollections).toBe(2);
+
+            const primary = result.collections.find(row => row.collectionId === 'collection-a');
+            expect(primary).toMatchObject({
+                name                   : 'neo-native-graph',
+                metadataSegmentId      : 'meta-a',
+                vectorSegmentId        : 'vec-a',
+                duplicateCollectionName: true,
+                ok                     : false,
+                metadataRowCount       : 4,
+                vectorIndexIdCount     : 4,
+                overlapCount           : 3,
+                missingFromVectorCount : 1,
+                extraInVectorCount     : 1,
+                missingFromVectorSample: ['missing'],
+                extraInVectorSample    : ['extra']
+            });
+
+            const missing = result.collections.find(row => row.collectionId === 'collection-b');
+            expect(missing).toMatchObject({
+                duplicateCollectionName: true,
+                ok                     : false,
+                metadataRowCount       : 1,
+                vectorIndexIdCount     : 0,
+                missingFromVectorCount : 1,
+                extraInVectorCount     : 0,
+                missingFromVectorSample: ['orphan'],
+                extraInVectorSample    : []
+            });
+            expect(missing.error).toContain('Vector index metadata file not found');
+        } finally {
+            await fs.remove(tmpDir);
+        }
     });
 });


### PR DESCRIPTION
Resolves #13503

Adds an exact, copy-first Chroma vector coverage audit to `ai/scripts/maintenance/checkChromaIntegrity.mjs`. The diagnostic now joins configured collection metadata rows from the SQLite snapshot to persisted HNSW `index_metadata.pickle` ids, reports overlap/missing/extra counts with bounded samples, and surfaces duplicate same-name collection rows and missing vector metadata files as coverage failures. It stays operator-invoked and outside KB/MC hot healthchecks.

Evidence: L2 (isolated unit fixtures + local read-only smoke) -> L2 required (operator-invoked diagnostic only; no live mutation, daemon topology, or hot path changes). Residual: broader repair/remediation remains in `#13496`.

## Deltas from ticket
Implemented the pickle read through a `python3` subprocess inside the existing maintenance script because Chroma persists `index_metadata.pickle` as Python pickle, while the script remains Node and already shells out for local diagnostic primitives (`sqlite3`). Added `--skip-vector-coverage` and `--vector-coverage-sample-size` so operators can isolate SQLite/API probes when needed.

## Test Evidence
- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` -> 12 passed
- `node ai/scripts/maintenance/checkChromaIntegrity.mjs --skip-api --json` -> exited 1 as expected on the live drifted store; reported exact coverage failures for configured collections, including `neo-knowledge-base` 30466 metadata / 30000 vector / 466 missing and duplicate `neo-native-graph` rows with one missing `index_metadata.pickle`.
- `git diff --check` -> passed
- Pre-push freshness: `merge-base HEAD origin/dev == origin/dev` after rebasing onto `5ba972ed01eebf64d5cec83a26633b3d6aef3a55`.

## Post-Merge Validation
- [ ] Run `node ai/scripts/maintenance/checkChromaIntegrity.mjs --skip-api --json` on the merged `dev` checkout before selecting any `#13496` repair action.

## Commits
- `dbc9846cc` — `fix(memory-core): add Chroma vector coverage audit (#13503)`

Related: #13496
Related: #13501
Related: #13502

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee050-c834-7503-b895-527ad55dd8c5.