### PR TITLE
fix(memory-core): paginate summarizeSession's memory fetch — stop the session-summary re-loop (#13576)

### DIFF
--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -1,19 +1,19 @@
-import aiConfig from '../../mcp/server/memory-core/config.mjs';
-import Base from '../../../src/core/Base.mjs';
-import {buildChatModel} from '../../provider/buildChatModel.mjs';
-import {invokeWithGuardrail} from './helpers/consumerFrictionHelper.mjs';
-import {withTimeout} from './helpers/withTimeout.mjs';
+import aiConfig                                      from '../../mcp/server/memory-core/config.mjs';
+import Base                                          from '../../../src/core/Base.mjs';
+import {buildChatModel}                              from '../../provider/buildChatModel.mjs';
+import {invokeWithGuardrail}                         from './helpers/consumerFrictionHelper.mjs';
+import {withTimeout}                                 from './helpers/withTimeout.mjs';
 import {appendWalEmbedMarker, readPendingWalRecords} from './helpers/memoryWalStore.mjs';
-import crypto from 'crypto';
-import GraphService from './GraphService.mjs';
-import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER} from '../../graph/identityRoots.mjs';
+import crypto                                        from 'crypto';
+import GraphService                                  from './GraphService.mjs';
+import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}   from '../../graph/identityRoots.mjs';
 
 import StorageRouter from './managers/StorageRouter.mjs';
