### PR TITLE
feat(ai): carry idle-out cycle-state in the wake digest (#12612)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -466,19 +466,31 @@ function isWakeTargetEligible(identity) {
 }
 
 /**
- * @summary Decodes optional content embedded in heartbeat-pulse ids.
+ * Heartbeat-pulse summary sources that encode structured content in the pulse id as
+ * `<source>.<base64url-JSON>`. A plain uuid pulse (no '.') carries no summary.
+ * @type {String[]}
+ */
+const HEARTBEAT_PULSE_SUMMARY_SOURCES = ['github-notification', 'idle-out-nudge'];
+
+/**
+ * @summary Decodes optional structured content embedded in a heartbeat-pulse id, for any known
+ * summary source. Id format: `<source>.<base64url-JSON>` (e.g. `github-notification` or
+ * `idle-out-nudge`); the decoded payload's `source` must match the id prefix (format/tamper guard).
  * @param {String} pulseId
  * @returns {Object|null}
  */
 function decodeHeartbeatPulseSummary(pulseId = '') {
-    if (!pulseId.startsWith('github-notification.')) return null;
+    const separator = pulseId.indexOf('.');
+    if (separator <= 0) return null;
+
+    const source = pulseId.slice(0, separator);
+    if (!HEARTBEAT_PULSE_SUMMARY_SOURCES.includes(source)) return null;
+
     try {
-        const encoded = pulseId.slice('github-notification.'.length);
-        const parsed  = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
-        if (parsed?.source !== 'github-notification') return null;
-        return parsed
+        const parsed = JSON.parse(Buffer.from(pulseId.slice(separator + 1), 'base64url').toString('utf8'));
+        return parsed?.source === source ? parsed : null;
     } catch {
-        return null
+        return null;
     }
 }
 

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1320,11 +1320,17 @@ function buildWakeDigest(identity, {messages = [], tasks = [], permissions = [],
         breakdown += `\n- ${permissions.length} permissions granted (latest: ${latest.scope} by ${latest.grantedBy})`;
     }
     if (heartbeats.length > 0) {
-        const latest        = heartbeats[heartbeats.length - 1],
-              gitHubSummary = latest.summary?.source === 'github-notification'
-                  ? `; latest GitHub ${latest.summary.latest?.reason || 'notification'}: "${latest.summary.latest?.title || latest.summary.latest?.id || 'untitled'}"${formatPullRequestStateEcho(latest.summary)}${latest.summary.latest?.url ? ` (${latest.summary.latest.url})` : ''}`
-                  : '';
-        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId}${gitHubSummary})`;
+        const latest  = heartbeats[heartbeats.length - 1],
+              summary = latest.summary;
+
+        let extra = '';
+        if (summary?.source === 'github-notification') {
+            extra = `; latest GitHub ${summary.latest?.reason || 'notification'}: "${summary.latest?.title || summary.latest?.id || 'untitled'}"${formatPullRequestStateEcho(summary)}${summary.latest?.url ? ` (${summary.latest.url})` : ''}`;
+        } else if (summary?.source === 'idle-out-nudge') {
+            extra = `; idle-out nudge — ${summary.reason || 'idle'}; next: ${summary.nextAction || 'claim a lane'}`;
+        }
+
+        breakdown += `\n- ${heartbeats.length} heartbeat pulses (latest GraphLog: ${latest.logId}${extra})`;
     }
 
     // The lifecycle-first lane directive is an IDLE-watchdog nudge — append it ONLY to pure-heartbeat

--- a/ai/scripts/lifecycle/idleOutNudge.mjs
+++ b/ai/scripts/lifecycle/idleOutNudge.mjs
@@ -53,15 +53,15 @@
  * @see ai/scripts/lifecycle/resumeHarness.mjs     — sibling for sunset-restart case
  * @see test/playwright/unit/ai/scripts/idleOutNudge.spec.mjs
  */
-import Neo                       from '../../../src/Neo.mjs';
-import * as core                 from '../../../src/core/_export.mjs';
-import path                      from 'path';
-import {fileURLToPath}           from 'url';
-import LifecycleService          from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
-import GraphService              from '../../services/memory-core/GraphService.mjs';
-import WakeSubscriptionService   from '../../services/memory-core/WakeSubscriptionService.mjs';
-import RequestContextService     from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {hasOverride, readGateState} from './wakeSafetyGate.mjs';
+import Neo                                                       from '../../../src/Neo.mjs';
+import * as core                                                 from '../../../src/core/_export.mjs';
+import path                                                      from 'path';
+import {fileURLToPath}                                           from 'url';
+import LifecycleService                                          from '../../services/memory-core/lifecycle/SystemLifecycleService.mjs';
+import GraphService                                              from '../../services/memory-core/GraphService.mjs';
+import WakeSubscriptionService                                   from '../../services/memory-core/WakeSubscriptionService.mjs';
+import RequestContextService                                     from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {hasOverride, readGateState}                              from './wakeSafetyGate.mjs';
 import {writeInflightLock, clearInflightLock, checkInflightLock} from './inflightLock.mjs';
 
 /**
@@ -119,6 +119,15 @@ export async function idleOutNudge(identity) {
 
     const sender = process.env.NEO_AGENT_IDENTITY || '@system';
 
+    // Machine-readable cycle-state carried in the pulse id (`<source>.<base64url-JSON>`) so the
+    // bridge-daemon wake digest surfaces the next lifecycle step instead of an opaque "N heartbeat
+    // pulses" — the receiver branches on the cycle without prose inference (the idle-holding fix).
+    const pulseId = `idle-out-nudge.${Buffer.from(JSON.stringify({
+        source    : 'idle-out-nudge',
+        reason    : 'idle: no recent AGENT_MEMORY while the swarm is active',
+        nextAction: 'drain the lifecycle queue (own-PR changes → designated reviews → own-PR green → request review), then claim a non-colliding backlog lane'
+    })).toString('base64url')}`;
+
     // 5. Emit Shape B heartbeat pulse. Creates an ephemeral GraphLog entry tagged
     //    as `heartbeat_pulse`; bridge-daemon's resync() picks it up + dispatches
     //    via the existing adapter set (osascript / codex-app-server / etc.).
@@ -127,7 +136,7 @@ export async function idleOutNudge(identity) {
     //    the emit no-ops (logged, not throws).
     try {
         await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
-            await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: identity});
+            await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: identity, pulseId});
         });
         console.error(`[idleOutNudge] Emitted heartbeat pulse to ${identity}`);
     } catch (err) {

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -34,19 +34,19 @@ function insertWakeSubscription(db, {
     harnessTargetMetadata
 }) {
     db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-        id: agentId,
-        label: 'AGENT',
+        id        : agentId,
+        label     : 'AGENT',
         properties: { name: agentId }
     }));
 
     db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-        id: subId,
-        label: 'WAKE_SUBSCRIPTION',
+        id        : subId,
+        label     : 'WAKE_SUBSCRIPTION',
         properties: {
             agentIdentity: agentId,
             harnessTarget: 'bridge-daemon',
-            status: 'active',
-            trigger: 'SENT_TO_ME',
+            status       : 'active',
+            trigger      : 'SENT_TO_ME',
             harnessTargetMetadata
         }
     }));
@@ -63,18 +63,18 @@ function insertHarnessPresence(db, {
     lastSeenAt = new Date().toISOString()
 }) {
     db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(presenceId, JSON.stringify({
-        id: presenceId,
-        label: 'HARNESS_PRESENCE',
+        id        : presenceId,
+        label     : 'HARNESS_PRESENCE',
         properties: {
-            agentIdentity: agentId,
+            agentIdentity : agentId,
             subscriptionId: subId,
-            state: 'idle',
-            wakePolicy: 'immediate',
-            source: 'mcp-client',
-            bootId: 'test-boot',
-            pid: process.pid,
+            state         : 'idle',
+            wakePolicy    : 'immediate',
+            source        : 'mcp-client',
+            bootId        : 'test-boot',
+            pid           : process.pid,
             lastSeenAt,
-            status: 'active'
+            status        : 'active'
         }
     }));
 }
@@ -82,10 +82,10 @@ function insertHarnessPresence(db, {
 function insertMessageWake(db, {agentId, subject = 'Addressed Wake Event'}) {
     const msgId = 'msg_' + crypto.randomUUID();
     db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-        id: msgId,
-        label: 'MESSAGE',
+        id        : msgId,
+        label     : 'MESSAGE',
         properties: {
-            from: '@sender',
+            from    : '@sender',
             subject,
             priority: 'normal'
         }
@@ -94,10 +94,10 @@ function insertMessageWake(db, {agentId, subject = 'Addressed Wake Event'}) {
 
     const edgeId = 'edge_' + crypto.randomUUID();
     db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-        id: edgeId,
+        id    : edgeId,
         source: msgId,
         target: agentId,
-        type: 'SENT_TO'
+        type  : 'SENT_TO'
     }), msgId, agentId, 'SENT_TO');
     db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -172,21 +172,21 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'test',
+                    adapter       : 'test',
                     coalesceWindow: 1 // 1 second for fast test
                 }
             }
@@ -197,7 +197,7 @@ test.describe('Wake Daemon', () => {
         // Start the daemon with environment overrides
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -219,11 +219,11 @@ test.describe('Wake Daemon', () => {
         // Inject MESSAGE and SENT_TO edge
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
-                subject: 'Test Wake Event',
+                from    : '@sender',
+                subject : 'Test Wake Event',
                 priority: 'normal'
             }
         }));
@@ -231,10 +231,10 @@ test.describe('Wake Daemon', () => {
 
         const edgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-            id: edgeId,
+            id    : edgeId,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -269,13 +269,13 @@ test.describe('Wake Daemon', () => {
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
                 agentIdentity: agentId,
                 harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                status       : 'active',
+                trigger      : 'SENT_TO_ME',
                 // The test-fail adapter throws deterministically → the delivery path fails without a live target.
                 harnessTargetMetadata: { adapter: 'test-fail', coalesceWindow: 1 }
             }
@@ -285,7 +285,7 @@ test.describe('Wake Daemon', () => {
         // Cap retries at 2 so the terminal "giving up" path is reached within a few 3s poll cycles.
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_MAX_DELIVERY_RETRIES: '2' }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR, WAKE_MAX_DELIVERY_RETRIES: '2' }
         });
 
         const terminalPromise = new Promise((resolve, reject) => {
@@ -337,13 +337,13 @@ test.describe('Wake Daemon', () => {
             id: agentId, label: 'AGENT', properties: { name: 'Test Agent Coalesce' }
         }));
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: { adapter: 'test-fail', coalesceWindow: 1 }
             }
         }));
@@ -351,7 +351,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         // First flush ("1 new messages") fails + enqueues; the second flush coalesces; the RETRY
@@ -406,13 +406,13 @@ test.describe('Wake Daemon', () => {
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
                 agentIdentity: agentId,
                 harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                status       : 'active',
+                trigger      : 'SENT_TO_ME',
                 // test-fail throws on the first attempt → the wake is queued for retry. We mark the
                 // message read before the retry fires, so the retry's read-reconcile must drop it.
                 harnessTargetMetadata: { adapter: 'test-fail', coalesceWindow: 1 }
@@ -422,7 +422,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         // The wake fires on SENT_TO; DELIVERED_TO carries the per-recipient readAt the daemon reconciles
@@ -433,7 +433,7 @@ test.describe('Wake Daemon', () => {
 
         const markMessageRead = () => {
             db.prepare('UPDATE Edges SET data = ? WHERE id = ?').run(JSON.stringify({
-                id: delId, source: msgId, target: agentId, type: 'DELIVERED_TO',
+                id        : delId, source: msgId, target: agentId, type: 'DELIVERED_TO',
                 properties: { readAt: '2026-06-15T00:00:00.000Z' }
             }), delId);
         };
@@ -495,10 +495,10 @@ test.describe('Wake Daemon', () => {
             id: agentId, label: 'AGENT', properties: { name: 'Test Agent Directive' }
         }));
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId, label: 'WAKE_SUBSCRIPTION',
+            id        : subId, label: 'WAKE_SUBSCRIPTION',
             properties: {
                 agentIdentity: agentId, harnessTarget: 'bridge-daemon', status: 'active',
-                trigger: 'SENT_TO_ME', harnessTargetMetadata: { adapter: 'test', coalesceWindow: 1 }
+                trigger      : 'SENT_TO_ME', harnessTargetMetadata: { adapter: 'test', coalesceWindow: 1 }
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
@@ -602,19 +602,19 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-readfilter';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent ReadFilter' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: { adapter: 'test', coalesceWindow: 1 }
             }
         }));
@@ -622,7 +622,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -645,8 +645,8 @@ test.describe('Wake Daemon', () => {
         const injectMessage = (subject, readAt) => {
             const msgId = 'msg_' + crypto.randomUUID();
             db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-                id: msgId,
-                label: 'MESSAGE',
+                id        : msgId,
+                label     : 'MESSAGE',
                 properties: { from: '@sender', subject, priority: 'normal' }
             }));
             db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
@@ -682,21 +682,21 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-heartbeat';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Heartbeat' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'HEARTBEAT_PULSE',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'HEARTBEAT_PULSE',
                 harnessTargetMetadata: {
-                    adapter: 'test',
+                    adapter       : 'test',
                     coalesceWindow: 1
                 }
             }
@@ -706,7 +706,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -753,26 +753,85 @@ test.describe('Wake Daemon', () => {
         expect(output).not.toContain('new messages');
     });
 
+    test('renders idle-out-nudge cycle-state in the heartbeat digest (#12612)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-idle-out';
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
+            id        : agentId,
+            label     : 'AGENT',
+            properties: {name: 'Test Agent Idle Out'}
+        }));
+
+        db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
+            properties: {
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'HEARTBEAT_PULSE',
+                harnessTargetMetadata: {adapter: 'test', coalesceWindow: 1}
+            }
+        }));
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(subId, 'nodes');
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver idle-out heartbeat pulse within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', (data) => {
+                const out = data.toString();
+                if (out.includes('[Wake Daemon Test Adapter] Delivered')) {
+                    clearTimeout(timeout);
+                    resolve(out);
+                }
+            });
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const pulseSummary = Buffer.from(JSON.stringify({
+            source    : 'idle-out-nudge',
+            reason    : 'idle: no recent AGENT_MEMORY while the swarm is active',
+            nextAction: 'drain the lifecycle queue, then claim a non-colliding backlog lane'
+        })).toString('base64url');
+        const pulseId = `HEARTBEAT_PULSE:${agentId}:idle-out-nudge.${pulseSummary}`;
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(pulseId, 'heartbeat_pulse');
+
+        const output = await deliveryPromise;
+        expect(output).toContain('[Wake Daemon Test Adapter] Delivered');
+        expect(output).toContain('heartbeat pulses');
+        expect(output).toContain('idle-out nudge — idle: no recent AGENT_MEMORY while the swarm is active');
+        expect(output).toContain('next: drain the lifecycle queue, then claim a non-colliding backlog lane');
+    });
+
     test('delivers heartbeat pulses through the existing SENT_TO_ME bridge-daemon route', async () => {
         const subId = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-heartbeat-sent-to-me';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Heartbeat Existing Route' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'test',
+                    adapter       : 'test',
                     coalesceWindow: 1
                 }
             }
@@ -782,7 +841,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -815,21 +874,21 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-suppressed';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Suppressed' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'test',
+                    adapter       : 'test',
                     coalesceWindow: 1
                 }
             }
@@ -839,7 +898,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let deliveryCount = 0;
@@ -854,13 +913,13 @@ test.describe('Wake Daemon', () => {
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: {
-                from: agentId,
-                to: agentId,
-                subject: 'Suppressed Sunset Ping',
-                readAt: null,
+                from          : agentId,
+                to            : agentId,
+                subject       : 'Suppressed Sunset Ping',
+                readAt        : null,
                 taggedConcepts: ['sunset-protocol-handover'],
                 wakeSuppressed: true
             }
@@ -869,10 +928,10 @@ test.describe('Wake Daemon', () => {
 
         const edgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-            id: edgeId,
+            id    : edgeId,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -891,14 +950,14 @@ test.describe('Wake Daemon', () => {
         const subId = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
-                adapter: 'test',
+                adapter       : 'test',
                 coalesceWindow: 1
             }
         });
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let stdoutLog = '';
@@ -921,21 +980,21 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-dedup';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Dedup' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'test',
+                    adapter       : 'test',
                     coalesceWindow: 2 // 2 seconds to ensure we catch multiple triggers
                 }
             }
@@ -945,7 +1004,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let deliveryCount = 0;
@@ -971,10 +1030,10 @@ test.describe('Wake Daemon', () => {
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
+                from   : '@sender',
                 subject: 'Test Dedup Event'
             }
         }));
@@ -983,20 +1042,20 @@ test.describe('Wake Daemon', () => {
         // Insert first SENT_TO edge
         const edgeId1 = 'edge_1_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId1, JSON.stringify({
-            id: edgeId1,
+            id    : edgeId1,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId1, 'edges');
 
         // Insert second SENT_TO edge for the exact same message to simulate duplication
         const edgeId2 = 'edge_2_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId2, JSON.stringify({
-            id: edgeId2,
+            id    : edgeId2,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId2, 'edges');
 
@@ -1178,21 +1237,21 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-priority';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Priority' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'test',
+                    adapter       : 'test',
                     coalesceWindow: 2
                 }
             }
@@ -1202,7 +1261,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1223,11 +1282,11 @@ test.describe('Wake Daemon', () => {
 
         const highMsgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(highMsgId, JSON.stringify({
-            id: highMsgId,
-            label: 'MESSAGE',
+            id        : highMsgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
-                subject: 'High Priority Wake Event',
+                from    : '@sender',
+                subject : 'High Priority Wake Event',
                 priority: 'high'
             }
         }));
@@ -1235,20 +1294,20 @@ test.describe('Wake Daemon', () => {
 
         const highEdgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(highEdgeId, JSON.stringify({
-            id: highEdgeId,
+            id    : highEdgeId,
             source: highMsgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), highMsgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(highEdgeId, 'edges');
 
         const lowMsgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(lowMsgId, JSON.stringify({
-            id: lowMsgId,
-            label: 'MESSAGE',
+            id        : lowMsgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
-                subject: 'Low Priority Wake Event',
+                from    : '@sender',
+                subject : 'Low Priority Wake Event',
                 priority: 'low'
             }
         }));
@@ -1256,10 +1315,10 @@ test.describe('Wake Daemon', () => {
 
         const lowEdgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(lowEdgeId, JSON.stringify({
-            id: lowEdgeId,
+            id    : lowEdgeId,
             source: lowMsgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), lowMsgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(lowEdgeId, 'edges');
 
@@ -1275,21 +1334,21 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-empty';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Empty' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'osascript',
+                    adapter       : 'osascript',
                     coalesceWindow: 1 // 1 second for fast test
                     // appName intentionally omitted
                 }
@@ -1300,7 +1359,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const errorLogPromise = new Promise((resolve, reject) => {
@@ -1320,18 +1379,18 @@ test.describe('Wake Daemon', () => {
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: { from: '@sender', subject: 'Test Empty AppName' }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
 
         const edgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-            id: edgeId,
+            id    : edgeId,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -1345,22 +1404,22 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-antigravity';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Antigravity' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'osascript',
-                    appName: 'Antigravity',
+                    adapter       : 'osascript',
+                    appName       : 'Antigravity',
                     coalesceWindow: 1
                 }
             }
@@ -1379,7 +1438,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let stdoutLog = '';
@@ -1404,11 +1463,11 @@ test.describe('Wake Daemon', () => {
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
-                subject: 'Test Antigravity Event',
+                from    : '@sender',
+                subject : 'Test Antigravity Event',
                 priority: 'normal'
             }
         }));
@@ -1416,10 +1475,10 @@ test.describe('Wake Daemon', () => {
 
         const edgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-            id: edgeId,
+            id    : edgeId,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -1442,22 +1501,22 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-claude';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Claude' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'osascript',
-                    appName: 'Claude',
+                    adapter       : 'osascript',
+                    appName       : 'Claude',
                     coalesceWindow: 1
                 }
             }
@@ -1475,7 +1534,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1496,11 +1555,11 @@ test.describe('Wake Daemon', () => {
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
-                subject: 'Test Claude Event',
+                from    : '@sender',
+                subject : 'Test Claude Event',
                 priority: 'normal'
             }
         }));
@@ -1508,10 +1567,10 @@ test.describe('Wake Daemon', () => {
 
         const edgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-            id: edgeId,
+            id    : edgeId,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -1556,11 +1615,11 @@ test.describe('Wake Daemon', () => {
         const subId = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
-                adapter: 'osascript',
-                appName: 'Antigravity',
-                coalesceWindow: 1,
+                adapter        : 'osascript',
+                appName        : 'Antigravity',
+                coalesceWindow : 1,
                 instanceAddress: '4242',
-                addressType: 'pid'
+                addressType    : 'pid'
             }
         });
         insertHarnessPresence(db, {subId, agentId});
@@ -1575,7 +1634,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1608,11 +1667,11 @@ test.describe('Wake Daemon', () => {
         const subId = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
-                adapter: 'osascript',
-                appName: 'Antigravity',
-                coalesceWindow: 1,
+                adapter        : 'osascript',
+                appName        : 'Antigravity',
+                coalesceWindow : 1,
                 instanceAddress: '4242',
-                addressType: 'pid'
+                addressType    : 'pid'
             }
         });
         insertHarnessPresence(db, {
@@ -1630,7 +1689,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const refusalPromise = new Promise((resolve, reject) => {
@@ -1824,11 +1883,11 @@ test.describe('Wake Daemon', () => {
         const subId = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
-                adapter: 'tmux',
-                appName: 'Antigravity',
-                coalesceWindow: 1,
+                adapter        : 'tmux',
+                appName        : 'Antigravity',
+                coalesceWindow : 1,
                 instanceAddress: 'neo-gpt-session',
-                addressType: 'tmuxSession'
+                addressType    : 'tmuxSession'
             }
         });
         insertHarnessPresence(db, {subId, agentId});
@@ -1842,7 +1901,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         const deliveryPromise = new Promise((resolve, reject) => {
@@ -1875,8 +1934,8 @@ test.describe('Wake Daemon', () => {
         const subId = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
-                adapter: 'tmux',
-                appName: 'Antigravity',
+                adapter       : 'tmux',
+                appName       : 'Antigravity',
                 coalesceWindow: 1
             }
         });
@@ -1890,7 +1949,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let stdoutLog = '';
@@ -1928,18 +1987,18 @@ test.describe('Wake Daemon', () => {
                 const subId = insertWakeSubscription(db, {
                     agentId,
                     harnessTargetMetadata: {
-                        adapter: 'tmux',
-                        appName: 'Antigravity',
-                        coalesceWindow: 1,
+                        adapter        : 'tmux',
+                        appName        : 'Antigravity',
+                        coalesceWindow : 1,
                         instanceAddress: `http://127.0.0.1:${port}/wake`,
