### PR TITLE
fix(ai): restore interactive heartbeat wakes; mixed-drop at flush (#13565)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -27,18 +27,18 @@
 // at module-load. `InstanceManager` binds `Neo.find` / `Neo.findFirst` / `Neo.get`
 // aliases + sets `Base.instanceManagerAvailable=true` + consumes pre-singleton
 // `Neo.idMap`. All 3 MUST run before consumed class imports.
-import Neo             from '../../../src/Neo.mjs';
-import * as core       from '../../../src/core/_export.mjs';
-import InstanceManager from '../../../src/manager/Instance.mjs';
-import AiConfig        from '../../config.mjs';
-import memoryCoreConfig from '../../mcp/server/memory-core/config.mjs';
+import Neo                   from '../../../src/Neo.mjs';
+import * as core             from '../../../src/core/_export.mjs';
+import InstanceManager       from '../../../src/manager/Instance.mjs';
+import AiConfig              from '../../config.mjs';
+import memoryCoreConfig      from '../../mcp/server/memory-core/config.mjs';
 import {WAKE_LANE_DIRECTIVE} from './wakeLaneDirective.mjs';
 
-import fs from 'fs-extra';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs                           from 'fs-extra';
+import path                         from 'path';
+import { fileURLToPath }            from 'url';
 import { constants as fsConstants } from 'fs';
-import { spawn, execSync } from 'child_process';
+import { spawn, execSync }          from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -69,7 +69,7 @@ import {
     shouldDeferFlush
 } from './flushDeferPolicy.mjs';
 import {clampWatermark, filterEventsByWatermark, maxLogId} from './wokenWatermark.mjs';
-import {IDENTITIES} from '../../graph/identityRoots.mjs';
+import {IDENTITIES}                                        from '../../graph/identityRoots.mjs';
 
 const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
 const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
@@ -428,7 +428,11 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
     }, trace);
 
     if (!result) return null;
-    if (result.type === 'heartbeat_pulse' && isPromptSubmittingSubscription(sub)) return null;
+
+    // heartbeat_pulse delivers through every adapter (incl. interactive osascript/tmux): emission is
+    // already idle-gated upstream (WakeDecisionService.decideWake — Wake = active AND idle AND ready),
+    // so the delivery layer trusts that gate rather than re-suppressing by adapter, which had dropped
+    // every interactive heartbeat while only non-interactive (codex-app-server) adapters kept theirs.
 
     // Map the shared evaluator's {type, payload, logId} onto the daemon's flat coalescing payload.
     const {payload, logId} = result;
