### PR TITLE
feat(ai): dry-run Stop-hook for idle-out enforcement + lane-state seam (#12633)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -30,11 +30,10 @@
  * log for handoff false-positives, then set `NEO_LANE_STATE_ENFORCE=1` to enforce. A buggy blocking
  * hook would trap every agent's turn-end, so the dry-run → audit → enforce ramp is the safe rollout.
  *
- * SEAM (pending the lane-state-terminal module): `parseLaneState` + `validateLaneStateTerminal` are
- * stubbed against their EXACT real signatures (the stub parser returns null — the absent-bucket
- * placeholder; a meaningful dry-run audit needs the real parser). The author's bodies drop in
- * unchanged. The pure `parseOutcomeToVerdict` (3 buckets → verdict) + `decideHookAction` (verdict +
- * enforcing → action) are exported + unit-tested independently of the I/O + the stubs.
+ * SEAM: `parseLaneState` (transcript → descriptor | null | throws) + `validateLaneStateTerminal`
+ * (descriptor → {valid, violations}) are imported from `ai/scripts/lifecycle/` — pure, zero-dependency
+ * modules so this hook stays light on every turn-end. The pure `parseOutcomeToVerdict` (3 buckets →
+ * verdict) + `decideHookAction` (verdict + enforcing → action) are exported + unit-tested independently.
  *
  * @see https://code.claude.com/docs/en/hooks — Stop hook contract (stdin payload, decision:block)
  */
@@ -42,6 +41,9 @@ import fs              from 'node:fs';
 import path            from 'node:path';
 import os              from 'node:os';
 import {pathToFileURL} from 'node:url';
+
+import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
 
 // Enforce ONLY when the operator explicitly activates it; default is DRY-RUN (log-only, never blocks).
 const ENFORCING = process.env.NEO_LANE_STATE_ENFORCE === '1';
@@ -80,37 +82,6 @@ function auditLog(line) {
         // best-effort; a log-write failure must never block a turn-end
     }
 }
-
-// ---- SEAM (stubbed against the real signatures; the author's parser + validator bodies drop in) ---
-/**
- * @summary STUB — extract the structured lane-state descriptor from the LAST fenced ```lane-state
- * block in the turn transcript. Real signature (the author's body replaces this stub):
- *   - returns the descriptor `{wakeDisposition, laneContinuation, namedGates, awaitingOwnPrOnly, backlogSurvey}`
- *   - returns null when NO block is present (the ABSENT bucket)
- *   - THROWS when a block is present but its JSON is malformed (the MALFORMED bucket — distinct from absent)
- * The stub returns null (absent-bucket placeholder) so the chain is exercised without the real parser.
- * @param {String} _transcript
- * @returns {Object|null}
- * @throws {Error} when a lane-state block is present but its JSON is malformed
- * @protected
- */
-function parseLaneState(_transcript) {
-    return null; // STUB — the emission-convention parser drops in here (returns descriptor | null | throws)
-}
-
-/**
- * @summary STUB — validate a parsed lane-state descriptor. Real signature returns
- * `{valid: Boolean, violations: String[]}` (the author's validator body replaces this stub). The stub
- * treats every descriptor as valid (empty violations) so the scaffold is safe until the real validator
- * — which MUST admit the all-lanes-handed-off terminal (`verified-no-lane` + a full-backlog survey).
- * @param {Object} _descriptor
- * @returns {{valid: Boolean, violations: String[]}}
- * @protected
- */
-function validateLaneStateTerminal(_descriptor) {
-    return {valid: true, violations: []};
-}
-// ---- end SEAM ------------------------------------------------------------------------------------
 
 /**
  * @summary Pure mapping of a parse OUTCOME to a terminal verdict — the 3-bucket chain. A malformed
@@ -202,8 +173,9 @@ async function main() {
     if (action === 'block') {
         auditLog(`BLOCK (session=${session}): ${reason}`);
         // Block the stop + inject the directive — Claude uses `reason` as its next instruction.
-        process.stdout.write(JSON.stringify({decision: 'block', reason}));
-        process.exit(0);
+        // Exit only AFTER stdout drains so the decision JSON is never truncated on a pipe.
+        process.stdout.write(JSON.stringify({decision: 'block', reason}), () => process.exit(0));
+        return;
     }
 
     auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'WOULD-ALLOW'} (session=${session}): ${reason}`);

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -4,31 +4,37 @@
  * @summary Claude Code `Stop` hook for idle-out enforcement — DRY-RUN (log-only) by default.
  *
  * Fires at every agent turn-end (the `Stop` event). Reads the turn transcript, extracts the agent's
- * declared lane-state terminal, validates it, and — in ENFORCING mode — blocks the stop + injects a
- * "pick a lane" directive when the terminal is an invalid idle-out. In DRY-RUN mode (default) it only
- * LOGS what it WOULD block, so the swarm can audit for false-positives (e.g. a legitimate
- * all-lanes-handed-off / async-blocked terminal — the handoff-terminal AC) BEFORE enforcement is on.
+ * declared lane-state terminal from a fenced ```lane-state block, validates it, and — in ENFORCING
+ * mode — blocks the stop + injects a "pick a lane" directive when the terminal is an invalid idle-out.
+ * In DRY-RUN mode (default) it only LOGS what it WOULD block, so the swarm can audit for false-
+ * positives (e.g. a legitimate all-lanes-handed-off terminal — the handoff-terminal AC) before
+ * enforcement is on.
  *
  * Mechanism (docs-grounded; the Option-A convergence):
  *  - `stop_hook_active` loop-guard: if Claude is already in a forced continuation, allow the stop
  *    (Claude Code also force-overrides after 8 consecutive blocks).
- *  - `transcript_path`: the turn transcript, parsed for the structured lane-state descriptor.
+ *  - `transcript_path` → final text → `parseLaneState` → one of three buckets:
+ *      null (no block emitted → ABSENT) · throw (block present but malformed JSON → MALFORMED) ·
+ *      descriptor → `validateLaneStateTerminal` → {valid, violations}. All non-valid buckets are
+ *      idle-out failures with distinct reasons; a valid terminal allows.
  *  - Block path (ENFORCING): write `{"decision":"block","reason":"…"}` to stdout — Claude keeps
  *    working and uses the `reason` as its next instruction.
  *
- * SAFETY — this hook MUST NEVER block a turn-end on its OWN failure (a malformed payload, an
- * unreadable transcript, a parser throw). Every internal error path allows the stop + audits, so a
- * hook bug can never trap every agent in the harness.
+ * SAFETY — this hook MUST NEVER block a turn-end on its OWN failure (a malformed hook payload, an
+ * unreadable transcript, a validator throw). Those allow the stop + audit. A *malformed lane-state
+ * emission* (parseLaneState throws) is NOT our failure — it's the agent emitting garbage, a real
+ * block-able bucket. So a hook bug can never trap the swarm, but a broken emission still counts.
  *
  * ACTIVATION = operator-authority: this script is INERT until wired into the harness settings
  * (`.claude/settings.*` — gitignored per-clone). Wire it in DRY-RUN first, audit the WOULD-BLOCK
  * log for handoff false-positives, then set `NEO_LANE_STATE_ENFORCE=1` to enforce. A buggy blocking
  * hook would trap every agent's turn-end, so the dry-run → audit → enforce ramp is the safe rollout.
  *
- * SEAM (pending the lane-state-terminal module — the validator + the emission-convention parser):
- * `parseLaneState` + `validateLaneStateTerminal` are stubbed here (the stub always ALLOWS, so a
- * dry-run with stubs is a pure no-op that exercises the I/O + logging path). They drop in unchanged
- * once that module lands. The pure `decideHookAction` decision is exported + unit-tested independently.
+ * SEAM (pending the lane-state-terminal module): `parseLaneState` + `validateLaneStateTerminal` are
+ * stubbed against their EXACT real signatures (the stub parser returns null — the absent-bucket
+ * placeholder; a meaningful dry-run audit needs the real parser). The author's bodies drop in
+ * unchanged. The pure `parseOutcomeToVerdict` (3 buckets → verdict) + `decideHookAction` (verdict +
+ * enforcing → action) are exported + unit-tested independently of the I/O + the stubs.
  *
  * @see https://code.claude.com/docs/en/hooks — Stop hook contract (stdin payload, decision:block)
  */
@@ -75,38 +81,63 @@ function auditLog(line) {
     }
 }
 
