### PR TITLE
feat(ai): fail-fast boot guard for stale config overlays (#13560)

### DIFF
--- a/ai/daemons/orchestrator/daemon.mjs
+++ b/ai/daemons/orchestrator/daemon.mjs
@@ -27,11 +27,12 @@ import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
 
 import {fileURLToPath, pathToFileURL} from 'url';
-import fs from 'fs-extra';
-import path from 'path';
-import {execSync} from 'child_process';
-import AiConfig from '../../config.mjs';
-import Orchestrator from './Orchestrator.mjs';
+import fs                             from 'fs-extra';
+import path                           from 'path';
+import {execSync}                     from 'child_process';
+import AiConfig                       from '../../config.mjs';
+import Orchestrator                   from './Orchestrator.mjs';
+import {assertConfigFresh}            from '../../scripts/setup/initServerConfigs.mjs';
 
 const DAEMON_DATA_DIR = process.env.NEO_AI_ORCHESTRATOR_DIR || '.neo-ai-data/orchestrator-daemon';
 const PID_FILE        = path.join(DAEMON_DATA_DIR, 'orchestrator-daemon.pid');
@@ -190,8 +191,12 @@ export async function startOrchestrator(options = {}) {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    startOrchestrator().catch(err => {
-        console.error(`[Orchestrator] Failed to start: ${err && err.stack ? err.stack : err}`);
-        process.exit(1);
-    });
+    // Boot guard: fail fast on a stale config overlay (missing a leaf its template added) with an
+    // actionable --migrate-config message, rather than letting the orchestrator crash cryptically.
+    assertConfigFresh()
+        .then(() => startOrchestrator())
+        .catch(err => {
+            console.error(`[Orchestrator] Failed to start: ${err && err.stack ? err.stack : err}`);
+            process.exit(1);
+        });
 }

--- a/ai/mcp/server/memory-core/mcp-server.mjs
+++ b/ai/mcp/server/memory-core/mcp-server.mjs
@@ -1,12 +1,14 @@
 import 'dotenv/config';
-import {Command}       from 'commander';
-import Neo             from '../../../../src/Neo.mjs';
-import * as core       from '../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../src/manager/Instance.mjs';
-import aiConfig        from './config.mjs';
-import logger          from './logger.mjs';
-import Server          from './Server.mjs';
-import {sanitizeInput} from '../../../../buildScripts/util/sanitizer.mjs';
+import {Command}           from 'commander';
+import Neo                 from '../../../../src/Neo.mjs';
+import * as core           from '../../../../src/core/_export.mjs';
+import InstanceManager     from '../../../../src/manager/Instance.mjs';
+import aiConfig            from './config.mjs';
+import logger              from './logger.mjs';
+import Server              from './Server.mjs';
+import {sanitizeInput}     from '../../../../buildScripts/util/sanitizer.mjs';
+import {fileURLToPath}     from 'node:url';
+import {assertConfigFresh} from '../../../scripts/setup/initServerConfigs.mjs';
 
 const program = new Command();
 
@@ -25,6 +27,10 @@ if (options.debug) {
 }
 
 try {
+    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
+    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
+    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+
     await Neo.create(Server, {
         configFile: options.config
     }).ready();

--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -601,6 +601,71 @@ export async function initTier1Config({argv = process.argv, logger = console, ai
     return {action: 'warn', drift}
 }
 
+/**
+ * @summary Boot-time freshness guard. Throws if a materialized overlay (`config.mjs`) is missing
+ * structural leaves its template (`config.template.mjs`) added — the crash-causing drift class that
+ * otherwise surfaces as a cryptic `reading '<x>' of undefined` at runtime (the stale-overlay-crash
+ * incident). Reuses the prepare-time {@link detectDrift} / {@link projectShape} detection but FAILS
+ * FAST at boot, scoped to CRASH-CAUSING drift (missing imports / exports / env-leaves); benign drift
+ * (a changed default for a leaf that still exists) warns rather than throws.
+ *
+ * Pairs with {@link initConfigs} / {@link initTier1Config}: those WARN at `npm prepare`; this is the
+ * last-line boot guard for the `git-pull-without-prepare` window, so a stale overlay names its missing
+ * leaves + the `--migrate-config` fix instead of crashing every consumer cryptically.
+ *
+ * @param {Object}   [options]
+ * @param {String}   [options.serverPath] An `ai/mcp/server/<name>/` dir whose `config.mjs` overlay to
+ *   additionally check; its Tier-1 import is materialized before the shape-compare (matching
+ *   {@link initConfigs}) so the template-vs-overlay import path is not read as false drift.
+ * @param {String}   [options.aiRoot=aiDir]  Tier-1 root; `ai/config.mjs` is always checked.
+ * @param {Object}   [options.logger=console] Log sink; injectable for tests.
+ * @returns {Promise<void>}
+ * @throws {Error} on crash-causing overlay drift, naming the missing leaves + the `--migrate-config` fix.
+ */
+export async function assertConfigFresh({serverPath, aiRoot = aiDir, logger = console} = {}) {
+    const stale = [];
+
+    const record = (label, drift) => {
+        const crashCausing = [...drift.missingImports, ...drift.missingExports, ...drift.missingEnvVars];
+
+        if (crashCausing.length > 0) {
+            stale.push({label, missing: crashCausing});
+        } else if (drift.hasDrift) {
+            logger.warn(`[Neo AI] ${label}: benign config drift (changed default only) — run \`npm run prepare -- ${MIGRATE_FLAG}\` to refresh (non-fatal).`);
+        }
+    };
+
+    const tier1Template = path.join(aiRoot, 'config.template.mjs');
+    const tier1Active   = path.join(aiRoot, 'config.mjs');
+
+    if (fs.existsSync(tier1Template) && fs.existsSync(tier1Active)) {
+        record('Tier-1 ai/config.mjs', detectDrift(await projectShape(tier1Template), await projectShape(tier1Active)));
+    }
+
+    if (serverPath) {
+        const serverTemplate = path.join(serverPath, 'config.template.mjs');
+        const serverActive   = path.join(serverPath, 'config.mjs');
+
+        if (fs.existsSync(serverTemplate) && fs.existsSync(serverActive)) {
+            // Materialize the template's Tier-1 import before the compare so the template-vs-overlay
+            // import path is not itself flagged as drift (matches the initConfigs per-server path).
+            const templateShape = projectSourceShape(materializeServerConfigTemplate(await fs.readFile(serverTemplate, 'utf-8'))),
+                  activeShape   = projectSourceShape(await fs.readFile(serverActive, 'utf-8'));
+
+            record(`${path.basename(serverPath)}/config.mjs`, detectDrift(templateShape, activeShape));
+        }
+    }
+
+    if (stale.length > 0) {
+        const detail = stale.map(item => `  - ${item.label}: missing ${item.missing.join(', ')}`).join('\n');
+
+        throw new Error(
+            `[Neo AI] Stale config overlay — a materialized config.mjs is missing leaves its template added:\n${detail}\n` +
+            `This will crash at runtime on an undefined config leaf. Refresh: \`npm run prepare -- ${MIGRATE_FLAG}\` (gitignored; safe), then restart.`
+        );
+    }
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
     (async () => {
         await initTier1Config();

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -15,13 +15,13 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import fs             from 'fs';
-import fsExtra        from 'fs-extra';
-import path           from 'path';
+import fs              from 'fs';
+import fsExtra         from 'fs-extra';
+import path            from 'path';
 
 test.describe.configure({mode: 'serial'});
 
@@ -739,5 +739,73 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
             expect(hasConfigTemplate(path.join(root, 'with-template'))).toBe(true);
             expect(hasConfigTemplate(path.join(root, 'no-template'))).toBe(false);
         });
+    });
+});
+
+test.describe('assertConfigFresh — boot freshness guard (#13560)', () => {
+    let assertConfigFresh;
+    let guardRoot;
+
+    const recordingLogger = () => {
+        const warn = [];
+        return {warn: (...args) => warn.push(args.join(' ')), entries: {warn}};
+    };
+
+    // A Tier-1 sandbox: an aiRoot dir holding a config.template.mjs + config.mjs pair.
+    const buildTier1 = ({name, templateContents, configContents}) => {
+        const root = path.join(guardRoot, name);
+        fs.mkdirSync(root, {recursive: true});
+        if (templateContents !== undefined) fs.writeFileSync(path.join(root, 'config.template.mjs'), templateContents);
+        if (configContents   !== undefined) fs.writeFileSync(path.join(root, 'config.mjs'), configContents);
+        return root;
+    };
+
+    const callGuard = async opts => {
+        let error = null;
+        try { await assertConfigFresh(opts); } catch (e) { error = e; }
+        return error;
+    };
+
+    test.beforeAll(async () => {
+        ({assertConfigFresh} = await import('../../../../../../ai/scripts/setup/initServerConfigs.mjs'));
+        guardRoot = path.resolve(process.cwd(), 'tmp', `assert-config-fresh-${process.pid}-${Date.now()}`);
+        fs.mkdirSync(guardRoot, {recursive: true});
+    });
+
+    test.afterAll(() => {
+        if (guardRoot && fs.existsSync(guardRoot)) fs.rmSync(guardRoot, {recursive: true, force: true});
+    });
+
+    // The template adds an env-bound leaf; a stale overlay missing it is the crash-causing class.
+    const TEMPLATE_WITH_LEAF = `export default {section: {enabled: leaf(true, 'NEO_SECTION_ENABLED', 'bool')}};\n`;
+
+    test('fails fast (throws) when the overlay is missing a leaf the template added', async () => {
+        const root  = buildTier1({name: 'stale', templateContents: TEMPLATE_WITH_LEAF, configContents: 'export default {};\n'});
+        const error = await callGuard({aiRoot: root, logger: recordingLogger()});
+
+        expect(error).not.toBeNull();
+        expect(error.message).toMatch(/Stale config overlay/);
+        expect(error.message).toContain('NEO_SECTION_ENABLED'); // names the missing leaf
+        expect(error.message).toContain('--migrate-config');     // names the fix
+    });
+
+    test('passes (no throw) when the overlay matches the template shape', async () => {
+        const root  = buildTier1({name: 'fresh', templateContents: TEMPLATE_WITH_LEAF, configContents: TEMPLATE_WITH_LEAF});
+        const error = await callGuard({aiRoot: root, logger: recordingLogger()});
+
+        expect(error).toBeNull();
+    });
+
+    test('benign drift (changed default only) warns but does NOT throw', async () => {
+        const root   = buildTier1({
+            name            : 'benign',
+            templateContents: `export default {model: leaf('a', 'NEO_MODEL', 'string')};\n`,
+            configContents  : `export default {model: leaf('b', 'NEO_MODEL', 'string')};\n`
+        });
+        const logger = recordingLogger();
+        const error  = await callGuard({aiRoot: root, logger});
+
+        expect(error).toBeNull();
+        expect(logger.entries.warn.some(w => w.includes('benign config drift'))).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary

Adds a boot-time freshness guard so a **stale materialized config overlay** (a `config.mjs` missing a leaf its `config.template.mjs` added) **fails fast at boot** with an actionable `--migrate-config` message — instead of crashing cryptically (`reading '<x>' of undefined`) at runtime, the exact failure that took down the Memory Core during the embed-drain-recovery session. Reuses the existing exported `detectDrift` / `projectShape` detection; per @neo-opus-grace's #13432 convergence, scoped to **crash-causing drift only** (benign drift warns, never blocks).

Resolves #13560

Refs #13432, #13495, #13553

## Deltas

- **`ai/scripts/setup/initServerConfigs.mjs`** — new exported `assertConfigFresh({serverPath, aiRoot, logger})`: reuses `detectDrift` / `projectShape` / `materializeServerConfigTemplate` to compare each overlay (`config.mjs`) against its template (`config.template.mjs`). Throws on **crash-causing drift** (missing imports / exports / env-leaves) naming the missing leaves + the `--migrate-config` fix; **benign drift** (a changed default for a leaf that still exists) **warns**, not throws. Materializes the per-server template's Tier-1 import before the compare (matching `initConfigs`) so the template-vs-overlay import path is not false-flagged.
- **`ai/mcp/server/memory-core/mcp-server.mjs`** — guard before `Neo.create` (checks Tier-1 + the memory-core overlay).
- **`ai/daemons/orchestrator/daemon.mjs`** — guard in the process-entry block before `startOrchestrator` (Tier-1); `startOrchestrator` stays guard-free so tests don't hit it.
- **`test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs`** — 3 `assertConfigFresh` specs (+ re-aligned the pre-existing import block per the lint-staged gate on the touched file).

## Test Evidence

Evidence: `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs`

```
29 passed (790ms)
```

3 new `assertConfigFresh` specs: stale-overlay-missing-leaf → throws + names the leaf (`NEO_SECTION_ENABLED`) + `--migrate-config`; in-shape overlay → no throw; benign drift (changed default only) → warns, no throw. The 26 existing `initServerConfigs` tests still pass. `node --check` clean on all 3 touched source files. The guard runs only in the process-entry paths (the `import.meta.url` boot block + the MC try-block), not on import, so it never fires inside the unit suite.

## Post-Merge Validation

- [ ] On a clone with a deliberately stale overlay (template advanced, overlay not `--migrate-config`'d), confirm the MC server + orchestrator FAIL FAST at boot with the named-leaf + `--migrate-config` message — not a cryptic undefined-deref crash.
- [ ] Confirm a fresh (in-shape) overlay boots clean, and an absent overlay (e.g. a CI env with no materialized `config.mjs`) is skipped (no throw).
- [ ] Confirm benign drift (an operator-changed default) does NOT block boot (warn only).

## Risk

Low — a boot-time check reusing the existing prepare-time detector; read-only (no config mutation); scoped to crash-causing drift so a functional overlay never false-positive-blocks boot; fails soft when an overlay is absent. `startOrchestrator` / `Server` logic is unchanged (the guard runs only in the process-entry paths). Closes the deployment-resilience gap @neo-opus-grace's #13432 flagged + the MC-wide crash from this session.

---

Authored by Vega (Claude Opus 4.8, Claude Code). Session 64ee317e-53b6-4f76-8241-f4eade1c084d.
