### PR TITLE
fix(wake): give Codex submit popovers time to settle (#13599)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1226,11 +1226,12 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                 // Codex Desktop can leave composer-side UI (mention/autocomplete/completion popovers)
                 // active after a pasted A2A digest such as `from @neo-opus-ada)`. Escape closes that
                 // transient UI so the following Enter submits the prompt instead of being consumed
-                // by the composer. Keep this Codex-scoped; other harnesses already have validated
-                // Enter behavior and should not inherit an untested pre-submit key.
+                // by the composer. The longer post-Escape settle is Codex-scoped: operator
+                // samples show human-delayed Enter succeeds after the scripted Enter is
+                // intermittently consumed, so do not shorten this back to the generic key delay.
                 ...(appName === 'Codex' ? [
                     '-e', '      key code 53',
-                    '-e', '      delay 0.1'
+                    '-e', '      delay 0.45'
                 ] : []),
                 '-e', '      key code 36',
                 '-e', '      delay 1.0',


### PR DESCRIPTION
Resolves #13599

Related: #13480

Codex `osascript` wake delivery now waits longer after the Codex-only Escape step before pressing Enter. This targets the current failure shape where the wake payload lands, the scripted Enter is intermittently consumed or ignored by transient composer UI, and a later human Enter succeeds. The patch keeps the existing `Submit attempted` / `turnStartProof=live-required` evidence vocabulary and stays scoped to Codex Desktop.

Evidence: L2 (mocked wake-daemon/osascript route and static gates) -> L4 required (direct Codex Desktop A2A wakes start turns without operator pass-through). Residual: live Codex post-merge observation [`#13480`].

## Deltas from ticket

This is a narrow submit-settle leaf for #13599, not a native turn-start proof primitive and not closure of the broader live tracker #13480. I rechecked the Codex app-server debug surface before patching; it still exposes only `send-message-v2`, which proves injection/acceptance but not submit or turn-start. If the recurrence survives this delay, #13480 stays open and moves to a native submit/turn-start primitive rather than more timing guesses.

## Test Evidence

- `git diff --check`
- `node --check ai/daemons/wake/daemon.mjs`
- `node buildScripts/util/check-block-alignment.mjs ai/daemons/wake/daemon.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs --workers=1` -> `35 passed` after refreshing ignored local configs with `npm run prepare -- --migrate-config`
- Pre-commit hooks passed on commit `5990b7248`

Notes: the first sandboxed focused unit run hit `listen EPERM` on the local webhook test, so I reran the same file outside the sandbox. After rebasing onto current `origin/dev`, the newly merged wake boot guard correctly rejected stale ignored local config overlays; `npm run prepare -- --migrate-config` refreshed ignored files only, and the focused rerun passed.

## Post-Merge Validation

- [ ] Ensure the live wake daemon is running the merged script.
- [ ] Send several unsuppressed direct A2A messages to `@neo-gpt` and confirm Codex starts turns without human Enter.
- [ ] Append the post-merge observation result to #13480; if pass-through still recurs, keep #13480 open for a native submit/turn-start primitive.

## Commits

- `5990b7248` - Codex post-Escape submit settle delay

Authored by Euclid (GPT-5, Codex Desktop). Session 152f9eee-42e2-4740-8bce-d23e1f575ec8.