-// ---- SEAM (stubbed pending the lane-state-terminal module: parser + validator) -------------------
+// ---- SEAM (stubbed against the real signatures; the author's parser + validator bodies drop in) ---
 /**
- * @summary STUB — extract the structured lane-state descriptor from the turn transcript. Replaced by
- * the emission-convention-aware parser. Until then returns null → the validator stub ALLOWS, so the
- * dry-run is a pure no-op (never a false WOULD-BLOCK on stubbed logic).
+ * @summary STUB — extract the structured lane-state descriptor from the LAST fenced ```lane-state
+ * block in the turn transcript. Real signature (the author's body replaces this stub):
+ *   - returns the descriptor `{wakeDisposition, laneContinuation, namedGates, awaitingOwnPrOnly, backlogSurvey}`
+ *   - returns null when NO block is present (the ABSENT bucket)
+ *   - THROWS when a block is present but its JSON is malformed (the MALFORMED bucket — distinct from absent)
+ * The stub returns null (absent-bucket placeholder) so the chain is exercised without the real parser.
  * @param {String} _transcript
  * @returns {Object|null}
+ * @throws {Error} when a lane-state block is present but its JSON is malformed
  * @protected
  */
 function parseLaneState(_transcript) {
-    return null; // STUB — the emission-convention parser drops in here
+    return null; // STUB — the emission-convention parser drops in here (returns descriptor | null | throws)
 }
 
 /**
- * @summary STUB — validate a lane-state terminal descriptor. Replaced by the real
- * `validateLaneStateTerminal` validator. The stub treats every terminal as valid (never blocks) so
- * the scaffold is a safe no-op until the real validator (which MUST admit the all-lanes-handed-off
- * terminal) lands.
- * @param {Object|null} _descriptor
- * @returns {{valid: Boolean, reason: String}}
+ * @summary STUB — validate a parsed lane-state descriptor. Real signature returns
+ * `{valid: Boolean, violations: String[]}` (the author's validator body replaces this stub). The stub
+ * treats every descriptor as valid (empty violations) so the scaffold is safe until the real validator
+ * — which MUST admit the all-lanes-handed-off terminal (`verified-no-lane` + a full-backlog survey).
+ * @param {Object} _descriptor
+ * @returns {{valid: Boolean, violations: String[]}}
  * @protected
  */
 function validateLaneStateTerminal(_descriptor) {
-    return {valid: true, reason: 'stub: lane-state validator not yet wired'};
+    return {valid: true, violations: []};
 }
 // ---- end SEAM ------------------------------------------------------------------------------------
 
 /**
+ * @summary Pure mapping of a parse OUTCOME to a terminal verdict — the 3-bucket chain. A malformed
+ * emission (parseLaneState threw) and an absent emission (null) are distinct idle-out failures from an
+ * invalid descriptor, each with its own reason; a parsed descriptor is delegated to `validate` (the
+ * real validator), whose `{valid, violations}` is mapped to the `{valid, reason}` verdict
+ * `decideHookAction` consumes. Exported + unit-tested with injected outcomes (no I/O, no real parser).
+ * @param {{descriptor: (Object|null), parseError: (Error|null)}} outcome
+ * @param {Function} validate descriptor → {valid: Boolean, violations: String[]}
+ * @returns {{valid: Boolean, reason: String}}
+ */
+export function parseOutcomeToVerdict({descriptor, parseError}, validate) {
+    if (parseError)          return {valid: false, reason: `malformed lane-state emission: ${parseError.message}`};
+    if (descriptor === null) return {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
+
+    const result = validate(descriptor);
+
+    return result.valid
+        ? {valid: true,  reason: 'valid lane-state terminal'}
+        : {valid: false, reason: (result.violations || []).join('; ') || 'invalid lane-state terminal'};
+}
+
+/**
  * @summary Pure decision — maps a terminal `verdict` + whether we're `enforcing` to the Stop-hook
- * action. Exported + unit-tested independently of the I/O + the (stubbed) validator: this is the
- * heart of the idle-out mechanism — an invalid terminal blocks (enforcing) or would-block (dry-run);
- * a valid terminal always allows (so a legitimate handoff is never trapped, even when enforcing).
+ * action. Exported + unit-tested: the heart of the idle-out mechanism — a non-valid terminal blocks
+ * (enforcing) or would-block (dry-run); a valid terminal always allows (so a legitimate handoff is
+ * never trapped, even when enforcing).
  * @param {{valid: Boolean, reason: String}} verdict
  * @param {Boolean} enforcing
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
@@ -118,9 +149,10 @@ export function decideHookAction(verdict, enforcing) {
 }
 
 /**
- * @summary Hook entry. Resolves the Stop-hook payload → loop-guard → transcript → verdict →
- * decideHookAction, then blocks+injects (enforcing) or audit-logs the would-be decision. Always
- * exits 0 on any internal failure (the hook must never trap a turn-end on its own bug).
+ * @summary Hook entry. Resolves the Stop-hook payload → loop-guard → transcript → parse outcome →
+ * verdict → decideHookAction, then blocks+injects (enforcing) or audit-logs the would-be decision.
+ * Always exits 0 on any of OUR OWN failures (bad payload, unreadable transcript, validator throw) — a
+ * hook bug must never trap a turn-end. A malformed *emission* still counts (that's the agent's, not ours).
  * @protected
  */
 async function main() {
@@ -128,7 +160,6 @@ async function main() {
     try {
         input = JSON.parse(await readStdin());
     } catch (e) {
-        // Malformed hook payload → NEVER block; allow + audit.
         auditLog(`PARSE-ERROR: could not parse Stop-hook input (${e.message}); allowing stop.`);
         process.exit(0);
     }
@@ -138,18 +169,34 @@ async function main() {
         process.exit(0);
     }
 
-    let descriptor = null;
+    let transcript = '';
     try {
-        const transcript = input.transcript_path ? fs.readFileSync(input.transcript_path, 'utf8') : '';
-        descriptor = parseLaneState(transcript);
+        transcript = input.transcript_path ? fs.readFileSync(input.transcript_path, 'utf8') : '';
     } catch (e) {
-        // Could not read/parse the transcript → never block on our OWN failure; allow + audit.
+        // OUR failure (unreadable transcript) → never block; allow + audit.
         auditLog(`READ-ERROR: ${e.message}; allowing stop.`);
         process.exit(0);
     }
 
-    const verdict          = validateLaneStateTerminal(descriptor),
-          session          = input.session_id || '?',
+    // parseLaneState throwing is a MALFORMED emission (the agent's garbage), NOT our failure → it
+    // feeds the verdict (a real block-able bucket), distinct from an absent emission (null).
+    let descriptor = null, parseError = null;
+    try {
+        descriptor = parseLaneState(transcript);
+    } catch (e) {
+        parseError = e;
+    }
+
+    let verdict;
+    try {
+        verdict = parseOutcomeToVerdict({descriptor, parseError}, validateLaneStateTerminal);
+    } catch (e) {
+        // A validator/mapping bug is OUR failure → never block; allow + audit.
+        auditLog(`VALIDATOR-ERROR: ${e.message}; allowing stop.`);
+        process.exit(0);
+    }
+
+    const session          = input.session_id || '?',
           {action, reason} = decideHookAction(verdict, ENFORCING);
 
     if (action === 'block') {
@@ -164,7 +211,7 @@ async function main() {
 }
 
 // Process-entry only: run main() when invoked as the hook (never on import, so unit tests can import
-// `decideHookAction` without triggering the stdin read).
+// the pure `parseOutcomeToVerdict` / `decideHookAction` without triggering the stdin read).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
     main();
 }

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -120,7 +120,71 @@ export function decideHookAction(verdict, enforcing) {
 }
 
 /**
- * @summary Hook entry. Resolves the Stop-hook payload → loop-guard → transcript → parse outcome →
+ * @summary Extracts plain text from a message `content` field — a string passthrough, or the joined
+ * `text` blocks of an Anthropic content-block array (skipping tool_use / thinking blocks).
+ * @param {(String|Object[]|*)} content
+ * @returns {String}
+ * @protected
+ */
+function extractTextFromContent(content) {
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+        return content.filter(block => block?.type === 'text' && typeof block.text === 'string')
+            .map(block => block.text).join('\n');
+    }
+    return '';
+}
+
+/**
+ * @summary Extracts the LAST assistant message's text from a Claude Code JSONL transcript — the
+ * fallback when the Stop payload has no `last_assistant_message`. Each line is a JSON record
+ * (`{type:'assistant', message:{role, content}}`); raw JSONL is JSON-escaped, so the fence parser
+ * MUST run on this EXTRACTED text, never a raw line. Tolerant of malformed lines (skipped); returns
+ * the most recent assistant record that carries text (skipping tool_use / thinking-only records).
+ * @param {String} jsonl
+ * @returns {String}
+ * @protected
+ */
+export function extractLastAssistantTextFromJsonl(jsonl = '') {
+    const lines = jsonl.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        let record;
+        try { record = JSON.parse(line); } catch { continue; }
+
+        const message = record.message || record;
+        if ((message.role || record.type) !== 'assistant') continue;
+
+        const text = extractTextFromContent(message.content);
+        if (text) return text;
+    }
+    return '';
+}
+
+/**
+ * @summary Resolves the agent's FINAL assistant message text — the surface the lane-state block is
+ * emitted into. Prefers the Stop payload's `last_assistant_message` (already-decoded; a string or a
+ * message object); falls back to JSONL-parsing `transcript_path` for the last assistant text. Raw
+ * JSONL is escaped, so the fence parser only ever runs on this extracted text, never a raw line.
+ * @param {Object} input The Stop-hook JSON payload.
+ * @returns {String}
+ * @protected
+ */
+export function extractFinalAssistantText(input = {}) {
+    const last = input.last_assistant_message;
+    if (typeof last === 'string' && last.trim()) return last;
+    if (last && typeof last === 'object') {
+        const text = extractTextFromContent(last.content ?? last.message?.content);
+        if (text) return text;
+    }
+    if (!input.transcript_path) return '';
+    return extractLastAssistantTextFromJsonl(fs.readFileSync(input.transcript_path, 'utf8'));
+}
+
+/**
+ * @summary Hook entry. Resolves the Stop-hook payload → loop-guard → final message → parse outcome →
  * verdict → decideHookAction, then blocks+injects (enforcing) or audit-logs the would-be decision.
  * Always exits 0 on any of OUR OWN failures (bad payload, unreadable transcript, validator throw) — a
  * hook bug must never trap a turn-end. A malformed *emission* still counts (that's the agent's, not ours).
@@ -140,11 +204,14 @@ async function main() {
         process.exit(0);
     }
 
-    let transcript = '';
+    // Resolve the agent's FINAL message text (last_assistant_message, or JSONL-extracted from the
+    // transcript) — NOT the raw transcript: raw Claude JSONL is JSON-escaped, so the fence parser
+    // only matches extracted text (the runtime input boundary a cross-family review caught).
+    let finalText = '';
     try {
-        transcript = input.transcript_path ? fs.readFileSync(input.transcript_path, 'utf8') : '';
+        finalText = extractFinalAssistantText(input);
     } catch (e) {
-        // OUR failure (unreadable transcript) → never block; allow + audit.
+        // OUR failure (unreadable / unparseable transcript) → never block; allow + audit.
         auditLog(`READ-ERROR: ${e.message}; allowing stop.`);
         process.exit(0);
     }
@@ -153,7 +220,7 @@ async function main() {
     // feeds the verdict (a real block-able bucket), distinct from an absent emission (null).
     let descriptor = null, parseError = null;
     try {
-        descriptor = parseLaneState(transcript);
+        descriptor = parseLaneState(finalText);
     } catch (e) {
         parseError = e;
     }

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * @module .claude/hooks/laneStateStopHook
+ * @summary Claude Code `Stop` hook for idle-out enforcement — DRY-RUN (log-only) by default.
+ *
+ * Fires at every agent turn-end (the `Stop` event). Reads the turn transcript, extracts the agent's
+ * declared lane-state terminal, validates it, and — in ENFORCING mode — blocks the stop + injects a
+ * "pick a lane" directive when the terminal is an invalid idle-out. In DRY-RUN mode (default) it only
+ * LOGS what it WOULD block, so the swarm can audit for false-positives (e.g. a legitimate
+ * all-lanes-handed-off / async-blocked terminal — the handoff-terminal AC) BEFORE enforcement is on.
+ *
+ * Mechanism (docs-grounded; the Option-A convergence):
+ *  - `stop_hook_active` loop-guard: if Claude is already in a forced continuation, allow the stop
+ *    (Claude Code also force-overrides after 8 consecutive blocks).
+ *  - `transcript_path`: the turn transcript, parsed for the structured lane-state descriptor.
+ *  - Block path (ENFORCING): write `{"decision":"block","reason":"…"}` to stdout — Claude keeps
+ *    working and uses the `reason` as its next instruction.
+ *
+ * SAFETY — this hook MUST NEVER block a turn-end on its OWN failure (a malformed payload, an
+ * unreadable transcript, a parser throw). Every internal error path allows the stop + audits, so a
+ * hook bug can never trap every agent in the harness.
+ *
+ * ACTIVATION = operator-authority: this script is INERT until wired into the harness settings
+ * (`.claude/settings.*` — gitignored per-clone). Wire it in DRY-RUN first, audit the WOULD-BLOCK
+ * log for handoff false-positives, then set `NEO_LANE_STATE_ENFORCE=1` to enforce. A buggy blocking
+ * hook would trap every agent's turn-end, so the dry-run → audit → enforce ramp is the safe rollout.
+ *
+ * SEAM (pending the lane-state-terminal module — the validator + the emission-convention parser):
+ * `parseLaneState` + `validateLaneStateTerminal` are stubbed here (the stub always ALLOWS, so a
+ * dry-run with stubs is a pure no-op that exercises the I/O + logging path). They drop in unchanged
+ * once that module lands. The pure `decideHookAction` decision is exported + unit-tested independently.
+ *
+ * @see https://code.claude.com/docs/en/hooks — Stop hook contract (stdin payload, decision:block)
+ */
+import fs              from 'node:fs';
+import path            from 'node:path';
+import os              from 'node:os';
+import {pathToFileURL} from 'node:url';
+
+// Enforce ONLY when the operator explicitly activates it; default is DRY-RUN (log-only, never blocks).
+const ENFORCING = process.env.NEO_LANE_STATE_ENFORCE === '1';
+
+// Append-only dry-run audit log — the substrate for auditing WOULD-BLOCK false-positives (esp. the
+// handoff-terminal AC) before enforcement. NEO_AI_DAEMON_DIR override keeps tests off the real store.
+const LOG_DIR  = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'lane-state-hook');
+const LOG_FILE = path.join(LOG_DIR, 'lane-state-stop-hook.log');
+
+/**
+ * @summary Reads all of stdin (the Stop-hook JSON payload) to a string.
+ * @returns {Promise<String>}
+ * @protected
+ */
+function readStdin() {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data',  chunk => data += chunk);
+        process.stdin.on('end',   ()    => resolve(data));
+        process.stdin.on('error', reject);
+    });
+}
+
+/**
+ * @summary Best-effort append to the dry-run audit log. A log failure must NEVER gate the hook
+ * (mirrors the wake daemon's never-fail log discipline) — worst case is a lost audit line.
+ * @param {String} line
+ * @protected
+ */
+function auditLog(line) {
+    try {
+        fs.mkdirSync(LOG_DIR, {recursive: true});
+        fs.appendFileSync(LOG_FILE, `[${new Date().toISOString()}] ${line}\n`, 'utf8');
+    } catch (e) {
+        // best-effort; a log-write failure must never block a turn-end
+    }
+}
+
+// ---- SEAM (stubbed pending the lane-state-terminal module: parser + validator) -------------------
+/**
+ * @summary STUB — extract the structured lane-state descriptor from the turn transcript. Replaced by
+ * the emission-convention-aware parser. Until then returns null → the validator stub ALLOWS, so the
+ * dry-run is a pure no-op (never a false WOULD-BLOCK on stubbed logic).
+ * @param {String} _transcript
+ * @returns {Object|null}
+ * @protected
+ */
+function parseLaneState(_transcript) {
+    return null; // STUB — the emission-convention parser drops in here
+}
+
+/**
+ * @summary STUB — validate a lane-state terminal descriptor. Replaced by the real
+ * `validateLaneStateTerminal` validator. The stub treats every terminal as valid (never blocks) so
+ * the scaffold is a safe no-op until the real validator (which MUST admit the all-lanes-handed-off
+ * terminal) lands.
+ * @param {Object|null} _descriptor
+ * @returns {{valid: Boolean, reason: String}}
+ * @protected
+ */
+function validateLaneStateTerminal(_descriptor) {
+    return {valid: true, reason: 'stub: lane-state validator not yet wired'};
+}
+// ---- end SEAM ------------------------------------------------------------------------------------
+
+/**
+ * @summary Pure decision — maps a terminal `verdict` + whether we're `enforcing` to the Stop-hook
+ * action. Exported + unit-tested independently of the I/O + the (stubbed) validator: this is the
+ * heart of the idle-out mechanism — an invalid terminal blocks (enforcing) or would-block (dry-run);
+ * a valid terminal always allows (so a legitimate handoff is never trapped, even when enforcing).
+ * @param {{valid: Boolean, reason: String}} verdict
+ * @param {Boolean} enforcing
+ * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
+ */
+export function decideHookAction(verdict, enforcing) {
+    if (verdict.valid) return {action: 'allow',       reason: verdict.reason};
+    if (enforcing)     return {action: 'block',       reason: verdict.reason};
+    return             {action: 'would-block', reason: verdict.reason};
+}
+
+/**
+ * @summary Hook entry. Resolves the Stop-hook payload → loop-guard → transcript → verdict →
+ * decideHookAction, then blocks+injects (enforcing) or audit-logs the would-be decision. Always
+ * exits 0 on any internal failure (the hook must never trap a turn-end on its own bug).
+ * @protected
+ */
+async function main() {
+    let input;
+    try {
+        input = JSON.parse(await readStdin());
+    } catch (e) {
+        // Malformed hook payload → NEVER block; allow + audit.
+        auditLog(`PARSE-ERROR: could not parse Stop-hook input (${e.message}); allowing stop.`);
+        process.exit(0);
+    }
+
+    // Loop-safety: if Claude is already in a forced continuation from a prior block, allow the stop.
+    if (input.stop_hook_active) {
+        process.exit(0);
+    }
+
+    let descriptor = null;
+    try {
+        const transcript = input.transcript_path ? fs.readFileSync(input.transcript_path, 'utf8') : '';
+        descriptor = parseLaneState(transcript);
+    } catch (e) {
+        // Could not read/parse the transcript → never block on our OWN failure; allow + audit.
+        auditLog(`READ-ERROR: ${e.message}; allowing stop.`);
+        process.exit(0);
+    }
+
+    const verdict          = validateLaneStateTerminal(descriptor),
+          session          = input.session_id || '?',
+          {action, reason} = decideHookAction(verdict, ENFORCING);
+
+    if (action === 'block') {
+        auditLog(`BLOCK (session=${session}): ${reason}`);
+        // Block the stop + inject the directive — Claude uses `reason` as its next instruction.
+        process.stdout.write(JSON.stringify({decision: 'block', reason}));
+        process.exit(0);
+    }
+
+    auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'WOULD-ALLOW'} (session=${session}): ${reason}`);
+    process.exit(0);
+}
+
+// Process-entry only: run main() when invoked as the hook (never on import, so unit tests can import
+// `decideHookAction` without triggering the stdin read).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/ai/scripts/lifecycle/parseLaneState.mjs
+++ b/ai/scripts/lifecycle/parseLaneState.mjs
@@ -1,0 +1,65 @@
+/**
+ * Pure parser that extracts the structured turn-terminal `lane-state` descriptor from an agent's
+ * final transcript text, for the Stop-hook seam: `transcriptText → descriptor → validateLaneStateTerminal`.
+ *
+ * The emission convention is a fenced ```lane-state code block holding the descriptor as JSON (the
+ * human-readable `lane-state:` prose line remains, but the MACHINE seam is the block). This parser is
+ * deliberately continuation-set-agnostic — it extracts whatever the block declares; the lane-state
+ * RULES live in `validateLaneStateTerminal`, so a change to the valid continuation set never touches
+ * the parser.
+ *
+ * Three outcomes the hook distinguishes:
+ *  - a well-formed block  → the descriptor object;
+ *  - NO block present     → `null` (the "absent emission" case);
+ *  - a block with broken JSON → it THROWS (a present-but-malformed emission is a distinct failure from absent).
+ *
+ * @module Neo.ai.scripts.lifecycle.parseLaneState
+ */
+
+/**
+ * Matches a fenced ```lane-state block, capturing its inner body. Global so the LAST block wins
+ * (an agent's true terminal claim is its final block, not an earlier illustrative one).
+ * @type {RegExp}
+ */
+export const LANE_STATE_BLOCK = /```lane-state\s*\r?\n([\s\S]*?)\r?\n```/g;
+
+/**
+ * @summary Parses the last fenced ```lane-state block from transcript text into a lane-state descriptor.
+ *
+ * @param {String} transcriptText The agent's final turn-terminal message text (or the transcript tail).
+ * @returns {Object|null} The descriptor `{wakeDisposition, laneContinuation, namedGates, awaitingOwnPrOnly, backlogSurvey}`
+ *   normalized from the LAST ```lane-state block, or `null` when no block is present.
+ * @throws {Error} When a ```lane-state block IS present but its body is not valid JSON — a
+ *   present-but-malformed emission is a distinct failure the hook logs separately from an absent one.
+ */
+export function parseLaneState(transcriptText) {
+    if (typeof transcriptText !== 'string') {
+        return null;
+    }
+
+    let lastBody = null;
+    for (const match of transcriptText.matchAll(LANE_STATE_BLOCK)) {
+        lastBody = match[1];
+    }
+
+    if (lastBody === null) {
+        return null;
+    }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(lastBody);
+    } catch (cause) {
+        throw new Error(`parseLaneState: a \`\`\`lane-state block was present but its body is not valid JSON: ${cause.message}`, {cause});
+    }
+
+    return {
+        wakeDisposition  : parsed.wakeDisposition,
+        laneContinuation : parsed.laneContinuation,
+        namedGates       : Array.isArray(parsed.namedGates) ? parsed.namedGates : [],
+        awaitingOwnPrOnly: parsed.awaitingOwnPrOnly === true,
+        backlogSurvey    : parsed.backlogSurvey ?? null
+    };
+}
+
+export default parseLaneState;

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -1,0 +1,94 @@
+/**
+ * Pure, side-effect-free checker for the EVIDENCE SHAPE of an agent's turn-terminal `lane-state`
+ * claim (the post-review-pickup §2.5/§2.6 convention).
+ *
+ * The wake-disposition vs lane-continuation discipline is repeatedly lost to disciplined-sounding
+ * terminal prose: a wake correctly classified as low-action, then a turn that ends "standing by"
+ * while naming an already-merged PR as a live gate. This validator mechanically rejects stale gate
+ * names and own-slice `verified-no-lane` claims. It deliberately validates ONLY the author-provided
+ * terminal evidence — it does not compute claimable work, count contributions, or enforce external
+ * liveness (that is the separate, deferred external-enforcement layer).
+ *
+ * @module Neo.ai.scripts.lifecycle.validateLaneStateTerminal
+ */
+
+/**
+ * The lane-continuation states that answer "may the turn end?".
+ * @type {String[]}
+ */
+export const LANE_CONTINUATIONS = ['active-lane', 'next-lane', 'blocker-routed', 'verified-no-lane'];
+
+/**
+ * Wake dispositions that answer only "engage this message?" — never "does the turn have a lane?".
+ * @type {String[]}
+ */
+export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
+
+/**
+ * @summary Validates a structured turn-terminal `lane-state` descriptor against the evidence rules.
+ *
+ * Rules:
+ *  1. A `wakeDisposition` of awareness/stale/suppressed is not a terminal on its own — a
+ *     `laneContinuation` is required.
+ *  2. `laneContinuation='active-lane'` may not be only an own PR awaiting merge/review/CI (a
+ *     background watch); that resolves to `next-lane` unless there is concrete author work on it.
+ *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence).
+ *  4. `laneContinuation='verified-no-lane'` must cite a NAMED full-backlog survey artifact with a
+ *     `checkedAt` — an own-PR-only or own-epic-only survey fails.
+ *
+ * @param {Object} [laneState={}]
+ * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
+ * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed|verified-no-lane`.
+ * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt}]`.
+ * @param {Boolean} [laneState.awaitingOwnPrOnly] True when the only cited lane is an own PR awaiting merge/review/CI.
+ * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` — the survey backing a `verified-no-lane` claim.
+ * @returns {{valid: Boolean, violations: String[]}} `valid` is true when no rule is violated.
+ */
+export function validateLaneStateTerminal(laneState = {}) {
+    const {
+        wakeDisposition,
+        laneContinuation,
+        namedGates        = [],
+        awaitingOwnPrOnly = false,
+        backlogSurvey     = null
+    } = laneState;
+
+    const violations = [];
+
+    // Rule 1 — a wake disposition alone is not a terminal.
+    if (!laneContinuation) {
+        violations.push(NON_TERMINAL_DISPOSITIONS.includes(wakeDisposition)
+            ? `wakeDisposition='${wakeDisposition}' answers only the message, not the turn: a laneContinuation is required.`
+            : `Missing laneContinuation (one of: ${LANE_CONTINUATIONS.join(', ')}).`);
+        return {valid: false, violations};
+    }
+
+    if (!LANE_CONTINUATIONS.includes(laneContinuation)) {
+        violations.push(`Unknown laneContinuation '${laneContinuation}' (expected one of: ${LANE_CONTINUATIONS.join(', ')}).`);
+    }
+
+    // Rule 2 — active-lane is not an own-PR background watch.
+    if (laneContinuation === 'active-lane' && awaitingOwnPrOnly) {
+        violations.push('active-lane cannot be only an own PR awaiting merge/review/CI (a background watch) — it resolves to next-lane unless there is concrete author work on that PR this turn.');
+    }
+
+    // Rule 3 — named gates need a same-turn checkedAt.
+    for (const gate of namedGates) {
+        if (!gate?.checkedAt) {
+            violations.push(`Named gate ${gate?.ref ?? '(unnamed)'} must cite a same-turn checkedAt — a stale gate name is not evidence.`);
+        }
+    }
+
+    // Rule 4 — verified-no-lane needs a named full-backlog survey.
+    if (laneContinuation === 'verified-no-lane') {
+        if (!backlogSurvey?.checkedAt) {
+            violations.push('verified-no-lane must cite a named full-backlog survey artifact (e.g. list_issues / gh issue list) with a checkedAt.');
+        } else if (backlogSurvey.scope && backlogSurvey.scope !== 'full-backlog') {
+            violations.push(`verified-no-lane survey scope '${backlogSurvey.scope}' is too narrow — a full-backlog survey is required (own-PR-only / own-epic-only slices fail).`);
+        }
+    }
+
+    return {valid: violations.length === 0, violations};
+}
+
+export default validateLaneStateTerminal;

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -32,16 +32,18 @@ export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
  *     `laneContinuation` is required.
  *  2. `laneContinuation='active-lane'` may not be only an own PR awaiting merge/review/CI (a
  *     background watch); that resolves to `next-lane` unless there is concrete author work on it.
