### PR TITLE
feat(memory-core): tenant-scope who_is_online AgentIdentity roster read (#13600)

### DIFF
--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -592,10 +592,32 @@ class WakeSubscriptionService extends Base {
         const sqlite = GraphService.db?.storage?.db;
         if (!sqlite) return [];
 
-        const rows  = sqlite.prepare(`
-            SELECT data FROM Nodes
-            WHERE json_extract(data, '$.label') = 'AgentIdentity'
-        `).all();
+        // Tenant-scope the roster read (the who_is_online visibility boundary). A caller
+        // sees its OWN tenant's agents (properties.userId === the caller's tenant) PLUS the globally-
+        // visible core swarm (userId IS NULL — the named maintainers, seeded via upsertGlobalNode),
+        // and NOT other tenants' agents. With no bound tenant (single-tenant / stdio swarm,
+        // getUserId() falsy) only the core swarm surfaces — which IS the swarm roster. Isolation
+        // lives HERE at the roster scope; the per-identity reads downstream (_readActivityRecency,
+        // turn-presence) inherit it because they only run for rostered identities. Per-caller RLS on
+        // those reads is the WRONG layer — it would hide same-tenant teammates (see _readActivityRecency).
+        const currentUserId = RequestContextService.getUserId(),
+              params        = currentUserId ? [currentUserId] : [],
+              rosterScope   = currentUserId
+                  ? `AND (json_extract(data, '$.properties.userId') IS NULL OR json_extract(data, '$.properties.userId') = ?)`
+                  : `AND json_extract(data, '$.properties.userId') IS NULL`;
+
+        let rows;
+        try {
+            rows = sqlite.prepare(`
+                SELECT data FROM Nodes
+                WHERE json_extract(data, '$.label') = 'AgentIdentity'
+                ${rosterScope}
+            `).all(...params);
+        } catch (error) {
+            logger.warn(`[WakeSubscription] who_is_online: tenant-scoped roster read failed: ${error.message}`);
+            return [];
+        }
+
         const nodes = [];
 
         for (const row of rows) {
@@ -670,8 +692,8 @@ class WakeSubscriptionService extends Base {
      * ({@link WakeSubscriptionService#_listAgentIdentityNodes}), not the per-caller tenant: raw
      * AGENT_MEMORY is tagged with each agent's own per-agent `userId`, so a per-caller `user_id` RLS
      * filter here would hide same-deployment teammates from each other.
-     * Cross-tenant isolation for a multi-tenant cloud belongs at the roster scope (a tenant-scoped
-     * `_listAgentIdentityNodes`), tracked separately. It reads the durable graph node, not Chroma, so it
+     * Cross-tenant isolation for a multi-tenant cloud is enforced at the roster scope — the AgentIdentity
+     * roster read (`_listAgentIdentityNodes`) is tenant-scoped. It reads the durable graph node, not Chroma, so it
      * survives an embed-drain; and `add_memory` is the universal activity write (no harness hook, no
      * per-deployment beacon), so the signal works identically in the swarm and a multi-tenant cloud.
      *
@@ -695,8 +717,8 @@ class WakeSubscriptionService extends Base {
         // same-deployment teammates from each other. (getAgentIdentityNodeId
         // is explicitly "NOT for isolation" per RequestContextService, and the prior filter keyed on
         // it against the normalizeUserId'd user_id column, so it never matched own writes either.)
-        // Cross-tenant isolation for a multi-tenant cloud belongs at the roster scope (tenant-scoped
-        // _listAgentIdentityNodes), tracked separately — not by isolating roster teammates here.
+        // Cross-tenant isolation for a multi-tenant cloud is enforced at the roster scope (tenant-scoped
+        // _listAgentIdentityNodes) — not by isolating roster teammates here.
         let latest;
         try {
             const row = sqlite.prepare(`

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -13,12 +13,12 @@ setup({
     }
 });
 
-import {test, expect}        from '@playwright/test';
-import crypto                from 'crypto';
-import fs                    from 'fs-extra';
-import path                  from 'path';
-import Neo                   from '../../../../../../src/Neo.mjs';
-import * as core             from '../../../../../../src/core/_export.mjs';
+import {test, expect} from '@playwright/test';
+import crypto         from 'crypto';
+import fs             from 'fs-extra';
+import path           from 'path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
 
 // Stub Neo.get to keep data-record boot behavior from masking wake-subscription coverage.
 // The setup regression is outside this spec's delivery contract.
@@ -126,17 +126,17 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 harnessTargetMetadata,
                 createdAt,
                 updatedAt,
-                userId      : owner,
-                sharedEntity: false,
+                userId       : owner,
+                sharedEntity : false,
                 status
             }
         };
         const edgeId = `EDGE:${crypto.randomUUID()}`;
         const edge = {
-            id    : edgeId,
-            source: owner,
-            target: subscriptionId,
-            type  : 'SUBSCRIBES_TO',
+            id        : edgeId,
+            source    : owner,
+            target    : subscriptionId,
+            type      : 'SUBSCRIBES_TO',
             properties: {
                 weight: 1,
                 userId: owner
@@ -158,13 +158,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         test('creates new subscription from identity template', async () => {
             // Give Alice a template
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -184,13 +184,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('bootstraps a volatile HarnessPresence overlay from boot address metadata (#12422)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -234,13 +234,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         test('returns existing subscription if it matches template (idempotent)', async () => {
             // Give Alice a template
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -258,33 +258,33 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('bootId mismatch plus dead pid retires stale HarnessPresence before upsert (#12422)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
             });
 
             GraphService.upsertNode({
-                id  : 'HARNESS_PRESENCE:@alice:old-boot',
-                type: 'HARNESS_PRESENCE',
-                name: 'HarnessPresence @alice',
+                id        : 'HARNESS_PRESENCE:@alice:old-boot',
+                type      : 'HARNESS_PRESENCE',
+                name      : 'HarnessPresence @alice',
                 properties: {
-                    agentIdentity: '@alice',
+                    agentIdentity : '@alice',
                     subscriptionId: 'WAKE_SUB:old',
-                    state        : 'idle',
-                    wakePolicy   : 'immediate',
-                    source       : 'mcp-client',
-                    bootId       : 'old-boot',
-                    pid          : 999999,
-                    lastSeenAt   : '2026-06-04T00:00:00.000Z',
-                    expiresAt    : '2026-06-04T00:10:00.000Z',
-                    status       : 'active'
+                    state         : 'idle',
+                    wakePolicy    : 'immediate',
+                    source        : 'mcp-client',
+                    bootId        : 'old-boot',
+                    pid           : 999999,
+                    lastSeenAt    : '2026-06-04T00:00:00.000Z',
+                    expiresAt     : '2026-06-04T00:10:00.000Z',
+                    status        : 'active'
                 }
             });
 
@@ -307,32 +307,32 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('TTL backstop retires HarnessPresence even without a pid (#12422)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
             });
 
             GraphService.upsertNode({
-                id  : 'HARNESS_PRESENCE:@alice:expired-boot',
-                type: 'HARNESS_PRESENCE',
-                name: 'HarnessPresence @alice',
+                id        : 'HARNESS_PRESENCE:@alice:expired-boot',
+                type      : 'HARNESS_PRESENCE',
+                name      : 'HarnessPresence @alice',
                 properties: {
-                    agentIdentity: '@alice',
+                    agentIdentity : '@alice',
                     subscriptionId: 'WAKE_SUB:expired',
-                    state        : 'idle',
-                    wakePolicy   : 'immediate',
-                    source       : 'mcp-client',
-                    bootId       : 'expired-boot',
-                    lastSeenAt   : '2026-06-04T00:00:00.000Z',
-                    expiresAt    : '2026-06-04T00:10:00.000Z',
-                    status       : 'active'
+                    state         : 'idle',
+                    wakePolicy    : 'immediate',
+                    source        : 'mcp-client',
+                    bootId        : 'expired-boot',
+                    lastSeenAt    : '2026-06-04T00:00:00.000Z',
+                    expiresAt     : '2026-06-04T00:10:00.000Z',
+                    status        : 'active'
                 }
             });
 
@@ -352,19 +352,19 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('recovers template from durable AgentIdentity row when cache is stale', async () => {
             GraphService.upsertNode({
-                id: '@neo-gpt',
-                type: 'AgentIdentity',
-                name: 'Codex',
+                id        : '@neo-gpt',
+                type      : 'AgentIdentity',
+                name      : 'Codex',
                 properties: {
-                    displayName: 'Codex',
-                    modelFamily: 'gpt',
+                    displayName         : 'Codex',
+                    modelFamily         : 'gpt',
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: {
-                            adapter: 'osascript',
-                            appName: 'Codex',
-                            tabShortcut: null,
+                            adapter     : 'osascript',
+                            appName     : 'Codex',
+                            tabShortcut : null,
                             focusSeedKey: 'r'
                         }
                     }
@@ -409,13 +409,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         test('reconciles duplicate active subscriptions at bootstrap, keeping newest (#11182)', async () => {
             // Give Alice a template
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -424,18 +424,18 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             // Seed 2 active subscriptions for @alice with identical route-tuple but
             // different creation times; only the newest route should remain active.
             const older = insertDurableSubscription({
-                subscriptionId: 'WAKE_SUB:older-uuid',
-                owner         : '@alice',
+                subscriptionId       : 'WAKE_SUB:older-uuid',
+                owner                : '@alice',
                 harnessTargetMetadata: {appName: 'Antigravity'},
-                createdAt     : '2026-05-08T17:57:00.000Z',
-                updatedAt     : '2026-05-08T17:57:00.000Z'
+                createdAt            : '2026-05-08T17:57:00.000Z',
+                updatedAt            : '2026-05-08T17:57:00.000Z'
             });
             const newer = insertDurableSubscription({
-                subscriptionId: 'WAKE_SUB:newer-uuid',
-                owner         : '@alice',
+                subscriptionId       : 'WAKE_SUB:newer-uuid',
+                owner                : '@alice',
                 harnessTargetMetadata: {appName: 'Antigravity'},
-                createdAt     : '2026-05-10T17:09:00.000Z',
-                updatedAt     : '2026-05-10T17:09:00.000Z'
+                createdAt            : '2026-05-10T17:09:00.000Z',
+                updatedAt            : '2026-05-10T17:09:00.000Z'
             });
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
@@ -461,13 +461,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('reconciler is idempotent on canonical single-active state (#11182)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -494,13 +494,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('reconciler retires N-1 when 3+ duplicates exist, keeping newest (#11182)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -545,13 +545,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             // harnessTarget + appName), not flatten by owner. Two legitimate routes
             // for the same agent must BOTH survive.
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -595,13 +595,13 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
         test('reconciler ignores already-retired or inactive subscriptions (#11182)', async () => {
             GraphService.upsertNode({
-                id: '@alice',
-                type: 'AGENT',
-                name: 'Alice',
+                id        : '@alice',
+                type      : 'AGENT',
+                name      : 'Alice',
                 properties: {
                     subscriptionTemplate: {
-                        trigger: 'SENT_TO_ME',
-                        harnessTarget: 'bridge-daemon',
+                        trigger              : 'SENT_TO_ME',
+                        harnessTarget        : 'bridge-daemon',
                         harnessTargetMetadata: { appName: 'Antigravity' }
                     }
                 }
@@ -708,8 +708,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe rejects non-canonical appName', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             await expect(WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'antigravity'}
             })).rejects.toThrow("Invalid appName 'antigravity'. Must be one of: Antigravity, Claude, Codex");
         });
@@ -721,7 +721,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 trigger              : 'SENT_TO_ME',
                 harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
-                    appName: 'Antigravity',
+                    appName        : 'Antigravity',
                     instanceAddress: '4242'
                 }
             })).rejects.toThrow('Shape C instance addressing requires harnessTargetMetadata.addressType');
@@ -734,9 +734,9 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 trigger              : 'SENT_TO_ME',
                 harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {
-                    appName: 'Antigravity',
+                    appName        : 'Antigravity',
                     instanceAddress: 'frontmost',
-                    addressType: 'frontmost'
+                    addressType    : 'frontmost'
                 }
             })).rejects.toThrow("Invalid addressType 'frontmost'. Must be one of: userDataDir, pid, tmuxSession, webhookUrl");
         });
@@ -788,8 +788,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe accepts canonical appName Antigravity', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             const res = await WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'Antigravity'}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
@@ -799,8 +799,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe accepts canonical appName Claude', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             const res = await WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'Claude'}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
@@ -810,8 +810,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     test('subscribe accepts canonical appName Codex', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
             const res = await WakeSubscriptionService.subscribe({
-                trigger      : 'SENT_TO_ME',
-                harnessTarget: 'bridge-daemon',
+                trigger              : 'SENT_TO_ME',
+                harnessTarget        : 'bridge-daemon',
                 harnessTargetMetadata: {appName: 'Codex'}
             });
             expect(res.subscriptionId).toMatch(/^WAKE_SUB:/);
@@ -1321,7 +1321,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 // mcp-notifications bypasses coalescing window and pushes immediately
                 await WakeSubscriptionService.subscribe({
-                    trigger: 'SENT_TO_ME',
+                    trigger      : 'SENT_TO_ME',
                     harnessTarget: 'mcp-notifications'
                 });
             });
@@ -1352,7 +1352,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
-                    trigger: 'SENT_TO_ME',
+                    trigger      : 'SENT_TO_ME',
                     harnessTarget: 'mcp-notifications'
                 });
             });
@@ -1546,9 +1546,9 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
                 await WakeSubscriptionService.subscribe({
-                    trigger: 'SENT_TO_ME',
+                    trigger      : 'SENT_TO_ME',
                     harnessTarget: 'mcp-notifications',
-                    filters: { priority: 'high' }
+                    filters      : { priority: 'high' }
                 });
             });
 

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1645,12 +1645,12 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
               T0ms = new Date(T0).getTime(),
               iso  = ms => new Date(ms).toISOString();
 
-        function seedAgent(id, {participationStatus = 'active', family = 'claude'} = {}) {
+        function seedAgent(id, {participationStatus = 'active', family = 'claude', userId} = {}) {
             GraphService.upsertNode({
                 id,
                 type      : 'AgentIdentity',
                 name      : id,
-                properties: {participationStatus, family, displayName: id}
+                properties: {participationStatus, family, displayName: id, userId}
             });
         }
 
@@ -1665,6 +1665,48 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
                 properties: {agentIdentity: owner, timestamp, sessionId: 'sess-test'}
             });
         }
+
+        // Tenant-scoped roster — multi-tenant cross-tenant isolation
+        test('tenant-scoped roster: a tenant sees its OWN agents + the core swarm, NOT other tenants', async () => {
+            seedAgent('@core-swarm');                        // userId undefined -> core swarm (globally visible)
+            seedAgent('@tenant-a-1', {userId: 'tenant-a'});
+            seedAgent('@tenant-a-2', {userId: 'tenant-a'});  // same-tenant teammate
+            seedAgent('@tenant-b-1', {userId: 'tenant-b'});
+
+            const result = await RequestContextService.run({userId: 'tenant-a'}, () =>
+                WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)}));
+            const ids    = result.agents.map(a => a.identity);
+
+            expect(ids).toContain('@core-swarm');     // shared baseline visible
+            expect(ids).toContain('@tenant-a-1');     // own agent
+            expect(ids).toContain('@tenant-a-2');     // same-tenant teammate NOT hidden
+            expect(ids).not.toContain('@tenant-b-1'); // cross-tenant isolated
+        });
+
+        test('tenant-scoped roster: a different tenant sees its own + core swarm, not tenant-a', async () => {
+            seedAgent('@core-swarm');
+            seedAgent('@tenant-a-1', {userId: 'tenant-a'});
+            seedAgent('@tenant-b-1', {userId: 'tenant-b'});
+
+            const result = await RequestContextService.run({userId: 'tenant-b'}, () =>
+                WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)}));
+            const ids    = result.agents.map(a => a.identity);
+
+            expect(ids).toEqual(expect.arrayContaining(['@core-swarm', '@tenant-b-1']));
+            expect(ids).not.toContain('@tenant-a-1');
+        });
+
+        test('no bound tenant (stdio swarm) -> only the core swarm surfaces, never a tenant roster', async () => {
+            seedAgent('@core-swarm');
+            seedAgent('@tenant-a-1', {userId: 'tenant-a'});
+
+            // no RequestContextService context -> getUserId() undefined -> core-swarm-only
+            const result = await WakeSubscriptionService.whoIsOnline({verbose: true, now: new Date(T0)});
+            const ids    = result.agents.map(a => a.identity);
+
+            expect(ids).toContain('@core-swarm');
+            expect(ids).not.toContain('@tenant-a-1');
+        });
 
         test('participationStatus hard gate: benched reports offline even with fresh activity (verbose)', async () => {
             seedAgent('@neo-benched', {participationStatus: 'operator_benched'});


### PR DESCRIPTION
## Summary

`who_is_online`'s roster read (`_listAgentIdentityNodes`) queried the full `AgentIdentity` node set with **no tenant filter** — in a multi-tenant cloud, every tenant's agents leaked into every other tenant's online view. This was the cross-tenant isolation gap the code itself documented as "tracked separately" (in `_readActivityRecency`'s doc-comment).

It now scopes the roster read to **the caller's tenant + the globally-visible core swarm**:

- `properties.userId === RequestContextService.getUserId()` — the caller's own tenant's agents
- `properties.userId IS NULL` — the core swarm (the named maintainers, seeded via `upsertGlobalNode`, which forces `userId: null`)
- every other tenant's agents are excluded

Isolation lives at the **roster scope** by design: the downstream per-identity reads (`_readActivityRecency`, turn-presence) only run for rostered identities, so they inherit the scope. A per-caller RLS filter on *those* reads would wrongly hide same-tenant teammates from each other — the anti-pattern `_readActivityRecency` explicitly documents against.

Resolves #13600.

## Deltas from ticket

None substantive — the diff implements the filed AC (tenant-scope the `who_is_online` AgentIdentity roster read). The only thing beyond the feature itself is a mechanical block-alignment drift re-align (commit 1) that the now-stricter `check-block-alignment` lint gate forces when the spec file is touched.

## Behavior / contract impact

- **Swarm (single-tenant / stdio): unchanged.** `getUserId()` is undefined, so the filter degrades to `userId IS NULL` = the core swarm = the whole swarm roster (exactly today's result). No swarm consumer sees any difference.
- **Multi-tenant cloud:** `who_is_online` returns only the caller's tenant + the shared core swarm. The prior cross-tenant visibility was the bug; the tool's output *shape* (`{agents: [...]}`) is unchanged, so no consumer signature/schema changes.

## Test Evidence

3 new multi-tenant unit tests (the `who_is_online` describe), exercising the real `getUserId()` + roster-filter seam with simulated tenants via `RequestContextService.run({userId})`:

- a tenant sees its own agents + the core swarm, **not** other tenants (and a same-tenant teammate is **not** hidden)
- a different tenant sees its own + core swarm, not the first tenant's
- no bound tenant (stdio swarm) -> only the core swarm surfaces

`npm run test-unit -- test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs -g "who_is_online"` -> **13/13 passed** (the 3 new + the 10 existing, no regression).

Evidence: L2 — unit tests exercise the real `getUserId()` + SQL-filter seam with simulated tenants; sufficient, since the close-target AC is the tenant-scope contract and is fully unit-covered. No runtime residual: single-tenant / swarm behavior is provably unchanged, and the multi-tenant path is the same seam at scale.

## Post-Merge Validation

None required for merge — the tenant-scope contract is fully unit-covered, and single-tenant / swarm behavior is provably unchanged (`getUserId()` is undefined there, so the filter degrades to the core swarm = today's roster). A live multi-tenant cloud deployment exercises the same `getUserId()` + roster-filter seam at scale; no separate runtime gate blocks merge.

## Commits

1. **chore** — re-align pre-existing block-alignment drift in the spec. Mechanical only: the now-stricter lint-staged `check-block-alignment` gate forces a whole-file re-align when the file is touched; split out so the feature diff stays reviewable.
2. **feat** — tenant-scope the roster read (`_listAgentIdentityNodes`) + the 3 multi-tenant tests + doc-comment updates.

---

Authored by Ada (Claude Opus 4.8, Claude Code). Session aab4962b-4da9-4b52-a212-3fda560d70ad.