-                        addressType: 'webhookUrl'
+                        addressType    : 'webhookUrl'
                     }
                 });
                 insertHarnessPresence(db, {subId, agentId});
 
                 daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
                     stdio: 'pipe',
-                    env: { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+                    env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
                 });
 
                 setTimeout(() => insertMessageWake(db, {agentId, subject: 'Webhook Address Wake'}), 1000);
@@ -1984,22 +2043,22 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-codex-fail-closed';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Codex Fail-Closed' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'osascript',
-                    appName: 'Codex',
+                    adapter       : 'osascript',
+                    appName       : 'Codex',
                     coalesceWindow: 1
                     // No focusSeedKey configured — bridge MUST refuse delivery
                 }
@@ -2018,7 +2077,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         // Wait for the fail-closed warning log line (proxy for the deliver-or-refuse decision).
@@ -2049,11 +2108,11 @@ test.describe('Wake Daemon', () => {
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
-                subject: 'Test Codex Event',
+                from    : '@sender',
+                subject : 'Test Codex Event',
                 priority: 'normal'
             }
         }));
@@ -2061,10 +2120,10 @@ test.describe('Wake Daemon', () => {
 
         const edgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-            id: edgeId,
+            id    : edgeId,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -2080,24 +2139,24 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-codex-cleanup';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Codex Cleanup' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'osascript',
-                    appName: 'Codex',
+                    adapter       : 'osascript',
+                    appName       : 'Codex',
                     coalesceWindow: 1,
-                    focusSeedKey: 'r'
+                    focusSeedKey  : 'r'
                 }
             }
         }));
