### PR TITLE
fix(memory-core): RLS reads tolerate both user_id forms (#13571)

### DIFF
--- a/ai/graph/storage/SQLite.mjs
+++ b/ai/graph/storage/SQLite.mjs
@@ -1,4 +1,4 @@
-import Base from './Base.mjs';
+import Base                            from './Base.mjs';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE } from './constants.mjs';
 
 const GRAPH_SCHEMA_VERSION = 1;
@@ -56,6 +56,7 @@ class SQLite extends Base {
         try {
             const rcs = await import('../../mcp/server/shared/services/RequestContextService.mjs');
             me.RequestContextService = rcs.default;
+            me.normalizeUserId       = rcs.normalizeUserId;
         } catch (e) {
             // Safe fallback for browser/UI isolated executions
         }
@@ -298,8 +299,8 @@ class SQLite extends Base {
             for (const node of nodesList) {
                 const isRecord = node.isRecord;
                 const nodeData = {
-                    id: isRecord ? node.get('id') : node.id,
-                    label: isRecord ? node.get('label') : node.label,
+                    id        : isRecord ? node.get('id') : node.id,
+                    label     : isRecord ? node.get('label') : node.label,
                     properties: isRecord ? node.get('properties') : node.properties
                 };
 
@@ -336,10 +337,10 @@ class SQLite extends Base {
             for (const edge of edgesList) {
                 const isRecord = edge.isRecord;
                 const edgeData = {
-                    id: isRecord ? edge.get('id') : edge.id,
-                    source: isRecord ? edge.get('source') : edge.source,
-                    target: isRecord ? edge.get('target') : edge.target,
-                    type: isRecord ? edge.get('type') : edge.type,
+                    id        : isRecord ? edge.get('id') : edge.id,
+                    source    : isRecord ? edge.get('source') : edge.source,
+                    target    : isRecord ? edge.get('target') : edge.target,
+                    type      : isRecord ? edge.get('type') : edge.type,
                     properties: isRecord ? edge.get('properties') : edge.properties
                 };
                 stmt.run(edgeData.id, edgeData.properties?.userId || null, edgeData.source, edgeData.target, edgeData.type || null, JSON.stringify(edgeData));
@@ -499,7 +500,7 @@ class SQLite extends Base {
         }
 
         return {
-            lastLogId: maxId,
+            lastLogId   : maxId,
             invalidNodes: Array.from(invalidNodes),
             invalidEdges: Array.from(invalidEdgesMap.values())
         };
@@ -519,9 +520,15 @@ class SQLite extends Base {
         let ids = Array.isArray(nodeIds) ? nodeIds : [nodeIds];
         if (ids.length === 0) return {nodes: [], edges: []};
 
-        // Resolve Identity for RLS natively synchronously
-        let userId = this.RequestContextService ? this.RequestContextService.getAgentIdentityNodeId() : null;
-        let rlsClause = `AND (user_id = ? OR user_id IS NULL OR json_extract(data, '$.properties.sharedEntity') = 1 OR json_extract(data, '$.properties.visibility') = 'team')`;
+        // Resolve the RLS key canonically (normalized, no-`@`) and match BOTH stored forms: the
+        // user_id column was written in @-prefixed AND normalized forms, so this cold lazy-load (the
+        // path getNode hits BEFORE GraphService.isRlsVisible) must tolerate both — recovering an
+        // owner's own normalized-user_id rows without widening across tenants. Mirrors searchNodes.
+        const rcs       = this.RequestContextService;
+        const rawUserId = rcs ? (rcs.getUserId?.() ?? rcs.getAgentIdentityNodeId?.()) : null;
+        const userId    = rawUserId == null ? null : (this.normalizeUserId ? this.normalizeUserId(rawUserId) : rawUserId);
+        const userIdAt  = userId == null ? null : '@' + userId;
+        let rlsClause = `AND (user_id = ? OR user_id = ? OR user_id IS NULL OR json_extract(data, '$.properties.sharedEntity') = 1 OR json_extract(data, '$.properties.visibility') = 'team')`;
 
         const chunkSize = SQLITE_IN_CLAUSE_BATCH_SIZE;
         let targetNodes = [];
@@ -532,10 +539,10 @@ class SQLite extends Base {
             let placeholders = chunk.map(() => '?').join(',');
 
             const nodesStmt = this.db.prepare(`SELECT data FROM Nodes WHERE id IN (${placeholders}) ${rlsClause}`);
-            targetNodes.push(...nodesStmt.all(...chunk, userId || null).map(r => JSON.parse(r.data)));
+            targetNodes.push(...nodesStmt.all(...chunk, userId, userIdAt).map(r => JSON.parse(r.data)));
 
             const edgesStmt = this.db.prepare(`SELECT data FROM Edges WHERE (source IN (${placeholders}) OR target IN (${placeholders})) ${rlsClause}`);
-            const edgesParams = [...chunk, ...chunk, userId || null];
+            const edgesParams = [...chunk, ...chunk, userId, userIdAt];
             edges.push(...edgesStmt.all(...edgesParams).map(r => JSON.parse(r.data)));
         }
 
@@ -552,7 +559,7 @@ class SQLite extends Base {
                 let chunk = adjIdsArray.slice(i, i + chunkSize);
                 let adjPl = chunk.map(() => '?').join(',');
                 let adjStmt = this.db.prepare(`SELECT data FROM Nodes WHERE id IN (${adjPl}) ${rlsClause}`);
-                adjacentNodes.push(...adjStmt.all(...chunk, userId || null).map(r => JSON.parse(r.data)));
+                adjacentNodes.push(...adjStmt.all(...chunk, userId, userIdAt).map(r => JSON.parse(r.data)));
             }
         }
 

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -1,11 +1,12 @@
-import path         from 'path';
-import aiConfig     from '../../mcp/server/memory-core/config.mjs';
-import logger       from '../../mcp/server/memory-core/logger.mjs';
-import Base         from '../../../src/core/Base.mjs';
-import CoreDatabase from '../../../ai/graph/Database.mjs';
-import SQLite       from '../../../ai/graph/storage/SQLite.mjs';
-import { IDENTITIES } from '../../../ai/graph/identityRoots.mjs';
-import fsExtra       from 'fs-extra';
+import path                from 'path';
+import aiConfig            from '../../mcp/server/memory-core/config.mjs';
+import logger              from '../../mcp/server/memory-core/logger.mjs';
+import Base                from '../../../src/core/Base.mjs';
+import CoreDatabase        from '../../../ai/graph/Database.mjs';
+import SQLite              from '../../../ai/graph/storage/SQLite.mjs';
+import { IDENTITIES }      from '../../../ai/graph/identityRoots.mjs';
+import { normalizeUserId } from '../../mcp/server/shared/services/RequestContextService.mjs';
+import fsExtra             from 'fs-extra';
 
 /**
  * Row-level-security visibility predicate for an in-memory graph **node or edge**, mirroring
@@ -27,11 +28,30 @@ function isRlsVisible(entity, requesterUserId) {
     const properties  = (entity.isRecord ? entity.get('properties') : entity.properties) || {},
           ownerUserId = properties.userId;
 
-    return ownerUserId == null              ||
-           ownerUserId === requesterUserId  ||
-           properties.sharedEntity === 1    ||
-           properties.sharedEntity === true ||
+    // Compare canonical-to-canonical: the stored owner key (`properties.userId`) exists in BOTH the
+    // `@`-prefixed (getAgentIdentityNodeId) and normalized (normalizeUserId(getUserId)) forms across
+    // node types, while `requesterUserId` is resolved canonically (resolveRlsUserId). Normalizing the
+    // owner key here matches an agent's OWN nodes regardless of which form they were stored in, and
+    // never widens across tenants (distinct tenants normalize to distinct ids).
+    return ownerUserId == null                              ||
+           normalizeUserId(ownerUserId) === requesterUserId ||
+           properties.sharedEntity === 1                    ||
+           properties.sharedEntity === true                 ||
            properties.visibility === 'team';
+}
+
+/**
+ * Resolves the canonical (normalized, no-`@`) RLS tenant key for the acting request. The isolation
+ * key is the userId (`RequestContextService.getUserId`); `getAgentIdentityNodeId` is an `@`-prefixed
+ * node id explicitly NOT for isolation, used only as a fallback when no userId is bound. Returning the
+ * normalized form lets the RLS predicate match an owner's own nodes regardless of the (historically
+ * inconsistent) stored `user_id` form.
+ * @param {Object|null|undefined} rcs The request-bound RequestContextService.
+ * @returns {String|null} Normalized userId, or null when no identity is bound.
+ */
+function resolveRlsUserId(rcs) {
+    const raw = rcs?.getUserId?.() ?? rcs?.getAgentIdentityNodeId?.() ?? null;
+    return raw == null ? null : normalizeUserId(raw);
 }
 
 /**
@@ -589,9 +609,9 @@ class GraphService extends Base {
         let systemNode = this.db.nodes.get('_SYSTEM_STATE');
         if (!systemNode) {
             this.upsertGlobalNode({
-                id: '_SYSTEM_STATE',
-                type: 'SYSTEM_CLOCK',
-                name: 'Global System Clock',
+                id         : '_SYSTEM_STATE',
+                type       : 'SYSTEM_CLOCK',
+                name       : 'Global System Clock',
                 description: 'Tracks algorithmic time intervals for global physics.'
             });
             systemNode = this.db.nodes.get('_SYSTEM_STATE');
@@ -660,7 +680,7 @@ class GraphService extends Base {
 
         // RLS: the node Store is a process-wide cache — re-check visibility at the
         // return boundary so a cross-requester cache-warmed node is not leaked.
-        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+        let rlsUserId = resolveRlsUserId(this.db.storage?.RequestContextService);
         if (!isRlsVisible(node, rlsUserId)) {
             return null;
         }
@@ -703,7 +723,7 @@ class GraphService extends Base {
 
         // RLS: the node Store is a process-wide cache — re-check visibility at the
         // return boundary so a cross-requester cache-warmed node is not leaked.
-        const rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+        const rlsUserId = resolveRlsUserId(this.db.storage?.RequestContextService);
         if (!isRlsVisible(node, rlsUserId)) {
             return null;
         }
@@ -752,7 +772,7 @@ class GraphService extends Base {
 
         // RLS: resolve the requester once; do not expose the vicinity of a node the
         // requester cannot see, and filter each neighbor by node + edge visibility.
-        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null,
+        let rlsUserId = resolveRlsUserId(this.db.storage?.RequestContextService),
             rootNode  = this.db.nodes.get(id);
 
         if (!rootNode || !isRlsVisible(rootNode, rlsUserId)) {
@@ -799,9 +819,12 @@ class GraphService extends Base {
 
         let q = `%${query.toLowerCase()}%`;
 
-        let userId = this.db.storage.RequestContextService ? this.db.storage.RequestContextService.getAgentIdentityNodeId() : null;
+        const userId = resolveRlsUserId(this.db.storage?.RequestContextService);
 
-        let rlsClause = `AND (user_id = ? OR user_id IS NULL OR json_extract(data, '$.properties.sharedEntity') = 1 OR json_extract(data, '$.properties.visibility') = 'team')`;
+        // Match the canonical (no-`@`) key AND its `@`-prefixed legacy form — the user_id column was
+        // written in both (see isRlsVisible) — so own-private rows stay visible to their owner
+        // regardless of stored form, without widening to other tenants.
+        let rlsClause = `AND (user_id = ? OR user_id = ? OR user_id IS NULL OR json_extract(data, '$.properties.sharedEntity') = 1 OR json_extract(data, '$.properties.visibility') = 'team')`;
 
         const stmt = this.db.storage.db.prepare(`
             SELECT data FROM Nodes
@@ -813,7 +836,7 @@ class GraphService extends Base {
         `);
 
         let matches = [];
-        const rows = stmt.all(q, q, q, userId || null);
+        const rows = stmt.all(q, q, q, userId, userId == null ? null : '@' + userId);
         for (const row of rows) {
             let node = JSON.parse(row.data);
             matches.push({
@@ -845,7 +868,7 @@ class GraphService extends Base {
 
         // RLS: the frontier anchor is shared, but its strategic neighbors may be
         // tenant-private — filter them at the return boundary.
-        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+        let rlsUserId = resolveRlsUserId(this.db.storage?.RequestContextService);
 
         const topology = {
             frontier          : {
@@ -906,7 +929,7 @@ class GraphService extends Base {
 
         // RLS: the node Store is a process-wide cache — re-check the cache-resident
         // root and every traversed node at the return boundary.
-        let rlsUserId = this.db.storage?.RequestContextService?.getAgentIdentityNodeId() ?? null;
+        let rlsUserId = resolveRlsUserId(this.db.storage?.RequestContextService);
         if (!isRlsVisible(rootNode, rlsUserId)) {
             logger.info(`[GraphService] Node ${nodeId} not visible to the active requester.`);
             return null;
@@ -1121,7 +1144,7 @@ class GraphService extends Base {
 
         if (!sqliteDb || !dbPath) {
             return {
-                available: false, memoryNodes: 0, sessionNodes: 0,
+                available  : false, memoryNodes: 0, sessionNodes: 0,
                 sqliteBytes: 0, sqliteWalBytes: 0, sqliteShmBytes: 0,
                 measuredAt, error: 'Graph SQLite storage is unavailable.'
             };
@@ -1168,7 +1191,7 @@ class GraphService extends Base {
             return census;
         } catch (e) {
             return {
-                available: false, memoryNodes: 0, sessionNodes: 0,
+                available  : false, memoryNodes: 0, sessionNodes: 0,
                 sqliteBytes: 0, sqliteWalBytes: 0, sqliteShmBytes: 0,
                 measuredAt, error: e?.message || String(e)
             };

--- a/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
@@ -28,8 +28,9 @@ import * as core      from '../../../../../../src/core/_export.mjs';
  * `GraphService.db` with a pre-warmed fake Store (the cache-warmed case) and assert the
  * `isRlsVisible` return-boundary predicate filters cross-tenant nodes and edges.
  *
- * RLS-visible to requester R iff: owner is null  OR  owner === R  OR  sharedEntity  OR
- * visibility === 'team' — mirroring the SQL clause.
+ * RLS-visible to requester R iff: owner is null  OR  normalizeUserId(owner) === canonical(R)  OR
+ * sharedEntity  OR  visibility === 'team'. The canonical comparison tolerates both stored user_id
+ * forms (`@`-prefixed identity vs normalized userId) — mirroring the SQL clause.
  */
 
 // Mutable holder so one fake db can switch the "active requester" between calls.
@@ -112,6 +113,23 @@ test.describe('GraphService — RLS read-side return boundary (#10011)', () => {
         requester.value = '@tenant-a';
 
         expect(GraphService.getNode({id: 'n-private-a'})?.id).toBe('n-private-a');
+    });
+
+    test('getNode returns the owner\'s own node regardless of stored user_id form (#13571)', () => {
+        // The user_id column was historically written in both `@`-prefixed (getAgentIdentityNodeId)
+        // and normalized (normalizeUserId(getUserId)) forms; the read key is resolved canonically, so
+        // an owner's own node resolves whichever form it was stored in — without widening across tenants.
+        GraphService.db = makeFakeDb([
+            node('n-own-atform',     {userId: '@tenant-b', name: 'own @-form'}),
+            node('n-own-normalized', {userId: 'tenant-b',  name: 'own normalized'}),
+            node('n-foreign-norm',   {userId: 'tenant-a',  name: 'foreign normalized'})
+        ]);
+        requester.value = '@tenant-b';
+
+        expect(GraphService.getNode({id: 'n-own-atform'})?.id).toBe('n-own-atform');
+        expect(GraphService.getNode({id: 'n-own-normalized'})?.id).toBe('n-own-normalized');
+        // No widening: a foreign tenant's normalized node stays hidden.
+        expect(GraphService.getNode({id: 'n-foreign-norm'})).toBeNull();
     });
 
     test('getNeighbors filters cross-tenant neighbor nodes', () => {
@@ -263,7 +281,7 @@ function makeWritableDb() {
     return {
         getAdjacentNodes() {},
         nodes: nodeMap,
-        edges  : {getByIndex() { return []; }},
+        edges: {getByIndex() { return []; }},
         addNode(spec) { nodeMap.set(spec.id, {id: spec.id, label: spec.label, properties: spec.properties}); },
         autoSave: false,
         storage : {RequestContextService: {getAgentIdentityNodeId: () => requester.value}}

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -250,6 +250,45 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         }
     });
 
+    test('cold SQLite lazy-load recovers an owner\'s own normalized-user_id node (#13571)', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
+        const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
+
+        let mockIdentity    = '@tenant-gamma';
+        const originalGetId = RequestContextService.getAgentIdentityNodeId;
+        RequestContextService.getAgentIdentityNodeId = () => mockIdentity;
+
+        const recool = () => {
+            const wasAutoSave        = GraphService.db.autoSave;
+            GraphService.db.autoSave = false;
+            GraphService.db.nodes.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+            GraphService.db.autoSave = wasAutoSave;
+        };
+
+        try {
+            // Seed directly into SQLite with a NORMALIZED (no-`@`) user_id — the form MemoryService
+            // writes and the old @-form-only cold predicate filtered out. Bypasses upsertNode's stamp.
+            GraphService.db.storage.addNodes([{
+                id        : 'cold-own-normalized',
+                label     : 'TestNode',
+                properties: {userId: 'tenant-gamma', name: 'cold own normalized'}
+            }]);
+
+            // Owner reads its own normalized-user_id node through the COLD lazy-load (loadNodeVicinitySync).
+            recool();
+            mockIdentity = '@tenant-gamma';
+            expect((await GraphService.getNode({id: 'cold-own-normalized'}))?.id).toBe('cold-own-normalized');
+
+            // Cross-tenant read on the persisted path → null (no widening on the cold load either).
+            recool();
+            mockIdentity = '@tenant-delta';
+            expect(await GraphService.getNode({id: 'cold-own-normalized'})).toBe(null);
+        } finally {
+            RequestContextService.getAgentIdentityNodeId = originalGetId;
+        }
+    });
+
     test('preBriefSession should hydrate episodic context through getNeighbors semanticVectorId', async () => {
         await GraphService.upsertNode({id: 'EpicA', name: 'Roadmap Planner'});
         await GraphService.upsertNode({id: 'MemoryA', name: 'Session Summary', semanticVectorId: 'summary-vector-1'});
@@ -354,12 +393,12 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
     test('upsertNode should lazy-load from SQLite to prevent cold-cache stub overwriting (resolves #10230)', async () => {
         // Bypass upsertNode to simulate a rich node seeded directly into SQLite
         GraphService.db.storage.addNodes([{
-            id: '@test-identity',
-            label: 'AgentIdentity',
+            id        : '@test-identity',
+            label     : 'AgentIdentity',
             properties: {
-                name: 'Test Identity',
+                name       : 'Test Identity',
                 githubLogin: 'test-user',
-                createdAt: '2026-04-23T00:00:00Z'
+                createdAt  : '2026-04-23T00:00:00Z'
             }
         }]);
 
@@ -713,8 +752,8 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         const originalIngest = MemorySessionIngestor.ingestSingleRow;
 
         MemorySessionIngestor.ingestSingleRow = async (id) => ({
-            success: false,
-            reason : 'chroma-row-not-found',
+            success    : false,
+            reason     : 'chroma-row-not-found',
             graphNodeId: id
         });
 


### PR DESCRIPTION
## Summary

GraphService RLS reads keyed the visibility predicate on the `@`-prefixed `getAgentIdentityNodeId` (RequestContextService docs: *"NOT for isolation"*), while the `user_id` column is written in BOTH forms across node types — normalized no-`@` (`normalizeUserId(getUserId)`: MemoryService raw memories, MEMORY/SESSION) and `@`-prefixed (`upsertNode`/`linkNodes` stamping: CONCEPT/CLASS/MESSAGE). So `user_id = '@id'` never matched the normalized rows, and an agent's own private nodes in those labels were **fail-CLOSED invisible to the agent itself** (`get_node` returned null on my own recent AGENT_MEMORY; 3,012 of 3,118 of my nodes hidden). This is the systemic cause behind who_is_online's all-dark (#13557 fixed who_is_online via roster-scoping; searchNodes/loadNodeVicinity/getNode remained exposed).

## What it does (read-side, migration-free)
- `resolveRlsUserId(rcs)` = `normalizeUserId(getUserId() ?? getAgentIdentityNodeId())` — the canonical (no-`@`) tenant key.
- `isRlsVisible` normalizes the stored owner key before comparing → tolerates both stored forms.
- The 5 read sites (getNode / getNodeRecord / getNeighbors / queryNodeTopology / getContextFrontier) + `searchNodes` (both-form SQL match) use it.
- **No widening:** canonical-to-canonical only matches an owner's own nodes; distinct tenants normalize to distinct ids (cross-tenant stays hidden).

## Deltas from ticket
- Dropped the proposed data migration: normalizing the read comparison makes the mixed-form column tolerable as-is — lower-risk than a migration. The writer-side canonicalization (`upsertNode`/`linkNodes` stamp `@`-form) is a separate consistency follow-up, not required for correctness.

Evidence: L2 (16/16 `GraphService.TenantIsolation` spec — new form-tolerance + no-widening test, existing cross-tenant tests unchanged) + read-only live-graph proof (own visible AGENT_MEMORY 106 → 3,118; foreign-tenant node stays invisible) → L4 required (live `get_node`/`searchNodes` through the restarted MCP). Residual: post-merge validation [#13571].

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs` → **16 passed**.
- `node --check ai/services/memory-core/GraphService.mjs` clean.
- Read-only live-graph sim of the new `isRlsVisible`: my AGENT_MEMORY 106 → 3,118 visible; `norm('neo-opus-vega') !== norm('@neo-opus-ada')` → no cross-tenant leak.
- Pre-commit hooks green (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation
- [ ] After MCP restart: `get_node` / `searchNodes` return an agent's own normalized-`user_id` nodes.
- [ ] Cross-tenant private node stays invisible (isolation regression check).

## Security note
This touches the tenant-isolation boundary. The fix is symmetric (canonical key on both the read predicate and the normalized owner key) so it does NOT widen visibility — verified by the unchanged cross-tenant tests + the live no-widening check. @neo-opus-grace looped on the identity↔userId boundary (#11318).

## Cross-family review
@neo-gpt (Euclid) — cross-family (Claude↔GPT) per §6.1. Security-sensitive RLS change; please probe the no-widening claim + the `searchNodes` both-form SQL.

Resolves #13571

Authored by Ada (Claude Opus 4.8). Session abe80be3-6235-4a9e-99bc-b14659ba806a.
