### PR TITLE
fix(memory-core): archive content-gone AGENT_MEMORY rows from the miniSummary backfill

### DIFF
--- a/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
+++ b/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.mjs
@@ -30,6 +30,8 @@ export function getPendingMemorySummaryBackfillJobs(db, {limit = 50} = {}) {
             FROM Nodes memory
             WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
               AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
+              -- exclude rows archived as structurally un-summarizable (no recoverable content)
+              AND json_extract(memory.data, '$.properties.archivedAt') IS NULL
             ORDER BY json_extract(memory.data, '$.properties.timestamp') DESC, memory.id DESC
             LIMIT ?
         `).all(numericLimit).map(row => row.id).filter(Boolean);
@@ -58,6 +60,8 @@ export function getPendingMemorySummaryBackfillCount(db) {
             FROM Nodes memory
             WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
               AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
+              -- exclude rows archived as structurally un-summarizable (no recoverable content)
+              AND json_extract(memory.data, '$.properties.archivedAt') IS NULL
         `).get();
 
         return Number.isInteger(row?.n) ? row.n : null;
@@ -90,6 +94,8 @@ export function getStillPendingMemorySummaryBackfillJobs(db, ids = []) {
             FROM Nodes memory
             WHERE json_extract(memory.data, '$.label') = 'AGENT_MEMORY'
               AND json_extract(memory.data, '$.properties.miniSummary') IS NULL
+              -- an archived row is no longer pending: it counts as progress, not a stuck attempt
+              AND json_extract(memory.data, '$.properties.archivedAt') IS NULL
               AND memory.id IN (${placeholders})
         `).all(...ids).map(row => row.id).filter(Boolean);
     } catch {

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1575,11 +1575,15 @@ class MemoryService extends Base {
               `).run(archivedAt, reason, id);
 
         // Node-cache coherence: getContextFrontier reads the in-memory node cache, which the SQL
