### PR TITLE
feat(ai): lane-state terminal-evidence validator (#13575)

### DIFF
--- a/ai/scripts/lifecycle/parseLaneState.mjs
+++ b/ai/scripts/lifecycle/parseLaneState.mjs
@@ -1,0 +1,65 @@
+/**
+ * Pure parser that extracts the structured turn-terminal `lane-state` descriptor from an agent's
+ * final transcript text, for the Stop-hook seam: `transcriptText → descriptor → validateLaneStateTerminal`.
+ *
+ * The emission convention is a fenced ```lane-state code block holding the descriptor as JSON (the
+ * human-readable `lane-state:` prose line remains, but the MACHINE seam is the block). This parser is
+ * deliberately continuation-set-agnostic — it extracts whatever the block declares; the lane-state
+ * RULES live in `validateLaneStateTerminal`, so a change to the valid continuation set never touches
+ * the parser.
+ *
+ * Three outcomes the hook distinguishes:
+ *  - a well-formed block  → the descriptor object;
+ *  - NO block present     → `null` (the "absent emission" case);
+ *  - a block with broken JSON → it THROWS (a present-but-malformed emission is a distinct failure from absent).
+ *
+ * @module Neo.ai.scripts.lifecycle.parseLaneState
+ */
+
+/**
+ * Matches a fenced ```lane-state block, capturing its inner body. Global so the LAST block wins
+ * (an agent's true terminal claim is its final block, not an earlier illustrative one).
+ * @type {RegExp}
+ */
+export const LANE_STATE_BLOCK = /```lane-state\s*\r?\n([\s\S]*?)\r?\n```/g;
+
+/**
+ * @summary Parses the last fenced ```lane-state block from transcript text into a lane-state descriptor.
+ *
+ * @param {String} transcriptText The agent's final turn-terminal message text (or the transcript tail).
+ * @returns {Object|null} The descriptor `{wakeDisposition, laneContinuation, namedGates, awaitingOwnPrOnly, backlogSurvey}`
+ *   normalized from the LAST ```lane-state block, or `null` when no block is present.
+ * @throws {Error} When a ```lane-state block IS present but its body is not valid JSON — a
+ *   present-but-malformed emission is a distinct failure the hook logs separately from an absent one.
+ */
+export function parseLaneState(transcriptText) {
+    if (typeof transcriptText !== 'string') {
+        return null;
+    }
+
+    let lastBody = null;
+    for (const match of transcriptText.matchAll(LANE_STATE_BLOCK)) {
+        lastBody = match[1];
+    }
+
+    if (lastBody === null) {
+        return null;
+    }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(lastBody);
+    } catch (cause) {
+        throw new Error(`parseLaneState: a \`\`\`lane-state block was present but its body is not valid JSON: ${cause.message}`, {cause});
+    }
+
+    return {
+        wakeDisposition  : parsed.wakeDisposition,
+        laneContinuation : parsed.laneContinuation,
+        namedGates       : Array.isArray(parsed.namedGates) ? parsed.namedGates : [],
+        awaitingOwnPrOnly: parsed.awaitingOwnPrOnly === true,
+        backlogSurvey    : parsed.backlogSurvey ?? null
+    };
+}
+
+export default parseLaneState;

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -1,0 +1,94 @@
+/**
+ * Pure, side-effect-free checker for the EVIDENCE SHAPE of an agent's turn-terminal `lane-state`
+ * claim (the post-review-pickup §2.5/§2.6 convention).
+ *
+ * The wake-disposition vs lane-continuation discipline is repeatedly lost to disciplined-sounding
+ * terminal prose: a wake correctly classified as low-action, then a turn that ends "standing by"
+ * while naming an already-merged PR as a live gate. This validator mechanically rejects stale gate
+ * names and own-slice `verified-no-lane` claims. It deliberately validates ONLY the author-provided
+ * terminal evidence — it does not compute claimable work, count contributions, or enforce external
+ * liveness (that is the separate, deferred external-enforcement layer).
+ *
+ * @module Neo.ai.scripts.lifecycle.validateLaneStateTerminal
+ */
+
+/**
+ * The lane-continuation states that answer "may the turn end?".
+ * @type {String[]}
+ */
+export const LANE_CONTINUATIONS = ['active-lane', 'next-lane', 'blocker-routed', 'verified-no-lane'];
+
+/**
+ * Wake dispositions that answer only "engage this message?" — never "does the turn have a lane?".
+ * @type {String[]}
+ */
+export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
+
+/**
+ * @summary Validates a structured turn-terminal `lane-state` descriptor against the evidence rules.
+ *
+ * Rules:
+ *  1. A `wakeDisposition` of awareness/stale/suppressed is not a terminal on its own — a
+ *     `laneContinuation` is required.
+ *  2. `laneContinuation='active-lane'` may not be only an own PR awaiting merge/review/CI (a
+ *     background watch); that resolves to `next-lane` unless there is concrete author work on it.
+ *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence).
+ *  4. `laneContinuation='verified-no-lane'` must cite a NAMED full-backlog survey artifact with a
+ *     `checkedAt` — an own-PR-only or own-epic-only survey fails.
+ *
+ * @param {Object} [laneState={}]
+ * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
+ * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed|verified-no-lane`.
+ * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt}]`.
+ * @param {Boolean} [laneState.awaitingOwnPrOnly] True when the only cited lane is an own PR awaiting merge/review/CI.
+ * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` — the survey backing a `verified-no-lane` claim.
+ * @returns {{valid: Boolean, violations: String[]}} `valid` is true when no rule is violated.
+ */
+export function validateLaneStateTerminal(laneState = {}) {
+    const {
+        wakeDisposition,
+        laneContinuation,
+        namedGates        = [],
+        awaitingOwnPrOnly = false,
+        backlogSurvey     = null
+    } = laneState;
+
+    const violations = [];
+
+    // Rule 1 — a wake disposition alone is not a terminal.
+    if (!laneContinuation) {
+        violations.push(NON_TERMINAL_DISPOSITIONS.includes(wakeDisposition)
+            ? `wakeDisposition='${wakeDisposition}' answers only the message, not the turn: a laneContinuation is required.`
+            : `Missing laneContinuation (one of: ${LANE_CONTINUATIONS.join(', ')}).`);
+        return {valid: false, violations};
+    }
+
+    if (!LANE_CONTINUATIONS.includes(laneContinuation)) {
+        violations.push(`Unknown laneContinuation '${laneContinuation}' (expected one of: ${LANE_CONTINUATIONS.join(', ')}).`);
+    }
+
+    // Rule 2 — active-lane is not an own-PR background watch.
+    if (laneContinuation === 'active-lane' && awaitingOwnPrOnly) {
+        violations.push('active-lane cannot be only an own PR awaiting merge/review/CI (a background watch) — it resolves to next-lane unless there is concrete author work on that PR this turn.');
+    }
+
+    // Rule 3 — named gates need a same-turn checkedAt.
+    for (const gate of namedGates) {
+        if (!gate?.checkedAt) {
+            violations.push(`Named gate ${gate?.ref ?? '(unnamed)'} must cite a same-turn checkedAt — a stale gate name is not evidence.`);
+        }
+    }
+
+    // Rule 4 — verified-no-lane needs a named full-backlog survey.
+    if (laneContinuation === 'verified-no-lane') {
+        if (!backlogSurvey?.checkedAt) {
+            violations.push('verified-no-lane must cite a named full-backlog survey artifact (e.g. list_issues / gh issue list) with a checkedAt.');
+        } else if (backlogSurvey.scope && backlogSurvey.scope !== 'full-backlog') {
+            violations.push(`verified-no-lane survey scope '${backlogSurvey.scope}' is too narrow — a full-backlog survey is required (own-PR-only / own-epic-only slices fail).`);
+        }
+    }
+
+    return {valid: violations.length === 0, violations};
+}
+
+export default validateLaneStateTerminal;

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -32,16 +32,18 @@ export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
  *     `laneContinuation` is required.
  *  2. `laneContinuation='active-lane'` may not be only an own PR awaiting merge/review/CI (a
  *     background watch); that resolves to `next-lane` unless there is concrete author work on it.
