### PR TITLE
fix(memory-core): who_is_online roster-liveness + terse output (#13557)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -202,17 +202,18 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: >
-        Reports per-maintainer live availability — "is the agent completing turns right now," not
-        "is the process up." Advisory liveness for review-routing, lane-handoff, lead-baton, and
+        Reports per-maintainer live availability — who is completing turns recently, not whether the
+        process is up. Advisory liveness for review-routing, lane-handoff, lead-baton, and
         wake-targeting: surfaces probably-dark maintainers so a request to a dark agent fails loud
         instead of stalling the merge gate silently.
 
 
-        Layers (precedence): (1) participationStatus hard gate — operator_benched /
-        temporarily_unreachable report offline; (2) add_memory-recency (primary) — the most-recent
-        caller-visible AGENT_MEMORY write within the freshness window means recently active. add_memory
-        is the universal, deployment-agnostic activity write (no harness beacon); the read is RLS-scoped
-        (never cross-tenant) and graph-backed (survives an embed-drain).
+        Terse by default: {summary, online[], idle[], benched[]} (identity arrays). Pass verbose:true
+        for the full per-agent projection + signal description. Signal (precedence): (1) participationStatus
+        hard gate — operator_benched / temporarily_unreachable report offline; (2) add_memory-recency —
+        a rostered agent's most-recent AGENT_MEMORY write within the freshness window means recently
+        active. add_memory is the universal, deployment-agnostic activity write (no harness beacon); the
+        read is roster-scoped and graph-backed (survives an embed-drain).
       tags: [Health]
       requestBody:
         required: false
@@ -224,6 +225,11 @@ paths:
                 family:
                   type: string
                   description: Optional model-family filter (e.g. 'claude', 'gpt').
+                verbose:
+                  type: boolean
+                  description: >
+                    Default false — terse roster summary. true — full per-agent projection
+                    (signalStatus + per-agent reason/signals) for diagnostics.
       responses:
         '200':
           description: Per-maintainer liveness projection.
@@ -231,15 +237,34 @@ paths:
             application/json:
               schema:
                 type: object
+                description: >
+                  Terse default: {generatedAt, summary, online[], idle[], benched[]}. With verbose:true:
+                  {generatedAt, signalStatus, agents[]}.
                 properties:
                   generatedAt:
                     type: string
                     description: ISO timestamp the projection was computed at.
+                  summary:
+                    type: string
+                    description: Terse default — e.g. "3 online · 7 idle · 2 benched".
+                  online:
+                    type: array
+                    items: {type: string}
+                    description: Terse default — identities with fresh add_memory activity.
+                  idle:
+                    type: array
+                    items: {type: string}
+                    description: Terse default — rostered + active identities with no fresh activity.
+                  benched:
+                    type: array
+                    items: {type: string}
+                    description: Terse default — identities whose participationStatus is not 'active'.
                   signalStatus:
                     type: string
-                    description: Describes the liveness signal — add_memory-recency, RLS-scoped and graph-backed.
+                    description: verbose:true only — describes the add_memory-recency signal.
                   agents:
                     type: array
+                    description: verbose:true only — full per-agent projection.
                     items:
                       type: object
                       properties:

--- a/ai/services/memory-core/TurnPresenceService.mjs
+++ b/ai/services/memory-core/TurnPresenceService.mjs
@@ -9,8 +9,9 @@ import RequestContextService from '../../mcp/server/shared/services/RequestConte
  *
  * `HARNESS_PRESENCE` is a wake-routing overlay: it says whether a receiver route appears
  * addressable. This service records a separate `AGENT_TURN_PRESENCE` interval: a trusted harness
- * turn began, may refresh progress, and eventually expires or terminalizes. The future
- * `who_is_online` projection consumes this writer's records as the primary active-turn proof.
+ * turn began, may refresh progress, and eventually expires or terminalizes. These turn-presence
+ * records are NOT the `who_is_online` liveness signal — `who_is_online` derives liveness from
+ * `add_memory` recency (roster-scoped); turn-presence is a separate active-turn substrate.
  *
  * @class Neo.ai.services.memory-core.TurnPresenceService
  * @extends Neo.core.Base

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -520,15 +520,15 @@ class WakeSubscriptionService extends Base {
      * Composes the liveness layers, in precedence order:
      * 1. **`participationStatus` hard gate** — `operator_benched` / `temporarily_unreachable`
      *    report `online:false` regardless of any softer signal.
-     * 2. **`add_memory`-recency (primary)** — the deployment-agnostic, tenant-scoped activity signal
-     *    ({@link WakeSubscriptionService#_readActivityRecency}): the most-recent caller-visible
+     * 2. **`add_memory`-recency (primary)** — the deployment-agnostic activity signal
+     *    ({@link WakeSubscriptionService#_readActivityRecency}): a rostered agent's most-recent OWN
      *    `AGENT_MEMORY` write within the freshness window ⇒ recently active ⇒ online; stale or none ⇒
      *    dark. `add_memory` is the universal activity write every authenticated agent produces — so the
      *    signal works identically in the swarm and a multi-tenant cloud deployment, unlike a harness
      *    beacon (emitted only by the neo-swarm harness, inert elsewhere) or process-presence
      *    (pid/clone-local — the "local neo activity" coupling that is not mergeable). The read is
-     *    RLS-scoped (never cross-tenant) and graph-backed (survives an embed-drain — it reads the
-     *    durable node, not Chroma).
+     *    roster-scoped (the AgentIdentity roster is the visibility boundary, not the per-caller tenant)
+     *    and graph-backed (survives an embed-drain — it reads the durable node, not Chroma).
      *
      * Deliberately **advisory**: it surfaces *probably-dark* maintainers for review-routing /
      * lane-handoff / lead-baton / wake-targeting so a request to a dark agent fails loud instead
@@ -536,21 +536,46 @@ class WakeSubscriptionService extends Base {
      *
      * @param {Object} [opts]
      * @param {String} [opts.family] Optional model-family filter (e.g. `'claude'`, `'gpt'`).
+     * @param {Boolean} [opts.verbose=false] When false (default) returns the terse roster summary
+     *   (`{generatedAt, summary, online, idle, benched}`) — a "who is online?" answer, not a
+     *   diagnostics dump. When true returns the full per-agent projection (signalStatus + per-agent
+     *   reason/signals) for diagnostics. Default stays terse so the per-call token cost is
+     *   proportional to the question.
      * @param {Date|String|Number} [opts.now=new Date()] Clock source (unit-test seam).
-     * @returns {Promise<Object>} `{generatedAt, signalStatus, agents}` where each agent is
+     * @returns {Promise<Object>} Terse (default): `{generatedAt, summary, online[], idle[], benched[]}`
+     *   (identity arrays). Verbose: `{generatedAt, signalStatus, agents}` where each agent is
      *   `{identity, name, family, participationStatus, online, reason, signals}`.
      */
-    async whoIsOnline({family, now = new Date()} = {}) {
-        const nowMs  = this._coerceDate(now).getTime(),
-              agents = this._listAgentIdentityNodes(family).map(node => this._projectAgentLiveness(node, nowMs));
+    async whoIsOnline({family, verbose = false, now = new Date()} = {}) {
+        const nowMs       = this._coerceDate(now).getTime(),
+              agents      = this._listAgentIdentityNodes(family).map(node => this._projectAgentLiveness(node, nowMs)),
+              generatedAt = new Date(nowMs).toISOString();
+
+        if (verbose) {
+            return {
+                generatedAt,
+                signalStatus: 'add_memory-recency: per maintainer, the most-recent roster-visible AGENT_MEMORY ' +
+                              'write within the freshness window. Deployment-agnostic (add_memory is the universal ' +
+                              'activity write — no harness beacon) and graph-backed (survives an embed-drain). ' +
+                              'Advisory, not a hard routing gate.',
+                agents
+            };
+        }
+
+        // Terse default — a "who is online?" answer, not a diagnostics book. The signalStatus essay
+        // and the per-agent reason/signals live behind verbose:true so the per-call token cost stays
+        // proportional to the question. online = fresh add_memory activity; idle = rostered
+        // and active but no fresh write; benched = participationStatus not 'active'.
+        const online  = agents.filter(agent => agent.online).map(agent => agent.identity),
+              benched = agents.filter(agent => !agent.online && agent.participationStatus !== 'active').map(agent => agent.identity),
+              idle    = agents.filter(agent => !agent.online && agent.participationStatus === 'active').map(agent => agent.identity);
 
         return {
-            generatedAt : new Date(nowMs).toISOString(),
-            signalStatus: 'add_memory-recency: per maintainer, the most-recent caller-visible AGENT_MEMORY ' +
-                          'write within the freshness window. Deployment-agnostic (add_memory is the universal ' +
-                          'activity write — no harness beacon), RLS-scoped (never cross-tenant), and graph-backed ' +
-                          '(survives an embed-drain). Advisory, not a hard routing gate.',
-            agents
+            generatedAt,
+            summary: `${online.length} online · ${idle.length} idle · ${benched.length} benched`,
+            online,
+            idle,
+            benched
         };
     }
 
@@ -592,7 +617,7 @@ class WakeSubscriptionService extends Base {
 
     /**
      * @summary Projects a single AgentIdentity node to its liveness verdict via the
-     * gate → beacon → corroboration precedence.
+     * participationStatus-gate → add_memory-recency precedence.
      * @param {Object} node Parsed AgentIdentity node.
      * @param {Number} nowMs Clock epoch ms.
      * @returns {Object} `{identity, name, family, participationStatus, online, reason, signals}`.
@@ -612,18 +637,18 @@ class WakeSubscriptionService extends Base {
                 reason: `roster: participationStatus is '${participationStatus}' (benched / unreachable)`, signals};
         }
 
-        // 2. add_memory-recency — the deployment-agnostic, tenant-scoped activity signal. Every
-        //    authenticated agent's memory write stamps an AGENT_MEMORY node (agentIdentity + timestamp);
-        //    a fresh most-recent caller-visible write ⇒ recently active ⇒ online. Unlike a harness
-        //    beacon (emitted only by the neo-swarm harness, inert in a multi-tenant/cloud deployment),
-        //    add_memory is universal — and the read is RLS-scoped (never cross-tenant) and graph-backed
-        //    (survives an embed-drain).
+        // 2. add_memory-recency — the deployment-agnostic activity signal. Every authenticated agent's
+        //    memory write stamps an AGENT_MEMORY node (agentIdentity + timestamp); this rostered
+        //    agent's fresh most-recent OWN write ⇒ recently active ⇒ online. Unlike a harness beacon
+        //    (emitted only by the neo-swarm harness, inert in a multi-tenant/cloud deployment),
+        //    add_memory is universal — and the read is roster-scoped (the AgentIdentity roster is the
+        //    visibility boundary) and graph-backed (survives an embed-drain).
         const activity = this._readActivityRecency(identity, nowMs);
         signals.activityRecency = activity;
 
         if (!activity) {
             return {identity, name, family, participationStatus, online: false,
-                reason: 'no caller-visible add_memory activity (dark — inactive, or no shared/team activity visible to the caller)', signals};
+                reason: 'no add_memory activity (dark — no AGENT_MEMORY write on record)', signals};
         }
         if (!activity.fresh) {
             return {identity, name, family, participationStatus, online: false,
@@ -635,36 +660,43 @@ class WakeSubscriptionService extends Base {
     }
 
     /**
-     * @summary Reads an agent's most-recent caller-visible `add_memory` activity — the
-     * deployment-agnostic, tenant-scoped liveness signal that replaced the harness beacon.
+     * @summary Reads a rostered agent's most-recent `add_memory` activity — the
+     * deployment-agnostic liveness signal that replaced the harness beacon.
      *
      * Every authenticated agent's memory write stamps an `AGENT_MEMORY` graph node with
      * `agentIdentity` + `timestamp` + `userId` ({@link Neo.ai.services.memory-core.MemoryService#addMemory}).
-     * This returns the freshness verdict for the most-recent such node the CALLER is entitled to see,
-     * RLS-scoped by the same `(user_id = ? OR user_id IS NULL OR sharedEntity OR visibility:team)`
-     * predicate `GraphService.searchNodes` uses — so who_is_online reads THROUGH tenant isolation
-     * rather than bypassing it via a raw owner-only read (the original cross-tenant defect this pivot
-     * fixes). It reads the durable graph node, not Chroma, so it survives an embed-drain; and
-     * `add_memory` is the universal activity write (no harness hook, no per-deployment beacon), so the
-     * signal works identically in the swarm and a multi-tenant cloud.
+     * This returns the freshness verdict for that agent's most-recent OWN write, matched by
+     * `agentIdentity`. who_is_online's visibility boundary is the AgentIdentity ROSTER
+     * ({@link WakeSubscriptionService#_listAgentIdentityNodes}), not the per-caller tenant: raw
+     * AGENT_MEMORY is tagged with each agent's own per-agent `userId`, so a per-caller `user_id` RLS
+     * filter here would hide same-deployment teammates from each other.
+     * Cross-tenant isolation for a multi-tenant cloud belongs at the roster scope (a tenant-scoped
+     * `_listAgentIdentityNodes`), tracked separately. It reads the durable graph node, not Chroma, so it
+     * survives an embed-drain; and `add_memory` is the universal activity write (no harness hook, no
+     * per-deployment beacon), so the signal works identically in the swarm and a multi-tenant cloud.
      *
      * Freshness window: `add_memory` lands at turn boundaries (the consolidate-then-save gate), so the
      * window must exceed a typical turn to avoid marking a mid-turn agent dark — the false-negative the
      * beacon design feared. 15 min covers "active within the last few turns" for an advisory tool.
      * @param {String} owner AgentIdentity node id.
      * @param {Number} nowMs Clock epoch ms.
-     * @returns {Object|null} `{lastActivityAt, ageMs, fresh}` or null when no caller-visible activity.
+     * @returns {Object|null} `{lastActivityAt, ageMs, fresh}` or null when the roster agent has no
+     *   AGENT_MEMORY activity.
      * @protected
      */
     _readActivityRecency(owner, nowMs) {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite || !owner) return null;
 
-        // RLS: scope to activity the caller is entitled to see — mirror GraphService's read predicate
-        // (own tenant + null-owner system + sharedEntity + visibility:team) keyed on the caller's bound
-        // identity, so this read goes THROUGH tenant isolation rather than bypassing it.
-        const callerUserId = GraphService.db?.storage?.RequestContextService?.getAgentIdentityNodeId?.() ?? null;
-
+        // Roster-liveness scope: report THIS rostered agent's OWN most-recent activity, matched by
+        // agentIdentity. who_is_online's visibility boundary is the AgentIdentity roster
+        // (_listAgentIdentityNodes), NOT the per-caller tenant: every agent's raw AGENT_MEMORY is
+        // tagged with its own per-agent userId, so a per-caller user_id RLS filter here hid
+        // same-deployment teammates from each other. (getAgentIdentityNodeId
+        // is explicitly "NOT for isolation" per RequestContextService, and the prior filter keyed on
+        // it against the normalizeUserId'd user_id column, so it never matched own writes either.)
+        // Cross-tenant isolation for a multi-tenant cloud belongs at the roster scope (tenant-scoped
+        // _listAgentIdentityNodes), tracked separately — not by isolating roster teammates here.
         let latest;
         try {
             const row = sqlite.prepare(`
@@ -672,11 +704,7 @@ class WakeSubscriptionService extends Base {
                 FROM Nodes
                 WHERE json_extract(data, '$.label') = 'AGENT_MEMORY'
                   AND json_extract(data, '$.properties.agentIdentity') = ?
-                  AND (user_id = ?
-                       OR user_id IS NULL
-                       OR json_extract(data, '$.properties.sharedEntity') = 1
-                       OR json_extract(data, '$.properties.visibility') = 'team')
-            `).get(owner, callerUserId);
+            `).get(owner);
             latest = row?.latest || null;
         } catch (error) {
             logger.warn(`[WakeSubscription] who_is_online: activity-recency read failed for ${owner}: ${error.message}`);

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1666,11 +1666,11 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
         }
 
-        test('participationStatus hard gate: benched reports offline even with fresh activity', async () => {
+        test('participationStatus hard gate: benched reports offline even with fresh activity (verbose)', async () => {
             seedAgent('@neo-benched', {participationStatus: 'operator_benched'});
             seedActivity('@neo-benched', {timestamp: T0});
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-benched');
 
             expect(entry).toBeTruthy();
@@ -1679,11 +1679,11 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.reason).toContain('benched');
         });
 
-        test('fresh add_memory activity → online (recency-primary)', async () => {
+        test('fresh add_memory activity → online (recency-primary, verbose)', async () => {
             seedAgent('@neo-active');
             seedActivity('@neo-active', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-active');
 
             expect(entry.online).toBe(true);
@@ -1691,12 +1691,12 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.signals.activityRecency.fresh).toBe(true);
         });
 
-        test('stale add_memory activity → offline (past the freshness window)', async () => {
+        test('stale add_memory activity → offline (past the freshness window, verbose)', async () => {
             seedAgent('@neo-stale');
             // last write 20 min ago — beyond the 15-min freshness window
             seedActivity('@neo-stale', {timestamp: iso(T0ms - 20 * 60 * 1000)});
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-stale');
 
             expect(entry.online).toBe(false);
@@ -1704,83 +1704,99 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.signals.activityRecency.fresh).toBe(false);
         });
 
-        test('no add_memory activity → offline (dark) + signals.activityRecency null', async () => {
+        test('no add_memory activity → offline (dark) + signals.activityRecency null (verbose)', async () => {
             seedAgent('@neo-dark');
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-dark');
 
             expect(entry.online).toBe(false);
-            expect(entry.reason).toContain('no caller-visible add_memory activity');
+            expect(entry.reason).toContain('no add_memory activity');
             expect(entry.signals.activityRecency).toBeNull();
         });
 
-        test('tenant-scoping: a different-user_id (private) AGENT_MEMORY does NOT mark online (RLS-filtered → dark)', async () => {
-            seedAgent('@neo-other-tenant');
-            // Fresh activity, but owned by a DIFFERENT tenant: userId set (not NULL), not shared, not team —
-            // so the RLS predicate (user_id = caller OR NULL OR sharedEntity OR visibility:'team') admits none
-            // of it for a non-matching caller. The private cross-tenant activity must stay invisible.
+        test('roster-scoping: an agent\'s OWN activity marks it online regardless of the user_id tenant tag', async () => {
+            seedAgent('@neo-foreign-tenant');
+            // who_is_online is a ROSTER tool: it reports each rostered agent's OWN latest activity
+            // (matched by agentIdentity), NOT per-caller tenant. Fresh activity tagged with a foreign
+            // userId therefore still marks the agent online. The prior per-caller user_id RLS here hid
+            // same-deployment teammates from each other. Cross-tenant isolation belongs at the roster
+            // scope (a tenant-scoped _listAgentIdentityNodes) for a multi-tenant cloud, tracked separately.
             GraphService.upsertNode({
-                id        : 'AGENT_MEMORY:@neo-other-tenant:private',
+                id        : 'AGENT_MEMORY:@neo-foreign-tenant:fresh',
                 type      : 'AGENT_MEMORY',
-                name      : 'Memory: private',
-                properties: {agentIdentity: '@neo-other-tenant', timestamp: iso(T0ms - 2 * 60 * 1000), userId: 'some-other-tenant', sessionId: 'sess-test'}
+                name      : 'Memory: fresh',
+                properties: {agentIdentity: '@neo-foreign-tenant', timestamp: iso(T0ms - 2 * 60 * 1000), userId: 'some-other-tenant', sessionId: 'sess-test'}
             });
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
-            const entry    = agents.find(a => a.identity === '@neo-other-tenant');
-
-            expect(entry.online).toBe(false);
-            expect(entry.reason).toContain('no caller-visible add_memory activity');
-            expect(entry.signals.activityRecency).toBeNull();
-        });
-
-        test('tenant-scoping: a team-visible AGENT_MEMORY (foreign user_id) DOES mark online (RLS-admitted)', async () => {
-            seedAgent('@neo-team-vis');
-            // Foreign userId, but visibility:'team' → the RLS predicate admits it cross-caller (the shared-board path),
-            // so caller-visible activity still reads online even when its userId is not the caller's.
-            GraphService.upsertNode({
-                id        : 'AGENT_MEMORY:@neo-team-vis:teamvis',
-                type      : 'AGENT_MEMORY',
-                name      : 'Memory: teamvis',
-                properties: {agentIdentity: '@neo-team-vis', timestamp: iso(T0ms - 2 * 60 * 1000), userId: 'some-other-tenant', visibility: 'team', sessionId: 'sess-test'}
-            });
-
-            const {agents} = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
-            const entry    = agents.find(a => a.identity === '@neo-team-vis');
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-foreign-tenant');
 
             expect(entry.online).toBe(true);
             expect(entry.signals.activityRecency.fresh).toBe(true);
         });
 
-        test('signalStatus names the add_memory-recency signal (no beacon field)', async () => {
-            seedAgent('@neo-sig');
+        test('terse default: {summary, online, idle, benched} identity arrays — no per-agent essay', async () => {
+            seedAgent('@neo-t-online');
+            seedActivity('@neo-t-online', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+            seedAgent('@neo-t-idle');                                              // active, no activity → idle
+            seedAgent('@neo-t-benched', {participationStatus: 'temporarily_unreachable'});
 
             const result = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
+
+            expect(typeof result.summary).toBe('string');
+            expect(result.agents).toBeUndefined();
+            expect(result.signalStatus).toBeUndefined();
+            expect(result.online).toContain('@neo-t-online');
+            expect(result.idle).toContain('@neo-t-idle');
+            expect(result.idle).not.toContain('@neo-t-online');
+            expect(result.benched).toContain('@neo-t-benched');
+            expect(result.summary).toContain(`${result.online.length} online`);
+        });
+
+        test('verbose:true returns the full per-agent projection + signalStatus (no terse summary)', async () => {
+            seedAgent('@neo-v');
+            seedActivity('@neo-v', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            const result = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+
+            expect(result.signalStatus).toContain('add_memory-recency');
+            expect(result.beaconStatus).toBeUndefined();
+            expect(result.summary).toBeUndefined();
+            expect(Array.isArray(result.agents)).toBe(true);
+            expect(result.agents.find(a => a.identity === '@neo-v').online).toBe(true);
+        });
+
+        test('signalStatus (verbose) names the add_memory-recency signal (no beacon field)', async () => {
+            seedAgent('@neo-sig');
+
+            const result = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
 
             expect(result.signalStatus).toContain('add_memory-recency');
             expect(result.beaconStatus).toBeUndefined();
         });
 
-        test('family filter narrows the roster', async () => {
+        test('family filter narrows the roster (verbose)', async () => {
             seedAgent('@neo-claude-x', {family: 'claude'});
             seedAgent('@neo-gpt-x',    {family: 'gpt'});
 
-            const {agents} = await WakeSubscriptionService.whoIsOnline({family: 'gpt', now: new Date(T0)});
+            const {agents} = await WakeSubscriptionService.whoIsOnline({family: 'gpt', verbose: true, now: new Date(T0)});
             const ids      = agents.map(a => a.identity);
 
             expect(ids).toContain('@neo-gpt-x');
             expect(ids).not.toContain('@neo-claude-x');
         });
 
-        test('callable through the MCP callTool dispatch (registration + openapi)', async () => {
+        test('callable through the MCP callTool dispatch — terse default (registration + openapi)', async () => {
             seedAgent('@neo-dispatch');
 
             const res = await callTool('who_is_online', {});
 
-            expect(Array.isArray(res.agents)).toBe(true);
-            expect(res.signalStatus).toContain('add_memory-recency');
-            expect(res.agents.some(a => a.identity === '@neo-dispatch')).toBe(true);
+            expect(typeof res.summary).toBe('string');
+            expect(Array.isArray(res.online)).toBe(true);
+            expect(Array.isArray(res.idle)).toBe(true);
+            // @neo-dispatch is rostered + active but has no activity → idle
+            expect(res.idle).toContain('@neo-dispatch');
         });
     });
 });


### PR DESCRIPTION
## Summary

`who_is_online` reported every maintainer dark despite active peers, and returned a verbose per-agent payload by default.

**Root cause** (verified via direct live `Nodes`-table queries — full writeup in the [#13557 correction comment](https://github.com/neomjs/neo/issues/13557#issuecomment-4753330848)): `_readActivityRecency` keyed its per-caller RLS on `getAgentIdentityNodeId()` (`@`-prefixed; `RequestContextService` docs: *"NOT for isolation"*) against the `normalizeUserId`'d `user_id` column, so it **never matched own writes**; and raw `AGENT_MEMORY` is tagged per-agent, so a per-caller filter **isolates same-deployment teammates**. who_is_online is a roster tool — `_listAgentIdentityNodes` already lists the whole roster un-RLS'd, so per-caller RLS on only the recency read was incoherent. Fails closed (no leak).

## What it does
- `_readActivityRecency`: **roster-scoped** — `MAX(timestamp)` by `agentIdentity`; dropped the per-caller `user_id` filter.
- `whoIsOnline`: **terse by default** `{generatedAt, summary, online[], idle[], benched[]}`; `signalStatus` essay + per-agent `reason`/`signals` behind `verbose:true`.
- `openapi`: `verbose` param + terse description (js-yaml-validated).
- spec: roster-scoping invariant + terse/verbose cases (replaces the per-caller-RLS tenant tests, obsolete by design).

## Deltas from ticket
- Re-scoped off the body's **WAL-overlay** diagnosis (wrong — graph projection is healthy); real cause is the RLS `@`-key + per-agent isolation. Corrected root cause + Contract Ledger in the [#13557 comment](https://github.com/neomjs/neo/issues/13557#issuecomment-4753330848).
- Added the operator-flagged **terse-by-default output** (bloat fix) on top of the visibility fix.

Evidence: L2 (69/69 unit — roster-scoping, terse-default, verbose-shape, terse-dispatch) + read-only live-DB simulation of the fixed query against the production graph (`3 online · 7 idle · 3 benched`) → L4 required (live `who_is_online` through the MCP after restart). Residual: post-merge validation [#13557].

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` → **69 passed**.
- `node --check` clean; `openapi.yaml` js-yaml-validated (verbose param + response props present).
- Read-only live-DB sim of the roster-scoped logic against the production graph: `3 online (@neo-gpt, @neo-opus-vega, @neo-opus-grace) · 7 idle · 3 benched`.
- Pre-commit hooks green (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, ticket-archaeology).

## Post-Merge Validation
- [ ] Restart the memory-core MCP; confirm `who_is_online` (terse) returns the active roster, not all-dark.
- [ ] Confirm `verbose:true` returns the per-agent projection.

## Cross-family review
Routing to @neo-gpt (Euclid) — cross-family (Claude↔GPT) per §6.1, and he reviewed the #13527 tenant surface this changes.

Resolves #13557

Authored by Ada (Claude Opus 4.8). Session abe80be3-6235-4a9e-99bc-b14659ba806a.
