### PR TITLE
docs(agentos): compact review-request liveness gate (#13522)

### DIFF
--- a/.agents/skills/post-review-pickup/references/author-concentration-detector.md
+++ b/.agents/skills/post-review-pickup/references/author-concentration-detector.md
@@ -12,7 +12,7 @@ Telemetry signal for authorship concentration across the swarm. **Successor to t
                   print(Counter(p['author']['login'] for p in json.load(sys.stdin)))"
   ```
 - **Merged-window trigger:** one family / agent dominates the merged window.
-- **Open-pipeline amber:** concentration in the *open* PR pipeline is an early-warning, read before it reaches the merged window.
+- **Open-pipeline amber:** open PR concentration, including routed-but-unmoving clean stacks, before it reaches the merged window.
 
 ## What It Is NOT (the retired FAIR-band failure modes)
 

--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -257,7 +257,8 @@ blocker bug from the active lane:
 
 - targeted review / re-review requests **where you are the assigned github
   reviewer** (verify: `gh pr view <N> --json reviewRequests`) — do not claim a PR
-  review you were not assigned to;
+  review you were not assigned to; clean assigned requests need
+  review/decline/handoff/blocker before new work;
 - assigned issues and currently self-authored PR follow-ups;
 - recent `[lanes-available]`, `[lane-claim]`, and `[lane-override]` A2A signals
   for collision state;

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -200,11 +200,11 @@ Use role-routing, not naked multi-peer pings:
    The A2A must include `Review role: primary-reviewer` and
    `Requested action: use /pr-review on PR #N`. Use round-robin unless a stated
    subsystem-familiarity override applies.
-2. **SLA / active-window decline:** primary reviewer has 24 hours;
+2. **SLA / active-window decline:** primary reviewer has 4h max;
    `reviewRequests` proves routing, not engagement. If clean assigned PRs stack
    with no review/decline/handoff/blocker while reviewer is active, author sends
    claim-or-decline A2A before more PRs. If reviewer cannot review,
-   they A2A `Requested action: unassign`; if silent 24h, author reassigns and
+   they A2A `Requested action: unassign`; if silent 4h, author reassigns and
    records timeout.
 3. **Observer:** no-action visibility must say `Review role: observer` and
    `Requested action: none`.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -200,9 +200,12 @@ Use role-routing, not naked multi-peer pings:
    The A2A must include `Review role: primary-reviewer` and
    `Requested action: use /pr-review on PR #N`. Use round-robin unless a stated
    subsystem-familiarity override applies.
-2. **SLA / decline:** primary reviewer has 24 hours. If they cannot review, they
-   A2A `Requested action: unassign` and remove themselves. If silent for 24
-   hours, author reassigns and records the timeout in a PR comment.
+2. **SLA / active-window decline:** primary reviewer has 24 hours;
+   `reviewRequests` proves routing, not engagement. If clean assigned PRs stack
+   with no review/decline/handoff/blocker while reviewer is active, author sends
+   claim-or-decline A2A before more PRs. If reviewer cannot review,
+   they A2A `Requested action: unassign`; if silent 24h, author reassigns and
+   records timeout.
 3. **Observer:** no-action visibility must say `Review role: observer` and
    `Requested action: none`.
 4. **Tie-breaker:** after one full author/reviewer disagreement cycle, post


### PR DESCRIPTION
Resolves #13522

Related: #10777
Related: #13523
Related: #13530

Compact successor to the closed `#13523` shape: codifies active-window review-request liveness in existing workflow/telemetry payloads without adding a new lifecycle reference file. `reviewRequests` now means routing; liveness requires review / decline / handoff / blocker before authors stack more PRs or reviewers take unrelated work.

Operator correction after review: the hard silence timeout for our agent team is **4h max**, not 24h. The original #13522 ticket text preserved the old 24h wording; this PR now supersedes that stale SLA in the shipped workflow substrate.

Evidence: L1 (static skill-substrate diff + manifest/whitespace checks) -> L1 required (workflow-doc ACs; no runtime surface). No residuals.

## Deltas from ticket

- Implemented the post-`#13523` compact shape: no new `review-request-liveness.md`, no A2A template file, and no growth waiver.
- `pull-request-workflow.md` now distinguishes routing, active-window liveness, and the **4h max** hard timeout in the existing SLA/decline bullet.
- `post-review-pickup-workflow.md` now blocks unrelated work for clean assigned review requests until review / decline / handoff / blocker is visible.
- `author-concentration-detector.md` treats routed-but-unmoving clean stacks as open-pipeline reviewer-scarcity telemetry.
- `ci-green-review-routing.md` remains unchanged; its green gate supplies the current-head precondition consumed by the compact rule.

## Slot Rationale

This mutates skill-loaded memory substrate, so `/turn-memory-pre-flight`, `/create-skill`, and ADR 0007 compaction taxonomy were applied.

- Disposition: `rewrite` inside existing conditional payloads; no new file or trigger.
- 3-axis: trigger-frequency = PR lifecycle / lane-discovery only; failure-severity = high (routed reviews age silently); enforceability = discipline-only with live GitHub checks.
- Load effect: 3 existing skill reference files, 9 insertions / 5 deletions plus the 4h SLA correction; `lint-skill-manifest` accepted net markdown growth under the 250-byte cap. Net always-loaded delta: zero.

Decision Record impact: none. This applies existing Agent OS workflow substrate; no ADR authority change.

## Test Evidence

- `git diff --check`
- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev`
- `node ./buildScripts/util/check-whitespace.mjs`
- `git diff --cached --check`
- Husky pre-commit reran `node ./buildScripts/util/check-whitespace.mjs`

## Post-Merge Validation

- [ ] Next active-window stale review stack routes targeted claim-or-decline A2A before another implementation PR is opened into the same queue.
- [ ] Next reviewer lifecycle boundary with clean assigned `reviewRequests` treats review / decline / handoff / blocker as the required state transition before unrelated work.
- [ ] Next silent primary-reviewer timeout uses the 4h max fallback, not the stale 24h wording.

## Commit

- `13785bd05` - `docs(agentos): compact review-request liveness gate (#13522)`
- `754e432ff` - `docs(agentos): cap reviewer silence timeout at 4h (#13522)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee050-c834-7503-b895-527ad55dd8c5.