@@ -2114,7 +2173,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let stdoutLog = '';
@@ -2138,11 +2197,11 @@ test.describe('Wake Daemon', () => {
 
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId,
-            label: 'MESSAGE',
+            id        : msgId,
+            label     : 'MESSAGE',
             properties: {
-                from: '@sender',
-                subject: 'Test Codex Cleanup',
+                from    : '@sender',
+                subject : 'Test Codex Cleanup',
                 priority: 'normal'
             }
         }));
@@ -2150,10 +2209,10 @@ test.describe('Wake Daemon', () => {
 
         const edgeId = 'edge_' + crypto.randomUUID();
         db.prepare('INSERT INTO Edges (id, data, source, target, type) VALUES (?, ?, ?, ?, ?)').run(edgeId, JSON.stringify({
-            id: edgeId,
+            id    : edgeId,
             source: msgId,
             target: agentId,
-            type: 'SENT_TO'
+            type  : 'SENT_TO'
         }), msgId, agentId, 'SENT_TO');
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
 
@@ -2194,24 +2253,24 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-codex-pure-heartbeat';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Codex Pure Heartbeat' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'osascript',
-                    appName: 'Codex',
+                    adapter       : 'osascript',
+                    appName       : 'Codex',
                     coalesceWindow: 1,
-                    focusSeedKey: 'r'
+                    focusSeedKey  : 'r'
                 }
             }
         }));
