### PR TITLE
feat(codex): add Stop hook lane-state probe (#13622)

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.codex/hooks/codex-lane-state-stop.mjs\"",
+            "timeout": 10,
+            "statusMessage": "Checking Codex lane state"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.codex/hooks/codex-lane-state-stop.mjs
+++ b/.codex/hooks/codex-lane-state-stop.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+/**
+ * @module .codex/hooks/codex-lane-state-stop
+ * @summary Codex `Stop` hook for no-hold lane-state reminders, dry-run and fail-open.
+ *
+ * Codex documents `Stop` command hooks, but the current public hook contract does not document a
+ * Claude-style `{"decision":"block"}` stop-blocking protocol. This hook therefore proves the
+ * transport layer conservatively: it runs at Stop, resolves the final assistant text, reuses the
+ * existing lane-state parser/validator seam, and audit-logs what it would block. It never writes a
+ * blocking decision to stdout until a future ticket proves Codex block/inject semantics.
+ */
+import fs              from 'node:fs';
+import path            from 'node:path';
+import os              from 'node:os';
+import {pathToFileURL} from 'node:url';
+
+import {parseLaneState}            from '../../ai/scripts/lifecycle/parseLaneState.mjs';
+import {validateLaneStateTerminal} from '../../ai/scripts/lifecycle/validateLaneStateTerminal.mjs';
+
+export const CODEX_STOP_BLOCK_INJECTION_SUPPORTED = false;
+
+const LOG_DIR = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'codex-lane-state-hook');
+
+/**
+ * @summary Reads all of stdin, which Codex passes to command hooks as the event payload.
+ * @returns {Promise<String>}
+ * @protected
+ */
+function readStdin() {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        process.stdin.setEncoding('utf8');
+        process.stdin.on('data',  chunk => data += chunk);
+        process.stdin.on('end',   ()    => resolve(data));
+        process.stdin.on('error', reject);
+    });
+}
+
+/**
+ * @summary Best-effort append to the Codex Stop audit log; logging failures must never gate a turn.
+ * @param {String} line
+ * @param {Object} [options]
+ * @param {String} [options.logDir]
+ * @protected
+ */
+export function auditLog(line, {logDir = LOG_DIR} = {}) {
+    const logFile = path.join(logDir, 'codex-lane-state-stop-hook.log');
+
+    try {
+        fs.mkdirSync(logDir, {recursive: true});
+        fs.appendFileSync(logFile, `[${new Date().toISOString()}] ${line}\n`, 'utf8');
+    } catch (e) {
+        // best-effort; a log-write failure must never block a Codex turn-end
+    }
+}
+
+/**
+ * @summary Extracts plain text from Codex/Claude/OpenAI-shaped content containers.
+ * @param {*} content
+ * @returns {String}
+ * @protected
+ */
+function extractTextFromContent(content) {
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+        return content.map(block => {
+            if (typeof block === 'string') return block;
+            if (typeof block?.text === 'string') return block.text;
+            if (typeof block?.content === 'string') return block.content;
+            return '';
+        }).filter(Boolean).join('\n');
+    }
+    if (content && typeof content === 'object') {
+        if (typeof content.text === 'string') return content.text;
+        if (typeof content.content === 'string') return content.content;
+    }
+    return '';
+}
+
+/**
+ * @summary Extracts assistant text from a generic message-like object.
+ * @param {*} message
+ * @returns {String}
+ * @protected
+ */
+function extractTextFromMessage(message) {
+    if (typeof message === 'string') return message;
+    if (!message || typeof message !== 'object') return '';
+
+    return extractTextFromContent(
+        message.content ??
+        message.message?.content ??
+        message.text ??
+        message.message?.text ??
+        message.output_text ??
+        message.output
+    );
+}
+
+/**
+ * @summary Returns whether a message-like object represents assistant output.
+ * @param {Object} message
+ * @returns {Boolean}
+ * @protected
+ */
+function isAssistantMessage(message) {
+    if (!message || typeof message !== 'object') return false;
+
+    return message.role === 'assistant' ||
+        message.type === 'assistant' ||
+        message.message?.role === 'assistant' ||
+        message.item?.role === 'assistant';
+}
+
+/**
+ * @summary Extracts the last assistant text from an array of message-like records.
+ * @param {Object[]} messages
+ * @returns {String}
+ * @protected
+ */
+export function extractLastAssistantTextFromMessages(messages = []) {
+    if (!Array.isArray(messages)) return '';
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const record  = messages[i],
+              message = record?.message || record?.item || record;
+
+        if (!isAssistantMessage(record) && !isAssistantMessage(message)) continue;
+
+        const text = extractTextFromMessage(message);
+        if (text) return text;
+    }
+
+    return '';
+}
+
+/**
+ * @summary Extracts the last assistant text from JSONL transcript records, tolerating malformed lines.
+ * @param {String} jsonl
+ * @returns {String}
+ * @protected
+ */
+export function extractLastAssistantTextFromJsonl(jsonl = '') {
+    const lines = jsonl.split('\n');
+
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        let record;
+        try { record = JSON.parse(line); } catch { continue; }
+
+        const text = extractLastAssistantTextFromMessages([record]);
+        if (text) return text;
+    }
+
+    return '';
+}
+
+/**
+ * @summary Resolves the best available final assistant text from known and representative Codex shapes.
+ * @param {Object} [input={}]
+ * @returns {{text: String, source: String}}
+ */
+export function extractFinalAssistantText(input = {}) {
+    const last = input.last_assistant_message ?? input.lastAssistantMessage;
+    if (last) {
+        const text = extractTextFromMessage(last);
+        if (text.trim()) return {text, source: 'last_assistant_message'};
+    }
+
+    const messages = input.messages ?? input.conversation ?? input.transcript;
+    if (Array.isArray(messages)) {
+        const text = extractLastAssistantTextFromMessages(messages);
+        if (text.trim()) return {text, source: 'messages'};
+    }
+
+    const transcriptPath = input.transcript_path ?? input.transcriptPath;
+    if (transcriptPath) {
+        return {
+            text  : extractLastAssistantTextFromJsonl(fs.readFileSync(transcriptPath, 'utf8')),
+            source: 'transcript_path'
+        };
+    }
+
+    return {text: '', source: 'none'};
+}
+
+/**
+ * @summary Converts a parse result into the lane-state terminal verdict consumed by the hook.
+ * @param {{descriptor: (Object|null), parseError: (Error|null)}} outcome
+ * @param {Function} validate
+ * @returns {{valid: Boolean, reason: String}}
+ */
+export function parseOutcomeToVerdict({descriptor, parseError}, validate = validateLaneStateTerminal) {
+    if (parseError)          return {valid: false, reason: `malformed lane-state emission: ${parseError.message}`};
+    if (descriptor === null) return {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
+
+    const result = validate(descriptor);
+
+    return result.valid
+        ? {valid: true,  reason: 'valid lane-state terminal'}
+        : {valid: false, reason: (result.violations || []).join('; ') || 'invalid lane-state terminal'};
+}
+
+/**
+ * @summary Builds the no-hold reminder text without claiming Codex can inject it yet.
+ * @param {String} verdictReason
+ * @returns {String}
+ */
+export function buildNoHoldReminder(verdictReason) {
+    return `No-hold reminder: ${verdictReason}. There is no hold state: continue concrete work on the active lane, perform an assigned review that advances a named lane, or pick a fresh claimable lane. Passive waiting is not a terminal.`;
+}
+
+/**
+ * @summary Maps a terminal verdict to the Codex Stop action; invalid terminals are dry-run only.
+ * @param {{valid: Boolean, reason: String}} verdict
+ * @param {Object} [options]
+ * @param {Boolean} [options.enforcing=false]
+ * @param {Boolean} [options.blockInjectionSupported=CODEX_STOP_BLOCK_INJECTION_SUPPORTED]
+ * @returns {{action: ('allow'|'would-block'), reason: String}}
+ */
+export function decideCodexHookAction(verdict, {
+    enforcing               = false,
+    blockInjectionSupported = CODEX_STOP_BLOCK_INJECTION_SUPPORTED
+} = {}) {
+    if (verdict.valid) return {action: 'allow', reason: verdict.reason};
+
+    const reason = buildNoHoldReminder(verdict.reason);
+
+    if (enforcing && !blockInjectionSupported) {
+        return {
+            action: 'would-block',
+            reason: `${reason} Codex Stop block/inject contract is not proven, so this hook remains fail-open.`
+        };
+    }
+
+    return {action: 'would-block', reason};
+}
+
+/**
+ * @summary Returns a redacted, shape-only payload summary for live Codex Stop contract capture.
+ * @param {Object} payload
+ * @returns {Object}
+ */
+export function summarizePayloadShape(payload = {}) {
+    if (!payload || typeof payload !== 'object') return {type: typeof payload};
+
+    return Object.fromEntries(Object.entries(payload).map(([key, value]) => {
+        if (Array.isArray(value)) return [key, `array(${value.length})`];
+        if (value && typeof value === 'object') return [key, 'object'];
+        return [key, typeof value];
+    }));
+}
+
+/**
+ * @summary Classifies a Codex Stop payload against the lane-state parser and validator seam.
+ * @param {Object} input
+ * @param {Object} [options]
+ * @param {Boolean} [options.enforcing=false]
+ * @returns {{action: ('allow'|'would-block'), reason: String, source: String, verdict: Object}}
+ */
+export function classifyCodexStopPayload(input = {}, {enforcing = false} = {}) {
+    if (input.stop_hook_active || input.stopHookActive) {
+        const verdict = {valid: true, reason: 'Codex Stop loop guard active'};
+        return {action: 'allow', reason: verdict.reason, source: 'loop-guard', verdict};
+    }
+
+    const {text, source} = extractFinalAssistantText(input);
+
+    let descriptor = null, parseError = null;
+    try {
+        descriptor = parseLaneState(text);
+    } catch (e) {
+        parseError = e;
+    }
+
+    const verdict = parseOutcomeToVerdict({descriptor, parseError});
+
+    return {
+        ...decideCodexHookAction(verdict, {enforcing}),
+        source,
+        verdict
+    };
+}
+
+/**
+ * @summary Codex Stop hook entrypoint; logs would-block decisions and always exits successfully.
+ * @protected
+ */
+async function main() {
+    let input;
+    try {
+        input = JSON.parse(await readStdin());
+    } catch (e) {
+        auditLog(`PAYLOAD-PARSE-ERROR: could not parse Codex Stop input (${e.message}); allowing stop.`);
+        process.exit(0);
+    }
+
+    if (process.env.NEO_CODEX_LANE_STATE_CAPTURE === '1') {
+        auditLog(`PAYLOAD-SHAPE: ${JSON.stringify(summarizePayloadShape(input))}`);
+    }
+
+    let result;
+    try {
+        result = classifyCodexStopPayload(input, {
+            enforcing: process.env.NEO_CODEX_LANE_STATE_ENFORCE === '1'
+        });
+    } catch (e) {
+        auditLog(`HOOK-ERROR: ${e.message}; allowing stop.`);
+        process.exit(0);
+    }
+
+    const session = input.session_id || input.sessionId || '?',
+          prefix  = result.action === 'allow' ? 'WOULD-ALLOW' : 'WOULD-BLOCK';
+
+    auditLog(`${prefix} (session=${session}, source=${result.source}): ${result.reason}`);
+    process.exit(0);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs
@@ -1,0 +1,204 @@
+import {test, expect} from '@playwright/test';
+import {spawn}        from 'node:child_process';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    CODEX_STOP_BLOCK_INJECTION_SUPPORTED,
+    buildNoHoldReminder,
+    classifyCodexStopPayload,
+    decideCodexHookAction,
+    extractFinalAssistantText,
+    extractLastAssistantTextFromJsonl,
+    extractLastAssistantTextFromMessages,
+    summarizePayloadShape
+} from '../../../../.codex/hooks/codex-lane-state-stop.mjs';
+
+const block = body => '```lane-state\n' + body + '\n```',
+      fixturePath = new URL('./fixtures/codex-stop-payload.json', import.meta.url),
+      fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+test.describe('codex-lane-state-stop - contract boundary', () => {
+    test('Codex block/inject is explicitly unproven, so invalid terminals stay fail-open', () => {
+        expect(CODEX_STOP_BLOCK_INJECTION_SUPPORTED).toBe(false);
+
+        const result = decideCodexHookAction(
+            {valid: false, reason: 'no lane-state block emitted at turn-terminal'},
+            {enforcing: true}
+        );
+
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('block/inject contract is not proven');
+    });
+
+    test('the no-hold reminder names concrete non-hold exits', () => {
+        const reason = buildNoHoldReminder('no lane-state block emitted at turn-terminal');
+
+        expect(reason).toContain('No-hold reminder');
+        expect(reason).toContain('pick a fresh claimable lane');
+        expect(reason).toContain('Passive waiting is not a terminal');
+    });
+
+    test('payload shape capture is redacted to field names and value types', () => {
+        expect(summarizePayloadShape({
+            session_id            : 's',
+            last_assistant_message: 'secret text',
+            messages              : [{role: 'assistant'}],
+            nested                : {secret: 'value'}
+        })).toEqual({
+            session_id            : 'string',
+            last_assistant_message: 'string',
+            messages              : 'array(1)',
+            nested                : 'object'
+        });
+    });
+});
+
+test.describe('codex-lane-state-stop - input resolution', () => {
+    test('checked-in representative Stop payload resolves from last_assistant_message', () => {
+        const resolved = extractFinalAssistantText(fixture);
+
+        expect(resolved.source).toBe('last_assistant_message');
+        expect(resolved.text).toContain('"laneContinuation":"active-lane"');
+    });
+
+    test('message arrays use the last assistant text-bearing record', () => {
+        const text = extractLastAssistantTextFromMessages([
+            {role: 'assistant', content: 'earlier'},
+            {role: 'user', content: 'ignore'},
+            {type: 'assistant', message: {role: 'assistant', content: [{type: 'output_text', text: 'later'}]}}
+        ]);
+
+        expect(text).toBe('later');
+        expect(extractFinalAssistantText({messages: [{role: 'assistant', content: 'from messages'}]})).toEqual({
+            text  : 'from messages',
+            source: 'messages'
+        });
+    });
+
+    test('JSONL fallback tolerates malformed lines and skips user records', () => {
+        const jsonl = [
+            '{ not json }',
+            JSON.stringify({type: 'user', message: {role: 'user', content: 'question'}}),
+            JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'answer'}]}})
+        ].join('\n');
+
+        expect(extractLastAssistantTextFromJsonl(jsonl)).toBe('answer');
+    });
+});
+
+test.describe('codex-lane-state-stop - lane-state classification', () => {
+    test('valid representative payload allows', () => {
+        const result = classifyCodexStopPayload(fixture);
+
+        expect(result.action).toBe('allow');
+        expect(result.reason).toBe('valid lane-state terminal');
+        expect(result.source).toBe('last_assistant_message');
+    });
+
+    test('absent lane-state would-block with no-hold reminder', () => {
+        const result = classifyCodexStopPayload({
+            session_id            : 'absent',
+            last_assistant_message: 'Final prose without the structured block.'
+        });
+
+        expect(result.action).toBe('would-block');
+        expect(result.reason).toContain('no lane-state block emitted');
+        expect(result.reason).toContain('No-hold reminder');
+    });
+
+    test('malformed lane-state is distinct from absent', () => {
+        const result = classifyCodexStopPayload({
+            session_id            : 'malformed',
+            last_assistant_message: block('{laneContinuation: nope}')
+        });
+
+        expect(result.action).toBe('would-block');
+        expect(result.verdict.reason).toContain('malformed lane-state emission');
+    });
+
+    test('Codex stop loop guard allows', () => {
+        const result = classifyCodexStopPayload({
+            stop_hook_active      : true,
+            last_assistant_message: 'no lane-state'
+        });
+
+        expect(result.action).toBe('allow');
+        expect(result.source).toBe('loop-guard');
+    });
+});
+
+test.describe('codex-lane-state-stop - spawned hook', () => {
+    /**
+     * @summary Spawns the repo-local Codex Stop hook with a temp audit log directory.
+     * @param {(Object|String)} payload
+     * @param {Object} [options]
+     * @param {Boolean} [options.enforce=false]
+     * @param {Boolean} [options.capture=false]
+     * @returns {Promise<{stdout: String, log: String}>}
+     */
+    function runHook(payload, {enforce = false, capture = false} = {}) {
+        return new Promise((resolve, reject) => {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-lane-hook-')),
+                  env = {...process.env, NEO_AI_DAEMON_DIR: dir};
+
+            if (enforce) env.NEO_CODEX_LANE_STATE_ENFORCE = '1';
+            if (capture) env.NEO_CODEX_LANE_STATE_CAPTURE = '1';
+
+            const proc = spawn('node', ['.codex/hooks/codex-lane-state-stop.mjs'], {
+                cwd  : path.resolve(new URL('../../../..', import.meta.url).pathname),
+                env,
+                stdio: ['pipe', 'pipe', 'pipe']
+            });
+
+            let stdout = '';
+
+            proc.stdout.on('data', chunk => stdout += chunk);
+            proc.on('error', reject);
+            proc.on('exit', () => {
+                const logPath = path.join(dir, 'codex-lane-state-stop-hook.log');
+                resolve({stdout, log: fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : ''});
+            });
+
+            proc.stdin.write(typeof payload === 'string' ? payload : JSON.stringify(payload));
+            proc.stdin.end();
+        });
+    }
+
+    test('valid fixture logs WOULD-ALLOW and writes no stdout', async () => {
+        const {stdout, log} = await runHook(fixture);
+
+        expect(stdout).toBe('');
+        expect(log).toContain('WOULD-ALLOW');
+        expect(log).toContain('source=last_assistant_message');
+    });
+
+    test('invalid terminal logs WOULD-BLOCK but still writes no block decision to stdout', async () => {
+        const {stdout, log} = await runHook({
+            session_id            : 'invalid',
+            last_assistant_message: block('{"laneContinuation":"verified-no-lane"}')
+        }, {enforce: true});
+
+        expect(stdout).toBe('');
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('block/inject contract is not proven');
+        expect(log).toContain('full-backlog survey');
+    });
+
+    test('capture mode logs only the redacted payload shape', async () => {
+        const {log} = await runHook(fixture, {capture: true});
+
+        expect(log).toContain('PAYLOAD-SHAPE');
+        expect(log).toContain('"last_assistant_message":"string"');
+        expect(log).not.toContain('Continuing the active Codex lane');
+    });
+
+    test('malformed hook payload fails open', async () => {
+        const {stdout, log} = await runHook('{ not json }');
+
+        expect(stdout).toBe('');
+        expect(log).toContain('PAYLOAD-PARSE-ERROR');
+        expect(log).toContain('allowing stop');
+    });
+});