-        // UPDATE does not touch. Mirror the marker so the topology frontier excludes it too.
-        const cached = GraphService.db?.nodes?.get(id);
-        if (cached?.properties) {
-            cached.properties.archivedAt     = archivedAt;
-            cached.properties.archivedReason = reason;
+        // UPDATE does not touch. Mirror the marker — but only on a REAL archive (info.changes > 0),
+        // so an idempotent re-run (the DB UPDATE no-ops, keeping the original archivedAt) does not
+        // stamp a fresh timestamp on the cache and drift it from the persisted row.
+        if (info.changes > 0) {
+            const cached = GraphService.db?.nodes?.get(id);
+            if (cached?.properties) {
+                cached.properties.archivedAt     = archivedAt;
+                cached.properties.archivedReason = reason;
+            }
         }
 
         return info.changes > 0;

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -1546,6 +1546,46 @@ class MemoryService extends Base {
     }
 
     /**
+     * @summary Reversibly archives a single `AGENT_MEMORY` graph node via the `archivedAt` marker —
+     * used by the miniSummary backfill for structurally-un-summarizable rows (no Chroma content, so
+     * the embedding never landed). Graph-only: a no-content row has no Chroma metadata row to stamp.
+     * Idempotent via the `archivedAt IS NULL` guard; reversible by clearing `archivedAt`. The recall
+     * and backfill pending queries already exclude `archivedAt`, so an archived node leaves both
+     * surfaces. Mirrors {@link MemoryService#archiveMemoriesByAgentIdentity} (the by-identity
+     * dual-store primitive), narrowed to one id and the graph store.
+     * @param {Object} options
+     * @param {String} options.id           The AGENT_MEMORY node id.
+     * @param {String} [options.reason='']  Provenance, stored as `archivedReason`.
+     * @returns {Boolean} `true` if a live (not-already-archived) row was archived.
+     */
+    archiveMemoryNode({id, reason = ''} = {}) {
+        const sqlite = GraphService.db?.storage?.db;
+
+        if (!sqlite || !id) {
+            return false;
+        }
+
+        const archivedAt = new Date().toISOString(),
+              info       = sqlite.prepare(`
+                  UPDATE Nodes
+                  SET data = json_set(json_set(data, '$.properties.archivedAt', ?), '$.properties.archivedReason', ?)
+                  WHERE id = ?
+                    AND json_extract(data, '$.label') = 'AGENT_MEMORY'
+                    AND json_extract(data, '$.properties.archivedAt') IS NULL
+              `).run(archivedAt, reason, id);
+
+        // Node-cache coherence: getContextFrontier reads the in-memory node cache, which the SQL
+        // UPDATE does not touch. Mirror the marker so the topology frontier excludes it too.
+        const cached = GraphService.db?.nodes?.get(id);
+        if (cached?.properties) {
+            cached.properties.archivedAt     = archivedAt;
+            cached.properties.archivedReason = reason;
+        }
+
+        return info.changes > 0;
+    }
+
+    /**
      * @summary Backfills compact per-turn summaries for existing `AGENT_MEMORY` graph rows.
      *
      * Mirrors the inline {@link addMemory} enrichment path for pre-existing memories and for
@@ -1629,6 +1669,11 @@ class MemoryService extends Base {
 
             const metadata = byId.get(row.id);
             if (!metadata || (!metadata.prompt && !metadata.response)) {
+                // No recoverable content (the embedding never landed or was purged) — reversibly
+                // archive the node so it leaves the pending set AND counts as progress, instead of
+                // skipping it forever (a permanent backlog floor that also misfires the scheduler's
+                // no-progress backoff). The pending + recall queries already exclude `archivedAt`.
+                this.archiveMemoryNode({id: row.id, reason: 'no-content'});
                 missingContent++;
                 continue;
             }

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs
@@ -3,6 +3,7 @@ import {
     buildNoProgressBackoffHook,
     buildMemorySummaryBackfillTrigger,
     getDueTask,
+    getPendingMemorySummaryBackfillCount,
     getPendingMemorySummaryBackfillJobs,
     getStillPendingMemorySummaryBackfillJobs,
     isNoProgressBackoffActive,
@@ -172,5 +173,26 @@ test.describe('orchestrator/scheduling/memorySummaryBackfill', () => {
         expect(taskState.noProgressBackoffReason).toBeUndefined();
         expect(taskState.noProgressBackoffAt).toBeUndefined();
         expect(taskState.noProgressPendingIds).toBeUndefined();
+    });
+
+    test('#13566: archived rows are excluded from fetch, count, and the no-progress re-check', () => {
+        const captured  = [],
+              captureDb = (rows = []) => ({
+                  prepare(sql) {
+                      captured.push(sql);
+                      return {all: () => rows, get: () => ({n: rows.length})};
+                  }
+              });
+
+        expect(getPendingMemorySummaryBackfillJobs(captureDb([{id: 'a'}]))).toEqual(['a']);
+        expect(getPendingMemorySummaryBackfillCount(captureDb([{}, {}]))).toBe(2);
+        expect(getStillPendingMemorySummaryBackfillJobs(captureDb([{id: 'a'}]), ['a'])).toEqual(['a']);
+
+        // All three pending surfaces must skip rows archived as structurally un-summarizable,
+        // so an archived no-content row stops inflating the metric + counts as backoff progress.
+        expect(captured).toHaveLength(3);
+        for (const sql of captured) {
+            expect(sql).toContain("'$.properties.archivedAt') IS NULL");
+        }
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveMemoryNode.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveMemoryNode.spec.mjs
@@ -1,0 +1,83 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MemoryServiceArchiveMemoryNodeTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Coverage for `MemoryService.archiveMemoryNode` — the reversible per-node `archivedAt` archive the
+ * miniSummary backfill uses for structurally-un-summarizable rows. Runs against the real
+ * in-memory SQLite graph (`unitTestMode` → `storagePaths.graph = ':memory:'`, like the sibling
+ * ArchiveByIdentity.PublicRecall spec) so the graph-SQL `json_set` stamp is exercised end-to-end.
+ */
+test.describe('MemoryService.archiveMemoryNode — reversible per-node archive', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let MemoryService, GraphService, LifecycleService;
+
+    test.beforeAll(async () => {
+        GraphService     = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        MemoryService    = (await import('../../../../../../ai/services/memory-core/MemoryService.mjs')).default;
+        LifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync();
+        } else {
+            await LifecycleService._initPromise;
+        }
+    });
+
+    const readNode = id => {
+        const row = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(id);
+        return row ? JSON.parse(row.data) : null;
+    };
+
+    test('archives a live AGENT_MEMORY node (sets archivedAt + archivedReason)', () => {
+        const id = 'archive-node-test-live';
+        GraphService.db.storage.addNodes([{
+            id,
+            label     : 'AGENT_MEMORY',
+            properties: {agentIdentity: '@x', timestamp: '2026-01-01T00:00:00.000Z'}
+        }]);
+
+        expect(readNode(id).properties.archivedAt ?? null).toBeNull();
+
+        expect(MemoryService.archiveMemoryNode({id, reason: 'no-content'})).toBe(true);
+
+        const after = readNode(id).properties;
+        expect(after.archivedAt).toBeTruthy();
+        expect(after.archivedReason).toBe('no-content');
+        // Reversible archive-not-delete: the node + its other properties are retained.
+        expect(after.agentIdentity).toBe('@x');
+    });
+
+    test('is idempotent — a second archive finds no live row (archivedAt IS NULL guard) → false', () => {
+        const id = 'archive-node-test-idem';
+        GraphService.db.storage.addNodes([{
+            id,
+            label     : 'AGENT_MEMORY',
+            properties: {agentIdentity: '@y', timestamp: '2026-01-01T00:00:00.000Z'}
+        }]);
+
+        expect(MemoryService.archiveMemoryNode({id})).toBe(true);
+        expect(MemoryService.archiveMemoryNode({id})).toBe(false);
+    });
+
+    test('returns false for a missing id', () => {
+        expect(MemoryService.archiveMemoryNode({id: 'archive-node-test-absent'})).toBe(false);
+        expect(MemoryService.archiveMemoryNode({})).toBe(false);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveMemoryNode.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryService.ArchiveMemoryNode.spec.mjs
@@ -80,4 +80,22 @@ test.describe('MemoryService.archiveMemoryNode — reversible per-node archive',
         expect(MemoryService.archiveMemoryNode({id: 'archive-node-test-absent'})).toBe(false);
         expect(MemoryService.archiveMemoryNode({})).toBe(false);
     });
+
+    test('mirrors archivedAt onto the in-memory node cache, gated on a real archive', () => {
+        // upsertGlobalNode populates BOTH the SQL row and the in-memory node cache getContextFrontier
+        // reads (addNodes is SQL-only) — so this exercises the archive op's cache-coherence mirror.
+        const id = 'AGENT_MEMORY:archive-cache-probe';
+        GraphService.upsertGlobalNode({id, type: 'AGENT_MEMORY', name: 'archive cache probe', properties: {agentIdentity: '@z'}});
+
+        expect(MemoryService.archiveMemoryNode({id, reason: 'no-content'})).toBe(true);
+        const cached = GraphService.db.nodes.get(id);
+        expect(cached.properties.archivedAt).toBeTruthy();
+        expect(cached.properties.archivedReason).toBe('no-content');
+
+        // Idempotent re-run: gated on info.changes → the DB UPDATE no-ops and the cache keeps the
+        // original stamp (no DB/cache drift).
+        const stamped = cached.properties.archivedAt;
+        expect(MemoryService.archiveMemoryNode({id, reason: 'no-content'})).toBe(false);
+        expect(GraphService.db.nodes.get(id).properties.archivedAt).toBe(stamped);
+    });
 });