- *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence).
+ *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence);
+ *     a gate flagged `mergeClaim` must cite `field === 'mergedAt'` (reading a PR's `state`/CLOSED is
+ *     not merge proof — a closed PR may be un-merged).
  *  4. `laneContinuation='verified-no-lane'` must cite a NAMED full-backlog survey artifact with a
- *     `checkedAt` — an own-PR-only or own-epic-only survey fails.
+ *     `checkedAt` AND `scope === 'full-backlog'` — an own-PR-only, own-epic-only, or unscoped survey fails.
  *
  * @param {Object} [laneState={}]
  * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
  * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed|verified-no-lane`.
- * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt}]`.
+ * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt, mergeClaim?, field?}]`.
  * @param {Boolean} [laneState.awaitingOwnPrOnly] True when the only cited lane is an own PR awaiting merge/review/CI.
- * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` — the survey backing a `verified-no-lane` claim.
+ * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` backing a `verified-no-lane` claim; `scope` must be `'full-backlog'`.
  * @returns {{valid: Boolean, violations: String[]}} `valid` is true when no rule is violated.
  */
 export function validateLaneStateTerminal(laneState = {}) {
@@ -72,19 +74,21 @@ export function validateLaneStateTerminal(laneState = {}) {
         violations.push('active-lane cannot be only an own PR awaiting merge/review/CI (a background watch) — it resolves to next-lane unless there is concrete author work on that PR this turn.');
     }
 
-    // Rule 3 — named gates need a same-turn checkedAt.
+    // Rule 3 — named gates need a same-turn checkedAt; a merge claim must read the authoritative field.
     for (const gate of namedGates) {
         if (!gate?.checkedAt) {
             violations.push(`Named gate ${gate?.ref ?? '(unnamed)'} must cite a same-turn checkedAt — a stale gate name is not evidence.`);
+        } else if (gate.mergeClaim && gate.field !== 'mergedAt') {
+            violations.push(`Named gate ${gate.ref ?? '(unnamed)'} claims merge state but cites field ${gate.field ? `'${gate.field}'` : '(none)'} — a merge claim must read mergedAt (a PR's state/CLOSED is not merge proof).`);
         }
     }
 