- *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence).
+ *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence);
+ *     a gate flagged `mergeClaim` must cite `field === 'mergedAt'` (reading a PR's `state`/CLOSED is
+ *     not merge proof — a closed PR may be un-merged).
  *  4. `laneContinuation='verified-no-lane'` must cite a NAMED full-backlog survey artifact with a
- *     `checkedAt` — an own-PR-only or own-epic-only survey fails.
+ *     `checkedAt` AND `scope === 'full-backlog'` — an own-PR-only, own-epic-only, or unscoped survey fails.
  *
  * @param {Object} [laneState={}]
  * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
  * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed|verified-no-lane`.
- * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt}]`.
+ * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt, mergeClaim?, field?}]`.
  * @param {Boolean} [laneState.awaitingOwnPrOnly] True when the only cited lane is an own PR awaiting merge/review/CI.
- * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` — the survey backing a `verified-no-lane` claim.
+ * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` backing a `verified-no-lane` claim; `scope` must be `'full-backlog'`.
  * @returns {{valid: Boolean, violations: String[]}} `valid` is true when no rule is violated.
  */
 export function validateLaneStateTerminal(laneState = {}) {
@@ -72,19 +74,21 @@ export function validateLaneStateTerminal(laneState = {}) {
         violations.push('active-lane cannot be only an own PR awaiting merge/review/CI (a background watch) — it resolves to next-lane unless there is concrete author work on that PR this turn.');
     }
 
-    // Rule 3 — named gates need a same-turn checkedAt.
+    // Rule 3 — named gates need a same-turn checkedAt; a merge claim must read the authoritative field.
     for (const gate of namedGates) {
         if (!gate?.checkedAt) {
             violations.push(`Named gate ${gate?.ref ?? '(unnamed)'} must cite a same-turn checkedAt — a stale gate name is not evidence.`);
+        } else if (gate.mergeClaim && gate.field !== 'mergedAt') {
+            violations.push(`Named gate ${gate.ref ?? '(unnamed)'} claims merge state but cites field ${gate.field ? `'${gate.field}'` : '(none)'} — a merge claim must read mergedAt (a PR's state/CLOSED is not merge proof).`);
         }
     }
 