-import Json from '../../../src/util/Json.mjs';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
-import logger from '../../mcp/server/memory-core/logger.mjs';
+import Json          from '../../../src/util/Json.mjs';
+import fs            from 'fs';
+import path          from 'path';
+import os            from 'os';
+import logger        from '../../mcp/server/memory-core/logger.mjs';
 import RequestContextService, {
     SHARED_USER_ID,
     normalizeUserId,
@@ -471,10 +471,32 @@ class SessionService extends Base {
             return null;
         }
 
-        const memories = await this.memoryCollection.get({
-            where: { sessionId },
-            include: ['documents', 'metadatas']
-        });
+        // Paginate — a single un-paginated .get (the prior behavior) hit Chroma's default page bound
+        // and undercounted larger sessions, so the written memoryCount fell below the drift-detector's
+        // paginated count and the session was re-summarized every sweep (and the summary was truncated
+        // to the first page). Advance by the actual page size and stop on an empty page, so this is
+        // correct regardless of the exact per-get bound.
+        const memories  = {ids: [], documents: [], metadatas: []};
+        const pageLimit = aiConfig.summarizationBatchLimit;
+        let pageOffset  = 0;
+
+        while (true) {
+            const page      = await this.memoryCollection.get({
+                where  : {sessionId},
+                include: ['documents', 'metadatas'],
+                limit  : pageLimit,
+                offset : pageOffset
+            });
+            const pageCount = page.ids?.length || 0;
+
+            if (pageCount === 0) break;
+
+            memories.ids.push(...page.ids);
+            memories.documents.push(...page.documents);
+            memories.metadatas.push(...page.metadatas);
+
+            pageOffset += pageCount;
+        }
 
         if (memories.ids.length === 0) return null;
 

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -474,10 +474,11 @@ class SessionService extends Base {
         // Paginate — a single un-paginated .get (the prior behavior) hit Chroma's default page bound
         // and undercounted larger sessions, so the written memoryCount fell below the drift-detector's
         // paginated count and the session was re-summarized every sweep (and the summary was truncated
-        // to the first page). Advance by the actual page size and stop on an empty page, so this is
-        // correct regardless of the exact per-get bound.
+        // to the first page). Dedup by id and stop once a page adds nothing new, so this terminates and
+        // stays correct regardless of the backing collection's exact per-get bound or offset behavior.
         const memories  = {ids: [], documents: [], metadatas: []};
         const pageLimit = aiConfig.summarizationBatchLimit;
+        const seenIds   = new Set();
         let pageOffset  = 0;
 
         while (true) {
@@ -491,9 +492,20 @@ class SessionService extends Base {
 
             if (pageCount === 0) break;
 
-            memories.ids.push(...page.ids);
-            memories.documents.push(...page.documents);
-            memories.metadatas.push(...page.metadatas);
+            let addedThisPage = 0;
+
+            for (let i = 0; i < pageCount; i++) {
+                if (seenIds.has(page.ids[i])) continue;
+                seenIds.add(page.ids[i]);
+                memories.ids.push(page.ids[i]);
+                memories.documents.push(page.documents[i]);
+                memories.metadatas.push(page.metadatas[i]);
+                addedThisPage++;
+            }
+
+            // No new ids — the collection ignored offset (an offset-blind mock) or repeated the last
+            // page; either way we've gathered everything, so stop instead of looping forever.
+            if (addedThisPage === 0) break;
 
             pageOffset += pageCount;
         }

--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -474,8 +474,9 @@ class SessionService extends Base {
         // Paginate — a single un-paginated .get (the prior behavior) hit Chroma's default page bound
         // and undercounted larger sessions, so the written memoryCount fell below the drift-detector's
         // paginated count and the session was re-summarized every sweep (and the summary was truncated
-        // to the first page). Dedup by id and stop once a page adds nothing new, so this terminates and
-        // stays correct regardless of the backing collection's exact per-get bound or offset behavior.
+        // to the first page). Real Chroma respects offset, so this gathers the full set; dedup-by-id +
+        // stop-when-a-page-adds-nothing-new is a defensive guard that safely terminates even if a backing
+        // collection (e.g. an offset-blind mock) repeats a page, instead of looping forever.
         const memories  = {ids: [], documents: [], metadatas: []};
         const pageLimit = aiConfig.summarizationBatchLimit;
         const seenIds   = new Set();

--- a/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
@@ -1,0 +1,83 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'SessionServiceSummarizePaginationTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Reproduces the session-summary re-loop: `summarizeSession` must paginate its per-session memory
+ * fetch. A single un-paginated `.get` gathered only Chroma's first (bounded) page, so the written
+ * `memoryCount` fell below `findSessionsToSummarize`'s full (paginated) count — the count-equality
+ * drift check never reconciled and the session was re-summarized every sweep.
+ */
+test.describe('SessionService.summarizeSession — memory-fetch pagination', () => {
+    test.describe.configure({mode: 'serial'});
+
+    let SDK;
+
+    test.beforeAll(async () => {
+        SDK = await import('../../../../../../ai/services.mjs');
+
+        if (!SDK.Memory_LifecycleService._initPromise) {
+            await SDK.Memory_LifecycleService.initAsync();
+        } else {
+            await SDK.Memory_LifecycleService.ready();
+        }
+    });
+
+    test('paginates the per-session memory fetch — gathers all turns past a single bounded page', async () => {
+        const svc       = SDK.Memory_SessionService,
+              origGet   = svc.memoryCollection.get,
+              origModel = svc.model;
+
+        // A 5-turn session, but each Chroma .get returns a bounded page of 2 (mirrors Chroma's
+        // per-get bound). Pre-fix: a single .get returned only the first 2 → memoryCount=2 ≠ the
+        // drift's 5 → infinite re-summarization. The fix paginates to all 5.
+        const ALL = Array.from({length: 5}, (_, i) => ({
+            id      : `m${i}`,
+            document: `turn ${i}`,
+            metadata: {sessionId: 'pg-pagination', timestamp: i + 1}
+        }));
+        const seenOffsets = [];
+
+        svc.memoryCollection.get = async ({offset = 0} = {}) => {
+            seenOffsets.push(offset);
+
+            const page = ALL.slice(offset, offset + 2); // bounded page of 2, regardless of requested limit
+
+            return {
+                ids      : page.map(r => r.id),
+                documents: page.map(r => r.document),
+                metadatas: page.map(r => r.metadata)
+            };
+        };
+
+        // Bail right after the (paginated) fetch — this test asserts only the fetch behavior. The
+        // guardrail wrapper catches the throw and summarizeSession returns null cleanly.
+        svc.model = {generateContent: async () => { throw new Error('mock model unavailable'); }};
+
+        try {
+            await svc.summarizeSession('pg-pagination');
+        } finally {
+            svc.memoryCollection.get = origGet;
+            svc.model               = origModel;
+        }
+
+        // Pre-fix: seenOffsets === [0] (only 2 of 5 turns fetched). Fixed: paginated across all 5,
+        // advancing by the actual page size until the empty page at offset 5 stops it.
+        expect(seenOffsets).toEqual([0, 2, 4, 5]);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
@@ -18,12 +18,17 @@ import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 
 /**
- * Reproduces the session-summary re-loop: `summarizeSession` must paginate its per-session memory
- * fetch. A single un-paginated `.get` gathered only Chroma's first (bounded) page, so the written
+ * Closed-loop proof for the session-summary re-loop fix: `summarizeSession` must paginate its
+ * per-session memory fetch. A single bounded `.get` gathered only the first page, so the written
  * `memoryCount` fell below `findSessionsToSummarize`'s full (paginated) count — the count-equality
  * drift check never reconciled and the session was re-summarized every sweep.
+ *
+ * This reproduces the whole loop offline with a batch limit of 2 over a 5-turn session: fetch all 5
+ * across multiple pages → write `memoryCount: 5` → re-run `findSessionsToSummarize` and confirm the
+ * session is no longer selected. Pre-fix the fetch stopped at the first page (`memoryCount: 2`), so
+ * the drift selector kept returning the session forever.
  */
-test.describe('SessionService.summarizeSession — memory-fetch pagination', () => {
+test.describe('SessionService.summarizeSession — memory-fetch pagination (closed loop)', () => {
     test.describe.configure({mode: 'serial'});
 
     let SDK;
@@ -38,25 +43,36 @@ test.describe('SessionService.summarizeSession — memory-fetch pagination', () 
         }
     });
 
-    test('paginates the per-session memory fetch — gathers all turns past a single bounded page', async () => {
-        const svc       = SDK.Memory_SessionService,
-              origGet   = svc.memoryCollection.get,
-              origModel = svc.model;
+    test('paginates the fetch, writes the full memoryCount, and the drift selector stops returning the session', async () => {
+        const svc          = SDK.Memory_SessionService,
+              aiConfig     = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+              origMemGet   = svc.memoryCollection.get,
+              origModel    = svc.model,
+              origSessions = svc.sessionsCollection,
+              origLimit    = aiConfig.summarizationBatchLimit;
 
-        // A 5-turn session, but each Chroma .get returns a bounded page of 2 (mirrors Chroma's
-        // per-get bound). Pre-fix: a single .get returned only the first 2 → memoryCount=2 ≠ the
-        // drift's 5 → infinite re-summarization. The fix paginates to all 5.
+        // Shrink the per-get batch to 2 so a 5-turn session forces multiple pages. Both summarizeSession
+        // (advance-by-actual-page) and findSessionsToSummarize (advance-by-limit) read with THIS limit.
+        aiConfig.summarizationBatchLimit = 2;
+
+        const SESSION = 'pg-pagination';
+
         const ALL = Array.from({length: 5}, (_, i) => ({
             id      : `m${i}`,
             document: `turn ${i}`,
-            metadata: {sessionId: 'pg-pagination', timestamp: i + 1}
+            metadata: {sessionId: SESSION, timestamp: i + 1}
         }));
-        const seenOffsets = [];
 
-        svc.memoryCollection.get = async ({offset = 0} = {}) => {
-            seenOffsets.push(offset);
+        const memGetOffsets = [];
+        const summaryStore  = [];
 
-            const page = ALL.slice(offset, offset + 2); // bounded page of 2, regardless of requested limit
+        // memoryCollection.get serves BOTH summarizeSession's per-session fetch AND
+        // findSessionsToSummarize's full count scan. It RESPECTS the requested limit (real Chroma
+        // behavior) — so with limit=2 each page holds 2, and both callers must paginate to see all 5.
+        svc.memoryCollection.get = async ({offset = 0, limit} = {}) => {
+            memGetOffsets.push(offset);
+
+            const page = ALL.slice(offset, offset + limit);
 
             return {
                 ids      : page.map(r => r.id),
@@ -65,19 +81,55 @@ test.describe('SessionService.summarizeSession — memory-fetch pagination', () 
             };
         };
 
-        // Bail right after the (paginated) fetch — this test asserts only the fetch behavior. The
-        // guardrail wrapper catches the throw and summarizeSession returns null cleanly.
-        svc.model = {generateContent: async () => { throw new Error('mock model unavailable'); }};
+        // A parseable summary so summarizeSession proceeds past synthesis to the memoryCount write.
+        svc.model = {
+            generateContent: async () => ({
+                response: {
+                    text: () => JSON.stringify({
+                        summary     : 'mock summary',
+                        title       : 'Mock Session',
+                        category    : 'test',
+                        quality     : 5,
+                        productivity: 5,
+                        impact      : 5,
+                        complexity  : 5,
+                        technologies: []
+                    })
+                }
+            })
+        };
+
+        // Fake summary collection: upsert captures the written metadata, get replays it (paginated) so
+        // findSessionsToSummarize reads the reconciled memoryCount back — no Chroma/embedding needed.
+        svc.sessionsCollection = {
+            upsert: async ({metadatas}) => { (metadatas || []).forEach(m => summaryStore.push({...m})); },
+            get   : async ({offset = 0, limit = 2} = {}) => {
+                const page = summaryStore.slice(offset, offset + limit);
+                return {ids: page.map((_, i) => `summary_${offset + i}`), metadatas: page};
+            }
+        };
 
         try {
-            await svc.summarizeSession('pg-pagination');
-        } finally {
-            svc.memoryCollection.get = origGet;
-            svc.model               = origModel;
-        }
+            const result = await svc.summarizeSession(SESSION);
 
-        // Pre-fix: seenOffsets === [0] (only 2 of 5 turns fetched). Fixed: paginated across all 5,
-        // advancing by the actual page size until the empty page at offset 5 stops it.
-        expect(seenOffsets).toEqual([0, 2, 4, 5]);
+            // 1. Fetched all 5 turns across pages of 2 (advance-by-actual, stop on the empty page).
+            expect(memGetOffsets).toEqual([0, 2, 4, 5]);
+
+            // 2. Wrote the FULL paginated count, not the first-page undercount — the exact AC the pre-fix
+            //    violated (it wrote 2, so the drift never reconciled).
+            expect(summaryStore).toHaveLength(1);
+            expect(summaryStore[0].memoryCount).toBe(5);
+            expect(result?.memoryCount).toBe(5);
+
+            // 3. Closed loop: with memoryCount=5 written, the drift selector (count === summaryCount) no
+            //    longer returns the session. Pre-fix (memoryCount=2 ≠ 5) it re-selected it every sweep.
+            const toSummarize = await svc.findSessionsToSummarize();
+            expect(toSummarize).not.toContain(SESSION);
+        } finally {
+            svc.memoryCollection.get         = origMemGet;
+            svc.model                        = origModel;
+            svc.sessionsCollection           = origSessions;
+            aiConfig.summarizationBatchLimit = origLimit;
+        }
     });
 });


### PR DESCRIPTION
Resolves #13576

Authored by @neo-opus-grace

Stops the periodic session-summary sweep from re-summarizing the same sessions forever (operator-reported 2026-06-20: machine fans pinned, `pending-session-summary:283` never moving, identical session set re-processed every ~25-min run).

## Root cause

`SessionService.findSessionsToSummarize` re-flags a session when its memory count ≠ the summary's recorded `memoryCount` (`:451`), assuming "once updated, the counts match." It computes the session count by **paginating** Chroma (`:348-367`), but `summarizeSession` wrote that `memoryCount` from a **single, un-paginated `.get`** that returned only Chroma's first bounded page. So the written count was permanently below the drift's full count → infinite re-summarization (and the summary was first-page-**truncated**).

## What changed

- **`summarizeSession`**: the per-session memory fetch now paginates — **dedup by id, stop once a page adds nothing new** — so `memoryCount` equals the drift's true full count (reconciles) and summaries are no longer truncated. The dedup-by-id / stop-on-no-new shape safely terminates regardless of the backing collection's offset behavior (real Chroma respects offset → full set; an offset-blind page won't infinite-loop).
- **`SessionService.SummarizePagination.spec`** — the full **closed-loop** proof, offline. With `summarizationBatchLimit=2` over a 5-turn session it (1) fetches all 5 across pages (`memGetOffsets [0,2,4,5]`), (2) writes `memoryCount: 5` (asserted via a faked summary collection that captures the upsert + summarizeSession's return), and (3) re-runs `findSessionsToSummarize` → the session is **no longer selected** (count 5 === summaryCount 5). Pre-fix wrote `memoryCount: 2` and the drift re-selected it every sweep.
- Block-alignment lint `--fix` on the touched files.

## Evidence

Evidence: L1 (the unit test reproduces the pre-fix undercount AND the closed loop — fetch → write count → drift no longer selects; all unit-reachable) → L1 required (the AC is the fetch/count/drift behavior). Confirmed **Case B** via `get_rem_pipeline_state` (1,354 summaries already in Chroma → the drift *finds* them; it's a count mismatch, not a missing summary).

## Test Evidence

`UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs` → **1/1 pass** (the closed loop). Full related set (`buildChatModel` + `SessionSummaryDegradedFallback` + `SummarizePagination`) → **18/18**.

## Evolution (review cycle)

- **Regression caught (Vega's CI-deferral):** the first pagination shape (advance-by-pageCount / stop-on-empty) infinite-looped on two summarizeSession specs whose mocks return a fixed set **ignoring offset** — real Chroma terminates, the offset-blind mocks didn't. Fixed with **dedup-by-id + stop-on-no-new** (`2240fe26c`).
- **RA1 (@neo-gpt CHANGES_REQUESTED, Vega concur):** the test proved the fetch paginated but bailed before the `memoryCount` write, so it didn't lock #13576's AC. Resolved (`724f9c513`) — the test now proves the full closed loop (write `memoryCount: 5` → drift no longer selects).
- **RA2:** tightened the over-claiming "correct regardless of offset behavior" comment to a safe-terminate framing.

## Post-Merge Validation

After deploy + orchestrator restart: the periodic sweep stops re-flagging summarized sessions; `pending-session-summary` drains to the true drainable backlog. Confirm via the orchestrator logs (no same-session re-loop).

## Deltas from ticket

- The fix runtime-reconciles for ANY session size including >2000 (Vega V-B-A'd: `summarizeSession` mirrors `findSessionsToSummarize`'s `summarizationBatchLimit` bound — no residual cap-mismatch).
- `#9959` (closed) was the externally-active-session exclusion — a different cause; not reused.