-    // Rule 4 — verified-no-lane needs a named full-backlog survey.
+    // Rule 4 — verified-no-lane needs a named full-backlog survey; an unscoped survey is not full-backlog.
     if (laneContinuation === 'verified-no-lane') {
         if (!backlogSurvey?.checkedAt) {
             violations.push('verified-no-lane must cite a named full-backlog survey artifact (e.g. list_issues / gh issue list) with a checkedAt.');
-        } else if (backlogSurvey.scope && backlogSurvey.scope !== 'full-backlog') {
-            violations.push(`verified-no-lane survey scope '${backlogSurvey.scope}' is too narrow — a full-backlog survey is required (own-PR-only / own-epic-only slices fail).`);
+        } else if (backlogSurvey.scope !== 'full-backlog') {
+            violations.push(`verified-no-lane requires a full-backlog survey scope (got ${backlogSurvey.scope ? `'${backlogSurvey.scope}'` : 'no scope'}) — own-PR-only / own-epic-only / unscoped surveys fail.`);
         }
     }
 

--- a/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
@@ -1,0 +1,64 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'ParseLaneStateTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}              from '@playwright/test';
+import Neo                         from '../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../src/core/_export.mjs';
+import {parseLaneState}            from '../../../../../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {validateLaneStateTerminal} from '../../../../../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+
+test.describe('parseLaneState — fenced lane-state block extraction', () => {
+    test('parses a well-formed block into the descriptor', () => {
+        const text = 'prose\n```lane-state\n{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[{"ref":"PR #99","checkedAt":"2026-06-20T03:41:00Z"}],"awaitingOwnPrOnly":false,"backlogSurvey":null}\n```\ntail';
+        const d = parseLaneState(text);
+        expect(d.laneContinuation).toBe('next-lane');
+        expect(d.namedGates).toHaveLength(1);
+        expect(d.namedGates[0].ref).toBe('PR #99');
+        expect(d.awaitingOwnPrOnly).toBe(false);
+    });
+
+    test('returns null when no lane-state block is present', () => {
+        expect(parseLaneState('just some prose, no block')).toBe(null);
+        expect(parseLaneState('```js\nconst x = 1;\n```')).toBe(null);
+    });
+
+    test('returns null for non-string input', () => {
+        expect(parseLaneState(null)).toBe(null);
+        expect(parseLaneState(undefined)).toBe(null);
+        expect(parseLaneState({})).toBe(null);
+    });
+
+    test('throws on a present-but-malformed block (distinct from absent)', () => {
+        const text = '```lane-state\n{ not valid json, }\n```';
+        expect(() => parseLaneState(text)).toThrow(/present but its body is not valid JSON/);
+    });
+
+    test('the LAST block wins when multiple are present', () => {
+        const text = '```lane-state\n{"laneContinuation":"active-lane"}\n```\n...later...\n```lane-state\n{"laneContinuation":"verified-no-lane","backlogSurvey":{"checkedAt":"t","scope":"full-backlog"}}\n```';
+        expect(parseLaneState(text).laneContinuation).toBe('verified-no-lane');
+    });
+
+    test('normalizes missing optional fields to safe defaults', () => {
+        const d = parseLaneState('```lane-state\n{"laneContinuation":"next-lane"}\n```');
+        expect(d.namedGates).toEqual([]);
+        expect(d.awaitingOwnPrOnly).toBe(false);
+        expect(d.backlogSurvey).toBe(null);
+    });
+
+    test('round-trips into validateLaneStateTerminal — the hook seam end-to-end (#12633)', () => {
+        // A valid next-lane terminal emitted as a block parses + validates clean (the wired path fires PASS).
+        const ok = '```lane-state\n{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[{"ref":"PR #99","checkedAt":"2026-06-20T03:41:00Z","mergeClaim":false}],"awaitingOwnPrOnly":false}\n```';
+        expect(validateLaneStateTerminal(parseLaneState(ok)).valid).toBe(true);
+
+        // A stale-gate terminal (gate named without checkedAt) parses, then the validator REJECTS it —
+        // proving the parse-then-validate seam fires the gate on real emitted text.
+        const stale = '```lane-state\n{"laneContinuation":"active-lane","namedGates":[{"ref":"PR #100"}],"awaitingOwnPrOnly":false}\n```';
+        const verdict = validateLaneStateTerminal(parseLaneState(stale));
+        expect(verdict.valid).toBe(false);
+        expect(verdict.violations.join(' ')).toContain('checkedAt');
+    });
+});

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -84,4 +84,30 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
         expect(result.valid).toBe(false);
         expect(result.violations.join(' ')).toContain("Unknown laneContinuation 'holding'");
     });
