### PR TITLE
fix(memory-core): fail partial Chroma exports (#13583)

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -45,7 +45,7 @@ class DatabaseService extends Base {
      * @param {Object} collection The ChromaDB collection to export.
      * @param {String} backupPath The directory to save the backup file.
      * @param {String} filePrefix The prefix for the backup filename.
-     * @returns {Promise<number>} The number of exported documents.
+     * @returns {Promise<{collection: String, backupFile: String|null, expected: Number, exported: Number, skipped: Number, skippedIds: String[]}>} Export statistics.
      * @private
      */
     async #exportCollection(collection, backupPath, filePrefix) {
@@ -55,7 +55,14 @@ class DatabaseService extends Base {
         const count = await collection.count();
         if (count === 0) {
             logger.log(`No documents found in ${collection.name} to export.`);
-            return 0;
+            return {
+                collection: collection.name,
+                backupFile: null,
+                expected  : 0,
+                exported  : 0,
+                skipped   : 0,
+                skippedIds: []
+            }
         }
 
         logger.log(`Found ${count} documents in ${collection.name} to export.`);
@@ -64,6 +71,14 @@ class DatabaseService extends Base {
         const timestamp   = new Date().toISOString().replace(/:/g, '-');
         const backupFile  = path.join(backupPath, `${filePrefix}-${timestamp}.jsonl`);
         const writeStream = fs.createWriteStream(backupFile);
+        const stats = {
+            collection: collection.name,
+            backupFile,
+            expected  : count,
+            exported  : 0,
+            skipped   : 0,
+            skippedIds: []
+        };
 
         // 2. Paginated Fetch
         const limit = 2000; // Safe batch size
@@ -105,7 +120,9 @@ class DatabaseService extends Base {
                             batch.embeddings.push(single.embeddings[0]);
                         }
                     } catch (singleErr) {
-                        logger.error(`Skipping corrupted vector ID during export: ${id}`);
+                        stats.skipped++;
+                        stats.skippedIds.push(id);
+                        logger.error(`Skipping corrupted vector ID during export: ${id} (${singleErr.message})`);
                     }
                 }
             }
@@ -120,14 +137,25 @@ class DatabaseService extends Base {
                     document : batch.documents[i]
                 };
                 writeStream.write(JSON.stringify(record) + '\n');
+                stats.exported++;
             }
 
             offset += limit;
         }
 
         await new Promise(resolve => writeStream.end(resolve));
-        logger.log(`Successfully exported ${count} documents to: ${backupFile}`);
-        return count;
+        if (stats.exported !== stats.expected) {
+            const error = new Error(
+                `PARTIAL_COLLECTION_EXPORT: ${collection.name} exported ${stats.exported}/${stats.expected} ` +
+                `records to ${backupFile}; skipped ${stats.skipped} corrupted vector id(s).`
+            );
+            error.code    = 'PARTIAL_COLLECTION_EXPORT';
+            error.details = stats;
+            throw error
+        }
+
+        logger.log(`Successfully exported ${stats.exported}/${stats.expected} documents to: ${backupFile}`);
+        return stats
     }
 
     /**
@@ -347,32 +375,46 @@ class DatabaseService extends Base {
      * @param {Object}    options
      * @param {String[]} [options.include=['memories','summaries','graph']] Array of collections to export.
      * @param {String}   [options.backupPath=aiConfig.backupPath]           Directory for the JSONL artifacts.
-     * @returns {Promise<{message: string}>}
+     * @returns {Promise<Object>}
      */
     async exportDatabase({include=['memories', 'summaries', 'graph'], backupPath = aiConfig.backupPath} = {}) {
         try {
             logger.log('Starting agent memory export...');
-            let memoryCount = 0, summaryCount = 0, graphCount = 0;
+            let memoryStats = null, summaryStats = null, graphStats = null;
 
             if (include.includes('memories')) {
                 const collection = await StorageRouter.getMemoryCollection();
-                memoryCount      = await this.#exportCollection(collection, backupPath, 'memory-backup');
+                memoryStats      = await this.#exportCollection(collection, backupPath, 'memory-backup');
             }
 
             if (include.includes('summaries')) {
                 const collection = await StorageRouter.getSummaryCollection();
-                summaryCount     = await this.#exportCollection(collection, backupPath, 'summaries-backup');
+                summaryStats     = await this.#exportCollection(collection, backupPath, 'summaries-backup');
             }
 
             if (include.includes('graph')) {
-                graphCount = await this.#exportGraph(backupPath, 'graph-backup');
+                const graphCount = await this.#exportGraph(backupPath, 'graph-backup');
+                graphStats       = {expected: graphCount, exported: graphCount};
             }
 
-            return {message: `Export complete. Exported ${memoryCount} memories, ${summaryCount} summaries, and ${graphCount} graph elements.`};
+            const memoryCount = memoryStats?.exported || 0,
+                  summaryCount = summaryStats?.exported || 0,
+                  graphCount   = graphStats?.exported || 0,
+                  result       = {
+                      message: `Export complete. Exported ${memoryCount} memories, ${summaryCount} summaries, and ${graphCount} graph elements.`,
+                      count  : memoryCount + summaryCount + graphCount
+                  };
+
+            if (memoryStats) result.memories = memoryStats;
+            if (summaryStats) result.summaries = summaryStats;
+            if (graphStats) result.graph = graphStats;
+
+            return result
         } catch (error) {
             logger.error('[DatabaseService] Error exporting database:', error);
             const exportError = new Error(`DATABASE_EXPORT_ERROR: ${error.message}`);
             exportError.code  = 'DATABASE_EXPORT_ERROR';
+            if (error.details) exportError.details = error.details;
             throw exportError;
         }
     }
