### PR TITLE
feat(memory-core): expose full Chroma vector drift ids (#13496)

### DIFF
--- a/ai/scripts/maintenance/checkChromaIntegrity.mjs
+++ b/ai/scripts/maintenance/checkChromaIntegrity.mjs
@@ -1,15 +1,15 @@
-import {program}                      from 'commander';
-import {ChromaClient}                 from 'chromadb';
-import {execFile}                     from 'child_process';
-import fs                             from 'fs-extra';
-import os                             from 'os';
-import path                           from 'path';
-import {pathToFileURL}                from 'url';
-import {promisify}                    from 'util';
-import Neo                            from '../../../src/Neo.mjs';
-import AiConfig                       from '../../config.mjs';
-import kbConfig                       from '../../mcp/server/knowledge-base/config.mjs';
-import mcConfig                       from '../../mcp/server/memory-core/config.mjs';
+import {program}       from 'commander';
+import {ChromaClient}  from 'chromadb';
+import {execFile}      from 'child_process';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'path';
+import {pathToFileURL} from 'url';
+import {promisify}     from 'util';
+import Neo             from '../../../src/Neo.mjs';
+import AiConfig        from '../../config.mjs';
+import kbConfig        from '../../mcp/server/knowledge-base/config.mjs';
+import mcConfig        from '../../mcp/server/memory-core/config.mjs';
 import {
     createDynamicTextEmbeddingFunction,
     registerNeoChromaEmbeddingFunctions
@@ -357,47 +357,78 @@ export async function readVectorIndexIds({
 }
 
 /**
- * @summary Computes exact overlap and drift samples between SQLite metadata ids and HNSW vector ids.
+ * @summary Enumerates exact id overlap and drift between SQLite metadata rows and HNSW vector ids.
  * @param {Object} options
  * @param {String[]} [options.metadataIds=[]]
  * @param {String[]} [options.vectorIds=[]]
- * @param {Number} [options.sampleSize=DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE]
- * @returns {Object}
+ * @returns {{allIds: String[], vectorIds: String[], missingVectorIds: String[], extraVectorIds: String[], overlapCount: Number}}
  */
-export function compareMetadataToVectorIds({
+export function enumerateMetadataVectorDrift({
     metadataIds = [],
-    vectorIds   = [],
-    sampleSize  = DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE
+    vectorIds   = []
 } = {}) {
     const metadataSet = new Set(metadataIds),
           vectorSet   = new Set(vectorIds),
+          allIds      = [...metadataSet],
           missing     = [],
           extra       = [];
 
     let overlapCount = 0;
 
-    for (const id of metadataSet) {
+    for (const id of allIds) {
         if (vectorSet.has(id)) {
             overlapCount++;
-        } else if (missing.length < sampleSize) {
+        } else {
             missing.push(id);
         }
     }
 
     for (const id of vectorSet) {
-        if (!metadataSet.has(id) && extra.length < sampleSize) {
+        if (!metadataSet.has(id)) {
             extra.push(id);
         }
     }
 
     return {
-        metadataRowCount      : metadataSet.size,
-        vectorIndexIdCount    : vectorSet.size,
-        overlapCount,
-        missingFromVectorCount: metadataSet.size - overlapCount,
-        extraInVectorCount    : vectorSet.size - overlapCount,
-        missingFromVectorSample: missing,
-        extraInVectorSample   : extra
+        allIds,
+        vectorIds       : [...vectorSet],
+        missingVectorIds: missing,
+        extraVectorIds  : extra,
+        overlapCount
+    }
+}
+
+/**
+ * @summary Computes exact overlap counts and bounded drift samples between SQLite metadata ids and HNSW vector ids.
+ * @param {Object} options
+ * @param {String[]} [options.metadataIds=[]]
+ * @param {String[]} [options.vectorIds=[]]
+ * @param {Number} [options.sampleSize=DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE]
+ * @param {Boolean} [options.includeFullIds=false] Include full id lists for repair tooling.
+ * @returns {Object}
+ */
+export function compareMetadataToVectorIds({
+    metadataIds     = [],
+    vectorIds       = [],
+    sampleSize      = DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE,
+    includeFullIds  = false
+} = {}) {
+    const drift = enumerateMetadataVectorDrift({metadataIds, vectorIds});
+
+    return {
+        metadataRowCount       : drift.allIds.length,
+        vectorIndexIdCount     : drift.vectorIds.length,
+        overlapCount           : drift.overlapCount,
+        missingFromVectorCount : drift.missingVectorIds.length,
+        extraInVectorCount     : drift.extraVectorIds.length,
+        missingFromVectorSample: drift.missingVectorIds.slice(0, sampleSize),
+        extraInVectorSample    : drift.extraVectorIds.slice(0, sampleSize),
+        ...(includeFullIds ? {
+            allIds          : drift.allIds,
+            vectorIds       : drift.vectorIds,
+            missingVectorIds: drift.missingVectorIds,
+            extraVectorIds  : drift.extraVectorIds
+        } : {})
     }
 }
 
@@ -408,6 +439,7 @@ export function compareMetadataToVectorIds({
  * @param {String} options.persistDir
  * @param {String[]} [options.collectionNames=[]]
  * @param {Number} [options.sampleSize=DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE]
+ * @param {Boolean} [options.includeFullIds=false]
  * @param {Function} [options.execFn=execFileAsync]
  * @param {Object} [options.fsModule=fs]
  * @returns {Promise<Object>}
@@ -417,6 +449,7 @@ export async function auditChromaVectorCoverage({
     persistDir,
     collectionNames = [],
     sampleSize      = DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE,
+    includeFullIds  = false,
     execFn          = execFileAsync,
     fsModule        = fs
 } = {}) {
@@ -453,7 +486,8 @@ export async function auditChromaVectorCoverage({
               comparison = compareMetadataToVectorIds({
                   metadataIds,
                   vectorIds : vectorResult.ids,
-                  sampleSize: normalizeVectorCoverageSampleSize(sampleSize)
+                  sampleSize: normalizeVectorCoverageSampleSize(sampleSize),
+                  includeFullIds
               }),
               ok = vectorResult.ok &&
                   comparison.missingFromVectorCount === 0 &&
@@ -783,6 +817,11 @@ export async function run(argv = process.argv) {
             'Number of missing/extra ids to preview for vector coverage drift.',
             String(DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE)
         )
+        .option(
+            '--include-vector-coverage-ids',
+            'Include full metadata/vector/missing/extra id lists in vector coverage output for repair planning.',
+            false
+        )
         .option('--keep-snapshot', 'Keep the copied SQLite snapshot instead of removing the temp dir.', false)
         .option('--json', 'Print machine-readable JSON.', false)
         .parse(argv);
@@ -798,7 +837,7 @@ export async function run(argv = process.argv) {
             checks      : []
         },
         coverage: null,
-        api: null
+        api     : null
     };
 
     for (const pragma of ['quick_check', 'integrity_check']) {
@@ -811,10 +850,11 @@ export async function run(argv = process.argv) {
     if (!options.skipVectorCoverage) {
         try {
             result.coverage = await auditChromaVectorCoverage({
-                snapshotPath    : snapshot.snapshotPath,
-                persistDir      : path.dirname(sourcePath),
-                collectionNames : resolveCollectionNames(),
-                sampleSize      : normalizeVectorCoverageSampleSize(options.vectorCoverageSampleSize)
+                snapshotPath   : snapshot.snapshotPath,
+                persistDir     : path.dirname(sourcePath),
+                collectionNames: resolveCollectionNames(),
+                sampleSize     : normalizeVectorCoverageSampleSize(options.vectorCoverageSampleSize),
+                includeFullIds : Boolean(options.includeVectorCoverageIds)
             });
         } catch (error) {
             result.coverage = {

--- a/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs
@@ -1,8 +1,8 @@
-import {execFile} from 'child_process';
-import fs         from 'fs-extra';
-import os         from 'os';
-import path       from 'path';
-import {promisify} from 'util';
+import {execFile}     from 'child_process';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+import {promisify}    from 'util';
 import {test, expect} from '@playwright/test';
 import {
     auditChromaVectorCoverage,
@@ -11,6 +11,7 @@ import {
     countFailedApiSteps,
     DEFAULT_STORED_EMBEDDING_EXPORTABILITY_SAMPLE_SIZE,
     DEFAULT_VECTOR_COVERAGE_SAMPLE_SIZE,
+    enumerateMetadataVectorDrift,
     normalizeExportabilitySampleSize,
     normalizeVectorCoverageSampleSize,
     probeCollection,
@@ -104,6 +105,33 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
             extraInVectorCount     : 2,
             missingFromVectorSample: ['c'],
             extraInVectorSample    : ['extra-1']
+        });
+    });
+
+    test('enumerates full metadata/vector drift ids for repair planning', () => {
+        expect(enumerateMetadataVectorDrift({
+            metadataIds: ['a', 'b', 'missing-a', 'missing-b'],
+            vectorIds  : ['a', 'extra']
+        })).toEqual({
+            allIds          : ['a', 'b', 'missing-a', 'missing-b'],
+            vectorIds       : ['a', 'extra'],
+            missingVectorIds: ['b', 'missing-a', 'missing-b'],
+            extraVectorIds  : ['extra'],
+            overlapCount    : 1
+        });
+
+        expect(compareMetadataToVectorIds({
+            metadataIds   : ['a', 'b', 'missing-a', 'missing-b'],
+            vectorIds     : ['a', 'extra'],
+            sampleSize    : 1,
+            includeFullIds: true
+        })).toMatchObject({
+            missingFromVectorSample: ['b'],
+            extraInVectorSample    : ['extra'],
+            allIds                 : ['a', 'b', 'missing-a', 'missing-b'],
+            vectorIds              : ['a', 'extra'],
+            missingVectorIds       : ['b', 'missing-a', 'missing-b'],
+            extraVectorIds         : ['extra']
         });
     });
 
@@ -307,7 +335,8 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
                 snapshotPath   : sqlitePath,
                 persistDir     : tmpDir,
                 collectionNames: ['neo-native-graph'],
-                sampleSize     : 2
+                sampleSize     : 2,
+                includeFullIds : true
             });
 
             expect(result.duplicateCollectionNames).toEqual([{
@@ -329,7 +358,10 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
                 missingFromVectorCount : 1,
                 extraInVectorCount     : 1,
                 missingFromVectorSample: ['missing'],
-                extraInVectorSample    : ['extra']
+                extraInVectorSample    : ['extra'],
+                allIds                 : ['a', 'b', 'c', 'missing'],
+                missingVectorIds       : ['missing'],
+                extraVectorIds         : ['extra']
             });
 
             const missing = result.collections.find(row => row.collectionId === 'collection-b');
@@ -341,7 +373,10 @@ test.describe('checkChromaIntegrity maintenance helpers', () => {
                 missingFromVectorCount : 1,
                 extraInVectorCount     : 0,
                 missingFromVectorSample: ['orphan'],
-                extraInVectorSample    : []
+                extraInVectorSample    : [],
+                allIds                 : ['orphan'],
+                missingVectorIds       : ['orphan'],
+                extraVectorIds         : []
             });
             expect(missing.error).toContain('Vector index metadata file not found');
         } finally {


### PR DESCRIPTION
Resolves #13612
Related: #13496

Exposes exact Chroma metadata/vector drift IDs from `checkChromaIntegrity` so the repair lane can enumerate every SQLite metadata row missing from the HNSW vector index before any write-side repair is attempted. The helper keeps existing sample-limited audit output by default and adds a CLI flag for full id payloads when repair planning explicitly needs them.

Evidence: L2 (focused unit coverage + syntax/alignment/pre-commit checks) -> L2 required (maintenance script API/CLI and unit coverage).

## Deltas from ticket (if any)

- Implements #13612 only: the AC2 prerequisite for parent #13496, full uncapped drift enumeration in the existing integrity checker.
- Adds `enumerateMetadataVectorDrift()` and `includeFullIds` plumbing through vector coverage audit/CLI.
- Keeps default audit output sample-bounded; full ID lists are opt-in via `--include-vector-coverage-ids`.
- Does not ship live repair writes, defrag automation, close parent #13496, or depend on unmerged #13603.

## Test Evidence

- `node --check ai/scripts/maintenance/checkChromaIntegrity.mjs` -> passed
- `node buildScripts/util/check-block-alignment.mjs ai/scripts/maintenance/checkChromaIntegrity.mjs test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` -> passed
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/CheckChromaIntegrity.spec.mjs` -> 13 passed
- `git diff origin/dev..HEAD --check` -> passed
- pre-commit hook -> passed (`check-whitespace`, `check-shorthand`, `check-aiconfig-test-mutation`, `check-jsdoc-types`, `check-ticket-archaeology`, `check-block-alignment`)

## Post-Merge Validation

- [ ] Run the full-id vector coverage audit on the affected Memory Core Chroma persist directory before enabling any write-side repair action.
- [ ] Reconcile this enumeration substrate with #13603 if that PR merges first; the repair implementation should consume the same full drift list rather than re-sampling.

## Commits

- `7b465c30f` - expose full Chroma vector drift ids

Authored by Euclid (GPT-5.5, Codex Desktop). Session 019ee050-c834-7503-b895-527ad55dd8c5.