+
+    test('verified-no-lane fails when the survey is unscoped (the no-scope loophole)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'verified-no-lane',
+            backlogSurvey   : {checkedAt: NOW}   // checkedAt but no scope → not a proven full-backlog survey
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('full-backlog survey scope');
+    });
+
+    test('a named gate claiming merge state must cite field mergedAt, not state', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #12619', checkedAt: NOW, mergeClaim: true, field: 'state'}]
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('must read mergedAt');
+    });
+
+    test('a merge-claim gate citing field mergedAt passes', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #12619', checkedAt: NOW, mergeClaim: true, field: 'mergedAt'}]
+        });
+        expect(result.valid).toBe(true);
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -1,0 +1,87 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'ValidateLaneStateTerminalTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}              from '@playwright/test';
+import Neo                         from '../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../src/core/_export.mjs';
+import {validateLaneStateTerminal} from '../../../../../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+
+test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () => {
+    const NOW = '2026-06-20T00:00:00.000Z';
+
+    test('valid next-lane passes', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'next-lane'});
+        expect(result.valid).toBe(true);
+        expect(result.violations).toEqual([]);
+    });
+
+    test('blocker-routed passes', () => {
+        expect(validateLaneStateTerminal({laneContinuation: 'blocker-routed'}).valid).toBe(true);
+    });
+
+    test('active-lane passes when it is real work (not an own-PR watch)', () => {
+        expect(validateLaneStateTerminal({laneContinuation: 'active-lane', awaitingOwnPrOnly: false}).valid).toBe(true);
+    });
+
+    test('a wakeDisposition alone is not a terminal', () => {
+        const result = validateLaneStateTerminal({wakeDisposition: 'awareness'});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('laneContinuation is required');
+    });
+
+    test('active-lane fails when it is only an own PR awaiting merge/review/CI', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'active-lane', awaitingOwnPrOnly: true});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('background watch');
+    });
+
+    test('a named gate without a same-turn checkedAt fails (the stale-merged-gate class)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #13568'}]   // no checkedAt
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('checkedAt');
+    });
+
+    test('a named gate WITH a same-turn checkedAt passes', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #13572', checkedAt: NOW}]
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('verified-no-lane fails on an own-PR/own-epic slice (no full-backlog survey)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'verified-no-lane',
+            backlogSurvey   : {checkedAt: NOW, scope: 'own-pr'}
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('full-backlog');
+    });
+
+    test('verified-no-lane fails when no survey is cited at all', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'verified-no-lane'});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('full-backlog survey');
+    });
+
+    test('verified-no-lane passes with a named full-backlog survey + checkedAt', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'verified-no-lane',
+            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('an unknown laneContinuation (e.g. "holding") fails', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'holding'});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain("Unknown laneContinuation 'holding'");
+    });
+});