@@ -686,7 +728,7 @@ class DatabaseService extends Base {
             operation,
             subsystem: 'memory-core',
             mode,
-            target: {
+            target   : {
                 sqlitePath: aiConfig.storagePaths.graph,
                 path      : aiConfig.storagePaths.graph,
                 repoRoot  : process.cwd()

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -15,12 +15,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import fs             from 'fs';
-import path           from 'path';
+import fs              from 'fs';
+import path            from 'path';
 
 // Serial mode: this file mutates KB + MC singleton collection accessors across
 // beforeAll/afterAll. Serial ordering within this file prevents local multi-worker
@@ -131,6 +131,12 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
 
         expect(result.subsystems.concepts).toEqual({copied: 2});
         expect(result.subsystems.trajectories).toEqual({copied: 1});
+        expect(result.subsystems.mc.count).toBe(2);
+
+        const mcIntegrity = result.meta.integrity.find(check => check.subsystem === 'mc');
+        expect(mcIntegrity.status).toBe('pass');
+        expect(mcIntegrity.sourceCount).toBe(2);
+        expect(mcIntegrity.bundleCount).toBe(2);
 
         // graph subfolder exists but GraphService.db is not wired in unit-test mode,
         // so no graph-backup file is emitted. This is the documented "source has no data"
@@ -167,11 +173,11 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         fs.writeFileSync(sentToCullSource, '{"culled":"msg-1"}\n{"culled":"msg-2"}\n');
 
         const result = await runBackup({
-            bundleRoot            : altBundleRoot,
+            bundleRoot          : altBundleRoot,
             conceptsSourceDir,
             trajectoriesSourceFile,
-            sentToCullSourceFile  : sentToCullSource,
-            logger                : silentLogger
+            sentToCullSourceFile: sentToCullSource,
+            logger              : silentLogger
         });
 
         expect(fs.existsSync(path.join(altBundleRoot, 'mailbox'))).toBe(true);
@@ -184,11 +190,11 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         const altBundleRoot = path.join(workRoot, 'bundle-meta-schema');
 
         await runBackup({
-            bundleRoot            : altBundleRoot,
+            bundleRoot          : altBundleRoot,
             conceptsSourceDir,
             trajectoriesSourceFile,
-            sentToCullSourceFile  : path.join(workRoot, 'does-not-exist-cull.jsonl'),
-            logger                : silentLogger
+            sentToCullSourceFile: path.join(workRoot, 'does-not-exist-cull.jsonl'),
+            logger              : silentLogger
         });
 
         const metaPath = path.join(altBundleRoot, 'bundle-meta.json');

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
@@ -15,12 +15,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
 import InstanceManager from '../../../../../../src/manager/Instance.mjs';
-import fs             from 'fs';
-import path           from 'path';
+import fs              from 'fs';
+import path            from 'path';
 
 // Serial mode: see DatabaseService.backup.spec.mjs for rationale (singleton mutation
 // across beforeAll/afterAll; local-DX safeguard — CI already uses workers:1).
@@ -92,10 +92,65 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
         });
 
         expect(result.message).toMatch(/Exported 1 memories, 1 summaries/);
+        expect(result.count).toBe(2);
+        expect(result.memories.exported).toBe(1);
+        expect(result.memories.expected).toBe(1);
+        expect(result.summaries.exported).toBe(1);
+        expect(result.summaries.expected).toBe(1);
 
         const produced = fs.readdirSync(tmpDir).filter(f => f.endsWith('.jsonl')).sort();
         expect(produced.length).toBe(2);
         expect(produced.some(f => f.startsWith('memory-backup-'))).toBe(true);
         expect(produced.some(f => f.startsWith('summaries-backup-'))).toBe(true);
+    });
+
+    test('fails loudly when corrupt vector ids make a collection export partial (#13496)', async () => {
+        const partialDir = path.join(tmpDir, `partial-${Date.now()}`);
+        fs.mkdirSync(partialDir, {recursive: true});
+
+        const rows = [
+            {id: 'mem-ok',      embedding: [0.1], metadata: {t: 'prompt'}, document: 'ok'},
+            {id: 'mem-corrupt', embedding: [0.2], metadata: {t: 'prompt'}, document: 'corrupt'}
+        ];
+
+        const partialCollection = {
+            name : 'fake-memories-partial',
+            count: async () => rows.length,
+            get  : async ({ids, include = [], limit, offset = 0} = {}) => {
+                if (ids) {
+                    const row = rows.find(item => item.id === ids[0]);
+                    if (row.id === 'mem-corrupt') throw new Error('Error finding id');
+
+                    return {
+                        ids       : [row.id],
+                        documents : [row.document],
+                        metadatas : [row.metadata],
+                        embeddings: [row.embedding]
+                    }
+                }
+
+                if (include.length === 0) return {ids: rows.map(r => r.id)};
+
+                throw new Error('batch embedding materialization failed');
+            }
+        };
+
+        Memory_StorageRouter.getMemoryCollection = async () => partialCollection;
+
+        await expect(Memory_DatabaseService.manageDatabaseBackup({
+            action    : 'export',
+            include   : ['memories'],
+            backupPath: partialDir
+        })).rejects.toThrow(/DATABASE_EXPORT_ERROR: PARTIAL_COLLECTION_EXPORT: fake-memories-partial exported 1\/2/);
+
+        const produced = fs.readdirSync(partialDir).filter(f => f.startsWith('memory-backup-'));
+        expect(produced.length).toBe(1);
+
+        const exportedLines = fs.readFileSync(path.join(partialDir, produced[0]), 'utf8')
+            .split('\n')
+            .filter(Boolean);
+        expect(exportedLines).toHaveLength(1);
+        expect(exportedLines[0]).toContain('mem-ok');
+        expect(exportedLines[0]).not.toContain('mem-corrupt');
     });
 });


