### PR TITLE
feat(memory-core): MC stored-embedding repair extraction-with-re-embed (#13601)

### DIFF
--- a/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
+++ b/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs
@@ -1,0 +1,116 @@
+/**
+ * Memory Core stored-embedding repair — extraction-with-re-embed.
+ *
+ * Memory Core Chroma collections suffer metadata/vector-index DIVERGENCE: many metadata rows are
+ * present (and queryable via the vectors that DO exist), but their stored vectors are absent from the
+ * HNSW persisted index, so `collection.get({include:['embeddings']})` fails `Error finding id` for those
+ * ids (e.g. neo-agent-memory had ~13,917 of 18,848 vectors missing). `defragChromaDB`'s
+ * shadow/parking promotion is therefore DISABLED for MC, because it extracts via `include:['embeddings']`.
+ *
+ * This module supplies the missing extraction half: partition each collection's ids into intact-vector
+ * vs missing-vector, extract intact rows with their stored embeddings, and **re-embed** the missing-vector
+ * rows from their DOCUMENTS (which still materialize — only the embedding fetch fails). The merged
+ * `{ids, embeddings, documents, metadatas}` then feeds defrag's existing `addCollectionData` →
+ * `validateLoadedCollection` → promote, unchanged. A missing-vector row with no recoverable document is
+ * reported as `unrecoverable` (counts surfaced, never silently dropped — the fail-loud discipline).
+ *
+ * The live shadow run + canonical promotion is operator/env-gated (out of scope without
+ * explicit authorization); this module is the pure extraction logic, unit-tested against mocked Chroma.
+ *
+ * @module Neo.ai.scripts.maintenance.repairMemoryCoreStoredEmbeddings
+ */
+
+/**
+ * @summary Extracts a Memory Core collection's data for a shadow rebuild, RE-EMBEDDING the rows whose
+ * stored vectors are missing from the HNSW index.
+ *
+ * Intact-vector rows keep their stored embeddings. Missing-vector rows are re-embedded from their
+ * documents via `embedFn`. A missing-vector row that returns no document (or is absent from the
+ * metadata read) is `unrecoverable` — surfaced with counts, not dropped.
+ *
+ * @param {Object}     options
+ * @param {Object}     options.collection       Chroma collection handle (`.get({ids, include})`).
+ * @param {String[]}   options.allIds           Every metadata id in the collection (from the coverage audit).
+ * @param {String[]}   options.missingVectorIds Ids whose vectors are absent from the HNSW index (coverage audit).
+ * @param {Function}   options.embedFn          `(documents: String[]) => Promise<Number[][]>` — re-embed a batch
+ *                                               (e.g. `TextEmbeddingService.embedTexts` bound to the MC provider).
+ * @param {Number}     [options.batchSize=1000] Chroma `.get` / embed batch size.
+ * @returns {Promise<{data: {ids: String[], embeddings: Number[][], documents: String[], metadatas: Object[]},
+ *                    unrecoverable: String[],
+ *                    counts: {total: Number, intact: Number, reEmbedded: Number, unrecoverable: Number}}>}
+ */
+export async function extractMemoryCoreCollectionData({collection, allIds = [], missingVectorIds = [], embedFn, batchSize = 1000} = {}) {
+    if (typeof embedFn !== 'function') {
+        throw new Error('extractMemoryCoreCollectionData: embedFn (documents -> embeddings) is required');
+    }
+
+    const missingSet = new Set(missingVectorIds);
+    const intactIds  = allIds.filter(id => !missingSet.has(id));
+    const data       = {ids: [], embeddings: [], documents: [], metadatas: []};
+
+    let intactCount = 0;
+
+    // 1. Intact rows — extract with their stored embeddings (these vectors exist in the HNSW index).
+    for (let i = 0; i < intactIds.length; i += batchSize) {
+        const batchIds = intactIds.slice(i, i + batchSize);
+        const got      = await collection.get({ids: batchIds, include: ['embeddings', 'documents', 'metadatas']});
+
+        for (let j = 0; j < (got.ids?.length || 0); j++) {
+            data.ids.push(got.ids[j]);
+            data.embeddings.push(got.embeddings[j]);
+            data.documents.push(got.documents?.[j] ?? '');
+            data.metadatas.push(got.metadatas?.[j] ?? {});
+            intactCount++;
+        }
+    }
+
+    // 2. Missing-vector rows — re-embed from documents (their stored embeddings cannot be fetched).
+    const unrecoverable = [];
+    let   reEmbedded    = 0;
+
+    for (let i = 0; i < missingVectorIds.length; i += batchSize) {
+        const batchIds = missingVectorIds.slice(i, i + batchSize);
+        // documents + metadatas DO materialize for missing-vector ids; only `embeddings` fails.
+        const got      = await collection.get({ids: batchIds, include: ['documents', 'metadatas']});
+        const returned = new Set(got.ids || []);
+
+        // An id that did not even come back from the metadata read is unrecoverable.
+        for (const id of batchIds) {
+            if (!returned.has(id)) unrecoverable.push(id);
+        }
+
+        const reEmbedIds = [], reEmbedDocs = [], reEmbedMetas = [];
+
+        for (let j = 0; j < (got.ids?.length || 0); j++) {
+            const doc = got.documents?.[j];
+            if (!doc) { unrecoverable.push(got.ids[j]); continue; }
+            reEmbedIds.push(got.ids[j]);
+            reEmbedDocs.push(doc);
+            reEmbedMetas.push(got.metadatas?.[j] ?? {});
+        }
+
+        if (reEmbedDocs.length > 0) {
+            const embeddings = await embedFn(reEmbedDocs);
+
+            if (!Array.isArray(embeddings) || embeddings.length !== reEmbedDocs.length) {
+                throw new Error(`extractMemoryCoreCollectionData: embedFn returned ${Array.isArray(embeddings) ? embeddings.length : 'non-array'} embeddings for ${reEmbedDocs.length} documents`);
+            }
+
+            for (let j = 0; j < reEmbedIds.length; j++) {
+                data.ids.push(reEmbedIds[j]);
+                data.embeddings.push(embeddings[j]);
+                data.documents.push(reEmbedDocs[j]);
+                data.metadatas.push(reEmbedMetas[j]);
+                reEmbedded++;
+            }
+        }
+    }
+
+    return {
+        data,
+        unrecoverable,
+        counts: {total: allIds.length, intact: intactCount, reEmbedded, unrecoverable: unrecoverable.length}
+    };
+}
+
+export default extractMemoryCoreCollectionData;

--- a/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs
@@ -1,0 +1,104 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'RepairMcStoredEmbeddingsTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}                    from '@playwright/test';
+import Neo                               from '../../../../../../src/Neo.mjs';
+import * as core                         from '../../../../../../src/core/_export.mjs';
+import {extractMemoryCoreCollectionData} from '../../../../../../ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs';
+
+/**
+ * Mock Chroma collection: `rows` is `{ id: {embedding?, document?, metadata?} }`. `.get` returns only
+ * the requested `include` fields, and only for ids present in `rows` (absent ids are simply not returned,
+ * mirroring a metadata read that can't find an id).
+ */
+function makeCollection(rows) {
+    return {
+        get: async ({ids, include = []}) => {
+            const out = {ids: []};
+            if (include.includes('embeddings')) out.embeddings = [];
+            if (include.includes('documents'))  out.documents  = [];
+            if (include.includes('metadatas'))  out.metadatas  = [];
+
+            for (const id of ids) {
+                const row = rows[id];
+                if (!row) continue;
+                out.ids.push(id);
+                if (out.embeddings) out.embeddings.push(row.embedding ?? null);
+                if (out.documents)  out.documents.push(row.document ?? null);
+                if (out.metadatas)  out.metadatas.push(row.metadata ?? {});
+            }
+            return out;
+        }
+    };
+}
+
+test.describe('extractMemoryCoreCollectionData — MC stored-embedding repair extraction', () => {
+    test('intact-only collection: extracts all, re-embeds none, embedFn never called', async () => {
+        const rows       = {a: {embedding: [1], document: 'da', metadata: {}}, b: {embedding: [2], document: 'db', metadata: {}}};
+        let   embedCalls = 0;
+        const embedFn    = async docs => { embedCalls++; return docs.map(() => [9]); };
+
+        const result = await extractMemoryCoreCollectionData({
+            collection: makeCollection(rows), allIds: ['a', 'b'], missingVectorIds: [], embedFn
+        });
+
+        expect(result.counts).toEqual({total: 2, intact: 2, reEmbedded: 0, unrecoverable: 0});
+        expect(result.data.ids.sort()).toEqual(['a', 'b']);
+        expect(embedCalls).toBe(0);
+    });
+
+    test('mixed: intact rows keep stored embeddings, missing rows are re-embedded from documents', async () => {
+        const rows    = {a: {embedding: [1], document: 'da', metadata: {}}, m: {document: 'dm', metadata: {k: 1}}};
+        const embedFn = async docs => docs.map(() => [7, 7]);
+
+        const result = await extractMemoryCoreCollectionData({
+            collection: makeCollection(rows), allIds: ['a', 'm'], missingVectorIds: ['m'], embedFn
+        });
+
+        expect(result.counts).toEqual({total: 2, intact: 1, reEmbedded: 1, unrecoverable: 0});
+        expect(result.data.embeddings[result.data.ids.indexOf('m')]).toEqual([7, 7]); // re-embedded
+        expect(result.data.embeddings[result.data.ids.indexOf('a')]).toEqual([1]);    // stored, untouched
+    });
+
+    test('a missing-vector row with no document is unrecoverable, not silently dropped', async () => {
+        const rows    = {m: {document: '', metadata: {}}, n: {document: 'dn', metadata: {}}};
+        const embedFn = async docs => docs.map(() => [5]);
+
+        const result = await extractMemoryCoreCollectionData({
+            collection: makeCollection(rows), allIds: ['m', 'n'], missingVectorIds: ['m', 'n'], embedFn
+        });
+
+        expect(result.unrecoverable).toEqual(['m']);
+        expect(result.counts).toEqual({total: 2, intact: 0, reEmbedded: 1, unrecoverable: 1});
+    });
+
+    test('a missing id absent from the metadata read is unrecoverable', async () => {
+        const rows    = {n: {document: 'dn', metadata: {}}}; // 'gone' is not in the row map
+        const embedFn = async docs => docs.map(() => [5]);
+
+        const result = await extractMemoryCoreCollectionData({
+            collection: makeCollection(rows), allIds: ['n', 'gone'], missingVectorIds: ['n', 'gone'], embedFn
+        });
+
+        expect(result.unrecoverable).toEqual(['gone']);
+        expect(result.counts.reEmbedded).toBe(1);
+    });
+
+    test('embedFn returning a wrong-length result throws (fail loud)', async () => {
+        const rows = {m: {document: 'dm', metadata: {}}};
+
+        await expect(extractMemoryCoreCollectionData({
+            collection: makeCollection(rows), allIds: ['m'], missingVectorIds: ['m'], embedFn: async () => []
+        })).rejects.toThrow(/returned 0 embeddings for 1 documents/);
+    });
+
+    test('a missing embedFn throws (required param)', async () => {
+        await expect(extractMemoryCoreCollectionData({
+            collection: makeCollection({}), allIds: [], missingVectorIds: []
+        })).rejects.toThrow(/embedFn .* is required/);
+    });
+});


### PR DESCRIPTION
Resolves #13601 (the #13496 AC4 repair — first slice, the novel extraction half)

## Summary

`defragChromaDB`'s shadow/parking promotion is DISABLED for Memory Core because it extracts via `collection.get({include:['embeddings']})`, which fails `Error finding id` for the missing-vector ids (metadata/HNSW divergence — `neo-agent-memory`: ~13,917 of 18,848 vectors missing, per #13496's ledger). This adds the missing extraction half: `extractMemoryCoreCollectionData` partitions a collection's ids into intact-vector vs missing-vector, extracts intact rows with their stored embeddings, and **re-embeds** the missing-vector rows from their documents (which still materialize) via `embedFn` (e.g. `TextEmbeddingService.embedTexts`). The merged `{ids,embeddings,documents,metadatas}` then feeds defrag's existing `addCollectionData → validateLoadedCollection → promote` unchanged.