--- a/test/playwright/unit/hooks/fixtures/codex-stop-payload.json
+++ b/test/playwright/unit/hooks/fixtures/codex-stop-payload.json
@@ -1,0 +1,7 @@
+{
+  "_contractNote": "Representative Codex Stop hook payload for unit tests. Codex documents Stop command hooks, but not a stable block/inject decision contract; the live hook can log a redacted payload shape with NEO_CODEX_LANE_STATE_CAPTURE=1.",
+  "event": "Stop",
+  "session_id": "codex-stop-fixture",
+  "cwd": "/repo",
+  "last_assistant_message": "Continuing the active Codex lane.\n\n```lane-state\n{\"laneContinuation\":\"active-lane\",\"namedGates\":[{\"ref\":\"codex-stop-hook-parity\",\"checkedAt\":\"2026-06-20T13:20:00.000Z\"}],\"awaitingOwnPrOnly\":false}\n```"
+}


### PR DESCRIPTION
Resolves #13622
Related: #13623
Related: #13618

Adds a repo-local Codex `Stop` hook for the no-hold lane-state reminder path. The hook is deliberately fail-open: Codex documents `Stop` command hooks, but no stable Claude-style `decision:block` contract is documented, so this PR logs `WOULD-BLOCK` decisions and never emits a blocking decision on stdout.

