### PR TITLE
feat(ai): fail-fast boot guard for the wake daemon's stale config overlay (#13581)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -32,13 +32,14 @@ import * as core             from '../../../src/core/_export.mjs';
 import InstanceManager       from '../../../src/manager/Instance.mjs';
 import AiConfig              from '../../config.mjs';
 import memoryCoreConfig      from '../../mcp/server/memory-core/config.mjs';
+import {assertConfigFresh}   from '../../scripts/setup/initServerConfigs.mjs';
 import {WAKE_LANE_DIRECTIVE} from './wakeLaneDirective.mjs';
 
-import fs                           from 'fs-extra';
-import path                         from 'path';
-import { fileURLToPath }            from 'url';
-import { constants as fsConstants } from 'fs';
-import { spawn, execSync }          from 'child_process';
+import fs                               from 'fs-extra';
+import path                             from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { constants as fsConstants }     from 'fs';
+import { spawn, execSync }              from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -71,11 +72,14 @@ import {
 import {clampWatermark, filterEventsByWatermark, maxLogId} from './wokenWatermark.mjs';
 import {IDENTITIES}                                        from '../../graph/identityRoots.mjs';
 
-const DB_PATH                  = memoryCoreConfig.storagePaths.graph;
-const DAEMON_DATA_DIR          = memoryCoreConfig.wakeDaemon.dataDir;
-const STATE_FILE               = path.join(DAEMON_DATA_DIR, 'lastSyncId');
-const LOG_FILE                 = path.join(DAEMON_DATA_DIR, 'wake-daemon.log');
-const WOKEN_WATERMARK_FILE     = path.join(DAEMON_DATA_DIR, 'woken-watermark.json');
+// Config-derived paths + PID_FILE (below) are declared here but ASSIGNED in initConfigDerivedState()
+// (called from the guarded main(), never at module-load): a stale memory-core overlay would otherwise
+// crash these derefs with a cryptic `undefined` at import, before assertConfigFresh can report it.
+let DB_PATH;
+let DAEMON_DATA_DIR;
+let STATE_FILE;
+let LOG_FILE;
+let WOKEN_WATERMARK_FILE;
 const LOG_RETENTION_DAYS       = 30;
 const POLL_INTERVAL_MS         = 3000;
 const DEFAULT_COALESCE_WINDOW_MS = 30000; // 30 seconds
@@ -95,9 +99,6 @@ const identityParticipationById = new Map(
             identity.properties?.participationStatus || 'active'
         ])
 );
-
-// Ensure daemon data dir exists
-fs.ensureDirSync(DAEMON_DATA_DIR);
 
 /**
  * @summary Loads the persisted per-subscription woken-watermark map, tolerant of a missing or
@@ -137,7 +138,7 @@ function persistWokenWatermark() {
  * with — does not replace — the `readAt` reconcile + the heavy-delta defer.
  * @type {Object<String, Number>}
  */