-    // Rule 4 — verified-no-lane needs a named full-backlog survey.
+    // Rule 4 — verified-no-lane needs a named full-backlog survey; an unscoped survey is not full-backlog.
     if (laneContinuation === 'verified-no-lane') {
         if (!backlogSurvey?.checkedAt) {
             violations.push('verified-no-lane must cite a named full-backlog survey artifact (e.g. list_issues / gh issue list) with a checkedAt.');
-        } else if (backlogSurvey.scope && backlogSurvey.scope !== 'full-backlog') {
-            violations.push(`verified-no-lane survey scope '${backlogSurvey.scope}' is too narrow — a full-backlog survey is required (own-PR-only / own-epic-only slices fail).`);
+        } else if (backlogSurvey.scope !== 'full-backlog') {
+            violations.push(`verified-no-lane requires a full-backlog survey scope (got ${backlogSurvey.scope ? `'${backlogSurvey.scope}'` : 'no scope'}) — own-PR-only / own-epic-only / unscoped surveys fail.`);
         }
     }
 

--- a/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/parseLaneState.spec.mjs
@@ -1,0 +1,64 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'ParseLaneStateTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}              from '@playwright/test';
+import Neo                         from '../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../src/core/_export.mjs';
+import {parseLaneState}            from '../../../../../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {validateLaneStateTerminal} from '../../../../../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+
+test.describe('parseLaneState — fenced lane-state block extraction', () => {
+    test('parses a well-formed block into the descriptor', () => {
+        const text = 'prose\n```lane-state\n{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[{"ref":"PR #99","checkedAt":"2026-06-20T03:41:00Z"}],"awaitingOwnPrOnly":false,"backlogSurvey":null}\n```\ntail';
+        const d = parseLaneState(text);
+        expect(d.laneContinuation).toBe('next-lane');
+        expect(d.namedGates).toHaveLength(1);
+        expect(d.namedGates[0].ref).toBe('PR #99');
+        expect(d.awaitingOwnPrOnly).toBe(false);
+    });
+
+    test('returns null when no lane-state block is present', () => {
+        expect(parseLaneState('just some prose, no block')).toBe(null);
+        expect(parseLaneState('```js\nconst x = 1;\n```')).toBe(null);
+    });
+
+    test('returns null for non-string input', () => {
+        expect(parseLaneState(null)).toBe(null);
+        expect(parseLaneState(undefined)).toBe(null);
+        expect(parseLaneState({})).toBe(null);
+    });
+
+    test('throws on a present-but-malformed block (distinct from absent)', () => {
+        const text = '```lane-state\n{ not valid json, }\n```';
+        expect(() => parseLaneState(text)).toThrow(/present but its body is not valid JSON/);
+    });
+
+    test('the LAST block wins when multiple are present', () => {
+        const text = '```lane-state\n{"laneContinuation":"active-lane"}\n```\n...later...\n```lane-state\n{"laneContinuation":"verified-no-lane","backlogSurvey":{"checkedAt":"t","scope":"full-backlog"}}\n```';
+        expect(parseLaneState(text).laneContinuation).toBe('verified-no-lane');
+    });
+
+    test('normalizes missing optional fields to safe defaults', () => {
+        const d = parseLaneState('```lane-state\n{"laneContinuation":"next-lane"}\n```');
+        expect(d.namedGates).toEqual([]);
+        expect(d.awaitingOwnPrOnly).toBe(false);
+        expect(d.backlogSurvey).toBe(null);
+    });
+
+    test('round-trips into validateLaneStateTerminal — the hook seam end-to-end (#12633)', () => {
+        // A valid next-lane terminal emitted as a block parses + validates clean (the wired path fires PASS).
+        const ok = '```lane-state\n{"wakeDisposition":"actionable","laneContinuation":"next-lane","namedGates":[{"ref":"PR #99","checkedAt":"2026-06-20T03:41:00Z","mergeClaim":false}],"awaitingOwnPrOnly":false}\n```';
+        expect(validateLaneStateTerminal(parseLaneState(ok)).valid).toBe(true);
+
+        // A stale-gate terminal (gate named without checkedAt) parses, then the validator REJECTS it —
+        // proving the parse-then-validate seam fires the gate on real emitted text.
+        const stale = '```lane-state\n{"laneContinuation":"active-lane","namedGates":[{"ref":"PR #100"}],"awaitingOwnPrOnly":false}\n```';
+        const verdict = validateLaneStateTerminal(parseLaneState(stale));
+        expect(verdict.valid).toBe(false);
+        expect(verdict.violations.join(' ')).toContain('checkedAt');
+    });
+});

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -84,4 +84,30 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
         expect(result.valid).toBe(false);
         expect(result.violations.join(' ')).toContain("Unknown laneContinuation 'holding'");
     });
