### PR TITLE
fix(ai): gate summary sweep behind miniSummary backlog (#13590)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/summary.mjs
+++ b/ai/daemons/orchestrator/scheduling/summary.mjs
@@ -2,6 +2,10 @@ import {
     getUnreadSunsetHandovers,
     markNodesAsRead
 } from '../../wake/queries.mjs';
+import {
+    getPendingMemorySummaryBackfillJobs,
+    isNoProgressBackoffActive as isMemorySummaryBackfillBackoffActive
+} from './memorySummaryBackfill.mjs';
 
 /**
  * Reads pending low-latency summarization markers from the coordinator table.
@@ -68,9 +72,8 @@ export function getPendingSummarizationCount(db) {
  * `properties.chromaId = summary_<sessionId>`). Minimal `SESSION` placeholders without a summary
  * Chroma id are deliberately excluded so they do not mask truly unsummarized sessions.
  *
- * @summary Feeds the periodic-sweep trigger reason so the orchestrator log reports the best
- * graph-backed session-summary backlog proxy available without opening Chroma. Fail-soft:
- * returns `null` when the graph table is unavailable.
+ * @summary Feeds the periodic-sweep trigger reason as a graph-backed proxy, not a claim that
+ * Chroma drift has drainable work. Fail-soft: returns `null` when the graph table is unavailable.
  * @param {Object} db SQLite database handle.
  * @returns {Number|null}
  */
@@ -117,12 +120,44 @@ export function getPendingSessionSummaryCount(db) {
 }
 
 /**
+ * Checks whether periodic session-summary drift should yield to miniSummary backfill first.
+ *
+ * @summary `summarizeSession()` falls back from raw turns to per-turn `miniSummary` rows when the
+ * raw prompt exceeds the safe band or times out. Periodic drift sweeps therefore depend on the
+ * backfill having a chance to drain. Sunset handovers and explicit pending summarization markers
+ * are handled before this guard; this predicate is only for the periodic fallback sweep.
+ * @param {Object} options
+ * @param {Object} options.db SQLite database handle.
+ * @param {Object} [options.state] Orchestrator task-state map.
+ * @param {Number} [options.now] Epoch milliseconds.
+ * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn]
+ * @param {Function} [options.isMemorySummaryBackfillBackoffActiveFn]
+ * @returns {Boolean}
+ */
+export function hasDrainableMemorySummaryBackfill({
+    db,
+    state = {},
+    now = Date.now(),
+    getPendingMemorySummaryBackfillJobsFn = getPendingMemorySummaryBackfillJobs,
+    isMemorySummaryBackfillBackoffActiveFn = isMemorySummaryBackfillBackoffActive
+} = {}) {
+    const pendingBackfillJobs = getPendingMemorySummaryBackfillJobsFn(db);
+    if (!Array.isArray(pendingBackfillJobs) || pendingBackfillJobs.length === 0) {
+        return false;
+    }
+
+    const taskState = state['memory-summary-backfill'] || {};
+    return !isMemorySummaryBackfillBackoffActiveFn({taskState, now});
+}
+
+/**
  * Builds the task trigger for the summarization sweep lane.
  *
  * Three wake-up sources, in priority order:
  * 1. Unread sunset handovers — priority because they unblock the next agent boot
  * 2. Pending disconnect markers — targeted low-latency session close handling
- * 3. Periodic sweep — fallback for ordinary unsummarized sessions
+ * 3. Periodic sweep — fallback for ordinary unsummarized sessions. The optional
+ *    `unsummarizedCount` is graph-backed observability, not Chroma drainability.
  *
  * Pure function. Test the scheduling contract without mounting the SQLite graph.
  *
@@ -164,7 +199,7 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [],
             taskName: 'summary',
             source  : 'periodic-sweep',
             reason  : Number.isInteger(unsummarizedCount)
-                ? `periodic-sweep:${intervalMs} pending-session-summary:${unsummarizedCount}`
+                ? `periodic-sweep:${intervalMs} graph-pending-session-summary:${unsummarizedCount}`
                 : `periodic-sweep:${intervalMs}`
         };
     }
@@ -183,6 +218,8 @@ export function buildSummaryTrigger({now, lastRunAt, intervalMs, handovers = [],
  * @param {Number} options.summarySweepIntervalMs Periodic summary sweep interval.
  * @param {Function} [options.getUnreadSunsetHandoversFn] Test seam for handover reads.
  * @param {Function} [options.getPendingSummarizationJobsFn] Test seam for pending marker reads.
+ * @param {Function} [options.getPendingMemorySummaryBackfillJobsFn] Test seam for miniSummary backlog.
+ * @param {Function} [options.isMemorySummaryBackfillBackoffActiveFn] Test seam for miniSummary backoff.
  * @param {Function} [options.markNodesAsReadFn] Test seam for handover mark-read writes.
  * @param {Function} [options.log] Optional orchestrator log function.
  * @returns {Object|null} Task trigger with optional `onSuccess` callback, or null.
@@ -196,6 +233,8 @@ export function getDueTask({
     getPendingSummarizationJobsFn = getPendingSummarizationJobs,
     getPendingSummarizationCountFn = getPendingSummarizationCount,
     getPendingSessionSummaryCountFn = getPendingSessionSummaryCount,
+    getPendingMemorySummaryBackfillJobsFn = getPendingMemorySummaryBackfillJobs,
+    isMemorySummaryBackfillBackoffActiveFn = isMemorySummaryBackfillBackoffActive,
     markNodesAsReadFn          = markNodesAsRead,
     log
 }) {
@@ -207,13 +246,25 @@ export function getDueTask({
     // sweep, never on every poll.
     const periodicSweepDue = handovers.length === 0 && pendingJobs.length === 0 &&
         summarySweepIntervalMs > 0 && now - lastRunAt >= summarySweepIntervalMs;
+    const periodicSweepBlockedByBackfill = periodicSweepDue && hasDrainableMemorySummaryBackfill({
+        db,
+        state,
+        now,
+        getPendingMemorySummaryBackfillJobsFn,
+        isMemorySummaryBackfillBackoffActiveFn
+    });
+
+    if (periodicSweepBlockedByBackfill) {
+        return null;
+    }
+
     const trigger   = buildSummaryTrigger({
         now,
         handovers,
         pendingJobs,
         totalPending     : pendingJobs.length > 0 ? getPendingSummarizationCountFn(db) : null,
         unsummarizedCount: periodicSweepDue ? getPendingSessionSummaryCountFn(db) : null,
-        intervalMs: summarySweepIntervalMs,
+        intervalMs       : summarySweepIntervalMs,
         lastRunAt
     });
 

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect} from '@playwright/test';
 import {
     buildSummaryTrigger,
+    hasDrainableMemorySummaryBackfill,
     getPendingSummarizationJobs,
     getPendingSessionSummaryCount,
     getDueTask
@@ -94,12 +95,12 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
 
     test('#12199: getDueTask reads pending markers when no handover is waiting', () => {
         const result = getDueTask({
-            db                            : 'mock-db',
-            state                         : {summary: {lastRunAt: 0}},
-            now                           : 100,
-            summarySweepIntervalMs        : 600000,
-            getUnreadSunsetHandoversFn    : () => [],
-            getPendingSummarizationJobsFn : () => ['session-1']
+            db                           : 'mock-db',
+            state                        : {summary: {lastRunAt: 0}},
+            now                          : 100,
+            summarySweepIntervalMs       : 600000,
+            getUnreadSunsetHandoversFn   : () => [],
+            getPendingSummarizationJobsFn: () => ['session-1']
         });
 
         expect(result).toEqual({
@@ -152,7 +153,7 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
     test('#12809: buildSummaryTrigger reports the TRUE backlog depth, not the fetch limit', () => {
         const fetched = Array.from({length: 50}, (_, i) => `session-${i}`);
         expect(buildSummaryTrigger({
-            now: 600000, lastRunAt: 0, intervalMs: 600000, handovers: [],
+            now        : 600000, lastRunAt: 0, intervalMs: 600000, handovers: [],
             pendingJobs: fetched, totalPending: 730
         })).toEqual({
             taskName    : 'summary',
@@ -178,11 +179,11 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
         });
     });
 
-    test('#12821: buildSummaryTrigger appends the unsummarized-session count to the periodic-sweep reason', () => {
+    test('#12821/#13590: buildSummaryTrigger appends the graph-backed session-summary count to the periodic-sweep reason', () => {
         expect(buildSummaryTrigger({now: 600000, lastRunAt: 0, intervalMs: 600000, handovers: [], unsummarizedCount: 42})).toEqual({
             taskName: 'summary',
             source  : 'periodic-sweep',
-            reason  : 'periodic-sweep:600000 pending-session-summary:42'
+            reason  : 'periodic-sweep:600000 graph-pending-session-summary:42'
         });
     });
 
@@ -194,7 +195,7 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
         });
     });
 
-    test('#12821: getDueTask threads the session-summary backlog count into the periodic-sweep reason', () => {
+    test('#12821/#13590: getDueTask threads the graph-backed session-summary backlog count into the periodic-sweep reason', () => {
         const result = getDueTask({
             db                             : 'mock-db',
             state                          : {summary: {lastRunAt: 0}},
@@ -206,8 +207,114 @@ test.describe('orchestrator/scheduling/summary (#11864 / Epic #11831)', () => {
         });
         expect(result).toMatchObject({
             source: 'periodic-sweep',
-            reason: 'periodic-sweep:600000 pending-session-summary:42'
+            reason: 'periodic-sweep:600000 graph-pending-session-summary:42'
         });
+    });
+
+    test('#13590: periodic drift sweep yields while miniSummary backfill has drainable work', () => {
+        const result = getDueTask({
+            db   : 'mock-db',
+            state: {
+                summary                  : {lastRunAt: 0},
+                'memory-summary-backfill': {}
+            },
+            now                                   : 600000,
+            summarySweepIntervalMs                : 600000,
+            getUnreadSunsetHandoversFn            : () => [],
+            getPendingSummarizationJobsFn         : () => [],
+            getPendingMemorySummaryBackfillJobsFn : () => ['memory-1'],
+            isMemorySummaryBackfillBackoffActiveFn: () => false,
+            getPendingSessionSummaryCountFn       : () => 42
+        });
+
+        expect(result).toBeNull();
+    });
+
+    test('#13590: periodic drift sweep proceeds when miniSummary backfill is in no-progress backoff', () => {
+        const result = getDueTask({
+            db   : 'mock-db',
+            state: {
+                summary                  : {lastRunAt: 0},
+                'memory-summary-backfill': {noProgressBackoffUntilMs: 700000}
+            },
+            now                                   : 600000,
+            summarySweepIntervalMs                : 600000,
+            getUnreadSunsetHandoversFn            : () => [],
+            getPendingSummarizationJobsFn         : () => [],
+            getPendingMemorySummaryBackfillJobsFn : () => ['memory-1'],
+            isMemorySummaryBackfillBackoffActiveFn: () => true,
+            getPendingSessionSummaryCountFn       : () => 42
+        });
+
+        expect(result).toMatchObject({
+            source: 'periodic-sweep',
+            reason: 'periodic-sweep:600000 graph-pending-session-summary:42'
+        });
+    });
+
+    test('#13590: sunset handovers are not blocked by miniSummary backfill', () => {
+        const result = getDueTask({
+            db                                    : 'mock-db',
+            state                                 : {summary: {lastRunAt: 0}},
+            now                                   : 600000,
+            summarySweepIntervalMs                : 600000,
+            getUnreadSunsetHandoversFn            : () => [{id: 'MESSAGE:1'}],
+            getPendingMemorySummaryBackfillJobsFn : () => ['memory-1'],
+            isMemorySummaryBackfillBackoffActiveFn: () => false,
+            markNodesAsReadFn                     : () => {}
+        });
+
+        expect(result).toMatchObject({
+            source       : 'sunset-handover',
+            reason       : 'sunset-handover:1',
+            handoverCount: 1
+        });
+    });
+
+    test('#13590: explicit pending summarization markers are not blocked by miniSummary backfill', () => {
+        const result = getDueTask({
+            db                                    : 'mock-db',
+            state                                 : {summary: {lastRunAt: 0}},
+            now                                   : 600000,
+            summarySweepIntervalMs                : 600000,
+            getUnreadSunsetHandoversFn            : () => [],
+            getPendingSummarizationJobsFn         : () => ['session-1'],
+            getPendingSummarizationCountFn        : () => 1,
+            getPendingMemorySummaryBackfillJobsFn : () => ['memory-1'],
+            isMemorySummaryBackfillBackoffActiveFn: () => false
+        });
+
+        expect(result).toMatchObject({
+            source      : 'pending-summarization',
+            reason      : 'pending-summarization:1',
+            pendingCount: 1
+        });
+    });
+
+    test('#13590: hasDrainableMemorySummaryBackfill reflects pending work minus no-progress backoff', () => {
+        expect(hasDrainableMemorySummaryBackfill({
+            db                                    : 'mock-db',
+            state                                 : {},
+            now                                   : 600000,
+            getPendingMemorySummaryBackfillJobsFn : () => [],
+            isMemorySummaryBackfillBackoffActiveFn: () => false
+        })).toBe(false);
+
+        expect(hasDrainableMemorySummaryBackfill({
+            db                                    : 'mock-db',
+            state                                 : {'memory-summary-backfill': {}},
+            now                                   : 600000,
+            getPendingMemorySummaryBackfillJobsFn : () => ['memory-1'],
+            isMemorySummaryBackfillBackoffActiveFn: () => false
+        })).toBe(true);
+
+        expect(hasDrainableMemorySummaryBackfill({
+            db                                    : 'mock-db',
+            state                                 : {'memory-summary-backfill': {noProgressBackoffUntilMs: 700000}},
+            now                                   : 600000,
+            getPendingMemorySummaryBackfillJobsFn : () => ['memory-1'],
+            isMemorySummaryBackfillBackoffActiveFn: () => true
+        })).toBe(false);
     });
 
     test('#12821: getPendingSessionSummaryCount is fail-soft when the graph table is unavailable', () => {


### PR DESCRIPTION
Resolves #13590

Periodic session-summary drift now yields when the miniSummary backfill has drainable work, so summary does not keep trying degraded session summaries before the prerequisite corpus exists. The scheduler still preserves the higher-priority summary paths for sunset handovers and explicit pending `SummarizationJobs`, and the periodic reason now labels the count as `graph-pending-session-summary:N` so operators do not confuse the graph anti-join proxy with Chroma-drainable work.

Evidence: L2 (pure scheduler + Orchestrator unit coverage verifies dispatch behavior and reason contract) -> L4 required (live orchestrator must demonstrate quiet-state convergence after deployment). Residual: post-merge validation [#13590].

## Deltas from ticket

The public #13590 body/title were reconciled before implementation to remove the stale dead-letter-primary premise. This PR implements the corrected narrow slice: miniSummary-prerequisite scheduling and graph-backed metric clarity.

Dead-lettering remains backstop-only and is not implemented here; truly oversize sessions still belong to `#12073`, and bounded sessions-per-sweep remains `#13592`.

Related: #13586
Related: #13592
Related: #12073

## Test Evidence

- `node --check ai/daemons/orchestrator/scheduling/summary.mjs`
- `git diff --check`
- `node buildScripts/util/check-block-alignment.mjs ai/daemons/orchestrator/scheduling/summary.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs`
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs --workers=1` -> 21 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/scheduling/summary.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/memorySummaryBackfill.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/picker.spec.mjs --workers=1` -> 66 passed.
- `npm run test-unit -- test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs --workers=1` -> 54 passed. The first sandboxed attempt hit `EPERM` opening the repo-local Memory Core log; rerun outside the sandbox passed.
- Pre-commit hook passed: whitespace, shorthand, AiConfig test mutation, JSDoc types, ticket archaeology, and block-alignment checks.

## Post-Merge Validation

- [ ] On the live orchestrator after deploy/restart, periodic `summary` does not run ahead of drainable `memory-summary-backfill` work.
- [ ] Orchestrator logs use `graph-pending-session-summary:N` for the graph-backed proxy and do not present it as Chroma drain truth.
- [ ] Once miniSummary backfill drains or enters no-progress backoff, summary resumes and the lane reaches a quiet or explicitly explained state.

## Commit

- `a01ff77c4` - `fix(ai): gate summary sweep behind miniSummary backlog (#13590)`

Authored by Euclid (GPT-5, Codex Desktop). Session 152f9eee-42e2-4740-8bce-d23e1f575ec8.
