### PR TITLE
fix(memory-core): make who_is_online use turn-presence primary (#13498)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -210,10 +210,10 @@ paths:
 
         Terse by default: {summary, online[], idle[], benched[]} (identity arrays). Pass verbose:true
         for the full per-agent projection + signal description. Signal (precedence): (1) participationStatus
-        hard gate — operator_benched / temporarily_unreachable report offline; (2) add_memory-recency —
-        a rostered agent's most-recent AGENT_MEMORY write within the freshness window means recently
-        active. add_memory is the universal, deployment-agnostic activity write (no harness beacon); the
-        read is roster-scoped and graph-backed (survives an embed-drain).
+        hard gate — operator_benched / temporarily_unreachable report offline; (2) AGENT_TURN_PRESENCE
+        interval — newest fresh active turn means online, newest stale/terminal turn means offline;
+        (3) add_memory-recency fallback only when no turn-presence beacon exists yet. The read is
+        roster-scoped and graph-backed.
       tags: [Health]
       requestBody:
         required: false
@@ -250,18 +250,18 @@ paths:
                   online:
                     type: array
                     items: {type: string}
-                    description: Terse default — identities with fresh add_memory activity.
+                    description: Terse default — identities with fresh active turn presence or no-beacon fresh fallback activity.
                   idle:
                     type: array
                     items: {type: string}
-                    description: Terse default — rostered + active identities with no fresh activity.
+                    description: Terse default — rostered + active identities with no fresh liveness signal.
                   benched:
                     type: array
                     items: {type: string}
                     description: Terse default — identities whose participationStatus is not 'active'.
                   signalStatus:
                     type: string
-                    description: verbose:true only — describes the add_memory-recency signal.
+                    description: verbose:true only — describes the turn-presence-primary signal and add_memory fallback.
                   agents:
                     type: array
                     description: verbose:true only — full per-agent projection.

--- a/ai/services/memory-core/TurnPresenceService.mjs
+++ b/ai/services/memory-core/TurnPresenceService.mjs
@@ -9,9 +9,9 @@ import RequestContextService, {normalizeUserId} from '../../mcp/server/shared/se
  *
  * `HARNESS_PRESENCE` is a wake-routing overlay: it says whether a receiver route appears
  * addressable. This service records a separate `AGENT_TURN_PRESENCE` interval: a trusted harness
- * turn began, may refresh progress, and eventually expires or terminalizes. These turn-presence
- * records are NOT the `who_is_online` liveness signal — `who_is_online` derives liveness from
- * `add_memory` recency (roster-scoped); turn-presence is a separate active-turn substrate.
+ * turn began, may refresh progress, and eventually expires or terminalizes. `who_is_online` reads
+ * the newest interval as its primary liveness signal and uses completed-turn activity only as a
+ * no-beacon fallback.
  *
  * @class Neo.ai.services.memory-core.TurnPresenceService
  * @extends Neo.core.Base
@@ -177,6 +177,64 @@ class TurnPresenceService extends Base {
      */
     _getTurnPresenceProperties(nodeId) {
         return GraphService.getNodeRecord({id: nodeId})?.properties || null;
+    }
+
+    /**
+     * @summary Reads the newest turn-presence interval for an AgentIdentity, regardless of status.
+     *
+     * The liveness projection must see terminal rows too. Reading only active rows can hide a newer
+     * terminal turn behind an older active interval and incorrectly project the agent as online.
+     * @param {String} agentIdentity AgentIdentity node id.
+     * @param {Date|String|Number} [now=new Date()] Clock source.
+     * @returns {Object|null} Turn-presence payload plus `{fresh, expired, terminal}` verdict flags.
+     */
+    readLatestTurnPresence(agentIdentity, now = new Date()) {
+        const sqlite = GraphService.db?.storage?.db;
+        if (!sqlite || !agentIdentity) return null;
+
+        const nowDate = this._coerceDate(now),
+              nowMs   = nowDate.getTime();
+
+        let row;
+        try {
+            row = sqlite.prepare(`
+                SELECT data FROM Nodes
+                WHERE json_extract(data, '$.label') = 'AGENT_TURN_PRESENCE'
+                  AND json_extract(data, '$.properties.agentIdentity') = ?
+                ORDER BY COALESCE(
+                  json_extract(data, '$.properties.updatedAt'),
+                  json_extract(data, '$.properties.lastProgressAt'),
+                  json_extract(data, '$.properties.startedAt')
+                ) DESC
+                LIMIT 1
+            `).get(agentIdentity);
+        } catch {
+            return null;
+        }
+
+        if (!row?.data) return null;
+
+        let properties;
+        try {
+            properties = JSON.parse(row.data).properties || {};
+        } catch {
+            return null;
+        }
+
+        const status       = properties.status || (properties.terminalState ? 'terminal' : 'active'),
+              terminal     = status === 'terminal' || Boolean(properties.terminalState),
+              freshUntilMs = new Date(properties.freshUntil).getTime(),
+              expiresAtMs  = new Date(properties.expiresAt).getTime(),
+              fresh        = status === 'active' && Number.isFinite(freshUntilMs) && freshUntilMs > nowMs,
+              expired      = Number.isFinite(expiresAtMs) && expiresAtMs <= nowMs;
+
+        return {
+            ...properties,
+            status,
+            fresh,
+            expired,
+            terminal
+        };
     }
 
     /**

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -7,6 +7,7 @@ import aiConfig                                                                 
 import RequestContextService, {normalizeUserId}                                                 from '../../mcp/server/shared/services/RequestContextService.mjs';
 import logger                                                                                   from '../../mcp/server/memory-core/logger.mjs';
 import CoalescingEngineService                                                                  from './CoalescingEngineService.mjs';
+import TurnPresenceService                                                                      from './TurnPresenceService.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
 
 /**
@@ -520,15 +521,12 @@ class WakeSubscriptionService extends Base {
      * Composes the liveness layers, in precedence order:
      * 1. **`participationStatus` hard gate** — `operator_benched` / `temporarily_unreachable`
      *    report `online:false` regardless of any softer signal.
-     * 2. **`add_memory`-recency (primary)** — the deployment-agnostic activity signal
-     *    ({@link WakeSubscriptionService#_readActivityRecency}): a rostered agent's most-recent OWN
-     *    `AGENT_MEMORY` write within the freshness window ⇒ recently active ⇒ online; stale or none ⇒
-     *    dark. `add_memory` is the universal activity write every authenticated agent produces — so the
-     *    signal works identically in the swarm and a multi-tenant cloud deployment, unlike a harness
-     *    beacon (emitted only by the neo-swarm harness, inert elsewhere) or process-presence
-     *    (pid/clone-local — the "local neo activity" coupling that is not mergeable). The read is
-     *    roster-scoped (the AgentIdentity roster is the visibility boundary, not the per-caller tenant)
-     *    and graph-backed (survives an embed-drain — it reads the durable node, not Chroma).
+     * 2. **`AGENT_TURN_PRESENCE` interval (primary)** — a trusted harness turn-start/progress/terminal
+     *    beacon. Fresh active interval ⇒ online; stale or terminal newest interval ⇒ offline. This
+     *    avoids the falsified `add_memory`-as-primary false negative when a live turn cannot complete
+     *    its end-of-turn memory write.
+     * 3. **`add_memory`-recency fallback** — used only when no turn-presence beacon exists yet, preserving
+     *    rollout/backward compatibility for harnesses that have not started writing turn presence.
      *
      * Deliberately **advisory**: it surfaces *probably-dark* maintainers for review-routing /
      * lane-handoff / lead-baton / wake-targeting so a request to a dark agent fails loud instead
@@ -554,9 +552,9 @@ class WakeSubscriptionService extends Base {
         if (verbose) {
             return {
                 generatedAt,
-                signalStatus: 'add_memory-recency: per maintainer, the most-recent roster-visible AGENT_MEMORY ' +
-                              'write within the freshness window. Deployment-agnostic (add_memory is the universal ' +
-                              'activity write — no harness beacon) and graph-backed (survives an embed-drain). ' +
+                signalStatus: 'turn-presence-primary: per maintainer, the newest AGENT_TURN_PRESENCE interval ' +
+                              'is primary; fresh active means online, stale or terminal means offline. ' +
+                              'add_memory-recency is a no-beacon fallback/corroboration path only. ' +
                               'Advisory, not a hard routing gate.',
                 agents
             };
@@ -564,8 +562,8 @@ class WakeSubscriptionService extends Base {
 
         // Terse default — a "who is online?" answer, not a diagnostics book. The signalStatus essay
         // and the per-agent reason/signals live behind verbose:true so the per-call token cost stays
-        // proportional to the question. online = fresh add_memory activity; idle = rostered
-        // and active but no fresh write; benched = participationStatus not 'active'.
+        // proportional to the question. online = fresh active turn presence or no-beacon fresh fallback
+        // activity; idle = rostered and active but no fresh signal; benched = participationStatus not 'active'.
         const online  = agents.filter(agent => agent.online).map(agent => agent.identity),
               benched = agents.filter(agent => !agent.online && agent.participationStatus !== 'active').map(agent => agent.identity),
               idle    = agents.filter(agent => !agent.online && agent.participationStatus === 'active').map(agent => agent.identity);
@@ -617,7 +615,7 @@ class WakeSubscriptionService extends Base {
 
     /**
      * @summary Projects a single AgentIdentity node to its liveness verdict via the
-     * participationStatus-gate → add_memory-recency precedence.
+     * participationStatus-gate → turn-presence primary → add_memory fallback precedence.
      * @param {Object} node Parsed AgentIdentity node.
      * @param {Number} nowMs Clock epoch ms.
      * @returns {Object} `{identity, name, family, participationStatus, online, reason, signals}`.
@@ -629,7 +627,7 @@ class WakeSubscriptionService extends Base {
               name                = node.name || props.displayName || node.id,
               family              = props.family || props.modelFamily || null,
               participationStatus = props.participationStatus || 'active',
-              signals             = {participationStatus, activityRecency: null};
+              signals             = {participationStatus, turnPresence: null, activityRecency: null};
 
         // 1. participationStatus HARD GATE — benched/unreachable overrides every softer signal.
         if (participationStatus !== 'active') {
@@ -637,31 +635,47 @@ class WakeSubscriptionService extends Base {
                 reason: `roster: participationStatus is '${participationStatus}' (benched / unreachable)`, signals};
         }
 
-        // 2. add_memory-recency — the deployment-agnostic activity signal. Every authenticated agent's
-        //    memory write stamps an AGENT_MEMORY node (agentIdentity + timestamp); this rostered
-        //    agent's fresh most-recent OWN write ⇒ recently active ⇒ online. Unlike a harness beacon
-        //    (emitted only by the neo-swarm harness, inert in a multi-tenant/cloud deployment),
-        //    add_memory is universal — and the read is roster-scoped (the AgentIdentity roster is the
-        //    visibility boundary) and graph-backed (survives an embed-drain).
+        // 2. turn-presence — trusted active-turn interval. The newest interval wins even when it is
+        //    terminal: skipping terminal rows can let an older active row incorrectly read online.
+        const turnPresence = TurnPresenceService.readLatestTurnPresence(identity, nowMs);
+        signals.turnPresence = turnPresence;
+
+        if (turnPresence) {
+            if (turnPresence.terminal || turnPresence.status === 'terminal') {
+                return {identity, name, family, participationStatus, online: false,
+                    reason: `turn-presence terminal (${turnPresence.terminalState || 'terminal'} at ${turnPresence.updatedAt || turnPresence.lastProgressAt})`, signals};
+            }
+
+            if (turnPresence.expired || !turnPresence.fresh) {
+                return {identity, name, family, participationStatus, online: false,
+                    reason: `stale turn-presence interval (freshUntil ${turnPresence.freshUntil || 'unknown'})`, signals};
+            }
+
+            return {identity, name, family, participationStatus, online: true,
+                reason: `fresh turn-presence interval (last progress ${turnPresence.lastProgressAt})`, signals};
+        }
+
+        // 3. add_memory-recency fallback — preserves rollout compatibility for agents whose harness
+        //    has not started writing AGENT_TURN_PRESENCE yet. This is no longer the primary signal.
         const activity = this._readActivityRecency(identity, nowMs);
         signals.activityRecency = activity;
 
         if (!activity) {
             return {identity, name, family, participationStatus, online: false,
-                reason: 'no add_memory activity (dark — no AGENT_MEMORY write on record)', signals};
+                reason: 'no turn-presence beacon or add_memory fallback activity (dark)', signals};
         }
         if (!activity.fresh) {
             return {identity, name, family, participationStatus, online: false,
-                reason: `stale add_memory activity (last write ${activity.lastActivityAt} — none within the freshness window)`, signals};
+                reason: `stale add_memory fallback activity (last write ${activity.lastActivityAt} — none within the freshness window)`, signals};
         }
 
         return {identity, name, family, participationStatus, online: true,
-            reason: `recent add_memory activity (last write ${activity.lastActivityAt})`, signals};
+            reason: `no turn-presence beacon; recent add_memory fallback activity (last write ${activity.lastActivityAt})`, signals};
     }
 
     /**
      * @summary Reads a rostered agent's most-recent `add_memory` activity — the
-     * deployment-agnostic liveness signal that replaced the harness beacon.
+     * no-beacon fallback for the turn-presence primary liveness signal.
      *
      * Every authenticated agent's memory write stamps an `AGENT_MEMORY` graph node with
      * `agentIdentity` + `timestamp` + `userId` ({@link Neo.ai.services.memory-core.MemoryService#addMemory}).
@@ -672,8 +686,8 @@ class WakeSubscriptionService extends Base {
      * filter here would hide same-deployment teammates from each other.
      * Cross-tenant isolation for a multi-tenant cloud belongs at the roster scope (a tenant-scoped
      * `_listAgentIdentityNodes`), tracked separately. It reads the durable graph node, not Chroma, so it
-     * survives an embed-drain; and `add_memory` is the universal activity write (no harness hook, no
-     * per-deployment beacon), so the signal works identically in the swarm and a multi-tenant cloud.
+     * survives an embed-drain. It intentionally does not override a stale or terminal turn-presence
+     * interval: once a trusted beacon exists, interval/terminal semantics are authoritative.
      *
      * Freshness window: `add_memory` lands at turn boundaries (the consolidate-then-save gate), so the
      * window must exceed a typical turn to avoid marking a mid-turn agent dark — the false-negative the

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1655,9 +1655,6 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         }
 
         function seedActivity(owner, {timestamp = T0} = {}) {
-            // Mirrors a swarm (stdio) add_memory graph projection: an AGENT_MEMORY node carrying
-            // agentIdentity + timestamp and NO userId (→ user_id NULL → RLS-visible to every caller,
-            // as stdio-mode memories are). The who_is_online recency read keys on this node.
             GraphService.upsertNode({
                 id        : `AGENT_MEMORY:${owner}:${timestamp}`,
                 type      : 'AGENT_MEMORY',
@@ -1666,9 +1663,37 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
         }
 
-        test('participationStatus hard gate: benched reports offline even with fresh activity (verbose)', async () => {
+        function seedTurnPresence(owner, {
+            turnId = 'turn',
+            status = 'active',
+            terminalState = null,
+            startedAt = iso(T0ms - 5 * 60 * 1000),
+            lastProgressAt = iso(T0ms - 2 * 60 * 1000),
+            freshUntil = iso(T0ms + 28 * 60 * 1000),
+            expiresAt = iso(T0ms + 58 * 60 * 1000),
+            updatedAt = lastProgressAt
+        } = {}) {
+            GraphService.upsertNode({
+                id        : `AGENT_TURN_PRESENCE:${owner}:${turnId}`,
+                type      : 'AGENT_TURN_PRESENCE',
+                name      : `TurnPresence ${owner}`,
+                properties: {
+                    agentIdentity: owner,
+                    turnId,
+                    startedAt,
+                    lastProgressAt,
+                    freshUntil,
+                    expiresAt,
+                    terminalState,
+                    status,
+                    updatedAt
+                }
+            });
+        }
+
+        test('participationStatus hard gate: benched reports offline even with fresh turn presence (verbose)', async () => {
             seedAgent('@neo-benched', {participationStatus: 'operator_benched'});
-            seedActivity('@neo-benched', {timestamp: T0});
+            seedTurnPresence('@neo-benched', {turnId: 'benched'});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-benched');
@@ -1677,51 +1702,124 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.online).toBe(false);
             expect(entry.participationStatus).toBe('operator_benched');
             expect(entry.reason).toContain('benched');
+            expect(entry.signals.turnPresence).toBeNull();
         });
 
-        test('fresh add_memory activity → online (recency-primary, verbose)', async () => {
+        test('fresh turn-presence beacon → online even without add_memory activity', async () => {
             seedAgent('@neo-active');
-            seedActivity('@neo-active', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+            seedTurnPresence('@neo-active', {turnId: 'fresh'});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-active');
 
             expect(entry.online).toBe(true);
-            expect(entry.reason).toContain('recent add_memory activity');
-            expect(entry.signals.activityRecency.fresh).toBe(true);
+            expect(entry.reason).toContain('fresh turn-presence interval');
+            expect(entry.signals.turnPresence.fresh).toBe(true);
+            expect(entry.signals.activityRecency).toBeNull();
         });
 
-        test('stale add_memory activity → offline (past the freshness window, verbose)', async () => {
+        test('stale active turn-presence beacon → offline even with fresh add_memory fallback activity', async () => {
             seedAgent('@neo-stale');
-            // last write 20 min ago — beyond the 15-min freshness window
-            seedActivity('@neo-stale', {timestamp: iso(T0ms - 20 * 60 * 1000)});
+            seedTurnPresence('@neo-stale', {
+                turnId        : 'stale-active',
+                lastProgressAt: iso(T0ms - 35 * 60 * 1000),
+                freshUntil    : iso(T0ms - 5 * 60 * 1000),
+                expiresAt     : iso(T0ms + 25 * 60 * 1000),
+                updatedAt     : iso(T0ms - 35 * 60 * 1000)
+            });
+            seedActivity('@neo-stale', {timestamp: iso(T0ms - 2 * 60 * 1000)});
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-stale');
 
             expect(entry.online).toBe(false);
-            expect(entry.reason).toContain('stale add_memory activity');
+            expect(entry.reason).toContain('stale turn-presence interval');
+            expect(entry.signals.turnPresence.fresh).toBe(false);
+            expect(entry.signals.activityRecency).toBeNull();
+        });
+
+        test('terminal turn-presence beacon → offline even with fresh add_memory fallback activity', async () => {
+            seedAgent('@neo-terminal');
+            seedTurnPresence('@neo-terminal', {
+                turnId       : 'terminal',
+                status       : 'terminal',
+                terminalState: 'completed',
+                updatedAt    : iso(T0ms - 60 * 1000)
+            });
+            seedActivity('@neo-terminal', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-terminal');
+
+            expect(entry.online).toBe(false);
+            expect(entry.reason).toContain('turn-presence terminal');
+            expect(entry.signals.turnPresence.terminal).toBe(true);
+            expect(entry.signals.activityRecency).toBeNull();
+        });
+
+        test('newest terminal turn wins over an older active turn (never online-forever)', async () => {
+            seedAgent('@neo-newest-terminal');
+            seedTurnPresence('@neo-newest-terminal', {
+                turnId        : 'older-active',
+                lastProgressAt: iso(T0ms - 10 * 60 * 1000),
+                freshUntil    : iso(T0ms + 20 * 60 * 1000),
+                updatedAt     : iso(T0ms - 10 * 60 * 1000)
+            });
+            seedTurnPresence('@neo-newest-terminal', {
+                turnId        : 'newer-terminal',
+                status        : 'terminal',
+                terminalState : 'blocked',
+                lastProgressAt: iso(T0ms - 60 * 1000),
+                updatedAt     : iso(T0ms - 60 * 1000)
+            });
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-newest-terminal');
+
+            expect(entry.online).toBe(false);
+            expect(entry.signals.turnPresence.turnId).toBe('newer-terminal');
+            expect(entry.reason).toContain('blocked');
+        });
+
+        test('no beacon but fresh add_memory activity → online via rollout fallback', async () => {
+            seedAgent('@neo-fallback');
+            seedActivity('@neo-fallback', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-fallback');
+
+            expect(entry.online).toBe(true);
+            expect(entry.reason).toContain('add_memory fallback activity');
+            expect(entry.signals.turnPresence).toBeNull();
+            expect(entry.signals.activityRecency.fresh).toBe(true);
+        });
+
+        test('no beacon and stale add_memory fallback activity → offline', async () => {
+            seedAgent('@neo-fallback-stale');
+            seedActivity('@neo-fallback-stale', {timestamp: iso(T0ms - 20 * 60 * 1000)});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@neo-fallback-stale');
+
+            expect(entry.online).toBe(false);
+            expect(entry.reason).toContain('stale add_memory fallback activity');
             expect(entry.signals.activityRecency.fresh).toBe(false);
         });
 
-        test('no add_memory activity → offline (dark) + signals.activityRecency null (verbose)', async () => {
+        test('no beacon or add_memory fallback activity → offline (dark)', async () => {
             seedAgent('@neo-dark');
 
             const {agents} = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
             const entry    = agents.find(a => a.identity === '@neo-dark');
 
             expect(entry.online).toBe(false);
-            expect(entry.reason).toContain('no add_memory activity');
+            expect(entry.reason).toContain('no turn-presence beacon');
+            expect(entry.signals.turnPresence).toBeNull();
             expect(entry.signals.activityRecency).toBeNull();
         });
 
-        test('roster-scoping: an agent\'s OWN activity marks it online regardless of the user_id tenant tag', async () => {
+        test('roster-scoping fallback: own add_memory activity ignores per-caller user_id tenant tag when no beacon exists', async () => {
             seedAgent('@neo-foreign-tenant');
-            // who_is_online is a ROSTER tool: it reports each rostered agent's OWN latest activity
-            // (matched by agentIdentity), NOT per-caller tenant. Fresh activity tagged with a foreign
-            // userId therefore still marks the agent online. The prior per-caller user_id RLS here hid
-            // same-deployment teammates from each other. Cross-tenant isolation belongs at the roster
-            // scope (a tenant-scoped _listAgentIdentityNodes) for a multi-tenant cloud, tracked separately.
             GraphService.upsertNode({
                 id        : 'AGENT_MEMORY:@neo-foreign-tenant:fresh',
                 type      : 'AGENT_MEMORY',
@@ -1733,13 +1831,14 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             const entry    = agents.find(a => a.identity === '@neo-foreign-tenant');
 
             expect(entry.online).toBe(true);
+            expect(entry.signals.turnPresence).toBeNull();
             expect(entry.signals.activityRecency.fresh).toBe(true);
         });
 
         test('terse default: {summary, online, idle, benched} identity arrays — no per-agent essay', async () => {
             seedAgent('@neo-t-online');
-            seedActivity('@neo-t-online', {timestamp: iso(T0ms - 2 * 60 * 1000)});
-            seedAgent('@neo-t-idle');                                              // active, no activity → idle
+            seedTurnPresence('@neo-t-online', {turnId: 'terse-online'});
+            seedAgent('@neo-t-idle');
             seedAgent('@neo-t-benched', {participationStatus: 'temporarily_unreachable'});
 
             const result = await WakeSubscriptionService.whoIsOnline({now: new Date(T0)});
@@ -1756,24 +1855,16 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('verbose:true returns the full per-agent projection + signalStatus (no terse summary)', async () => {
             seedAgent('@neo-v');
-            seedActivity('@neo-v', {timestamp: iso(T0ms - 2 * 60 * 1000)});
+            seedTurnPresence('@neo-v', {turnId: 'verbose'});
 
             const result = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
 
+            expect(result.signalStatus).toContain('turn-presence-primary');
             expect(result.signalStatus).toContain('add_memory-recency');
             expect(result.beaconStatus).toBeUndefined();
             expect(result.summary).toBeUndefined();
             expect(Array.isArray(result.agents)).toBe(true);
             expect(result.agents.find(a => a.identity === '@neo-v').online).toBe(true);
-        });
-
-        test('signalStatus (verbose) names the add_memory-recency signal (no beacon field)', async () => {
-            seedAgent('@neo-sig');
-
-            const result = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
-
-            expect(result.signalStatus).toContain('add_memory-recency');
-            expect(result.beaconStatus).toBeUndefined();
         });
 
         test('family filter narrows the roster (verbose)', async () => {
@@ -1795,7 +1886,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(typeof res.summary).toBe('string');
             expect(Array.isArray(res.online)).toBe(true);
             expect(Array.isArray(res.idle)).toBe(true);
-            // @neo-dispatch is rostered + active but has no activity → idle
+            // @neo-dispatch is rostered + active but has no signal → idle
             expect(res.idle).toContain('@neo-dispatch');
         });
     });


### PR DESCRIPTION
Resolves #13498

Related: #13499
Related: #13495

`who_is_online` now treats the newest `AGENT_TURN_PRESENCE` interval as the primary liveness signal: fresh active interval means online, stale or terminal newest interval means offline, and `participationStatus` still hard-gates benched/unreachable maintainers offline. `add_memory` recency remains only as a no-beacon rollout fallback for harnesses that have not emitted turn presence yet.

Evidence: L2 (focused Memory Core service + MCP-dispatch unit coverage, syntax checks, diff hygiene, and MCP test-location lint) -> L2 required (Substrate B read-projection ACs are unit-verifiable; Substrate A writer was delivered by #13500). No residuals.

## Deltas from ticket

Substrate A was delivered separately by #13500. This PR consumes the resulting `AGENT_TURN_PRESENCE` interval ledger instead of overloading `HARNESS_PRESENCE`, keeping process addressability out of the decisive liveness path. The only retained `add_memory` behavior is a no-beacon compatibility fallback; once a turn-presence row exists, stale/terminal interval semantics are authoritative.

## Signal Ledger

- `[AUTHOR_SIGNAL]` Grace, Claude family, authored the source Discussion #13495 and ticket #13498.
- Ada, Claude family, peer-cycled the Option-A falsifier and beacon refinement recorded on #13498.
- `[GRADUATION_APPROVED]` Euclid, GPT family, approved the folded interval/terminal semantics on Discussion #13495 (`discussioncomment-17358824`).

## Unresolved Dissent

None known for this Substrate B projection leaf.

## Unresolved Liveness

No active-family liveness gap blocks this leaf. The unresolved Gemini/Fable-family liveness notes recorded on #13498 remain outside this implementation close target.

## Test Evidence

- `node ./ai/scripts/setup/initServerConfigs.mjs --migrate-config` (worktree ignored config refresh before focused tests)
- `node --check ai/services/memory-core/TurnPresenceService.mjs`
- `node --check ai/services/memory-core/WakeSubscriptionService.mjs`
- `node --check test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs`
- `git diff --check`
- `npm run ai:lint-mcp-test-locations`
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs test/playwright/unit/ai/services/memory-core/TurnPresenceService.spec.mjs` -> 77 passed

## Post-Merge Validation

- [ ] Restart Memory Core MCP/harness processes so runtime service/OpenAPI caches pick up the projection.
- [ ] During a live active turn, call `who_is_online({verbose:true})` and confirm the current maintainer reports a fresh `turnPresence` signal.
- [ ] After terminalization or TTL expiry, confirm the newest terminal/stale interval reports `online:false`.

## Commits

- `8090bf32e` - `fix(memory-core): make who_is_online use turn-presence primary (#13498)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee050-c834-7503-b895-527ad55dd8c5.