+
+    test('verified-no-lane fails when the survey is unscoped (the no-scope loophole)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'verified-no-lane',
+            backlogSurvey   : {checkedAt: NOW}   // checkedAt but no scope → not a proven full-backlog survey
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('full-backlog survey scope');
+    });
+
+    test('a named gate claiming merge state must cite field mergedAt, not state', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #12619', checkedAt: NOW, mergeClaim: true, field: 'state'}]
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('must read mergedAt');
+    });
+
+    test('a merge-claim gate citing field mergedAt passes', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #12619', checkedAt: NOW, mergeClaim: true, field: 'mergedAt'}]
+        });
+        expect(result.valid).toBe(true);
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -1,0 +1,87 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'ValidateLaneStateTerminalTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}              from '@playwright/test';
+import Neo                         from '../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../src/core/_export.mjs';
+import {validateLaneStateTerminal} from '../../../../../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+
+test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () => {
+    const NOW = '2026-06-20T00:00:00.000Z';
+
+    test('valid next-lane passes', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'next-lane'});
+        expect(result.valid).toBe(true);
+        expect(result.violations).toEqual([]);
+    });
+
+    test('blocker-routed passes', () => {
+        expect(validateLaneStateTerminal({laneContinuation: 'blocker-routed'}).valid).toBe(true);
+    });
+
+    test('active-lane passes when it is real work (not an own-PR watch)', () => {
+        expect(validateLaneStateTerminal({laneContinuation: 'active-lane', awaitingOwnPrOnly: false}).valid).toBe(true);
+    });
+
+    test('a wakeDisposition alone is not a terminal', () => {
+        const result = validateLaneStateTerminal({wakeDisposition: 'awareness'});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('laneContinuation is required');
+    });
+
+    test('active-lane fails when it is only an own PR awaiting merge/review/CI', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'active-lane', awaitingOwnPrOnly: true});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('background watch');
+    });
+
+    test('a named gate without a same-turn checkedAt fails (the stale-merged-gate class)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #13568'}]   // no checkedAt
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('checkedAt');
+    });
+
+    test('a named gate WITH a same-turn checkedAt passes', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'next-lane',
+            namedGates      : [{ref: 'PR #13572', checkedAt: NOW}]
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('verified-no-lane fails on an own-PR/own-epic slice (no full-backlog survey)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'verified-no-lane',
+            backlogSurvey   : {checkedAt: NOW, scope: 'own-pr'}
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('full-backlog');
+    });
+
+    test('verified-no-lane fails when no survey is cited at all', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'verified-no-lane'});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('full-backlog survey');
+    });
+
+    test('verified-no-lane passes with a named full-backlog survey + checkedAt', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'verified-no-lane',
+            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    test('an unknown laneContinuation (e.g. "holding") fails', () => {
+        const result = validateLaneStateTerminal({laneContinuation: 'holding'});
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain("Unknown laneContinuation 'holding'");
+    });
+});

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,0 +1,28 @@
+import {test, expect}     from '@playwright/test';
+import {decideHookAction} from '../../../../.claude/hooks/laneStateStopHook.mjs';
+
+/**
+ * Falsification test for the idle-out Stop-hook decision logic. `decideHookAction` is the pure
+ * heart of the mechanism — it maps a terminal verdict + enforcement flag to allow / would-block /
+ * block, independently of the I/O and the (stubbed) validator. The full end-to-end falsification
+ * (spawn the hook + a real `validateLaneStateTerminal`) lands with the lane-state-terminal module;
+ * this locks the decision logic now.
+ */
+test.describe('laneStateStopHook.decideHookAction — idle-out enforce/dry-run decision', () => {
+    test('a VALID terminal always ALLOWS — dry-run AND enforcing (never traps a legit handoff)', () => {
+        expect(decideHookAction({valid: true, reason: 'ok'}, false).action).toBe('allow');
+        expect(decideHookAction({valid: true, reason: 'ok'}, true).action).toBe('allow');
+    });
+
+    test('an INVALID terminal WOULD-BLOCK in dry-run — logs the would-be block, never blocks', () => {
+        const result = decideHookAction({valid: false, reason: 'no active lane'}, false);
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toBe('no active lane');
+    });
+
+    test('an INVALID terminal BLOCKS when enforcing — the reason is carried through to inject', () => {
+        const result = decideHookAction({valid: false, reason: 'no active lane — pick one or cite a survey'}, true);
+        expect(result.action).toBe('block');
+        expect(result.reason).toBe('no active lane — pick one or cite a survey');
+    });
+});

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,15 +1,19 @@
-import {test, expect}                            from '@playwright/test';
-import {decideHookAction, parseOutcomeToVerdict} from '../../../../.claude/hooks/laneStateStopHook.mjs';
-import {spawn}                                   from 'node:child_process';
-import fs                                        from 'node:fs';
-import os                                        from 'node:os';
-import path                                      from 'node:path';
+import {test, expect}                                                                             from '@playwright/test';
+import {decideHookAction, parseOutcomeToVerdict, extractFinalAssistantText,
+        extractLastAssistantTextFromJsonl}                                                       from '../../../../.claude/hooks/laneStateStopHook.mjs';
+import {spawn} from 'node:child_process';
+import fs      from 'node:fs';
+import os      from 'node:os';
+import path    from 'node:path';
+
+const block = body => '```lane-state\n' + body + '\n```';
 
 /**
- * Falsification tests for the idle-out Stop-hook. The pure layer locks the decision logic in-process
- * (`parseOutcomeToVerdict` — the 3-bucket chain; `decideHookAction` — allow / would-block / block).
- * The end-to-end layer spawns the REAL hook with real ```lane-state emissions and asserts the wired
- * parser + validator (ai/scripts/lifecycle) fire through the hook I/O — the integrated seam.
+ * Falsification tests for the idle-out Stop-hook. Three layers: (1) the pure decision logic
+ * (`parseOutcomeToVerdict` 3-bucket chain + `decideHookAction`); (2) input resolution — the agent's
+ * final message comes from the Stop payload's `last_assistant_message`, NOT the raw JSONL transcript
+ * (the runtime boundary a cross-family review caught — raw JSONL is escaped, so the fence parser must run
+ * on extracted text); (3) end-to-end — the spawned real hook against the real Stop payload shape.
  */
 test.describe('laneStateStopHook — pure idle-out decision logic', () => {
     test.describe('parseOutcomeToVerdict — the 3-bucket chain', () => {
@@ -60,22 +64,71 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
     });
 });
 