**Evidence:** the #13496 ledger measured the divergence (metadata rows present + queryable, stored vectors absent from the HNSW index) and confirmed `get metadata/document=ok, get embedding by id=Error finding id` — so the documents DO materialize for the missing ids, which is what makes re-embedding viable.

## Deltas

- **`ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.mjs`** (new): `extractMemoryCoreCollectionData({collection, allIds, missingVectorIds, embedFn})` → `{data, unrecoverable, counts}`. Intact rows keep their stored vectors; missing-vector rows are re-embedded from documents; document-less / metadata-absent rows surface as `unrecoverable` with counts (fail-loud, never silently dropped — the #13584 discipline).

## Test Evidence

`test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs` — **6/6 pass** (mocked Chroma collection + mocked `embedFn`): intact-only (embedFn never called); mixed (intact keep stored vectors, missing re-embedded from docs); document-less missing row → `unrecoverable`; metadata-absent missing id → `unrecoverable`; `embedFn` wrong-length → throws; missing `embedFn` → throws.

## Scope / Follow-up (env boundary)

This PR is the pure extraction logic (#13601 AC1 + AC3), fully unit-validated. Deferred to follow-up slices: AC2 (wire into defrag's shadow/parking behind a default-off operator flag) + AC4 (pre-repair runbook). The **live shadow run + canonical promotion** against the real Chroma store is operator/env-gated — the sandbox can't reach Chroma (IPv6-loopback only, per #13496's ledger), and #13496 Out-of-Scope bars live mutation without operator authorization.

## Post-Merge Validation

- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/repairMemoryCoreStoredEmbeddings.spec.mjs` → 6/6 on dev.
- The next slice wires this into defrag (AC2) + an operator runbook (AC4); the live shadow validation is the operator's Tier-4 step.

---

Authored by @neo-opus-ada (Claude Opus 4.8). Origin session ID: abe80be3-6235-4a9e-99bc-b14659ba806a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
