### PR TITLE
feat(ai): add 'owned-but-blocked' lane-state continuation (#13605)

### DIFF
--- a/ai/scripts/lifecycle/parseLaneState.mjs
+++ b/ai/scripts/lifecycle/parseLaneState.mjs
@@ -28,7 +28,9 @@ export const LANE_STATE_BLOCK = /```lane-state\s*\r?\n([\s\S]*?)\r?\n```/g;
  *
  * @param {String} transcriptText The agent's final turn-terminal message text (or the transcript tail).
  * @returns {Object|null} The descriptor `{wakeDisposition, laneContinuation, namedGates, awaitingOwnPrOnly, backlogSurvey}`
- *   normalized from the LAST ```lane-state block, or `null` when no block is present.
+ *   normalized from the LAST ```lane-state block, or `null` when no block is present. `namedGates`
+ *   entries pass through whole (e.g. `{ref, checkedAt, mergeClaim, field, blockReason}`); the valid
+ *   continuation set — incl. `owned-but-blocked` — is owned by `validateLaneStateTerminal`, never here.
  * @throws {Error} When a ```lane-state block IS present but its body is not valid JSON — a
  *   present-but-malformed emission is a distinct failure the hook logs separately from an absent one.
  */

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -29,10 +29,14 @@ export const LANE_CONTINUATIONS = ['active-lane', 'next-lane', 'blocker-routed',
  * "holding" (the idle-dodge the operator escalated on):
  *  - `peer-pending-artifact`    — a named peer owes the next step (their A2A / graph message exists);
  *  - `ticket-documented-sizing` — the lane's own ticket body documents the block / sizing;
- *  - `adr-grounded-pacing`      — an ADR's pacing / sequencing rule gates the lane.
+ *  - `adr-grounded-pacing`      — an ADR's pacing / sequencing rule gates the lane;
+ *  - `pr-pending-merge`         — a named PR gate awaiting merge (an own PR at the human merge gate, OR a
+ *    slice blocked on an unmerged dep): the PR's `mergedAt` is null. Rule 5 additionally requires its gate
+ *    to cite `field === 'mergedAt'`, reusing Rule 3's authoritative-merge-field discipline (a PR's
+ *    `state` / CLOSED is not unmerged-proof). This expresses the *canonical* owned-but-blocked shape.
  * @type {String[]}
  */
-export const OWNED_BUT_BLOCKED_REASONS = ['peer-pending-artifact', 'ticket-documented-sizing', 'adr-grounded-pacing'];
+export const OWNED_BUT_BLOCKED_REASONS = ['peer-pending-artifact', 'ticket-documented-sizing', 'adr-grounded-pacing', 'pr-pending-merge'];
 
 /**
  * Wake dispositions that answer only "engage this message?" — never "does the turn have a lane?".
@@ -56,9 +60,10 @@ export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
  *     or unscoped survey fails.
  *  5. `laneContinuation='owned-but-blocked'` (owned in-flight lanes all blocked ≠ verified-no-lane) needs
  *     DUAL evidence: (a) at least one `namedGates` entry, EACH with a `blockReason` in
- *     `OWNED_BUT_BLOCKED_REASONS` (externally-verifiable, not a bare "holding"); AND (b) a full-backlog
- *     survey (`scope='full-backlog'`), proving no UNCLAIMED-claimable lane either. (Per-gate `checkedAt`
- *     is enforced by Rule 3.)
+ *     `OWNED_BUT_BLOCKED_REASONS` (externally-verifiable, not a bare "holding") — and a `pr-pending-merge`
+ *     reason additionally must cite `field === 'mergedAt'` (reusing Rule 3's authoritative-merge-field
+ *     discipline); AND (b) a full-backlog survey (`scope='full-backlog'`), proving no UNCLAIMED-claimable
+ *     lane either. (Per-gate `checkedAt` is enforced by Rule 3.)
  *
  * @param {Object} [laneState={}]
  * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
@@ -125,6 +130,8 @@ export function validateLaneStateTerminal(laneState = {}) {
                 violations.push(`owned-but-blocked gate ${gate?.ref ?? '(unnamed)'} must cite a blockReason — a bare "holding" with no externally-verifiable block is the idle-dodge.`);
             } else if (!OWNED_BUT_BLOCKED_REASONS.includes(gate.blockReason)) {
                 violations.push(`owned-but-blocked gate ${gate?.ref ?? '(unnamed)'} cites blockReason '${gate.blockReason}', not an externally-verifiable one (${OWNED_BUT_BLOCKED_REASONS.join(', ')}).`);
+            } else if (gate.blockReason === 'pr-pending-merge' && gate.field !== 'mergedAt') {
+                violations.push(`owned-but-blocked gate ${gate?.ref ?? '(unnamed)'} cites 'pr-pending-merge' but field ${gate.field ? `'${gate.field}'` : '(none)'} — pending-merge must read mergedAt (a PR's state/CLOSED is not unmerged-proof; mirrors Rule 3's merge-claim discipline).`);
             }
         }
 

--- a/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
+++ b/ai/scripts/lifecycle/validateLaneStateTerminal.mjs
@@ -14,9 +14,25 @@
 
 /**
  * The lane-continuation states that answer "may the turn end?".
+ *
+ * `verified-no-lane` means **no actionable-CLAIMABLE lane** (backed by a full-backlog survey) — NOT
+ * literally zero-lane. An agent whose OWNED in-flight lanes are all blocked/gated (own PRs at the human
+ * merge gate, a lane handed to a peer, a slice blocked on an unmerged dep) is in `owned-but-blocked`,
+ * categorically distinct from zero-lane — so it must not be forced to assert a false `verified-no-lane`.
  * @type {String[]}
  */
-export const LANE_CONTINUATIONS = ['active-lane', 'next-lane', 'blocker-routed', 'verified-no-lane'];
+export const LANE_CONTINUATIONS = ['active-lane', 'next-lane', 'blocker-routed', 'owned-but-blocked', 'verified-no-lane'];
+
+/**
+ * Externally-verifiable block reasons that justify an `owned-but-blocked` gate — each is checkable by a
+ * third party (the cited artifact provably exists), which is what separates it from a bare, unverifiable
+ * "holding" (the idle-dodge the operator escalated on):
+ *  - `peer-pending-artifact`    — a named peer owes the next step (their A2A / graph message exists);
+ *  - `ticket-documented-sizing` — the lane's own ticket body documents the block / sizing;
+ *  - `adr-grounded-pacing`      — an ADR's pacing / sequencing rule gates the lane.
+ * @type {String[]}
+ */
+export const OWNED_BUT_BLOCKED_REASONS = ['peer-pending-artifact', 'ticket-documented-sizing', 'adr-grounded-pacing'];
 
 /**
  * Wake dispositions that answer only "engage this message?" — never "does the turn have a lane?".
@@ -35,15 +51,21 @@ export const NON_TERMINAL_DISPOSITIONS = ['awareness', 'stale', 'suppressed'];
  *  3. Every named PR/issue gate must cite a same-turn `checkedAt` (stale gate names are not evidence);
  *     a gate flagged `mergeClaim` must cite `field === 'mergedAt'` (reading a PR's `state`/CLOSED is
  *     not merge proof — a closed PR may be un-merged).
- *  4. `laneContinuation='verified-no-lane'` must cite a NAMED full-backlog survey artifact with a
- *     `checkedAt` AND `scope === 'full-backlog'` — an own-PR-only, own-epic-only, or unscoped survey fails.
+ *  4. `laneContinuation='verified-no-lane'` (no actionable-CLAIMABLE lane) must cite a NAMED full-backlog
+ *     survey artifact with a `checkedAt` AND `scope === 'full-backlog'` — an own-PR-only, own-epic-only,
+ *     or unscoped survey fails.
+ *  5. `laneContinuation='owned-but-blocked'` (owned in-flight lanes all blocked ≠ verified-no-lane) needs
+ *     DUAL evidence: (a) at least one `namedGates` entry, EACH with a `blockReason` in
+ *     `OWNED_BUT_BLOCKED_REASONS` (externally-verifiable, not a bare "holding"); AND (b) a full-backlog
+ *     survey (`scope='full-backlog'`), proving no UNCLAIMED-claimable lane either. (Per-gate `checkedAt`
+ *     is enforced by Rule 3.)
  *
  * @param {Object} [laneState={}]
  * @param {String} [laneState.wakeDisposition] One of `actionable|awareness|stale|suppressed|incident`.
- * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed|verified-no-lane`.
- * @param {Object[]} [laneState.namedGates] Named PR/issue gates this terminal cites: `[{ref, checkedAt, mergeClaim?, field?}]`.
+ * @param {String} [laneState.laneContinuation] One of `active-lane|next-lane|blocker-routed|owned-but-blocked|verified-no-lane`.
+ * @param {Object[]} [laneState.namedGates] Named PR/issue gates: `[{ref, checkedAt, mergeClaim?, field?, blockReason?}]` (`blockReason` required per gate for `owned-but-blocked`).
  * @param {Boolean} [laneState.awaitingOwnPrOnly] True when the only cited lane is an own PR awaiting merge/review/CI.
- * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` backing a `verified-no-lane` claim; `scope` must be `'full-backlog'`.
+ * @param {Object} [laneState.backlogSurvey] `{checkedAt, scope}` backing a `verified-no-lane` or `owned-but-blocked` claim; `scope` must be `'full-backlog'`.
  * @returns {{valid: Boolean, violations: String[]}} `valid` is true when no rule is violated.
  */
 export function validateLaneStateTerminal(laneState = {}) {
@@ -89,6 +111,25 @@ export function validateLaneStateTerminal(laneState = {}) {
             violations.push('verified-no-lane must cite a named full-backlog survey artifact (e.g. list_issues / gh issue list) with a checkedAt.');
         } else if (backlogSurvey.scope !== 'full-backlog') {
             violations.push(`verified-no-lane requires a full-backlog survey scope (got ${backlogSurvey.scope ? `'${backlogSurvey.scope}'` : 'no scope'}) — own-PR-only / own-epic-only / unscoped surveys fail.`);
+        }
+    }
+
+    // Rule 5 — owned-but-blocked needs verifiable per-gate blocks AND a full-backlog survey (the anti-idle-dodge).
+    if (laneContinuation === 'owned-but-blocked') {
+        if (namedGates.length === 0) {
+            violations.push('owned-but-blocked must cite at least one named in-flight lane (namedGates) — with no owned lane, the honest terminal is verified-no-lane, not owned-but-blocked.');
+        }
+
+        for (const gate of namedGates) {
+            if (!gate?.blockReason) {
+                violations.push(`owned-but-blocked gate ${gate?.ref ?? '(unnamed)'} must cite a blockReason — a bare "holding" with no externally-verifiable block is the idle-dodge.`);
+            } else if (!OWNED_BUT_BLOCKED_REASONS.includes(gate.blockReason)) {
+                violations.push(`owned-but-blocked gate ${gate?.ref ?? '(unnamed)'} cites blockReason '${gate.blockReason}', not an externally-verifiable one (${OWNED_BUT_BLOCKED_REASONS.join(', ')}).`);
+            }
+        }
+
+        if (!backlogSurvey?.checkedAt || backlogSurvey.scope !== 'full-backlog') {
+            violations.push('owned-but-blocked must ALSO cite a full-backlog survey (scope=full-backlog) — proving no UNCLAIMED-claimable lane either, not just that owned lanes are blocked.');
         }
     }
 

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -110,4 +110,57 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
         });
         expect(result.valid).toBe(true);
     });
+
+    test('owned-but-blocked passes with verifiable per-gate blocks + a full-backlog survey', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'owned-but-blocked',
+            namedGates      : [
+                {ref: 'PR #13602', checkedAt: NOW, blockReason: 'peer-pending-artifact'},
+                {ref: '#13601',    checkedAt: NOW, blockReason: 'ticket-documented-sizing'}
+            ],
+            backlogSurvey: {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(true);
+        expect(result.violations).toEqual([]);
+    });
+
+    test('owned-but-blocked fails on a bare gate with no blockReason (the holding idle-dodge)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'owned-but-blocked',
+            namedGates      : [{ref: 'PR #13602', checkedAt: NOW}],   // checkedAt but no blockReason
+            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('must cite a blockReason');
+    });
+
+    test('owned-but-blocked fails when a blockReason is not externally-verifiable (e.g. "fresh-head")', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'owned-but-blocked',
+            namedGates      : [{ref: 'PR #13602', checkedAt: NOW, blockReason: 'fresh-head'}],
+            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('not an externally-verifiable one');
+    });
+
+    test('owned-but-blocked fails without a full-backlog survey (owned-blocked is not no-claimable-lane)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'owned-but-blocked',
+            namedGates      : [{ref: 'PR #13602', checkedAt: NOW, blockReason: 'peer-pending-artifact'}]
+            // no backlogSurvey
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('full-backlog survey');
+    });
+
+    test('owned-but-blocked fails with no named in-flight lane (that state is verified-no-lane)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'owned-but-blocked',
+            namedGates      : [],
+            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('at least one named in-flight lane');
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/validateLaneStateTerminal.spec.mjs
@@ -163,4 +163,24 @@ test.describe('validateLaneStateTerminal — turn-terminal evidence shape', () =
         expect(result.valid).toBe(false);
         expect(result.violations.join(' ')).toContain('at least one named in-flight lane');
     });
+
+    test('owned-but-blocked accepts pr-pending-merge when the gate cites field mergedAt (the canonical own-PR-at-gate case)', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'owned-but-blocked',
+            namedGates      : [{ref: 'PR #13602', checkedAt: NOW, blockReason: 'pr-pending-merge', field: 'mergedAt'}],
+            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(true);
+        expect(result.violations).toEqual([]);
+    });
+
+    test('owned-but-blocked rejects pr-pending-merge that cites state instead of mergedAt', () => {
+        const result = validateLaneStateTerminal({
+            laneContinuation: 'owned-but-blocked',
+            namedGates      : [{ref: 'PR #13602', checkedAt: NOW, blockReason: 'pr-pending-merge', field: 'state'}],
+            backlogSurvey   : {checkedAt: NOW, scope: 'full-backlog'}
+        });
+        expect(result.valid).toBe(false);
+        expect(result.violations.join(' ')).toContain('pending-merge must read mergedAt');
+    });
 });


### PR DESCRIPTION
## Summary

Adds the 5th `laneContinuation` — **`owned-but-blocked`** — to `validateLaneStateTerminal` (the lane-state validator merged via #13589's Stop hook). It closes a real gap: `verified-no-lane` means *no actionable-CLAIMABLE lane* (backed by a full-backlog survey), but an agent whose OWNED in-flight lanes are all blocked/gated — own PRs at the human merge gate, a lane handed to a peer, a slice blocked on an unmerged dep — was forced to assert a false `verified-no-lane`. `owned-but-blocked` is the honest, categorically-distinct state.

**Loophole-proof via DUAL evidence (the anti-idle-dodge, converged @neo-opus-ada + @neo-opus-grace):**
- (a) at least one `namedGates` entry, EACH with a same-turn `checkedAt` (Rule 3) AND an externally-verifiable `blockReason` — one of `peer-pending-artifact` / `ticket-documented-sizing` / `adr-grounded-pacing` / `pr-pending-merge` (each checkable by a third party: the A2A message / ticket body / ADR / the PR's `mergedAt:null`), vs a bare unverifiable "holding". `pr-pending-merge` is the **canonical** case (own PR at the merge gate, or a slice blocked on an unmerged dep) and additionally must cite `field='mergedAt'`, reusing Rule 3's authoritative-merge-field discipline;
- (b) a full-backlog survey (`scope='full-backlog'`) — proving no UNCLAIMED-claimable lane either.

Also clarifies `verified-no-lane` = "no actionable-claimable lane" (not literally zero-lane), so the name stops inviting the wrong read.

Resolves #13605

## Evidence

Evidence: L1/L2 (the pure validator is fully unit-tested — the new Rule 5 + the existing 4 — and `parseLaneState` carries the new field through) → no L3/L4 required (pure function; the #13589 Stop hook delegates to this validator continuation-agnostically, so the new state flows through without a hook change).

## Test Evidence

```
node --check: validateLaneStateTerminal.mjs + parseLaneState.mjs — pass
validateLaneStateTerminal.spec : 21 passed (+ parseLaneState.spec : 7)
  + 7 owned-but-blocked cases: valid · bare-block → rejected · non-verifiable-blockReason → rejected ·
    missing-survey → rejected · no-named-gate → rejected · pr-pending-merge + field=mergedAt → valid ·
    pr-pending-merge + field=state → rejected
block-alignment --fix : clean
```

## Post-Merge Validation

- [ ] When the #13589 Stop hook is activated (operator), an `owned-but-blocked` terminal with dual evidence validates (not blocked); a bare "holding" with no verifiable block still blocks.

## Deltas

- `parseLaneState` is continuation-agnostic by design — no code change; its doc now notes `namedGates` carry `blockReason` through and the continuation set is validator-owned.
- The #13589 Stop hook delegates to the validator (no enumeration) → no hook change. The workflow skill payloads don't enumerate the continuation set → no skill-payload change. So the change is contained to the validator + its spec (+ the parser doc).
- Design converged @neo-opus-ada (author, from ~20 lived terminals this session) + @neo-opus-grace; refines #13575 / #13589 / #12633.
- **Design-author fold-in (@neo-opus-ada, on this PR):** added the 4th reason `pr-pending-merge`. #13605's prose cited "own PR at the merge gate" + "slice blocked on an unmerged dep" but its reason-set omitted them — the *canonical* owned-but-blocked shape; folded in (head `1164fe5cb`) so the enum expresses its own motivating case, reusing Rule 3's `field='mergedAt'` machinery.

Authored by Vega (Claude Opus 4.8, Claude Code). Session a49940b9.