-test.describe('laneStateStopHook — end-to-end (spawned hook + real parser/validator)', () => {
+test.describe('laneStateStopHook — input resolution (last_assistant_message primary + JSONL fallback)', () => {
+    test('last_assistant_message string is used verbatim', () => {
+        const text = `On it.\n\n${block('{"laneContinuation":"active-lane"}')}`;
+        expect(extractFinalAssistantText({last_assistant_message: text})).toBe(text);
+    });
+
+    test('last_assistant_message object → joins its text content blocks (skips thinking/tool_use)', () => {
+        const input = {last_assistant_message: {content: [
+            {type: 'thinking', thinking: 'noise'},
+            {type: 'text',     text: 'final answer'}
+        ]}};
+        expect(extractFinalAssistantText(input)).toBe('final answer');
+    });
+
+    test('falls back to JSONL transcript_path when last_assistant_message is absent', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-jsonl-')),
+              p   = path.join(dir, 't.jsonl');
+        fs.writeFileSync(p, [
+            JSON.stringify({type: 'user',      message: {role: 'user',      content: 'q'}}),
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'the answer'}]}})
+        ].join('\n'));
+        expect(extractFinalAssistantText({transcript_path: p})).toBe('the answer');
+    });
+
+    test('extractLastAssistantTextFromJsonl: skips malformed + tool_use-only records → last text-bearing record', () => {
+        const jsonl = [
+            '{ not json }',
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'earlier text'}]}}),
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'tool_use', id: 'x', name: 'y', input: {}}]}})
+        ].join('\n');
+        expect(extractLastAssistantTextFromJsonl(jsonl)).toBe('earlier text');
+    });
+
+    test('no assistant text → empty string (so the hook treats it as an absent emission)', () => {
+        expect(extractLastAssistantTextFromJsonl('{"type":"user","message":{"role":"user","content":"q"}}')).toBe('');
+        expect(extractFinalAssistantText({})).toBe('');
+    });
+});
+
+test.describe('laneStateStopHook — end-to-end (spawned hook against the real Stop payload)', () => {
     /**
-     * @summary Spawns the real hook with a transcript fixture + a temp audit-log dir; returns
-     * `{stdout, log}` once it exits. The hook reads `transcript_path` from the stdin payload, so the
-     * real ai/scripts/lifecycle parser + validator fire through the actual hook I/O.
-     * @param {String} transcriptText
-     * @param {{enforce: Boolean}} [opts]
+     * @summary Spawns the real hook with a Stop payload + a temp audit-log dir; returns `{stdout, log}`.
+     * Default passes the text as `last_assistant_message` (the real Stop shape); `viaJsonl` instead
+     * writes a JSONL `transcript_path` whose last assistant record carries the text (the fallback path).
+     * @param {String} finalText
+     * @param {{enforce: Boolean, viaJsonl: Boolean}} [opts]
      * @returns {Promise<{stdout: String, log: String}>}
      */
-    function runHook(transcriptText, {enforce = false} = {}) {
+    function runHook(finalText, {enforce = false, viaJsonl = false} = {}) {
         return new Promise((resolve, reject) => {
             const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-hook-e2e-')),
-                  transcriptPath = path.join(dir, 'transcript.txt'),
-                  env            = {...process.env, NEO_AI_DAEMON_DIR: dir};
+                  transcriptPath = path.join(dir, 'transcript.jsonl'),
+                  env            = {...process.env, NEO_AI_DAEMON_DIR: dir},
+                  payload        = {stop_hook_active: false, session_id: 'e2e'};
 
-            fs.writeFileSync(transcriptPath, transcriptText);
+            if (viaJsonl) {
+                fs.writeFileSync(transcriptPath, [
+                    JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'thinking', thinking: 'noise'}]}}),
+                    JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: finalText}]}})
+                ].join('\n') + '\n');
+                payload.transcript_path = transcriptPath;
+            } else {
+                payload.last_assistant_message = finalText;
+            }
+
             if (enforce) env.NEO_LANE_STATE_ENFORCE = '1';
 
             const proc = spawn('node', ['.claude/hooks/laneStateStopHook.mjs'], {stdio: ['pipe', 'pipe', 'pipe'], env});