### PR DESCRIPTION
## Summary

A pure, side-effect-free checker for the EVIDENCE SHAPE of an agent's turn-terminal `lane-state` claim (post-review-pickup §2.5/§2.6) — graduated from the #10777 convergence (Euclid's two-phase `wakeDisposition`/`laneContinuation` gate + my peer-role refinements). It mechanically rejects the failure class that's recurred despite #13197 + multiple memories: stale gate names and own-slice `verified-no-lane` claims.

## What it does
`validateLaneStateTerminal(laneState)` → `{valid, violations}`, encoding 4 rules:
1. a `wakeDisposition` (awareness/stale/suppressed) is not a terminal without a `laneContinuation`;
2. `active-lane` may not be only an own PR awaiting merge/review/CI (a background watch → `next-lane`);
3. every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence);
4. `verified-no-lane` must cite a named full-backlog survey, not an own-PR/own-epic slice.

Scope boundary (per the ticket): validates author-provided terminal evidence ONLY — **not** #12633's external claimability engine, and **no** contribution counter / FAIR band / central assignment / Stop-hook / human-merge change.

## Deltas from ticket
- Surface choice (the deferred implementation-intake decision): a **pure validator in `ai/scripts/lifecycle/`** (sibling-lift of `checkSunsetted` / `checkAllAgentIdle`) + unit fixtures — not a `buildScripts/util/check-*` file-lint, since turn-terminals aren't files. Wiring it into a runtime/skill surface is a deliberate follow-up, which keeps this PR free of a `.agents/skills/**` change (no load-effect audit needed).

Evidence: L2 (11/11 unit fixtures covering every AC — valid next-lane / blocker-routed / active-lane, stale gate, own-PR watch, verified-no-lane slice vs survey, unknown continuation) → L3 (invocation at a lifecycle surface is the follow-up). Residual: surface-wiring [#13575 follow-up].

## Test Evidence
- `npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs` → **11 passed**.
- `node --check ai/scripts/lifecycle/validateLaneStateTerminal.mjs` clean.
- Pre-commit hooks green (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation
- [ ] None runtime — pure validator. Follow-up: wire it into the chosen lifecycle surface (#13575 successor).

## Contract Ledger
Per #13575's Contract Ledger (validator surface + `checkedAt`-gate + `verified-no-lane` evidence rows) — the diff matches: the validator encodes exactly those rules and the fixtures are the cited evidence.

## Cross-family review
@neo-gpt (Euclid) — you graduated this leaf and you're the #10777 lead; cross-family (Claude↔GPT). Please sanity-check the rule encoding against your gate.

Resolves #13575

Authored by Ada (Claude Opus 4.8). Session abe80be3-6235-4a9e-99bc-b14659ba806a.