@@ -461,26 +465,6 @@ function isWakeTargetEligible(identity) {
           participationStatus = identityParticipationById.get(normalizedIdentity);
 
     return !participationStatus || participationStatus === 'active';
-}
-
-/**
- * @summary Resolves the effective wake adapter for a subscription.
- * @param {Object} subscription WAKE_SUBSCRIPTION node.
- * @returns {String}
- */
-function getSubscriptionAdapter(subscription) {
-    const meta = subscription.properties?.harnessTargetMetadata || {};
-    return meta.adapter || (process.platform === 'darwin' ? 'osascript' : 'tmux');
-}
-
-/**
- * @summary True when heartbeat-only delivery would submit into an interactive prompt.
- * @param {Object} subscription WAKE_SUBSCRIPTION node.
- * @returns {Boolean}
- */
-function isPromptSubmittingSubscription(subscription) {
-    const adapter = getSubscriptionAdapter(subscription);
-    return adapter === 'osascript' || adapter === 'tmux';
 }
 
 /**
@@ -721,6 +705,18 @@ async function flushSubscription(subId) {
     permissions = filterEventsByWatermark(permissions, watermark);
     heartbeats  = filterEventsByWatermark(heartbeats,  watermark);
 
+    // Mixed-wake heartbeat suppression (digest content only): a heartbeat is the idle-watchdog nudge,
+    // but when it coalesces with an actionable wake (message / task / permission) the agent is already
+    // being woken — so the redundant heartbeat is dropped FROM THE DIGEST. A heartbeat-only queue still
+    // delivers, including through interactive osascript/tmux adapters: this is the correctly-scoped
+    // successor to the per-adapter evaluateSubscription drop that had killed ALL interactive heartbeats.
+    // `consumedHeartbeats` keeps the dropped logIds for the watermark below so a re-queued backlog
+    // cannot re-deliver them.
+    const consumedHeartbeats = heartbeats;
+    if (messages.length > 0 || tasks.length > 0 || permissions.length > 0) {
+        heartbeats = [];
+    }
+
     // Nothing genuinely-new survived (the delta was entirely already-read or already-woken) → suppress.
     if (messages.length === 0 && tasks.length === 0 && permissions.length === 0 && heartbeats.length === 0) {
         return;
@@ -742,7 +738,7 @@ async function flushSubscription(subId) {
     // Advance the per-subscription watermark to the highest delivered logId so these events are not
     // re-counted if the backlog is re-queued; persist for restart durability. logId is monotonic
     // (append-only GraphLog), so genuinely-new events always land strictly above this mark.
-    const deliveredMax = maxLogId([...messages, ...tasks, ...permissions, ...heartbeats]);
+    const deliveredMax = maxLogId([...messages, ...tasks, ...permissions, ...consumedHeartbeats]);
     if (deliveredMax !== null && deliveredMax > (wokenWatermark[subId] ?? 0)) {
         wokenWatermark[subId] = deliveredMax;
         persistWokenWatermark();

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1,13 +1,13 @@
-import { test, expect } from '@playwright/test';
-import fs from 'fs-extra';
-import path from 'path';
-import Database from 'better-sqlite3';
-import { spawn } from 'child_process';
-import crypto from 'crypto';
-import http from 'http';
-import os from 'os';
+import { test, expect }                                                                        from '@playwright/test';
+import fs                                                                                      from 'fs-extra';
+import path                                                                                    from 'path';
+import Database                                                                                from 'better-sqlite3';
+import { spawn }                                                                               from 'child_process';
+import crypto                                                                                  from 'crypto';
+import http                                                                                    from 'http';
+import os                                                                                      from 'os';
 import { collapseDuplicateShapeCRoutes, getActiveHarnessPresence, getNodesData, getEdgesData } from '../../../../../../ai/daemons/wake/queries.mjs';
-import { SQLITE_IN_CLAUSE_BATCH_SIZE } from '../../../../../../ai/graph/storage/constants.mjs';
+import { SQLITE_IN_CLAUSE_BATCH_SIZE }                                                         from '../../../../../../ai/graph/storage/constants.mjs';
 
 /**
  * @summary Stubs `ps` for subprocess daemon tests so instance-resolution branches do not depend
@@ -1870,7 +1870,7 @@ test.describe('Wake Daemon', () => {
         expect(args.at(-1)).toBe('C-m');
     });
 
-    test('tmux wake does not queue pure-heartbeat interactive submit (#13456)', async () => {
+    test('tmux wake delivers pure-heartbeat interactive submit (idle-gated at emit, not delivery)', async () => {
         const agentId = '@test-agent-tmux-pure-heartbeat';
         const subId = insertWakeSubscription(db, {
             agentId,
@@ -1905,8 +1905,8 @@ test.describe('Wake Daemon', () => {
 
         await new Promise(resolve => setTimeout(resolve, 5000));
 
-        expect(fs.existsSync(mockOutPath)).toBe(false);
-        expect(stdoutLog).not.toContain(`Delivered ${subId}`);
+        expect(fs.existsSync(mockOutPath)).toBe(true);
+        expect(stdoutLog).toContain(`Delivered ${subId}`);
         expect(stdoutLog).not.toContain(`Suppressed ${subId}`);
     });
 
@@ -2189,7 +2189,7 @@ test.describe('Wake Daemon', () => {
         );
     });
 
-    test('Codex UI wake does not queue pure-heartbeat interactive submit (#13456)', async () => {
+    test('Codex UI wake submits pure-heartbeat interactively (idle-gated at emit, not delivery)', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-pure-heartbeat';
 
@@ -2243,9 +2243,8 @@ test.describe('Wake Daemon', () => {
 
         await new Promise(resolve => setTimeout(resolve, 5000));
 
-        expect(fs.existsSync(mockOutPath)).toBe(false);
-        expect(stdoutLog).not.toContain(`Delivered ${subId}`);
-        expect(stdoutLog).not.toContain(`Submit attempted ${subId}`);
+        expect(fs.existsSync(mockOutPath)).toBe(true);
+        expect(stdoutLog).toContain(`Submit attempted ${subId}`);
         expect(stdoutLog).not.toContain(`Suppressed ${subId}`);
     });
 


### PR DESCRIPTION
## Summary

Restores heartbeat wakes for interactive (osascript/tmux) agents — operator-flagged ("we need them back"). Since #13457, no local interactive agent received a heartbeat wake for ~17h; only the `codex-app-server` adapter (@neo-gpt) kept theirs, which is why the regression was invisible to its author. A2A (message) wakes were unaffected.

**Root cause:** #13457's `evaluateSubscription` guard `if (result.type === 'heartbeat_pulse' && isPromptSubmittingSubscription(sub)) return null;` dropped heartbeat delivery for every `osascript`/`tmux` adapter (osascript is the darwin default). Emission is already idle-gated upstream (`WakeDecisionService.decideWake` — Wake = active AND idle AND ready), so a heartbeat only fires for an idle agent — the delivery-side per-adapter suppression was redundant.

## What it does
- `daemon.mjs`: removes the `evaluateSubscription` per-adapter heartbeat suppression + its two now-dead helpers (`getSubscriptionAdapter`, `isPromptSubmittingSubscription`); keeps the benched-filter (`isWakeTargetEligible`).
- `daemon.mjs`: preserves #13456's intent at the correctly-scoped layer — `flushSubscription` drops the heartbeat from the digest ONLY when it coalesces with an actionable event (message/task/permission); a heartbeat-only queue delivers. Watermark advances past consumed heartbeats so a re-queue can't re-deliver.
- `daemon.spec.mjs`: the two pure-heartbeat tests now assert delivery; the mixed-coalesce test (heartbeat dropped) stays green.
- import-from block-alignment (#13558 lint) applied to both touched files.

## Deltas from ticket
- Chose the flush-layer mixed-drop over a blanket revert: restores the regression (pure-heartbeat) while preserving Euclid's #13456 mixed behavior, so the mixed-coalesce test stays green.

Evidence: L2 (35/35 daemon spec — pure-heartbeat delivery for tmux + Codex, mixed-drop preserved, benched-filter retained) → L4 required (live interactive agents receive heartbeat wakes after wake-daemon restart). Residual: post-merge validation [#13565].

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` → **35 passed** (incl. the two flipped pure-heartbeat tests, the unchanged mixed-coalesce test, and the benched-filter test).
- `node --check ai/daemons/wake/daemon.mjs` clean.
- Pre-commit hooks green (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation
- [ ] Restart the wake/orchestrator daemons; confirm local interactive (osascript) Claude agents receive heartbeat wakes again.
- [ ] Confirm a heartbeat coalesced with a message still delivers the message without a redundant heartbeat line.

## Cross-family review
Routing to @neo-gpt (Euclid) — this reverses the delivery-side of his #13456 AC3 (#13457). The reversal is justified by the emit-side idle-gate; the mixed-drop intent is preserved at the flush layer. Please confirm the emit-gate reasoning holds.

Resolves #13565

Authored by Ada (Claude Opus 4.8). Session abe80be3-6235-4a9e-99bc-b14659ba806a.