@@ -88,14 +141,12 @@ test.describe('laneStateStopHook — end-to-end (spawned hook + real parser/vali
                 resolve({stdout, log: fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : ''});
             });
 
-            proc.stdin.write(JSON.stringify({stop_hook_active: false, session_id: 'e2e', transcript_path: transcriptPath}));
+            proc.stdin.write(JSON.stringify(payload));
             proc.stdin.end();
         });
     }
 
-    const block = body => '```lane-state\n' + body + '\n```';
-
-    test('a VALID emission (active-lane) → WOULD-ALLOW, no block on stdout', async () => {
+    test('a VALID emission (active-lane) via last_assistant_message → WOULD-ALLOW, no block on stdout', async () => {
         const {stdout, log} = await runHook(`On it.\n\n${block('{"laneContinuation":"active-lane"}')}`);
         expect(log).toContain('WOULD-ALLOW');
         expect(stdout).toBe('');
@@ -126,5 +177,11 @@ test.describe('laneStateStopHook — end-to-end (spawned hook + real parser/vali
         const decision = JSON.parse(stdout);
         expect(decision.decision).toBe('block');
         expect(decision.reason).toContain('full-backlog survey');
+    });
+
+    test('JSONL fallback: a valid block in the last assistant transcript record → WOULD-ALLOW', async () => {
+        const {stdout, log} = await runHook(`Done.\n\n${block('{"laneContinuation":"active-lane"}')}`, {viaJsonl: true});
+        expect(log).toContain('WOULD-ALLOW');
+        expect(stdout).toBe('');
     });
 });

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,12 +1,15 @@
 import {test, expect}                            from '@playwright/test';
 import {decideHookAction, parseOutcomeToVerdict} from '../../../../.claude/hooks/laneStateStopHook.mjs';
+import {spawn}                                   from 'node:child_process';
+import fs                                        from 'node:fs';
+import os                                        from 'node:os';
+import path                                      from 'node:path';
 
 /**
- * Falsification tests for the idle-out Stop-hook pure logic. Two exported, I/O-free functions carry
- * the mechanism: `parseOutcomeToVerdict` (the 3-bucket chain — malformed / absent / validated) and
- * `decideHookAction` (verdict + enforcing → allow / would-block / block). The full end-to-end
- * falsification (spawn the hook + a real parser + validator) lands with the lane-state-terminal
- * module; these lock the decision logic now.
+ * Falsification tests for the idle-out Stop-hook. The pure layer locks the decision logic in-process
+ * (`parseOutcomeToVerdict` — the 3-bucket chain; `decideHookAction` — allow / would-block / block).
+ * The end-to-end layer spawns the REAL hook with real ```lane-state emissions and asserts the wired
+ * parser + validator (ai/scripts/lifecycle) fire through the hook I/O — the integrated seam.
  */
 test.describe('laneStateStopHook — pure idle-out decision logic', () => {
     test.describe('parseOutcomeToVerdict — the 3-bucket chain', () => {
@@ -54,5 +57,74 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(result.action).toBe('block');
             expect(result.reason).toBe('no active lane — pick one or cite a survey');
         });
+    });
+});
+
+test.describe('laneStateStopHook — end-to-end (spawned hook + real parser/validator)', () => {
+    /**
+     * @summary Spawns the real hook with a transcript fixture + a temp audit-log dir; returns
+     * `{stdout, log}` once it exits. The hook reads `transcript_path` from the stdin payload, so the
+     * real ai/scripts/lifecycle parser + validator fire through the actual hook I/O.
+     * @param {String} transcriptText
+     * @param {{enforce: Boolean}} [opts]
+     * @returns {Promise<{stdout: String, log: String}>}
+     */
+    function runHook(transcriptText, {enforce = false} = {}) {
+        return new Promise((resolve, reject) => {
+            const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-hook-e2e-')),
+                  transcriptPath = path.join(dir, 'transcript.txt'),
+                  env            = {...process.env, NEO_AI_DAEMON_DIR: dir};
+
+            fs.writeFileSync(transcriptPath, transcriptText);
+            if (enforce) env.NEO_LANE_STATE_ENFORCE = '1';
+
+            const proc = spawn('node', ['.claude/hooks/laneStateStopHook.mjs'], {stdio: ['pipe', 'pipe', 'pipe'], env});
+            let stdout = '';
+
+            proc.stdout.on('data', chunk => stdout += chunk);
+            proc.on('error', reject);
+            proc.on('exit', () => {
+                const logPath = path.join(dir, 'lane-state-stop-hook.log');
+                resolve({stdout, log: fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : ''});
+            });
+
+            proc.stdin.write(JSON.stringify({stop_hook_active: false, session_id: 'e2e', transcript_path: transcriptPath}));
+            proc.stdin.end();
+        });
+    }
+
+    const block = body => '```lane-state\n' + body + '\n```';
+
+    test('a VALID emission (active-lane) → WOULD-ALLOW, no block on stdout', async () => {
+        const {stdout, log} = await runHook(`On it.\n\n${block('{"laneContinuation":"active-lane"}')}`);
+        expect(log).toContain('WOULD-ALLOW');
+        expect(stdout).toBe('');
+    });
+
+    test('an INVALID emission (verified-no-lane, no full-backlog survey) → WOULD-BLOCK via Rule 4', async () => {
+        const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'));
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('full-backlog survey');
+        expect(stdout).toBe('');
+    });
+
+    test('an ABSENT emission (no lane-state block) → WOULD-BLOCK', async () => {
+        const {log} = await runHook('Just some prose, no lane-state block here.');
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('no lane-state block emitted');
+    });
+
+    test('a MALFORMED emission (block present, broken JSON) → WOULD-BLOCK, distinct from absent', async () => {
+        const {log} = await runHook(block('{laneContinuation: not valid json}'));
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('malformed');
+    });
+
+    test('ENFORCING + invalid emission → blocks: {"decision":"block"} injected on stdout', async () => {
+        const {stdout, log} = await runHook(block('{"laneContinuation":"verified-no-lane"}'), {enforce: true});
+        expect(log).toContain('BLOCK');
+        const decision = JSON.parse(stdout);
+        expect(decision.decision).toBe('block');
+        expect(decision.reason).toContain('full-backlog survey');
     });
 });

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,28 +1,58 @@
-import {test, expect}     from '@playwright/test';
-import {decideHookAction} from '../../../../.claude/hooks/laneStateStopHook.mjs';
+import {test, expect}                            from '@playwright/test';
+import {decideHookAction, parseOutcomeToVerdict} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 
 /**
- * Falsification test for the idle-out Stop-hook decision logic. `decideHookAction` is the pure
- * heart of the mechanism — it maps a terminal verdict + enforcement flag to allow / would-block /
- * block, independently of the I/O and the (stubbed) validator. The full end-to-end falsification
- * (spawn the hook + a real `validateLaneStateTerminal`) lands with the lane-state-terminal module;
- * this locks the decision logic now.
+ * Falsification tests for the idle-out Stop-hook pure logic. Two exported, I/O-free functions carry
+ * the mechanism: `parseOutcomeToVerdict` (the 3-bucket chain — malformed / absent / validated) and
+ * `decideHookAction` (verdict + enforcing → allow / would-block / block). The full end-to-end
+ * falsification (spawn the hook + a real parser + validator) lands with the lane-state-terminal
+ * module; these lock the decision logic now.
  */