### PR DESCRIPTION
Resolves #13583
Related: #13496

Fails Memory Core Chroma exports when the collection write is partial instead of reporting the original source count as success. Successful exports now return a numeric aggregate `count` plus per-collection stats, so the atomic backup bundle verifier can validate Memory Core JSONL row-count parity.

Evidence: L2 (focused unit coverage over mocked complete and corrupt-vector export paths + backup bundle verifier assertions) -> L2 required (SDK/export behavior is unit-testable; no live Chroma mutation or repair path in scope). Residual: #13496 still owns repair/rebuild selection for the already-diagnosed vector-index drift.

## Deltas from ticket

This PR intentionally closes only the export-completeness leaf. It does not attempt live Chroma repair, re-embedding, or collection rebuild.

## Test Evidence

- `node --check ai/services/memory-core/DatabaseService.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs`
- `node --check test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs`
- `git diff --check`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs --workers=1` -> 9 passed
- Pre-commit hook passed: whitespace, shorthand, AiConfig test-mutation, JSDoc type parsing, ticket archaeology, and block-alignment checks

Note: a sandboxed first run of `DatabaseService.backupPath.spec.mjs` hit the known `.neo-ai-data/logs` EPERM ceiling; the same focused suite passed outside the sandbox.

## Post-Merge Validation

- [ ] Run `npm run ai:backup` or the equivalent operator backup path on a non-mutating maintenance window; if Memory Core contains corrupted vector IDs, verify the export fails loudly instead of producing a silently complete-looking bundle.

## Commit

- `6f7551375` - `fix(memory-core): fail partial Chroma exports (#13583)`

Authored by Euclid (GPT-5, Codex Desktop). Session 152f9eee-42e2-4740-8bce-d23e1f575ec8.
