### PR TITLE
feat(agentos): block strict-merge-ready on outstanding reviewRequests (#13587)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -118,7 +118,9 @@ real system defect, file or route the bug ticket, then continue lane selection.
 review/merge status MUST first run live `gh pr view <N> --json state,mergedAt,baseRefName`;
 wakes are hints, not cache. For stacked PRs, also name base readiness; a dirty/stale
 base is routable, not `human-gate` / `verified-empty`. Relay the review body's §9 verdict,
-not the flattened enum.
+not the flattened enum. Also fetch `reviewRequests`: a non-empty list is not strict-merge-ready
+even at `reviewDecision=APPROVED` — name the reviewer(s) as the remaining gate until each is
+disposed. `validateMergeReady` (ai/scripts/lifecycle) encodes this contract.
 
 ## 2.5. Mandatory `lane-state:` Declaration at Every Lifecycle Boundary
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -348,7 +348,7 @@ For multi-cycle reviews, after posting a review comment **capture its `commentId
 
 ### 10.1 PR-State Freshness Gate
 
-Before relaying any review outcome / merge-eligibility claim / lane-state naming a PR, use the mechanical A2A/wake PR-state echo only for the same mailbox/wake read you are acting on now. It is not a cache: if minutes elapsed or the lifecycle action changed, run `gh pr view <N> --json state,mergedAt`. Relay the review body's §9 verdict, not the flattened `reviewDecision` enum.
+Before relaying any review outcome / merge-eligibility claim / lane-state naming a PR, use the mechanical A2A/wake PR-state echo only for the same mailbox/wake read you are acting on now. It is not a cache: if minutes elapsed or the lifecycle action changed, run `gh pr view <N> --json state,mergedAt`. Relay the review body's §9 verdict, not the flattened `reviewDecision` enum. Include `reviewRequests`: a non-empty list isn't strict-merge-ready even at `reviewDecision=APPROVED` — dispose each (formal review / step-out / unrequest; an A2A approval doesn't clear a slot). `validateMergeReady` encodes it.
 
 ## 11. Post-Review-Cycle Reviewer Pickup
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -161,6 +161,9 @@ You MUST follow this exact handoff protocol:
 PR Review state (`reviewDecision: APPROVED`); a comment alone is insufficient.
 Author family is resolved from the §5 Social Name, with `author.login` fallback.
 
+A formal `reviewDecision: APPROVED` is necessary but NOT sufficient: a non-empty `reviewRequests`
+blocks merge-handoff until each requested reviewer is disposed. `validateMergeReady` encodes this.
+
 Exceptions are narrow and must be stated in the PR/review thread:
 - Micro-change: `chore` and `< 20` changed lines, or pure documentation with no runtime impact.
 - 7-day-open fallback: PR open >= 7 days and no cross-family thread engagement;

--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -24,25 +24,30 @@ export const NON_MERGEABLE_STATES = ['DIRTY', 'BEHIND', 'BLOCKED'];
  *
  * Rules (all must hold for `strictMergeReady`):
  *  1. `reviewDecision === 'APPROVED'`.
- *  2. `checksGreen` (all required CI checks pass).
- *  3. `mergeStateStatus` is not a non-mergeable state (DIRTY/BEHIND/BLOCKED — a conflict / stale base).
- *  4. Every explicitly-requested reviewer in `reviewRequests` is disposed — i.e. `reviewRequests`
+ *  2. `checksGreen === true` (all required CI checks pass).
+ *  3. `mergeStateStatus` is fetched AND not a non-mergeable state (DIRTY/BEHIND/BLOCKED — a conflict / stale base).
+ *  4. `reviewRequests` is fetched AND every explicitly-requested reviewer is disposed — i.e. `reviewRequests`
  *     minus `disposedReviewers` is empty (the reviewer-contract gate).
+ *
+ * Fail-CLOSED contract: `checksGreen`, `mergeStateStatus`, and `reviewRequests` that were NOT fetched
+ * (`undefined`) each block readiness — an un-queried field cannot certify a green surface, and an
+ * omitted `reviewRequests` must never be read as "no outstanding reviewers". Pass `reviewRequests: []`
+ * to assert it was fetched-and-empty.
  *
  * @param {Object} [pr={}]
  * @param {String} [pr.reviewDecision] GitHub flattened review decision (`APPROVED` | `CHANGES_REQUESTED` | `REVIEW_REQUIRED` | null).
- * @param {Boolean} [pr.checksGreen] True when all required CI checks pass.
- * @param {String} [pr.mergeStateStatus] GitHub mergeStateStatus (`CLEAN` | `UNSTABLE` | `DIRTY` | `BEHIND` | `BLOCKED` | ...).
- * @param {String[]} [pr.reviewRequests] Logins of still-requested reviewers (the explicit author/operator contract).
+ * @param {Boolean} [pr.checksGreen] True when all required CI checks pass; `undefined` (not fetched) fails closed.
+ * @param {String} [pr.mergeStateStatus] GitHub mergeStateStatus (`CLEAN` | `UNSTABLE` | `DIRTY` | `BEHIND` | `BLOCKED` | ...); `undefined` (not fetched) fails closed.
+ * @param {String[]} [pr.reviewRequests] Logins of still-requested reviewers (the explicit author/operator contract); `undefined` (not fetched) fails closed, `[]` asserts fetched-and-empty.
  * @param {String[]} [pr.disposedReviewers] Requested reviewers already disposed (formal review / visible step-out / unrequest).
  * @returns {{strictMergeReady: Boolean, blockers: String[]}}
  */
 export function validateMergeReady(pr = {}) {
     const {
         reviewDecision,
-        checksGreen       = false,
+        checksGreen,
         mergeStateStatus,
-        reviewRequests    = [],
+        reviewRequests,
         disposedReviewers = []
     } = pr;
 
@@ -51,16 +56,28 @@ export function validateMergeReady(pr = {}) {
     if (reviewDecision !== 'APPROVED') {
         blockers.push(`reviewDecision is '${reviewDecision ?? 'none'}', not APPROVED.`);
     }
-    if (!checksGreen) {
-        blockers.push('not all required CI checks are green.');
+
+    // Fail CLOSED on un-fetched fields: a field that was never queried cannot certify readiness,
+    // so an omitted reviewRequests/mergeStateStatus must block — never silently pass as "no problem".
+    if (checksGreen !== true) {
+        blockers.push(checksGreen === undefined
+            ? 'checksGreen was not fetched — cannot certify CI; failing closed.'
+            : 'not all required CI checks are green.');
     }
-    if (mergeStateStatus && NON_MERGEABLE_STATES.includes(mergeStateStatus)) {
+
+    if (mergeStateStatus === undefined) {
+        blockers.push('mergeStateStatus was not fetched — cannot certify mergeability; failing closed.');
+    } else if (NON_MERGEABLE_STATES.includes(mergeStateStatus)) {
         blockers.push(`mergeStateStatus is '${mergeStateStatus}' (a conflict or stale base — not mergeable).`);
     }
 
-    const outstanding = reviewRequests.filter(reviewer => !disposedReviewers.includes(reviewer));
-    if (outstanding.length > 0) {
-        blockers.push(`outstanding requested reviewer(s) [${outstanding.join(', ')}] — an explicit reviewer contract is not strict-merge-ready until each is disposed (formal review, visible step-out, or unrequest); an A2A approval does not clear the slot.`);
+    if (reviewRequests === undefined) {
+        blockers.push('reviewRequests was not fetched — cannot certify the reviewer contract is disposed; failing closed.');
+    } else {
+        const outstanding = reviewRequests.filter(reviewer => !disposedReviewers.includes(reviewer));
+        if (outstanding.length > 0) {
+            blockers.push(`outstanding requested reviewer(s) [${outstanding.join(', ')}] — an explicit reviewer contract is not strict-merge-ready until each is disposed (formal review, visible step-out, or unrequest); an A2A approval does not clear the slot.`);
+        }
     }
 
     return {strictMergeReady: blockers.length === 0, blockers};

--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -14,10 +14,13 @@
  */
 
 /**
- * `mergeStateStatus` values that are NOT mergeable (a conflict or stale base — not a strict-ready surface).
+ * The ONLY `mergeStateStatus` values that confirm a PR is mergeable. An allowlist, NOT a denylist:
+ * any other state — `DIRTY`/`BEHIND`/`BLOCKED` (a conflict / stale base) or `UNKNOWN` (GitHub has not
+ * computed mergeability yet) — fails closed, since an unconfirmed state cannot certify strict readiness.
+ * `UNSTABLE` is admitted (it is mergeable; the separate `checksGreen` gate covers CI).
  * @type {String[]}
  */
-export const NON_MERGEABLE_STATES = ['DIRTY', 'BEHIND', 'BLOCKED'];
+export const MERGEABLE_STATES = ['CLEAN', 'UNSTABLE'];
 
 /**
  * @summary Validates whether a PR is STRICT merge-ready against the full review/merge contract.
@@ -25,7 +28,8 @@ export const NON_MERGEABLE_STATES = ['DIRTY', 'BEHIND', 'BLOCKED'];
  * Rules (all must hold for `strictMergeReady`):
  *  1. `reviewDecision === 'APPROVED'`.
  *  2. `checksGreen === true` (all required CI checks pass).
- *  3. `mergeStateStatus` is fetched AND not a non-mergeable state (DIRTY/BEHIND/BLOCKED — a conflict / stale base).
+ *  3. `mergeStateStatus` is fetched AND a confirmed-mergeable state (allowlist `CLEAN`/`UNSTABLE`); `UNKNOWN`
+ *     (mergeability not yet computed) and DIRTY/BEHIND/BLOCKED all fail closed.
  *  4. `reviewRequests` is fetched AND every explicitly-requested reviewer is disposed — i.e. `reviewRequests`
  *     minus `disposedReviewers` is empty (the reviewer-contract gate).
  *
@@ -67,8 +71,8 @@ export function validateMergeReady(pr = {}) {
 
     if (mergeStateStatus === undefined) {
         blockers.push('mergeStateStatus was not fetched — cannot certify mergeability; failing closed.');
-    } else if (NON_MERGEABLE_STATES.includes(mergeStateStatus)) {
-        blockers.push(`mergeStateStatus is '${mergeStateStatus}' (a conflict or stale base — not mergeable).`);
+    } else if (!MERGEABLE_STATES.includes(mergeStateStatus)) {
+        blockers.push(`mergeStateStatus is '${mergeStateStatus}' — not a confirmed-mergeable state (only ${MERGEABLE_STATES.join('/')} certify; DIRTY/BEHIND/BLOCKED/UNKNOWN fail closed).`);
     }
 
     if (reviewRequests === undefined) {

--- a/ai/scripts/lifecycle/validateMergeReady.mjs
+++ b/ai/scripts/lifecycle/validateMergeReady.mjs
@@ -1,0 +1,69 @@
+/**
+ * Pure, side-effect-free checker for STRICT merge-readiness of a pull request.
+ *
+ * `reviewDecision=APPROVED` + green checks are necessary but NOT sufficient: GitHub flattens
+ * `reviewDecision` to APPROVED as soon as it has enough formal review state, even while an
+ * explicitly-requested reviewer is still outstanding (`reviewRequests` non-empty). The author/operator's
+ * requested-reviewer set is an explicit contract — a non-empty `reviewRequests` blocks strict
+ * merge-readiness until each request is disposed (a formal APPROVED / CHANGES_REQUESTED review, a
+ * visible step-out, or an author/operator unrequest). An A2A peer approval does NOT clear a
+ * requested-reviewer slot. Human-only merge authority is unchanged; this only validates the *claim*
+ * that a PR is strict-merge-ready, so a stale reviewer contract is not reported as a green surface.
+ *
+ * @module Neo.ai.scripts.lifecycle.validateMergeReady
+ */
+
+/**
+ * `mergeStateStatus` values that are NOT mergeable (a conflict or stale base — not a strict-ready surface).
+ * @type {String[]}
+ */
+export const NON_MERGEABLE_STATES = ['DIRTY', 'BEHIND', 'BLOCKED'];
+
+/**
+ * @summary Validates whether a PR is STRICT merge-ready against the full review/merge contract.
+ *
+ * Rules (all must hold for `strictMergeReady`):
+ *  1. `reviewDecision === 'APPROVED'`.
+ *  2. `checksGreen` (all required CI checks pass).
+ *  3. `mergeStateStatus` is not a non-mergeable state (DIRTY/BEHIND/BLOCKED — a conflict / stale base).
+ *  4. Every explicitly-requested reviewer in `reviewRequests` is disposed — i.e. `reviewRequests`
+ *     minus `disposedReviewers` is empty (the reviewer-contract gate).
+ *
+ * @param {Object} [pr={}]
+ * @param {String} [pr.reviewDecision] GitHub flattened review decision (`APPROVED` | `CHANGES_REQUESTED` | `REVIEW_REQUIRED` | null).
+ * @param {Boolean} [pr.checksGreen] True when all required CI checks pass.
+ * @param {String} [pr.mergeStateStatus] GitHub mergeStateStatus (`CLEAN` | `UNSTABLE` | `DIRTY` | `BEHIND` | `BLOCKED` | ...).
+ * @param {String[]} [pr.reviewRequests] Logins of still-requested reviewers (the explicit author/operator contract).
+ * @param {String[]} [pr.disposedReviewers] Requested reviewers already disposed (formal review / visible step-out / unrequest).
+ * @returns {{strictMergeReady: Boolean, blockers: String[]}}
+ */
+export function validateMergeReady(pr = {}) {
+    const {
+        reviewDecision,
+        checksGreen       = false,
+        mergeStateStatus,
+        reviewRequests    = [],
+        disposedReviewers = []
+    } = pr;
+
+    const blockers = [];
+
+    if (reviewDecision !== 'APPROVED') {
+        blockers.push(`reviewDecision is '${reviewDecision ?? 'none'}', not APPROVED.`);
+    }
+    if (!checksGreen) {
+        blockers.push('not all required CI checks are green.');
+    }
+    if (mergeStateStatus && NON_MERGEABLE_STATES.includes(mergeStateStatus)) {
+        blockers.push(`mergeStateStatus is '${mergeStateStatus}' (a conflict or stale base — not mergeable).`);
+    }
+
+    const outstanding = reviewRequests.filter(reviewer => !disposedReviewers.includes(reviewer));
+    if (outstanding.length > 0) {
+        blockers.push(`outstanding requested reviewer(s) [${outstanding.join(', ')}] — an explicit reviewer contract is not strict-merge-ready until each is disposed (formal review, visible step-out, or unrequest); an A2A approval does not clear the slot.`);
+    }
+
+    return {strictMergeReady: blockers.length === 0, blockers};
+}
+
+export default validateMergeReady;

--- a/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
@@ -1,0 +1,68 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'ValidateMergeReadyTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}       from '@playwright/test';
+import Neo                  from '../../../../../../src/Neo.mjs';
+import * as core            from '../../../../../../src/core/_export.mjs';
+import {validateMergeReady} from '../../../../../../ai/scripts/lifecycle/validateMergeReady.mjs';
+
+test.describe('validateMergeReady — strict merge-readiness contract', () => {
+    test('a fully-disposed approved PR is strict-merge-ready', () => {
+        const result = validateMergeReady({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN', reviewRequests: []
+        });
+        expect(result.strictMergeReady).toBe(true);
+        expect(result.blockers).toEqual([]);
+    });
+
+    test('APPROVED + green + CLEAN with an OUTSTANDING requested reviewer is NOT strict-merge-ready (#13587)', () => {
+        // The false-positive class: reviewDecision flattens to APPROVED + CLEAN, but a requested reviewer is outstanding.
+        const result = validateMergeReady({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN',
+            reviewRequests: ['neo-opus-grace']
+        });
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('outstanding requested reviewer');
+        expect(result.blockers.join(' ')).toContain('neo-opus-grace');
+    });
+
+    test('an outstanding reviewer who is later disposed no longer blocks', () => {
+        const result = validateMergeReady({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN',
+            reviewRequests: ['neo-opus-grace'], disposedReviewers: ['neo-opus-grace']
+        });
+        expect(result.strictMergeReady).toBe(true);
+    });
+
+    test('a non-APPROVED reviewDecision blocks', () => {
+        const result = validateMergeReady({reviewDecision: 'REVIEW_REQUIRED', checksGreen: true, mergeStateStatus: 'CLEAN'});
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('not APPROVED');
+    });
+
+    test('red CI blocks even when approved', () => {
+        const result = validateMergeReady({reviewDecision: 'APPROVED', checksGreen: false, mergeStateStatus: 'CLEAN'});
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('CI checks');
+    });
+
+    test('a DIRTY merge state (conflict / stale base) blocks', () => {
+        const result = validateMergeReady({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'DIRTY', reviewRequests: []
+        });
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain("'DIRTY'");
+    });
+
+    test('UNSTABLE (mergeable, CI in flux) is not itself a non-mergeable blocker', () => {
+        // UNSTABLE is mergeable; checksGreen is the CI gate, not mergeStateStatus.
+        const result = validateMergeReady({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'UNSTABLE', reviewRequests: []
+        });
+        expect(result.strictMergeReady).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
@@ -86,4 +86,13 @@ test.describe('validateMergeReady — strict merge-readiness contract', () => {
         });
         expect(result.strictMergeReady).toBe(true);
     });
+
+    test('UNKNOWN mergeStateStatus fails closed — GitHub has not computed mergeability (#13588 cycle-2)', () => {
+        // Allowlist: only CLEAN/UNSTABLE certify; an uncomputed UNKNOWN must NOT certify strict-ready.
+        const result = validateMergeReady({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'UNKNOWN', reviewRequests: []
+        });
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('UNKNOWN');
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateMergeReady.spec.mjs
@@ -65,4 +65,25 @@ test.describe('validateMergeReady — strict merge-readiness contract', () => {
         });
         expect(result.strictMergeReady).toBe(true);
     });
+
+    test('fails CLOSED when reviewRequests was not fetched (undefined, not [])', () => {
+        // The omission false-positive: APPROVED + green + CLEAN but reviewRequests never queried.
+        const result = validateMergeReady({reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN'});
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('reviewRequests was not fetched');
+    });
+
+    test('fails CLOSED when mergeStateStatus was not fetched', () => {
+        const result = validateMergeReady({reviewDecision: 'APPROVED', checksGreen: true, reviewRequests: []});
+        expect(result.strictMergeReady).toBe(false);
+        expect(result.blockers.join(' ')).toContain('mergeStateStatus was not fetched');
+    });
+
+    test('an empty-array reviewRequests (fetched-and-empty) does NOT fail closed', () => {
+        // [] is the explicit "fetched, none outstanding" assertion — distinct from undefined.
+        const result = validateMergeReady({
+            reviewDecision: 'APPROVED', checksGreen: true, mergeStateStatus: 'CLEAN', reviewRequests: []
+        });
+        expect(result.strictMergeReady).toBe(true);
+    });
 });


### PR DESCRIPTION
Resolves #13587

## Summary

A flattened `reviewDecision=APPROVED` + `mergeStateStatus=CLEAN` is a merge-ready **false positive** when an explicitly-requested reviewer is still outstanding (`reviewRequests` non-empty), OR when required PR-state fields were never fetched / cannot confirm mergeability. This codifies the reviewer-contract gate: a non-empty `reviewRequests` is **not strict-merge-ready** until each request is disposed (formal review, visible step-out, or `manage_pr_reviewers` unrequest); an A2A approval does **not** clear a slot. **Fail-closed semantics:** an un-fetched `reviewRequests` / `mergeStateStatus` / `checksGreen` (undefined) blocks; and `mergeStateStatus` is checked against an **allowlist** of confirmed-mergeable states (`CLEAN` / `UNSTABLE`) — a fetched `UNKNOWN` (GitHub has not computed mergeability) and any other/unlisted state fail closed rather than slip through a denylist.

**Evidence:** origin is my own #13584 cross-family review — `gh pr view 13584` returned `reviewDecision=APPROVED` + `CLEAN` + `reviewRequests=[neo-opus-grace]`. The operator judgment was the stricter rule.

## Deltas

- **`ai/scripts/lifecycle/validateMergeReady.mjs`** (new): pure checker → `{strictMergeReady, blockers}`. Fails CLOSED on un-fetched `reviewRequests` / `mergeStateStatus` / `checksGreen` (undefined blocks; `[]` asserts fetched-and-empty). `mergeStateStatus` uses a **`MERGEABLE_STATES` allowlist** (`CLEAN` / `UNSTABLE`) — a fetched `UNKNOWN` / `DIRTY` / `BEHIND` / `BLOCKED` / any unlisted state all fail closed (closes the class, not a single enum). Rule 4 = the reviewer-contract gate.
- **Reviewer-contract rule** added to all three independently-consumed merge-readiness surfaces: `post-review-pickup-workflow.md` (+244, turn-boundary gate), `pr-review-guide.md` (+230, review-time gate), `pull-request-workflow.md` §6.1 (+198, author-handoff gate). Each per-file delta ≤250.

## Test Evidence

`validateMergeReady.spec.mjs` — **11/11 pass** (cold). Covers the #13584 shape (outstanding reviewer → false), the disposed case, non-APPROVED, red CI, DIRTY, UNSTABLE, the fail-closed regressions (omitted `reviewRequests` → false; omitted `mergeStateStatus` → false; explicit `[]` → true), and the **`UNKNOWN mergeStateStatus` allowlist regression** (`UNKNOWN` → false — the cycle-2 falsifier). `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` → OK.

## Skill-Manifest Budget

Net skill-Markdown delta is **+672**, carried by a single-line `[skill-growth-justified]` commit token: the reviewer-contract invariant must fire at all three merge-readiness surfaces, each loaded without the others, so a pointer would defeat the gate. **Per-file** deltas are all ≤250 (244 / 230 / 198) — within the non-exception-able per-file budget.

## Load-Effect Audit (substrate edit)

Per the compaction taxonomy (0007): the three skill edits are **skill-loaded** (each only when its skill is invoked), adding one rule to each existing merge-readiness gate. `validateMergeReady.mjs` + spec are **not context-loaded** (runtime + test). Net +672 across three skill payloads is justified by the cross-surface invariant; per-file all ≤250.

## Contract Ledger

#13587 carries the `## Contract Ledger Matrix` (3 rows); this implementation matches all three — `validateMergeReady` is the merge-readiness-claim row; the three guidance edits encode the reviewer-invitation + A2A-signal rows (including the `pull-request` author-handoff consumer named in the ledger).

## Scope / Follow-Up

- AC1-3 (guidance, all three surfaces) + AC5 (tests) delivered; fail-closed semantics — un-fetched fields (cycle-1) + the fetched-`UNKNOWN` / allowlist merge-state (cycle-2) — added per the #13588 review.
- **AC4** (a mechanical merge-ready lint) flagged as a follow-up — `validateMergeReady` is the ready-to-wire primitive; same enforcement-seam as #13577 → #12633.

## Post-Merge Validation

- Re-run `validateMergeReady.spec.mjs` on dev (expect **11/11**).
- Next time a PR reaches `reviewDecision=APPROVED` with an outstanding requested reviewer (or a fetched `UNKNOWN` / un-fetched merge state), confirm the guidance names it as the remaining gate, not "merge-ready".

---

Authored by @neo-opus-ada (Claude Opus 4.8). Origin session ID: abe80be3-6235-4a9e-99bc-b14659ba806a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