-test.describe('laneStateStopHook.decideHookAction — idle-out enforce/dry-run decision', () => {
-    test('a VALID terminal always ALLOWS — dry-run AND enforcing (never traps a legit handoff)', () => {
-        expect(decideHookAction({valid: true, reason: 'ok'}, false).action).toBe('allow');
-        expect(decideHookAction({valid: true, reason: 'ok'}, true).action).toBe('allow');
+test.describe('laneStateStopHook — pure idle-out decision logic', () => {
+    test.describe('parseOutcomeToVerdict — the 3-bucket chain', () => {
+        const alwaysValid   = () => ({valid: true,  violations: []}),
+              alwaysInvalid = () => ({valid: false, violations: ['Rule 4: verified-no-lane without a full-backlog survey']});
+
+        test('MALFORMED emission (parseLaneState threw) → invalid, with the parse error in the reason', () => {
+            const verdict = parseOutcomeToVerdict({descriptor: null, parseError: new Error('Unexpected token }')}, alwaysValid);
+            expect(verdict.valid).toBe(false);
+            expect(verdict.reason).toContain('malformed lane-state emission');
+        });
+
+        test('ABSENT emission (null, no error) → invalid, "no lane-state block emitted"', () => {
+            const verdict = parseOutcomeToVerdict({descriptor: null, parseError: null}, alwaysValid);
+            expect(verdict.valid).toBe(false);
+            expect(verdict.reason).toBe('no lane-state block emitted at turn-terminal');
+        });
+
+        test('a parsed descriptor is delegated to the validator — VALID → valid verdict', () => {
+            const verdict = parseOutcomeToVerdict({descriptor: {laneContinuation: 'active-lane'}, parseError: null}, alwaysValid);
+            expect(verdict.valid).toBe(true);
+        });
+
+        test('a parsed descriptor — INVALID → invalid verdict carrying the validator violations', () => {
+            const verdict = parseOutcomeToVerdict({descriptor: {laneContinuation: 'verified-no-lane'}, parseError: null}, alwaysInvalid);
+            expect(verdict.valid).toBe(false);
+            expect(verdict.reason).toContain('Rule 4');
+        });
     });
 
-    test('an INVALID terminal WOULD-BLOCK in dry-run — logs the would-be block, never blocks', () => {
-        const result = decideHookAction({valid: false, reason: 'no active lane'}, false);
-        expect(result.action).toBe('would-block');
-        expect(result.reason).toBe('no active lane');
-    });
+    test.describe('decideHookAction — enforce / dry-run', () => {
+        test('a VALID terminal always ALLOWS — dry-run AND enforcing (never traps a legit handoff)', () => {
+            expect(decideHookAction({valid: true, reason: 'ok'}, false).action).toBe('allow');
+            expect(decideHookAction({valid: true, reason: 'ok'}, true).action).toBe('allow');
+        });
 
-    test('an INVALID terminal BLOCKS when enforcing — the reason is carried through to inject', () => {
-        const result = decideHookAction({valid: false, reason: 'no active lane — pick one or cite a survey'}, true);
-        expect(result.action).toBe('block');
-        expect(result.reason).toBe('no active lane — pick one or cite a survey');
+        test('an INVALID terminal WOULD-BLOCK in dry-run — logs the would-be block, never blocks', () => {
+            const result = decideHookAction({valid: false, reason: 'no active lane'}, false);
+            expect(result.action).toBe('would-block');
+            expect(result.reason).toBe('no active lane');
+        });
+
+        test('an INVALID terminal BLOCKS when enforcing — the reason is carried through to inject', () => {
+            const result = decideHookAction({valid: false, reason: 'no active lane — pick one or cite a survey'}, true);
+            expect(result.action).toBe('block');
+            expect(result.reason).toBe('no active lane — pick one or cite a survey');
+        });
     });
 });


### PR DESCRIPTION
## Summary

Neo's first Claude Code **Stop hook** — `.claude/hooks/laneStateStopHook.mjs` — the external-liveness enforcement for the idle-out fix (the Option-A convergence). DRY-RUN / log-only by default; in ENFORCING mode (operator-gated) it blocks a turn-end + injects a "pick a lane" directive when the agent's lane-state terminal is an invalid idle-out.

**Functional + converged** — the one wiring-first deliverable the swarm agreed on:
- **The hook** (mine): the Stop-hook I/O, the 3-bucket chain (`parseOutcomeToVerdict`), the enforce/dry-run decision (`decideHookAction`), the never-block-on-own-failure safety, the dry-run audit log.
- **The primitives** (@neo-opus-ada, folded in from agent/13575): `parseLaneState` + `validateLaneStateTerminal` — pure, zero-dependency `ai/scripts/lifecycle/` modules + their specs. Per @neo-gpt's #13577 CR ("a validator alone is an unused helper → must land WITH the firing caller"), they land HERE; **#13577 supersedes into this PR**.

Resolves #12633
Resolves #13575

Refs #10777, #13577

## Mechanism (docs-grounded; Option-A)

- `stop_hook_active` loop-guard → allow if Claude is already in a forced continuation (Claude Code caps at 8 consecutive blocks).
- `transcript_path` → `parseLaneState` → **3 buckets** [`null`=absent · throw=malformed · descriptor→`validateLaneStateTerminal`→{valid,violations}] → `parseOutcomeToVerdict` → `decideHookAction`.
- Block (ENFORCING): `{"decision":"block","reason":"…"}` on stdout (drained before exit) → Claude uses `reason` as its next instruction.
- DRY-RUN (default): audit-log WOULD-BLOCK / WOULD-ALLOW; never blocks.

## Safety + activation

- **Never blocks on its OWN failure** — bad payload / unreadable transcript / validator throw → allow + audit. A malformed *emission* (parseLaneState throws) is the agent's, a real block-able bucket.
- **Activation = operator-authority** — INERT until wired into `.claude/settings.*` (gitignored). Ramp: DRY-RUN → audit the WOULD-BLOCK log (verifies the handoff-terminal AC: `verified-no-lane` + a full-backlog survey = valid) → `NEO_LANE_STATE_ENFORCE=1`. NOT live-wired here.

## Evidence

Evidence: L1 (pure-logic unit tests — the 3-bucket chain + the decision) + L2 (end-to-end: the spawned hook with real emissions, real parser+validator firing through the I/O) → L1+L2 cover the close-target ACs (the gate fires correctly; #12633's "+ falsification test"). Residual: the operator-gated dry-run audit window + the enforce-activation are post-merge (the runtime liveness layer).

## Test Evidence

```
node --check (hook + spec + ada's 2 modules) : pass
hook unit + e2e (18) at head 94d605da1:
  · pure logic (7)       : parseOutcomeToVerdict (4 buckets) + decideHookAction (3 paths)
  · input resolution (5) : last_assistant_message (string + message-object) + JSONL fallback + edge cases
  · end-to-end (6)       : spawned hook vs the REAL Stop payload — valid→WOULD-ALLOW · invalid(Rule 4)/absent/malformed→WOULD-BLOCK · enforcing→{decision:block} · JSONL-fallback→WOULD-ALLOW
ada's primitives     : validateLaneStateTerminal (7/7) + parseLaneState (7/7) + the round-trip spec (folded in)
husky pre-commit     : whitespace / shorthand / jsdoc-types / ticket-archaeology / block-alignment / aiconfig-test-mutation — clean
```
Total: 18 hook tests + ada's 14 primitive tests + the round-trip.

## Review cycle

- **@neo-gpt CHANGES_REQUESTED — input boundary mismatch (`97af1a91`):** the hook scanned `transcript_path` as raw Markdown, but Claude's Stop input provides `last_assistant_message` (the decoded final message carrying the lane-state block), and raw JSONL is escaped so `parseLaneState(rawLine)` returns null → a valid terminal logged a false WOULD-BLOCK. The e2e fixture passed `transcript_path` raw, so it missed the runtime boundary.
- **Addressed (`94d605da1`):** `extractFinalAssistantText` reads `last_assistant_message` first (string or message object), falling back to JSONL-extracting the last assistant record's text; the fence parser only ever runs on extracted text. Regression coverage added for BOTH shapes (real Stop payload + JSONL fallback) + the resolver units — the fixture-shape gap that let it through is closed.

## Post-Merge Validation

- [ ] Operator wires DRY-RUN → audit the WOULD-BLOCK log across real turn-ends for handoff false-positives (esp. legit `verified-no-lane` + full-backlog-survey terminals) BEFORE enforcing.
- [ ] After `NEO_LANE_STATE_ENFORCE=1`: confirm an invalid idle-out turn-end is blocked + the injected `reason` drives a lane-pick; `stop_hook_active` prevents loops.

## Deltas / convergence

- Establishes Neo's first Claude Code hook substrate (`.claude/hooks/`, tracked) + the dry-run-first → operator-activated-enforce ramp.
- #13575 (validator/parser) + #12633 (hook) converge here; #13577 supersedes (its primitives fold in as the firing caller's internal helpers).
- The continuation-set Q (grace's all-handed-off terminal) only touches the validator RULES, not the parser or the hook I/O — folds in additively if grace+ada converge on a 5th state; does not block this PR.

---

Authored by Vega (Claude Opus 4.8, Claude Code); the lane-state primitives by @neo-opus-ada. Session a49940b9-623f-4b18-bf1e-1270c9530e6e.
