### PR TITLE
fix(ai): lint-skill-manifest names skipped byte-delta gates on no-base runs (#13595)

### DIFF
--- a/ai/scripts/lint/lint-skill-manifest.mjs
+++ b/ai/scripts/lint/lint-skill-manifest.mjs
@@ -6,11 +6,11 @@
  * data for CI and governance checks; this script enforces one-way consistency
  * plus local substrate-budget and harness-symlink invariants.
  */
-import fs from 'fs/promises';
+import fs                                                            from 'fs/promises';
 import {existsSync, lstatSync, readFileSync, readlinkSync, statSync} from 'fs';
-import path from 'path';
-import {execFileSync} from 'child_process';
-import {fileURLToPath} from 'url';
+import path                                                          from 'path';
+import {execFileSync}                                                from 'child_process';
+import {fileURLToPath}                                               from 'url';
 
 const __filename    = fileURLToPath(import.meta.url);
 const __dirname     = path.dirname(__filename);
@@ -254,7 +254,7 @@ function parseSectionTriggers(text) {
         if (triggerMatch) {
             index.push({
                 anchor,
-                trigger: triggerMatch[1].trim(),
+                trigger    : triggerMatch[1].trim(),
                 subRulePath: triggerMatch[2].trim(),
                 bodySizeBytes
             });
@@ -700,7 +700,7 @@ function checkSkillReferenceIntegrity(changedRelPaths, allMarkdownFiles, {change
                 validateSectionRef({
                     sourceRelPath,
                     lineNo,
-                    target: sectionRef.target,
+                    target    : sectionRef.target,
                     sectionRef: sectionRef.sectionRef,
                     index,
                     errors
@@ -717,7 +717,7 @@ function checkSkillReferenceIntegrity(changedRelPaths, allMarkdownFiles, {change
                 validateSectionRef({
                     sourceRelPath,
                     lineNo,
-                    target: match[1],
+                    target    : match[1],
                     sectionRef: match[2],
                     index,
                     errors
@@ -1277,7 +1277,11 @@ async function main() {
         process.exit(1);
     }
 
-    console.log('[lint-skill-manifest] OK');
+    if (options.base) {
+        console.log('[lint-skill-manifest] OK');
+    } else {
+        console.log('[lint-skill-manifest] OK (structural checks only — byte-delta gates skipped; run with --base origin/dev, as CI does, to check the <=250 per-file + net skill-Markdown growth budgets)');
+    }
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {

--- a/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs
@@ -34,6 +34,30 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
         expect(result.stdout).toContain('[lint-skill-manifest] OK');
     });
 
+    test('no-base success names the skipped byte-delta gates, not an indistinguishable bare OK (#13595)', () => {
+        const result = spawnSync('node', [scriptPath], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        // the false-green guard: a no-base run must name the skipped gates, not read as a full pass
+        expect(result.stdout).toContain('byte-delta gates skipped');
+        expect(result.stdout).toContain('--base origin/dev');
+        expect(result.stdout.trim()).not.toBe('[lint-skill-manifest] OK');
+    });
+
+    test('--base success keeps the bare OK unchanged, no skipped-gates notice (#13595)', () => {
+        const result = spawnSync('node', [scriptPath, '--base', 'HEAD'], {
+            cwd     : process.cwd(),
+            encoding: 'utf8'
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('[lint-skill-manifest] OK');
+        expect(result.stdout).not.toContain('byte-delta gates skipped');
+    });
+
     test('frontmatter parser preserves colon-bearing description text', () => {
         const parsed = parseFrontmatter(`---\nname: test-skill\ndescription: Short: description\n---\n# Body\n`, 'fixture/SKILL.md');
 
@@ -118,15 +142,15 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
+                routerByteBudget     : 12,
                 payloadBudget        : 80000,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: []
             },
             skills: {
                 broken: {
-                    name                : 'broken',
-                    routerByteBudget    : 12,
+                    name                 : 'broken',
+                    routerByteBudget     : 12,
                     payloadBudget        : 80000,
                     claudeSymlinkRequired: true,
                     downstreamDocsTargets: []
@@ -147,7 +171,7 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
+                routerByteBudget     : 12,
                 payloadBudget        : 80000,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: [],
@@ -155,13 +179,13 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             },
             skills: {
                 extra: {
-                    name                : 'extra',
-                    description         : 'has extra key',
-                    routerByteBudget    : 12,
+                    name                 : 'extra',
+                    description          : 'has extra key',
+                    routerByteBudget     : 12,
                     payloadBudget        : 80000,
                     claudeSymlinkRequired: true,
                     downstreamDocsTargets: [],
-                    extraSkill          : true
+                    extraSkill           : true
                 }
             },
             extraRoot: true
@@ -182,16 +206,16 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
+                routerByteBudget     : 12,
                 payloadBudget        : 80000,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: []
             },
             skills: {
                 optional: {
-                    name                : 'optional',
-                    description         : 'relationship field omitted intentionally',
-                    routerByteBudget    : 12,
+                    name                 : 'optional',
+                    description          : 'relationship field omitted intentionally',
+                    routerByteBudget     : 12,
                     payloadBudget        : 80000,
                     claudeSymlinkRequired: true,
                     downstreamDocsTargets: []
@@ -217,9 +241,9 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
-                payloadBudget       : 80000,
-                perFilePayloadBudget: 25000,
+                routerByteBudget     : 12,
+                payloadBudget        : 80000,
+                perFilePayloadBudget : 25000,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: []
             },
@@ -240,18 +264,18 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
-                payloadBudget       : 80000,
+                routerByteBudget     : 12,
+                payloadBudget        : 80000,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: []
             },
             skills: {
                 'monolith-skill': {
-                    name                : 'monolith-skill',
-                    description         : 'temporary override for migration-period monolith',
-                    routerByteBudget    : 12,
-                    payloadBudget       : 80000,
-                    perFilePayloadBudget: 66000,
+                    name                 : 'monolith-skill',
+                    description          : 'temporary override for migration-period monolith',
+                    routerByteBudget     : 12,
+                    payloadBudget        : 80000,
+                    perFilePayloadBudget : 66000,
                     claudeSymlinkRequired: true,
                     downstreamDocsTargets: []
                 }
@@ -272,9 +296,9 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
-                payloadBudget       : 80000,
-                perFilePayloadBudget: 0,
+                routerByteBudget     : 12,
+                payloadBudget        : 80000,
+                perFilePayloadBudget : 0,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: []
             },
@@ -287,18 +311,18 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
-                payloadBudget       : 80000,
+                routerByteBudget     : 12,
+                payloadBudget        : 80000,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: []
             },
             skills: {
                 'bad-budget': {
-                    name                : 'bad-budget',
-                    description         : 'negative budget',
-                    routerByteBudget    : 12,
-                    payloadBudget       : 80000,
-                    perFilePayloadBudget: -100,
+                    name                 : 'bad-budget',
+                    description          : 'negative budget',
+                    routerByteBudget     : 12,
+                    payloadBudget        : 80000,
+                    perFilePayloadBudget : -100,
                     claudeSymlinkRequired: true,
                     downstreamDocsTargets: []
                 }
@@ -355,17 +379,17 @@ test.describe('ai/scripts/lint/lint-skill-manifest (#11275)', () => {
             schemaVersion: 1,
             sourceOfTruth: 'test',
             defaults     : {
-                routerByteBudget    : 12,
-                payloadBudget       : 80000,
+                routerByteBudget     : 12,
+                payloadBudget        : 80000,
                 claudeSymlinkRequired: true,
                 downstreamDocsTargets: []
             },
             skills: {
                 'legacy-skill': {
-                    name                : 'legacy-skill',
-                    description         : 'pre-#11320 manifest entry without perFilePayloadBudget',
-                    routerByteBudget    : 12,
-                    payloadBudget       : 80000,
+                    name                 : 'legacy-skill',
+                    description          : 'pre-#11320 manifest entry without perFilePayloadBudget',
+                    routerByteBudget     : 12,
+                    payloadBudget        : 80000,
                     claudeSymlinkRequired: true,
                     downstreamDocsTargets: []
                 }


### PR DESCRIPTION
Resolves #13595

## Summary

`ai/scripts/lint/lint-skill-manifest.mjs` gave a **false-green** without `--base`: it guards both byte-delta gates (per-file ≤250 + net ≤250) behind `if (base)` and skips them, yet still printed a bare `[lint-skill-manifest] OK`. An agent editing a `.agents/skills/**` workflow-map runs the local `npm run ai:lint-skill-manifest`, sees `OK`, assumes the budgets passed — then CI (`--base origin/dev`) fails on the delta. This adds a notice to the no-`--base` success line so it can't be mistaken for a full pass.

**Evidence:** hit twice on PR #13588 — the local no-base lint read green while the `--base` CI caught the +672 net (and separately a multi-line `[skill-growth-justified]` token that the `[^\]\n]+` regex silently rejected).

## Deltas

- `lint-skill-manifest.mjs` `main()`: the no-`--base` success line now names the skipped byte-delta gates + the `--base origin/dev` form; a `--base` run prints the bare `OK` unchanged.
- `lintSkillManifest.spec.mjs`: **+2 `spawnSync` CLI regression tests** pinning the output contract.
- (Hook-forced, mechanical — no behavior change) the block-alignment husky hook checks the whole touched file (`check-block-alignment.mjs:364` iterates passed files, no changed-line filter), so committing both files normalized **pre-existing** colon/import alignment drift (the lint script's import block; the spec's schema-test fixtures, e.g. `routerByteBudget    :` → `routerByteBudget     :` to align with the block's longest key).

## Test Evidence

`test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` — **45/45 pass** (43 existing + 2 new). The new `spawnSync('node', [scriptPath, ...])` tests lock the output contract:
- **no-`--base`**: stdout contains `byte-delta gates skipped` + `--base origin/dev`, and `stdout.trim()` is NOT the bare `[lint-skill-manifest] OK` — the false-green guard, so old vs new no-base output are now distinguishable (the existing suite passed before because it only asserted the bare OK *substring*, which both old and new output satisfy).
- **`--base HEAD`**: stdout is the bare `[lint-skill-manifest] OK` with no notice (unchanged).

*(Correction to the prior body: it claimed the lint "isn't unit-testable in the playwright env" — that was wrong. The canonical spec already `spawnSync`s the CLI binary. The false claim came from a wrong-filename grep — `lint-skill-manifest.*spec` vs the camelCase `lintSkillManifest.spec` — thanks @neo-gpt for the catch.)*

Supplementary direct CLI checks: `node ai/scripts/lint/lint-skill-manifest.mjs` → the notice; `... --base origin/dev` → bare OK.

## Post-Merge Validation

- On dev, `npm run test-unit -- test/playwright/unit/ai/scripts/lint/lintSkillManifest.spec.mjs` → 45/45, including the two no-base/`--base` output-contract tests.
- `npm run ai:lint-skill-manifest` (no args) prints the structural-only notice; the CI `--base origin/dev` invocation prints the bare `OK` on a clean run.

---

Authored by @neo-opus-ada (Claude Opus 4.8). Origin session ID: abe80be3-6235-4a9e-99bc-b14659ba806a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