### PR DESCRIPTION
Resolves #13566

Authored by @neo-opus-grace

Wires the miniSummary backfill into the existing `archivedAt` archive-not-delete model (converged with @neo-opus-vega on #12065) so structurally-un-summarizable rows stop being a permanent backlog floor.

## What changed
- `MemoryService.backfillMiniSummaries`: a `missingContent` row (no Chroma `prompt`/`response`) is now reversibly archived via `archiveMemoryNode` instead of skipped forever — it leaves the pending set AND counts as progress, killing the no-progress-backoff misfire.
- New `MemoryService.archiveMemoryNode({id, reason})`: per-node graph-only `archivedAt` marker (mirrors the proven `archiveMemoriesByAgentIdentity`, narrowed to one id — a no-content row has no Chroma row to stamp; idempotent + reversible).
- `memorySummaryBackfill.mjs`: the fetch, count, and no-progress re-check queries now exclude `archivedAt IS NOT NULL`.

## Why
Live data (#12065): 4,347 / 12,496 AGENT_MEMORY pending; **3,327 (77%) have no Chroma embedding** (orphan-residue, content-gone — only 2 WAL-recoverable). They could never receive a `miniSummary`, so the pending metric never zeroed ("still an issue") and a newest-50 batch dominated by them armed the no-progress backoff. Archive-not-delete is reversible, which dissolves the recover-vs-tombstone question (per @neo-opus-vega).

Evidence: L1 (unit test of the three query exclusions; `archiveMemoryNode` mirrors the L-tested `archiveMemoriesByAgentIdentity`) → L1 required (the ACs are unit/contract-level; no runtime surface CI can't reach). Residual: the one-shot archive of the 3,327 is a post-merge operational step.

## Test Evidence
`npx playwright test test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs` → **14/14 pass** (13 existing + the new `#13566: archived rows are excluded from fetch, count, and the no-progress re-check`).

## Post-Merge Validation
One-shot reconcile (reversible, ephemeral `/tmp` script): archive the existing 3,327 content-gone nodes + re-embed the 2 in-WAL recoverables; verify the backfill pending count drops to the true drainable backlog (~1,018).

## Deltas from ticket
- `archiveMemoryNode` is a per-node narrowing of the **existing** `archivedAt` model, not a new model — V-B-A found `archiveMemoriesByAgentIdentity` + the recall-query exclusions already exist; this reuses them.
- Fast-follow: a direct `archiveMemoryNode` integration test (real `:memory:` graph). It currently mirrors the L-tested by-identity primitive; flagging for the review cycle.
