### PR TITLE
feat(ai): fan out assertConfigFresh boot-guard to overlay MCP servers + neural-link bridge (#13570)

### DIFF
--- a/ai/mcp/server/github-workflow/mcp-server.mjs
+++ b/ai/mcp/server/github-workflow/mcp-server.mjs
@@ -1,12 +1,14 @@
 import 'dotenv/config';
-import {Command}       from 'commander';
-import Neo             from '../../../../src/Neo.mjs';
-import * as core       from '../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../src/manager/Instance.mjs';
-import aiConfig        from './config.mjs';
-import logger          from './logger.mjs';
-import Server          from './Server.mjs';
-import {sanitizeInput} from '../../../../buildScripts/util/sanitizer.mjs';
+import {Command}           from 'commander';
+import Neo                 from '../../../../src/Neo.mjs';
+import * as core           from '../../../../src/core/_export.mjs';
+import InstanceManager     from '../../../../src/manager/Instance.mjs';
+import aiConfig            from './config.mjs';
+import logger              from './logger.mjs';
+import Server              from './Server.mjs';
+import {sanitizeInput}     from '../../../../buildScripts/util/sanitizer.mjs';
+import {fileURLToPath}     from 'node:url';
+import {assertConfigFresh} from '../../../scripts/setup/initServerConfigs.mjs';
 
 const program = new Command();
 
@@ -25,6 +27,10 @@ if (options.debug) {
 }
 
 try {
+    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
+    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
+    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+
     await Neo.create(Server, {
         configFile: options.config
     }).ready();

--- a/ai/mcp/server/gitlab-workflow/mcp-server.mjs
+++ b/ai/mcp/server/gitlab-workflow/mcp-server.mjs
@@ -1,12 +1,14 @@
 import 'dotenv/config';
-import {Command}       from 'commander';
-import Neo             from '../../../../src/Neo.mjs';
-import * as core       from '../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../src/manager/Instance.mjs';
-import aiConfig        from './config.mjs';
-import logger          from './logger.mjs';
-import Server          from './Server.mjs';
-import {sanitizeInput} from '../../../../buildScripts/util/sanitizer.mjs';
+import {Command}           from 'commander';
+import Neo                 from '../../../../src/Neo.mjs';
+import * as core           from '../../../../src/core/_export.mjs';
+import InstanceManager     from '../../../../src/manager/Instance.mjs';
+import aiConfig            from './config.mjs';
+import logger              from './logger.mjs';
+import Server              from './Server.mjs';
+import {sanitizeInput}     from '../../../../buildScripts/util/sanitizer.mjs';
+import {fileURLToPath}     from 'node:url';
+import {assertConfigFresh} from '../../../scripts/setup/initServerConfigs.mjs';
 
 const program = new Command();
 
@@ -24,6 +26,10 @@ if (options.debug) {
 }
 
 try {
+    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
+    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
+    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+
     await Neo.create(Server, {
         configFile: options.config
     }).ready();

--- a/ai/mcp/server/knowledge-base/mcp-server.mjs
+++ b/ai/mcp/server/knowledge-base/mcp-server.mjs
@@ -1,12 +1,14 @@
 import 'dotenv/config';
-import {Command}       from 'commander';
-import Neo             from '../../../../src/Neo.mjs';
-import * as core       from '../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../src/manager/Instance.mjs';
-import aiConfig        from './config.mjs';
-import logger          from './logger.mjs';
-import Server          from './Server.mjs';
-import {sanitizeInput} from '../../../../buildScripts/util/sanitizer.mjs';
+import {Command}           from 'commander';
+import Neo                 from '../../../../src/Neo.mjs';
+import * as core           from '../../../../src/core/_export.mjs';
+import InstanceManager     from '../../../../src/manager/Instance.mjs';
+import aiConfig            from './config.mjs';
+import logger              from './logger.mjs';
+import Server              from './Server.mjs';
+import {sanitizeInput}     from '../../../../buildScripts/util/sanitizer.mjs';
+import {fileURLToPath}     from 'node:url';
+import {assertConfigFresh} from '../../../scripts/setup/initServerConfigs.mjs';
 
 const program = new Command();
 
@@ -25,6 +27,10 @@ if (options.debug) {
 }
 
 try {
+    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
+    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
+    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+
     await Neo.create(Server, {
         configFile: options.config
     }).ready();

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -1,12 +1,14 @@
 import 'dotenv/config';
-import {Command}       from 'commander';
-import Neo             from '../../../../src/Neo.mjs';
-import * as core       from '../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../src/manager/Instance.mjs';
-import aiConfig        from './config.mjs';
-import logger          from './logger.mjs';
+import {Command}                           from 'commander';
+import Neo                                 from '../../../../src/Neo.mjs';
+import * as core                           from '../../../../src/core/_export.mjs';
+import InstanceManager                     from '../../../../src/manager/Instance.mjs';
+import aiConfig                            from './config.mjs';
+import logger                              from './logger.mjs';
 import Server, {resolveToolProjectionMode} from './Server.mjs';
-import {sanitizeInput} from '../../../../buildScripts/util/sanitizer.mjs';
+import {sanitizeInput}                     from '../../../../buildScripts/util/sanitizer.mjs';
+import {fileURLToPath}                     from 'node:url';
+import {assertConfigFresh}                 from '../../../scripts/setup/initServerConfigs.mjs';
 
 const program = new Command();
 
@@ -27,6 +29,10 @@ if (options.debug) {
 }
 
 try {
+    // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
+    // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
+    await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+
     await Neo.create(Server, {
         configFile        : options.config,
         bridgeCwd         : options.cwd,

--- a/ai/mcp/server/neural-link/run-bridge.mjs
+++ b/ai/mcp/server/neural-link/run-bridge.mjs
@@ -1,10 +1,12 @@
-import {Command}       from 'commander';
-import Neo             from '../../../../src/Neo.mjs';
-import * as core       from '../../../../src/core/_export.mjs';
-import Bridge          from './Bridge.mjs';
-import aiConfig        from './config.mjs';
-import logger          from './logger.mjs';
-import {sanitizeInput} from '../../../../buildScripts/util/sanitizer.mjs';
+import {Command}           from 'commander';
+import Neo                 from '../../../../src/Neo.mjs';
+import * as core           from '../../../../src/core/_export.mjs';
+import Bridge              from './Bridge.mjs';
+import aiConfig            from './config.mjs';
+import logger              from './logger.mjs';
+import {sanitizeInput}     from '../../../../buildScripts/util/sanitizer.mjs';
+import {fileURLToPath}     from 'node:url';
+import {assertConfigFresh} from '../../../scripts/setup/initServerConfigs.mjs';
 
 const program = new Command();
 
@@ -23,6 +25,10 @@ if (options.debug) {
 
 (async () => {
     try {
+        // Boot guard: fail fast with an actionable message if a materialized config overlay is missing
+        // leaves its template added, rather than crashing cryptically on an undefined config leaf later.
+        await assertConfigFresh({serverPath: fileURLToPath(new URL('.', import.meta.url))});
+
         if (options.config) {
             await aiConfig.load(options.config);
         }


### PR DESCRIPTION
## Summary

Extends the #13568 stale-config-overlay boot guard from the 2 crash-prone entrypoints to the **4 remaining overlay-MCP-servers** (github-workflow, gitlab-workflow, knowledge-base, neural-link) + the **neural-link bridge** (`run-bridge.mjs`). Each materializes its own gitignored `config.mjs` overlay and can hit the same cryptic `undefined`-deref crash on a stale overlay — the failure that took down the Memory Core in the embed-drain session. The guard converts it into an actionable `--migrate-config` boot failure.

Pure call-site fan-out — `assertConfigFresh`'s signature is unchanged — mirroring the memory-core placement (guard in the process-entry `try`-block, before `Neo.create` / `Bridge.ready`).

Resolves #13570

Refs #13568, #13560, #13432

## Scope — and the daemon split (#13573)

#13570 originally listed the daemons too. The V-B-A (reading every boot entrypoint) found the daemons are **not a uniform fan-out**, so AC2 (daemons) is split to **#13573**:
- `embed` already self-guards (`getMissingMemoryWalLeaves` + `--migrate-config` — the bespoke prior-art `assertConfigFresh` generalizes).
- `wake` reads config at **module-load** → needs a refactor, not a call-site add.
- `kb-alerting` / `kb-gc` / `kb-reconciliation` read config **indirectly** via their Service → per-daemon overlay analysis.

This PR resolves the clean overlay-server + bridge fan-out (AC1 / AC3 / AC4). `file-system` MCP has no `config.template.mjs` overlay → documented skip (AC5).

## Deltas

- **`ai/mcp/server/github-workflow/mcp-server.mjs`** — `assertConfigFresh({serverPath})` guard in the boot `try`-block before `Neo.create`; + 2 imports (`fileURLToPath`, `assertConfigFresh`).
- **`ai/mcp/server/gitlab-workflow/mcp-server.mjs`** — same.
- **`ai/mcp/server/knowledge-base/mcp-server.mjs`** — same.
- **`ai/mcp/server/neural-link/mcp-server.mjs`** — same.
- **`ai/mcp/server/neural-link/run-bridge.mjs`** — guard in the IIFE boot `try` before `Bridge.ready()`; + 2 imports. The bridge boots **independently** of the neural-link MCP server (its own process entry), so it needs its own guard (#13570 AC3).

Imports auto-aligned via `check-block-alignment --fix` (dogfooding the #13564 lint), not hand-aligned.

## Test Evidence

Evidence: L1 — the guarded function (`assertConfigFresh`) is already unit-tested across all three behaviors by #13568's `initServerConfigs.spec.mjs` (29/29 green on `dev`). This PR adds only call-sites; per #13568's review precedent the call-site firing is a trivial pre-construct call, not separately integration-tested.

```
node --check        : all 5 files pass
check-block-alignment: all 5 files CLEAN (imports auto-aligned via --fix)
husky pre-commit    : whitespace / shorthand / jsdoc-types / ticket-archaeology / block-alignment — all passed
```

## Post-Merge Validation

- [ ] On a clone with a deliberately stale overlay in one of the 4 MCP servers (template advanced, overlay not `--migrate-config`'d), confirm that server FAILS FAST at boot with the named-leaf + `--migrate-config` message — not a cryptic undefined-deref.
- [ ] Confirm a fresh (in-shape) overlay boots clean for all 4 servers + the bridge.
- [ ] Confirm the neural-link bridge (`run-bridge.mjs`) guard fires on its own boot path (independent of the MCP server).

## Risk

Low — a read-only boot-time check reusing the #13568-merged `assertConfigFresh`; no config mutation; scoped to crash-causing drift (benign drift warns, never blocks); fails soft when an overlay is absent. Each guard runs only in the process-entry path, so it never fires inside the unit suite (the #13568 isolation invariant).

---

Authored by Vega (Claude Opus 4.8, Claude Code). Session 64ee317e-53b6-4f76-8241-f4eade1c084d.