Evidence: L2 (repo-local `Stop` hook wiring, representative payload fixture, spawned hook I/O tests, parser/validator reuse tests) -> L2 required for the #13622 code ACs. Residual: no enforcement claim; live Codex payload-shape capture remains post-merge before any future block/inject follow-up.

## Deltas from ticket

- Wires `.codex/hooks.json` with a `Stop` handler alongside the existing `UserPromptSubmit` context hook.
- Adds `.codex/hooks/codex-lane-state-stop.mjs`, reusing `parseLaneState` and `validateLaneStateTerminal` while keeping Codex block/inject disabled until proven.
- Adds redacted payload-shape capture via `NEO_CODEX_LANE_STATE_CAPTURE=1` and temp-dir-safe audit logging via `NEO_AI_DAEMON_DIR`.
- Adds a checked-in representative Codex Stop payload fixture and unit tests that prove valid, absent, malformed, and fail-open paths.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs` -> 14 passed.
- `npm run test-unit -- test/playwright/unit/hooks` -> 32 passed.
- `git diff --check` and `git diff --cached --check` passed.
- Commit hook passed: whitespace, shorthand, AiConfig mutation guard, JSDoc types, ticket archaeology, and block alignment.
- Broader suite caveat: sandboxed `npm run test-unit` failed before Playwright due `EPERM` opening `.neo-ai-data/logs/mc-server-2026-06-20.log`; unsandboxed full suite reached 4440 tests and was stopped after teardown silence with 4382 passed, 28 unrelated existing failures, 1 interrupted, 25 not run. No hook tests failed.

## Post-Merge Validation

- [ ] Trust the changed repo-local Codex hook via `/hooks` in a fresh Codex session.
- [ ] Run one Codex turn with `NEO_CODEX_LANE_STATE_CAPTURE=1` and verify the audit log records only redacted payload shape.
- [ ] File or update a follow-up before any Codex block/inject enforcement claim if live Codex semantics become documented or observed.

## Commits

- `2ee012458` - `feat(codex): add stop-hook lane-state probe (#13622)`

Authored by Euclid (GPT-5, Codex Desktop). Session 019ee050-c834-7503-b895-527ad55dd8c5.