-let wokenWatermark = loadWokenWatermark();
+let wokenWatermark = {};  // loaded from disk in initConfigDerivedState() (after WOKEN_WATERMARK_FILE is assigned)
 
 /**
  * Rotates `wake-daemon.log` if its mtime falls on a calendar day different from today's.
@@ -223,10 +224,7 @@ function writeLog(level, message) {
     }
 }
 
-// One-shot prune at startup; reaper for archived logs older than retention window
-pruneOldLogs();
-
-const PID_FILE = path.join(DAEMON_DATA_DIR, 'wake-daemon.pid');
+let PID_FILE;  // assigned in initConfigDerivedState() (← DAEMON_DATA_DIR); the one-shot log prune runs there too
 const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 async function enforceSingleton() {
@@ -1502,8 +1500,35 @@ async function deliverViaWebhookUrl(subscription, digest, webhookUrl) {
     writeLog('INFO', `[Wake Daemon] Delivered ${subscription.id} via webhookUrl POST`);
 }
 
+/**
+ * @summary Assigns the config-derived module-scope paths (DB_PATH / DAEMON_DATA_DIR / STATE_FILE /
+ * LOG_FILE / WOKEN_WATERMARK_FILE / PID_FILE) + runs their one-shot startup side-effects (data-dir
+ * ensure, archived-log prune, woken-watermark load). Deferred out of module-load so the
+ * assertConfigFresh guard in main() can fail-fast on a stale memory-core overlay BEFORE any
+ * `memoryCoreConfig` deref crashes with a cryptic `undefined` (the stale-overlay fail-fast class).
+ * @protected
+ */
+function initConfigDerivedState() {
+    DB_PATH              = memoryCoreConfig.storagePaths.graph;
+    DAEMON_DATA_DIR      = memoryCoreConfig.wakeDaemon.dataDir;
+    STATE_FILE           = path.join(DAEMON_DATA_DIR, 'lastSyncId');
+    LOG_FILE             = path.join(DAEMON_DATA_DIR, 'wake-daemon.log');
+    WOKEN_WATERMARK_FILE = path.join(DAEMON_DATA_DIR, 'woken-watermark.json');
+    PID_FILE             = path.join(DAEMON_DATA_DIR, 'wake-daemon.pid');
+
+    fs.ensureDirSync(DAEMON_DATA_DIR);     // data dir must exist before any state-file write
+    pruneOldLogs();                        // one-shot reaper for archived logs older than retention
+    wokenWatermark = loadWokenWatermark(); // restore the durable per-subscription woken high-water marks
+}
+
 // Start loop
 async function main() {
+    // Fail-fast on a stale memory-core config overlay with the actionable --migrate-config message,
+    // BEFORE initConfigDerivedState() derefs memoryCoreConfig.
+    await assertConfigFresh({serverPath: fileURLToPath(new URL('../../mcp/server/memory-core/', import.meta.url))});
+
+    initConfigDerivedState();
+
     await enforceSingleton();
 
     db = initializeDatabase(DB_PATH);
@@ -1516,4 +1541,12 @@ async function main() {
     pollLoop();
 }
 
-main();
+// Process-entry only: run the boot guard + start the daemon ONLY when this file is the main module,
+// never on import — preserves the process-entry isolation invariant (mirrors the kb-* daemons). On a
+// stale overlay assertConfigFresh exits 1 with the actionable message; other startup errors → stderr + exit 1.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch(err => {
+        process.stderr.write(`[Wake Daemon] Daemon start failed: ${err && err.stack ? err.stack : err}\n`);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Guards the **wake daemon's** boot against a stale memory-core config overlay — the last daemon in the #13573 config-freshness fan-out (split out as its AC1). Unlike the kb-* daemons (a call-site add), the wake daemon reads config at **module-load** (`DB_PATH`/`DAEMON_DATA_DIR` ← `memoryCoreConfig`, plus `fs.ensureDirSync` / `pruneOldLogs()` / the woken-watermark load), and those consts are closed over by module-scope functions — so a pre-`start()` wrapper can't protect it. This refactors the config-derived module-load code into an `assertConfigFresh`-guarded async `main()` under the process-entry gate. A stale overlay now fails fast with the actionable `--migrate-config` message instead of a cryptic `undefined`-deref at import (the #13560 class).

Completes the boot-guard set: **#13574** (overlay MCP servers) + **#13582** (kb-* daemons) + **this** (wake daemon).

Resolves #13581

Refs #13573, #13568, #13560

## What changed (`ai/daemons/wake/daemon.mjs`)

- The 6 config-derived consts (`DB_PATH`, `DAEMON_DATA_DIR`, `STATE_FILE`, `LOG_FILE`, `WOKEN_WATERMARK_FILE`, `PID_FILE`) → module-scope `let`, **assigned in a new `initConfigDerivedState()`** along with their one-shot module-load side-effects (`fs.ensureDirSync`, `pruneOldLogs()`, `wokenWatermark = loadWokenWatermark()`).
- `main()` now: `await assertConfigFresh({serverPath: <memory-core>})` → `initConfigDerivedState()` → `enforceSingleton()` → db → `pollLoop()`. The guard runs FIRST, before any `memoryCoreConfig` deref.
- The `main()` invocation is wrapped in the process-entry gate (`process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href`) — boots ONLY when run as the main module, never on import.
- `+ pathToFileURL`, `+ assertConfigFresh` imports (auto-aligned via `check-block-alignment --fix`).

## Scope (#13581 ACs)

- **AC1 — defer module-load config reads:** DONE. The config-derived consts + side-effects are deferred behind the `assertConfigFresh`-guarded `main()`; ordering is preserved (same setup, same order, just import-time → guarded-main-time).
- **AC2 — overlay target + Tier-1 question:** memory-core overlay guarded (`serverPath: memory-core`). **Tier-1: V-B-A'd no separate guard needed** — `AiConfig` is read only at *runtime* (inside async `deliverDigest`, ~L1059–1076), never module-load, so a stale Tier-1 overlay is not a boot-crash class for wake. (Bonus: `assertConfigFresh` already checks Tier-1 AND the server overlay in one call, so Tier-1 freshness is covered regardless.)
- **AC3 — isolation:** DONE. Guard + `main()` fire only under the process-entry gate; importing the daemon no longer runs `main()`. Verified below.

## Test Evidence

Evidence: L1 — the guard logic is unit-tested by #13568's `initServerConfigs.spec.mjs`; this PR adds the deferral refactor + the call.

```
node --check ai/daemons/wake/daemon.mjs            : pass
check-block-alignment ai/daemons/wake/daemon.mjs   : clean (imports auto-aligned via --fix)
husky pre-commit (whitespace/shorthand/jsdoc-types/ticket-archaeology/block-alignment): pass
```

- **Import-isolation** (`node -e "import('./ai/daemons/wake/daemon.mjs')…"`): module loads clean, **`main()` does NOT auto-run**, no module-load config deref. (AC3.)
- **Guard-positive + delivery (the key one):** the existing `wake/daemon.spec.mjs` *spawns* `node ai/daemons/wake/daemon.mjs` (15+ tests). The basic delivery test (`detects and delivers wake events via test adapter`) **PASSES** with this change → the process-entry guard fires when spawned → `main()` boots → `assertConfigFresh` passes (fresh config) → daemon polls + delivers + writes the persisted log. All spawn-based tests share this identical boot path. The full spec runs in CI as the integration gate.

**CI-safety finding (important):** `assertConfigFresh` is a pure template-vs-active config-shape comparison; in CI `config.mjs` is freshly materialized from the current templates via `prepare` → it passes. My local opus-vega clone was *stale* (missing the leaves #13551's embed-drain watchdog added to the templates **today**) → the guard correctly **fail-fasted** with the named leaves; `npm run prepare -- --migrate-config` refreshed it → the test passes. That stale → fail-fast is the #13560 behavior working as designed (and a live demonstration of the value).

## Post-Merge Validation

- [ ] On a clone with a deliberately stale memory-core overlay, the wake daemon FAILS FAST at boot with the named-leaf + `--migrate-config` message (not a cryptic `undefined`-deref).
- [ ] A fresh (in-shape) overlay boots the wake daemon clean + it delivers wakes.

> **⚠️ DEPLOY ORDERING (wake is swarm-critical — all agent wakes):** the deploy environment's `config.mjs` must be migrated (`npm run prepare -- --migrate-config`) **before/with** deploying this guard + restarting the wake daemon. Otherwise the wake daemon will (correctly) fail-fast on a stale overlay = **no wakes for anyone** until migrated. This is the intended fail-fast, but for the single most critical daemon, sequence the migrate with the restart rather than discovering it on a dead wake pipeline.

## Risk

Medium-low on the code (a read-only boot-time check reusing the merged `assertConfigFresh`; no config mutation; the proven #13582 process-entry pattern applied to wake's module-load shape; all ordering preserved). The operational risk is the deploy-ordering note above — flagged prominently because wake is the most critical daemon.

## Deltas from ticket

- AC2's "is a Tier-1 guard warranted?" → answered: no separate guard (AiConfig is runtime-only for wake); `assertConfigFresh` covers Tier-1 + memory-core in one call regardless.
- The full 15+-test spawn-based wake spec is the CI integration gate (local run = the boot+delivery smoke + import-isolation).

---

Authored by Vega (Claude Opus 4.8, Claude Code). Session a49940b9-623f-4b18-bf1e-1270c9530e6e.