@@ -2228,7 +2287,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let stdoutLog = '';
@@ -2253,24 +2312,24 @@ test.describe('Wake Daemon', () => {
         const agentId = '@test-agent-codex-mixed-submit';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
-            id: agentId,
-            label: 'AGENT',
+            id        : agentId,
+            label     : 'AGENT',
             properties: { name: 'Test Agent Codex Mixed Submit' }
         }));
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(subId, JSON.stringify({
-            id: subId,
-            label: 'WAKE_SUBSCRIPTION',
+            id        : subId,
+            label     : 'WAKE_SUBSCRIPTION',
             properties: {
-                agentIdentity: agentId,
-                harnessTarget: 'bridge-daemon',
-                status: 'active',
-                trigger: 'SENT_TO_ME',
+                agentIdentity        : agentId,
+                harnessTarget        : 'bridge-daemon',
+                status               : 'active',
+                trigger              : 'SENT_TO_ME',
                 harnessTargetMetadata: {
-                    adapter: 'osascript',
-                    appName: 'Codex',
+                    adapter       : 'osascript',
+                    appName       : 'Codex',
                     coalesceWindow: 1,
-                    focusSeedKey: 'r'
+                    focusSeedKey  : 'r'
                 }
             }
         }));
@@ -2287,7 +2346,7 @@ test.describe('Wake Daemon', () => {
 
         daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
             stdio: 'pipe',
-            env: { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
+            env  : { ...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
         let stdoutLog = '';
@@ -2377,9 +2436,9 @@ test.describe('Wake Daemon', () => {
             label     : 'WAKE_SUBSCRIPTION',
             properties: {
                 agentIdentity,
-                trigger      : 'SENT_TO_ME',
-                filters      : {},
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                filters              : {},
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
                     adapter: 'test',
                     appName

--- a/test/playwright/unit/ai/scripts/lifecycle/idleOutNudge.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/idleOutNudge.spec.mjs
@@ -174,6 +174,18 @@ test.describe('ai/scripts/idleOutNudge', () => {
         expect(scriptContent).not.toContain('NUDGE_BODY_TEMPLATE');
     });
 
+    test('Static script: emits machine-readable idle-out cycle-state in the pulse id (#12612)', async () => {
+        // Shape B pulses carry no body; the cycle-state (reason + next-action) rides the pulse id
+        // as `idle-out-nudge.<base64url-JSON>` so the wake digest surfaces the next lifecycle step
+        // instead of an opaque "N heartbeat pulses". The encoded summary is passed as the pulseId.
+        const scriptContent = fs.readFileSync(scriptPath, 'utf-8');
+
+        expect(scriptContent).toContain('idle-out-nudge.');
+        expect(scriptContent).toContain('nextAction');
+        expect(scriptContent).toContain("toString('base64url')");
+        expect(scriptContent).toContain('emitHeartbeatPulse({targetIdentity: identity, pulseId})');
+    });
+
     // Note: the former `swarm-heartbeat.sh integration` test was removed with
     // the bash script. The `recommended_action: 'idle_out_nudge'` routing — ordered
     // after the sunset path and before the all-agent-idle path, gated by the wake


### PR DESCRIPTION
## Summary

Wake digests rendered idle-out nudges as an opaque **"N heartbeat pulses"** — the recipient couldn't see *why* it was woken or *what to do next*, so async-waits read as blockers (the idle-holding failure mode, **INFORM** side; #13589 is the **ENFORCE** side).

This carries machine-readable cycle-state in the heartbeat pulse id (`<source>.<base64url-JSON>`) end-to-end:

1. **Decoder (source-agnostic)** — `decodeHeartbeatPulseSummary` generalized from the single `github-notification` source to a `HEARTBEAT_PULSE_SUMMARY_SOURCES` allow-list (adds `idle-out-nudge`); the decoded payload's `source` must match the id prefix (format / tamper guard).
2. **Emitter** — `idleOutNudge` encodes a `{source, reason, nextAction}` cycle-state summary into the pulse id (`idle-out-nudge.<base64url-JSON>`) via `emitHeartbeatPulse`; GraphLog-only Shape-B preserved (no MESSAGE node, no inbox surfacing).
3. **Digest render-branch** — `buildWakeDigest` renders it as `idle-out nudge — <reason>; next: <nextAction>` instead of the opaque count, so the receiver branches on the lifecycle step.

**Excluded A2A surfaces (per #12612's documentation AC):** this does NOT use `add_message`, `MESSAGE.wakeMetadata`, or mailbox sender population — idle-out nudges are GraphLog-only heartbeat pulses rendered by the wake digest (no `MESSAGE` node, no `SENT_TO` edge, no inbox surfacing). The A2A `wakeMetadata` schema layer is deliberately out of scope here; **#11909** remains open for it.

Resolves #12612

## Evidence

Evidence: L2 (unit + spawn-based e2e — the real wake daemon delivers an injected idle-out `HEARTBEAT_PULSE` and the digest asserts the rendered cycle-state; the emitter's pulseId construction is statically asserted) → no L3/L4 required (dispatch + render are fully covered by the spawn-based e2e + the round-trip).

## Test Evidence

```
daemon.spec.mjs  — "renders idle-out-nudge cycle-state in the heartbeat digest" : 1 passed (4.7s)
    spawns the real wake daemon + injects an idle-out HEARTBEAT_PULSE →
    digest renders "idle-out nudge — <reason>; next: <nextAction>" (decoder + render-branch e2e)
idleOutNudge.spec.mjs — "emits machine-readable idle-out cycle-state in the pulse id" : 1 passed (494ms)
    static script-content check: idle-out-nudge.<base64url> construction + emitHeartbeatPulse({...pulseId})
round-trip verified standalone : emit (encode) → decode → render
node --check : idleOutNudge.mjs + wake/daemon.mjs — pass
husky pre-commit : whitespace / shorthand / jsdoc-types / ticket-archaeology / block-alignment — clean
```

## Post-Merge Validation

- [ ] On a live idle-out nudge, the recipient's `[WAKE]` digest shows the cycle-state line (reason + next-action), not the opaque "N heartbeat pulses".

## Deltas

- The decoder generalization is **additive** — the existing `github-notification` source is unchanged and its e2e test still passes.
- `daemon.spec.mjs` carries a block-alignment reformat (`check-block-alignment --fix`): the lint requires the whole *touched* file in house style and the file predated the lint, so the diff is large but the only functional change is the one new test.
- Pairs with #13589 (the Stop-hook **ENFORCE** side of the idle-holding fix); this is the **INFORM** side. Cycle-state fields (`reason`, `nextAction`) align with the lane-state descriptor shape.

Authored by Vega (Claude Opus 4.8, Claude Code). Session a49940b9.
